### PR TITLE
[#475][#513] feat: 파스토 출고처 수정 연동 기능 추가

### DIFF
--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/FasstoWarehouseController.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/FasstoWarehouseController.java
@@ -3,14 +3,19 @@ package com.personal.marketnote.fulfillment.adapter.in.web.vendor.controller;
 import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
 import com.personal.marketnote.fulfillment.adapter.in.web.vendor.controller.apidocs.GetFasstoWarehousesApiDocs;
 import com.personal.marketnote.fulfillment.adapter.in.web.vendor.controller.apidocs.RegisterFasstoWarehouseApiDocs;
+import com.personal.marketnote.fulfillment.adapter.in.web.vendor.controller.apidocs.UpdateFasstoWarehouseApiDocs;
 import com.personal.marketnote.fulfillment.adapter.in.web.vendor.mapper.FasstoWarehouseRequestToCommandMapper;
 import com.personal.marketnote.fulfillment.adapter.in.web.vendor.request.RegisterFasstoWarehouseRequest;
+import com.personal.marketnote.fulfillment.adapter.in.web.vendor.request.UpdateFasstoWarehouseRequest;
 import com.personal.marketnote.fulfillment.adapter.in.web.vendor.response.FasstoWarehouseRegisterResponse;
+import com.personal.marketnote.fulfillment.adapter.in.web.vendor.response.FasstoWarehouseUpdateResponse;
 import com.personal.marketnote.fulfillment.adapter.in.web.vendor.response.GetFasstoWarehousesResponse;
 import com.personal.marketnote.fulfillment.port.in.result.vendor.GetFasstoWarehousesResult;
 import com.personal.marketnote.fulfillment.port.in.result.vendor.RegisterFasstoWarehouseResult;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.UpdateFasstoWarehouseResult;
 import com.personal.marketnote.fulfillment.port.in.usecase.vendor.GetFasstoWarehousesUseCase;
 import com.personal.marketnote.fulfillment.port.in.usecase.vendor.RegisterFasstoWarehouseUseCase;
+import com.personal.marketnote.fulfillment.port.in.usecase.vendor.UpdateFasstoWarehouseUseCase;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -29,6 +34,7 @@ import static com.personal.marketnote.common.utility.ApiConstant.ADMIN_POINTCUT;
 public class FasstoWarehouseController {
     private final RegisterFasstoWarehouseUseCase registerFasstoWarehouseUseCase;
     private final GetFasstoWarehousesUseCase getFasstoWarehousesUseCase;
+    private final UpdateFasstoWarehouseUseCase updateFasstoWarehouseUseCase;
 
     /**
      * (관리자) 파스토 출고처 등록 요청
@@ -89,6 +95,39 @@ public class FasstoWarehouseController {
                         HttpStatus.OK,
                         DEFAULT_SUCCESS_CODE,
                         "파스토 출고처 목록 조회 성공"
+                ),
+                HttpStatus.OK
+        );
+    }
+
+    /**
+     * (관리자) 파스토 출고처 수정 요청
+     *
+     * @param customerCode 파스토 고객사 코드
+     * @param accessToken  파스토 액세스 토큰
+     * @param request      출고처 수정 요청 정보
+     * @Author 성효빈
+     * @Date 2026-01-25
+     * @Description 파스토 출고처를 수정합니다.
+     */
+    @PutMapping("/{customerCode}")
+    @PreAuthorize(ADMIN_POINTCUT)
+    @UpdateFasstoWarehouseApiDocs
+    public ResponseEntity<BaseResponse<FasstoWarehouseUpdateResponse>> updateWarehouse(
+            @PathVariable String customerCode,
+            @RequestHeader("accessToken") String accessToken,
+            @Valid @RequestBody UpdateFasstoWarehouseRequest request
+    ) {
+        UpdateFasstoWarehouseResult result = updateFasstoWarehouseUseCase.updateWarehouse(
+                FasstoWarehouseRequestToCommandMapper.mapToUpdateCommand(customerCode, accessToken, request)
+        );
+
+        return new ResponseEntity<>(
+                BaseResponse.of(
+                        FasstoWarehouseUpdateResponse.from(result),
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "파스토 출고처 수정 성공"
                 ),
                 HttpStatus.OK
         );

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/apidocs/UpdateFasstoWarehouseApiDocs.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/apidocs/UpdateFasstoWarehouseApiDocs.java
@@ -1,0 +1,197 @@
+package com.personal.marketnote.fulfillment.adapter.in.web.vendor.controller.apidocs;
+
+import com.personal.marketnote.fulfillment.adapter.in.web.vendor.request.UpdateFasstoWarehouseRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Operation(
+        summary = "(관리자) 파스토 출고처 수정 요청",
+        description = """
+                작성일자: 2026-01-26
+                
+                작성자: 성효빈
+                
+                ---
+                
+                ## Description
+                
+                파스토 출고처 정보를 수정합니다.
+                
+                ---
+                
+                ## Request
+                
+                | **키** | **위치** | **타입** | **설명** | **필수 여부** | **예시** |
+                | --- | --- | --- | --- | --- | --- |
+                | accessToken | header | string | 파스토 액세스 토큰 | Y | 85352dc5e54811f0be620ab49498ff55 |
+                | customerCode | path | string | 파스토 고객사 코드 | Y | 94388 |
+                
+                ---
+                
+                ## Request Body
+                
+                | **키** | **타입** | **설명** | **필수 여부** | **예시** |
+                | --- | --- | --- | --- | --- |
+                | shopCd | string | 출고처 코드(수정 시 필수) | Y | "94388001" |
+                | shopNm | string | 출고처명 | Y | "테스트 창고1" |
+                | cstShopCd | string | 고객사 출고처 코드 | N | "" |
+                | dealStrDt | string | 거래 시작일자 | N | "" |
+                | dealEndDt | string | 거래 종료일자 | N | "" |
+                | zipNo | string | 우편번호 | N | "12345" |
+                | addr1 | string | 주소1 | N | "서울특별시 양천구 목동동로 123 132동 101호" |
+                | addr2 | string | 주소2 | N | "서울특별시 양천구 목동동로 123 132동 102호" |
+                | ceoNm | string | 대표자명 | N | "홍길동" |
+                | busNo | string | 사업자번호 | N | "1234567" |
+                | telNo | string | 전화번호 | N | "01012345678" |
+                | unloadWay | string | 하차방식(01: 지게차, 02: 수작업) | N | "02" |
+                | checkWay | string | 검수방식(01: 전수검수, 02: 샘플검수) | N | "02" |
+                | standYn | string | 대기여부 | N | "N" |
+                | formType | string | 거래명세서 양식(STDF001: 택배기본, STDF002: 차량기본) | N | "STDF001" |
+                | empNm | string | 담당자명 | N | "서영락" |
+                | empPosit | string | 담당자직위 | N | "대리" |
+                | empTelNo | string | 담당자전화번호 | N | "01012345678" |
+                | useYn | string | 사용여부 | N | "Y" |
+                
+                ---
+                
+                ## Response
+                
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | statusCode | number | 상태 코드 | 200: 성공 / 400: 클라이언트 요청 오류 / 401: 인증 실패 / 403: 인가 실패 / 500: 그 외 |
+                | code | string | 응답 코드 | "SUC01" / "BAD_REQUEST" / "UNAUTHORIZED" / "FORBIDDEN" / "INTERNAL_SERVER_ERROR" |
+                | timestamp | string(datetime) | 응답 일시 | "2025-01-02T12:12:30.013" |
+                | content | object | 응답 본문 | { ... } |
+                | message | string | 처리 결과 | "파스토 출고처 수정 성공" |
+                
+                ---
+                
+                ### Response > content
+                
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | shopInfo | object | 출고처 수정 결과 | { ... } |
+                
+                ---
+                
+                ### Response > content > shopInfo
+                
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | msg | string | 처리 결과 | "SUCCESS" |
+                | code | string | 응답 코드 | "200" |
+                | shopCd | string | 출고처 코드 | "94388001" |
+                """,
+        security = {@SecurityRequirement(name = "bearer")},
+        parameters = {
+                @Parameter(
+                        name = "accessToken",
+                        description = "파스토 액세스 토큰",
+                        in = ParameterIn.HEADER,
+                        required = true,
+                        schema = @Schema(type = "string", example = "85352dc5e54811f0be620ab49498ff55")
+                ),
+                @Parameter(
+                        name = "customerCode",
+                        description = "파스토 고객사 코드",
+                        in = ParameterIn.PATH,
+                        required = true,
+                        schema = @Schema(type = "string", example = "94388")
+                )
+        },
+        requestBody = @RequestBody(
+                required = true,
+                content = @Content(
+                        schema = @Schema(implementation = UpdateFasstoWarehouseRequest.class),
+                        examples = @ExampleObject("""
+                                {
+                                  "shopCd": "94388001",
+                                  "shopNm": "테스트 창고1",
+                                  "cstShopCd": "",
+                                  "dealStrDt": "",
+                                  "dealEndDt": "",
+                                  "zipNo": "12345",
+                                  "addr1": "서울특별시 양천구 목동동로 123 132동 101호",
+                                  "addr2": "서울특별시 양천구 목동동로 123 132동 102호",
+                                  "ceoNm": "홍길동",
+                                  "busNo": "1234567",
+                                  "telNo": "01012345678",
+                                  "unloadWay": "02",
+                                  "checkWay": "02",
+                                  "standYn": "N",
+                                  "formType": "STDF001",
+                                  "empNm": "서영락",
+                                  "empPosit": "대리",
+                                  "empTelNo": "01012345678",
+                                  "useYn": "Y"
+                                }
+                                """)
+                )
+        ),
+        responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "파스토 출고처 수정 성공",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 200,
+                                          "code": "SUC01",
+                                          "timestamp": "2026-01-26T10:28:54.060835",
+                                          "content": {
+                                            "shopInfo": {
+                                              "msg": "SUCCESS",
+                                              "code": "200",
+                                              "shopCd": "94388007"
+                                            }
+                                          },
+                                          "message": "파스토 출고처 수정 성공"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "401",
+                        description = "토큰 인증 실패",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 401,
+                                          "code": "UNAUTHORIZED",
+                                          "timestamp": "2025-01-02T10:12:30.013",
+                                          "content": null,
+                                          "message": "Invalid token"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "403",
+                        description = "토큰 인가 실패",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 403,
+                                          "code": "FORBIDDEN",
+                                          "timestamp": "2025-01-02T10:12:30.013",
+                                          "content": null,
+                                          "message": "Access Denied"
+                                        }
+                                        """)
+                        )
+                )
+        })
+public @interface UpdateFasstoWarehouseApiDocs {
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/mapper/FasstoWarehouseRequestToCommandMapper.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/mapper/FasstoWarehouseRequestToCommandMapper.java
@@ -1,8 +1,10 @@
 package com.personal.marketnote.fulfillment.adapter.in.web.vendor.mapper;
 
 import com.personal.marketnote.fulfillment.adapter.in.web.vendor.request.RegisterFasstoWarehouseRequest;
+import com.personal.marketnote.fulfillment.adapter.in.web.vendor.request.UpdateFasstoWarehouseRequest;
 import com.personal.marketnote.fulfillment.port.in.command.vendor.GetFasstoWarehousesCommand;
 import com.personal.marketnote.fulfillment.port.in.command.vendor.RegisterFasstoWarehouseCommand;
+import com.personal.marketnote.fulfillment.port.in.command.vendor.UpdateFasstoWarehouseCommand;
 
 public class FasstoWarehouseRequestToCommandMapper {
     public static RegisterFasstoWarehouseCommand mapToRegisterCommand(
@@ -39,5 +41,35 @@ public class FasstoWarehouseRequestToCommandMapper {
             String accessToken
     ) {
         return GetFasstoWarehousesCommand.of(customerCode, accessToken);
+    }
+
+    public static UpdateFasstoWarehouseCommand mapToUpdateCommand(
+            String customerCode,
+            String accessToken,
+            UpdateFasstoWarehouseRequest request
+    ) {
+        return UpdateFasstoWarehouseCommand.of(
+                customerCode,
+                accessToken,
+                request.getShopCd(),
+                request.getShopNm(),
+                request.getCstShopCd(),
+                request.getDealStrDt(),
+                request.getDealEndDt(),
+                request.getZipNo(),
+                request.getAddr1(),
+                request.getAddr2(),
+                request.getCeoNm(),
+                request.getBusNo(),
+                request.getTelNo(),
+                request.getUnloadWay(),
+                request.getCheckWay(),
+                request.getStandYn(),
+                request.getFormType(),
+                request.getEmpNm(),
+                request.getEmpPosit(),
+                request.getEmpTelNo(),
+                request.getUseYn()
+        );
     }
 }

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/request/UpdateFasstoWarehouseRequest.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/request/UpdateFasstoWarehouseRequest.java
@@ -1,0 +1,143 @@
+package com.personal.marketnote.fulfillment.adapter.in.web.vendor.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+import lombok.Getter;
+
+@Getter
+public class UpdateFasstoWarehouseRequest {
+    @Schema(
+            name = "shopCd",
+            description = "출고처 코드(수정 시 필수)",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    @NotEmpty(message = "출고처 코드는 필수값입니다.")
+    private String shopCd;
+
+    @Schema(
+            name = "shopNm",
+            description = "출고처명",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    @NotEmpty(message = "출고처명은 필수값입니다.")
+    private String shopNm;
+
+    @Schema(
+            name = "cstShopCd",
+            description = "고객사 출고처 코드(없으면 자동 생성)",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String cstShopCd;
+
+    @Schema(
+            name = "dealStrDt",
+            description = "거래 시작일자",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String dealStrDt;
+
+    @Schema(
+            name = "dealEndDt",
+            description = "거래 종료일자",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String dealEndDt;
+
+    @Schema(
+            name = "zipNo",
+            description = "우편번호",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String zipNo;
+
+    @Schema(
+            name = "addr1",
+            description = "주소1",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String addr1;
+
+    @Schema(
+            name = "addr2",
+            description = "주소2",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String addr2;
+
+    @Schema(
+            name = "ceoNm",
+            description = "대표자명",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String ceoNm;
+
+    @Schema(
+            name = "busNo",
+            description = "사업자번호",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String busNo;
+
+    @Schema(
+            name = "telNo",
+            description = "전화번호",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String telNo;
+
+    @Schema(
+            name = "unloadWay",
+            description = "하차방식(01: 지게차, 02: 수작업)",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String unloadWay;
+
+    @Schema(
+            name = "checkWay",
+            description = "검수방식(01: 전수검수, 02: 샘플검수)",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String checkWay;
+
+    @Schema(
+            name = "standYn",
+            description = "대기여부",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String standYn;
+
+    @Schema(
+            name = "formType",
+            description = "거래명세서 양식(STDF001: 택배기본, STDF002: 차량기본)",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String formType;
+
+    @Schema(
+            name = "empNm",
+            description = "담당자명",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String empNm;
+
+    @Schema(
+            name = "empPosit",
+            description = "담당자 직위",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String empPosit;
+
+    @Schema(
+            name = "empTelNo",
+            description = "담당자 전화번호",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String empTelNo;
+
+    @Schema(
+            name = "useYn",
+            description = "사용 여부",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String useYn;
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/response/FasstoWarehouseUpdateResponse.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/response/FasstoWarehouseUpdateResponse.java
@@ -1,0 +1,11 @@
+package com.personal.marketnote.fulfillment.adapter.in.web.vendor.response;
+
+import com.personal.marketnote.fulfillment.port.in.result.vendor.UpdateFasstoWarehouseResult;
+
+public record FasstoWarehouseUpdateResponse(
+        UpdateFasstoWarehouseResult shopInfo
+) {
+    public static FasstoWarehouseUpdateResponse from(UpdateFasstoWarehouseResult shopInfo) {
+        return new FasstoWarehouseUpdateResponse(shopInfo);
+    }
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/client/FasstoAuthClient.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/client/FasstoAuthClient.java
@@ -1,4 +1,4 @@
-package com.personal.marketnote.fulfillment.adapter.out.vendor.fassto;
+package com.personal.marketnote.fulfillment.adapter.out.vendor.fassto.client;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.personal.marketnote.common.adapter.out.VendorAdapter;
@@ -328,7 +328,7 @@ public class FasstoAuthClient implements RequestFasstoAuthPort, DisconnectFassto
             payload.put("status", response.getStatusCode().value());
         }
 
-        FasstoAuthResponse body = response != null ? response.getBody() : null;
+        FasstoAuthResponse body = FormatValidator.hasValue(response) ? response.getBody() : null;
         if (FormatValidator.hasValue(body) && FormatValidator.hasValue(body.header())) {
             payload.put("code", body.header().code());
             payload.put("message", body.header().msg());

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/UpdateFasstoWarehouseFailedException.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/UpdateFasstoWarehouseFailedException.java
@@ -1,0 +1,14 @@
+package com.personal.marketnote.fulfillment.exception;
+
+import com.personal.marketnote.common.exception.ExternalOperationFailedException;
+
+import java.io.IOException;
+
+public class UpdateFasstoWarehouseFailedException extends ExternalOperationFailedException {
+    private static final String UPDATE_FASSTO_WAREHOUSE_FAILED_EXCEPTION_MESSAGE =
+            "Fassto warehouse update request failed.";
+
+    public UpdateFasstoWarehouseFailedException(IOException cause) {
+        super(UPDATE_FASSTO_WAREHOUSE_FAILED_EXCEPTION_MESSAGE, cause);
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/mapper/FasstoWarehouseCommandToRequestMapper.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/mapper/FasstoWarehouseCommandToRequestMapper.java
@@ -4,6 +4,7 @@ import com.personal.marketnote.fulfillment.domain.vendor.fassto.warehouse.Fassto
 import com.personal.marketnote.fulfillment.domain.vendor.fassto.warehouse.FasstoWarehouseQuery;
 import com.personal.marketnote.fulfillment.port.in.command.vendor.GetFasstoWarehousesCommand;
 import com.personal.marketnote.fulfillment.port.in.command.vendor.RegisterFasstoWarehouseCommand;
+import com.personal.marketnote.fulfillment.port.in.command.vendor.UpdateFasstoWarehouseCommand;
 
 public class FasstoWarehouseCommandToRequestMapper {
     public static FasstoWarehouseMapper mapToRegisterRequest(RegisterFasstoWarehouseCommand command) {
@@ -35,6 +36,32 @@ public class FasstoWarehouseCommandToRequestMapper {
         return FasstoWarehouseQuery.of(
                 command.customerCode(),
                 command.accessToken()
+        );
+    }
+
+    public static FasstoWarehouseMapper mapToUpdateRequest(UpdateFasstoWarehouseCommand command) {
+        return FasstoWarehouseMapper.update(
+                command.customerCode(),
+                command.accessToken(),
+                command.shopCd(),
+                command.shopNm(),
+                command.cstShopCd(),
+                command.dealStrDt(),
+                command.dealEndDt(),
+                command.zipNo(),
+                command.addr1(),
+                command.addr2(),
+                command.ceoNm(),
+                command.busNo(),
+                command.telNo(),
+                command.unloadWay(),
+                command.checkWay(),
+                command.standYn(),
+                command.formType(),
+                command.empNm(),
+                command.empPosit(),
+                command.empTelNo(),
+                command.useYn()
         );
     }
 }

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/vendor/UpdateFasstoWarehouseCommand.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/vendor/UpdateFasstoWarehouseCommand.java
@@ -1,0 +1,73 @@
+package com.personal.marketnote.fulfillment.port.in.command.vendor;
+
+public record UpdateFasstoWarehouseCommand(
+        String customerCode,
+        String accessToken,
+        String shopCd,
+        String shopNm,
+        String cstShopCd,
+        String dealStrDt,
+        String dealEndDt,
+        String zipNo,
+        String addr1,
+        String addr2,
+        String ceoNm,
+        String busNo,
+        String telNo,
+        String unloadWay,
+        String checkWay,
+        String standYn,
+        String formType,
+        String empNm,
+        String empPosit,
+        String empTelNo,
+        String useYn
+) {
+    public static UpdateFasstoWarehouseCommand of(
+            String customerCode,
+            String accessToken,
+            String shopCd,
+            String shopNm,
+            String cstShopCd,
+            String dealStrDt,
+            String dealEndDt,
+            String zipNo,
+            String addr1,
+            String addr2,
+            String ceoNm,
+            String busNo,
+            String telNo,
+            String unloadWay,
+            String checkWay,
+            String standYn,
+            String formType,
+            String empNm,
+            String empPosit,
+            String empTelNo,
+            String useYn
+    ) {
+        return new UpdateFasstoWarehouseCommand(
+                customerCode,
+                accessToken,
+                shopCd,
+                shopNm,
+                cstShopCd,
+                dealStrDt,
+                dealEndDt,
+                zipNo,
+                addr1,
+                addr2,
+                ceoNm,
+                busNo,
+                telNo,
+                unloadWay,
+                checkWay,
+                standYn,
+                formType,
+                empNm,
+                empPosit,
+                empTelNo,
+                useYn
+        );
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/result/vendor/UpdateFasstoWarehouseResult.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/result/vendor/UpdateFasstoWarehouseResult.java
@@ -1,0 +1,11 @@
+package com.personal.marketnote.fulfillment.port.in.result.vendor;
+
+public record UpdateFasstoWarehouseResult(
+        String msg,
+        String code,
+        String shopCd
+) {
+    public static UpdateFasstoWarehouseResult of(String msg, String code, String shopCd) {
+        return new UpdateFasstoWarehouseResult(msg, code, shopCd);
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/usecase/vendor/UpdateFasstoWarehouseUseCase.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/usecase/vendor/UpdateFasstoWarehouseUseCase.java
@@ -1,0 +1,15 @@
+package com.personal.marketnote.fulfillment.port.in.usecase.vendor;
+
+import com.personal.marketnote.fulfillment.port.in.command.vendor.UpdateFasstoWarehouseCommand;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.UpdateFasstoWarehouseResult;
+
+public interface UpdateFasstoWarehouseUseCase {
+    /**
+     * @param command 출고처 수정 커맨드
+     * @return 출고처 수정 결과 {@link UpdateFasstoWarehouseResult}
+     * @Date 2026-01-25
+     * @Author 성효빈
+     * @Description 파스토 출고처를 수정합니다.
+     */
+    UpdateFasstoWarehouseResult updateWarehouse(UpdateFasstoWarehouseCommand command);
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/vendor/UpdateFasstoWarehousePort.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/vendor/UpdateFasstoWarehousePort.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.fulfillment.port.out.vendor;
+
+import com.personal.marketnote.fulfillment.domain.vendor.fassto.warehouse.FasstoWarehouseMapper;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.UpdateFasstoWarehouseResult;
+
+public interface UpdateFasstoWarehousePort {
+    UpdateFasstoWarehouseResult updateWarehouse(FasstoWarehouseMapper request);
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/vendor/UpdateFasstoWarehouseService.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/vendor/UpdateFasstoWarehouseService.java
@@ -1,0 +1,26 @@
+package com.personal.marketnote.fulfillment.service.vendor;
+
+import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.fulfillment.mapper.FasstoWarehouseCommandToRequestMapper;
+import com.personal.marketnote.fulfillment.port.in.command.vendor.UpdateFasstoWarehouseCommand;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.UpdateFasstoWarehouseResult;
+import com.personal.marketnote.fulfillment.port.in.usecase.vendor.UpdateFasstoWarehouseUseCase;
+import com.personal.marketnote.fulfillment.port.out.vendor.UpdateFasstoWarehousePort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional(isolation = READ_COMMITTED, readOnly = true)
+public class UpdateFasstoWarehouseService implements UpdateFasstoWarehouseUseCase {
+    private final UpdateFasstoWarehousePort updateFasstoWarehousePort;
+
+    @Override
+    public UpdateFasstoWarehouseResult updateWarehouse(UpdateFasstoWarehouseCommand command) {
+        return updateFasstoWarehousePort.updateWarehouse(
+                FasstoWarehouseCommandToRequestMapper.mapToUpdateRequest(command)
+        );
+    }
+}

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/warehouse/FasstoWarehouseMapper.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/warehouse/FasstoWarehouseMapper.java
@@ -57,31 +57,77 @@ public class FasstoWarehouseMapper {
             String empTelNo,
             String useYn
     ) {
-        FasstoWarehouseMapper mapper = FasstoWarehouseMapper.builder()
-                .customerCode(customerCode)
-                .accessToken(accessToken)
-                .shopCd(REGISTRATION_MARKETNOTE_CODE)
-                .shopNm(shopNm)
-                .cstShopCd(cstShopCd)
-                .dealStrDt(dealStrDt)
-                .dealEndDt(dealEndDt)
-                .zipNo(zipNo)
-                .addr1(addr1)
-                .addr2(addr2)
-                .ceoNm(ceoNm)
-                .busNo(busNo)
-                .telNo(telNo)
-                .unloadWay(unloadWay)
-                .checkWay(checkWay)
-                .standYn(standYn)
-                .formType(formType)
-                .empNm(empNm)
-                .empPosit(empPosit)
-                .empTelNo(empTelNo)
-                .useYn(useYn)
-                .build();
-        mapper.validate();
-        return mapper;
+        return create(
+                customerCode,
+                accessToken,
+                REGISTRATION_MARKETNOTE_CODE,
+                shopNm,
+                cstShopCd,
+                dealStrDt,
+                dealEndDt,
+                zipNo,
+                addr1,
+                addr2,
+                ceoNm,
+                busNo,
+                telNo,
+                unloadWay,
+                checkWay,
+                standYn,
+                formType,
+                empNm,
+                empPosit,
+                empTelNo,
+                useYn
+        );
+    }
+
+    public static FasstoWarehouseMapper update(
+            String customerCode,
+            String accessToken,
+            String shopCd,
+            String shopNm,
+            String cstShopCd,
+            String dealStrDt,
+            String dealEndDt,
+            String zipNo,
+            String addr1,
+            String addr2,
+            String ceoNm,
+            String busNo,
+            String telNo,
+            String unloadWay,
+            String checkWay,
+            String standYn,
+            String formType,
+            String empNm,
+            String empPosit,
+            String empTelNo,
+            String useYn
+    ) {
+        return create(
+                customerCode,
+                accessToken,
+                shopCd,
+                shopNm,
+                cstShopCd,
+                dealStrDt,
+                dealEndDt,
+                zipNo,
+                addr1,
+                addr2,
+                ceoNm,
+                busNo,
+                telNo,
+                unloadWay,
+                checkWay,
+                standYn,
+                formType,
+                empNm,
+                empPosit,
+                empTelNo,
+                useYn
+        );
     }
 
     public Map<String, Object> toPayload() {
@@ -118,10 +164,10 @@ public class FasstoWarehouseMapper {
             throw new IllegalArgumentException("accessToken is required.");
         }
         if (FormatValidator.hasNoValue(shopCd)) {
-            throw new IllegalArgumentException("shopCd is required for shop registration.");
+            throw new IllegalArgumentException("shopCd is required for warehouse request.");
         }
         if (FormatValidator.hasNoValue(shopNm)) {
-            throw new IllegalArgumentException("shopNm is required for shop registration.");
+            throw new IllegalArgumentException("shopNm is required for warehouse request.");
         }
     }
 
@@ -129,5 +175,55 @@ public class FasstoWarehouseMapper {
         if (FormatValidator.hasValue(value)) {
             payload.put(key, value);
         }
+    }
+
+    private static FasstoWarehouseMapper create(
+            String customerCode,
+            String accessToken,
+            String shopCd,
+            String shopNm,
+            String cstShopCd,
+            String dealStrDt,
+            String dealEndDt,
+            String zipNo,
+            String addr1,
+            String addr2,
+            String ceoNm,
+            String busNo,
+            String telNo,
+            String unloadWay,
+            String checkWay,
+            String standYn,
+            String formType,
+            String empNm,
+            String empPosit,
+            String empTelNo,
+            String useYn
+    ) {
+        FasstoWarehouseMapper mapper = FasstoWarehouseMapper.builder()
+                .customerCode(customerCode)
+                .accessToken(accessToken)
+                .shopCd(shopCd)
+                .shopNm(shopNm)
+                .cstShopCd(cstShopCd)
+                .dealStrDt(dealStrDt)
+                .dealEndDt(dealEndDt)
+                .zipNo(zipNo)
+                .addr1(addr1)
+                .addr2(addr2)
+                .ceoNm(ceoNm)
+                .busNo(busNo)
+                .telNo(telNo)
+                .unloadWay(unloadWay)
+                .checkWay(checkWay)
+                .standYn(standYn)
+                .formType(formType)
+                .empNm(empNm)
+                .empPosit(empPosit)
+                .empTelNo(empTelNo)
+                .useYn(useYn)
+                .build();
+        mapper.validate();
+        return mapper;
     }
 }


### PR DESCRIPTION
## partially addresses #475
## resolves #513

## Task
- [x] 파스토 출고처 수정 연동 요청
- [x] 파스토 출고처 수정 연동 비즈니스 로직
- [x] 파스토 서버에 출고처 수정 요청
- [x] 200 status code 응답
- [x] Swagger docs