### PR TITLE
[#216][#268] feat: 재고 차감 시 Redis Cache Memory에 현재 재고 저장 로직 추가

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/cache/CacheStockRedisAdapter.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/cache/CacheStockRedisAdapter.java
@@ -1,14 +1,22 @@
 package com.personal.marketnote.commerce.adapter.out.cache;
 
-import com.personal.marketnote.commerce.port.out.inventory.SaveStockPort;
+import com.personal.marketnote.commerce.domain.inventory.Inventory;
+import com.personal.marketnote.commerce.port.out.inventory.SaveCacheStockPort;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Repository;
 
+import java.util.Set;
+
 @Repository
 @RequiredArgsConstructor
-public class StockRedisAdapter implements SaveStockPort {
+public class CacheStockRedisAdapter implements SaveCacheStockPort {
     private final StringRedisTemplate stringRedisTemplate;
+
+    @Override
+    public void save(Set<Inventory> inventories) {
+        inventories.forEach(inventory -> save(inventory.getPricePolicyId(), inventory.getStockValue()));
+    }
 
     @Override
     public void save(Long pricePolicyId, int stock) {

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/inventory/SaveCacheStockPort.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/inventory/SaveCacheStockPort.java
@@ -1,0 +1,11 @@
+package com.personal.marketnote.commerce.port.out.inventory;
+
+import com.personal.marketnote.commerce.domain.inventory.Inventory;
+
+import java.util.Set;
+
+public interface SaveCacheStockPort {
+    void save(Set<Inventory> inventories);
+
+    void save(Long pricePolicyId, int stock);
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/inventory/SaveStockPort.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/inventory/SaveStockPort.java
@@ -1,6 +1,0 @@
-package com.personal.marketnote.commerce.port.out.inventory;
-
-public interface SaveStockPort {
-    void save(Long pricePolicyId, int stock);
-}
-

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/inventory/RegisterInventoryService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/inventory/RegisterInventoryService.java
@@ -3,8 +3,8 @@ package com.personal.marketnote.commerce.service.inventory;
 import com.personal.marketnote.commerce.domain.inventory.Inventory;
 import com.personal.marketnote.commerce.port.in.command.inventory.RegisterInventoryCommand;
 import com.personal.marketnote.commerce.port.in.usecase.inventory.RegisterInventoryUseCase;
+import com.personal.marketnote.commerce.port.out.inventory.SaveCacheStockPort;
 import com.personal.marketnote.commerce.port.out.inventory.SaveInventoryPort;
-import com.personal.marketnote.commerce.port.out.inventory.SaveStockPort;
 import com.personal.marketnote.common.application.UseCase;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,13 +17,13 @@ import static org.springframework.transaction.annotation.Isolation.READ_COMMITTE
 @Transactional(isolation = READ_COMMITTED)
 public class RegisterInventoryService implements RegisterInventoryUseCase {
     private final SaveInventoryPort saveInventoryPort;
-    private final SaveStockPort saveStockPort;
+    private final SaveCacheStockPort saveCacheStockPort;
 
     @Override
     public void registerInventory(RegisterInventoryCommand command) {
         Inventory inventory = Inventory.of(command.pricePolicyId());
         saveInventoryPort.save(inventory);
 
-        saveStockPort.save(command.pricePolicyId(), ZERO);
+        saveCacheStockPort.save(command.pricePolicyId(), ZERO);
     }
 }


### PR DESCRIPTION
## partially addresses #216
## resolves #268

## Task
- [x] Key 미존재 시: 생성
    - [x] TTL(유효 기한): 무기한
- [x] Key 존재 시: 재고 수량 업데이트