### PR TITLE
[#128][#221] feat: 장바구니 상품 옵션 변경 시 기존 담긴 상품의 가격 정책 중복 확인 로직 추가

### DIFF
--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/cart/CartPersistenceAdapter.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/cart/CartPersistenceAdapter.java
@@ -48,6 +48,11 @@ public class CartPersistenceAdapter implements SaveCartProductPort, FindCartProd
     }
 
     @Override
+    public boolean existsByUserIdAndPolicyId(Long userId, Long pricePolicyId) {
+        return cartJpaRepository.existsByUserIdAndPolicyId(userId, pricePolicyId);
+    }
+
+    @Override
     public void update(CartProduct cartProduct, Long originalPricePolicyId) throws CartProductNotFoundException {
         CartProductJpaEntity entity = findCartProductEntity(
                 cartProduct.getUserId(),

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/cart/repository/CartJpaRepository.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/cart/repository/CartJpaRepository.java
@@ -50,4 +50,14 @@ public interface CartJpaRepository extends JpaRepository<CartProductJpaEntity, L
                     """
     )
     void deleteByUserId(Long userId);
+
+    @Query(
+            """
+                    SELECT COUNT(*) FROM CartProductJpaEntity c 
+                    WHERE 1 = 1
+                    AND c.id.userId = :userId 
+                    AND c.id.pricePolicyId = :pricePolicyId
+                    """
+    )
+    boolean existsByUserIdAndPolicyId(Long userId, Long pricePolicyId);
 }

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/pricepolicy/repository/PricePolicyJpaRepository.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/pricepolicy/repository/PricePolicyJpaRepository.java
@@ -10,16 +10,19 @@ import java.util.List;
 import java.util.Optional;
 
 public interface PricePolicyJpaRepository extends JpaRepository<PricePolicyJpaEntity, Long> {
-    boolean existsByIdAndProductJpaEntity_Id(Long id, Long productId);
-
     @Query("""
-            select p from PricePolicyJpaEntity p
+            select p
+            from PricePolicyJpaEntity p
             where p.id = (
-                select popp.id.pricePolicyId
-                from ProductOptionPricePolicyJpaEntity popp
-                where popp.id.productOptionId in :optionIds
-                group by popp.id.pricePolicyId
-                having count(distinct popp.id.productOptionId) = :#{#optionIds.size()}
+                select max(matched.id.pricePolicyId)
+                from ProductOptionPricePolicyJpaEntity matched
+                where matched.id.pricePolicyId in (
+                    select popp.id.pricePolicyId
+                    from ProductOptionPricePolicyJpaEntity popp
+                    where popp.id.productOptionId in :optionIds
+                    group by popp.id.pricePolicyId
+                    having count(distinct popp.id.productOptionId) = :#{#optionIds.size()}
+                )
             )
             """)
     Optional<PricePolicyJpaEntity> findByOptionIds(List<Long> optionIds);

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/exception/CartProductAlreadyExistsException.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/exception/CartProductAlreadyExistsException.java
@@ -1,0 +1,13 @@
+package com.personal.marketnote.product.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CartProductAlreadyExistsException extends IllegalStateException {
+    private static final String CART_PRODUCT_ALREADY_EXISTS_EXCEPTION_MESSAGE
+            = "장바구니에 이미 해당 상품이 존재합니다. 전송된 사용자 ID: %d, 가격 정책 ID: %d";
+
+    public CartProductAlreadyExistsException(Long userId, Long policyId) {
+        super(String.format(CART_PRODUCT_ALREADY_EXISTS_EXCEPTION_MESSAGE, userId, policyId));
+    }
+}

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/usecase/cart/GetCartProductUseCase.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/usecase/cart/GetCartProductUseCase.java
@@ -9,4 +9,6 @@ public interface GetCartProductUseCase {
      * @return 장바구니 상품 {@link CartProduct}
      */
     CartProduct getCartProduct(Long userId, Long pricePolicyId);
+
+    boolean existsByUserIdAndPolicyId(Long userId, Long policyId);
 }

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/out/cart/FindCartProductPort.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/out/cart/FindCartProductPort.java
@@ -6,4 +6,6 @@ import java.util.Optional;
 
 public interface FindCartProductPort {
     Optional<CartProduct> findCartProductByUserIdAndPricePolicyId(Long userId, Long pricePolicyId);
+
+    boolean existsByUserIdAndPolicyId(Long userId, Long pricePolicyId);
 }

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/service/cart/GetCartProductService.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/service/cart/GetCartProductService.java
@@ -21,4 +21,9 @@ public class GetCartProductService implements GetCartProductUseCase {
         return findCartProductPort.findCartProductByUserIdAndPricePolicyId(userId, pricePolicyId)
                 .orElseThrow(() -> new CartProductNotFoundException(pricePolicyId));
     }
+
+    @Override
+    public boolean existsByUserIdAndPolicyId(Long userId, Long policyId) {
+        return findCartProductPort.existsByUserIdAndPolicyId(userId, policyId);
+    }
 }


### PR DESCRIPTION
## partially addresses #128
## resolves #221

## Task
장바구니 상품 옵션 변경 시 기존 담긴 상품의 가격 정책 중복 확인 로직 추가