### PR TITLE
[#300][#374] feat: 리뷰에 좋아요/취소 선택 시 클라이언트에서 좋아요/취소 여부를 명시적으로 전송(따닥 이슈 방지)하도록 변경

### DIFF
--- a/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/in/client/like/controller/apidocs/UpsertLikeApiDocs.java
+++ b/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/in/client/like/controller/apidocs/UpsertLikeApiDocs.java
@@ -39,6 +39,7 @@ import java.lang.annotation.*;
                 | --- | --- | --- | --- | --- |
                 | targetType | string | 대상 유형(REVIEW/BOARD) | Y | "REVIEW" |
                 | targetId | number | 대상 ID | Y | 10 |
+                | isLiked | boolean | 좋아요 여부(좋아요/취소) | Y | true |
                 
                 ---
                 
@@ -68,7 +69,8 @@ import java.lang.annotation.*;
                         examples = @ExampleObject("""
                                 {
                                   "targetType": "REVIEW",
-                                  "targetId": 10
+                                  "targetId": 10,
+                                  "isLiked": true
                                 }
                                 """)
                 )

--- a/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/in/client/like/mapper/LikeRequestToCommandMapper.java
+++ b/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/in/client/like/mapper/LikeRequestToCommandMapper.java
@@ -5,6 +5,6 @@ import com.personal.marketnote.community.port.in.command.like.UpsertLikeCommand;
 
 public class LikeRequestToCommandMapper {
     public static UpsertLikeCommand mapToCommand(UpsertLikeRequest request, Long userId) {
-        return UpsertLikeCommand.of(request.targetType(), request.targetId(), userId);
+        return UpsertLikeCommand.of(request.targetType(), request.targetId(), request.isLiked(), userId);
     }
 }

--- a/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/in/client/like/request/UpsertLikeRequest.java
+++ b/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/in/client/like/request/UpsertLikeRequest.java
@@ -11,6 +11,10 @@ public record UpsertLikeRequest(
 
         @Schema(description = "대상 ID", requiredMode = Schema.RequiredMode.REQUIRED)
         @NotNull(message = "대상 ID는 필수입니다.")
-        Long targetId
+        Long targetId,
+
+        @Schema(description = "좋아요 여부(좋아요/취소)", requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotNull(message = "좋아요 여부는 필수입니다.")
+        boolean isLiked
 ) {
 }

--- a/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/in/client/review/controller/ReviewController.java
+++ b/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/in/client/review/controller/ReviewController.java
@@ -14,7 +14,6 @@ import com.personal.marketnote.community.domain.review.ReviewSortProperty;
 import com.personal.marketnote.community.port.in.result.review.GetReviewsResult;
 import com.personal.marketnote.community.port.in.result.review.ProductReviewAggregateResult;
 import com.personal.marketnote.community.port.in.result.review.RegisterReviewResult;
-import com.personal.marketnote.community.port.in.usecase.report.RegisterReportUseCase;
 import com.personal.marketnote.community.port.in.usecase.review.DeleteReviewUseCase;
 import com.personal.marketnote.community.port.in.usecase.review.GetReviewUseCase;
 import com.personal.marketnote.community.port.in.usecase.review.RegisterReviewUseCase;
@@ -43,7 +42,6 @@ public class ReviewController {
     private final GetReviewUseCase getReviewUseCase;
     private final UpdateReviewUseCase updateReviewUseCase;
     private final DeleteReviewUseCase deleteReviewUseCase;
-    private final RegisterReportUseCase registerReportUseCase;
 
     /**
      * 리뷰 등록

--- a/community-service/community-application/src/main/java/com/personal/marketnote/community/port/in/command/like/UpsertLikeCommand.java
+++ b/community-service/community-application/src/main/java/com/personal/marketnote/community/port/in/command/like/UpsertLikeCommand.java
@@ -5,9 +5,10 @@ import com.personal.marketnote.community.domain.like.LikeTargetType;
 public record UpsertLikeCommand(
         LikeTargetType targetType,
         Long targetId,
+        boolean isLiked,
         Long userId
 ) {
-    public static UpsertLikeCommand of(LikeTargetType targetType, Long targetId, Long userId) {
-        return new UpsertLikeCommand(targetType, targetId, userId);
+    public static UpsertLikeCommand of(LikeTargetType targetType, Long targetId, boolean isLiked, Long userId) {
+        return new UpsertLikeCommand(targetType, targetId, isLiked, userId);
     }
 }

--- a/community-service/community-application/src/main/java/com/personal/marketnote/community/service/like/UpsertLikeService.java
+++ b/community-service/community-application/src/main/java/com/personal/marketnote/community/service/like/UpsertLikeService.java
@@ -27,8 +27,12 @@ public class UpsertLikeService implements UpsertLikeUseCase {
     public UpsertLikeResult upsertLike(UpsertLikeCommand command) {
         try {
             Like like = getLikeUseCase.getLike(command.targetType(), command.targetId(), command.userId());
-            like.revert();
-            updateLikePort.update(like);
+
+            // 좋아요 상태가 변경된 경우에만 갱신(따닥 이슈 방지)
+            if (like.isStatusChanged(command.isLiked())) {
+                like.revert();
+                updateLikePort.update(like);
+            }
 
             return UpsertLikeResult.from(like, false);
         } catch (LikeNotFoundException lnfe) {

--- a/community-service/community-domain/src/main/java/com/personal/marketnote/community/domain/like/Like.java
+++ b/community-service/community-domain/src/main/java/com/personal/marketnote/community/domain/like/Like.java
@@ -37,6 +37,14 @@ public class Like {
                 .build();
     }
 
+    public boolean isStatusChanged(boolean isLiked) {
+        if (isLiked) {
+            return status.isInactive();
+        }
+
+        return status.isActive();
+    }
+
     public void revert() {
         status = EntityStatus.from(!isLiked());
     }


### PR DESCRIPTION
## partially addresses #300
## resolves #374

## Task
- [x] 클라이언트 요청 시 isLiked 파라미터 추가
- [x] 비즈니스 로직에서 기존 상태와 동일한지 체크하는 절차 추가