### PR TITLE
[#128][#194][#197][#200][#201] refactor: 상품 서비스 파일 목록 조회 기능 리팩터링

### DIFF
--- a/common/src/main/java/com/personal/marketnote/common/utility/FormatValidator.java
+++ b/common/src/main/java/com/personal/marketnote/common/utility/FormatValidator.java
@@ -11,7 +11,7 @@ public class FormatValidator {
     }
 
     public static boolean hasValue(Object value) {
-        return value != null && !value.toString().trim().isEmpty();
+        return value != null && !value.toString().isBlank();
     }
 
     public static boolean hasValue(Collection<?> value) {

--- a/file-service/file-adapters/src/main/java/com/personal/marketnote/file/adapter/out/persistence/file/FilePersistenceAdapter.java
+++ b/file-service/file-adapters/src/main/java/com/personal/marketnote/file/adapter/out/persistence/file/FilePersistenceAdapter.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.file.adapter.out.persistence.file;
 
 import com.personal.marketnote.common.adapter.out.PersistenceAdapter;
+import com.personal.marketnote.common.domain.file.FileSort;
 import com.personal.marketnote.common.domain.file.OwnerType;
 import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.file.adapter.out.persistence.file.entity.FileJpaEntity;
@@ -70,8 +71,10 @@ public class FilePersistenceAdapter implements SaveFilesPort, FindFilesPort {
     }
 
     @Override
-    public List<FileDomain> findByOwnerAndSort(OwnerType ownerType, Long ownerId, String sort) {
-        return fileJpaRepository.findTop5ByOwnerTypeAndOwnerIdAndSortOrderByOrderNumDesc(ownerType, ownerId, sort).stream()
+    public List<FileDomain> findByOwnerAndSort(OwnerType ownerType, Long ownerId, FileSort sort) {
+        List<FileJpaEntity> entities = getEntities(ownerType, ownerId, sort);
+
+        return entities.stream()
                 .map(entity -> FileDomain.of(
                         entity.getId(),
                         entity.getOwnerType(),
@@ -85,6 +88,19 @@ public class FilePersistenceAdapter implements SaveFilesPort, FindFilesPort {
                         entity.getOrderNum()
                 ))
                 .toList();
+    }
+
+    private List<FileJpaEntity> getEntities(OwnerType ownerType, Long ownerId, FileSort sort) {
+        String sortName = sort.name();
+        if (sort.isCatalogImage()) {
+            return fileJpaRepository.findTop1ByOwnerTypeAndOwnerIdAndSortOrderByOrderNumDesc(
+                    ownerType, ownerId, sortName
+            );
+        }
+
+        return fileJpaRepository.findTop5ByOwnerTypeAndOwnerIdAndSortOrderByOrderNumDesc(
+                ownerType, ownerId, sortName
+        );
     }
 }
 

--- a/file-service/file-adapters/src/main/java/com/personal/marketnote/file/adapter/out/persistence/file/repository/FileJpaRepository.java
+++ b/file-service/file-adapters/src/main/java/com/personal/marketnote/file/adapter/out/persistence/file/repository/FileJpaRepository.java
@@ -9,5 +9,7 @@ import java.util.List;
 public interface FileJpaRepository extends JpaRepository<FileJpaEntity, Long> {
     List<FileJpaEntity> findAllByOwnerTypeAndOwnerIdOrderByIdAsc(OwnerType ownerType, Long ownerId);
 
+    List<FileJpaEntity> findTop1ByOwnerTypeAndOwnerIdAndSortOrderByOrderNumDesc(OwnerType ownerType, Long ownerId, String sort);
+
     List<FileJpaEntity> findTop5ByOwnerTypeAndOwnerIdAndSortOrderByOrderNumDesc(OwnerType ownerType, Long ownerId, String sort);
 }

--- a/file-service/file-application/src/main/java/com/personal/marketnote/file/port/out/file/FindFilesPort.java
+++ b/file-service/file-application/src/main/java/com/personal/marketnote/file/port/out/file/FindFilesPort.java
@@ -1,5 +1,6 @@
 package com.personal.marketnote.file.port.out.file;
 
+import com.personal.marketnote.common.domain.file.FileSort;
 import com.personal.marketnote.common.domain.file.OwnerType;
 import com.personal.marketnote.file.domain.file.FileDomain;
 
@@ -8,7 +9,7 @@ import java.util.List;
 public interface FindFilesPort {
     List<FileDomain> findByOwner(OwnerType ownerType, Long ownerId);
 
-    List<FileDomain> findByOwnerAndSort(OwnerType ownerType, Long ownerId, String sort);
+    List<FileDomain> findByOwnerAndSort(OwnerType ownerType, Long ownerId, FileSort sort);
 }
 
 

--- a/file-service/file-application/src/main/java/com/personal/marketnote/file/service/file/GetFilesService.java
+++ b/file-service/file-application/src/main/java/com/personal/marketnote/file/service/file/GetFilesService.java
@@ -1,7 +1,9 @@
 package com.personal.marketnote.file.service.file;
 
 import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.common.domain.file.FileSort;
 import com.personal.marketnote.common.domain.file.OwnerType;
+import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.file.domain.file.FileDomain;
 import com.personal.marketnote.file.domain.file.ResizedFile;
 import com.personal.marketnote.file.port.in.result.GetFilesResult;
@@ -27,9 +29,9 @@ public class GetFilesService implements GetFilesUseCase {
     @Override
     public GetFilesResult getFiles(String ownerType, Long ownerId, String sort) {
         OwnerType type = OwnerType.from(ownerType);
-        List<FileDomain> files = (sort == null || sort.isBlank())
+        List<FileDomain> files = (!FormatValidator.hasValue(sort))
                 ? findFilesPort.findByOwner(type, ownerId)
-                : findFilesPort.findByOwnerAndSort(type, ownerId, sort);
+                : findFilesPort.findByOwnerAndSort(type, ownerId, FileSort.from(sort));
 
         List<Long> fileIds = files.stream().map(FileDomain::getId).toList();
         List<ResizedFile> resized = findResizedFilesPort.findByFileIds(fileIds);

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/client/product/controller/apidocs/GetProductInfoApiDocs.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/client/product/controller/apidocs/GetProductInfoApiDocs.java
@@ -138,14 +138,6 @@ import java.lang.annotation.*;
         
         | **키** | **타입** | **설명** | **예시** |
         | --- | --- | --- | --- |
-        | images | array | 상단 대표 이미지 목록 | [ ... ] |
-        
-        ---
-        
-        ### Response > content > representativeImages > images
-        
-        | **키** | **타입** | **설명** | **예시** |
-        | --- | --- | --- | --- |
         | id | number | 이미지 ID | 1 |
         | sort | string | 이미지 종류 | "PRODUCT_REPRESENTATIVE_IMAGE" |
         | extension | string | 이미지 확장자 | "png" |
@@ -157,14 +149,6 @@ import java.lang.annotation.*;
         ---
         
         ### Response > content > contentImages
-        
-        | **키** | **타입** | **설명** | **예시** |
-        | --- | --- | --- | --- |
-        | images | array | 본문 이미지 목록 | [ ... ] |
-        
-        ---
-        
-        ### Response > content > contentImages > images
         
         | **키** | **타입** | **설명** | **예시** |
         | --- | --- | --- | --- |
@@ -225,7 +209,7 @@ import java.lang.annotation.*;
                                                 "id": 23,
                                                 "price": 43000,
                                                 "discountPrice": 36000,
-                                                "discountRate": 1.4,
+                                                "discountRate": 16.3,
                                                 "accumulatedPoint": 500
                                               },
                                               "sales": 0,
@@ -293,126 +277,122 @@ import java.lang.annotation.*;
                                                 ]
                                               }
                                             ],
-                                            "representativeImages": {
-                                              "images": [
-                                                {
-                                                  "id": 41,
-                                                  "sort": "PRODUCT_REPRESENTATIVE_IMAGE",
-                                                  "extension": "png",
-                                                  "name": "스프링노트2",
-                                                  "s3Url": "https://marketnote.s3.amazonaws.com/product/30/1763534195681_image.png",
-                                                  "resizedS3Urls": [
-                                                    "https://marketnote.s3.amazonaws.com/product/30/1763534195922_image_600.png",
-                                                    "https://marketnote.s3.amazonaws.com/product/30/1763534195988_image_800.png"
-                                                  ],
-                                                  "orderNum": 41
-                                                },
-                                                {
-                                                  "id": 39,
-                                                  "sort": "PRODUCT_REPRESENTATIVE_IMAGE",
-                                                  "extension": "png",
-                                                  "name": "스프링노트2",
-                                                  "s3Url": "https://marketnote.s3.amazonaws.com/product/30/1763534193377_image.png",
-                                                  "resizedS3Urls": [
-                                                    "https://marketnote.s3.amazonaws.com/product/30/1763534193688_image_600.png",
-                                                    "https://marketnote.s3.amazonaws.com/product/30/1763534193761_image_800.png"
-                                                  ],
-                                                  "orderNum": 39
-                                                },
-                                                {
-                                                  "id": 37,
-                                                  "sort": "PRODUCT_REPRESENTATIVE_IMAGE",
-                                                  "extension": "png",
-                                                  "name": "스프링노트2",
-                                                  "s3Url": "https://marketnote.s3.amazonaws.com/product/30/1763533915880_image.png",
-                                                  "resizedS3Urls": [
-                                                    "https://marketnote.s3.amazonaws.com/product/30/1763533916081_image_600.png",
-                                                    "https://marketnote.s3.amazonaws.com/product/30/1763533916187_image_800.png"
-                                                  ],
-                                                  "orderNum": 37
-                                                },
-                                                {
-                                                  "id": 35,
-                                                  "sort": "PRODUCT_REPRESENTATIVE_IMAGE",
-                                                  "extension": "png",
-                                                  "name": "스프링노트2",
-                                                  "s3Url": "https://marketnote.s3.amazonaws.com/product/30/1763533914726_image.png",
-                                                  "resizedS3Urls": [
-                                                    "https://marketnote.s3.amazonaws.com/product/30/1763533914954_image_600.png",
-                                                    "https://marketnote.s3.amazonaws.com/product/30/1763533915038_image_800.png"
-                                                  ],
-                                                  "orderNum": 35
-                                                },
-                                                {
-                                                  "id": 33,
-                                                  "sort": "PRODUCT_REPRESENTATIVE_IMAGE",
-                                                  "extension": "png",
-                                                  "name": "스프링노트2",
-                                                  "s3Url": "https://marketnote.s3.amazonaws.com/product/30/1763533911501_image.png",
-                                                  "resizedS3Urls": [
-                                                    "https://marketnote.s3.amazonaws.com/product/30/1763533911804_image_600.png",
-                                                    "https://marketnote.s3.amazonaws.com/product/30/1763533911854_image_800.png"
-                                                  ],
-                                                  "orderNum": 33
-                                                }
-                                              ]
-                                            },
-                                            "contentImages": {
-                                              "images": [
-                                                {
-                                                  "id": 40,
-                                                  "sort": "PRODUCT_CONTENT_IMAGE",
-                                                  "extension": "jpg",
-                                                  "name": "스프링노트1",
-                                                  "s3Url": "https://marketnote.s3.amazonaws.com/product/30/1763534195623_grafana-icon.png",
-                                                  "resizedS3Urls": [],
-                                                  "orderNum": 40
-                                                },
-                                                {
-                                                  "id": 38,
-                                                  "sort": "PRODUCT_CONTENT_IMAGE",
-                                                  "extension": "jpg",
-                                                  "name": "스프링노트1",
-                                                  "s3Url": "https://marketnote.s3.amazonaws.com/product/30/1763534193258_grafana-icon.png",
-                                                  "resizedS3Urls": [],
-                                                  "orderNum": 38
-                                                },
-                                                {
-                                                  "id": 36,
-                                                  "sort": "PRODUCT_CONTENT_IMAGE",
-                                                  "extension": "jpg",
-                                                  "name": "스프링노트1",
-                                                  "s3Url": "https://marketnote.s3.amazonaws.com/product/30/1763533915837_grafana-icon.png",
-                                                  "resizedS3Urls": [],
-                                                  "orderNum": 36
-                                                },
-                                                {
-                                                  "id": 34,
-                                                  "sort": "PRODUCT_CONTENT_IMAGE",
-                                                  "extension": "jpg",
-                                                  "name": "스프링노트1",
-                                                  "s3Url": "https://marketnote.s3.amazonaws.com/product/30/1763533914674_grafana-icon.png",
-                                                  "resizedS3Urls": [],
-                                                  "orderNum": 34
-                                                },
-                                                {
-                                                  "id": 32,
-                                                  "sort": "PRODUCT_CONTENT_IMAGE",
-                                                  "extension": "jpg",
-                                                  "name": "스프링노트1",
-                                                  "s3Url": "https://marketnote.s3.amazonaws.com/product/30/1763533911286_grafana-icon.png",
-                                                  "resizedS3Urls": [],
-                                                  "orderNum": 32
-                                                }
-                                              ]
-                                            },
+                                            "representativeImages": [
+                                              {
+                                                "id": 41,
+                                                "sort": "PRODUCT_REPRESENTATIVE_IMAGE",
+                                                "extension": "png",
+                                                "name": "스프링노트2",
+                                                "s3Url": "https://marketnote.s3.amazonaws.com/product/30/1763534195681_image.png",
+                                                "resizedS3Urls": [
+                                                  "https://marketnote.s3.amazonaws.com/product/30/1763534195922_image_600.png",
+                                                  "https://marketnote.s3.amazonaws.com/product/30/1763534195988_image_800.png"
+                                                ],
+                                                "orderNum": 41
+                                              },
+                                              {
+                                                "id": 39,
+                                                "sort": "PRODUCT_REPRESENTATIVE_IMAGE",
+                                                "extension": "png",
+                                                "name": "스프링노트2",
+                                                "s3Url": "https://marketnote.s3.amazonaws.com/product/30/1763534193377_image.png",
+                                                "resizedS3Urls": [
+                                                  "https://marketnote.s3.amazonaws.com/product/30/1763534193688_image_600.png",
+                                                  "https://marketnote.s3.amazonaws.com/product/30/1763534193761_image_800.png"
+                                                ],
+                                                "orderNum": 39
+                                              },
+                                              {
+                                                "id": 37,
+                                                "sort": "PRODUCT_REPRESENTATIVE_IMAGE",
+                                                "extension": "png",
+                                                "name": "스프링노트2",
+                                                "s3Url": "https://marketnote.s3.amazonaws.com/product/30/1763533915880_image.png",
+                                                "resizedS3Urls": [
+                                                  "https://marketnote.s3.amazonaws.com/product/30/1763533916081_image_600.png",
+                                                  "https://marketnote.s3.amazonaws.com/product/30/1763533916187_image_800.png"
+                                                ],
+                                                "orderNum": 37
+                                              },
+                                              {
+                                                "id": 35,
+                                                "sort": "PRODUCT_REPRESENTATIVE_IMAGE",
+                                                "extension": "png",
+                                                "name": "스프링노트2",
+                                                "s3Url": "https://marketnote.s3.amazonaws.com/product/30/1763533914726_image.png",
+                                                "resizedS3Urls": [
+                                                  "https://marketnote.s3.amazonaws.com/product/30/1763533914954_image_600.png",
+                                                  "https://marketnote.s3.amazonaws.com/product/30/1763533915038_image_800.png"
+                                                ],
+                                                "orderNum": 35
+                                              },
+                                              {
+                                                "id": 33,
+                                                "sort": "PRODUCT_REPRESENTATIVE_IMAGE",
+                                                "extension": "png",
+                                                "name": "스프링노트2",
+                                                "s3Url": "https://marketnote.s3.amazonaws.com/product/30/1763533911501_image.png",
+                                                "resizedS3Urls": [
+                                                  "https://marketnote.s3.amazonaws.com/product/30/1763533911804_image_600.png",
+                                                  "https://marketnote.s3.amazonaws.com/product/30/1763533911854_image_800.png"
+                                                ],
+                                                "orderNum": 33
+                                              }
+                                            ],
+                                            "contentImages": [
+                                              {
+                                                "id": 40,
+                                                "sort": "PRODUCT_CONTENT_IMAGE",
+                                                "extension": "jpg",
+                                                "name": "스프링노트1",
+                                                "s3Url": "https://marketnote.s3.amazonaws.com/product/30/1763534195623_grafana-icon.png",
+                                                "resizedS3Urls": [],
+                                                "orderNum": 40
+                                              },
+                                              {
+                                                "id": 38,
+                                                "sort": "PRODUCT_CONTENT_IMAGE",
+                                                "extension": "jpg",
+                                                "name": "스프링노트1",
+                                                "s3Url": "https://marketnote.s3.amazonaws.com/product/30/1763534193258_grafana-icon.png",
+                                                "resizedS3Urls": [],
+                                                "orderNum": 38
+                                              },
+                                              {
+                                                "id": 36,
+                                                "sort": "PRODUCT_CONTENT_IMAGE",
+                                                "extension": "jpg",
+                                                "name": "스프링노트1",
+                                                "s3Url": "https://marketnote.s3.amazonaws.com/product/30/1763533915837_grafana-icon.png",
+                                                "resizedS3Urls": [],
+                                                "orderNum": 36
+                                              },
+                                              {
+                                                "id": 34,
+                                                "sort": "PRODUCT_CONTENT_IMAGE",
+                                                "extension": "jpg",
+                                                "name": "스프링노트1",
+                                                "s3Url": "https://marketnote.s3.amazonaws.com/product/30/1763533914674_grafana-icon.png",
+                                                "resizedS3Urls": [],
+                                                "orderNum": 34
+                                              },
+                                              {
+                                                "id": 32,
+                                                "sort": "PRODUCT_CONTENT_IMAGE",
+                                                "extension": "jpg",
+                                                "name": "스프링노트1",
+                                                "s3Url": "https://marketnote.s3.amazonaws.com/product/30/1763533911286_grafana-icon.png",
+                                                "resizedS3Urls": [],
+                                                "orderNum": 32
+                                              }
+                                            ],
                                             "pricePolicies": [
                                               {
                                                 "id": 23,
                                                 "price": 43000,
                                                 "discountPrice": 36000,
                                                 "accumulatedPoint": 500,
-                                                "discountRate": 1.4,
+                                                "discountRate": 16.3,
                                                 "optionIds": null
                                               },
                                               {

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/client/product/controller/apidocs/GetProductsApiDocs.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/client/product/controller/apidocs/GetProductsApiDocs.java
@@ -88,7 +88,7 @@ import java.lang.annotation.*;
         | pricePolicy | object | 가격 정책 | { ... } |
         | sales | number | 판매량 | 0 |
         | productTags | array | 상품 태그 목록 | [ ... ] |
-        | catalogImages | object | 상품 카탈로그 이미지 목록 | { ... } |
+        | catalogImage | object | 상품 카탈로그 이미지 | { ... } |
         | orderNum | number | 정렬 순서 | 1 |
         | status | string | 상태 | "ACTIVE" |
         
@@ -119,15 +119,7 @@ import java.lang.annotation.*;
         
         ---
         
-        ### Response > content > products > catalogImages
-        
-        | **키** | **타입** | **설명** | **예시** |
-        | --- | --- | --- | --- |
-        | images | array | 이미지 목록 | [ ... ] |
-        
-        ---
-        
-        ### Response > content > products > catalogImages > images
+        ### Response > content > products > catalogImage
         
         | **키** | **타입** | **설명** | **예시** |
         | --- | --- | --- | --- |
@@ -259,64 +251,16 @@ import java.lang.annotation.*;
                                                       "status": "ACTIVE"
                                                     }
                                                   ],
-                                                  "catalogImages": {
-                                                    "images": [
-                                                      {
-                                                        "id": 28,
-                                                        "sort": "PRODUCT_CATALOG_IMAGE",
-                                                        "extension": "jpg",
-                                                        "name": "스프링노트1",
-                                                        "s3Url": "https://marketnote.s3.amazonaws.com/product/30/1763521042462_grafana-icon.png",
-                                                        "resizedS3Urls": [
-                                                          "https://marketnote.s3.amazonaws.com/product/30/1763521042802_grafana-icon_300x300.png"
-                                                        ],
-                                                        "orderNum": 28
-                                                      },
-                                                      {
-                                                        "id": 26,
-                                                        "sort": "PRODUCT_CATALOG_IMAGE",
-                                                        "extension": "jpg",
-                                                        "name": "스프링노트1",
-                                                        "s3Url": "https://marketnote.s3.amazonaws.com/product/30/1763521039723_grafana-icon.png",
-                                                        "resizedS3Urls": [
-                                                          "https://marketnote.s3.amazonaws.com/product/30/1763521040050_grafana-icon_300x300.png"
-                                                        ],
-                                                        "orderNum": 26
-                                                      },
-                                                      {
-                                                        "id": 18,
-                                                        "sort": "PRODUCT_CATALOG_IMAGE",
-                                                        "extension": "jpg",
-                                                        "name": "스프링노트1",
-                                                        "s3Url": "https://marketnote.s3.amazonaws.com/product/30/1763517310521_grafana-icon.png",
-                                                        "resizedS3Urls": [
-                                                          "https://marketnote.s3.amazonaws.com/product/30/1763517310821_grafana-icon_300x300.png"
-                                                        ],
-                                                        "orderNum": 18
-                                                      },
-                                                      {
-                                                        "id": 16,
-                                                        "sort": "PRODUCT_CATALOG_IMAGE",
-                                                        "extension": "jpg",
-                                                        "name": "스프링노트1",
-                                                        "s3Url": "https://marketnote.s3.amazonaws.com/product/30/1763517302521_grafana-icon.png",
-                                                        "resizedS3Urls": [
-                                                          "https://marketnote.s3.amazonaws.com/product/30/1763517302838_grafana-icon_300x300.png"
-                                                        ],
-                                                        "orderNum": 16
-                                                      },
-                                                      {
-                                                        "id": 14,
-                                                        "sort": "PRODUCT_CATALOG_IMAGE",
-                                                        "extension": "jpg",
-                                                        "name": "스프링노트1",
-                                                        "s3Url": "https://marketnote.s3.amazonaws.com/product/30/1763517295839_grafana-icon.png",
-                                                        "resizedS3Urls": [
-                                                          "https://marketnote.s3.amazonaws.com/product/30/1763517296419_grafana-icon_300x300.png"
-                                                        ],
-                                                        "orderNum": 14
-                                                      }
-                                                    ]
+                                                  "catalogImage": {
+                                                    "id": 28,
+                                                    "sort": "PRODUCT_CATALOG_IMAGE",
+                                                    "extension": "jpg",
+                                                    "name": "스프링노트1",
+                                                    "s3Url": "https://marketnote.s3.amazonaws.com/product/30/1763521042462_grafana-icon.png",
+                                                    "resizedS3Urls": [
+                                                      "https://marketnote.s3.amazonaws.com/product/30/1763521042802_grafana-icon_300x300.png"
+                                                    ],
+                                                    "orderNum": 28
                                                   },
                                                   "selectedOptions": [
                                                     {
@@ -362,64 +306,16 @@ import java.lang.annotation.*;
                                                       "status": "ACTIVE"
                                                     }
                                                   ],
-                                                  "catalogImages": {
-                                                    "images": [
-                                                      {
-                                                        "id": 28,
-                                                        "sort": "PRODUCT_CATALOG_IMAGE",
-                                                        "extension": "jpg",
-                                                        "name": "스프링노트1",
-                                                        "s3Url": "https://marketnote.s3.amazonaws.com/product/30/1763521042462_grafana-icon.png",
-                                                        "resizedS3Urls": [
-                                                          "https://marketnote.s3.amazonaws.com/product/30/1763521042802_grafana-icon_300x300.png"
-                                                        ],
-                                                        "orderNum": 28
-                                                      },
-                                                      {
-                                                        "id": 26,
-                                                        "sort": "PRODUCT_CATALOG_IMAGE",
-                                                        "extension": "jpg",
-                                                        "name": "스프링노트1",
-                                                        "s3Url": "https://marketnote.s3.amazonaws.com/product/30/1763521039723_grafana-icon.png",
-                                                        "resizedS3Urls": [
-                                                          "https://marketnote.s3.amazonaws.com/product/30/1763521040050_grafana-icon_300x300.png"
-                                                        ],
-                                                        "orderNum": 26
-                                                      },
-                                                      {
-                                                        "id": 18,
-                                                        "sort": "PRODUCT_CATALOG_IMAGE",
-                                                        "extension": "jpg",
-                                                        "name": "스프링노트1",
-                                                        "s3Url": "https://marketnote.s3.amazonaws.com/product/30/1763517310521_grafana-icon.png",
-                                                        "resizedS3Urls": [
-                                                          "https://marketnote.s3.amazonaws.com/product/30/1763517310821_grafana-icon_300x300.png"
-                                                        ],
-                                                        "orderNum": 18
-                                                      },
-                                                      {
-                                                        "id": 16,
-                                                        "sort": "PRODUCT_CATALOG_IMAGE",
-                                                        "extension": "jpg",
-                                                        "name": "스프링노트1",
-                                                        "s3Url": "https://marketnote.s3.amazonaws.com/product/30/1763517302521_grafana-icon.png",
-                                                        "resizedS3Urls": [
-                                                          "https://marketnote.s3.amazonaws.com/product/30/1763517302838_grafana-icon_300x300.png"
-                                                        ],
-                                                        "orderNum": 16
-                                                      },
-                                                      {
-                                                        "id": 14,
-                                                        "sort": "PRODUCT_CATALOG_IMAGE",
-                                                        "extension": "jpg",
-                                                        "name": "스프링노트1",
-                                                        "s3Url": "https://marketnote.s3.amazonaws.com/product/30/1763517295839_grafana-icon.png",
-                                                        "resizedS3Urls": [
-                                                          "https://marketnote.s3.amazonaws.com/product/30/1763517296419_grafana-icon_300x300.png"
-                                                        ],
-                                                        "orderNum": 14
-                                                      }
-                                                    ]
+                                                  "catalogImage": {
+                                                    "id": 28,
+                                                    "sort": "PRODUCT_CATALOG_IMAGE",
+                                                    "extension": "jpg",
+                                                    "name": "스프링노트1",
+                                                    "s3Url": "https://marketnote.s3.amazonaws.com/product/30/1763521042462_grafana-icon.png",
+                                                    "resizedS3Urls": [
+                                                      "https://marketnote.s3.amazonaws.com/product/30/1763521042802_grafana-icon_300x300.png"
+                                                    ],
+                                                    "orderNum": 28
                                                   },
                                                   "selectedOptions": [
                                                     {
@@ -465,64 +361,16 @@ import java.lang.annotation.*;
                                                       "status": "ACTIVE"
                                                     }
                                                   ],
-                                                  "catalogImages": {
-                                                    "images": [
-                                                      {
-                                                        "id": 28,
-                                                        "sort": "PRODUCT_CATALOG_IMAGE",
-                                                        "extension": "jpg",
-                                                        "name": "스프링노트1",
-                                                        "s3Url": "https://marketnote.s3.amazonaws.com/product/30/1763521042462_grafana-icon.png",
-                                                        "resizedS3Urls": [
-                                                          "https://marketnote.s3.amazonaws.com/product/30/1763521042802_grafana-icon_300x300.png"
-                                                        ],
-                                                        "orderNum": 28
-                                                      },
-                                                      {
-                                                        "id": 26,
-                                                        "sort": "PRODUCT_CATALOG_IMAGE",
-                                                        "extension": "jpg",
-                                                        "name": "스프링노트1",
-                                                        "s3Url": "https://marketnote.s3.amazonaws.com/product/30/1763521039723_grafana-icon.png",
-                                                        "resizedS3Urls": [
-                                                          "https://marketnote.s3.amazonaws.com/product/30/1763521040050_grafana-icon_300x300.png"
-                                                        ],
-                                                        "orderNum": 26
-                                                      },
-                                                      {
-                                                        "id": 18,
-                                                        "sort": "PRODUCT_CATALOG_IMAGE",
-                                                        "extension": "jpg",
-                                                        "name": "스프링노트1",
-                                                        "s3Url": "https://marketnote.s3.amazonaws.com/product/30/1763517310521_grafana-icon.png",
-                                                        "resizedS3Urls": [
-                                                          "https://marketnote.s3.amazonaws.com/product/30/1763517310821_grafana-icon_300x300.png"
-                                                        ],
-                                                        "orderNum": 18
-                                                      },
-                                                      {
-                                                        "id": 16,
-                                                        "sort": "PRODUCT_CATALOG_IMAGE",
-                                                        "extension": "jpg",
-                                                        "name": "스프링노트1",
-                                                        "s3Url": "https://marketnote.s3.amazonaws.com/product/30/1763517302521_grafana-icon.png",
-                                                        "resizedS3Urls": [
-                                                          "https://marketnote.s3.amazonaws.com/product/30/1763517302838_grafana-icon_300x300.png"
-                                                        ],
-                                                        "orderNum": 16
-                                                      },
-                                                      {
-                                                        "id": 14,
-                                                        "sort": "PRODUCT_CATALOG_IMAGE",
-                                                        "extension": "jpg",
-                                                        "name": "스프링노트1",
-                                                        "s3Url": "https://marketnote.s3.amazonaws.com/product/30/1763517295839_grafana-icon.png",
-                                                        "resizedS3Urls": [
-                                                          "https://marketnote.s3.amazonaws.com/product/30/1763517296419_grafana-icon_300x300.png"
-                                                        ],
-                                                        "orderNum": 14
-                                                      }
-                                                    ]
+                                                  "catalogImage": {
+                                                    "id": 28,
+                                                    "sort": "PRODUCT_CATALOG_IMAGE",
+                                                    "extension": "jpg",
+                                                    "name": "스프링노트1",
+                                                    "s3Url": "https://marketnote.s3.amazonaws.com/product/30/1763521042462_grafana-icon.png",
+                                                    "resizedS3Urls": [
+                                                      "https://marketnote.s3.amazonaws.com/product/30/1763521042802_grafana-icon_300x300.png"
+                                                    ],
+                                                    "orderNum": 28
                                                   },
                                                   "selectedOptions": [
                                                     {
@@ -568,64 +416,16 @@ import java.lang.annotation.*;
                                                       "status": "ACTIVE"
                                                     }
                                                   ],
-                                                  "catalogImages": {
-                                                    "images": [
-                                                      {
-                                                        "id": 28,
-                                                        "sort": "PRODUCT_CATALOG_IMAGE",
-                                                        "extension": "jpg",
-                                                        "name": "스프링노트1",
-                                                        "s3Url": "https://marketnote.s3.amazonaws.com/product/30/1763521042462_grafana-icon.png",
-                                                        "resizedS3Urls": [
-                                                          "https://marketnote.s3.amazonaws.com/product/30/1763521042802_grafana-icon_300x300.png"
-                                                        ],
-                                                        "orderNum": 28
-                                                      },
-                                                      {
-                                                        "id": 26,
-                                                        "sort": "PRODUCT_CATALOG_IMAGE",
-                                                        "extension": "jpg",
-                                                        "name": "스프링노트1",
-                                                        "s3Url": "https://marketnote.s3.amazonaws.com/product/30/1763521039723_grafana-icon.png",
-                                                        "resizedS3Urls": [
-                                                          "https://marketnote.s3.amazonaws.com/product/30/1763521040050_grafana-icon_300x300.png"
-                                                        ],
-                                                        "orderNum": 26
-                                                      },
-                                                      {
-                                                        "id": 18,
-                                                        "sort": "PRODUCT_CATALOG_IMAGE",
-                                                        "extension": "jpg",
-                                                        "name": "스프링노트1",
-                                                        "s3Url": "https://marketnote.s3.amazonaws.com/product/30/1763517310521_grafana-icon.png",
-                                                        "resizedS3Urls": [
-                                                          "https://marketnote.s3.amazonaws.com/product/30/1763517310821_grafana-icon_300x300.png"
-                                                        ],
-                                                        "orderNum": 18
-                                                      },
-                                                      {
-                                                        "id": 16,
-                                                        "sort": "PRODUCT_CATALOG_IMAGE",
-                                                        "extension": "jpg",
-                                                        "name": "스프링노트1",
-                                                        "s3Url": "https://marketnote.s3.amazonaws.com/product/30/1763517302521_grafana-icon.png",
-                                                        "resizedS3Urls": [
-                                                          "https://marketnote.s3.amazonaws.com/product/30/1763517302838_grafana-icon_300x300.png"
-                                                        ],
-                                                        "orderNum": 16
-                                                      },
-                                                      {
-                                                        "id": 14,
-                                                        "sort": "PRODUCT_CATALOG_IMAGE",
-                                                        "extension": "jpg",
-                                                        "name": "스프링노트1",
-                                                        "s3Url": "https://marketnote.s3.amazonaws.com/product/30/1763517295839_grafana-icon.png",
-                                                        "resizedS3Urls": [
-                                                          "https://marketnote.s3.amazonaws.com/product/30/1763517296419_grafana-icon_300x300.png"
-                                                        ],
-                                                        "orderNum": 14
-                                                      }
-                                                    ]
+                                                  "catalogImage": {
+                                                    "id": 28,
+                                                    "sort": "PRODUCT_CATALOG_IMAGE",
+                                                    "extension": "jpg",
+                                                    "name": "스프링노트1",
+                                                    "s3Url": "https://marketnote.s3.amazonaws.com/product/30/1763521042462_grafana-icon.png",
+                                                    "resizedS3Urls": [
+                                                      "https://marketnote.s3.amazonaws.com/product/30/1763521042802_grafana-icon_300x300.png"
+                                                    ],
+                                                    "orderNum": 28
                                                   },
                                                   "selectedOptions": [
                                                     {

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/client/product/response/GetProductInfoResponse.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/client/product/response/GetProductInfoResponse.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.product.adapter.in.client.product.response;
 
-import com.personal.marketnote.common.application.file.port.in.result.GetFilesResult;
+import com.personal.marketnote.common.application.file.port.in.result.GetFileResult;
 import com.personal.marketnote.product.adapter.in.client.option.response.SelectableProductOptionCategoryResponse;
 import com.personal.marketnote.product.port.in.result.pricepolicy.GetProductPricePolicyWithOptionsResult;
 import com.personal.marketnote.product.port.in.result.product.GetProductInfoResult;
@@ -18,8 +18,8 @@ import java.util.List;
 public class GetProductInfoResponse {
     private GetProductInfoResult productInfo;
     private List<SelectableProductOptionCategoryResponse> categories;
-    private GetFilesResult representativeImages;
-    private GetFilesResult contentImages;
+    private List<GetFileResult> representativeImages;
+    private List<GetFileResult> contentImages;
     private List<GetProductPricePolicyWithOptionsResult> pricePolicies;
 
     public static GetProductInfoResponse from(GetProductInfoWithOptionsResult getProductInfoWithOptionsResult) {
@@ -30,8 +30,8 @@ public class GetProductInfoResponse {
                                 .map(SelectableProductOptionCategoryResponse::from)
                                 .toList()
                 )
-                .representativeImages(getProductInfoWithOptionsResult.representativeImages())
-                .contentImages(getProductInfoWithOptionsResult.contentImages())
+                .representativeImages(getProductInfoWithOptionsResult.representativeImages().images())
+                .contentImages(getProductInfoWithOptionsResult.contentImages().images())
                 .pricePolicies(getProductInfoWithOptionsResult.pricePolicies())
                 .build();
     }

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/client/product/response/ProductItemResponse.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/client/product/response/ProductItemResponse.java
@@ -1,8 +1,6 @@
 package com.personal.marketnote.product.adapter.in.client.product.response;
 
 import com.personal.marketnote.common.application.file.port.in.result.GetFileResult;
-import com.personal.marketnote.common.application.file.port.in.result.GetFilesResult;
-import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.product.domain.product.ProductTag;
 import com.personal.marketnote.product.port.in.result.option.ProductOptionItemResult;
 import com.personal.marketnote.product.port.in.result.pricepolicy.GetProductPricePolicyResult;
@@ -25,7 +23,7 @@ public class ProductItemResponse {
     private GetProductPricePolicyResult pricePolicy;
     private Integer sales;
     private List<ProductTag> productTags;
-    private CatalogImagesResponse catalogImages;
+    private GetFileResult catalogImage;
     private List<ProductOptionItemResult> selectedOptions;
     private Long orderNum;
     private String status;
@@ -39,55 +37,11 @@ public class ProductItemResponse {
                 .pricePolicy(result.pricePolicy())
                 .sales(result.sales())
                 .productTags(result.productTags())
-                .catalogImages(CatalogImagesResponse.from(result.catalogImages()))
+                .catalogImage(result.catalogImage())
                 .selectedOptions(result.selectedOptions())
                 .orderNum(result.orderNum())
                 .status(result.status())
                 .build();
-    }
-
-    @AllArgsConstructor(access = AccessLevel.PRIVATE)
-    @Builder(access = AccessLevel.PRIVATE)
-    @Getter
-    public static class CatalogImagesResponse {
-        private List<CatalogImageItemResponse> images;
-
-        public static CatalogImagesResponse from(GetFilesResult getFilesResult) {
-            if (FormatValidator.hasValue(getFilesResult) && FormatValidator.hasValue(getFilesResult)) {
-                return CatalogImagesResponse.builder()
-                        .images(getFilesResult.images()
-                                .stream()
-                                .map(CatalogImageItemResponse::from).toList())
-                        .build();
-            }
-
-            return new CatalogImagesResponse(List.of());
-        }
-    }
-
-    @AllArgsConstructor(access = AccessLevel.PRIVATE)
-    @Builder(access = AccessLevel.PRIVATE)
-    @Getter
-    public static class CatalogImageItemResponse {
-        private Long id;
-        private String sort;
-        private String extension;
-        private String name;
-        private String s3Url;
-        private List<String> resizedS3Urls;
-        private Long orderNum;
-
-        public static CatalogImageItemResponse from(GetFileResult getFileResult) {
-            return CatalogImageItemResponse.builder()
-                    .id(getFileResult.id())
-                    .sort(getFileResult.sort())
-                    .extension(getFileResult.extension())
-                    .name(getFileResult.name())
-                    .s3Url(getFileResult.s3Url())
-                    .resizedS3Urls(getFileResult.resizedS3Urls())
-                    .orderNum(getFileResult.orderNum())
-                    .build();
-        }
     }
 }
 

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/file/FileServiceClient.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/file/FileServiceClient.java
@@ -53,6 +53,10 @@ public class FileServiceClient implements FindProductImagesPort {
         headers.setBearerAuth(adminAccessToken);
         HttpEntity<Void> httpEntity = new HttpEntity<>(headers);
 
+        return sendRequest(uri, httpEntity, productId, sort);
+    }
+
+    public Optional<GetFilesResult> sendRequest(URI uri, HttpEntity<Void> httpEntity, Long productId, FileSort sort) {
         for (int i = 0; i < INTER_SERVER_MAX_REQUEST_COUNT; i++) {
             try {
                 ResponseEntity<BaseResponse<FilesContent>> response =
@@ -74,7 +78,8 @@ public class FileServiceClient implements FindProductImagesPort {
                     return Optional.empty();
                 }
 
-                List<GetFileResult> getFileResults = filesContent.files.stream()
+                List<GetFileResult> getFileResults = filesContent.files
+                        .stream()
                         .map(getFileResult -> new GetFileResult(
                                 getFileResult.id,
                                 getFileResult.sort,
@@ -89,15 +94,16 @@ public class FileServiceClient implements FindProductImagesPort {
                 return Optional.of(new GetFilesResult(getFileResults));
             } catch (Exception e) {
                 log.warn(e.getMessage(), e);
+
+                try {
+                    Thread.sleep(3000);
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                }
             }
         }
 
         log.error("Failed to find images by product id: {} and sort: {}", productId, sort);
-        return Optional.empty();
-    }
-
-    @Override
-    public Optional<GetFileResult> findCatalogImageByProductId(Long productId) {
         return Optional.empty();
     }
 

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/result/product/ProductItemResult.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/result/product/ProductItemResult.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.product.port.in.result.product;
 
-import com.personal.marketnote.common.application.file.port.in.result.GetFilesResult;
+import com.personal.marketnote.common.application.file.port.in.result.GetFileResult;
 import com.personal.marketnote.product.domain.option.ProductOption;
 import com.personal.marketnote.product.domain.pricepolicy.PricePolicy;
 import com.personal.marketnote.product.domain.product.Product;
@@ -21,7 +21,7 @@ public record ProductItemResult(
         GetProductPricePolicyResult pricePolicy,
         Integer sales,
         List<ProductTag> productTags,
-        GetFilesResult catalogImages,
+        GetFileResult catalogImage,
         List<ProductOptionItemResult> selectedOptions,
         Long orderNum,
         String status
@@ -61,7 +61,7 @@ public record ProductItemResult(
                 .build();
     }
 
-    public static ProductItemResult withCatalogImages(ProductItemResult productItemResult, GetFilesResult catalogImages) {
+    public static ProductItemResult from(ProductItemResult productItemResult, GetFileResult catalogImage) {
         return ProductItemResult.builder()
                 .id(productItemResult.id())
                 .sellerId(productItemResult.sellerId())
@@ -70,7 +70,7 @@ public record ProductItemResult(
                 .pricePolicy(productItemResult.pricePolicy())
                 .sales(productItemResult.sales())
                 .productTags(productItemResult.productTags())
-                .catalogImages(catalogImages)
+                .catalogImage(catalogImage)
                 .selectedOptions(productItemResult.selectedOptions())
                 .orderNum(productItemResult.orderNum())
                 .status(productItemResult.status())

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/out/file/FindProductImagesPort.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/out/file/FindProductImagesPort.java
@@ -1,6 +1,5 @@
 package com.personal.marketnote.product.port.out.file;
 
-import com.personal.marketnote.common.application.file.port.in.result.GetFileResult;
 import com.personal.marketnote.common.application.file.port.in.result.GetFilesResult;
 import com.personal.marketnote.common.domain.file.FileSort;
 
@@ -8,6 +7,4 @@ import java.util.Optional;
 
 public interface FindProductImagesPort {
     Optional<GetFilesResult> findImagesByProductIdAndSort(Long productId, FileSort sort);
-
-    Optional<GetFileResult> findCatalogImageByProductId(Long productId);
 }

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/service/product/GetProductService.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/service/product/GetProductService.java
@@ -179,7 +179,12 @@ public class GetProductService implements GetProductUseCase {
         CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
 
         List<ProductItemResult> pageItemsWithImage = pageItems.stream()
-                .map(item -> ProductItemResult.withCatalogImages(item, productIdToImages.get(item.id())))
+                .map(item -> ProductItemResult.from(
+                        item,
+                        productIdToImages.get(item.id())
+                                .images()
+                                .getFirst())
+                )
                 .collect(Collectors.toList());
 
         Long totalElements = null;


### PR DESCRIPTION
## partially addresses #128
## partially addresses #194
## resolves #197
## resolves #200
## resolves #201

## Task
- [x] 상품 이미지 목록 조회 실패 시 재시도 주기를 3초로 연장(총 5회, 3초 X 4회 재시도)
- [x] 상품 카탈로그 이미지 조회 시 한 장만 조회하도록 변경
- [x] 상품 목록 조회 시 카탈로그 이미지 응답 구조 depth 축소
- [x] 상품 상세 정보 조회 시 상단 대표 이미지 목록 및 본문 이미지 목록 응답 구조 depth 축소
- [x] Swagger 문서 업데이트