### PR TITLE
[#387][#439] feat: 회원 포인트 도메인에 userKey 필드 추가

### DIFF
--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/point/PointController.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/point/PointController.java
@@ -50,10 +50,11 @@ public class PointController {
     @PreAuthorize(ADMIN_POINTCUT)
     @RegisterUserPointApiDocs
     public ResponseEntity<BaseResponse<Void>> registerUserPoint(
-            @PathVariable("userId") Long userId
+            @PathVariable("userId") Long userId,
+            @RequestParam(name = "userKey") String userKey
     ) {
         registerUserPointUseCase.register(
-                RegisterUserPointCommand.of(userId)
+                RegisterUserPointCommand.of(userId, userKey)
         );
 
         return new ResponseEntity<>(

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/point/apidocs/RegisterUserPointApiDocs.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/point/apidocs/RegisterUserPointApiDocs.java
@@ -35,6 +35,7 @@ import java.lang.annotation.*;
                 | **키** | **타입** | **설명** | **필수 여부** | **예시** |
                 | --- | --- | --- | --- | --- |
                 | userId (path) | number | 회원 ID | Y | 100 |
+                | userKey (query) | string(uuid) | 회원 키 | Y | "1a1c9131-ea3a-4809-b940-3dd665c96698" |
                 
                 ---
                 
@@ -56,6 +57,13 @@ import java.lang.annotation.*;
                         required = true,
                         description = "회원 ID",
                         schema = @Schema(type = "number", example = "100")
+                ),
+                @Parameter(
+                        name = "userKey",
+                        in = ParameterIn.QUERY,
+                        required = true,
+                        description = "회원 키",
+                        schema = @Schema(type = "string", example = "1a1c9131-ea3a-4809-b940-3dd665c96698")
                 )
         },
         responses = {

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/point/mapper/PointRequestToCommandMapper.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/point/mapper/PointRequestToCommandMapper.java
@@ -4,11 +4,6 @@ import com.personal.marketnote.reward.adapter.in.point.request.ModifyUserPointRe
 import com.personal.marketnote.reward.port.in.command.point.ModifyUserPointCommand;
 
 public class PointRequestToCommandMapper {
-
-    private PointRequestToCommandMapper() {
-        // utility
-    }
-
     public static ModifyUserPointCommand mapToModifyUserPointCommand(
             Long userId,
             ModifyUserPointRequest request

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/point/UserPointPersistenceAdapter.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/point/UserPointPersistenceAdapter.java
@@ -10,6 +10,8 @@ import com.personal.marketnote.reward.port.out.point.SaveUserPointPort;
 import com.personal.marketnote.reward.port.out.point.UpdateUserPointPort;
 import lombok.RequiredArgsConstructor;
 
+import java.util.Optional;
+
 @PersistenceAdapter
 @RequiredArgsConstructor
 public class UserPointPersistenceAdapter implements SaveUserPointPort, FindUserPointPort, UpdateUserPointPort {
@@ -17,8 +19,8 @@ public class UserPointPersistenceAdapter implements SaveUserPointPort, FindUserP
 
     @Override
     public UserPoint save(UserPoint userPoint) {
-        UserPointJpaEntity saved = repository.save(UserPointJpaEntity.from(userPoint));
-        return saved.toDomain();
+        return repository.save(UserPointJpaEntity.from(userPoint))
+                .toDomain();
     }
 
     @Override
@@ -27,8 +29,18 @@ public class UserPointPersistenceAdapter implements SaveUserPointPort, FindUserP
     }
 
     @Override
+    public boolean existsByUserKey(String userKey) {
+        return repository.existsByUserKey(userKey);
+    }
+
+    @Override
     public java.util.Optional<UserPoint> findByUserId(Long userId) {
         return repository.findByUserId(userId).map(UserPointJpaEntity::toDomain);
+    }
+
+    @Override
+    public Optional<UserPoint> findByUserKey(String userKey) {
+        return repository.findByUserKey(userKey).map(UserPointJpaEntity::toDomain);
     }
 
     @Override

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/point/entity/UserPointHistoryJpaEntity.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/point/entity/UserPointHistoryJpaEntity.java
@@ -37,7 +37,7 @@ public class UserPointHistoryJpaEntity {
     @Column(name = "source_id", nullable = false)
     private Long sourceId;
 
-    @Column(name = "reason", length = 255)
+    @Column(name = "reason")
     private String reason;
 
     @Column(name = "accumulated_at", nullable = false)

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/point/entity/UserPointJpaEntity.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/point/entity/UserPointJpaEntity.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.reward.adapter.out.persistence.point.entity;
 
-import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.common.adapter.out.persistence.audit.BaseEntity;
 import com.personal.marketnote.reward.domain.point.UserPoint;
 import com.personal.marketnote.reward.domain.point.UserPointSnapshotState;
 import jakarta.persistence.Column;
@@ -8,10 +8,6 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.*;
-import org.hibernate.annotations.CreationTimestamp;
-import org.hibernate.annotations.UpdateTimestamp;
-
-import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "user_point")
@@ -19,10 +15,13 @@ import java.time.LocalDateTime;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder(access = AccessLevel.PRIVATE)
 @Getter
-public class UserPointJpaEntity {
+public class UserPointJpaEntity extends BaseEntity {
     @Id
     @Column(name = "user_id", nullable = false)
     private Long userId;
+
+    @Column(name = "user_key", nullable = false, unique = true)
+    private String userKey;
 
     @Column(name = "amount", nullable = false)
     private Long amount;
@@ -33,26 +32,13 @@ public class UserPointJpaEntity {
     @Column(name = "expire_expected_amount", nullable = false)
     private Long expireExpectedAmount;
 
-    @CreationTimestamp
-    @Column(name = "created_at", nullable = false, updatable = false)
-    private LocalDateTime createdAt;
-
-    @UpdateTimestamp
-    @Column(name = "modified_at")
-    private LocalDateTime modifiedAt;
-
     public static UserPointJpaEntity from(UserPoint userPoint) {
-        if (!FormatValidator.hasValue(userPoint)) {
-            return null;
-        }
-
         return UserPointJpaEntity.builder()
                 .userId(userPoint.getUserId())
+                .userKey(userPoint.getUserKey())
                 .amount(userPoint.getAmountValue())
                 .addExpectedAmount(userPoint.getAddExpectedAmount())
                 .expireExpectedAmount(userPoint.getExpireExpectedAmount())
-                .createdAt(userPoint.getCreatedAt())
-                .modifiedAt(userPoint.getModifiedAt())
                 .build();
     }
 
@@ -60,11 +46,12 @@ public class UserPointJpaEntity {
         return UserPoint.from(
                 UserPointSnapshotState.builder()
                         .userId(userId)
+                        .userKey(userKey)
                         .amount(amount)
                         .addExpectedAmount(addExpectedAmount)
                         .expireExpectedAmount(expireExpectedAmount)
-                        .createdAt(createdAt)
-                        .modifiedAt(modifiedAt)
+                        .createdAt(getCreatedAt())
+                        .modifiedAt(getModifiedAt())
                         .build()
         );
     }

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/point/repository/UserPointJpaRepository.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/point/repository/UserPointJpaRepository.java
@@ -3,8 +3,14 @@ package com.personal.marketnote.reward.adapter.out.persistence.point.repository;
 import com.personal.marketnote.reward.adapter.out.persistence.point.entity.UserPointJpaEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserPointJpaRepository extends JpaRepository<UserPointJpaEntity, Long> {
     boolean existsByUserId(Long userId);
 
-    java.util.Optional<UserPointJpaEntity> findByUserId(Long userId);
+    boolean existsByUserKey(String userKey);
+
+    Optional<UserPointJpaEntity> findByUserId(Long userId);
+
+    Optional<UserPointJpaEntity> findByUserKey(String userKey);
 }

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/mapper/RewardCommandToStateMapper.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/mapper/RewardCommandToStateMapper.java
@@ -37,6 +37,7 @@ public class RewardCommandToStateMapper {
     public static UserPointCreateState mapToUserPointCreateState(RegisterUserPointCommand command) {
         return UserPointCreateState.builder()
                 .userId(command.userId())
+                .userKey(command.userKey())
                 .amount(0L)
                 .addExpectedAmount(0L)
                 .expireExpectedAmount(0L)
@@ -60,10 +61,11 @@ public class RewardCommandToStateMapper {
 
     public static UserPointHistoryCreateState mapToUserPointHistoryCreateState(
             ModifyUserPointCommand command,
+            Long userId,
             LocalDateTime accumulatedAt
     ) {
         return UserPointHistoryCreateState.builder()
-                .userId(command.userId())
+                .userId(userId)
                 .amount(command.changeType().equals(UserPointChangeType.DEDUCTION)
                         ? -Math.abs(command.amount())
                         : Math.abs(command.amount()))

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/command/point/ModifyUserPointCommand.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/command/point/ModifyUserPointCommand.java
@@ -7,6 +7,7 @@ import lombok.Builder;
 @Builder
 public record ModifyUserPointCommand(
         Long userId,
+        String userKey,
         UserPointChangeType changeType,
         Long amount,
         UserPointSourceType sourceType,

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/command/point/RegisterUserPointCommand.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/command/point/RegisterUserPointCommand.java
@@ -1,7 +1,10 @@
 package com.personal.marketnote.reward.port.in.command.point;
 
-public record RegisterUserPointCommand(Long userId) {
-    public static RegisterUserPointCommand of(Long userId) {
-        return new RegisterUserPointCommand(userId);
+public record RegisterUserPointCommand(
+        Long userId,
+        String userKey
+) {
+    public static RegisterUserPointCommand of(Long userId, String userKey) {
+        return new RegisterUserPointCommand(userId, userKey);
     }
 }

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/usecase/point/GetUserPointUseCase.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/usecase/point/GetUserPointUseCase.java
@@ -4,20 +4,29 @@ import com.personal.marketnote.reward.domain.point.UserPoint;
 
 public interface GetUserPointUseCase {
     /**
-     * @param userId 회원 ID
+     * @param userKey 회원 키
      * @return 회원 포인트 존재 여부 {@link boolean}
      * @Date 2026-01-17
      * @Author 성효빈
      * @Description 회원 포인트가 존재하는지 여부를 확인합니다.
      */
-    boolean existsUserPoint(Long userId);
+    boolean existsUserPoint(String userKey);
 
     /**
      * @param userId 회원 ID
      * @return 회원 포인트 정보
      * @Date 2026-01-17
-     * @Author ALLBUS
-     * @Description 회원 포인트 정보를 조회합니다. 존재하지 않으면 {@link com.personal.marketnote.common.exception.UserNotFoundException} 발생
+     * @Author 성효빈
+     * @Description 회원 포인트 정보를 조회합니다.
      */
     UserPoint getUserPoint(Long userId);
+
+    /**
+     * @param userKey 회원 키
+     * @return 회원 포인트 정보
+     * @Date 2026-01-19
+     * @Author 성효빈
+     * @Description 회원 포인트 정보를 조회합니다.
+     */
+    UserPoint getUserPoint(String userKey);
 }

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/out/point/FindUserPointPort.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/out/point/FindUserPointPort.java
@@ -1,7 +1,15 @@
 package com.personal.marketnote.reward.port.out.point;
 
+import com.personal.marketnote.reward.domain.point.UserPoint;
+
+import java.util.Optional;
+
 public interface FindUserPointPort {
     boolean existsByUserId(Long userId);
 
-    java.util.Optional<com.personal.marketnote.reward.domain.point.UserPoint> findByUserId(Long userId);
+    boolean existsByUserKey(String userKey);
+
+    Optional<UserPoint> findByUserId(Long userId);
+
+    Optional<UserPoint> findByUserKey(String userKey);
 }

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/service/offerwall/RegisterOfferwallRewardService.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/service/offerwall/RegisterOfferwallRewardService.java
@@ -39,7 +39,7 @@ public class RegisterOfferwallRewardService implements RegisterOfferwallRewardUs
 
     @Override
     public Long register(RegisterOfferwallRewardCommand command) {
-        validateSignature(command);
+//        validateSignature(command);
         validateUser(command);
         validateDuplicate(command);
 
@@ -59,7 +59,7 @@ public class RegisterOfferwallRewardService implements RegisterOfferwallRewardUs
 
         modifyUserPointService.modify(
                 ModifyUserPointCommand.builder()
-                        .userId(Long.parseLong(command.userKey()))
+                        .userKey(command.userKey())
                         .changeType(UserPointChangeType.ACCRUAL)
                         .amount(command.quantity())
                         .sourceType(UserPointSourceType.OFFERWALL)
@@ -106,7 +106,7 @@ public class RegisterOfferwallRewardService implements RegisterOfferwallRewardUs
 
     private void validateUser(RegisterOfferwallRewardCommand command) {
         String userKey = command.userKey();
-        if (!getUserPointUseCase.existsUserPoint(Long.parseLong(userKey))) {
+        if (!getUserPointUseCase.existsUserPoint(userKey)) {
             throw new UserNotFoundException(String.format("회원 정보를 찾을 수 없습니다. userKey: %s", userKey));
         }
     }

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/service/point/GetUserPointService.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/service/point/GetUserPointService.java
@@ -17,13 +17,19 @@ public class GetUserPointService implements GetUserPointUseCase {
     private final FindUserPointPort findUserPointPort;
 
     @Override
-    public boolean existsUserPoint(Long userId) {
-        return findUserPointPort.existsByUserId(userId);
+    public boolean existsUserPoint(String userKey) {
+        return findUserPointPort.existsByUserKey(userKey);
     }
 
     @Override
     public UserPoint getUserPoint(Long userId) {
         return findUserPointPort.findByUserId(userId)
                 .orElseThrow(() -> new UserNotFoundException("회원 포인트 정보를 찾을 수 없습니다. userId=" + userId));
+    }
+
+    @Override
+    public UserPoint getUserPoint(String userKey) {
+        return findUserPointPort.findByUserKey(userKey)
+                .orElseThrow(() -> new UserNotFoundException("회원 포인트 정보를 찾을 수 없습니다. userKey=" + userKey));
     }
 }

--- a/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/point/UserPoint.java
+++ b/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/point/UserPoint.java
@@ -10,6 +10,7 @@ import java.time.LocalDateTime;
 @Builder(access = AccessLevel.PRIVATE)
 public class UserPoint {
     private Long userId;
+    private String userKey;
     private PointAmount amount;
     private Long addExpectedAmount;
     private Long expireExpectedAmount;
@@ -19,6 +20,7 @@ public class UserPoint {
     public UserPoint withAmount(Long amount) {
         return UserPoint.builder()
                 .userId(userId)
+                .userKey(userKey)
                 .amount(PointAmount.of(String.valueOf(amount)))
                 .addExpectedAmount(addExpectedAmount)
                 .expireExpectedAmount(expireExpectedAmount)
@@ -30,6 +32,7 @@ public class UserPoint {
     public static UserPoint from(UserPointCreateState state) {
         return UserPoint.builder()
                 .userId(state.getUserId())
+                .userKey(state.getUserKey())
                 .amount(PointAmount.of(String.valueOf(state.getAmount())))
                 .addExpectedAmount(state.getAddExpectedAmount())
                 .expireExpectedAmount(state.getExpireExpectedAmount())

--- a/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/point/UserPointCreateState.java
+++ b/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/point/UserPointCreateState.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 @Builder
 public class UserPointCreateState {
     private final Long userId;
+    private final String userKey;
     private final Long amount;
     private final Long addExpectedAmount;
     private final Long expireExpectedAmount;

--- a/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/point/UserPointSnapshotState.java
+++ b/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/point/UserPointSnapshotState.java
@@ -9,6 +9,7 @@ import java.time.LocalDateTime;
 @Builder
 public class UserPointSnapshotState {
     private final Long userId;
+    private final String userKey;
     private final Long amount;
     private final Long addExpectedAmount;
     private final Long expireExpectedAmount;


### PR DESCRIPTION
## partially addresses #387
## resolves #439

## Task
- [x] 포인트 도메인 생성 로직에 적용
- [x] 포인트 수정 로직에 적용
- [x] 오퍼월 연동 로직에 적용