### PR TITLE
[#475][#572] feat: (관리자) 상품 상세 정보 조회(파스토 연동) 기능 추가

### DIFF
--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/FasstoWarehousingController.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/FasstoWarehousingController.java
@@ -66,7 +66,7 @@ public class FasstoWarehousingController {
     }
 
     /**
-     * (관리자) 파스토 입고 목록 조회
+     * (관리자) 파스토 상품 입고 목록 조회
      *
      * @param customerCode 파스토 고객사 코드
      * @param accessToken  파스토 액세스 토큰
@@ -74,7 +74,7 @@ public class FasstoWarehousingController {
      * @param endDate      조회 종료일(YYYYMMDD)
      * @Author 성효빈
      * @Date 2026-01-31
-     * @Description 파스토 입고 목록을 조회합니다.
+     * @Description 파스토 상품 입고 목록을 조회합니다.
      */
     @GetMapping("/{customerCode}/{startDate}/{endDate}")
     @PreAuthorize(ADMIN_POINTCUT)
@@ -94,7 +94,7 @@ public class FasstoWarehousingController {
                         GetFasstoWarehousingResponse.from(result),
                         HttpStatus.OK,
                         DEFAULT_SUCCESS_CODE,
-                        "파스토 입고 목록 조회 성공"
+                        "파스토 상품 입고 목록 조회 성공"
                 ),
                 HttpStatus.OK
         );

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/apidocs/GetFasstoWarehousingApiDocs.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/apidocs/GetFasstoWarehousingApiDocs.java
@@ -15,7 +15,7 @@ import java.lang.annotation.*;
 @Retention(RetentionPolicy.RUNTIME)
 @Inherited
 @Operation(
-        summary = "(관리자) 파스토 입고 목록 조회",
+        summary = "(관리자) 파스토 상품 입고 목록 조회",
         description = """
                 작성일자: 2026-01-31
                 
@@ -25,7 +25,7 @@ import java.lang.annotation.*;
                 
                 ## Description
                 
-                파스토 입고 목록을 조회합니다.
+                파스토 상품 입고 목록을 조회합니다.
                 
                 ---
                 
@@ -48,7 +48,7 @@ import java.lang.annotation.*;
                 | code | string | 응답 코드 | "SUC01" / "BAD_REQUEST" / "UNAUTHORIZED" / "FORBIDDEN" / "INTERNAL_SERVER_ERROR" |
                 | timestamp | string(datetime) | 응답 일시 | "2026-01-31T12:12:30.013" |
                 | content | object | 응답 본문 | { ... } |
-                | message | string | 처리 결과 | "파스토 입고 목록 조회 성공" |
+                | message | string | 처리 결과 | "파스토 상품 입고 목록 조회 성공" |
                 
                 ---
                 
@@ -57,7 +57,7 @@ import java.lang.annotation.*;
                 | **키** | **타입** | **설명** | **예시** |
                 | --- | --- | --- | --- |
                 | dataCount | number | 조회 건수 | 1 |
-                | warehousing | array | 입고 목록 | [ ... ] |
+                | warehousing | array | 상품 입고 목록 | [ ... ] |
                 
                 ---
                 
@@ -122,7 +122,7 @@ import java.lang.annotation.*;
         responses = {
                 @ApiResponse(
                         responseCode = "200",
-                        description = "파스토 입고 목록 조회 성공",
+                        description = "파스토 상품 입고 목록 조회 성공",
                         content = @Content(
                                 examples = @ExampleObject("""
                                         {
@@ -158,7 +158,7 @@ import java.lang.annotation.*;
                                               }
                                             ]
                                           },
