### PR TITLE
[#475][#599] feat: 파스토 상품 입고 목록 조회 연동 기능 추가

### DIFF
--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/FasstoWarehousingController.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/FasstoWarehousingController.java
@@ -1,11 +1,15 @@
 package com.personal.marketnote.fulfillment.adapter.in.web.vendor.controller;
 
 import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
+import com.personal.marketnote.fulfillment.adapter.in.web.vendor.controller.apidocs.GetFasstoWarehousingApiDocs;
 import com.personal.marketnote.fulfillment.adapter.in.web.vendor.controller.apidocs.RegisterFasstoWarehousingApiDocs;
 import com.personal.marketnote.fulfillment.adapter.in.web.vendor.mapper.FasstoWarehousingRequestToCommandMapper;
 import com.personal.marketnote.fulfillment.adapter.in.web.vendor.request.RegisterFasstoWarehousingRequest;
+import com.personal.marketnote.fulfillment.adapter.in.web.vendor.response.GetFasstoWarehousingResponse;
 import com.personal.marketnote.fulfillment.adapter.in.web.vendor.response.RegisterFasstoWarehousingResponse;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.GetFasstoWarehousingResult;
 import com.personal.marketnote.fulfillment.port.in.result.vendor.RegisterFasstoWarehousingResult;
+import com.personal.marketnote.fulfillment.port.in.usecase.vendor.GetFasstoWarehousingUseCase;
 import com.personal.marketnote.fulfillment.port.in.usecase.vendor.RegisterFasstoWarehousingUseCase;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -26,6 +30,7 @@ import static com.personal.marketnote.common.utility.ApiConstant.ADMIN_POINTCUT;
 @RequiredArgsConstructor
 public class FasstoWarehousingController {
     private final RegisterFasstoWarehousingUseCase registerFasstoWarehousingUseCase;
+    private final GetFasstoWarehousingUseCase getFasstoWarehousingUseCase;
 
     /**
      * (관리자) 파스토 상품 입고 요청
@@ -57,6 +62,41 @@ public class FasstoWarehousingController {
                         "파스토 상품 입고 요청 성공"
                 ),
                 HttpStatus.CREATED
+        );
+    }
+
+    /**
+     * (관리자) 파스토 상품 입고 목록 조회
+     *
+     * @param customerCode 파스토 고객사 코드
+     * @param accessToken  파스토 액세스 토큰
+     * @param startDate    조회 시작일(YYYYMMDD)
+     * @param endDate      조회 종료일(YYYYMMDD)
+     * @Author 성효빈
+     * @Date 2026-02-03
+     * @Description 파스토 상품 입고 목록을 조회합니다.
+     */
+    @GetMapping("/{customerCode}/{startDate}/{endDate}")
+    @PreAuthorize(ADMIN_POINTCUT)
+    @GetFasstoWarehousingApiDocs
+    public ResponseEntity<BaseResponse<GetFasstoWarehousingResponse>> getWarehousing(
+            @PathVariable String customerCode,
+            @PathVariable String startDate,
+            @PathVariable String endDate,
+            @RequestHeader("accessToken") String accessToken
+    ) {
+        GetFasstoWarehousingResult result = getFasstoWarehousingUseCase.getWarehousing(
+                FasstoWarehousingRequestToCommandMapper.mapToWarehousingQuery(customerCode, accessToken, startDate, endDate)
+        );
+
+        return new ResponseEntity<>(
+                BaseResponse.of(
+                        GetFasstoWarehousingResponse.from(result),
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "파스토 입고 목록 조회 성공"
+                ),
+                HttpStatus.OK
         );
     }
 }

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/apidocs/GetFasstoWarehousingApiDocs.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/apidocs/GetFasstoWarehousingApiDocs.java
@@ -1,0 +1,200 @@
+package com.personal.marketnote.fulfillment.adapter.in.web.vendor.controller.apidocs;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Operation(
+        summary = "(관리자) 파스토 입고 목록 조회",
+        description = """
+                작성일자: 2026-02-03
+                
+                작성자: 성효빈
+                
+                ---
+                
+                ## Description
+                
+                파스토 상품 입고 목록을 조회합니다.
+                
+                ---
+                
+                ## Request
+                
+                | **키** | **위치** | **타입** | **설명** | **필수 여부** | **예시** |
+                | --- | --- | --- | --- | --- | --- |
+                | accessToken | header | string | 파스토 액세스 토큰 | Y | 3169eb15ef7a11f0be620ab49498ff55 |
+                | customerCode | path | string | 파스토 고객사 코드 | Y | 94388 |
+                | startDate | path | string | 조회 시작일(YYYYMMDD) | Y | 20260112 |
+                | endDate | path | string | 조회 종료일(YYYYMMDD) | Y | 20260112 |
+                
+                ---
+                
+                ## Response
+                
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | statusCode | number | 상태 코드 | 200: 성공 / 400: 클라이언트 요청 오류 / 401: 인증 실패 / 403: 인가 실패 / 500: 그 외 |
+                | code | string | 응답 코드 | "SUC01" / "BAD_REQUEST" / "UNAUTHORIZED" / "FORBIDDEN" / "INTERNAL_SERVER_ERROR" |
+                | timestamp | string(datetime) | 응답 일시 | "2026-02-03T12:12:30.013" |
+                | content | object | 응답 본문 | { ... } |
+                | message | string | 처리 결과 | "파스토 상품 입고 목록 조회 성공" |
+                
+                ---
+                
+                ### Response > content
+                
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | dataCount | number | 조회 건수 | 1 |
+                | warehousing | array | 입고 목록 | [ ... ] |
+                
+                ---
+                
+                ### Response > content > warehousing
+                
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | ordDt | string | 입고 요청일 | "20260112" |
+                | whCd | string | 창고 코드 | "TEST" |
+                | whNm | string | 창고명 | "테스트" |
+                | slipNo | string | 입고 요청번호 | "TESTIO260112000003" |
+                | ordNo | string | 주문번호 | "" |
+                | cstCd | string | 고객사 코드 | "94388" |
+                | cstNm | string | 고객사명 | "마켓노트 주식회사 테스트" |
+                | supCd | string | 공급사 코드 | "99999999" |
+                | cstSupCd | string | 고객사 공급사 코드 | null |
+                | supNm | string | 공급사명 | "미지정 공급사" |
+                | sku | number | SKU 수량 | 1 |
+                | ordQty | number | 주문수량 | 1 |
+                | inQty | number | 입고수량 | 0 |
+                | tarQty | number | 대상수량 | 1 |
+                | inWay | string | 입고방법 코드 | "01" |
+                | inWayNm | string | 입고방법명 | "택배" |
+                | parcelComp | string | 택배사명 | "" |
+                | parcelInvoiceNo | string | 송장번호 | "" |
+                | wrkStat | string | 작업상태 코드 | "1" |
+                | wrkStatNm | string | 작업상태명 | "입고요청" |
+                | emgrYn | string | 긴급 여부 | null |
+                | remark | string | 비고 | "" |
+                | goodsSerialNo | array | 상품 일련번호 목록 | [] |
+                """,
+        security = {@SecurityRequirement(name = "bearer")},
+        parameters = {
+                @Parameter(
+                        name = "accessToken",
+                        description = "파스토 액세스 토큰",
+                        in = ParameterIn.HEADER,
+                        required = true,
+                        schema = @Schema(type = "string", example = "3169eb15ef7a11f0be620ab49498ff55")
+                ),
+                @Parameter(
+                        name = "customerCode",
+                        description = "파스토 고객사 코드",
+                        in = ParameterIn.PATH,
+                        required = true,
+                        schema = @Schema(type = "string", example = "94388")
+                ),
+                @Parameter(
+                        name = "startDate",
+                        description = "조회 시작일(YYYYMMDD)",
+                        in = ParameterIn.PATH,
+                        required = true,
+                        schema = @Schema(type = "string", example = "20260112")
+                ),
+                @Parameter(
+                        name = "endDate",
+                        description = "조회 종료일(YYYYMMDD)",
+                        in = ParameterIn.PATH,
+                        required = true,
+                        schema = @Schema(type = "string", example = "20260112")
+                )
+        },
+        responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "파스토 상품 입고 목록 조회 성공",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 200,
+                                          "code": "SUC01",
+                                          "timestamp": "2026-02-03T12:12:30.013",
+                                          "content": {
+                                            "dataCount": 1,
+                                            "warehousing": [
+                                              {
+                                                "ordDt": "20260112",
+                                                "whCd": "TEST",
+                                                "whNm": "테스트",
+                                                "slipNo": "TESTIO260112000003",
+                                                "ordNo": "",
+                                                "cstCd": "94388",
+                                                "cstNm": "마켓노트 주식회사 테스트",
+                                                "supCd": "99999999",
+                                                "cstSupCd": null,
+                                                "supNm": "미지정 공급사",
+                                                "sku": 1,
+                                                "ordQty": 1,
+                                                "inQty": 0,
+                                                "tarQty": 1,
+                                                "inWay": "01",
+                                                "inWayNm": "택배",
+                                                "parcelComp": "",
+                                                "parcelInvoiceNo": "",
+                                                "wrkStat": "1",
+                                                "wrkStatNm": "입고 요청",
+                                                "emgrYn": null,
+                                                "remark": "",
+                                                "goodsSerialNo": []
+                                              }
+                                            ]
+                                          },
+                                          "message": "파스토 상품 입고 목록 조회 성공"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "401",
+                        description = "토큰 인증 실패",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 401,
+                                          "code": "UNAUTHORIZED",
+                                          "timestamp": "2026-02-03T12:12:30.013",
+                                          "content": null,
+                                          "message": "Invalid token"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "403",
+                        description = "토큰 인가 실패",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 403,
+                                          "code": "FORBIDDEN",
+                                          "timestamp": "2026-02-03T12:12:30.013",
+                                          "content": null,
+                                          "message": "Access Denied"
+                                        }
+                                        """)
+                        )
+                )
+        })
+public @interface GetFasstoWarehousingApiDocs {
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/mapper/FasstoWarehousingRequestToCommandMapper.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/mapper/FasstoWarehousingRequestToCommandMapper.java
@@ -2,6 +2,7 @@ package com.personal.marketnote.fulfillment.adapter.in.web.vendor.mapper;
 
 import com.personal.marketnote.fulfillment.adapter.in.web.vendor.request.RegisterFasstoWarehousingGoodsRequest;
 import com.personal.marketnote.fulfillment.adapter.in.web.vendor.request.RegisterFasstoWarehousingRequest;
+import com.personal.marketnote.fulfillment.port.in.command.vendor.GetFasstoWarehousingCommand;
 import com.personal.marketnote.fulfillment.port.in.command.vendor.RegisterFasstoWarehousingCommand;
 import com.personal.marketnote.fulfillment.port.in.command.vendor.RegisterFasstoWarehousingGoodsCommand;
 import com.personal.marketnote.fulfillment.port.in.command.vendor.RegisterFasstoWarehousingItemCommand;
@@ -19,6 +20,15 @@ public class FasstoWarehousingRequestToCommandMapper {
                 .toList();
 
         return RegisterFasstoWarehousingCommand.of(customerCode, accessToken, warehousingRequests);
+    }
+
+    public static GetFasstoWarehousingCommand mapToWarehousingQuery(
+            String customerCode,
+            String accessToken,
+            String startDate,
+            String endDate
+    ) {
+        return GetFasstoWarehousingCommand.of(customerCode, accessToken, startDate, endDate);
     }
 
     private static RegisterFasstoWarehousingItemCommand mapItem(RegisterFasstoWarehousingRequest item) {

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/response/GetFasstoWarehousingResponse.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/response/GetFasstoWarehousingResponse.java
@@ -1,0 +1,15 @@
+package com.personal.marketnote.fulfillment.adapter.in.web.vendor.response;
+
+import com.personal.marketnote.fulfillment.port.in.result.vendor.FasstoWarehousingInfoResult;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.GetFasstoWarehousingResult;
+
+import java.util.List;
+
+public record GetFasstoWarehousingResponse(
+        Integer dataCount,
+        List<FasstoWarehousingInfoResult> warehousing
+) {
+    public static GetFasstoWarehousingResponse from(GetFasstoWarehousingResult result) {
+        return new GetFasstoWarehousingResponse(result.dataCount(), result.warehousing());
+    }
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoWarehousingItemResponse.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoWarehousingItemResponse.java
@@ -1,0 +1,33 @@
+package com.personal.marketnote.fulfillment.adapter.out.vendor.fassto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record FasstoWarehousingItemResponse(
+        String ordDt,
+        String whCd,
+        String whNm,
+        String slipNo,
+        String ordNo,
+        String cstCd,
+        String cstNm,
+        String supCd,
+        String cstSupCd,
+        String supNm,
+        Integer sku,
+        Integer ordQty,
+        Integer inQty,
+        Integer tarQty,
+        String inWay,
+        String inWayNm,
+        String parcelComp,
+        String parcelInvoiceNo,
+        String wrkStat,
+        String wrkStatNm,
+        String emgrYn,
+        String remark,
+        List<Object> goodsSerialNo
+) {
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoWarehousingListResponse.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoWarehousingListResponse.java
@@ -1,0 +1,16 @@
+package com.personal.marketnote.fulfillment.adapter.out.vendor.fassto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record FasstoWarehousingListResponse(
+        FasstoResponseHeader header,
+        List<FasstoWarehousingItemResponse> data,
+        FasstoErrorInfo errorInfo
+) implements FasstoApiResponse {
+    public boolean isSuccess() {
+        return header != null && header.isSuccess() && data != null;
+    }
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/resources/application.yml
+++ b/fulfillment-service/fulfillment-adapters/src/main/resources/application.yml
@@ -56,6 +56,7 @@ vendor:
       goods-path: ${FASSTO_GOODS_PATH:/api/v1/goods/{customerCode}}
       goods-element-path: ${FASSTO_GOODS_ELEMENT_PATH:/api/v1/goods/element/{customerCode}}
       warehousing-path: ${FASSTO_WAREHOUSING_PATH:/api/v1/warehousing/{customerCode}}
+      warehousing-list-path: ${FASSTO_WAREHOUSING_LIST_PATH:/api/v1/warehousing/{customerCode}/{startDate}/{endDate}}
       api-cd: ${FASSTO_API_CD:change-me}
       api-key: ${FASSTO_API_KEY:change-me}
 

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/configuration/FasstoAuthProperties.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/configuration/FasstoAuthProperties.java
@@ -20,4 +20,5 @@ public class FasstoAuthProperties {
     private String goodsPath = "/api/v1/goods/{customerCode}";
     private String goodsElementPath = "/api/v1/goods/element/{customerCode}";
     private String warehousingPath = "/api/v1/warehousing/{customerCode}";
+    private String warehousingListPath = "/api/v1/warehousing/{customerCode}/{startDate}/{endDate}";
 }

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/GetFasstoWarehousingFailedException.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/GetFasstoWarehousingFailedException.java
@@ -1,0 +1,25 @@
+package com.personal.marketnote.fulfillment.exception;
+
+import com.personal.marketnote.common.exception.ExternalOperationFailedException;
+import com.personal.marketnote.common.utility.FormatValidator;
+
+import java.io.IOException;
+
+public class GetFasstoWarehousingFailedException extends ExternalOperationFailedException {
+    private static final String DEFAULT_MESSAGE = "파스토 입고 목록 조회 중 오류가 발생했습니다.";
+
+    public GetFasstoWarehousingFailedException(IOException cause) {
+        super(DEFAULT_MESSAGE, cause);
+    }
+
+    public GetFasstoWarehousingFailedException(String vendorMessage, IOException cause) {
+        super(resolveMessage(vendorMessage), cause);
+    }
+
+    private static String resolveMessage(String vendorMessage) {
+        if (FormatValidator.hasValue(vendorMessage)) {
+            return String.format("파스토 입고 목록 조회 실패: %s", vendorMessage);
+        }
+        return DEFAULT_MESSAGE;
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/mapper/FasstoWarehousingCommandToRequestMapper.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/mapper/FasstoWarehousingCommandToRequestMapper.java
@@ -3,6 +3,8 @@ package com.personal.marketnote.fulfillment.mapper;
 import com.personal.marketnote.fulfillment.domain.vendor.fassto.warehousing.FasstoWarehousingGoodsMapper;
 import com.personal.marketnote.fulfillment.domain.vendor.fassto.warehousing.FasstoWarehousingItemMapper;
 import com.personal.marketnote.fulfillment.domain.vendor.fassto.warehousing.FasstoWarehousingMapper;
+import com.personal.marketnote.fulfillment.domain.vendor.fassto.warehousing.FasstoWarehousingQuery;
+import com.personal.marketnote.fulfillment.port.in.command.vendor.GetFasstoWarehousingCommand;
 import com.personal.marketnote.fulfillment.port.in.command.vendor.RegisterFasstoWarehousingCommand;
 import com.personal.marketnote.fulfillment.port.in.command.vendor.RegisterFasstoWarehousingGoodsCommand;
 import com.personal.marketnote.fulfillment.port.in.command.vendor.RegisterFasstoWarehousingItemCommand;
@@ -19,6 +21,15 @@ public class FasstoWarehousingCommandToRequestMapper {
                 command.customerCode(),
                 command.accessToken(),
                 requests
+        );
+    }
+
+    public static FasstoWarehousingQuery mapToQuery(GetFasstoWarehousingCommand command) {
+        return FasstoWarehousingQuery.of(
+                command.customerCode(),
+                command.accessToken(),
+                command.startDate(),
+                command.endDate()
         );
     }
 

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/vendor/GetFasstoWarehousingCommand.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/vendor/GetFasstoWarehousingCommand.java
@@ -1,0 +1,17 @@
+package com.personal.marketnote.fulfillment.port.in.command.vendor;
+
+public record GetFasstoWarehousingCommand(
+        String customerCode,
+        String accessToken,
+        String startDate,
+        String endDate
+) {
+    public static GetFasstoWarehousingCommand of(
+            String customerCode,
+            String accessToken,
+            String startDate,
+            String endDate
+    ) {
+        return new GetFasstoWarehousingCommand(customerCode, accessToken, startDate, endDate);
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/result/vendor/FasstoWarehousingInfoResult.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/result/vendor/FasstoWarehousingInfoResult.java
@@ -1,0 +1,81 @@
+package com.personal.marketnote.fulfillment.port.in.result.vendor;
+
+import java.util.List;
+
+public record FasstoWarehousingInfoResult(
+        String ordDt,
+        String whCd,
+        String whNm,
+        String slipNo,
+        String ordNo,
+        String cstCd,
+        String cstNm,
+        String supCd,
+        String cstSupCd,
+        String supNm,
+        Integer sku,
+        Integer ordQty,
+        Integer inQty,
+        Integer tarQty,
+        String inWay,
+        String inWayNm,
+        String parcelComp,
+        String parcelInvoiceNo,
+        String wrkStat,
+        String wrkStatNm,
+        String emgrYn,
+        String remark,
+        List<Object> goodsSerialNo
+) {
+    public static FasstoWarehousingInfoResult of(
+            String ordDt,
+            String whCd,
+            String whNm,
+            String slipNo,
+            String ordNo,
+            String cstCd,
+            String cstNm,
+            String supCd,
+            String cstSupCd,
+            String supNm,
+            Integer sku,
+            Integer ordQty,
+            Integer inQty,
+            Integer tarQty,
+            String inWay,
+            String inWayNm,
+            String parcelComp,
+            String parcelInvoiceNo,
+            String wrkStat,
+            String wrkStatNm,
+            String emgrYn,
+            String remark,
+            List<Object> goodsSerialNo
+    ) {
+        return new FasstoWarehousingInfoResult(
+                ordDt,
+                whCd,
+                whNm,
+                slipNo,
+                ordNo,
+                cstCd,
+                cstNm,
+                supCd,
+                cstSupCd,
+                supNm,
+                sku,
+                ordQty,
+                inQty,
+                tarQty,
+                inWay,
+                inWayNm,
+                parcelComp,
+                parcelInvoiceNo,
+                wrkStat,
+                wrkStatNm,
+                emgrYn,
+                remark,
+                goodsSerialNo
+        );
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/result/vendor/GetFasstoWarehousingResult.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/result/vendor/GetFasstoWarehousingResult.java
@@ -1,0 +1,15 @@
+package com.personal.marketnote.fulfillment.port.in.result.vendor;
+
+import java.util.List;
+
+public record GetFasstoWarehousingResult(
+        Integer dataCount,
+        List<FasstoWarehousingInfoResult> warehousing
+) {
+    public static GetFasstoWarehousingResult of(
+            Integer dataCount,
+            List<FasstoWarehousingInfoResult> warehousing
+    ) {
+        return new GetFasstoWarehousingResult(dataCount, warehousing);
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/usecase/vendor/GetFasstoWarehousingUseCase.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/usecase/vendor/GetFasstoWarehousingUseCase.java
@@ -1,0 +1,15 @@
+package com.personal.marketnote.fulfillment.port.in.usecase.vendor;
+
+import com.personal.marketnote.fulfillment.port.in.command.vendor.GetFasstoWarehousingCommand;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.GetFasstoWarehousingResult;
+
+public interface GetFasstoWarehousingUseCase {
+    /**
+     * @param command 상품 입고 목록 조회 커맨드
+     * @return 상품 입고 목록 조회 결과 {@link GetFasstoWarehousingResult}
+     * @Date 2026-02-03
+     * @Author 성효빈
+     * @Description 파스토 상품 입고 목록을 조회합니다.
+     */
+    GetFasstoWarehousingResult getWarehousing(GetFasstoWarehousingCommand command);
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/vendor/GetFasstoWarehousingPort.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/vendor/GetFasstoWarehousingPort.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.fulfillment.port.out.vendor;
+
+import com.personal.marketnote.fulfillment.domain.vendor.fassto.warehousing.FasstoWarehousingQuery;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.GetFasstoWarehousingResult;
+
+public interface GetFasstoWarehousingPort {
+    GetFasstoWarehousingResult getWarehousing(FasstoWarehousingQuery query);
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/vendor/GetFasstoWarehousingService.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/vendor/GetFasstoWarehousingService.java
@@ -1,0 +1,26 @@
+package com.personal.marketnote.fulfillment.service.vendor;
+
+import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.fulfillment.mapper.FasstoWarehousingCommandToRequestMapper;
+import com.personal.marketnote.fulfillment.port.in.command.vendor.GetFasstoWarehousingCommand;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.GetFasstoWarehousingResult;
+import com.personal.marketnote.fulfillment.port.in.usecase.vendor.GetFasstoWarehousingUseCase;
+import com.personal.marketnote.fulfillment.port.out.vendor.GetFasstoWarehousingPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional(isolation = READ_COMMITTED, readOnly = true)
+public class GetFasstoWarehousingService implements GetFasstoWarehousingUseCase {
+    private final GetFasstoWarehousingPort getFasstoWarehousingPort;
+
+    @Override
+    public GetFasstoWarehousingResult getWarehousing(GetFasstoWarehousingCommand command) {
+        return getFasstoWarehousingPort.getWarehousing(
+                FasstoWarehousingCommandToRequestMapper.mapToQuery(command)
+        );
+    }
+}

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/warehousing/FasstoWarehousingQuery.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/warehousing/FasstoWarehousingQuery.java
@@ -1,0 +1,46 @@
+package com.personal.marketnote.fulfillment.domain.vendor.fassto.warehousing;
+
+import com.personal.marketnote.common.utility.FormatValidator;
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+public class FasstoWarehousingQuery {
+    private String customerCode;
+    private String accessToken;
+    private String startDate;
+    private String endDate;
+
+    public static FasstoWarehousingQuery of(
+            String customerCode,
+            String accessToken,
+            String startDate,
+            String endDate
+    ) {
+        FasstoWarehousingQuery query = FasstoWarehousingQuery.builder()
+                .customerCode(customerCode)
+                .accessToken(accessToken)
+                .startDate(startDate)
+                .endDate(endDate)
+                .build();
+        query.validate();
+        return query;
+    }
+
+    private void validate() {
+        if (FormatValidator.hasNoValue(customerCode)) {
+            throw new IllegalArgumentException("customerCode is required.");
+        }
+        if (FormatValidator.hasNoValue(accessToken)) {
+            throw new IllegalArgumentException("accessToken is required.");
+        }
+        if (FormatValidator.hasNoValue(startDate)) {
+            throw new IllegalArgumentException("startDate is required.");
+        }
+        if (FormatValidator.hasNoValue(endDate)) {
+            throw new IllegalArgumentException("endDate is required.");
+        }
+    }
+}


### PR DESCRIPTION
## partially addresses #475
## resolves #599

## Task
- [x] 파스토 상품 입고 목록 조회 연동 요청
- [x] 파스토 상품 입고 목록 조회 연동 비즈니스 로직
- [x] 파스토 서버에 상품 입고 목록 요청
- [x] 200 status code 응답
- [x] Swagger docs