### PR TITLE
[#1][#566] feat: 전체 서비스 통신 재시도 프로세스에 jitter 적용

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/web/cart/CartServiceClient.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/web/cart/CartServiceClient.java
@@ -13,7 +13,9 @@ import org.springframework.web.util.UriComponentsBuilder;
 
 import java.net.URI;
 import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
 
+import static com.personal.marketnote.common.utility.ApiConstant.INTER_SERVER_DEFAULT_RETRIAL_PENDING_MILLI_SECOND;
 import static com.personal.marketnote.common.utility.ApiConstant.INTER_SERVER_MAX_REQUEST_COUNT;
 
 @ServiceAdapter
@@ -53,7 +55,10 @@ public class CartServiceClient implements DeleteOrderedCartProductsPort {
                 log.warn(e.getMessage(), e);
 
                 try {
-                    Thread.sleep(1000);
+                    // 대상 서비스 장애 시 요청 트래픽 폭주를 방지하기 위해 jitter 설정
+                    long jitteredSleepMillis = ThreadLocalRandom.current()
+                            .nextLong(Math.max(1L, INTER_SERVER_DEFAULT_RETRIAL_PENDING_MILLI_SECOND) + 1);
+                    Thread.sleep(jitteredSleepMillis);
                 } catch (InterruptedException ie) {
                     Thread.currentThread().interrupt();
                 }

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/web/product/ProductServiceClient.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/web/product/ProductServiceClient.java
@@ -23,7 +23,9 @@ import java.net.URI;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
 
+import static com.personal.marketnote.common.utility.ApiConstant.INTER_SERVER_DEFAULT_RETRIAL_PENDING_MILLI_SECOND;
 import static com.personal.marketnote.common.utility.ApiConstant.INTER_SERVER_MAX_REQUEST_COUNT;
 
 @ServiceAdapter
@@ -83,7 +85,10 @@ public class ProductServiceClient implements FindProductByPricePolicyPort {
                 }
 
                 try {
-                    Thread.sleep(1000);
+                    // jitter to avoid request bursts during downstream outage
+                    long jitteredSleepMillis = ThreadLocalRandom.current()
+                            .nextLong(Math.max(1L, INTER_SERVER_DEFAULT_RETRIAL_PENDING_MILLI_SECOND) + 1);
+                    Thread.sleep(jitteredSleepMillis);
                 } catch (InterruptedException ie) {
                     Thread.currentThread().interrupt();
                 }

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/web/reward/RewardServiceClient.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/web/reward/RewardServiceClient.java
@@ -15,6 +15,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.ThreadLocalRandom;
 
 import static com.personal.marketnote.common.utility.ApiConstant.*;
 
@@ -98,6 +99,7 @@ public class RewardServiceClient implements ModifyUserPointPort {
             }
 
             sleep(sleepMillis);
+            // exponential backoff 적용
             sleepMillis = sleepMillis * INTER_SERVER_DEFAULT_EXPONENTIAL_BACKOFF_VALUE;
         }
 
@@ -123,7 +125,10 @@ public class RewardServiceClient implements ModifyUserPointPort {
 
     private void sleep(long millis) {
         try {
-            Thread.sleep(millis);
+            // 대상 서비스 장애 시 요청 트래픽 폭주를 방지하기 위해 jitter 설정
+            long jitteredSleepMillis = ThreadLocalRandom.current()
+                    .nextLong(Math.max(1L, millis) + 1);
+            Thread.sleep(jitteredSleepMillis);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
         }

--- a/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/out/web/commerce/CommerceServiceClient.java
+++ b/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/out/web/commerce/CommerceServiceClient.java
@@ -12,7 +12,9 @@ import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.net.URI;
+import java.util.concurrent.ThreadLocalRandom;
 
+import static com.personal.marketnote.common.utility.ApiConstant.INTER_SERVER_DEFAULT_RETRIAL_PENDING_MILLI_SECOND;
 import static com.personal.marketnote.common.utility.ApiConstant.INTER_SERVER_MAX_REQUEST_COUNT;
 
 @ServiceAdapter
@@ -58,7 +60,10 @@ public class CommerceServiceClient implements UpdateOrderProductReviewStatusPort
                 }
 
                 try {
-                    Thread.sleep(1000);
+                    // jitter to avoid request bursts during downstream outage
+                    long jitteredSleepMillis = ThreadLocalRandom.current()
+                            .nextLong(Math.max(1L, INTER_SERVER_DEFAULT_RETRIAL_PENDING_MILLI_SECOND) + 1);
+                    Thread.sleep(jitteredSleepMillis);
                 } catch (InterruptedException ie) {
                     Thread.currentThread().interrupt();
                 }

--- a/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/out/web/file/FileServiceClient.java
+++ b/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/out/web/file/FileServiceClient.java
@@ -24,9 +24,11 @@ import org.springframework.web.util.UriComponentsBuilder;
 import java.net.URI;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.ThreadLocalRandom;
 
 import static com.personal.marketnote.common.domain.file.OwnerType.POST;
 import static com.personal.marketnote.common.domain.file.OwnerType.REVIEW;
+import static com.personal.marketnote.common.utility.ApiConstant.INTER_SERVER_DEFAULT_RETRIAL_PENDING_MILLI_SECOND;
 import static com.personal.marketnote.common.utility.ApiConstant.INTER_SERVER_MAX_REQUEST_COUNT;
 
 @ServiceAdapter
@@ -110,7 +112,10 @@ public class FileServiceClient implements FindReviewImagesPort, FindPostImagesPo
                 log.warn(e.getMessage(), e);
 
                 try {
-                    Thread.sleep(1000);
+                    // jitter to avoid request bursts during downstream outage
+                    long jitteredSleepMillis = ThreadLocalRandom.current()
+                            .nextLong(Math.max(1L, INTER_SERVER_DEFAULT_RETRIAL_PENDING_MILLI_SECOND) + 1);
+                    Thread.sleep(jitteredSleepMillis);
                 } catch (InterruptedException ie) {
                     Thread.currentThread().interrupt();
                 }

--- a/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/out/web/product/ProductServiceClient.java
+++ b/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/out/web/product/ProductServiceClient.java
@@ -22,7 +22,9 @@ import java.net.URI;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
 
+import static com.personal.marketnote.common.utility.ApiConstant.INTER_SERVER_DEFAULT_RETRIAL_PENDING_MILLI_SECOND;
 import static com.personal.marketnote.common.utility.ApiConstant.INTER_SERVER_MAX_REQUEST_COUNT;
 
 @ServiceAdapter
@@ -83,7 +85,10 @@ public class ProductServiceClient implements FindProductByPricePolicyPort {
                 }
 
                 try {
-                    Thread.sleep(1000);
+                    // jitter to avoid request bursts during downstream outage
+                    long jitteredSleepMillis = ThreadLocalRandom.current()
+                            .nextLong(Math.max(1L, INTER_SERVER_DEFAULT_RETRIAL_PENDING_MILLI_SECOND) + 1);
+                    Thread.sleep(jitteredSleepMillis);
                 } catch (InterruptedException ie) {
                     Thread.currentThread().interrupt();
                 }

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/client/FasstoAuthClient.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/client/FasstoAuthClient.java
@@ -33,6 +33,7 @@ import java.net.URI;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
 
 import static com.personal.marketnote.common.utility.ApiConstant.*;
 
@@ -102,6 +103,7 @@ public class FasstoAuthClient implements RequestFasstoAuthPort, DisconnectFassto
                 }
 
                 sleep(sleepMillis);
+                // exponential backoff applied
                 sleepMillis = sleepMillis * INTER_SERVER_DEFAULT_EXPONENTIAL_BACKOFF_VALUE;
                 continue;
             }
