### PR TITLE
[#475][#511] feat: 파스토 고객사 출고처 등록 연동 기능 추가

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/configuration/CommerceSwaggerConfig.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/configuration/CommerceSwaggerConfig.java
@@ -122,7 +122,7 @@ public class CommerceSwaggerConfig {
                                                             new Example().value("""
                                                                     {
                                                                         "statusCode": 401,
-                                                                        "timestamp": "2026-01-22T19:56:58.7278032",
+                                                                        "timestamp": "2025-12-26T19:56:58.7278032",
                                                                         "errorCode": "AUTH001",
                                                                         "errorName": "AUTHENTICATION_FAILED",
                                                                         "message": "Authentication Failed"
@@ -140,7 +140,7 @@ public class CommerceSwaggerConfig {
                                                             new Example().value("""
                                                                     {
                                                                         "statusCode": 403,
-                                                                        "timestamp": "2026-01-22T19:56:58.7278032",
+                                                                        "timestamp": "2025-12-26T19:56:58.7278032",
                                                                         "errorCode": "AUTH002",
                                                                         "errorName": "AUTHORIZATION_FAILED",
                                                                         "message": "Authorization Failed"

--- a/common/src/main/java/com/personal/marketnote/common/adapter/in/web/identification/apidocs/WhoAmIApiDocs.java
+++ b/common/src/main/java/com/personal/marketnote/common/adapter/in/web/identification/apidocs/WhoAmIApiDocs.java
@@ -61,7 +61,7 @@ import java.lang.annotation.*;
                                         {
                                           "statusCode": 200,
                                           "code": "SUC01",
-                                          "timestamp": "2026-01-22T22:52:31.889943",
+                                          "timestamp": "2025-12-26T22:52:31.889943",
                                           "content": {
                                             "ip": "192.168.0.1"
                                           },

--- a/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/in/configuration/CommunitySwaggerConfig.java
+++ b/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/in/configuration/CommunitySwaggerConfig.java
@@ -125,7 +125,7 @@ public class CommunitySwaggerConfig {
                                                             new Example().value("""
                                                                     {
                                                                         "statusCode": 401,
-                                                                        "timestamp": "2026-01-22T19:56:58.7278032",
+                                                                        "timestamp": "2025-12-26T19:56:58.7278032",
                                                                         "errorCode": "AUTH001",
                                                                         "errorName": "AUTHENTICATION_FAILED",
                                                                         "message": "Authentication Failed"
@@ -143,7 +143,7 @@ public class CommunitySwaggerConfig {
                                                             new Example().value("""
                                                                     {
                                                                         "statusCode": 403,
-                                                                        "timestamp": "2026-01-22T19:56:58.7278032",
+                                                                        "timestamp": "2025-12-26T19:56:58.7278032",
                                                                         "errorCode": "AUTH002",
                                                                         "errorName": "AUTHORIZATION_FAILED",
                                                                         "message": "Authorization Failed"

--- a/file-service/file-adapters/src/main/java/com/personal/marketnote/file/adapter/in/configuration/FileSwaggerConfig.java
+++ b/file-service/file-adapters/src/main/java/com/personal/marketnote/file/adapter/in/configuration/FileSwaggerConfig.java
@@ -124,7 +124,7 @@ public class FileSwaggerConfig {
                                                             new Example().value("""
                                                                     {
                                                                         "statusCode": 401,
-                                                                        "timestamp": "2026-01-22T19:56:58.7278032",
+                                                                        "timestamp": "2025-12-26T19:56:58.7278032",
                                                                         "errorCode": "AUTH001",
                                                                         "errorName": "AUTHENTICATION_FAILED",
                                                                         "message": "Authentication Failed"
@@ -142,7 +142,7 @@ public class FileSwaggerConfig {
                                                             new Example().value("""
                                                                     {
                                                                         "statusCode": 403,
-                                                                        "timestamp": "2026-01-22T19:56:58.7278032",
+                                                                        "timestamp": "2025-12-26T19:56:58.7278032",
                                                                         "errorCode": "AUTH002",
                                                                         "errorName": "AUTHORIZATION_FAILED",
                                                                         "message": "Authorization Failed"

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter.in.configuration/FulfillmentSwaggerConfig.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter.in.configuration/FulfillmentSwaggerConfig.java
@@ -121,7 +121,7 @@ public class FulfillmentSwaggerConfig {
                                                             new Example().value("""
                                                                     {
                                                                         "statusCode": 401,
-                                                                        "timestamp": "2026-01-22T19:56:58.7278032",
+                                                                        "timestamp": "2025-12-26T19:56:58.7278032",
                                                                         "errorCode": "AUTH001",
                                                                         "errorName": "AUTHENTICATION_FAILED",
                                                                         "message": "Authentication Failed"
@@ -139,7 +139,7 @@ public class FulfillmentSwaggerConfig {
                                                             new Example().value("""
                                                                     {
                                                                         "statusCode": 403,
-                                                                        "timestamp": "2026-01-22T19:56:58.7278032",
+                                                                        "timestamp": "2025-12-26T19:56:58.7278032",
                                                                         "errorCode": "AUTH002",
                                                                         "errorName": "AUTHORIZATION_FAILED",
                                                                         "message": "Authorization Failed"

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/FasstoWarehouseController.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/FasstoWarehouseController.java
@@ -1,0 +1,60 @@
+package com.personal.marketnote.fulfillment.adapter.in.web.vendor.controller;
+
+import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
+import com.personal.marketnote.fulfillment.adapter.in.web.vendor.controller.apidocs.RegisterFasstoWarehouseApiDocs;
+import com.personal.marketnote.fulfillment.adapter.in.web.vendor.mapper.FasstoWarehouseRequestToCommandMapper;
+import com.personal.marketnote.fulfillment.adapter.in.web.vendor.request.RegisterFasstoWarehouseRequest;
+import com.personal.marketnote.fulfillment.adapter.in.web.vendor.response.FasstoWarehouseRegisterResponse;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.RegisterFasstoWarehouseResult;
+import com.personal.marketnote.fulfillment.port.in.usecase.vendor.RegisterFasstoWarehouseUseCase;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import static com.personal.marketnote.common.domain.exception.ExceptionCode.DEFAULT_SUCCESS_CODE;
+import static com.personal.marketnote.common.utility.ApiConstant.ADMIN_POINTCUT;
+
+@RestController
+@RequestMapping("/api/v1/vendors/fassto/marketnotes")
+@Tag(name = "파스토 출고처 API", description = "파스토 출고처 관련 API")
+@RequiredArgsConstructor
+public class FasstoWarehouseController {
+    private final RegisterFasstoWarehouseUseCase registerFasstoWarehouseUseCase;
+
+    /**
+     * (관리자) 파스토 출고처 등록 요청
+     *
+     * @param customerCode 파스토 고객사 코드
+     * @param accessToken  파스토 액세스 토큰
+     * @param request      출고처 등록 요청 정보
+     * @Author 성효빈
+     * @Date 2026-01-25
+     * @Description 파스토 출고처 등록을 요청합니다.
+     */
+    @PostMapping("/{customerCode}")
+    @PreAuthorize(ADMIN_POINTCUT)
+    @RegisterFasstoWarehouseApiDocs
+    public ResponseEntity<BaseResponse<FasstoWarehouseRegisterResponse>> registerWarehouse(
+            @PathVariable String customerCode,
+            @RequestHeader("accessToken") String accessToken,
+            @Valid @RequestBody RegisterFasstoWarehouseRequest request
+    ) {
+        RegisterFasstoWarehouseResult result = registerFasstoWarehouseUseCase.registerWarehouse(
+                FasstoWarehouseRequestToCommandMapper.mapToRegisterCommand(customerCode, accessToken, request)
+        );
+
+        return new ResponseEntity<>(
+                BaseResponse.of(
+                        FasstoWarehouseRegisterResponse.from(result),
+                        HttpStatus.CREATED,
+                        DEFAULT_SUCCESS_CODE,
+                        "파스토 출고처 등록 성공"
+                ),
+                HttpStatus.CREATED
+        );
+    }
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/apidocs/RegisterFasstoWarehouseApiDocs.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/apidocs/RegisterFasstoWarehouseApiDocs.java
@@ -1,0 +1,195 @@
+package com.personal.marketnote.fulfillment.adapter.in.web.vendor.controller.apidocs;
+
+import com.personal.marketnote.fulfillment.adapter.in.web.vendor.request.RegisterFasstoWarehouseRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Operation(
+        summary = "(관리자) 파스토 출고처 등록 요청",
+        description = """
+                작성일자: 2026-01-25
+                
+                작성자: 성효빈
+                
+                ---
+                
+                ## Description
+                
+                파스토 출고처 등록을 요청합니다.
+                
+                ---
+                
+                ## Request
+                
+                | **키** | **위치** | **타입** | **설명** | **필수 여부** | **예시** |
+                | --- | --- | --- | --- | --- | --- |
+                | accessToken | header | string | 파스토 액세스 토큰 | Y | 85352dc5e54811f0be620ab49498ff55 |
+                | customerCode | path | string | 파스토 고객사 코드 | Y | 94388 |
+                
+                ---
+                
+                ## Request Body
+                
+                | **키** | **타입** | **설명** | **필수 여부** | **예시** |
+                | --- | --- | --- | --- | --- |
+                | shopNm | string | 출고처명 | Y | "테스트 창고1" |
+                | cstShopCd | string | 고객사 출고처 코드 | N | "" |
+                | dealStrDt | string | 거래 시작일자 | N | "" |
+                | dealEndDt | string | 거래 종료일자 | N | "" |
+                | zipNo | string | 우편번호 | N | "12345" |
+                | addr1 | string | 주소1 | N | "서울특별시 양천구 목동동로 123 132동 101호" |
+                | addr2 | string | 주소2 | N | "서울특별시 양천구 목동동로 123 132동 102호" |
+                | ceoNm | string | 대표자명 | N | "홍길동" |
+                | busNo | string | 사업자번호 | N | "1234567" |
+                | telNo | string | 전화번호 | N | "01012345678" |
+                | unloadWay | string | 하차방식(01: 지게차, 02: 수작업) | N | "02" |
+                | checkWay | string | 검수방식(01: 전수검수, 02: 샘플검수) | N | "02" |
+                | standYn | string | 대기여부 | N | "N" |
+                | formType | string | 거래명세서 양식(STDF001: 택배기본, STDF002: 차량기본) | N | "STDF001" |
+                | empNm | string | 담당자명 | N | "서영락" |
+                | empPosit | string | 담당자직위 | N | "대리" |
+                | empTelNo | string | 담당자전화번호 | N | "01012345678" |
+                | useYn | string | 사용여부 | N | "Y" |
+                
+                ---
+                
+                ## Response
+                
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | statusCode | number | 상태 코드 | 200: 성공 / 400: 클라이언트 요청 오류 / 401: 인증 실패 / 403: 인가 실패 / 500: 그 외 |
+                | code | string | 응답 코드 | "SUC01" / "BAD_REQUEST" / "UNAUTHORIZED" / "FORBIDDEN" / "INTERNAL_SERVER_ERROR" |
+                | timestamp | string(datetime) | 응답 일시 | "2026-01-25T12:12:30.013" |
+                | content | object | 응답 본문 | { ... } |
+                | message | string | 처리 결과 | "파스토 출고처 등록 성공" |
+                
+                ---
+                
+                ### Response > content
+                
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | shopInfo | object | 출고처 등록 결과 | { ... } |
+                
+                ---
+                
+                ### Response > content > shopInfo
+                
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | msg | string | 처리 결과 | "SUCCESS" |
+                | code | string | 응답 코드 | "200" |
+                | shopCd | string | 출고처 코드 | "94388001" |
+                """,
+        security = {@SecurityRequirement(name = "bearer")},
+        parameters = {
+                @Parameter(
+                        name = "accessToken",
+                        description = "파스토 액세스 토큰",
+                        in = ParameterIn.HEADER,
+                        required = true,
+                        schema = @Schema(type = "string", example = "85352dc5e54811f0be620ab49498ff55")
+                ),
+                @Parameter(
+                        name = "customerCode",
+                        description = "파스토 고객사 코드",
+                        in = ParameterIn.PATH,
+                        required = true,
+                        schema = @Schema(type = "string", example = "94388")
+                )
+        },
+        requestBody = @RequestBody(
+                required = true,
+                content = @Content(
+                        schema = @Schema(implementation = RegisterFasstoWarehouseRequest.class),
+                        examples = @ExampleObject("""
+                                {
+                                  "shopNm": "테스트 창고1",
+                                  "cstShopCd": "",
+                                  "dealStrDt": "",
+                                  "dealEndDt": "",
+                                  "zipNo": "12345",
+                                  "addr1": "서울특별시 양천구 목동동로 123 132동 101호",
+                                  "addr2": "서울특별시 양천구 목동동로 123 132동 102호",
+                                  "ceoNm": "홍길동",
+                                  "busNo": "1234567",
+                                  "telNo": "01012345678",
+                                  "unloadWay": "02",
+                                  "checkWay": "02",
+                                  "standYn": "N",
+                                  "formType": "STDF001",
+                                  "empNm": "서영락",
+                                  "empPosit": "대리",
+                                  "empTelNo": "01012345678",
+                                  "useYn": "Y"
+                                }
+                                """)
+                )
+        ),
+        responses = {
+                @ApiResponse(
+                        responseCode = "201",
+                        description = "파스토 출고처 등록 성공",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 201,
+                                          "code": "SUC01",
+                                          "timestamp": "2026-01-25T09:07:08.013",
+                                          "content": {
+                                            "shopInfo": {
+                                              "msg": "SUCCESS",
+                                              "code": "200",
+                                              "shopCd": "94388001"
+                                            }
+                                          },
+                                          "message": "파스토 출고처 등록 성공"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "401",
+                        description = "토큰 인증 실패",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 401,
+                                          "code": "UNAUTHORIZED",
+                                          "timestamp": "2026-01-25T12:12:30.013",
+                                          "content": null,
+                                          "message": "Invalid token"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "403",
+                        description = "토큰 인가 실패",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 403,
+                                          "code": "FORBIDDEN",
+                                          "timestamp": "2026-01-25T12:12:30.013",
+                                          "content": null,
+                                          "message": "Access Denied"
+                                        }
+                                        """)
+                        )
+                )
+        })
+public @interface RegisterFasstoWarehouseApiDocs {
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/mapper/FasstoWarehouseRequestToCommandMapper.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/mapper/FasstoWarehouseRequestToCommandMapper.java
@@ -1,0 +1,35 @@
+package com.personal.marketnote.fulfillment.adapter.in.web.vendor.mapper;
+
+import com.personal.marketnote.fulfillment.adapter.in.web.vendor.request.RegisterFasstoWarehouseRequest;
+import com.personal.marketnote.fulfillment.port.in.command.vendor.RegisterFasstoWarehouseCommand;
+
+public class FasstoWarehouseRequestToCommandMapper {
+    public static RegisterFasstoWarehouseCommand mapToRegisterCommand(
+            String customerCode,
+            String accessToken,
+            RegisterFasstoWarehouseRequest request
+    ) {
+        return RegisterFasstoWarehouseCommand.of(
+                customerCode,
+                accessToken,
+                request.getShopNm(),
+                request.getCstShopCd(),
+                request.getDealStrDt(),
+                request.getDealEndDt(),
+                request.getZipNo(),
+                request.getAddr1(),
+                request.getAddr2(),
+                request.getCeoNm(),
+                request.getBusNo(),
+                request.getTelNo(),
+                request.getUnloadWay(),
+                request.getCheckWay(),
+                request.getStandYn(),
+                request.getFormType(),
+                request.getEmpNm(),
+                request.getEmpPosit(),
+                request.getEmpTelNo(),
+                request.getUseYn()
+        );
+    }
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/request/RegisterFasstoWarehouseRequest.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/request/RegisterFasstoWarehouseRequest.java
@@ -1,0 +1,135 @@
+package com.personal.marketnote.fulfillment.adapter.in.web.vendor.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+import lombok.Getter;
+
+@Getter
+public class RegisterFasstoWarehouseRequest {
+    @Schema(
+            name = "shopNm",
+            description = "출고처명",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    @NotEmpty(message = "출고처명은 필수값입니다.")
+    private String shopNm;
+
+    @Schema(
+            name = "cstShopCd",
+            description = "고객사 출고처 코드(없으면 자동 생성)",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String cstShopCd;
+
+    @Schema(
+            name = "dealStrDt",
+            description = "거래 시작일자",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String dealStrDt;
+
+    @Schema(
+            name = "dealEndDt",
+            description = "거래 종료일자",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String dealEndDt;
+
+    @Schema(
+            name = "zipNo",
+            description = "우편번호",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String zipNo;
+
+    @Schema(
+            name = "addr1",
+            description = "주소1",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String addr1;
+
+    @Schema(
+            name = "addr2",
+            description = "주소2",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String addr2;
+
+    @Schema(
+            name = "ceoNm",
+            description = "대표자명",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String ceoNm;
+
+    @Schema(
+            name = "busNo",
+            description = "사업자번호",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String busNo;
+
+    @Schema(
+            name = "telNo",
+            description = "전화번호",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String telNo;
+
+    @Schema(
+            name = "unloadWay",
+            description = "하차방식(01: 지게차, 02: 수작업)",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String unloadWay;
+
+    @Schema(
+            name = "checkWay",
+            description = "검수방식(01: 전수검수, 02: 샘플검수)",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String checkWay;
+
+    @Schema(
+            name = "standYn",
+            description = "대기여부",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String standYn;
+
+    @Schema(
+            name = "formType",
+            description = "거래명세서 양식(STDF001: 택배기본, STDF002: 차량기본)",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String formType;
+
+    @Schema(
+            name = "empNm",
+            description = "담당자명",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String empNm;
+
+    @Schema(
+            name = "empPosit",
+            description = "담당자 직위",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String empPosit;
+
+    @Schema(
+            name = "empTelNo",
+            description = "담당자 전화번호",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String empTelNo;
+
+    @Schema(
+            name = "useYn",
+            description = "사용 여부",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String useYn;
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/response/FasstoWarehouseRegisterResponse.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/response/FasstoWarehouseRegisterResponse.java
@@ -1,0 +1,11 @@
+package com.personal.marketnote.fulfillment.adapter.in.web.vendor.response;
+
+import com.personal.marketnote.fulfillment.port.in.result.vendor.RegisterFasstoWarehouseResult;
+
+public record FasstoWarehouseRegisterResponse(
+        RegisterFasstoWarehouseResult shopInfo
+) {
+    public static FasstoWarehouseRegisterResponse from(RegisterFasstoWarehouseResult shopInfo) {
+        return new FasstoWarehouseRegisterResponse(shopInfo);
+    }
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/FasstoWarehouseClient.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/FasstoWarehouseClient.java
@@ -1,0 +1,304 @@
+package com.personal.marketnote.fulfillment.adapter.out.vendor.fassto;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.common.adapter.out.VendorAdapter;
+import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.fulfillment.adapter.out.vendor.fassto.response.RegisterFasstoWarehouseResponse;
+import com.personal.marketnote.fulfillment.configuration.FasstoAuthProperties;
+import com.personal.marketnote.fulfillment.domain.vendor.fassto.warehouse.FasstoWarehouseMapper;
+import com.personal.marketnote.fulfillment.domain.vendorcommunication.FulfillmentVendorCommunicationTargetType;
+import com.personal.marketnote.fulfillment.domain.vendorcommunication.FulfillmentVendorCommunicationType;
+import com.personal.marketnote.fulfillment.domain.vendorcommunication.FulfillmentVendorName;
+import com.personal.marketnote.fulfillment.exception.RegisterFasstoWarehouseFailedException;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.RegisterFasstoWarehouseResult;
+import com.personal.marketnote.fulfillment.port.out.vendor.RegisterFasstoWarehousePort;
+import com.personal.marketnote.fulfillment.utility.VendorCommunicationFailureHandler;
+import com.personal.marketnote.fulfillment.utility.VendorCommunicationPayloadGenerator;
+import com.personal.marketnote.fulfillment.utility.VendorCommunicationRecorder;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.*;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.personal.marketnote.common.utility.ApiConstant.*;
+
+@VendorAdapter
+@RequiredArgsConstructor
+@Slf4j
+public class FasstoWarehouseClient implements RegisterFasstoWarehousePort {
+    private static final String ACCESS_TOKEN_HEADER = "accessToken";
+    private static final String CUSTOMER_CODE_PLACEHOLDER = "{customerCode}";
+
+    private final RestTemplate restTemplate;
+    private final ObjectMapper objectMapper;
+    private final FasstoAuthProperties properties;
+    private final VendorCommunicationRecorder vendorCommunicationRecorder;
+    private final VendorCommunicationPayloadGenerator vendorCommunicationPayloadGenerator;
+    private final VendorCommunicationFailureHandler vendorCommunicationFailureHandler;
+
+    @Override
+    public RegisterFasstoWarehouseResult registerWarehouse(FasstoWarehouseMapper request) {
+        if (FormatValidator.hasNoValue(request)) {
+            throw new IllegalArgumentException("Fassto shop request is required.");
+        }
+
+        URI uri = buildShopUri(request.getCustomerCode());
+        HttpEntity<Map<String, Object>> httpEntity = new HttpEntity<>(request.toPayload(), buildHeaders(request.getAccessToken()));
+
+        Exception error = new Exception();
+        long sleepMillis = INTER_SERVER_DEFAULT_RETRIAL_PENDING_MILLI_SECOND;
+        FulfillmentVendorCommunicationTargetType targetType = FulfillmentVendorCommunicationTargetType.WAREHOUSE;
+        FulfillmentVendorName vendorName = FulfillmentVendorName.FASSTO;
+
+        for (int i = 0; i < INTER_SERVER_MAX_REQUEST_COUNT; i++) {
+            int attempt = i + 1;
+            JsonNode requestPayloadJson = buildRequestPayloadJson(request, uri, attempt);
+            String requestPayload = requestPayloadJson.toString();
+
+            ResponseEntity<String> response;
+            try {
+                response = restTemplate.exchange(
+                        uri,
+                        HttpMethod.POST,
+                        httpEntity,
+                        String.class
+                );
+            } catch (Exception e) {
+                Map<String, Object> errorPayload = new LinkedHashMap<>();
+                errorPayload.put("error", e.getClass().getSimpleName());
+                errorPayload.put("message", e.getMessage());
+                errorPayload.put("attempt", attempt);
+
+                vendorCommunicationFailureHandler.handleFailure(
+                        targetType,
+                        vendorName,
+                        requestPayload,
+                        requestPayloadJson,
+                        errorPayload,
+                        e
+                );
+
+                log.warn("Failed to register Fassto shop: attempt={}, message={}", attempt, e.getMessage(), e);
+                if (i == INTER_SERVER_MAX_REQUEST_COUNT - 1) {
+                    error = e;
+                }
+
+                sleep(sleepMillis);
+                sleepMillis = sleepMillis * INTER_SERVER_DEFAULT_EXPONENTIAL_BACKOFF_VALUE;
+                continue;
+            }
+
+            JsonNode responsePayloadJson = buildResponsePayloadJson(response, attempt);
+            String responsePayload = responsePayloadJson.toString();
+
+            RegisterFasstoWarehouseResponse parsedResponse = parseResponseBody(response);
+            boolean isSuccess = isSuccessResponse(response, parsedResponse);
+            String exception = isSuccess ? null : resolveResponseException(response, parsedResponse);
+
+            recordCommunication(
+                    targetType,
+                    vendorName,
+                    FulfillmentVendorCommunicationType.REQUEST,
+                    requestPayload,
+                    requestPayloadJson,
+                    exception
+            );
+            recordCommunication(
+                    targetType,
+                    vendorName,
+                    FulfillmentVendorCommunicationType.RESPONSE,
+                    responsePayload,
+                    responsePayloadJson,
+                    exception
+            );
+
+            if (isSuccess) {
+                return RegisterFasstoWarehouseResult.of(
+                        parsedResponse.data().msg(),
+                        parsedResponse.data().code(),
+                        parsedResponse.data().shopCd()
+                );
+            }
+
+            log.warn("Fassto shop registration failed: attempt={}, status={}, exception={}",
+                    attempt,
+                    response != null ? response.getStatusCode() : null,
+                    exception
+            );
+
+            sleep(sleepMillis);
+            sleepMillis = sleepMillis * INTER_SERVER_DEFAULT_EXPONENTIAL_BACKOFF_VALUE;
+        }
+
+        log.error("Failed to register Fassto shop: {} with error: {}", uri, error.getMessage(), error);
+        throw new RegisterFasstoWarehouseFailedException(new IOException(error));
+    }
+
+    private URI buildShopUri(String customerCode) {
+        validateShopProperties();
+        return UriComponentsBuilder.fromUriString(properties.getBaseUrl())
+                .path(properties.getShopPath())
+                .buildAndExpand(customerCode)
+                .toUri();
+    }
+
+    private HttpHeaders buildHeaders(String accessToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setAccept(List.of(MediaType.APPLICATION_JSON));
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.add(ACCESS_TOKEN_HEADER, accessToken);
+        return headers;
+    }
+
+    private void validateShopProperties() {
+        if (FormatValidator.hasNoValue(properties.getBaseUrl())) {
+            throw new IllegalStateException("Fassto base URL is required.");
+        }
+        if (FormatValidator.hasNoValue(properties.getShopPath())) {
+            throw new IllegalStateException("Fassto shop path is required.");
+        }
+        if (!properties.getShopPath().contains(CUSTOMER_CODE_PLACEHOLDER)) {
+            throw new IllegalStateException("Fassto shop path must include {customerCode}.");
+        }
+    }
+
+    private RegisterFasstoWarehouseResponse parseResponseBody(ResponseEntity<String> response) {
+        if (FormatValidator.hasNoValue(response)) {
+            return null;
+        }
+
+        String body = response.getBody();
+        if (FormatValidator.hasNoValue(body)) {
+            return null;
+        }
+
+        try {
+            return objectMapper.readValue(body, RegisterFasstoWarehouseResponse.class);
+        } catch (Exception e) {
+            log.warn("Failed to parse Fassto shop response: {}", e.getMessage(), e);
+            return null;
+        }
+    }
+
+    private boolean isSuccessResponse(ResponseEntity<String> response, RegisterFasstoWarehouseResponse parsedResponse) {
+        return response != null
+                && response.getStatusCode().value() == 200
+                && parsedResponse != null
+                && parsedResponse.isSuccess()
+                && parsedResponse.data() != null;
+    }
+
+    private String resolveResponseException(ResponseEntity<String> response, RegisterFasstoWarehouseResponse parsedResponse) {
+        if (response == null) {
+            return "NO_RESPONSE";
+        }
+        if (response.getStatusCode().value() != 200) {
+            return "HTTP_" + response.getStatusCode().value();
+        }
+        if (parsedResponse == null) {
+            return "INVALID_RESPONSE";
+        }
+        if (parsedResponse.header() == null || !parsedResponse.header().isSuccess()) {
+            return "HEADER_FAILURE";
+        }
+        if (parsedResponse.data() == null || !parsedResponse.data().isSuccess()) {
+            return "DATA_FAILURE";
+        }
+        return "UNKNOWN_FAILURE";
+    }
+
+    private JsonNode buildRequestPayloadJson(FasstoWarehouseMapper request, URI uri, int attempt) {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("method", HttpMethod.POST.name());
+        payload.put("url", uri.toString());
+        payload.put("customerCode", request.getCustomerCode());
+        payload.put(ACCESS_TOKEN_HEADER, maskValue(request.getAccessToken()));
+        payload.put("body", request.toPayload());
+        payload.put("attempt", attempt);
+        return vendorCommunicationPayloadGenerator.buildPayloadJson(payload);
+    }
+
+    private JsonNode buildResponsePayloadJson(ResponseEntity<String> response, int attempt) {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        if (FormatValidator.hasValue(response)) {
+            payload.put("status", response.getStatusCode().value());
+            payload.put("headers", toSingleValueMap(response.getHeaders()));
+
+            String body = response.getBody();
+            if (FormatValidator.hasValue(body)) {
+                payload.put("body", body);
+            }
+        }
+        payload.put("attempt", attempt);
+        return vendorCommunicationPayloadGenerator.buildPayloadJson(payload);
+    }
+
+    private Map<String, String> toSingleValueMap(HttpHeaders headers) {
+        if (FormatValidator.hasNoValue(headers)) {
+            return Map.of();
+        }
+
+        return headers.toSingleValueMap();
+    }
+
+    private void recordCommunication(
+            FulfillmentVendorCommunicationTargetType targetType,
+            FulfillmentVendorName vendorName,
+            FulfillmentVendorCommunicationType communicationType,
+            String payload,
+            JsonNode payloadJson,
+            String exception
+    ) {
+        if (FormatValidator.hasValue(exception)) {
+            vendorCommunicationRecorder.record(
+                    targetType,
+                    communicationType,
+                    null,
+                    vendorName,
+                    payload,
+                    payloadJson,
+                    exception
+            );
+            return;
+        }
+
+        vendorCommunicationRecorder.record(
+                targetType,
+                communicationType,
+                null,
+                vendorName,
+                payload,
+                payloadJson
+        );
+    }
+
+    private String maskValue(String value) {
+        if (FormatValidator.hasNoValue(value)) {
+            return value;
+        }
+
+        int visible = Math.min(4, value.length());
+        int maskedLength = value.length() - visible;
+        if (maskedLength <= 0) {
+            return value;
+        }
+
+        return "*".repeat(maskedLength) + value.substring(value.length() - visible);
+    }
+
+    private void sleep(long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoAuthResponse.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoAuthResponse.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record FasstoAuthResponse(
-        FasstoAuthHeaderResponse header,
+        FasstoResponseHeader header,
         FasstoAuthDataResponse data,
         Object errorInfo
 ) {

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoResponseHeader.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoResponseHeader.java
@@ -3,7 +3,7 @@ package com.personal.marketnote.fulfillment.adapter.out.vendor.fassto.response;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public record FasstoAuthHeaderResponse(
+public record FasstoResponseHeader(
         String code,
         String msg,
         Integer dataCount

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/RegisterFasstoWarehouseDataResponse.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/RegisterFasstoWarehouseDataResponse.java
@@ -1,0 +1,16 @@
+package com.personal.marketnote.fulfillment.adapter.out.vendor.fassto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record RegisterFasstoWarehouseDataResponse(
+        String msg,
+        String code,
+        String shopCd
+) {
+    private static final String SUCCESS_CODE = "200";
+
+    public boolean isSuccess() {
+        return SUCCESS_CODE.equals(code);
+    }
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/RegisterFasstoWarehouseResponse.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/RegisterFasstoWarehouseResponse.java
@@ -1,0 +1,14 @@
+package com.personal.marketnote.fulfillment.adapter.out.vendor.fassto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record RegisterFasstoWarehouseResponse(
+        FasstoResponseHeader header,
+        RegisterFasstoWarehouseDataResponse data,
+        Object errorInfo
+) {
+    public boolean isSuccess() {
+        return header != null && header.isSuccess() && data != null && data.isSuccess();
+    }
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/resources/application.yml
+++ b/fulfillment-service/fulfillment-adapters/src/main/resources/application.yml
@@ -51,6 +51,7 @@ vendor:
       base-url: ${FASSTO_BASE_URL:https://stg-fmsapi.fassto.ai}
       connect-path: ${FASSTO_AUTH_CONNECT_PATH:/api/v1/auth/connect}
       disconnect-path: ${FASSTO_AUTH_DISCONNECT_PATH:/api/v1/auth/disconnect}
+      shop-path: ${FASSTO_MARKETNOTE_PATH:/api/v1/marketnote/{customerCode}}
       api-cd: ${FASSTO_API_CD:change-me}
       api-key: ${FASSTO_API_KEY:change-me}
 

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/configuration/FasstoAuthProperties.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/configuration/FasstoAuthProperties.java
@@ -15,4 +15,5 @@ public class FasstoAuthProperties {
     private String apiKey;
     private String connectPath = "/api/v1/auth/connect";
     private String disconnectPath = "/api/v1/auth/disconnect";
+    private String shopPath = "/api/v1/marketnote/{customerCode}";
 }

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/RegisterFasstoWarehouseFailedException.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/RegisterFasstoWarehouseFailedException.java
@@ -1,0 +1,14 @@
+package com.personal.marketnote.fulfillment.exception;
+
+import com.personal.marketnote.common.exception.ExternalOperationFailedException;
+
+import java.io.IOException;
+
+public class RegisterFasstoWarehouseFailedException extends ExternalOperationFailedException {
+    private static final String REGISTER_FASSTO_WAREHOUSE_FAILED_EXCEPTION_MESSAGE =
+            "Fassto warehouse registration request failed.";
+
+    public RegisterFasstoWarehouseFailedException(IOException cause) {
+        super(REGISTER_FASSTO_WAREHOUSE_FAILED_EXCEPTION_MESSAGE, cause);
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/mapper/FasstoWarehouseCommandToRequestMapper.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/mapper/FasstoWarehouseCommandToRequestMapper.java
@@ -1,0 +1,31 @@
+package com.personal.marketnote.fulfillment.mapper;
+
+import com.personal.marketnote.fulfillment.domain.vendor.fassto.warehouse.FasstoWarehouseMapper;
+import com.personal.marketnote.fulfillment.port.in.command.vendor.RegisterFasstoWarehouseCommand;
+
+public class FasstoWarehouseCommandToRequestMapper {
+    public static FasstoWarehouseMapper mapToRegisterRequest(RegisterFasstoWarehouseCommand command) {
+        return FasstoWarehouseMapper.register(
+                command.customerCode(),
+                command.accessToken(),
+                command.shopNm(),
+                command.cstShopCd(),
+                command.dealStrDt(),
+                command.dealEndDt(),
+                command.zipNo(),
+                command.addr1(),
+                command.addr2(),
+                command.ceoNm(),
+                command.busNo(),
+                command.telNo(),
+                command.unloadWay(),
+                command.checkWay(),
+                command.standYn(),
+                command.formType(),
+                command.empNm(),
+                command.empPosit(),
+                command.empTelNo(),
+                command.useYn()
+        );
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/vendor/RegisterFasstoWarehouseCommand.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/vendor/RegisterFasstoWarehouseCommand.java
@@ -1,0 +1,70 @@
+package com.personal.marketnote.fulfillment.port.in.command.vendor;
+
+public record RegisterFasstoWarehouseCommand(
+        String customerCode,
+        String accessToken,
+        String shopNm,
+        String cstShopCd,
+        String dealStrDt,
+        String dealEndDt,
+        String zipNo,
+        String addr1,
+        String addr2,
+        String ceoNm,
+        String busNo,
+        String telNo,
+        String unloadWay,
+        String checkWay,
+        String standYn,
+        String formType,
+        String empNm,
+        String empPosit,
+        String empTelNo,
+        String useYn
+) {
+    public static RegisterFasstoWarehouseCommand of(
+            String customerCode,
+            String accessToken,
+            String shopNm,
+            String cstShopCd,
+            String dealStrDt,
+            String dealEndDt,
+            String zipNo,
+            String addr1,
+            String addr2,
+            String ceoNm,
+            String busNo,
+            String telNo,
+            String unloadWay,
+            String checkWay,
+            String standYn,
+            String formType,
+            String empNm,
+            String empPosit,
+            String empTelNo,
+            String useYn
+    ) {
+        return new RegisterFasstoWarehouseCommand(
+                customerCode,
+                accessToken,
+                shopNm,
+                cstShopCd,
+                dealStrDt,
+                dealEndDt,
+                zipNo,
+                addr1,
+                addr2,
+                ceoNm,
+                busNo,
+                telNo,
+                unloadWay,
+                checkWay,
+                standYn,
+                formType,
+                empNm,
+                empPosit,
+                empTelNo,
+                useYn
+        );
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/result/vendor/FasstoAccessTokenResult.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/result/vendor/FasstoAccessTokenResult.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.fulfillment.port.in.result.vendor;
 
-import com.personal.marketnote.fulfillment.domain.vendor.FasstoAccessToken;
+import com.personal.marketnote.fulfillment.domain.FasstoAccessToken;
 
 import java.time.LocalDateTime;
 

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/result/vendor/RegisterFasstoWarehouseResult.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/result/vendor/RegisterFasstoWarehouseResult.java
@@ -1,0 +1,11 @@
+package com.personal.marketnote.fulfillment.port.in.result.vendor;
+
+public record RegisterFasstoWarehouseResult(
+        String msg,
+        String code,
+        String shopCd
+) {
+    public static RegisterFasstoWarehouseResult of(String msg, String code, String shopCd) {
+        return new RegisterFasstoWarehouseResult(msg, code, shopCd);
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/usecase/vendor/DisconnectFasstoAuthUseCase.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/usecase/vendor/DisconnectFasstoAuthUseCase.java
@@ -4,7 +4,7 @@ public interface DisconnectFasstoAuthUseCase {
     /**
      * @param accessToken Fassto access token
      * @Date 2026-01-25
-     * @Author Codex
+     * @Author 성효빈
      * @Description Disconnect Fassto access token.
      */
     void disconnectAccessToken(String accessToken);

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/usecase/vendor/RegisterFasstoWarehouseUseCase.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/usecase/vendor/RegisterFasstoWarehouseUseCase.java
@@ -1,0 +1,15 @@
+package com.personal.marketnote.fulfillment.port.in.usecase.vendor;
+
+import com.personal.marketnote.fulfillment.port.in.command.vendor.RegisterFasstoWarehouseCommand;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.RegisterFasstoWarehouseResult;
+
+public interface RegisterFasstoWarehouseUseCase {
+    /**
+     * @param command 출고처 등록 커맨드
+     * @return 출고처 등록 결과 {@link RegisterFasstoWarehouseResult}
+     * @Date 2026-01-25
+     * @Author 성효빈
+     * @Description 파스토 출고처를 등록합니다.
+     */
+    RegisterFasstoWarehouseResult registerWarehouse(RegisterFasstoWarehouseCommand command);
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/usecase/vendor/RequestFasstoAuthUseCase.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/usecase/vendor/RequestFasstoAuthUseCase.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.fulfillment.port.in.usecase.vendor;
 
-import com.personal.marketnote.fulfillment.domain.vendor.FasstoAccessToken;
+import com.personal.marketnote.fulfillment.domain.FasstoAccessToken;
 
 public interface RequestFasstoAuthUseCase {
     /**

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/vendor/RegisterFasstoWarehousePort.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/vendor/RegisterFasstoWarehousePort.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.fulfillment.port.out.vendor;
+
+import com.personal.marketnote.fulfillment.domain.vendor.fassto.warehouse.FasstoWarehouseMapper;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.RegisterFasstoWarehouseResult;
+
+public interface RegisterFasstoWarehousePort {
+    RegisterFasstoWarehouseResult registerWarehouse(FasstoWarehouseMapper request);
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/vendor/RequestFasstoAuthPort.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/vendor/RequestFasstoAuthPort.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.fulfillment.port.out.vendor;
 
-import com.personal.marketnote.fulfillment.domain.vendor.FasstoAccessToken;
+import com.personal.marketnote.fulfillment.domain.FasstoAccessToken;
 
 public interface RequestFasstoAuthPort {
     FasstoAccessToken requestAccessToken();

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/vendor/RegisterFasstoWarehouseService.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/vendor/RegisterFasstoWarehouseService.java
@@ -1,0 +1,26 @@
+package com.personal.marketnote.fulfillment.service.vendor;
+
+import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.fulfillment.mapper.FasstoWarehouseCommandToRequestMapper;
+import com.personal.marketnote.fulfillment.port.in.command.vendor.RegisterFasstoWarehouseCommand;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.RegisterFasstoWarehouseResult;
+import com.personal.marketnote.fulfillment.port.in.usecase.vendor.RegisterFasstoWarehouseUseCase;
+import com.personal.marketnote.fulfillment.port.out.vendor.RegisterFasstoWarehousePort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional(isolation = READ_COMMITTED, readOnly = true)
+public class RegisterFasstoWarehouseService implements RegisterFasstoWarehouseUseCase {
+    private final RegisterFasstoWarehousePort registerFasstoWarehousePort;
+
+    @Override
+    public RegisterFasstoWarehouseResult registerWarehouse(RegisterFasstoWarehouseCommand command) {
+        return registerFasstoWarehousePort.registerWarehouse(
+                FasstoWarehouseCommandToRequestMapper.mapToRegisterRequest(command)
+        );
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/vendor/RequestFasstoAuthService.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/vendor/RequestFasstoAuthService.java
@@ -1,7 +1,7 @@
 package com.personal.marketnote.fulfillment.service.vendor;
 
 import com.personal.marketnote.common.application.UseCase;
-import com.personal.marketnote.fulfillment.domain.vendor.FasstoAccessToken;
+import com.personal.marketnote.fulfillment.domain.FasstoAccessToken;
 import com.personal.marketnote.fulfillment.port.in.usecase.vendor.RequestFasstoAuthUseCase;
 import com.personal.marketnote.fulfillment.port.out.vendor.RequestFasstoAuthPort;
 import lombok.RequiredArgsConstructor;

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/FasstoAccessToken.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/FasstoAccessToken.java
@@ -1,4 +1,4 @@
-package com.personal.marketnote.fulfillment.domain.vendor;
+package com.personal.marketnote.fulfillment.domain;
 
 import com.personal.marketnote.common.domain.exception.illegalargument.invalidvalue.ParsingLocalDateTimeException;
 import com.personal.marketnote.common.utility.FormatValidator;

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/warehouse/FasstoWarehouseMapper.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/warehouse/FasstoWarehouseMapper.java
@@ -1,0 +1,133 @@
+package com.personal.marketnote.fulfillment.domain.vendor.fassto.warehouse;
+
+import com.personal.marketnote.common.utility.FormatValidator;
+import lombok.*;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+public class FasstoWarehouseMapper {
+    private static final String REGISTRATION_MARKETNOTE_CODE = "registration";
+
+    private String customerCode;
+    private String accessToken;
+    private String shopCd;
+    private String shopNm;
+    private String cstShopCd;
+    private String dealStrDt;
+    private String dealEndDt;
+    private String zipNo;
+    private String addr1;
+    private String addr2;
+    private String ceoNm;
+    private String busNo;
+    private String telNo;
+    private String unloadWay;
+    private String checkWay;
+    private String standYn;
+    private String formType;
+    private String empNm;
+    private String empPosit;
+    private String empTelNo;
+    private String useYn;
+
+    public static FasstoWarehouseMapper register(
+            String customerCode,
+            String accessToken,
+            String shopNm,
+            String cstShopCd,
+            String dealStrDt,
+            String dealEndDt,
+            String zipNo,
+            String addr1,
+            String addr2,
+            String ceoNm,
+            String busNo,
+            String telNo,
+            String unloadWay,
+            String checkWay,
+            String standYn,
+            String formType,
+            String empNm,
+            String empPosit,
+            String empTelNo,
+            String useYn
+    ) {
+        FasstoWarehouseMapper mapper = FasstoWarehouseMapper.builder()
+                .customerCode(customerCode)
+                .accessToken(accessToken)
+                .shopCd(REGISTRATION_MARKETNOTE_CODE)
+                .shopNm(shopNm)
+                .cstShopCd(cstShopCd)
+                .dealStrDt(dealStrDt)
+                .dealEndDt(dealEndDt)
+                .zipNo(zipNo)
+                .addr1(addr1)
+                .addr2(addr2)
+                .ceoNm(ceoNm)
+                .busNo(busNo)
+                .telNo(telNo)
+                .unloadWay(unloadWay)
+                .checkWay(checkWay)
+                .standYn(standYn)
+                .formType(formType)
+                .empNm(empNm)
+                .empPosit(empPosit)
+                .empTelNo(empTelNo)
+                .useYn(useYn)
+                .build();
+        mapper.validate();
+        return mapper;
+    }
+
+    public Map<String, Object> toPayload() {
+        Map<String, Object> payload = new LinkedHashMap<>();
+
+        putIfNotBlank(payload, "shopCd", shopCd);
+        putIfNotBlank(payload, "shopNm", shopNm);
+        putIfNotBlank(payload, "cstShopCd", cstShopCd);
+        putIfNotBlank(payload, "dealStrDt", dealStrDt);
+        putIfNotBlank(payload, "dealEndDt", dealEndDt);
+        putIfNotBlank(payload, "zipNo", zipNo);
+        putIfNotBlank(payload, "addr1", addr1);
+        putIfNotBlank(payload, "addr2", addr2);
+        putIfNotBlank(payload, "ceoNm", ceoNm);
+        putIfNotBlank(payload, "busNo", busNo);
+        putIfNotBlank(payload, "telNo", telNo);
+        putIfNotBlank(payload, "unloadWay", unloadWay);
+        putIfNotBlank(payload, "checkWay", checkWay);
+        putIfNotBlank(payload, "standYn", standYn);
+        putIfNotBlank(payload, "formType", formType);
+        putIfNotBlank(payload, "empNm", empNm);
+        putIfNotBlank(payload, "empPosit", empPosit);
+        putIfNotBlank(payload, "empTelNo", empTelNo);
+        putIfNotBlank(payload, "useYn", useYn);
+
+        return payload;
+    }
+
+    private void validate() {
+        if (FormatValidator.hasNoValue(customerCode)) {
+            throw new IllegalArgumentException("customerCode is required.");
+        }
+        if (FormatValidator.hasNoValue(accessToken)) {
+            throw new IllegalArgumentException("accessToken is required.");
+        }
+        if (FormatValidator.hasNoValue(shopCd)) {
+            throw new IllegalArgumentException("shopCd is required for shop registration.");
+        }
+        if (FormatValidator.hasNoValue(shopNm)) {
+            throw new IllegalArgumentException("shopNm is required for shop registration.");
+        }
+    }
+
+    private void putIfNotBlank(Map<String, Object> payload, String key, String value) {
+        if (FormatValidator.hasValue(value)) {
+            payload.put(key, value);
+        }
+    }
+}

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendorcommunication/FulfillmentVendorCommunicationTargetType.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendorcommunication/FulfillmentVendorCommunicationTargetType.java
@@ -4,7 +4,8 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public enum FulfillmentVendorCommunicationTargetType {
-    AUTHENTICATION("인증");
+    AUTHENTICATION("인증"),
+    WAREHOUSE("출고처");
 
     private final String description;
 }

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/configuration/ProductSwaggerConfig.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/configuration/ProductSwaggerConfig.java
@@ -126,7 +126,7 @@ public class ProductSwaggerConfig {
                                                             new Example().value("""
                                                                     {
                                                                         "statusCode": 401,
-                                                                        "timestamp": "2026-01-22T19:56:58.7278032",
+                                                                        "timestamp": "2025-12-26T19:56:58.7278032",
                                                                         "errorCode": "AUTH001",
                                                                         "errorName": "AUTHENTICATION_FAILED",
                                                                         "message": "Authentication Failed"
@@ -144,7 +144,7 @@ public class ProductSwaggerConfig {
                                                             new Example().value("""
                                                                     {
                                                                         "statusCode": 403,
-                                                                        "timestamp": "2026-01-22T19:56:58.7278032",
+                                                                        "timestamp": "2025-12-26T19:56:58.7278032",
                                                                         "errorCode": "AUTH002",
                                                                         "errorName": "AUTHORIZATION_FAILED",
                                                                         "message": "Authorization Failed"

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/cart/controller/apidocs/AddCartProductApiDocs.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/cart/controller/apidocs/AddCartProductApiDocs.java
@@ -81,7 +81,7 @@ import java.lang.annotation.*;
                                         {
                                           "statusCode": 201,
                                           "code": "SUC01",
-                                          "timestamp": "2026-01-25T12:12:30.013",
+                                          "timestamp": "2025-12-30T12:12:30.013",
                                           "content": null,
                                           "message": "장바구니 상품 추가 성공"
                                         }
@@ -96,7 +96,7 @@ import java.lang.annotation.*;
                                         {
                                           "statusCode": 401,
                                           "code": "UNAUTHORIZED",
-                                          "timestamp": "2026-01-25T12:12:30.013",
+                                          "timestamp": "2025-12-30T12:12:30.013",
                                           "content": null,
                                           "message": "Invalid token"
                                         }
@@ -111,7 +111,7 @@ import java.lang.annotation.*;
                                         {
                                           "statusCode": 403,
                                           "code": "FORBIDDEN",«
-                                          "timestamp": "2026-01-25T12:12:30.013",
+                                          "timestamp": "2025-12-30T12:12:30.013",
                                           "content": null,
                                           "message": "Access Denied"
                                         }

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/cart/controller/apidocs/GetMyCartProductsApiDocs.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/cart/controller/apidocs/GetMyCartProductsApiDocs.java
@@ -216,7 +216,7 @@ import java.lang.annotation.*;
                                         {
                                           "statusCode": 401,
                                           "code": "UNAUTHORIZED",
-                                          "timestamp": "2026-01-25T12:12:30.013",
+                                          "timestamp": "2025-12-30T12:12:30.013",
                                           "content": null,
                                           "message": "Invalid token"
                                         }
@@ -231,7 +231,7 @@ import java.lang.annotation.*;
                                         {
                                           "statusCode": 403,
                                           "code": "FORBIDDEN",
-                                          "timestamp": "2026-01-25T12:12:30.013",
+                                          "timestamp": "2025-12-30T12:12:30.013",
                                           "content": null,
                                           "message": "Access Denied"
                                         }

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/cart/controller/apidocs/GetMyOrderingProductsApiDocs.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/cart/controller/apidocs/GetMyOrderingProductsApiDocs.java
@@ -255,7 +255,7 @@ import java.lang.annotation.*;
                                         {
                                           "statusCode": 401,
                                           "code": "UNAUTHORIZED",
-                                          "timestamp": "2026-01-25T12:12:30.013",
+                                          "timestamp": "2025-12-30T12:12:30.013",
                                           "content": null,
                                           "message": "Invalid token"
                                         }
@@ -270,7 +270,7 @@ import java.lang.annotation.*;
                                         {
                                           "statusCode": 403,
                                           "code": "FORBIDDEN",
-                                          "timestamp": "2026-01-25T12:12:30.013",
+                                          "timestamp": "2025-12-30T12:12:30.013",
                                           "content": null,
                                           "message": "Access Denied"
                                         }

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/cart/controller/apidocs/UpdateCartProductOptionApiDocs.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/cart/controller/apidocs/UpdateCartProductOptionApiDocs.java
@@ -86,7 +86,7 @@ import java.lang.annotation.*;
                                         {
                                           "statusCode": 401,
                                           "code": "UNAUTHORIZED",
-                                          "timestamp": "2026-01-25T12:12:30.013",
+                                          "timestamp": "2025-12-30T12:12:30.013",
                                           "content": null,
                                           "message": "Invalid token"
                                         }
@@ -101,7 +101,7 @@ import java.lang.annotation.*;
                                         {
                                           "statusCode": 403,
                                           "code": "FORBIDDEN",
-                                          "timestamp": "2026-01-25T12:12:30.013",
+                                          "timestamp": "2025-12-30T12:12:30.013",
                                           "content": null,
                                           "message": "Access Denied"
                                         }

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/cart/controller/apidocs/UpdateCartProductQuantityApiDocs.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/cart/controller/apidocs/UpdateCartProductQuantityApiDocs.java
@@ -84,7 +84,7 @@ import java.lang.annotation.*;
                                         {
                                           "statusCode": 401,
                                           "code": "UNAUTHORIZED",
-                                          "timestamp": "2026-01-25T12:12:30.013",
+                                          "timestamp": "2025-12-30T12:12:30.013",
                                           "content": null,
                                           "message": "Invalid token"
                                         }
@@ -99,7 +99,7 @@ import java.lang.annotation.*;
                                         {
                                           "statusCode": 403,
                                           "code": "FORBIDDEN",
-                                          "timestamp": "2026-01-25T12:12:30.013",
+                                          "timestamp": "2025-12-30T12:12:30.013",
                                           "content": null,
                                           "message": "Access Denied"
                                         }

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/category/controller/apidocs/RegisterProductCategoriesApiDocs.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/category/controller/apidocs/RegisterProductCategoriesApiDocs.java
@@ -113,7 +113,7 @@ import java.lang.annotation.*;
                                         {
                                           "statusCode": 401,
                                           "code": "UNAUTHORIZED",
-                                          "timestamp": "2026-01-24T10:19:52.558748",
+                                          "timestamp": "2025-12-29T10:19:52.558748",
                                           "content": null,
                                           "message": "Invalid token"
                                         }
@@ -128,7 +128,7 @@ import java.lang.annotation.*;
                                         {
                                           "statusCode": 403,
                                           "code": "FORBIDDEN",
-                                          "timestamp": "2026-01-24T10:19:52.558748",
+                                          "timestamp": "2025-12-29T10:19:52.558748",
                                           "content": null,
                                           "message": "Access Denied"
                                         }

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/option/controller/apidocs/GetProductOptionsApiDocs.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/option/controller/apidocs/GetProductOptionsApiDocs.java
@@ -196,7 +196,7 @@ import java.lang.annotation.*;
                                         {
                                           "statusCode": 401,
                                           "code": "UNAUTHORIZED",
-                                          "timestamp": "2026-01-25T12:12:30.013",
+                                          "timestamp": "2025-12-30T12:12:30.013",
                                           "content": null,
                                           "message": "Invalid token"
                                         }
@@ -211,7 +211,7 @@ import java.lang.annotation.*;
                                         {
                                           "statusCode": 403,
                                           "code": "FORBIDDEN",
-                                          "timestamp": "2026-01-25T12:12:30.013",
+                                          "timestamp": "2025-12-30T12:12:30.013",
                                           "content": null,
                                           "message": "Access Denied"
                                         }

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/product/controller/ProductController.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/product/controller/ProductController.java
@@ -54,7 +54,7 @@ public class ProductController {
      * @param request 상품 등록 요청
      * @return 상품 등록 응답 {@link RegisterProductResponse}
      * @Author 성효빈
-     * @Date 2026-01-25
+     * @Date 2025-12-30
      * @Description 상품을 등록합니다.
      */
     @PostMapping

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/product/controller/apidocs/RegisterProductApiDocs.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/product/controller/apidocs/RegisterProductApiDocs.java
@@ -17,7 +17,7 @@ import java.lang.annotation.*;
 @Operation(
         summary = "(판매자/관리자) 상품 등록",
         description = """
-                작성일자: 2026-01-25
+                작성일자: 2025-12-30
                 
                 작성자: 성효빈
                 
@@ -53,7 +53,7 @@ import java.lang.annotation.*;
                 | --- | --- | --- | --- |
                 | statusCode | number | 상태 코드 | 201: 성공 / 400: 클라이언트 요청 오류 / 401: 인증 실패 / 403: 인가 실패 / 404: 리소스 조회 실패 / 409: 충돌 / 500: 그 외 |
                 | code | string | 응답 코드 | "SUC01" / "BAD_REQUEST" / "UNAUTHORIZED" / "FORBIDDEN" / "NOT_FOUND" / "CONFLICT" / "INTERNAL_SERVER_ERROR" |
-                | timestamp | string(datetime) | 응답 일시 | "2026-01-25T12:12:30.013" |
+                | timestamp | string(datetime) | 응답 일시 | "2025-12-30T12:12:30.013" |
                 | content | object | 응답 본문 | { ... } |
                 | message | string | 처리 결과 | "상품 등록 성공" |
                 
@@ -93,7 +93,7 @@ import java.lang.annotation.*;
                                         {
                                           "statusCode": 201,
                                           "code": "SUC01",
-                                          "timestamp": "2026-01-25T12:12:30.013",
+                                          "timestamp": "2025-12-30T12:12:30.013",
                                           "content": {
                                             "id": 1
                                           },
@@ -110,7 +110,7 @@ import java.lang.annotation.*;
                                         {
                                           "statusCode": 401,
                                           "code": "UNAUTHORIZED",
-                                          "timestamp": "2026-01-25T12:12:30.013",
+                                          "timestamp": "2025-12-30T12:12:30.013",
                                           "content": null,
                                           "message": "Invalid token"
                                         }
@@ -125,7 +125,7 @@ import java.lang.annotation.*;
                                         {
                                           "statusCode": 403,
                                           "code": "FORBIDDEN",
-                                          "timestamp": "2026-01-25T12:12:30.013",
+                                          "timestamp": "2025-12-30T12:12:30.013",
                                           "content": null,
                                           "message": "Access Denied"
                                         }

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/product/controller/apidocs/UpdateProductApiDocs.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/product/controller/apidocs/UpdateProductApiDocs.java
@@ -92,7 +92,7 @@ import java.lang.annotation.*;
                                         {
                                           "statusCode": 401,
                                           "code": "UNAUTHORIZED",
-                                          "timestamp": "2026-01-25T12:12:30.013",
+                                          "timestamp": "2025-12-30T12:12:30.013",
                                           "content": null,
                                           "message": "Invalid token"
                                         }
@@ -107,7 +107,7 @@ import java.lang.annotation.*;
                                         {
                                           "statusCode": 403,
                                           "code": "FORBIDDEN",
-                                          "timestamp": "2026-01-25T12:12:30.013",
+                                          "timestamp": "2025-12-30T12:12:30.013",
                                           "content": null,
                                           "message": "Access Denied"
                                         }

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/configuration/RewardSwaggerConfig.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/configuration/RewardSwaggerConfig.java
@@ -124,7 +124,7 @@ public class RewardSwaggerConfig {
                                                             new Example().value("""
                                                                     {
                                                                         "statusCode": 401,
-                                                                        "timestamp": "2026-01-22T19:56:58.7278032",
+                                                                        "timestamp": "2025-12-26T19:56:58.7278032",
                                                                         "errorCode": "AUTH001",
                                                                         "errorName": "AUTHENTICATION_FAILED",
                                                                         "message": "Authentication Failed"
@@ -142,7 +142,7 @@ public class RewardSwaggerConfig {
                                                             new Example().value("""
                                                                     {
                                                                         "statusCode": 403,
-                                                                        "timestamp": "2026-01-22T19:56:58.7278032",
+                                                                        "timestamp": "2025-12-26T19:56:58.7278032",
                                                                         "errorCode": "AUTH002",
                                                                         "errorName": "AUTHORIZATION_FAILED",
                                                                         "message": "Authorization Failed"

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/configuration/UserSwaggerConfig.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/configuration/UserSwaggerConfig.java
@@ -132,7 +132,7 @@ public class UserSwaggerConfig {
                                                             new Example().value("""
                                                                     {
                                                                         "statusCode": 401,
-                                                                        "timestamp": "2026-01-22T19:56:58.7278032",
+                                                                        "timestamp": "2025-12-26T19:56:58.7278032",
                                                                         "errorCode": "AUTH001",
                                                                         "errorName": "AUTHENTICATION_FAILED",
                                                                         "message": "Authentication Failed"
@@ -150,7 +150,7 @@ public class UserSwaggerConfig {
                                                             new Example().value("""
                                                                     {
                                                                         "statusCode": 403,
-                                                                        "timestamp": "2026-01-22T19:56:58.7278032",
+                                                                        "timestamp": "2025-12-26T19:56:58.7278032",
                                                                         "errorCode": "AUTH002",
                                                                         "errorName": "AUTHORIZATION_FAILED",
                                                                         "message": "Authorization Failed"

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/authentication/controller/apidocs/Oauth2LoginApiDocs.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/authentication/controller/apidocs/Oauth2LoginApiDocs.java
@@ -18,7 +18,7 @@ import java.lang.annotation.*;
 @Operation(
         summary = "OAuth 2.0 콜백 URI",
         description = """
-                작성일자: 2026-01-22
+                작성일자: 2025-12-26
                 
                 작성자: 성효빈
                 

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/authentication/controller/apidocs/RefreshAccessTokenApiDocs.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/authentication/controller/apidocs/RefreshAccessTokenApiDocs.java
@@ -19,7 +19,7 @@ import java.lang.annotation.*;
 @Operation(
         summary = "Refresh Token으로 새로운 Access Token 발급",
         description = """
-                작성일자: 2026-01-22
+                작성일자: 2025-12-26
                 
                 작성자: 성효빈
                 
@@ -69,7 +69,7 @@ import java.lang.annotation.*;
                                 examples = @ExampleObject("""
                                         {
                                           "statusCode": 201,
-                                          "timestamp": "2026-01-22T09:53:02.089234",
+                                          "timestamp": "2025-12-26T09:53:02.089234",
                                           "code": "SUC01",
                                           "content": {
                                             "accessToken": "eyJhbGciOiJIUzI1NiJ9.eyJ0b2tlblR5cGUiOiJBQ0NFU1NfVE9LRU4iLCJpYXQiOjE3NjE1MzI0MTEsImV4cCI6MTc2MTUzNDIxMSwic3ViIjoibnVsbCIsInJvbGVJZHMiOlsiUk9MRV9CVVlFUiJdLCJhdXRoVmVuZG9yIjoiTkFUSVZFIn0.ZzIV6LtD8jd5VQKdKcWschPDkyzOTSbIdhUE4ezvwk4"
@@ -87,7 +87,7 @@ import java.lang.annotation.*;
                                 examples = @ExampleObject("""
                                         {
                                           "statusCode": 400,
-                                          "timestamp": "2026-01-22T09:53:02.089234",
+                                          "timestamp": "2025-12-26T09:53:02.089234",
                                           "code": "BAD_REQUEST",
                                           "content": null,
                                           "message": "지원하지 않는 리프레시 토큰입니다."

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/authentication/controller/apidocs/SendEmailVerificationApiDocs.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/authentication/controller/apidocs/SendEmailVerificationApiDocs.java
@@ -40,7 +40,7 @@ import java.lang.annotation.*;
                 | --- | --- | --- | --- |
                 | statusCode | number | 상태 코드 | 200: 성공 / 400: 클라이언트 요청 오류 / 401: 인증 실패 / 403: 인가 실패 / 404: 리소스 조회 실패 / 409: 충돌 / 500: 그 외 |
                 | code | string | 응답 코드 | "SUC01" / "BAD_REQUEST" / "NOT_FOUND" / "BAD_GATEWAY" |
-                | timestamp | string(datetime) | 응답 일시 | "2026-01-22T12:12:30.013" |
+                | timestamp | string(datetime) | 응답 일시 | "2025-12-26T12:12:30.013" |
                 | content | object | 응답 본문 | { ... } |
                 | message | string | 처리 결과 | "이메일 인증 요청 전송 성공" |
                 

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/user/controller/UserAdminController.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/user/controller/UserAdminController.java
@@ -34,7 +34,7 @@ import static com.personal.marketnote.common.utility.ApiConstant.DEFAULT_PAGE_NU
  * 회원 관리자 컨트롤러
  *
  * @Author 성효빈
- * @Date 2026-01-24
+ * @Date 2025-12-29
  * @Description 회원 관련 관리자 API를 제공합니다.
  */
 @RestController
@@ -64,7 +64,7 @@ public class UserAdminController {
      * @param searchKeyword 검색 키워드
      * @return 회원 목록 조회 응답 {@link GetUsersResponse}
      * @Author 성효빈
-     * @Date 2026-01-24
+     * @Date 2025-12-29
      * @Description 회원 정보를 조회합니다. 관리자만 가능합니다.
      */
     @GetMapping
@@ -106,7 +106,7 @@ public class UserAdminController {
      * @param id 회원 ID
      * @return 회원 정보 조회 응답 {@link GetUserInfoResponse}
      * @Author 성효빈
-     * @Date 2026-01-24
+     * @Date 2025-12-29
      * @Description 회원 정보를 조회합니다. 관리자만 가능합니다.
      */
     @GetMapping("/{id}")
@@ -134,7 +134,7 @@ public class UserAdminController {
      * @param updateUserInfoRequest 회원 정보 수정 요청
      * @return 회원 정보 수정 응답 {@link Void}
      * @Author 성효빈
-     * @Date 2026-01-24
+     * @Date 2025-12-29
      * @Description 계정 비활성화를 포함한 회원 정보를 수정합니다. 관리자만 가능합니다.
      */
     @PatchMapping("/{id}")
@@ -169,7 +169,7 @@ public class UserAdminController {
      * @param sortProperty  정렬 속성
      * @return 로그인 내역 목록 조회 응답 {@link GetLoginHistoriesResponse}
      * @Author 시스템
-     * @Date 2026-01-25
+     * @Date 2025-12-30
      * @Description 특정 회원의 로그인 내역을 조회합니다. 관리자만 가능합니다.
      */
     @GetMapping("/{userId}/login-histories")

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/user/controller/UserController.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/user/controller/UserController.java
@@ -405,7 +405,7 @@ public class UserController {
      * @param googleAccessToken Google 액세스 토큰
      * @return 회원 탈퇴 응답 {@link WithdrawResponse}
      * @Author 성효빈
-     * @Date 2026-01-24
+     * @Date 2025-12-29
      * @Description 회원 탈퇴를 수행합니다.
      */
     @DeleteMapping

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/user/controller/apidocs/AcceptOrCancelTermsApiDocs.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/user/controller/apidocs/AcceptOrCancelTermsApiDocs.java
@@ -45,7 +45,7 @@ import java.lang.annotation.*;
                 | --- | --- | --- | --- |
                 | statusCode | number | 상태 코드 | 200: 성공 / 400: 클라이언트 요청 오류 / 401: 인증 실패 / 403: 인가 실패 / 404: 리소스 조회 실패 / 409: 충돌 / 500: 그 외 |
                 | code | string | 응답 코드 | "SUC01" / "UNAUTHORIZED" |
-                | timestamp | string(datetime) | 응답 일시 | "2026-01-22T12:12:30.013" |
+                | timestamp | string(datetime) | 응답 일시 | "2025-12-26T12:12:30.013" |
                 | content | object | 응답 본문 | { ... } |
                 | message | string | 처리 결과 | "약관 동의/철회 성공" |
                 

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/user/controller/apidocs/GetAllTermsApiDocs.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/user/controller/apidocs/GetAllTermsApiDocs.java
@@ -39,7 +39,7 @@ import java.lang.annotation.*;
                 | --- | --- | --- | --- |
                 | statusCode | number | 상태 코드 | 200: 성공 / 400: 클라이언트 요청 오류 / 401: 인증 실패 / 403: 인가 실패 / 404: 리소스 조회 실패 / 409: 충돌 / 500: 그 외 |
                 | code | string | 응답 코드 | "SUC01" |
-                | timestamp | string(datetime) | 응답 일시 | "2026-01-22T12:12:30.013" |
+                | timestamp | string(datetime) | 응답 일시 | "2025-12-26T12:12:30.013" |
                 | content | object | 응답 본문 | { ... } |
                 | message | string | 처리 결과 | "회원 약관 목록 조회 성공" |
                 
@@ -71,7 +71,7 @@ import java.lang.annotation.*;
                                         {
                                           "statusCode": 200,
                                           "code": "SUC01",
-                                          "timestamp": "2026-01-22T22:52:31.889943",
+                                          "timestamp": "2025-12-26T22:52:31.889943",
                                           "content": {
                                             "terms": [
                                              {

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/user/controller/apidocs/GetLoginHistoriesApiDocs.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/user/controller/apidocs/GetLoginHistoriesApiDocs.java
@@ -17,7 +17,7 @@ import java.lang.annotation.*;
 @Operation(
         summary = "(관리자) 회원 로그인 내역 조회",
         description = """
-                작성일자: 2026-01-25
+                작성일자: 2025-12-30
                 
                 작성자: 성효빈
                 
@@ -49,7 +49,7 @@ import java.lang.annotation.*;
                 | --- | --- | --- | --- |
                 | statusCode | number | 상태 코드 | 200 |
                 | code | string | 응답 코드 | "SUC01" |
-                | timestamp | string(datetime) | 응답 일시 | "2026-01-25T12:12:30.013" |
+                | timestamp | string(datetime) | 응답 일시 | "2025-12-30T12:12:30.013" |
                 | content | object | 응답 본문 | { ... } |
                 | message | string | 처리 결과 | "회원 로그인 내역 조회 성공" |
                 
@@ -122,7 +122,7 @@ import java.lang.annotation.*;
                                 {
                                   "statusCode": 200,
                                   "code": "SUC01",
-                                  "timestamp": "2026-01-25T13:32:27.721435519",
+                                  "timestamp": "2025-12-30T13:32:27.721435519",
                                   "content": {
                                     "pageSize": 10,
                                     "pageNumber": 1,
@@ -135,49 +135,49 @@ import java.lang.annotation.*;
                                         "userId": 13,
                                         "authVendor": "KAKAO",
                                         "ipAddress": "221.147.24.144",
-                                        "loggedInAt": "2026-01-25T13:31:08.926108"
+                                        "loggedInAt": "2025-12-30T13:31:08.926108"
                                       },
                                       {
                                         "id": 12,
                                         "userId": 13,
                                         "authVendor": "KAKAO",
                                         "ipAddress": "221.147.24.144",
-                                        "loggedInAt": "2026-01-25T13:30:04.124981"
+                                        "loggedInAt": "2025-12-30T13:30:04.124981"
                                       },
                                       {
                                         "id": 11,
                                         "userId": 13,
                                         "authVendor": "KAKAO",
                                         "ipAddress": "221.147.24.144",
-                                        "loggedInAt": "2026-01-25T13:29:48.890364"
+                                        "loggedInAt": "2025-12-30T13:29:48.890364"
                                       },
                                       {
                                         "id": 10,
                                         "userId": 13,
                                         "authVendor": "KAKAO",
                                         "ipAddress": "221.147.24.144",
-                                        "loggedInAt": "2026-01-25T22:28:21.960414"
+                                        "loggedInAt": "2025-12-30T22:28:21.960414"
                                       },
                                       {
                                         "id": 9,
                                         "userId": 13,
                                         "authVendor": "NATIVE",
                                         "ipAddress": "221.147.24.144",
-                                        "loggedInAt": "2026-01-25T13:16:49.951182"
+                                        "loggedInAt": "2025-12-30T13:16:49.951182"
                                       },
                                       {
                                         "id": 8,
                                         "userId": 13,
                                         "authVendor": "GOOGLE",
                                         "ipAddress": "221.147.24.144",
-                                        "loggedInAt": "2026-01-25T13:16:39.257946"
+                                        "loggedInAt": "2025-12-30T13:16:39.257946"
                                       },
                                       {
                                         "id": 7,
                                         "userId": 13,
                                         "authVendor": "GOOGLE",
                                         "ipAddress": "221.147.24.144",
-                                        "loggedInAt": "2026-01-25T13:16:16.724356"
+                                        "loggedInAt": "2025-12-30T13:16:16.724356"
                                       }
                                     ]
                                   },

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/user/controller/apidocs/GetMyInfoApiDocs.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/user/controller/apidocs/GetMyInfoApiDocs.java
@@ -39,7 +39,7 @@ import java.lang.annotation.*;
                 | --- | --- | --- | --- |
                 | statusCode | number | 상태 코드 | 200: 성공 / 400: 클라이언트 요청 오류 / 401: 인증 실패 / 403: 인가 실패 / 404: 리소스 조회 실패 / 409: 충돌 / 500: 그 외 |
                 | code | string | 응답 코드 | "SUC01" / "UNAUTHORIZED" / "NOT_FOUND" |
-                | timestamp | string(datetime) | 응답 일시 | "2026-01-22T12:12:30.013" |
+                | timestamp | string(datetime) | 응답 일시 | "2025-12-26T12:12:30.013" |
                 | content | object | 응답 본문 | { ... } |
                 | message | string | 처리 결과 | "회원 정보 조회 성공" |
                 
@@ -65,8 +65,8 @@ import java.lang.annotation.*;
                 | phoneNumber | string | 전화번호 | "010-1234-5678" |
                 | referenceCode | string | 참조 코드 | "1234567890" |
                 | roleId | string | 역할 ID | "ROLE_BUYER" |
-                | signedUpAt | string(datetime) | 가입 일시 | "2026-01-24T10:19:52.558748" |
-                | lastLoggedInAt | string(datetime) | 마지막 로그인 일시 | "2026-01-24T10:19:52.558748" |
+                | signedUpAt | string(datetime) | 가입 일시 | "2025-12-29T10:19:52.558748" |
+                | lastLoggedInAt | string(datetime) | 마지막 로그인 일시 | "2025-12-29T10:19:52.558748" |
                 | status | string | 상태 | "ACTIVE" / "INACTIVE" / "DELETED" |
                 
                 ---
@@ -96,7 +96,7 @@ import java.lang.annotation.*;
                                         {
                                           "statusCode": 200,
                                           "code": "SUC01",
-                                          "timestamp": "2026-01-24T14:48:49.550308",
+                                          "timestamp": "2025-12-29T14:48:49.550308",
                                           "content": {
                                             "userInfo": {
                                               "id": 83,
@@ -159,7 +159,7 @@ import java.lang.annotation.*;
                                         {
                                           "statusCode": 404,
                                           "code": "NOT_FOUND",
-                                          "timestamp": "2026-01-22T09:53:02.089234",
+                                          "timestamp": "2025-12-26T09:53:02.089234",
                                           "content": null,
                                           "message": "존재하지 않는 회원입니다. 회원 ID: 1"
                                         }

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/user/controller/apidocs/GetMyKeyApiDocs.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/user/controller/apidocs/GetMyKeyApiDocs.java
@@ -39,7 +39,7 @@ import java.lang.annotation.*;
                 | --- | --- | --- | --- |
                 | statusCode | number | 상태 코드 | 200: 성공 / 400: 클라이언트 요청 오류 / 401: 인증 실패 / 403: 인가 실패 / 404: 리소스 조회 실패 / 409: 충돌 / 500: 그 외 |
                 | code | string | 응답 코드 | "SUC01" / "UNAUTHORIZED" / "NOT_FOUND" |
-                | timestamp | string(datetime) | 응답 일시 | "2026-01-22T12:12:30.013" |
+                | timestamp | string(datetime) | 응답 일시 | "2025-12-26T12:12:30.013" |
                 | content | object | 응답 본문 | { ... } |
                 | message | string | 처리 결과 | "자신의 회원 키 조회 성공" |
                 
@@ -93,7 +93,7 @@ import java.lang.annotation.*;
                                         {
                                           "statusCode": 404,
                                           "code": "NOT_FOUND",
-                                          "timestamp": "2026-01-22T09:53:02.089234",
+                                          "timestamp": "2025-12-26T09:53:02.089234",
                                           "content": null,
                                           "message": "존재하지 않는 회원입니다. 회원 ID: 123"
                                         }

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/user/controller/apidocs/GetUserInfoApiDocs.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/user/controller/apidocs/GetUserInfoApiDocs.java
@@ -17,7 +17,7 @@ import java.lang.annotation.*;
 @Operation(
         summary = "(관리자) 회원 정보 조회",
         description = """
-                작성일자: 2026-01-24
+                작성일자: 2025-12-29
                 
                 작성자: 성효빈
                 
@@ -45,7 +45,7 @@ import java.lang.annotation.*;
                 | --- | --- | --- | --- |
                 | statusCode | number | 상태 코드 | 200: 성공 / 400: 클라이언트 요청 오류 / 401: 인증 실패 / 403: 인가 실패 / 404: 리소스 조회 실패 / 409: 충돌 / 500: 그 외 |
                 | code | string | 응답 코드 | "SUC01" / "UNAUTHORIZED" / "FORBIDDEN" / "NOT_FOUND" |
-                | timestamp | string(datetime) | 응답 일시 | "2026-01-24T12:12:30.013" |
+                | timestamp | string(datetime) | 응답 일시 | "2025-12-29T12:12:30.013" |
                 | content | object | 응답 본문 | { ... } |
                 | message | string | 처리 결과 | "회원 정보 조회 성공" |
                 
@@ -71,8 +71,8 @@ import java.lang.annotation.*;
                 | phoneNumber | string | 전화번호 | "010-1234-5678" |
                 | referenceCode | string | 참조 코드 | "1234567890" |
                 | roleId | string | 역할 ID | "ROLE_BUYER" |
-                | signedUpAt | string(datetime) | 가입 일시 | "2026-01-24T10:19:52.558748" |
-                | lastLoggedInAt | string(datetime) | 마지막 로그인 일시 | "2026-01-24T10:19:52.558748" |
+                | signedUpAt | string(datetime) | 가입 일시 | "2025-12-29T10:19:52.558748" |
+                | lastLoggedInAt | string(datetime) | 마지막 로그인 일시 | "2025-12-29T10:19:52.558748" |
                 | status | string | 상태 | "ACTIVE" / "INACTIVE" / "DELETED" |
                 | isWithdrawn | boolean | 탈퇴 여부 | true / false |
                 | orderNum | number | 정렬 순서 | 1 |
@@ -112,7 +112,7 @@ import java.lang.annotation.*;
                                         {
                                           "statusCode": 200,
                                           "code": "SUC01",
-                                          "timestamp": "2026-01-24T14:47:28.455214",
+                                          "timestamp": "2025-12-29T14:47:28.455214",
                                           "content": {
                                             "userInfo": {
                                               "id": 84,
@@ -162,7 +162,7 @@ import java.lang.annotation.*;
                                         {
                                           "statusCode": 401,
                                           "code": "UNAUTHORIZED",
-                                          "timestamp": "2026-01-24T10:19:52.558748",
+                                          "timestamp": "2025-12-29T10:19:52.558748",
                                           "content": null,
                                           "message": "Invalid token"
                                         }
@@ -177,7 +177,7 @@ import java.lang.annotation.*;
                                         {
                                           "statusCode": 403,
                                           "code": "FORBIDDEN",
-                                          "timestamp": "2026-01-24T10:19:52.558748",
+                                          "timestamp": "2025-12-29T10:19:52.558748",
                                           "content": null,
                                           "message": "Access Denied"
                                         }
@@ -192,7 +192,7 @@ import java.lang.annotation.*;
                                         {
                                           "statusCode": 404,
                                           "code": "NOT_FOUND",
-                                          "timestamp": "2026-01-24T10:19:52.558748",
+                                          "timestamp": "2025-12-29T10:19:52.558748",
                                           "content": null,
                                           "message": "존재하지 않는 회원입니다. 회원 ID: 1"
                                         }

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/user/controller/apidocs/GetUserTermsApiDocs.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/user/controller/apidocs/GetUserTermsApiDocs.java
@@ -39,7 +39,7 @@ import java.lang.annotation.*;
                 | --- | --- | --- | --- |
                 | statusCode | number | 상태 코드 | 200: 성공 / 400: 클라이언트 요청 오류 / 401: 인증 실패 / 403: 인가 실패 / 404: 리소스 조회 실패 / 409: 충돌 / 500: 그 외 |
                 | code | string | 응답 코드 | "SUC01" / "UNAUTHORIZED" |
-                | timestamp | string(datetime) | 응답 일시 | "2026-01-22T12:12:30.013" |
+                | timestamp | string(datetime) | 응답 일시 | "2025-12-26T12:12:30.013" |
                 | content | object | 응답 본문 | { ... } |
                 | message | string | 처리 결과 | "회원 약관 동의 여부 목록 조회 성공" |
                 

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/user/controller/apidocs/GetUsersApiDocs.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/user/controller/apidocs/GetUsersApiDocs.java
@@ -17,7 +17,7 @@ import java.lang.annotation.*;
 @Operation(
         summary = "(관리자) 회원 목록 조회",
         description = """
-                작성일자: 2026-01-24
+                작성일자: 2025-12-29
                 
                 작성자: 성효빈
                 
@@ -50,7 +50,7 @@ import java.lang.annotation.*;
                 | --- | --- | --- | --- |
                 | statusCode | number | 상태 코드 | 200: 성공 / 400: 클라이언트 요청 오류 / 401: 인증 실패 / 403: 인가 실패 / 404: 리소스 조회 실패 / 409: 충돌 / 500: 그 외 |
                 | code | string | 응답 코드 | "SUC01" / "UNAUTHORIZED" / / "FORBIDDEN" / "NOT_FOUND" |
-                | timestamp | string(datetime) | 응답 일시 | "2026-01-24T12:12:30.013" |
+                | timestamp | string(datetime) | 응답 일시 | "2025-12-29T12:12:30.013" |
                 | content | object | 응답 본문 | { ... } |
                 | message | string | 처리 결과 | "회원 목록 조회 성공" |
                 
@@ -81,8 +81,8 @@ import java.lang.annotation.*;
                 | phoneNumber | string | 전화번호 | "010-1234-5678" |
                 | referenceCode | string | 참조 코드 | "1234567890" |
                 | roleId | string | 역할 ID | "ROLE_BUYER" |
-                | signedUpAt | string(datetime) | 가입 일시 | "2026-01-24T10:19:52.558748" |
-                | lastLoggedInAt | string(datetime) | 마지막 로그인 일시 | "2026-01-24T10:19:52.558748" |
+                | signedUpAt | string(datetime) | 가입 일시 | "2025-12-29T10:19:52.558748" |
+                | lastLoggedInAt | string(datetime) | 마지막 로그인 일시 | "2025-12-29T10:19:52.558748" |
                 | status | string | 상태 | "ACTIVE" / "INACTIVE" / "DELETED" |
                 | isWithdrawn | boolean | 탈퇴 여부 | true / false |
                 | orderNum | number | 정렬 순서 | 1 |
@@ -157,7 +157,7 @@ import java.lang.annotation.*;
                                         {
                                           "statusCode": 200,
                                           "code": "SUC01",
-                                          "timestamp": "2026-01-24T17:12:17.565718",
+                                          "timestamp": "2025-12-29T17:12:17.565718",
                                           "content": {
                                             "pageSize": 3,
                                             "pageNumber": 2,
@@ -228,7 +228,7 @@ import java.lang.annotation.*;
                                                 "referenceCode": "H8M7G6",
                                                 "roleId": "ROLE_BUYER",
                                                 "signedUpAt": "2025-12-28T15:59:59.132803",
-                                                "lastLoggedInAt": "2026-01-24T15:22:45.433588",
+                                                "lastLoggedInAt": "2025-12-29T15:22:45.433588",
                                                 "status": "ACTIVE",
                                                 "isWithdrawn": false,
                                                 "orderNum": 2
@@ -248,7 +248,7 @@ import java.lang.annotation.*;
                                         {
                                           "statusCode": 401,
                                           "code": "UNAUTHORIZED",
-                                          "timestamp": "2026-01-24T10:19:52.558748",
+                                          "timestamp": "2025-12-29T10:19:52.558748",
                                           "content": null,
                                           "message": "Invalid token"
                                         }
@@ -263,7 +263,7 @@ import java.lang.annotation.*;
                                         {
                                           "statusCode": 403,
                                           "code": "FORBIDDEN",
-                                          "timestamp": "2026-01-24T10:19:52.558748",
+                                          "timestamp": "2025-12-29T10:19:52.558748",
                                           "content": null,
                                           "message": "Access Denied"
                                         }

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/user/controller/apidocs/RegisterReferredUserCodeApiDocs.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/user/controller/apidocs/RegisterReferredUserCodeApiDocs.java
@@ -40,7 +40,7 @@ import java.lang.annotation.*;
                 | --- | --- | --- | --- |
                 | statusCode | number | 상태 코드 | 200: 성공 / 400: 클라이언트 요청 오류 / 401: 인증 실패 / 403: 인가 실패 / 404: 리소스 조회 실패 / 409: 충돌 / 500: 그 외 |
                 | code | string | 응답 코드 | "SUC01" / "ERR01" / "ERR02" |
-                | timestamp | string(datetime) | 응답 일시 | "2026-01-22T12:12:30.013" |
+                | timestamp | string(datetime) | 응답 일시 | "2025-12-26T12:12:30.013" |
                 | content | object | 응답 본문 | { ... } |
                 | message | string | 처리 결과 | "초대 코드 등록 성공" |
                 

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/user/controller/apidocs/SignInApiDocs.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/user/controller/apidocs/SignInApiDocs.java
@@ -50,7 +50,7 @@ import java.lang.annotation.*;
                 | --- | --- | --- | --- |
                 | statusCode | number | 상태 코드 | 200: 성공 / 400: 클라이언트 요청 오류 / 401: 인증 실패 / 403: 인가 실패 / 404: 리소스 조회 실패 / 409: 충돌 / 500: 그 외 |
                 | code | string | 응답 코드 | "SUC01" / "ERR01" / "ERR02" / "NOT_FOUND" |
-                | timestamp | string(datetime) | 응답 일시 | "2026-01-22T12:12:30.013" |
+                | timestamp | string(datetime) | 응답 일시 | "2025-12-26T12:12:30.013" |
                 | content | object | 응답 본문 | { ... } |
                 | message | string | 처리 결과 | "회원 로그인 성공" |
                 
@@ -92,7 +92,7 @@ import java.lang.annotation.*;
                                         {
                                           "statusCode": 200,
                                           "code": "SUC01",
-                                          "timestamp": "2026-01-22T22:52:31.889943",
+                                          "timestamp": "2025-12-26T22:52:31.889943",
                                           "content": {
                                             "accessToken": "eyJhbGciOiJIUzI1NiJ9.eyJ0b2tlblR5cGUiOiJBQ0NFU1NfVE9LRU4iLCJpYXQiOjE3NjE1MjgzMTYsImV4cCI6MTc2MTUzMDExNiwic3ViIjoiOCIsInJvbGVJZHMiOlsiUk9MRV9CVVlFUiJdLCJ1c2VySWQiOjgsImF1dGhWZW5kb3IiOiJOQVRJVkUifQ.3nhlFNz9NBfcJKIteTICcUyN7F1w068CJKu5uy5kB0I",
                                             "refreshToken": "eyJhbGciOiJIUzI1NiJ9.eyJ0b2tlblR5cGUiOiJSRUZSRVNIX1RPS0VOIiwiaWF0IjoxNzYxNDg2NzUxLCJleHAiOjE3NjI2OTYzNTEsInN1YiI6Im51bGwiLCJyb2xlSWRzIjpbIlJPTEVfQlVZRVIiXSwiYXV0aFZlbmRvciI6Ik5BVElWRSJ9._YvI9YT4aklPzJdN5D4IRqx0uzsyz4wjBMgCLGcf_CA",
@@ -126,7 +126,7 @@ import java.lang.annotation.*;
                                         {
                                           "statusCode": 404,
                                           "code": "NOT_FOUND",
-                                          "timestamp": "2026-01-22T09:53:02.089234",
+                                          "timestamp": "2025-12-26T09:53:02.089234",
                                           "content": null,
                                           "message": "존재하지 않는 회원입니다. 전송된 회원 이메일 주소: example@example.com"
                                         }

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/user/controller/apidocs/SignOutApiDocs.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/user/controller/apidocs/SignOutApiDocs.java
@@ -36,7 +36,7 @@ import java.lang.annotation.*;
                 | --- | --- | --- | --- |
                 | statusCode | number | 상태 코드 | 200: 성공 / 400: 클라이언트 요청 오류 / 401: 인증 실패 / 403: 인가 실패 / 404: 리소스 조회 실패 / 409: 충돌 / 500: 그 외 |
                 | code | string | 응답 코드 | "SUC01" |
-                | timestamp | string(datetime) | 응답 일시 | "2026-01-22T12:12:30.013" |
+                | timestamp | string(datetime) | 응답 일시 | "2025-12-26T12:12:30.013" |
                 | content | object | 응답 본문 | { ... } |
                 | message | string | 처리 결과 | "회원 로그아웃 성공" |
                 """,
@@ -50,7 +50,7 @@ import java.lang.annotation.*;
                                         {
                                           "statusCode": 200,
                                           "code": "SUC01",
-                                          "timestamp": "2026-01-22T22:52:31.889943",
+                                          "timestamp": "2025-12-26T22:52:31.889943",
                                           "content": null,
                                           "message": "회원 로그아웃 성공"
                                         }

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/user/controller/apidocs/SignUpApiDocs.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/user/controller/apidocs/SignUpApiDocs.java
@@ -17,7 +17,7 @@ import java.lang.annotation.*;
 @Operation(
         summary = "회원 가입",
         description = """
-                작성일자: 2026-01-22
+                작성일자: 2025-12-26
                 
                 작성자: 성효빈
                 
@@ -61,7 +61,7 @@ import java.lang.annotation.*;
                 | --- | --- | --- | --- |
                 | statusCode | number | 상태 코드 | 201: 성공 / 400: 클라이언트 요청 오류 / 401: 인증 실패 / 403: 인가 실패 / 404: 리소스 조회 실패 / 409: 충돌 / 500: 그 외 |
                 | code | string | 응답 코드 | "SUC01" / "ERR01" / "ERR02" / "ERR03" / "ERR04" / "ERR05" / "ERR06" |
-                | timestamp | string(datetime) | 응답 일시 | "2026-01-22T12:12:30.013" |
+                | timestamp | string(datetime) | 응답 일시 | "2025-12-26T12:12:30.013" |
                 | content | object | 응답 본문 | { ... } |
                 | message | string | 처리 결과 | "회원 가입 성공" |
                 

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/user/controller/apidocs/UpdateMyInfoApiDocs.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/user/controller/apidocs/UpdateMyInfoApiDocs.java
@@ -56,7 +56,7 @@ import java.lang.annotation.*;
                 | --- | --- | --- | --- |
                 | statusCode | number | 상태 코드 | 200: 성공 / 400: 클라이언트 요청 오류 / 401: 인증 실패 / 403: 인가 실패 / 404: 리소스 조회 실패 / 409: 충돌 / 500: 그 외 |
                 | code | string | 응답 코드 | "SUC01" / "BAD_REQUEST" / "UNAUTHORIZED" / "NOT_FOUND" / "ERR01" / "ERR02" / "ERR03" / "ERR04" / "ERR05" / "ERR06" |
-                | timestamp | string(datetime) | 응답 일시 | "2026-01-24T12:12:30.013" |
+                | timestamp | string(datetime) | 응답 일시 | "2025-12-29T12:12:30.013" |
                 | content | object | 응답 본문 | { ... } |
                 | message | string | 처리 결과 | "자신의 정보 수정 성공" |
                 """,
@@ -126,7 +126,7 @@ import java.lang.annotation.*;
                                         {
                                           "statusCode": 404,
                                           "code": "NOT_FOUND",
-                                          "timestamp": "2026-01-24T09:53:02.089234",
+                                          "timestamp": "2025-12-29T09:53:02.089234",
                                           "content": null,
                                           "message": "존재하지 않는 회원입니다. 회원 ID: 1"
                                         }

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/user/controller/apidocs/UpdateUserInfoApiDocs.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/user/controller/apidocs/UpdateUserInfoApiDocs.java
@@ -19,7 +19,7 @@ import java.lang.annotation.*;
 @Operation(
         summary = "(관리자) 회원 정보 수정",
         description = """
-                작성일자: 2026-01-24
+                작성일자: 2025-12-29
                 
                 작성자: 성효빈
                 
@@ -63,7 +63,7 @@ import java.lang.annotation.*;
                 | --- | --- | --- | --- |
                 | statusCode | number | 상태 코드 | 200: 성공 / 400: 클라이언트 요청 오류 / 401: 인증 실패 / 403: 인가 실패 / 404: 리소스 조회 실패 / 409: 충돌 / 500: 그 외 |
                 | code | string | 응답 코드 | "SUC01" / "BAD_REQUEST" / "UNAUTHORIZED" / "FORBIDDEN" / "NOT_FOUND" / "ERR01" / "ERR02" / "ERR03" / "ERR04" / "ERR05" / "ERR06" |
-                | timestamp | string(datetime) | 응답 일시 | "2026-01-24T10:19:52.558748" |
+                | timestamp | string(datetime) | 응답 일시 | "2025-12-29T10:19:52.558748" |
                 | content | object | 응답 본문 | { ... } |
                 | message | string | 처리 결과 | "회원 정보 수정 성공" |
                 """,
@@ -97,7 +97,7 @@ import java.lang.annotation.*;
                                         {
                                           "statusCode": 200,
                                           "code": "SUC01",
-                                          "timestamp": "2026-01-24T10:19:52.558748",
+                                          "timestamp": "2025-12-29T10:19:52.558748",
                                           "content": null,
                                           "message": "회원 정보 수정 성공"
                                         }
@@ -112,7 +112,7 @@ import java.lang.annotation.*;
                                         {
                                           "statusCode": 400,
                                           "code": "BAD_REQUEST",
-                                          "timestamp": "2026-01-24T10:19:52.558748",
+                                          "timestamp": "2025-12-29T10:19:52.558748",
                                           "content": null,
                                           "message": "업데이트할 대상과 값을 전송해야 합니다."
                                         }
@@ -127,7 +127,7 @@ import java.lang.annotation.*;
                                         {
                                           "statusCode": 401,
                                           "code": "UNAUTHORIZED",
-                                          "timestamp": "2026-01-24T10:19:52.558748",
+                                          "timestamp": "2025-12-29T10:19:52.558748",
                                           "content": null,
                                           "message": "Invalid token"
                                         }
@@ -142,7 +142,7 @@ import java.lang.annotation.*;
                                         {
                                           "statusCode": 403,
                                           "code": "FORBIDDEN",
-                                          "timestamp": "2026-01-24T10:19:52.558748",
+                                          "timestamp": "2025-12-29T10:19:52.558748",
                                           "content": null,
                                           "message": "Access Denied"
                                         }
@@ -157,7 +157,7 @@ import java.lang.annotation.*;
                                         {
                                           "statusCode": 404,
                                           "code": "NOT_FOUND",
-                                          "timestamp": "2026-01-24T10:19:52.558748",
+                                          "timestamp": "2025-12-29T10:19:52.558748",
                                           "content": null,
                                           "message": "존재하지 않는 회원입니다. 회원 ID: 1"
                                         }
@@ -172,7 +172,7 @@ import java.lang.annotation.*;
                                         {
                                           "statusCode": 409,
                                           "code": "ERR01",
-                                          "timestamp": "2026-01-24T10:19:52.558748",
+                                          "timestamp": "2025-12-29T10:19:52.558748",
                                           "content": null,
                                           "message": "업데이트할 대상의 값과 입력한 값이 동일합니다. 전송한 값: abc"
                                         }

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/user/controller/apidocs/WithdrawalApiDocs.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/user/controller/apidocs/WithdrawalApiDocs.java
@@ -15,7 +15,7 @@ import java.lang.annotation.*;
 @Operation(
         summary = "회원 탈퇴",
         description = """
-                작성일자: 2026-01-24
+                작성일자: 2025-12-29
                 
                  작성자: 성효빈
                 
@@ -45,7 +45,7 @@ import java.lang.annotation.*;
                  | --- | --- | --- | --- |
                  | statusCode | number | 상태 코드 | 200: 성공 / 400: 클라이언트 요청 오류 / 401: 인증 실패 / 403: 인가 실패 / 404: 리소스 조회 실패 / 409: 충돌 / 500: 그 외 |
                  | code | string | 응답 코드 | "SUC01" / "BAD_REQUEST" / "UNAUTHORIZED" / "FORBIDDEN" / "NOT_FOUND" / "CONFLICT" / "INTERNAL_SERVER_ERROR" |
-                 | timestamp | string(datetime) | 응답 일시 | "2026-01-24T12:12:30.013" |
+                 | timestamp | string(datetime) | 응답 일시 | "2025-12-29T12:12:30.013" |
                  | content | object | 응답 본문 | { ... } |
                  | message | string | 처리 결과 | "회원 탈퇴 성공" |
                 
@@ -76,7 +76,7 @@ import java.lang.annotation.*;
                                         {
                                           "statusCode": 200,
                                           "code": "SUC01",
-                                          "timestamp": "2026-01-22T22:52:31.889943",
+                                          "timestamp": "2025-12-26T22:52:31.889943",
                                           "content": {
                                             "isKakaoDisconnected": true,
                                             "isGoogleDisconnected": true,
@@ -95,7 +95,7 @@ import java.lang.annotation.*;
                                         {
                                           "statusCode": 401,
                                           "code": "UNAUTHORIZED",
-                                          "timestamp": "2026-01-25T12:12:30.013",
+                                          "timestamp": "2025-12-30T12:12:30.013",
                                           "content": null,
                                           "message": "Invalid token"
                                         }
@@ -110,7 +110,7 @@ import java.lang.annotation.*;
                                         {
                                           "statusCode": 403,
                                           "code": "FORBIDDEN",
-                                          "timestamp": "2026-01-25T12:12:30.013",
+                                          "timestamp": "2025-12-30T12:12:30.013",
                                           "content": null,
                                           "message": "Access Denied"
                                         }

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/port/in/usecase/user/GetUserUseCase.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/port/in/usecase/user/GetUserUseCase.java
@@ -53,7 +53,7 @@ public interface GetUserUseCase {
     /**
      * @param id 회원 ID
      * @return 회원 도메인 {@link User}
-     * @Date 2026-01-24
+     * @Date 2025-12-29
      * @Author 성효빈
      * @Description 활성화/비활성화/비노출 회원을 조회합니다.
      */
@@ -72,7 +72,7 @@ public interface GetUserUseCase {
      * @param authVendor 인증 제공자
      * @param oidcId     외부 인증 ID
      * @return 회원 도메인 {@link User}
-     * @Date 2026-01-25
+     * @Date 2025-12-30
      * @Author 성효빈
      * @Description 활성화/비활성화/비노출 회원을 조회합니다.
      */
@@ -99,7 +99,7 @@ public interface GetUserUseCase {
     /**
      * @param id 회원 ID
      * @return 회원 정보 조회 결과 {@link GetUserInfoResult}
-     * @Date 2026-01-24
+     * @Date 2025-12-29
      * @Author 성효빈
      * @Description 활성화/비활성화/비노출 회원 정보를 조회합니다.
      */
@@ -113,7 +113,7 @@ public interface GetUserUseCase {
      * @param searchTarget  검색 대상
      * @param searchKeyword 검색 키워드
      * @return 회원 목록 조회 결과 {@link List< GetUserResult >}
-     * @Date 2026-01-24
+     * @Date 2025-12-29
      * @Author 성효빈
      * @Description 활성화/비활성화/비노출 회원 목록을 조회합니다.
      */

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/port/in/usecase/user/WithdrawUseCase.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/port/in/usecase/user/WithdrawUseCase.java
@@ -6,7 +6,7 @@ public interface WithdrawUseCase {
     /**
      * @param id                회원 ID
      * @param googleAccessToken 현재 구글 로그인 중인 경우 액세스 토큰(연결 해제 시도)
-     * @Date 2026-01-24
+     * @Date 2025-12-29
      * @Author 성효빈
      * @Description 회원에서 탈퇴하고 소셜 연결 해제 결과를 반환합니다.
      */

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/port/out/authentication/SaveEmailVerificationCodePort.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/port/out/authentication/SaveEmailVerificationCodePort.java
@@ -6,7 +6,7 @@ public interface SaveEmailVerificationCodePort {
      * @param verificationCode 인증 코드
      * @param ttlMinutes       인증 코드 유효 시간(분)
      * @Author 성효빈
-     * @Date 2026-01-25
+     * @Date 2025-12-30
      * @Description 인증 코드를 저장합니다.
      */
     void save(String email, String verificationCode, int ttlMinutes);

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/service/user/SignUpService.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/service/user/SignUpService.java
@@ -31,7 +31,7 @@ import static org.springframework.transaction.annotation.Isolation.READ_COMMITTE
 
 @RequiredArgsConstructor
 @UseCase
-@Transactional(isolation = READ_COMMITTED, timeout = 180)
+@Transactional(isolation = READ_COMMITTED)
 public class SignUpService implements SignUpUseCase {
     private final GetUserUseCase getUserUseCase;
     private final SaveUserPort saveUserPort;

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/service/user/UpdateUserService.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/service/user/UpdateUserService.java
@@ -19,7 +19,7 @@ import static org.springframework.transaction.annotation.Isolation.READ_COMMITTE
 
 @RequiredArgsConstructor
 @UseCase
-@Transactional(isolation = READ_COMMITTED, timeout = 180)
+@Transactional(isolation = READ_COMMITTED)
 public class UpdateUserService implements UpdateUserUseCase {
     private final GetUserUseCase getUserUseCase;
     private final FindUserPort findUserPort;
@@ -52,6 +52,7 @@ public class UpdateUserService implements UpdateUserUseCase {
             user.validateDifferentEmail(email);
             validateDuplicateEmail(email);
             user.updateEmail(email);
+
             return;
         }
 
@@ -60,6 +61,7 @@ public class UpdateUserService implements UpdateUserUseCase {
             user.validateDifferentNickname(nickname);
             validateDuplicateNickname(nickname);
             user.updateNickname(nickname);
+
             return;
         }
 
@@ -68,6 +70,7 @@ public class UpdateUserService implements UpdateUserUseCase {
             user.validateDifferentPhoneNumber(phoneNumber);
             validateDuplicatePhoneNumber(phoneNumber);
             user.updatePhoneNumber(phoneNumber);
+
             return;
         }
 

--- a/user-service/user-application/src/test/java/com/personal/marketnote/user/service/user/RegisterEmailUseCaseTest.java
+++ b/user-service/user-application/src/test/java/com/personal/marketnote/user/service/user/RegisterEmailUseCaseTest.java
@@ -1,0 +1,97 @@
+package com.personal.marketnote.user.service.user;
+
+import com.personal.marketnote.common.exception.UserNotFoundException;
+import com.personal.marketnote.user.domain.user.User;
+import com.personal.marketnote.user.exception.UserExistsException;
+import com.personal.marketnote.user.port.out.user.FindUserPort;
+import com.personal.marketnote.user.port.out.user.UpdateUserPort;
+import com.personal.marketnote.user.security.token.vendor.AuthVendor;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static com.personal.marketnote.common.domain.exception.ExceptionCode.FIRST_ERROR_CODE;
+import static com.personal.marketnote.user.exception.ExceptionMessage.EMAIL_ALREADY_EXISTS_EXCEPTION_MESSAGE;
+import static com.personal.marketnote.user.exception.ExceptionMessage.USER_ID_NOT_FOUND_EXCEPTION_MESSAGE;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class RegisterEmailUseCaseTest {
+    @Mock
+    private FindUserPort findUserPort;
+    @Mock
+    private UpdateUserPort updateUserPort;
+
+    @InjectMocks
+    private RegisterEmailService registerEmailService;
+
+    @Test
+    @DisplayName("회원 이메일 주소를 등록하면 회원 도메인의 이메일 주소가 갱신된다")
+    void registerEmail_success_updatesUser() {
+        // given
+        Long id = 1L;
+        String email = "user@test.com";
+        User user = mock(User.class);
+
+        when(findUserPort.findById(id)).thenReturn(Optional.of(user));
+        when(findUserPort.existsByEmail(email)).thenReturn(false);
+
+        // when
+        registerEmailService.registerEmail(id, AuthVendor.KAKAO, email);
+
+        // then
+        verify(findUserPort).findById(id);
+        verify(findUserPort).existsByEmail(email);
+        verify(user).registerEmail(email);
+        verify(updateUserPort).update(user);
+        verifyNoMoreInteractions(findUserPort, updateUserPort, user);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 회원의 이메일 주소 등록을 시도하면 예외를 던진다")
+    void registerEmail_userNotFound_throws() {
+        // given
+        Long id = 999L;
+        String email = "user@test.com";
+
+        when(findUserPort.findById(id)).thenReturn(Optional.empty());
+
+        // expect
+        assertThatThrownBy(() -> registerEmailService.registerEmail(id, AuthVendor.GOOGLE, email))
+                .isInstanceOf(UserNotFoundException.class)
+                .hasMessage(String.format(USER_ID_NOT_FOUND_EXCEPTION_MESSAGE, id));
+
+        verify(findUserPort).findById(id);
+        verifyNoMoreInteractions(findUserPort);
+        verifyNoInteractions(updateUserPort);
+    }
+
+    @Test
+    @DisplayName("이미 사용 중인 이메일 주소를 등록 시도하면 예외를 던진다")
+    void registerEmail_duplicateEmail_throws() {
+        // given
+        Long id = 2L;
+        String email = "user@test.com";
+        User user = mock(User.class);
+
+        when(findUserPort.findById(id)).thenReturn(Optional.of(user));
+        when(findUserPort.existsByEmail(email)).thenReturn(true);
+
+        // expect
+        assertThatThrownBy(() -> registerEmailService.registerEmail(id, AuthVendor.KAKAO, email))
+                .isInstanceOf(UserExistsException.class)
+                .hasMessage(String.format(EMAIL_ALREADY_EXISTS_EXCEPTION_MESSAGE, FIRST_ERROR_CODE, email));
+
+        verify(findUserPort).findById(id);
+        verify(findUserPort).existsByEmail(email);
+        verify(user, never()).registerEmail(anyString());
+        verifyNoInteractions(updateUserPort);
+        verifyNoMoreInteractions(findUserPort, user);
+    }
+}

--- a/user-service/user-application/src/test/java/com/personal/marketnote/user/service/user/UpdateUserUseCaseTest.java
+++ b/user-service/user-application/src/test/java/com/personal/marketnote/user/service/user/UpdateUserUseCaseTest.java
@@ -1,0 +1,339 @@
+package com.personal.marketnote.user.service.user;
+
+import com.personal.marketnote.common.domain.exception.illegalargument.novalue.UpdateTargetNoValueException;
+import com.personal.marketnote.common.exception.UserNotFoundException;
+import com.personal.marketnote.user.domain.user.User;
+import com.personal.marketnote.user.exception.UserExistsException;
+import com.personal.marketnote.user.port.in.command.UpdateUserInfoCommand;
+import com.personal.marketnote.user.port.in.usecase.user.GetUserUseCase;
+import com.personal.marketnote.user.port.out.user.FindUserPort;
+import com.personal.marketnote.user.port.out.user.UpdateUserPort;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import static com.personal.marketnote.common.domain.exception.ExceptionCode.*;
+import static com.personal.marketnote.user.exception.ExceptionMessage.*;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class UpdateUserUseCaseTest {
+    @Mock
+    private GetUserUseCase getUserUseCase;
+    @Mock
+    private FindUserPort findUserPort;
+    @Mock
+    private UpdateUserPort updateUserPort;
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @InjectMocks
+    private UpdateUserService updateUserService;
+
+    @Test
+    @DisplayName("회원 상태 변경 요청 시 회원 도메인의 상태를 갱신한다")
+    void updateUserInfo_adminUpdatesStatus() {
+        // given
+        Long id = 1L;
+        boolean isActive = false;
+        UpdateUserInfoCommand command = UpdateUserInfoCommand.builder()
+                .isActive(isActive)
+                .build();
+        User user = mock(User.class);
+
+        when(getUserUseCase.getAllStatusUser(id)).thenReturn(user);
+
+        // when
+        updateUserService.updateUserInfo(true, id, command);
+
+        // then
+        verify(getUserUseCase).getAllStatusUser(id);
+        verify(user).updateStatus(isActive);
+        verify(updateUserPort).update(user);
+        verifyNoMoreInteractions(getUserUseCase, user, updateUserPort);
+        verifyNoInteractions(findUserPort, passwordEncoder);
+    }
+
+    @Test
+    @DisplayName("관리자가 아닌 경우 회원 활성 상태를 변경하려 시도하면 예외를 던진다")
+    void updateUserInfo_nonAdminWithIsActive_throws() {
+        // given
+        Long id = 2L;
+        UpdateUserInfoCommand command = UpdateUserInfoCommand.builder()
+                .isActive(true)
+                .build();
+        User user = mock(User.class);
+
+        when(getUserUseCase.getUser(id)).thenReturn(user);
+
+        // expect
+        assertThatThrownBy(() -> updateUserService.updateUserInfo(false, id, command))
+                .isInstanceOf(UpdateTargetNoValueException.class);
+
+        verify(getUserUseCase).getUser(id);
+        verifyNoMoreInteractions(getUserUseCase);
+        verifyNoInteractions(findUserPort, updateUserPort, passwordEncoder);
+        verifyNoMoreInteractions(user);
+    }
+
+    @Test
+    @DisplayName("회원 정보 수정 요청 시 대상 회원이 존재하지 않으면 예외를 던진다")
+    void updateUserInfo_noUpdateTarget_throws() {
+        // given
+        Long id = 3L;
+        UpdateUserInfoCommand command = UpdateUserInfoCommand.builder().build();
+        User user = mock(User.class);
+
+        when(getUserUseCase.getUser(id)).thenReturn(user);
+
+        // expect
+        assertThatThrownBy(() -> updateUserService.updateUserInfo(false, id, command))
+                .isInstanceOf(UpdateTargetNoValueException.class);
+
+        verify(getUserUseCase).getUser(id);
+        verifyNoMoreInteractions(getUserUseCase);
+        verifyNoInteractions(findUserPort, updateUserPort, passwordEncoder);
+        verifyNoMoreInteractions(user);
+    }
+
+    @Test
+    @DisplayName("회원 비밀번호 변경 요청 시 회원 도메인의 비밀번호를 갱신한다")
+    void updateUserInfo_updatesPassword() {
+        // given
+        Long id = 4L;
+        String password = "new-password";
+        UpdateUserInfoCommand command = UpdateUserInfoCommand.builder()
+                .password(password)
+                .build();
+        User user = mock(User.class);
+
+        when(getUserUseCase.getUser(id)).thenReturn(user);
+
+        // when
+        updateUserService.updateUserInfo(false, id, command);
+
+        // then
+        verify(getUserUseCase).getUser(id);
+        verify(user).updatePassword(password, passwordEncoder);
+        verify(updateUserPort).update(user);
+        verifyNoMoreInteractions(getUserUseCase, user, updateUserPort);
+        verifyNoInteractions(findUserPort);
+    }
+
+    @Test
+    @DisplayName("회원 비밀번호 변경 요청 시 이메일 변경 요청은 무시된다")
+    void updateUserInfo_passwordTakesPrecedenceOverEmail() {
+        // given
+        Long id = 5L;
+        String password = "new-password";
+        String email = "new@test.com";
+        UpdateUserInfoCommand command = UpdateUserInfoCommand.builder()
+                .password(password)
+                .email(email)
+                .build();
+        User user = mock(User.class);
+
+        when(getUserUseCase.getUser(id)).thenReturn(user);
+
+        // when
+        updateUserService.updateUserInfo(false, id, command);
+
+        // then
+        verify(getUserUseCase).getUser(id);
+        verify(user).updatePassword(password, passwordEncoder);
+        verify(user, never()).validateDifferentEmail(anyString());
+        verify(user, never()).updateEmail(anyString());
+        verify(updateUserPort).update(user);
+        verifyNoMoreInteractions(getUserUseCase, user, updateUserPort);
+        verifyNoInteractions(findUserPort);
+    }
+
+    @Test
+    @DisplayName("회원 이메일 주소 변경 요청 시 회원 도메인의 이메일 주소를 갱신한다")
+    void updateUserInfo_updatesEmail() {
+        // given
+        Long id = 6L;
+        String email = "new@test.com";
+        UpdateUserInfoCommand command = UpdateUserInfoCommand.builder()
+                .email(email)
+                .build();
+        User user = mock(User.class);
+
+        when(getUserUseCase.getUser(id)).thenReturn(user);
+        when(findUserPort.existsByEmail(email)).thenReturn(false);
+
+        // when
+        updateUserService.updateUserInfo(false, id, command);
+
+        // then
+        verify(getUserUseCase).getUser(id);
+        verify(user).validateDifferentEmail(email);
+        verify(findUserPort).existsByEmail(email);
+        verify(user).updateEmail(email);
+        verify(updateUserPort).update(user);
+        verifyNoMoreInteractions(getUserUseCase, user, updateUserPort);
+        verifyNoMoreInteractions(findUserPort);
+    }
+
+    @Test
+    @DisplayName("이미 사용 중인 이메일 주소를 등록 시도하면 예외를 던진다")
+    void updateUserInfo_duplicateEmail_throws() {
+        // given
+        Long id = 7L;
+        String email = "dup@test.com";
+        UpdateUserInfoCommand command = UpdateUserInfoCommand.builder()
+                .email(email)
+                .build();
+        User user = mock(User.class);
+
+        when(getUserUseCase.getUser(id)).thenReturn(user);
+        when(findUserPort.existsByEmail(email)).thenReturn(true);
+
+        // expect
+        assertThatThrownBy(() -> updateUserService.updateUserInfo(false, id, command))
+                .isInstanceOf(UserExistsException.class)
+                .hasMessage(String.format(EMAIL_ALREADY_EXISTS_EXCEPTION_MESSAGE, FOURTH_ERROR_CODE, email));
+
+        verify(getUserUseCase).getUser(id);
+        verify(user).validateDifferentEmail(email);
+        verify(findUserPort).existsByEmail(email);
+        verify(user, never()).updateEmail(anyString());
+        verifyNoInteractions(updateUserPort);
+        verifyNoMoreInteractions(getUserUseCase, user, findUserPort);
+    }
+
+    @Test
+    @DisplayName("회원 닉네임 변경 요청 시 회원 도메인의 닉네임을 갱신한다")
+    void updateUserInfo_updatesNickname() {
+        // given
+        Long id = 8L;
+        String nickname = "new-nick";
+        UpdateUserInfoCommand command = UpdateUserInfoCommand.builder()
+                .nickname(nickname)
+                .build();
+        User user = mock(User.class);
+
+        when(getUserUseCase.getUser(id)).thenReturn(user);
+        when(findUserPort.existsByNickname(nickname)).thenReturn(false);
+
+        // when
+        updateUserService.updateUserInfo(false, id, command);
+
+        // then
+        verify(getUserUseCase).getUser(id);
+        verify(user).validateDifferentNickname(nickname);
+        verify(findUserPort).existsByNickname(nickname);
+        verify(user).updateNickname(nickname);
+        verify(updateUserPort).update(user);
+        verifyNoMoreInteractions(getUserUseCase, user, updateUserPort);
+        verifyNoMoreInteractions(findUserPort);
+    }
+
+    @Test
+    @DisplayName("이미 사용 중인 닉네임을 등록 시도하면 예외를 던진다")
+    void updateUserInfo_duplicateNickname_throws() {
+        // given
+        Long id = 9L;
+        String nickname = "dup-nick";
+        UpdateUserInfoCommand command = UpdateUserInfoCommand.builder()
+                .nickname(nickname)
+                .build();
+        User user = mock(User.class);
+
+        when(getUserUseCase.getUser(id)).thenReturn(user);
+        when(findUserPort.existsByNickname(nickname)).thenReturn(true);
+
+        // expect
+        assertThatThrownBy(() -> updateUserService.updateUserInfo(false, id, command))
+                .isInstanceOf(UserExistsException.class)
+                .hasMessage(String.format(NICKNAME_ALREADY_EXISTS_EXCEPTION_MESSAGE, FIFTH_ERROR_CODE, nickname));
+
+        verify(getUserUseCase).getUser(id);
+        verify(user).validateDifferentNickname(nickname);
+        verify(findUserPort).existsByNickname(nickname);
+        verify(user, never()).updateNickname(anyString());
+        verifyNoInteractions(updateUserPort);
+        verifyNoMoreInteractions(getUserUseCase, user, findUserPort);
+    }
+
+    @Test
+    @DisplayName("회원 전화번호 변경 요청 시 회원 도메인의 전화번호를 갱신한다")
+    void updateUserInfo_updatesPhoneNumber() {
+        // given
+        Long id = 10L;
+        String phoneNumber = "010-1111-2222";
+        UpdateUserInfoCommand command = UpdateUserInfoCommand.builder()
+                .phoneNumber(phoneNumber)
+                .build();
+        User user = mock(User.class);
+
+        when(getUserUseCase.getUser(id)).thenReturn(user);
+        when(findUserPort.existsByPhoneNumber(phoneNumber)).thenReturn(false);
+
+        // when
+        updateUserService.updateUserInfo(false, id, command);
+
+        // then
+        verify(getUserUseCase).getUser(id);
+        verify(user).validateDifferentPhoneNumber(phoneNumber);
+        verify(findUserPort).existsByPhoneNumber(phoneNumber);
+        verify(user).updatePhoneNumber(phoneNumber);
+        verify(updateUserPort).update(user);
+        verifyNoMoreInteractions(getUserUseCase, user, updateUserPort);
+        verifyNoMoreInteractions(findUserPort);
+    }
+
+    @Test
+    @DisplayName("이미 사용 중인 전화번호를 등록 시도하면 예외를 던진다")
+    void updateUserInfo_duplicatePhoneNumber_throws() {
+        // given
+        Long id = 11L;
+        String phoneNumber = "010-3333-4444";
+        UpdateUserInfoCommand command = UpdateUserInfoCommand.builder()
+                .phoneNumber(phoneNumber)
+                .build();
+        User user = mock(User.class);
+
+        when(getUserUseCase.getUser(id)).thenReturn(user);
+        when(findUserPort.existsByPhoneNumber(phoneNumber)).thenReturn(true);
+
+        // expect
+        assertThatThrownBy(() -> updateUserService.updateUserInfo(false, id, command))
+                .isInstanceOf(UserExistsException.class)
+                .hasMessage(String.format(PHONE_NUMBER_ALREADY_EXISTS_EXCEPTION_MESSAGE, SIXTH_ERROR_CODE, phoneNumber));
+
+        verify(getUserUseCase).getUser(id);
+        verify(user).validateDifferentPhoneNumber(phoneNumber);
+        verify(findUserPort).existsByPhoneNumber(phoneNumber);
+        verify(user, never()).updatePhoneNumber(anyString());
+        verifyNoInteractions(updateUserPort);
+        verifyNoMoreInteractions(getUserUseCase, user, findUserPort);
+    }
+
+    @Test
+    @DisplayName("회원 조회 요청 시 회원이 존재하지 않는 경우 예외를 던진다")
+    void updateUserInfo_userNotFound_throws() {
+        // given
+        Long id = 12L;
+        UpdateUserInfoCommand command = UpdateUserInfoCommand.builder()
+                .email("user@test.com")
+                .build();
+        UserNotFoundException exception = new UserNotFoundException("not found");
+
+        when(getUserUseCase.getUser(id)).thenThrow(exception);
+
+        // expect
+        assertThatThrownBy(() -> updateUserService.updateUserInfo(false, id, command))
+                .isSameAs(exception);
+
+        verify(getUserUseCase).getUser(id);
+        verifyNoMoreInteractions(getUserUseCase);
+        verifyNoInteractions(findUserPort, updateUserPort, passwordEncoder);
+    }
+}

--- a/user-service/user-application/src/test/java/com/personal/marketnote/user/service/user/WithdrawUseCaseTest.java
+++ b/user-service/user-application/src/test/java/com/personal/marketnote/user/service/user/WithdrawUseCaseTest.java
@@ -1,0 +1,242 @@
+package com.personal.marketnote.user.service.user;
+
+import com.personal.marketnote.common.exception.UserNotFoundException;
+import com.personal.marketnote.user.domain.user.User;
+import com.personal.marketnote.user.port.in.result.WithdrawResult;
+import com.personal.marketnote.user.port.in.usecase.user.GetUserUseCase;
+import com.personal.marketnote.user.port.out.oauth.Oauth2AccountUnlinkPort;
+import com.personal.marketnote.user.port.out.user.UpdateUserPort;
+import com.personal.marketnote.user.service.exception.UnlinkOauth2AccountFailedException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class WithdrawUseCaseTest {
+    @Mock
+    private GetUserUseCase getUserUseCase;
+    @Mock
+    private UpdateUserPort updateUserPort;
+    @Mock
+    private Oauth2AccountUnlinkPort oauth2AccountUnlinkPort;
+
+    @InjectMocks
+    private WithdrawService withdrawService;
+
+    @Test
+    @DisplayName("회원 탈퇴 요청 시 소셜 계정이 없으면 모두 연결 해제된 상태로 반환한다")
+    void withdrawUser_withoutSocialAccounts_returnsAllTrue() {
+        // given
+        Long id = 1L;
+        User user = mock(User.class);
+
+        when(getUserUseCase.getAllStatusUser(id)).thenReturn(user);
+
+        // when
+        WithdrawResult result = withdrawService.withdrawUser(id, null);
+
+        // then
+        assertThat(result.isKakaoDisconnected()).isTrue();
+        assertThat(result.isGoogleDisconnected()).isTrue();
+        assertThat(result.isAppleDisconnected()).isTrue();
+
+        verify(getUserUseCase).getAllStatusUser(id);
+        verify(user).withdraw();
+        verify(user, never()).removeKakaoOidcId();
+        verify(user, never()).removeGoogleOidcId();
+        verify(user, never()).removeAppleOidcId();
+        verify(updateUserPort).update(user);
+        verifyNoMoreInteractions(getUserUseCase, updateUserPort);
+        verifyNoInteractions(oauth2AccountUnlinkPort);
+    }
+
+    @Test
+    @DisplayName("회원 탈퇴 요청 시 카카오 계정이 있으면 연결 해제 후 결과를 반환한다")
+    void withdrawUser_kakaoUnlinkSuccess_returnsKakaoTrue() throws Exception {
+        // given
+        Long id = 2L;
+        String kakaoOidcId = "kakao-oidc";
+        User user = mock(User.class);
+
+        when(getUserUseCase.getAllStatusUser(id)).thenReturn(user);
+        when(user.getKakaoOidcId()).thenReturn(kakaoOidcId);
+
+        // when
+        WithdrawResult result = withdrawService.withdrawUser(id, null);
+
+        // then
+        assertThat(result.isKakaoDisconnected()).isTrue();
+        assertThat(result.isGoogleDisconnected()).isTrue();
+        assertThat(result.isAppleDisconnected()).isTrue();
+
+        verify(getUserUseCase).getAllStatusUser(id);
+        verify(user).withdraw();
+        verify(oauth2AccountUnlinkPort).unlinkKakaoAccount(kakaoOidcId);
+        verify(user).removeKakaoOidcId();
+        verify(updateUserPort).update(user);
+        verifyNoMoreInteractions(getUserUseCase, updateUserPort, oauth2AccountUnlinkPort);
+    }
+
+    @Test
+    @DisplayName("회원 탈퇴 요청 시 카카오 연결 해제에 실패해도 예외를 전파하지 않는다")
+    void withdrawUser_kakaoUnlinkFails_returnsKakaoFalse() throws Exception {
+        // given
+        Long id = 3L;
+        String kakaoOidcId = "kakao-oidc";
+        User user = mock(User.class);
+        UnlinkOauth2AccountFailedException exception = new UnlinkOauth2AccountFailedException("fail");
+
+        when(getUserUseCase.getAllStatusUser(id)).thenReturn(user);
+        when(user.getKakaoOidcId()).thenReturn(kakaoOidcId);
+        doThrow(exception).when(oauth2AccountUnlinkPort).unlinkKakaoAccount(kakaoOidcId);
+
+        // when
+        WithdrawResult result = withdrawService.withdrawUser(id, null);
+
+        // then
+        assertThat(result.isKakaoDisconnected()).isFalse();
+        assertThat(result.isGoogleDisconnected()).isTrue();
+        assertThat(result.isAppleDisconnected()).isTrue();
+
+        verify(getUserUseCase).getAllStatusUser(id);
+        verify(user).withdraw();
+        verify(oauth2AccountUnlinkPort).unlinkKakaoAccount(kakaoOidcId);
+        verify(user).removeKakaoOidcId();
+        verify(updateUserPort).update(user);
+        verifyNoMoreInteractions(getUserUseCase, updateUserPort, oauth2AccountUnlinkPort);
+    }
+
+    @Test
+    @DisplayName("회원 탈퇴 요청 시 구글 계정이 있고 토큰이 있으면 연결 해제 후 결과를 반환한다")
+    void withdrawUser_googleUnlinkSuccess_returnsGoogleTrue() throws Exception {
+        // given
+        Long id = 4L;
+        String googleAccessToken = "google-token";
+        User user = mock(User.class);
+
+        when(getUserUseCase.getAllStatusUser(id)).thenReturn(user);
+        when(user.hasGoogleAccount()).thenReturn(true);
+
+        // when
+        WithdrawResult result = withdrawService.withdrawUser(id, googleAccessToken);
+
+        // then
+        assertThat(result.isKakaoDisconnected()).isTrue();
+        assertThat(result.isGoogleDisconnected()).isTrue();
+        assertThat(result.isAppleDisconnected()).isTrue();
+
+        verify(getUserUseCase).getAllStatusUser(id);
+        verify(user).withdraw();
+        verify(oauth2AccountUnlinkPort).unlinkGoogleAccount(googleAccessToken);
+        verify(user).removeGoogleOidcId();
+        verify(updateUserPort).update(user);
+        verifyNoMoreInteractions(getUserUseCase, updateUserPort, oauth2AccountUnlinkPort);
+    }
+
+    @Test
+    @DisplayName("회원 탈퇴 요청 시 구글 계정이 있지만 토큰이 없으면 연결 해제 결과가 실패로 반환된다")
+    void withdrawUser_googleTokenMissing_returnsGoogleFalse() throws Exception {
+        // given
+        Long id = 5L;
+        User user = mock(User.class);
+
+        when(getUserUseCase.getAllStatusUser(id)).thenReturn(user);
+        when(user.hasGoogleAccount()).thenReturn(true);
+
+        // when
+        WithdrawResult result = withdrawService.withdrawUser(id, null);
+
+        // then
+        assertThat(result.isKakaoDisconnected()).isTrue();
+        assertThat(result.isGoogleDisconnected()).isFalse();
+        assertThat(result.isAppleDisconnected()).isTrue();
+
+        verify(getUserUseCase).getAllStatusUser(id);
+        verify(user).withdraw();
+        verify(oauth2AccountUnlinkPort, never()).unlinkGoogleAccount(anyString());
+        verify(user).removeGoogleOidcId();
+        verify(updateUserPort).update(user);
+        verifyNoMoreInteractions(getUserUseCase, updateUserPort, oauth2AccountUnlinkPort);
+    }
+
+    @Test
+    @DisplayName("회원 탈퇴 요청 시 구글 연결 해제에 실패해도 예외를 전파하지 않는다")
+    void withdrawUser_googleUnlinkFails_returnsGoogleFalse() throws Exception {
+        // given
+        Long id = 6L;
+        String googleAccessToken = "google-token";
+        User user = mock(User.class);
+        UnlinkOauth2AccountFailedException exception = new UnlinkOauth2AccountFailedException("fail");
+
+        when(getUserUseCase.getAllStatusUser(id)).thenReturn(user);
+        when(user.hasGoogleAccount()).thenReturn(true);
+        doThrow(exception).when(oauth2AccountUnlinkPort).unlinkGoogleAccount(googleAccessToken);
+
+        // when
+        WithdrawResult result = withdrawService.withdrawUser(id, googleAccessToken);
+
+        // then
+        assertThat(result.isKakaoDisconnected()).isTrue();
+        assertThat(result.isGoogleDisconnected()).isFalse();
+        assertThat(result.isAppleDisconnected()).isTrue();
+
+        verify(getUserUseCase).getAllStatusUser(id);
+        verify(user).withdraw();
+        verify(oauth2AccountUnlinkPort).unlinkGoogleAccount(googleAccessToken);
+        verify(user).removeGoogleOidcId();
+        verify(updateUserPort).update(user);
+        verifyNoMoreInteractions(getUserUseCase, updateUserPort, oauth2AccountUnlinkPort);
+    }
+
+    @Test
+    @DisplayName("회원 탈퇴 요청 시 애플 계정이 있으면 연결 해제 결과가 실패로 반환된다")
+    void withdrawUser_appleAccount_returnsAppleFalse() {
+        // given
+        Long id = 7L;
+        User user = mock(User.class);
+
+        when(getUserUseCase.getAllStatusUser(id)).thenReturn(user);
+        when(user.hasAppleAccount()).thenReturn(true);
+
+        // when
+        WithdrawResult result = withdrawService.withdrawUser(id, null);
+
+        // then
+        assertThat(result.isKakaoDisconnected()).isTrue();
+        assertThat(result.isGoogleDisconnected()).isTrue();
+        assertThat(result.isAppleDisconnected()).isFalse();
+
+        verify(getUserUseCase).getAllStatusUser(id);
+        verify(user).withdraw();
+        verify(user).removeAppleOidcId();
+        verify(updateUserPort).update(user);
+        verifyNoMoreInteractions(getUserUseCase, updateUserPort);
+        verifyNoInteractions(oauth2AccountUnlinkPort);
+    }
+
+    @Test
+    @DisplayName("회원 탈퇴 요청 시 회원 조회에 실패하면 예외를 던진다")
+    void withdrawUser_userNotFound_throws() {
+        // given
+        Long id = 8L;
+        UserNotFoundException exception = new UserNotFoundException("not found");
+
+        when(getUserUseCase.getAllStatusUser(id)).thenThrow(exception);
+
+        // expect
+        assertThatThrownBy(() -> withdrawService.withdrawUser(id, "token"))
+                .isSameAs(exception);
+
+        verify(getUserUseCase).getAllStatusUser(id);
+        verifyNoMoreInteractions(getUserUseCase);
+        verifyNoInteractions(updateUserPort, oauth2AccountUnlinkPort);
+    }
+}


### PR DESCRIPTION
## partially addresses #475
## resolves #511

## Task
- [x] 파스토 고객사 출고처 등록 연동 요청
- [x] 파스토 고객사 출고처 등록 연동 비즈니스 로직
- [x] 파스토 서버에 고객사 출고처 등록 요청
- [x] 201 status code 응답
- [x] Swagger docs