### PR TITLE
[#1][#8] chore: Prometheus Dockerfile의 Prometheus 이미지 출처를 GCR로 변경

### DIFF
--- a/monitoring/prometheus/Dockerfile
+++ b/monitoring/prometheus/Dockerfile
@@ -1,4 +1,5 @@
-FROM prom/prometheus:latest
+ARG BASE_IMAGE=ghcr.io/prometheus/prometheus:v3.7.1
+FROM ${BASE_IMAGE}
 COPY prometheus.yml /etc/prometheus/prometheus.yml
 EXPOSE 9090
 ENTRYPOINT [ "/bin/prometheus" ]


### PR DESCRIPTION
## partially addresses #1
## partially addresses #8

## 작업내용
- Prometheus Dockerfile의 Prometheus 이미지 출처를 GCR로 변경