### PR TITLE
[#475][#613] feat: 파스토 서버 상품 재고 튜플과 커머스 서비스 재고 튜플 동기화 기능 추가

### DIFF
--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/web/commerce/CommerceServiceClient.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/web/commerce/CommerceServiceClient.java
@@ -1,0 +1,189 @@
+package com.personal.marketnote.fulfillment.adapter.out.web.commerce;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.personal.marketnote.common.adapter.out.ServiceAdapter;
+import com.personal.marketnote.common.exception.CommerceServiceRequestFailedException;
+import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.fulfillment.adapter.out.web.commerce.request.SyncFulfillmentVendorInventoryRequest;
+import com.personal.marketnote.fulfillment.domain.servicecommunication.FulfillmentServiceCommunicationSenderType;
+import com.personal.marketnote.fulfillment.domain.servicecommunication.FulfillmentServiceCommunicationTargetType;
+import com.personal.marketnote.fulfillment.domain.servicecommunication.FulfillmentServiceCommunicationType;
+import com.personal.marketnote.fulfillment.port.out.commerce.UpdateCommerceInventoryCommand;
+import com.personal.marketnote.fulfillment.port.out.commerce.UpdateCommerceInventoryItemCommand;
+import com.personal.marketnote.fulfillment.port.out.commerce.UpdateCommerceInventoryPort;
+import com.personal.marketnote.fulfillment.utility.ServiceCommunicationPayloadGenerator;
+import com.personal.marketnote.fulfillment.utility.ServiceCommunicationRecorder;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.Objects;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.Collectors;
+
+import static com.personal.marketnote.common.utility.ApiConstant.*;
+
+@ServiceAdapter
+@RequiredArgsConstructor
+@Slf4j
+public class CommerceServiceClient implements UpdateCommerceInventoryPort {
+    private static final FulfillmentServiceCommunicationTargetType TARGET_TYPE =
+            FulfillmentServiceCommunicationTargetType.COMMERCE_INVENTORY;
+    private static final FulfillmentServiceCommunicationSenderType REQUEST_SENDER =
+            FulfillmentServiceCommunicationSenderType.FULFILLMENT;
+    private static final FulfillmentServiceCommunicationSenderType RESPONSE_SENDER =
+            FulfillmentServiceCommunicationSenderType.COMMERCE;
+
+    @Value("${commerce-service.base-url}")
+    private String commerceServiceBaseUrl;
+
+    @Value("${spring.jwt.admin-access-token}")
+    private String adminAccessToken;
+
+    private final RestTemplate restTemplate;
+    private final ServiceCommunicationRecorder serviceCommunicationRecorder;
+    private final ServiceCommunicationPayloadGenerator serviceCommunicationPayloadGenerator;
+
+    @Override
+    public void updateInventories(UpdateCommerceInventoryCommand command) {
+        if (FormatValidator.hasNoValue(command) || FormatValidator.hasNoValue(command.inventories())) {
+            throw new IllegalArgumentException("Update commerce inventory command is required.");
+        }
+        if (FormatValidator.hasNoValue(commerceServiceBaseUrl) || FormatValidator.hasNoValue(adminAccessToken)) {
+            throw new CommerceServiceRequestFailedException(new IOException());
+        }
+
+        String baseUrl = Objects.requireNonNull(commerceServiceBaseUrl, "commerceServiceBaseUrl");
+        String accessToken = Objects.requireNonNull(adminAccessToken, "adminAccessToken");
+
+        URI uri = UriComponentsBuilder
+                .fromUriString(baseUrl)
+                .path("/api/v1/inventories/fulfillment/vendors/stocks/sync")
+                .build()
+                .toUri();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(accessToken);
+
+        SyncFulfillmentVendorInventoryRequest request = SyncFulfillmentVendorInventoryRequest.from(command);
+        HttpEntity<SyncFulfillmentVendorInventoryRequest> httpEntity = new HttpEntity<>(request, headers);
+
+        String targetId = resolveTargetId(command);
+        sendRequest(uri, httpEntity, targetId);
+    }
+
+    private void sendRequest(
+            URI uri,
+            HttpEntity<SyncFulfillmentVendorInventoryRequest> httpEntity,
+            String targetId
+    ) {
+        long sleepMillis = INTER_SERVER_DEFAULT_RETRIAL_PENDING_MILLI_SECOND;
+        Exception error = new Exception();
+        URI requestUri = Objects.requireNonNull(uri, "uri");
+        HttpMethod method = Objects.requireNonNull(HttpMethod.POST, "method");
+
+        for (int i = 0; i < INTER_SERVER_MAX_REQUEST_COUNT; i++) {
+            int attempt = i + 1;
+            try {
+                restTemplate.exchange(requestUri, method, httpEntity, Void.class);
+                return;
+            } catch (Exception e) {
+                String exception = e.getClass().getSimpleName();
+                JsonNode requestPayloadJson = serviceCommunicationPayloadGenerator.buildRequestPayloadJson(
+                        method,
+                        requestUri,
+                        httpEntity.getBody(),
+                        attempt
+                );
+                String requestPayload = requestPayloadJson.toString();
+                JsonNode responsePayloadJson = serviceCommunicationPayloadGenerator.buildErrorPayloadJson(
+                        exception,
+                        e.getMessage(),
+                        attempt
+                );
+                String responsePayload = responsePayloadJson.toString();
+                recordCommunication(
+                        TARGET_TYPE,
+                        targetId,
+                        FulfillmentServiceCommunicationType.REQUEST,
+                        requestPayload,
+                        requestPayloadJson,
+                        exception
+                );
+                recordCommunication(
+                        TARGET_TYPE,
+                        targetId,
+                        FulfillmentServiceCommunicationType.RESPONSE,
+                        responsePayload,
+                        responsePayloadJson,
+                        exception
+                );
+                log.warn(e.getMessage(), e);
+                if (i == INTER_SERVER_MAX_REQUEST_COUNT - 1) {
+                    error = e;
+                }
+
+                try {
+                    // 대상 서비스 장애 시 요청 트래픽 폭주를 방지하기 위해 jitter 설정
+                    long jitteredSleepMillis = ThreadLocalRandom.current()
+                            .nextLong(Math.max(1L, sleepMillis) + 1);
+                    Thread.sleep(jitteredSleepMillis);
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    break;
+                }
+
+                // exponential backoff 적용
+                sleepMillis = sleepMillis * INTER_SERVER_DEFAULT_EXPONENTIAL_BACKOFF_VALUE;
+            }
+        }
+
+        log.error("Failed to sync commerce inventories: {} with error: {}", requestUri, error.getMessage(), error);
+        throw new CommerceServiceRequestFailedException(new IOException(error));
+    }
+
+    private String resolveTargetId(UpdateCommerceInventoryCommand command) {
+        if (FormatValidator.hasNoValue(command) || FormatValidator.hasNoValue(command.inventories())) {
+            return null;
+        }
+
+        return command.inventories().stream()
+                .map(UpdateCommerceInventoryItemCommand::productId)
+                .filter(productId -> FormatValidator.hasValue(productId))
+                .map(String::valueOf)
+                .limit(10)
+                .collect(Collectors.joining(","));
+    }
+
+    private void recordCommunication(
+            FulfillmentServiceCommunicationTargetType targetType,
+            String targetId,
+            FulfillmentServiceCommunicationType communicationType,
+            String payload,
+            JsonNode payloadJson,
+            String exception
+    ) {
+        if (FormatValidator.hasNoValue(exception)) {
+            return;
+        }
+
+        FulfillmentServiceCommunicationSenderType sender =
+                communicationType == FulfillmentServiceCommunicationType.REQUEST ? REQUEST_SENDER : RESPONSE_SENDER;
+        serviceCommunicationRecorder.record(
+                targetType,
+                communicationType,
+                sender,
+                targetId,
+                payload,
+                payloadJson,
+                exception
+        );
+    }
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/web/commerce/request/SyncFulfillmentVendorInventoryItemRequest.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/web/commerce/request/SyncFulfillmentVendorInventoryItemRequest.java
@@ -1,0 +1,23 @@
+package com.personal.marketnote.fulfillment.adapter.out.web.commerce.request;
+
+import com.personal.marketnote.fulfillment.port.out.commerce.UpdateCommerceInventoryItemCommand;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SyncFulfillmentVendorInventoryItemRequest {
+    private Long productId;
+    private Integer stock;
+
+    public static SyncFulfillmentVendorInventoryItemRequest from(UpdateCommerceInventoryItemCommand command) {
+        return SyncFulfillmentVendorInventoryItemRequest.builder()
+                .productId(command.productId())
+                .stock(command.stock())
+                .build();
+    }
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/web/commerce/request/SyncFulfillmentVendorInventoryRequest.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/web/commerce/request/SyncFulfillmentVendorInventoryRequest.java
@@ -1,0 +1,26 @@
+package com.personal.marketnote.fulfillment.adapter.out.web.commerce.request;
+
+import com.personal.marketnote.fulfillment.port.out.commerce.UpdateCommerceInventoryCommand;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SyncFulfillmentVendorInventoryRequest {
+    private List<SyncFulfillmentVendorInventoryItemRequest> inventories;
+
+    public static SyncFulfillmentVendorInventoryRequest from(UpdateCommerceInventoryCommand command) {
+        List<SyncFulfillmentVendorInventoryItemRequest> items = command.inventories().stream()
+                .map(SyncFulfillmentVendorInventoryItemRequest::from)
+                .toList();
+        return SyncFulfillmentVendorInventoryRequest.builder()
+                .inventories(items)
+                .build();
+    }
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/resources/application.yml
+++ b/fulfillment-service/fulfillment-adapters/src/main/resources/application.yml
@@ -61,6 +61,9 @@ vendor:
       api-cd: ${FASSTO_API_CD:change-me}
       api-key: ${FASSTO_API_KEY:change-me}
 
+commerce-service:
+  base-url: ${COMMERCE_SERVICE_SERVER_ORIGIN:http://localhost:8082}
+
 logging:
   config: classpath:logback-spring.xml
   level:

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/vendor/SyncFasstoStockCommand.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/vendor/SyncFasstoStockCommand.java
@@ -1,0 +1,15 @@
+package com.personal.marketnote.fulfillment.port.in.command.vendor;
+
+import java.util.List;
+
+public record SyncFasstoStockCommand(
+        String customerCode,
+        List<Long> productIds
+) {
+    public static SyncFasstoStockCommand of(
+            String customerCode,
+            List<Long> productIds
+    ) {
+        return new SyncFasstoStockCommand(customerCode, productIds);
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/usecase/vendor/SyncFasstoStockUseCase.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/usecase/vendor/SyncFasstoStockUseCase.java
@@ -1,0 +1,13 @@
+package com.personal.marketnote.fulfillment.port.in.usecase.vendor;
+
+import com.personal.marketnote.fulfillment.port.in.command.vendor.SyncFasstoStockCommand;
+
+public interface SyncFasstoStockUseCase {
+    /**
+     * @param command 파스토 재고 동기화 커맨드
+     * @Date 2026-02-07
+     * @Author 성효빈
+     * @Description 파스토 상품 재고를 커머스 재고와 동기화합니다.
+     */
+    void sync(SyncFasstoStockCommand command);
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/commerce/UpdateCommerceInventoryCommand.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/commerce/UpdateCommerceInventoryCommand.java
@@ -1,0 +1,21 @@
+package com.personal.marketnote.fulfillment.port.out.commerce;
+
+import com.personal.marketnote.common.utility.FormatValidator;
+
+import java.util.List;
+
+public record UpdateCommerceInventoryCommand(
+        List<UpdateCommerceInventoryItemCommand> inventories
+) {
+    public UpdateCommerceInventoryCommand {
+        if (FormatValidator.hasNoValue(inventories)) {
+            throw new IllegalArgumentException("Inventory sync items are required for commerce inventory sync.");
+        }
+    }
+
+    public static UpdateCommerceInventoryCommand of(
+            List<UpdateCommerceInventoryItemCommand> inventories
+    ) {
+        return new UpdateCommerceInventoryCommand(inventories);
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/commerce/UpdateCommerceInventoryItemCommand.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/commerce/UpdateCommerceInventoryItemCommand.java
@@ -1,0 +1,27 @@
+package com.personal.marketnote.fulfillment.port.out.commerce;
+
+import com.personal.marketnote.common.utility.FormatValidator;
+
+public record UpdateCommerceInventoryItemCommand(
+        Long productId,
+        Integer stock
+) {
+    public UpdateCommerceInventoryItemCommand {
+        if (FormatValidator.hasNoValue(productId)) {
+            throw new IllegalArgumentException("Product id is required for commerce inventory sync.");
+        }
+        if (FormatValidator.hasNoValue(stock)) {
+            throw new IllegalArgumentException("Stock is required for commerce inventory sync.");
+        }
+        if (stock < 0) {
+            throw new IllegalArgumentException("Stock cannot be negative for commerce inventory sync.");
+        }
+    }
+
+    public static UpdateCommerceInventoryItemCommand of(
+            Long productId,
+            Integer stock
+    ) {
+        return new UpdateCommerceInventoryItemCommand(productId, stock);
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/commerce/UpdateCommerceInventoryPort.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/commerce/UpdateCommerceInventoryPort.java
@@ -1,0 +1,5 @@
+package com.personal.marketnote.fulfillment.port.out.commerce;
+
+public interface UpdateCommerceInventoryPort {
+    void updateInventories(UpdateCommerceInventoryCommand command);
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/vendor/SyncFasstoStockService.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/vendor/SyncFasstoStockService.java
@@ -1,0 +1,105 @@
+package com.personal.marketnote.fulfillment.service.vendor;
+
+import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.fulfillment.domain.FasstoAccessToken;
+import com.personal.marketnote.fulfillment.port.in.command.vendor.GetFasstoStockDetailCommand;
+import com.personal.marketnote.fulfillment.port.in.command.vendor.SyncFasstoStockCommand;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.FasstoStockInfoResult;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.GetFasstoStocksResult;
+import com.personal.marketnote.fulfillment.port.in.usecase.vendor.GetFasstoStockDetailUseCase;
+import com.personal.marketnote.fulfillment.port.in.usecase.vendor.RequestFasstoAuthUseCase;
+import com.personal.marketnote.fulfillment.port.in.usecase.vendor.SyncFasstoStockUseCase;
+import com.personal.marketnote.fulfillment.port.out.commerce.UpdateCommerceInventoryCommand;
+import com.personal.marketnote.fulfillment.port.out.commerce.UpdateCommerceInventoryItemCommand;
+import com.personal.marketnote.fulfillment.port.out.commerce.UpdateCommerceInventoryPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional(isolation = READ_COMMITTED, readOnly = true)
+public class SyncFasstoStockService implements SyncFasstoStockUseCase {
+    private static final String OUT_OF_STOCK_INCLUDED = "Y";
+
+    private final RequestFasstoAuthUseCase requestFasstoAuthUseCase;
+    private final GetFasstoStockDetailUseCase getFasstoStockDetailUseCase;
+    private final UpdateCommerceInventoryPort updateCommerceInventoryPort;
+
+    @Override
+    public void sync(SyncFasstoStockCommand command) {
+        if (FormatValidator.hasNoValue(command)) {
+            throw new IllegalArgumentException("Sync Fassto stock command is required.");
+        }
+        if (FormatValidator.hasNoValue(command.customerCode())) {
+            throw new IllegalArgumentException("Customer code is required for Fassto stock sync.");
+        }
+        if (FormatValidator.hasNoValue(command.productIds())) {
+            throw new IllegalArgumentException("Product ids are required for Fassto stock sync.");
+        }
+
+        List<Long> productIds = command.productIds().stream()
+                .filter(productId -> FormatValidator.hasValue(productId))
+                .distinct()
+                .toList();
+        if (FormatValidator.hasNoValue(productIds)) {
+            throw new IllegalArgumentException("Valid product ids are required for Fassto stock sync.");
+        }
+
+        FasstoAccessToken accessToken = requestFasstoAuthUseCase.requestAccessToken();
+        if (FormatValidator.hasNoValue(accessToken) || FormatValidator.hasNoValue(accessToken.getValue())) {
+            throw new IllegalArgumentException("Fassto access token is required for stock sync.");
+        }
+
+        List<UpdateCommerceInventoryItemCommand> inventories = new ArrayList<>();
+        for (Long productId : productIds) {
+            GetFasstoStocksResult stockDetail = getFasstoStockDetailUseCase.getStockDetail(
+                    GetFasstoStockDetailCommand.of(
+                            command.customerCode(),
+                            accessToken.getValue(),
+                            String.valueOf(productId),
+                            OUT_OF_STOCK_INCLUDED
+                    )
+            );
+            int stockQuantity = resolveStockQuantity(stockDetail);
+            inventories.add(UpdateCommerceInventoryItemCommand.of(productId, stockQuantity));
+        }
+
+        updateCommerceInventoryPort.updateInventories(UpdateCommerceInventoryCommand.of(inventories));
+    }
+
+    private int resolveStockQuantity(GetFasstoStocksResult result) {
+        if (FormatValidator.hasNoValue(result) || FormatValidator.hasNoValue(result.stocks())) {
+            return 0;
+        }
+
+        int totalStock = 0;
+        for (FasstoStockInfoResult stockInfo : result.stocks()) {
+            if (FormatValidator.hasNoValue(stockInfo)) {
+                continue;
+            }
+            Integer quantity = resolveAvailableQuantity(stockInfo);
+            if (FormatValidator.hasValue(quantity)) {
+                totalStock += Math.max(0, quantity);
+            }
+        }
+        return totalStock;
+    }
+
+    private Integer resolveAvailableQuantity(FasstoStockInfoResult stockInfo) {
+        if (FormatValidator.hasNoValue(stockInfo)) {
+            return null;
+        }
+
+        Integer canStockQty = stockInfo.canStockQty();
+        if (FormatValidator.hasValue(canStockQty)) {
+            return canStockQty;
+        }
+        return stockInfo.stockQty();
+    }
+}

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/servicecommunication/FulfillmentServiceCommunicationTargetType.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/servicecommunication/FulfillmentServiceCommunicationTargetType.java
@@ -4,7 +4,9 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public enum FulfillmentServiceCommunicationTargetType {
-    GENERAL("일반");
+    GENERAL("일반"),
+    COMMERCE_INVENTORY("커머스 재고");
 
+    @SuppressWarnings("unused")
     private final String description;
 }


### PR DESCRIPTION
## partially addresses #475
## resolves #613

## Task
- [x] 파스토 서버 상품 재고 튜플 조회(풀필먼트 서비스 → 파스토 서버)
- [x] 커머스 서비스 재고 튜플 동기화(풀필먼트 서비스 → 커머스 서비스)