### PR TITLE
[#475][#612] feat: (관리자) 파스토 단일 상품 조회 연동 기능 추가

### DIFF
--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/FasstoGoodsController.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/FasstoGoodsController.java
@@ -1,10 +1,7 @@
 package com.personal.marketnote.fulfillment.adapter.in.web.vendor.controller;
 
 import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
-import com.personal.marketnote.fulfillment.adapter.in.web.vendor.controller.apidocs.GetFasstoGoodsApiDocs;
-import com.personal.marketnote.fulfillment.adapter.in.web.vendor.controller.apidocs.GetFasstoGoodsElementsApiDocs;
-import com.personal.marketnote.fulfillment.adapter.in.web.vendor.controller.apidocs.RegisterFasstoGoodsApiDocs;
-import com.personal.marketnote.fulfillment.adapter.in.web.vendor.controller.apidocs.UpdateFasstoGoodsApiDocs;
+import com.personal.marketnote.fulfillment.adapter.in.web.vendor.controller.apidocs.*;
 import com.personal.marketnote.fulfillment.adapter.in.web.vendor.mapper.FasstoGoodsRequestToCommandMapper;
 import com.personal.marketnote.fulfillment.adapter.in.web.vendor.request.RegisterFasstoGoodsRequest;
 import com.personal.marketnote.fulfillment.adapter.in.web.vendor.request.UpdateFasstoGoodsRequest;
@@ -16,10 +13,7 @@ import com.personal.marketnote.fulfillment.port.in.result.vendor.GetFasstoGoodsE
 import com.personal.marketnote.fulfillment.port.in.result.vendor.GetFasstoGoodsResult;
 import com.personal.marketnote.fulfillment.port.in.result.vendor.RegisterFasstoGoodsResult;
 import com.personal.marketnote.fulfillment.port.in.result.vendor.UpdateFasstoGoodsResult;
-import com.personal.marketnote.fulfillment.port.in.usecase.vendor.GetFasstoGoodsElementsUseCase;
-import com.personal.marketnote.fulfillment.port.in.usecase.vendor.GetFasstoGoodsUseCase;
-import com.personal.marketnote.fulfillment.port.in.usecase.vendor.RegisterFasstoGoodsUseCase;
-import com.personal.marketnote.fulfillment.port.in.usecase.vendor.UpdateFasstoGoodsUseCase;
+import com.personal.marketnote.fulfillment.port.in.usecase.vendor.*;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -40,6 +34,7 @@ import static com.personal.marketnote.common.utility.ApiConstant.ADMIN_POINTCUT;
 public class FasstoGoodsController {
     private final RegisterFasstoGoodsUseCase registerFasstoGoodsUseCase;
     private final GetFasstoGoodsUseCase getFasstoGoodsUseCase;
+    private final GetFasstoGoodsDetailUseCase getFasstoGoodsDetailUseCase;
     private final UpdateFasstoGoodsUseCase updateFasstoGoodsUseCase;
     private final GetFasstoGoodsElementsUseCase getFasstoGoodsElementsUseCase;
 
@@ -102,6 +97,39 @@ public class FasstoGoodsController {
                         HttpStatus.OK,
                         DEFAULT_SUCCESS_CODE,
                         "파스토 상품 목록 조회 성공"
+                ),
+                HttpStatus.OK
+        );
+    }
+
+    /**
+     * (관리자) 파스토 단일 상품 조회
+     *
+     * @param customerCode 파스토 고객사 코드
+     * @param accessToken  파스토 액세스 토큰
+     * @param godNm        조회 대상 상품 식별자(고객사상품코드)
+     * @Author 성효빈
+     * @Date 2026-02-05
+     * @Description 파스토 단일 상품을 조회합니다.
+     */
+    @GetMapping("/detail/{customerCode}")
+    @PreAuthorize(ADMIN_POINTCUT)
+    @GetFasstoGoodsDetailApiDocs
+    public ResponseEntity<BaseResponse<GetFasstoGoodsResponse>> getGoodsDetail(
+            @PathVariable String customerCode,
+            @RequestHeader("accessToken") String accessToken,
+            @RequestParam("godNm") String godNm
+    ) {
+        GetFasstoGoodsResult result = getFasstoGoodsDetailUseCase.getGoodsDetail(
+                FasstoGoodsRequestToCommandMapper.mapToGoodsDetailCommand(customerCode, accessToken, godNm)
+        );
+
+        return new ResponseEntity<>(
+                BaseResponse.of(
+                        GetFasstoGoodsResponse.from(result),
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "파스토 단일 상품 조회 성공"
                 ),
                 HttpStatus.OK
         );

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/apidocs/GetFasstoGoodsDetailApiDocs.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/apidocs/GetFasstoGoodsDetailApiDocs.java
@@ -1,0 +1,268 @@
+package com.personal.marketnote.fulfillment.adapter.in.web.vendor.controller.apidocs;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Operation(
+        summary = "(관리자) 파스토 단일 상품 조회",
+        description = """
+                작성일자: 2026-02-05
+                
+                작성자: 성효빈
+                
+                ---
+                
+                ## Description
+                
+                파스토 상품을 조회합니다.
+                
+                ---
+                
+                ## Request
+                
+                | **키** | **위치** | **타입** | **설명** | **필수 여부** | **예시** |
+                | --- | --- | --- | --- | --- | --- |
+                | accessToken | header | string | 파스토 액세스 토큰 | Y | 23ea2ab4f0e111f0be620ab49498ff55 |
+                | customerCode | path | string | 파스토 고객사 코드 | Y | 94388 |
+                | godNm | query | string | 상품 조회용 고객사상품코드(cstGodCd) | Y | 51 |
+                
+                ---
+                
+                ## Response
+                
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | statusCode | number | 상태 코드 | 200: 성공 / 400: 클라이언트 요청 오류 / 401: 인증 실패 / 403: 인가 실패 / 500: 그 외 |
+                | code | string | 응답 코드 | "SUC01" / "BAD_REQUEST" / "UNAUTHORIZED" / "FORBIDDEN" / "INTERNAL_SERVER_ERROR" |
+                | timestamp | string(datetime) | 응답 일시 | "2026-02-05T12:12:30.013" |
+                | content | object | 응답 본문 | { ... } |
+                | message | string | 처리 결과 | "파스토 단일 상품 조회 성공" |
+                
+                ---
+                
+                ### Response > content
+                
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | dataCount | number | 조회 건수 | 1 |
+                | goods | array | 상품 목록 | [ ... ] |
+                
+                ---
+                
+                ### Response > content > goods
+                
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | godCd | string | 상품코드 | "9438851" |
+                | godType | string | 상품유형 | "1" |
+                | godNm | string | 상품명 | "스프링노트1" |
+                | godTypeNm | string | 상품유형명 | "단품" |
+                | invGodNmUseYn | string | 송장출력용 상품명 사용여부 | "N" |
+                | cstGodCd | string | 고객사상품코드 | "51" |
+                | godOptCd1 | string | 상품옵션코드1 | null |
+                | godOptCd2 | string | 상품옵션코드2 | null |
+                | cstCd | string | 고객사코드 | "94388" |
+                | cstNm | string | 고객사명 | "마켓노트 주식회사 테스트" |
+                | supCd | string | 공급사코드 | "94388001" |
+                | supNm | string | 공급사명 | "테스트 상점1" |
+                | cateCd | string | 카테고리코드 | "A001" |
+                | cateNm | string | 카테고리명 | null |
+                | seasonCd | string | 계절상품 코드 | "0" |
+                | genderCd | string | 성별상품 코드 | "A" |
+                | godPr | string | 단가 | "10000" |
+                | inPr | string | 공급가 | "0" |
+                | salPr | string | 판매가 | "9000" |
+                | dealTemp | string | 취급온도 | "03" |
+                | pickFac | string | 피킹설비 | null |
+                | giftDiv | string | 사은품구분 | "01" |
+                | giftDivNm | string | 상품구분명 | "본품" |
+                | godWidth | string | 상품가로길이 | "0.000" |
+                | godLength | string | 상품세로길이 | "0.000" |
+                | godHeight | string | 상품높이길이 | "0.000" |
+                | makeYr | string | 연식 | "" |
+                | godBulk | string | 상품체적 | "0" |
+                | godWeight | string | 상품무게 | "0" |
+                | godSideSum | string | 상품규격(3면의합) | "0.000" |
+                | godVolume | string | 상품중량 | "" |
+                | godBarcd | string | 상품바코드 | null |
+                | boxWidth | string | 내품BOX가로길이 | "0" |
+                | boxLength | string | 내품BOX세로길이 | "0" |
+                | boxHeight | string | 내품BOX높이길이 | "0" |
+                | boxBulk | string | 내품BOX체적 | "0" |
+                | boxWeight | string | 내품BOX무게 | "0" |
+                | inBoxBarcd | string | 내품BOX바코드 | null |
+                | inBoxLength | string | 입고BOX세로길이 | "0" |
+                | inBoxHeight | string | 입고BOX높이길이 | "0" |
+                | inBoxBulk | string | 입고BOX체적 | "0" |
+                | inBoxWidth | string | 내품BOX가로길이 | "0" |
+                | inBoxWeight | string | 입고BOX무게 | "0" |
+                | inBoxSideSum | string | 입고BOX규격(3면의합) | "0" |
+                | boxInCnt | string | 내품박스입수 | "0" |
+                | inBoxInCnt | string | 입고박스입수 | "0" |
+                | pltInCnt | string | 팔레트입수 | "0" |
+                | origin | string | 원산지 | null |
+                | distTermMgtYn | string | 유통기한관리여부 | "N" |
+                | useTermDay | string | 사용기한 | "0" |
+                | outCanDay | string | 출고가능일수 | "0" |
+                | inCanDay | string | 입고가능일수 | "0" |
+                | boxDiv | string | 출고박스 | "1" |
+                | bufGodYn | string | 완충상품여부 | "Y" |
+                | loadingDirection | string | 출고박스 상품 적재 기준 | "NONE" |
+                | firstInDt | string | 최초입고일자 | null |
+                | useYn | string | 사용여부 | "Y" |
+                | feeYn | string | 요금적용여부 | null |
+                | saleUnitQty | string | 판매단위수량 | "1" |
+                | cstOneDayDeliveryYn | string | 원데이배송여부 | null |
+                | safetyStock | string | 안전재고수량 | "1" |
+                """,
+        security = {@SecurityRequirement(name = "bearer")},
+        parameters = {
+                @Parameter(
+                        name = "accessToken",
+                        description = "파스토 액세스 토큰",
+                        in = ParameterIn.HEADER,
+                        required = true,
+                        schema = @Schema(type = "string", example = "23ea2ab4f0e111f0be620ab49498ff55")
+                ),
+                @Parameter(
+                        name = "customerCode",
+                        description = "파스토 고객사 코드",
+                        in = ParameterIn.PATH,
+                        required = true,
+                        schema = @Schema(type = "string", example = "94388")
+                ),
+                @Parameter(
+                        name = "godNm",
+                        description = "상품 조회용 고객사상품코드(cstGodCd)",
+                        in = ParameterIn.QUERY,
+                        required = true,
+                        schema = @Schema(type = "string", example = "51")
+                )
+        },
+        responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "파스토 단일 상품 조회 성공",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 200,
+                                          "code": "SUC01",
+                                          "timestamp": "2026-02-05T12:12:30.013",
+                                          "content": {
+                                            "dataCount": 1,
+                                            "goods": [
+                                              {
+                                                "godCd": "9438851",
+                                                "godType": "1",
+                                                "godNm": "스프링노트1",
+                                                "godTypeNm": "단품",
+                                                "invGodNmUseYn": "N",
+                                                "cstGodCd": "51",
+                                                "godOptCd1": null,
+                                                "godOptCd2": null,
+                                                "cstCd": "94388",
+                                                "cstNm": "마켓노트 주식회사 테스트",
+                                                "supCd": "94388001",
+                                                "supNm": "테스트 상점1",
+                                                "cateCd": "A001",
+                                                "cateNm": null,
+                                                "seasonCd": "0",
+                                                "genderCd": "A",
+                                                "godPr": "10000",
+                                                "inPr": "0",
+                                                "salPr": "9000",
+                                                "dealTemp": "03",
+                                                "pickFac": null,
+                                                "giftDiv": "01",
+                                                "giftDivNm": "본품",
+                                                "godWidth": "0.000",
+                                                "godLength": "0.000",
+                                                "godHeight": "0.000",
+                                                "makeYr": "",
+                                                "godBulk": "0",
+                                                "godWeight": "0",
+                                                "godSideSum": "0.000",
+                                                "godVolume": "",
+                                                "godBarcd": null,
+                                                "boxWidth": "0",
+                                                "boxLength": "0",
+                                                "boxHeight": "0",
+                                                "boxBulk": "0",
+                                                "boxWeight": "0",
+                                                "inBoxBarcd": null,
+                                                "inBoxLength": "0",
+                                                "inBoxHeight": "0",
+                                                "inBoxBulk": "0",
+                                                "inBoxWidth": "0",
+                                                "inBoxWeight": "0",
+                                                "inBoxSideSum": "0",
+                                                "boxInCnt": "0",
+                                                "inBoxInCnt": "0",
+                                                "pltInCnt": "0",
+                                                "origin": null,
+                                                "distTermMgtYn": "N",
+                                                "useTermDay": "0",
+                                                "outCanDay": "0",
+                                                "inCanDay": "0",
+                                                "boxDiv": "1",
+                                                "bufGodYn": "Y",
+                                                "loadingDirection": "NONE",
+                                                "firstInDt": null,
+                                                "useYn": "Y",
+                                                "feeYn": null,
+                                                "saleUnitQty": "1",
+                                                "cstOneDayDeliveryYn": null,
+                                                "safetyStock": "1"
+                                              }
+                                            ]
+                                          },
+                                          "message": "파스토 단일 상품 조회 성공"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "401",
+                        description = "토큰 인증 실패",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 401,
+                                          "code": "UNAUTHORIZED",
+                                          "timestamp": "2026-02-05T12:12:30.013",
+                                          "content": null,
+                                          "message": "Invalid token"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "403",
+                        description = "토큰 인가 실패",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 403,
+                                          "code": "FORBIDDEN",
+                                          "timestamp": "2026-02-05T12:12:30.013",
+                                          "content": null,
+                                          "message": "Access Denied"
+                                        }
+                                        """)
+                        )
+                )
+        })
+public @interface GetFasstoGoodsDetailApiDocs {
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/mapper/FasstoGoodsRequestToCommandMapper.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/mapper/FasstoGoodsRequestToCommandMapper.java
@@ -62,6 +62,14 @@ public class FasstoGoodsRequestToCommandMapper {
         return GetFasstoGoodsCommand.of(customerCode, accessToken);
     }
 
+    public static GetFasstoGoodsDetailCommand mapToGoodsDetailCommand(
+            String customerCode,
+            String accessToken,
+            String godNm
+    ) {
+        return GetFasstoGoodsDetailCommand.of(customerCode, accessToken, godNm);
+    }
+
     public static GetFasstoGoodsElementsCommand mapToGoodsElementsCommand(
             String customerCode,
             String accessToken

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/GetFasstoGoodsDetailFailedException.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/GetFasstoGoodsDetailFailedException.java
@@ -1,0 +1,25 @@
+package com.personal.marketnote.fulfillment.exception;
+
+import com.personal.marketnote.common.exception.ExternalOperationFailedException;
+import com.personal.marketnote.common.utility.FormatValidator;
+
+import java.io.IOException;
+
+public class GetFasstoGoodsDetailFailedException extends ExternalOperationFailedException {
+    private static final String DEFAULT_MESSAGE = "파스토 단일 상품 조회 중 오류가 발생했습니다.";
+
+    public GetFasstoGoodsDetailFailedException(IOException cause) {
+        super(DEFAULT_MESSAGE, cause);
+    }
+
+    public GetFasstoGoodsDetailFailedException(String vendorMessage, IOException cause) {
+        super(resolveMessage(vendorMessage), cause);
+    }
+
+    private static String resolveMessage(String vendorMessage) {
+        if (FormatValidator.hasValue(vendorMessage)) {
+            return String.format("파스토 단일 상품 조회 실패: %s", vendorMessage);
+        }
+        return DEFAULT_MESSAGE;
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/mapper/FasstoGoodsCommandToRequestMapper.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/mapper/FasstoGoodsCommandToRequestMapper.java
@@ -1,9 +1,6 @@
 package com.personal.marketnote.fulfillment.mapper;
 
-import com.personal.marketnote.fulfillment.domain.vendor.fassto.goods.FasstoGoodsElementQuery;
-import com.personal.marketnote.fulfillment.domain.vendor.fassto.goods.FasstoGoodsItemMapper;
-import com.personal.marketnote.fulfillment.domain.vendor.fassto.goods.FasstoGoodsMapper;
-import com.personal.marketnote.fulfillment.domain.vendor.fassto.goods.FasstoGoodsQuery;
+import com.personal.marketnote.fulfillment.domain.vendor.fassto.goods.*;
 import com.personal.marketnote.fulfillment.port.in.command.vendor.*;
 
 import java.util.List;
@@ -25,6 +22,14 @@ public class FasstoGoodsCommandToRequestMapper {
         return FasstoGoodsQuery.of(
                 command.customerCode(),
                 command.accessToken()
+        );
+    }
+
+    public static FasstoGoodsDetailQuery mapToGoodsDetailQuery(GetFasstoGoodsDetailCommand command) {
+        return FasstoGoodsDetailQuery.of(
+                command.customerCode(),
+                command.accessToken(),
+                command.godNm()
         );
     }
 

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/vendor/GetFasstoGoodsDetailCommand.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/vendor/GetFasstoGoodsDetailCommand.java
@@ -1,0 +1,15 @@
+package com.personal.marketnote.fulfillment.port.in.command.vendor;
+
+public record GetFasstoGoodsDetailCommand(
+        String customerCode,
+        String accessToken,
+        String godNm
+) {
+    public static GetFasstoGoodsDetailCommand of(
+            String customerCode,
+            String accessToken,
+            String godNm
+    ) {
+        return new GetFasstoGoodsDetailCommand(customerCode, accessToken, godNm);
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/usecase/vendor/GetFasstoGoodsDetailUseCase.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/usecase/vendor/GetFasstoGoodsDetailUseCase.java
@@ -1,0 +1,15 @@
+package com.personal.marketnote.fulfillment.port.in.usecase.vendor;
+
+import com.personal.marketnote.fulfillment.port.in.command.vendor.GetFasstoGoodsDetailCommand;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.GetFasstoGoodsResult;
+
+public interface GetFasstoGoodsDetailUseCase {
+    /**
+     * @param command 상품 조회 커맨드
+     * @return 상품 조회 결과 {@link GetFasstoGoodsResult}
+     * @Date 2026-02-05
+     * @Author 성효빈
+     * @Description 파스토 상품을 조회합니다.
+     */
+    GetFasstoGoodsResult getGoodsDetail(GetFasstoGoodsDetailCommand command);
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/vendor/GetFasstoGoodsDetailPort.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/vendor/GetFasstoGoodsDetailPort.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.fulfillment.port.out.vendor;
+
+import com.personal.marketnote.fulfillment.domain.vendor.fassto.goods.FasstoGoodsDetailQuery;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.GetFasstoGoodsResult;
+
+public interface GetFasstoGoodsDetailPort {
+    GetFasstoGoodsResult getGoodsDetail(FasstoGoodsDetailQuery query);
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/vendor/GetFasstoGoodsDetailService.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/vendor/GetFasstoGoodsDetailService.java
@@ -1,0 +1,26 @@
+package com.personal.marketnote.fulfillment.service.vendor;
+
+import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.fulfillment.mapper.FasstoGoodsCommandToRequestMapper;
+import com.personal.marketnote.fulfillment.port.in.command.vendor.GetFasstoGoodsDetailCommand;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.GetFasstoGoodsResult;
+import com.personal.marketnote.fulfillment.port.in.usecase.vendor.GetFasstoGoodsDetailUseCase;
+import com.personal.marketnote.fulfillment.port.out.vendor.GetFasstoGoodsDetailPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional(isolation = READ_COMMITTED, readOnly = true)
+public class GetFasstoGoodsDetailService implements GetFasstoGoodsDetailUseCase {
+    private final GetFasstoGoodsDetailPort getFasstoGoodsDetailPort;
+
+    @Override
+    public GetFasstoGoodsResult getGoodsDetail(GetFasstoGoodsDetailCommand command) {
+        return getFasstoGoodsDetailPort.getGoodsDetail(
+                FasstoGoodsCommandToRequestMapper.mapToGoodsDetailQuery(command)
+        );
+    }
+}

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/goods/FasstoGoodsDetailQuery.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/goods/FasstoGoodsDetailQuery.java
@@ -1,0 +1,40 @@
+package com.personal.marketnote.fulfillment.domain.vendor.fassto.goods;
+
+import com.personal.marketnote.common.utility.FormatValidator;
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+public class FasstoGoodsDetailQuery {
+    private String customerCode;
+    private String accessToken;
+    private String godNm;
+
+    public static FasstoGoodsDetailQuery of(
+            String customerCode,
+            String accessToken,
+            String godNm
+    ) {
+        FasstoGoodsDetailQuery query = FasstoGoodsDetailQuery.builder()
+                .customerCode(customerCode)
+                .accessToken(accessToken)
+                .godNm(godNm)
+                .build();
+        query.validate();
+        return query;
+    }
+
+    private void validate() {
+        if (FormatValidator.hasNoValue(customerCode)) {
+            throw new IllegalArgumentException("customerCode is required.");
+        }
+        if (FormatValidator.hasNoValue(accessToken)) {
+            throw new IllegalArgumentException("accessToken is required.");
+        }
+        if (FormatValidator.hasNoValue(godNm)) {
+            throw new IllegalArgumentException("godNm is required.");
+        }
+    }
+}


### PR DESCRIPTION
## partially addresses #475
## resolves #612

## Task
- [x] 파스토 단일 상품 조회 연동 요청
- [x] 파스토 단일 상품 조회 연동 비즈니스 로직
- [x] 파스토 서버에 단일 상품 데이터 요청
- [x] 200 status code 응답
- [x] Swagger docs