### PR TITLE
[#475][#633] feat: 파스토 서버 전체 상품 재고 튜플과 커머스 서비스 재고 튜플 동기화 기능 추가

### DIFF
--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/vendor/SyncFasstoAllStockCommand.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/vendor/SyncFasstoAllStockCommand.java
@@ -1,0 +1,13 @@
+package com.personal.marketnote.fulfillment.port.in.command.vendor;
+
+public record SyncFasstoAllStockCommand(
+        String customerCode,
+        String outOfStockYn
+) {
+    public static SyncFasstoAllStockCommand of(
+            String customerCode,
+            String outOfStockYn
+    ) {
+        return new SyncFasstoAllStockCommand(customerCode, outOfStockYn);
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/usecase/vendor/SyncFasstoAllStockUseCase.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/usecase/vendor/SyncFasstoAllStockUseCase.java
@@ -1,0 +1,13 @@
+package com.personal.marketnote.fulfillment.port.in.usecase.vendor;
+
+import com.personal.marketnote.fulfillment.port.in.command.vendor.SyncFasstoAllStockCommand;
+
+public interface SyncFasstoAllStockUseCase {
+    /**
+     * @param command 전체 재고 동기화 커맨드
+     * @Date 2026-02-07
+     * @Author 성효빈
+     * @Description 파스토 재고 목록을 기준으로 커머스 재고를 동기화합니다.
+     */
+    void syncAll(SyncFasstoAllStockCommand command);
+}


### PR DESCRIPTION
## partially addresses #475
## resolves #633

## Task
- [x] 파스토 서버 전체 상품 재고 튜플 조회(풀필먼트 서비스 → 파스토 서버)
- [x] 커머스 서비스 재고 튜플 동기화(풀필먼트 서비스 → 커머스 서비스)