### PR TITLE
[#475][#569] feat: (관리자) 상품 수정 시 파스토 상품 수정 연동 요청 기능 추가

### DIFF
--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter.in.configuration/FulfillmentSwaggerConfig.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter.in.configuration/FulfillmentSwaggerConfig.java
@@ -32,6 +32,10 @@ public class FulfillmentSwaggerConfig {
 
     private static final List<String> TAGS_ORDER = List.of(
             "파스토 인증 API",
+            "파스토 공급사 API",
+            "파스토 상품 입고 API",
+            "파스토 상품 API",
+            "파스토 재고 API",
             "파스토 출고처 API",
             "서버 정보 API"
     );

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/product/controller/ProductController.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/product/controller/ProductController.java
@@ -326,7 +326,7 @@ public class ProductController {
      * @param request 상품 정보 수정 요청
      * @Author 성효빈
      * @Date 2026-01-01
-     * @Description 상품 정보를 수정합니다.
+     * @Description 상품 정보를 수정합니다. 연동된 파스토 상품 정보도 함께 수정합니다.
      */
     @PutMapping("/{id}")
     @PreAuthorize(ADMIN_OR_SELLER_POINTCUT)

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/product/controller/apidocs/GetAdminProductDetailApiDocs.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/product/controller/apidocs/GetAdminProductDetailApiDocs.java
@@ -64,7 +64,7 @@ import java.lang.annotation.*;
                 | representativeImages | array | 상품 상세 정보 상단 대표 이미지 목록 | [ ... ] |
                 | contentImages | array | 상품 상세 정보 본문 이미지 목록 | [ ... ] |
                 | pricePolicies | array | 상품 가격 정책 목록 | [ ... ] |
-                | fasstoGoodsInfo | object | 파스토 상품 정보(매칭 없으면 null) | { ... } |
+                | fasstoGoods | object | 파스토 상품 정보(매칭 없으면 null) | { ... } |
                 | fasstoGoodsElement | object | 파스토 모음상품 정보(모음상품이 아니면 null) | { ... } |
                 
                 ---
@@ -90,7 +90,7 @@ import java.lang.annotation.*;
                 
                 ---
                 
-                ### Response > content > fasstoGoodsInfo
+                ### Response > content > fasstoGoods
                 
                 | **키** | **타입** | **설명** | **예시** |
                 | --- | --- | --- | --- |
@@ -236,7 +236,7 @@ import java.lang.annotation.*;
                                             "representativeImages": null,
                                             "contentImages": null,
                                             "pricePolicies": [],
-                                            "fasstoGoodsInfo": {
+                                            "fasstoGoods": {
                                               "godCd": "943881",
                                               "godType": "1",
                                               "godNm": "테스트 상품1",

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/product/controller/apidocs/UpdateProductApiDocs.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/product/controller/apidocs/UpdateProductApiDocs.java
@@ -17,7 +17,7 @@ import java.lang.annotation.*;
 @Operation(
         summary = "(판매자/관리자) 상품 정보 수정",
         description = """
-                작성일자: 2026-01-01
+                작성일자: 2026-02-03
                 
                 작성자: 성효빈
                 
@@ -28,6 +28,8 @@ import java.lang.annotation.*;
                 - 상품 정보를 수정합니다.
                 
                 - 판매자 또는 관리자만 가능합니다.
+                
+                - 파스토 상품 정보 수정 파라미터가 전달되면 파스토 상품 정보도 함께 수정합니다.
                 
                 ---
                 
@@ -40,6 +42,7 @@ import java.lang.annotation.*;
                 | detail | string | 상품 설명 | Y | "스프링노트1 설명" |
                 | isFindAllOptions | boolean | 상품 목록 조회 시 옵션마다 개별 상품으로 조회 여부 | Y | true |
                 | tags | array<string> | 상품 태그 목록(없는 경우 빈 배열) | Y | ["루테인", "아스타잔틴"] |
+                | fulfillmentVendorGoods | object | 파스토 상품 수정 파라미터(요청 시 godType/giftDiv 필수) | N | { ... } |
                 ---
                 
                 ## Response
@@ -63,7 +66,15 @@ import java.lang.annotation.*;
                                   "brandName": "노트왕",
                                   "detail": "스프링노트1 설명",
                                   "isFindAllOptions": true,
-                                  "tags": ["루테인", "아스타잔틴"]
+                                  "tags": ["루테인", "아스타잔틴"],
+                                  "fulfillmentVendorGoods": {
+                                    "godType": "1",
+                                    "giftDiv": "01",
+                                    "supCd": "94388001",
+                                    "cateCd": "A001",
+                                    "seasonCd": "0",
+                                    "genderCd": "A"
+                                  }
                                 }
                                 """)
                 )
@@ -117,5 +128,3 @@ import java.lang.annotation.*;
         })
 public @interface UpdateProductApiDocs {
 }
-
-

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/product/mapper/ProductRequestToCommandMapper.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/product/mapper/ProductRequestToCommandMapper.java
@@ -1,10 +1,12 @@
 package com.personal.marketnote.product.adapter.in.web.product.mapper;
 
+import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.product.adapter.in.web.cart.request.GetMyOrderingProductsRequest;
 import com.personal.marketnote.product.adapter.in.web.category.request.RegisterProductCategoriesRequest;
 import com.personal.marketnote.product.adapter.in.web.option.request.UpdateProductOptionsRequest;
 import com.personal.marketnote.product.adapter.in.web.product.request.RegisterProductFulfillmentVendorGoodsRequest;
 import com.personal.marketnote.product.adapter.in.web.product.request.RegisterProductRequest;
+import com.personal.marketnote.product.adapter.in.web.product.request.UpdateProductFulfillmentVendorGoodsRequest;
 import com.personal.marketnote.product.adapter.in.web.product.request.UpdateProductRequest;
 import com.personal.marketnote.product.port.in.command.*;
 
@@ -27,7 +29,49 @@ public class ProductRequestToCommandMapper {
     }
 
     private static FulfillmentVendorGoodsOptionCommand mapToCommand(RegisterProductFulfillmentVendorGoodsRequest request) {
-        if (request == null) {
+        if (FormatValidator.hasNoValue(request)) {
+            return null;
+        }
+
+        return FulfillmentVendorGoodsOptionCommand.builder()
+                .godType(request.getGodType())
+                .giftDiv(request.getGiftDiv())
+                .godOptCd1(request.getGodOptCd1())
+                .godOptCd2(request.getGodOptCd2())
+                .invGodNmUseYn(request.getInvGodNmUseYn())
+                .invGodNm(request.getInvGodNm())
+                .supCd(request.getSupCd())
+                .cateCd(request.getCateCd())
+                .seasonCd(request.getSeasonCd())
+                .genderCd(request.getGenderCd())
+                .makeYr(request.getMakeYr())
+                .godPr(request.getGodPr())
+                .inPr(request.getInPr())
+                .salPr(request.getSalPr())
+                .dealTemp(request.getDealTemp())
+                .pickFac(request.getPickFac())
+                .godBarcd(request.getGodBarcd())
+                .boxWeight(request.getBoxWeight())
+                .origin(request.getOrigin())
+                .distTermMgtYn(request.getDistTermMgtYn())
+                .useTermDay(request.getUseTermDay())
+                .outCanDay(request.getOutCanDay())
+                .inCanDay(request.getInCanDay())
+                .boxDiv(request.getBoxDiv())
+                .bufGodYn(request.getBufGodYn())
+                .loadingDirection(request.getLoadingDirection())
+                .subMate(request.getSubMate())
+                .useYn(request.getUseYn())
+                .safetyStock(request.getSafetyStock())
+                .feeYn(request.getFeeYn())
+                .saleUnitQty(request.getSaleUnitQty())
+                .cstGodImgUrl(request.getCstGodImgUrl())
+                .externalGodImgUrl(request.getExternalGodImgUrl())
+                .build();
+    }
+
+    private static FulfillmentVendorGoodsOptionCommand mapToCommand(UpdateProductFulfillmentVendorGoodsRequest request) {
+        if (FormatValidator.hasNoValue(request)) {
             return null;
         }
 
@@ -106,6 +150,7 @@ public class ProductRequestToCommandMapper {
                 .detail(request.getDetail())
                 .isFindAllOptions(request.getIsFindAllOptions())
                 .tags(request.getTags())
+                .fulfillmentVendorGoods(mapToCommand(request.getFulfillmentVendorGoods()))
                 .build();
     }
 

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/product/request/UpdateProductFulfillmentVendorGoodsRequest.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/product/request/UpdateProductFulfillmentVendorGoodsRequest.java
@@ -1,0 +1,241 @@
+package com.personal.marketnote.product.adapter.in.web.product.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+import lombok.Getter;
+
+@Getter
+public class UpdateProductFulfillmentVendorGoodsRequest {
+    @Schema(
+            name = "godType",
+            description = "상품유형(1:단일, 2:모음, 3:세트, 4:대표상품)",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    @NotEmpty(message = "상품유형은 필수값입니다.")
+    private String godType;
+
+    @Schema(
+            name = "giftDiv",
+            description = "사은품구분(01:본품, 02:사은품, 03:부자재)",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    @NotEmpty(message = "사은품구분은 필수값입니다.")
+    private String giftDiv;
+
+    @Schema(
+            name = "godOptCd1",
+            description = "상품옵션코드1",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String godOptCd1;
+
+    @Schema(
+            name = "godOptCd2",
+            description = "상품옵션코드2",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String godOptCd2;
+
+    @Schema(
+            name = "invGodNmUseYn",
+            description = "송장출력용 상품명 사용여부 (Y/N)",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String invGodNmUseYn;
+
+    @Schema(
+            name = "invGodNm",
+            description = "송장출력용 상품명",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String invGodNm;
+
+    @Schema(
+            name = "supCd",
+            description = "공급사코드",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String supCd;
+
+    @Schema(
+            name = "cateCd",
+            description = "카테고리코드",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String cateCd;
+
+    @Schema(
+            name = "seasonCd",
+            description = "계절상품 코드(0:공용, 1:S/S, 2:F/W)",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String seasonCd;
+
+    @Schema(
+            name = "genderCd",
+            description = "성별상품 코드(A:Unisex, M:men, W:woman, K:kids)",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String genderCd;
+
+    @Schema(
+            name = "makeYr",
+            description = "연식",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String makeYr;
+
+    @Schema(
+            name = "godPr",
+            description = "단가",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String godPr;
+
+    @Schema(
+            name = "inPr",
+            description = "공급가",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String inPr;
+
+    @Schema(
+            name = "salPr",
+            description = "판매가",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String salPr;
+
+    @Schema(
+            name = "dealTemp",
+            description = "취급온도",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String dealTemp;
+
+    @Schema(
+            name = "pickFac",
+            description = "피킹설비",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String pickFac;
+
+    @Schema(
+            name = "godBarcd",
+            description = "상품바코드",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String godBarcd;
+
+    @Schema(
+            name = "boxWeight",
+            description = "내품BOX무게",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String boxWeight;
+
+    @Schema(
+            name = "origin",
+            description = "원산지",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String origin;
+
+    @Schema(
+            name = "distTermMgtYn",
+            description = "유통기한관리여부",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String distTermMgtYn;
+
+    @Schema(
+            name = "useTermDay",
+            description = "사용기한",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String useTermDay;
+
+    @Schema(
+            name = "outCanDay",
+            description = "출고가능일수",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String outCanDay;
+
+    @Schema(
+            name = "inCanDay",
+            description = "입고가능일수",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String inCanDay;
+
+    @Schema(
+            name = "boxDiv",
+            description = "출고박스",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String boxDiv;
+
+    @Schema(
+            name = "bufGodYn",
+            description = "완충상품여부(Y:사용,N:미사용,A:추가완충제)",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String bufGodYn;
+
+    @Schema(
+            name = "loadingDirection",
+            description = "출고박스 상품 적재 기준(NONE:관계없음, UP:세워서 적재)",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String loadingDirection;
+
+    @Schema(
+            name = "subMate",
+            description = "부자재코드(01:홍보물, 02:출력물, 03:쇼핑백, 04:포장지, 05:고객사테이프, 06:케이스, 07:단상자, 08:세트제작용 부자재, 09:출고용 패킹박스, 10:습자지, 11:고객사인박스)",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String subMate;
+
+    @Schema(
+            name = "useYn",
+            description = "사용여부(Y/N)",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String useYn;
+
+    @Schema(
+            name = "safetyStock",
+            description = "안전재고수량",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String safetyStock;
+
+    @Schema(
+            name = "feeYn",
+            description = "요금적용여부",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String feeYn;
+
+    @Schema(
+            name = "saleUnitQty",
+            description = "상품판매단위",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String saleUnitQty;
+
+    @Schema(
+            name = "cstGodImgUrl",
+            description = "고객상품이미지URL",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String cstGodImgUrl;
+
+    @Schema(
+            name = "externalGodImgUrl",
+            description = "상품이미지 URL",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String externalGodImgUrl;
+}

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/product/request/UpdateProductRequest.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/product/request/UpdateProductRequest.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.product.adapter.in.web.product.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
 
@@ -45,4 +46,12 @@ public class UpdateProductRequest {
             requiredMode = Schema.RequiredMode.REQUIRED
     )
     private List<String> tags;
+
+    @Schema(
+            name = "fulfillmentVendorGoods",
+            description = "파스토 상품 수정 파라미터",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    @Valid
+    private UpdateProductFulfillmentVendorGoodsRequest fulfillmentVendorGoods;
 }

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/product/response/GetAdminProductDetailResponse.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/product/response/GetAdminProductDetailResponse.java
@@ -22,7 +22,7 @@ public class GetAdminProductDetailResponse {
     private List<GetFileResult> representativeImages;
     private List<GetFileResult> contentImages;
     private List<GetProductPricePolicyWithOptionsResult> pricePolicies;
-    private FasstoGoodsItemResponse fasstoGoodsInfo;
+    private FasstoGoodsItemResponse fasstoGoods;
     private FasstoGoodsElementResponse fasstoGoodsElement;
 
     public static GetAdminProductDetailResponse from(GetAdminProductDetailResult result) {
@@ -34,9 +34,9 @@ public class GetAdminProductDetailResponse {
                 .representativeImages(productResponse.getRepresentativeImages())
                 .contentImages(productResponse.getContentImages())
                 .pricePolicies(productResponse.getPricePolicies())
-                .fasstoGoodsInfo(
-                        FormatValidator.hasValue(result.fasstoGoodsInfo())
-                                ? FasstoGoodsItemResponse.from(result.fasstoGoodsInfo())
+                .fasstoGoods(
+                        FormatValidator.hasValue(result.fasstoGoods())
+                                ? FasstoGoodsItemResponse.from(result.fasstoGoods())
                                 : null
                 )
                 .fasstoGoodsElement(

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/web/fulfillment/request/UpdateFasstoGoodsItemRequest.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/web/fulfillment/request/UpdateFasstoGoodsItemRequest.java
@@ -1,0 +1,89 @@
+package com.personal.marketnote.product.adapter.out.web.fulfillment.request;
+
+import com.personal.marketnote.product.port.out.fulfillment.UpdateFulfillmentVendorGoodsCommand;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UpdateFasstoGoodsItemRequest {
+    private String cstGodCd;
+    private String godNm;
+    private String godType;
+    private String giftDiv;
+    private String godOptCd1;
+    private String godOptCd2;
+    private String invGodNmUseYn;
+    private String invGodNm;
+    private String supCd;
+    private String cateCd;
+    private String seasonCd;
+    private String genderCd;
+    private String makeYr;
+    private String godPr;
+    private String inPr;
+    private String salPr;
+    private String dealTemp;
+    private String pickFac;
+    private String godBarcd;
+    private String boxWeight;
+    private String origin;
+    private String distTermMgtYn;
+    private String useTermDay;
+    private String outCanDay;
+    private String inCanDay;
+    private String boxDiv;
+    private String bufGodYn;
+    private String loadingDirection;
+    private String subMate;
+    private String useYn;
+    private String safetyStock;
+    private String feeYn;
+    private String saleUnitQty;
+    private String cstGodImgUrl;
+    private String externalGodImgUrl;
+
+    public static UpdateFasstoGoodsItemRequest from(UpdateFulfillmentVendorGoodsCommand command) {
+        return UpdateFasstoGoodsItemRequest.builder()
+                .cstGodCd(command.cstGodCd())
+                .godNm(command.godNm())
+                .godType(command.godType())
+                .giftDiv(command.giftDiv())
+                .godOptCd1(command.godOptCd1())
+                .godOptCd2(command.godOptCd2())
+                .invGodNmUseYn(command.invGodNmUseYn())
+                .invGodNm(command.invGodNm())
+                .supCd(command.supCd())
+                .cateCd(command.cateCd())
+                .seasonCd(command.seasonCd())
+                .genderCd(command.genderCd())
+                .makeYr(command.makeYr())
+                .godPr(command.godPr())
+                .inPr(command.inPr())
+                .salPr(command.salPr())
+                .dealTemp(command.dealTemp())
+                .pickFac(command.pickFac())
+                .godBarcd(command.godBarcd())
+                .boxWeight(command.boxWeight())
+                .origin(command.origin())
+                .distTermMgtYn(command.distTermMgtYn())
+                .useTermDay(command.useTermDay())
+                .outCanDay(command.outCanDay())
+                .inCanDay(command.inCanDay())
+                .boxDiv(command.boxDiv())
+                .bufGodYn(command.bufGodYn())
+                .loadingDirection(command.loadingDirection())
+                .subMate(command.subMate())
+                .useYn(command.useYn())
+                .safetyStock(command.safetyStock())
+                .feeYn(command.feeYn())
+                .saleUnitQty(command.saleUnitQty())
+                .cstGodImgUrl(command.cstGodImgUrl())
+                .externalGodImgUrl(command.externalGodImgUrl())
+                .build();
+    }
+}

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/web/fulfillment/response/UpdateFasstoGoodsItemResponse.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/web/fulfillment/response/UpdateFasstoGoodsItemResponse.java
@@ -1,0 +1,18 @@
+package com.personal.marketnote.product.adapter.out.web.fulfillment.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record UpdateFasstoGoodsItemResponse(
+        String fmsSlipNo,
+        String orderNo,
+        String msg,
+        String code,
+        Object outOfStockGoodsDetail
+) {
+    private static final String SUCCESS_CODE = "200";
+
+    public boolean isSuccess() {
+        return SUCCESS_CODE.equals(code);
+    }
+}

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/web/fulfillment/response/UpdateFasstoGoodsResponse.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/web/fulfillment/response/UpdateFasstoGoodsResponse.java
@@ -1,0 +1,17 @@
+package com.personal.marketnote.product.adapter.out.web.fulfillment.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.personal.marketnote.common.utility.FormatValidator;
+
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record UpdateFasstoGoodsResponse(
+        Integer dataCount,
+        List<UpdateFasstoGoodsItemResponse> goods
+) {
+    public boolean isSuccess() {
+        return FormatValidator.hasValue(goods)
+                && goods.stream().allMatch(UpdateFasstoGoodsItemResponse::isSuccess);
+    }
+}

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/mapper/FulfillmentVendorGoodsCommandMapper.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/mapper/FulfillmentVendorGoodsCommandMapper.java
@@ -5,6 +5,7 @@ import com.personal.marketnote.product.domain.product.Product;
 import com.personal.marketnote.product.exception.ProductInfoNoValueException;
 import com.personal.marketnote.product.port.in.command.FulfillmentVendorGoodsOptionCommand;
 import com.personal.marketnote.product.port.out.fulfillment.RegisterFulfillmentVendorGoodsCommand;
+import com.personal.marketnote.product.port.out.fulfillment.UpdateFulfillmentVendorGoodsCommand;
 
 import static com.personal.marketnote.common.domain.exception.ExceptionCode.*;
 
@@ -35,6 +36,61 @@ public class FulfillmentVendorGoodsCommandMapper {
         }
 
         return RegisterFulfillmentVendorGoodsCommand.builder()
+                .cstGodCd(String.valueOf(product.getId()))
+                .godNm(product.getName())
+                .godType(options.godType())
+                .giftDiv(options.giftDiv())
+                .godOptCd1(options.godOptCd1())
+                .godOptCd2(options.godOptCd2())
+                .invGodNmUseYn(options.invGodNmUseYn())
+                .invGodNm(options.invGodNm())
+                .supCd(options.supCd())
+                .cateCd(options.cateCd())
+                .seasonCd(options.seasonCd())
+                .genderCd(options.genderCd())
+                .makeYr(options.makeYr())
+                .godPr(options.godPr())
+                .inPr(options.inPr())
+                .salPr(options.salPr())
+                .dealTemp(options.dealTemp())
+                .pickFac(options.pickFac())
+                .godBarcd(options.godBarcd())
+                .boxWeight(options.boxWeight())
+                .origin(options.origin())
+                .distTermMgtYn(options.distTermMgtYn())
+                .useTermDay(options.useTermDay())
+                .outCanDay(options.outCanDay())
+                .inCanDay(options.inCanDay())
+                .boxDiv(options.boxDiv())
+                .bufGodYn(options.bufGodYn())
+                .loadingDirection(options.loadingDirection())
+                .subMate(options.subMate())
+                .useYn(options.useYn())
+                .safetyStock(options.safetyStock())
+                .feeYn(options.feeYn())
+                .saleUnitQty(options.saleUnitQty())
+                .cstGodImgUrl(options.cstGodImgUrl())
+                .externalGodImgUrl(options.externalGodImgUrl())
+                .build();
+    }
+
+    public static UpdateFulfillmentVendorGoodsCommand mapToUpdateCommand(
+            Product product, FulfillmentVendorGoodsOptionCommand options
+    ) {
+        if (FormatValidator.hasNoValue(product)) {
+            throw new ProductInfoNoValueException("%s:: 상품이 존재하지 않습니다.", FIRST_ERROR_CODE);
+        }
+        if (FormatValidator.hasNoValue(product.getId())) {
+            throw new ProductInfoNoValueException("%s:: 상품 ID가 존재하지 않습니다.", SECOND_ERROR_CODE);
+        }
+        if (FormatValidator.hasNoValue(product.getName())) {
+            throw new ProductInfoNoValueException("%s:: 상품명이 존재하지 않습니다.", THIRD_ERROR_CODE);
+        }
+        if (FormatValidator.hasNoValue(options)) {
+            throw new ProductInfoNoValueException("%s:: 파스토 상품 수정 정보가 존재하지 않습니다.", FOURTH_ERROR_CODE);
+        }
+
+        return UpdateFulfillmentVendorGoodsCommand.builder()
                 .cstGodCd(String.valueOf(product.getId()))
                 .godNm(product.getName())
                 .godType(options.godType())

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/command/UpdateProductCommand.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/command/UpdateProductCommand.java
@@ -11,6 +11,7 @@ public record UpdateProductCommand(
         String brandName,
         String detail,
         Boolean isFindAllOptions,
-        List<String> tags
+        List<String> tags,
+        FulfillmentVendorGoodsOptionCommand fulfillmentVendorGoods
 ) {
 }

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/result/product/GetAdminProductDetailResult.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/result/product/GetAdminProductDetailResult.java
@@ -5,14 +5,14 @@ import com.personal.marketnote.product.port.in.result.fulfillment.FulfillmentVen
 
 public record GetAdminProductDetailResult(
         GetProductInfoWithOptionsResult product,
-        FulfillmentVendorGoodsInfoResult fasstoGoodsInfo,
+        FulfillmentVendorGoodsInfoResult fasstoGoods,
         FulfillmentVendorGoodsElementInfoResult fasstoGoodsElement
 ) {
     public static GetAdminProductDetailResult of(
             GetProductInfoWithOptionsResult product,
-            FulfillmentVendorGoodsInfoResult fasstoGoodsInfo,
+            FulfillmentVendorGoodsInfoResult fasstoGoods,
             FulfillmentVendorGoodsElementInfoResult fasstoGoodsElement
     ) {
-        return new GetAdminProductDetailResult(product, fasstoGoodsInfo, fasstoGoodsElement);
+        return new GetAdminProductDetailResult(product, fasstoGoods, fasstoGoodsElement);
     }
 }

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/out/fulfillment/UpdateFulfillmentVendorGoodsCommand.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/out/fulfillment/UpdateFulfillmentVendorGoodsCommand.java
@@ -1,0 +1,58 @@
+package com.personal.marketnote.product.port.out.fulfillment;
+
+import com.personal.marketnote.common.utility.FormatValidator;
+import lombok.Builder;
+
+@Builder
+public record UpdateFulfillmentVendorGoodsCommand(
+        String cstGodCd,
+        String godNm,
+        String godType,
+        String giftDiv,
+        String godOptCd1,
+        String godOptCd2,
+        String invGodNmUseYn,
+        String invGodNm,
+        String supCd,
+        String cateCd,
+        String seasonCd,
+        String genderCd,
+        String makeYr,
+        String godPr,
+        String inPr,
+        String salPr,
+        String dealTemp,
+        String pickFac,
+        String godBarcd,
+        String boxWeight,
+        String origin,
+        String distTermMgtYn,
+        String useTermDay,
+        String outCanDay,
+        String inCanDay,
+        String boxDiv,
+        String bufGodYn,
+        String loadingDirection,
+        String subMate,
+        String useYn,
+        String safetyStock,
+        String feeYn,
+        String saleUnitQty,
+        String cstGodImgUrl,
+        String externalGodImgUrl
+) {
+    public UpdateFulfillmentVendorGoodsCommand {
+        if (FormatValidator.hasNoValue(cstGodCd)) {
+            throw new IllegalArgumentException("cstGodCd is required for Fassto goods update.");
+        }
+        if (FormatValidator.hasNoValue(godNm)) {
+            throw new IllegalArgumentException("godNm is required for Fassto goods update.");
+        }
+        if (FormatValidator.hasNoValue(godType)) {
+            throw new IllegalArgumentException("godType is required for Fassto goods update.");
+        }
+        if (FormatValidator.hasNoValue(giftDiv)) {
+            throw new IllegalArgumentException("giftDiv is required for Fassto goods update.");
+        }
+    }
+}

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/out/fulfillment/UpdateFulfillmentVendorGoodsPort.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/out/fulfillment/UpdateFulfillmentVendorGoodsPort.java
@@ -1,0 +1,5 @@
+package com.personal.marketnote.product.port.out.fulfillment;
+
+public interface UpdateFulfillmentVendorGoodsPort {
+    void updateFulfillmentVendorGoods(UpdateFulfillmentVendorGoodsCommand command);
+}

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/service/product/UpdateProductService.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/service/product/UpdateProductService.java
@@ -1,11 +1,14 @@
 package com.personal.marketnote.product.service.product;
 
 import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.product.domain.product.Product;
 import com.personal.marketnote.product.exception.NotProductOwnerException;
+import com.personal.marketnote.product.mapper.FulfillmentVendorGoodsCommandMapper;
 import com.personal.marketnote.product.port.in.command.UpdateProductCommand;
 import com.personal.marketnote.product.port.in.usecase.product.GetProductUseCase;
 import com.personal.marketnote.product.port.in.usecase.product.UpdateProductUseCase;
+import com.personal.marketnote.product.port.out.fulfillment.UpdateFulfillmentVendorGoodsPort;
 import com.personal.marketnote.product.port.out.product.FindProductPort;
 import com.personal.marketnote.product.port.out.product.UpdateProductPort;
 import lombok.RequiredArgsConstructor;
@@ -21,6 +24,7 @@ public class UpdateProductService implements UpdateProductUseCase {
     private final GetProductUseCase getProductUseCase;
     private final FindProductPort findProductPort;
     private final UpdateProductPort updateProductPort;
+    private final UpdateFulfillmentVendorGoodsPort updateFulfillmentVendorGoodsPort;
 
     @Override
     public void update(Long userId, boolean isAdmin, UpdateProductCommand command) {
@@ -35,5 +39,11 @@ public class UpdateProductService implements UpdateProductUseCase {
         );
 
         updateProductPort.update(product);
+
+        if (FormatValidator.hasValue(command.fulfillmentVendorGoods())) {
+            updateFulfillmentVendorGoodsPort.updateFulfillmentVendorGoods(
+                    FulfillmentVendorGoodsCommandMapper.mapToUpdateCommand(product, command.fulfillmentVendorGoods())
+            );
+        }
     }
 }


### PR DESCRIPTION
## partially addresses #475
## resolves #569

## Task
- [x] 파스토 상품 정보 수정 관련 요청 파라미터 추가
- [x] 상품 수정 시 풀필먼트 서비스 벤더 연동 요청(상품 서비스 -> 풀필먼트 서비스)