### PR TITLE
[#43][#116] feat: 카카오 계정 연결 해제 기능 추가

### DIFF
--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/client/user/controller/UserController.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/client/user/controller/UserController.java
@@ -43,10 +43,7 @@ import static com.personal.marketnote.user.security.token.utility.TokenConstant.
  */
 @RestController
 @RequestMapping("/api/v1/users")
-@Tag(
-        name = "회원 API",
-        description = "회원 관련 API"
-)
+@Tag(name = "회원 API", description = "회원 관련 API")
 @RequiredArgsConstructor
 @Slf4j
 public class UserController {
@@ -73,8 +70,7 @@ public class UserController {
     @SignUpApiDocs
     public ResponseEntity<BaseResponse<SignUpResponse>> signUpUser(
             @Valid @RequestBody SignUpRequest signUpRequest,
-            @AuthenticationPrincipal OAuth2AuthenticatedPrincipal principal
-    ) {
+            @AuthenticationPrincipal OAuth2AuthenticatedPrincipal principal) {
         AuthVendor authVendor = AuthVendor.NATIVE;
         String oidcId = null;
 
@@ -84,8 +80,8 @@ public class UserController {
             authVendor = resolveVendorFromIssuer(FormatConverter.toUpperCase(issuer));
         }
 
-        SignUpResult signUpResult =
-                signUpUseCase.signUp(UserRequestToCommandMapper.mapToCommand(signUpRequest), authVendor, oidcId);
+        SignUpResult signUpResult = signUpUseCase.signUp(UserRequestToCommandMapper.mapToCommand(signUpRequest),
+                authVendor, oidcId);
 
         List<String> roleIds = List.of(signUpResult.roleId());
         Long id = signUpResult.id();
@@ -98,10 +94,8 @@ public class UserController {
                         SignUpResponse.of(accessToken, refreshToken, signUpResult.isNewUser()),
                         HttpStatus.CREATED,
                         DEFAULT_SUCCESS_CODE,
-                        "회원 가입 성공"
-                ),
-                HttpStatus.CREATED
-        );
+                        "회원 가입 성공"),
+                HttpStatus.CREATED);
     }
 
     /**
@@ -117,21 +111,17 @@ public class UserController {
     @RegisterReferredUserCodeApiDocs
     public ResponseEntity<BaseResponse<Void>> registerReferredUserCode(
             @Valid @RequestParam String referredUserCode,
-            @AuthenticationPrincipal OAuth2AuthenticatedPrincipal principal
-    ) {
+            @AuthenticationPrincipal OAuth2AuthenticatedPrincipal principal) {
         registerReferredUserCodeUseCase.registerReferredUserCode(
-                ElementExtractor.extractUserId(principal), referredUserCode
-        );
+                ElementExtractor.extractUserId(principal), referredUserCode);
 
         return new ResponseEntity<>(
                 BaseResponse.of(
                         null,
                         HttpStatus.OK,
                         DEFAULT_SUCCESS_CODE,
-                        "초대 코드 등록 성공"
-                ),
-                HttpStatus.OK
-        );
+                        "초대 코드 등록 성공"),
+                HttpStatus.OK);
     }
 
     /**
@@ -159,8 +149,8 @@ public class UserController {
             authVendor = resolveVendorFromIssuer(FormatConverter.toUpperCase(issuer));
         }
 
-        SignInResult signInResult =
-                signInUseCase.signIn(UserRequestToCommandMapper.mapToCommand(signInRequest), authVendor, oidcId);
+        SignInResult signInResult = signInUseCase.signIn(UserRequestToCommandMapper.mapToCommand(signInRequest),
+                authVendor, oidcId);
 
         List<String> roleIds = List.of(signInResult.roleId());
         Long id = signInResult.id();
@@ -170,13 +160,12 @@ public class UserController {
 
         return new ResponseEntity<>(
                 BaseResponse.of(
-                        SignInResponse.of(accessToken, refreshToken, signInResult.isRequiredTermsAgreed()),
+                        SignInResponse.of(accessToken, refreshToken,
+                                signInResult.isRequiredTermsAgreed()),
                         HttpStatus.OK,
                         DEFAULT_SUCCESS_CODE,
-                        "회원 로그인 성공"
-                ),
-                HttpStatus.OK
-        );
+                        "회원 로그인 성공"),
+                HttpStatus.OK);
     }
 
     private AuthVendor resolveVendorFromIssuer(String issuer) {
@@ -207,21 +196,17 @@ public class UserController {
     @GetMapping("/me")
     @GetMyInfoApiDocs
     public ResponseEntity<BaseResponse<GetUserInfoResponse>> getMyInfo(
-            @AuthenticationPrincipal OAuth2AuthenticatedPrincipal principal
-    ) {
+            @AuthenticationPrincipal OAuth2AuthenticatedPrincipal principal) {
         GetUserInfoResponse getUserInfoResponse = GetUserInfoResponse.from(
-                getUserUseCase.getUserInfo(ElementExtractor.extractUserId(principal))
-        );
+                getUserUseCase.getUserInfo(ElementExtractor.extractUserId(principal)));
 
         return new ResponseEntity<>(
                 BaseResponse.of(
                         getUserInfoResponse,
                         HttpStatus.OK,
                         DEFAULT_SUCCESS_CODE,
-                        "자신의 정보 조회 성공"
-                ),
-                HttpStatus.OK
-        );
+                        "자신의 정보 조회 성공"),
+                HttpStatus.OK);
     }
 
     /**
@@ -243,18 +228,15 @@ public class UserController {
         updateUserUseCase.updateUserInfo(
                 false,
                 ElementExtractor.extractUserId(principal),
-                UserRequestToCommandMapper.mapToCommand(updateUserInfoRequest)
-        );
+                UserRequestToCommandMapper.mapToCommand(updateUserInfoRequest));
 
         return new ResponseEntity<>(
                 BaseResponse.of(
                         null,
                         HttpStatus.OK,
                         DEFAULT_SUCCESS_CODE,
-                        "자신의 정보 수정 성공"
-                ),
-                HttpStatus.OK
-        );
+                        "자신의 정보 수정 성공"),
+                HttpStatus.OK);
     }
 
     /**
@@ -281,10 +263,8 @@ public class UserController {
                         SignOutResponse.of(accessToken, refreshToken),
                         HttpStatus.OK,
                         DEFAULT_SUCCESS_CODE,
-                        "회원 로그아웃 성공"
-                ),
-                HttpStatus.OK
-        );
+                        "회원 로그아웃 성공"),
+                HttpStatus.OK);
     }
 
     /**
@@ -307,9 +287,7 @@ public class UserController {
                         null,
                         HttpStatus.OK,
                         DEFAULT_SUCCESS_CODE,
-                        "회원 탈퇴 성공"
-                ),
-                HttpStatus.OK
-        );
+                        "회원 탈퇴 성공"),
+                HttpStatus.OK);
     }
 }

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/out/oauth/kakao/Oauth2AccountClient.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/out/oauth/kakao/Oauth2AccountClient.java
@@ -1,0 +1,49 @@
+package com.personal.marketnote.user.adapter.out.oauth.kakao;
+
+import com.personal.marketnote.user.port.out.oauth.Oauth2AccountUnlinkPort;
+import com.personal.marketnote.user.service.exception.UnlinkOauth2AccountFailedException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.RequestEntity;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+import static com.personal.marketnote.user.service.exception.ExceptionMessage.UNLINK_KAKAO_ACCOUNT_FAILED_EXCEPTION_MESSAGE;
+
+@Component
+@Slf4j
+public class Oauth2AccountClient implements Oauth2AccountUnlinkPort {
+    private static final String KAKAO_UNLINK_URL = "https://kapi.kakao.com/v1/user/unlink";
+
+    @Value("${oauth2.kakao.admin-key}")
+    private String kakaoAdminKey;
+
+    private final RestTemplate restTemplate;
+
+    public Oauth2AccountClient(RestTemplate restTemplate) {
+        this.restTemplate = restTemplate;
+    }
+
+    @Override
+    public void unlinkKakaoAccount(String oidcId) throws UnlinkOauth2AccountFailedException {
+        MultiValueMap<String, String> form = new LinkedMultiValueMap<>();
+        form.add("target_id_type", "user_id");
+        form.add("target_id", oidcId);
+
+        RequestEntity<MultiValueMap<String, String>> requestEntity = RequestEntity.post(KAKAO_UNLINK_URL)
+                .header(HttpHeaders.AUTHORIZATION, "KakaoAK " + kakaoAdminKey)
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .body(form);
+
+        ResponseEntity<String> response = restTemplate.exchange(requestEntity, String.class);
+
+        if (!response.getStatusCode().is2xxSuccessful()) {
+            throw new UnlinkOauth2AccountFailedException(UNLINK_KAKAO_ACCOUNT_FAILED_EXCEPTION_MESSAGE);
+        }
+    }
+}

--- a/user-service/user-adapters/src/main/resources/application.yml
+++ b/user-service/user-adapters/src/main/resources/application.yml
@@ -10,7 +10,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: none
     open-in-view: false
 
   sql:
@@ -74,6 +74,7 @@ oauth2:
   kakao:
     client-id: ${KAKAO_CLIENT_ID:abc}
     client-secret: ${KAKAO_CLIENT_SECRET:def}
+    admin-key: ${KAKAO_ADMIN_KEY:ghi}
 
 management:
   endpoints:

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/port/in/usecase/user/WithdrawUseCase.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/port/in/usecase/user/WithdrawUseCase.java
@@ -5,7 +5,9 @@ public interface WithdrawUseCase {
      * @param id 회원 ID
      * @Date 2025-12-29
      * @Author 성효빈
-     * @Description 회원을 탈퇴합니다.
+     * @Description 회원에서 탈퇴합니다.
      */
