### PR TITLE
[#128][#142] feat: 상품 목록 조회 시 가격 정책 ID 목록 파라미터 기반 조회 로직 추가

### DIFF
--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/client/product/controller/ProductController.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/client/product/controller/ProductController.java
@@ -126,12 +126,14 @@ public class ProductController {
     /**
      * 상품 목록 조회
      *
-     * @param cursor
-     * @param pageSize      페이지 크기
-     * @param sortDirection 정렬 방향
-     * @param sortProperty  정렬 속성
-     * @param searchTarget  검색 대상
-     * @param searchKeyword 검색 키워드
+     * @param categoryId     카테고리 ID
+     * @param pricePolicyIds 가격 정책 ID 목록
+     * @param cursor         커서(무한 스크롤 페이지 설정)
+     * @param pageSize       페이지 크기
+     * @param sortDirection  정렬 방향
+     * @param sortProperty   정렬 속성
+     * @param searchTarget   검색 대상
+     * @param searchKeyword  검색 키워드
      * @return 상품 목록 조회 응답 {@link GetProductsResponse}
      * @Author 성효빈
      * @Date 2025-12-31
@@ -141,6 +143,7 @@ public class ProductController {
     @GetProductsApiDocs
     public ResponseEntity<BaseResponse<GetProductsResponse>> getProducts(
             @RequestParam(value = "categoryId", required = false) Long categoryId,
+            @RequestParam(value = "pricePolicyIds", required = false) List<Long> pricePolicyIds,
             @RequestParam(value = "cursor", required = false, defaultValue = MINUS_ONE) Long cursor,
             @RequestParam(value = "page-size", defaultValue = GET_PRODUCTS_DEFAULT_PAGE_SIZE) int pageSize,
             @RequestParam(required = false, defaultValue = "DESC") Sort.Direction sortDirection,
@@ -150,6 +153,7 @@ public class ProductController {
     ) {
         GetProductsResult result = getProductUseCase.getProducts(
                 categoryId,
+                pricePolicyIds,
                 cursor,
                 pageSize,
                 sortDirection,

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/client/product/controller/apidocs/GetProductsApiDocs.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/client/product/controller/apidocs/GetProductsApiDocs.java
@@ -46,6 +46,7 @@ import java.lang.annotation.*;
                 
                 | **키** | **타입** | **설명** | **필수 여부** | **예시** |
                 | --- | --- | --- | --- | --- |
+                | pricePolicyIds | array<number> | 가격 정책 ID 목록 | N | 1, 2 |
                 | categoryId | number | 카테고리 ID | N | 1001 |
                 | cursor | number | 이전 페이지의 nextCursor 값, 전송하지 않는 경우 첫 데이터부터 조회 | N | default: -1 |
                 | page-size | number | 페이지 크기 | N | 4 |
@@ -146,6 +147,12 @@ import java.lang.annotation.*;
         @SecurityRequirement(name = "bearer")
 },
         parameters = {
+                @Parameter(
+                        name = "pricePolicyIds",
+                        description = "가격 정책 ID 목록",
+                        in = ParameterIn.QUERY,
+                        schema = @Schema(type = "array")
+                ),
                 @Parameter(
                         name = "categoryId",
                         in = ParameterIn.QUERY,

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/pricepolicy/PricePolicyPersistenceAdapter.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/pricepolicy/PricePolicyPersistenceAdapter.java
@@ -156,6 +156,7 @@ public class PricePolicyPersistenceAdapter implements SavePricePolicyPort, FindP
 
     @Override
     public List<PricePolicy> findActivePage(
+            List<Long> pricePolicyIds,
             Long cursor,
             Pageable pageable,
             ProductSortProperty sortProperty,
@@ -172,6 +173,7 @@ public class PricePolicyPersistenceAdapter implements SavePricePolicyPort, FindP
 
         List<PricePolicyJpaEntity> entities = isAsc
                 ? pricePolicyJpaRepository.findAllActiveByCursorAsc(
+                pricePolicyIds,
                 cursor,
                 pageable,
                 sortProperty.getCamelCaseValue(),
@@ -180,6 +182,7 @@ public class PricePolicyPersistenceAdapter implements SavePricePolicyPort, FindP
                 null
         )
                 : pricePolicyJpaRepository.findAllActiveByCursorDesc(
+                pricePolicyIds,
                 cursor,
                 pageable,
                 sortProperty.getCamelCaseValue(),
@@ -198,6 +201,7 @@ public class PricePolicyPersistenceAdapter implements SavePricePolicyPort, FindP
     @Override
     public List<PricePolicy> findActivePageByCategoryId(
             Long categoryId,
+            List<Long> pricePolicyIds,
             Long cursor,
             Pageable pageable,
             ProductSortProperty sortProperty,
@@ -214,6 +218,7 @@ public class PricePolicyPersistenceAdapter implements SavePricePolicyPort, FindP
 
         List<PricePolicyJpaEntity> entities = isAsc
                 ? pricePolicyJpaRepository.findAllActiveByCursorAsc(
+                pricePolicyIds,
                 cursor,
                 pageable,
                 sortProperty.getCamelCaseValue(),
@@ -222,6 +227,7 @@ public class PricePolicyPersistenceAdapter implements SavePricePolicyPort, FindP
                 categoryId
         )
                 : pricePolicyJpaRepository.findAllActiveByCursorDesc(
+                pricePolicyIds,
                 cursor,
                 pageable,
                 sortProperty.getCamelCaseValue(),

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/pricepolicy/repository/PricePolicyJpaRepository.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/pricepolicy/repository/PricePolicyJpaRepository.java
@@ -48,60 +48,34 @@ public interface PricePolicyJpaRepository extends JpaRepository<PricePolicyJpaEn
                           AND pc.categoryId = :categoryId
                  )
               )
+              /* >>> 변경 부분 시작: pricePolicyIds 조건 추가 */
+              AND (
+                    :pricePolicyIds IS NULL
+                    OR pp.id IN (:pricePolicyIds)
+              )
+              /* <<< 변경 부분 끝 */
               AND (
                     :cursor IS NULL
                  OR NOT EXISTS (SELECT 1 FROM PricePolicyJpaEntity pp0 WHERE pp0.id = :cursor)
                  OR (
                         (:sortProperty = 'orderNum' AND (
-                              pp.orderNum > (
-                                  SELECT pp2.orderNum
-                                  FROM PricePolicyJpaEntity pp2
-                                  WHERE pp2.id = :cursor
-                              )
-                           OR (pp.orderNum = (
-                                    SELECT pp2.orderNum
-                                    FROM PricePolicyJpaEntity pp2
-                                    WHERE pp2.id = :cursor
-                                )
+                              pp.orderNum > (SELECT pp2.orderNum FROM PricePolicyJpaEntity pp2 WHERE pp2.id = :cursor)
+                           OR (pp.orderNum = (SELECT pp2.orderNum FROM PricePolicyJpaEntity pp2 WHERE pp2.id = :cursor)
                                AND pp.id > :cursor)
                         ))
                      OR (:sortProperty = 'popularity' AND (
-                              pp.popularity > (
-                                  SELECT pp3.popularity
-                                  FROM PricePolicyJpaEntity pp3
-                                  WHERE pp3.id = :cursor
-                              )
-                           OR (pp.popularity = (
-                                    SELECT pp3.popularity
-                                    FROM PricePolicyJpaEntity pp3
-                                    WHERE pp3.id = :cursor
-                                )
+                              pp.popularity > (SELECT pp3.popularity FROM PricePolicyJpaEntity pp3 WHERE pp3.id = :cursor)
+                           OR (pp.popularity = (SELECT pp3.popularity FROM PricePolicyJpaEntity pp3 WHERE pp3.id = :cursor)
                                AND pp.id > :cursor)
                         ))
                      OR (:sortProperty = 'discountPrice' AND (
-                              pp.discountPrice > (
-                                  SELECT pp4.discountPrice
-                                  FROM PricePolicyJpaEntity pp4
-                                  WHERE pp4.id = :cursor
-                              )
-                           OR (pp.discountPrice = (
-                                    SELECT pp4.discountPrice
-                                    FROM PricePolicyJpaEntity pp4
-                                    WHERE pp4.id = :cursor
-                                )
+                              pp.discountPrice > (SELECT pp4.discountPrice FROM PricePolicyJpaEntity pp4 WHERE pp4.id = :cursor)
+                           OR (pp.discountPrice = (SELECT pp4.discountPrice FROM PricePolicyJpaEntity pp4 WHERE pp4.id = :cursor)
                                AND pp.id > :cursor)
                         ))
                      OR (:sortProperty = 'accumulatedPoint' AND (
-                              pp.accumulatedPoint > (
-                                  SELECT pp5.accumulatedPoint
-                                  FROM PricePolicyJpaEntity pp5
-                                  WHERE pp5.id = :cursor
-                              )
-                           OR (pp.accumulatedPoint = (
-                                    SELECT pp5.accumulatedPoint
-                                    FROM PricePolicyJpaEntity pp5
-                                    WHERE pp5.id = :cursor
-                                )
+                              pp.accumulatedPoint > (SELECT pp5.accumulatedPoint FROM PricePolicyJpaEntity pp5 WHERE pp5.id = :cursor)
+                           OR (pp.accumulatedPoint = (SELECT pp5.accumulatedPoint FROM PricePolicyJpaEntity pp5 WHERE pp5.id = :cursor)
                                AND pp.id > :cursor)
                         ))
                  )
@@ -114,6 +88,7 @@ public interface PricePolicyJpaRepository extends JpaRepository<PricePolicyJpaEn
                 pp.id ASC
             """)
     List<PricePolicyJpaEntity> findAllActiveByCursorAsc(
+            @Param("pricePolicyIds") List<Long> pricePolicyIds,
             @Param("cursor") Long cursor,
             Pageable pageable,
             @Param("sortProperty") String sortProperty,
@@ -142,6 +117,10 @@ public interface PricePolicyJpaRepository extends JpaRepository<PricePolicyJpaEn
                         WHERE pc.productId = p.id
                           AND pc.categoryId = :categoryId
                  )
+              )
+              AND (
+                    :pricePolicyIds IS NULL
+                 OR pp.id IN :pricePolicyIds
               )
               AND (
                     :cursor IS NULL
@@ -209,6 +188,7 @@ public interface PricePolicyJpaRepository extends JpaRepository<PricePolicyJpaEn
                 pp.id DESC
             """)
     List<PricePolicyJpaEntity> findAllActiveByCursorDesc(
+            @Param("pricePolicyIds") List<Long> pricePolicyIds,
             @Param("cursor") Long cursor,
             Pageable pageable,
             @Param("sortProperty") String sortProperty,
@@ -216,5 +196,4 @@ public interface PricePolicyJpaRepository extends JpaRepository<PricePolicyJpaEn
             @Param("pattern") String pattern,
             @Param("categoryId") Long categoryId
     );
-
 }

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/usecase/product/GetProductUseCase.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/usecase/product/GetProductUseCase.java
@@ -30,13 +30,14 @@ public interface GetProductUseCase {
     GetProductInfoWithOptionsResult getProductInfo(Long id, List<Long> selectedOptionIds);
 
     /**
-     * @param categoryId    카테고리 ID
-     * @param cursor        커서
-     * @param pageSize      페이지 크기
-     * @param sortDirection 정렬 방향
-     * @param sortProperty  정렬 속성
-     * @param searchTarget  검색 대상
-     * @param searchKeyword 검색 키워드
+     * @param categoryId     카테고리 ID
+     * @param pricePolicyIds 가격 정책 ID 목록
+     * @param cursor         커서(무한 스크롤 페이지 설정)
+     * @param pageSize       페이지 크기
+     * @param sortDirection  정렬 방향
+     * @param sortProperty   정렬 속성
+     * @param searchTarget   검색 대상
+     * @param searchKeyword  검색 키워드
      * @return 상품 목록 조회 결과 {@link GetProductsResult}
      * @Date 2025-12-31
      * @Author 성효빈
@@ -44,6 +45,7 @@ public interface GetProductUseCase {
      */
     GetProductsResult getProducts(
             Long categoryId,
+            List<Long> pricePolicyIds,
             Long cursor,
             int pageSize,
             Sort.Direction sortDirection,

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/out/pricepolicy/FindPricePoliciesPort.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/out/pricepolicy/FindPricePoliciesPort.java
@@ -13,6 +13,7 @@ public interface FindPricePoliciesPort {
     List<PricePolicy> findByIds(List<Long> ids);
 
     List<PricePolicy> findActivePage(
+            List<Long> pricePolicyIds,
             Long cursor,
             Pageable pageable,
             ProductSortProperty sortProperty,
@@ -22,6 +23,7 @@ public interface FindPricePoliciesPort {
 
     List<PricePolicy> findActivePageByCategoryId(
             Long categoryId,
+            List<Long> pricePolicyIds,
             Long cursor,
             Pageable pageable,
             ProductSortProperty sortProperty,

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/service/product/GetProductService.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/service/product/GetProductService.java
@@ -152,6 +152,7 @@ public class GetProductService implements GetProductUseCase {
     @Override
     public GetProductsResult getProducts(
             Long categoryId,
+            List<Long> pricePolicyIds,
             Long cursor,
             int pageSize,
             Sort.Direction sortDirection,
@@ -170,6 +171,7 @@ public class GetProductService implements GetProductUseCase {
         List<PricePolicy> pricePolicies = isCategorized
                 ? findPricePoliciesPort.findActivePageByCategoryId(
                 categoryId,
+                pricePolicyIds,
                 cursor,
                 pageable,
                 sortProperty,
@@ -177,6 +179,7 @@ public class GetProductService implements GetProductUseCase {
                 searchKeyword
         )
                 : findPricePoliciesPort.findActivePage(
+                pricePolicyIds,
                 cursor,
                 pageable,
                 sortProperty,
@@ -192,7 +195,7 @@ public class GetProductService implements GetProductUseCase {
 
         Long nextCursor = null;
         if (FormatValidator.hasValue(pagePolicies)) {
-            nextCursor = pagePolicies.get(pagePolicies.size() - 1).getId();
+            nextCursor = pagePolicies.getLast().getId();
         }
 
         List<ProductItemResult> pageItems = pagePolicies.stream()


### PR DESCRIPTION
## partially addresses #128
## resolves #142

## Task
- [x] 요청 파라미터에 가격 정책 ID 목록 추가
- [x] RDBMS에서 가격 정책 ID 목록 기반 상품 목록 조회 로직 추가
- [x] Swagger 문서 업데이트