### PR TITLE
[#475][#633] feat: 파스토 전체 재고 동기화 연동 시 창고 코드 옵션 추가

### DIFF
--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/FasstoStockController.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/FasstoStockController.java
@@ -99,10 +99,11 @@ public class FasstoStockController {
         );
     }
 
-    /**
+     /**
      * (관리자) 전체 상품 재고 동기화
      *
      * @param customerCode 파스토 고객사 코드
+     * @param whCd         창고 코드
      * @Author 성효빈
      * @Date 2026-02-07
      * @Description 전체 상품 재고와 파스토 재고를 동기화합니다.
@@ -111,10 +112,11 @@ public class FasstoStockController {
     @PreAuthorize(ADMIN_POINTCUT)
     @SyncFasstoAllStocksApiDocs
     public ResponseEntity<BaseResponse<Void>> syncAllStocks(
-            @PathVariable String customerCode
+            @PathVariable String customerCode,
+            @RequestParam(required = false) String whCd
     ) {
         syncFasstoAllStockUseCase.syncAll(
-                FasstoStockRequestToCommandMapper.mapToSyncAllCommand(customerCode)
+                FasstoStockRequestToCommandMapper.mapToSyncAllCommand(customerCode, whCd)
         );
 
         return new ResponseEntity<>(

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/apidocs/SyncFasstoAllStocksApiDocs.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/apidocs/SyncFasstoAllStocksApiDocs.java
@@ -34,6 +34,7 @@ import java.lang.annotation.*;
                 | **키** | **위치** | **타입** | **설명** | **필수 여부** | **예시** |
                 | --- | --- | --- | --- | --- | --- |
                 | customerCode | path | string | 파스토 고객사 코드 | Y | 94388 |
+                | whCd | query | string | 창고 코드 | N | TEST |
                 
                 ---
                 
@@ -55,6 +56,13 @@ import java.lang.annotation.*;
                         in = ParameterIn.PATH,
                         required = true,
                         schema = @Schema(type = "string", example = "94388")
+                ),
+                @Parameter(
+                        name = "whCd",
+                        description = "창고 코드",
+                        in = ParameterIn.QUERY,
+                        required = false,
+                        schema = @Schema(type = "string", example = "TEST")
                 )
         },
         responses = {

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/mapper/FasstoStockRequestToCommandMapper.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/mapper/FasstoStockRequestToCommandMapper.java
@@ -24,8 +24,9 @@ public class FasstoStockRequestToCommandMapper {
     }
 
     public static SyncFasstoAllStockCommand mapToSyncAllCommand(
-            String customerCode
+            String customerCode,
+            String whCd
     ) {
-        return SyncFasstoAllStockCommand.of(customerCode);
+        return SyncFasstoAllStockCommand.of(customerCode, whCd);
     }
 }

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/vendor/SyncFasstoAllStockCommand.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/vendor/SyncFasstoAllStockCommand.java
@@ -1,11 +1,19 @@
 package com.personal.marketnote.fulfillment.port.in.command.vendor;
 
 public record SyncFasstoAllStockCommand(
-        String customerCode
+        String customerCode,
+        String whCd
 ) {
     public static SyncFasstoAllStockCommand of(
             String customerCode
     ) {
-        return new SyncFasstoAllStockCommand(customerCode);
+        return new SyncFasstoAllStockCommand(customerCode, null);
+    }
+
+    public static SyncFasstoAllStockCommand of(
+            String customerCode,
+            String whCd
+    ) {
+        return new SyncFasstoAllStockCommand(customerCode, whCd);
     }
 }

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/vendor/SyncFasstoStockService.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/vendor/SyncFasstoStockService.java
@@ -93,7 +93,9 @@ public class SyncFasstoStockService implements SyncFasstoStockUseCase, SyncFasst
         GetFasstoStocksResult stocksResult = getFasstoStocksUseCase.getStocks(
                 GetFasstoStocksCommand.of(
                         command.customerCode(),
-                        accessToken.getValue()
+                        accessToken.getValue(),
+                        null,
+                        command.whCd()
                 )
         );
         List<UpdateCommerceInventoryItemCommand> inventories = resolveInventories(stocksResult);


### PR DESCRIPTION
## partially addresses #475
## resolves #633

## Task
- [x] 파스토 서버 전체 상품 재고 튜플 조회(풀필먼트 서비스 → 파스토 서버)
- [x] 커머스 서비스 재고 튜플 동기화(풀필먼트 서비스 → 커머스 서비스)