@@ -144,6 +146,7 @@ public class FasstoAuthClient implements RequestFasstoAuthPort, DisconnectFassto
             }
 
             sleep(sleepMillis);
+            // exponential backoff applied
             sleepMillis = sleepMillis * INTER_SERVER_DEFAULT_EXPONENTIAL_BACKOFF_VALUE;
         }
 
@@ -208,6 +211,7 @@ public class FasstoAuthClient implements RequestFasstoAuthPort, DisconnectFassto
                 }
 
                 sleep(sleepMillis);
+                // exponential backoff applied
                 sleepMillis = sleepMillis * INTER_SERVER_DEFAULT_EXPONENTIAL_BACKOFF_VALUE;
                 continue;
             }
@@ -251,6 +255,7 @@ public class FasstoAuthClient implements RequestFasstoAuthPort, DisconnectFassto
             );
 
             sleep(sleepMillis);
+            // exponential backoff applied
             sleepMillis = sleepMillis * INTER_SERVER_DEFAULT_EXPONENTIAL_BACKOFF_VALUE;
         }
 
@@ -431,7 +436,10 @@ public class FasstoAuthClient implements RequestFasstoAuthPort, DisconnectFassto
 
     private void sleep(long millis) {
         try {
-            Thread.sleep(millis);
+            // jitter to avoid request bursts during downstream outage
+            long jitteredSleepMillis = ThreadLocalRandom.current()
+                    .nextLong(Math.max(1L, millis) + 1);
+            Thread.sleep(jitteredSleepMillis);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
         }

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/client/FasstoGoodsClient.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/client/FasstoGoodsClient.java
@@ -33,6 +33,7 @@ import java.net.URI;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
 
 import static com.personal.marketnote.common.utility.ApiConstant.*;
 
@@ -115,6 +116,7 @@ public class FasstoGoodsClient implements RegisterFasstoGoodsPort {
                 }
 
                 sleep(sleepMillis);
+                // exponential backoff applied
                 sleepMillis = sleepMillis * INTER_SERVER_DEFAULT_EXPONENTIAL_BACKOFF_VALUE;
                 continue;
             }
