### PR TITLE
[#475][#573] feat: 파스토 모음상품 상세 정보 조회 연동 기능 추가

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/apidocs/GetOrderInfoApiDocs.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/apidocs/GetOrderInfoApiDocs.java
@@ -122,6 +122,7 @@ import java.lang.annotation.*;
                 | **키** | **타입** | **설명** | **예시** |
                 | --- | --- | --- | --- |
                 | sellerId | number | 판매자 회원 ID | 1 |
+                | productId | number | 상품 ID | 1 |
                 | pricePolicyId | number | 가격 정책 ID | 1 |
                 | sharerId | number | 링크 공유 회원 ID | 1 |
                 | quantity | number | 주문 수량 | 2 |
@@ -177,6 +178,7 @@ import java.lang.annotation.*;
                                               "orderPrducts": [
                                                 {
                                                   "sellerId": 12,
+                                                  "productId": 1,
                                                   "pricePolicyId": 180,
                                                   "sharerId": 1,
                                                   "quantity": 10,
@@ -201,6 +203,7 @@ import java.lang.annotation.*;
                                                 },
                                                 {
                                                   "sellerId": 11,
+                                                  "productId": 2,
                                                   "pricePolicyId": 166,
                                                   "sharerId": null,
                                                   "quantity": 2,

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/apidocs/GetOrderProductsApiDocs.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/apidocs/GetOrderProductsApiDocs.java
@@ -68,6 +68,7 @@ import java.lang.annotation.*;
                 | orderDate | string(date) | 주문 생성일(일 단위) | "2026-01-31" |
                 | orderStatus | string | 주문 상태 | "DELIVERED" |
                 | sellerId | number | 판매자 회원 ID | 1 |
+                | productId | number | 상품 ID | 1 |
                 | pricePolicyId | number | 가격 정책 ID | 1 |
                 | sharerId | number | 링크 공유 회원 ID | 1 |
                 | quantity | number | 주문 수량 | 2 |
@@ -116,13 +117,14 @@ import java.lang.annotation.*;
                                                 "orderDate": "2026-01-31",
                                                 "orderStatus": "DELIVERED",
                                                 "sellerId": 12,
+                                                "productId": 1,
                                                 "pricePolicyId": 166,
                                                 "sharerId": 1,
                                                 "quantity": 2,
                                                 "unitAmount": 50000,
                                                 "imageUrl": "https://marketnote.s3.amazonaws.com/product/30/1763534195922_image_600.png",
                                                 "brandName": "브랜드명1",
-                                                "productName": "스프링노트12345",
+                                                "productName": "공책",
                                                 "selectedOptions": [
                                                   {
                                                     "id": 55,

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/apidocs/GetOrdersApiDocs.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/apidocs/GetOrdersApiDocs.java
@@ -126,6 +126,7 @@ import java.lang.annotation.*;
                 | **키** | **타입** | **설명** | **예시** |
                 | --- | --- | --- | --- |
                 | sellerId | number | 판매자 회원 ID | 1 |
+                | productId | number | 상품 ID | 1 |
                 | pricePolicyId | number | 가격 정책 ID | 1 |
                 | sharerId | number | 링크 공유 회원 ID | 1 |
                 | quantity | number | 주문 수량 | 2 |
@@ -176,6 +177,7 @@ import java.lang.annotation.*;
                                                     "orderProducts": [
                                                       {
                                                         "sellerId": 12,
+                                                        "productId": 1,
                                                         "pricePolicyId": 166,
                                                         "sharerId": 1,
                                                         "quantity": 2,
@@ -195,6 +197,7 @@ import java.lang.annotation.*;
                                                       },
                                                       {
                                                         "sellerId": 12,
+                                                        "productId": 2,
                                                         "pricePolicyId": 180,
                                                         "sharerId": 1,
                                                         "quantity": 10,
@@ -232,6 +235,7 @@ import java.lang.annotation.*;
                                                     "orderProducts": [
                                                       {
                                                         "sellerId": 1,
+                                                        "productId": 3,
                                                         "pricePolicyId": 144,
                                                         "sharerId": 1,
                                                         "quantity": 10,
@@ -261,6 +265,7 @@ import java.lang.annotation.*;
                                                       },
                                                       {
                                                         "sellerId": 1,
+                                                        "productId": 4,
                                                         "pricePolicyId": 189,
                                                         "sharerId": null,
                                                         "quantity": 2,
@@ -303,6 +308,7 @@ import java.lang.annotation.*;
                                                     "orderProducts": [
                                                       {
                                                         "sellerId": 1,
+                                                        "productId": 5,
                                                         "pricePolicyId": 159,
                                                         "sharerId": null,
                                                         "quantity": 2,
@@ -327,6 +333,7 @@ import java.lang.annotation.*;
                                                       },
                                                       {
                                                         "sellerId": 1,
+                                                        "productId": 6,
                                                         "pricePolicyId": 185,
                                                         "sharerId": 1,
                                                         "quantity": 10,

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/web/product/ProductServiceClient.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/web/product/ProductServiceClient.java
@@ -134,6 +134,7 @@ public class ProductServiceClient implements FindProductByPricePolicyPort {
             productInfoResultsByPricePolicyId.put(
                     pricePolicyId,
                     new ProductInfoResult(
+                            productInfo.id(),
                             productInfo.name(),
                             productInfo.brandName(),
                             productInfo.selectedOptions()

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/web/product/response/ProductsInfoResponse.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/web/product/response/ProductsInfoResponse.java
@@ -8,6 +8,7 @@ import java.util.List;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record ProductsInfoResponse(
+        Long id,
         String name,
         String brandName,
         ProductPricePolicyInfoResult pricePolicy,

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/result/order/GetBuyerOrderProductResult.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/result/order/GetBuyerOrderProductResult.java
@@ -19,6 +19,7 @@ public record GetBuyerOrderProductResult(
         LocalDate orderDate,
         OrderStatus orderStatus,
         Long sellerId,
+        Long productId,
         Long pricePolicyId,
         Long sharerId,
         Integer quantity,
@@ -49,6 +50,7 @@ public record GetBuyerOrderProductResult(
                 .orderDate(resolvedOrderDate)
                 .orderStatus(orderProductResult.orderStatus())
                 .sellerId(orderProductResult.sellerId())
+                .productId(orderProductResult.productId())
                 .pricePolicyId(orderProductResult.pricePolicyId())
                 .sharerId(orderProductResult.sharerId())
                 .quantity(orderProductResult.quantity())

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/result/order/GetOrderProductResult.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/result/order/GetOrderProductResult.java
@@ -14,6 +14,7 @@ import java.util.List;
 @Builder(access = AccessLevel.PRIVATE)
 public record GetOrderProductResult(
         Long sellerId,
+        Long productId,
         Long pricePolicyId,
         Long sharerId,
         Integer quantity,
@@ -35,6 +36,11 @@ public record GetOrderProductResult(
 
         return GetOrderProductResult.builder()
                 .sellerId(orderProduct.getSellerId())
+                .productId(
+                        orderedProductExists
+                                ? productInfo.id()
+                                : null
+                )
                 .pricePolicyId(orderProduct.getPricePolicyId())
                 .sharerId(orderProduct.getSharerId())
                 .quantity(orderProduct.getQuantity())

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/result/product/ProductInfoResult.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/result/product/ProductInfoResult.java
@@ -5,6 +5,7 @@ import com.personal.marketnote.commerce.port.out.product.result.ProductOptionInf
 import java.util.List;
 
 public record ProductInfoResult(
+        Long id,
         String name,
         String brandName,
         List<ProductOptionInfoResult> selectedOptions

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/FasstoGoodsController.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/FasstoGoodsController.java
@@ -2,17 +2,21 @@ package com.personal.marketnote.fulfillment.adapter.in.web.vendor.controller;
 
 import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
 import com.personal.marketnote.fulfillment.adapter.in.web.vendor.controller.apidocs.GetFasstoGoodsApiDocs;
+import com.personal.marketnote.fulfillment.adapter.in.web.vendor.controller.apidocs.GetFasstoGoodsElementsApiDocs;
 import com.personal.marketnote.fulfillment.adapter.in.web.vendor.controller.apidocs.RegisterFasstoGoodsApiDocs;
 import com.personal.marketnote.fulfillment.adapter.in.web.vendor.controller.apidocs.UpdateFasstoGoodsApiDocs;
 import com.personal.marketnote.fulfillment.adapter.in.web.vendor.mapper.FasstoGoodsRequestToCommandMapper;
 import com.personal.marketnote.fulfillment.adapter.in.web.vendor.request.RegisterFasstoGoodsRequest;
 import com.personal.marketnote.fulfillment.adapter.in.web.vendor.request.UpdateFasstoGoodsRequest;
+import com.personal.marketnote.fulfillment.adapter.in.web.vendor.response.GetFasstoGoodsElementsResponse;
 import com.personal.marketnote.fulfillment.adapter.in.web.vendor.response.GetFasstoGoodsResponse;
 import com.personal.marketnote.fulfillment.adapter.in.web.vendor.response.RegisterFasstoGoodsResponse;
 import com.personal.marketnote.fulfillment.adapter.in.web.vendor.response.UpdateFasstoGoodsResponse;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.GetFasstoGoodsElementsResult;
 import com.personal.marketnote.fulfillment.port.in.result.vendor.GetFasstoGoodsResult;
 import com.personal.marketnote.fulfillment.port.in.result.vendor.RegisterFasstoGoodsResult;
 import com.personal.marketnote.fulfillment.port.in.result.vendor.UpdateFasstoGoodsResult;
+import com.personal.marketnote.fulfillment.port.in.usecase.vendor.GetFasstoGoodsElementsUseCase;
 import com.personal.marketnote.fulfillment.port.in.usecase.vendor.GetFasstoGoodsUseCase;
 import com.personal.marketnote.fulfillment.port.in.usecase.vendor.RegisterFasstoGoodsUseCase;
 import com.personal.marketnote.fulfillment.port.in.usecase.vendor.UpdateFasstoGoodsUseCase;
@@ -37,6 +41,7 @@ public class FasstoGoodsController {
     private final RegisterFasstoGoodsUseCase registerFasstoGoodsUseCase;
     private final GetFasstoGoodsUseCase getFasstoGoodsUseCase;
     private final UpdateFasstoGoodsUseCase updateFasstoGoodsUseCase;
+    private final GetFasstoGoodsElementsUseCase getFasstoGoodsElementsUseCase;
 
     /**
      * (관리자) 파스토 상품 등록 요청
@@ -97,6 +102,37 @@ public class FasstoGoodsController {
                         HttpStatus.OK,
                         DEFAULT_SUCCESS_CODE,
                         "파스토 상품 목록 조회 성공"
+                ),
+                HttpStatus.OK
+        );
+    }
+
+    /**
+     * (관리자) 파스토 모음상품 상세 정보 조회
+     *
+     * @param customerCode 파스토 고객사 코드
+     * @param accessToken  파스토 액세스 토큰
+     * @Author 성효빈
+     * @Date 2026-01-31
+     * @Description 파스토 모음상품 상세 정보를 조회합니다.
+     */
+    @GetMapping("/element/{customerCode}")
+    @PreAuthorize(ADMIN_POINTCUT)
+    @GetFasstoGoodsElementsApiDocs
+    public ResponseEntity<BaseResponse<GetFasstoGoodsElementsResponse>> getGoodsElements(
+            @PathVariable String customerCode,
+            @RequestHeader("accessToken") String accessToken
+    ) {
+        GetFasstoGoodsElementsResult result = getFasstoGoodsElementsUseCase.getGoodsElements(
+                FasstoGoodsRequestToCommandMapper.mapToGoodsElementsCommand(customerCode, accessToken)
+        );
+
+        return new ResponseEntity<>(
+                BaseResponse.of(
+                        GetFasstoGoodsElementsResponse.from(result),
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "파스토 모음상품 상세 정보 조회 성공"
                 ),
                 HttpStatus.OK
         );

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/apidocs/GetFasstoGoodsElementsApiDocs.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/apidocs/GetFasstoGoodsElementsApiDocs.java
@@ -1,0 +1,192 @@
+package com.personal.marketnote.fulfillment.adapter.in.web.vendor.controller.apidocs;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Operation(
+        summary = "(관리자) 파스토 모음상품 상세 정보 조회",
+        description = """
+                작성일자: 2026-01-31
+                
+                작성자: 성효빈
+                
+                ---
+                
+                ## Description
+                
+                파스토 모음상품 상세 정보를 조회합니다.
+                
+                ---
+                
+                ## Request
+                
+                | **키** | **위치** | **타입** | **설명** | **필수 여부** | **예시** |
+                | --- | --- | --- | --- | --- | --- |
+                | accessToken | header | string | 파스토 액세스 토큰 | Y | 3169eb15ef7a11f0be620ab49498ff55 |
+                | customerCode | path | string | 파스토 고객사 코드 | Y | 94388 |
+                
+                ---
+                
+                ## Response
+                
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | statusCode | number | 상태 코드 | 200: 성공 / 400: 클라이언트 요청 오류 / 401: 인증 실패 / 403: 인가 실패 / 500: 그 외 |
+                | code | string | 응답 코드 | "SUC01" / "BAD_REQUEST" / "UNAUTHORIZED" / "FORBIDDEN" / "INTERNAL_SERVER_ERROR" |
+                | timestamp | string(datetime) | 응답 일시 | "2026-01-31T12:12:30.013" |
+                | content | object | 응답 본문 | { ... } |
+                | message | string | 처리 결과 | "파스토 모음상품 상세 정보 조회 성공" |
+                
+                ---
+                
+                ### Response > content
+                
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | dataCount | number | 조회 건수 | 0 |
+                | elements | array | 모음상품 목록 | [ ... ] |
+                
+                ---
+                
+                ### Response > content > elements
+                
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | godCd | string | 상품코드 | "943881" |
+                | cstGodCd | string | 고객사상품코드 | "1" |
+                | godNm | string | 상품명 | "테스트 모음상품" |
+                | useYn | string | 사용여부 | "Y" |
+                | elementList | array | 구성상품 목록 | [ ... ] |
+                
+                ---
+                
+                ### Response > content > elements > elementList
+                
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | godCd | string | 상품코드 | "94388001" |
+                | cstGodCd | string | 고객사상품코드 | "1" |
+                | godBarcd | string | 상품바코드 | "ABC123" |
+                | godNm | string | 상품명 | "구성 상품1" |
+                | godType | string | 상품유형 | "1" |
+                | godTypeNm | string | 상품유형명 | "단품" |
+                | qty | number | 수량 | 1 |
+                """,
+        security = {@SecurityRequirement(name = "bearer")},
+        parameters = {
+                @Parameter(
+                        name = "accessToken",
+                        description = "파스토 액세스 토큰",
+                        in = ParameterIn.HEADER,
+                        required = true,
+                        schema = @Schema(type = "string", example = "3169eb15ef7a11f0be620ab49498ff55")
+                ),
+                @Parameter(
+                        name = "customerCode",
+                        description = "파스토 고객사 코드",
+                        in = ParameterIn.PATH,
+                        required = true,
+                        schema = @Schema(type = "string", example = "94388")
+                )
+        },
+        responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "파스토 모음상품 상세 정보 조회 성공",
+                        content = @Content(
+                                examples = {
+                                        @ExampleObject(
+                                                name = "empty",
+                                                value = """
+                                                        {
+                                                          "statusCode": 200,
+                                                          "code": "SUC01",
+                                                          "timestamp": "2026-01-31T12:12:30.013",
+                                                          "content": {
+                                                            "dataCount": 0,
+                                                            "elements": []
+                                                          },
+                                                          "message": "파스토 모음상품 상세 정보 조회 성공"
+                                                        }
+                                                        """
+                                        ),
+                                        @ExampleObject(
+                                                name = "sample",
+                                                value = """
+                                                        {
+                                                          "statusCode": 200,
+                                                          "code": "SUC01",
+                                                          "timestamp": "2026-01-31T12:12:30.013",
+                                                          "content": {
+                                                            "dataCount": 1,
+                                                            "elements": [
+                                                              {
+                                                                "godCd": "943881",
+                                                                "cstGodCd": "1",
+                                                                "godNm": "테스트 모음상품",
+                                                                "useYn": "Y",
+                                                                "elementList": [
+                                                                  {
+                                                                    "godCd": "94388001",
+                                                                    "cstGodCd": "1",
+                                                                    "godBarcd": "ABC123",
+                                                                    "godNm": "구성 상품1",
+                                                                    "godType": "1",
+                                                                    "godTypeNm": "단품",
+                                                                    "qty": 1
+                                                                  }
+                                                                ]
+                                                              }
+                                                            ]
+                                                          },
+                                                          "message": "파스토 모음상품 상세 정보 조회 성공"
+                                                        }
+                                                        """
+                                        )
+                                }
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "401",
+                        description = "토큰 인증 실패",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 401,
+                                          "code": "UNAUTHORIZED",
+                                          "timestamp": "2026-01-31T12:12:30.013",
+                                          "content": null,
+                                          "message": "Invalid token"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "403",
+                        description = "토큰 인가 실패",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 403,
+                                          "code": "FORBIDDEN",
+                                          "timestamp": "2026-01-31T12:12:30.013",
+                                          "content": null,
+                                          "message": "Access Denied"
+                                        }
+                                        """)
+                        )
+                )
+        })
+public @interface GetFasstoGoodsElementsApiDocs {
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/mapper/FasstoGoodsRequestToCommandMapper.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/mapper/FasstoGoodsRequestToCommandMapper.java
@@ -62,6 +62,13 @@ public class FasstoGoodsRequestToCommandMapper {
         return GetFasstoGoodsCommand.of(customerCode, accessToken);
     }
 
+    public static GetFasstoGoodsElementsCommand mapToGoodsElementsCommand(
+            String customerCode,
+            String accessToken
+    ) {
+        return GetFasstoGoodsElementsCommand.of(customerCode, accessToken);
+    }
+
     public static UpdateFasstoGoodsCommand mapToUpdateCommand(
             String customerCode,
             String accessToken,

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/response/GetFasstoGoodsElementsResponse.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/response/GetFasstoGoodsElementsResponse.java
@@ -1,0 +1,15 @@
+package com.personal.marketnote.fulfillment.adapter.in.web.vendor.response;
+
+import com.personal.marketnote.fulfillment.port.in.result.vendor.FasstoGoodsElementInfoResult;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.GetFasstoGoodsElementsResult;
+
+import java.util.List;
+
+public record GetFasstoGoodsElementsResponse(
+        Integer dataCount,
+        List<FasstoGoodsElementInfoResult> elements
+) {
+    public static GetFasstoGoodsElementsResponse from(GetFasstoGoodsElementsResult result) {
+        return new GetFasstoGoodsElementsResponse(result.dataCount(), result.elements());
+    }
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoGoodsElementItemResponse.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoGoodsElementItemResponse.java
@@ -1,0 +1,15 @@
+package com.personal.marketnote.fulfillment.adapter.out.vendor.fassto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record FasstoGoodsElementItemResponse(
+        String godCd,
+        String cstGodCd,
+        String godBarcd,
+        String godNm,
+        String godType,
+        String godTypeNm,
+        Integer qty
+) {
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoGoodsElementResponse.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoGoodsElementResponse.java
@@ -1,0 +1,15 @@
+package com.personal.marketnote.fulfillment.adapter.out.vendor.fassto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record FasstoGoodsElementResponse(
+        String godCd,
+        String cstGodCd,
+        String godNm,
+        String useYn,
+        List<FasstoGoodsElementItemResponse> elementList
+) {
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoGoodsElementsResponse.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoGoodsElementsResponse.java
@@ -1,0 +1,16 @@
+package com.personal.marketnote.fulfillment.adapter.out.vendor.fassto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record FasstoGoodsElementsResponse(
+        FasstoResponseHeader header,
+        List<FasstoGoodsElementResponse> data,
+        FasstoErrorInfo errorInfo
+) implements FasstoApiResponse {
+    public boolean isSuccess() {
+        return header != null && header.isSuccess() && data != null;
+    }
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/resources/application.yml
+++ b/fulfillment-service/fulfillment-adapters/src/main/resources/application.yml
@@ -54,6 +54,7 @@ vendor:
       shop-path: ${FASSTO_MARKETNOTE_PATH:/api/v1/marketnote/{customerCode}}
       supplier-path: ${FASSTO_SUPPLIER_PATH:/api/v1/supplier/{customerCode}}
       goods-path: ${FASSTO_GOODS_PATH:/api/v1/goods/{customerCode}}
+      goods-element-path: ${FASSTO_GOODS_ELEMENT_PATH:/api/v1/goods/element/{customerCode}}
       api-cd: ${FASSTO_API_CD:change-me}
       api-key: ${FASSTO_API_KEY:change-me}
 

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/configuration/FasstoAuthProperties.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/configuration/FasstoAuthProperties.java
@@ -18,4 +18,5 @@ public class FasstoAuthProperties {
     private String shopPath = "/api/v1/marketnote/{customerCode}";
     private String supplierPath = "/api/v1/supplier/{customerCode}";
     private String goodsPath = "/api/v1/goods/{customerCode}";
+    private String goodsElementPath = "/api/v1/goods/element/{customerCode}";
 }

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/GetFasstoGoodsElementsFailedException.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/GetFasstoGoodsElementsFailedException.java
@@ -1,0 +1,25 @@
+package com.personal.marketnote.fulfillment.exception;
+
+import com.personal.marketnote.common.exception.ExternalOperationFailedException;
+import com.personal.marketnote.common.utility.FormatValidator;
+
+import java.io.IOException;
+
+public class GetFasstoGoodsElementsFailedException extends ExternalOperationFailedException {
+    private static final String DEFAULT_MESSAGE = "파스토 모음상품 상세 정보 조회 중 오류가 발생했습니다.";
+
+    public GetFasstoGoodsElementsFailedException(IOException cause) {
+        super(DEFAULT_MESSAGE, cause);
+    }
+
+    public GetFasstoGoodsElementsFailedException(String vendorMessage, IOException cause) {
+        super(resolveMessage(vendorMessage), cause);
+    }
+
+    private static String resolveMessage(String vendorMessage) {
+        if (FormatValidator.hasValue(vendorMessage)) {
+            return String.format("파스토 모음상품 상세 정보 조회 실패: %s", vendorMessage);
+        }
+        return DEFAULT_MESSAGE;
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/mapper/FasstoGoodsCommandToRequestMapper.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/mapper/FasstoGoodsCommandToRequestMapper.java
@@ -1,5 +1,6 @@
 package com.personal.marketnote.fulfillment.mapper;
 
+import com.personal.marketnote.fulfillment.domain.vendor.fassto.goods.FasstoGoodsElementQuery;
 import com.personal.marketnote.fulfillment.domain.vendor.fassto.goods.FasstoGoodsItemMapper;
 import com.personal.marketnote.fulfillment.domain.vendor.fassto.goods.FasstoGoodsMapper;
 import com.personal.marketnote.fulfillment.domain.vendor.fassto.goods.FasstoGoodsQuery;
@@ -22,6 +23,13 @@ public class FasstoGoodsCommandToRequestMapper {
 
     public static FasstoGoodsQuery mapToGoodsQuery(GetFasstoGoodsCommand command) {
         return FasstoGoodsQuery.of(
+                command.customerCode(),
+                command.accessToken()
+        );
+    }
+
+    public static FasstoGoodsElementQuery mapToGoodsElementsQuery(GetFasstoGoodsElementsCommand command) {
+        return FasstoGoodsElementQuery.of(
                 command.customerCode(),
                 command.accessToken()
         );

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/vendor/GetFasstoGoodsElementsCommand.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/vendor/GetFasstoGoodsElementsCommand.java
@@ -1,0 +1,10 @@
+package com.personal.marketnote.fulfillment.port.in.command.vendor;
+
+public record GetFasstoGoodsElementsCommand(
+        String customerCode,
+        String accessToken
+) {
+    public static GetFasstoGoodsElementsCommand of(String customerCode, String accessToken) {
+        return new GetFasstoGoodsElementsCommand(customerCode, accessToken);
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/result/vendor/FasstoGoodsElementInfoResult.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/result/vendor/FasstoGoodsElementInfoResult.java
@@ -1,0 +1,27 @@
+package com.personal.marketnote.fulfillment.port.in.result.vendor;
+
+import java.util.List;
+
+public record FasstoGoodsElementInfoResult(
+        String godCd,
+        String cstGodCd,
+        String godNm,
+        String useYn,
+        List<FasstoGoodsElementItemResult> elementList
+) {
+    public static FasstoGoodsElementInfoResult of(
+            String godCd,
+            String cstGodCd,
+            String godNm,
+            String useYn,
+            List<FasstoGoodsElementItemResult> elementList
+    ) {
+        return new FasstoGoodsElementInfoResult(
+                godCd,
+                cstGodCd,
+                godNm,
+                useYn,
+                elementList
+        );
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/result/vendor/FasstoGoodsElementItemResult.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/result/vendor/FasstoGoodsElementItemResult.java
@@ -1,0 +1,31 @@
+package com.personal.marketnote.fulfillment.port.in.result.vendor;
+
+public record FasstoGoodsElementItemResult(
+        String godCd,
+        String cstGodCd,
+        String godBarcd,
+        String godNm,
+        String godType,
+        String godTypeNm,
+        Integer qty
+) {
+    public static FasstoGoodsElementItemResult of(
+            String godCd,
+            String cstGodCd,
+            String godBarcd,
+            String godNm,
+            String godType,
+            String godTypeNm,
+            Integer qty
+    ) {
+        return new FasstoGoodsElementItemResult(
+                godCd,
+                cstGodCd,
+                godBarcd,
+                godNm,
+                godType,
+                godTypeNm,
+                qty
+        );
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/result/vendor/GetFasstoGoodsElementsResult.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/result/vendor/GetFasstoGoodsElementsResult.java
@@ -1,0 +1,15 @@
+package com.personal.marketnote.fulfillment.port.in.result.vendor;
+
+import java.util.List;
+
+public record GetFasstoGoodsElementsResult(
+        Integer dataCount,
+        List<FasstoGoodsElementInfoResult> elements
+) {
+    public static GetFasstoGoodsElementsResult of(
+            Integer dataCount,
+            List<FasstoGoodsElementInfoResult> elements
+    ) {
+        return new GetFasstoGoodsElementsResult(dataCount, elements);
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/usecase/vendor/GetFasstoGoodsElementsUseCase.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/usecase/vendor/GetFasstoGoodsElementsUseCase.java
@@ -1,0 +1,15 @@
+package com.personal.marketnote.fulfillment.port.in.usecase.vendor;
+
+import com.personal.marketnote.fulfillment.port.in.command.vendor.GetFasstoGoodsElementsCommand;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.GetFasstoGoodsElementsResult;
+
+public interface GetFasstoGoodsElementsUseCase {
+    /**
+     * @param command 모음상품 상세 정보 조회 커맨드
+     * @return 모음상품 상세 정보 조회 결과 {@link GetFasstoGoodsElementsResult}
+     * @Date 2026-01-31
+     * @Author 성효빈
+     * @Description 파스토 모음상품 상세 정보를 조회합니다.
+     */
+    GetFasstoGoodsElementsResult getGoodsElements(GetFasstoGoodsElementsCommand command);
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/vendor/GetFasstoGoodsElementsPort.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/vendor/GetFasstoGoodsElementsPort.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.fulfillment.port.out.vendor;
+
+import com.personal.marketnote.fulfillment.domain.vendor.fassto.goods.FasstoGoodsElementQuery;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.GetFasstoGoodsElementsResult;
+
+public interface GetFasstoGoodsElementsPort {
+    GetFasstoGoodsElementsResult getGoodsElements(FasstoGoodsElementQuery query);
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/vendor/GetFasstoGoodsElementsService.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/vendor/GetFasstoGoodsElementsService.java
@@ -1,0 +1,26 @@
+package com.personal.marketnote.fulfillment.service.vendor;
+
+import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.fulfillment.mapper.FasstoGoodsCommandToRequestMapper;
+import com.personal.marketnote.fulfillment.port.in.command.vendor.GetFasstoGoodsElementsCommand;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.GetFasstoGoodsElementsResult;
+import com.personal.marketnote.fulfillment.port.in.usecase.vendor.GetFasstoGoodsElementsUseCase;
+import com.personal.marketnote.fulfillment.port.out.vendor.GetFasstoGoodsElementsPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional(isolation = READ_COMMITTED, readOnly = true)
+public class GetFasstoGoodsElementsService implements GetFasstoGoodsElementsUseCase {
+    private final GetFasstoGoodsElementsPort getFasstoGoodsElementsPort;
+
+    @Override
+    public GetFasstoGoodsElementsResult getGoodsElements(GetFasstoGoodsElementsCommand command) {
+        return getFasstoGoodsElementsPort.getGoodsElements(
+                FasstoGoodsCommandToRequestMapper.mapToGoodsElementsQuery(command)
+        );
+    }
+}

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/goods/FasstoGoodsElementQuery.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/goods/FasstoGoodsElementQuery.java
@@ -1,0 +1,31 @@
+package com.personal.marketnote.fulfillment.domain.vendor.fassto.goods;
+
+import com.personal.marketnote.common.utility.FormatValidator;
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+public class FasstoGoodsElementQuery {
+    private String customerCode;
+    private String accessToken;
+
+    public static FasstoGoodsElementQuery of(String customerCode, String accessToken) {
+        FasstoGoodsElementQuery query = FasstoGoodsElementQuery.builder()
+                .customerCode(customerCode)
+                .accessToken(accessToken)
+                .build();
+        query.validate();
+        return query;
+    }
+
+    private void validate() {
+        if (FormatValidator.hasNoValue(customerCode)) {
+            throw new IllegalArgumentException("customerCode is required.");
+        }
+        if (FormatValidator.hasNoValue(accessToken)) {
+            throw new IllegalArgumentException("accessToken is required.");
+        }
+    }
+}

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/option/response/ProductOptionResponse.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/option/response/ProductOptionResponse.java
@@ -22,5 +22,3 @@ public class ProductOptionResponse {
                 .build();
     }
 }
-
-


### PR DESCRIPTION
## partially addresses #475
## resolves #573

## Task
- [x] 파스토 모음상품 상세 정보 조회 연동 요청
- [x] 파스토 모음상품 상세 정보 조회 연동 비즈니스 로직
- [x] 파스토 서버에 모음상품 상세 정보 조회 요청
- [x] 200 status code 응답
- [x] Swagger docs