### PR TITLE
[#387][#394] feat: 애드팝콘 서비스 연동 시 회원 디바이스 정보 파라미터 및 연동 컬럼 추가

### DIFF
--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/offerwall/OfferwallController.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/offerwall/OfferwallController.java
@@ -10,6 +10,7 @@ import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.reward.adapter.in.offerwall.mapper.RewardRequestToCommandMapper;
 import com.personal.marketnote.reward.domain.offerwall.OfferwallMapper;
 import com.personal.marketnote.reward.domain.offerwall.OfferwallType;
+import com.personal.marketnote.reward.domain.offerwall.UserDeviceType;
 import com.personal.marketnote.reward.domain.vendorcommunication.RewardVendorCommunicationTargetType;
 import com.personal.marketnote.reward.domain.vendorcommunication.RewardVendorCommunicationType;
 import com.personal.marketnote.reward.domain.vendorcommunication.RewardVendorName;
@@ -63,6 +64,7 @@ public class OfferwallController {
             @RequestParam("reward_key") String rewardKey,
             @RequestParam("usn") String userId,
             @RequestParam("campaign_key") String campaignKey,
+            @RequestParam("user_device_type") UserDeviceType userDeviceType,
             @RequestParam(value = "campaign_type", required = false) Integer campaignType,
             @RequestParam(value = "campaign_name", required = false) String campaignName,
             @RequestParam(value = "quantity") Long quantity,
@@ -95,6 +97,7 @@ public class OfferwallController {
                 OfferwallType.ADPOPCORN,
                 rewardKey,
                 userId,
+                userDeviceType,
                 campaignKey,
                 campaignType,
                 campaignName,

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/offerwall/mapper/RewardRequestToCommandMapper.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/offerwall/mapper/RewardRequestToCommandMapper.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.reward.adapter.in.offerwall.mapper;
 
 import com.personal.marketnote.reward.domain.offerwall.OfferwallType;
+import com.personal.marketnote.reward.domain.offerwall.UserDeviceType;
 import com.personal.marketnote.reward.port.in.command.offerwall.OfferwallCallbackCommand;
 
 import java.time.LocalDateTime;
@@ -11,6 +12,7 @@ public class RewardRequestToCommandMapper {
             OfferwallType offerwallType,
             String rewardKey,
             String userKey,
+            UserDeviceType userDeviceType,
             String campaignKey,
             Integer campaignType,
             String campaignName,
@@ -27,6 +29,7 @@ public class RewardRequestToCommandMapper {
                 .offerwallType(offerwallType)
                 .rewardKey(rewardKey)
                 .userId(userKey)
+                .userDeviceType(userDeviceType)
                 .campaignKey(campaignKey)
                 .campaignType(campaignType)
                 .campaignName(campaignName)

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/offerwall/entity/OfferwallMapperJpaEntity.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/offerwall/entity/OfferwallMapperJpaEntity.java
@@ -4,6 +4,7 @@ import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.reward.domain.offerwall.OfferwallMapper;
 import com.personal.marketnote.reward.domain.offerwall.OfferwallMapperSnapshotState;
 import com.personal.marketnote.reward.domain.offerwall.OfferwallType;
+import com.personal.marketnote.reward.domain.offerwall.UserDeviceType;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
@@ -38,6 +39,10 @@ public class OfferwallMapperJpaEntity {
 
     @Column(name = "user_id", nullable = false, length = 128)
     private String userId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "user_device_type", nullable = false, length = 15)
+    private UserDeviceType userDeviceType;
 
     @Column(name = "campaign_key", nullable = false, length = 50)
     private String campaignKey;
@@ -86,6 +91,7 @@ public class OfferwallMapperJpaEntity {
                 .offerwallType(offerwallMapper.getOfferwallType())
                 .rewardKey(offerwallMapper.getRewardKey())
                 .userId(offerwallMapper.getUserId())
+                .userDeviceType(offerwallMapper.getUserDeviceType())
                 .campaignKey(offerwallMapper.getCampaignKey())
                 .campaignType(offerwallMapper.getCampaignType())
                 .campaignName(offerwallMapper.getCampaignName())
@@ -108,6 +114,7 @@ public class OfferwallMapperJpaEntity {
                         .offerwallType(offerwallType)
                         .rewardKey(rewardKey)
                         .userId(userId)
+                        .userDeviceType(userDeviceType)
                         .campaignKey(campaignKey)
                         .campaignType(campaignType)
                         .campaignName(campaignName)

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/exception/RewardTargetInfoNotFoundException.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/exception/RewardTargetInfoNotFoundException.java
@@ -1,0 +1,10 @@
+package com.personal.marketnote.reward.exception;
+
+import lombok.Getter;
+
+@Getter
+public class RewardTargetInfoNotFoundException extends IllegalStateException {
+    public RewardTargetInfoNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/mapper/RewardCommandToStateMapper.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/mapper/RewardCommandToStateMapper.java
@@ -10,6 +10,7 @@ public class RewardCommandToStateMapper {
                 .offerwallType(command.getOfferwallType())
                 .rewardKey(command.getRewardKey())
                 .userId(command.getUserId())
+                .userDeviceType(command.getUserDeviceType())
                 .campaignKey(command.getCampaignKey())
                 .campaignType(command.getCampaignType())
                 .campaignName(command.getCampaignName())

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/command/offerwall/OfferwallCallbackCommand.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/command/offerwall/OfferwallCallbackCommand.java
@@ -1,7 +1,7 @@
 package com.personal.marketnote.reward.port.in.command.offerwall;
 
-import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.reward.domain.offerwall.OfferwallType;
+import com.personal.marketnote.reward.domain.offerwall.UserDeviceType;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -13,6 +13,7 @@ public class OfferwallCallbackCommand {
     private final OfferwallType offerwallType;
     private final String rewardKey;
     private final String userId;
+    private final UserDeviceType userDeviceType;
     private final String campaignKey;
     private final Integer campaignType;
     private final String campaignName;
@@ -26,10 +27,10 @@ public class OfferwallCallbackCommand {
     private final LocalDateTime attendedAt;
 
     public boolean isAndroid() {
-        return FormatValidator.hasValue(adid);
+        return userDeviceType.isAndroid();
     }
 
     public boolean isIos() {
-        return FormatValidator.hasValue(idfa);
+        return userDeviceType.isIos();
     }
 }

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/service/offerwall/RegisterOfferwallRewardService.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/service/offerwall/RegisterOfferwallRewardService.java
@@ -6,6 +6,7 @@ import com.personal.marketnote.common.security.vendor.VendorVerificationProcesso
 import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.reward.configuration.AdpopcornHashKeyProperties;
 import com.personal.marketnote.reward.domain.offerwall.OfferwallMapper;
+import com.personal.marketnote.reward.exception.RewardTargetInfoNotFoundException;
 import com.personal.marketnote.reward.mapper.RewardCommandToStateMapper;
 import com.personal.marketnote.reward.port.in.command.offerwall.OfferwallCallbackCommand;
 import com.personal.marketnote.reward.port.in.usecase.offerwall.RegisterOfferwallRewardUseCase;
@@ -41,7 +42,7 @@ public class RegisterOfferwallRewardService implements RegisterOfferwallRewardUs
             return requireHashKey(adpopcornHashKeyProperties.getIos());
         }
 
-        throw new VendorVerificationFailedException("애드팝콘 리워드 지급 대상 디바이스 정보가 없습니다.");
+        throw new RewardTargetInfoNotFoundException("애드팝콘 리워드 지급 대상 디바이스 정보가 없습니다.");
     }
 
     private String requireHashKey(String hashKey) {

--- a/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/offerwall/OfferwallMapper.java
+++ b/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/offerwall/OfferwallMapper.java
@@ -13,6 +13,7 @@ public class OfferwallMapper {
     private OfferwallType offerwallType;
     private String rewardKey;
     private String userId;
+    private UserDeviceType userDeviceType;
     private String campaignKey;
     private Integer campaignType;
     private String campaignName;
@@ -31,6 +32,7 @@ public class OfferwallMapper {
                 .offerwallType(state.getOfferwallType())
                 .rewardKey(state.getRewardKey())
                 .userId(state.getUserId())
+                .userDeviceType(state.getUserDeviceType())
                 .campaignKey(state.getCampaignKey())
                 .campaignType(state.getCampaignType())
                 .campaignName(state.getCampaignName())
@@ -51,6 +53,7 @@ public class OfferwallMapper {
                 .offerwallType(state.getOfferwallType())
                 .rewardKey(state.getRewardKey())
                 .userId(state.getUserId())
+                .userDeviceType(state.getUserDeviceType())
                 .campaignKey(state.getCampaignKey())
                 .campaignType(state.getCampaignType())
                 .campaignName(state.getCampaignName())

--- a/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/offerwall/OfferwallMapperCreateState.java
+++ b/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/offerwall/OfferwallMapperCreateState.java
@@ -11,6 +11,7 @@ public class OfferwallMapperCreateState {
     private final OfferwallType offerwallType;
     private final String rewardKey;
     private final String userId;
+    private final UserDeviceType userDeviceType;
     private final String campaignKey;
     private final Integer campaignType;
     private final String campaignName;

--- a/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/offerwall/OfferwallMapperSnapshotState.java
+++ b/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/offerwall/OfferwallMapperSnapshotState.java
@@ -12,6 +12,7 @@ public class OfferwallMapperSnapshotState {
     private final OfferwallType offerwallType;
     private final String rewardKey;
     private final String userId;
+    private final UserDeviceType userDeviceType;
     private final String campaignKey;
     private final Integer campaignType;
     private final String campaignName;

--- a/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/offerwall/OfferwallType.java
+++ b/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/offerwall/OfferwallType.java
@@ -1,6 +1,11 @@
 package com.personal.marketnote.reward.domain.offerwall;
 
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
 public enum OfferwallType {
-    ADPOPCORN,
-    TNK
+    ADPOPCORN("애드팝콘"),
+    TNK("TNK");
+
+    private final String description;
 }

--- a/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/offerwall/UserDeviceType.java
+++ b/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/offerwall/UserDeviceType.java
@@ -1,0 +1,19 @@
+package com.personal.marketnote.reward.domain.offerwall;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum UserDeviceType {
+    ANDROID("안드로이드"),
+    IOS("IOS");
+
+    private final String description;
+
+    public boolean isAndroid() {
+        return this == ANDROID;
+    }
+
+    public boolean isIos() {
+        return this == IOS;
+    }
+}


### PR DESCRIPTION
## partially addresses #387
## resolves #394

## Task
- [x] ANDROID
- [x] IOS