@@ -170,6 +172,7 @@ public class FasstoGoodsClient implements RegisterFasstoGoodsPort {
             }
 
             sleep(sleepMillis);
+            // exponential backoff applied
             sleepMillis = sleepMillis * INTER_SERVER_DEFAULT_EXPONENTIAL_BACKOFF_VALUE;
         }
 
@@ -360,7 +363,10 @@ public class FasstoGoodsClient implements RegisterFasstoGoodsPort {
 
     private void sleep(long millis) {
         try {
-            Thread.sleep(millis);
+            // jitter to avoid request bursts during downstream outage
+            long jitteredSleepMillis = ThreadLocalRandom.current()
+                    .nextLong(Math.max(1L, millis) + 1);
+            Thread.sleep(jitteredSleepMillis);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
         }

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/client/FasstoShopClient.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/client/FasstoShopClient.java
@@ -41,6 +41,7 @@ import java.net.URI;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
 
 import static com.personal.marketnote.common.utility.ApiConstant.*;
 
@@ -124,6 +125,7 @@ public class FasstoShopClient implements RegisterFasstoShopPort, GetFasstoShopsP
                 }
 
                 sleep(sleepMillis);
+                // exponential backoff applied
                 sleepMillis = sleepMillis * INTER_SERVER_DEFAULT_EXPONENTIAL_BACKOFF_VALUE;
                 continue;
             }
@@ -173,6 +175,7 @@ public class FasstoShopClient implements RegisterFasstoShopPort, GetFasstoShopsP
             }
 
             sleep(sleepMillis);
+            // exponential backoff applied
             sleepMillis = sleepMillis * INTER_SERVER_DEFAULT_EXPONENTIAL_BACKOFF_VALUE;
         }
 
@@ -349,7 +352,10 @@ public class FasstoShopClient implements RegisterFasstoShopPort, GetFasstoShopsP
 
     private void sleep(long millis) {
         try {
-            Thread.sleep(millis);
+            // jitter to avoid request bursts during downstream outage
+            long jitteredSleepMillis = ThreadLocalRandom.current()
+                    .nextLong(Math.max(1L, millis) + 1);
+            Thread.sleep(jitteredSleepMillis);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
         }
@@ -413,6 +419,7 @@ public class FasstoShopClient implements RegisterFasstoShopPort, GetFasstoShopsP
                 }
 
                 sleep(sleepMillis);
+                // exponential backoff applied
                 sleepMillis = sleepMillis * INTER_SERVER_DEFAULT_EXPONENTIAL_BACKOFF_VALUE;
                 continue;
             }
@@ -467,6 +474,7 @@ public class FasstoShopClient implements RegisterFasstoShopPort, GetFasstoShopsP
             }
 
             sleep(sleepMillis);
+            // exponential backoff applied
             sleepMillis = sleepMillis * INTER_SERVER_DEFAULT_EXPONENTIAL_BACKOFF_VALUE;
         }
 

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/client/FasstoSupplierClient.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/client/FasstoSupplierClient.java
@@ -41,6 +41,7 @@ import java.net.URI;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
 
 import static com.personal.marketnote.common.utility.ApiConstant.*;
 
