### PR TITLE
[#475][#500] feat: 파스토 권한 인증 해제 연동 기능 추가

### DIFF
--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/FasstoAuthController.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/FasstoAuthController.java
@@ -1,18 +1,18 @@
 package com.personal.marketnote.fulfillment.adapter.in.web.vendor.controller;
 
 import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
+import com.personal.marketnote.fulfillment.adapter.in.web.vendor.controller.apidocs.DisconnectFasstoAuthApiDocs;
 import com.personal.marketnote.fulfillment.adapter.in.web.vendor.controller.apidocs.RequestFasstoAuthApiDocs;
 import com.personal.marketnote.fulfillment.adapter.in.web.vendor.response.FasstoAuthTokenResponse;
 import com.personal.marketnote.fulfillment.port.in.result.vendor.FasstoAccessTokenResult;
+import com.personal.marketnote.fulfillment.port.in.usecase.vendor.DisconnectFasstoAuthUseCase;
 import com.personal.marketnote.fulfillment.port.in.usecase.vendor.RequestFasstoAuthUseCase;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import static com.personal.marketnote.common.domain.exception.ExceptionCode.DEFAULT_SUCCESS_CODE;
 import static com.personal.marketnote.common.utility.ApiConstant.ADMIN_POINTCUT;
@@ -23,13 +23,14 @@ import static com.personal.marketnote.common.utility.ApiConstant.ADMIN_POINTCUT;
 @RequiredArgsConstructor
 public class FasstoAuthController {
     private final RequestFasstoAuthUseCase requestFasstoAuthUseCase;
+    private final DisconnectFasstoAuthUseCase disconnectFasstoAuthUseCase;
 
     /**
-     * (관리자) 파스토 엑세스 토큰 요청
+     * (관리자) 파스토 인증 요청
      *
      * @Author 성효빈
      * @Date 2026-01-24
-     * @Description 파스토 엑세스 토큰 발급을 요청합니다.
+     * @Description 파스토 인증을 요청합니다.
      */
     @PostMapping
     @PreAuthorize(ADMIN_POINTCUT)
@@ -42,7 +43,34 @@ public class FasstoAuthController {
                         FasstoAuthTokenResponse.from(result),
                         HttpStatus.OK,
                         DEFAULT_SUCCESS_CODE,
-                        "파스토 엑세스 토큰 발급 성공"
+                        "파스토 인증 요청 성공"
+                ),
+                HttpStatus.OK
+        );
+    }
+
+    /**
+     * (관리자) 파스토 인증 해제 요청
+     *
+     * @param accessToken 파스토 액세스 토큰
+     * @Author 성효빈
+     * @Date 2026-01-25
+     * @Description 파스토 인증 해제를 요청합니다.
+     */
+    @GetMapping("/disconnect")
+    @PreAuthorize(ADMIN_POINTCUT)
+    @DisconnectFasstoAuthApiDocs
+    public ResponseEntity<BaseResponse<Void>> disconnectAccessToken(
+            @RequestHeader("accessToken") String accessToken
+    ) {
+        disconnectFasstoAuthUseCase.disconnectAccessToken(accessToken);
+
+        return new ResponseEntity<>(
+                BaseResponse.of(
+                        null,
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "파스토 인증 해제 성공"
                 ),
                 HttpStatus.OK
         );

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/apidocs/DisconnectFasstoAuthApiDocs.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/apidocs/DisconnectFasstoAuthApiDocs.java
@@ -1,6 +1,8 @@
 package com.personal.marketnote.fulfillment.adapter.in.web.vendor.controller.apidocs;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -12,9 +14,9 @@ import java.lang.annotation.*;
 @Retention(RetentionPolicy.RUNTIME)
 @Inherited
 @Operation(
-        summary = "(관리자) 파스토 인증 요청",
+        summary = "(관리자) 파스토 인증 해제 요청",
         description = """
-                작성일자: 2026-01-24
+                작성일자: 2026-01-25
                 
                 작성자: 성효빈
                 
@@ -22,12 +24,13 @@ import java.lang.annotation.*;
                 
                 ## Description
                 
-                파스토 엑세스 토큰 발급을 요청합니다.
+                파스토 액세스 토큰 만료를 요청합니다.
                 
                 ## Request
                 
-                | **키** | **타입** | **설명** | **필수 여부** | **예시** |
-                | --- | --- | --- | --- | --- |
+                | **키** | **위치** | **타입** | **설명** | **필수 여부** | **예시** |
+                | --- | --- | --- | --- | --- | --- |
+                | accessToken | header | string | 파스토 액세스 토큰 | Y | 5a2af269e54f11f0be620ab49498ff55 |
                 
                 ---
                 
@@ -37,46 +40,32 @@ import java.lang.annotation.*;
                 | --- | --- | --- | --- |
                 | statusCode | number | 상태 코드 | 200: 성공 / 400: 클라이언트 요청 오류 / 401: 인증 실패 / 403: 인가 실패 / 500: 그 외 |
                 | code | string | 응답 코드 | "SUC01" / "BAD_REQUEST" / "UNAUTHORIZED" / "FORBIDDEN" / "INTERNAL_SERVER_ERROR" |
-                | timestamp | string(datetime) | 응답 일시 | "2026-01-24T12:12:30.013" |
-                | content | object | 응답 본문 | { ... } |
-                | message | string | 처리 결과 | "파스토 인증 요청 성공" |
-                
-                ---
-                
-                ### Response > content
-                
-                | **키** | **타입** | **설명** | **예시** |
-                | --- | --- | --- | --- |
-                | tokenInfo | object | 토큰 정보 | { ... } |
-                
-                ---
-                
-                ### Response > content > tokenInfo
-                
-                | **키** | **타입** | **설명** | **예시** |
-                | --- | --- | --- | --- |
-                | accessToken | string | 파스토 액세스 토큰 | "ede4785770ab4949816247d1f0beff55" |
-                | expiresAt | string(datetime) | 만료 일시 | "2026-01-25T14:40:32" |
+                | timestamp | string(datetime) | 응답 일시 | "2026-01-25T12:12:30.013" |
+                | content | object | 응답 본문 | null |
+                | message | string | 처리 결과 | "파스토 인증 해제 성공" |
                 
                 """,
         security = {@SecurityRequirement(name = "bearer")},
+        parameters = {
+                @Parameter(
+                        name = "accessToken",
+                        description = "파스토 액세스 토큰",
+                        in = ParameterIn.HEADER,
+                        required = true
+                )
+        },
         responses = {
                 @ApiResponse(
                         responseCode = "200",
-                        description = "파스토 인증 요청 성공",
+                        description = "파스토 인증 해제 성공",
                         content = @Content(
                                 examples = @ExampleObject("""
                                         {
                                           "statusCode": 200,
                                           "code": "SUC01",
-                                          "timestamp": "2026-01-24T14:40:32.868332",
-                                          "content": {
-                                            "tokenInfo": {
-                                              "accessToken": "ede4785770ab4949816247d1f0beff55",
-                                              "expiresAt": "2026-01-25T14:40:32"
-                                            }
-                                          },
-                                          "message": "파스토 인증 요청 성공"
+                                          "timestamp": "2026-01-25T12:12:30.013",
+                                          "content": null,
+                                          "message": "파스토 인증 해제 성공"
                                         }
                                         """)
                         )
@@ -89,7 +78,7 @@ import java.lang.annotation.*;
                                         {
                                           "statusCode": 401,
                                           "code": "UNAUTHORIZED",
-                                          "timestamp": "2026-01-24T12:12:30.013",
+                                          "timestamp": "2026-01-25T12:12:30.013",
                                           "content": null,
                                           "message": "Invalid token"
                                         }
@@ -104,7 +93,7 @@ import java.lang.annotation.*;
                                         {
                                           "statusCode": 403,
                                           "code": "FORBIDDEN",
-                                          "timestamp": "2026-01-24T12:12:30.013",
+                                          "timestamp": "2026-01-25T12:12:30.013",
                                           "content": null,
                                           "message": "Access Denied"
                                         }
@@ -112,5 +101,5 @@ import java.lang.annotation.*;
                         )
                 )
         })
