### PR TITLE
[#128][#287] feat: 상품 옵션 등록 시 가격 정책 설정 로직 일부 수정

### DIFF
--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/pricepolicy/entity/PricePolicyJpaEntity.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/pricepolicy/entity/PricePolicyJpaEntity.java
@@ -6,6 +6,8 @@ import com.personal.marketnote.product.adapter.out.persistence.productoption.ent
 import com.personal.marketnote.product.domain.pricepolicy.PricePolicy;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
 
 import java.math.BigDecimal;
 import java.util.List;
@@ -15,6 +17,8 @@ import static jakarta.persistence.CascadeType.PERSIST;
 
 @Entity
 @Table(name = "price_policy")
+@DynamicInsert
+@DynamicUpdate
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder(access = AccessLevel.PRIVATE)

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/pricepolicy/repository/PricePolicyJpaRepository.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/pricepolicy/repository/PricePolicyJpaRepository.java
@@ -262,4 +262,10 @@ public interface PricePolicyJpaRepository extends JpaRepository<PricePolicyJpaEn
     List<PricePolicyJpaEntity> findAllWithProductAndOptionMappingsByIdIn(
             @Param("pricePolicyIds") List<Long> pricePolicyIds
     );
+
+    @Query("""
+            DELETE FROM PricePolicyJpaEntity pp
+            WHERE pp.productJpaEntity.id = :productId
+            """)
+    void deleteByProductId(Long productId);
 }

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/productoption/ProductOptionPersistenceAdapter.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/productoption/ProductOptionPersistenceAdapter.java
@@ -16,6 +16,7 @@ import com.personal.marketnote.product.adapter.out.persistence.productoption.rep
 import com.personal.marketnote.product.domain.option.ProductOptionCategory;
 import com.personal.marketnote.product.domain.pricepolicy.PricePolicy;
 import com.personal.marketnote.product.domain.pricepolicy.PricePolicyCreateState;
+import com.personal.marketnote.product.exception.ProductNoPricePolicyException;
 import com.personal.marketnote.product.exception.ProductNotFoundException;
 import com.personal.marketnote.product.port.out.productoption.DeleteProductOptionCategoryPort;
 import com.personal.marketnote.product.port.out.productoption.FindProductOptionCategoryPort;
@@ -49,48 +50,19 @@ public class ProductOptionPersistenceAdapter implements SaveProductOptionsPort, 
         savedCategory.addOrderNum();
 
         // 생성된 각 옵션 및 기존 옵션과의 조합에 대해 기본 가격 정책 등록
-        PricePolicyJpaEntity defaultPricePolicy = product.getDefaultPricePolicy();
-
-        if (FormatValidator.hasNoValue(defaultPricePolicy)) {
-            return ProductJpaEntityToDomainMapper.mapToDomain(savedCategory).orElse(null);
-        }
+        // region
 
         // 상품의 모든 활성 카테고리와 옵션 가져오기
         List<ProductOptionCategoryJpaEntity> allCategories = productOptionCategoryJpaRepository
                 .findActiveWithOptionsByProductId(productId);
-
-        // 1. 새로 생성된 카테고리의 각 옵션에 대해 가격 정책 생성
         List<PricePolicyJpaEntity> newPolicies = new ArrayList<>();
         List<ProductOptionPricePolicyJpaEntity> newOptionPolicies = new ArrayList<>();
-        savedCategory.getProductOptionJpaEntities()
-                .forEach(newOption -> {
-                    PricePolicyJpaEntity pricePolicy = createPricePolicyFromDefault(product, defaultPricePolicy);
-                    newPolicies.add(pricePolicy);
-                    newOptionPolicies.add(ProductOptionPricePolicyJpaEntity.of(newOption, pricePolicy));
-                });
+        registerPricePoliciesToOptionCombinations(allCategories, savedCategory, newPolicies, newOptionPolicies, product);
 
-        // 2. 모든 카테고리의 옵션 조합에 대해 가격 정책 생성
-        if (allCategories.size() > 1) {
-            List<List<ProductOptionJpaEntity>> optionGroups = allCategories.stream()
-                    .map(ProductOptionCategoryJpaEntity::getProductOptionJpaEntities)
-                    .filter(FormatValidator::hasValue)
-                    .toList();
+        // 기존 가격 정책 전체 삭제
+        pricePolicyJpaRepository.deleteByProductId(productId);
 
-            if (FormatValidator.hasValue(optionGroups) && optionGroups.size() > 1) {
-                List<List<ProductOptionJpaEntity>> productOptionCombinations = cartesianProduct(optionGroups);
-                productOptionCombinations.forEach(productOptionCombination -> {
-                    PricePolicyJpaEntity pricePolicy = createPricePolicyFromDefault(product, defaultPricePolicy);
-                    newPolicies.add(pricePolicy);
-
-                    // 조합의 모든 옵션과 가격 정책 연결
-                    productOptionCombination.forEach(
-                            option -> newOptionPolicies.add(
-                                    ProductOptionPricePolicyJpaEntity.of(option, pricePolicy)
-                            )
-                    );
-                });
-            }
-        }
+        // endregion
 
         List<PricePolicyJpaEntity> savedPricePolicyJpaEntities = pricePolicyJpaRepository.saveAll(newPolicies);
         savedPricePolicyJpaEntities.forEach(PricePolicyJpaEntity::setIdToOrderNum);
@@ -99,21 +71,59 @@ public class ProductOptionPersistenceAdapter implements SaveProductOptionsPort, 
         return ProductJpaEntityToDomainMapper.mapToDomain(savedCategory).orElse(null);
     }
 