@@ -124,6 +125,7 @@ public class FasstoSupplierClient implements RegisterFasstoSupplierPort, GetFass
                 }
 
                 sleep(sleepMillis);
+                // exponential backoff applied
                 sleepMillis = sleepMillis * INTER_SERVER_DEFAULT_EXPONENTIAL_BACKOFF_VALUE;
                 continue;
             }
@@ -173,6 +175,7 @@ public class FasstoSupplierClient implements RegisterFasstoSupplierPort, GetFass
             }
 
             sleep(sleepMillis);
+            // exponential backoff applied
             sleepMillis = sleepMillis * INTER_SERVER_DEFAULT_EXPONENTIAL_BACKOFF_VALUE;
         }
 
@@ -238,6 +241,7 @@ public class FasstoSupplierClient implements RegisterFasstoSupplierPort, GetFass
                 }
 
                 sleep(sleepMillis);
+                // exponential backoff applied
                 sleepMillis = sleepMillis * INTER_SERVER_DEFAULT_EXPONENTIAL_BACKOFF_VALUE;
                 continue;
             }
@@ -292,6 +296,7 @@ public class FasstoSupplierClient implements RegisterFasstoSupplierPort, GetFass
             }
 
             sleep(sleepMillis);
+            // exponential backoff applied
             sleepMillis = sleepMillis * INTER_SERVER_DEFAULT_EXPONENTIAL_BACKOFF_VALUE;
         }
 
@@ -566,7 +571,10 @@ public class FasstoSupplierClient implements RegisterFasstoSupplierPort, GetFass
 
     private void sleep(long millis) {
         try {
-            Thread.sleep(millis);
+            // jitter to avoid request bursts during downstream outage
+            long jitteredSleepMillis = ThreadLocalRandom.current()
+                    .nextLong(Math.max(1L, millis) + 1);
+            Thread.sleep(jitteredSleepMillis);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
         }

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/web/commerce/CommerceServiceClient.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/web/commerce/CommerceServiceClient.java
@@ -24,6 +24,7 @@ import java.net.URI;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 
 import static com.personal.marketnote.common.utility.ApiConstant.*;
@@ -71,12 +72,16 @@ public class CommerceServiceClient implements RegisterInventoryPort, FindStockPo
                 }
 
                 try {
-                    Thread.sleep(sleepMillis);
+                    // 대상 서비스 장애 시 요청 트래픽 폭주를 방지하기 위해 jitter 설정
+                    long jitteredSleepMillis = ThreadLocalRandom.current()
+                            .nextLong(Math.max(1L, sleepMillis) + 1);
+                    Thread.sleep(jitteredSleepMillis);
                 } catch (InterruptedException ie) {
                     Thread.currentThread().interrupt();
                     return;
                 }
 
+                // exponential backoff 적용
                 sleepMillis = sleepMillis * INTER_SERVER_DEFAULT_EXPONENTIAL_BACKOFF_VALUE;
             }
         }
@@ -107,6 +112,9 @@ public class CommerceServiceClient implements RegisterInventoryPort, FindStockPo
     }
 
     public GetInventoriesResponse sendRequest(URI uri, HttpHeaders headers, List<Long> pricePolicyIds) {
+        long sleepMillis = INTER_SERVER_DEFAULT_RETRIAL_PENDING_MILLI_SECOND;
+        Exception error = new Exception();
+
         for (int i = 0; i < INTER_SERVER_MAX_REQUEST_COUNT; i++) {
             try {
                 BaseResponse<GetInventoriesResponse> response =
@@ -130,14 +138,17 @@ public class CommerceServiceClient implements RegisterInventoryPort, FindStockPo
                 log.warn(e.getMessage(), e);
 
                 try {
-                    Thread.sleep(1000);
+                    // 대상 서비스 장애 시 요청 트래픽 폭주를 방지하기 위해 jitter 설정
+                    long jitteredSleepMillis = ThreadLocalRandom.current()
+                            .nextLong(Math.max(1L, INTER_SERVER_DEFAULT_RETRIAL_PENDING_MILLI_SECOND) + 1);
+                    Thread.sleep(jitteredSleepMillis);
                 } catch (InterruptedException ie) {
                     Thread.currentThread().interrupt();
                 }
             }
         }
 
-        log.error("Failed to register inventory: {}", pricePolicyIds);
+        log.error("Failed to get inventories: {} with error: {}", uri, error.getMessage(), error);
         throw new CommerceServiceRequestFailedException(new IOException());
     }
 }

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/web/file/FileServiceClient.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/web/file/FileServiceClient.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.ThreadLocalRandom;
 
 import static com.personal.marketnote.common.domain.file.OwnerType.PRODUCT;
 import static com.personal.marketnote.common.utility.ApiConstant.INTER_SERVER_MAX_REQUEST_COUNT;
