### PR TITLE
[#475][#644] feat: (관리자) 파스토 물류비 일별비용 조회 연동 기능 추가

### DIFF
--- a/.github/ISSUE_TEMPLATE/test_request.md
+++ b/.github/ISSUE_TEMPLATE/test_request.md
@@ -1,0 +1,10 @@
+---
+name: Test request
+about: Add automatic tests for production features
+title: '[Test] '
+labels: 'test'
+assignees: ''
+
+---
+
+## Test Case

--- a/community-service/community-domain/src/main/java/com/personal/marketnote/community/domain/like/LikeTargetType.java
+++ b/community-service/community-domain/src/main/java/com/personal/marketnote/community/domain/like/LikeTargetType.java
@@ -13,6 +13,6 @@ public enum LikeTargetType {
 
     LikeTargetType(String description) {
         this.description = description;
-        this.camelCaseValue = FormatConverter.snakeToCamel(this.name());
+        this.camelCaseValue = FormatConverter.snakeToCamel(name());
     }
 }

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter.in.configuration/FulfillmentSwaggerConfig.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter.in.configuration/FulfillmentSwaggerConfig.java
@@ -37,6 +37,7 @@ public class FulfillmentSwaggerConfig {
             "파스토 상품 API",
             "파스토 재고 API",
             "파스토 출고처 API",
+            "파스토 정산 API",
             "서버 정보 API"
     );
 

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/FasstoSettlementController.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/FasstoSettlementController.java
@@ -1,0 +1,60 @@
+package com.personal.marketnote.fulfillment.adapter.in.web.vendor.controller;
+
+import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
+import com.personal.marketnote.fulfillment.adapter.in.web.vendor.controller.apidocs.GetFasstoSettlementDailyCostsApiDocs;
+import com.personal.marketnote.fulfillment.adapter.in.web.vendor.mapper.FasstoSettlementRequestToCommandMapper;
+import com.personal.marketnote.fulfillment.adapter.in.web.vendor.response.GetFasstoSettlementDailyCostsResponse;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.GetFasstoSettlementDailyCostsResult;
+import com.personal.marketnote.fulfillment.port.in.usecase.vendor.GetFasstoSettlementDailyCostsUseCase;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import static com.personal.marketnote.common.domain.exception.ExceptionCode.DEFAULT_SUCCESS_CODE;
+import static com.personal.marketnote.common.utility.ApiConstant.ADMIN_POINTCUT;
+
+@RestController
+@RequestMapping("/api/v1/vendors/fassto/settlements")
+@Tag(name = "파스토 정산 API", description = "파스토 정산 관련 API")
+@RequiredArgsConstructor
+public class FasstoSettlementController {
+    private final GetFasstoSettlementDailyCostsUseCase getFasstoSettlementDailyCostsUseCase;
+
+    /**
+     * (관리자) 파스토 물류비 일별 비용 조회
+     *
+     * @param yearMonth    정산 월(YYYYMM)
+     * @param whCd         창고 코드
+     * @param customerCode 파스토 고객사 코드
+     * @param accessToken  파스토 액세스 토큰
+     * @Author 성효빈
+     * @Date 2026-02-08
+     * @Description 파스토 물류비 일별 비용을 조회합니다.
+     */
+    @GetMapping("/daily-costs/{yearMonth}/{whCd}/{customerCode}")
+    @PreAuthorize(ADMIN_POINTCUT)
+    @GetFasstoSettlementDailyCostsApiDocs
+    public ResponseEntity<BaseResponse<GetFasstoSettlementDailyCostsResponse>> getDailyCosts(
+            @PathVariable String yearMonth,
+            @PathVariable String whCd,
+            @PathVariable String customerCode,
+            @RequestHeader("accessToken") String accessToken
+    ) {
+        GetFasstoSettlementDailyCostsResult result = getFasstoSettlementDailyCostsUseCase.getDailyCosts(
+                FasstoSettlementRequestToCommandMapper.mapToDailyCostsCommand(yearMonth, whCd, customerCode, accessToken)
+        );
+
+        return new ResponseEntity<>(
+                BaseResponse.of(
+                        GetFasstoSettlementDailyCostsResponse.from(result),
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "파스토 물류비 일별 비용 조회 성공"
+                ),
+                HttpStatus.OK
+        );
+    }
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/apidocs/GetFasstoSettlementDailyCostsApiDocs.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/apidocs/GetFasstoSettlementDailyCostsApiDocs.java
@@ -1,0 +1,195 @@
+package com.personal.marketnote.fulfillment.adapter.in.web.vendor.controller.apidocs;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Operation(
+        summary = "(관리자) 파스토 물류비 일별 비용 조회",
+        description = """
+                작성일자: 2026-02-08
+                
+                작성자: 성효빈
+                
+                ---
+                
+                ## Description
+                
+                파스토 물류비 일별 비용을 조회합니다.
+                
+                ---
+                
+                ## Request
+                
+                | **키** | **위치** | **타입** | **설명** | **필수 여부** | **예시** |
+                | --- | --- | --- | --- | --- | --- |
+                | accessToken | header | string | 파스토 액세스 토큰 | Y | ad8c0accf2a011f0be620ab49498ff55 |
+                | yearMonth | path | string | 정산 월(YYYYMM) | Y | 202601 |
+                | whCd | path | string | 창고 코드 | Y | TEST |
+                | customerCode | path | string | 파스토 고객사 코드 | Y | 94388 |
+                
+                ---
+                
+                ## Response
+                
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | statusCode | number | 상태 코드 | 200: 성공 / 400: 클라이언트 요청 오류 / 401: 인증 실패 / 403: 인가 실패 / 500: 그 외 |
+                | code | string | 응답 코드 | "SUC01" / "BAD_REQUEST" / "UNAUTHORIZED" / "FORBIDDEN" / "INTERNAL_SERVER_ERROR" |
+                | timestamp | string(datetime) | 응답 일시 | "2026-02-08T12:12:30.013" |
+                | content | object | 응답 본문 | { ... } |
+                | message | string | 처리 결과 | "파스토 물류비 일별 비용 조회 성공" |
+                
+                ---
+                
+                ### Response > content
+                
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | dataCount | number | 조회 건수 | 2 |
+                | dailyCosts | array | 일별 비용 목록 | [ ... ] |
+                
+                ---
+                
+                ### Response > content > dailyCosts
+                
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | cloDt | string | 마감일자 | "2026-02-08" |
+                | whCd | string | 창고 코드 | "YI21" |
+                | cstCd | string | 고객사 코드 | "94EVA" |
+                | inpAmt | string | 입고 비용 | "0" |
+                | outAmt | string | 출고 비용 | "46650" |
+                | outcarAmt | string | 차량 출고 비용 | "0" |
+                | outairAmt | string | 항공 출고 비용 | "0" |
+                | keepAmt | string | 보관 비용 | "4420" |
+                | retAmt | string | 반품 비용 | "0" |
+                | cashAmt | string | 현금 결제 비용 | "0" |
+                | founAmt | string | 파손 비용 | "0" |
+                | othAmt | string | 기타 비용 | "0" |
+                | totAmt | string | 총 비용 | "51070" |
+                """,
+        security = {@SecurityRequirement(name = "bearer")},
+        parameters = {
+                @Parameter(
+                        name = "accessToken",
+                        description = "파스토 액세스 토큰",
+                        in = ParameterIn.HEADER,
+                        required = true,
+                        schema = @Schema(type = "string", example = "ad8c0accf2a011f0be620ab49498ff55")
+                ),
+                @Parameter(
+                        name = "yearMonth",
+                        description = "정산 월(YYYYMM)",
+                        in = ParameterIn.PATH,
+                        required = true,
+                        schema = @Schema(type = "string", example = "202601")
+                ),
+                @Parameter(
+                        name = "whCd",
+                        description = "창고 코드",
+                        in = ParameterIn.PATH,
+                        required = true,
+                        schema = @Schema(type = "string", example = "TEST")
+                ),
+                @Parameter(
+                        name = "customerCode",
+                        description = "파스토 고객사 코드",
+                        in = ParameterIn.PATH,
+                        required = true,
+                        schema = @Schema(type = "string", example = "94388")
+                )
+        },
+        responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "파스토 물류비 일별 비용 조회 성공",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 200,
+                                          "code": "SUC01",
+                                          "timestamp": "2026-02-08T12:12:30.013",
+                                          "content": {
+                                            "dataCount": 2,
+                                            "dailyCosts": [
+                                              {
+                                                "cloDt": "2026-02-08",
+                                                "whCd": "YI21",
+                                                "cstCd": "94EVA",
+                                                "inpAmt": "0",
+                                                "outAmt": "46650",
+                                                "outcarAmt": "0",
+                                                "outairAmt": "0",
+                                                "keepAmt": "4420",
+                                                "retAmt": "0",
+                                                "cashAmt": "0",
+                                                "founAmt": "0",
+                                                "othAmt": "0",
+                                                "totAmt": "51070"
+                                              },
+                                              {
+                                                "cloDt": "2026-02-05",
+                                                "whCd": "YI21",
+                                                "cstCd": "94EVA",
+                                                "inpAmt": "0",
+                                                "outAmt": "96100",
+                                                "outcarAmt": "0",
+                                                "outairAmt": "0",
+                                                "keepAmt": "4420",
+                                                "retAmt": "3650",
+                                                "cashAmt": "0",
+                                                "founAmt": "0",
+                                                "othAmt": "0",
+                                                "totAmt": "104170"
+                                              }
+                                            ]
+                                          },
+                                          "message": "파스토 물류비 일별 비용 조회 성공"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "401",
+                        description = "토큰 인증 실패",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 401,
+                                          "code": "UNAUTHORIZED",
+                                          "timestamp": "2026-02-08T12:12:30.013",
+                                          "content": null,
+                                          "message": "Invalid token"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "403",
+                        description = "토큰 인가 실패",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 403,
+                                          "code": "FORBIDDEN",
+                                          "timestamp": "2026-02-08T12:12:30.013",
+                                          "content": null,
+                                          "message": "Access Denied"
+                                        }
+                                        """)
+                        )
+                )
+        })
+public @interface GetFasstoSettlementDailyCostsApiDocs {
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/mapper/FasstoSettlementRequestToCommandMapper.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/mapper/FasstoSettlementRequestToCommandMapper.java
@@ -1,0 +1,14 @@
+package com.personal.marketnote.fulfillment.adapter.in.web.vendor.mapper;
+
+import com.personal.marketnote.fulfillment.port.in.command.vendor.GetFasstoSettlementDailyCostsCommand;
+
+public class FasstoSettlementRequestToCommandMapper {
+    public static GetFasstoSettlementDailyCostsCommand mapToDailyCostsCommand(
+            String yearMonth,
+            String whCd,
+            String customerCode,
+            String accessToken
+    ) {
+        return GetFasstoSettlementDailyCostsCommand.of(yearMonth, whCd, customerCode, accessToken);
+    }
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/response/GetFasstoSettlementDailyCostsResponse.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/response/GetFasstoSettlementDailyCostsResponse.java
@@ -1,0 +1,15 @@
+package com.personal.marketnote.fulfillment.adapter.in.web.vendor.response;
+
+import com.personal.marketnote.fulfillment.port.in.result.vendor.FasstoSettlementDailyCostInfoResult;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.GetFasstoSettlementDailyCostsResult;
+
+import java.util.List;
+
+public record GetFasstoSettlementDailyCostsResponse(
+        Integer dataCount,
+        List<FasstoSettlementDailyCostInfoResult> dailyCosts
+) {
+    public static GetFasstoSettlementDailyCostsResponse from(GetFasstoSettlementDailyCostsResult result) {
+        return new GetFasstoSettlementDailyCostsResponse(result.dataCount(), result.dailyCosts());
+    }
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/client/FasstoSettlementClient.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/client/FasstoSettlementClient.java
@@ -1,0 +1,365 @@
+package com.personal.marketnote.fulfillment.adapter.out.vendor.fassto.client;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.common.adapter.out.VendorAdapter;
+import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.common.utility.http.client.CommunicationFailureHandler;
+import com.personal.marketnote.fulfillment.adapter.out.vendor.fassto.response.FasstoErrorResponse;
+import com.personal.marketnote.fulfillment.adapter.out.vendor.fassto.response.FasstoSettlementDailyCostItemResponse;
+import com.personal.marketnote.fulfillment.adapter.out.vendor.fassto.response.FasstoSettlementDailyCostListResponse;
+import com.personal.marketnote.fulfillment.configuration.FasstoAuthProperties;
+import com.personal.marketnote.fulfillment.domain.vendor.fassto.settlement.FasstoSettlementDailyCostQuery;
+import com.personal.marketnote.fulfillment.domain.vendorcommunication.FulfillmentVendorCommunicationSenderType;
+import com.personal.marketnote.fulfillment.domain.vendorcommunication.FulfillmentVendorCommunicationTargetType;
+import com.personal.marketnote.fulfillment.domain.vendorcommunication.FulfillmentVendorCommunicationType;
+import com.personal.marketnote.fulfillment.domain.vendorcommunication.FulfillmentVendorName;
+import com.personal.marketnote.fulfillment.exception.GetFasstoSettlementDailyCostsFailedException;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.FasstoSettlementDailyCostInfoResult;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.GetFasstoSettlementDailyCostsResult;
+import com.personal.marketnote.fulfillment.port.out.vendor.GetFasstoSettlementDailyCostsPort;
+import com.personal.marketnote.fulfillment.utility.VendorCommunicationFailureHandler;
+import com.personal.marketnote.fulfillment.utility.VendorCommunicationPayloadGenerator;
+import com.personal.marketnote.fulfillment.utility.VendorCommunicationRecorder;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.*;
+import org.springframework.web.client.RestClientResponseException;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
+
+import static com.personal.marketnote.common.utility.ApiConstant.*;
+
+@VendorAdapter
+@RequiredArgsConstructor
+@Slf4j
+public class FasstoSettlementClient implements GetFasstoSettlementDailyCostsPort {
+    private static final String ACCESS_TOKEN_HEADER = "accessToken";
+    private static final String YEAR_MONTH_PLACEHOLDER = "{yearMonth}";
+    private static final String WH_CODE_PLACEHOLDER = "{whCd}";
+    private static final String CUSTOMER_CODE_PLACEHOLDER = "{customerCode}";
+
+    private final RestTemplate restTemplate;
+    private final ObjectMapper objectMapper;
+    private final FasstoAuthProperties properties;
+    private final VendorCommunicationRecorder vendorCommunicationRecorder;
+    private final VendorCommunicationPayloadGenerator vendorCommunicationPayloadGenerator;
+    private final VendorCommunicationFailureHandler vendorCommunicationFailureHandler;
+
+    @Override
+    public GetFasstoSettlementDailyCostsResult getDailyCosts(FasstoSettlementDailyCostQuery query) {
+        if (FormatValidator.hasNoValue(query)) {
+            throw new IllegalArgumentException("Fassto settlement daily cost query is required.");
+        }
+
+        URI uri = buildSettlementDailyCostUri(query.getYearMonth(), query.getWhCd(), query.getCustomerCode());
+        HttpEntity<Void> httpEntity = new HttpEntity<>(buildHeaders(query.getAccessToken(), false));
+
+        Exception error = new Exception();
+        String failureMessage = null;
+        long sleepMillis = INTER_SERVER_DEFAULT_RETRIAL_PENDING_MILLI_SECOND;
+        FulfillmentVendorCommunicationTargetType targetType = FulfillmentVendorCommunicationTargetType.SETTLEMENT;
+        FulfillmentVendorName vendorName = FulfillmentVendorName.FASSTO;
+
+        for (int i = 0; i < INTER_SERVER_MAX_REQUEST_COUNT; i++) {
+            int attempt = i + 1;
+            JsonNode requestPayloadJson = buildListRequestPayloadJson(query, uri, attempt);
+            String requestPayload = requestPayloadJson.toString();
+
+            ResponseEntity<String> response;
+            try {
+                response = restTemplate.exchange(
+                        uri,
+                        HttpMethod.GET,
+                        httpEntity,
+                        String.class
+                );
+            } catch (Exception e) {
+                Map<String, Object> errorPayload = new LinkedHashMap<>();
+                errorPayload.put("error", e.getClass().getSimpleName());
+                errorPayload.put("message", e.getMessage());
+                errorPayload.put("attempt", attempt);
+
+                vendorCommunicationFailureHandler.handleFailure(
+                        targetType,
+                        vendorName,
+                        requestPayload,
+                        requestPayloadJson,
+                        errorPayload,
+                        e
+                );
+
+                String vendorMessage = resolveVendorMessageFromException(e);
+                if (FormatValidator.hasValue(vendorMessage)) {
+                    failureMessage = vendorMessage;
+                    error = new Exception(vendorMessage);
+                }
+
+                log.warn("Failed to get Fassto settlement daily costs: attempt={}, message={}", attempt, e.getMessage(), e);
+                if (i == INTER_SERVER_MAX_REQUEST_COUNT - 1) {
+                    error = e;
+                }
+
+                sleep(sleepMillis);
+                sleepMillis = sleepMillis * INTER_SERVER_DEFAULT_EXPONENTIAL_BACKOFF_VALUE;
+
+                continue;
+            }
+
+            JsonNode responsePayloadJson = buildResponsePayloadJson(response, attempt);
+            String responsePayload = responsePayloadJson.toString();
+
+            FasstoSettlementDailyCostListResponse parsedResponse = parseDailyCostListResponse(response);
+            boolean isSuccess = isDailyCostListSuccess(response, parsedResponse);
+            String exception = isSuccess ? null : resolveDailyCostListException(response, parsedResponse);
+
+            vendorCommunicationRecorder.record(
+                    targetType,
+                    FulfillmentVendorCommunicationType.REQUEST,
+                    FulfillmentVendorCommunicationSenderType.SERVER,
+                    vendorName,
+                    requestPayload,
+                    requestPayloadJson,
+                    exception
+            );
+            vendorCommunicationRecorder.record(
+                    targetType,
+                    FulfillmentVendorCommunicationType.RESPONSE,
+                    FulfillmentVendorCommunicationSenderType.VENDOR,
+                    vendorName,
+                    responsePayload,
+                    responsePayloadJson,
+                    exception
+            );
+
+            if (isSuccess) {
+                return mapDailyCostListResult(parsedResponse);
+            }
+
+            String vendorMessage = resolveVendorMessage(parsedResponse, FormatValidator.hasValue(response) ? response.getBody() : null);
+            if (FormatValidator.hasValue(vendorMessage)) {
+                failureMessage = vendorMessage;
+                error = new Exception(vendorMessage);
+            }
+
+            log.warn("Fassto settlement daily costs request failed: attempt={}, status={}, exception={}",
+                    attempt,
+                    FormatValidator.hasValue(response) ? response.getStatusCode() : null,
+                    exception
+            );
+
+            if (CommunicationFailureHandler.isCertainFailure(response)) {
+                break;
+            }
+
+            sleep(sleepMillis);
+            sleepMillis = sleepMillis * INTER_SERVER_DEFAULT_EXPONENTIAL_BACKOFF_VALUE;
+        }
+
+        log.error("Failed to get Fassto settlement daily costs: {} with error: {}", uri, error.getMessage(), error);
+        throw new GetFasstoSettlementDailyCostsFailedException(failureMessage, new IOException(error));
+    }
+
+    private URI buildSettlementDailyCostUri(String yearMonth, String whCd, String customerCode) {
+        validateSettlementDailyCostProperties();
+        return UriComponentsBuilder.fromUriString(properties.getBaseUrl())
+                .path(properties.getSettlementDailyCostPath())
+                .buildAndExpand(yearMonth, whCd, customerCode)
+                .toUri();
+    }
+
+    private void validateSettlementDailyCostProperties() {
+        if (FormatValidator.hasNoValue(properties.getBaseUrl())) {
+            throw new IllegalStateException("Fassto base URL is required.");
+        }
+        if (FormatValidator.hasNoValue(properties.getSettlementDailyCostPath())) {
+            throw new IllegalStateException("Fassto settlement daily cost path is required.");
+        }
+        String path = properties.getSettlementDailyCostPath();
+        if (!path.contains(YEAR_MONTH_PLACEHOLDER) || !path.contains(WH_CODE_PLACEHOLDER) || !path.contains(CUSTOMER_CODE_PLACEHOLDER)) {
+            throw new IllegalStateException("Fassto settlement daily cost path must include {yearMonth}, {whCd}, {customerCode}.");
+        }
+    }
+
+    private HttpHeaders buildHeaders(String accessToken, boolean includeContentType) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setAccept(List.of(MediaType.APPLICATION_JSON));
+        if (includeContentType) {
+            headers.setContentType(MediaType.APPLICATION_JSON);
+        }
+        headers.add(ACCESS_TOKEN_HEADER, accessToken);
+        return headers;
+    }
+
+    private FasstoSettlementDailyCostListResponse parseDailyCostListResponse(ResponseEntity<String> response) {
+        if (FormatValidator.hasNoValue(response)) {
+            return null;
+        }
+
+        String body = response.getBody();
+        if (FormatValidator.hasNoValue(body)) {
+            return null;
+        }
+
+        try {
+            return objectMapper.readValue(body, FasstoSettlementDailyCostListResponse.class);
+        } catch (Exception e) {
+            log.warn("Failed to parse Fassto settlement daily costs response: {}", e.getMessage(), e);
+            return null;
+        }
+    }
+
+    private boolean isDailyCostListSuccess(ResponseEntity<String> response, FasstoSettlementDailyCostListResponse parsedResponse) {
+        return FormatValidator.hasValue(response)
+                && response.getStatusCode().value() == 200
+                && FormatValidator.hasValue(parsedResponse)
+                && parsedResponse.isSuccess();
+    }
+
+    private String resolveDailyCostListException(
+            ResponseEntity<String> response,
+            FasstoSettlementDailyCostListResponse parsedResponse
+    ) {
+        if (FormatValidator.hasNoValue(response)) {
+            return "NO_RESPONSE";
+        }
+        if (response.getStatusCode().value() != 200) {
+            return "HTTP_" + response.getStatusCode().value();
+        }
+        if (FormatValidator.hasNoValue(parsedResponse)) {
+            return "INVALID_RESPONSE";
+        }
+        if (FormatValidator.hasNoValue(parsedResponse.header()) || !parsedResponse.header().isSuccess()) {
+            return "HEADER_FAILURE";
+        }
+        if (FormatValidator.hasNoValue(parsedResponse.data())) {
+            return "DATA_MISSING";
+        }
+        return "UNKNOWN_FAILURE";
+    }
+
+    private JsonNode buildListRequestPayloadJson(FasstoSettlementDailyCostQuery query, URI uri, int attempt) {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("method", HttpMethod.GET.name());
+        payload.put("url", uri.toString());
+        payload.put("yearMonth", query.getYearMonth());
+        payload.put("whCd", query.getWhCd());
+        payload.put("customerCode", query.getCustomerCode());
+        payload.put(ACCESS_TOKEN_HEADER, maskValue(query.getAccessToken()));
+        payload.put("attempt", attempt);
+        return vendorCommunicationPayloadGenerator.buildPayloadJson(payload);
+    }
+
+    private JsonNode buildResponsePayloadJson(ResponseEntity<String> response, int attempt) {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        if (FormatValidator.hasValue(response)) {
+            payload.put("status", response.getStatusCode().value());
+            payload.put("headers", toSingleValueMap(response.getHeaders()));
+
+            String body = response.getBody();
+            if (FormatValidator.hasValue(body)) {
+                payload.put("body", body);
+            }
+        }
+        payload.put("attempt", attempt);
+        return vendorCommunicationPayloadGenerator.buildPayloadJson(payload);
+    }
+
+    private Map<String, String> toSingleValueMap(HttpHeaders headers) {
+        if (FormatValidator.hasNoValue(headers)) {
+            return Map.of();
+        }
+
+        return headers.toSingleValueMap();
+    }
+
+    private GetFasstoSettlementDailyCostsResult mapDailyCostListResult(FasstoSettlementDailyCostListResponse response) {
+        List<FasstoSettlementDailyCostInfoResult> dailyCosts = response.data().stream()
+                .map(this::mapDailyCostInfo)
+                .toList();
+        Integer dataCount = FormatValidator.hasValue(response.header()) ? response.header().dataCount() : null;
+        return GetFasstoSettlementDailyCostsResult.of(dataCount, dailyCosts);
+    }
+
+    private FasstoSettlementDailyCostInfoResult mapDailyCostInfo(FasstoSettlementDailyCostItemResponse item) {
+        return FasstoSettlementDailyCostInfoResult.of(
+                item.cloDt(),
+                item.whCd(),
+                item.cstCd(),
+                item.inpAmt(),
+                item.outAmt(),
+                item.outcarAmt(),
+                item.outairAmt(),
+                item.keepAmt(),
+                item.retAmt(),
+                item.cashAmt(),
+                item.founAmt(),
+                item.othAmt(),
+                item.totAmt()
+        );
+    }
+
+    private String maskValue(String value) {
+        if (FormatValidator.hasNoValue(value)) {
+            return value;
+        }
+
+        int visible = Math.min(4, value.length());
+        int maskedLength = value.length() - visible;
+        if (maskedLength <= 0) {
+            return value;
+        }
+
+        return "*".repeat(maskedLength) + value.substring(value.length() - visible);
+    }
+
+    private void sleep(long millis) {
+        try {
+            long jitteredSleepMillis = ThreadLocalRandom.current()
+                    .nextLong(Math.max(1L, millis) + 1);
+            Thread.sleep(jitteredSleepMillis);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private String resolveVendorMessage(FasstoSettlementDailyCostListResponse response, String rawBody) {
+        if (FormatValidator.hasValue(response)) {
+            String message = response.resolveErrorMessage();
+            if (FormatValidator.hasValue(message)) {
+                return message;
+            }
+        }
+        return resolveVendorMessage(rawBody);
+    }
+
+    private String resolveVendorMessage(String rawBody) {
+        if (FormatValidator.hasNoValue(rawBody)) {
+            return null;
+        }
+
+        try {
+            FasstoErrorResponse response = objectMapper.readValue(rawBody, FasstoErrorResponse.class);
+            return response.resolveErrorMessage();
+        } catch (Exception e) {
+            log.warn("Failed to parse Fassto error response: {}", e.getMessage(), e);
+            return null;
+        }
+    }
+
+    private String resolveVendorMessageFromException(Exception e) {
+        if (!(e instanceof RestClientResponseException responseException)) {
+            return null;
+        }
+
+        String body = responseException.getResponseBodyAsString();
+        return resolveVendorMessage(body);
+    }
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoSettlementDailyCostItemResponse.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoSettlementDailyCostItemResponse.java
@@ -1,0 +1,21 @@
+package com.personal.marketnote.fulfillment.adapter.out.vendor.fassto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record FasstoSettlementDailyCostItemResponse(
+        String cloDt,
+        String whCd,
+        String cstCd,
+        String inpAmt,
+        String outAmt,
+        String outcarAmt,
+        String outairAmt,
+        String keepAmt,
+        String retAmt,
+        String cashAmt,
+        String founAmt,
+        String othAmt,
+        String totAmt
+) {
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoSettlementDailyCostListResponse.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoSettlementDailyCostListResponse.java
@@ -1,0 +1,16 @@
+package com.personal.marketnote.fulfillment.adapter.out.vendor.fassto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record FasstoSettlementDailyCostListResponse(
+        FasstoResponseHeader header,
+        List<FasstoSettlementDailyCostItemResponse> data,
+        FasstoErrorInfo errorInfo
+) implements FasstoApiResponse {
+    public boolean isSuccess() {
+        return header != null && header.isSuccess() && data != null;
+    }
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/resources/application.yml
+++ b/fulfillment-service/fulfillment-adapters/src/main/resources/application.yml
@@ -58,6 +58,7 @@ vendor:
       warehousing-path: ${FASSTO_WAREHOUSING_PATH:/api/v1/warehousing/{customerCode}}
       warehousing-list-path: ${FASSTO_WAREHOUSING_LIST_PATH:/api/v1/warehousing/{customerCode}/{startDate}/{endDate}}
       stock-list-path: ${FASSTO_STOCK_LIST_PATH:/api/v1/stock/list/{customerCode}}
+      settlement-daily-cost-path: ${FASSTO_SETTLEMENT_DAILY_COST_PATH:/api/v1/settlement/{yearMonth}/{whCd}/{customerCode}}
       api-cd: ${FASSTO_API_CD:change-me}
       api-key: ${FASSTO_API_KEY:change-me}
 

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/configuration/FasstoAuthProperties.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/configuration/FasstoAuthProperties.java
@@ -22,4 +22,5 @@ public class FasstoAuthProperties {
     private String warehousingPath = "/api/v1/warehousing/{customerCode}";
     private String warehousingListPath = "/api/v1/warehousing/{customerCode}/{startDate}/{endDate}";
     private String stockListPath = "/api/v1/stock/list/{customerCode}";
+    private String settlementDailyCostPath = "/api/v1/settlement/{yearMonth}/{whCd}/{customerCode}";
 }

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/GetFasstoSettlementDailyCostsFailedException.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/GetFasstoSettlementDailyCostsFailedException.java
@@ -1,0 +1,25 @@
+package com.personal.marketnote.fulfillment.exception;
+
+import com.personal.marketnote.common.exception.ExternalOperationFailedException;
+import com.personal.marketnote.common.utility.FormatValidator;
+
+import java.io.IOException;
+
+public class GetFasstoSettlementDailyCostsFailedException extends ExternalOperationFailedException {
+    private static final String DEFAULT_MESSAGE = "파스토 물류비 일별 비용 조회 중 오류가 발생했습니다.";
+
+    public GetFasstoSettlementDailyCostsFailedException(IOException cause) {
+        super(DEFAULT_MESSAGE, cause);
+    }
+
+    public GetFasstoSettlementDailyCostsFailedException(String vendorMessage, IOException cause) {
+        super(resolveMessage(vendorMessage), cause);
+    }
+
+    private static String resolveMessage(String vendorMessage) {
+        if (FormatValidator.hasValue(vendorMessage)) {
+            return String.format("파스토 물류비 일별 비용 조회 실패: %s", vendorMessage);
+        }
+        return DEFAULT_MESSAGE;
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/mapper/FasstoSettlementCommandToRequestMapper.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/mapper/FasstoSettlementCommandToRequestMapper.java
@@ -1,0 +1,15 @@
+package com.personal.marketnote.fulfillment.mapper;
+
+import com.personal.marketnote.fulfillment.domain.vendor.fassto.settlement.FasstoSettlementDailyCostQuery;
+import com.personal.marketnote.fulfillment.port.in.command.vendor.GetFasstoSettlementDailyCostsCommand;
+
+public class FasstoSettlementCommandToRequestMapper {
+    public static FasstoSettlementDailyCostQuery mapToQuery(GetFasstoSettlementDailyCostsCommand command) {
+        return FasstoSettlementDailyCostQuery.of(
+                command.yearMonth(),
+                command.whCd(),
+                command.customerCode(),
+                command.accessToken()
+        );
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/vendor/GetFasstoSettlementDailyCostsCommand.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/vendor/GetFasstoSettlementDailyCostsCommand.java
@@ -1,0 +1,17 @@
+package com.personal.marketnote.fulfillment.port.in.command.vendor;
+
+public record GetFasstoSettlementDailyCostsCommand(
+        String yearMonth,
+        String whCd,
+        String customerCode,
+        String accessToken
+) {
+    public static GetFasstoSettlementDailyCostsCommand of(
+            String yearMonth,
+            String whCd,
+            String customerCode,
+            String accessToken
+    ) {
+        return new GetFasstoSettlementDailyCostsCommand(yearMonth, whCd, customerCode, accessToken);
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/result/vendor/FasstoSettlementDailyCostInfoResult.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/result/vendor/FasstoSettlementDailyCostInfoResult.java
@@ -1,0 +1,49 @@
+package com.personal.marketnote.fulfillment.port.in.result.vendor;
+
+public record FasstoSettlementDailyCostInfoResult(
+        String cloDt,
+        String whCd,
+        String cstCd,
+        String inpAmt,
+        String outAmt,
+        String outcarAmt,
+        String outairAmt,
+        String keepAmt,
+        String retAmt,
+        String cashAmt,
+        String founAmt,
+        String othAmt,
+        String totAmt
+) {
+    public static FasstoSettlementDailyCostInfoResult of(
+            String cloDt,
+            String whCd,
+            String cstCd,
+            String inpAmt,
+            String outAmt,
+            String outcarAmt,
+            String outairAmt,
+            String keepAmt,
+            String retAmt,
+            String cashAmt,
+            String founAmt,
+            String othAmt,
+            String totAmt
+    ) {
+        return new FasstoSettlementDailyCostInfoResult(
+                cloDt,
+                whCd,
+                cstCd,
+                inpAmt,
+                outAmt,
+                outcarAmt,
+                outairAmt,
+                keepAmt,
+                retAmt,
+                cashAmt,
+                founAmt,
+                othAmt,
+                totAmt
+        );
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/result/vendor/GetFasstoSettlementDailyCostsResult.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/result/vendor/GetFasstoSettlementDailyCostsResult.java
@@ -1,0 +1,15 @@
+package com.personal.marketnote.fulfillment.port.in.result.vendor;
+
+import java.util.List;
+
+public record GetFasstoSettlementDailyCostsResult(
+        Integer dataCount,
+        List<FasstoSettlementDailyCostInfoResult> dailyCosts
+) {
+    public static GetFasstoSettlementDailyCostsResult of(
+            Integer dataCount,
+            List<FasstoSettlementDailyCostInfoResult> dailyCosts
+    ) {
+        return new GetFasstoSettlementDailyCostsResult(dataCount, dailyCosts);
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/usecase/vendor/GetFasstoSettlementDailyCostsUseCase.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/usecase/vendor/GetFasstoSettlementDailyCostsUseCase.java
@@ -1,0 +1,15 @@
+package com.personal.marketnote.fulfillment.port.in.usecase.vendor;
+
+import com.personal.marketnote.fulfillment.port.in.command.vendor.GetFasstoSettlementDailyCostsCommand;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.GetFasstoSettlementDailyCostsResult;
+
+public interface GetFasstoSettlementDailyCostsUseCase {
+    /**
+     * @param command 정산 일별 비용 조회 커맨드
+     * @return 정산 일별 비용 조회 결과 {@link GetFasstoSettlementDailyCostsResult}
+     * @Date 2026-02-08
+     * @Author 성효빈
+     * @Description 파스토 물류비 일별 비용을 조회합니다.
+     */
+    GetFasstoSettlementDailyCostsResult getDailyCosts(GetFasstoSettlementDailyCostsCommand command);
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/vendor/GetFasstoSettlementDailyCostsPort.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/vendor/GetFasstoSettlementDailyCostsPort.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.fulfillment.port.out.vendor;
+
+import com.personal.marketnote.fulfillment.domain.vendor.fassto.settlement.FasstoSettlementDailyCostQuery;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.GetFasstoSettlementDailyCostsResult;
+
+public interface GetFasstoSettlementDailyCostsPort {
+    GetFasstoSettlementDailyCostsResult getDailyCosts(FasstoSettlementDailyCostQuery query);
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/vendor/GetFasstoSettlementDailyCostsService.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/vendor/GetFasstoSettlementDailyCostsService.java
@@ -1,0 +1,26 @@
+package com.personal.marketnote.fulfillment.service.vendor;
+
+import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.fulfillment.mapper.FasstoSettlementCommandToRequestMapper;
+import com.personal.marketnote.fulfillment.port.in.command.vendor.GetFasstoSettlementDailyCostsCommand;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.GetFasstoSettlementDailyCostsResult;
+import com.personal.marketnote.fulfillment.port.in.usecase.vendor.GetFasstoSettlementDailyCostsUseCase;
+import com.personal.marketnote.fulfillment.port.out.vendor.GetFasstoSettlementDailyCostsPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional(isolation = READ_COMMITTED, readOnly = true)
+public class GetFasstoSettlementDailyCostsService implements GetFasstoSettlementDailyCostsUseCase {
+    private final GetFasstoSettlementDailyCostsPort getFasstoSettlementDailyCostsPort;
+
+    @Override
+    public GetFasstoSettlementDailyCostsResult getDailyCosts(GetFasstoSettlementDailyCostsCommand command) {
+        return getFasstoSettlementDailyCostsPort.getDailyCosts(
+                FasstoSettlementCommandToRequestMapper.mapToQuery(command)
+        );
+    }
+}

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/settlement/FasstoSettlementDailyCostQuery.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/settlement/FasstoSettlementDailyCostQuery.java
@@ -1,0 +1,46 @@
+package com.personal.marketnote.fulfillment.domain.vendor.fassto.settlement;
+
+import com.personal.marketnote.common.utility.FormatValidator;
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+public class FasstoSettlementDailyCostQuery {
+    private String yearMonth;
+    private String whCd;
+    private String customerCode;
+    private String accessToken;
+
+    public static FasstoSettlementDailyCostQuery of(
+            String yearMonth,
+            String whCd,
+            String customerCode,
+            String accessToken
+    ) {
+        FasstoSettlementDailyCostQuery query = FasstoSettlementDailyCostQuery.builder()
+                .yearMonth(yearMonth)
+                .whCd(whCd)
+                .customerCode(customerCode)
+                .accessToken(accessToken)
+                .build();
+        query.validate();
+        return query;
+    }
+
+    private void validate() {
+        if (FormatValidator.hasNoValue(yearMonth)) {
+            throw new IllegalArgumentException("yearMonth is required.");
+        }
+        if (FormatValidator.hasNoValue(whCd)) {
+            throw new IllegalArgumentException("whCd is required.");
+        }
+        if (FormatValidator.hasNoValue(customerCode)) {
+            throw new IllegalArgumentException("customerCode is required.");
+        }
+        if (FormatValidator.hasNoValue(accessToken)) {
+            throw new IllegalArgumentException("accessToken is required.");
+        }
+    }
+}

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendorcommunication/FulfillmentVendorCommunicationTargetType.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendorcommunication/FulfillmentVendorCommunicationTargetType.java
@@ -9,7 +9,8 @@ public enum FulfillmentVendorCommunicationTargetType {
     SUPPLIER("공급사"),
     GOODS("상품"),
     WAREHOUSING("입고"),
-    STOCK("재고");
+    STOCK("재고"),
+    SETTLEMENT("정산");
 
     private final String description;
 }


### PR DESCRIPTION
## partially addresses #475
## resolves #644

## Task
- [x] 파스토 일별비용 조회 연동 요청
- [x] 파스토 일별비용 조회 연동 비즈니스 로직
- [x] 파스토 서버에 단일 일별비용 데이터 요청
- [x] 200 status code 응답
- [x] Swagger docs