### PR TITLE
[#387][#394] feat: 애드팝콘 서비스 연동 시 보안성 검증 로직 추가

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -50,6 +50,8 @@ def buildMarketNoteTaskDefinition(env) {
                 [name: "COMMUNITY_SERVICE_SERVER_ORIGIN",value: env.COMMUNITY_SERVICE_SERVER_ORIGIN],
                 [name: "REWARD_SERVICE_SERVER_ORIGIN",   value: env.REWARD_SERVICE_SERVER_ORIGIN],
                 [name: "JWT_ADMIN_ACCESS_TOKEN",         value: env.JWT_ADMIN_ACCESS_TOKEN],
+                [name: "ADPOPCORN_ANDROID_HASH_KEY",     value: env.ADPOPCORN_ANDROID_HASH_KEY],
+                [name: "ADPOPCORN_IOS_HASH_KEY",         value: env.ADPOPCORN_IOS_HASH_KEY],
             ],
             logConfiguration: [
                 logDriver: "awslogs",
@@ -592,6 +594,8 @@ pipeline {
 						string(credentialsId: 'MARKETNOTE_QA_COMMUNITY_SERVICE_SERVER_ORIGIN', variable: 'COMMUNITY_SERVICE_SERVER_ORIGIN'),
 						string(credentialsId: 'MARKETNOTE_QA_REWARD_SERVICE_SERVER_ORIGIN',    variable: 'REWARD_SERVICE_SERVER_ORIGIN'),
 						string(credentialsId: 'MARKETNOTE_QA_JWT_ADMIN_ACCESS_TOKEN',          variable: 'JWT_ADMIN_ACCESS_TOKEN'),
+						string(credentialsId: 'MARKETNOTE_QA_ADPOPCORN_ANDROID_HASH_KEY',      variable: 'ADPOPCORN_ANDROID_HASH_KEY'),
+						string(credentialsId: 'MARKETNOTE_QA_ADPOPCORN_IOS_HASH_KEY',          variable: 'ADPOPCORN_IOS_HASH_KEY'),
 					]) {
 						sh '''
                   LG="$CLOUDWATCH_LOG_GROUP"

--- a/common/src/main/java/com/personal/marketnote/common/security/vendor/VendorVerificationProcessor.java
+++ b/common/src/main/java/com/personal/marketnote/common/security/vendor/VendorVerificationProcessor.java
@@ -1,0 +1,33 @@
+package com.personal.marketnote.common.security.vendor;
+
+import com.personal.marketnote.common.domain.exception.token.VendorVerificationFailedException;
+import com.personal.marketnote.common.utility.FormatValidator;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+
+public class VendorVerificationProcessor {
+    public static void validateAdpopcornSignature(String secret, String text, String signature) {
+        try {
+            Mac mac = Mac.getInstance("HmacMD5");
+            mac.init(new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), "HmacMD5"));
+            byte[] result = mac.doFinal(text.getBytes(StandardCharsets.UTF_8));
+
+            if (!FormatValidator.equalsIgnoreCase(toHex(result), signature)) {
+                throw new VendorVerificationFailedException("애드팝콘 리워드 지급 연동 중 signed value 검증에 실패했습니다.");
+            }
+        } catch (Exception e) {
+            throw new VendorVerificationFailedException("invalid signed value");
+        }
+    }
+
+    private static String toHex(byte[] bytes) {
+        StringBuilder sb = new StringBuilder(bytes.length * 2);
+        for (byte b : bytes) {
+            sb.append(String.format("%02x", b));
+        }
+
+        return sb.toString();
+    }
+}

--- a/common/src/main/java/com/personal/marketnote/common/utility/FormatValidator.java
+++ b/common/src/main/java/com/personal/marketnote/common/utility/FormatValidator.java
@@ -26,6 +26,10 @@ public class FormatValidator {
         return hasValue(value1) && hasValue(value2) && value1.equals(value2);
     }
 
+    public static boolean equalsIgnoreCase(String value1, String value2) {
+        return hasValue(value1) && hasValue(value2) && value1.equalsIgnoreCase(value2);
+    }
+
     public static boolean containsKeyword(String target, String keyword) {
         return target.toLowerCase().contains(keyword.toLowerCase());
     }

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/offerwall/mapper/RewardRequestToCommandMapper.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/offerwall/mapper/RewardRequestToCommandMapper.java
@@ -26,7 +26,7 @@ public class RewardRequestToCommandMapper {
         return OfferwallCallbackCommand.builder()
                 .offerwallType(offerwallType)
                 .rewardKey(rewardKey)
-                .userKey(userKey)
+                .userId(userKey)
                 .campaignKey(campaignKey)
                 .campaignType(campaignType)
                 .campaignName(campaignName)

--- a/reward-service/reward-adapters/src/main/resources/application.yml
+++ b/reward-service/reward-adapters/src/main/resources/application.yml
@@ -51,6 +51,13 @@ server:
     whitelabel:
       enabled: false
 
+vendor:
+  offerwall:
+    adpopcorn:
+      hash-key:
+        android: ${ADPOPCORN_ANDROID_HASH_KEY:abc}
+        ios: ${ADPOPCORN_IOS_HASH_KEY:def}
+
 logging:
   config: classpath:logback-spring.xml
   level:

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/configuration/AdpopcornHashKeyProperties.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/configuration/AdpopcornHashKeyProperties.java
@@ -1,0 +1,15 @@
+package com.personal.marketnote.reward.configuration;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "vendor.offerwall.adpopcorn.hash-key")
+public class AdpopcornHashKeyProperties {
+    private String android;
+    private String ios;
+}

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/mapper/RewardCommandToStateMapper.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/mapper/RewardCommandToStateMapper.java
@@ -9,7 +9,7 @@ public class RewardCommandToStateMapper {
         return OfferwallMapperCreateState.builder()
                 .offerwallType(command.getOfferwallType())
                 .rewardKey(command.getRewardKey())
-                .userId(command.getUserKey())
+                .userId(command.getUserId())
                 .campaignKey(command.getCampaignKey())
                 .campaignType(command.getCampaignType())
                 .campaignName(command.getCampaignName())

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/command/offerwall/OfferwallCallbackCommand.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/command/offerwall/OfferwallCallbackCommand.java
@@ -1,5 +1,6 @@
 package com.personal.marketnote.reward.port.in.command.offerwall;
 
+import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.reward.domain.offerwall.OfferwallType;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,7 +12,7 @@ import java.time.LocalDateTime;
 public class OfferwallCallbackCommand {
     private final OfferwallType offerwallType;
     private final String rewardKey;
-    private final String userKey;
+    private final String userId;
     private final String campaignKey;
     private final Integer campaignType;
     private final String campaignName;
@@ -23,4 +24,12 @@ public class OfferwallCallbackCommand {
     private final String idfa;
     private final Boolean isSuccess;
     private final LocalDateTime attendedAt;
+
+    public boolean isAndroid() {
+        return FormatValidator.hasValue(adid);
+    }
+
+    public boolean isIos() {
+        return FormatValidator.hasValue(idfa);
+    }
 }


### PR DESCRIPTION
## partially addresses #387
## resolves #394

## Task
- [x] Platform: Android, iOS
- [x] Encryption Target: usn, rewardkey, quantity, campaignkey
- [x] Encryption Algorithm: HMAC-MD5