### PR TITLE
[#128][#574] feat: 관리자 페이지의 상품 상세 정보 조회 시 풀필먼트 서비스로의 파스토 상품 연동 요청 엔드포인트를 파스토 상품 목록 조회 API에서 파스토 단일 상품 조회 API로 변경

### DIFF
--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/web/fulfillment/FulfillmentServiceClient.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/web/fulfillment/FulfillmentServiceClient.java
@@ -83,15 +83,18 @@ public class FulfillmentServiceClient implements
     }
 
     @Override
-    public GetFulfillmentVendorGoodsResult getFulfillmentVendorGoods() {
+    public GetFulfillmentVendorGoodsResult getFulfillmentVendorGoods(String godNm) {
         String fulfillmentVendorAccessToken = requestFulfillmentVendorAccessToken();
-        if (FormatValidator.hasNoValue(fulfillmentVendorCustomerCode) || FormatValidator.hasNoValue(fulfillmentVendorAccessToken)) {
+        if (FormatValidator.hasNoValue(fulfillmentVendorCustomerCode)
+                || FormatValidator.hasNoValue(fulfillmentVendorAccessToken)
+                || FormatValidator.hasNoValue(godNm)) {
             throw new FulfillmentServiceRequestFailedException(new IOException());
         }
 
         URI uri = UriComponentsBuilder
                 .fromUriString(fulfillmentServiceBaseUrl)
-                .path("/api/v1/vendors/fassto/goods/{customerCode}")
+                .path("/api/v1/vendors/fassto/goods/detail/{customerCode}")
+                .queryParam("godNm", godNm)
                 .buildAndExpand(fulfillmentVendorCustomerCode)
                 .toUri();
 

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/out/fulfillment/GetFulfillmentVendorGoodsPort.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/out/fulfillment/GetFulfillmentVendorGoodsPort.java
@@ -3,5 +3,5 @@ package com.personal.marketnote.product.port.out.fulfillment;
 import com.personal.marketnote.product.port.in.result.fulfillment.GetFulfillmentVendorGoodsResult;
 
 public interface GetFulfillmentVendorGoodsPort {
-    GetFulfillmentVendorGoodsResult getFulfillmentVendorGoods();
+    GetFulfillmentVendorGoodsResult getFulfillmentVendorGoods(String godNm);
 }

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/service/product/GetAdminProductDetailService.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/service/product/GetAdminProductDetailService.java
@@ -37,7 +37,9 @@ public class GetAdminProductDetailService implements GetAdminProductDetailUseCas
 
         GetProductInfoWithOptionsResult productInfo = getProductUseCase.getProductInfo(id, options);
 
-        GetFulfillmentVendorGoodsResult goodsResult = getFulfillmentVendorGoodsPort.getFulfillmentVendorGoods();
+        GetFulfillmentVendorGoodsResult goodsResult = getFulfillmentVendorGoodsPort.getFulfillmentVendorGoods(
+                String.valueOf(id)
+        );
         GetFulfillmentVendorGoodsElementsResult elementsResult
                 = getFulfillmentVendorGoodsElementsPort.getFulfillmentVendorGoodsElements();
 


### PR DESCRIPTION
## partially addresses #128
## resolves #574

## Task
- [x] 관리자 페이지의 상품 상세 정보 조회 시 풀필먼트 서비스로의 파스토 상품 연동 요청 엔드포인트를 파스토 상품 목록 조회 API에서 파스토 단일 상품 조회 API로 변경