### PR TITLE
[#387][#402] refactor: 회원 포인트 적립/차감 로직 수정

### DIFF
--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/offerwall/OfferwallController.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/offerwall/OfferwallController.java
@@ -109,8 +109,7 @@ public class OfferwallController {
                 appName,
                 adid,
                 idfa,
-                attendedAt,
-                true
+                attendedAt
         );
 
         RewardVendorCommunicationTargetType targetType = RewardVendorCommunicationTargetType.OFFERWALL;

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/offerwall/mapper/RewardRequestToCommandMapper.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/offerwall/mapper/RewardRequestToCommandMapper.java
@@ -7,7 +7,6 @@ import com.personal.marketnote.reward.port.in.command.offerwall.RegisterOfferwal
 import java.time.LocalDateTime;
 
 public class RewardRequestToCommandMapper {
-
     public static RegisterOfferwallRewardCommand mapToOfferwallCallbackCommand(
             OfferwallType offerwallType,
             String rewardKey,
@@ -22,8 +21,7 @@ public class RewardRequestToCommandMapper {
             String appName,
             String adid,
             String idfa,
-            LocalDateTime attendedAt,
-            Boolean isSuccess
+            LocalDateTime attendedAt
     ) {
         return RegisterOfferwallRewardCommand.builder()
                 .offerwallType(offerwallType)
@@ -39,7 +37,6 @@ public class RewardRequestToCommandMapper {
                 .appName(appName)
                 .adid(adid)
                 .idfa(idfa)
-                .isSuccess(isSuccess)
                 .attendedAt(attendedAt)
                 .build();
     }

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/point/UserPointPersistenceAdapter.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/point/UserPointPersistenceAdapter.java
@@ -4,13 +4,15 @@ import com.personal.marketnote.common.adapter.out.PersistenceAdapter;
 import com.personal.marketnote.reward.adapter.out.persistence.point.entity.UserPointJpaEntity;
 import com.personal.marketnote.reward.adapter.out.persistence.point.repository.UserPointJpaRepository;
 import com.personal.marketnote.reward.domain.point.UserPoint;
+import com.personal.marketnote.reward.exception.UserPointNotFoundException;
 import com.personal.marketnote.reward.port.out.point.FindUserPointPort;
 import com.personal.marketnote.reward.port.out.point.SaveUserPointPort;
+import com.personal.marketnote.reward.port.out.point.UpdateUserPointPort;
 import lombok.RequiredArgsConstructor;
 
 @PersistenceAdapter
 @RequiredArgsConstructor
-public class UserPointPersistenceAdapter implements SaveUserPointPort, FindUserPointPort {
+public class UserPointPersistenceAdapter implements SaveUserPointPort, FindUserPointPort, UpdateUserPointPort {
     private final UserPointJpaRepository repository;
 
     @Override
@@ -27,5 +29,19 @@ public class UserPointPersistenceAdapter implements SaveUserPointPort, FindUserP
     @Override
     public java.util.Optional<UserPoint> findByUserId(Long userId) {
         return repository.findByUserId(userId).map(UserPointJpaEntity::toDomain);
+    }
+
+    @Override
+    public UserPoint update(UserPoint userPoint) throws UserPointNotFoundException {
+        UserPointJpaEntity userPointJpaEntity
+                = findEntityByUserId(userPoint.getUserId());
+        userPointJpaEntity.updateFrom(userPoint);
+
+        return userPoint;
+    }
+
+    private UserPointJpaEntity findEntityByUserId(Long userId) throws UserPointNotFoundException {
+        return repository.findByUserId(userId)
+                .orElseThrow(() -> new UserPointNotFoundException(userId));
     }
 }

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/point/entity/UserPointJpaEntity.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/point/entity/UserPointJpaEntity.java
@@ -48,7 +48,7 @@ public class UserPointJpaEntity {
 
         return UserPointJpaEntity.builder()
                 .userId(userPoint.getUserId())
-                .amount(userPoint.getAmount())
+                .amount(userPoint.getAmountValue())
                 .addExpectedAmount(userPoint.getAddExpectedAmount())
                 .expireExpectedAmount(userPoint.getExpireExpectedAmount())
                 .createdAt(userPoint.getCreatedAt())
@@ -67,5 +67,11 @@ public class UserPointJpaEntity {
                         .modifiedAt(modifiedAt)
                         .build()
         );
+    }
+
+    public void updateFrom(UserPoint userPoint) {
+        this.amount = userPoint.getAmountValue();
+        this.addExpectedAmount = userPoint.getAddExpectedAmount();
+        this.expireExpectedAmount = userPoint.getExpireExpectedAmount();
     }
 }

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/exception/UserPointNotFoundException.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/exception/UserPointNotFoundException.java
@@ -1,0 +1,11 @@
+package com.personal.marketnote.reward.exception;
+
+import jakarta.persistence.EntityNotFoundException;
+
+public class UserPointNotFoundException extends EntityNotFoundException {
+    private static final String USER_POINT_NOT_FOUND_EXCEPTION_MESSAGE = "회원 포인트 정보를 찾을 수 없습니다. 전송된 회원 ID: %d";
+
+    public UserPointNotFoundException(Long userId) {
+        super(String.format(USER_POINT_NOT_FOUND_EXCEPTION_MESSAGE, userId));
+    }
+}

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/command/point/ModifyUserPointCommand.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/command/point/ModifyUserPointCommand.java
@@ -13,4 +13,7 @@ public record ModifyUserPointCommand(
         Long sourceId,
         String reason
 ) {
+    public boolean isAccrual() {
+        return changeType.isAccrual();
+    }
 }

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/result/point/UpdateUserPointResult.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/result/point/UpdateUserPointResult.java
@@ -15,7 +15,7 @@ public record UpdateUserPointResult(
     public static UpdateUserPointResult from(UserPoint userPoint) {
         return new UpdateUserPointResult(
                 userPoint.getUserId(),
-                userPoint.getAmount(),
+                userPoint.getAmountValue(),
                 userPoint.getAddExpectedAmount(),
                 userPoint.getExpireExpectedAmount(),
                 userPoint.getCreatedAt(),

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/out/point/UpdateUserPointPort.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/out/point/UpdateUserPointPort.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.reward.port.out.point;
+
+import com.personal.marketnote.reward.domain.point.UserPoint;
+import com.personal.marketnote.reward.exception.UserPointNotFoundException;
+
+public interface UpdateUserPointPort {
+    UserPoint update(UserPoint userPoint) throws UserPointNotFoundException;
+}

--- a/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/exception/InvalidPointAmountException.java
+++ b/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/exception/InvalidPointAmountException.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.reward.domain.exception;
+
+public class InvalidPointAmountException extends IllegalArgumentException {
+    public InvalidPointAmountException(String message) {
+        super(message);
+    }
+}

--- a/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/exception/PointAmountNoValueException.java
+++ b/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/exception/PointAmountNoValueException.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.reward.domain.exception;
+
+public class PointAmountNoValueException extends IllegalArgumentException {
+    public PointAmountNoValueException(String message) {
+        super(message);
+    }
+}

--- a/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/point/PointAmount.java
+++ b/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/point/PointAmount.java
@@ -1,29 +1,69 @@
 package com.personal.marketnote.reward.domain.point;
 
+import com.personal.marketnote.common.utility.FormatConverter;
+import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.reward.domain.exception.InvalidPointAmountException;
+import com.personal.marketnote.reward.domain.exception.PointAmountNoValueException;
+
+import static com.personal.marketnote.common.utility.RegularExpressionConstant.ZERO_OR_POSITIVE_INTEGER_PATTERN;
+
 public class PointAmount {
-    private final long value;
+    private static final String POINT_AMOUNT_NO_VALUE_EXCEPTION_MESSAGE = "포인트 금액은 필수값입니다.";
+    private static final String INVALID_POINT_AMOUNT_EXCEPTION_MESSAGE = "포인트 금액은 0 또는 양의 정수(0 이상의 숫자값)여야 합니다. 차감 후 포인트: %s";
 
-    private PointAmount(long value) {
-        this.value = value;
+    private final long amount;
+
+    private PointAmount(long amount) {
+        this.amount = amount;
     }
 
-    public static PointAmount of(Long value) {
-        long validated = value != null ? value : 0L;
-        if (validated < 0) {
-            throw new NegativeUserPointAmountException(validated);
-        }
-        return new PointAmount(validated);
+    public static PointAmount of(String amount) {
+        validate(amount);
+        return new PointAmount(FormatConverter.parseToLong(amount));
     }
 
-    public long add(long delta) {
-        long result = value + delta;
-        if (result < 0) {
-            throw new NegativeUserPointAmountException(result);
+    private static void validate(String amount) {
+        checkAmountIsNotBlank(amount);
+        checkAmountPattern(amount);
+    }
+
+    private static void checkAmountIsNotBlank(String amount) {
+        if (!FormatValidator.hasValue(amount)) {
+            throw new PointAmountNoValueException(POINT_AMOUNT_NO_VALUE_EXCEPTION_MESSAGE);
         }
-        return result;
+    }
+
+    private static void checkAmountPattern(String amount) {
+        if (!amount.matches(ZERO_OR_POSITIVE_INTEGER_PATTERN)) {
+            throw new InvalidPointAmountException(String.format(INVALID_POINT_AMOUNT_EXCEPTION_MESSAGE, amount));
+        }
+    }
+
+    public static PointAmount generateChangedAmount(boolean isAccrual, PointAmount currentAmount, Long requestedAmount) {
+        PointAmount addedAmount = PointAmount.of(
+                String.valueOf(requestedAmount)
+        );
+
+        if (isAccrual) {
+            return accumulate(currentAmount, addedAmount);
+        }
+
+        return reduce(currentAmount, addedAmount);
+    }
+
+    private static PointAmount accumulate(PointAmount currentAmount, PointAmount addedAmount) {
+        return PointAmount.of(
+                String.valueOf(currentAmount.getValue() + addedAmount.getValue())
+        );
+    }
+
+    private static PointAmount reduce(PointAmount currentAmount, PointAmount reducedAmount) {
+        return PointAmount.of(
+                String.valueOf(currentAmount.getValue() - reducedAmount.getValue())
+        );
     }
 
     public long getValue() {
-        return value;
+        return amount;
     }
 }

--- a/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/point/UserPoint.java
+++ b/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/point/UserPoint.java
@@ -10,7 +10,7 @@ import java.time.LocalDateTime;
 @Builder(access = AccessLevel.PRIVATE)
 public class UserPoint {
     private Long userId;
-    private Long amount;
+    private PointAmount amount;
     private Long addExpectedAmount;
     private Long expireExpectedAmount;
     private LocalDateTime createdAt;
@@ -19,7 +19,7 @@ public class UserPoint {
     public UserPoint withAmount(Long amount) {
         return UserPoint.builder()
                 .userId(userId)
-                .amount(amount)
+                .amount(PointAmount.of(String.valueOf(amount)))
                 .addExpectedAmount(addExpectedAmount)
                 .expireExpectedAmount(expireExpectedAmount)
                 .createdAt(createdAt)
@@ -30,7 +30,7 @@ public class UserPoint {
     public static UserPoint from(UserPointCreateState state) {
         return UserPoint.builder()
                 .userId(state.getUserId())
-                .amount(state.getAmount())
+                .amount(PointAmount.of(String.valueOf(state.getAmount())))
                 .addExpectedAmount(state.getAddExpectedAmount())
                 .expireExpectedAmount(state.getExpireExpectedAmount())
                 .build();
@@ -39,11 +39,19 @@ public class UserPoint {
     public static UserPoint from(UserPointSnapshotState state) {
         return UserPoint.builder()
                 .userId(state.getUserId())
-                .amount(state.getAmount())
+                .amount(PointAmount.of(String.valueOf(state.getAmount())))
                 .addExpectedAmount(state.getAddExpectedAmount())
                 .expireExpectedAmount(state.getExpireExpectedAmount())
                 .createdAt(state.getCreatedAt())
                 .modifiedAt(state.getModifiedAt())
                 .build();
+    }
+
+    public void changeAmount(boolean isAccrual, Long amount) {
+        this.amount = PointAmount.generateChangedAmount(isAccrual, this.amount, amount);
+    }
+
+    public Long getAmountValue() {
+        return amount.getValue();
     }
 }

--- a/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/point/UserPointChangeType.java
+++ b/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/point/UserPointChangeType.java
@@ -1,6 +1,15 @@
 package com.personal.marketnote.reward.domain.point;
 
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
 public enum UserPointChangeType {
-    ACCRUAL,
-    DEDUCTION
+    ACCRUAL("적립"),
+    DEDUCTION("차감");
+
+    private final String description;
+
+    public boolean isAccrual() {
+        return this == ACCRUAL;
+    }
 }


### PR DESCRIPTION
## partially addresses #387
## resolves #402

## Task
- [x] 포인트 갱신 시 PointAmount 포장 객체 기반으로 작업하도록 변경
- [x] 포인트 갱신 시 savePort가 아닌 updatePort 인터페이스를 호출하여 영속성 업데이트를 수행하도록 변경
- [x] 포인트 튜플이 항상 무결성을 유지하도록 로직 개선
- [x] 포인트 무결성 검증 시 예외 처리 클래스 및 메시지 수정
- [x] 서비스 레이어의 포인트 갱신 비즈니스 로직 간소화
- [x] 적립/차감 타입 enum 클래스에 description 필드 추가
- [x] 포인트 히스토리 튜플의 생성일시가 부모 포인트 튜플 수정일시를 기반으로 하도록 변경