### PR TITLE
[#216][#295] feat: 상품 재고 목록 조회 요청 시 재고 도메인이 존재하지 않는 경우, 튜플 생성 및 Cache Memory에 저장하도록 변경

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/inventory/InventoryPersistenceAdapter.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/inventory/InventoryPersistenceAdapter.java
@@ -32,6 +32,15 @@ public class InventoryPersistenceAdapter implements SaveInventoryPort, FindInven
     }
 
     @Override
+    public void save(Set<Inventory> inventories) {
+        inventoryJpaRepository.saveAll(
+                inventories.stream()
+                        .map(InventoryJpaEntity::from)
+                        .toList()
+        );
+    }
+
+    @Override
     public Set<Inventory> findByPricePolicyIds(Set<Long> pricePolicyIds) {
         return inventoryJpaRepository.findByPricePolicyIds(pricePolicyIds)
                 .stream()

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/command/inventory/RegisterInventoryCommand.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/command/inventory/RegisterInventoryCommand.java
@@ -3,7 +3,6 @@ package com.personal.marketnote.commerce.port.in.command.inventory;
 public record RegisterInventoryCommand(
         Long pricePolicyId
 ) {
-
     public static RegisterInventoryCommand of(
             Long pricePolicyId
     ) {

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/inventory/RegisterInventoryUseCase.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/inventory/RegisterInventoryUseCase.java
@@ -1,6 +1,9 @@
 package com.personal.marketnote.commerce.port.in.usecase.inventory;
 
+import com.personal.marketnote.commerce.domain.inventory.Inventory;
 import com.personal.marketnote.commerce.port.in.command.inventory.RegisterInventoryCommand;
+
+import java.util.Set;
 
 public interface RegisterInventoryUseCase {
     /**
@@ -10,4 +13,12 @@ public interface RegisterInventoryUseCase {
      * @Description 재고 도메인을 등록합니다.
      */
     void registerInventory(RegisterInventoryCommand command);
+
+    /**
+     * @param commands 재고 도메인 등록 커맨드 목록
+     * @Date 2026-01-09
+     * @Author 성효빈
+     * @Description 재고 도메인을 등록합니다.
+     */
+    Set<Inventory> registerInventories(Set<RegisterInventoryCommand> commands);
 }

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/inventory/SaveInventoryPort.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/inventory/SaveInventoryPort.java
@@ -2,7 +2,11 @@ package com.personal.marketnote.commerce.port.out.inventory;
 
 import com.personal.marketnote.commerce.domain.inventory.Inventory;
 
+import java.util.Set;
+
 public interface SaveInventoryPort {
     void save(Inventory inventory);
+
+    void save(Set<Inventory> inventories);
 }
 

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/inventory/GetInventoryService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/inventory/GetInventoryService.java
@@ -1,7 +1,9 @@
 package com.personal.marketnote.commerce.service.inventory;
 
 import com.personal.marketnote.commerce.domain.inventory.Inventory;
+import com.personal.marketnote.commerce.port.in.command.inventory.RegisterInventoryCommand;
 import com.personal.marketnote.commerce.port.in.usecase.inventory.GetInventoryUseCase;
+import com.personal.marketnote.commerce.port.in.usecase.inventory.RegisterInventoryUseCase;
 import com.personal.marketnote.commerce.port.out.inventory.FindInventoryPort;
 import com.personal.marketnote.common.application.UseCase;
 import lombok.RequiredArgsConstructor;
@@ -17,10 +19,27 @@ import static org.springframework.transaction.annotation.Isolation.READ_COMMITTE
 @RequiredArgsConstructor
 @Transactional(isolation = READ_COMMITTED, readOnly = true)
 public class GetInventoryService implements GetInventoryUseCase {
+    private final RegisterInventoryUseCase registerInventoryUseCase;
     private final FindInventoryPort findInventoryPort;
 
     @Override
     public Set<Inventory> getInventories(List<Long> pricePolicyIds) {
-        return findInventoryPort.findByPricePolicyIds(new HashSet<>(pricePolicyIds));
+        Set<Inventory> inventories = findInventoryPort.findByPricePolicyIds(new HashSet<>(pricePolicyIds));
+
+        // FIXME: Kafka 이벤트 Production으로 변경
+        // 존재하지 않는 재고 튜플/Cache Memory 신규 생성
+        if (inventories.size() != pricePolicyIds.size()) {
+            Set<RegisterInventoryCommand> commands = new HashSet<>();
+            pricePolicyIds.stream()
+                    .filter(pricePolicyId -> inventories.stream()
+                            .filter(inventory -> inventory.isMe(pricePolicyId))
+                            .findFirst()
+                            .isEmpty())
+                    .forEach(pricePolicyId -> commands.add(RegisterInventoryCommand.of(pricePolicyId)));
+
+            inventories.addAll(registerInventoryUseCase.registerInventories(commands));
+        }
+
+        return inventories;
     }
 }

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/inventory/Inventory.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/inventory/Inventory.java
@@ -1,6 +1,9 @@
 package com.personal.marketnote.commerce.domain.inventory;
 
+import com.personal.marketnote.common.utility.FormatValidator;
 import lombok.*;
+
+import static org.hibernate.type.descriptor.java.IntegerJavaType.ZERO;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
@@ -13,6 +16,7 @@ public class Inventory {
     public static Inventory of(Long pricePolicyId) {
         return Inventory.builder()
                 .pricePolicyId(pricePolicyId)
+                .stock(Stock.of(ZERO.toString()))
                 .build();
     }
 
@@ -30,5 +34,9 @@ public class Inventory {
 
     public Integer getStockValue() {
         return stock.getValue();
+    }
+
+    public boolean isMe(Long pricePolicyId) {
+        return FormatValidator.equals(this.pricePolicyId, pricePolicyId);
     }
 }

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/usecase/product/GetProductInventoryUseCase.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/usecase/product/GetProductInventoryUseCase.java
@@ -7,7 +7,7 @@ public interface GetProductInventoryUseCase {
     /**
      * @param pricePolicyIds 가격 정책 ID 목록
      * @return 상품 재고 목록 {@link Map<Long, Integer>}
-     * @Date 2026-01-08
+     * @Date 2026-01-09
      * @Author 성효빈
      * @Description 가격 정책 ID 목록에 해당하는 상품 재고 목록을 조회합니다.
      */

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/service/product/GetProductInventoryService.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/service/product/GetProductInventoryService.java
@@ -5,7 +5,6 @@ import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.product.port.in.usecase.product.GetProductInventoryUseCase;
 import com.personal.marketnote.product.port.out.inventory.FindCacheStockPort;
 import com.personal.marketnote.product.port.out.inventory.FindStockPort;
-import com.personal.marketnote.product.port.out.inventory.SaveCacheStockPort;
 import com.personal.marketnote.product.port.out.result.GetInventoryResult;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,7 +19,6 @@ import static org.springframework.transaction.annotation.Isolation.READ_COMMITTE
 @RequiredArgsConstructor
 @Transactional(isolation = READ_COMMITTED)
 public class GetProductInventoryService implements GetProductInventoryUseCase {
-    private final SaveCacheStockPort saveCacheStockPort;
     private final FindCacheStockPort findCacheStockPort;
     private final FindStockPort findStockPort;
 
@@ -42,14 +40,7 @@ public class GetProductInventoryService implements GetProductInventoryUseCase {
                 = findStockPort.findByPricePolicyIds(pricePolicyIdsWithoutStocks);
 
         restInventories.forEach(
-                restInventory -> {
-                    Long pricePolicyId = restInventory.pricePolicyId();
-                    Integer stock = restInventory.stock();
-                    inventories.put(pricePolicyId, stock);
-
-                    // Cache Memory에 재고 수량 저장
-                    saveCacheStockPort.save(pricePolicyId, stock);
-                }
+                restInventory -> inventories.put(restInventory.pricePolicyId(), restInventory.stock())
         );
 
         return inventories;

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/service/product/GetProductService.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/service/product/GetProductService.java
@@ -80,7 +80,6 @@ public class GetProductService implements GetProductUseCase {
         Product product = getProduct(id);
         List<ProductOptionCategory> categories
                 = findProductOptionCategoryPort.findActiveWithOptionsByProductId(product.getId());
-
         List<PricePolicy> pricePolicies
                 = findPricePoliciesPort.findByProductId(product.getId());
         PricePolicy defaultPricePolicy = pricePolicies.stream()
@@ -107,8 +106,7 @@ public class GetProductService implements GetProductUseCase {
         Long pricePolicyId = selectedPricePolicy.getId();
 
         // 상품 재고 수량 조회
-        Map<Long, Integer> inventories
-                = getProductInventoryUseCase.getProductStocks(List.of(pricePolicyId));
+        Map<Long, Integer> inventories = getProductInventoryUseCase.getProductStocks(List.of(pricePolicyId));
 
         GetProductInfoResult productInfo
                 = GetProductInfoResult.from(product, selectedPricePolicy, inventories.get(pricePolicyId));


### PR DESCRIPTION
## partially addresses #216
## resolves #295

## Task
- [x] 재고 튜플 저장
- [x] 재고 Cache Memory 저장