### PR TITLE
[#43][#493] test: 전체 회원 정보 조회 기능 자동화 테스트 추가

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/inventory/controller/apidocs/GetInventoriesApiDocs.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/inventory/controller/apidocs/GetInventoriesApiDocs.java
@@ -80,7 +80,7 @@ import java.lang.annotation.*;
                                         {
                                           "statusCode": 200,
                                           "code": "SUC01",
-                                          "timestamp": "2026-01-24T13:42:54.309143665",
+                                          "timestamp": "2026-01-23T13:42:54.309143665",
                                           "content": {
                                             "inventories": [
                                               {


### PR DESCRIPTION
## partially addresses #43
## resolves #493

## Test Case
- [x]  Auth Vendor와 OIDC ID를 전송해 전체 회원 도메인을 조회한다
- [x]  Auth Vendor와 OIDC ID로 전체 회원 조회 시 회원이 존재하지 않으면 예외를 던진다
- [x]  존재하지 않는 회원 ID로 전체 회원을 조회하면 예외를 던진다
- [x]  이메일을 전송해 전체 회원 도메인을 조회한다
- [x]  이메일로 전체 회원 조회 시 회원이 존재하지 않으면 예외를 던진다
- [x]  회원 ID로 전체 회원 조회 시 회원이 존재하지 않으면 예외를 던진다
- [x]  회원 ID를 전송해 전체 회원 도메인을 조회한다
- [x]  회원 ID를 전송해 전체 회원 정보 결과를 조회한다