### PR TITLE
[#43][#83] feat: 회원 로그아웃 및 리프레시 토큰 관련 로직 변경사항 적용

### DIFF
--- a/common/src/main/java/com/personal/marketnote/common/configuration/security/OpaqueTokenIntrospectorConfig.java
+++ b/common/src/main/java/com/personal/marketnote/common/configuration/security/OpaqueTokenIntrospectorConfig.java
@@ -54,6 +54,7 @@ public class OpaqueTokenIntrospectorConfig {
                         .requestMatchers("/actuator/**").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/v1/users/sign-up").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/v1/users/sign-in").permitAll()
+                        .requestMatchers(HttpMethod.DELETE, "/api/v1/users/sign-out").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/v1/authentication/access-token/refresh").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/v1/terms").permitAll()
                         .anyRequest().authenticated())

--- a/common/src/main/java/com/personal/marketnote/common/utility/http/cookie/HttpCookieName.java
+++ b/common/src/main/java/com/personal/marketnote/common/utility/http/cookie/HttpCookieName.java
@@ -12,7 +12,7 @@ public enum HttpCookieName {
     ACCESS_TOKEN("access_token"),
     PROFILE_IMAGE_URL("profile_image_url"),
     REFRESH_TOKEN("refresh_token"),
-    USER_ID("member_id");
+    USER_ID("user_id");
 
     private final String cookieName;
 }

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/mapper/ProductCommandToStateMapper.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/mapper/ProductCommandToStateMapper.java
@@ -9,8 +9,8 @@ import com.personal.marketnote.product.port.in.command.RegisterProductOptionsCom
 
 import java.util.stream.Collectors;
 
