### PR TITLE
[#387][#419] feat: 주문 등록 API에 공유자 ID 파라미터 추가

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/client/order/controller/apidocs/GetOrderInfoApiDocs.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/client/order/controller/apidocs/GetOrderInfoApiDocs.java
@@ -123,6 +123,7 @@ import java.lang.annotation.*;
                 | **키** | **타입** | **설명** | **예시** |
                 | --- | --- | --- | --- |
                 | pricePolicyId | number | 가격 정책 ID | 1 |
+                | sharerId | number | 링크 공유 회원 ID | 1 |
                 | quantity | number | 주문 수량 | 2 |
                 | unitAmount | number | 단위 금액(원) | 50000 |
                 | imageUrl | string | 상품 이미지 URL | "https://marketnote.s3.amazonaws.com/product/30/1763534195922_image_600.png" |
@@ -176,6 +177,7 @@ import java.lang.annotation.*;
                                               "orderPrducts": [
                                                 {
                                                   "pricePolicyId": 180,
+                                                  "sharerId": 1,
                                                   "quantity": 10,
                                                   "unitAmount": 70000,
                                                   "imageUrl": "https://marketnote.s3.amazonaws.com/product/30/1763533916081_image_600.png",
@@ -197,6 +199,7 @@ import java.lang.annotation.*;
                                                 },
                                                 {
                                                   "pricePolicyId": 166,
+                                                  "sharerId": null,
                                                   "quantity": 2,
                                                   "unitAmount": 50000,
                                                   "imageUrl": "https://marketnote.s3.amazonaws.com/product/30/1763534195922_image_600.png",

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/client/order/controller/apidocs/GetOrdersApiDocs.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/client/order/controller/apidocs/GetOrdersApiDocs.java
@@ -127,6 +127,7 @@ import java.lang.annotation.*;
                 | **키** | **타입** | **설명** | **예시** |
                 | --- | --- | --- | --- |
                 | pricePolicyId | number | 가격 정책 ID | 1 |
+                | sharerId | number | 링크 공유 회원 ID | 1 |
                 | quantity | number | 주문 수량 | 2 |
                 | unitAmount | number | 단위 금액(원) | 50000 |
                 | imageUrl | string | 상품 이미지 URL | "https://marketnote.s3.amazonaws.com/product/30/1763534195922_image_600.png" |
@@ -175,6 +176,7 @@ import java.lang.annotation.*;
                                                     "orderProducts": [
                                                       {
                                                         "pricePolicyId": 166,
+                                                        "sharerId": 1,
                                                         "quantity": 2,
                                                         "unitAmount": 50000,
                                                         "imageUrl": "https://marketnote.s3.amazonaws.com/product/30/1763534195922_image_600.png",
@@ -191,6 +193,7 @@ import java.lang.annotation.*;
                                                       },
                                                       {
                                                         "pricePolicyId": 180,
+                                                        "sharerId": 1,
                                                         "quantity": 10,
                                                         "unitAmount": 70000,
                                                         "imageUrl": "https://marketnote.s3.amazonaws.com/product/30/1763533916081_image_600.png",
@@ -226,6 +229,7 @@ import java.lang.annotation.*;
                                                     "orderProducts": [
                                                       {
                                                         "pricePolicyId": 144,
+                                                        "sharerId": 1,
                                                         "quantity": 10,
                                                         "unitAmount": 70000,
                                                         "imageUrl": "https://marketnote.s3.amazonaws.com/product/30/1763533916081_image_600.png",
@@ -252,6 +256,7 @@ import java.lang.annotation.*;
                                                       },
                                                       {
                                                         "pricePolicyId": 189,
+                                                        "sharerId": null,
                                                         "quantity": 2,
                                                         "unitAmount": 50000,
                                                         "imageUrl": "https://marketnote.s3.amazonaws.com/product/30/1763534195922_image_600.png",
@@ -292,6 +297,7 @@ import java.lang.annotation.*;
                                                     "orderProducts": [
                                                       {
                                                         "pricePolicyId": 159,
+                                                        "sharerId": null,
                                                         "quantity": 2,
                                                         "unitAmount": 50000,
                                                         "imageUrl": "https://marketnote.s3.amazonaws.com/product/30/1763534195922_image_600.png",
@@ -313,6 +319,7 @@ import java.lang.annotation.*;
                                                       },
                                                       {
                                                         "pricePolicyId": 185,
+                                                        "sharerId": 1,
                                                         "quantity": 10,
                                                         "unitAmount": 70000,
                                                         "imageUrl": "https://marketnote.s3.amazonaws.com/product/30/1763533916081_image_600.png",

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/client/order/mapper/OrderRequestToCommandMapper.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/client/order/mapper/OrderRequestToCommandMapper.java
@@ -3,7 +3,7 @@ package com.personal.marketnote.commerce.adapter.in.client.order.mapper;
 import com.personal.marketnote.commerce.adapter.in.client.order.request.ChangeOrderStatusRequest;
 import com.personal.marketnote.commerce.adapter.in.client.order.request.RegisterOrderRequest;
 import com.personal.marketnote.commerce.port.in.command.order.ChangeOrderStatusCommand;
-import com.personal.marketnote.commerce.port.in.command.order.OrderProductItem;
+import com.personal.marketnote.commerce.port.in.command.order.OrderProductItemCommand;
 import com.personal.marketnote.commerce.port.in.command.order.RegisterOrderCommand;
 
 import java.util.List;
@@ -13,9 +13,10 @@ public class OrderRequestToCommandMapper {
             RegisterOrderRequest request,
             Long buyerId
     ) {
-        List<OrderProductItem> orderProducts = request.getOrderProducts().stream()
-                .map(item -> OrderProductItem.builder()
+        List<OrderProductItemCommand> orderProducts = request.getOrderProducts().stream()
+                .map(item -> OrderProductItemCommand.builder()
                         .pricePolicyId(item.getPricePolicyId())
+                        .sharerId(item.getSharerId())
                         .quantity(item.getQuantity())
                         .unitAmount(item.getUnitAmount())
                         .imageUrl(item.getImageUrl())

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/client/order/request/OrderProductItemRequest.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/client/order/request/OrderProductItemRequest.java
@@ -1,0 +1,54 @@
+package com.personal.marketnote.commerce.adapter.in.client.order.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class OrderProductItemRequest {
+    @Schema(
+            name = "pricePolicyId",
+            description = "가격 정책 ID",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    @NotNull(message = "가격 정책 ID는 필수값입니다.")
+    @Min(value = 1, message = "가격 정책 ID는 1 이상이어야 합니다.")
+    @Max(value = Long.MAX_VALUE, message = "가격 정책 ID는 정수형 최대값을 초과할 수 없습니다.")
+    private Long pricePolicyId;
+
+    @Schema(
+            name = "sharerId",
+            description = "링크 공유 회원 ID",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    @Min(value = 1, message = "링크 공유 회원 ID는 1 이상이어야 합니다.")
+    @Max(value = Long.MAX_VALUE, message = "링크 공유 회원 ID는 정수형 최대값을 초과할 수 없습니다.")
+    private Long sharerId;
+
+    @Schema(
+            name = "quantity",
+            description = "주문 수량",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    @NotNull(message = "주문 수량은 필수값입니다.")
+    @Min(value = 1, message = "주문 수량은 1 이상이어야 합니다.")
+    private Integer quantity;
+
+    @Schema(
+            name = "unitAmount",
+            description = "단가(원)",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    @NotNull(message = "단가는 필수값입니다.")
+    @Min(value = 0, message = "단가는 0 이상이어야 합니다.")
+    private Long unitAmount;
+
+    @Schema(
+            name = "imageUrl",
+            description = "상품 이미지 URL",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String imageUrl;
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/client/order/request/RegisterOrderRequest.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/client/order/request/RegisterOrderRequest.java
@@ -53,43 +53,4 @@ public class RegisterOrderRequest {
     @NotEmpty(message = "주문 상품 목록은 필수값입니다.")
     @Valid
     private List<OrderProductItemRequest> orderProducts;
-
-    @Getter
-    public static class OrderProductItemRequest {
-        @Schema(
-                name = "pricePolicyId",
-                description = "가격 정책 ID",
-                requiredMode = Schema.RequiredMode.REQUIRED
-        )
-        @NotNull(message = "가격 정책 ID는 필수값입니다.")
-        @Min(value = 1, message = "가격 정책 ID는 1 이상이어야 합니다.")
-        @Max(value = Long.MAX_VALUE, message = "가격 정책 ID는 정수형 최대값을 초과할 수 없습니다.")
-        private Long pricePolicyId;
-
-        @Schema(
-                name = "quantity",
-                description = "주문 수량",
-                requiredMode = Schema.RequiredMode.REQUIRED
-        )
-        @NotNull(message = "주문 수량은 필수값입니다.")
-        @Min(value = 1, message = "주문 수량은 1 이상이어야 합니다.")
-        private Integer quantity;
-
-        @Schema(
-                name = "unitAmount",
-                description = "단가(원)",
-                requiredMode = Schema.RequiredMode.REQUIRED
-        )
-        @NotNull(message = "단가는 필수값입니다.")
-        @Min(value = 0, message = "단가는 0 이상이어야 합니다.")
-        private Long unitAmount;
-
-        @Schema(
-                name = "imageUrl",
-                description = "상품 이미지 URL",
-                requiredMode = Schema.RequiredMode.NOT_REQUIRED
-        )
-        private String imageUrl;
-    }
 }
-

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/mapper/InventoryJpaEntityToDomainMapper.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/mapper/InventoryJpaEntityToDomainMapper.java
@@ -8,7 +8,13 @@ import java.util.Optional;
 public class InventoryJpaEntityToDomainMapper {
     public static Optional<Inventory> mapToDomain(InventoryJpaEntity inventoryJpaEntity) {
         return Optional.ofNullable(inventoryJpaEntity)
-                .map(entity -> Inventory.of(entity.getPricePolicyId(), entity.getStock(), entity.getVersion()));
+                .map(entity -> {
+                    Long version = entity.getVersion();
+                    if (version == null) {
+                        version = 0L;
+                    }
+                    return Inventory.of(entity.getPricePolicyId(), entity.getStock(), version);
+                });
     }
 }
 

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/mapper/OrderJpaEntityToDomainMapper.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/mapper/OrderJpaEntityToDomainMapper.java
@@ -16,7 +16,7 @@ public class OrderJpaEntityToDomainMapper {
         return Optional.ofNullable(orderJpaEntity)
                 .map(entity -> {
                     List<OrderProductSnapshotState> productStates = entity.getOrderProductJpaEntities().stream()
-                            .map(OrderJpaEntityToDomainMapper::mapToSnapshotState)
+                            .map(OrderJpaEntityToDomainMapper::mapToOrderProductSnapshotState)
                             .filter(Optional::isPresent)
                             .map(Optional::get)
                             .toList();
@@ -26,6 +26,7 @@ public class OrderJpaEntityToDomainMapper {
                                     .id(entity.getId())
                                     .sellerId(entity.getSellerId())
                                     .buyerId(entity.getBuyerId())
+                                    .sharerId(entity.getSharerId())
                                     .orderNumber(entity.getOrderNumber())
                                     .orderStatus(entity.getOrderStatus())
                                     .totalAmount(entity.getTotalAmount())
@@ -46,7 +47,7 @@ public class OrderJpaEntityToDomainMapper {
         return Optional.ofNullable(orderJpaEntity)
                 .map(entity -> {
                     List<OrderProductSnapshotState> productStates = entity.getOrderProductJpaEntities().stream()
-                            .map(OrderJpaEntityToDomainMapper::mapToSnapshotState)
+                            .map(OrderJpaEntityToDomainMapper::mapToOrderProductSnapshotState)
                             .filter(Optional::isPresent)
                             .map(Optional::get)
                             .toList();
@@ -56,6 +57,7 @@ public class OrderJpaEntityToDomainMapper {
                                     .id(entity.getId())
                                     .sellerId(entity.getSellerId())
                                     .buyerId(entity.getBuyerId())
+                                    .sharerId(entity.getSharerId())
                                     .orderStatus(entity.getOrderStatus())
                                     .statusChangeReasonCategory(orderStatusInfo.getReasonCategory())
                                     .statusChangeReason(orderStatusInfo.getReason())
@@ -71,11 +73,14 @@ public class OrderJpaEntityToDomainMapper {
                 });
     }
 
-    private static Optional<OrderProductSnapshotState> mapToSnapshotState(OrderProductJpaEntity orderProductJpaEntity) {
+    private static Optional<OrderProductSnapshotState> mapToOrderProductSnapshotState(
+            OrderProductJpaEntity orderProductJpaEntity
+    ) {
         return Optional.ofNullable(orderProductJpaEntity)
                 .map(entity -> OrderProductSnapshotState.builder()
                         .orderId(entity.getId().getOrderId())
                         .pricePolicyId(entity.getId().getPricePolicyId())
+                        .sharerId(entity.getSharerId())
                         .quantity(entity.getQuantity())
                         .unitAmount(entity.getUnitAmount())
                         .imageUrl(entity.getImageUrl())
@@ -84,12 +89,13 @@ public class OrderJpaEntityToDomainMapper {
                         .build());
     }
 
-    public static Optional<OrderProduct> mapToDomain(OrderProductJpaEntity orderProductJpaEntity) {
+    public static Optional<OrderProduct> mapToOrderProductDomain(OrderProductJpaEntity orderProductJpaEntity) {
         return Optional.ofNullable(orderProductJpaEntity)
                 .map(entity -> OrderProduct.from(
                         OrderProductSnapshotState.builder()
                                 .orderId(entity.getId().getOrderId())
                                 .pricePolicyId(entity.getId().getPricePolicyId())
+                                .sharerId(entity.getSharerId())
                                 .quantity(entity.getQuantity())
                                 .unitAmount(entity.getUnitAmount())
                                 .imageUrl(entity.getImageUrl())

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/inventory/InventoryPersistenceAdapter.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/inventory/InventoryPersistenceAdapter.java
@@ -13,7 +13,6 @@ import com.personal.marketnote.commerce.port.out.inventory.SaveInventoryDeductio
 import com.personal.marketnote.commerce.port.out.inventory.SaveInventoryPort;
 import com.personal.marketnote.commerce.port.out.inventory.UpdateInventoryPort;
 import com.personal.marketnote.common.adapter.out.PersistenceAdapter;
-import jakarta.persistence.OptimisticLockException;
 import lombok.RequiredArgsConstructor;
 
 import java.util.Optional;
@@ -64,10 +63,6 @@ public class InventoryPersistenceAdapter implements SaveInventoryPort, FindInven
                     .filter(entity -> entity.getPricePolicyId().equals(inventory.getPricePolicyId()))
                     .findFirst()
                     .orElseThrow(() -> new InventoryNotFoundException(inventory.getPricePolicyId()));
-
-            if (!inventoryEntity.getVersion().equals(inventory.getVersion())) {
-                throw new OptimisticLockException("재고 버전 불일치: pricePolicyId=" + inventory.getPricePolicyId());
-            }
 
             inventoryEntity.updateFrom(inventory);
         }

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/inventory/entity/InventoryJpaEntity.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/inventory/entity/InventoryJpaEntity.java
@@ -2,6 +2,7 @@ package com.personal.marketnote.commerce.adapter.out.persistence.inventory.entit
 
 import com.personal.marketnote.commerce.domain.inventory.Inventory;
 import com.personal.marketnote.common.adapter.out.persistence.audit.BaseEntity;
+import com.personal.marketnote.common.utility.FormatValidator;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -25,6 +26,7 @@ public class InventoryJpaEntity extends BaseEntity {
 
     // RDBMS 낙관적 락 기반의 동시성 제어
     @Version
+    @Column(name = "version", nullable = false, columnDefinition = "BIGINT DEFAULT 0")
     private Long version;
 
     private InventoryJpaEntity(Long pricePolicyId, Integer stock, Long version) {
@@ -34,15 +36,37 @@ public class InventoryJpaEntity extends BaseEntity {
     }
 
     public static InventoryJpaEntity from(Inventory inventory) {
+        Long version = inventory.getVersion();
+        if (!FormatValidator.hasValue(version)) {
+            version = 0L;
+        }
+
         return new InventoryJpaEntity(
                 inventory.getPricePolicyId(),
                 inventory.getStockValue(),
-                inventory.getVersion()
+                version
         );
     }
 
     public void updateFrom(Inventory inventory) {
+        if (this.version == null) {
+            // 초기 버전 미설정 데이터 보호
+            this.version = 0L;
+        }
         this.stock = inventory.getStockValue();
-        this.version = inventory.getVersion();
+    }
+
+    @PostLoad
+    private void initVersionAfterLoad() {
+        if (this.version == null) {
+            this.version = 0L;
+        }
+    }
+
+    @PrePersist
+    private void initVersionBeforePersist() {
+        if (this.version == null) {
+            this.version = 0L;
+        }
     }
 }

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/order/OrderPersistenceAdapter.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/order/OrderPersistenceAdapter.java
@@ -119,7 +119,7 @@ public class OrderPersistenceAdapter implements SaveOrderPort, FindOrderPort, Fi
 
     @Override
     public Optional<OrderProduct> findByOrderIdAndPricePolicyId(Long orderId, Long pricePolicyId) {
-        return OrderJpaEntityToDomainMapper.mapToDomain(
+        return OrderJpaEntityToDomainMapper.mapToOrderProductDomain(
                 orderProductJpaRepository.findByOrderIdAndPricePolicyId(orderId, pricePolicyId).orElse(null)
         );
     }

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/order/entity/OrderJpaEntity.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/order/entity/OrderJpaEntity.java
@@ -38,6 +38,9 @@ public class OrderJpaEntity extends BaseEntity {
     @Column(name = "buyer_id", nullable = false)
     private Long buyerId;
 
+    @Column(name = "sharer_id")
+    private Long sharerId;
+
     @Column(name = "order_number", nullable = false, length = 31, unique = true)
     private String orderNumber;
 

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/order/entity/OrderProductJpaEntity.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/order/entity/OrderProductJpaEntity.java
@@ -27,6 +27,9 @@ public class OrderProductJpaEntity extends BaseEntity {
     @JoinColumn(name = "order_id", nullable = false)
     private OrderJpaEntity orderJpaEntity;
 
+    @Column(name = "sharer_id")
+    private Long sharerId;
+
     @Column(name = "quantity", nullable = false)
     private Integer quantity;
 
@@ -47,6 +50,7 @@ public class OrderProductJpaEntity extends BaseEntity {
         return OrderProductJpaEntity.builder()
                 .id(new OrderProductId(orderProduct.getPricePolicyId(), orderJpaEntity.getId()))
                 .orderJpaEntity(orderJpaEntity)
+                .sharerId(orderProduct.getSharerId())
                 .quantity(orderProduct.getQuantity())
                 .unitAmount(orderProduct.getUnitAmount())
                 .imageUrl(orderProduct.getImageUrl())

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/command/order/OrderProductItemCommand.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/command/order/OrderProductItemCommand.java
@@ -1,0 +1,13 @@
+package com.personal.marketnote.commerce.port.in.command.order;
+
+import lombok.Builder;
+
+@Builder
+public record OrderProductItemCommand(
+        Long pricePolicyId,
+        Long sharerId,
+        Integer quantity,
+        Long unitAmount,
+        String imageUrl
+) {
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/command/order/RegisterOrderCommand.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/command/order/RegisterOrderCommand.java
@@ -11,6 +11,6 @@ public record RegisterOrderCommand(
         Long totalAmount,
         Long couponAmount,
         Long pointAmount,
-        List<OrderProductItem> orderProducts
+        List<OrderProductItemCommand> orderProducts
 ) {
 }

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/result/order/GetOrderProductResult.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/result/order/GetOrderProductResult.java
@@ -14,6 +14,7 @@ import java.util.List;
 @Builder(access = AccessLevel.PRIVATE)
 public record GetOrderProductResult(
         Long pricePolicyId,
+        Long sharerId,
         Integer quantity,
         Long unitAmount,
         String imageUrl,
@@ -32,6 +33,7 @@ public record GetOrderProductResult(
 
         return GetOrderProductResult.builder()
                 .pricePolicyId(orderProduct.getPricePolicyId())
+                .sharerId(orderProduct.getSharerId())
                 .quantity(orderProduct.getQuantity())
                 .unitAmount(orderProduct.getUnitAmount())
                 .imageUrl(orderProduct.getImageUrl())

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/RegisterOrderService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/RegisterOrderService.java
@@ -26,6 +26,7 @@ public class RegisterOrderService implements RegisterOrderUseCase {
         List<OrderProductCreateState> orderProductStates = command.orderProducts().stream()
                 .map(item -> OrderProductCreateState.builder()
                         .pricePolicyId(item.pricePolicyId())
+                        .sharerId(item.sharerId())
                         .quantity(item.quantity())
                         .unitAmount(item.unitAmount())
                         .imageUrl(item.imageUrl())

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/order/OrderCreateState.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/order/OrderCreateState.java
@@ -13,6 +13,7 @@ import java.util.List;
 public class OrderCreateState {
     private final Long sellerId;
     private final Long buyerId;
+    private final Long sharerId;
     private final Long totalAmount;
     private final Long couponAmount;
     private final Long pointAmount;

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/order/OrderProduct.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/order/OrderProduct.java
@@ -9,6 +9,7 @@ import lombok.*;
 public class OrderProduct {
     private Long orderId;
     private Long pricePolicyId;
+    private Long sharerId;
     private Integer quantity;
     private Long unitAmount;
     private String imageUrl;
@@ -18,6 +19,7 @@ public class OrderProduct {
     public static OrderProduct from(OrderProductCreateState state) {
         return OrderProduct.builder()
                 .pricePolicyId(state.getPricePolicyId())
+                .sharerId(state.getSharerId())
                 .quantity(state.getQuantity())
                 .unitAmount(state.getUnitAmount())
                 .imageUrl(state.getImageUrl())
@@ -29,6 +31,7 @@ public class OrderProduct {
         return OrderProduct.builder()
                 .orderId(state.getOrderId())
                 .pricePolicyId(state.getPricePolicyId())
+                .sharerId(state.getSharerId())
                 .quantity(state.getQuantity())
                 .unitAmount(state.getUnitAmount())
                 .imageUrl(state.getImageUrl())

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/order/OrderProductCreateState.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/order/OrderProductCreateState.java
@@ -10,6 +10,7 @@ import lombok.Getter;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class OrderProductCreateState {
     private final Long pricePolicyId;
+    private final Long sharerId;
     private final Integer quantity;
     private final Long unitAmount;
     private final String imageUrl;

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/order/OrderProductSnapshotState.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/order/OrderProductSnapshotState.java
@@ -11,6 +11,7 @@ import lombok.Getter;
 public class OrderProductSnapshotState {
     private final Long orderId;
     private final Long pricePolicyId;
+    private final Long sharerId;
     private final Integer quantity;
     private final Long unitAmount;
     private final String imageUrl;

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/order/OrderSnapshotState.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/order/OrderSnapshotState.java
@@ -15,6 +15,7 @@ public class OrderSnapshotState {
     private final Long id;
     private final Long sellerId;
     private final Long buyerId;
+    private final Long sharerId;
     private final String orderNumber;
     private final OrderStatus orderStatus;
     private final OrderStatusReasonCategory statusChangeReasonCategory;

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/client/cart/controller/apidocs/AddCartProductApiDocs.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/client/cart/controller/apidocs/AddCartProductApiDocs.java
@@ -110,7 +110,7 @@ import java.lang.annotation.*;
                                 examples = @ExampleObject("""
                                         {
                                           "statusCode": 403,
-                                          "code": "FORBIDDEN",
+                                          "code": "FORBIDDEN",«
                                           "timestamp": "2025-12-30T12:12:30.013",
                                           "content": null,
                                           "message": "Access Denied"

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/client/cart/request/AddCartProductRequest.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/client/cart/request/AddCartProductRequest.java
@@ -17,7 +17,7 @@ public record AddCartProductRequest(
                 description = "링크 공유 회원 ID",
                 requiredMode = Schema.RequiredMode.NOT_REQUIRED
         )
-        @Min(value = 1, message = "링크 공유 회원는 1 이상이어야 합니다.")
+        @Min(value = 1, message = "링크 공유 회원 ID는 1 이상이어야 합니다.")
         @Max(value = Long.MAX_VALUE, message = "링크 공유 회원 ID는 정수형 최대값을 초과할 수 없습니다.")
         Long sharerId,
 

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/client/cart/request/OrderingItemRequest.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/client/cart/request/OrderingItemRequest.java
@@ -17,7 +17,7 @@ public record OrderingItemRequest(
                 description = "링크 공유 회원 ID",
                 requiredMode = Schema.RequiredMode.NOT_REQUIRED
         )
-        @Min(value = 1, message = "링크 공유 회원는 1 이상이어야 합니다.")
+        @Min(value = 1, message = "링크 공유 회원 ID는 1 이상이어야 합니다.")
         @Max(value = Long.MAX_VALUE, message = "링크 공유 회원 ID는 정수형 최대값을 초과할 수 없습니다.")
         Long sharerId,
 


### PR DESCRIPTION
## partially addresses #387
## resolves #419

## Task
- [x] 주문 등록 API에 공유자 ID 파라미터 추가
- [x] 주문 상품 내역 조회 API에 공유자 ID 파라미터 추가
- [x] 주문 상세 정보 조회 API에 공유자 ID 파라미터 추가
- [x] Swagger 문서 업데이트