### PR TITLE
[#216][#299] feat: 회원 주문 내역 조회 시 날짜 별 정렬/필터/검색 기능 추가

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/client/order/controller/OrderController.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/client/order/controller/OrderController.java
@@ -10,7 +10,11 @@ import com.personal.marketnote.commerce.adapter.in.client.order.request.Register
 import com.personal.marketnote.commerce.adapter.in.client.order.response.GetOrderResponse;
 import com.personal.marketnote.commerce.adapter.in.client.order.response.GetOrdersResponse;
 import com.personal.marketnote.commerce.adapter.in.client.order.response.RegisterOrderResponse;
+import com.personal.marketnote.commerce.domain.order.OrderPeriod;
+import com.personal.marketnote.commerce.domain.order.OrderStatusFilter;
+import com.personal.marketnote.commerce.port.in.command.order.GetOrdersQuery;
 import com.personal.marketnote.commerce.port.in.result.order.GetOrderResult;
+import com.personal.marketnote.commerce.port.in.result.order.GetOrdersDomainResult;
 import com.personal.marketnote.commerce.port.in.result.order.GetOrdersResult;
 import com.personal.marketnote.commerce.port.in.result.order.RegisterOrderResult;
 import com.personal.marketnote.commerce.port.in.usecase.order.ChangeOrderStatusUseCase;
@@ -108,10 +112,22 @@ public class OrderController {
     @GetMapping
     @GetOrdersApiDocs
     public ResponseEntity<BaseResponse<GetOrdersResponse>> getOrderHistory(
-            @AuthenticationPrincipal OAuth2AuthenticatedPrincipal principal
+            @AuthenticationPrincipal OAuth2AuthenticatedPrincipal principal,
+            @RequestParam(value = "period", required = false) OrderPeriod period,
+            @RequestParam(value = "status", required = false) OrderStatusFilter statusFilter,
+            @RequestParam(value = "productName", required = false) String productName
     ) {
+        GetOrdersDomainResult domainResult = getOrderUseCase.getOrders(
+                GetOrdersQuery.of(
+                        ElementExtractor.extractUserId(principal),
+                        period,
+                        statusFilter,
+                        productName
+                )
+        );
         GetOrdersResult getOrdersResult = GetOrdersResult.from(
-                getOrderUseCase.getOrders(ElementExtractor.extractUserId(principal))
+                domainResult.orders(),
+                domainResult.productSummaries()
         );
 
         return new ResponseEntity<>(

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/client/order/controller/apidocs/GetOrdersApiDocs.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/client/order/controller/apidocs/GetOrdersApiDocs.java
@@ -14,7 +14,7 @@ import java.lang.annotation.*;
 @Operation(
         summary = "회원 주문 내역 조회",
         description = """
-                작성일자: 2026-01-06
+                작성일자: 2026-01-09
                 
                 작성자: 성효빈
                 
@@ -30,6 +30,9 @@ import java.lang.annotation.*;
                 
                 | **키** | **타입** | **설명** | **필수 여부** | **예시** |
                 | --- | --- | --- | --- | --- |
+                | period | string | 조회 기간(ONE_MONTH, THREE_MONTHS, SIX_MONTHS, ONE_YEAR, ALL) | N | ONE_YEAR |
+                | status | string | 주문 상태 필터(SHIPPING, DELIVERED, CONFIRMED, CANCEL_EXCHANGE_REFUND, ALL) | N | SHIPPING |
+                | productName | string | 상품명 검색 키워드(부분 일치) | N | "밀토스테놀" |
                 
                 ---
                 
@@ -39,7 +42,7 @@ import java.lang.annotation.*;
                 | --- | --- | --- | --- |
                 | statusCode | number | 상태 코드 | 201: 성공 / 400: 클라이언트 요청 오류 / 401: 인증 실패 / 403: 인가 실패 / 404: 리소스 조회 실패 / 409: 충돌 / 500: 그 외 |
                 | code | string | 응답 코드 | "SUC01" / "BAD_REQUEST" / "UNAUTHORIZED" / "FORBIDDEN" / "NOT_FOUND" / "CONFLICT" / "INTERNAL_SERVER_ERROR" |
-                | timestamp | string(datetime) | 응답 일시 | "2026-01-06T12:12:30.013" |
+                | timestamp | string(datetime) | 응답 일시 | "2026-01-09T12:12:30.013" |
                 | content | object | 응답 본문 | { ... } |
                 | message | string | 처리 결과 | "회원 주문 내역 조회 성공" |
                 
@@ -49,7 +52,16 @@ import java.lang.annotation.*;
                 
                 | **키** | **타입** | **설명** | **예시** |
                 | --- | --- | --- | --- |
-                | orders | array | 주문 내역 목록 | [ ... ] |
+                | orderHistories | array | 날짜별 주문 내역 묶음 | [ ... ] |
+                
+                ---
+                ### Response > orderHistories
+                
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | orderDate | string(date) | 주문 생성일(일 단위) | "2025-11-01" |
+                | count | number | 해당 날짜의 주문 건수 | 3 |
+                | orders | array | 주문 목록(주문 ID 내림차순) | [ ... ] |
                 
                 ---
                 
@@ -60,7 +72,7 @@ import java.lang.annotation.*;
                 | id | number | 주문 ID | 1 |
                 | sellerId | number | 판매자 회원 ID | 1 |
                 | buyerId | number | 구매자 회원 ID | 1 |
-                | orderStatus | string | 주문 상태 | "PAYMENT_PENDING" |
+                | orderStatus | string | 주문 상태 | "DELIVERED" |
                 | totalAmount | number | 총 주문 금액(원) | 100000 |
                 | paidAmount | number | 결제 금액(원) | 100000 |
                 | couponAmount | number | 쿠폰 할인 금액(원) | 5000 |
@@ -78,6 +90,8 @@ import java.lang.annotation.*;
                 | unitAmount | number | 단위 금액(원) | 50000 |
                 | imageUrl | string | 상품 이미지 URL | "https://marketnote.s3.amazonaws.com/product/30/1763534195922_image_600.png" |
                 | orderStatus | string | 주문 상태 | "PAYMENT_PENDING" |
+                | productId | number | 상품 ID | 10 |
+                | productName | string | 상품명 | "밀토스테놀" |
                 """,
         security = {@SecurityRequirement(name = "bearer")},
         responses = {
@@ -87,67 +101,59 @@ import java.lang.annotation.*;
                         content = @Content(
                                 examples = @ExampleObject("""
                                         {
-                                          "statusCode": 200,
-                                          "code": "SUC01",
-                                          "timestamp": "2026-01-06T11:18:48.109239",
-                                          "content": {
-                                            "orders": [
-                                              {
-                                                "id": 2,
-                                                "sellerId": 1,
-                                                "buyerId": 4,
-                                                "orderStatus": "PAYMENT_PENDING",
-                                                "totalAmount": 120000,
-                                                "paidAmount": null,
-                                                "couponAmount": 5000,
-                                                "pointAmount": 5000,
-                                                "orderProducts": [
-                                                  {
-                                                    "pricePolicyId": 23,
-                                                    "quantity": 2,
-                                                    "unitAmount": 50000,
-                                                    "imageUrl": "https://marketnote.s3.amazonaws.com/product/30/1763534195922_image_600.png",
-                                                    "orderStatus": "PAYMENT_PENDING"
-                                                  },
-                                                  {
-                                                    "pricePolicyId": 14,
-                                                    "quantity": 10,
-                                                    "unitAmount": 70000,
-                                                    "imageUrl": "https://marketnote.s3.amazonaws.com/product/30/1763533916081_image_600.png",
-                                                    "orderStatus": "PAYMENT_PENDING"
-                                                  }
-                                                ]
-                                              },
-                                              {
-                                                "id": 3,
-                                                "sellerId": 1,
-                                                "buyerId": 4,
-                                                "orderStatus": "PAID",
-                                                "totalAmount": 120000,
-                                                "paidAmount": 120000,
-                                                "couponAmount": 5000,
-                                                "pointAmount": 5000,
-                                                "orderProducts": [
-                                                  {
-                                                    "pricePolicyId": 13,
-                                                    "quantity": 2,
-                                                    "unitAmount": 50000,
-                                                    "imageUrl": "https://marketnote.s3.amazonaws.com/product/30/1763534195922_image_600.png",
-                                                    "orderStatus": "PAID"
-                                                  },
-                                                  {
-                                                    "pricePolicyId": 14,
-                                                    "quantity": 10,
-                                                    "unitAmount": 70000,
-                                                    "imageUrl": "https://marketnote.s3.amazonaws.com/product/30/1763533916081_image_600.png",
-                                                    "orderStatus": "PAID"
-                                                  }
-                                                ]
+                                                "statusCode": 200,
+                                                "code": "SUC01",
+                                                "timestamp": "2026-01-09T11:18:48.109239",
+                                                "content": {
+                                                  "orderHistories": [
+                                                    {
+                                                      "orderDate": "2026-01-09",
+                                                      "count": 2,
+                                                      "orders": [
+                                                        {
+                                                          "id": 3,
+                                                          "sellerId": 1,
+                                                          "buyerId": 4,
+                                                          "orderStatus": "DELIVERED",
+                                                          "totalAmount": 120000,
+                                                          "paidAmount": 120000,
+                                                          "couponAmount": 5000,
+                                                          "pointAmount": 5000,
+                                                          "orderProducts": [
+                                                            {
+                                                              "pricePolicyId": 13,
+                                                              "quantity": 2,
+                                                              "unitAmount": 50000,
+                                                              "imageUrl": "https://marketnote.s3.amazonaws.com/product/30/1763534195922_image_600.png",
+                                                              "orderStatus": "DELIVERED"
+                                                            }
+                                                          ]
+                                                        },
+                                                        {
+                                                          "id": 2,
+                                                          "sellerId": 1,
+                                                          "buyerId": 4,
+                                                          "orderStatus": "CONFIRMED",
+                                                          "totalAmount": 120000,
+                                                          "paidAmount": 120000,
+                                                          "couponAmount": 5000,
+                                                          "pointAmount": 5000,
+                                                          "orderProducts": [
+                                                            {
+                                                              "pricePolicyId": 14,
+                                                              "quantity": 10,
+                                                              "unitAmount": 70000,
+                                                              "imageUrl": "https://marketnote.s3.amazonaws.com/product/30/1763533916081_image_600.png",
+                                                              "orderStatus": "CONFIRMED"
+                                                            }
+                                                          ]
+                                                        }
+                                                      ]
+                                                    }
+                                                  ]
+                                                },
+                                                "message": "회원 주문 내역 조회 성공"
                                               }
-                                            ]
-                                          },
-                                          "message": "회원 주문 내역 조회 성공"
-                                        }
                                         """)
                         )
                 ),
@@ -159,7 +165,7 @@ import java.lang.annotation.*;
                                         {
                                           "statusCode": 401,
                                           "code": "UNAUTHORIZED",
-                                          "timestamp": "2026-01-06T12:12:30.013",
+                                          "timestamp": "2026-01-09T12:12:30.013",
                                           "content": null,
                                           "message": "Invalid token"
                                         }
@@ -174,7 +180,7 @@ import java.lang.annotation.*;
                                         {
                                           "statusCode": 403,
                                           "code": "FORBIDDEN",
-                                          "timestamp": "2026-01-06T12:12:30.013",
+                                          "timestamp": "2026-01-09T12:12:30.013",
                                           "content": null,
                                           "message": "Access Denied"
                                         }
@@ -184,4 +190,3 @@ import java.lang.annotation.*;
         })
 public @interface GetOrdersApiDocs {
 }
-

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/client/order/response/GetOrdersResponse.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/client/order/response/GetOrdersResponse.java
@@ -1,17 +1,17 @@
 package com.personal.marketnote.commerce.adapter.in.client.order.response;
 
-import com.personal.marketnote.commerce.port.in.result.order.GetOrderResult;
 import com.personal.marketnote.commerce.port.in.result.order.GetOrdersResult;
-import lombok.AccessLevel;
-import lombok.Builder;
 
 import java.util.List;
 
-@Builder(access = AccessLevel.PRIVATE)
 public record GetOrdersResponse(
-        List<GetOrderResult> orders
+        List<OrderHistoryByDateResponse> orderHistories
 ) {
     public static GetOrdersResponse from(GetOrdersResult getOrdersResult) {
-        return new GetOrdersResponse(getOrdersResult.orders());
+        return new GetOrdersResponse(
+                getOrdersResult.orderHistories().stream()
+                        .map(OrderHistoryByDateResponse::from)
+                        .toList()
+        );
     }
 }

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/client/order/response/OrderHistoryByDateResponse.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/client/order/response/OrderHistoryByDateResponse.java
@@ -1,0 +1,21 @@
+package com.personal.marketnote.commerce.adapter.in.client.order.response;
+
+import com.personal.marketnote.commerce.port.in.result.order.GetOrderResult;
+import com.personal.marketnote.commerce.port.in.result.order.OrderHistoryByDateResult;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record OrderHistoryByDateResponse(
+        LocalDate orderDate,
+        Integer count,
+        List<GetOrderResult> orders
+) {
+    public static OrderHistoryByDateResponse from(OrderHistoryByDateResult result) {
+        return new OrderHistoryByDateResponse(
+                result.orderDate(),
+                result.count(),
+                result.orders()
+        );
+    }
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/mapper/OrderJpaEntityToDomainMapper.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/mapper/OrderJpaEntityToDomainMapper.java
@@ -27,7 +27,9 @@ public class OrderJpaEntityToDomainMapper {
                             entity.getPaidAmount(),
                             entity.getCouponAmount(),
                             entity.getPointAmount(),
-                            orderProducts
+                            orderProducts,
+                            entity.getCreatedAt(),
+                            entity.getModifiedAt()
                     );
                 });
     }
@@ -35,8 +37,8 @@ public class OrderJpaEntityToDomainMapper {
     private static Optional<OrderProduct> mapToDomain(OrderProductJpaEntity orderProductJpaEntity) {
         return Optional.ofNullable(orderProductJpaEntity)
                 .map(entity -> OrderProduct.of(
-                        entity.getId().getPricePolicyId(),
                         entity.getId().getOrderId(),
+                        entity.getId().getPricePolicyId(),
                         entity.getQuantity(),
                         entity.getUnitAmount(),
                         entity.getImageUrl(),
@@ -44,4 +46,3 @@ public class OrderJpaEntityToDomainMapper {
                 ));
     }
 }
-

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/order/repository/OrderJpaRepository.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/order/repository/OrderJpaRepository.java
@@ -2,10 +2,30 @@ package com.personal.marketnote.commerce.adapter.out.persistence.order.repositor
 
 import com.personal.marketnote.commerce.adapter.out.persistence.order.entity.OrderJpaEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface OrderJpaRepository extends JpaRepository<OrderJpaEntity, Long> {
-    List<OrderJpaEntity> findByBuyerId(Long buyerId);
-}
+    @Query(value = """
+            SELECT DISTINCT o.id
+            FROM orders o
+            WHERE o.buyer_id = :buyerId
+              AND o.order_status <> 'PAYMENT_PENDING'
+              AND (CAST(:startDate AS timestamp) IS NULL OR o.created_at >= CAST(:startDate AS timestamp))
+              AND (CAST(:endDate   AS timestamp) IS NULL OR o.created_at <  CAST(:endDate   AS timestamp))
+              AND (:statusSize = 0 OR o.order_status IN (:statuses))
+            ORDER BY o.id DESC
+            """, nativeQuery = true)
+    List<Long> findIdsByBuyerIdWithFilters(
+            @Param("buyerId") Long buyerId,
+            @Param("startDate") java.time.LocalDateTime startDate,
+            @Param("endDate") java.time.LocalDateTime endDate,
+            @Param("statuses") List<String> statuses,
+            @Param("statusSize") int statusSize
+    );
 
+    @Query("select distinct o from OrderJpaEntity o left join fetch o.orderProductJpaEntities where o.id in :ids")
+    List<OrderJpaEntity> findWithProductsByIds(@Param("ids") List<Long> ids);
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/service/product/ProductServiceClient.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/service/product/ProductServiceClient.java
@@ -1,0 +1,105 @@
+package com.personal.marketnote.commerce.adapter.out.service.product;
+
+import com.personal.marketnote.commerce.adapter.out.service.product.dto.ProductCursorResponse;
+import com.personal.marketnote.commerce.adapter.out.service.product.dto.ProductItemResponse;
+import com.personal.marketnote.commerce.adapter.out.service.product.dto.ProductListResponse;
+import com.personal.marketnote.commerce.port.out.product.FindProductByPricePolicyPort;
+import com.personal.marketnote.commerce.port.out.result.product.GetOrderedProductResult;
+import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
+import com.personal.marketnote.common.adapter.out.ServiceAdapter;
+import com.personal.marketnote.common.utility.FormatValidator;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@ServiceAdapter
+@RequiredArgsConstructor
+@Slf4j
+public class ProductServiceClient implements FindProductByPricePolicyPort {
+    @Value("${product-service.base-url:http://localhost:8081}")
+    private String productServiceBaseUrl;
+
+    @Value("${spring.jwt.admin-access-token}")
+    private String adminAccessToken;
+
+    private final RestTemplate restTemplate;
+
+    @Override
+    public Map<Long, GetOrderedProductResult> findByPricePolicyIds(List<Long> pricePolicyIds) {
+        if (!FormatValidator.hasValue(pricePolicyIds)) {
+            return Map.of();
+        }
+
+        URI uri = UriComponentsBuilder.fromUriString(productServiceBaseUrl)
+                .path("/api/v1/products")
+                .queryParam("pricePolicyIds", pricePolicyIds)
+                .build()
+                .toUri();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(adminAccessToken);
+        HttpEntity<Void> request = new HttpEntity<>(headers);
+
+        try {
+            ResponseEntity<BaseResponse<ProductListResponse>> response = restTemplate.exchange(
+                    uri,
+                    HttpMethod.GET,
+                    request,
+                    new ParameterizedTypeReference<>() {
+                    }
+            );
+
+            BaseResponse<ProductListResponse> baseResponse = response.getBody();
+            ProductListResponse content = FormatValidator.hasValue(baseResponse)
+                    ? baseResponse.getContent()
+                    : null;
+            if (!FormatValidator.hasValue(content)) {
+                return Map.of();
+            }
+
+            ProductCursorResponse<ProductItemResponse> products = content.products();
+            List<ProductItemResponse> productItems = FormatValidator.hasValue(products)
+                    && FormatValidator.hasValue(products.contents())
+                    ? products.contents()
+                    : List.of();
+
+            Map<Long, GetOrderedProductResult> result = new HashMap<>();
+            for (ProductItemResponse item : productItems) {
+                if (!FormatValidator.hasValue(item) || !FormatValidator.hasValue(item.pricePolicy())) {
+                    continue;
+                }
+
+                Long policyId = item.pricePolicy().id();
+                if (!FormatValidator.hasValue(policyId) || result.containsKey(policyId)) {
+                    continue;
+                }
+
+                result.put(
+                        policyId,
+                        new GetOrderedProductResult(
+                                item.id(),
+                                item.name(),
+                                item.brandName()
+                        )
+                );
+            }
+
+            return result;
+        } catch (Exception e) {
+            log.warn("Failed to fetch product info from product-service: {}", e.getMessage(), e);
+            return Map.of();
+        }
+    }
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/service/product/dto/ProductCursorResponse.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/service/product/dto/ProductCursorResponse.java
@@ -1,0 +1,11 @@
+package com.personal.marketnote.commerce.adapter.out.service.product.dto;
+
+import java.util.List;
+
+public record ProductCursorResponse<T>(
+        Long totalElements,
+        Boolean hasNext,
+        Long nextCursor,
+        List<T> contents
+) {
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/service/product/dto/ProductItemResponse.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/service/product/dto/ProductItemResponse.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.commerce.adapter.out.service.product.dto;
+
+public record ProductItemResponse(
+        Long id,
+        String name,
+        String brandName,
+        ProductPricePolicyResponse pricePolicy
+) {
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/service/product/dto/ProductListResponse.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/service/product/dto/ProductListResponse.java
@@ -1,0 +1,6 @@
+package com.personal.marketnote.commerce.adapter.out.service.product.dto;
+
+public record ProductListResponse(
+        ProductCursorResponse<ProductItemResponse> products
+) {
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/service/product/dto/ProductPricePolicyResponse.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/service/product/dto/ProductPricePolicyResponse.java
@@ -1,0 +1,6 @@
+package com.personal.marketnote.commerce.adapter.out.service.product.dto;
+
+public record ProductPricePolicyResponse(
+        Long id
+) {
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/command/order/GetOrdersQuery.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/command/order/GetOrdersQuery.java
@@ -1,0 +1,45 @@
+package com.personal.marketnote.commerce.port.in.command.order;
+
+import com.personal.marketnote.commerce.domain.order.OrderPeriod;
+import com.personal.marketnote.commerce.domain.order.OrderStatus;
+import com.personal.marketnote.commerce.domain.order.OrderStatusFilter;
+import com.personal.marketnote.common.utility.FormatValidator;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+
+public record GetOrdersQuery(
+        Long buyerId,
+        OrderPeriod period,
+        OrderStatusFilter status,
+        String productName
+) {
+    public static GetOrdersQuery of(
+            Long buyerId,
+            OrderPeriod period,
+            OrderStatusFilter status,
+            String productName
+    ) {
+        return new GetOrdersQuery(buyerId, period, status, productName);
+    }
+
+    public LocalDateTime calculateStartDate(LocalDate now) {
+        OrderPeriod resolved = period != null ? period : OrderPeriod.ALL;
+        return resolved.startDate(now);
+    }
+
+    public LocalDateTime calculateEndDate(LocalDate now) {
+        return LocalDateTime.of(now.plusDays(1), LocalTime.MIDNIGHT);
+    }
+
+    public List<OrderStatus> resolveStatuses() {
+        OrderStatusFilter resolved = status != null ? status : OrderStatusFilter.ALL;
+        return resolved.toStatuses();
+    }
+
+    public String resolvedProductName() {
+        return FormatValidator.hasValue(productName) ? productName.trim() : null;
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/result/order/GetOrderProductResult.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/result/order/GetOrderProductResult.java
@@ -2,21 +2,37 @@ package com.personal.marketnote.commerce.port.in.result.order;
 
 import com.personal.marketnote.commerce.domain.order.OrderProduct;
 import com.personal.marketnote.commerce.domain.order.OrderStatus;
+import com.personal.marketnote.commerce.port.out.result.product.GetOrderedProductResult;
+import com.personal.marketnote.common.utility.FormatValidator;
 
 public record GetOrderProductResult(
         Long pricePolicyId,
         Integer quantity,
         Long unitAmount,
         String imageUrl,
-        OrderStatus orderStatus
+        OrderStatus orderStatus,
+        Long productId,
+        String productName
 ) {
     public static GetOrderProductResult from(OrderProduct orderProduct) {
+        return from(orderProduct, null);
+    }
+
+    public static GetOrderProductResult from(
+            OrderProduct orderProduct,
+            GetOrderedProductResult productSummary
+    ) {
+        Long productId = FormatValidator.hasValue(productSummary) ? productSummary.productId() : null;
+        String productName = FormatValidator.hasValue(productSummary) ? productSummary.name() : null;
+
         return new GetOrderProductResult(
                 orderProduct.getPricePolicyId(),
                 orderProduct.getQuantity(),
                 orderProduct.getUnitAmount(),
                 orderProduct.getImageUrl(),
-                orderProduct.getOrderStatus()
+                orderProduct.getOrderStatus(),
+                productId,
+                productName
         );
     }
 }

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/result/order/GetOrderResult.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/result/order/GetOrderResult.java
@@ -2,10 +2,12 @@ package com.personal.marketnote.commerce.port.in.result.order;
 
 import com.personal.marketnote.commerce.domain.order.Order;
 import com.personal.marketnote.commerce.domain.order.OrderStatus;
+import com.personal.marketnote.commerce.port.out.result.product.GetOrderedProductResult;
 import lombok.AccessLevel;
 import lombok.Builder;
 
 import java.util.List;
+import java.util.Map;
 
 @Builder(access = AccessLevel.PRIVATE)
 public record GetOrderResult(
@@ -20,6 +22,13 @@ public record GetOrderResult(
         List<GetOrderProductResult> orderProducts
 ) {
     public static GetOrderResult from(Order order) {
+        return from(order, Map.of());
+    }
+
+    public static GetOrderResult from(
+            Order order,
+            Map<Long, GetOrderedProductResult> productSummaries
+    ) {
         return GetOrderResult.builder()
                 .id(order.getId())
                 .sellerId(order.getSellerId())
@@ -29,7 +38,16 @@ public record GetOrderResult(
                 .paidAmount(order.getPaidAmount())
                 .couponAmount(order.getCouponAmount())
                 .pointAmount(order.getPointAmount())
-                .orderProducts(order.getOrderProducts().stream().map(GetOrderProductResult::from).toList())
+                .orderProducts(order.getOrderProducts().stream()
+                        .map(orderProduct -> {
+                            GetOrderedProductResult summary =
+                                    productSummaries.get(orderProduct.getPricePolicyId());
+                            return GetOrderProductResult.from(
+                                    orderProduct,
+                                    summary
+                            );
+                        })
+                        .toList())
                 .build();
     }
 }

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/result/order/GetOrdersDomainResult.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/result/order/GetOrdersDomainResult.java
@@ -1,0 +1,19 @@
+package com.personal.marketnote.commerce.port.in.result.order;
+
+import com.personal.marketnote.commerce.domain.order.Order;
+import com.personal.marketnote.commerce.port.out.result.product.GetOrderedProductResult;
+
+import java.util.List;
+import java.util.Map;
+
+public record GetOrdersDomainResult(
+        List<Order> orders,
+        Map<Long, GetOrderedProductResult> productSummaries
+) {
+    public static GetOrdersDomainResult of(
+            List<Order> orders,
+            Map<Long, GetOrderedProductResult> productSummaries
+    ) {
+        return new GetOrdersDomainResult(orders, productSummaries);
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/result/order/GetOrdersResult.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/result/order/GetOrdersResult.java
@@ -1,20 +1,44 @@
 package com.personal.marketnote.commerce.port.in.result.order;
 
 import com.personal.marketnote.commerce.domain.order.Order;
+import com.personal.marketnote.commerce.port.out.result.product.GetOrderedProductResult;
+import com.personal.marketnote.common.utility.FormatValidator;
 import lombok.AccessLevel;
 import lombok.Builder;
 
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 @Builder(access = AccessLevel.PRIVATE)
 public record GetOrdersResult(
-        List<GetOrderResult> orders
+        List<OrderHistoryByDateResult> orderHistories
 ) {
-    public static GetOrdersResult from(List<Order> orders) {
-        return new GetOrdersResult(
-                orders.stream()
-                        .map(GetOrderResult::from)
-                        .toList()
-        );
+    public static GetOrdersResult from(
+            List<Order> orders,
+            Map<Long, GetOrderedProductResult> productSummaries
+    ) {
+        Map<Long, GetOrderedProductResult> summaries =
+                com.personal.marketnote.common.utility.FormatValidator.hasValue(
+                        productSummaries != null ? productSummaries.values() : null
+                ) ? productSummaries : Map.of();
+        Map<LocalDate, List<Order>> grouped = new LinkedHashMap<>();
+
+        for (Order order : orders) {
+            LocalDate orderDate = FormatValidator.hasValue(order.getCreatedAt())
+                    ? order.getCreatedAt().toLocalDate()
+                    : LocalDate.now();
+
+            grouped.computeIfAbsent(orderDate, key -> new ArrayList<>())
+                    .add(order);
+        }
+
+        List<OrderHistoryByDateResult> histories = grouped.entrySet().stream()
+                .map(entry -> OrderHistoryByDateResult.of(entry.getKey(), entry.getValue(), summaries))
+                .toList();
+
+        return new GetOrdersResult(histories);
     }
 }

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/result/order/OrderHistoryByDateResult.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/result/order/OrderHistoryByDateResult.java
@@ -1,0 +1,30 @@
+package com.personal.marketnote.commerce.port.in.result.order;
+
+import com.personal.marketnote.commerce.domain.order.Order;
+import com.personal.marketnote.commerce.port.out.result.product.GetOrderedProductResult;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+
+public record OrderHistoryByDateResult(
+        LocalDate orderDate,
+        Integer count,
+        List<GetOrderResult> orders
+) {
+    public static OrderHistoryByDateResult of(
+            LocalDate orderDate,
+            List<Order> orders,
+            Map<Long, GetOrderedProductResult> productSummaries
+    ) {
+        Map<Long, GetOrderedProductResult> summaries =
+                com.personal.marketnote.common.utility.FormatValidator.hasValue(
+                        productSummaries != null ? productSummaries.values() : null
+                ) ? productSummaries : Map.of();
+        List<GetOrderResult> orderResults = orders.stream()
+                .map(order -> GetOrderResult.from(order, summaries))
+                .toList();
+
+        return new OrderHistoryByDateResult(orderDate, orderResults.size(), orderResults);
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/order/GetOrderUseCase.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/order/GetOrderUseCase.java
@@ -1,8 +1,8 @@
 package com.personal.marketnote.commerce.port.in.usecase.order;
 
 import com.personal.marketnote.commerce.domain.order.Order;
-
-import java.util.List;
+import com.personal.marketnote.commerce.port.in.command.order.GetOrdersQuery;
+import com.personal.marketnote.commerce.port.in.result.order.GetOrdersDomainResult;
 
 public interface GetOrderUseCase {
     /**
@@ -14,5 +14,5 @@ public interface GetOrderUseCase {
      */
     Order getOrder(Long id);
 
-    List<Order> getOrders(Long buyerId);
+    GetOrdersDomainResult getOrders(GetOrdersQuery query);
 }

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/order/FindOrderPort.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/order/FindOrderPort.java
@@ -1,13 +1,19 @@
 package com.personal.marketnote.commerce.port.out.order;
 
 import com.personal.marketnote.commerce.domain.order.Order;
+import com.personal.marketnote.commerce.domain.order.OrderStatus;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
 public interface FindOrderPort {
     Optional<Order> findById(Long id);
 
-    List<Order> findByBuyerId(Long buyerId);
+    List<Order> findByBuyerId(
+            Long buyerId,
+            LocalDateTime startDate,
+            LocalDateTime endDate,
+            List<OrderStatus> statuses
+    );
 }
-

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/product/FindProductByPricePolicyPort.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/product/FindProductByPricePolicyPort.java
@@ -1,0 +1,10 @@
+package com.personal.marketnote.commerce.port.out.product;
+
+import com.personal.marketnote.commerce.port.out.result.product.GetOrderedProductResult;
+
+import java.util.List;
+import java.util.Map;
+
+public interface FindProductByPricePolicyPort {
+    Map<Long, GetOrderedProductResult> findByPricePolicyIds(List<Long> pricePolicyIds);
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/result/product/GetOrderedProductResult.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/result/product/GetOrderedProductResult.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.commerce.port.out.result.product;
+
+public record GetOrderedProductResult(
+        Long productId,
+        String name,
+        String brandName
+) {
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/GetOrderService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/GetOrderService.java
@@ -2,14 +2,22 @@ package com.personal.marketnote.commerce.service.order;
 
 import com.personal.marketnote.commerce.domain.order.Order;
 import com.personal.marketnote.commerce.exception.OrderNotFoundException;
+import com.personal.marketnote.commerce.port.in.command.order.GetOrdersQuery;
+import com.personal.marketnote.commerce.port.in.result.order.GetOrdersDomainResult;
 import com.personal.marketnote.commerce.port.in.usecase.order.GetOrderUseCase;
 import com.personal.marketnote.commerce.port.out.order.FindOrderPort;
+import com.personal.marketnote.commerce.port.out.product.FindProductByPricePolicyPort;
+import com.personal.marketnote.commerce.port.out.result.product.GetOrderedProductResult;
 import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.common.utility.FormatValidator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
+import static java.time.LocalDate.now;
 import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
 
 @UseCase
@@ -17,6 +25,7 @@ import static org.springframework.transaction.annotation.Isolation.READ_COMMITTE
 @Transactional(isolation = READ_COMMITTED, readOnly = true)
 public class GetOrderService implements GetOrderUseCase {
     private final FindOrderPort findOrderPort;
+    private final FindProductByPricePolicyPort findProductByPricePolicyPort;
 
     @Override
     public Order getOrder(Long id) {
@@ -25,7 +34,48 @@ public class GetOrderService implements GetOrderUseCase {
     }
 
     @Override
-    public List<Order> getOrders(Long buyerId) {
-        return findOrderPort.findByBuyerId(buyerId);
+    public GetOrdersDomainResult getOrders(GetOrdersQuery query) {
+        List<Order> orders = findOrderPort.findByBuyerId(
+                query.buyerId(),
+                query.calculateStartDate(now()),
+                query.calculateEndDate(now()),
+                query.resolveStatuses()
+        );
+
+        if (!FormatValidator.hasValue(orders)) {
+            return GetOrdersDomainResult.of(List.of(), Map.of());
+        }
+
+        List<Long> pricePolicyIds = orders.stream()
+                .flatMap(order -> order.getOrderProducts().stream())
+                .map(orderProduct -> orderProduct.getPricePolicyId())
+                .filter(FormatValidator::hasValue)
+                .distinct()
+                .toList();
+
+        Map<Long, GetOrderedProductResult> productSummaryMap =
+                Optional.ofNullable(findProductByPricePolicyPort.findByPricePolicyIds(pricePolicyIds))
+                        .orElse(Map.of());
+
+        String productNameKeyword = query.resolvedProductName();
+        if (FormatValidator.hasValue(productNameKeyword)) {
+
+            String keyword = productNameKeyword.toLowerCase();
+
+            orders = orders.stream()
+                    .filter(order -> order.getOrderProducts().stream()
+                            .anyMatch(orderProduct -> {
+                                GetOrderedProductResult summary =
+                                        productSummaryMap.get(orderProduct.getPricePolicyId());
+
+                                return summary != null
+                                        && summary.name() != null
+                                        && summary.name().toLowerCase().contains(keyword);
+                            })
+                    )
+                    .toList();
+        }
+
+        return GetOrdersDomainResult.of(orders, productSummaryMap);
     }
 }

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/order/Order.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/order/Order.java
@@ -2,6 +2,7 @@ package com.personal.marketnote.commerce.domain.order;
 
 import lombok.*;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -18,6 +19,8 @@ public class Order {
     private Long couponAmount;
     private Long pointAmount;
     private List<OrderProduct> orderProducts;
+    private LocalDateTime createdAt;
+    private LocalDateTime modifiedAt;
 
     public static Order of(
             Long sellerId,
@@ -62,6 +65,34 @@ public class Order {
                 .build();
     }
 
+    public static Order of(
+            Long id,
+            Long sellerId,
+            Long buyerId,
+            OrderStatus orderStatus,
+            Long totalAmount,
+            Long paidAmount,
+            Long couponAmount,
+            Long pointAmount,
+            List<OrderProduct> orderProducts,
+            LocalDateTime createdAt,
+            LocalDateTime modifiedAt
+    ) {
+        return Order.builder()
+                .id(id)
+                .sellerId(sellerId)
+                .buyerId(buyerId)
+                .orderStatus(orderStatus)
+                .totalAmount(totalAmount)
+                .paidAmount(paidAmount)
+                .couponAmount(couponAmount)
+                .pointAmount(pointAmount)
+                .orderProducts(orderProducts)
+                .createdAt(createdAt)
+                .modifiedAt(modifiedAt)
+                .build();
+    }
+
     public void changeProductsStatus(List<Long> pricePolicyIds, OrderStatus orderStatus) {
         orderProducts.stream()
                 .filter(orderProduct -> pricePolicyIds.contains(orderProduct.getPricePolicyId()))
@@ -80,4 +111,3 @@ public class Order {
         this.orderStatus = orderStatus;
     }
 }
-

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/order/OrderPeriod.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/order/OrderPeriod.java
@@ -1,0 +1,27 @@
+package com.personal.marketnote.commerce.domain.order;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+public enum OrderPeriod {
+    ONE_MONTH(1),
+    THREE_MONTHS(3),
+    SIX_MONTHS(6),
+    ONE_YEAR(12),
+    ALL(null);
+
+    private final Integer months;
+
+    OrderPeriod(Integer months) {
+        this.months = months;
+    }
+
+    public LocalDateTime startDate(LocalDate now) {
+        if (months == null) {
+            return null;
+        }
+
+        return LocalDateTime.of(now.minusMonths(months), LocalTime.MIDNIGHT);
+    }
+}

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/order/OrderProduct.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/order/OrderProduct.java
@@ -7,8 +7,8 @@ import lombok.*;
 @Builder(access = AccessLevel.PRIVATE)
 @Getter
 public class OrderProduct {
-    private Long pricePolicyId;
     private Long orderId;
+    private Long pricePolicyId;
     private Integer quantity;
     private Long unitAmount;
     private String imageUrl;
@@ -30,16 +30,16 @@ public class OrderProduct {
     }
 
     public static OrderProduct of(
-            Long pricePolicyId,
             Long orderId,
+            Long pricePolicyId,
             Integer quantity,
             Long unitAmount,
             String imageUrl,
             OrderStatus orderStatus
     ) {
         return OrderProduct.builder()
-                .pricePolicyId(pricePolicyId)
                 .orderId(orderId)
+                .pricePolicyId(pricePolicyId)
                 .quantity(quantity)
                 .unitAmount(unitAmount)
                 .imageUrl(imageUrl)

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/order/OrderStatusFilter.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/order/OrderStatusFilter.java
@@ -1,0 +1,40 @@
+package com.personal.marketnote.commerce.domain.order;
+
+import java.util.Collections;
+import java.util.List;
+
+public enum OrderStatusFilter {
+    SHIPPING(List.of(
+            OrderStatus.PREPARING,
+            OrderStatus.PREPARED,
+            OrderStatus.SHIPPING,
+            OrderStatus.EXCHANGE_SHIPPING,
+            OrderStatus.REFUND_SHIPPING
+    )),
+    DELIVERED(List.of(OrderStatus.DELIVERED)),
+    CONFIRMED(List.of(OrderStatus.CONFIRMED)),
+    CANCEL_EXCHANGE_REFUND(List.of(
+            OrderStatus.CANCEL_REQUESTED,
+            OrderStatus.CANCELLED,
+            OrderStatus.EXCHANGE_REQUESTED,
+            OrderStatus.EXCHANGE_RECALLING,
+            OrderStatus.EXCHANGE_SHIPPING,
+            OrderStatus.EXCHANGED,
+            OrderStatus.REFUND_REQUESTED,
+            OrderStatus.REFUND_RECALLING,
+            OrderStatus.REFUND_SHIPPING,
+            OrderStatus.PARTIALLY_REFUNDED,
+            OrderStatus.REFUNDED
+    )),
+    ALL(Collections.emptyList());
+
+    private final List<OrderStatus> statuses;
+
+    OrderStatusFilter(List<OrderStatus> statuses) {
+        this.statuses = statuses;
+    }
+
+    public List<OrderStatus> toStatuses() {
+        return statuses;
+    }
+}


### PR DESCRIPTION
## partially addresses #216
## resolves #299

## Task
- [x] 날짜 별 정렬
- [x] 필터
    - [x] 결제 완료 날짜
        - [x] 1개월
        - [x] 3개월
        - [x] 6개월
        - [x] 1년
    - [x] 주문 상태
        - [x] 배송중
        - [x] 배송완료
        - [x] 구매확정
        - [x] 취소/교환/반품
- [x] 검색
    - [x] 상품명