-    private PricePolicyJpaEntity createPricePolicyFromDefault(
-            ProductJpaEntity product,
-            PricePolicyJpaEntity defaultPricePolicy
+    private void registerPricePoliciesToOptionCombinations(
+            List<ProductOptionCategoryJpaEntity> allCategories,
+            ProductOptionCategoryJpaEntity category,
+            List<PricePolicyJpaEntity> newPolicies,
+            List<ProductOptionPricePolicyJpaEntity> newOptionPolicies,
+            ProductJpaEntity product
     ) {
-        PricePolicy pricePolicy = PricePolicy.from(
-                PricePolicyCreateState.builder()
-                        .price(defaultPricePolicy.getPrice())
-                        .discountPrice(defaultPricePolicy.getDiscountPrice())
-                        .discountRate(defaultPricePolicy.getDiscountRate())
-                        .accumulatedPoint(defaultPricePolicy.getAccumulatedPoint())
-                        .accumulationRate(defaultPricePolicy.getAccumulationRate())
-                        .build()
-        );
+        PricePolicyJpaEntity defaultPricePolicy = product.getDefaultPricePolicy();
 
-        return PricePolicyJpaEntity.from(product, pricePolicy);
+        // 상품 가격 정책이 존재하지 않는 경우 예외 발생
+        if (FormatValidator.hasNoValue(defaultPricePolicy)) {
+            throw new ProductNoPricePolicyException(product.getId());
+        }
+
+        // 옵션 카테고리가 새로 생성된 것 하나인 경우 새로 생성된 카테고리의 각 옵션에 대해 가격 정책 생성
+        // region
+
+        if (allCategories.size() == 1) {
+            category.getProductOptionJpaEntities()
+                    .forEach(newOption -> {
+                        PricePolicyJpaEntity pricePolicy = createPricePolicyFromDefault(product, product.getDefaultPricePolicy());
+                        newPolicies.add(pricePolicy);
+                        newOptionPolicies.add(ProductOptionPricePolicyJpaEntity.of(newOption, pricePolicy));
+                    });
+            return;
+        }
+
+        // endregion
+
+        // 기존에 옵션 카테고리가 있는 경우, 모든 카테고리의 각 옵션들을 조합한 결과에 대해 가격 정책 생성(예: 옵션 카테고리가 총 3개인 경우 모든 옵션 3개 조합에 대한 가격 정책 생성)
+        // region
+
+        // 옵션 카테고리별로 옵션 목록 정렬
+        List<List<ProductOptionJpaEntity>> optionGroups = allCategories.stream()
+                .map(ProductOptionCategoryJpaEntity::getProductOptionJpaEntities)
+                .toList();
+
+        // 각 옵션 조합 목록 생성
+        List<List<ProductOptionJpaEntity>> productOptionCombinations = cartesianProduct(optionGroups);
+
+        productOptionCombinations.forEach(productOptionCombination -> {
+            PricePolicyJpaEntity pricePolicy = createPricePolicyFromDefault(product, defaultPricePolicy);
+            newPolicies.add(pricePolicy);
+
+            // 옵션 조합과 가격 정책 연결
+            productOptionCombination.forEach(
+                    option -> newOptionPolicies.add(
+                            ProductOptionPricePolicyJpaEntity.of(option, pricePolicy)
+                    )
+            );
+        });
+
+        // endregion
     }
 
     private List<List<ProductOptionJpaEntity>> cartesianProduct(
@@ -144,6 +154,23 @@ public class ProductOptionPersistenceAdapter implements SaveProductOptionsPort, 
             backtrackCartesian(optionGroups, depth + 1, path, result);
             path.removeLast();
         }
+    }
+
+    private PricePolicyJpaEntity createPricePolicyFromDefault(
+            ProductJpaEntity product,
+            PricePolicyJpaEntity defaultPricePolicy
+    ) {
+        PricePolicy pricePolicy = PricePolicy.from(
+                PricePolicyCreateState.builder()
+                        .price(defaultPricePolicy.getPrice())
+                        .discountPrice(defaultPricePolicy.getDiscountPrice())
+                        .discountRate(defaultPricePolicy.getDiscountRate())
+                        .accumulatedPoint(defaultPricePolicy.getAccumulatedPoint())
+                        .accumulationRate(defaultPricePolicy.getAccumulationRate())
+                        .build()
+        );
+
+        return PricePolicyJpaEntity.from(product, pricePolicy);
     }
 
     @Override

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/exception/ProductNoPricePolicyException.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/exception/ProductNoPricePolicyException.java
@@ -1,0 +1,12 @@
+package com.personal.marketnote.product.exception;
+
+import lombok.Getter;
+
+@Getter
+public class ProductNoPricePolicyException extends IllegalStateException {
+    private static final String PRODUCT_NO_PRICE_POLICY_EXCEPTION_MESSAGE = "상품에 가격 정책이 존재하지 않습니다. 대상 상품 ID: %d";
+
+    public ProductNoPricePolicyException(Long productId) {
+        super(String.format(PRODUCT_NO_PRICE_POLICY_EXCEPTION_MESSAGE, productId));
+    }
+}


### PR DESCRIPTION
## partially addresses #128
## resolves #287

## Task
- [x] 전체 비즈니스 로직 리팩터링
- [x] 새 옵션 등록 시 기존 옵션과 신규 옵션의 조합에 대한 가격 정책 생성 후, 기존 가격 정책 전체 삭제하도록 변경