-                                          "message": "파스토 입고 목록 조회 성공"
+                                          "message": "파스토 상품 입고 목록 조회 성공"
                                         }
                                         """)
                         )

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/GetFasstoWarehousingFailedException.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/GetFasstoWarehousingFailedException.java
@@ -6,7 +6,7 @@ import com.personal.marketnote.common.utility.FormatValidator;
 import java.io.IOException;
 
 public class GetFasstoWarehousingFailedException extends ExternalOperationFailedException {
-    private static final String DEFAULT_MESSAGE = "파스토 입고 목록 조회 중 오류가 발생했습니다.";
+    private static final String DEFAULT_MESSAGE = "파스토 상품 입고 목록 조회 중 오류가 발생했습니다.";
 
     public GetFasstoWarehousingFailedException(IOException cause) {
         super(DEFAULT_MESSAGE, cause);
@@ -18,7 +18,7 @@ public class GetFasstoWarehousingFailedException extends ExternalOperationFailed
 
     private static String resolveMessage(String vendorMessage) {
         if (FormatValidator.hasValue(vendorMessage)) {
-            return String.format("파스토 입고 목록 조회 실패: %s", vendorMessage);
+            return String.format("파스토 상품 입고 목록 조회 실패: %s", vendorMessage);
         }
         return DEFAULT_MESSAGE;
     }

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/usecase/vendor/GetFasstoWarehousingUseCase.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/usecase/vendor/GetFasstoWarehousingUseCase.java
@@ -5,11 +5,11 @@ import com.personal.marketnote.fulfillment.port.in.result.vendor.GetFasstoWareho
 
 public interface GetFasstoWarehousingUseCase {
     /**
-     * @param command 입고 목록 조회 커맨드
-     * @return 입고 목록 조회 결과 {@link GetFasstoWarehousingResult}
+     * @param command 상품 입고 목록 조회 커맨드
+     * @return 상품 입고 목록 조회 결과 {@link GetFasstoWarehousingResult}
      * @Date 2026-01-31
      * @Author 성효빈
-     * @Description 파스토 입고 목록을 조회합니다.
+     * @Description 파스토 상품 입고 목록을 조회합니다.
      */
     GetFasstoWarehousingResult getWarehousing(GetFasstoWarehousingCommand command);
 }

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/product/controller/ProductController.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/product/controller/ProductController.java
@@ -44,6 +44,7 @@ public class ProductController {
     private final GetProductSearchTargetsUseCase getProductSearchTargetsUseCase;
     private final GetProductUseCase getProductUseCase;
     private final GetAdminProductsUseCase getAdminProductsUseCase;
+    private final GetAdminProductDetailUseCase getAdminProductDetailUseCase;
     private final UpdateProductUseCase updateProductUseCase;
     private final DeleteProductUseCase deleteProductUseCase;
     private final DeleteProductImageUseCase deleteProductImageUseCase;
@@ -174,7 +175,7 @@ public class ProductController {
     }
 
     /**
-     * (관리자) 상품 목록 조회(파스토 연동)
+     * (관리자) 상품 목록 조회
      *
      * @param categoryId     카테고리 ID
      * @param pricePolicyIds 가격 정책 ID 목록
@@ -187,7 +188,7 @@ public class ProductController {
      * @return 관리자 상품 목록 조회 응답 {@link GetAdminProductsResponse}
      * @Author 성효빈
      * @Date 2026-02-03
-     * @Description 관리자 상품 목록을 조회합니다. 파스토 상품 정보를 상품 항목에 함께 반환합니다.
+     * @Description 관리자 상품 목록을 조회합니다.
      */
     @GetMapping("/admin")
     @PreAuthorize(ADMIN_POINTCUT)
@@ -219,6 +220,42 @@ public class ProductController {
                         HttpStatus.OK,
                         DEFAULT_SUCCESS_CODE,
                         "관리자 상품 목록 조회 성공"
+                )
+        );
+    }
+
+    /**
+     * (관리자) 상품 상세 정보 조회(파스토 연동)
+     *
+     * @param id                상품 ID
+     * @param selectedOptionIds 선택된 옵션 ID 목록
+     * @return 관리자 상품 상세 정보 조회 응답 {@link GetAdminProductDetailResponse}
+     * @Author 성효빈
+     * @Date 2026-02-03
+     * @Description 관리자 상품 상세 정보를 조회합니다. 파스토 상품/모음상품 정보를 함께 반환합니다.
+     */
+    @GetMapping("/admin/{id}")
+    @PreAuthorize(ADMIN_POINTCUT)
+    @GetAdminProductDetailApiDocs
+    public ResponseEntity<BaseResponse<GetAdminProductDetailResponse>> getAdminProductDetail(
+            @PathVariable("id") Long id,
+            @RequestParam(value = "selectedOptionIds", required = false) List<Long> selectedOptionIds
+    ) {
+        if (FormatValidator.hasNoValue(selectedOptionIds)) {
+            selectedOptionIds = List.of();
+        }
+
+        GetAdminProductDetailResult result = getAdminProductDetailUseCase.getAdminProductDetail(
+                id,
+                selectedOptionIds
+        );
+
+        return ResponseEntity.ok(
+                BaseResponse.of(
+                        GetAdminProductDetailResponse.from(result),
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "관리자 상품 상세 정보 조회 성공"
                 )
         );
     }

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/product/controller/apidocs/GetAdminProductDetailApiDocs.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/product/controller/apidocs/GetAdminProductDetailApiDocs.java
@@ -1,0 +1,327 @@
+package com.personal.marketnote.product.adapter.in.web.product.controller.apidocs;
+
+import com.personal.marketnote.common.adapter.in.api.schema.StringResponseSchema;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Operation(
+        summary = "(관리자) 상품 상세 정보 조회(파스토 연동)",
+        description = """
+                작성일자: 2026-02-03
+                
+                작성자: 성효빈
+                
+                ---
+                
+                ## Description
+                
+                - 관리자 페이지에서 상품 상세 정보를 조회합니다.
+                
+                - 파스토 상품 정보는 cstGodCd(고객사상품코드)와 상품 ID를 기준으로 매칭합니다.
+                
+                - 모음 상품이 아닌 경우 파스토 모음상품 정보는 null로 반환됩니다.
+                
+                ---
+                
+                ## Request
+                
+                | **키** | **타입** | **설명** | **필수 여부** | **예시** |
+                | --- | --- | --- | --- | --- |
+                | id | number | 상품 ID | Y | 1 |
+                | selectedOptionIds | array<number> | 선택된 옵션 ID 목록 | N | [4, 7] |
+                
+                ---
+                
+                ## Response
+                
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | statusCode | number | 상태 코드 | 200: 성공 / 400: 클라이언트 요청 오류 / 401: 인증 실패 / 403: 인가 실패 / 404: 리소스 조회 실패 / 409: 충돌 / 500: 그 외 |
+                | code | string | 응답 코드 | "SUC01" / "BAD_REQUEST" / "UNAUTHORIZED" / "FORBIDDEN" / "NOT_FOUND" / "CONFLICT" / "INTERNAL_SERVER_ERROR" |
+                | timestamp | string(datetime) | 응답 일시 | "2026-02-03T12:12:30.013" |
+                | content | object | 응답 본문 | { ... } |
+                | message | string | 처리 결과 | "관리자 상품 상세 정보 조회 성공" |
+                
+                ---
+                
+                ### Response > content
+                
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | productInfo | object | 상품 상세 정보 | { ... } |
+                | categories | array | 옵션 카테고리 목록 | [ ... ] |
+                | representativeImages | array | 상품 상세 정보 상단 대표 이미지 목록 | [ ... ] |
+                | contentImages | array | 상품 상세 정보 본문 이미지 목록 | [ ... ] |
+                | pricePolicies | array | 상품 가격 정책 목록 | [ ... ] |
+                | fasstoGoodsInfo | object | 파스토 상품 정보(매칭 없으면 null) | { ... } |
+                | fasstoGoodsElement | object | 파스토 모음상품 정보(모음상품이 아니면 null) | { ... } |
+                
+                ---
+                
+                ### Response > content > productInfo
+                
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | id | number | 상품 ID | 1 |
+                | sellerId | number | 판매자 ID | 1 |
+                | name | string | 상품명 | "테스트 모음상품" |
+                | brandName | string | 브랜드명 | "노트왕" |
+                | detail | string | 상품 상세 설명 | "테스트 모음상품 상세" |
+                | selectedPricePolicy | object | 선택된 가격 정책 | { ... } |
+                | sales | number | 판매량 | 0 |
+                | viewCount | number | 조회수 | 0 |
+                | popularity | number | 인기도 | 0 |
+                | findAllOptionsYn | boolean | 모든 옵션 선택 여부 | false |
+                | productTags | array | 상품 태그 목록 | [ ... ] |
+                | stock | number | 재고 수량 | 0 |
+                | orderNum | number | 정렬 순서 | 1 |
+                | status | string | 상태 | "ACTIVE" |
+                
+                ---
+                
+                ### Response > content > fasstoGoodsInfo
+                
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | godCd | string | 상품코드 | "943881" |
+                | godType | string | 상품유형 | "1" |
+                | godNm | string | 상품명 | "테스트 상품1" |
+                | godTypeNm | string | 상품유형명 | "단품" |
+                | invGodNmUseYn | string | 송장출력용 상품명 사용여부 | "N" |
+                | cstGodCd | string | 고객사상품코드 | "1" |
+                | godOptCd1 | string | 상품옵션코드1 | "" |
+                | godOptCd2 | string | 상품옵션코드2 | "" |
+                | cstCd | string | 고객사코드 | "94388" |
+                | cstNm | string | 고객사명 | "마켓노트 주식회사 테스트" |
+                | supCd | string | 공급사코드 | "" |
+                | supNm | string | 공급사명 | null |
+                | cateCd | string | 카테고리코드 | "" |
+                | cateNm | string | 카테고리명 | null |
+                | seasonCd | string | 계절상품 코드 | "0" |
+                | genderCd | string | 성별상품 코드 | "A" |
+                | godPr | string | 단가 | "0" |
+                | inPr | string | 공급가 | "0" |
+                | salPr | string | 판매가 | "0" |
+                | dealTemp | string | 취급온도 | "03" |
+                | pickFac | string | 피킹설비 | "" |
+                | giftDiv | string | 사은품구분 | "01" |
+                | giftDivNm | string | 상품구분명 | "본품" |
+                | godWidth | string | 상품가로길이 | "0.000" |
+                | godLength | string | 상품세로길이 | "0.000" |
+                | godHeight | string | 상품높이길이 | "0.000" |
+                | makeYr | string | 연식 | "" |
+                | godBulk | string | 상품체적 | "0" |
+                | godWeight | string | 상품무게 | "0" |
+                | godSideSum | string | 상품규격(3면의합) | "0.000" |
+                | godVolume | string | 상품중량 | "" |
+                | godBarcd | string | 상품바코드 | "" |
+                | boxWidth | string | 내품BOX가로길이 | "0" |
+                | boxLength | string | 내품BOX세로길이 | "0" |
+                | boxHeight | string | 내품BOX높이길이 | "0" |
+                | boxBulk | string | 내품BOX체적 | "0" |
+                | boxWeight | string | 내품BOX무게 | "0" |
+                | inBoxBarcd | string | 내품BOX바코드 | null |
+                | inBoxLength | string | 입고BOX세로길이 | "0" |
+                | inBoxHeight | string | 입고BOX높이길이 | "0" |
+                | inBoxBulk | string | 입고BOX체적 | "0" |
+                | inBoxWidth | string | 내품BOX가로길이 | "0" |
+                | inBoxWeight | string | 입고BOX무게 | "0" |
+                | inBoxSideSum | string | 입고BOX규격(3면의합) | "0" |
+                | boxInCnt | string | 내품박스입수 | "0" |
+                | inBoxInCnt | string | 입고박스입수 | "0" |
+                | pltInCnt | string | 팔레트입수 | "0" |
+                | origin | string | 원산지 | "" |
+                | distTermMgtYn | string | 유통기한관리여부 | "N" |
+                | useTermDay | string | 사용기한 | "0" |
+                | outCanDay | string | 출고가능일수 | "0" |
+                | inCanDay | string | 입고가능일수 | "0" |
+                | boxDiv | string | 출고박스 | "1" |
+                | bufGodYn | string | 완충상품여부 | "Y" |
+                | loadingDirection | string | 출고박스 상품 적재 기준 | "NONE" |
+                | firstInDt | string | 최초입고일자 | null |
+                | useYn | string | 사용여부 | "Y" |
+                | feeYn | string | 요금적용여부 | "" |
+                | saleUnitQty | string | 판매단위수량 | "1" |
+                | cstOneDayDeliveryYn | string | 원데이배송여부 | null |
+                | safetyStock | string | 안전재고수량 | "1" |
+                
+                ---
+                
+                ### Response > content > fasstoGoodsElement
+                
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | godCd | string | 상품코드 | "943881" |
+                | cstGodCd | string | 고객사상품코드 | "1" |
+                | godNm | string | 상품명 | "테스트 모음상품" |
+                | useYn | string | 사용여부 | "Y" |
+                | elementList | array | 구성상품 목록 | [ ... ] |
+                
+                ---
+                
+                ### Response > content > fasstoGoodsElement > elementList
+                
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | godCd | string | 상품코드 | "94388001" |
+                | cstGodCd | string | 고객사상품코드 | "1" |
+                | godBarcd | string | 상품바코드 | "ABC123" |
+                | godNm | string | 상품명 | "구성 상품1" |
+                | godType | string | 상품유형 | "1" |
+                | godTypeNm | string | 상품유형명 | "단품" |
+                | qty | number | 수량 | 1 |
+                """,
+        security = {@SecurityRequirement(name = "bearer")},
+        parameters = {
+                @Parameter(
+                        name = "id",
+                        in = ParameterIn.PATH,
+                        description = "상품 ID",
+                        schema = @Schema(type = "number", example = "1")
+                ),
+                @Parameter(
+                        name = "selectedOptionIds",
+                        description = "선택된 옵션 ID 목록",
+                        in = ParameterIn.QUERY,
+                        schema = @Schema(type = "array", example = "[1, 2, 3]")
+                )
+        },
+        responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "관리자 상품 상세 정보 조회 성공",
+                        content = @Content(
+                                schema = @Schema(implementation = StringResponseSchema.class),
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 200,
+                                          "code": "SUC01",
+                                          "timestamp": "2026-02-03T12:12:30.013",
+                                          "content": {
+                                            "productInfo": {
+                                              "id": 1,
+                                              "sellerId": 1,
+                                              "name": "테스트 모음상품",
+                                              "brandName": "노트왕",
+                                              "detail": "테스트 모음상품 상세",
+                                              "selectedPricePolicy": {
+                                                "id": 28,
+                                                "price": 45000,
+                                                "discountPrice": 37000,
+                                                "discountRate": 3.2,
+                                                "accumulatedPoint": 1200,
+                                                "optionIds": []
+                                              },
+                                              "sales": 0,
+                                              "viewCount": 0,
+                                              "popularity": 0,
+                                              "findAllOptionsYn": false,
+                                              "productTags": [],
+                                              "stock": 0,
+                                              "orderNum": 1,
+                                              "status": "ACTIVE"
+                                            },
+                                            "categories": [],
+                                            "representativeImages": null,
+                                            "contentImages": null,
+                                            "pricePolicies": [],
+                                            "fasstoGoodsInfo": {
+                                              "godCd": "943881",
+                                              "godType": "1",
+                                              "godNm": "테스트 상품1",
+                                              "godTypeNm": "단품",
+                                              "invGodNmUseYn": "N",
+                                              "cstGodCd": "1",
+                                              "godOptCd1": "",
+                                              "godOptCd2": "",
+                                              "cstCd": "94388",
+                                              "cstNm": "마켓노트 주식회사 테스트",
+                                              "supCd": "",
+                                              "supNm": null,
+                                              "cateCd": "",
+                                              "cateNm": null,
+                                              "seasonCd": "0",
+                                              "genderCd": "A",
+                                              "godPr": "0",
+                                              "inPr": "0",
+                                              "salPr": "0",
+                                              "dealTemp": "03",
+                                              "pickFac": "",
+                                              "giftDiv": "01",
+                                              "giftDivNm": "본품",
+                                              "godWidth": "0.000",
+                                              "godLength": "0.000",
+                                              "godHeight": "0.000",
+                                              "makeYr": "",
+                                              "godBulk": "0",
+                                              "godWeight": "0",
+                                              "godSideSum": "0.000",
+                                              "godVolume": "",
+                                              "godBarcd": "",
+                                              "boxWidth": "0",
+                                              "boxLength": "0",
+                                              "boxHeight": "0",
+                                              "boxBulk": "0",
+                                              "boxWeight": "0",
+                                              "inBoxBarcd": null,
+                                              "inBoxLength": "0",
+                                              "inBoxHeight": "0",
+                                              "inBoxBulk": "0",
+                                              "inBoxWidth": "0",
+                                              "inBoxWeight": "0",
+                                              "inBoxSideSum": "0",
+                                              "boxInCnt": "0",
+                                              "inBoxInCnt": "0",
+                                              "pltInCnt": "0",
+                                              "origin": "",
+                                              "distTermMgtYn": "N",
+                                              "useTermDay": "0",
+                                              "outCanDay": "0",
+                                              "inCanDay": "0",
+                                              "boxDiv": "1",
+                                              "bufGodYn": "Y",
+                                              "loadingDirection": "NONE",
+                                              "firstInDt": null,
+                                              "useYn": "Y",
+                                              "feeYn": "",
+                                              "saleUnitQty": "1",
+                                              "cstOneDayDeliveryYn": null,
+                                              "safetyStock": "1"
+                                            },
+                                            "fasstoGoodsElement": {
+                                              "godCd": "943881",
+                                              "cstGodCd": "1",
+                                              "godNm": "테스트 모음상품",
+                                              "useYn": "Y",
+                                              "elementList": [
+                                                {
+                                                  "godCd": "94388001",
+                                                  "cstGodCd": "1",
+                                                  "godBarcd": "ABC123",
+                                                  "godNm": "구성 상품1",
+                                                  "godType": "1",
+                                                  "godTypeNm": "단품",
+                                                  "qty": 1
+                                                }
+                                              ]
+                                            }
+                                          },
+                                          "message": "관리자 상품 상세 정보 조회 성공"
+                                        }
+                                        """)
+                        )
+                )
+        })
+public @interface GetAdminProductDetailApiDocs {
+}

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/product/controller/apidocs/GetAdminProductsApiDocs.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/product/controller/apidocs/GetAdminProductsApiDocs.java
@@ -16,7 +16,7 @@ import java.lang.annotation.*;
 @Retention(RetentionPolicy.RUNTIME)
 @Inherited
 @Operation(
-        summary = "(관리자) 상품 목록 조회(파스토 연동)",
+        summary = "(관리자) 상품 목록 조회",
         description = """
                 작성일자: 2026-02-03
                 
@@ -27,10 +27,6 @@ import java.lang.annotation.*;
                 ## Description
                 
                 - 관리자 페이지에서 상품 목록을 조회합니다.
-                
-                - 상품 항목마다 파스토 연동 정보를 함께 반환합니다.
-                
-                - 파스토 상품 정보는 cstGodCd(고객사상품코드)와 상품 ID를 기준으로 매칭합니다.
                 
                 - 페이로드에 cursor 값이 없는 경우(첫 페이지): 총 상품 개수 반환 O
                 
@@ -102,7 +98,6 @@ import java.lang.annotation.*;
                 | totalCount | number | 리뷰 총 개수 | 8 |
                 | status | string | 상태 | "ACTIVE" |
                 | orderNum | number | 정렬 순서 | 1 |
-                | fasstoGoods | object | 파스토 상품 정보(매칭 없으면 null) | { ... } |
                 
                 ---
                 
@@ -153,73 +148,6 @@ import java.lang.annotation.*;
                 | content | string | 옵션 내용 | "1박스" |
                 | status | string | 상태 | "ACTIVE" |
                 
-                ---
-                
-                ### Response > content > products > items > fasstoGoods
-                
-                | **키** | **타입** | **설명** | **예시** |
-                | --- | --- | --- | --- |
-                | godCd | string | 상품코드 | "943881" |
-                | godType | string | 상품유형 | "1" |
-                | godNm | string | 상품명 | "테스트 상품1" |
-                | godTypeNm | string | 상품유형명 | "단품" |
-                | invGodNmUseYn | string | 송장출력용 상품명 사용여부 | "N" |
-                | cstGodCd | string | 고객사상품코드 | "1" |
-                | godOptCd1 | string | 상품옵션코드1 | "" |
-                | godOptCd2 | string | 상품옵션코드2 | "" |
-                | cstCd | string | 고객사코드 | "94388" |
-                | cstNm | string | 고객사명 | "마켓노트 주식회사 테스트" |
-                | supCd | string | 공급사코드 | "" |
-                | supNm | string | 공급사명 | null |
-                | cateCd | string | 카테고리코드 | "" |
-                | cateNm | string | 카테고리명 | null |
-                | seasonCd | string | 계절상품 코드 | "0" |
-                | genderCd | string | 성별상품 코드 | "A" |
-                | godPr | string | 단가 | "0" |
-                | inPr | string | 공급가 | "0" |
-                | salPr | string | 판매가 | "0" |
-                | dealTemp | string | 취급온도 | "03" |
-                | pickFac | string | 피킹설비 | "" |
-                | giftDiv | string | 사은품구분 | "01" |
-                | giftDivNm | string | 상품구분명 | "본품" |
-                | godWidth | string | 상품가로길이 | "0.000" |
-                | godLength | string | 상품세로길이 | "0.000" |
-                | godHeight | string | 상품높이길이 | "0.000" |
-                | makeYr | string | 연식 | "" |
-                | godBulk | string | 상품체적 | "0" |
-                | godWeight | string | 상품무게 | "0" |
-                | godSideSum | string | 상품규격(3면의합) | "0.000" |
-                | godVolume | string | 상품중량 | "" |
-                | godBarcd | string | 상품바코드 | "" |
-                | boxWidth | string | 내품BOX가로길이 | "0" |
-                | boxLength | string | 내품BOX세로길이 | "0" |
-                | boxHeight | string | 내품BOX높이길이 | "0" |
-                | boxBulk | string | 내품BOX체적 | "0" |
-                | boxWeight | string | 내품BOX무게 | "0" |
-                | inBoxBarcd | string | 내품BOX바코드 | null |
-                | inBoxLength | string | 입고BOX세로길이 | "0" |
-                | inBoxHeight | string | 입고BOX높이길이 | "0" |
-                | inBoxBulk | string | 입고BOX체적 | "0" |
-                | inBoxWidth | string | 내품BOX가로길이 | "0" |
-                | inBoxWeight | string | 입고BOX무게 | "0" |
-                | inBoxSideSum | string | 입고BOX규격(3면의합) | "0" |
-                | boxInCnt | string | 내품박스입수 | "0" |
-                | inBoxInCnt | string | 입고박스입수 | "0" |
-                | pltInCnt | string | 팔레트입수 | "0" |
-                | origin | string | 원산지 | "" |
-                | distTermMgtYn | string | 유통기한관리여부 | "N" |
-                | useTermDay | string | 사용기한 | "0" |
-                | outCanDay | string | 출고가능일수 | "0" |
-                | inCanDay | string | 입고가능일수 | "0" |
-                | boxDiv | string | 출고박스 | "1" |
-                | bufGodYn | string | 완충상품여부 | "Y" |
-                | loadingDirection | string | 출고박스 상품 적재 기준 | "NONE" |
-                | firstInDt | string | 최초입고일자 | null |
-                | useYn | string | 사용여부 | "Y" |
-                | feeYn | string | 요금적용여부 | "" |
-                | saleUnitQty | string | 판매단위수량 | "1" |
-                | cstOneDayDeliveryYn | string | 원데이배송여부 | null |
-                | safetyStock | string | 안전재고수량 | "1" |
                 """,
         security = {@SecurityRequirement(name = "bearer")},
         parameters = {
@@ -335,70 +263,7 @@ import java.lang.annotation.*;
                                                   "averageRating": 4.5,
                                                   "totalCount": 8,
                                                   "orderNum": 1,
-                                                  "status": "ACTIVE",
-                                                  "fasstoGoods": {
-                                                    "godCd": "943881",
-                                                    "godType": "1",
-                                                    "godNm": "테스트 상품1",
-                                                    "godTypeNm": "단품",
-                                                    "invGodNmUseYn": "N",
-                                                    "cstGodCd": "1",
-                                                    "godOptCd1": "",
-                                                    "godOptCd2": "",
-                                                    "cstCd": "94388",
-                                                    "cstNm": "마켓노트 주식회사 테스트",
-                                                    "supCd": "",
-                                                    "supNm": null,
-                                                    "cateCd": "",
-                                                    "cateNm": null,
-                                                    "seasonCd": "0",
-                                                    "genderCd": "A",
-                                                    "godPr": "0",
-                                                    "inPr": "0",
-                                                    "salPr": "0",
-                                                    "dealTemp": "03",
-                                                    "pickFac": "",
-                                                    "giftDiv": "01",
-                                                    "giftDivNm": "본품",
-                                                    "godWidth": "0.000",
-                                                    "godLength": "0.000",
-                                                    "godHeight": "0.000",
-                                                    "makeYr": "",
-                                                    "godBulk": "0",
-                                                    "godWeight": "0",
-                                                    "godSideSum": "0.000",
-                                                    "godVolume": "",
-                                                    "godBarcd": "",
-                                                    "boxWidth": "0",
-                                                    "boxLength": "0",
-                                                    "boxHeight": "0",
-                                                    "boxBulk": "0",
-                                                    "boxWeight": "0",
-                                                    "inBoxBarcd": null,
-                                                    "inBoxLength": "0",
-                                                    "inBoxHeight": "0",
-                                                    "inBoxBulk": "0",
-                                                    "inBoxWidth": "0",
-                                                    "inBoxWeight": "0",
-                                                    "inBoxSideSum": "0",
-                                                    "boxInCnt": "0",
-                                                    "inBoxInCnt": "0",
-                                                    "pltInCnt": "0",
-                                                    "origin": "",
-                                                    "distTermMgtYn": "N",
-                                                    "useTermDay": "0",
-                                                    "outCanDay": "0",
-                                                    "inCanDay": "0",
-                                                    "boxDiv": "1",
-                                                    "bufGodYn": "Y",
-                                                    "loadingDirection": "NONE",
-                                                    "firstInDt": null,
-                                                    "useYn": "Y",
-                                                    "feeYn": "",
-                                                    "saleUnitQty": "1",
-                                                    "cstOneDayDeliveryYn": null,
-                                                    "safetyStock": "1"
-                                                  }
+                                                  "status": "ACTIVE"
                                                 }
                                               ]
                                             }

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/product/response/FasstoGoodsElementItemResponse.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/product/response/FasstoGoodsElementItemResponse.java
@@ -1,0 +1,25 @@
+package com.personal.marketnote.product.adapter.in.web.product.response;
+
+import com.personal.marketnote.product.port.in.result.fulfillment.FulfillmentVendorGoodsElementItemResult;
+
+public record FasstoGoodsElementItemResponse(
+        String godCd,
+        String cstGodCd,
+        String godBarcd,
+        String godNm,
+        String godType,
+        String godTypeNm,
+        Integer qty
+) {
+    public static FasstoGoodsElementItemResponse from(FulfillmentVendorGoodsElementItemResult result) {
+        return new FasstoGoodsElementItemResponse(
+                result.godCd(),
+                result.cstGodCd(),
+                result.godBarcd(),
+                result.godNm(),
+                result.godType(),
+                result.godTypeNm(),
+                result.qty()
+        );
+    }
+}

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/product/response/FasstoGoodsElementResponse.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/product/response/FasstoGoodsElementResponse.java
@@ -1,0 +1,30 @@
+package com.personal.marketnote.product.adapter.in.web.product.response;
+
+import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.product.port.in.result.fulfillment.FulfillmentVendorGoodsElementInfoResult;
+
+import java.util.List;
+
+public record FasstoGoodsElementResponse(
+        String godCd,
+        String cstGodCd,
+        String godNm,
+        String useYn,
+        List<FasstoGoodsElementItemResponse> elementList
+) {
+    public static FasstoGoodsElementResponse from(FulfillmentVendorGoodsElementInfoResult result) {
+        List<FasstoGoodsElementItemResponse> elementList = FormatValidator.hasValue(result.elementList())
+                ? result.elementList().stream()
+                .map(FasstoGoodsElementItemResponse::from)
+                .toList()
+                : List.of();
+
+        return new FasstoGoodsElementResponse(
+                result.godCd(),
+                result.cstGodCd(),
+                result.godNm(),
+                result.useYn(),
+                elementList
+        );
+    }
+}

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/product/response/GetAdminProductDetailResponse.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/product/response/GetAdminProductDetailResponse.java
@@ -1,0 +1,49 @@
+package com.personal.marketnote.product.adapter.in.web.product.response;
+
+import com.personal.marketnote.common.application.file.port.in.result.GetFileResult;
+import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.product.adapter.in.web.option.response.SelectableProductOptionCategoryResponse;
+import com.personal.marketnote.product.port.in.result.pricepolicy.GetProductPricePolicyWithOptionsResult;
+import com.personal.marketnote.product.port.in.result.product.GetAdminProductDetailResult;
+import com.personal.marketnote.product.port.in.result.product.GetProductInfoResult;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+@Getter
+public class GetAdminProductDetailResponse {
+    private GetProductInfoResult productInfo;
+    private List<SelectableProductOptionCategoryResponse> categories;
+    private List<GetFileResult> representativeImages;
+    private List<GetFileResult> contentImages;
+    private List<GetProductPricePolicyWithOptionsResult> pricePolicies;
+    private FasstoGoodsItemResponse fasstoGoodsInfo;
+    private FasstoGoodsElementResponse fasstoGoodsElement;
+
+    public static GetAdminProductDetailResponse from(GetAdminProductDetailResult result) {
+        GetProductInfoResponse productResponse = GetProductInfoResponse.from(result.product());
+
+        return GetAdminProductDetailResponse.builder()
+                .productInfo(productResponse.getProductInfo())
+                .categories(productResponse.getCategories())
+                .representativeImages(productResponse.getRepresentativeImages())
+                .contentImages(productResponse.getContentImages())
+                .pricePolicies(productResponse.getPricePolicies())
+                .fasstoGoodsInfo(
+                        FormatValidator.hasValue(result.fasstoGoodsInfo())
+                                ? FasstoGoodsItemResponse.from(result.fasstoGoodsInfo())
+                                : null
+                )
+                .fasstoGoodsElement(
+                        FormatValidator.hasValue(result.fasstoGoodsElement())
+                                ? FasstoGoodsElementResponse.from(result.fasstoGoodsElement())
+                                : null
+                )
+                .build();
+    }
+}

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/product/response/GetAdminProductsResponse.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/product/response/GetAdminProductsResponse.java
@@ -13,7 +13,7 @@ import java.util.stream.Collectors;
 @Builder(access = AccessLevel.PRIVATE)
 @Getter
 public class GetAdminProductsResponse {
-    private CursorResponse<AdminProductItemResponse> products;
+    private CursorResponse<ProductItemResponse> products;
 
     public static GetAdminProductsResponse from(GetAdminProductsResult result) {
         return new GetAdminProductsResponse(
@@ -22,7 +22,7 @@ public class GetAdminProductsResponse {
                         result.hasNext(),
                         result.nextCursor(),
                         result.products().stream()
-                                .map(AdminProductItemResponse::from)
+                                .map(ProductItemResponse::from)
                                 .collect(Collectors.toList())
                 )
         );

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/web/fulfillment/response/FasstoGoodsElementItemResponse.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/web/fulfillment/response/FasstoGoodsElementItemResponse.java
@@ -1,0 +1,15 @@
+package com.personal.marketnote.product.adapter.out.web.fulfillment.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record FasstoGoodsElementItemResponse(
+        String godCd,
+        String cstGodCd,
+        String godBarcd,
+        String godNm,
+        String godType,
+        String godTypeNm,
+        Integer qty
+) {
+}

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/web/fulfillment/response/FasstoGoodsElementResponse.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/web/fulfillment/response/FasstoGoodsElementResponse.java
@@ -1,0 +1,15 @@
+package com.personal.marketnote.product.adapter.out.web.fulfillment.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record FasstoGoodsElementResponse(
+        String godCd,
+        String cstGodCd,
+        String godNm,
+        String useYn,
+        List<FasstoGoodsElementItemResponse> elementList
+) {
+}

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/web/fulfillment/response/GetFasstoGoodsElementsResponse.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/web/fulfillment/response/GetFasstoGoodsElementsResponse.java
@@ -1,0 +1,15 @@
+package com.personal.marketnote.product.adapter.out.web.fulfillment.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record GetFasstoGoodsElementsResponse(
+        Integer dataCount,
+        List<FasstoGoodsElementResponse> elements
+) {
+    public boolean isSuccess() {
+        return elements != null;
+    }
+}

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/result/fulfillment/FulfillmentVendorGoodsElementInfoResult.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/result/fulfillment/FulfillmentVendorGoodsElementInfoResult.java
@@ -1,0 +1,27 @@
+package com.personal.marketnote.product.port.in.result.fulfillment;
+
+import java.util.List;
+
+public record FulfillmentVendorGoodsElementInfoResult(
+        String godCd,
+        String cstGodCd,
+        String godNm,
+        String useYn,
+        List<FulfillmentVendorGoodsElementItemResult> elementList
+) {
+    public static FulfillmentVendorGoodsElementInfoResult of(
+            String godCd,
+            String cstGodCd,
+            String godNm,
+            String useYn,
+            List<FulfillmentVendorGoodsElementItemResult> elementList
+    ) {
+        return new FulfillmentVendorGoodsElementInfoResult(
+                godCd,
+                cstGodCd,
+                godNm,
+                useYn,
+                elementList
+        );
+    }
+}

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/result/fulfillment/FulfillmentVendorGoodsElementItemResult.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/result/fulfillment/FulfillmentVendorGoodsElementItemResult.java
@@ -1,0 +1,31 @@
+package com.personal.marketnote.product.port.in.result.fulfillment;
+
+public record FulfillmentVendorGoodsElementItemResult(
+        String godCd,
+        String cstGodCd,
+        String godBarcd,
+        String godNm,
+        String godType,
+        String godTypeNm,
+        Integer qty
+) {
+    public static FulfillmentVendorGoodsElementItemResult of(
+            String godCd,
+            String cstGodCd,
+            String godBarcd,
+            String godNm,
+            String godType,
+            String godTypeNm,
+            Integer qty
+    ) {
+        return new FulfillmentVendorGoodsElementItemResult(
+                godCd,
+                cstGodCd,
+                godBarcd,
+                godNm,
+                godType,
+                godTypeNm,
+                qty
+        );
+    }
+}

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/result/fulfillment/GetFulfillmentVendorGoodsElementsResult.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/result/fulfillment/GetFulfillmentVendorGoodsElementsResult.java
@@ -1,0 +1,15 @@
+package com.personal.marketnote.product.port.in.result.fulfillment;
+
+import java.util.List;
+
+public record GetFulfillmentVendorGoodsElementsResult(
+        Integer dataCount,
+        List<FulfillmentVendorGoodsElementInfoResult> elements
+) {
+    public static GetFulfillmentVendorGoodsElementsResult of(
+            Integer dataCount,
+            List<FulfillmentVendorGoodsElementInfoResult> elements
+    ) {
+        return new GetFulfillmentVendorGoodsElementsResult(dataCount, elements);
+    }
+}

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/result/product/GetAdminProductDetailResult.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/result/product/GetAdminProductDetailResult.java
@@ -1,0 +1,18 @@
+package com.personal.marketnote.product.port.in.result.product;
+
+import com.personal.marketnote.product.port.in.result.fulfillment.FulfillmentVendorGoodsElementInfoResult;
+import com.personal.marketnote.product.port.in.result.fulfillment.FulfillmentVendorGoodsInfoResult;
+
+public record GetAdminProductDetailResult(
+        GetProductInfoWithOptionsResult product,
+        FulfillmentVendorGoodsInfoResult fasstoGoodsInfo,
+        FulfillmentVendorGoodsElementInfoResult fasstoGoodsElement
+) {
+    public static GetAdminProductDetailResult of(
+            GetProductInfoWithOptionsResult product,
+            FulfillmentVendorGoodsInfoResult fasstoGoodsInfo,
+            FulfillmentVendorGoodsElementInfoResult fasstoGoodsElement
+    ) {
+        return new GetAdminProductDetailResult(product, fasstoGoodsInfo, fasstoGoodsElement);
+    }
+}

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/result/product/GetAdminProductsResult.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/result/product/GetAdminProductsResult.java
@@ -6,13 +6,13 @@ public record GetAdminProductsResult(
         Long totalElements,
         Long nextCursor,
         boolean hasNext,
-        List<AdminProductItemResult> products
+        List<ProductItemResult> products
 ) {
     public static GetAdminProductsResult of(
             Long totalElements,
             Long nextCursor,
             boolean hasNext,
-            List<AdminProductItemResult> products
+            List<ProductItemResult> products
     ) {
         return new GetAdminProductsResult(totalElements, nextCursor, hasNext, products);
     }

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/usecase/product/GetAdminProductDetailUseCase.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/usecase/product/GetAdminProductDetailUseCase.java
@@ -1,0 +1,17 @@
+package com.personal.marketnote.product.port.in.usecase.product;
+
+import com.personal.marketnote.product.port.in.result.product.GetAdminProductDetailResult;
+
+import java.util.List;
+
+public interface GetAdminProductDetailUseCase {
+    /**
+     * @param id                상품 ID
+     * @param selectedOptionIds 선택된 옵션 ID 목록
+     * @return 관리자 상품 상세 정보 조회 결과 {@link GetAdminProductDetailResult}
+     * @Date 2026-02-03
+     * @Author 성효빈
+     * @Description 관리자 상품 상세 정보를 조회합니다. 파스토 상품/모음상품 정보를 함께 반환합니다.
+     */
+    GetAdminProductDetailResult getAdminProductDetail(Long id, List<Long> selectedOptionIds);
+}

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/usecase/product/GetAdminProductsUseCase.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/usecase/product/GetAdminProductsUseCase.java
@@ -20,7 +20,7 @@ public interface GetAdminProductsUseCase {
      * @return 관리자 상품 목록 조회 결과 {@link GetAdminProductsResult}
      * @Date 2026-02-03
      * @Author 성효빈
-     * @Description 관리자 상품 목록을 조회합니다. 파스토 상품 정보를 상품 항목에 함께 반환합니다.
+     * @Description 관리자 상품 목록을 조회합니다.
      */
     GetAdminProductsResult getAdminProducts(
             Long categoryId,

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/out/fulfillment/GetFulfillmentVendorGoodsElementsPort.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/out/fulfillment/GetFulfillmentVendorGoodsElementsPort.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.product.port.out.fulfillment;
+
+import com.personal.marketnote.product.port.in.result.fulfillment.GetFulfillmentVendorGoodsElementsResult;
+
+public interface GetFulfillmentVendorGoodsElementsPort {
+    GetFulfillmentVendorGoodsElementsResult getFulfillmentVendorGoodsElements();
+}

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/service/product/GetAdminProductDetailService.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/service/product/GetAdminProductDetailService.java
@@ -1,0 +1,107 @@
+package com.personal.marketnote.product.service.product;
+
+import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.product.port.in.result.fulfillment.FulfillmentVendorGoodsElementInfoResult;
+import com.personal.marketnote.product.port.in.result.fulfillment.FulfillmentVendorGoodsInfoResult;
+import com.personal.marketnote.product.port.in.result.fulfillment.GetFulfillmentVendorGoodsElementsResult;
+import com.personal.marketnote.product.port.in.result.fulfillment.GetFulfillmentVendorGoodsResult;
+import com.personal.marketnote.product.port.in.result.product.GetAdminProductDetailResult;
+import com.personal.marketnote.product.port.in.result.product.GetProductInfoWithOptionsResult;
+import com.personal.marketnote.product.port.in.usecase.product.GetAdminProductDetailUseCase;
+import com.personal.marketnote.product.port.in.usecase.product.GetProductUseCase;
+import com.personal.marketnote.product.port.out.fulfillment.GetFulfillmentVendorGoodsElementsPort;
+import com.personal.marketnote.product.port.out.fulfillment.GetFulfillmentVendorGoodsPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional(isolation = READ_COMMITTED, readOnly = true)
+public class GetAdminProductDetailService implements GetAdminProductDetailUseCase {
+    private final GetProductUseCase getProductUseCase;
+    private final GetFulfillmentVendorGoodsPort getFulfillmentVendorGoodsPort;
+    private final GetFulfillmentVendorGoodsElementsPort getFulfillmentVendorGoodsElementsPort;
+
+    @Override
+    public GetAdminProductDetailResult getAdminProductDetail(Long id, List<Long> selectedOptionIds) {
+        List<Long> options = FormatValidator.hasValue(selectedOptionIds)
+                ? selectedOptionIds
+                : List.of();
+
+        GetProductInfoWithOptionsResult productInfo = getProductUseCase.getProductInfo(id, options);
+
+        GetFulfillmentVendorGoodsResult goodsResult = getFulfillmentVendorGoodsPort.getFulfillmentVendorGoods();
+        GetFulfillmentVendorGoodsElementsResult elementsResult
+                = getFulfillmentVendorGoodsElementsPort.getFulfillmentVendorGoodsElements();
+
+        FulfillmentVendorGoodsInfoResult goodsInfo = resolveGoodsInfo(id, goodsResult);
+        FulfillmentVendorGoodsElementInfoResult elementInfo = resolveElementInfo(id, elementsResult);
+
+        return GetAdminProductDetailResult.of(productInfo, goodsInfo, elementInfo);
+    }
+
+    private FulfillmentVendorGoodsInfoResult resolveGoodsInfo(
+            Long id,
+            GetFulfillmentVendorGoodsResult goodsResult
+    ) {
+        if (FormatValidator.hasNoValue(id)) {
+            return null;
+        }
+        Map<String, FulfillmentVendorGoodsInfoResult> goodsByCstGodCd = mapGoodsByCstGodCd(goodsResult);
+        return goodsByCstGodCd.get(String.valueOf(id));
+    }
+
+    private FulfillmentVendorGoodsElementInfoResult resolveElementInfo(
+            Long id,
+            GetFulfillmentVendorGoodsElementsResult elementsResult
+    ) {
+        if (FormatValidator.hasNoValue(id)) {
+            return null;
+        }
+        Map<String, FulfillmentVendorGoodsElementInfoResult> elementsByCstGodCd = mapElementsByCstGodCd(elementsResult);
+        return elementsByCstGodCd.get(String.valueOf(id));
+    }
+
+    private Map<String, FulfillmentVendorGoodsInfoResult> mapGoodsByCstGodCd(
+            GetFulfillmentVendorGoodsResult goodsResult
+    ) {
+        if (FormatValidator.hasNoValue(goodsResult)
+                || FormatValidator.hasNoValue(goodsResult.goods())) {
+            return Map.of();
+        }
+
+        Map<String, FulfillmentVendorGoodsInfoResult> goodsByCstGodCd = new HashMap<>();
+        for (FulfillmentVendorGoodsInfoResult item : goodsResult.goods()) {
+            if (FormatValidator.hasNoValue(item) || FormatValidator.hasNoValue(item.cstGodCd())) {
+                continue;
+            }
+            goodsByCstGodCd.putIfAbsent(item.cstGodCd(), item);
+        }
+        return goodsByCstGodCd;
+    }
+
+    private Map<String, FulfillmentVendorGoodsElementInfoResult> mapElementsByCstGodCd(
+            GetFulfillmentVendorGoodsElementsResult elementsResult
+    ) {
+        if (FormatValidator.hasNoValue(elementsResult)
+                || FormatValidator.hasNoValue(elementsResult.elements())) {
+            return Map.of();
+        }
+
+        Map<String, FulfillmentVendorGoodsElementInfoResult> elementsByCstGodCd = new HashMap<>();
+        for (FulfillmentVendorGoodsElementInfoResult element : elementsResult.elements()) {
+            if (FormatValidator.hasNoValue(element) || FormatValidator.hasNoValue(element.cstGodCd())) {
+                continue;
+            }
+            elementsByCstGodCd.putIfAbsent(element.cstGodCd(), element);
+        }
+        return elementsByCstGodCd;
+    }
+}

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/service/product/GetAdminProductsService.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/service/product/GetAdminProductsService.java
@@ -1,24 +1,17 @@
 package com.personal.marketnote.product.service.product;
 
 import com.personal.marketnote.common.application.UseCase;
-import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.product.domain.product.ProductSearchTarget;
 import com.personal.marketnote.product.domain.product.ProductSortProperty;
-import com.personal.marketnote.product.port.in.result.fulfillment.FulfillmentVendorGoodsInfoResult;
-import com.personal.marketnote.product.port.in.result.fulfillment.GetFulfillmentVendorGoodsResult;
-import com.personal.marketnote.product.port.in.result.product.AdminProductItemResult;
 import com.personal.marketnote.product.port.in.result.product.GetAdminProductsResult;
 import com.personal.marketnote.product.port.in.result.product.GetProductsResult;
 import com.personal.marketnote.product.port.in.usecase.product.GetAdminProductsUseCase;
 import com.personal.marketnote.product.port.in.usecase.product.GetProductUseCase;
-import com.personal.marketnote.product.port.out.fulfillment.GetFulfillmentVendorGoodsPort;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Sort;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
 
@@ -27,7 +20,6 @@ import static org.springframework.transaction.annotation.Isolation.READ_COMMITTE
 @Transactional(isolation = READ_COMMITTED, readOnly = true)
 public class GetAdminProductsService implements GetAdminProductsUseCase {
     private final GetProductUseCase getProductUseCase;
-    private final GetFulfillmentVendorGoodsPort getFulfillmentVendorGoodsPort;
 
     @Override
     public GetAdminProductsResult getAdminProducts(
@@ -50,40 +42,12 @@ public class GetAdminProductsService implements GetAdminProductsUseCase {
                 searchTarget,
                 searchKeyword
         );
-        GetFulfillmentVendorGoodsResult fulfillmentGoods = getFulfillmentVendorGoodsPort.getFulfillmentVendorGoods();
-        Map<String, FulfillmentVendorGoodsInfoResult> goodsByCstGodCd = mapGoodsByCstGodCd(fulfillmentGoods);
-        List<AdminProductItemResult> items = products.products().stream()
-                .map(item -> AdminProductItemResult.of(
-                        item,
-                        FormatValidator.hasValue(item.getId())
-                                ? goodsByCstGodCd.get(String.valueOf(item.getId()))
-                                : null
-                ))
-                .toList();
 
         return GetAdminProductsResult.of(
                 products.totalElements(),
                 products.nextCursor(),
                 products.hasNext(),
-                items
+                products.products()
         );
-    }
-
-    private Map<String, FulfillmentVendorGoodsInfoResult> mapGoodsByCstGodCd(
-            GetFulfillmentVendorGoodsResult fulfillmentGoods
-    ) {
-        if (FormatValidator.hasNoValue(fulfillmentGoods)
-                || FormatValidator.hasNoValue(fulfillmentGoods.goods())) {
-            return Map.of();
-        }
-
-        Map<String, FulfillmentVendorGoodsInfoResult> goodsByCstGodCd = new HashMap<>();
-        for (FulfillmentVendorGoodsInfoResult item : fulfillmentGoods.goods()) {
-            if (FormatValidator.hasNoValue(item) || FormatValidator.hasNoValue(item.cstGodCd())) {
-                continue;
-            }
-            goodsByCstGodCd.putIfAbsent(item.cstGodCd(), item);
-        }
-        return goodsByCstGodCd;
     }
 }

--- a/product-service/product-domain/src/main/java/com/personal/marketnote/product/domain/servicecommunication/ProductServiceCommunicationTargetType.java
+++ b/product-service/product-domain/src/main/java/com/personal/marketnote/product/domain/servicecommunication/ProductServiceCommunicationTargetType.java
@@ -8,7 +8,8 @@ public enum ProductServiceCommunicationTargetType {
     INVENTORY("재고"),
     PRODUCT_IMAGE("상품 이미지"),
     FULFILLMENT_AUTH("풀필먼트 인증"),
-    FULFILLMENT_GOODS("풀필먼트 상품");
+    FULFILLMENT_GOODS("풀필먼트 상품"),
+    FULFILLMENT_GOODS_ELEMENT("풀필먼트 모음상품");
 
     private final String description;
 }


### PR DESCRIPTION
## partially addresses #475
## resolves #572

## Task
- [x] 상품 상세 정보 조회 요청
- [x] 상품 상세 정보 조회 비즈니스 로직
    - [x] 상품 튜플 조회
    - [x] 풀필먼트 서비스에 파스토 상품 정보 조회 요청
    - [x] 풀필먼트 서비스에 파스토 모음 상품 상세 정보 조회 요청
- [x] 200 status code 응답
- [x] Swagger docs
- [x] 관리자 페이지 상품 목록 조회 시 파스토 연동부 제거