### PR TITLE
[#387][#390] refactor: 애드팝콘 연동 프로세스 리팩터링

### DIFF
--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/offerwall/OfferwallController.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/offerwall/OfferwallController.java
@@ -8,7 +8,6 @@ import com.personal.marketnote.common.exception.UserNotFoundException;
 import com.personal.marketnote.common.utility.FormatConverter;
 import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.reward.adapter.in.offerwall.apidocs.AdpopcornCallbackApiDocs;
-import com.personal.marketnote.reward.adapter.in.offerwall.mapper.RewardRequestToCommandMapper;
 import com.personal.marketnote.reward.domain.offerwall.OfferwallMapper;
 import com.personal.marketnote.reward.domain.offerwall.OfferwallType;
 import com.personal.marketnote.reward.domain.offerwall.UserDeviceType;
@@ -95,22 +94,22 @@ public class OfferwallController {
         );
         String payloadString = payloadJson.toString();
 
-        RegisterOfferwallRewardCommand command = RewardRequestToCommandMapper.mapToOfferwallCallbackCommand(
-                OfferwallType.ADPOPCORN,
-                rewardKey,
-                userId,
-                userDeviceType,
-                campaignKey,
-                campaignType,
-                campaignName,
-                quantity,
-                signedValue,
-                appKey,
-                appName,
-                adid,
-                idfa,
-                attendedAt
-        );
+        RegisterOfferwallRewardCommand command = RegisterOfferwallRewardCommand.builder()
+                .offerwallType(OfferwallType.ADPOPCORN)
+                .rewardKey(rewardKey)
+                .userId(userId)
+                .userDeviceType(userDeviceType)
+                .campaignKey(campaignKey)
+                .campaignType(campaignType)
+                .campaignName(campaignName)
+                .quantity(quantity)
+                .signedValue(signedValue)
+                .appKey(appKey)
+                .appName(appName)
+                .adid(adid)
+                .idfa(idfa)
+                .attendedAt(attendedAt)
+                .build();
 
         RewardVendorCommunicationTargetType targetType = RewardVendorCommunicationTargetType.OFFERWALL;
         RewardVendorName vendorName = RewardVendorName.ADPOPCORN;
@@ -128,12 +127,16 @@ public class OfferwallController {
 
             return ResponseEntity.ok(successPayload);
         } catch (VendorVerificationFailedException e) {
+            // 서명 검증 실패
             return handleFailure(targetType, vendorName, payloadString, payloadJson, e, 1100, "invalid signed value");
         } catch (UserNotFoundException e) {
+            // 회원 포인트 도메인 정보 조회 실패
             return handleFailure(targetType, vendorName, payloadString, payloadJson, e, 3200, "invalid user");
         } catch (DuplicateOfferwallRewardException e) {
+            // 중복 리워드 지급 시도
             return handleFailure(targetType, vendorName, payloadString, payloadJson, e, 3100, "duplicate transaction");
         } catch (Exception e) {
+            // 그 외
             return handleFailure(targetType, vendorName, payloadString, payloadJson, e, 4000, "custom error message");
         }
     }

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/mapper/RewardCommandToStateMapper.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/mapper/RewardCommandToStateMapper.java
@@ -12,8 +12,9 @@ import com.personal.marketnote.reward.port.in.command.point.RegisterUserPointCom
 import java.time.LocalDateTime;
 
 public class RewardCommandToStateMapper {
-
-    public static OfferwallMapperCreateState mapToOfferwallMapperCreateState(RegisterOfferwallRewardCommand command) {
+    public static OfferwallMapperCreateState mapToOfferwallMapperCreateState(
+            RegisterOfferwallRewardCommand command, boolean isSuccess
+    ) {
         return OfferwallMapperCreateState.builder()
                 .offerwallType(command.offerwallType())
                 .rewardKey(command.rewardKey())
@@ -28,7 +29,7 @@ public class RewardCommandToStateMapper {
                 .appName(command.appName())
                 .adid(command.adid())
                 .idfa(command.idfa())
-                .isSuccess(command.isSuccess())
+                .isSuccess(isSuccess)
                 .attendedAt(command.attendedAt())
                 .build();
     }
@@ -53,7 +54,7 @@ public class RewardCommandToStateMapper {
                 .sourceType(UserPointHistorySourceType.USER)
                 .sourceId(command.userId())
                 .reason("회원 가입")
-                .accumulatedAt(accumulatedAt != null ? accumulatedAt : LocalDateTime.now())
+                .accumulatedAt(accumulatedAt)
                 .build();
     }
 
@@ -70,7 +71,7 @@ public class RewardCommandToStateMapper {
                 .sourceType(command.sourceType())
                 .sourceId(command.sourceId())
                 .reason(command.reason())
-                .accumulatedAt(accumulatedAt != null ? accumulatedAt : LocalDateTime.now())
+                .accumulatedAt(accumulatedAt)
                 .build();
     }
 }

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/command/offerwall/RegisterOfferwallRewardCommand.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/command/offerwall/RegisterOfferwallRewardCommand.java
@@ -21,7 +21,6 @@ public record RegisterOfferwallRewardCommand(
         String appName,
         String adid,
         String idfa,
-        Boolean isSuccess,
         LocalDateTime attendedAt
 ) {
     public boolean isAndroid() {

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/service/offerwall/RegisterOfferwallRewardRewardService.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/service/offerwall/RegisterOfferwallRewardRewardService.java
@@ -38,7 +38,7 @@ public class RegisterOfferwallRewardRewardService implements RegisterOfferwallRe
         validateDuplicate(command);
 
         OfferwallMapper offerwallMapper = saveOfferwallMapperPort.save(
-                OfferwallMapper.from(RewardCommandToStateMapper.mapToOfferwallMapperCreateState(command))
+                OfferwallMapper.from(RewardCommandToStateMapper.mapToOfferwallMapperCreateState(command, true))
         );
 
         // 회원 리워드 포인트 적립

--- a/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/offerwall/OfferwallMapper.java
+++ b/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/offerwall/OfferwallMapper.java
@@ -42,7 +42,7 @@ public class OfferwallMapper {
                 .appName(state.getAppName())
                 .adid(state.getAdid())
                 .idfa(state.getIdfa())
-                .isSuccess(state.getIsSuccess() != null ? state.getIsSuccess() : Boolean.TRUE)
+                .isSuccess(state.isSuccess())
                 .attendedAt(state.getAttendedAt())
                 .build();
     }

--- a/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/offerwall/OfferwallMapperCreateState.java
+++ b/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/offerwall/OfferwallMapperCreateState.java
@@ -21,6 +21,6 @@ public class OfferwallMapperCreateState {
     private final String appName;
     private final String adid;
     private final String idfa;
-    private final Boolean isSuccess;
+    private final boolean isSuccess;
     private final LocalDateTime attendedAt;
 }


### PR DESCRIPTION
## partially addresses #387
## resolves #390

## Task
- [x] isSuccess 플래그를 Adapter Layer가 아닌 Application Layer에서 컨트롤하도록 변경
- [x] Command 객체를 Mapper가 아닌 Controller에서 Builder를 통해 변환하도록 변경(파라미터 오입 방지)
- [x] 예외 처리 관련 주석 추가