### PR TITLE
[#128][#365] refactor: 상품 서비스의 재고 조회 기능 리팩터링

### DIFF
--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/client/product/controller/apidocs/GetProductInfoApiDocs.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/client/product/controller/apidocs/GetProductInfoApiDocs.java
@@ -82,7 +82,7 @@ import java.lang.annotation.*;
                 | popularity | number | 인기도 | 0 |
                 | findAllOptionsYn | boolean | 모든 옵션 선택 여부 | true |
                 | productTags | array | 상품 태그 목록 | [ ... ] |
-                | stock | number | 재고 수량 | 2200 |
+                | stock | number | 재고 수량(재고 서버와 통신 실패한 경우 -1 반환) | 2200 |
                 | orderNum | number | 정렬 순서 | 19 |
                 | status | string | 상태 | "ACTIVE" |
                 ---

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/client/product/controller/apidocs/GetProductsApiDocs.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/client/product/controller/apidocs/GetProductsApiDocs.java
@@ -69,18 +69,18 @@ import java.lang.annotation.*;
                 
                 ---
                 
-                ### Response > content
+                ### Response > content > products
                 
                 | **키** | **타입** | **설명** | **예시** |
                 | --- | --- | --- | --- |
-                | products | array | 상품 목록 | [ ... ] |
+                | totalElements | number | 총 아이템 수 | 30 |
                 | nextCursor | number | 현재 페이지에서 조회한 마지막 리소스의 식별자 | 18 |
                 | hasNext | boolean | 다음 페이지 존재 여부 | true |
-                | totalElements | number | 총 아이템 수 | 30 |
+                | items | array | 상품 목록 | [ ... ] |
                 
                 ---
                 
-                ### Response > content > products
+                ### Response > content > products > items
                 
                 | **키** | **타입** | **설명** | **예시** |
                 | --- | --- | --- | --- |
@@ -92,8 +92,10 @@ import java.lang.annotation.*;
                 | sales | number | 판매량 | 0 |
                 | productTags | array | 상품 태그 목록 | [ ... ] |
                 | catalogImage | object | 상품 카탈로그 이미지 | { ... } |
-                | orderNum | number | 정렬 순서 | 1 |
+                | selectedOptions | array | 선택된 옵션 목록 | [ ... ] |
+                | stock | number | 재고 수량(재고 서버와 통신 실패한 경우 -1 반환) | 10 |
                 | status | string | 상태 | "ACTIVE" |
+                | orderNum | number | 정렬 순서 | 1 |
                 
                 ---
                 

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/service/commerce/CommerceServiceClient.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/service/commerce/CommerceServiceClient.java
@@ -24,6 +24,7 @@ import java.net.URI;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static com.personal.marketnote.common.utility.ApiConstant.INTER_SERVER_MAX_REQUEST_COUNT;
 
@@ -87,7 +88,13 @@ public class CommerceServiceClient implements RegisterInventoryPort, FindStockPo
         HttpHeaders headers = new HttpHeaders();
         headers.setBearerAuth(adminAccessToken);
 
-        return sendRequest(uri, headers, pricePolicyIds).inventories();
+        try {
+            return sendRequest(uri, headers, pricePolicyIds).inventories();
+        } catch (CommerceServiceRequestFailedException csrfe) {
+            return pricePolicyIds.stream()
+                    .map(GetInventoryResult::generateResultWithoutStock)
+                    .collect(Collectors.toSet());
+        }
     }
 
     public GetInventoriesResponse sendRequest(URI uri, HttpHeaders headers, List<Long> pricePolicyIds) {

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/out/result/GetInventoryResult.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/out/result/GetInventoryResult.java
@@ -1,6 +1,9 @@
 package com.personal.marketnote.product.port.out.result;
 
+import com.personal.marketnote.common.utility.FormatConverter;
 import com.personal.marketnote.common.utility.FormatValidator;
+
+import static com.personal.marketnote.common.utility.NumberConstant.MINUS_ONE;
 
 public record GetInventoryResult(
         Long pricePolicyId,
@@ -8,6 +11,10 @@ public record GetInventoryResult(
 ) {
     public static GetInventoryResult of(Long pricePolicyId, Integer stock) {
         return new GetInventoryResult(pricePolicyId, stock);
+    }
+
+    public static GetInventoryResult generateResultWithoutStock(Long pricePolicyId) {
+        return new GetInventoryResult(pricePolicyId, FormatConverter.parseToInteger(MINUS_ONE));
     }
 
     public boolean hasNoStock() {

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/service/product/GetProductService.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/service/product/GetProductService.java
@@ -195,8 +195,10 @@ public class GetProductService implements GetProductUseCase {
                 .toList();
         CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
 
-        // 상품 재고 수량 조회
-        Map<Long, Integer> inventories = getProductInventoryUseCase.getProductStocks(
+        // 상품 재고 수량 조회(pricePolicyIds를 통한 요청인 경우 제외)
+        Map<Long, Integer> inventories = FormatValidator.hasValue(pricePolicyIds)
+                ? Map.of()
+                : getProductInventoryUseCase.getProductStocks(
                 pagedPolicies.stream()
                         .map(PricePolicy::getId)
                         .toList()


### PR DESCRIPTION
## partially addresses #128
## resolves #365

## Task
- [x] 커머스 서비스 및 커뮤니티 서비스에서 상품 목록 요청 시, 커머스 서비스로의 상품 재고 정보 요청 로직을 제외하도록 변경
- [x] 상품 목록 조회/상품 상세 정보 조회 중 재고 정보 조회에 실패하는 경우, 재고를 -1로 반환하도록 변경