### PR TITLE
[#128][#158] feat: 상품 목록 조회 시 전체 정렬 기준을 가격 정책 테이블 컬럼으로 변경

### DIFF
--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/client/option/controller/apidocs/RegisterProductOptionsApiDocs.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/client/option/controller/apidocs/RegisterProductOptionsApiDocs.java
@@ -87,10 +87,10 @@ import java.lang.annotation.*;
                         schema = @Schema(implementation = UpdateProductOptionsRequest.class),
                         examples = @ExampleObject("""
                                 {
-                                  "categoryName": "수량",
+                                  "categoryName": "개당 수량",
                                   "options": [
-                                    { "content": "1박스" },
-                                    { "content": "3박스" }
+                                    { "content": "30개입" },
+                                    { "content": "60개입" }
                                   ]
                                 }
                                 """)

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/client/option/controller/apidocs/UpdateProductOptionsApiDocs.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/client/option/controller/apidocs/UpdateProductOptionsApiDocs.java
@@ -95,8 +95,9 @@ import java.lang.annotation.*;
                                 {
                                   "categoryName": "수량",
                                   "options": [
-                                    { "content": "1박스" },
-                                    { "content": "3박스" }
+                                    { "content": "2박스" },
+                                    { "content": "4박스" },
+                                    { "content": "6박스" }
                                   ]
                                 }
                                 """)

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/client/pricepolicy/controller/apidocs/GetPricePoliciesApiDocs.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/client/pricepolicy/controller/apidocs/GetPricePoliciesApiDocs.java
@@ -67,8 +67,327 @@ import java.lang.annotation.*;
                                           "timestamp": "2026-01-02T10:37:32.320824",
                                           "content": {
                                             "policies": [
-                                              { "id": 12, "price": 45000, "discountPrice": 37000, "accumulatedPoint": 1200, "discountRate": 17.8, "basePolicy": true, "optionIds": [] },
-                                              { "id": 13, "price": 55000, "discountPrice": 43000, "accumulatedPoint": 1500, "discountRate": 21.8, "basePolicy": false, "optionIds": [3,7] }
+                                              {
+                                                "id": 115,
+                                                "price": 100000,
+                                                "discountPrice": 50000,
+                                                "accumulatedPoint": 30000,
+                                                "discountRate": 60,
+                                                "basePolicy": false,
+                                                "optionIds": [
+                                                  34,
+                                                  40
+                                                ]
+                                              },
+                                              {
+                                                "id": 114,
+                                                "price": 100000,
+                                                "discountPrice": 50000,
+                                                "accumulatedPoint": 30000,
+                                                "discountRate": 60,
+                                                "basePolicy": false,
+                                                "optionIds": [
+                                                  34,
+                                                  40
+                                                ]
+                                              },
+                                              {
+                                                "id": 112,
+                                                "price": 10000,
+                                                "discountPrice": 9000,
+                                                "accumulatedPoint": 1000,
+                                                "discountRate": 11.1,
+                                                "basePolicy": false,
+                                                "optionIds": [
+                                                  34,
+                                                  39
+                                                ]
+                                              },
+                                              {
+                                                "id": 111,
+                                                "price": 10000,
+                                                "discountPrice": 9000,
+                                                "accumulatedPoint": 1000,
+                                                "discountRate": 11.1,
+                                                "basePolicy": false,
+                                                "optionIds": [
+                                                  34,
+                                                  38
+                                                ]
+                                              },
+                                              {
+                                                "id": 110,
+                                                "price": 10000,
+                                                "discountPrice": 9000,
+                                                "accumulatedPoint": 1000,
+                                                "discountRate": 11.1,
+                                                "basePolicy": false,
+                                                "optionIds": [
+                                                  33,
+                                                  40
+                                                ]
+                                              },
+                                              {
+                                                "id": 109,
+                                                "price": 10000,
+                                                "discountPrice": 9000,
+                                                "accumulatedPoint": 1000,
+                                                "discountRate": 11.1,
+                                                "basePolicy": false,
+                                                "optionIds": [
+                                                  33,
+                                                  39
+                                                ]
+                                              },
+                                              {
+                                                "id": 108,
+                                                "price": 10000,
+                                                "discountPrice": 9000,
+                                                "accumulatedPoint": 1000,
+                                                "discountRate": 11.1,
+                                                "basePolicy": false,
+                                                "optionIds": [
+                                                  33,
+                                                  38
+                                                ]
+                                              },
+                                              {
+                                                "id": 107,
+                                                "price": 10000,
+                                                "discountPrice": 9000,
+                                                "accumulatedPoint": 1000,
+                                                "discountRate": 11.1,
+                                                "basePolicy": false,
+                                                "optionIds": [
+                                                  32,
+                                                  40
+                                                ]
+                                              },
+                                              {
+                                                "id": 106,
+                                                "price": 10000,
+                                                "discountPrice": 9000,
+                                                "accumulatedPoint": 1000,
+                                                "discountRate": 11.1,
+                                                "basePolicy": false,
+                                                "optionIds": [
+                                                  32,
+                                                  39
+                                                ]
+                                              },
+                                              {
+                                                "id": 105,
+                                                "price": 10000,
+                                                "discountPrice": 9000,
+                                                "accumulatedPoint": 1000,
+                                                "discountRate": 11.1,
+                                                "basePolicy": false,
+                                                "optionIds": [
+                                                  32,
+                                                  38
+                                                ]
+                                              },
+                                              {
+                                                "id": 104,
+                                                "price": 10000,
+                                                "discountPrice": 9000,
+                                                "accumulatedPoint": 1000,
+                                                "discountRate": 11.1,
+                                                "basePolicy": false,
+                                                "optionIds": [
+                                                  40
+                                                ]
+                                              },
+                                              {
+                                                "id": 103,
+                                                "price": 10000,
+                                                "discountPrice": 9000,
+                                                "accumulatedPoint": 1000,
+                                                "discountRate": 11.1,
+                                                "basePolicy": false,
+                                                "optionIds": [
+                                                  39
+                                                ]
+                                              },
+                                              {
+                                                "id": 102,
+                                                "price": 10000,
+                                                "discountPrice": 9000,
+                                                "accumulatedPoint": 1000,
+                                                "discountRate": 11.1,
+                                                "basePolicy": false,
+                                                "optionIds": [
+                                                  38
+                                                ]
+                                              },
+                                              {
+                                                "id": 101,
+                                                "price": 10000,
+                                                "discountPrice": 9000,
+                                                "accumulatedPoint": 1000,
+                                                "discountRate": 11.1,
+                                                "basePolicy": false,
+                                                "optionIds": [
+                                                  34
+                                                ]
+                                              },
+                                              {
+                                                "id": 100,
+                                                "price": 10000,
+                                                "discountPrice": 9000,
+                                                "accumulatedPoint": 1000,
+                                                "discountRate": 11.1,
+                                                "basePolicy": false,
+                                                "optionIds": [
+                                                  34
+                                                ]
+                                              },
+                                              {
+                                                "id": 99,
+                                                "price": 10000,
+                                                "discountPrice": 9000,
+                                                "accumulatedPoint": 1000,
+                                                "discountRate": 11.1,
+                                                "basePolicy": false,
+                                                "optionIds": [
+                                                  34
+                                                ]
+                                              },
+                                              {
+                                                "id": 98,
+                                                "price": 10000,
+                                                "discountPrice": 9000,
+                                                "accumulatedPoint": 1000,
+                                                "discountRate": 11.1,
+                                                "basePolicy": false,
+                                                "optionIds": [
+                                                  33
+                                                ]
+                                              },
+                                              {
+                                                "id": 97,
+                                                "price": 10000,
+                                                "discountPrice": 9000,
+                                                "accumulatedPoint": 1000,
+                                                "discountRate": 11.1,
+                                                "basePolicy": false,
+                                                "optionIds": [
+                                                  33
+                                                ]
+                                              },
+                                              {
+                                                "id": 96,
+                                                "price": 10000,
+                                                "discountPrice": 9000,
+                                                "accumulatedPoint": 1000,
+                                                "discountRate": 11.1,
+                                                "basePolicy": false,
+                                                "optionIds": [
+                                                  33
+                                                ]
+                                              },
+                                              {
+                                                "id": 95,
+                                                "price": 10000,
+                                                "discountPrice": 9000,
+                                                "accumulatedPoint": 1000,
+                                                "discountRate": 11.1,
+                                                "basePolicy": false,
+                                                "optionIds": [
+                                                  32
+                                                ]
+                                              },
+                                              {
+                                                "id": 94,
+                                                "price": 10000,
+                                                "discountPrice": 9000,
+                                                "accumulatedPoint": 1000,
+                                                "discountRate": 11.1,
+                                                "basePolicy": false,
+                                                "optionIds": [
+                                                  32
+                                                ]
+                                              },
+                                              {
+                                                "id": 93,
+                                                "price": 10000,
+                                                "discountPrice": 9000,
+                                                "accumulatedPoint": 1000,
+                                                "discountRate": 11.1,
+                                                "basePolicy": false,
+                                                "optionIds": [
+                                                  32
+                                                ]
+                                              },
+                                              {
+                                                "id": 92,
+                                                "price": 10000,
+                                                "discountPrice": 9000,
+                                                "accumulatedPoint": 1000,
+                                                "discountRate": 11.1,
+                                                "basePolicy": false,
+                                                "optionIds": []
+                                              },
+                                              {
+                                                "id": 91,
+                                                "price": 10000,
+                                                "discountPrice": 9000,
+                                                "accumulatedPoint": 1000,
+                                                "discountRate": 11.1,
+                                                "basePolicy": false,
+                                                "optionIds": []
+                                              },
+                                              {
+                                                "id": 90,
+                                                "price": 10000,
+                                                "discountPrice": 9000,
+                                                "accumulatedPoint": 1000,
+                                                "discountRate": 11.1,
+                                                "basePolicy": false,
+                                                "optionIds": []
+                                              },
+                                              {
+                                                "id": 89,
+                                                "price": 10000,
+                                                "discountPrice": 9000,
+                                                "accumulatedPoint": 1000,
+                                                "discountRate": 11.1,
+                                                "basePolicy": false,
+                                                "optionIds": [
+                                                  34
+                                                ]
+                                              },
+                                              {
+                                                "id": 88,
+                                                "price": 10000,
+                                                "discountPrice": 9000,
+                                                "accumulatedPoint": 1000,
+                                                "discountRate": 11.1,
+                                                "basePolicy": false,
+                                                "optionIds": [
+                                                  33
+                                                ]
+                                              },
+                                              {
+                                                "id": 87,
+                                                "price": 10000,
+                                                "discountPrice": 9000,
+                                                "accumulatedPoint": 1000,
+                                                "discountRate": 11.1,
+                                                "basePolicy": false,
+                                                "optionIds": [
+                                                  32
+                                                ]
+                                              },
+                                              {
+                                                "id": 86,
+                                                "price": 10000,
+                                                "discountPrice": 9000,
+                                                "accumulatedPoint": 1000,
+                                                "discountRate": 11.1,
+                                                "basePolicy": false,
+                                                "optionIds": []
+                                              }
                                             ]
                                           },
                                           "message": "상품 가격 정책 목록 조회 성공"

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/mapper/PricePolicyJpaEntityToDomainMapper.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/mapper/PricePolicyJpaEntityToDomainMapper.java
@@ -17,7 +17,10 @@ public class PricePolicyJpaEntityToDomainMapper {
                                     pricePolicyJpaEntity.getDiscountPrice(),
                                     pricePolicyJpaEntity.getDiscountRate(),
                                     pricePolicyJpaEntity.getAccumulatedPoint(),
-                                    pricePolicyJpaEntity.getAccumulationRate()
+                                    pricePolicyJpaEntity.getAccumulationRate(),
+                                    pricePolicyJpaEntity.getPopularity(),
+                                    pricePolicyJpaEntity.getStatus(),
+                                    pricePolicyJpaEntity.getOrderNum()
                             );
                             pricePolicy.addProduct(
                                     ProductJpaEntityToDomainMapper.mapToDomainWithoutPolicyProduct(entity.getProductJpaEntity())
@@ -40,6 +43,9 @@ public class PricePolicyJpaEntityToDomainMapper {
                                     pricePolicyJpaEntity.getDiscountRate(),
                                     pricePolicyJpaEntity.getAccumulatedPoint(),
                                     pricePolicyJpaEntity.getAccumulationRate(),
+                                    pricePolicyJpaEntity.getPopularity(),
+                                    pricePolicyJpaEntity.getStatus(),
+                                    pricePolicyJpaEntity.getOrderNum(),
                                     optionIds
                             );
                             pricePolicy.addProduct(

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/pricepolicy/PricePolicyReadPersistenceAdapter.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/pricepolicy/PricePolicyReadPersistenceAdapter.java
@@ -1,52 +1,9 @@
 package com.personal.marketnote.product.adapter.out.persistence.pricepolicy;
 
 import com.personal.marketnote.common.adapter.out.PersistenceAdapter;
-import com.personal.marketnote.product.adapter.out.mapper.PricePolicyJpaEntityToDomainMapper;
-import com.personal.marketnote.product.adapter.out.persistence.pricepolicy.entity.PricePolicyJpaEntity;
-import com.personal.marketnote.product.adapter.out.persistence.pricepolicy.repository.PricePolicyJpaRepository;
-import com.personal.marketnote.product.adapter.out.persistence.productoption.repository.ProductOptionPricePolicyJpaRepository;
-import com.personal.marketnote.product.domain.pricepolicy.PricePolicy;
-import com.personal.marketnote.product.port.out.pricepolicy.FindPricePoliciesPort;
 import lombok.RequiredArgsConstructor;
-
-import java.util.List;
-import java.util.Optional;
 
 @PersistenceAdapter
 @RequiredArgsConstructor
-public class PricePolicyReadPersistenceAdapter implements FindPricePoliciesPort {
-    private final PricePolicyJpaRepository pricePolicyJpaRepository;
-    private final ProductOptionPricePolicyJpaRepository productOptionPricePolicyJpaRepository;
-
-    @Override
-    public List<PricePolicy> findByProductId(Long productId) {
-        List<PricePolicyJpaEntity> policyEntities = pricePolicyJpaRepository.findAll().stream()
-                .filter(policyEntity -> policyEntity.getProductJpaEntity().getId().equals(productId))
-                .sorted((a, b) -> Long.compare(b.getId(), a.getId()))
-                .toList();
-
-        return policyEntities.stream()
-                .map(policyEntity -> PricePolicyJpaEntityToDomainMapper.mapToDomain(
-                        policyEntity, productOptionPricePolicyJpaRepository.findOptionIdsByPricePolicyId(policyEntity.getId())
-                ))
-                .filter(Optional::isPresent)
-                .map(Optional::get)
-                .toList();
-    }
-
-    @Override
-    public List<PricePolicy> findByIds(List<Long> ids) {
-        return pricePolicyJpaRepository.findAllById(ids).stream()
-                .map(
-                        policyEntity -> PricePolicyJpaEntityToDomainMapper.mapToDomain(
-                                policyEntity,
-                                productOptionPricePolicyJpaRepository.findOptionIdsByPricePolicyId(policyEntity.getId())
-                        )
-                )
-                .filter(Optional::isPresent)
-                .map(Optional::get)
-                .toList();
-    }
+public class PricePolicyReadPersistenceAdapter {
 }
-
-

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/pricepolicy/entity/PricePolicyJpaEntity.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/pricepolicy/entity/PricePolicyJpaEntity.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.product.adapter.out.persistence.pricepolicy.entity;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.BaseGeneralEntity;
+import com.personal.marketnote.common.adapter.out.persistence.audit.BaseOrderedGeneralEntity;
 import com.personal.marketnote.product.adapter.out.persistence.product.entity.ProductJpaEntity;
 import com.personal.marketnote.product.domain.pricepolicy.PricePolicy;
 import jakarta.persistence.*;
@@ -14,7 +14,7 @@ import java.math.BigDecimal;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder(access = AccessLevel.PRIVATE)
 @Getter
-public class PricePolicyJpaEntity extends BaseGeneralEntity {
+public class PricePolicyJpaEntity extends BaseOrderedGeneralEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "product_id", nullable = false, foreignKey = @ForeignKey(name = "fk_price_policy_product"))
     private ProductJpaEntity productJpaEntity;
@@ -25,27 +25,26 @@ public class PricePolicyJpaEntity extends BaseGeneralEntity {
     @Column(name = "discount_price", nullable = false)
     private Long discountPrice;
 
-    // start_at, end_at removed per latest spec
-
-    @Column(name = "accumulation_rate", nullable = false, precision = 3, scale = 1)
-    private BigDecimal accumulationRate;
+    @Column(name = "discount_rate", nullable = false, precision = 3, scale = 1)
+    private BigDecimal discountRate;
 
     @Column(name = "accumulated_point", nullable = false)
     private Long accumulatedPoint;
 
-    @Column(name = "discount_rate", nullable = false, precision = 3, scale = 1)
-    private BigDecimal discountRate;
+    @Column(name = "accumulation_rate", nullable = false, precision = 3, scale = 1)
+    private BigDecimal accumulationRate;
+
+    @Column(name = "popularity", nullable = false, insertable = false, columnDefinition = "BIGINT DEFAULT 0")
+    private Long popularity;
 
     public static PricePolicyJpaEntity from(ProductJpaEntity productRef, PricePolicy pricePolicy) {
-        return com.personal.marketnote.product.adapter.out.persistence.pricepolicy.entity.PricePolicyJpaEntity.builder()
+        return PricePolicyJpaEntity.builder()
                 .productJpaEntity(productRef)
                 .price(pricePolicy.getPrice())
                 .discountPrice(pricePolicy.getDiscountPrice())
-                .accumulationRate(pricePolicy.getAccumulationRate())
-                .accumulatedPoint(pricePolicy.getAccumulatedPoint())
                 .discountRate(pricePolicy.getDiscountRate())
+                .accumulatedPoint(pricePolicy.getAccumulatedPoint())
+                .accumulationRate(pricePolicy.getAccumulationRate())
                 .build();
     }
 }
-
-

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/pricepolicy/repository/PricePolicyJpaRepository.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/pricepolicy/repository/PricePolicyJpaRepository.java
@@ -1,8 +1,10 @@
 package com.personal.marketnote.product.adapter.out.persistence.pricepolicy.repository;
 
 import com.personal.marketnote.product.adapter.out.persistence.pricepolicy.entity.PricePolicyJpaEntity;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -21,4 +23,195 @@ public interface PricePolicyJpaRepository extends JpaRepository<PricePolicyJpaEn
             )
             """)
     Optional<PricePolicyJpaEntity> findByOptionIds(List<Long> optionIds);
