### PR TITLE
[#128][#293] feat: 장바구니 및 주문 대기 상품 목록 조회 시 현재 재고 조회 로직 추가

### DIFF
--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/client/cart/controller/apidocs/AddCartProductApiDocs.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/client/cart/controller/apidocs/AddCartProductApiDocs.java
@@ -37,7 +37,6 @@ import java.lang.annotation.*;
                 
                 | **키** | **타입** | **설명** | **필수 여부** | **예시** |
                 | --- | --- | --- | --- | --- |
-                | productId | number | 상품 ID | Y | 1 |
                 | pricePolicyId | number | 가격 정책 ID | Y | 1 |
                 | imageUrl | string | 상품 이미지 URL | Y | "https://marketnote.s3.amazonaws.com/product/30/1763534195922_image_600.png" |
                 | quantity | number | 상품 수량 | Y | 1 |
@@ -62,7 +61,6 @@ import java.lang.annotation.*;
                         schema = @Schema(implementation = AddCartProductRequest.class),
                         examples = @ExampleObject("""
                                 {
-                                    "productId": 1,
                                     "pricePolicyId": 1,
                                     "imageUrl": "https://marketnote.s3.amazonaws.com/product/30/1763534195922_image_600.png",
                                     "quantity": 1

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/client/cart/request/AddCartProductRequest.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/client/cart/request/AddCartProductRequest.java
@@ -6,12 +6,6 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 
 public record AddCartProductRequest(
-        @Schema(description = "상품 ID")
-        @NotNull(message = "상품 ID는 필수입니다.")
-        @Min(value = 1, message = "상품 ID는 1 이상이어야 합니다.")
-        @Max(value = Long.MAX_VALUE, message = "상품 ID는 정수형 최대값을 초과할 수 없습니다.")
-        Long productId,
-
         @Schema(description = "가격 정책 ID")
         @NotNull(message = "가격 정책 ID는 필수입니다.")
         @Min(value = 1, message = "가격 정책 ID는 1 이상이어야 합니다.")

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/result/cart/GetCartProductResult.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/result/cart/GetCartProductResult.java
@@ -10,21 +10,24 @@ import lombok.Builder;
 public record GetCartProductResult(
         CartProductItemResult product,
         GetProductPricePolicyResult pricePolicy,
+        Integer stock,
         Short quantity
 ) {
-    public static GetCartProductResult from(CartProduct cartProduct) {
+    public static GetCartProductResult from(CartProduct cartProduct, Integer stock) {
         return GetCartProductResult.builder()
                 .pricePolicy(GetProductPricePolicyResult.from(cartProduct.getPricePolicy()))
                 .product(CartProductItemResult.from(cartProduct.getPricePolicy().getProduct(), cartProduct.getImageUrl()))
+                .stock(stock)
                 .quantity(cartProduct.getQuantity())
                 .build();
     }
 
-    public static GetCartProductResult from(PricePolicy pricePolicy, String imageUrl, Short quantity) {
+    public static GetCartProductResult of(PricePolicy pricePolicy, String imageUrl, Short quantity, Integer stock) {
         return GetCartProductResult.builder()
                 .pricePolicy(GetProductPricePolicyResult.from(pricePolicy))
                 .product(CartProductItemResult.from(pricePolicy.getProduct(), imageUrl))
                 .quantity(quantity)
+                .stock(stock)
                 .build();
     }
 }

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/result/cart/GetMyCartProductsResult.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/result/cart/GetMyCartProductsResult.java
@@ -1,21 +1,20 @@
 package com.personal.marketnote.product.port.in.result.cart;
 
 import com.personal.marketnote.product.domain.cart.CartProduct;
-import lombok.AccessLevel;
-import lombok.Builder;
 
 import java.util.List;
+import java.util.Map;
 
-@Builder(access = AccessLevel.PRIVATE)
 public record GetMyCartProductsResult(
         List<GetCartProductResult> cartProducts
 ) {
-    public static GetMyCartProductsResult from(List<CartProduct> userCartProducts) {
-        return GetMyCartProductsResult.builder()
-                .cartProducts(userCartProducts.stream()
-                        .map(GetCartProductResult::from)
+    public static GetMyCartProductsResult from(List<CartProduct> userCartProducts, Map<Long, Integer> inventories) {
+        return new GetMyCartProductsResult(
+                userCartProducts.stream()
+                        .map(cartProduct -> GetCartProductResult.from(
+                                cartProduct, inventories.get(cartProduct.getPricePolicyId())
+                        ))
                         .toList()
-                )
-                .build();
+        );
     }
 }

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/result/product/ProductItemResult.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/result/product/ProductItemResult.java
@@ -81,7 +81,9 @@ public class ProductItemResult {
                 .build();
     }
 
-    public static ProductItemResult from(ProductItemResult productItemResult, GetFileResult catalogImage) {
+    public static ProductItemResult from(
+            ProductItemResult productItemResult, GetFileResult catalogImage, Integer stock
+    ) {
         return ProductItemResult.builder()
                 .id(productItemResult.getId())
                 .sellerId(productItemResult.getSellerId())
@@ -92,6 +94,7 @@ public class ProductItemResult {
                 .productTags(productItemResult.getProductTags())
                 .catalogImage(catalogImage)
                 .selectedOptions(productItemResult.getSelectedOptions())
+                .stock(stock)
                 .orderNum(productItemResult.getOrderNum())
                 .status(productItemResult.getStatus())
                 .build();
@@ -99,9 +102,5 @@ public class ProductItemResult {
 
     public Long getPricePolicyId() {
         return pricePolicy.id();
-    }
-
-    public void addStock(Integer stock) {
-        this.stock = stock;
     }
 }

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/usecase/pricepolicy/GetPricePoliciesUseCase.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/usecase/pricepolicy/GetPricePoliciesUseCase.java
@@ -10,5 +10,3 @@ public interface GetPricePoliciesUseCase {
 
     List<PricePolicy> getPricePolicies(List<Long> ids);
 }
-
-

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/usecase/product/GetProductInventoryUseCase.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/usecase/product/GetProductInventoryUseCase.java
@@ -1,0 +1,15 @@
+package com.personal.marketnote.product.port.in.usecase.product;
+
+import java.util.List;
+import java.util.Map;
+
+public interface GetProductInventoryUseCase {
+    /**
+     * @param pricePolicyIds 가격 정책 ID 목록
+     * @return 상품 재고 목록 {@link Map<Long, Integer>}
+     * @Date 2026-01-08
+     * @Author 성효빈
+     * @Description 가격 정책 ID 목록에 해당하는 상품 재고 목록을 조회합니다.
+     */
+    Map<Long, Integer> getProductStocks(List<Long> pricePolicyIds);
+}

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/out/inventory/FindCacheStockPort.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/out/inventory/FindCacheStockPort.java
@@ -3,9 +3,10 @@ package com.personal.marketnote.product.port.out.inventory;
 import com.personal.marketnote.common.domain.exception.illegalargument.numberformat.ParsingIntegerException;
 
 import java.util.List;
+import java.util.Map;
 
 public interface FindCacheStockPort {
     int findByPricePolicyId(Long pricePolicyId) throws ParsingIntegerException;
 
-    List<Integer> findByPricePolicyIds(List<Long> pricePolicyIds);
+    Map<Long, Integer> findByPricePolicyIds(List<Long> pricePolicyIds);
 }

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/out/result/GetInventoryResult.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/out/result/GetInventoryResult.java
@@ -1,10 +1,20 @@
 package com.personal.marketnote.product.port.out.result;
 
+import com.personal.marketnote.common.utility.FormatValidator;
+
 public record GetInventoryResult(
         Long pricePolicyId,
         Integer stock
 ) {
     public static GetInventoryResult of(Long pricePolicyId, Integer stock) {
         return new GetInventoryResult(pricePolicyId, stock);
+    }
+
+    public boolean hasNoStock() {
+        return !FormatValidator.hasValue(stock);
+    }
+
+    public boolean isMe(Long pricePolicyId) {
+        return FormatValidator.equals(this.pricePolicyId, pricePolicyId);
     }
 }

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/service/cart/GetMyCartProductsService.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/service/cart/GetMyCartProductsService.java
@@ -1,11 +1,16 @@
 package com.personal.marketnote.product.service.cart;
 
 import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.product.domain.cart.CartProduct;
 import com.personal.marketnote.product.port.in.result.cart.GetMyCartProductsResult;
 import com.personal.marketnote.product.port.in.usecase.cart.GetMyCartProductsUseCase;
+import com.personal.marketnote.product.port.in.usecase.product.GetProductInventoryUseCase;
 import com.personal.marketnote.product.port.out.cart.FindCartProductsPort;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
 
 import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
 
@@ -13,10 +18,18 @@ import static org.springframework.transaction.annotation.Isolation.READ_COMMITTE
 @RequiredArgsConstructor
 @Transactional(isolation = READ_COMMITTED, readOnly = true)
 public class GetMyCartProductsService implements GetMyCartProductsUseCase {
+    private final GetProductInventoryUseCase getProductInventoryUseCase;
     private final FindCartProductsPort findCartProductsPort;
 
     @Override
     public GetMyCartProductsResult getMyCartProducts(Long userId) {
-        return GetMyCartProductsResult.from(findCartProductsPort.findByUserId(userId));
+        List<CartProduct> cartProducts = findCartProductsPort.findByUserId(userId);
+        Map<Long, Integer> inventories = getProductInventoryUseCase.getProductStocks(
+                cartProducts.stream()
+                        .map(CartProduct::getPricePolicyId)
+                        .toList()
+        );
+
+        return GetMyCartProductsResult.from(cartProducts, inventories);
     }
 }

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/service/product/GetMyOrderingProductsService.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/service/product/GetMyOrderingProductsService.java
@@ -9,11 +9,13 @@ import com.personal.marketnote.product.port.in.result.cart.GetCartProductResult;
 import com.personal.marketnote.product.port.in.result.product.GetMyOrderProductsResult;
 import com.personal.marketnote.product.port.in.usecase.pricepolicy.GetPricePoliciesUseCase;
 import com.personal.marketnote.product.port.in.usecase.product.GetMyOrderingProductsUseCase;
+import com.personal.marketnote.product.port.in.usecase.product.GetProductInventoryUseCase;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
 
@@ -22,17 +24,21 @@ import static org.springframework.transaction.annotation.Isolation.READ_COMMITTE
 @Transactional(isolation = READ_COMMITTED, readOnly = true)
 public class GetMyOrderingProductsService implements GetMyOrderingProductsUseCase {
     private final GetPricePoliciesUseCase getPricePoliciesUseCase;
+    private final GetProductInventoryUseCase getProductInventoryUseCase;
 
     @Override
     public GetMyOrderProductsResult getMyOrderingProducts(
             GetMyOrderingProductsCommand getMyOrderingProductsCommand
     ) {
-        List<PricePolicy> pricePolicies = getPricePoliciesUseCase.getPricePolicies(
-                getMyOrderingProductsCommand.orderingItemCommands()
-                        .stream()
-                        .map(OrderingItemCommand::pricePolicyId)
-                        .toList()
-        );
+        List<Long> pricePolicyIds = getMyOrderingProductsCommand.orderingItemCommands()
+                .stream()
+                .map(OrderingItemCommand::pricePolicyId)
+                .toList();
+
+        List<PricePolicy> pricePolicies = getPricePoliciesUseCase.getPricePolicies(pricePolicyIds);
+
+        // 상품 재고 수량 조회
+        Map<Long, Integer> stocks = getProductInventoryUseCase.getProductStocks(pricePolicyIds);
 
         List<GetCartProductResult> orderingProducts = new ArrayList<>();
         pricePolicies.forEach(
@@ -46,8 +52,11 @@ public class GetMyOrderingProductsService implements GetMyOrderingProductsUseCas
                         .findFirst()
                         .ifPresent(
                                 command -> orderingProducts.add(
-                                        GetCartProductResult.from(
-                                                pricePolicy, command.imageUrl(), command.quantity()
+                                        GetCartProductResult.of(
+                                                pricePolicy,
+                                                command.imageUrl(),
+                                                command.quantity(),
+                                                stocks.get(pricePolicy.getId())
                                         )
                                 )
                         )

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/service/product/GetProductInventoryService.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/service/product/GetProductInventoryService.java
@@ -1,0 +1,57 @@
+package com.personal.marketnote.product.service.product;
+
+import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.product.port.in.usecase.product.GetProductInventoryUseCase;
+import com.personal.marketnote.product.port.out.inventory.FindCacheStockPort;
+import com.personal.marketnote.product.port.out.inventory.FindStockPort;
+import com.personal.marketnote.product.port.out.inventory.SaveCacheStockPort;
+import com.personal.marketnote.product.port.out.result.GetInventoryResult;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional(isolation = READ_COMMITTED)
+public class GetProductInventoryService implements GetProductInventoryUseCase {
+    private final SaveCacheStockPort saveCacheStockPort;
+    private final FindCacheStockPort findCacheStockPort;
+    private final FindStockPort findStockPort;
+
+    @Override
+    public Map<Long, Integer> getProductStocks(List<Long> pricePolicyIds) {
+        // Cache Memory에서 상품 재고 수량 조회
+        Map<Long, Integer> inventories = findCacheStockPort.findByPricePolicyIds(pricePolicyIds);
+
+        List<Long> pricePolicyIdsWithoutStocks = pricePolicyIds.stream()
+                .filter(pricePolicyId -> !FormatValidator.hasValue(inventories.get(pricePolicyId)))
+                .toList();
+
+        if (!FormatValidator.hasValue(pricePolicyIdsWithoutStocks)) {
+            return inventories;
+        }
+
+        // Cache Memory에 저장돼 있지 않은 재고 수량 목록은 커머스 서비스 요청을 통해 조회
+        Set<GetInventoryResult> restInventories
+                = findStockPort.findByPricePolicyIds(pricePolicyIdsWithoutStocks);
+
+        restInventories.forEach(
+                restInventory -> {
+                    Long pricePolicyId = restInventory.pricePolicyId();
+                    Integer stock = restInventory.stock();
+                    inventories.put(pricePolicyId, stock);
+
+                    // Cache Memory에 재고 수량 저장
+                    saveCacheStockPort.save(pricePolicyId, stock);
+                }
+        );
+
+        return inventories;
+    }
+}

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/service/product/RegisterProductService.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/service/product/RegisterProductService.java
@@ -42,6 +42,7 @@ public class RegisterProductService implements RegisterProductUseCase {
                 sellerId, false, RegisterPricePolicyCommand.from(savedProduct.getId(), registerProductCommand)
         );
 
+        // FIXME: Kafka 이벤트 Production으로 변경
         registerInventoryPort.registerInventory(registerPricePolicyResult.id());
 
         return RegisterProductResult.from(savedProduct);

--- a/product-service/product-domain/src/main/java/com/personal/marketnote/product/domain/cart/CartProduct.java
+++ b/product-service/product-domain/src/main/java/com/personal/marketnote/product/domain/cart/CartProduct.java
@@ -51,6 +51,10 @@ public class CartProduct extends BaseDomain {
         return cartProduct;
     }
 
+    public Long getPricePolicyId() {
+        return pricePolicy.getId();
+    }
+
     public void updateQuantity(Short newQuantity) {
         quantity = newQuantity;
     }


### PR DESCRIPTION
## partially addresses #128
## resolves #293

## Task
- [x] 기존 재고 조회 로직 리팩터링 및 서비스 분리
- [x] 장바구니 상품 목록 조회 시 현재 재고 조회 로직 추가
- [x] 주문 대기 상품 목록 조회 시 현재 재고 조회 로직 추가
- [x] Swagger docs