### PR TITLE
[#475][#499] feat: 풀필먼트 서비스 벤더 통신 기록에 전송 주체 추가

### DIFF
--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/persistence/vendorcommunication/entity/FulfillmentVendorCommunicationHistoryJpaEntity.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/persistence/vendorcommunication/entity/FulfillmentVendorCommunicationHistoryJpaEntity.java
@@ -31,8 +31,8 @@ public class FulfillmentVendorCommunicationHistoryJpaEntity {
     @Column(name = "target_type", nullable = false, length = 31)
     private FulfillmentVendorCommunicationTargetType targetType;
 
-    @Column(name = "target_id")
-    private Long targetId;
+    @Column(name = "target_id", length = 63)
+    private String targetId;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "vendor_name", nullable = false, length = 31)
@@ -41,6 +41,10 @@ public class FulfillmentVendorCommunicationHistoryJpaEntity {
     @Enumerated(EnumType.STRING)
     @Column(name = "communication_type", nullable = false, length = 15)
     private FulfillmentVendorCommunicationType communicationType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "sender", nullable = false, length = 15)
+    private FulfillmentVendorCommunicationSenderType sender;
 
     @Column(name = "exception", length = 63)
     private String exception;
@@ -65,6 +69,7 @@ public class FulfillmentVendorCommunicationHistoryJpaEntity {
                 .targetId(history.getTargetId())
                 .vendorName(history.getVendorName())
                 .communicationType(history.getCommunicationType())
+                .sender(history.getSender())
                 .exception(history.getException())
                 .payload(history.getPayload())
                 .payloadJson(history.getPayloadJson())
@@ -80,6 +85,7 @@ public class FulfillmentVendorCommunicationHistoryJpaEntity {
                         .targetId(targetId)
                         .vendorName(vendorName)
                         .communicationType(communicationType)
+                        .sender(sender)
                         .exception(exception)
                         .payload(payload)
                         .payloadJson(payloadJson)

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/client/FasstoAuthClient.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/client/FasstoAuthClient.java
@@ -9,6 +9,7 @@ import com.personal.marketnote.fulfillment.adapter.out.vendor.fassto.response.Fa
 import com.personal.marketnote.fulfillment.adapter.out.vendor.fassto.response.FasstoResponseHeader;
 import com.personal.marketnote.fulfillment.configuration.FasstoAuthProperties;
 import com.personal.marketnote.fulfillment.domain.FasstoAccessToken;
+import com.personal.marketnote.fulfillment.domain.vendorcommunication.FulfillmentVendorCommunicationSenderType;
 import com.personal.marketnote.fulfillment.domain.vendorcommunication.FulfillmentVendorCommunicationTargetType;
 import com.personal.marketnote.fulfillment.domain.vendorcommunication.FulfillmentVendorCommunicationType;
 import com.personal.marketnote.fulfillment.domain.vendorcommunication.FulfillmentVendorName;
@@ -439,11 +440,14 @@ public class FasstoAuthClient implements RequestFasstoAuthPort, DisconnectFassto
             JsonNode payloadJson,
             String exception
     ) {
+        FulfillmentVendorCommunicationSenderType sender = communicationType == FulfillmentVendorCommunicationType.REQUEST
+                ? FulfillmentVendorCommunicationSenderType.SERVER
+                : FulfillmentVendorCommunicationSenderType.VENDOR;
         if (FormatValidator.hasValue(exception)) {
             vendorCommunicationRecorder.record(
                     targetType,
                     communicationType,
-                    null,
+                    sender,
                     vendorName,
                     payload,
                     payloadJson,
@@ -455,7 +459,7 @@ public class FasstoAuthClient implements RequestFasstoAuthPort, DisconnectFassto
         vendorCommunicationRecorder.record(
                 targetType,
                 communicationType,
-                null,
+                sender,
                 vendorName,
                 payload,
                 payloadJson

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/client/FasstoShopClient.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/client/FasstoShopClient.java
@@ -11,6 +11,7 @@ import com.personal.marketnote.fulfillment.adapter.out.vendor.fassto.response.Re
 import com.personal.marketnote.fulfillment.configuration.FasstoAuthProperties;
 import com.personal.marketnote.fulfillment.domain.vendor.fassto.shop.FasstoShopMapper;
 import com.personal.marketnote.fulfillment.domain.vendor.fassto.shop.FasstoShopQuery;
+import com.personal.marketnote.fulfillment.domain.vendorcommunication.FulfillmentVendorCommunicationSenderType;
 import com.personal.marketnote.fulfillment.domain.vendorcommunication.FulfillmentVendorCommunicationTargetType;
 import com.personal.marketnote.fulfillment.domain.vendorcommunication.FulfillmentVendorCommunicationType;
 import com.personal.marketnote.fulfillment.domain.vendorcommunication.FulfillmentVendorName;
@@ -301,11 +302,14 @@ public class FasstoShopClient implements RegisterFasstoShopPort, GetFasstoShopsP
             JsonNode payloadJson,
             String exception
     ) {
+        FulfillmentVendorCommunicationSenderType sender = communicationType == FulfillmentVendorCommunicationType.REQUEST
+                ? FulfillmentVendorCommunicationSenderType.SERVER
+                : FulfillmentVendorCommunicationSenderType.VENDOR;
         if (FormatValidator.hasValue(exception)) {
             vendorCommunicationRecorder.record(
                     targetType,
                     communicationType,
-                    null,
+                    sender,
                     vendorName,
                     payload,
                     payloadJson,
@@ -317,7 +321,7 @@ public class FasstoShopClient implements RegisterFasstoShopPort, GetFasstoShopsP
         vendorCommunicationRecorder.record(
                 targetType,
                 communicationType,
-                null,
+                sender,
                 vendorName,
                 payload,
                 payloadJson

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/client/FasstoSupplierClient.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/client/FasstoSupplierClient.java
@@ -11,6 +11,7 @@ import com.personal.marketnote.fulfillment.adapter.out.vendor.fassto.response.Re
 import com.personal.marketnote.fulfillment.configuration.FasstoAuthProperties;
 import com.personal.marketnote.fulfillment.domain.vendor.fassto.supplier.FasstoSupplierMapper;
 import com.personal.marketnote.fulfillment.domain.vendor.fassto.supplier.FasstoSupplierQuery;
+import com.personal.marketnote.fulfillment.domain.vendorcommunication.FulfillmentVendorCommunicationSenderType;
 import com.personal.marketnote.fulfillment.domain.vendorcommunication.FulfillmentVendorCommunicationTargetType;
 import com.personal.marketnote.fulfillment.domain.vendorcommunication.FulfillmentVendorCommunicationType;
 import com.personal.marketnote.fulfillment.domain.vendorcommunication.FulfillmentVendorName;
@@ -429,11 +430,14 @@ public class FasstoSupplierClient implements RegisterFasstoSupplierPort, GetFass
             JsonNode payloadJson,
             String exception
     ) {
+        FulfillmentVendorCommunicationSenderType sender = communicationType == FulfillmentVendorCommunicationType.REQUEST
+                ? FulfillmentVendorCommunicationSenderType.SERVER
+                : FulfillmentVendorCommunicationSenderType.VENDOR;
         if (FormatValidator.hasValue(exception)) {
             vendorCommunicationRecorder.record(
                     targetType,
                     communicationType,
-                    null,
+                    sender,
                     vendorName,
                     payload,
                     payloadJson,
@@ -445,7 +449,7 @@ public class FasstoSupplierClient implements RegisterFasstoSupplierPort, GetFass
         vendorCommunicationRecorder.record(
                 targetType,
                 communicationType,
-                null,
+                sender,
                 vendorName,
                 payload,
                 payloadJson

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/utility/VendorCommunicationFailureHandler.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/utility/VendorCommunicationFailureHandler.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.fulfillment.utility;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.personal.marketnote.fulfillment.domain.vendorcommunication.FulfillmentVendorCommunicationSenderType;
 import com.personal.marketnote.fulfillment.domain.vendorcommunication.FulfillmentVendorCommunicationTargetType;
 import com.personal.marketnote.fulfillment.domain.vendorcommunication.FulfillmentVendorCommunicationType;
 import com.personal.marketnote.fulfillment.domain.vendorcommunication.FulfillmentVendorName;
@@ -28,7 +29,7 @@ public class VendorCommunicationFailureHandler {
 
     public void handleFailure(
             FulfillmentVendorCommunicationTargetType targetType,
-            Long targetId,
+            String targetId,
             FulfillmentVendorName vendorName,
             String requestPayload,
             JsonNode requestPayloadJson,
@@ -41,6 +42,7 @@ public class VendorCommunicationFailureHandler {
         vendorCommunicationRecorder.record(
                 targetType,
                 FulfillmentVendorCommunicationType.REQUEST,
+                FulfillmentVendorCommunicationSenderType.SERVER,
                 targetId,
                 vendorName,
                 requestPayload,
@@ -54,6 +56,7 @@ public class VendorCommunicationFailureHandler {
         vendorCommunicationRecorder.record(
                 targetType,
                 FulfillmentVendorCommunicationType.RESPONSE,
+                FulfillmentVendorCommunicationSenderType.VENDOR,
                 targetId,
                 vendorName,
                 responsePayload,

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/utility/VendorCommunicationRecorder.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/utility/VendorCommunicationRecorder.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.fulfillment.utility;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.personal.marketnote.fulfillment.domain.vendorcommunication.FulfillmentVendorCommunicationSenderType;
 import com.personal.marketnote.fulfillment.domain.vendorcommunication.FulfillmentVendorCommunicationTargetType;
 import com.personal.marketnote.fulfillment.domain.vendorcommunication.FulfillmentVendorCommunicationType;
 import com.personal.marketnote.fulfillment.domain.vendorcommunication.FulfillmentVendorName;
@@ -17,7 +18,29 @@ public class VendorCommunicationRecorder {
     public void record(
             FulfillmentVendorCommunicationTargetType targetType,
             FulfillmentVendorCommunicationType communicationType,
-            Long targetId,
+            FulfillmentVendorCommunicationSenderType sender,
+            FulfillmentVendorName vendorName,
+            String payload,
+            JsonNode payloadJson
+    ) {
+        recordVendorCommunicationHistoryUseCase.record(
+                FulfillmentVendorCommunicationHistoryCommand.builder()
+                        .targetType(targetType)
+                        .targetId(null)
+                        .vendorName(vendorName)
+                        .communicationType(communicationType)
+                        .sender(sender)
+                        .payload(payload)
+                        .payloadJson(payloadJson)
+                        .build()
+        );
+    }
+
+    public void record(
+            FulfillmentVendorCommunicationTargetType targetType,
+            FulfillmentVendorCommunicationType communicationType,
+            FulfillmentVendorCommunicationSenderType sender,
+            String targetId,
             FulfillmentVendorName vendorName,
             String payload,
             JsonNode payloadJson
@@ -28,6 +51,7 @@ public class VendorCommunicationRecorder {
                         .targetId(targetId)
                         .vendorName(vendorName)
                         .communicationType(communicationType)
+                        .sender(sender)
                         .payload(payload)
                         .payloadJson(payloadJson)
                         .build()
@@ -37,6 +61,7 @@ public class VendorCommunicationRecorder {
     public void record(
             FulfillmentVendorCommunicationTargetType targetType,
             FulfillmentVendorCommunicationType communicationType,
+            FulfillmentVendorCommunicationSenderType sender,
             FulfillmentVendorName vendorName,
             String payload,
             JsonNode payloadJson,
@@ -47,6 +72,7 @@ public class VendorCommunicationRecorder {
                         .targetType(targetType)
                         .vendorName(vendorName)
                         .communicationType(communicationType)
+                        .sender(sender)
                         .exception(exception)
                         .payload(payload)
                         .payloadJson(payloadJson)
@@ -57,7 +83,8 @@ public class VendorCommunicationRecorder {
     public void record(
             FulfillmentVendorCommunicationTargetType targetType,
             FulfillmentVendorCommunicationType communicationType,
-            Long targetId,
+            FulfillmentVendorCommunicationSenderType sender,
+            String targetId,
             FulfillmentVendorName vendorName,
             String payload,
             JsonNode payloadJson,
@@ -69,6 +96,7 @@ public class VendorCommunicationRecorder {
                         .targetId(targetId)
                         .vendorName(vendorName)
                         .communicationType(communicationType)
+                        .sender(sender)
                         .exception(exception)
                         .payload(payload)
                         .payloadJson(payloadJson)

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/mapper/FulfillmentVendorCommunicationHistoryCommandToStateMapper.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/mapper/FulfillmentVendorCommunicationHistoryCommandToStateMapper.java
@@ -15,6 +15,7 @@ public class FulfillmentVendorCommunicationHistoryCommandToStateMapper {
                 .targetId(command.getTargetId())
                 .vendorName(command.getVendorName())
                 .communicationType(command.getCommunicationType())
+                .sender(command.getSender())
                 .exception(command.getException())
                 .payload(command.getPayload())
                 .payloadJson(command.getPayloadJson())

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/vendorcommunication/FulfillmentVendorCommunicationHistoryCommand.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/vendorcommunication/FulfillmentVendorCommunicationHistoryCommand.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.fulfillment.port.in.command.vendorcommunication;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.personal.marketnote.fulfillment.domain.vendorcommunication.FulfillmentVendorCommunicationSenderType;
 import com.personal.marketnote.fulfillment.domain.vendorcommunication.FulfillmentVendorCommunicationTargetType;
 import com.personal.marketnote.fulfillment.domain.vendorcommunication.FulfillmentVendorCommunicationType;
 import com.personal.marketnote.fulfillment.domain.vendorcommunication.FulfillmentVendorName;
@@ -11,9 +12,10 @@ import lombok.Getter;
 @Builder
 public class FulfillmentVendorCommunicationHistoryCommand {
     private final FulfillmentVendorCommunicationTargetType targetType;
-    private final Long targetId;
+    private final String targetId;
     private final FulfillmentVendorName vendorName;
     private final FulfillmentVendorCommunicationType communicationType;
+    private final FulfillmentVendorCommunicationSenderType sender;
     private final String exception;
     private final String payload;
     private final JsonNode payloadJson;

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendorcommunication/FulfillmentVendorCommunicationHistory.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendorcommunication/FulfillmentVendorCommunicationHistory.java
@@ -12,9 +12,10 @@ import java.time.LocalDateTime;
 public class FulfillmentVendorCommunicationHistory {
     private Long id;
     private FulfillmentVendorCommunicationTargetType targetType;
-    private Long targetId;
+    private String targetId;
     private FulfillmentVendorName vendorName;
     private FulfillmentVendorCommunicationType communicationType;
+    private FulfillmentVendorCommunicationSenderType sender;
     private String exception;
     private String payload;
     private JsonNode payloadJson;
@@ -26,6 +27,7 @@ public class FulfillmentVendorCommunicationHistory {
                 .targetId(state.getTargetId())
                 .vendorName(state.getVendorName())
                 .communicationType(state.getCommunicationType())
+                .sender(state.getSender())
                 .exception(state.getException())
                 .payload(state.getPayload())
                 .payloadJson(state.getPayloadJson())
@@ -39,6 +41,7 @@ public class FulfillmentVendorCommunicationHistory {
                 .targetId(state.getTargetId())
                 .vendorName(state.getVendorName())
                 .communicationType(state.getCommunicationType())
+                .sender(state.getSender())
                 .exception(state.getException())
                 .payload(state.getPayload())
                 .payloadJson(state.getPayloadJson())

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendorcommunication/FulfillmentVendorCommunicationHistoryCreateState.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendorcommunication/FulfillmentVendorCommunicationHistoryCreateState.java
@@ -8,9 +8,10 @@ import lombok.Getter;
 @Builder
 public class FulfillmentVendorCommunicationHistoryCreateState {
     private final FulfillmentVendorCommunicationTargetType targetType;
-    private final Long targetId;
+    private final String targetId;
     private final FulfillmentVendorName vendorName;
     private final FulfillmentVendorCommunicationType communicationType;
+    private final FulfillmentVendorCommunicationSenderType sender;
     private final String exception;
     private final String payload;
     private final JsonNode payloadJson;

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendorcommunication/FulfillmentVendorCommunicationHistorySnapshotState.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendorcommunication/FulfillmentVendorCommunicationHistorySnapshotState.java
@@ -11,9 +11,10 @@ import java.time.LocalDateTime;
 public class FulfillmentVendorCommunicationHistorySnapshotState {
     private final Long id;
     private final FulfillmentVendorCommunicationTargetType targetType;
-    private final Long targetId;
+    private final String targetId;
     private final FulfillmentVendorName vendorName;
     private final FulfillmentVendorCommunicationType communicationType;
+    private final FulfillmentVendorCommunicationSenderType sender;
     private final String exception;
     private final String payload;
     private final JsonNode payloadJson;

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendorcommunication/FulfillmentVendorCommunicationSenderType.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendorcommunication/FulfillmentVendorCommunicationSenderType.java
@@ -1,0 +1,11 @@
+package com.personal.marketnote.fulfillment.domain.vendorcommunication;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum FulfillmentVendorCommunicationSenderType {
+    SERVER("서버에서 전송"),
+    VENDOR("벤더에서 전송");
+
+    private final String description;
+}


### PR DESCRIPTION
## partially addresses #475
## resolves #499

## Task
- [x] 벤더 커뮤니케이션 히스토리 테이블에 sender 컬럼 추가
- [x] 벤더 통신 시 전송 주체 정보를 기록하는 기능 추가