### PR TITLE
[#128][#199] feat: 상품 카탈로그 썸네일 이미지 조회 기능 추가

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -473,6 +473,8 @@ pipeline {
 						string(credentialsId: 'MARKETNOTE_REDIS_PASSWORD',                  variable: 'REDIS_PASSWORD'),
 						string(credentialsId: 'MARKETNOTE_REDIS_HOST_NAME',                 variable: 'REDIS_HOST_NAME'),
 						string(credentialsId: 'MARKETNOTE_REDIS_EMAIL_VERIFICATION_PREFIX', variable: 'REDIS_EMAIL_VERIFICATION_PREFIX'),
+						string(credentialsId: 'MARKETNOTE_QA_FILE_SERVICE_SERVER_ORIGIN',   variable: 'FILE_SERVICE_SERVER_ORIGIN'),
+						string(credentialsId: 'MARKETNOTE_QA_JWT_ADMIN_ACCESS_TOKEN',       variable: 'JWT_ADMIN_ACCESS_TOKEN'),
 					]) {
 						sh '''
                   LG="$CLOUDWATCH_LOG_GROUP"
@@ -523,7 +525,9 @@ pipeline {
 									[name: "MAIL_VERIFICATION_TTL_MINUTES",  value: env.MAIL_VERIFICATION_TTL_MINUTES],
 									[name: "REDIS_HOST_NAME",                value: env.REDIS_HOST_NAME],
 									[name: "REDIS_PASSWORD",                 value: env.REDIS_PASSWORD],
-									[name: "REDIS_EMAIL_VERIFICATION_PREFIX",value: env.REDIS_EMAIL_VERIFICATION_PREFIX]
+									[name: "REDIS_EMAIL_VERIFICATION_PREFIX",value: env.REDIS_EMAIL_VERIFICATION_PREFIX],
+									[name: "FILE_SERVICE_SERVER_ORIGIN",     value: env.FILE_SERVICE_SERVER_ORIGIN],
+									[name: "JWT_ADMIN_ACCESS_TOKEN",         value: env.JWT_ADMIN_ACCESS_TOKEN],
 								],
 								logConfiguration: [
 									logDriver: "awslogs",

--- a/common/src/main/java/com/personal/marketnote/common/adapter/out/ServiceAdapter.java
+++ b/common/src/main/java/com/personal/marketnote/common/adapter/out/ServiceAdapter.java
@@ -1,0 +1,15 @@
+package com.personal.marketnote.common.adapter.out;
+
+import org.springframework.core.annotation.AliasFor;
+import org.springframework.stereotype.Component;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Component
+public @interface ServiceAdapter {
+    @AliasFor(annotation = Component.class)
+    String value() default "";
+}

--- a/common/src/main/java/com/personal/marketnote/common/configuration/security/OpaqueTokenIntrospectorConfig.java
+++ b/common/src/main/java/com/personal/marketnote/common/configuration/security/OpaqueTokenIntrospectorConfig.java
@@ -57,6 +57,7 @@ public class OpaqueTokenIntrospectorConfig {
                         .requestMatchers(HttpMethod.DELETE, "/api/v1/users/sign-out").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/v1/authentication/access-token/refresh").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/v1/terms").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/v1/products/**").permitAll()
                         .anyRequest().authenticated())
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .formLogin(AbstractHttpConfigurer::disable)

--- a/common/src/main/java/com/personal/marketnote/common/domain/file/FileSort.java
+++ b/common/src/main/java/com/personal/marketnote/common/domain/file/FileSort.java
@@ -1,4 +1,4 @@
-package com.personal.marketnote.file.domain.file;
+package com.personal.marketnote.common.domain.file;
 
 import com.personal.marketnote.common.utility.FormatValidator;
 import lombok.Getter;

--- a/common/src/main/java/com/personal/marketnote/common/domain/file/OwnerType.java
+++ b/common/src/main/java/com/personal/marketnote/common/domain/file/OwnerType.java
@@ -1,4 +1,4 @@
-package com.personal.marketnote.file.domain.file;
+package com.personal.marketnote.common.domain.file;
 
 import com.personal.marketnote.common.utility.FormatValidator;
 import lombok.Getter;

--- a/file-service/file-adapters/src/main/java/com/personal/marketnote/file/adapter/in/client/file/controller/apidocs/GetFilesApiDocs.java
+++ b/file-service/file-adapters/src/main/java/com/personal/marketnote/file/adapter/in/client/file/controller/apidocs/GetFilesApiDocs.java
@@ -86,7 +86,7 @@ import java.lang.annotation.*;
                 | extension | string | 파일 확장자 | "jpg" |
                 | name | string | 파일명 | "스프링노트1" |
                 | s3Url | string | S3 URL | "https://bucket.s3.amazonaws.com/product/1/original.jpg" |
-                | resizedSizes | array | 리사이즈 크기 목록 | ["300x300", "500x500"] |
+                | resizedS3Urls | array | 리사이즈 이미지 S3 URL 목록 | ["https://bucket.s3.amazonaws.com/product/1/300x300_original.jpg", "https://bucket.s3.amazonaws.com/product/1/500x500_original.jpg"] |
                 """,
         security = {@SecurityRequirement(name = "bearer")},
         parameters = {
@@ -121,9 +121,9 @@ import java.lang.annotation.*;
                                                 "extension": "png",
                                                 "name": "스프링노트1",
                                                 "s3Url": "https://marketnote.s3.amazonaws.com/product/1/1763456309061_gungisick1.png",
-                                                "resizedSizes": [
-                                                  "300x300",
-                                                  "500x500"
+                                                "resizedS3Urls": [
+                                                  "https://marketnote.s3.amazonaws.com/product/1/1763456309061_gungisick1_300x300.png",
+                                                  "https://marketnote.s3.amazonaws.com/product/1/1763456309061_gungisick1_500x500.png"
                                                 ]
                                               },
                                               {
@@ -132,9 +132,9 @@ import java.lang.annotation.*;
                                                 "extension": "png",
                                                 "name": "스프링노트2",
                                                 "s3Url": "https://marketnote.s3.amazonaws.com/product/1/1763456845957_gungisick2.png",
-                                                "resizedSizes": [
-                                                  "300x300",
-                                                  "500x500"
+                                                "resizedS3Urls": [
+                                                  "https://marketnote.s3.amazonaws.com/product/1/1763456845957_gungisick2_300x300.png",
+                                                  "https://marketnote.s3.amazonaws.com/product/1/1763456845957_gungisick2_500x500.png"
                                                 ]
                                               }
                                             ]

--- a/file-service/file-adapters/src/main/java/com/personal/marketnote/file/adapter/out/persistence/file/FilePersistenceAdapter.java
+++ b/file-service/file-adapters/src/main/java/com/personal/marketnote/file/adapter/out/persistence/file/FilePersistenceAdapter.java
@@ -1,10 +1,10 @@
 package com.personal.marketnote.file.adapter.out.persistence.file;
 
 import com.personal.marketnote.common.adapter.out.PersistenceAdapter;
+import com.personal.marketnote.common.domain.file.OwnerType;
 import com.personal.marketnote.file.adapter.out.persistence.file.entity.FileJpaEntity;
 import com.personal.marketnote.file.adapter.out.persistence.file.repository.FileJpaRepository;
 import com.personal.marketnote.file.domain.file.FileDomain;
-import com.personal.marketnote.file.domain.file.OwnerType;
 import com.personal.marketnote.file.port.out.file.FindFilesPort;
 import com.personal.marketnote.file.port.out.file.SaveFilesPort;
 import lombok.RequiredArgsConstructor;
@@ -32,17 +32,20 @@ public class FilePersistenceAdapter implements SaveFilesPort, FindFilesPort {
         }
 
         List<FileJpaEntity> savedList = fileJpaRepository.saveAll(toSave);
+        savedList.forEach(FileJpaEntity::setIdToOrderNum);
+
         return savedList.stream()
-                .map(e -> FileDomain.of(
-                        e.getId(),
-                        e.getOwnerType(),
-                        e.getOwnerId(),
-                        e.getSort(),
-                        e.getExtension(),
-                        e.getName(),
-                        e.getS3Url(),
-                        e.getCreatedAt(),
-                        e.getStatus()
+                .map(entity -> FileDomain.of(
+                        entity.getId(),
+                        entity.getOwnerType(),
+                        entity.getOwnerId(),
+                        entity.getSort(),
+                        entity.getExtension(),
+                        entity.getName(),
+                        entity.getS3Url(),
+                        entity.getCreatedAt(),
+                        entity.getStatus(),
+                        entity.getOrderNum()
                 ))
                 .toList();
     }
@@ -50,33 +53,35 @@ public class FilePersistenceAdapter implements SaveFilesPort, FindFilesPort {
     @Override
     public List<FileDomain> findByOwner(OwnerType ownerType, Long ownerId) {
         return fileJpaRepository.findAllByOwnerTypeAndOwnerIdOrderByIdAsc(ownerType, ownerId).stream()
-                .map(e -> FileDomain.of(
-                        e.getId(),
-                        e.getOwnerType(),
-                        e.getOwnerId(),
-                        e.getSort(),
-                        e.getExtension(),
-                        e.getName(),
-                        e.getS3Url(),
-                        e.getCreatedAt(),
-                        e.getStatus()
+                .map(entity -> FileDomain.of(
+                        entity.getId(),
+                        entity.getOwnerType(),
+                        entity.getOwnerId(),
+                        entity.getSort(),
+                        entity.getExtension(),
+                        entity.getName(),
+                        entity.getS3Url(),
+                        entity.getCreatedAt(),
+                        entity.getStatus(),
+                        entity.getOrderNum()
                 ))
                 .toList();
     }
 
     @Override
     public List<FileDomain> findByOwnerAndSort(OwnerType ownerType, Long ownerId, String sort) {
-        return fileJpaRepository.findAllByOwnerTypeAndOwnerIdAndSortOrderByIdAsc(ownerType, ownerId, sort).stream()
-                .map(e -> FileDomain.of(
-                        e.getId(),
-                        e.getOwnerType(),
-                        e.getOwnerId(),
-                        e.getSort(),
-                        e.getExtension(),
-                        e.getName(),
-                        e.getS3Url(),
-                        e.getCreatedAt(),
-                        e.getStatus()
+        return fileJpaRepository.findTop5ByOwnerTypeAndOwnerIdAndSortOrderByOrderNumDesc(ownerType, ownerId, sort).stream()
+                .map(entity -> FileDomain.of(
+                        entity.getId(),
+                        entity.getOwnerType(),
+                        entity.getOwnerId(),
+                        entity.getSort(),
+                        entity.getExtension(),
+                        entity.getName(),
+                        entity.getS3Url(),
+                        entity.getCreatedAt(),
+                        entity.getStatus(),
+                        entity.getOrderNum()
                 ))
                 .toList();
     }

--- a/file-service/file-adapters/src/main/java/com/personal/marketnote/file/adapter/out/persistence/file/ResizedFilePersistenceAdapter.java
+++ b/file-service/file-adapters/src/main/java/com/personal/marketnote/file/adapter/out/persistence/file/ResizedFilePersistenceAdapter.java
@@ -27,7 +27,7 @@ public class ResizedFilePersistenceAdapter implements SaveResizedFilesPort, Find
         List<ResizedFileJpaEntity> toSave = new ArrayList<>(resizedFiles.size());
         for (ResizedFile f : resizedFiles) {
             FileJpaEntity fileRef = fileJpaRepository.getReferenceById(f.getFileId());
-            toSave.add(ResizedFileJpaEntity.of(fileRef, f.getSize()));
+            toSave.add(ResizedFileJpaEntity.of(fileRef, f.getSize(), f.getS3Url()));
         }
         resizedFileJpaRepository.saveAll(toSave);
     }
@@ -42,6 +42,7 @@ public class ResizedFilePersistenceAdapter implements SaveResizedFilesPort, Find
                         e.getId(),
                         e.getFile().getId(),
                         e.getSize(),
+                        e.getS3Url(),
                         e.getCreatedAt(),
                         e.getStatus()
                 )).toList();

--- a/file-service/file-adapters/src/main/java/com/personal/marketnote/file/adapter/out/persistence/file/entity/FileJpaEntity.java
+++ b/file-service/file-adapters/src/main/java/com/personal/marketnote/file/adapter/out/persistence/file/entity/FileJpaEntity.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
-import com.personal.marketnote.file.domain.file.OwnerType;
+import com.personal.marketnote.common.domain.file.OwnerType;
 import jakarta.persistence.*;
 import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
@@ -57,6 +57,8 @@ public class FileJpaEntity {
     @Enumerated(EnumType.STRING)
     private EntityStatus status;
 
+    private Long orderNum;
+
     public static FileJpaEntity from(com.personal.marketnote.file.domain.file.FileDomain domain, String s3Url) {
         return FileJpaEntity.builder()
                 .ownerType(domain.getOwnerType())
@@ -67,5 +69,9 @@ public class FileJpaEntity {
                 .s3Url(s3Url)
                 .status(EntityStatus.ACTIVE)
                 .build();
+    }
+
+    public void setIdToOrderNum() {
+        orderNum = id;
     }
 }

--- a/file-service/file-adapters/src/main/java/com/personal/marketnote/file/adapter/out/persistence/file/entity/ResizedFileJpaEntity.java
+++ b/file-service/file-adapters/src/main/java/com/personal/marketnote/file/adapter/out/persistence/file/entity/ResizedFileJpaEntity.java
@@ -34,6 +34,9 @@ public class ResizedFileJpaEntity {
     @Column(name = "size", nullable = false, length = 255)
     private String size;
 
+    @Column(name = "s3_url", nullable = false, length = 1024)
+    private String s3Url;
+
     @CreatedDate
     @Column(name = "created_at", nullable = false, updatable = false)
     @JsonSerialize(using = LocalDateTimeSerializer.class)
@@ -48,6 +51,15 @@ public class ResizedFileJpaEntity {
         return ResizedFileJpaEntity.builder()
                 .file(file)
                 .size(size)
+                .status(EntityStatus.ACTIVE)
+                .build();
+    }
+
+    public static ResizedFileJpaEntity of(FileJpaEntity file, String size, String s3Url) {
+        return ResizedFileJpaEntity.builder()
+                .file(file)
+                .size(size)
+                .s3Url(s3Url)
                 .status(EntityStatus.ACTIVE)
                 .build();
     }

--- a/file-service/file-adapters/src/main/java/com/personal/marketnote/file/adapter/out/persistence/file/repository/FileJpaRepository.java
+++ b/file-service/file-adapters/src/main/java/com/personal/marketnote/file/adapter/out/persistence/file/repository/FileJpaRepository.java
@@ -1,7 +1,7 @@
 package com.personal.marketnote.file.adapter.out.persistence.file.repository;
 
+import com.personal.marketnote.common.domain.file.OwnerType;
 import com.personal.marketnote.file.adapter.out.persistence.file.entity.FileJpaEntity;
-import com.personal.marketnote.file.domain.file.OwnerType;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -9,7 +9,5 @@ import java.util.List;
 public interface FileJpaRepository extends JpaRepository<FileJpaEntity, Long> {
     List<FileJpaEntity> findAllByOwnerTypeAndOwnerIdOrderByIdAsc(OwnerType ownerType, Long ownerId);
 
-    List<FileJpaEntity> findAllByOwnerTypeAndOwnerIdAndSortOrderByIdAsc(OwnerType ownerType, Long ownerId, String sort);
+    List<FileJpaEntity> findTop5ByOwnerTypeAndOwnerIdAndSortOrderByOrderNumDesc(OwnerType ownerType, Long ownerId, String sort);
 }
-
-

--- a/file-service/file-adapters/src/main/java/com/personal/marketnote/file/adapter/out/storage/S3FileStorageAdapter.java
+++ b/file-service/file-adapters/src/main/java/com/personal/marketnote/file/adapter/out/storage/S3FileStorageAdapter.java
@@ -1,9 +1,9 @@
 package com.personal.marketnote.file.adapter.out.storage;
 
+import com.personal.marketnote.common.domain.file.OwnerType;
 import com.personal.marketnote.common.utility.FormatConverter;
 import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.file.adapter.out.exception.S3UploadFailedException;
-import com.personal.marketnote.file.domain.file.OwnerType;
 import com.personal.marketnote.file.port.out.storage.UploadFilesPort;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;

--- a/file-service/file-application/src/main/java/com/personal/marketnote/file/port/in/usecase/file/result/GetFilesResult.java
+++ b/file-service/file-application/src/main/java/com/personal/marketnote/file/port/in/usecase/file/result/GetFilesResult.java
@@ -1,16 +1,34 @@
 package com.personal.marketnote.file.port.in.usecase.file.result;
 
+import com.personal.marketnote.file.domain.file.FileDomain;
+import lombok.AccessLevel;
+import lombok.Builder;
+
 import java.util.List;
+import java.util.Map;
 
 public record GetFilesResult(List<FileItem> files) {
+    @Builder(access = AccessLevel.PRIVATE)
     public record FileItem(
             Long id,
             String sort,
             String extension,
             String name,
             String s3Url,
-            List<String> resizedSizes
+            List<String> resizedS3Urls,
+            Long orderNum
     ) {
+        public static GetFilesResult.FileItem from(FileDomain file, Map<Long, List<String>> fileIdToUrls) {
+            return FileItem.builder()
+                    .id(file.getId())
+                    .sort(file.getSort().name())
+                    .extension(file.getExtension())
+                    .name(file.getName())
+                    .s3Url(file.getS3Url())
+                    .resizedS3Urls(fileIdToUrls.getOrDefault(file.getId(), List.of()))
+                    .orderNum(file.getOrderNum())
+                    .build();
+        }
     }
 }
 

--- a/file-service/file-application/src/main/java/com/personal/marketnote/file/port/out/file/FindFilesPort.java
+++ b/file-service/file-application/src/main/java/com/personal/marketnote/file/port/out/file/FindFilesPort.java
@@ -1,7 +1,7 @@
 package com.personal.marketnote.file.port.out.file;
 
+import com.personal.marketnote.common.domain.file.OwnerType;
 import com.personal.marketnote.file.domain.file.FileDomain;
-import com.personal.marketnote.file.domain.file.OwnerType;
 
 import java.util.List;
 

--- a/file-service/file-application/src/main/java/com/personal/marketnote/file/port/out/storage/UploadFilesPort.java
+++ b/file-service/file-application/src/main/java/com/personal/marketnote/file/port/out/storage/UploadFilesPort.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.file.port.out.storage;
 
-import com.personal.marketnote.file.domain.file.OwnerType;
+import com.personal.marketnote.common.domain.file.OwnerType;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;

--- a/file-service/file-application/src/main/java/com/personal/marketnote/file/service/file/GetFilesService.java
+++ b/file-service/file-application/src/main/java/com/personal/marketnote/file/service/file/GetFilesService.java
@@ -1,8 +1,8 @@
 package com.personal.marketnote.file.service.file;
 
 import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.common.domain.file.OwnerType;
 import com.personal.marketnote.file.domain.file.FileDomain;
-import com.personal.marketnote.file.domain.file.OwnerType;
 import com.personal.marketnote.file.domain.file.ResizedFile;
 import com.personal.marketnote.file.port.in.usecase.file.GetFilesUseCase;
 import com.personal.marketnote.file.port.in.usecase.file.result.GetFilesResult;
@@ -33,20 +33,14 @@ public class GetFilesService implements GetFilesUseCase {
 
         List<Long> fileIds = files.stream().map(FileDomain::getId).toList();
         List<ResizedFile> resized = findResizedFilesPort.findByFileIds(fileIds);
-        Map<Long, List<String>> fileIdToSizes = resized.stream()
+        Map<Long, List<String>> fileIdToUrls = resized.stream()
                 .collect(Collectors.groupingBy(ResizedFile::getFileId,
-                        Collectors.mapping(ResizedFile::getSize, Collectors.toList())));
+                        Collectors.mapping(ResizedFile::getS3Url, Collectors.toList())));
 
-        List<GetFilesResult.FileItem> items = files.stream().map(f ->
-                new GetFilesResult.FileItem(
-                        f.getId(),
-                        f.getSort().name(),
-                        f.getExtension(),
-                        f.getName(),
-                        f.getS3Url(),
-                        fileIdToSizes.getOrDefault(f.getId(), List.of())
-                )
-        ).toList();
+        List<GetFilesResult.FileItem> items = files.stream()
+                .map(
+                        file -> GetFilesResult.FileItem.from(file, fileIdToUrls)
+                ).toList();
         return new GetFilesResult(items);
     }
 }

--- a/file-service/file-domain/src/main/java/com/personal/marketnote/file/domain/file/FileDomain.java
+++ b/file-service/file-domain/src/main/java/com/personal/marketnote/file/domain/file/FileDomain.java
@@ -1,6 +1,8 @@
 package com.personal.marketnote.file.domain.file;
 
 import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.file.FileSort;
+import com.personal.marketnote.common.domain.file.OwnerType;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -21,6 +23,7 @@ public class FileDomain {
     private String s3Url;
     private LocalDateTime createdAt;
     private EntityStatus status;
+    private Long orderNum;
 
     public static FileDomain of(
             String ownerType,
@@ -47,7 +50,8 @@ public class FileDomain {
             String name,
             String s3Url,
             LocalDateTime createdAt,
-            EntityStatus status
+            EntityStatus status,
+            Long orderNum
     ) {
         return FileDomain.builder()
                 .id(id)
@@ -59,6 +63,7 @@ public class FileDomain {
                 .s3Url(s3Url)
                 .createdAt(createdAt)
                 .status(status)
+                .orderNum(orderNum)
                 .build();
     }
 }

--- a/file-service/file-domain/src/main/java/com/personal/marketnote/file/domain/file/ResizedFile.java
+++ b/file-service/file-domain/src/main/java/com/personal/marketnote/file/domain/file/ResizedFile.java
@@ -15,6 +15,7 @@ public class ResizedFile {
     private Long id;
     private Long fileId;
     private String size;
+    private String s3Url;
     private LocalDateTime createdAt;
     private EntityStatus status;
 
@@ -25,11 +26,30 @@ public class ResizedFile {
                 .build();
     }
 
+    public static ResizedFile of(Long fileId, String size, String s3Url) {
+        return ResizedFile.builder()
+                .fileId(fileId)
+                .size(size)
+                .s3Url(s3Url)
+                .build();
+    }
+
     public static ResizedFile of(Long id, Long fileId, String size, LocalDateTime createdAt, EntityStatus status) {
         return ResizedFile.builder()
                 .id(id)
                 .fileId(fileId)
                 .size(size)
+                .createdAt(createdAt)
+                .status(status)
+                .build();
+    }
+
+    public static ResizedFile of(Long id, Long fileId, String size, String s3Url, LocalDateTime createdAt, EntityStatus status) {
+        return ResizedFile.builder()
+                .id(id)
+                .fileId(fileId)
+                .size(size)
+                .s3Url(s3Url)
                 .createdAt(createdAt)
                 .status(status)
                 .build();

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/client/product/controller/ProductController.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/client/product/controller/ProductController.java
@@ -3,6 +3,7 @@ package com.personal.marketnote.product.adapter.in.client.product.controller;
 import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
 import com.personal.marketnote.common.utility.AuthorityValidator;
 import com.personal.marketnote.common.utility.ElementExtractor;
+import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.product.adapter.in.client.product.controller.apidocs.*;
 import com.personal.marketnote.product.adapter.in.client.product.mapper.ProductRequestToCommandMapper;
 import com.personal.marketnote.product.adapter.in.client.product.request.RegisterProductRequest;
@@ -131,7 +132,7 @@ public class ProductController {
      * @param sortProperty  정렬 속성
      * @param searchTarget  검색 대상
      * @param searchKeyword 검색 키워드
-     * @return 회원 목록 조회 응답 {@link GetProductsResponse}
+     * @return 상품 목록 조회 응답 {@link GetProductsResponse}
      * @Author 성효빈
      * @Date 2025-12-31
      * @Description 상품 목록을 조회합니다.
@@ -210,7 +211,7 @@ public class ProductController {
             }
             optionContents = flattened.isEmpty() ? optionContents : flattened;
         }
-        if (optionIds != null && !optionIds.isEmpty()) {
+        if (FormatValidator.hasValue(optionIds)) {
             List<String> flattenedIds = new ArrayList<>();
             for (String raw : optionIds) {
                 if (raw == null) continue;
@@ -288,7 +289,7 @@ public class ProductController {
     }
 
     /**
-     * (판매자/관리자) 상품 삭제 (논리 삭제)
+     * (판매자/관리자) 상품 삭제
      *
      * @param id 상품 ID
      * @Author 성효빈

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/client/product/controller/apidocs/GetProductsApiDocs.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/client/product/controller/apidocs/GetProductsApiDocs.java
@@ -175,77 +175,329 @@ import java.lang.annotation.*;
                         content = @Content(
                                 schema = @Schema(implementation = StringResponseSchema.class),
                                 examples = @ExampleObject("""
-                                                                                {
-                                                                                  "statusCode": 200,
-                                                                                  "code": "SUC01",
-                                                                                  "timestamp": "2026-01-01T10:34:29.332952183",
-                                                                                  "content": {
-                                                                                    "products": {
-                                                                                      "totalElements": null,
-                                                                                      "hasNext": true,
-                                                                                      "nextCursor": 19,
-                                                                                      "items": [
-                                                                                        {
-                                                                                          "id": 20,
-                                                                                          "sellerId": 12,
-                                                                                          "name": "스프링노트2",
-                                                                                          "brandName": "노트킹",
-                                                                                          "price": 45000,
-                                                                                          "discountPrice": 20000,
-                                                                                          "discountRate": 17.8,
-                                                                                          "accumulatedPoint": 1500,
-                                                                                          "sales": 0,
-                                                                                          "productTags": [],
-                                                                                          "orderNum": 20,
-                                                                                          "status": "ACTIVE"
-                                                                                        },
-                                                                                        {
-                                                                                          "id": 19,
-                                                                                          "sellerId": 1,
-                                                                                          "name": "스프링노트1 (1박스 / 30개입)",
-                                                                                          "brandName": "노트왕",
-                                                                                          "price": 92000,
-                                                                                          "discountPrice": 84000,
-                                                                                          "discountRate": 17.8,
-                                                                                          "accumulatedPoint": 7400,
-                                                                                          "sales": 0,
-                                                                                          "productTags": [],
-                                                                                          "orderNum": 19,
-                                                                                          "status": "ACTIVE"
-                                                                                        },
-                                                                                        {
-                                                                                          "id": 19,
-                                                                                          "sellerId": 1,
-                                                                                          "name": "스프링노트1 (1박스 / 60개입)",
-                                                                                          "brandName": "노트왕",
-                                                                                          "price": 102000,
-                                                                                          "discountPrice": 94000,
-                                                                                          "discountRate": 17.8,
-                                                                                          "accumulatedPoint": 12400,
-                                                                                          "sales": 0,
-                                                                                          "productTags": [],
-                                                                                          "orderNum": 19,
-                                                                                          "status": "ACTIVE"
-                                                                                        },
-                                                                                        {
-                                                                                          "id": 19,
-                                                                                          "sellerId": 1,
-                                                                                          "name": "스프링노트1 (3박스 / 30개입)",
-                                                                                          "brandName": "노트왕",
-                                                                                          "price": 154000,
-                                                                                          "discountPrice": 146000,
-                                                                                          "discountRate": 17.8,
-                                                                                          "accumulatedPoint": 8200,
-                                                                                          "sales": 0,
-                                                                                          "productTags": [],
-                                                                                          "orderNum": 19,
-                                        탭                                                  "status": "ACTIVE"
-                                                                                        }
-                                                                                      ]
-                                                                                    }
-                                                                                  },
-                                                                                  "message": "상품 목록 조회 성공"
-                                                                                }
+                                        {
+                                          "statusCode": 200,
+                                          "code": "SUC01",
+                                          "timestamp": "2026-01-04T11:44:56.772398",
+                                          "content": {
+                                            "products": {
+                                              "totalElements": 14,
+                                              "hasNext": true,
+                                              "nextCursor": 30,
+                                              "items": [
+                                                {
+                                                  "id": 30,
+                                                  "sellerId": 1,
+                                                  "name": "건기식테스트1 (1박스 / 30개입)",
+                                                  "brandName": "노트왕",
+                                                  "price": 40000,
+                                                  "discountPrice": 32000,
+                                                  "discountRate": 20,
+                                                  "accumulatedPoint": 800,
+                                                  "sales": 0,
+                                                  "productTags": [
+                                                    {
+                                                      "id": 13,
+                                                      "productId": 30,
+                                                      "name": "루테인",
+                                                      "orderNum": null,
+                                                      "status": "ACTIVE"
+                                                    },
+                                                    {
+                                                      "id": 14,
+                                                      "productId": 30,
+                                                      "name": "아스타잔틴",
+                                                      "orderNum": null,
+                                                      "status": "ACTIVE"
+                                                    }
+                                                  ],
+                                                  "orderNum": 30,
+                                                  "status": "ACTIVE",
+                                                  "catalogImages": {
+                                                    "files": [
+                                                      {
+                                                        "id": 12,
+                                                        "sort": "PRODUCT_CATALOG_IMAGE",
+                                                        "extension": "jpg",
+                                                        "name": "스프링노트1",
+                                                        "s3Url": "https://marketnote.s3.amazonaws.com/product/30/1763517082648_grafana-icon.png",
+                                                        "resizedS3Urls": [
+                                                          "https://marketnote.s3.amazonaws.com/product/30/1763517083251_grafana-icon_300x300.png"
+                                                        ],
+                                                        "orderNum": null
+                                                      },
+                                                      {
+                                                        "id": 14,
+                                                        "sort": "PRODUCT_CATALOG_IMAGE",
+                                                        "extension": "jpg",
+                                                        "name": "스프링노트1",
+                                                        "s3Url": "https://marketnote.s3.amazonaws.com/product/30/1763517295839_grafana-icon.png",
+                                                        "resizedS3Urls": [
+                                                          "https://marketnote.s3.amazonaws.com/product/30/1763517296419_grafana-icon_300x300.png"
+                                                        ],
+                                                        "orderNum": null
+                                                      },
+                                                      {
+                                                        "id": 16,
+                                                        "sort": "PRODUCT_CATALOG_IMAGE",
+                                                        "extension": "jpg",
+                                                        "name": "스프링노트1",
+                                                        "s3Url": "https://marketnote.s3.amazonaws.com/product/30/1763517302521_grafana-icon.png",
+                                                        "resizedS3Urls": [
+                                                          "https://marketnote.s3.amazonaws.com/product/30/1763517302838_grafana-icon_300x300.png"
+                                                        ],
+                                                        "orderNum": null
+                                                      },
+                                                      {
+                                                        "id": 18,
+                                                        "sort": "PRODUCT_CATALOG_IMAGE",
+                                                        "extension": "jpg",
+                                                        "name": "스프링노트1",
+                                                        "s3Url": "https://marketnote.s3.amazonaws.com/product/30/1763517310521_grafana-icon.png",
+                                                        "resizedS3Urls": [
+                                                          "https://marketnote.s3.amazonaws.com/product/30/1763517310821_grafana-icon_300x300.png"
+                                                        ],
+                                                        "orderNum": null
+                                                      }
+                                                    ]
+                                                  }
+                                                },
+                                                {
+                                                  "id": 30,
+                                                  "sellerId": 1,
+                                                  "name": "건기식테스트1 (1박스 / 60개입)",
+                                                  "brandName": "노트왕",
+                                                  "price": 45000,
+                                                  "discountPrice": 37000,
+                                                  "discountRate": 17.8,
+                                                  "accumulatedPoint": 1200,
+                                                  "sales": 0,
+                                                  "productTags": [
+                                                    {
+                                                      "id": 13,
+                                                      "productId": 30,
+                                                      "name": "루테인",
+                                                      "orderNum": null,
+                                                      "status": "ACTIVE"
+                                                    },
+                                                    {
+                                                      "id": 14,
+                                                      "productId": 30,
+                                                      "name": "아스타잔틴",
+                                                      "orderNum": null,
+                                                      "status": "ACTIVE"
+                                                    }
+                                                  ],
+                                                  "orderNum": 30,
+                                                  "status": "ACTIVE",
+                                                  "catalogImages": {
+                                                    "files": [
+                                                      {
+                                                        "id": 12,
+                                                        "sort": "PRODUCT_CATALOG_IMAGE",
+                                                        "extension": "jpg",
+                                                        "name": "스프링노트1",
+                                                        "s3Url": "https://marketnote.s3.amazonaws.com/product/30/1763517082648_grafana-icon.png",
+                                                        "resizedS3Urls": [
+                                                          "https://marketnote.s3.amazonaws.com/product/30/1763517083251_grafana-icon_300x300.png"
+                                                        ],
+                                                        "orderNum": null
+                                                      },
+                                                      {
+                                                        "id": 14,
+                                                        "sort": "PRODUCT_CATALOG_IMAGE",
+                                                        "extension": "jpg",
+                                                        "name": "스프링노트1",
+                                                        "s3Url": "https://marketnote.s3.amazonaws.com/product/30/1763517295839_grafana-icon.png",
+                                                        "resizedS3Urls": [
+                                                          "https://marketnote.s3.amazonaws.com/product/30/1763517296419_grafana-icon_300x300.png"
+                                                        ],
+                                                        "orderNum": null
+                                                      },
+                                                      {
+                                                        "id": 16,
+                                                        "sort": "PRODUCT_CATALOG_IMAGE",
+                                                        "extension": "jpg",
+                                                        "name": "스프링노트1",
+                                                        "s3Url": "https://marketnote.s3.amazonaws.com/product/30/1763517302521_grafana-icon.png",
+                                                        "resizedS3Urls": [
+                                                          "https://marketnote.s3.amazonaws.com/product/30/1763517302838_grafana-icon_300x300.png"
+                                                        ],
+                                                        "orderNum": null
+                                                      },
+                                                      {
+                                                        "id": 18,
+                                                        "sort": "PRODUCT_CATALOG_IMAGE",
+                                                        "extension": "jpg",
+                                                        "name": "스프링노트1",
+                                                        "s3Url": "https://marketnote.s3.amazonaws.com/product/30/1763517310521_grafana-icon.png",
+                                                        "resizedS3Urls": [
+                                                          "https://marketnote.s3.amazonaws.com/product/30/1763517310821_grafana-icon_300x300.png"
+                                                        ],
+                                                        "orderNum": null
+                                                      }
+                                                    ]
+                                                  }
+                                                },
+                                                {
+                                                  "id": 30,
+                                                  "sellerId": 1,
+                                                  "name": "건기식테스트1 (3박스 / 30개입)",
+                                                  "brandName": "노트왕",
+                                                  "price": 60000,
+                                                  "discountPrice": 40000,
+                                                  "discountRate": 33.3,
+                                                  "accumulatedPoint": 3000,
+                                                  "sales": 0,
+                                                  "productTags": [
+                                                    {
+                                                      "id": 13,
+                                                      "productId": 30,
+                                                      "name": "루테인",
+                                                      "orderNum": null,
+                                                      "status": "ACTIVE"
+                                                    },
+                                                    {
+                                                      "id": 14,
+                                                      "productId": 30,
+                                                      "name": "아스타잔틴",
+                                                      "orderNum": null,
+                                                      "status": "ACTIVE"
+                                                    }
+                                                  ],
+                                                  "orderNum": 30,
+                                                  "status": "ACTIVE",
+                                                  "catalogImages": {
+                                                    "files": [
+                                                      {
+                                                        "id": 12,
+                                                        "sort": "PRODUCT_CATALOG_IMAGE",
+                                                        "extension": "jpg",
+                                                        "name": "스프링노트1",
+                                                        "s3Url": "https://marketnote.s3.amazonaws.com/product/30/1763517082648_grafana-icon.png",
+                                                        "resizedS3Urls": [
+                                                          "https://marketnote.s3.amazonaws.com/product/30/1763517083251_grafana-icon_300x300.png"
+                                                        ],
+                                                        "orderNum": null
+                                                      },
+                                                      {
+                                                        "id": 14,
+                                                        "sort": "PRODUCT_CATALOG_IMAGE",
+                                                        "extension": "jpg",
+                                                        "name": "스프링노트1",
+                                                        "s3Url": "https://marketnote.s3.amazonaws.com/product/30/1763517295839_grafana-icon.png",
+                                                        "resizedS3Urls": [
+                                                          "https://marketnote.s3.amazonaws.com/product/30/1763517296419_grafana-icon_300x300.png"
+                                                        ],
+                                                        "orderNum": null
+                                                      },
+                                                      {
+                                                        "id": 16,
+                                                        "sort": "PRODUCT_CATALOG_IMAGE",
+                                                        "extension": "jpg",
+                                                        "name": "스프링노트1",
+                                                        "s3Url": "https://marketnote.s3.amazonaws.com/product/30/1763517302521_grafana-icon.png",
+                                                        "resizedS3Urls": [
+                                                          "https://marketnote.s3.amazonaws.com/product/30/1763517302838_grafana-icon_300x300.png"
+                                                        ],
+                                                        "orderNum": null
+                                                      },
+                                                      {
+                                                        "id": 18,
+                                                        "sort": "PRODUCT_CATALOG_IMAGE",
+                                                        "extension": "jpg",
+                                                        "name": "스프링노트1",
+                                                        "s3Url": "https://marketnote.s3.amazonaws.com/product/30/1763517310521_grafana-icon.png",
+                                                        "resizedS3Urls": [
+                                                          "https://marketnote.s3.amazonaws.com/product/30/1763517310821_grafana-icon_300x300.png"
+                                                        ],
+                                                        "orderNum": null
+                                                      }
+                                                    ]
+                                                  }
+                                                },
+                                                {
+                                                  "id": 30,
+                                                  "sellerId": 1,
+                                                  "name": "건기식테스트1 (3박스 / 60개입)",
+                                                  "brandName": "노트왕",
+                                                  "price": 50000,
+                                                  "discountPrice": 40000,
+                                                  "discountRate": 20,
+                                                  "accumulatedPoint": 2000,
+                                                  "sales": 0,
+                                                  "productTags": [
+                                                    {
+                                                      "id": 13,
+                                                      "productId": 30,
+                                                      "name": "루테인",
+                                                      "orderNum": null,
+                                                      "status": "ACTIVE"
+                                                    },
+                                                    {
+                                                      "id": 14,
+                                                      "productId": 30,
+                                                      "name": "아스타잔틴",
+                                                      "orderNum": null,
+                                                      "status": "ACTIVE"
+                                                    }
+                                                  ],
+                                                  "orderNum": 30,
+                                                  "status": "ACTIVE",
+                                                  "catalogImages": {
+                                                    "files": [
+                                                      {
+                                                        "id": 12,
+                                                        "sort": "PRODUCT_CATALOG_IMAGE",
+                                                        "extension": "jpg",
+                                                        "name": "스프링노트1",
+                                                        "s3Url": "https://marketnote.s3.amazonaws.com/product/30/1763517082648_grafana-icon.png",
+                                                        "resizedS3Urls": [
+                                                          "https://marketnote.s3.amazonaws.com/product/30/1763517083251_grafana-icon_300x300.png"
+                                                        ],
+                                                        "orderNum": 18
+                                                      },
+                                                      {
+                                                        "id": 14,
+                                                        "sort": "PRODUCT_CATALOG_IMAGE",
+                                                        "extension": "jpg",
+                                                        "name": "스프링노트1",
+                                                        "s3Url": "https://marketnote.s3.amazonaws.com/product/30/1763517295839_grafana-icon.png",
+                                                        "resizedS3Urls": [
+                                                          "https://marketnote.s3.amazonaws.com/product/30/1763517296419_grafana-icon_300x300.png"
+                                                        ],
+                                                        "orderNum": 16
+                                                      },
+                                                      {
+                                                        "id": 16,
+                                                        "sort": "PRODUCT_CATALOG_IMAGE",
+                                                        "extension": "jpg",
+                                                        "name": "스프링노트1",
+                                                        "s3Url": "https://marketnote.s3.amazonaws.com/product/30/1763517302521_grafana-icon.png",
+                                                        "resizedS3Urls": [
+                                                          "https://marketnote.s3.amazonaws.com/product/30/1763517302838_grafana-icon_300x300.png"
+                                                        ],
+                                                        "orderNum": 1
+                                                      },
+                                                      {
+                                                        "id": 18,
+                                                        "sort": "PRODUCT_CATALOG_IMAGE",
+                                                        "extension": "jpg",
+                                                        "name": "스프링노트1",
+                                                        "s3Url": "https://marketnote.s3.amazonaws.com/product/30/1763517310521_grafana-icon.png",
+                                                        "resizedS3Urls": [
+                                                          "https://marketnote.s3.amazonaws.com/product/30/1763517310821_grafana-icon_300x300.png"
+                                                        ],
+                                                        "orderNum": 18
+                                                      }
+                                                    ]
+                                                  }
+                                                }
+                                              ]
+                                            }
+                                          },
+                                          "message": "상품 목록 조회 성공"
+                                        }
                                         """)
                         )
                 ),

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/client/product/response/ProductItemResponse.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/client/product/response/ProductItemResponse.java
@@ -2,6 +2,7 @@ package com.personal.marketnote.product.adapter.in.client.product.response;
 
 import com.personal.marketnote.product.domain.product.ProductTag;
 import com.personal.marketnote.product.port.in.result.ProductItemResult;
+import com.personal.marketnote.product.port.out.file.dto.GetFilesResult;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -26,6 +27,7 @@ public class ProductItemResponse {
     private List<ProductTag> productTags;
     private Long orderNum;
     private String status;
+    private CatalogImagesResponse catalogImages;
 
     public static ProductItemResponse from(ProductItemResult result) {
         return ProductItemResponse.builder()
@@ -41,7 +43,49 @@ public class ProductItemResponse {
                 .productTags(result.productTags())
                 .orderNum(result.orderNum())
                 .status(result.status())
+                .catalogImages(CatalogImagesResponse.from(result.catalogImages()))
                 .build();
+    }
+
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    @Builder(access = AccessLevel.PRIVATE)
+    @Getter
+    public static class CatalogImagesResponse {
+        private List<CatalogImageItemResponse> files;
+
+        public static CatalogImagesResponse from(GetFilesResult dto) {
+            if (dto == null || dto.files() == null) {
+                return new CatalogImagesResponse(List.of());
+            }
+            return CatalogImagesResponse.builder()
+                    .files(dto.files().stream().map(CatalogImageItemResponse::from).toList())
+                    .build();
+        }
+    }
+
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    @Builder(access = AccessLevel.PRIVATE)
+    @Getter
+    public static class CatalogImageItemResponse {
+        private Long id;
+        private String sort;
+        private String extension;
+        private String name;
+        private String s3Url;
+        private List<String> resizedS3Urls;
+        private Long orderNum;
+
+        public static CatalogImageItemResponse from(GetFilesResult.FileItem item) {
+            return CatalogImageItemResponse.builder()
+                    .id(item.id())
+                    .sort(item.sort())
+                    .extension(item.extension())
+                    .name(item.name())
+                    .s3Url(item.s3Url())
+                    .resizedS3Urls(item.resizedS3Urls())
+                    .orderNum(item.orderNum())
+                    .build();
+        }
     }
 }
 

--- a/product-service/product-adapters/src/main/resources/application.yml
+++ b/product-service/product-adapters/src/main/resources/application.yml
@@ -4,6 +4,7 @@ spring:
 
   jwt:
     secret: ${JWT_SECRET_KEY:dev-secret-change-me}
+    admin-access-token: ${JWT_ADMIN_ACCESS_TOKEN:abc}
 
   datasource:
     driver-class-name: org.postgresql.Driver
@@ -41,6 +42,8 @@ logging:
   level:
     org.springframework.security: ERROR
 
+file-service:
+  base-url: ${FILE_SERVICE_SERVER_ORIGIN:http://localhost:9000}
 management:
   endpoints:
     web:

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/result/ProductItemResult.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/result/ProductItemResult.java
@@ -2,6 +2,7 @@ package com.personal.marketnote.product.port.in.result;
 
 import com.personal.marketnote.product.domain.product.Product;
 import com.personal.marketnote.product.domain.product.ProductTag;
+import com.personal.marketnote.product.port.out.file.dto.GetFilesResult;
 
 import java.math.BigDecimal;
 import java.util.List;
@@ -18,7 +19,8 @@ public record ProductItemResult(
         Integer sales,
         List<ProductTag> productTags,
         Long orderNum,
-        String status
+        String status,
+        GetFilesResult catalogImages
 ) {
     public static ProductItemResult from(Product product) {
         return new ProductItemResult(
@@ -33,7 +35,8 @@ public record ProductItemResult(
                 product.getSales(),
                 product.getProductTags(),
                 product.getOrderNum(),
-                product.getStatus().name()
+                product.getStatus().name(),
+                null
         );
     }
 
@@ -57,7 +60,26 @@ public record ProductItemResult(
                 product.getSales(),
                 product.getProductTags(),
                 product.getOrderNum(),
-                product.getStatus().name()
+                product.getStatus().name(),
+                null
+        );
+    }
+
+    public static ProductItemResult withCatalogImages(ProductItemResult base, GetFilesResult catalogImages) {
+        return new ProductItemResult(
+                base.id(),
+                base.sellerId(),
+                base.name(),
+                base.brandName(),
+                base.price(),
+                base.discountPrice(),
+                base.discountRate(),
+                base.accumulatedPoint(),
+                base.sales(),
+                base.productTags(),
+                base.orderNum(),
+                base.status(),
+                catalogImages
         );
     }
 }

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/out/file/FindProductCatalogImagePort.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/out/file/FindProductCatalogImagePort.java
@@ -1,0 +1,11 @@
+package com.personal.marketnote.product.port.out.file;
+
+import com.personal.marketnote.product.port.out.file.dto.GetFilesResult;
+
+import java.util.Optional;
+
+public interface FindProductCatalogImagePort {
+    Optional<GetFilesResult> findCatalogImagesByProductId(Long productId);
+}
+
+

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/out/file/dto/GetFilesResult.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/out/file/dto/GetFilesResult.java
@@ -1,0 +1,18 @@
+package com.personal.marketnote.product.port.out.file.dto;
+
+import java.util.List;
+
+public record GetFilesResult(List<FileItem> files) {
+    public record FileItem(
+            Long id,
+            String sort,
+            String extension,
+            String name,
+            String s3Url,
+            List<String> resizedS3Urls,
+            Long orderNum
+    ) {
+    }
+}
+
+

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/configuration/security/OpaqueTokenIntrospectorConfig.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/configuration/security/OpaqueTokenIntrospectorConfig.java
@@ -57,6 +57,7 @@ public class OpaqueTokenIntrospectorConfig {
                         .requestMatchers(HttpMethod.DELETE, "/api/v1/users/sign-out").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/v1/authentication/access-token/refresh").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/v1/terms").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/v1/products/*").permitAll()
                         .anyRequest().authenticated())
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .formLogin(AbstractHttpConfigurer::disable)

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/configuration/security/SecurityConfig.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/configuration/security/SecurityConfig.java
@@ -8,7 +8,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
-import org.springframework.http.HttpMethod;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -36,13 +35,6 @@ public class SecurityConfig {
         http.csrf(AbstractHttpConfigurer::disable)
                 .cors(Customizer.withDefaults())
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/v3/api-docs/**", "/swagger-ui.html", "/swagger-ui/**").permitAll()
-                        .requestMatchers(HttpMethod.POST, "/api/v1/users/sign-up").permitAll()
-                        .requestMatchers(HttpMethod.POST, "/api/v1/users/sign-in").permitAll()
-                        .requestMatchers(HttpMethod.DELETE, "/api/v1/users/sign-out").permitAll()
-                        .requestMatchers(HttpMethod.POST, "/api/v1/authentication/access-token/refresh").permitAll()
-                        .requestMatchers("/actuator/**").permitAll()
-                        .requestMatchers(HttpMethod.GET, "/api/v1/terms").permitAll()
                         .anyRequest().permitAll())
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .formLogin(AbstractHttpConfigurer::disable);


### PR DESCRIPTION
## partially addresses #128
## resolves #199

## Task
- [x] 상품 목록 조회 시 파일 서비스에 각 상품의 썸네일 이미지 조회 요청
    - [x] Authentication Header: 관리자 JWT Access Token
    - [x] Sort: PRODUCT_CATALOG_IMAGE
- [x] 200 status 응답
- [x] Swagger Docs