### PR TITLE
[#216][#406] fix: ECS 환경에서 커머스 서비스가 Redisson의 DI 컨테이너 싱글턴 인스턴스를 생성하지 못하는 이슈 대응

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/configuration/RedissonConfig.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/configuration/RedissonConfig.java
@@ -15,11 +15,15 @@ public class RedissonConfig {
     @Value("${spring.data.redis.port}")
     private int port;
 
+    @Value("${spring.data.redis.password}")
+    private String password;
+
     @Bean
     public RedissonClient redissonClient() {
         Config config = new Config();
         config.useSingleServer()
-                .setAddress("redis://" + host + ":" + port);
+                .setAddress("redis://" + host + ":" + port)
+                .setPassword(password);
 
         return Redisson.create(config);
     }


### PR DESCRIPTION
## partially addresses #216
## resolves #406

## Task
- [x] DI 컨테이너 인스턴스 생성 시 password 설정 로직 추가