### PR TITLE
[#128][#158] fix: 상품 목록 조회 시 적립금, 인기도의 정렬 방향이 반대로 조회되는 버그 수정

### DIFF
--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/pricepolicy/repository/PricePolicyJpaRepository.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/pricepolicy/repository/PricePolicyJpaRepository.java
@@ -108,9 +108,9 @@ public interface PricePolicyJpaRepository extends JpaRepository<PricePolicyJpaEn
               )
             ORDER BY
                 CASE WHEN :sortProperty = 'orderNum' THEN pp.orderNum END ASC,
-                CASE WHEN :sortProperty = 'popularity' THEN pp.popularity END DESC,
+                CASE WHEN :sortProperty = 'popularity' THEN pp.popularity END ASC,
                 CASE WHEN :sortProperty = 'discountPrice' THEN pp.discountPrice END ASC,
-                CASE WHEN :sortProperty = 'accumulatedPoint' THEN pp.accumulatedPoint END DESC,
+                CASE WHEN :sortProperty = 'accumulatedPoint' THEN pp.accumulatedPoint END ASC,
                 pp.id ASC
             """)
     List<PricePolicyJpaEntity> findAllActiveByCursorAsc(
@@ -203,9 +203,9 @@ public interface PricePolicyJpaRepository extends JpaRepository<PricePolicyJpaEn
               )
             ORDER BY
                 CASE WHEN :sortProperty = 'orderNum' THEN pp.orderNum END DESC,
-                CASE WHEN :sortProperty = 'popularity' THEN pp.popularity END ASC,
+                CASE WHEN :sortProperty = 'popularity' THEN pp.popularity END DESC,
                 CASE WHEN :sortProperty = 'discountPrice' THEN pp.discountPrice END DESC,
-                CASE WHEN :sortProperty = 'accumulatedPoint' THEN pp.accumulatedPoint END ASC,
+                CASE WHEN :sortProperty = 'accumulatedPoint' THEN pp.accumulatedPoint END DESC,
                 pp.id DESC
             """)
     List<PricePolicyJpaEntity> findAllActiveByCursorDesc(

--- a/product-service/product-domain/src/main/java/com/personal/marketnote/product/domain/product/ProductSortProperty.java
+++ b/product-service/product-domain/src/main/java/com/personal/marketnote/product/domain/product/ProductSortProperty.java
@@ -5,18 +5,16 @@ import lombok.Getter;
 
 @Getter
 public enum ProductSortProperty {
-    ORDER_NUM("정렬 순서", "orderNum"),
-    POPULARITY("인기도", "popularity"),
-    ACCUMULATED_POINT("적립금", "createdAt"),
-    DISCOUNT_PRICE("할인 가격", "modifiedAt");
+    ORDER_NUM("정렬 순서"),
+    POPULARITY("인기도"),
+    ACCUMULATED_POINT("적립금"),
+    DISCOUNT_PRICE("할인 가격");
 
     private final String description;
-    private final String alternativeKey;
     private final String camelCaseValue;
 
-    ProductSortProperty(String description, String alternativeKey) {
+    ProductSortProperty(String description) {
         this.description = description;
-        this.alternativeKey = alternativeKey;
         camelCaseValue = FormatConverter.snakeToCamel(this.name());
     }
 }


### PR DESCRIPTION
## partially addresses #128
## resolves #158

## Task
- [x] ASC -> DESC
- [x] DESC -> ASC