### PR TITLE
[#216][#406] feat: 재고 차감 시 다중 스레드의 공유 자원 경합에 대한 Redis/RDBMS 이중 동시성 제어 로직 추가

### DIFF
--- a/commerce-service/commerce-adapters/build.gradle.kts
+++ b/commerce-service/commerce-adapters/build.gradle.kts
@@ -50,6 +50,9 @@ dependencies {
     // Spring Data Redis
     implementation("org.springframework.boot:spring-boot-starter-data-redis")
 
+    // Redisson
+    implementation("org.redisson:redisson-spring-boot-starter:3.17.4")
+
     //querydsl 설정
     implementation("jakarta.persistence:jakarta.persistence-api:3.1.0")
     annotationProcessor("jakarta.persistence:jakarta.persistence-api:3.1.0")

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/lock/InventoryLockRedissonAdapter.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/lock/InventoryLockRedissonAdapter.java
@@ -1,0 +1,60 @@
+package com.personal.marketnote.commerce.adapter.out.lock;
+
+import com.personal.marketnote.commerce.exception.InventoryLockAcquisitionException;
+import com.personal.marketnote.commerce.exception.InventoryLockInterruptedException;
+import com.personal.marketnote.commerce.port.out.inventory.InventoryLockPort;
+import lombok.RequiredArgsConstructor;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Repository;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+@Repository
+@RequiredArgsConstructor
+public class InventoryLockRedissonAdapter implements InventoryLockPort {
+    private static final String LOCK_KEY_PREFIX = "lock:inventory:price-policy:";
+    private static final long WAIT_TIME_SECONDS = 3L;
+    private static final long LEASE_TIME_SECONDS = 10L;
+
+    private final RedissonClient redissonClient;
+
+    @Override
+    public void executeWithLock(Set<Long> pricePolicyIds, Runnable task) {
+        List<RLock> acquiredLocks = new ArrayList<>();
+        List<Long> sortedIds = pricePolicyIds.stream()
+                .sorted()
+                .toList();
+
+        try {
+            for (Long pricePolicyId : sortedIds) {
+                RLock lock = redissonClient.getLock(buildKey(pricePolicyId));
+                boolean locked = lock.tryLock(WAIT_TIME_SECONDS, LEASE_TIME_SECONDS, TimeUnit.SECONDS);
+                if (!locked) {
+                    throw new InventoryLockAcquisitionException(pricePolicyId);
+                }
+                acquiredLocks.add(lock);
+            }
+
+            task.run();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new InventoryLockInterruptedException(e);
+        } finally {
+            for (int i = acquiredLocks.size() - 1; i >= 0; i--) {
+                RLock lock = acquiredLocks.get(i);
+                if (lock.isHeldByCurrentThread()) {
+                    lock.unlock();
+                }
+            }
+        }
+    }
+
+    private String buildKey(Long pricePolicyId) {
+        return LOCK_KEY_PREFIX + pricePolicyId;
+    }
+}
+

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/mapper/InventoryJpaEntityToDomainMapper.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/mapper/InventoryJpaEntityToDomainMapper.java
@@ -8,7 +8,7 @@ import java.util.Optional;
 public class InventoryJpaEntityToDomainMapper {
     public static Optional<Inventory> mapToDomain(InventoryJpaEntity inventoryJpaEntity) {
         return Optional.ofNullable(inventoryJpaEntity)
-                .map(entity -> Inventory.of(entity.getPricePolicyId(), entity.getStock()));
+                .map(entity -> Inventory.of(entity.getPricePolicyId(), entity.getStock(), entity.getVersion()));
     }
 }
 

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/inventory/entity/InventoryJpaEntity.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/inventory/entity/InventoryJpaEntity.java
@@ -2,10 +2,7 @@ package com.personal.marketnote.commerce.adapter.out.persistence.inventory.entit
 
 import com.personal.marketnote.commerce.domain.inventory.Inventory;
 import com.personal.marketnote.common.adapter.out.persistence.audit.BaseEntity;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -26,15 +23,26 @@ public class InventoryJpaEntity extends BaseEntity {
     @Column(name = "stock", nullable = false, columnDefinition = "INT DEFAULT 0")
     private Integer stock;
 
-    private InventoryJpaEntity(Long pricePolicyId) {
+    // RDBMS 낙관적 락 기반의 동시성 제어
+    @Version
+    private Long version;
+
+    private InventoryJpaEntity(Long pricePolicyId, Integer stock, Long version) {
         this.pricePolicyId = pricePolicyId;
+        this.stock = stock;
+        this.version = version;
     }
 
     public static InventoryJpaEntity from(Inventory inventory) {
-        return new InventoryJpaEntity(inventory.getPricePolicyId());
+        return new InventoryJpaEntity(
+                inventory.getPricePolicyId(),
+                inventory.getStockValue(),
+                inventory.getVersion()
+        );
     }
 
     public void updateFrom(Inventory inventory) {
-        stock = inventory.getStockValue();
+        this.stock = inventory.getStockValue();
+        this.version = inventory.getVersion();
     }
 }

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/configuration/RedissonConfig.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/configuration/RedissonConfig.java
@@ -1,0 +1,26 @@
+package com.personal.marketnote.commerce.configuration;
+
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RedissonConfig {
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public RedissonClient redissonClient() {
+        Config config = new Config();
+        config.useSingleServer()
+                .setAddress("redis://" + host + ":" + port);
+
+        return Redisson.create(config);
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/exception/InventoryLockAcquisitionException.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/exception/InventoryLockAcquisitionException.java
@@ -1,0 +1,10 @@
+package com.personal.marketnote.commerce.exception;
+
+public class InventoryLockAcquisitionException extends RuntimeException {
+    private static final String MESSAGE = "재고 락을 획득하지 못했습니다. 가격 정책 ID: %d";
+
+    public InventoryLockAcquisitionException(Long pricePolicyId) {
+        super(String.format(MESSAGE, pricePolicyId));
+    }
+}
+

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/exception/InventoryLockInterruptedException.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/exception/InventoryLockInterruptedException.java
@@ -1,0 +1,10 @@
+package com.personal.marketnote.commerce.exception;
+
+public class InventoryLockInterruptedException extends RuntimeException {
+    private static final String MESSAGE = "재고 락 처리 중 인터럽트가 발생했습니다.";
+
+    public InventoryLockInterruptedException(Throwable cause) {
+        super(MESSAGE, cause);
+    }
+}
+

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/inventory/ReduceProductInventoryUseCase.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/inventory/ReduceProductInventoryUseCase.java
@@ -10,7 +10,7 @@ public interface ReduceProductInventoryUseCase {
      * @param reason        재고 차감 이유
      * @Date 2026-01-06
      * @Author 성효빈
-     * @Description 주문 상품의 재고를 차감합니다.
+     * @Description 주문 상품의 재고를 차감합니다. 분산 락/낙관적 락 이중 동시성 제어 로직이 적용되어 있습니다.
      */
     void reduce(List<OrderProduct> orderProducts, String reason);
 }

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/inventory/InventoryLockPort.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/inventory/InventoryLockPort.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.commerce.port.out.inventory;
+
+import java.util.Set;
+
+public interface InventoryLockPort {
+    void executeWithLock(Set<Long> pricePolicyIds, Runnable task);
+}

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/inventory/Inventory.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/inventory/Inventory.java
@@ -12,11 +12,13 @@ import static org.hibernate.type.descriptor.java.IntegerJavaType.ZERO;
 public class Inventory {
     private Long pricePolicyId;
     private Stock stock;
+    private Long version;
 
     public static Inventory of(Long pricePolicyId) {
         return Inventory.builder()
                 .pricePolicyId(pricePolicyId)
                 .stock(Stock.of(ZERO.toString()))
+                .version(null)
                 .build();
     }
 
@@ -24,6 +26,15 @@ public class Inventory {
         return Inventory.builder()
                 .pricePolicyId(pricePolicyId)
                 .stock(Stock.of(stock.toString()))
+                .version(null)
+                .build();
+    }
+
+    public static Inventory of(Long pricePolicyId, Integer stock, Long version) {
+        return Inventory.builder()
+                .pricePolicyId(pricePolicyId)
+                .stock(Stock.of(stock.toString()))
+                .version(version)
                 .build();
     }
 


### PR DESCRIPTION
## partially addresses #216
## resolves #406

## Task
- [x] Redis: Redisson 기반의 Pub/Sub 모델 분산 락(Locking 채널 구독/발행을 통한 대기열 관리)
    - [x] 자원 수정 시도 전 채널 생성 및 Locking 후 작업 진행
    - [x] 타 스레드에서 자원 수정 시도 시 채널이 Locking 상태인 경우 해당 채널을 구독 후 대기
    - [x] 자원 수정 완료 후 채널 구독 중인 타 스레드에 Unlocking을 고지하는 메시지 발행
    - [x] 구독 스레드 순번대로 채널 Locking 및 작업 진행 반복
- [x] RDBMS(PostgreSQL): 낙관적 락(자원 버전 관리를 통한 무결성 유지)
    - [x] 자원 수정 후 영구 반영 직전 동일 데이터를 다시 조회해 수정 전 버전과의 동일성 검증
    - [x] 버전이 변경되지 않은 경우 영구 반영(재고 차감) 후 버전 업데이트
    - [x] 버전이 변경된 경우(타 스레드에서 자원 수정을 먼저 완료한 경우) 현재 변경사항을 취소 후 (최신 재고 수량이 반영된) 새로운 버전에 대해 데이터 수정 재시도