### PR TITLE
[#128][#300][#627][#639] test: 상품 목록 조회 및 상품 리뷰 목록 조회 자동화 테스트 DisplayName 수정

### DIFF
--- a/community-service/community-application/src/test/java/com/personal/marketnote/community/service/review/GetReviewUseCaseTest.java
+++ b/community-service/community-application/src/test/java/com/personal/marketnote/community/service/review/GetReviewUseCaseTest.java
@@ -164,7 +164,7 @@ class GetReviewUseCaseTest {
     }
 
     @Test
-    @DisplayName("상품 리뷰 목록 조회 시 Cursor가 있으면 총 개수 조회를 생략한다")
+    @DisplayName("상품 리뷰 목록 조회 시 첫 페이지가 아니면(Cursor 값 존재) 총 개수 조회를 생략한다")
     void getProductReviews_withCursor_skipsTotalElements() {
         Long productId = 30L;
         Long cursor = 200L;

--- a/product-service/product-application/src/test/java/com/personal/marketnote/product/service/product/GetProductUseCaseTest.java
+++ b/product-service/product-application/src/test/java/com/personal/marketnote/product/service/product/GetProductUseCaseTest.java
@@ -364,7 +364,7 @@ class GetProductUseCaseTest {
     }
 
     @Test
-    @DisplayName("카테고리 Filter와 Cursor가 있으면 총 개수 조회를 생략한다")
+    @DisplayName("첫 페이지가 아니면(Cursor 값 존재) 총 개수 조회를 생략한다")
     void getProducts_withCategoryAndCursor_skipsTotalElements() {
         stubProductImageExecutor();
         Product product = buildProduct(40L, false);


### PR DESCRIPTION
## partially addresses #128
## partially addresses #300`
## resolves #627
## resolves #639

## Test Case
- [x] 상품 목록 조회: 첫 페이지가 아니면(Cursor 값 존재) 총 개수 조회를 생략한다
- [x] 상품 리뷰 목록: 상품 리뷰 목록 조회 시 첫 페이지가 아니면(Cursor 값 존재) 총 개수 조회를 생략한다