### PR TITLE
[#43][#527] test: 회원 이용 약관 동의 여부 목록 조회 기능 자동화 테스트 추가

### DIFF
--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/out/vendor/authentication/WebBasedAuthenticationServiceAdapter.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/out/vendor/authentication/WebBasedAuthenticationServiceAdapter.java
@@ -12,7 +12,7 @@ import com.personal.marketnote.user.adapter.in.web.authentication.response.OAuth
 import com.personal.marketnote.user.adapter.in.web.authentication.response.RefreshedAccessTokenResponse;
 import com.personal.marketnote.user.adapter.in.web.authentication.response.WebBasedTokenRefreshResponse;
 import com.personal.marketnote.user.port.in.result.LoginResult;
-import com.personal.marketnote.user.port.in.usecase.authentication.LoginUseCase;
+import com.personal.marketnote.user.port.in.usecase.authentication.Oauth2LoginUseCase;
 import com.personal.marketnote.user.security.token.dto.GrantedTokenInfo;
 import com.personal.marketnote.user.security.token.support.TokenSupport;
 import com.personal.marketnote.user.security.token.vendor.AuthVendor;
@@ -44,7 +44,7 @@ public class WebBasedAuthenticationServiceAdapter {
     private static final long REFRESH_TOKEN_COOKIE_MAX_AGE = 2592000000L;
     private static final Pattern REDIRECTION_DESTINATION_PATTERN
             = Pattern.compile("^(http|https)://[a-zA-Z0-9]+(\\.[a-zA-Z0-9]+)*(:\\d{1,5})?$");
-    private final LoginUseCase loginUseCase;
+    private final Oauth2LoginUseCase oauth2LoginUseCase;
     private final TokenSupport tokenSupport;
     private final String serverOrigin;
     private final String clientOrigin;
@@ -56,7 +56,7 @@ public class WebBasedAuthenticationServiceAdapter {
     private Long refreshTokenTtlMillis;
 
     public WebBasedAuthenticationServiceAdapter(
-            LoginUseCase loginUseCase,
+            Oauth2LoginUseCase oauth2LoginUseCase,
             TokenSupport tokenSupport,
             @Value("${server.origin}") String serverOrigin,
             @Value("${client.origin}") List<String> clientOrigins,
@@ -64,7 +64,7 @@ public class WebBasedAuthenticationServiceAdapter {
             JwtUtil jwtUtil,
             StringRedisTemplate stringRedisTemplate
     ) {
-        this.loginUseCase = loginUseCase;
+        this.oauth2LoginUseCase = oauth2LoginUseCase;
         this.tokenSupport = tokenSupport;
         this.serverOrigin = serverOrigin;
         this.clientOrigin = clientOrigins.getFirst();
@@ -78,7 +78,7 @@ public class WebBasedAuthenticationServiceAdapter {
         String redirectUri = serverOrigin + servletRequest.getRequestURI();
 
         LoginResult loginResult =
-                loginUseCase.loginByOAuth2(oAuth2LoginRequest.code(), redirectUri, AuthVendor.valueOfIgnoreCase(oAuth2LoginRequest.authVendor()));
+                oauth2LoginUseCase.loginByOAuth2(oAuth2LoginRequest.code(), redirectUri, AuthVendor.valueOfIgnoreCase(oAuth2LoginRequest.authVendor()));
 
         String redirectionDestination = getRedirectionDestination(oAuth2LoginRequest.state());
         log.debug("redirectionDestination={}", redirectionDestination);

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/port/in/usecase/authentication/Oauth2LoginUseCase.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/port/in/usecase/authentication/Oauth2LoginUseCase.java
@@ -4,7 +4,7 @@ import com.personal.marketnote.common.domain.exception.token.UnsupportedCodeExce
 import com.personal.marketnote.user.port.in.result.LoginResult;
 import com.personal.marketnote.user.security.token.vendor.AuthVendor;
 
-public interface LoginUseCase {
+public interface Oauth2LoginUseCase {
     /**
      * @param code        인증 코드
      * @param redirectUri 리다이렉트 URI

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/service/authentication/Oauth2LoginService.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/service/authentication/Oauth2LoginService.java
@@ -6,7 +6,7 @@ import com.personal.marketnote.common.domain.exception.token.UnsupportedCodeExce
 import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.user.domain.user.User;
 import com.personal.marketnote.user.port.in.result.LoginResult;
-import com.personal.marketnote.user.port.in.usecase.authentication.LoginUseCase;
+import com.personal.marketnote.user.port.in.usecase.authentication.Oauth2LoginUseCase;
 import com.personal.marketnote.user.port.out.user.FindUserPort;
 import com.personal.marketnote.user.security.token.dto.GrantedTokenInfo;
 import com.personal.marketnote.user.security.token.dto.OAuth2UserInfo;
@@ -22,7 +22,7 @@ import static org.springframework.transaction.annotation.Isolation.READ_COMMITTE
 @UseCase
 @RequiredArgsConstructor
 @Transactional(isolation = READ_COMMITTED, timeout = 180)
-public class LoginService implements LoginUseCase {
+public class Oauth2LoginService implements Oauth2LoginUseCase {
     private final TokenSupport tokenSupport;
     private final FindUserPort findUserPort;
 

--- a/user-service/user-application/src/test/java/com/personal/marketnote/user/service/terms/GetTermsUseCaseTest.java
+++ b/user-service/user-application/src/test/java/com/personal/marketnote/user/service/terms/GetTermsUseCaseTest.java
@@ -1,8 +1,12 @@
 package com.personal.marketnote.user.service.terms;
 
 import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.exception.UserNotFoundException;
 import com.personal.marketnote.user.domain.user.Terms;
+import com.personal.marketnote.user.domain.user.User;
+import com.personal.marketnote.user.domain.user.UserTerms;
 import com.personal.marketnote.user.port.in.result.GetTermsResult;
+import com.personal.marketnote.user.port.in.result.GetUserTermsResult;
 import com.personal.marketnote.user.port.out.user.FindTermsPort;
 import com.personal.marketnote.user.port.out.user.FindUserPort;
 import org.junit.jupiter.api.DisplayName;
@@ -14,8 +18,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
+import static com.personal.marketnote.user.exception.ExceptionMessage.USER_ID_NOT_FOUND_EXCEPTION_MESSAGE;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -80,5 +87,100 @@ class GetTermsUseCaseTest {
         assertThat(result.getTermResults()).isEmpty();
         verify(findTermsPort).findAll();
         verifyNoMoreInteractions(findTermsPort, findUserPort);
+    }
+
+    @Test
+    @DisplayName("회원 이용 약관 동의 여부 목록을 조회한다")
+    void getUserTerms_success_mapsResults() {
+        // given
+        Long userId = 1L;
+        User user = mock(User.class);
+        Terms terms1 = TermsTestObjectFactory.createTerms(
+                1L,
+                "required-terms",
+                true,
+                LocalDateTime.of(2024, 3, 1, 0, 0),
+                LocalDateTime.of(2024, 3, 2, 0, 0),
+                EntityStatus.ACTIVE
+        );
+        Terms terms2 = TermsTestObjectFactory.createTerms(
+                2L,
+                "optional-terms",
+                false,
+                LocalDateTime.of(2024, 4, 1, 0, 0),
+                LocalDateTime.of(2024, 4, 2, 0, 0),
+                EntityStatus.ACTIVE
+        );
+        UserTerms userTerms1 = TermsTestObjectFactory.createUserTerms(
+                user,
+                terms1,
+                true,
+                LocalDateTime.of(2024, 3, 1, 0, 0),
+                LocalDateTime.of(2024, 3, 2, 0, 0)
+        );
+        UserTerms userTerms2 = TermsTestObjectFactory.createUserTerms(
+                user,
+                terms2,
+                false,
+                LocalDateTime.of(2024, 4, 1, 0, 0),
+                LocalDateTime.of(2024, 4, 2, 0, 0)
+        );
+
+        when(findUserPort.findById(userId)).thenReturn(Optional.of(user));
+        when(user.getUserTerms()).thenReturn(List.of(userTerms1, userTerms2));
+
+        // when
+        GetUserTermsResult result = getTermsService.getUserTerms(userId);
+
+        // then
+        assertThat(result.userTerms()).hasSize(2);
+        assertThat(result.userTerms().get(0).id()).isEqualTo(1L);
+        assertThat(result.userTerms().get(0).content()).isEqualTo("required-terms");
+        assertThat(result.userTerms().get(0).isRequired()).isTrue();
+        assertThat(result.userTerms().get(0).isAgreed()).isTrue();
+        assertThat(result.userTerms().get(1).id()).isEqualTo(2L);
+        assertThat(result.userTerms().get(1).content()).isEqualTo("optional-terms");
+        assertThat(result.userTerms().get(1).isRequired()).isFalse();
+        assertThat(result.userTerms().get(1).isAgreed()).isFalse();
+
+        verify(findUserPort).findById(userId);
+        verify(user).getUserTerms();
+        verifyNoMoreInteractions(findUserPort, findTermsPort, user);
+    }
+
+    @Test
+    @DisplayName("회원 이용 약관 동의 목록이 없으면 빈 리스트를 반환한다")
+    void getUserTerms_empty_returnsEmptyResult() {
+        // given
+        Long userId = 2L;
+        User user = mock(User.class);
+
+        when(findUserPort.findById(userId)).thenReturn(Optional.of(user));
+        when(user.getUserTerms()).thenReturn(List.of());
+
+        // when
+        GetUserTermsResult result = getTermsService.getUserTerms(userId);
+
+        // then
+        assertThat(result.userTerms()).isEmpty();
+        verify(findUserPort).findById(userId);
+        verify(user).getUserTerms();
+        verifyNoMoreInteractions(findUserPort, findTermsPort, user);
+    }
+
+    @Test
+    @DisplayName("회원 이용 약관 동의 목록 조회 대상 회원이 존재하지 않으면 예외를 던진다")
+    void getUserTerms_userNotFound_throws() {
+        // given
+        Long userId = 3L;
+        when(findUserPort.findById(userId)).thenReturn(Optional.empty());
+
+        // expect
+        assertThatThrownBy(() -> getTermsService.getUserTerms(userId))
+                .isInstanceOf(UserNotFoundException.class)
+                .hasMessage(String.format(USER_ID_NOT_FOUND_EXCEPTION_MESSAGE, userId));
+
+        verify(findUserPort).findById(userId);
+        verifyNoMoreInteractions(findUserPort, findTermsPort);
     }
 }

--- a/user-service/user-application/src/test/java/com/personal/marketnote/user/service/terms/TermsTestObjectFactory.java
+++ b/user-service/user-application/src/test/java/com/personal/marketnote/user/service/terms/TermsTestObjectFactory.java
@@ -1,15 +1,11 @@
 package com.personal.marketnote.user.service.terms;
 
 import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
-import com.personal.marketnote.user.domain.user.Terms;
-import com.personal.marketnote.user.domain.user.TermsSnapshotState;
+import com.personal.marketnote.user.domain.user.*;
 
 import java.time.LocalDateTime;
 
-final class TermsTestObjectFactory {
-    private TermsTestObjectFactory() {
-    }
-
+class TermsTestObjectFactory {
     static Terms createTerms(
             Long id,
             String content,
@@ -25,6 +21,22 @@ final class TermsTestObjectFactory {
                 .createdAt(createdAt)
                 .modifiedAt(modifiedAt)
                 .status(status)
+                .build());
+    }
+
+    static UserTerms createUserTerms(
+            User user,
+            Terms terms,
+            boolean agreementYn,
+            LocalDateTime createdAt,
+            LocalDateTime modifiedAt
+    ) {
+        return UserTerms.from(UserTermsSnapshotState.builder()
+                .user(user)
+                .terms(terms)
+                .agreementYn(agreementYn)
+                .createdAt(createdAt)
+                .modifiedAt(modifiedAt)
                 .build());
     }
 }


### PR DESCRIPTION
## partially addresses #43
## resolves #527

## Test Case
- [x] 회원 이용 약관 동의 여부 목록을 조회한다
- [x] 회원 이용 약관 동의 목록이 없으면 빈 리스트를 반환한다
- [x] 회원 이용 약관 동의 목록 조회 대상 회원이 존재하지 않으면 예외를 던진다