-public class ProductCommandToDomainMapper {
-    public static ProductOptionCategory mapToDomain(
+public class ProductCommandToStateMapper {
+    public static ProductOptionCategory mapToState(
             Product product, RegisterProductOptionsCommand registerProductOptionsCommand
     ) {
         return ProductOptionCategory.of(
@@ -18,16 +18,20 @@ public class ProductCommandToDomainMapper {
                 registerProductOptionsCommand.categoryName(),
                 registerProductOptionsCommand.options()
                         .stream()
-                        .map(ProductCommandToDomainMapper::mapToDomain)
+                        .map(ProductCommandToStateMapper::mapToState)
                         .collect(Collectors.toList())
         );
     }
 
-    public static ProductOption mapToDomain(RegisterProductOptionsCommand.OptionItem optionItem) {
-        return ProductOption.of(optionItem.content());
+    public static ProductOption mapToState(RegisterProductOptionsCommand.OptionItem optionItem) {
+        return ProductOption.of(
+                optionItem.content(),
+                optionItem.price(),
+                optionItem.accumulatedPoint()
+        );
     }
 
-    public static PricePolicy mapToDomain(
+    public static PricePolicy mapToState(
             Product product, RegisterPricePolicyCommand command
     ) {
         java.math.BigDecimal price = java.math.BigDecimal.valueOf(command.price());
@@ -52,6 +56,7 @@ public class ProductCommandToDomainMapper {
                 command.discountPrice(),
                 accumulationRate,
                 command.accumulatedPoint(),
-                discountRate);
+                discountRate
+        );
     }
 }

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/service/product/RegisterPricePolicyService.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/service/product/RegisterPricePolicyService.java
@@ -4,7 +4,7 @@ import com.personal.marketnote.common.application.UseCase;
 import com.personal.marketnote.product.domain.product.PricePolicy;
 import com.personal.marketnote.product.domain.product.Product;
 import com.personal.marketnote.product.exception.NotProductOwnerException;
-import com.personal.marketnote.product.mapper.ProductCommandToDomainMapper;
+import com.personal.marketnote.product.mapper.ProductCommandToStateMapper;
 import com.personal.marketnote.product.port.in.command.RegisterPricePolicyCommand;
 import com.personal.marketnote.product.port.in.result.RegisterPricePolicyResult;
 import com.personal.marketnote.product.port.in.usecase.product.GetProductUseCase;
@@ -37,7 +37,7 @@ public class RegisterPricePolicyService implements RegisterPricePolicyUseCase {
 
         Product product = getProductUseCase.getProduct(productId);
 
-        PricePolicy pricePolicy = ProductCommandToDomainMapper.mapToDomain(product, command);
+        PricePolicy pricePolicy = ProductCommandToStateMapper.mapToState(product, command);
         Long id = savePricePolicyPort.save(pricePolicy);
 
         if (command.optionIds() != null && !command.optionIds().isEmpty()) {

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/service/product/RegisterProductOptionsService.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/service/product/RegisterProductOptionsService.java
@@ -6,7 +6,7 @@ import com.personal.marketnote.product.domain.product.Product;
 import com.personal.marketnote.product.domain.product.ProductOptionCategory;
 import com.personal.marketnote.product.exception.NotProductOwnerException;
 import com.personal.marketnote.product.exception.OptionsNoValueException;
-import com.personal.marketnote.product.mapper.ProductCommandToDomainMapper;
+import com.personal.marketnote.product.mapper.ProductCommandToStateMapper;
 import com.personal.marketnote.product.port.in.command.RegisterProductOptionsCommand;
 import com.personal.marketnote.product.port.in.result.UpsertProductOptionsResult;
 import com.personal.marketnote.product.port.in.usecase.product.GetProductUseCase;
@@ -46,7 +46,7 @@ public class RegisterProductOptionsService implements RegisterProductOptionsUseC
         }
 
         ProductOptionCategory savedCategory = saveProductOptionsPort.save(
-                ProductCommandToDomainMapper.mapToDomain(product, command)
+                ProductCommandToStateMapper.mapToState(product, command)
         );
 
         return UpsertProductOptionsResult.from(savedCategory);

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/service/product/UpdateProductOptionsService.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/service/product/UpdateProductOptionsService.java
@@ -6,7 +6,7 @@ import com.personal.marketnote.product.domain.product.Product;
 import com.personal.marketnote.product.domain.product.ProductOptionCategory;
 import com.personal.marketnote.product.exception.NotProductOwnerException;
 import com.personal.marketnote.product.exception.OptionsNoValueException;
-import com.personal.marketnote.product.mapper.ProductCommandToDomainMapper;
+import com.personal.marketnote.product.mapper.ProductCommandToStateMapper;
 import com.personal.marketnote.product.port.in.command.RegisterProductOptionsCommand;
 import com.personal.marketnote.product.port.in.command.UpdateProductOptionsCommand;
 import com.personal.marketnote.product.port.in.result.UpsertProductOptionsResult;
@@ -53,7 +53,7 @@ public class UpdateProductOptionsService implements UpdateProductOptionsUseCase 
 
         // 새 카테고리/옵션 저장
         ProductOptionCategory savedCategory = saveProductOptionsPort.save(
-                ProductCommandToDomainMapper.mapToDomain(
+                ProductCommandToStateMapper.mapToState(
                         product,
                         RegisterProductOptionsCommand.of(
                                 productId,

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/client/authentication/controller/apidocs/RefreshAccessTokenApiDocs.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/client/authentication/controller/apidocs/RefreshAccessTokenApiDocs.java
@@ -2,6 +2,8 @@ package com.personal.marketnote.user.adapter.in.client.authentication.controller
 
 import com.personal.marketnote.user.adapter.in.client.authentication.controller.schema.RefreshedAccessTokenResponseSchema;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.headers.Header;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
@@ -53,6 +55,12 @@ import java.lang.annotation.*;
                 | --- | --- | --- | --- |
                 | accessToken | string | 신규 발급된 Access Token | "f8310f8asohvh80scvh0zio3hr31d" |
                 """,
+        parameters = @Parameter(
+                name = "refresh_token",
+                in = ParameterIn.COOKIE,
+                required = true,
+                description = "Refresh Token; HTTP-only"
+        ),
         responses = {
                 @ApiResponse(
                         responseCode = "201",

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/configuration/security/OpaqueTokenIntrospectorConfig.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/configuration/security/OpaqueTokenIntrospectorConfig.java
@@ -54,6 +54,7 @@ public class OpaqueTokenIntrospectorConfig {
                         .requestMatchers("/actuator/**").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/v1/users/sign-up").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/v1/users/sign-in").permitAll()
+                        .requestMatchers(HttpMethod.DELETE, "/api/v1/users/sign-out").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/v1/authentication/access-token/refresh").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/v1/terms").permitAll()
                         .anyRequest().authenticated())

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/configuration/security/SecurityConfig.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/configuration/security/SecurityConfig.java
@@ -39,6 +39,7 @@ public class SecurityConfig {
                         .requestMatchers("/v3/api-docs/**", "/swagger-ui.html", "/swagger-ui/**").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/v1/users/sign-up").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/v1/users/sign-in").permitAll()
+                        .requestMatchers(HttpMethod.DELETE, "/api/v1/users/sign-out").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/v1/authentication/access-token/refresh").permitAll()
                         .requestMatchers("/actuator/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/v1/terms").permitAll()

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/out/cache/RefreshTokenRedisAdapter.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/out/cache/RefreshTokenRedisAdapter.java
@@ -1,0 +1,20 @@
+package com.personal.marketnote.user.adapter.out.cache;
+
+import com.personal.marketnote.user.port.out.authentication.DeleteRefreshTokenPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class RefreshTokenRedisAdapter implements DeleteRefreshTokenPort {
+    private final StringRedisTemplate stringRedisTemplate;
+
+    @Override
+    public void deleteByUserId(Long userId) {
+        String key = "refreshToken:" + userId;
+        stringRedisTemplate.delete(key);
+    }
+}
+
+

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/out/token/RefreshTokenParserAdapter.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/out/token/RefreshTokenParserAdapter.java
@@ -1,0 +1,26 @@
+package com.personal.marketnote.user.adapter.out.token;
+
+import com.personal.marketnote.common.domain.exception.token.InvalidRefreshTokenException;
+import com.personal.marketnote.user.port.out.authentication.ParseRefreshTokenPort;
+import com.personal.marketnote.user.utility.jwt.JwtUtil;
+import com.personal.marketnote.user.utility.jwt.claims.TokenClaims;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class RefreshTokenParserAdapter implements ParseRefreshTokenPort {
+    private final JwtUtil jwtUtil;
+
+    @Override
+    public Long extractUserId(String refreshToken) {
+        try {
+            TokenClaims claims = jwtUtil.parseRefreshToken(refreshToken);
+            return claims.getUserId();
+        } catch (Exception e) {
+            throw new InvalidRefreshTokenException(e.getMessage());
+        }
+    }
+}
+
+

--- a/user-service/user-application/build.gradle.kts
+++ b/user-service/user-application/build.gradle.kts
@@ -45,6 +45,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-security") // Spring Security
     implementation("org.springframework.boot:spring-boot-starter-oauth2-resource-server") // OAuth 2.0 Resource server
     implementation("org.springframework.boot:spring-boot-starter-mail") // JavaMailSender
+    implementation("org.springframework.boot:spring-boot-starter-data-redis") // Redis template
 
     //querydsl 설정
     implementation("jakarta.persistence:jakarta.persistence-api:3.1.0")

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/port/in/usecase/user/SignOutUseCase.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/port/in/usecase/user/SignOutUseCase.java
@@ -1,0 +1,13 @@
+package com.personal.marketnote.user.port.in.usecase.user;
+
+import org.springframework.http.HttpHeaders;
+
+public interface SignOutUseCase {
+    /**
+     * @return HttpHeaders {@link HttpHeaders}
+     * @Author 성효빈
+     * @Date 2026-01-02
+     * @Description 회원 로그아웃을 수행합니다.
+     */
+    HttpHeaders signOut(String refreshToken);
+}

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/port/in/usecase/user/SignUpUseCase.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/port/in/usecase/user/SignUpUseCase.java
@@ -11,7 +11,7 @@ public interface SignUpUseCase {
      * @param oidcId        외부 인증 ID
      * @param ipAddress     클라이언트 IP 주소
      * @return 회원 가입 결과 {@link SignUpResult}
-     * @Author 성효입
+     * @Author 성효빈
      * @Date 2025-12-28
      * @Description 회원으로 가입합니다.
      */

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/port/out/authentication/DeleteRefreshTokenPort.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/port/out/authentication/DeleteRefreshTokenPort.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.user.port.out.authentication;
+
+public interface DeleteRefreshTokenPort {
+    void deleteByUserId(Long userId);
+}
+
+

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/port/out/authentication/ParseRefreshTokenPort.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/port/out/authentication/ParseRefreshTokenPort.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.user.port.out.authentication;
+
+public interface ParseRefreshTokenPort {
+    Long extractUserId(String refreshToken);
+}
+
+

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/service/user/SignOutService.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/service/user/SignOutService.java
@@ -1,0 +1,44 @@
+package com.personal.marketnote.user.service.user;
+
+import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.common.utility.http.cookie.HttpCookieName;
+import com.personal.marketnote.common.utility.http.cookie.HttpCookieUtils;
+import com.personal.marketnote.user.port.in.usecase.user.SignOutUseCase;
+import com.personal.marketnote.user.port.out.authentication.DeleteRefreshTokenPort;
+import com.personal.marketnote.user.port.out.authentication.ParseRefreshTokenPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+
+@RequiredArgsConstructor
+@UseCase
+public class SignOutService implements SignOutUseCase {
+    private final HttpCookieUtils httpCookieUtils;
+    private final DeleteRefreshTokenPort deleteRefreshTokenPort;
+    private final ParseRefreshTokenPort parseRefreshTokenPort;
+
+    @Override
+    public HttpHeaders signOut(String refreshToken) {
+        Long userId = parseRefreshTokenPort.extractUserId(refreshToken);
+        deleteRefreshTokenPort.deleteByUserId(userId);
+
+        return generateInvalidCookieHeaders();
+    }
+
+    private HttpHeaders generateInvalidCookieHeaders() {
+        HttpHeaders httpHeaders = new HttpHeaders();
+        httpHeaders.add(
+                HttpHeaders.SET_COOKIE,
+                httpCookieUtils.invalidateCookie(HttpCookieName.USER_ID, false).asSetCookieHeaderValue()
+        );
+        httpHeaders.add(
+                HttpHeaders.SET_COOKIE,
+                httpCookieUtils.invalidateCookie(HttpCookieName.ACCESS_TOKEN, false).asSetCookieHeaderValue()
+        );
+        httpHeaders.add(
+                HttpHeaders.SET_COOKIE,
+                httpCookieUtils.invalidateCookie(HttpCookieName.REFRESH_TOKEN, false).asSetCookieHeaderValue()
+        );
+
+        return httpHeaders;
+    }
+}


### PR DESCRIPTION
## partially addresses #43
## resolves #83

## Task
- [x] 동시에 한 브라우저/기기에서만 로그인 가능하도록 변경
- [x] 회원 가입/로그인/엑세스 토큰 재발급 시 리프레시 토큰을 HttpOnly Cookie에 전송하도록 변경
- [x] 리프레시 토큰 발급 시 Redis에 화이트리스트 저장 로직 추가
    - [x] TTL: 리프레시 토큰 TTL과 동일
    - [x] Key: userId
    - [x] Value: 리프레시 토큰을 SHA-256으로 해싱한 값
- [x] 로그아웃 시 화이트리스트에서 리프레시 토큰 제거 로직 추가
- [x] 로그아웃 시 쿠키 헤더 무효화 로직 추가