### PR TITLE
[#43][#101] feat: 회원 이메일 주소 검증 기능 추가

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -412,9 +412,8 @@ pipeline {
 						string(credentialsId: 'MARKETNOTE_MAIL_FROM',                       variable: 'MAIL_FROM'),
 						string(credentialsId: 'MARKETNOTE_MAIL_SENDER_NAME',                variable: 'MAIL_SENDER_NAME'),
 						string(credentialsId: 'MARKETNOTE_MAIL_VERIFICATION_TTL_MINUTES',   variable: 'MAIL_VERIFICATION_TTL_MINUTES'),
-						string(credentialsId: 'MARKETNOTE_REDIS_SERVICE_NAME',              variable: 'REDIS_SERVICE_NAME'),
 						string(credentialsId: 'MARKETNOTE_REDIS_PASSWORD',                  variable: 'REDIS_PASSWORD'),
-						string(credentialsId: 'MARKETNOTE_REDIS_SERVICE_NAME',              variable: 'REDIS_SERVICE_NAME'),
+						string(credentialsId: 'MARKETNOTE_REDIS_HOST_NAME',                 variable: 'REDIS_HOST_NAME'),
 						string(credentialsId: 'MARKETNOTE_REDIS_EMAIL_VERIFICATION_PREFIX', variable: 'REDIS_EMAIL_VERIFICATION_PREFIX'),
 					]) {
 						sh '''
@@ -463,9 +462,8 @@ pipeline {
 							  { "name": "MAIL_FROM",                      "value": "'"$MAIL_FROM"'" },
 							  { "name": "MAIL_SENDER_NAME",               "value": "'"$MAIL_SENDER_NAME"'" },
 							  { "name": "MAIL_VERIFICATION_TTL_MINUTES",  "value": "'"$MAIL_VERIFICATION_TTL_MINUTES"'" },
-							  { "name": "REDIS_SERVICE_NAME",             "value": "'"$REDIS_SERVICE_NAME"'" },
+							  { "name": "REDIS_HOST_NAME",                "value": "'"$REDIS_HOST_NAME"'" },
 							  { "name": "REDIS_PASSWORD",                 "value": "'"$REDIS_PASSWORD"'" },
-							  { "name": "REDIS_HOST_NAME",                "value": "'"$REDIS_SERVICE_NAME"'" },
 							  { "name": "REDIS_EMAIL_VERIFICATION_PREFIX","value": "'"$REDIS_EMAIL_VERIFICATION_PREFIX"'" }
 							],
                             "logConfiguration": {

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/client/user/controller/UserController.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/client/user/controller/UserController.java
@@ -11,10 +11,7 @@ import com.personal.marketnote.user.adapter.in.client.user.request.SignInRequest
 import com.personal.marketnote.user.adapter.in.client.user.request.SignOutRequest;
 import com.personal.marketnote.user.adapter.in.client.user.request.SignUpRequest;
 import com.personal.marketnote.user.adapter.in.client.user.request.UpdateUserInfoRequest;
-import com.personal.marketnote.user.adapter.in.client.user.response.AuthenticationTokenResponse;
-import com.personal.marketnote.user.adapter.in.client.user.response.SignInResponse;
-import com.personal.marketnote.user.adapter.in.client.user.response.SignOutResponse;
-import com.personal.marketnote.user.adapter.in.client.user.response.SignUpResponse;
+import com.personal.marketnote.user.adapter.in.client.user.response.*;
 import com.personal.marketnote.user.port.in.usecase.user.*;
 import com.personal.marketnote.user.security.token.vendor.AuthVendor;
 import com.personal.marketnote.user.utility.jwt.JwtUtil;
@@ -72,7 +69,7 @@ public class UserController {
      */
     @PostMapping("/sign-up")
     @SignUpApiDocs
-    public ResponseEntity<BaseResponse<AuthenticationTokenResponse>> signUpUser(
+    public ResponseEntity<BaseResponse<SignUpTokenResponse>> signUpUser(
             @Valid @RequestBody SignUpRequest signUpRequest,
             @AuthenticationPrincipal OAuth2AuthenticatedPrincipal principal
     ) {
@@ -97,7 +94,7 @@ public class UserController {
 
         return new ResponseEntity<>(
                 BaseResponse.of(
-                        new AuthenticationTokenResponse(accessToken, refreshToken),
+                        SignUpTokenResponse.of(accessToken, refreshToken, signUpResponse.isNewUser()),
                         HttpStatus.CREATED,
                         DEFAULT_SUCCESS_CODE,
                         "회원 가입 성공"
@@ -173,7 +170,7 @@ public class UserController {
 
         return new ResponseEntity<>(
                 BaseResponse.of(
-                        new AuthenticationTokenResponse(accessToken, refreshToken),
+                        AuthenticationTokenResponse.of(accessToken, refreshToken),
                         HttpStatus.OK,
                         DEFAULT_SUCCESS_CODE,
                         "회원 로그인 성공"

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/client/user/controller/apidocs/SignUpApiDocs.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/client/user/controller/apidocs/SignUpApiDocs.java
@@ -23,9 +23,9 @@ import java.lang.annotation.*;
                 ---
                 
                 ## Description
-                - **소셜 로그인**은 OAuth2 콜백 URI를 통해 발급된 Access Token이 필요합니다.
+                - **소셜 로그인**은 OAuth2 콜백 URI를 통해 발급된 **Access Token**과 **이메일 주소**, 회원 이메일 주소로 발송된 **인증 코드**가 필요합니다.
                 
-                - **일반 로그인**은 이메일 주소와 비밀번호가 필요합니다.
+                - **일반 로그인**은 **이메일 주소**와 **비밀번호**, 회원 이메일 주소로 발송된 **인증 코드**가 필요합니다.
                 
                     - 이메일 주소: example@example.com과 같은 형식이어야 합니다.
                 
@@ -35,15 +35,18 @@ import java.lang.annotation.*;
                 
                     - 비밀번호: 8자 이상, 대문자, 소문자, 숫자, 특수문자를 포함해야 합니다.
                 
+                - 이미 **다른 방법으로 가입된 회원**인 경우 **isNewUser**: **false**를 반환합니다. 이 경우 계정이 새로 생성되지 않고, 기존 계정에 통합됩니다.
+                
                 ---
                 
                 ## Request
                 
                 | **키** | **타입** | **설명** | **필수 여부** | **예시** |
                 | --- | --- | --- | --- | --- |
-                | nickname | string | 닉네임(2~20자, 한글) | N | "고길동" |
                 | email | string | 이메일 주소(형식: example@example.com) | Y | "example@example.com" |
                 | password | string | 비밀번호(8자 이상, 대문자, 소문자, 숫자, 특수문자 포함) | N | "Password123!" |
+                | verificationCode | string | 인증 코드 | Y | "NZW32E" |
+                | nickname | string | 닉네임(2~20자, 한글) | N | "고길동" |
                 | fullName | string | 성명(2~10자, 한글) | N | "홍길동" |
                 | phoneNumber | string | 전화번호(형식: 010-1234-5678) | N | "010-1234-5678" |
                 
@@ -54,7 +57,7 @@ import java.lang.annotation.*;
                 | **키** | **타입** | **설명** | **예시** |
                 | --- | --- | --- | --- |
                 | statusCode | number | 상태 코드 | 201: 성공 / 400: 클라이언트 요청 오류 / 401: 인증 실패 / 403: 인가 실패 / 404: 리소스 조회 실패 / 409: 충돌 / 500: 그 외 |
-                | code | string | 응답 코드 | "SUC01" / "ERR01" / "ERR02" / "ERR03" / "ERR04" |
+                | code | string | 응답 코드 | "SUC01" / "ERR01" / "ERR02" / "ERR03" / "ERR04" / "ERR05" / "ERR06" |
                 | timestamp | string(datetime) | 응답 일시 | "2025-12-26T12:12:30.013" |
                 | content | object | 응답 본문 | { ... } |
                 | message | string | 처리 결과 | "회원 가입 성공" |
@@ -67,6 +70,7 @@ import java.lang.annotation.*;
                 | --- | --- | --- | --- |
                 | accessToken | string | 신규 발급된 Access Token | "f8310f8asohvh80scvh0zio3hr31d" |
                 | refreshToken | string | 신규 발급된 Refresh Token | "f8310f8asohvh80scvh0zio3hr31d" |
+                | isNewUser | boolean | 신규 회원 여부 | true |
                 
                 """,
         security = {@SecurityRequirement(name = "bearer")},
@@ -76,11 +80,9 @@ import java.lang.annotation.*;
                         schema = @Schema(implementation = SignUpRequest.class),
                         examples = @ExampleObject("""
                                 {
-                                    "nickname": "고길동",
                                     "email": "example@example.com",
                                     "password": "Password123!",
-                                    "fullName": "홍길동",
-                                    "phoneNumber": "010-1234-5678"
+                                    "verificationCode": "NZW32E"
                                 }
                                 """)
                 )
@@ -94,10 +96,11 @@ import java.lang.annotation.*;
                                         {
                                           "statusCode": 201,
                                           "code": "SUC01",
-                                          "timestamp": "2025-12-26T22:52:31.889943",
+                                          "timestamp": "2025-12-28T10:38:42.720864",
                                           "content": {
-                                            "accessToken": "eyJhbGciOiJIUzI1NiJ9.eyJ0b2tlblR5cGUiOiJBQ0NFU1NfVE9LRU4iLCJpYXQiOjE3NjE1MjgzMTYsImV4cCI6MTc2MTUzMDExNiwic3ViIjoiOCIsInJvbGVJZHMiOlsiUk9MRV9CVVlFUiJdLCJ1c2VySWQiOjgsImF1dGhWZW5kb3IiOiJOQVRJVkUifQ.3nhlFNz9NBfcJKIteTICcUyN7F1w068CJKu5uy5kB0I",
-                                            "refreshToken": "eyJhbGciOiJIUzI1NiJ9.eyJ0b2tlblR5cGUiOiJSRUZSRVNIX1RPS0VOIiwiaWF0IjoxNzYxNDg2NzUxLCJleHAiOjE3NjI2OTYzNTEsInN1YiI6Im51bGwiLCJyb2xlSWRzIjpbIlJPTEVfQlVZRVIiXSwiYXV0aFZlbmRvciI6Ik5BVElWRSJ9._YvI9YT4aklPzJdN5D4IRqx0uzsyz4wjBMgCLGcf_CA"
+                                            "accessToken": "eyJhbGciOiJIUzI1NiJ9.eyJ0b2tlblR5cGUiOiJBQ0NFU1NfVE9LRU4iLCJpYXQiOjE3NjIzMDY3MjIsImV4cCI6MTc2MjMwODUyMiwic3ViIjoiODUiLCJyb2xlSWRzIjpbIlJPTEVfQlVZRVIiXSwidXNlcklkIjo4NSwiYXV0aFZlbmRvciI6Ik5BVElWRSJ9.O053YP2Vs41O_LYI2P3IGk7GLzaMeYM5mGgj0PZklxY",
+                                            "refreshToken": "eyJhbGciOiJIUzI1NiJ9.eyJ0b2tlblR5cGUiOiJSRUZSRVNIX1RPS0VOIiwiaWF0IjoxNzYyMzA2NzIyLCJleHAiOjE3NjM1MTYzMjIsInN1YiI6Ijg1Iiwicm9sZUlkcyI6WyJST0xFX0JVWUVSIl0sInVzZXJJZCI6ODUsImF1dGhWZW5kb3IiOiJOQVRJVkUifQ.k55p3WUr3i0GB1AIZCtIFLuQiAcXfPOv3qwmUMhAjmc",
+                                            "isNewUser": true
                                           },
                                           "message": "회원 가입 성공"
                                         }

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/client/user/mapper/UserRequestToCommandMapper.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/client/user/mapper/UserRequestToCommandMapper.java
@@ -10,9 +10,10 @@ import com.personal.marketnote.user.port.in.command.UpdateUserInfoCommand;
 public class UserRequestToCommandMapper {
     public static SignUpCommand mapToCommand(SignUpRequest signUpRequest) {
         return SignUpCommand.of(
-                signUpRequest.getNickname(),
                 signUpRequest.getEmail(),
                 signUpRequest.getPassword(),
+                signUpRequest.getVerificationCode(),
+                signUpRequest.getNickname(),
                 signUpRequest.getFullName(),
                 signUpRequest.getPhoneNumber()
         );

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/client/user/request/SignUpRequest.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/client/user/request/SignUpRequest.java
@@ -11,14 +11,6 @@ import static com.personal.marketnote.common.utility.RegularExpressionConstant.P
 @Getter
 public class SignUpRequest {
     @Schema(
-            name = "nickname",
-            description = "닉네임",
-            requiredMode = Schema.RequiredMode.NOT_REQUIRED
-    )
-//    @Pattern(regexp = NICKNAME_PATTERN, message = "닉네임은 한글만 가능하며, 6글자 이하여야 합니다.")
-    private String nickname;
-
-    @Schema(
             name = "email",
             description = "이메일 주소",
             requiredMode = Schema.RequiredMode.REQUIRED
@@ -34,6 +26,22 @@ public class SignUpRequest {
     )
 //    @Pattern(regexp = PASSWORD_PATTERN, message = "비밀번호는 8자 이상, 대문자, 소문자, 숫자, 특수문자를 포함해야 합니다.")
     private String password;
+
+    @Schema(
+            name = "verificationCode",
+            description = "인증 코드",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    @NotEmpty(message = "인증 코드는 필수값입니다.")
+    private String verificationCode;
+
+    @Schema(
+            name = "nickname",
+            description = "닉네임",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+//    @Pattern(regexp = NICKNAME_PATTERN, message = "닉네임은 한글만 가능하며, 6글자 이하여야 합니다.")
+    private String nickname;
 
     @Schema(
             name = "fullName",

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/client/user/response/AuthenticationTokenResponse.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/client/user/response/AuthenticationTokenResponse.java
@@ -4,5 +4,8 @@ public record AuthenticationTokenResponse(
         String accessToken,
         String refreshToken
 ) {
+    public static AuthenticationTokenResponse of(String accessToken, String refreshToken) {
+        return new AuthenticationTokenResponse(accessToken, refreshToken);
+    }
 }
 

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/client/user/response/SignUpResponse.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/client/user/response/SignUpResponse.java
@@ -4,9 +4,10 @@ import com.personal.marketnote.user.port.in.result.SignUpResult;
 
 public record SignUpResponse(
         Long id,
-        String roleId
+        String roleId,
+        boolean isNewUser
 ) {
     public static SignUpResponse from(SignUpResult signUpResult) {
-        return new SignUpResponse(signUpResult.id(), signUpResult.roleId());
+        return new SignUpResponse(signUpResult.id(), signUpResult.roleId(), signUpResult.isNewUser());
     }
 }

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/client/user/response/SignUpTokenResponse.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/client/user/response/SignUpTokenResponse.java
@@ -1,0 +1,11 @@
+package com.personal.marketnote.user.adapter.in.client.user.response;
+
+public record SignUpTokenResponse(
+        String accessToken,
+        String refreshToken,
+        boolean isNewUser
+) {
+    public static SignUpTokenResponse of(String accessToken, String refreshToken, boolean isNewUser) {
+        return new SignUpTokenResponse(accessToken, refreshToken, isNewUser);
+    }
+}

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/out/cache/EmailVerificationCodeRedisAdapter.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/out/cache/EmailVerificationCodeRedisAdapter.java
@@ -1,0 +1,44 @@
+package com.personal.marketnote.user.adapter.out.cache;
+
+import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.user.port.out.authentication.SaveEmailVerificationCodePort;
+import com.personal.marketnote.user.port.out.authentication.VerifyEmailVerificationCodePort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+
+@Repository
+@RequiredArgsConstructor
+public class EmailVerificationCodeRedisAdapter
+        implements SaveEmailVerificationCodePort, VerifyEmailVerificationCodePort {
+    private final StringRedisTemplate stringRedisTemplate;
+
+    @Value("${verification.redis.prefix:email:verification:}")
+    private String keyPrefix;
+
+    @Override
+    public void save(String email, String verificationCode, int ttlMinutes) {
+        String key = buildKey(email);
+        stringRedisTemplate.opsForValue().set(key, verificationCode, Duration.ofMinutes(ttlMinutes));
+    }
+
+    @Override
+    public boolean verifyAndConsume(String email, String targetCode) {
+        String key = buildKey(email);
+        String storedCode = stringRedisTemplate.opsForValue().get(key);
+        boolean isMatch = FormatValidator.equals(storedCode, targetCode);
+
+        if (isMatch) {
+            stringRedisTemplate.delete(key);
+        }
+
+        return isMatch;
+    }
+
+    private String buildKey(String email) {
+        return keyPrefix + email;
+    }
+}

--- a/user-service/user-adapters/src/main/resources/application.yml
+++ b/user-service/user-adapters/src/main/resources/application.yml
@@ -89,3 +89,7 @@ mail:
   sender-name: ${MAIL_SENDER_NAME:shop}
   verification:
     ttl-minutes: ${MAIL_VERIFICATION_TTL_MINUTES:5}
+
+verification:
+  redis:
+    prefix: ${REDIS_EMAIL_VERIFICATION_PREFIX:email:verification:}

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/exception/InvalidVerificationCodeException.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/exception/InvalidVerificationCodeException.java
@@ -1,0 +1,14 @@
+package com.personal.marketnote.user.exception;
+
+import lombok.Getter;
+import org.springframework.security.authentication.BadCredentialsException;
+
+@Getter
+public class InvalidVerificationCodeException extends BadCredentialsException {
+    private static final String INVALID_EMAIL_VERIFICATION_CODE_EXCEPTION_MESSAGE
+            = "%s:: 이메일 인증 코드가 유효하지 않거나 만료되었습니다. 이메일 주소: %s";
+
+    public InvalidVerificationCodeException(String code, String email) {
+        super(String.format(INVALID_EMAIL_VERIFICATION_CODE_EXCEPTION_MESSAGE, code, email));
+    }
+}

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/port/in/command/SignUpCommand.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/port/in/command/SignUpCommand.java
@@ -5,22 +5,28 @@ import lombok.Getter;
 
 @Getter
 public class SignUpCommand {
-    private final String nickname;
     private final String email;
     private final String password;
+    private final String verificationCode;
+    private final String nickname;
     private final String fullName;
     private final String phoneNumber;
 
-    private SignUpCommand(String nickname, String email, String password, String fullName, String phoneNumber) {
-        this.nickname = nickname;
+    private SignUpCommand(
+            String email, String password, String verificationCode, String nickname, String fullName, String phoneNumber
+    ) {
         this.email = email;
         this.password = password;
+        this.verificationCode = verificationCode;
+        this.nickname = nickname;
         this.fullName = fullName;
         this.phoneNumber = phoneNumber;
     }
 
-    public static SignUpCommand of(String nickname, String email, String password, String fullName, String phoneNumber) {
-        return new SignUpCommand(nickname, email, password, fullName, phoneNumber);
+    public static SignUpCommand of(
+            String email, String password, String verificationCode, String nickname, String fullName, String phoneNumber
+    ) {
+        return new SignUpCommand(email, password, verificationCode, nickname, fullName, phoneNumber);
     }
 
     public boolean hasPassword() {

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/port/in/result/SignUpResult.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/port/in/result/SignUpResult.java
@@ -4,9 +4,10 @@ import com.personal.marketnote.user.domain.user.User;
 
 public record SignUpResult(
         Long id,
-        String roleId
+        String roleId,
+        boolean isNewUser
 ) {
-    public static SignUpResult from(User user) {
-        return new SignUpResult(user.getId(), user.getRole().getId());
+    public static SignUpResult from(User user, boolean isNewUser) {
+        return new SignUpResult(user.getId(), user.getRole().getId(), isNewUser);
     }
 }

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/port/out/authentication/SaveEmailVerificationCodePort.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/port/out/authentication/SaveEmailVerificationCodePort.java
@@ -1,0 +1,5 @@
+package com.personal.marketnote.user.port.out.authentication;
+
+public interface SaveEmailVerificationCodePort {
+    void save(String email, String verificationCode, int ttlMinutes);
+}

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/port/out/authentication/VerifyEmailVerificationCodePort.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/port/out/authentication/VerifyEmailVerificationCodePort.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.user.port.out.authentication;
+
+public interface VerifyEmailVerificationCodePort {
+    boolean verifyAndConsume(String email, String targetCode);
+}
+
+

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/service/authentication/SendEmailVerificationService.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/service/authentication/SendEmailVerificationService.java
@@ -3,6 +3,7 @@ package com.personal.marketnote.user.service.authentication;
 import com.personal.marketnote.common.application.UseCase;
 import com.personal.marketnote.common.utility.RandomCodeGenerator;
 import com.personal.marketnote.user.port.in.usecase.authentication.SendEmailVerificationUseCase;
+import com.personal.marketnote.user.port.out.authentication.SaveEmailVerificationCodePort;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
@@ -23,13 +24,14 @@ public class SendEmailVerificationService implements SendEmailVerificationUseCas
               <p style="font-size:18px;font-weight:700;letter-spacing:2px">인증 코드: %s</p>
               <p>이 코드는 %d분 동안만 유효하며, 한 번만 사용할 수 있습니다.</p>
               <p style="color:#666">이 코드는 개인용이며, 다른 사람과 공유하지 마세요.<br>
-              고객센터에서도 절대 코드 요청을 하지 않습니다.</p>
-              <p style="margin-top:16px;color:#666">감사합니다.<br>마켓노트 고객센터 드림</p>
+              고객센터에서도 절대 코드 요청을 하지 않습니다.<br>감사합니다.<br></p>
+              <p style="margin-top:16px;color:#666">마켓노트 고객센터 드림</p>
               <p style=\\"color:#666\\">본 메일은 발신 전용입니다.</p>
             </div>
             """;
 
     private final JavaMailSender mailSender;
+    private final SaveEmailVerificationCodePort saveEmailVerificationCodePort;
 
     @Value("${mail.from:no-reply@example.com}")
     private String fromAddress;
@@ -43,14 +45,15 @@ public class SendEmailVerificationService implements SendEmailVerificationUseCas
     @Override
     public void sendEmailVerification(String email) {
         String verificationCode = RandomCodeGenerator.generateEmailVerificationCode();
+        saveEmailVerificationCodePort.save(email, verificationCode, ttlMinutes);
         sendVerificationEmail(email, verificationCode);
     }
 
-    private void sendVerificationEmail(String to, String verificationCode) {
+    private void sendVerificationEmail(String email, String verificationCode) {
         MimeMessage message = mailSender.createMimeMessage();
         try {
             MimeMessageHelper helper = new MimeMessageHelper(message, false, StandardCharsets.UTF_8.name());
-            helper.setTo(to);
+            helper.setTo(email);
             helper.setFrom(fromAddress, senderName);
             helper.setSubject("[마켓노트] 이메일 인증 코드");
 


### PR DESCRIPTION
## partially addresses #43
## resolves #101

## Task
- [x] 이메일 인증 요청 시 주기억장치에 이메일 주소(Key)와 인증 코드(Value) 저장
- [x] 회원 가입 요청 시 인증 코드 전송
- [x] 주기억장치 데이터 기반 인증 코드 검증
- [x] 검증 성공한 경우 회원가입 진행
- [x] 검증 실패 시 예외 반환