### PR TITLE
[#128][#251] feat: 상품 상세 정보 조회 시 현재 재고 수량 조회 기능 추가

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/client/inventory/controller/InventoryController.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/client/inventory/controller/InventoryController.java
@@ -71,7 +71,9 @@ public class InventoryController {
     @GetMapping
     @PreAuthorize(ADMIN_OR_SELLER_POINTCUT)
     @GetInventoriesApiDocs
-    public ResponseEntity<BaseResponse<GetInventoriesResponse>> getInventories(@Valid @RequestParam List<Long> pricePolicyIds) {
+    public ResponseEntity<BaseResponse<GetInventoriesResponse>> getInventories(
+            @Valid @RequestParam List<Long> pricePolicyIds
+    ) {
         GetInventoriesResult getInventoriesResult
                 = GetInventoriesResult.from(getInventoryUseCase.getInventories(pricePolicyIds));
 

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/client/category/controller/CategoryController.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/client/category/controller/CategoryController.java
@@ -6,6 +6,7 @@ import com.personal.marketnote.common.utility.ElementExtractor;
 import com.personal.marketnote.product.adapter.in.client.category.controller.apidocs.DeleteCategoryApiDocs;
 import com.personal.marketnote.product.adapter.in.client.category.controller.apidocs.GetCategoriesApiDocs;
 import com.personal.marketnote.product.adapter.in.client.category.controller.apidocs.RegisterCategoryApiDocs;
+import com.personal.marketnote.product.adapter.in.client.category.controller.apidocs.RegisterProductCategoriesApiDocs;
 import com.personal.marketnote.product.adapter.in.client.category.mapper.CategoryRequestToCommandMapper;
 import com.personal.marketnote.product.adapter.in.client.category.request.RegisterCategoryRequest;
 import com.personal.marketnote.product.adapter.in.client.category.request.RegisterProductCategoriesRequest;
@@ -132,7 +133,7 @@ public class CategoryController {
     }
 
     /**
-     * 상품 카테고리 등록
+     * 상품 카테고리 등록/수정
      *
      * @param productId 상품 ID
      * @param request   상품 카테고리 등록 요청
@@ -143,6 +144,7 @@ public class CategoryController {
      */
     @PutMapping("{productId}/categories")
     @PreAuthorize(ADMIN_OR_SELLER_POINTCUT)
+    @RegisterProductCategoriesApiDocs
     public ResponseEntity<BaseResponse<RegisterProductCategoriesResponse>> registerProductCategories(
             @PathVariable("productId") Long productId,
             @Valid @RequestBody RegisterProductCategoriesRequest request,

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/client/pricepolicy/GetMyCartProductsApiDocs.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/client/pricepolicy/GetMyCartProductsApiDocs.java
@@ -20,7 +20,7 @@ import java.lang.annotation.*;
         
         ## Description
         
-        장바구니 상품 목록을 조회합니다.
+        - 회원의 장바구니 상품 목록을 조회합니다.
         
         ---
         
@@ -38,7 +38,7 @@ import java.lang.annotation.*;
         | code | string | 응답 코드 | "SUC01" / "BAD_REQUEST" / "UNAUTHORIZED" / "FORBIDDEN" / "NOT_FOUND" / "CONFLICT" / "INTERNAL_SERVER_ERROR" |
         | timestamp | string(datetime) | 응답 일시 | "2026-01-04T12:12:30.013" |
         | content | object | 응답 본문 | { ... } |
-        | message | string | 처리 결과 | "장바구니 상품 목록 조회 성공" |
+        | message | string | 처리 결과 | "회원 장바구니 상품 목록 조회 성공" |
         
         ---
         
@@ -85,8 +85,8 @@ import java.lang.annotation.*;
         security = {@SecurityRequirement(name = "bearer")},
         responses = {
                 @ApiResponse(
-                        responseCode = "201",
-                        description = "장바구니 상품 추가 성공",
+                        responseCode = "200",
+                        description = "회원 장바구니 상품 목록 조회 성공",
                         content = @Content(
                                 examples = @ExampleObject("""
                                         {

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/client/pricepolicy/GetMyOrderingProductsApiDocs.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/client/pricepolicy/GetMyOrderingProductsApiDocs.java
@@ -120,7 +120,7 @@ import java.lang.annotation.*;
         responses = {
                 @ApiResponse(
                         responseCode = "200",
-                        description = "장바구니 상품 추가 성공",
+                        description = "회원 주문 대기 상품 목록 조회 성공",
                         content = @Content(
                                 examples = @ExampleObject("""
                                         {

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/client/product/controller/apidocs/GetProductInfoApiDocs.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/client/product/controller/apidocs/GetProductInfoApiDocs.java
@@ -62,6 +62,7 @@ import java.lang.annotation.*;
         | representativeImages | object | 상품 상세 정보 상단 대표 이미지 목록 | { ... } |
         | contentImages | object | 상품 상세 정보 본문 이미지 목록 | { ... } |
         | selectedOptionIds | array<number> | 선택된 옵션 ID 목록 | [4, 7] |
+        | stock | number | 재고 수량 | 2200 |
         
         ---
         
@@ -427,7 +428,8 @@ import java.lang.annotation.*;
                                                 "discountRate": 17.8,
                                                 "optionIds": null
                                               }
-                                            ]
+                                            ],
+                                            "stock": 2200
                                           },
                                           "message": "상품 상세 정보 조회 성공"
                                         }

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/client/product/response/GetProductInfoResponse.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/client/product/response/GetProductInfoResponse.java
@@ -1,6 +1,8 @@
 package com.personal.marketnote.product.adapter.in.client.product.response;
 
 import com.personal.marketnote.common.application.file.port.in.result.GetFileResult;
+import com.personal.marketnote.common.application.file.port.in.result.GetFilesResult;
+import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.product.adapter.in.client.option.response.SelectableProductOptionCategoryResponse;
 import com.personal.marketnote.product.port.in.result.pricepolicy.GetProductPricePolicyWithOptionsResult;
 import com.personal.marketnote.product.port.in.result.product.GetProductInfoResult;
@@ -21,8 +23,12 @@ public class GetProductInfoResponse {
     private List<GetFileResult> representativeImages;
     private List<GetFileResult> contentImages;
     private List<GetProductPricePolicyWithOptionsResult> pricePolicies;
+    private int stock;
 
     public static GetProductInfoResponse from(GetProductInfoWithOptionsResult getProductInfoWithOptionsResult) {
+        GetFilesResult representativeImages = getProductInfoWithOptionsResult.representativeImages();
+        GetFilesResult contentImages = getProductInfoWithOptionsResult.contentImages();
+
         return GetProductInfoResponse.builder()
                 .productInfo(getProductInfoWithOptionsResult.productInfo())
                 .categories(
@@ -30,9 +36,18 @@ public class GetProductInfoResponse {
                                 .map(SelectableProductOptionCategoryResponse::from)
                                 .toList()
                 )
-                .representativeImages(getProductInfoWithOptionsResult.representativeImages().images())
-                .contentImages(getProductInfoWithOptionsResult.contentImages().images())
+                .representativeImages(
+                        FormatValidator.hasValue(representativeImages)
+                                ? representativeImages.images()
+                                : null
+                )
+                .contentImages(
+                        FormatValidator.hasValue(contentImages)
+                                ? contentImages.images()
+                                : null
+                )
                 .pricePolicies(getProductInfoWithOptionsResult.pricePolicies())
+                .stock(getProductInfoWithOptionsResult.stock())
                 .build();
     }
 }

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/cache/CacheStockRedisAdapter.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/cache/CacheStockRedisAdapter.java
@@ -1,0 +1,33 @@
+package com.personal.marketnote.product.adapter.out.cache;
+
+import com.personal.marketnote.common.domain.exception.illegalargument.numberformat.ParsingIntegerException;
+import com.personal.marketnote.common.utility.FormatConverter;
+import com.personal.marketnote.product.port.out.inventory.FindCacheStockPort;
+import com.personal.marketnote.product.port.out.inventory.SaveCacheStockPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class CacheStockRedisAdapter implements SaveCacheStockPort, FindCacheStockPort {
+    private final StringRedisTemplate stringRedisTemplate;
+
+    @Override
+    public void save(Long pricePolicyId, int stock) {
+        String key = buildKey(pricePolicyId);
+        stringRedisTemplate.opsForValue().set(key, String.valueOf(stock));
+    }
+
+    @Override
+    public int findByPricePolicyId(Long pricePolicyId) throws ParsingIntegerException {
+        return FormatConverter.parseToInteger((
+                stringRedisTemplate.opsForValue()
+                        .get(buildKey(pricePolicyId)))
+        );
+    }
+
+    private String buildKey(Long pricePolicyId) {
+        return "pricePolicy:" + pricePolicyId + ":stock";
+    }
+}

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/response/GetInventoriesResponse.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/response/GetInventoriesResponse.java
@@ -1,0 +1,10 @@
+package com.personal.marketnote.product.adapter.out.response;
+
+import com.personal.marketnote.product.port.out.result.GetInventoryResult;
+
+import java.util.Set;
+
+public record GetInventoriesResponse(
+        Set<GetInventoryResult> inventories
+) {
+}

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/service/file/FileServiceClient.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/service/file/FileServiceClient.java
@@ -96,7 +96,7 @@ public class FileServiceClient implements FindProductImagesPort {
                 log.warn(e.getMessage(), e);
 
                 try {
-                    Thread.sleep(3000);
+                    Thread.sleep(2000);
                 } catch (InterruptedException ie) {
                     Thread.currentThread().interrupt();
                 }

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/result/product/GetProductInfoWithOptionsResult.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/result/product/GetProductInfoWithOptionsResult.java
@@ -15,7 +15,8 @@ public record GetProductInfoWithOptionsResult(
         List<SelectableProductOptionCategoryItemResult> categories,
         GetFilesResult representativeImages,
         GetFilesResult contentImages,
-        List<GetProductPricePolicyWithOptionsResult> pricePolicies
+        List<GetProductPricePolicyWithOptionsResult> pricePolicies,
+        int stock
 ) {
     public static GetProductInfoWithOptionsResult of(
             GetProductInfoResult productInfo,
@@ -32,7 +33,8 @@ public record GetProductInfoWithOptionsResult(
             List<SelectableProductOptionCategoryItemResult> categories,
             GetFilesResult representativeImages,
             GetFilesResult contentImages,
-            List<PricePolicy> pricePolicies
+            List<PricePolicy> pricePolicies,
+            int stock
     ) {
         return GetProductInfoWithOptionsResult.builder()
                 .productInfo(productInfo)
@@ -44,6 +46,7 @@ public record GetProductInfoWithOptionsResult(
                                 .map(GetProductPricePolicyWithOptionsResult::from)
                                 .toList()
                 )
+                .stock(stock)
                 .build();
     }
 }

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/out/inventory/FindCacheStockPort.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/out/inventory/FindCacheStockPort.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.product.port.out.inventory;
+
+import com.personal.marketnote.common.domain.exception.illegalargument.numberformat.ParsingIntegerException;
+
+public interface FindCacheStockPort {
+    int findByPricePolicyId(Long pricePolicyId) throws ParsingIntegerException;
+}

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/out/inventory/FindStockPort.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/out/inventory/FindStockPort.java
@@ -1,0 +1,10 @@
+package com.personal.marketnote.product.port.out.inventory;
+
+import com.personal.marketnote.product.port.out.result.GetInventoryResult;
+
+import java.util.List;
+import java.util.Set;
+
+public interface FindStockPort {
+    Set<GetInventoryResult> findByPricePolicyIds(List<Long> pricePolicyIds);
+}

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/out/inventory/SaveCacheStockPort.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/out/inventory/SaveCacheStockPort.java
@@ -1,0 +1,5 @@
+package com.personal.marketnote.product.port.out.inventory;
+
+public interface SaveCacheStockPort {
+    void save(Long pricePolicyId, int stock);
+}

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/out/result/GetInventoryResult.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/out/result/GetInventoryResult.java
@@ -1,0 +1,11 @@
+package com.personal.marketnote.product.port.out.result;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+
+@Builder(access = AccessLevel.PRIVATE)
+public record GetInventoryResult(
+        Long pricePolicyId,
+        Integer stock
+) {
+}


### PR DESCRIPTION
## partially addresses #128
## resolves #251

## Task
- [x] 상품 상세 정보 조회 시 현재 재고 수량 조회 요청
    - [x] Redis Cache Memory에 저장돼 있는 경우: Redis에서 조회
    - [x] Redis Cache Memory에 저장돼 있지 않은 경우: 커머스 서비스 요청을 통해 조회
        - [x] Redis Cache Memory에 재고 수량 저장
- [x] 200 status code 응답
- [x] Swagger Docs