### PR TITLE
[#128][#143] fix: 카테고리 삭제 시 상위 카테고리 무결성 검사 로직에 INACTIVE(비활성화) 조건 추가

### DIFF
--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/category/CategoryPersistenceAdapter.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/category/CategoryPersistenceAdapter.java
@@ -60,7 +60,7 @@ public class CategoryPersistenceAdapter implements FindCategoryPort, SaveCategor
 
     @Override
     public boolean existsChildren(Long id) {
-        return categoryJpaRepository.existsByParentCategoryId(id);
+        return categoryJpaRepository.existsByParentCategoryIdAndStatus(id, EntityStatus.ACTIVE);
     }
 
     @Override

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/category/repository/CategoryJpaRepository.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/category/repository/CategoryJpaRepository.java
@@ -31,5 +31,5 @@ public interface CategoryJpaRepository extends JpaRepository<CategoryJpaEntity, 
             """)
     List<CategoryJpaEntity> findAllByIdInAndStatus(@Param("ids") List<Long> ids, @Param("status") EntityStatus status);
 
-    boolean existsByParentCategoryId(Long parentCategoryId);
+    boolean existsByParentCategoryIdAndStatus(Long parentCategoryId, EntityStatus status);
 }


### PR DESCRIPTION
## partially addresses #128
## resolves #143

## Task
카테고리 삭제 시 상위 카테고리 무결성 검사 로직에 INACTIVE(비활성화) 조건 추가