+
+    @Query("""
+            SELECT pp
+            FROM PricePolicyJpaEntity pp
+              JOIN pp.productJpaEntity p
+            WHERE 1 = 1
+              AND p.status = com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus.ACTIVE
+              AND (
+                    :pattern IS NULL
+                 OR (:searchTarget = 'name' AND p.name LIKE :pattern)
+                 OR (:searchTarget = 'brandName' AND p.brandName LIKE :pattern)
+                 OR (:searchTarget <> 'name' AND :searchTarget <> 'brandName' AND (p.name LIKE :pattern OR p.brandName LIKE :pattern))
+              )
+              AND (
+                    :categoryId IS NULL
+                 OR EXISTS (
+                        SELECT 1
+                        FROM ProductCategoryJpaEntity pc
+                        WHERE pc.productId = p.id
+                          AND pc.categoryId = :categoryId
+                 )
+              )
+              AND (
+                    :cursor IS NULL
+                 OR NOT EXISTS (SELECT 1 FROM PricePolicyJpaEntity pp0 WHERE pp0.id = :cursor)
+                 OR (
+                        (:sortProperty = 'orderNum' AND (
+                              pp.orderNum > (
+                                  SELECT pp2.orderNum
+                                  FROM PricePolicyJpaEntity pp2
+                                  WHERE pp2.id = :cursor
+                              )
+                           OR (pp.orderNum = (
+                                    SELECT pp2.orderNum
+                                    FROM PricePolicyJpaEntity pp2
+                                    WHERE pp2.id = :cursor
+                                )
+                               AND pp.id > :cursor)
+                        ))
+                     OR (:sortProperty = 'popularity' AND (
+                              pp.popularity > (
+                                  SELECT pp3.popularity
+                                  FROM PricePolicyJpaEntity pp3
+                                  WHERE pp3.id = :cursor
+                              )
+                           OR (pp.popularity = (
+                                    SELECT pp3.popularity
+                                    FROM PricePolicyJpaEntity pp3
+                                    WHERE pp3.id = :cursor
+                                )
+                               AND pp.id > :cursor)
+                        ))
+                     OR (:sortProperty = 'discountPrice' AND (
+                              pp.discountPrice > (
+                                  SELECT pp4.discountPrice
+                                  FROM PricePolicyJpaEntity pp4
+                                  WHERE pp4.id = :cursor
+                              )
+                           OR (pp.discountPrice = (
+                                    SELECT pp4.discountPrice
+                                    FROM PricePolicyJpaEntity pp4
+                                    WHERE pp4.id = :cursor
+                                )
+                               AND pp.id > :cursor)
+                        ))
+                     OR (:sortProperty = 'accumulatedPoint' AND (
+                              pp.accumulatedPoint > (
+                                  SELECT pp5.accumulatedPoint
+                                  FROM PricePolicyJpaEntity pp5
+                                  WHERE pp5.id = :cursor
+                              )
+                           OR (pp.accumulatedPoint = (
+                                    SELECT pp5.accumulatedPoint
+                                    FROM PricePolicyJpaEntity pp5
+                                    WHERE pp5.id = :cursor
+                                )
+                               AND pp.id > :cursor)
+                        ))
+                 )
+              )
+            ORDER BY
+                CASE WHEN :sortProperty = 'orderNum' THEN pp.orderNum END ASC,
+                CASE WHEN :sortProperty = 'popularity' THEN pp.popularity END DESC,
+                CASE WHEN :sortProperty = 'discountPrice' THEN pp.discountPrice END ASC,
+                CASE WHEN :sortProperty = 'accumulatedPoint' THEN pp.accumulatedPoint END DESC,
+                pp.id ASC
+            """)
+    List<PricePolicyJpaEntity> findAllActiveByCursorAsc(
+            @Param("cursor") Long cursor,
+            Pageable pageable,
+            @Param("sortProperty") String sortProperty,
+            @Param("searchTarget") String searchTarget,
+            @Param("pattern") String pattern,
+            @Param("categoryId") Long categoryId
+    );
+
+    @Query("""
+            SELECT pp
+            FROM PricePolicyJpaEntity pp
+              JOIN pp.productJpaEntity p
+            WHERE 1 = 1
+              AND p.status = com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus.ACTIVE
+              AND (
+                    :pattern IS NULL
+                 OR (:searchTarget = 'name' AND p.name LIKE :pattern)
+                 OR (:searchTarget = 'brandName' AND p.brandName LIKE :pattern)
+                 OR (:searchTarget <> 'name' AND :searchTarget <> 'brandName' AND (p.name LIKE :pattern OR p.brandName LIKE :pattern))
+              )
+              AND (
+                    :categoryId IS NULL
+                 OR EXISTS (
+                        SELECT 1
+                        FROM ProductCategoryJpaEntity pc
+                        WHERE pc.productId = p.id
+                          AND pc.categoryId = :categoryId
+                 )
+              )
+              AND (
+                    :cursor IS NULL
+                 OR NOT EXISTS (SELECT 1 FROM PricePolicyJpaEntity pp0 WHERE pp0.id = :cursor)
+                 OR (
+                        (:sortProperty = 'orderNum' AND (
+                              pp.orderNum < (
+                                  SELECT pp2.orderNum
+                                  FROM PricePolicyJpaEntity pp2
+                                  WHERE pp2.id = :cursor
+                              )
+                           OR (pp.orderNum = (
+                                    SELECT pp2.orderNum
+                                    FROM PricePolicyJpaEntity pp2
+                                    WHERE pp2.id = :cursor
+                                )
+                               AND pp.id < :cursor)
+                        ))
+                     OR (:sortProperty = 'popularity' AND (
+                              pp.popularity < (
+                                  SELECT pp3.popularity
+                                  FROM PricePolicyJpaEntity pp3
+                                  WHERE pp3.id = :cursor
+                              )
+                           OR (pp.popularity = (
+                                    SELECT pp3.popularity
+                                    FROM PricePolicyJpaEntity pp3
+                                    WHERE pp3.id = :cursor
+                                )
+                               AND pp.id < :cursor)
+                        ))
+                     OR (:sortProperty = 'discountPrice' AND (
+                              pp.discountPrice < (
+                                  SELECT pp4.discountPrice
+                                  FROM PricePolicyJpaEntity pp4
+                                  WHERE pp4.id = :cursor
+                              )
+                           OR (pp.discountPrice = (
+                                    SELECT pp4.discountPrice
+                                    FROM PricePolicyJpaEntity pp4
+                                    WHERE pp4.id = :cursor
+                                )
+                               AND pp.id < :cursor)
+                        ))
+                     OR (:sortProperty = 'accumulatedPoint' AND (
+                              pp.accumulatedPoint < (
+                                  SELECT pp5.accumulatedPoint
+                                  FROM PricePolicyJpaEntity pp5
+                                  WHERE pp5.id = :cursor
+                              )
+                           OR (pp.accumulatedPoint = (
+                                    SELECT pp5.accumulatedPoint
+                                    FROM PricePolicyJpaEntity pp5
+                                    WHERE pp5.id = :cursor
+                                )
+                               AND pp.id < :cursor)
+                        ))
+                 )
+              )
+            ORDER BY
+                CASE WHEN :sortProperty = 'orderNum' THEN pp.orderNum END DESC,
+                CASE WHEN :sortProperty = 'popularity' THEN pp.popularity END ASC,
+                CASE WHEN :sortProperty = 'discountPrice' THEN pp.discountPrice END DESC,
+                CASE WHEN :sortProperty = 'accumulatedPoint' THEN pp.accumulatedPoint END ASC,
+                pp.id DESC
+            """)
+    List<PricePolicyJpaEntity> findAllActiveByCursorDesc(
+            @Param("cursor") Long cursor,
+            Pageable pageable,
+            @Param("sortProperty") String sortProperty,
+            @Param("searchTarget") String searchTarget,
+            @Param("pattern") String pattern,
+            @Param("categoryId") Long categoryId
+    );
+
 }

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/product/repository/ProductJpaRepository.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/product/repository/ProductJpaRepository.java
@@ -463,6 +463,7 @@ public interface ProductJpaRepository extends JpaRepository<ProductJpaEntity, Lo
                 SELECT 1
                 FROM PricePolicyJpaEntity pp
                 WHERE 1 = 1
