### PR TITLE
[#43][#117] feat: 구글 계정 연결 해제 기능 추가

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,7 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-title: ''
+title: '[Fix] '
 labels: 'bug'
 assignees: ''
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,7 +1,7 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-title: ''
+title: '[Feature] '
 labels: 'enhancement'
 assignees: ''
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-## partially resolve
-## resolve
+## partially addresses 
+## resolves 
 
 ## Task

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/client/user/controller/UserController.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/client/user/controller/UserController.java
@@ -149,8 +149,9 @@ public class UserController {
             authVendor = resolveVendorFromIssuer(FormatConverter.toUpperCase(issuer));
         }
 
-        SignInResult signInResult = signInUseCase.signIn(UserRequestToCommandMapper.mapToCommand(signInRequest),
-                authVendor, oidcId);
+        SignInResult signInResult = signInUseCase.signIn(
+                UserRequestToCommandMapper.mapToCommand(signInRequest), authVendor, oidcId
+        );
 
         List<String> roleIds = List.of(signInResult.roleId());
         Long id = signInResult.id();
@@ -270,7 +271,8 @@ public class UserController {
     /**
      * 회원 탈퇴
      *
-     * @param principal 사용자 인증 정보
+     * @param principal         사용자 인증 정보
+     * @param googleAccessToken Google 액세스 토큰
      * @Author 성효빈
      * @Date 2025-12-29
      * @Description 회원 탈퇴를 수행합니다.
@@ -278,9 +280,10 @@ public class UserController {
     @DeleteMapping
     @WithdrawalApiDocs
     public ResponseEntity<BaseResponse<Void>> withdrawUser(
-            @AuthenticationPrincipal OAuth2AuthenticatedPrincipal principal
+            @AuthenticationPrincipal OAuth2AuthenticatedPrincipal principal,
+            @RequestHeader(value = "X-Google-Access-Token", required = false) String googleAccessToken
     ) {
-        withdrawUseCase.withdrawUser(ElementExtractor.extractUserId(principal));
+        withdrawUseCase.withdrawUser(ElementExtractor.extractUserId(principal), googleAccessToken);
 
         return new ResponseEntity<>(
                 BaseResponse.of(

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/client/user/controller/apidocs/WithdrawalApiDocs.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/client/user/controller/apidocs/WithdrawalApiDocs.java
@@ -28,6 +28,7 @@ import java.lang.annotation.*;
                 
                  | **키** | **타입** | **설명** | **필수 여부** | **예시** |
                  | --- | --- | --- | --- | --- |
+                 | googleAccessToken | string | 구글 액세스 토큰(현재 구글 로그인 상태인 경우 함께 전송) | N | "f8310f8asohvh80scvh0zio3hr31d" |
                 
                  ---
                 

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/out/oauth/kakao/Oauth2AccountClient.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/out/oauth/kakao/Oauth2AccountClient.java
@@ -13,12 +13,14 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 
+import static com.personal.marketnote.user.service.exception.ExceptionMessage.UNLINK_GOOGLE_ACCOUNT_FAILED_EXCEPTION_MESSAGE;
 import static com.personal.marketnote.user.service.exception.ExceptionMessage.UNLINK_KAKAO_ACCOUNT_FAILED_EXCEPTION_MESSAGE;
 
 @Component
 @Slf4j
 public class Oauth2AccountClient implements Oauth2AccountUnlinkPort {
     private static final String KAKAO_UNLINK_URL = "https://kapi.kakao.com/v1/user/unlink";
+    private static final String GOOGLE_REVOKE_URL = "https://oauth2.googleapis.com/revoke";
 
     @Value("${oauth2.kakao.admin-key}")
     private String kakaoAdminKey;
@@ -44,6 +46,22 @@ public class Oauth2AccountClient implements Oauth2AccountUnlinkPort {
 
         if (!response.getStatusCode().is2xxSuccessful()) {
             throw new UnlinkOauth2AccountFailedException(UNLINK_KAKAO_ACCOUNT_FAILED_EXCEPTION_MESSAGE);
+        }
+    }
+
+    @Override
+    public void unlinkGoogleAccount(String accessToken) throws UnlinkOauth2AccountFailedException {
+        MultiValueMap<String, String> form = new LinkedMultiValueMap<>();
+        form.add("token", accessToken);
+
+        RequestEntity<MultiValueMap<String, String>> requestEntity = RequestEntity.post(GOOGLE_REVOKE_URL)
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .body(form);
+
+        ResponseEntity<String> response = restTemplate.exchange(requestEntity, String.class);
+
+        if (!response.getStatusCode().is2xxSuccessful()) {
+            throw new UnlinkOauth2AccountFailedException(UNLINK_GOOGLE_ACCOUNT_FAILED_EXCEPTION_MESSAGE);
         }
     }
 }

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/port/in/usecase/user/WithdrawUseCase.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/port/in/usecase/user/WithdrawUseCase.java
@@ -7,7 +7,7 @@ public interface WithdrawUseCase {
      * @Author 성효빈
      * @Description 회원에서 탈퇴합니다.
      */
-    default void withdrawUser(Long id) {
-        withdrawUser(id);
+    default void withdrawUser(Long id, String googleAccessToken) {
+        withdrawUser(id, googleAccessToken);
     }
 }

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/port/out/oauth/Oauth2AccountUnlinkPort.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/port/out/oauth/Oauth2AccountUnlinkPort.java
@@ -10,6 +10,9 @@ public interface Oauth2AccountUnlinkPort {
      * 사용자의 카카오 액세스 토큰으로 카카오 계정 연결 해제
      */
     void unlinkKakaoAccount(String oidcId) throws UnlinkOauth2AccountFailedException;
+
+    /**
+     * 구글 토큰 취소 API로 연결 해제 (access token 또는 refresh token)
+     */
+    void unlinkGoogleAccount(String accessToken) throws UnlinkOauth2AccountFailedException;
 }
-
-

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/security/token/support/RestTemplateGoogleTokenProcessor.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/security/token/support/RestTemplateGoogleTokenProcessor.java
@@ -59,8 +59,9 @@ public class RestTemplateGoogleTokenProcessor implements TokenProcessor {
                 .contentType(MediaType.APPLICATION_FORM_URLENCODED)
                 .body(requestBody);
 
-        ResponseEntity<OAuth2GrantedToken> responseEntity = restTemplate.exchange(requestEntity,
-                OAuth2GrantedToken.class);
+        ResponseEntity<OAuth2GrantedToken> responseEntity = restTemplate.exchange(
+                requestEntity, OAuth2GrantedToken.class
+        );
 
         if (responseEntity.getStatusCode().is4xxClientError()) {
             throw new UnsupportedCodeException("Code is invalid");

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/service/exception/ExceptionMessage.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/service/exception/ExceptionMessage.java
@@ -2,4 +2,5 @@ package com.personal.marketnote.user.service.exception;
 
 public class ExceptionMessage {
     public static final String UNLINK_KAKAO_ACCOUNT_FAILED_EXCEPTION_MESSAGE = "이메일 주소 형식이 잘못되었습니다. 예: abcd@abc.com\n전송된 이메일 주소: %s";
+    public static final String UNLINK_GOOGLE_ACCOUNT_FAILED_EXCEPTION_MESSAGE = "구글 계정 연결 해제에 실패했습니다.";
 }

--- a/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/user/User.java
+++ b/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/user/User.java
@@ -225,14 +225,9 @@ public class User {
         return withdrawalYn;
     }
 
-    public boolean hasKakaoAccount() {
-        return userOauth2Vendors.stream()
-                .anyMatch(userOauth2Vendor -> userOauth2Vendor.isKakao());
-    }
-
     public String getKakaoOidcId() {
         return userOauth2Vendors.stream()
-                .filter(userOauth2Vendor -> userOauth2Vendor.isKakao())
+                .filter(UserOauth2Vendor::isKakao)
                 .map(UserOauth2Vendor::getOidcId)
                 .findFirst()
                 .orElse(null);
@@ -240,7 +235,29 @@ public class User {
 
     public void removeKakaoOidcId() {
         userOauth2Vendors.stream()
-                .filter(userOauth2Vendor -> userOauth2Vendor.isKakao())
+                .filter(UserOauth2Vendor::isKakao)
+                .forEach(UserOauth2Vendor::removeOidcId);
+    }
+
+    public boolean hasGoogleAccount() {
+        return userOauth2Vendors.stream()
+                .anyMatch(UserOauth2Vendor::hasGoogleAccount);
+    }
+
+    public void removeGoogleOidcId() {
+        userOauth2Vendors.stream()
+                .filter(UserOauth2Vendor::isGoogle)
+                .forEach(UserOauth2Vendor::removeOidcId);
+    }
+
+    public boolean hasAppleAccount() {
+        return userOauth2Vendors.stream()
+                .anyMatch(UserOauth2Vendor::hasAppleAccount);
+    }
+
+    public void removeAppleOidcId() {
+        userOauth2Vendors.stream()
+                .filter(UserOauth2Vendor::isApple)
                 .forEach(UserOauth2Vendor::removeOidcId);
     }
 }

--- a/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/user/UserOauth2Vendor.java
+++ b/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/user/UserOauth2Vendor.java
@@ -59,8 +59,24 @@ public class UserOauth2Vendor {
         this.oidcId = oidcId;
     }
 
+    public boolean hasGoogleAccount() {
+        return isGoogle() && FormatValidator.hasValue(oidcId);
+    }
+
+    public boolean hasAppleAccount() {
+        return isApple() && FormatValidator.hasValue(oidcId);
+    }
+
     public boolean isKakao() {
         return authVendor.isKakao();
+    }
+
+    public boolean isGoogle() {
+        return authVendor.isGoogle();
+    }
+
+    public boolean isApple() {
+        return authVendor.isApple();
     }
 
     public void removeOidcId() {

--- a/user-service/user-domain/src/main/java/com/personal/marketnote/user/security/token/vendor/AuthVendor.java
+++ b/user-service/user-domain/src/main/java/com/personal/marketnote/user/security/token/vendor/AuthVendor.java
@@ -46,4 +46,12 @@ public enum AuthVendor {
     public boolean isKakao() {
         return this == KAKAO;
     }
+
+    public boolean isGoogle() {
+        return this == GOOGLE;
+    }
+
+    public boolean isApple() {
+        return this == APPLE;
+    }
 }


### PR DESCRIPTION
## partially addresses #43
## resolves #117

## Task
- [x] 회원 탈퇴 시 구글 엑세스 토큰 포함 요청
- [x] 구글 계정 가입 여부 확인
- [x] 계정 존재 시 구글에 계정 연결 해제 요청
- [x] 회원 OAuth2 튜플의 구글 oidcId 삭제