@@ -99,7 +100,10 @@ public class FileServiceClient implements FindProductImagesPort, DeleteProductIm
                 log.warn(e.getMessage(), e);
 
                 try {
-                    Thread.sleep(2000);
+                    // jitter to avoid request bursts during downstream outage
+                    long jitteredSleepMillis = ThreadLocalRandom.current()
+                            .nextLong(Math.max(1L, 2000L) + 1);
+                    Thread.sleep(jitteredSleepMillis);
                 } catch (InterruptedException ie) {
                     Thread.currentThread().interrupt();
                 }

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/web/fulfillment/FulfillmentServiceClient.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/web/fulfillment/FulfillmentServiceClient.java
@@ -20,6 +20,7 @@ import org.springframework.web.util.UriComponentsBuilder;
 
 import java.io.IOException;
 import java.net.URI;
+import java.util.concurrent.ThreadLocalRandom;
 
 import static com.personal.marketnote.common.utility.ApiConstant.*;
 
@@ -85,12 +86,16 @@ public class FulfillmentServiceClient implements RegisterFulfillmentVendorGoodsP
                 }
 
                 try {
-                    Thread.sleep(sleepMillis);
+                    // jitter to avoid request bursts during downstream outage
+                    long jitteredSleepMillis = ThreadLocalRandom.current()
+                            .nextLong(Math.max(1L, sleepMillis) + 1);
+                    Thread.sleep(jitteredSleepMillis);
                 } catch (InterruptedException ie) {
                     Thread.currentThread().interrupt();
                     return null;
                 }
 
+                // exponential backoff applied
                 sleepMillis = sleepMillis * INTER_SERVER_DEFAULT_EXPONENTIAL_BACKOFF_VALUE;
             }
         }


### PR DESCRIPTION
## partially addresses #1
## resolves #566

## Task
- [x] (상품 서비스 -> 커머스 서비스) 재고 도메인 등록 요청
- [x] (상품 서비스 -> 커머스 서비스) 재고 목록 조회 요청
- [x] (상품 서비스 -> 풀필먼트 서비스) Fassto 인증 토큰 요청
- [x] (상품 서비스 -> 파일 서비스) 상품 이미지 목록 조회 요청
- [x] (커머스 서비스 -> 리워드 서비스) 링크 공유 상품 구매 시 포인트 적립 요청
- [x] (커머스 서비스 -> 상품 서비스) 주문 상품 장바구니 삭제 요청
- [x] (커머스 서비스 -> 상품 서비스) 가격정책 ID 기반 상품 정보 조회 요청
- [x] (커뮤니티 서비스 -> 상품 서비스) 가격정책 ID 기반 상품 정보 조회 요청
- [x] (커뮤니티 서비스 -> 파일 서비스) 리뷰 이미지 목록 조회 요청
- [x] (커뮤니티 서비스 -> 파일 서비스) 게시글 이미지 목록 조회 요청
- [x] (커뮤니티 서비스 -> 커머스 서비스) 주문 상품 리뷰 상태 업데이트 요청
- [x] (회원 서비스 -> 리워드 서비스) 사용자 포인트 등록 요청
- [x] (회원 서비스 -> 리워드 서비스) 추천인/피추천인 포인트 적립 요청
- [x] (풀필먼트 서비스 -> Fassto) 인증 토큰 발급 요청
- [x] (풀필먼트 서비스 -> Fassto) 인증 토큰 해제 요청
- [x] (풀필먼트 서비스 -> Fassto) 상품 등록 요청
- [x] (풀필먼트 서비스 -> Fassto) 출고지 등록 요청
- [x] (풀필먼트 서비스 -> Fassto) 출고지 목록 조회 요청
- [x] (풀필먼트 서비스 -> Fassto) 출고지 수정 요청
- [x] (풀필먼트 서비스 -> Fassto) 공급사 등록 요청
- [x] (풀필먼트 서비스 -> Fassto) 공급사 목록 조회 요청
- [x] (풀필먼트 서비스 -> Fassto) 공급사 수정 요청