### PR TITLE
[#387][#393] feat: 리워드 서비스 벤더 통신 기록에 전송 주체 추가

### DIFF
--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/offerwall/OfferwallController.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/offerwall/OfferwallController.java
@@ -12,6 +12,7 @@ import com.personal.marketnote.reward.adapter.in.web.offerwall.apidocs.TnkCallba
 import com.personal.marketnote.reward.adapter.in.web.point.response.UpdateUserPointResponse;
 import com.personal.marketnote.reward.domain.offerwall.OfferwallType;
 import com.personal.marketnote.reward.domain.offerwall.UserDeviceType;
+import com.personal.marketnote.reward.domain.vendorcommunication.RewardVendorCommunicationSenderType;
 import com.personal.marketnote.reward.domain.vendorcommunication.RewardVendorCommunicationTargetType;
 import com.personal.marketnote.reward.domain.vendorcommunication.RewardVendorCommunicationType;
 import com.personal.marketnote.reward.domain.vendorcommunication.RewardVendorName;
@@ -126,10 +127,22 @@ public class OfferwallController {
             String successPayload = successPayloadJson.toString();
 
             vendorCommunicationRecorder.record(
-                    targetType, RewardVendorCommunicationType.REQUEST, id, vendorName, payloadString, payloadJson
+                    targetType,
+                    RewardVendorCommunicationType.REQUEST,
+                    RewardVendorCommunicationSenderType.VENDOR,
+                    id,
+                    vendorName,
+                    payloadString,
+                    payloadJson
             );
             vendorCommunicationRecorder.record(
-                    targetType, RewardVendorCommunicationType.RESPONSE, id, vendorName, successPayload, successPayloadJson
+                    targetType,
+                    RewardVendorCommunicationType.RESPONSE,
+                    RewardVendorCommunicationSenderType.SERVER,
+                    id,
+                    vendorName,
+                    successPayload,
+                    successPayloadJson
             );
 
             return ResponseEntity.ok(successPayload);
@@ -217,10 +230,22 @@ public class OfferwallController {
             String successPayload = successPayloadJson.toString();
 
             vendorCommunicationRecorder.record(
-                    targetType, RewardVendorCommunicationType.REQUEST, id, vendorName, payloadString, payloadJson
+                    targetType,
+                    RewardVendorCommunicationType.REQUEST,
+                    RewardVendorCommunicationSenderType.VENDOR,
+                    id,
+                    vendorName,
+                    payloadString,
+                    payloadJson
             );
             vendorCommunicationRecorder.record(
-                    targetType, RewardVendorCommunicationType.RESPONSE, id, vendorName, successPayload, successPayloadJson
+                    targetType,
+                    RewardVendorCommunicationType.RESPONSE,
+                    RewardVendorCommunicationSenderType.SERVER,
+                    id,
+                    vendorName,
+                    successPayload,
+                    successPayloadJson
             );
 
             return ResponseEntity.ok(
@@ -327,10 +352,22 @@ public class OfferwallController {
             String successPayload = successPayloadJson.toString();
 
             vendorCommunicationRecorder.record(
-                    targetType, RewardVendorCommunicationType.REQUEST, id, vendorName, payloadString, payloadJson
+                    targetType,
+                    RewardVendorCommunicationType.REQUEST,
+                    RewardVendorCommunicationSenderType.VENDOR,
+                    id,
+                    vendorName,
+                    payloadString,
+                    payloadJson
             );
             vendorCommunicationRecorder.record(
-                    targetType, RewardVendorCommunicationType.RESPONSE, id, vendorName, successPayload, successPayloadJson
+                    targetType,
+                    RewardVendorCommunicationType.RESPONSE,
+                    RewardVendorCommunicationSenderType.SERVER,
+                    id,
+                    vendorName,
+                    successPayload,
+                    successPayloadJson
             );
 
             return ResponseEntity.ok(

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/vendorcommunication/entity/RewardVendorCommunicationHistoryJpaEntity.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/vendorcommunication/entity/RewardVendorCommunicationHistoryJpaEntity.java
@@ -43,6 +43,10 @@ public class RewardVendorCommunicationHistoryJpaEntity {
     @Column(name = "communication_type", nullable = false, length = 15)
     private RewardVendorCommunicationType communicationType;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "sender", nullable = false, length = 15)
+    private RewardVendorCommunicationSenderType sender;
+
     @Column(name = "exception", length = 63)
     private String exception;
 
@@ -70,6 +74,7 @@ public class RewardVendorCommunicationHistoryJpaEntity {
                 .targetId(history.getTargetId())
                 .vendorName(history.getVendorName())
                 .communicationType(history.getCommunicationType())
+                .sender(history.getSender())
                 .exception(history.getException())
                 .payload(history.getPayload())
                 .payloadJson(history.getPayloadJson())
@@ -85,6 +90,7 @@ public class RewardVendorCommunicationHistoryJpaEntity {
                         .targetId(targetId)
                         .vendorName(vendorName)
                         .communicationType(communicationType)
+                        .sender(sender)
                         .exception(exception)
                         .payload(payload)
                         .payloadJson(payloadJson)

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/utility/VendorCommunicationFailureHandler.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/utility/VendorCommunicationFailureHandler.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.reward.utility;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.personal.marketnote.reward.domain.vendorcommunication.RewardVendorCommunicationSenderType;
 import com.personal.marketnote.reward.domain.vendorcommunication.RewardVendorCommunicationTargetType;
 import com.personal.marketnote.reward.domain.vendorcommunication.RewardVendorCommunicationType;
 import com.personal.marketnote.reward.domain.vendorcommunication.RewardVendorName;
@@ -30,6 +31,7 @@ public class VendorCommunicationFailureHandler {
         vendorCommunicationRecorder.record(
                 targetType,
                 RewardVendorCommunicationType.REQUEST,
+                RewardVendorCommunicationSenderType.VENDOR,
                 vendorName,
                 requestPayload,
                 requestPayloadJson,
@@ -44,6 +46,7 @@ public class VendorCommunicationFailureHandler {
         vendorCommunicationRecorder.record(
                 targetType,
                 RewardVendorCommunicationType.RESPONSE,
+                RewardVendorCommunicationSenderType.SERVER,
                 vendorName,
                 responsePayload,
                 responsePayloadJson,

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/utility/VendorCommunicationRecorder.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/utility/VendorCommunicationRecorder.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.reward.utility;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.personal.marketnote.reward.domain.vendorcommunication.RewardVendorCommunicationSenderType;
 import com.personal.marketnote.reward.domain.vendorcommunication.RewardVendorCommunicationTargetType;
 import com.personal.marketnote.reward.domain.vendorcommunication.RewardVendorCommunicationType;
 import com.personal.marketnote.reward.domain.vendorcommunication.RewardVendorName;
@@ -17,6 +18,7 @@ public class VendorCommunicationRecorder {
     public void record(
             RewardVendorCommunicationTargetType targetType,
             RewardVendorCommunicationType communicationType,
+            RewardVendorCommunicationSenderType sender,
             Long targetId,
             RewardVendorName vendorName,
             String payload,
@@ -28,6 +30,7 @@ public class VendorCommunicationRecorder {
                         .targetId(targetId)
                         .vendorName(vendorName)
                         .communicationType(communicationType)
+                        .sender(sender)
                         .payload(payload)
                         .payloadJson(payloadJson)
                         .build()
@@ -37,6 +40,7 @@ public class VendorCommunicationRecorder {
     public void record(
             RewardVendorCommunicationTargetType targetType,
             RewardVendorCommunicationType communicationType,
+            RewardVendorCommunicationSenderType sender,
             RewardVendorName vendorName,
             String payload,
             JsonNode payloadJson,
@@ -47,6 +51,7 @@ public class VendorCommunicationRecorder {
                         .targetType(targetType)
                         .vendorName(vendorName)
                         .communicationType(communicationType)
+                        .sender(sender)
                         .exception(exception)
                         .payload(payload)
                         .payloadJson(payloadJson)

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/mapper/RewardVendorCommunicationHistoryCommandToStateMapper.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/mapper/RewardVendorCommunicationHistoryCommandToStateMapper.java
@@ -14,6 +14,7 @@ public class RewardVendorCommunicationHistoryCommandToStateMapper {
                 .targetId(command.getTargetId())
                 .vendorName(command.getVendorName())
                 .communicationType(command.getCommunicationType())
+                .sender(command.getSender())
                 .exception(command.getException())
                 .payload(command.getPayload())
                 .payloadJson(command.getPayloadJson())

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/command/vendorcommunication/RewardVendorCommunicationHistoryCommand.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/command/vendorcommunication/RewardVendorCommunicationHistoryCommand.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.reward.port.in.command.vendorcommunication;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.personal.marketnote.reward.domain.vendorcommunication.RewardVendorCommunicationSenderType;
 import com.personal.marketnote.reward.domain.vendorcommunication.RewardVendorCommunicationTargetType;
 import com.personal.marketnote.reward.domain.vendorcommunication.RewardVendorCommunicationType;
 import com.personal.marketnote.reward.domain.vendorcommunication.RewardVendorName;
@@ -14,6 +15,7 @@ public class RewardVendorCommunicationHistoryCommand {
     private final Long targetId;
     private final RewardVendorName vendorName;
     private final RewardVendorCommunicationType communicationType;
+    private final RewardVendorCommunicationSenderType sender;
     private final String exception;
     private final String payload;
     private final JsonNode payloadJson;

--- a/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/vendorcommunication/RewardVendorCommunicationHistory.java
+++ b/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/vendorcommunication/RewardVendorCommunicationHistory.java
@@ -15,6 +15,7 @@ public class RewardVendorCommunicationHistory {
     private Long targetId;
     private RewardVendorName vendorName;
     private RewardVendorCommunicationType communicationType;
+    private RewardVendorCommunicationSenderType sender;
     private String exception;
     private String payload;
     private JsonNode payloadJson;
@@ -26,6 +27,7 @@ public class RewardVendorCommunicationHistory {
                 .targetId(state.getTargetId())
                 .vendorName(state.getVendorName())
                 .communicationType(state.getCommunicationType())
+                .sender(state.getSender())
                 .exception(state.getException())
                 .payload(state.getPayload())
                 .payloadJson(state.getPayloadJson())
@@ -39,6 +41,7 @@ public class RewardVendorCommunicationHistory {
                 .targetId(state.getTargetId())
                 .vendorName(state.getVendorName())
                 .communicationType(state.getCommunicationType())
+                .sender(state.getSender())
                 .exception(state.getException())
                 .payload(state.getPayload())
                 .payloadJson(state.getPayloadJson())

--- a/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/vendorcommunication/RewardVendorCommunicationHistoryCreateState.java
+++ b/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/vendorcommunication/RewardVendorCommunicationHistoryCreateState.java
@@ -11,6 +11,7 @@ public class RewardVendorCommunicationHistoryCreateState {
     private final Long targetId;
     private final RewardVendorName vendorName;
     private final RewardVendorCommunicationType communicationType;
+    private final RewardVendorCommunicationSenderType sender;
     private final String exception;
     private final String payload;
     private final JsonNode payloadJson;

--- a/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/vendorcommunication/RewardVendorCommunicationHistorySnapshotState.java
+++ b/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/vendorcommunication/RewardVendorCommunicationHistorySnapshotState.java
@@ -14,6 +14,7 @@ public class RewardVendorCommunicationHistorySnapshotState {
     private final Long targetId;
     private final RewardVendorName vendorName;
     private final RewardVendorCommunicationType communicationType;
+    private final RewardVendorCommunicationSenderType sender;
     private final String exception;
     private final String payload;
     private final JsonNode payloadJson;

--- a/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/vendorcommunication/RewardVendorCommunicationSenderType.java
+++ b/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/vendorcommunication/RewardVendorCommunicationSenderType.java
@@ -1,0 +1,6 @@
+package com.personal.marketnote.reward.domain.vendorcommunication;
+
+public enum RewardVendorCommunicationSenderType {
+    SERVER,
+    VENDOR
+}


### PR DESCRIPTION
## partially addresses #387
## resolves #393

## Task
- [x] 벤더 커뮤니케이션 히스토리 테이블에 sender 컬럼 추가
- [x] 벤더 통신 시 전송 주체 정보를 기록하는 기능 추가