### PR TITLE
[#43][#123] feat: 회원 정렬 순서 기능 추가

### DIFF
--- a/common/src/main/java/com/personal/marketnote/common/adapter/out/persistence/audit/BaseOrderedEntity.java
+++ b/common/src/main/java/com/personal/marketnote/common/adapter/out/persistence/audit/BaseOrderedEntity.java
@@ -1,0 +1,17 @@
+package com.personal.marketnote.common.adapter.out.persistence.audit;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@EntityListeners(value = AuditingEntityListener.class)
+@MappedSuperclass
+@Getter
+public abstract class BaseOrderedEntity extends BaseGeneralEntity {
+    private Long orderNum;
+
+    public void setIdToOrderNum() {
+        orderNum = getId();
+    }
+}

--- a/common/src/main/java/com/personal/marketnote/common/utility/FormatConverter.java
+++ b/common/src/main/java/com/personal/marketnote/common/utility/FormatConverter.java
@@ -79,4 +79,30 @@ public class FormatConverter {
 
         return value.toUpperCase();
     }
+
+    public static String snakeToCamel(String name) {
+        if (!FormatValidator.hasValue(name)) {
+            return "";
+        }
+
+        StringBuilder result = new StringBuilder();
+        boolean nextUpper = false;
+
+        for (char c : name.toCharArray()) {
+            if (c == '_') {
+                nextUpper = true;
+                continue;
+            }
+
+            if (nextUpper) {
+                result.append(Character.toUpperCase(c));
+                nextUpper = false;
+                continue;
+            }
+
+            result.append(Character.toLowerCase(c));
+        }
+
+        return result.toString();
+    }
 }

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/client/user/controller/UserAdminController.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/client/user/controller/UserAdminController.java
@@ -73,8 +73,8 @@ public class UserAdminController {
     public ResponseEntity<BaseResponse<GetUsersResponse>> getUsers(
             @RequestParam(required = false, defaultValue = GET_USERS_DEFAULT_PAGE_SIZE) int pageSize,
             @RequestParam(required = false, defaultValue = DEFAULT_PAGE_NUMBER) int pageNumber,
-            @RequestParam(required = false, defaultValue = "ASC") Sort.Direction sortDirection,
-            @RequestParam(required = false, defaultValue = "EMAIL") SortProperty sortProperty,
+            @RequestParam(required = false, defaultValue = "DESC") Sort.Direction sortDirection,
+            @RequestParam(required = false, defaultValue = "ORDER_NUM") SortProperty sortProperty,
             @RequestParam(required = false, defaultValue = "EMAIL") SearchTarget searchTarget,
             @RequestParam(required = false) String searchKeyword
     ) {

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/client/user/controller/apidocs/GetUserInfoApiDocs.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/client/user/controller/apidocs/GetUserInfoApiDocs.java
@@ -74,7 +74,7 @@ import java.lang.annotation.*;
                 | lastLoggedInAt | string(datetime) | 마지막 로그인 일시 | "2025-12-29T10:19:52.558748" |
                 | status | string | 상태 | "ACTIVE" / "INACTIVE" / "DELETED" |
                 | isWithdrawn | boolean | 탈퇴 여부 | true / false |
-                
+                | orderNum | number | 정렬 순서 | 1 |
                 ---
                 
                 ### Response > content > userInfo > accountInfo
@@ -143,7 +143,8 @@ import java.lang.annotation.*;
                                               "roleId": "ROLE_BUYER",
                                               "lastLoggedInAt": "2025-12-28T16:23:26.964246",
                                               "status": "ACTIVE",
-                                              "isWithdrawn": false
+                                              "isWithdrawn": false,
+                                              "orderNum": 1
                                             }
                                           },
                                           "message": "회원 정보 조회 성공"

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/client/user/controller/apidocs/GetUsersApiDocs.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/client/user/controller/apidocs/GetUsersApiDocs.java
@@ -37,10 +37,10 @@ import java.lang.annotation.*;
                 | --- | --- | --- | --- | --- |
                 | pageSize | number | 페이지 크기 | N | default: 10 |
                 | pageNumber | number | 페이지 번호(1부터) | N | default: 1 |
-                | sortDirection | string | 정렬 방향 | N | default: "ASC" |
-                | sortProperty | string | 정렬 속성 | N | default: "ID" |
-                | searchTarget | string | 검색 대상 | N | default: "ID" |
-                | searchKeyword | string | 검색 키워드 | N | default: "" |
+                | sortDirection | string | 정렬 방향 | N | default: "DESC" |
+                | sortProperty | string | 정렬 속성 | N | default: "ORDER_NUM" |
+                | searchTarget | string | 검색 대상 | N | default: "EMAIL" |
+                | searchKeyword | string | 검색 키워드 | N | default: "ample@example.co" |
                 
                 ---
                 