-public @interface RequestFasstoAuthApiDocs {
+public @interface DisconnectFasstoAuthApiDocs {
 }

--- a/fulfillment-service/fulfillment-adapters/src/main/resources/application.yml
+++ b/fulfillment-service/fulfillment-adapters/src/main/resources/application.yml
@@ -48,7 +48,9 @@ server:
 vendor:
   fassto:
     auth:
-      base-url: ${FASSTO_BASE_URL:abc}
+      base-url: ${FASSTO_BASE_URL:https://stg-fmsapi.fassto.ai}
+      connect-path: ${FASSTO_AUTH_CONNECT_PATH:/api/v1/auth/connect}
+      disconnect-path: ${FASSTO_AUTH_DISCONNECT_PATH:/api/v1/auth/disconnect}
       api-cd: ${FASSTO_API_CD:change-me}
       api-key: ${FASSTO_API_KEY:change-me}
 

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/configuration/FasstoAuthProperties.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/configuration/FasstoAuthProperties.java
@@ -14,4 +14,5 @@ public class FasstoAuthProperties {
     private String apiCd;
     private String apiKey;
     private String connectPath = "/api/v1/auth/connect";
+    private String disconnectPath = "/api/v1/auth/disconnect";
 }

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/FasstoAuthDisconnectFailedException.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/FasstoAuthDisconnectFailedException.java
@@ -1,0 +1,14 @@
+package com.personal.marketnote.fulfillment.exception;
+
+import com.personal.marketnote.common.exception.ExternalOperationFailedException;
+
+import java.io.IOException;
+
+public class FasstoAuthDisconnectFailedException extends ExternalOperationFailedException {
+    private static final String FASSTO_AUTH_DISCONNECT_FAILED_EXCEPTION_MESSAGE =
+            "Fassto authentication disconnect request failed.";
+
+    public FasstoAuthDisconnectFailedException(IOException cause) {
+        super(FASSTO_AUTH_DISCONNECT_FAILED_EXCEPTION_MESSAGE, cause);
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/usecase/vendor/DisconnectFasstoAuthUseCase.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/usecase/vendor/DisconnectFasstoAuthUseCase.java
@@ -1,0 +1,11 @@
+package com.personal.marketnote.fulfillment.port.in.usecase.vendor;
+
+public interface DisconnectFasstoAuthUseCase {
+    /**
+     * @param accessToken Fassto access token
+     * @Date 2026-01-25
+     * @Author Codex
+     * @Description Disconnect Fassto access token.
+     */
+    void disconnectAccessToken(String accessToken);
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/vendor/DisconnectFasstoAuthPort.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/vendor/DisconnectFasstoAuthPort.java
@@ -1,0 +1,5 @@
+package com.personal.marketnote.fulfillment.port.out.vendor;
+
+public interface DisconnectFasstoAuthPort {
+    void disconnectAccessToken(String accessToken);
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/vendor/DisconnectFasstoAuthService.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/vendor/DisconnectFasstoAuthService.java
@@ -1,0 +1,21 @@
+package com.personal.marketnote.fulfillment.service.vendor;
+
+import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.fulfillment.port.in.usecase.vendor.DisconnectFasstoAuthUseCase;
+import com.personal.marketnote.fulfillment.port.out.vendor.DisconnectFasstoAuthPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional(isolation = READ_COMMITTED, readOnly = true)
+public class DisconnectFasstoAuthService implements DisconnectFasstoAuthUseCase {
+    private final DisconnectFasstoAuthPort disconnectFasstoAuthPort;
+
+    @Override
+    public void disconnectAccessToken(String accessToken) {
+        disconnectFasstoAuthPort.disconnectAccessToken(accessToken);
+    }
+}


### PR DESCRIPTION
## partially addresses #475
## resolves #500

## Task
- [x] 파스토 권한 인증 해제 연동 요청
- [x] 파스토 권한 인증 해제 연동 비즈니스 로직
- [x] 파스토 서버에 엑세스 토큰 만료 요청
- [x] 200 status code 응답
- [x] Swagger docs