### PR TITLE
[#475][#618] feat: (관리자) 파스토 단일 상품 재고 정보 조회 연동 기능 추가

### DIFF
--- a/file-service/file-adapters/src/main/java/com/personal/marketnote/file/adapter/out/persistence/file/entity/FileJpaEntity.java
+++ b/file-service/file-adapters/src/main/java/com/personal/marketnote/file/adapter/out/persistence/file/entity/FileJpaEntity.java
@@ -34,7 +34,7 @@ public class FileJpaEntity extends BaseGeneralEntity {
     @Column(name = "extension", nullable = false, length = 31)
     private String extension;
 
-    @Column(name = "name", nullable = false, length = 255)
+    @Column(name = "name", nullable = false)
     private String name;
 
     @Column(name = "s3_url", nullable = false, length = 511)

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/FasstoStockController.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/FasstoStockController.java
@@ -1,10 +1,12 @@
 package com.personal.marketnote.fulfillment.adapter.in.web.vendor.controller;
 
 import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
+import com.personal.marketnote.fulfillment.adapter.in.web.vendor.controller.apidocs.GetFasstoStockDetailApiDocs;
 import com.personal.marketnote.fulfillment.adapter.in.web.vendor.controller.apidocs.GetFasstoStocksApiDocs;
 import com.personal.marketnote.fulfillment.adapter.in.web.vendor.mapper.FasstoStockRequestToCommandMapper;
 import com.personal.marketnote.fulfillment.adapter.in.web.vendor.response.GetFasstoStocksResponse;
 import com.personal.marketnote.fulfillment.port.in.result.vendor.GetFasstoStocksResult;
+import com.personal.marketnote.fulfillment.port.in.usecase.vendor.GetFasstoStockDetailUseCase;
 import com.personal.marketnote.fulfillment.port.in.usecase.vendor.GetFasstoStocksUseCase;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -22,6 +24,7 @@ import static com.personal.marketnote.common.utility.ApiConstant.ADMIN_POINTCUT;
 @RequiredArgsConstructor
 public class FasstoStockController {
     private final GetFasstoStocksUseCase getFasstoStocksUseCase;
+    private final GetFasstoStockDetailUseCase getFasstoStockDetailUseCase;
 
     /**
      * (관리자) 파스토 재고 목록 조회
@@ -30,7 +33,7 @@ public class FasstoStockController {
      * @param accessToken  파스토 액세스 토큰
      * @param outOfStockYn 품절 상품 조회 여부(Y/N)
      * @Author 성효빈
-     * @Date 2026-02-03
+     * @Date 2026-02-05
      * @Description 파스토 재고 목록을 조회합니다.
      */
     @GetMapping("/{customerCode}")
@@ -51,6 +54,41 @@ public class FasstoStockController {
                         HttpStatus.OK,
                         DEFAULT_SUCCESS_CODE,
                         "파스토 재고 목록 조회 성공"
+                ),
+                HttpStatus.OK
+        );
+    }
+
+    /**
+     * (관리자) 파스토 단일 상품 재고 정보 조회
+     *
+     * @param customerCode 파스토 고객사 코드
+     * @param accessToken  파스토 액세스 토큰
+     * @param cstGodCd     고객사상품코드
+     * @param outOfStockYn 품절 상품 조회 여부(Y/N)
+     * @Author 성효빈
+     * @Date 2026-02-03
+     * @Description 파스토 단일 상품 재고를 조회합니다.
+     */
+    @GetMapping("/detail/{customerCode}")
+    @PreAuthorize(ADMIN_POINTCUT)
+    @GetFasstoStockDetailApiDocs
+    public ResponseEntity<BaseResponse<GetFasstoStocksResponse>> getStockDetail(
+            @PathVariable String customerCode,
+            @RequestHeader("accessToken") String accessToken,
+            @RequestParam("cstGodCd") String cstGodCd,
+            @RequestParam(required = false) String outOfStockYn
+    ) {
+        GetFasstoStocksResult result = getFasstoStockDetailUseCase.getStockDetail(
+                FasstoStockRequestToCommandMapper.mapToStockDetailCommand(customerCode, accessToken, cstGodCd, outOfStockYn)
+        );
+
+        return new ResponseEntity<>(
+                BaseResponse.of(
+                        GetFasstoStocksResponse.from(result),
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "파스토 단일 상품 재고 정보 조회 성공"
                 ),
                 HttpStatus.OK
         );

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/apidocs/GetFasstoStockDetailApiDocs.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/apidocs/GetFasstoStockDetailApiDocs.java
@@ -1,0 +1,184 @@
+package com.personal.marketnote.fulfillment.adapter.in.web.vendor.controller.apidocs;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Operation(
+        summary = "(관리자) 파스토 단일 상품 재고 정보 조회",
+        description = """
+                작성일자: 2026-02-05
+                
+                작성자: 성효빈
+                
+                ---
+                
+                ## Description
+                
+                파스토 단일 상품 재고를 조회합니다.
+                
+                ---
+                
+                ## Request
+                
+                | **키** | **위치** | **타입** | **설명** | **필수 여부** | **예시** |
+                | --- | --- | --- | --- | --- | --- |
+                | accessToken | header | string | 파스토 액세스 토큰 | Y | 23ea2ab4f0e111f0be620ab49498ff55 |
+                | customerCode | path | string | 파스토 고객사 코드 | Y | 94388 |
+                | cstGodCd | query | string | 고객사상품코드 | Y | 51 |
+                | outOfStockYn | query | string | 품절 상품 조회 여부(Y/N) | N | Y |
+                
+                ---
+                
+                ## Response
+                
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | statusCode | number | 상태 코드 | 200: 성공 / 400: 클라이언트 요청 오류 / 401: 인증 실패 / 403: 인가 실패 / 500: 그 외 |
+                | code | string | 응답 코드 | "SUC01" / "BAD_REQUEST" / "UNAUTHORIZED" / "FORBIDDEN" / "INTERNAL_SERVER_ERROR" |
+                | timestamp | string(datetime) | 응답 일시 | "2026-02-05T12:12:30.013" |
+                | content | object | 응답 본문 | { ... } |
+                | message | string | 처리 결과 | "파스토 단일 상품 재고 정보 조회 성공" |
+                
+                ---
+                
+                ### Response > content
+                
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | dataCount | number | 조회 건수 | 1 |
+                | stocks | array | 재고 목록 | [ ... ] |
+                
+                ---
+                
+                ### Response > content > stocks
+                
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | whCd | string | 창고번호 | "TEST" |
+                | godCd | string | 상품코드 | "94388IBA00001" |
+                | cstGodCd | string | 고객사상품코드 | "51" |
+                | godNm | string | 상품명 | "테스트상품1" |
+                | distTermDt | string | 유통기한일자 | "" |
+                | distTermMgtYn | string | 유통기한관리여부 | "N" |
+                | godBarcd | string | 상품바코드 | "51" |
+                | stockQty | number | 재고수량 | 10000 |
+                | badStockQty | number | 불용재고 | 0 |
+                | canStockQty | number | 주문가능수량 | 9999 |
+                | cstSupCd | string | 고객사공급사코드 | null |
+                | supNm | string | 공급사명 | "테스트 상점1" |
+                | giftDiv | string | 사은품구분(01:본품, 02:사은품, 03:부자재) | "01" |
+                | goodsSerialNo | array | 상품 일련번호 목록 | [] |
+                | slipNo | string | 입고지시번호 | "TESTIO251226000001" |
+                """,
+        security = {@SecurityRequirement(name = "bearer")},
+        parameters = {
+                @Parameter(
+                        name = "accessToken",
+                        description = "파스토 액세스 토큰",
+                        in = ParameterIn.HEADER,
+                        required = true,
+                        schema = @Schema(type = "string", example = "23ea2ab4f0e111f0be620ab49498ff55")
+                ),
+                @Parameter(
+                        name = "customerCode",
+                        description = "파스토 고객사 코드",
+                        in = ParameterIn.PATH,
+                        required = true,
+                        schema = @Schema(type = "string", example = "94388")
+                ),
+                @Parameter(
+                        name = "cstGodCd",
+                        description = "고객사상품코드",
+                        in = ParameterIn.QUERY,
+                        required = true,
+                        schema = @Schema(type = "string", example = "51")
+                ),
+                @Parameter(
+                        name = "outOfStockYn",
+                        description = "품절 상품 조회 여부(Y/N)",
+                        in = ParameterIn.QUERY,
+                        required = false,
+                        schema = @Schema(type = "string", example = "Y")
+                )
+        },
+        responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "파스토 단일 상품 재고 정보 조회 성공",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 200,
+                                          "code": "SUC01",
+                                          "timestamp": "2026-02-05T12:12:30.013",
+                                          "content": {
+                                            "dataCount": 1,
+                                            "stocks": [
+                                              {
+                                                "whCd": "TEST",
+                                                "godCd": "94388IBA00001",
+                                                "cstGodCd": "51",
+                                                "godNm": "테스트상품1",
+                                                "distTermDt": "",
+                                                "distTermMgtYn": "N",
+                                                "godBarcd": "51",
+                                                "stockQty": 10000,
+                                                "badStockQty": 0,
+                                                "canStockQty": 9999,
+                                                "cstSupCd": null,
+                                                "supNm": "테스트 상점1",
+                                                "giftDiv": "01",
+                                                "goodsSerialNo": [],
+                                                "slipNo": "TESTIO251226000001"
+                                              }
+                                            ]
+                                          },
+                                          "message": "파스토 단일 상품 재고 정보 조회 성공"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "401",
+                        description = "토큰 인증 실패",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 401,
+                                          "code": "UNAUTHORIZED",
+                                          "timestamp": "2026-02-05T12:12:30.013",
+                                          "content": null,
+                                          "message": "Invalid token"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "403",
+                        description = "토큰 인가 실패",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 403,
+                                          "code": "FORBIDDEN",
+                                          "timestamp": "2026-02-05T12:12:30.013",
+                                          "content": null,
+                                          "message": "Access Denied"
+                                        }
+                                        """)
+                        )
+                )
+        })
+public @interface GetFasstoStockDetailApiDocs {
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/mapper/FasstoStockRequestToCommandMapper.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/mapper/FasstoStockRequestToCommandMapper.java
@@ -1,5 +1,6 @@
 package com.personal.marketnote.fulfillment.adapter.in.web.vendor.mapper;
 
+import com.personal.marketnote.fulfillment.port.in.command.vendor.GetFasstoStockDetailCommand;
 import com.personal.marketnote.fulfillment.port.in.command.vendor.GetFasstoStocksCommand;
 
 public class FasstoStockRequestToCommandMapper {
@@ -9,5 +10,14 @@ public class FasstoStockRequestToCommandMapper {
             String outOfStockYn
     ) {
         return GetFasstoStocksCommand.of(customerCode, accessToken, outOfStockYn);
+    }
+
+    public static GetFasstoStockDetailCommand mapToStockDetailCommand(
+            String customerCode,
+            String accessToken,
+            String cstGodCd,
+            String outOfStockYn
+    ) {
+        return GetFasstoStockDetailCommand.of(customerCode, accessToken, cstGodCd, outOfStockYn);
     }
 }

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/GetFasstoStockDetailFailedException.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/GetFasstoStockDetailFailedException.java
@@ -1,0 +1,25 @@
+package com.personal.marketnote.fulfillment.exception;
+
+import com.personal.marketnote.common.exception.ExternalOperationFailedException;
+import com.personal.marketnote.common.utility.FormatValidator;
+
+import java.io.IOException;
+
+public class GetFasstoStockDetailFailedException extends ExternalOperationFailedException {
+    private static final String DEFAULT_MESSAGE = "파스토 단일 상품 재고 정보 조회 중 오류가 발생했습니다.";
+
+    public GetFasstoStockDetailFailedException(IOException cause) {
+        super(DEFAULT_MESSAGE, cause);
+    }
+
+    public GetFasstoStockDetailFailedException(String vendorMessage, IOException cause) {
+        super(resolveMessage(vendorMessage), cause);
+    }
+
+    private static String resolveMessage(String vendorMessage) {
+        if (FormatValidator.hasValue(vendorMessage)) {
+            return String.format("파스토 단일 상품 재고 정보 조회 실패: %s", vendorMessage);
+        }
+        return DEFAULT_MESSAGE;
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/mapper/FasstoStockCommandToRequestMapper.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/mapper/FasstoStockCommandToRequestMapper.java
@@ -1,6 +1,8 @@
 package com.personal.marketnote.fulfillment.mapper;
 
+import com.personal.marketnote.fulfillment.domain.vendor.fassto.stock.FasstoStockDetailQuery;
 import com.personal.marketnote.fulfillment.domain.vendor.fassto.stock.FasstoStockQuery;
+import com.personal.marketnote.fulfillment.port.in.command.vendor.GetFasstoStockDetailCommand;
 import com.personal.marketnote.fulfillment.port.in.command.vendor.GetFasstoStocksCommand;
 
 public class FasstoStockCommandToRequestMapper {
@@ -8,6 +10,15 @@ public class FasstoStockCommandToRequestMapper {
         return FasstoStockQuery.of(
                 command.customerCode(),
                 command.accessToken(),
+                command.outOfStockYn()
+        );
+    }
+
+    public static FasstoStockDetailQuery mapToDetailQuery(GetFasstoStockDetailCommand command) {
+        return FasstoStockDetailQuery.of(
+                command.customerCode(),
+                command.accessToken(),
+                command.cstGodCd(),
                 command.outOfStockYn()
         );
     }

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/vendor/GetFasstoStockDetailCommand.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/vendor/GetFasstoStockDetailCommand.java
@@ -1,0 +1,17 @@
+package com.personal.marketnote.fulfillment.port.in.command.vendor;
+
+public record GetFasstoStockDetailCommand(
+        String customerCode,
+        String accessToken,
+        String cstGodCd,
+        String outOfStockYn
+) {
+    public static GetFasstoStockDetailCommand of(
+            String customerCode,
+            String accessToken,
+            String cstGodCd,
+            String outOfStockYn
+    ) {
+        return new GetFasstoStockDetailCommand(customerCode, accessToken, cstGodCd, outOfStockYn);
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/usecase/vendor/GetFasstoStockDetailUseCase.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/usecase/vendor/GetFasstoStockDetailUseCase.java
@@ -1,0 +1,15 @@
+package com.personal.marketnote.fulfillment.port.in.usecase.vendor;
+
+import com.personal.marketnote.fulfillment.port.in.command.vendor.GetFasstoStockDetailCommand;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.GetFasstoStocksResult;
+
+public interface GetFasstoStockDetailUseCase {
+    /**
+     * @param command 단일 상품 재고 정보 조회 커맨드
+     * @return 단일 상품 재고 정보 조회 결과 {@link GetFasstoStocksResult}
+     * @Date 2026-02-05
+     * @Author 성효빈
+     * @Description 파스토 단일 상품 재고 정보를 조회합니다.
+     */
+    GetFasstoStocksResult getStockDetail(GetFasstoStockDetailCommand command);
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/vendor/GetFasstoStockDetailPort.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/vendor/GetFasstoStockDetailPort.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.fulfillment.port.out.vendor;
+
+import com.personal.marketnote.fulfillment.domain.vendor.fassto.stock.FasstoStockDetailQuery;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.GetFasstoStocksResult;
+
+public interface GetFasstoStockDetailPort {
+    GetFasstoStocksResult getStockDetail(FasstoStockDetailQuery query);
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/vendor/GetFasstoStockDetailService.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/vendor/GetFasstoStockDetailService.java
@@ -1,0 +1,26 @@
+package com.personal.marketnote.fulfillment.service.vendor;
+
+import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.fulfillment.mapper.FasstoStockCommandToRequestMapper;
+import com.personal.marketnote.fulfillment.port.in.command.vendor.GetFasstoStockDetailCommand;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.GetFasstoStocksResult;
+import com.personal.marketnote.fulfillment.port.in.usecase.vendor.GetFasstoStockDetailUseCase;
+import com.personal.marketnote.fulfillment.port.out.vendor.GetFasstoStockDetailPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional(isolation = READ_COMMITTED, readOnly = true)
+public class GetFasstoStockDetailService implements GetFasstoStockDetailUseCase {
+    private final GetFasstoStockDetailPort getFasstoStockDetailPort;
+
+    @Override
+    public GetFasstoStocksResult getStockDetail(GetFasstoStockDetailCommand command) {
+        return getFasstoStockDetailPort.getStockDetail(
+                FasstoStockCommandToRequestMapper.mapToDetailQuery(command)
+        );
+    }
+}

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/stock/FasstoStockDetailQuery.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/stock/FasstoStockDetailQuery.java
@@ -1,0 +1,43 @@
+package com.personal.marketnote.fulfillment.domain.vendor.fassto.stock;
+
+import com.personal.marketnote.common.utility.FormatValidator;
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+public class FasstoStockDetailQuery {
+    private String customerCode;
+    private String accessToken;
+    private String cstGodCd;
+    private String outOfStockYn;
+
+    public static FasstoStockDetailQuery of(
+            String customerCode,
+            String accessToken,
+            String cstGodCd,
+            String outOfStockYn
+    ) {
+        FasstoStockDetailQuery query = FasstoStockDetailQuery.builder()
+                .customerCode(customerCode)
+                .accessToken(accessToken)
+                .cstGodCd(cstGodCd)
+                .outOfStockYn(outOfStockYn)
+                .build();
+        query.validate();
+        return query;
+    }
+
+    private void validate() {
+        if (FormatValidator.hasNoValue(customerCode)) {
+            throw new IllegalArgumentException("customerCode is required.");
+        }
+        if (FormatValidator.hasNoValue(accessToken)) {
+            throw new IllegalArgumentException("accessToken is required.");
+        }
+        if (FormatValidator.hasNoValue(cstGodCd)) {
+            throw new IllegalArgumentException("cstGodCd is required.");
+        }
+    }
+}


### PR DESCRIPTION
## partially addresses #475
## resolves #618

## Task
- [x] 파스토 단일 상품 재고 정보 조회 연동 요청
- [x] 파스토 단일 상품 재고 정보 조회 연동 비즈니스 로직
- [x] 파스토 서버에 단일 상품 재고 정보 데이터 요청
- [x] 200 status code 응답
- [x] Swagger docs