### PR TITLE
[#216][#237] docs: 주문 상태 변경 기능 Swagger 문서 업데이트

### DIFF
--- a/order-service/order-adapters/src/main/java/com/personal/marketnote/order/adapter/in/client/order/controller/apidocs/ChangeOrderStatusApiDocs.java
+++ b/order-service/order-adapters/src/main/java/com/personal/marketnote/order/adapter/in/client/order/controller/apidocs/ChangeOrderStatusApiDocs.java
@@ -33,6 +33,30 @@ import java.lang.annotation.*;
                 
                 - 가격 정책 목록 미전송 시, 모든 주문 상품의 상태를 변경합니다.
                 
+                - 주문 상태 목록
+                
+                    - "PAYMENT_PENDING": 결제 대기
+                
+                    - "PAID": 결제 완료
+                
+                    - "FAILED": 결제 실패
+                
+                    - "PREPARING": 상품 준비중
+                
+                    - "PREPARED": 상품 준비 완료
+                
+                    - "CANCELLED": 주문 취소
+                
+                    - "SHIPPING": 배송중
+                
+                    - "DELIVERED": 배송 완료
+                
+                    - "REFUNDING": 환불 진행중
+                
+                    - "PARTIALLY_REFUNDED": 부분 환불
+                
+                    - "REFUNDED": 환불 완료
+                
                 ---
                 
                 ## Request
@@ -41,14 +65,6 @@ import java.lang.annotation.*;
                 | --- | --- | --- | --- | --- |
                 | pricePolicyIds | array<number> | 가격 정책 ID 목록 | Y | [1, 2, 3] |
                 | orderStatus | string | 주문 상태 | Y | "PAYMENT_PENDING" |
-                
-                ---
-                
-                ### Request > pricePolicyIds
-                
-                | **키** | **타입** | **설명** | **필수 여부** | **예시** |
-                | --- | --- | --- | --- | --- |
-                | number | number | 가격 정책 ID | Y | 1 |
                 
                 ---
                 


### PR DESCRIPTION
## partially addresses #216
## resolves #237

## Task
- [x] Description 상태값 정보 추가
    - [x] "PAYMENT_PENDING": 결제 대기
    - [x] "PAID": 결제 완료
    - [x] "FAILED": 결제 실패
    - [x] "PREPARING": 상품 준비중
    - [x] "PREPARED": 상품 준비 완료
    - [x] "CANCELLED": 주문 취소
    - [x] "SHIPPING": 배송중
    - [x] "DELIVERED": 배송 완료
    - [x] "REFUNDING": 환불 진행중
    - [x] "PARTIALLY_REFUNDED": 부분 환불
    - [x] "REFUNDED": 환불 완료