### PR TITLE
[#387][#428] feat: 오퍼월 리워드 지급 연동 실패 시 offerwall_mapper 튜플 생성 로직 추가

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/client/order/controller/apidocs/RegisterOrderApiDocs.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/client/order/controller/apidocs/RegisterOrderApiDocs.java
@@ -48,6 +48,7 @@ import java.lang.annotation.*;
                 | **키** | **타입** | **설명** | **필수 여부** | **예시** |
                 | --- | --- | --- | --- | --- |
                 | pricePolicyId | number | 가격 정책 ID | Y | 1 |
+                | sharerId | number | 링크 공유 회원 ID | N | 1 |
                 | quantity | number | 주문 수량 | Y | 2 |
                 | unitAmount | number | 단위 금액(원) | Y | 50000 |
                 | imageUrl | string | 상품 이미지 URL | N | "https://marketnote.s3.amazonaws.com/product/30/1763534195922_image_600.png" |
@@ -86,6 +87,7 @@ import java.lang.annotation.*;
                                   "orderProducts": [
                                     {
                                       "pricePolicyId": 23,
+                                      "sharerId": 1,
                                       "quantity": 2,
                                       "unitAmount": 50000,
                                       "imageUrl": "https://marketnote.s3.amazonaws.com/product/30/1763534195922_image_600.png"

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/offerwall/OfferwallController.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/offerwall/OfferwallController.java
@@ -8,7 +8,6 @@ import com.personal.marketnote.common.exception.UserNotFoundException;
 import com.personal.marketnote.common.utility.FormatConverter;
 import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.reward.adapter.in.offerwall.apidocs.AdpopcornCallbackApiDocs;
-import com.personal.marketnote.reward.domain.offerwall.OfferwallMapper;
 import com.personal.marketnote.reward.domain.offerwall.OfferwallType;
 import com.personal.marketnote.reward.domain.offerwall.UserDeviceType;
 import com.personal.marketnote.reward.domain.vendorcommunication.RewardVendorCommunicationTargetType;
@@ -17,7 +16,7 @@ import com.personal.marketnote.reward.domain.vendorcommunication.RewardVendorNam
 import com.personal.marketnote.reward.exception.DuplicateOfferwallRewardException;
 import com.personal.marketnote.reward.port.in.command.offerwall.RegisterOfferwallRewardCommand;
 import com.personal.marketnote.reward.port.in.command.vendorcommunication.RewardVendorCommunicationHistoryCommand;
-import com.personal.marketnote.reward.port.in.usecase.offerwall.RegisterOfferwallRewardUseCase;
+import com.personal.marketnote.reward.port.in.usecase.offerwall.HandleOfferwallRewardUseCase;
 import com.personal.marketnote.reward.port.in.usecase.vendorcommunication.RewardRecordVendorCommunicationHistoryUseCase;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -37,7 +36,7 @@ import java.time.LocalDateTime;
 @RequiredArgsConstructor
 @Slf4j
 public class OfferwallController {
-    private final RegisterOfferwallRewardUseCase registerOfferwallRewardUseCase;
+    private final HandleOfferwallRewardUseCase handleOfferwallRewardUseCase;
     private final RewardRecordVendorCommunicationHistoryUseCase recordVendorCommunicationHistoryUseCase;
     private final ObjectMapper objectMapper;
 
@@ -115,15 +114,14 @@ public class OfferwallController {
         RewardVendorName vendorName = RewardVendorName.ADPOPCORN;
 
         try {
-            OfferwallMapper saved = registerOfferwallRewardUseCase.register(command);
-            Long targetId = FormatValidator.hasValue(saved) ? saved.getId() : null;
+            Long id = handleOfferwallRewardUseCase.handle(command);
 
-            recordCommunication(targetType, RewardVendorCommunicationType.REQUEST, targetId, vendorName, payloadString, payloadJson, null);
+            recordCommunication(targetType, RewardVendorCommunicationType.REQUEST, id, vendorName, payloadString, payloadJson, null);
 
             JsonNode successPayloadJson = buildResponsePayloadJson(true, 1, "success");
             String successPayload = successPayloadJson.toString();
 
-            recordCommunication(targetType, RewardVendorCommunicationType.RESPONSE, targetId, vendorName, successPayload, successPayloadJson, null);
+            recordCommunication(targetType, RewardVendorCommunicationType.RESPONSE, id, vendorName, successPayload, successPayloadJson, null);
 
             return ResponseEntity.ok(successPayload);
         } catch (VendorVerificationFailedException e) {

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/usecase/offerwall/HandleOfferwallRewardUseCase.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/usecase/offerwall/HandleOfferwallRewardUseCase.java
@@ -2,6 +2,6 @@ package com.personal.marketnote.reward.port.in.usecase.offerwall;
 
 import com.personal.marketnote.reward.port.in.command.offerwall.RegisterOfferwallRewardCommand;
 
-public interface RegisterOfferwallRewardUseCase {
-    Long register(RegisterOfferwallRewardCommand command);
+public interface HandleOfferwallRewardUseCase {
+    Long handle(RegisterOfferwallRewardCommand command);
 }

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/service/offerwall/HandleOfferwallRewardService.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/service/offerwall/HandleOfferwallRewardService.java
@@ -1,0 +1,30 @@
+package com.personal.marketnote.reward.service.offerwall;
+
+import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.reward.domain.offerwall.OfferwallMapper;
+import com.personal.marketnote.reward.mapper.RewardCommandToStateMapper;
+import com.personal.marketnote.reward.port.in.command.offerwall.RegisterOfferwallRewardCommand;
+import com.personal.marketnote.reward.port.in.usecase.offerwall.HandleOfferwallRewardUseCase;
+import com.personal.marketnote.reward.port.in.usecase.offerwall.RegisterOfferwallRewardUseCase;
+import com.personal.marketnote.reward.port.out.offerwall.SaveOfferwallMapperPort;
+import lombok.RequiredArgsConstructor;
+
+@UseCase
+@RequiredArgsConstructor
+public class HandleOfferwallRewardService implements HandleOfferwallRewardUseCase {
+    private final RegisterOfferwallRewardUseCase registerOfferwallRewardUseCase;
+    private final SaveOfferwallMapperPort saveOfferwallMapperPort;
+
+    @Override
+    public Long handle(RegisterOfferwallRewardCommand command) {
+        try {
+            return registerOfferwallRewardUseCase.register(command);
+        } catch (Exception e) {
+            saveOfferwallMapperPort.save(
+                    OfferwallMapper.from(RewardCommandToStateMapper.mapToOfferwallMapperCreateState(command, false))
+            );
+
+            throw e;
+        }
+    }
+}

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/service/offerwall/RegisterOfferwallRewardService.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/service/offerwall/RegisterOfferwallRewardService.java
@@ -2,38 +2,71 @@ package com.personal.marketnote.reward.service.offerwall;
 
 import com.personal.marketnote.common.application.UseCase;
 import com.personal.marketnote.common.domain.exception.token.VendorVerificationFailedException;
+import com.personal.marketnote.common.exception.UserNotFoundException;
 import com.personal.marketnote.common.security.vendor.VendorVerificationProcessor;
+import com.personal.marketnote.common.utility.FormatConverter;
 import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.reward.configuration.AdpopcornHashKeyProperties;
 import com.personal.marketnote.reward.domain.offerwall.OfferwallMapper;
+import com.personal.marketnote.reward.domain.point.UserPointChangeType;
+import com.personal.marketnote.reward.domain.point.UserPointSourceType;
+import com.personal.marketnote.reward.exception.DuplicateOfferwallRewardException;
 import com.personal.marketnote.reward.exception.RewardTargetInfoNotFoundException;
 import com.personal.marketnote.reward.mapper.RewardCommandToStateMapper;
-import com.personal.marketnote.reward.port.in.command.offerwall.OfferwallCallbackCommand;
+import com.personal.marketnote.reward.port.in.command.offerwall.RegisterOfferwallRewardCommand;
+import com.personal.marketnote.reward.port.in.command.point.ModifyUserPointCommand;
+import com.personal.marketnote.reward.port.in.usecase.offerwall.GetPostOfferwallMapperUseCase;
 import com.personal.marketnote.reward.port.in.usecase.offerwall.RegisterOfferwallRewardUseCase;
+import com.personal.marketnote.reward.port.in.usecase.point.GetUserPointUseCase;
 import com.personal.marketnote.reward.port.out.offerwall.SaveOfferwallMapperPort;
+import com.personal.marketnote.reward.service.point.ModifyUserPointService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
 
 @UseCase
+@Transactional(isolation = READ_COMMITTED)
 @RequiredArgsConstructor
 public class RegisterOfferwallRewardService implements RegisterOfferwallRewardUseCase {
+    private final GetUserPointUseCase getUserPointUseCase;
+    private final ModifyUserPointService modifyUserPointService;
     private final SaveOfferwallMapperPort saveOfferwallMapperPort;
+    private final GetPostOfferwallMapperUseCase getPostOfferwallMapperUseCase;
     private final AdpopcornHashKeyProperties adpopcornHashKeyProperties;
 
     @Override
-    public OfferwallMapper register(OfferwallCallbackCommand command) {
+    public Long register(RegisterOfferwallRewardCommand command) {
         validateSignature(command);
-        return saveOfferwallMapperPort.save(
-                OfferwallMapper.from(RewardCommandToStateMapper.mapToOfferwallMapperCreateState(command))
+        validateUser(command);
+        validateDuplicate(command);
+
+        OfferwallMapper offerwallMapper = saveOfferwallMapperPort.save(
+                OfferwallMapper.from(RewardCommandToStateMapper.mapToOfferwallMapperCreateState(command, true))
         );
+
+        // 회원 리워드 포인트 적립
+        modifyUserPointService.modify(
+                ModifyUserPointCommand.builder()
+                        .userId(FormatConverter.parseId(command.userId()))
+                        .changeType(UserPointChangeType.ACCRUAL)
+                        .amount(command.quantity())
+                        .sourceType(UserPointSourceType.OFFERWALL)
+                        .sourceId(offerwallMapper.getId())
+                        .reason(String.format("%s 리워드 보상 적립", command.offerwallType().getDescription()))
+                        .build()
+        );
+
+        return offerwallMapper.getId();
     }
 
-    private void validateSignature(OfferwallCallbackCommand command) {
+    private void validateSignature(RegisterOfferwallRewardCommand command) {
         String hashKey = resolveHashKey(command);
         String plainText = buildPlainText(command);
-        VendorVerificationProcessor.validateAdpopcornSignature(hashKey, plainText, command.getSignedValue());
+        VendorVerificationProcessor.validateAdpopcornSignature(hashKey, plainText, command.signedValue());
     }
 
-    private String resolveHashKey(OfferwallCallbackCommand command) {
+    private String resolveHashKey(RegisterOfferwallRewardCommand command) {
         if (command.isAndroid()) {
             return requireHashKey(adpopcornHashKeyProperties.getAndroid());
         }
@@ -53,10 +86,26 @@ public class RegisterOfferwallRewardService implements RegisterOfferwallRewardUs
         throw new VendorVerificationFailedException("애드팝콘 해시 키가 설정되지 않았습니다.");
     }
 
-    private String buildPlainText(OfferwallCallbackCommand command) {
-        return command.getUserId()
-                + command.getRewardKey()
-                + command.getQuantity()
-                + command.getCampaignKey();
+    private String buildPlainText(RegisterOfferwallRewardCommand command) {
+        return command.userId()
+                + command.rewardKey()
+                + command.quantity()
+                + command.campaignKey();
+    }
+
+    private void validateUser(RegisterOfferwallRewardCommand command) {
+        Long userId = FormatConverter.parseId(command.userId());
+        if (!getUserPointUseCase.existsUserPoint(userId)) {
+            throw new UserNotFoundException(String.format("회원 정보를 찾을 수 없습니다. userId: %s", userId));
+        }
+    }
+
+    private void validateDuplicate(RegisterOfferwallRewardCommand command) {
+        if (getPostOfferwallMapperUseCase.existsSucceededOfferwallMapper(
+                command.offerwallType(),
+                command.rewardKey()
+        )) {
+            throw new DuplicateOfferwallRewardException(command.rewardKey());
+        }
     }
 }


### PR DESCRIPTION
## partially addresses #387
## resolves #428

## Task
- [x] registering 중복 리워드 지급 유효성 감사 메서드명을 existsSucceededOfferwallMapper로 변경
- [x] 엔티티 개수 조회 로직 조건에 isSuccess 추가