### PR TITLE
[#216][#663] feat: 주문 확정 시 일부 상품 주문 확정에 대한 로직 추가

### DIFF
--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/ChangeOrderStatusService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/ChangeOrderStatusService.java
@@ -37,7 +37,7 @@ public class ChangeOrderStatusService implements ChangeOrderStatusUseCase {
         Order order = getOrderUseCase.getOrder(command.id());
         OrderStatus status = command.orderStatus();
 
-        if (status.isMe(order.getOrderStatus())) {
+        if (status.isMe(order.getOrderStatus()) && status.isNotPartialChanged()) {
             throw new OrderStatusAlreadyChangedException(status);
         }
 

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/order/Order.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/order/Order.java
@@ -77,8 +77,21 @@ public class Order {
                 .filter(orderProduct -> pricePolicyIds.contains(orderProduct.getPricePolicyId()))
                 .forEach(orderProduct -> orderProduct.changeOrderStatus(orderStatus));
 
-        if (orderStatus.isRefunded()) {
+        if (
+                orderStatus.isRefunded()
+                        && orderProducts.stream()
+                        .anyMatch(orderProduct -> !orderProduct.getOrderStatus().isRefunded())
+        ) {
             this.orderStatus = OrderStatus.getPartiallyRefunded();
+            return;
+        }
+
+        if (
+                orderStatus.isConfirmed()
+                        && orderProducts.stream()
+                        .anyMatch(orderProduct -> !orderProduct.getOrderStatus().isConfirmed())
+        ) {
+            this.orderStatus = OrderStatus.getPartiallyConfirmed();
             return;
         }
 

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/order/OrderStatus.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/order/OrderStatus.java
@@ -15,6 +15,7 @@ public enum OrderStatus {
     CANCELLED("주문 취소"),
     SHIPPING("배송중"),
     DELIVERED("배송 완료"),
+    PARTIALLY_CONFIRMED("부분 구매 확정"),
     CONFIRMED("구매 확정"),
     EXCHANGE_REQUESTED("교환 요청됨"),
     EXCHANGE_RECALLING("교환 회수 중"),
@@ -32,6 +33,10 @@ public enum OrderStatus {
         return this == REFUNDED;
     }
 
+    public static OrderStatus getPartiallyConfirmed() {
+        return PARTIALLY_CONFIRMED;
+    }
+
     public static OrderStatus getPartiallyRefunded() {
         return PARTIALLY_REFUNDED;
     }
@@ -46,5 +51,13 @@ public enum OrderStatus {
 
     public boolean isPending() {
         return this == PAYMENT_PENDING;
+    }
+
+    public boolean isConfirmed() {
+        return this == CONFIRMED;
+    }
+
+    public boolean isNotPartialChanged() {
+        return this != PARTIALLY_CONFIRMED && this != PARTIALLY_REFUNDED;
     }
 }


### PR DESCRIPTION
## partially addresses #216
## resolves #663

## Task
- [x] 부분 확정 상태 추가
- [x] 부분 확정 시 전체 주문 상태가 부분 확정 상태가 되도록 변경
- [x] 부분 확정 요청 시 전체 상품이 확정되는 경우 전체 주문 상태가 확정 상태가 되도록 변경
- [x] 중복 예외 처리 시 부분 확정 여부 검증 로직 추가