### PR TITLE
[#475][#496] feat: 파스토 권한 인증 연동 기능 추가

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -58,6 +58,9 @@ def buildMarketnoteTaskDefinition(env) {
                 [name: "TNK_IOS_HASH_KEY",                  value: env.TNK_IOS_HASH_KEY],
                 [name: "ADISCOPE_ANDROID_HASH_KEY",         value: env.ADISCOPE_ANDROID_HASH_KEY],
                 [name: "ADISCOPE_IOS_HASH_KEY",             value: env.ADISCOPE_IOS_HASH_KEY],
+                [name: "FASSTO_BASE_URL",                   value: env.FASSTO_BASE_URL],
+                [name: "FASSTO_API_CD",                     value: env.FASSTO_API_CD],
+                [name: "FASSTO_API_KEY",                    value: env.FASSTO_API_KEY],
             ],
             logConfiguration: [
                 logDriver: "awslogs",
@@ -621,6 +624,9 @@ pipeline {
                         string(credentialsId: 'MARKETNOTE_QA_TNK_IOS_HASH_KEY',                   variable: 'TNK_IOS_HASH_KEY'),
                         string(credentialsId: 'MARKETNOTE_QA_ADISCOPE_ANDROID_HASH_KEY',          variable: 'ADISCOPE_ANDROID_HASH_KEY'),
                         string(credentialsId: 'MARKETNOTE_QA_ADISCOPE_IOS_HASH_KEY',              variable: 'ADISCOPE_IOS_HASH_KEY'),
+                        string(credentialsId: 'MARKETNOTE_QA_FASSTO_BASE_URL',                    variable: 'FASSTO_BASE_URL'),
+                        string(credentialsId: 'MARKETNOTE_QA_FASSTO_API_CD',                      variable: 'FASSTO_API_CD'),
+                        string(credentialsId: 'MARKETNOTE_QA_FASSTO_API_KEY',                     variable: 'FASSTO_API_KEY'),
                     ]) {
                         sh '''
                           LG="$CLOUDWATCH_LOG_GROUP"

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/FulfillmentApplication.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/FulfillmentApplication.java
@@ -1,0 +1,13 @@
+package com.personal.marketnote.fulfillment;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication(scanBasePackages = {
+        "com.personal.marketnote"
+})
+public class FulfillmentApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(FulfillmentApplication.class, args);
+    }
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter.in.configuration/FulfillmentSwaggerConfig.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter.in.configuration/FulfillmentSwaggerConfig.java
@@ -1,0 +1,153 @@
+package com.personal.marketnote.fulfillment.adapter.in.configuration;
+
+import com.personal.marketnote.common.utility.FormatValidator;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.examples.Example;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.servers.Server;
+import io.swagger.v3.oas.models.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
+import org.springdoc.core.customizers.OpenApiCustomizer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Configuration
+@Slf4j
+public class FulfillmentSwaggerConfig {
+    @Value("${server.origin}")
+    private String serverOrigin;
+
+    private static final List<String> TAGS_ORDER = List.of(
+            "파스토 인증 API",
+            "서버 정보 API"
+    );
+
+    private static final Map<String, Integer> ORDER_MAP = new ConcurrentHashMap<>();
+
+    static {
+        for (int i = 0; i < TAGS_ORDER.size(); i++) {
+            ORDER_MAP.put(TAGS_ORDER.get(i), i);
+        }
+    }
+
+    @Bean
+    public OpenApiCustomizer tagOnlySorter() {
+        return (OpenAPI openApi) -> {
+            if (FormatValidator.hasNoValue(openApi.getTags())) {
+                return;
+            }
+
+            Map<String, Integer> originalIndex = new ConcurrentHashMap<>();
+            for (int i = 0; i < openApi.getTags().size(); i++) {
+                originalIndex.put(openApi.getTags().get(i).getName(), i);
+            }
+
+            Comparator<Tag> comparator = (t1, t2) -> {
+                Integer p1 = ORDER_MAP.get(t1.getName());
+                Integer p2 = ORDER_MAP.get(t2.getName());
+
+                if (FormatValidator.hasNoValue(p1) && FormatValidator.hasNoValue(p2)) {
+                    return Integer.compare(
+                            originalIndex.getOrDefault(t1.getName(), Integer.MAX_VALUE),
+                            originalIndex.getOrDefault(t2.getName(), Integer.MAX_VALUE)
+                    );
+                }
+
+                if (FormatValidator.hasNoValue(p1)) {
+                    return 1;
+                }
+
+                if (FormatValidator.hasNoValue(p2)) {
+                    return -1;
+                }
+
+                return Integer.compare(p1, p2);
+            };
+
+            openApi.setTags(
+                    openApi.getTags().stream()
+                            .sorted(comparator)
+                            .toList()
+            );
+        };
+    }
+
+    @Bean
+    public OpenAPI apiV1() {
+        OpenAPI openApi = new OpenAPI();
+
+        io.swagger.v3.oas.models.security.SecurityScheme securityScheme = new io.swagger.v3.oas.models.security.SecurityScheme()
+                .type(io.swagger.v3.oas.models.security.SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT")
+                .in(io.swagger.v3.oas.models.security.SecurityScheme.In.HEADER)
+                .name(HttpHeaders.AUTHORIZATION);
+
+        openApi.info(new Info()
+                        .title("마켓노트 풀필먼트 API 서버")
+                        .description("마켓노트 서비스 풀필먼트 API 서버입니다.")
+                        .version("1.0"))
+                .components(new Components()
+                        .addSecuritySchemes("bearer", securityScheme))
+                .addSecurityItem(new SecurityRequirement().addList("bearer"))
+                .servers(List.of(
+                        new Server().url(serverOrigin)
+                ));
+
+        return openApi;
+    }
+
+    private void addAuthorizationInfo(Operation operation) {
+        if (FormatValidator.hasValue(operation)) {
+            operation.getResponses().addApiResponse(
+                            "401",
+                            new ApiResponse().description("Bearer Token is invalid or no bearer token")
+                                    .content(
+                                            new Content().addMediaType("*/*",
+                                                    new MediaType().addExamples("Not authenticated",
+                                                            new Example().value("""
+                                                                    {
+                                                                        "statusCode": 401,
+                                                                        "timestamp": "2026-01-22T19:56:58.7278032",
+                                                                        "errorCode": "AUTH001",
+                                                                        "errorName": "AUTHENTICATION_FAILED",
+                                                                        "message": "Authentication Failed"
+                                                                    }
+                                                                    """))
+                                            )
+                                    )
+                    )
+                    .addApiResponse(
+                            "403",
+                            new ApiResponse().description("You are authenticated but not allowed authorization")
+                                    .content(
+                                            new Content().addMediaType("*/*",
+                                                    new MediaType().addExamples("Not authorized",
+                                                            new Example().value("""
+                                                                    {
+                                                                        "statusCode": 403,
+                                                                        "timestamp": "2026-01-22T19:56:58.7278032",
+                                                                        "errorCode": "AUTH002",
+                                                                        "errorName": "AUTHORIZATION_FAILED",
+                                                                        "message": "Authorization Failed"
+                                                                    }
+                                                                    """))
+                                            )
+                                    )
+                    );
+        }
+    }
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/FasstoAuthController.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/FasstoAuthController.java
@@ -1,0 +1,50 @@
+package com.personal.marketnote.fulfillment.adapter.in.web.vendor.controller;
+
+import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
+import com.personal.marketnote.fulfillment.adapter.in.web.vendor.controller.apidocs.RequestFasstoAuthApiDocs;
+import com.personal.marketnote.fulfillment.adapter.in.web.vendor.response.FasstoAuthTokenResponse;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.FasstoAccessTokenResult;
+import com.personal.marketnote.fulfillment.port.in.usecase.vendor.RequestFasstoAuthUseCase;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static com.personal.marketnote.common.domain.exception.ExceptionCode.DEFAULT_SUCCESS_CODE;
+import static com.personal.marketnote.common.utility.ApiConstant.ADMIN_POINTCUT;
+
+@RestController
+@RequestMapping("/api/v1/vendors/fassto/auth")
+@Tag(name = "파스토 인증 API", description = "파스토 인증 관련 API")
+@RequiredArgsConstructor
+public class FasstoAuthController {
+    private final RequestFasstoAuthUseCase requestFasstoAuthUseCase;
+
+    /**
+     * (관리자) 파스토 엑세스 토큰 요청
+     *
+     * @Author 성효빈
+     * @Date 2026-01-23
+     * @Description 파스토 엑세스 토큰 발급을 요청합니다.
+     */
+    @PostMapping
+    @PreAuthorize(ADMIN_POINTCUT)
+    @RequestFasstoAuthApiDocs
+    public ResponseEntity<BaseResponse<FasstoAuthTokenResponse>> requestAccessToken() {
+        FasstoAccessTokenResult result = FasstoAccessTokenResult.from(requestFasstoAuthUseCase.requestAccessToken());
+
+        return new ResponseEntity<>(
+                BaseResponse.of(
+                        FasstoAuthTokenResponse.from(result),
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "파스토 엑세스 토큰 발급 성공"
+                ),
+                HttpStatus.OK
+        );
+    }
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/apidocs/RequestFasstoAuthApiDocs.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/apidocs/RequestFasstoAuthApiDocs.java
@@ -1,0 +1,116 @@
+package com.personal.marketnote.fulfillment.adapter.in.web.vendor.controller.apidocs;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Operation(
+        summary = "(관리자) 파스토 엑세스 토큰 발급 요청",
+        description = """
+                작성일자: 2026-01-23
+                
+                작성자: 성효빈
+                
+                ---
+                
+                ## Description
+                
+                파스토 엑세스 토큰 발급을 요청합니다.
+                
+                ## Request
+                
+                | **키** | **타입** | **설명** | **필수 여부** | **예시** |
+                | --- | --- | --- | --- | --- |
+                
+                ---
+                
+                ## Response
+                
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | statusCode | number | 상태 코드 | 200: 성공 / 400: 클라이언트 요청 오류 / 401: 인증 실패 / 403: 인가 실패 / 500: 그 외 |
+                | code | string | 응답 코드 | "SUC01" / "BAD_REQUEST" / "UNAUTHORIZED" / "FORBIDDEN" / "INTERNAL_SERVER_ERROR" |
+                | timestamp | string(datetime) | 응답 일시 | "2026-01-23T12:12:30.013" |
+                | content | object | 응답 본문 | { ... } |
+                | message | string | 처리 결과 | "파스토 엑세스 토큰 발급 성공" |
+                
+                ---
+                
+                ### Response > content
+                
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | tokenInfo | object | 토큰 정보 | { ... } |
+                
+                ---
+                
+                ### Response > content > tokenInfo
+                
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | accessToken | string | 파스토 액세스 토큰 | "ede4785770ab4949816247d1f0beff55" |
+                | expiresAt | string(datetime) | 만료 일시 | "2025-12-30T14:40:32" |
+                
+                """,
+        security = {@SecurityRequirement(name = "bearer")},
+        responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "파스토 엑세스 토큰 발급 성공",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 200,
+                                          "code": "SUC01",
+                                          "timestamp": "2026-01-23T14:40:32.868332",
+                                          "content": {
+                                            "tokenInfo": {
+                                              "accessToken": "ede4785770ab4949816247d1f0beff55",
+                                              "expiresAt": "2025-12-30T14:40:32"
+                                            }
+                                          },
+                                          "message": "파스토 엑세스 토큰 발급 성공"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "401",
+                        description = "토큰 인증 실패",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 401,
+                                          "code": "UNAUTHORIZED",
+                                          "timestamp": "2026-01-23T12:12:30.013",
+                                          "content": null,
+                                          "message": "Invalid token"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "403",
+                        description = "토큰 인가 실패",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 403,
+                                          "code": "FORBIDDEN",
+                                          "timestamp": "2026-01-23T12:12:30.013",
+                                          "content": null,
+                                          "message": "Access Denied"
+                                        }
+                                        """)
+                        )
+                )
+        })
+public @interface RequestFasstoAuthApiDocs {
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/response/FasstoAuthTokenResponse.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/response/FasstoAuthTokenResponse.java
@@ -1,0 +1,11 @@
+package com.personal.marketnote.fulfillment.adapter.in.web.vendor.response;
+
+import com.personal.marketnote.fulfillment.port.in.result.vendor.FasstoAccessTokenResult;
+
+public record FasstoAuthTokenResponse(
+        FasstoAccessTokenResult tokenInfo
+) {
+    public static FasstoAuthTokenResponse from(FasstoAccessTokenResult tokenInfo) {
+        return new FasstoAuthTokenResponse(tokenInfo);
+    }
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/FasstoAuthClient.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/FasstoAuthClient.java
@@ -1,0 +1,150 @@
+package com.personal.marketnote.fulfillment.adapter.out.vendor.fassto;
+
+import com.personal.marketnote.common.adapter.out.VendorAdapter;
+import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.fulfillment.adapter.out.vendor.fassto.response.FasstoAuthHeaderResponse;
+import com.personal.marketnote.fulfillment.adapter.out.vendor.fassto.response.FasstoAuthResponse;
+import com.personal.marketnote.fulfillment.configuration.FasstoAuthProperties;
+import com.personal.marketnote.fulfillment.domain.vendor.FasstoAccessToken;
+import com.personal.marketnote.fulfillment.exception.FasstoAuthRequestFailedException;
+import com.personal.marketnote.fulfillment.port.out.vendor.RequestFasstoAuthPort;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.*;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.List;
+
+import static com.personal.marketnote.common.utility.ApiConstant.*;
+
+@VendorAdapter
+@RequiredArgsConstructor
+@Slf4j
+public class FasstoAuthClient implements RequestFasstoAuthPort {
+    private static final String API_CD_PARAM = "apiCd";
+    private static final String API_KEY_PARAM = "apiKey";
+
+    private final RestTemplate restTemplate;
+    private final FasstoAuthProperties properties;
+
+    @Override
+    public FasstoAccessToken requestAccessToken() {
+        URI uri = buildAuthUri();
+        HttpEntity<Void> request = new HttpEntity<>(buildHeaders());
+
+        Exception error = new Exception();
+        long sleepMillis = INTER_SERVER_DEFAULT_RETRIAL_PENDING_MILLI_SECOND;
+
+        for (int i = 0; i < INTER_SERVER_MAX_REQUEST_COUNT; i++) {
+            try {
+                ResponseEntity<FasstoAuthResponse> response = restTemplate.exchange(
+                        uri,
+                        HttpMethod.POST,
+                        request,
+                        FasstoAuthResponse.class
+                );
+
+                FasstoAccessToken accessToken = parseResponse(response);
+
+                if (FormatValidator.hasValue(accessToken)) {
+                    return accessToken;
+                }
+            } catch (Exception e) {
+                log.warn("Failed to request Fassto auth: attempt={}, message={}", i + 1, e.getMessage(), e);
+                if (i == INTER_SERVER_MAX_REQUEST_COUNT - 1) {
+                    error = e;
+                }
+            }
+
+            sleep(sleepMillis);
+            sleepMillis = sleepMillis * INTER_SERVER_DEFAULT_EXPONENTIAL_BACKOFF_VALUE;
+        }
+
+        log.error("Failed to request Fassto auth: {} with error: {}", uri, error.getMessage(), error);
+        throw new FasstoAuthRequestFailedException(new IOException(error));
+    }
+
+    private URI buildAuthUri() {
+        validateProperties();
+        return UriComponentsBuilder.fromUriString(properties.getBaseUrl())
+                .path(properties.getConnectPath())
+                .queryParam(API_CD_PARAM, properties.getApiCd())
+                .queryParam(API_KEY_PARAM, properties.getApiKey())
+                .build(true)
+                .toUri();
+    }
+
+    private HttpHeaders buildHeaders() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setAccept(List.of(MediaType.APPLICATION_JSON));
+        return headers;
+    }
+
+    private void validateProperties() {
+        if (FormatValidator.hasNoValue(properties.getBaseUrl())) {
+            throw new IllegalStateException("Fassto base URL is required.");
+        }
+        if (FormatValidator.hasNoValue(properties.getApiCd())) {
+            throw new IllegalStateException("Fassto apiCd is required.");
+        }
+        if (FormatValidator.hasNoValue(properties.getApiKey())) {
+            throw new IllegalStateException("Fassto apiKey is required.");
+        }
+        if (FormatValidator.hasNoValue(properties.getConnectPath())) {
+            throw new IllegalStateException("Fassto auth connect path is required.");
+        }
+    }
+
+    private FasstoAccessToken parseResponse(ResponseEntity<FasstoAuthResponse> response) {
+        if (FormatValidator.hasNoValue(response)) {
+            log.warn("Fassto auth response is null.");
+            return null;
+        }
+
+        if (!response.getStatusCode().is2xxSuccessful()) {
+            log.warn("Fassto auth returned non-2xx status: {}", response.getStatusCode());
+            return null;
+        }
+
+        FasstoAuthResponse body = response.getBody();
+        if (FormatValidator.hasNoValue(body) || !body.isSuccess()) {
+            log.warn("Fassto auth returned failure: {}", formatError(body));
+            return null;
+        }
+
+        if (
+                FormatValidator.hasNoValue(body.data())
+                        || FormatValidator.hasNoValue(body.data().accessToken())
+                        || FormatValidator.hasNoValue(body.data().expreDatetime())
+        ) {
+            log.warn("Fassto auth response is missing token data.");
+            return null;
+        }
+
+        return FasstoAccessToken.of(body.data().accessToken(), body.data().expreDatetime());
+    }
+
+    private String formatError(FasstoAuthResponse response) {
+        if (FormatValidator.hasNoValue(response)) {
+            return "no response body";
+        }
+
+        FasstoAuthHeaderResponse header = response.header();
+        String code = FormatValidator.hasValue(header) ? header.code() : null;
+        String message = FormatValidator.hasValue(header) ? header.msg() : null;
+        String errorInfo = FormatValidator.hasValue(response.errorInfo()) ? response.errorInfo().toString() : null;
+
+        return String.format("code=%s, message=%s, errorInfo=%s", code, message, errorInfo);
+    }
+
+    private void sleep(long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoAuthDataResponse.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoAuthDataResponse.java
@@ -1,0 +1,10 @@
+package com.personal.marketnote.fulfillment.adapter.out.vendor.fassto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record FasstoAuthDataResponse(
+        String accessToken,
+        String expreDatetime
+) {
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoAuthHeaderResponse.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoAuthHeaderResponse.java
@@ -1,0 +1,16 @@
+package com.personal.marketnote.fulfillment.adapter.out.vendor.fassto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record FasstoAuthHeaderResponse(
+        String code,
+        String msg,
+        Integer dataCount
+) {
+    private static final String SUCCESS_CODE = "200";
+
+    public boolean isSuccess() {
+        return SUCCESS_CODE.equals(code);
+    }
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoAuthResponse.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoAuthResponse.java
@@ -1,0 +1,14 @@
+package com.personal.marketnote.fulfillment.adapter.out.vendor.fassto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record FasstoAuthResponse(
+        FasstoAuthHeaderResponse header,
+        FasstoAuthDataResponse data,
+        Object errorInfo
+) {
+    public boolean isSuccess() {
+        return header != null && header.isSuccess();
+    }
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/configuration/CommonConfig.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/configuration/CommonConfig.java
@@ -1,0 +1,18 @@
+package com.personal.marketnote.fulfillment.configuration;
+
+import com.personal.marketnote.common.application.aop.LoggingAspect;
+import com.personal.marketnote.common.configuration.security.OpaqueTokenIntrospectorConfig;
+import com.personal.marketnote.common.configuration.security.OpaqueTokenIntrospectorProvider;
+import com.personal.marketnote.common.domain.exception.GlobalExceptionHandler;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+@Configuration
+@Import({
+        LoggingAspect.class,
+        GlobalExceptionHandler.class,
+        OpaqueTokenIntrospectorConfig.class,
+        OpaqueTokenIntrospectorProvider.class
+})
+public class CommonConfig {
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/resources/application.yml
+++ b/fulfillment-service/fulfillment-adapters/src/main/resources/application.yml
@@ -45,6 +45,13 @@ server:
     whitelabel:
       enabled: false
 
+vendor:
+  fassto:
+    auth:
+      base-url: ${FASSTO_BASE_URL:abc}
+      api-cd: ${FASSTO_API_CD:change-me}
+      api-key: ${FASSTO_API_KEY:change-me}
+
 logging:
   config: classpath:logback-spring.xml
   level:

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/configuration/FasstoAuthProperties.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/configuration/FasstoAuthProperties.java
@@ -1,0 +1,17 @@
+package com.personal.marketnote.fulfillment.configuration;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "vendor.fassto.auth")
+public class FasstoAuthProperties {
+    private String baseUrl;
+    private String apiCd;
+    private String apiKey;
+    private String connectPath = "/api/v1/auth/connect";
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/FasstoAuthRequestFailedException.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/FasstoAuthRequestFailedException.java
@@ -1,0 +1,14 @@
+package com.personal.marketnote.fulfillment.exception;
+
+import com.personal.marketnote.common.exception.ExternalOperationFailedException;
+
+import java.io.IOException;
+
+public class FasstoAuthRequestFailedException extends ExternalOperationFailedException {
+    private static final String FASSTO_AUTH_REQUEST_FAILED_EXCEPTION_MESSAGE =
+            "Fassto authentication request failed.";
+
+    public FasstoAuthRequestFailedException(IOException cause) {
+        super(FASSTO_AUTH_REQUEST_FAILED_EXCEPTION_MESSAGE, cause);
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/result/vendor/FasstoAccessTokenResult.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/result/vendor/FasstoAccessTokenResult.java
@@ -1,0 +1,14 @@
+package com.personal.marketnote.fulfillment.port.in.result.vendor;
+
+import com.personal.marketnote.fulfillment.domain.vendor.FasstoAccessToken;
+
+import java.time.LocalDateTime;
+
+public record FasstoAccessTokenResult(
+        String accessToken,
+        LocalDateTime expiresAt
+) {
+    public static FasstoAccessTokenResult from(FasstoAccessToken fasstoAccessToken) {
+        return new FasstoAccessTokenResult(fasstoAccessToken.getValue(), fasstoAccessToken.getExpiresAt());
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/usecase/vendor/RequestFasstoAuthUseCase.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/usecase/vendor/RequestFasstoAuthUseCase.java
@@ -1,0 +1,13 @@
+package com.personal.marketnote.fulfillment.port.in.usecase.vendor;
+
+import com.personal.marketnote.fulfillment.domain.vendor.FasstoAccessToken;
+
+public interface RequestFasstoAuthUseCase {
+    /**
+     * @return Fassto access token {@link FasstoAccessToken}
+     * @Date 2026-01-23
+     * @Author 성효빈
+     * @Description Request a Fassto access token.
+     */
+    FasstoAccessToken requestAccessToken();
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/vendor/RequestFasstoAuthPort.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/vendor/RequestFasstoAuthPort.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.fulfillment.port.out.vendor;
+
+import com.personal.marketnote.fulfillment.domain.vendor.FasstoAccessToken;
+
+public interface RequestFasstoAuthPort {
+    FasstoAccessToken requestAccessToken();
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/vendor/RequestFasstoAuthService.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/vendor/RequestFasstoAuthService.java
@@ -1,0 +1,22 @@
+package com.personal.marketnote.fulfillment.service.vendor;
+
+import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.fulfillment.domain.vendor.FasstoAccessToken;
+import com.personal.marketnote.fulfillment.port.in.usecase.vendor.RequestFasstoAuthUseCase;
+import com.personal.marketnote.fulfillment.port.out.vendor.RequestFasstoAuthPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional(isolation = READ_COMMITTED, readOnly = true)
+public class RequestFasstoAuthService implements RequestFasstoAuthUseCase {
+    private final RequestFasstoAuthPort requestFasstoAuthPort;
+
+    @Override
+    public FasstoAccessToken requestAccessToken() {
+        return requestFasstoAuthPort.requestAccessToken();
+    }
+}

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/FasstoAccessToken.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/FasstoAccessToken.java
@@ -1,0 +1,50 @@
+package com.personal.marketnote.fulfillment.domain.vendor;
+
+import com.personal.marketnote.common.domain.exception.illegalargument.invalidvalue.ParsingLocalDateTimeException;
+import com.personal.marketnote.common.utility.FormatValidator;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+@Getter
+public class FasstoAccessToken {
+    private static final DateTimeFormatter EXPIRE_DATETIME_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMddHHmmss");
+
+    private String value;
+    private LocalDateTime expiresAt;
+
+    public static FasstoAccessToken of(String value, String expreDatetime) {
+        if (FormatValidator.hasNoValue(value)) {
+            throw new IllegalArgumentException("Fassto access token value is required.");
+        }
+        if (FormatValidator.hasNoValue(expreDatetime)) {
+            throw new IllegalArgumentException("Fassto access token expiration is required.");
+        }
+
+        return FasstoAccessToken.builder()
+                .value(value)
+                .expiresAt(parseExpiration(expreDatetime))
+                .build();
+    }
+
+    public boolean isExpired(LocalDateTime now) {
+        if (FormatValidator.hasNoValue(now) || FormatValidator.hasNoValue(expiresAt)) {
+            return false;
+        }
+
+        return now.isAfter(expiresAt);
+    }
+
+    private static LocalDateTime parseExpiration(String expreDatetime) {
+        try {
+            return LocalDateTime.parse(expreDatetime, EXPIRE_DATETIME_FORMATTER);
+        } catch (DateTimeParseException e) {
+            throw new ParsingLocalDateTimeException("Failed to parse Fassto expiration datetime: " + expreDatetime);
+        }
+    }
+}


### PR DESCRIPTION
## partially addresses #475
## resolves #496

## Task
- [x] 파스토 권한 인증 연동 요청
- [x] 파스토 권한 인증 연동 비즈니스 로직
- [x] 파스토 서버에 엑세스 토큰 발급 요청
- [x] 200 status code 응답
- [x] Swagger docs
- [x] Jenkins Credentials
    - [x] SHOP_QA_FASSTO_BASE_URL
    - [x] SHOP_QA_FASSTO_API_CD
    - [x] SHOP_QA_FASSTO_API_KEY