+                    AND pp.productJpaEntity = p
                     AND pp.id IN :pricePolicyIds
               )
             """)

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/result/product/ProductItemResult.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/result/product/ProductItemResult.java
@@ -45,6 +45,23 @@ public class ProductItemResult {
 
     public static ProductItemResult from(
             Product product,
+            PricePolicy pricePolicy
+    ) {
+        return ProductItemResult.builder()
+                .id(product.getId())
+                .sellerId(product.getSellerId())
+                .name(product.getName())
+                .brandName(product.getBrandName())
+                .pricePolicy(GetProductPricePolicyResult.from(pricePolicy))
+                .sales(product.getSales())
+                .productTags(product.getProductTags())
+                .orderNum(product.getOrderNum())
+                .status(product.getStatus().name())
+                .build();
+    }
+
+    public static ProductItemResult from(
+            Product product,
             List<ProductOption> selectedOptions,
             PricePolicy pricePolicy
     ) {

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/out/pricepolicy/FindPricePoliciesPort.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/out/pricepolicy/FindPricePoliciesPort.java
@@ -1,6 +1,9 @@
 package com.personal.marketnote.product.port.out.pricepolicy;
 
 import com.personal.marketnote.product.domain.pricepolicy.PricePolicy;
+import com.personal.marketnote.product.domain.product.ProductSearchTarget;
+import com.personal.marketnote.product.domain.product.ProductSortProperty;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
@@ -8,4 +11,21 @@ public interface FindPricePoliciesPort {
     List<PricePolicy> findByProductId(Long productId);
 
     List<PricePolicy> findByIds(List<Long> ids);
+
+    List<PricePolicy> findActivePage(
+            Long cursor,
+            Pageable pageable,
+            ProductSortProperty sortProperty,
+            ProductSearchTarget searchTarget,
+            String searchKeyword
+    );
+
+    List<PricePolicy> findActivePageByCategoryId(
+            Long categoryId,
+            Long cursor,
+            Pageable pageable,
+            ProductSortProperty sortProperty,
+            ProductSearchTarget searchTarget,
+            String searchKeyword
+    );
 }

--- a/product-service/product-domain/src/main/java/com/personal/marketnote/product/domain/pricepolicy/PricePolicy.java
+++ b/product-service/product-domain/src/main/java/com/personal/marketnote/product/domain/pricepolicy/PricePolicy.java
@@ -28,8 +28,10 @@ public class PricePolicy {
     private BigDecimal discountRate;
     private Long accumulatedPoint;
     private BigDecimal accumulationRate;
-    private List<Long> optionIds;
+    private Long popularity;
     private EntityStatus status;
+    private Long orderNum;
+    private List<Long> optionIds;
 
     @JsonCreator
     private static PricePolicy jsonCreator(
@@ -39,10 +41,15 @@ public class PricePolicy {
             @JsonProperty("discountRate") BigDecimal discountRate,
             @JsonProperty("accumulatedPoint") Long accumulatedPoint,
             @JsonProperty("accumulationRate") BigDecimal accumulationRate,
-            @JsonProperty("optionIds") List<Long> optionIds,
-            @JsonProperty("status") EntityStatus status
+            @JsonProperty("popularity") Long popularity,
+            @JsonProperty("status") EntityStatus status,
+            @JsonProperty("orderNum") Long orderNum,
+            @JsonProperty("optionIds") List<Long> optionIds
     ) {
-        return of(id, price, discountPrice, discountRate, accumulatedPoint, accumulationRate, optionIds);
+        return of(
+                id, price, discountPrice, discountRate, accumulatedPoint,
+                accumulationRate, popularity, status, orderNum, optionIds
+        );
     }
 
     public static PricePolicy of(
@@ -51,7 +58,10 @@ public class PricePolicy {
             Long discountPrice,
             BigDecimal discountRate,
             Long accumulatedPoint,
-            BigDecimal accumulationRate
+            BigDecimal accumulationRate,
+            Long popularity,
+            EntityStatus status,
+            Long orderNum
     ) {
         return PricePolicy.builder()
                 .product(product)
@@ -60,7 +70,9 @@ public class PricePolicy {
                 .discountRate(discountRate)
                 .accumulatedPoint(accumulatedPoint)
                 .accumulationRate(accumulationRate)
-                .status(EntityStatus.ACTIVE)
+                .popularity(popularity)
+                .status(status)
+                .orderNum(orderNum)
                 .build();
     }
 
@@ -71,7 +83,10 @@ public class PricePolicy {
             Long discountPrice,
             BigDecimal discountRate,
             Long accumulatedPoint,
-            BigDecimal accumulationRate
+            BigDecimal accumulationRate,
+            Long popularity,
+            EntityStatus status,
+            Long orderNum
     ) {
         return PricePolicy.builder()
                 .id(id)
@@ -81,7 +96,9 @@ public class PricePolicy {
                 .discountRate(discountRate)
                 .accumulatedPoint(accumulatedPoint)
                 .accumulationRate(accumulationRate)
-                .status(EntityStatus.ACTIVE)
+                .popularity(popularity)
+                .status(status)
+                .orderNum(orderNum)
                 .build();
     }
 
@@ -91,7 +108,10 @@ public class PricePolicy {
             Long discountPrice,
             BigDecimal discountRate,
             Long accumulatedPoint,
-            BigDecimal accumulationRate
+            BigDecimal accumulationRate,
+            Long popularity,
+            EntityStatus status,
+            Long orderNum
     ) {
         return PricePolicy.builder()
                 .id(id)
@@ -100,7 +120,9 @@ public class PricePolicy {
                 .discountRate(discountRate)
                 .accumulatedPoint(accumulatedPoint)
                 .accumulationRate(accumulationRate)
-                .status(EntityStatus.ACTIVE)
+                .popularity(popularity)
+                .status(status)
+                .orderNum(orderNum)
                 .build();
     }
 
@@ -128,6 +150,9 @@ public class PricePolicy {
             BigDecimal discountRate,
             Long accumulatedPoint,
             BigDecimal accumulationRate,
+            Long popularity,
+            EntityStatus status,
+            Long orderNum,
             List<Long> optionIds
     ) {
         return PricePolicy.builder()
@@ -137,8 +162,10 @@ public class PricePolicy {
                 .discountRate(discountRate)
                 .accumulatedPoint(accumulatedPoint)
                 .accumulationRate(accumulationRate)
+                .popularity(popularity)
+                .status(status)
+                .orderNum(orderNum)
                 .optionIds(optionIds)
-                .status(EntityStatus.ACTIVE)
                 .build();
     }
 
@@ -148,5 +175,9 @@ public class PricePolicy {
 
     public void addProduct(Product product) {
         this.product = product;
+    }
+
+    public Long getProductId() {
+        return product.getId();
     }
 }


### PR DESCRIPTION
## partially addresses #128
## resolves #158

## Task
- [x] 가격 정책 테이블에 order_num, popularity 컬럼 추가
- [x] 가격 정책 튜플 생성 시 order_num 삽입 로직 추가
- [x] 상품 목록 조회 기능 무한 스크롤 및 정렬 기준 전체 로직 수정