@@ -84,6 +84,7 @@ import java.lang.annotation.*;
                 | lastLoggedInAt | string(datetime) | 마지막 로그인 일시 | "2025-12-29T10:19:52.558748" |
                 | status | string | 상태 | "ACTIVE" / "INACTIVE" / "DELETED" |
                 | isWithdrawn | boolean | 탈퇴 여부 | true / false |
+                | orderNum | number | 정렬 순서 | 1 |
                 ---
                 
                 ### Response > content > users > accountInfo
@@ -122,21 +123,21 @@ import java.lang.annotation.*;
                         in = ParameterIn.QUERY,
                         required = false,
                         description = "정렬 방향",
-                        schema = @Schema(type = "string", example = "ASC")
+                        schema = @Schema(type = "string", example = "DESC")
                 ),
                 @Parameter(
                         name = "sortProperty",
                         in = ParameterIn.QUERY,
                         required = false,
                         description = "정렬 속성",
-                        schema = @Schema(type = "string", example = "ID")
+                        schema = @Schema(type = "string", example = "ORDER_NUM")
                 ),
                 @Parameter(
                         name = "searchTarget",
                         in = ParameterIn.QUERY,
                         required = false,
                         description = "검색 대상",
-                        schema = @Schema(type = "string", example = "ID")
+                        schema = @Schema(type = "string", example = "EMAIL")
                 ),
                 @Parameter(
                         name = "searchKeyword",
@@ -193,7 +194,8 @@ import java.lang.annotation.*;
                                                 "roleId": "ROLE_BUYER",
                                                 "lastLoggedInAt": "2025-12-28T15:04:14.896225",
                                                 "status": "INACTIVE",
-                                                "isWithdrawn": true
+                                                "isWithdrawn": true,
+                                                "orderNum": 1
                                               },
                                               {
                                                 "id": 87,
@@ -225,7 +227,8 @@ import java.lang.annotation.*;
                                                 "roleId": "ROLE_BUYER",
                                                 "lastLoggedInAt": "2025-12-29T15:22:45.433588",
                                                 "status": "ACTIVE",
-                                                "isWithdrawn": false
+                                                "isWithdrawn": false,
+                                                "orderNum": 2
                                               }
                                             ]
                                           },

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/client/user/response/GetUserResponse.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/client/user/response/GetUserResponse.java
@@ -19,7 +19,8 @@ public record GetUserResponse(
         String roleId,
         LocalDateTime lastLoggedInAt,
         String status,
-        boolean isWithdrawn
+        boolean isWithdrawn,
+        Long orderNum
 ) {
     public static GetUserResponse from(GetUserResult getUserResult) {
         return GetUserResponse.builder()
@@ -34,6 +35,7 @@ public record GetUserResponse(
                 .lastLoggedInAt(getUserResult.lastLoggedInAt())
                 .status(getUserResult.status())
                 .isWithdrawn(getUserResult.isWithdrawn())
+                .orderNum(getUserResult.orderNum())
                 .build();
     }
 }

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/out/mapper/UserJpaEntityToDomainMapper.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/out/mapper/UserJpaEntityToDomainMapper.java
@@ -38,7 +38,8 @@ public class UserJpaEntityToDomainMapper {
                             userTerms,
                             entity.getLastLoggedInAt(),
                             entity.getStatus(),
-                            entity.getWithdrawalYn()
+                            entity.getWithdrawalYn(),
+                            entity.getOrderNum()
                     );
 
                     vendors.forEach(v -> v.addUser(user));

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/out/persistence/UserPersistenceAdapter.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/out/persistence/UserPersistenceAdapter.java
@@ -37,9 +37,10 @@ public class UserPersistenceAdapter
 
     @Override
     public User save(User user) {
-        UserJpaEntity userJpaEntity = UserJpaEntity.from(user, termsJpaRepository);
+        UserJpaEntity savedEntity = userJpaRepository.save(UserJpaEntity.from(user, termsJpaRepository));
+        savedEntity.setIdToOrderNum();
 
-        return UserJpaEntityToDomainMapper.mapToDomain(userJpaRepository.save(userJpaEntity)).get();
+        return UserJpaEntityToDomainMapper.mapToDomain(savedEntity).get();
     }
 
     @Override

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/out/persistence/user/entity/UserJpaEntity.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/out/persistence/user/entity/UserJpaEntity.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
-import com.personal.marketnote.common.adapter.out.persistence.audit.BaseGeneralEntity;
+import com.personal.marketnote.common.adapter.out.persistence.audit.BaseOrderedEntity;
 import com.personal.marketnote.user.adapter.out.persistence.authentication.entity.RoleJpaEntity;
 import com.personal.marketnote.user.adapter.out.persistence.user.repository.TermsJpaRepository;
 import com.personal.marketnote.user.domain.user.User;
@@ -26,7 +26,7 @@ import static jakarta.persistence.CascadeType.PERSIST;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder(access = AccessLevel.PRIVATE)
 @Getter
-public class UserJpaEntity extends BaseGeneralEntity {
+public class UserJpaEntity extends BaseOrderedEntity {
     @Column(name = "nickname", nullable = false, unique = true, length = 31)
     private String nickname;
 

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/out/persistence/user/repository/UserJpaRepository.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/out/persistence/user/repository/UserJpaRepository.java
@@ -67,7 +67,7 @@ public interface UserJpaRepository extends JpaRepository<UserJpaEntity, Long> {
             FROM UserJpaEntity u
             WHERE u.status = com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus.ACTIVE
                 AND u.id = :id
-            ORDER BY u.id ASC
+            ORDER BY u.orderNum ASC
             """)
     Optional<UserJpaEntity> findById(@Param("id") Long id);
 
@@ -83,7 +83,7 @@ public interface UserJpaRepository extends JpaRepository<UserJpaEntity, Long> {
               AND uov.authVendor = :authVendor
               AND uov.oidcId = :oidcId
               )
-            ORDER BY u.id ASC
+            ORDER BY u.orderNum ASC
             """)
     Optional<UserJpaEntity> findByAuthVendorAndOidcId(@Param("authVendor") AuthVendor authVendor,
                                                       @Param("oidcId") String oidcId);
@@ -94,7 +94,7 @@ public interface UserJpaRepository extends JpaRepository<UserJpaEntity, Long> {
             WHERE 1 = 1
                 AND u.status = com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus.ACTIVE
                 AND u.phoneNumber = :phoneNumber
-            ORDER BY u.id ASC
+            ORDER BY u.orderNum ASC
             """)
     Optional<UserJpaEntity> findByPhoneNumber(@Param("phoneNumber") String phoneNumber);
 
@@ -104,7 +104,7 @@ public interface UserJpaRepository extends JpaRepository<UserJpaEntity, Long> {
             WHERE 1 = 1
                 AND u.status = com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus.ACTIVE
                 AND u.email = :email
-            ORDER BY u.id ASC
+            ORDER BY u.orderNum ASC
             """)
     Optional<UserJpaEntity> findByEmail(@Param("email") String email);
 
@@ -112,7 +112,7 @@ public interface UserJpaRepository extends JpaRepository<UserJpaEntity, Long> {
             SELECT u
             FROM UserJpaEntity u
             WHERE 1 = 1
-                AND u.id = :id
+                AND u.orderNum = :id
             """)
     Optional<UserJpaEntity> findAllStatusUserById(@Param("id") Long id);
 
@@ -128,7 +128,7 @@ public interface UserJpaRepository extends JpaRepository<UserJpaEntity, Long> {
             SELECT u
             FROM UserJpaEntity u
             WHERE 1 = 1
-            ORDER BY u.id ASC
+            ORDER BY u.orderNum ASC
             """)
     List<UserJpaEntity> findAllStatusUsers();
 

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/port/in/result/GetUserInfoResult.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/port/in/result/GetUserInfoResult.java
@@ -18,7 +18,8 @@ public record GetUserInfoResult(
         String roleId,
         LocalDateTime lastLoggedInAt,
         String status,
-        boolean isWithdrawn
+        boolean isWithdrawn,
+        Long orderNum
 ) {
     public static GetUserInfoResult from(User user) {
         return GetUserInfoResult.builder()
@@ -33,6 +34,7 @@ public record GetUserInfoResult(
                 .lastLoggedInAt(user.getLastLoggedInAt())
                 .status(user.getStatus().name())
                 .isWithdrawn(user.isWithdrawn())
+                .orderNum(user.getOrderNum())
                 .build();
     }
 }

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/port/in/result/GetUserResult.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/port/in/result/GetUserResult.java
@@ -18,7 +18,8 @@ public record GetUserResult(
         String roleId,
         LocalDateTime lastLoggedInAt,
         String status,
-        boolean isWithdrawn
+        boolean isWithdrawn,
+        Long orderNum
 ) {
     public static GetUserResult from(User user) {
         return GetUserResult.builder()
@@ -33,6 +34,7 @@ public record GetUserResult(
                 .lastLoggedInAt(user.getLastLoggedInAt())
                 .status(user.getStatus().name())
                 .isWithdrawn(user.isWithdrawn())
+                .orderNum(user.getOrderNum())
                 .build();
     }
 }

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/service/user/GetUserService.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/service/user/GetUserService.java
@@ -76,7 +76,7 @@ public class GetUserService implements GetUserUseCase {
             Sort.Direction sortDirection, SortProperty sortProperty,
             SearchTarget searchTarget, String searchKeyword
     ) {
-        Pageable pageable = PageRequest.of(pageNumber, pageSize, Sort.by(sortDirection, sortProperty.getLowerValue()));
+        Pageable pageable = PageRequest.of(pageNumber, pageSize, Sort.by(sortDirection, sortProperty.getCamelCaseValue()));
 
         return findUserPort.findAllStatusUsersByPage(pageable, searchTarget, searchKeyword)
                 .map(GetUserResult::from);

--- a/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/user/SortProperty.java
+++ b/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/user/SortProperty.java
@@ -1,20 +1,21 @@
 package com.personal.marketnote.user.domain.user;
 
+import com.personal.marketnote.common.utility.FormatConverter;
 import lombok.Getter;
 
 @Getter
 public enum SortProperty {
-
+    ORDER_NUM("정렬 순서"),
     ID("회원 기본키"),
     NICKNAME("닉네임"),
     EMAIL("이메일 주소"),
     PHONE_NUMBER("전화번호");
 
-    private final String lowerValue;
     private final String description;
+    private final String camelCaseValue;
 
     SortProperty(String description) {
-        lowerValue = this.name().toLowerCase();
         this.description = description;
+        camelCaseValue = FormatConverter.snakeToCamel(this.name());
     }
 }

--- a/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/user/User.java
+++ b/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/user/User.java
@@ -37,6 +37,7 @@ public class User {
     private LocalDateTime lastLoggedInAt;
     private EntityStatus status;
     private boolean withdrawalYn;
+    private Long orderNum;
 
     public static User from(AuthVendor authVendor, String oidcId) {
         return User.builder()
@@ -60,10 +61,12 @@ public class User {
         List<UserOauth2Vendor> userOauth2Vendors = new ArrayList<>(AuthVendor.size());
         AuthVendor[] allAuthVendors = AuthVendor.values();
 
+        // 최초 회원 가입 시 모든 공급업체 튜플 추가
         for (AuthVendor authVendor : allAuthVendors) {
             UserOauth2Vendor userOauth2Vendor = UserOauth2Vendor.of(authVendor);
             userOauth2Vendors.add(userOauth2Vendor);
 
+            // 실제 가입한 공급업체만 OIDC ID 삽입
             if (authVendor.isMe(targetAuthVendor)) {
                 userOauth2Vendor.addOidcId(targetAuthVendor, oidcId, email);
             }
@@ -80,10 +83,12 @@ public class User {
                 .lastLoggedInAt(LocalDateTime.now())
                 .build();
 
+        // 일반 회원 가입인 경우 비밀번호 설정
         if (targetAuthVendor.isNative() && FormatValidator.hasValue(password)) {
             user.password = passwordEncoder.encode(password);
         }
 
+        // 최초 회원 가입 시 모든 이용 약관 튜플 추가
         user.userTerms = terms.stream()
                 .map(term -> UserTerms.of(user, term))
                 .collect(Collectors.toList());
@@ -105,7 +110,8 @@ public class User {
             List<UserTerms> userTerms,
             LocalDateTime lastLoggedInAt,
             EntityStatus status,
-            boolean withdrawalYn
+            boolean withdrawalYn,
+            Long orderNum
     ) {
         return User.builder()
                 .id(id)
@@ -122,6 +128,7 @@ public class User {
                 .lastLoggedInAt(lastLoggedInAt)
                 .status(status)
                 .withdrawalYn(withdrawalYn)
+                .orderNum(orderNum)
                 .build();
     }
 


### PR DESCRIPTION
## partially addresses #43
## resolves #123

## Task
- [x] 회원 가입 시 초기값을 Primary Key와 동일하게 설정
- [x] 기본 조회 정렬값으로 설정
- [x] 회원 목록 조회 시 정렬 기준에 추가
    - [x] 기본 정렬 속성을 ORDER_NUM으로 변경
    - [x] 기본 정렬 방향을 DESC(Descendent)로 변경
- [x] 회원 목록 조회 시 응답값에 추가
- [x] 회원 정보 조회 시 응답값에 추가
- [x] Swagger 문서 업데이트