-    void withdrawUser(Long id);
+    default void withdrawUser(Long id) {
+        withdrawUser(id);
+    }
 }

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/port/out/oauth/Oauth2AccountUnlinkPort.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/port/out/oauth/Oauth2AccountUnlinkPort.java
@@ -1,0 +1,15 @@
+package com.personal.marketnote.user.port.out.oauth;
+
+import com.personal.marketnote.user.service.exception.UnlinkOauth2AccountFailedException;
+
+/**
+ * 외부 OAuth2 API와의 연결 해제를 위한 아웃바운드 포트
+ */
+public interface Oauth2AccountUnlinkPort {
+    /**
+     * 사용자의 카카오 액세스 토큰으로 카카오 계정 연결 해제
+     */
+    void unlinkKakaoAccount(String oidcId) throws UnlinkOauth2AccountFailedException;
+}
+
+

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/security/token/resolver/JsonBearerTokenResolver.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/security/token/resolver/JsonBearerTokenResolver.java
@@ -7,6 +7,8 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.security.oauth2.server.resource.web.BearerTokenResolver;
 import org.springframework.stereotype.Component;
 
+import static com.personal.marketnote.user.security.token.utility.TokenConstant.AUTHENTICATION_SCHEME;
+
 @Component
 @Profile("!qa.test & !prod")
 @RequiredArgsConstructor
