### PR TITLE
[#475][#614] feat: 상품 입고 시 파스토 재고 동기화 기능 추가

### DIFF
--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/FasstoStockController.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/FasstoStockController.java
@@ -99,7 +99,7 @@ public class FasstoStockController {
         );
     }
 
-     /**
+    /**
      * (관리자) 전체 상품 재고 동기화
      *
      * @param customerCode 파스토 고객사 코드

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/mapper/FasstoWarehousingRequestToCommandMapper.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/mapper/FasstoWarehousingRequestToCommandMapper.java
@@ -50,20 +50,20 @@ public class FasstoWarehousingRequestToCommandMapper {
                 .map(FasstoWarehousingRequestToCommandMapper::mapGoods)
                 .toList();
 
-        return RegisterFasstoWarehousingItemCommand.of(
-                item.getOrdDt(),
-                item.getOrdNo(),
-                item.getInWay(),
-                item.getSlipNo(),
-                item.getParcelComp(),
-                item.getParcelInvoiceNo(),
-                item.getRemark(),
-                item.getCstSupCd(),
-                item.getDistTermDt(),
-                item.getMakeDt(),
-                item.getPreArv(),
-                goods
-        );
+        return RegisterFasstoWarehousingItemCommand.builder()
+                .ordDt(item.getOrdDt())
+                .ordNo(item.getOrdNo())
+                .inWay(item.getInWay())
+                .slipNo(item.getSlipNo())
+                .parcelComp(item.getParcelComp())
+                .parcelInvoiceNo(item.getParcelInvoiceNo())
+                .remark(item.getRemark())
+                .cstSupCd(item.getCstSupCd())
+                .distTermDt(item.getDistTermDt())
+                .makeDt(item.getMakeDt())
+                .preArv(item.getPreArv())
+                .godCds(goods)
+                .build();
     }
 
     private static UpdateFasstoWarehousingItemCommand mapUpdateItem(UpdateFasstoWarehousingRequest item) {

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/scheduler/FasstoWarehousingPollingScheduler.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/scheduler/FasstoWarehousingPollingScheduler.java
@@ -1,0 +1,230 @@
+package com.personal.marketnote.fulfillment.adapter.out.scheduler;
+
+import com.personal.marketnote.common.adapter.out.ServiceAdapter;
+import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.fulfillment.domain.FasstoAccessToken;
+import com.personal.marketnote.fulfillment.port.in.command.vendor.GetFasstoWarehousingCommand;
+import com.personal.marketnote.fulfillment.port.in.command.vendor.SyncFasstoAllStockCommand;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.FasstoWarehousingInfoResult;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.GetFasstoWarehousingResult;
+import com.personal.marketnote.fulfillment.port.in.usecase.vendor.GetFasstoWarehousingUseCase;
+import com.personal.marketnote.fulfillment.port.in.usecase.vendor.RequestFasstoAuthUseCase;
+import com.personal.marketnote.fulfillment.port.in.usecase.vendor.SyncFasstoAllStockUseCase;
+import com.personal.marketnote.fulfillment.port.out.scheduler.ScheduleFasstoWarehousingPollingCommand;
+import com.personal.marketnote.fulfillment.port.out.scheduler.ScheduleFasstoWarehousingPollingPort;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.TaskScheduler;
+
+import java.time.*;
+import java.time.format.DateTimeFormatter;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ScheduledFuture;
+
+@Slf4j
+@ServiceAdapter
+@RequiredArgsConstructor
+public class FasstoWarehousingPollingScheduler implements ScheduleFasstoWarehousingPollingPort {
+    private static final ZoneId DEFAULT_ZONE = ZoneId.of("Asia/Seoul");
+    private static final LocalTime POLLING_START_TIME = LocalTime.of(9, 30);
+    private static final LocalTime POLLING_END_TIME = LocalTime.of(19, 0);
+    private static final int POLLING_INTERVAL_MINUTES = 30;
+    private static final String COMPLETED_WORK_STATUS_CONFIRMED = "4";
+    private static final String COMPLETED_WORK_STATUS_COMPLETED = "5";
+
+    private final TaskScheduler taskScheduler;
+    private final Clock clock;
+    private final RequestFasstoAuthUseCase requestFasstoAuthUseCase;
+    private final GetFasstoWarehousingUseCase getFasstoWarehousingUseCase;
+    private final SyncFasstoAllStockUseCase syncFasstoAllStockUseCase;
+
+    private final Map<String, ScheduledFuture<?>> scheduledTasks = new ConcurrentHashMap<>();
+
+    @Override
+    public void schedule(ScheduleFasstoWarehousingPollingCommand command) {
+        Instant requestAt = clock.instant();
+        if (FormatValidator.hasNoValue(command)
+                || FormatValidator.hasNoValue(command.customerCode())
+                || FormatValidator.hasNoValue(command.ordNo())) {
+            return;
+        }
+
+        PollingContext context = PollingContext.from(command, requestAt);
+        if (FormatValidator.hasNoValue(context.startDate())
+                || FormatValidator.hasNoValue(context.endDate())) {
+            log.warn("Warehousing polling skipped due to invalid date: ordNo={}", context.ordNo());
+            return;
+        }
+
+        stopPolling(context.ordNo());
+        Instant firstRun = resolveFirstRunAt(context, requestAt);
+        if (FormatValidator.hasValue(firstRun)) {
+            scheduleNext(context, firstRun);
+        }
+    }
+
+    private void scheduleNext(PollingContext context, Instant scheduledAt) {
+        if (FormatValidator.hasNoValue(scheduledAt) || scheduledAt.isAfter(context.windowEnd())) {
+            stopPolling(context.ordNo());
+            return;
+        }
+        ScheduledFuture<?> future = taskScheduler.schedule(
+                () -> poll(context),
+                scheduledAt
+        );
+        if (FormatValidator.hasValue(future)) {
+            scheduledTasks.put(context.ordNo(), future);
+        }
+    }
+
+    private void poll(PollingContext context) {
+        Instant now = clock.instant();
+        if (context.isExpired(now)) {
+            stopPolling(context.ordNo());
+            return;
+        }
+        if (!context.isWithinWindow(now)) {
+            scheduleNext(context, context.windowStart());
+            return;
+        }
+
+        try {
+            FasstoAccessToken accessToken = requestFasstoAuthUseCase.requestAccessToken();
+            if (FormatValidator.hasNoValue(accessToken) || FormatValidator.hasNoValue(accessToken.getValue())) {
+                scheduleNext(context, resolveNextRunAt(context, now));
+                return;
+            }
+
+            FasstoWarehousingInfoResult completed = resolveCompletedWarehousing(
+                    accessToken.getValue(),
+                    context,
+                    COMPLETED_WORK_STATUS_CONFIRMED
+            );
+            if (FormatValidator.hasNoValue(completed)) {
+                completed = resolveCompletedWarehousing(
+                        accessToken.getValue(),
+                        context,
+                        COMPLETED_WORK_STATUS_COMPLETED
+                );
+            }
+            if (FormatValidator.hasValue(completed)) {
+                String whCd = completed.whCd();
+                if (FormatValidator.hasValue(whCd)) {
+                    syncFasstoAllStockUseCase.syncAll(
+                            SyncFasstoAllStockCommand.of(context.customerCode(), whCd)
+                    );
+                    stopPolling(context.ordNo());
+                    return;
+                }
+            }
+        } catch (Exception e) {
+            log.warn("Failed to poll Fassto warehousing: ordNo={}", context.ordNo(), e);
+        }
+
+        scheduleNext(context, resolveNextRunAt(context, now));
+    }
+
+    private FasstoWarehousingInfoResult resolveCompletedWarehousing(
+            String accessToken,
+            PollingContext context,
+            String workStatus
+    ) {
+        GetFasstoWarehousingResult result = getFasstoWarehousingUseCase.getWarehousing(
+                GetFasstoWarehousingCommand.of(
+                        context.customerCode(),
+                        accessToken,
+                        context.startDate(),
+                        context.endDate(),
+                        null,
+                        context.ordNo(),
+                        workStatus
+                )
+        );
+        if (FormatValidator.hasNoValue(result) || FormatValidator.hasNoValue(result.warehousing())) {
+            return null;
+        }
+
+        return result.warehousing().stream()
+                .filter(item -> FormatValidator.hasValue(item) && workStatus.equals(item.wrkStat()))
+                .findFirst()
+                .orElse(null);
+    }
+
+    private void stopPolling(String ordNo) {
+        ScheduledFuture<?> scheduled = scheduledTasks.remove(ordNo);
+        if (FormatValidator.hasValue(scheduled)) {
+            scheduled.cancel(false);
+        }
+    }
+
+    private Instant resolveFirstRunAt(PollingContext context, Instant requestAt) {
+        if (requestAt.isAfter(context.windowEnd())) {
+            return null;
+        }
+
+        if (requestAt.isBefore(context.windowStart())) {
+            return context.windowStart();
+        }
+
+        return requestAt;
+    }
+
+    private Instant resolveNextRunAt(PollingContext context, Instant now) {
+        Instant next = ZonedDateTime.ofInstant(now, DEFAULT_ZONE)
+                .plusMinutes(POLLING_INTERVAL_MINUTES)
+                .toInstant();
+        if (next.isAfter(context.windowEnd())) {
+            return null;
+        }
+        return next;
+    }
+
+    private static String normalizeOrdDate(Instant requestAt) {
+        LocalDate requestDate = resolveRequestDate(requestAt);
+        return requestDate.format(DateTimeFormatter.BASIC_ISO_DATE);
+    }
+
+    private static LocalDate resolveRequestDate(Instant requestAt) {
+        LocalDate fallbackDate = LocalDate.now(DEFAULT_ZONE);
+        if (FormatValidator.hasNoValue(requestAt)) {
+            return fallbackDate;
+        }
+
+        return ZonedDateTime.ofInstant(requestAt, DEFAULT_ZONE).toLocalDate();
+    }
+
+    private record PollingContext(
+            String customerCode,
+            String ordNo,
+            String startDate,
+            String endDate,
+            LocalDate requestDate,
+            Instant windowStart,
+            Instant windowEnd
+    ) {
+        private static PollingContext from(ScheduleFasstoWarehousingPollingCommand command, Instant requestAt) {
+            LocalDate requestDate = resolveRequestDate(requestAt);
+            String normalizedDate = normalizeOrdDate(requestAt);
+            Instant windowStart = ZonedDateTime.of(requestDate, POLLING_START_TIME, DEFAULT_ZONE).toInstant();
+            Instant windowEnd = ZonedDateTime.of(requestDate, POLLING_END_TIME, DEFAULT_ZONE).toInstant();
+            return new PollingContext(
+                    command.customerCode(),
+                    command.ordNo(),
+                    normalizedDate,
+                    normalizedDate,
+                    requestDate,
+                    windowStart,
+                    windowEnd
+            );
+        }
+
+        private boolean isWithinWindow(Instant now) {
+            return !now.isBefore(windowStart) && !now.isAfter(windowEnd);
+        }
+
+        private boolean isExpired(Instant now) {
+            return now.isAfter(windowEnd);
+        }
+    }
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/configuration/SchedulingConfig.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/configuration/SchedulingConfig.java
@@ -1,9 +1,28 @@
 package com.personal.marketnote.fulfillment.configuration;
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+import java.time.Clock;
+import java.time.ZoneId;
 
 @Configuration
 @EnableScheduling
 public class SchedulingConfig {
+    @Bean
+    public ThreadPoolTaskScheduler taskScheduler() {
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        scheduler.setPoolSize(4);
+        scheduler.setThreadNamePrefix("fulfillment-scheduler-");
+        scheduler.setWaitForTasksToCompleteOnShutdown(true);
+        scheduler.setAwaitTerminationSeconds(30);
+        return scheduler;
+    }
+
+    @Bean
+    public Clock fulfillmentClock() {
+        return Clock.system(ZoneId.of("Asia/Seoul"));
+    }
 }

--- a/fulfillment-service/fulfillment-adapters/src/test/java/com/personal/marketnote/fulfillment/adapter/out/scheduler/FasstoWarehousingPollingSchedulerTest.java
+++ b/fulfillment-service/fulfillment-adapters/src/test/java/com/personal/marketnote/fulfillment/adapter/out/scheduler/FasstoWarehousingPollingSchedulerTest.java
@@ -1,0 +1,322 @@
+package com.personal.marketnote.fulfillment.adapter.out.scheduler;
+
+import com.personal.marketnote.fulfillment.domain.FasstoAccessToken;
+import com.personal.marketnote.fulfillment.port.in.command.vendor.GetFasstoWarehousingCommand;
+import com.personal.marketnote.fulfillment.port.in.command.vendor.SyncFasstoAllStockCommand;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.FasstoWarehousingInfoResult;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.GetFasstoWarehousingResult;
+import com.personal.marketnote.fulfillment.port.in.usecase.vendor.GetFasstoWarehousingUseCase;
+import com.personal.marketnote.fulfillment.port.in.usecase.vendor.RequestFasstoAuthUseCase;
+import com.personal.marketnote.fulfillment.port.in.usecase.vendor.SyncFasstoAllStockUseCase;
+import com.personal.marketnote.fulfillment.port.out.scheduler.ScheduleFasstoWarehousingPollingCommand;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.Trigger;
+
+import java.time.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Delayed;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class FasstoWarehousingPollingSchedulerTest {
+    private static final ZoneId DEFAULT_ZONE = ZoneId.of("Asia/Seoul");
+
+    private RecordingTaskScheduler taskScheduler;
+    private MutableClock clock;
+
+    @Mock
+    private RequestFasstoAuthUseCase requestFasstoAuthUseCase;
+    @Mock
+    private GetFasstoWarehousingUseCase getFasstoWarehousingUseCase;
+    @Mock
+    private SyncFasstoAllStockUseCase syncFasstoAllStockUseCase;
+
+    private FasstoWarehousingPollingScheduler scheduler;
+
+    @BeforeEach
+    void setUp() {
+        taskScheduler = new RecordingTaskScheduler();
+        clock = new MutableClock(parseInstant("2026-02-08T08:00:00"));
+        scheduler = new FasstoWarehousingPollingScheduler(
+                taskScheduler,
+                clock,
+                requestFasstoAuthUseCase,
+                getFasstoWarehousingUseCase,
+                syncFasstoAllStockUseCase
+        );
+    }
+
+    @Test
+    @DisplayName("09:30 이전 요청이면 당일 09:30부터 polling을 시작한다")
+    void schedule_beforeWindow_startsAtWindowStart() {
+        clock.setInstant(parseInstant("2026-02-08T07:30:00"));
+
+        scheduler.schedule(buildCommand("ORD-1"));
+
+        assertThat(taskScheduler.tasks()).hasSize(1);
+        assertThat(taskScheduler.tasks().get(0).scheduledAt())
+                .isEqualTo(parseInstant("2026-02-08T09:30:00"));
+    }
+
+    @Test
+    @DisplayName("19:00 이후 요청이면 스케줄링하지 않는다")
+    void schedule_afterWindow_doesNotSchedule() {
+        clock.setInstant(parseInstant("2026-02-08T19:30:00"));
+
+        scheduler.schedule(buildCommand("ORD-2"));
+
+        assertThat(taskScheduler.tasks()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("wrkStat 4가 발견되면 재고 동기화를 호출한다")
+    void poll_whenConfirmed_syncsStocks() {
+        clock.setInstant(parseInstant("2026-02-08T10:00:00"));
+        when(requestFasstoAuthUseCase.requestAccessToken())
+                .thenReturn(FasstoAccessToken.of("token", "20260116120000"));
+
+        FasstoWarehousingInfoResult item = buildWarehousingInfo("ORD-1", "WH1", "4");
+        GetFasstoWarehousingResult result = GetFasstoWarehousingResult.of(1, List.of(item));
+        when(getFasstoWarehousingUseCase.getWarehousing(
+                argThat(command -> command != null && "4".equals(command.wrkStat()))
+        ))
+                .thenReturn(result);
+        scheduler.schedule(buildCommand("ORD-1"));
+        taskScheduler.tasks().get(0).runnable().run();
+
+        ArgumentCaptor<SyncFasstoAllStockCommand> syncCaptor =
+                ArgumentCaptor.forClass(SyncFasstoAllStockCommand.class);
+        verify(syncFasstoAllStockUseCase).syncAll(syncCaptor.capture());
+        assertThat(syncCaptor.getValue().customerCode()).isEqualTo("CUST");
+        assertThat(syncCaptor.getValue().whCd()).isEqualTo("WH1");
+
+        ArgumentCaptor<GetFasstoWarehousingCommand> commandCaptor =
+                ArgumentCaptor.forClass(GetFasstoWarehousingCommand.class);
+        verify(getFasstoWarehousingUseCase).getWarehousing(commandCaptor.capture());
+        assertThat(commandCaptor.getValue().startDate()).isEqualTo("20260116");
+        assertThat(commandCaptor.getValue().endDate()).isEqualTo("20260116");
+        assertThat(commandCaptor.getValue().wrkStat()).isEqualTo("4");
+
+        verify(getFasstoWarehousingUseCase, never())
+                .getWarehousing(argThat(command -> "5".equals(command.wrkStat())));
+    }
+
+    @Test
+    @DisplayName("wrkStat 4가 없고 5가 있으면 5 기준으로 동기화를 수행한다")
+    void poll_whenCompleted_syncsStocks() {
+        clock.setInstant(parseInstant("2026-02-08T11:00:00"));
+        when(requestFasstoAuthUseCase.requestAccessToken())
+                .thenReturn(FasstoAccessToken.of("token", "20260116120000"));
+
+        FasstoWarehousingInfoResult completed = buildWarehousingInfo("ORD-3", "WH2", "5");
+
+        when(getFasstoWarehousingUseCase.getWarehousing(any()))
+                .thenAnswer(invocation -> {
+                    GetFasstoWarehousingCommand command = invocation.getArgument(0);
+                    if ("4".equals(command.wrkStat())) {
+                        return GetFasstoWarehousingResult.of(0, List.of());
+                    }
+                    return GetFasstoWarehousingResult.of(1, List.of(completed));
+                });
+
+        scheduler.schedule(buildCommand("ORD-3"));
+        taskScheduler.tasks().get(0).runnable().run();
+
+        ArgumentCaptor<SyncFasstoAllStockCommand> syncCaptor =
+                ArgumentCaptor.forClass(SyncFasstoAllStockCommand.class);
+        verify(syncFasstoAllStockUseCase).syncAll(syncCaptor.capture());
+        assertThat(syncCaptor.getValue().whCd()).isEqualTo("WH2");
+
+        ArgumentCaptor<GetFasstoWarehousingCommand> commandCaptor =
+                ArgumentCaptor.forClass(GetFasstoWarehousingCommand.class);
+        verify(getFasstoWarehousingUseCase, org.mockito.Mockito.times(2))
+                .getWarehousing(commandCaptor.capture());
+        assertThat(commandCaptor.getAllValues())
+                .extracting(GetFasstoWarehousingCommand::wrkStat)
+                .containsExactly("4", "5");
+    }
+
+    private ScheduleFasstoWarehousingPollingCommand buildCommand(String ordNo) {
+        return ScheduleFasstoWarehousingPollingCommand.of("CUST", ordNo, "20260116");
+    }
+
+    private FasstoWarehousingInfoResult buildWarehousingInfo(String ordNo, String whCd, String wrkStat) {
+        return FasstoWarehousingInfoResult.of(
+                "20260116",
+                whCd,
+                null,
+                ordNo,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                wrkStat,
+                null,
+                null,
+                null,
+                List.of()
+        );
+    }
+
+    private Instant parseInstant(String localDateTime) {
+        return LocalDateTime.parse(localDateTime).atZone(DEFAULT_ZONE).toInstant();
+    }
+
+    private static class RecordingTaskScheduler implements TaskScheduler {
+        private final List<ScheduledTask> tasks = new ArrayList<>();
+
+        List<ScheduledTask> tasks() {
+            return tasks;
+        }
+
+        @Override
+        public ScheduledFuture<?> schedule(Runnable task, Instant startTime) {
+            ScheduledTask scheduledTask = new ScheduledTask(task, startTime, new TestScheduledFuture());
+            tasks.add(scheduledTask);
+            return scheduledTask.future();
+        }
+
+        @Override
+        public ScheduledFuture<?> schedule(Runnable task, Trigger trigger) {
+            throw new UnsupportedOperationException("Trigger scheduling is not supported in this test.");
+        }
+
+        @Override
+        public ScheduledFuture<?> schedule(Runnable task, java.util.Date startTime) {
+            throw new UnsupportedOperationException("Date scheduling is not supported in this test.");
+        }
+
+        @Override
+        public ScheduledFuture<?> scheduleAtFixedRate(Runnable task, java.util.Date startTime, long period) {
+            throw new UnsupportedOperationException("Fixed rate scheduling is not supported in this test.");
+        }
+
+        @Override
+        public ScheduledFuture<?> scheduleAtFixedRate(Runnable task, Instant startTime, Duration period) {
+            throw new UnsupportedOperationException("Fixed rate scheduling is not supported in this test.");
+        }
+
+        @Override
+        public ScheduledFuture<?> scheduleAtFixedRate(Runnable task, Duration period) {
+            throw new UnsupportedOperationException("Fixed rate scheduling is not supported in this test.");
+        }
+
+        @Override
+        public ScheduledFuture<?> scheduleAtFixedRate(Runnable task, long period) {
+            throw new UnsupportedOperationException("Fixed rate scheduling is not supported in this test.");
+        }
+
+        @Override
+        public ScheduledFuture<?> scheduleWithFixedDelay(Runnable task, java.util.Date startTime, long delay) {
+            throw new UnsupportedOperationException("Fixed delay scheduling is not supported in this test.");
+        }
+
+        @Override
+        public ScheduledFuture<?> scheduleWithFixedDelay(Runnable task, Instant startTime, Duration delay) {
+            throw new UnsupportedOperationException("Fixed delay scheduling is not supported in this test.");
+        }
+
+        @Override
+        public ScheduledFuture<?> scheduleWithFixedDelay(Runnable task, Duration delay) {
+            throw new UnsupportedOperationException("Fixed delay scheduling is not supported in this test.");
+        }
+
+        @Override
+        public ScheduledFuture<?> scheduleWithFixedDelay(Runnable task, long delay) {
+            throw new UnsupportedOperationException("Fixed delay scheduling is not supported in this test.");
+        }
+    }
+
+    private record ScheduledTask(Runnable runnable, Instant scheduledAt, TestScheduledFuture future) {
+    }
+
+    private static class TestScheduledFuture implements ScheduledFuture<Object> {
+        private boolean cancelled;
+
+        @Override
+        public boolean cancel(boolean mayInterruptIfRunning) {
+            cancelled = true;
+            return true;
+        }
+
+        @Override
+        public boolean isCancelled() {
+            return cancelled;
+        }
+
+        @Override
+        public boolean isDone() {
+            return cancelled;
+        }
+
+        @Override
+        public Object get() {
+            return null;
+        }
+
+        @Override
+        public Object get(long timeout, TimeUnit unit) {
+            return null;
+        }
+
+        @Override
+        public long getDelay(TimeUnit unit) {
+            return 0;
+        }
+
+        @Override
+        public int compareTo(Delayed other) {
+            return 0;
+        }
+    }
+
+    private static class MutableClock extends Clock {
+        private Instant instant;
+
+        MutableClock(Instant instant) {
+            this.instant = instant;
+        }
+
+        void setInstant(Instant instant) {
+            this.instant = instant;
+        }
+
+        @Override
+        public ZoneId getZone() {
+            return DEFAULT_ZONE;
+        }
+
+        @Override
+        public Clock withZone(ZoneId zone) {
+            return Clock.fixed(instant, zone);
+        }
+
+        @Override
+        public Instant instant() {
+            return instant;
+        }
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/vendor/RegisterFasstoWarehousingItemCommand.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/vendor/RegisterFasstoWarehousingItemCommand.java
@@ -1,7 +1,10 @@
 package com.personal.marketnote.fulfillment.port.in.command.vendor;
 
+import lombok.Builder;
+
 import java.util.List;
 
+@Builder
 public record RegisterFasstoWarehousingItemCommand(
         String ordDt,
         String ordNo,
@@ -16,33 +19,4 @@ public record RegisterFasstoWarehousingItemCommand(
         String preArv,
         List<RegisterFasstoWarehousingGoodsCommand> godCds
 ) {
-    public static RegisterFasstoWarehousingItemCommand of(
-            String ordDt,
-            String ordNo,
-            String inWay,
-            String slipNo,
-            String parcelComp,
-            String parcelInvoiceNo,
-            String remark,
-            String cstSupCd,
-            String distTermDt,
-            String makeDt,
-            String preArv,
-            List<RegisterFasstoWarehousingGoodsCommand> godCds
-    ) {
-        return new RegisterFasstoWarehousingItemCommand(
-                ordDt,
-                ordNo,
-                inWay,
-                slipNo,
-                parcelComp,
-                parcelInvoiceNo,
-                remark,
-                cstSupCd,
-                distTermDt,
-                makeDt,
-                preArv,
-                godCds
-        );
-    }
 }

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/scheduler/ScheduleFasstoWarehousingPollingCommand.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/scheduler/ScheduleFasstoWarehousingPollingCommand.java
@@ -1,0 +1,15 @@
+package com.personal.marketnote.fulfillment.port.out.scheduler;
+
+public record ScheduleFasstoWarehousingPollingCommand(
+        String customerCode,
+        String ordNo,
+        String ordDt
+) {
+    public static ScheduleFasstoWarehousingPollingCommand of(
+            String customerCode,
+            String ordNo,
+            String ordDt
+    ) {
+        return new ScheduleFasstoWarehousingPollingCommand(customerCode, ordNo, ordDt);
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/scheduler/ScheduleFasstoWarehousingPollingPort.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/scheduler/ScheduleFasstoWarehousingPollingPort.java
@@ -1,0 +1,5 @@
+package com.personal.marketnote.fulfillment.port.out.scheduler;
+
+public interface ScheduleFasstoWarehousingPollingPort {
+    void schedule(ScheduleFasstoWarehousingPollingCommand command);
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/vendor/RegisterFasstoWarehousingService.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/vendor/RegisterFasstoWarehousingService.java
@@ -1,10 +1,14 @@
 package com.personal.marketnote.fulfillment.service.vendor;
 
 import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.fulfillment.mapper.FasstoWarehousingCommandToRequestMapper;
 import com.personal.marketnote.fulfillment.port.in.command.vendor.RegisterFasstoWarehousingCommand;
+import com.personal.marketnote.fulfillment.port.in.command.vendor.RegisterFasstoWarehousingItemCommand;
 import com.personal.marketnote.fulfillment.port.in.result.vendor.RegisterFasstoWarehousingResult;
 import com.personal.marketnote.fulfillment.port.in.usecase.vendor.RegisterFasstoWarehousingUseCase;
+import com.personal.marketnote.fulfillment.port.out.scheduler.ScheduleFasstoWarehousingPollingCommand;
+import com.personal.marketnote.fulfillment.port.out.scheduler.ScheduleFasstoWarehousingPollingPort;
 import com.personal.marketnote.fulfillment.port.out.vendor.RegisterFasstoWarehousingPort;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,11 +20,36 @@ import static org.springframework.transaction.annotation.Isolation.READ_COMMITTE
 @Transactional(isolation = READ_COMMITTED, readOnly = true)
 public class RegisterFasstoWarehousingService implements RegisterFasstoWarehousingUseCase {
     private final RegisterFasstoWarehousingPort registerFasstoWarehousingPort;
+    private final ScheduleFasstoWarehousingPollingPort scheduleFasstoWarehousingPollingPort;
 
     @Override
     public RegisterFasstoWarehousingResult registerWarehousing(RegisterFasstoWarehousingCommand command) {
-        return registerFasstoWarehousingPort.registerWarehousing(
+        RegisterFasstoWarehousingResult result = registerFasstoWarehousingPort.registerWarehousing(
                 FasstoWarehousingCommandToRequestMapper.mapToRegisterRequest(command)
         );
+        schedulePolling(command, result);
+        return result;
+    }
+
+    private void schedulePolling(RegisterFasstoWarehousingCommand command, RegisterFasstoWarehousingResult result) {
+        if (FormatValidator.hasNoValue(command)
+                || FormatValidator.hasNoValue(command.warehousingRequests())
+                || FormatValidator.hasNoValue(result)) {
+            return;
+        }
+
+        for (RegisterFasstoWarehousingItemCommand item : command.warehousingRequests()) {
+            if (FormatValidator.hasNoValue(item) || FormatValidator.hasNoValue(item.ordNo())) {
+                continue;
+            }
+
+            scheduleFasstoWarehousingPollingPort.schedule(
+                    ScheduleFasstoWarehousingPollingCommand.of(
+                            command.customerCode(),
+                            item.ordNo(),
+                            item.ordDt()
+                    )
+            );
+        }
     }
 }

--- a/fulfillment-service/fulfillment-application/src/test/java/com/personal/marketnote/fulfillment/service/vendor/RegisterFasstoWarehousingServiceTest.java
+++ b/fulfillment-service/fulfillment-application/src/test/java/com/personal/marketnote/fulfillment/service/vendor/RegisterFasstoWarehousingServiceTest.java
@@ -1,0 +1,77 @@
+package com.personal.marketnote.fulfillment.service.vendor;
+
+import com.personal.marketnote.fulfillment.port.in.command.vendor.RegisterFasstoWarehousingCommand;
+import com.personal.marketnote.fulfillment.port.in.command.vendor.RegisterFasstoWarehousingGoodsCommand;
+import com.personal.marketnote.fulfillment.port.in.command.vendor.RegisterFasstoWarehousingItemCommand;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.RegisterFasstoWarehousingItemResult;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.RegisterFasstoWarehousingResult;
+import com.personal.marketnote.fulfillment.port.out.scheduler.ScheduleFasstoWarehousingPollingCommand;
+import com.personal.marketnote.fulfillment.port.out.scheduler.ScheduleFasstoWarehousingPollingPort;
+import com.personal.marketnote.fulfillment.port.out.vendor.RegisterFasstoWarehousingPort;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RegisterFasstoWarehousingServiceTest {
+    @Mock
+    private RegisterFasstoWarehousingPort registerFasstoWarehousingPort;
+    @Mock
+    private ScheduleFasstoWarehousingPollingPort scheduleFasstoWarehousingPollingPort;
+
+    @InjectMocks
+    private RegisterFasstoWarehousingService registerFasstoWarehousingService;
+
+    @Test
+    @DisplayName("입고 요청 성공 후 ordNo별 polling 스케줄을 등록한다")
+    void registerWarehousing_schedulesPollingPerOrdNo() {
+        RegisterFasstoWarehousingCommand command = RegisterFasstoWarehousingCommand.of(
+                "CUST",
+                "token",
+                List.of(
+                        buildItem("20260116", "ORD-1"),
+                        buildItem("20260116", "ORD-2")
+                )
+        );
+
+        RegisterFasstoWarehousingResult result = RegisterFasstoWarehousingResult.of(
+                2,
+                List.of(
+                        RegisterFasstoWarehousingItemResult.of("OK", "200", "SLIP-1", "ORD-1"),
+                        RegisterFasstoWarehousingItemResult.of("OK", "200", "SLIP-2", "ORD-2")
+                )
+        );
+        when(registerFasstoWarehousingPort.registerWarehousing(any())).thenReturn(result);
+
+        registerFasstoWarehousingService.registerWarehousing(command);
+
+        ArgumentCaptor<ScheduleFasstoWarehousingPollingCommand> captor
+                = ArgumentCaptor.forClass(ScheduleFasstoWarehousingPollingCommand.class);
+        verify(scheduleFasstoWarehousingPollingPort, org.mockito.Mockito.times(2))
+                .schedule(captor.capture());
+
+        assertThat(captor.getAllValues())
+                .extracting(ScheduleFasstoWarehousingPollingCommand::ordNo)
+                .containsExactlyInAnyOrder("ORD-1", "ORD-2");
+    }
+
+    private RegisterFasstoWarehousingItemCommand buildItem(String ordDt, String ordNo) {
+        return RegisterFasstoWarehousingItemCommand.builder()
+                .ordDt(ordDt)
+                .ordNo(ordNo)
+                .inWay("01")
+                .godCds(List.of(RegisterFasstoWarehousingGoodsCommand.of("P1", null, 1)))
+                .build();
+    }
+}


### PR DESCRIPTION
## partially addresses #475
## resolves #614

## Task
- [x] 파스토에 상품 입고 요청 이후 입고 데이터 polling 시작
- [x] 09:30~19:00: 30분 간격
- [x] 입고 완료되면 파스토 재고 튜플 조회 후 서버 재고 동기화
- [x] polling 중지