@@ -18,7 +20,7 @@ public class JsonBearerTokenResolver implements BearerTokenResolver {
             return null;
         }
 
-        return authorization.startsWith("Bearer ")
+        return authorization.startsWith(AUTHENTICATION_SCHEME)
                 ? authorization.substring(7)
                 : authorization;
     }

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/security/token/support/RestTemplateGoogleTokenProcessor.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/security/token/support/RestTemplateGoogleTokenProcessor.java
@@ -22,6 +22,7 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 
+import static com.personal.marketnote.user.security.token.utility.TokenConstant.AUTHENTICATION_SCHEME;
 import static com.personal.marketnote.user.security.token.utility.TokenConstant.SUB_CLAIM_KEY;
 
 @Component
@@ -88,7 +89,7 @@ public class RestTemplateGoogleTokenProcessor implements TokenProcessor {
     @Override
     public OAuth2AuthenticationInfo authenticate(String accessToken) throws InvalidAccessTokenException {
         RequestEntity<Void> requestEntity = RequestEntity.get(GOOGLE_ME_URL)
-                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                .header(HttpHeaders.AUTHORIZATION, AUTHENTICATION_SCHEME + accessToken)
                 .build();
 
         ResponseEntity<String> responseEntity = this.restTemplate.exchange(requestEntity, String.class);
@@ -107,7 +108,7 @@ public class RestTemplateGoogleTokenProcessor implements TokenProcessor {
     @Override
     public OAuth2UserInfo retrieveUserInfo(String accessToken) throws InvalidAccessTokenException {
         RequestEntity<Void> requestEntity = RequestEntity.get(GOOGLE_USER_INFO_URL)
-                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                .header(HttpHeaders.AUTHORIZATION, AUTHENTICATION_SCHEME + accessToken)
                 .build();
 
         ResponseEntity<String> responseEntity = this.restTemplate.exchange(requestEntity, String.class);

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/security/token/support/RestTemplateKakaoTokenProcessor.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/security/token/support/RestTemplateKakaoTokenProcessor.java
@@ -23,6 +23,7 @@ import org.springframework.web.client.RestTemplate;
 
 import java.util.Base64;
 
+import static com.personal.marketnote.user.security.token.utility.TokenConstant.AUTHENTICATION_SCHEME;
 import static com.personal.marketnote.user.security.token.utility.TokenConstant.SUB_CLAIM_KEY;
 
 @Component
@@ -120,7 +121,7 @@ public class RestTemplateKakaoTokenProcessor implements TokenProcessor {
     @Override
     public OAuth2AuthenticationInfo authenticate(String accessToken) throws InvalidAccessTokenException {
         RequestEntity<Void> requestEntity = RequestEntity.get(KAKAO_OIDC_USER_INFO_URL)
-                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                .header(HttpHeaders.AUTHORIZATION, AUTHENTICATION_SCHEME + accessToken)
                 .build();
 
         ResponseEntity<String> responseEntity =
@@ -140,7 +141,7 @@ public class RestTemplateKakaoTokenProcessor implements TokenProcessor {
     @Override
     public OAuth2UserInfo retrieveUserInfo(String accessToken) throws InvalidAccessTokenException {
         RequestEntity<Void> requestEntity = RequestEntity.get(KAKAO_ME_URL)
-                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                .header(HttpHeaders.AUTHORIZATION, AUTHENTICATION_SCHEME + accessToken)
                 .build();
 
         ResponseEntity<String> responseEntity = restTemplate.exchange(requestEntity, String.class);

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/security/token/utility/TokenConstant.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/security/token/utility/TokenConstant.java
@@ -3,4 +3,5 @@ package com.personal.marketnote.user.security.token.utility;
 public class TokenConstant {
     public static final String SUB_CLAIM_KEY = "sub";
     public static final String ISS_CLAIM_KEY = "iss";
+    public static final String AUTHENTICATION_SCHEME = "Bearer ";
 }

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/service/exception/ExceptionMessage.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/service/exception/ExceptionMessage.java
@@ -1,0 +1,5 @@
+package com.personal.marketnote.user.service.exception;
+
+public class ExceptionMessage {
+    public static final String UNLINK_KAKAO_ACCOUNT_FAILED_EXCEPTION_MESSAGE = "이메일 주소 형식이 잘못되었습니다. 예: abcd@abc.com\n전송된 이메일 주소: %s";
+}

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/service/exception/UnlinkOauth2AccountFailedException.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/service/exception/UnlinkOauth2AccountFailedException.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.user.service.exception;
+
+import java.io.IOException;
+
+public class UnlinkOauth2AccountFailedException extends IOException {
+    public UnlinkOauth2AccountFailedException(String message) {
+        super(message);
+    }
+}

--- a/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/user/User.java
+++ b/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/user/User.java
@@ -224,4 +224,23 @@ public class User {
     public boolean isWithdrawn() {
         return withdrawalYn;
     }
+
+    public boolean hasKakaoAccount() {
+        return userOauth2Vendors.stream()
+                .anyMatch(userOauth2Vendor -> userOauth2Vendor.isKakao());
+    }
+
+    public String getKakaoOidcId() {
+        return userOauth2Vendors.stream()
+                .filter(userOauth2Vendor -> userOauth2Vendor.isKakao())
+                .map(UserOauth2Vendor::getOidcId)
+                .findFirst()
+                .orElse(null);
+    }
+
+    public void removeKakaoOidcId() {
+        userOauth2Vendors.stream()
+                .filter(userOauth2Vendor -> userOauth2Vendor.isKakao())
+                .forEach(UserOauth2Vendor::removeOidcId);
+    }
 }

--- a/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/user/UserOauth2Vendor.java
+++ b/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/user/UserOauth2Vendor.java
@@ -58,4 +58,12 @@ public class UserOauth2Vendor {
 
         this.oidcId = oidcId;
     }
+
+    public boolean isKakao() {
+        return authVendor.isKakao();
+    }
+
+    public void removeOidcId() {
+        oidcId = null;
+    }
 }

--- a/user-service/user-domain/src/main/java/com/personal/marketnote/user/security/token/vendor/AuthVendor.java
+++ b/user-service/user-domain/src/main/java/com/personal/marketnote/user/security/token/vendor/AuthVendor.java
@@ -42,4 +42,8 @@ public enum AuthVendor {
     public boolean isMe(AuthVendor authVendor) {
         return this == authVendor;
     }
+
+    public boolean isKakao() {
+        return this == KAKAO;
+    }
 }


### PR DESCRIPTION
## partially addresses #43
## resolves #116

## Task
- [x] 회원 탈퇴 시 카카오 계정 가입 여부 확인
- [x] 계정 존재 시 카카오에 계정 연결 해제 요청
- [x] 회원 OAuth2 튜플의 카카오 oidcId 삭제