### PR TITLE
[#475][#662] feat: 파스토 출고 목록 조회 연동 기능 응답 파라미터 추가 및 Swagger Docs 업데이트

### DIFF
--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/apidocs/GetFasstoDeliveriesApiDocs.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/apidocs/GetFasstoDeliveriesApiDocs.java
@@ -17,7 +17,7 @@ import java.lang.annotation.*;
 @Operation(
         summary = "(관리자) 파스토 출고 목록 조회",
         description = """
-                작성일자: 2026-02-11
+                작성일자: 2026-02-12
                 
                 작성자: 성효빈
                 
@@ -68,42 +68,45 @@ import java.lang.annotation.*;
                 
                 | **키** | **타입** | **설명** | **예시** |
                 | --- | --- | --- | --- |
-                | ordDt | string | 주문일자 | "2026-02-11" |
+                | outDt | string | 출고일자 | null |
+                | ordDt | string | 주문일자 | "20260121" |
                 | whCd | string | 창고코드 | "TEST" |
                 | whNm | string | 창고명 | "테스트" |
-                | slipNo | string | 전표번호 | "TESTDO260120000001" |
+                | slipNo | string | 전표번호 | "TESTOO260121000042" |
                 | cstCd | string | 고객사코드 | "94388" |
                 | cstNm | string | 고객사명 | "마켓노트 주식회사 테스트" |
-                | shopNm | string | 출고처명 | "기본 출고처" |
+                | shopCd | string | 출고처코드 | "99999999" |
+                | mapSlipNo | string | 매핑전표번호 | "" |
+                | shopNm | string | 출고처명 | "미지정 출고" |
                 | sku | number | SKU 수량 | 1 |
                 | ordQty | number | 지시수량(요청수량) | 1 |
                 | addGodOrdQty | number | 딸린상품 지시수량 | 0 |
-                | outDiv | string | 출고구분(1:택배, 2:차량/기타) | "1" |
-                | outDivNm | string | 출고구분명 | "택배" |
-                | cstShopCd | string | 고객사출고처코드 | "SHOP01" |
-                | ordNo | string | 고객사 주문번호 | "202601200001" |
+                | outDiv | string | 출고구분(1:택배, 2:차량/기타) | null |
+                | outDivNm | string | 출고구분명 | null |
+                | cstShopCd | string | 고객사출고처코드 | null |
+                | ordNo | string | 고객사 주문번호 | "asdf" |
                 | ordSeq | number | 고객사 주문 요청순번 | 1 |
                 | shipReqTerm | string | 배송요청사항 | "" |
                 | salChanel | string | 판매채널 | "" |
                 | outWay | string | 출고방식(1:선입선출,2:후입선출,3:유통기한지정) | "1" |
                 | ordDiv | string | 배송유형구분 | "N" |
                 | outWayNm | string | 출고방식명 | "선입선출" |
-                | wrkStat | string | 작업진행상태코드 | "ORDER" |
+                | wrkStat | string | 작업진행상태코드 | "1" |
                 | wrkStatNm | string | 작업진행상태명 | "출고요청" |
-                | invoiceNo | string | 송장번호 | "" |
-                | parcelNm | string | 택배사명 | "" |
-                | parcelCd | string | 택배사코드 | "" |
-                | updTime | string | 수정일 | "" |
+                | invoiceNo | string | 송장번호 | null |
+                | parcelNm | string | 택배사명 | null |
+                | parcelCd | string | 택배사코드 | null |
                 | custNm | string | 배송 수령인 | "홍길동" |
-                | goodsSerialNo | array | 상품 일련번호 목록 | [] |
-                | custAddr | string | 배송 주소 | "서울" |
-                | supCd | string | 공급사코드 | "94388001" |
+                | custAddr | string | 배송 주소 | "서울특별시 마포구 와우산로29바길 12" |
                 | custTelNo | string | 수령인 번호 | "01012345678" |
-                | supNm | string | 공급사명 | "테스트 상점1" |
-                | remark | string | 비고 | "" |
                 | sendNm | string | 발송자명 | "" |
                 | sendTelNo | string | 발송자 번호 | "" |
-                | updUserNm | string | 수정자 | "" |
+                | updUserNm | string | 수정자 | "OPEN_API (94388)" |
+                | updTime | string | 수정일 | "202601211159" |
+                | goodsSerialNo | array | 상품 일련번호 목록 | [] |
+                | supCd | string | 공급사코드 | "" |
+                | supNm | string | 공급사명 | null |
+                | remark | string | 비고 | "" |
                 """,
         security = {@SecurityRequirement(name = "bearer")},
         parameters = {
@@ -166,10 +169,52 @@ import java.lang.annotation.*;
                                         {
                                           "statusCode": 200,
                                           "code": "SUC01",
-                                          "timestamp": "2026-02-11T12:12:30.013",
+                                          "timestamp": "2026-02-12T12:12:30.013",
                                           "content": {
-                                            "dataCount": 0,
-                                            "deliveries": []
+                                            "dataCount": 1,
+                                            "deliveries": [
+                                              {
+                                                "outDt": null,
+                                                "ordDt": "20260121",
+                                                "whCd": "TEST",
+                                                "whNm": "테스트",
+                                                "slipNo": "TESTOO260121000042",
+                                                "cstCd": "94388",
+                                                "cstNm": "마켓노트 주식회사 테스트",
+                                                "shopCd": "99999999",
+                                                "mapSlipNo": "",
+                                                "shopNm": "미지정 출고",
+                                                "sku": 1,
+                                                "ordQty": 1,
+                                                "addGodOrdQty": 0,
+                                                "outDiv": null,
+                                                "outDivNm": null,
+                                                "cstShopCd": null,
+                                                "ordNo": "asdf",
+                                                "ordSeq": 1,
+                                                "shipReqTerm": "",
+                                                "salChanel": "",
+                                                "outWay": "1",
+                                                "ordDiv": "N",
+                                                "outWayNm": "선입선출",
+                                                "wrkStat": "1",
+                                                "wrkStatNm": "출고요청",
+                                                "invoiceNo": null,
+                                                "parcelNm": null,
+                                                "parcelCd": null,
+                                                "custNm": "홍길동",
+                                                "custAddr": "서울특별시 마포구 와우산로29바길 12",
+                                                "custTelNo": "01012345678",
+                                                "sendNm": "",
+                                                "sendTelNo": "",
+                                                "updUserNm": "OPEN_API (94388)",
+                                                "updTime": "202601211159",
+                                                "goodsSerialNo": [],
+                                                "supCd": "",
+                                                "supNm": null,
+                                                "remark": ""
+                                              }
+                                            ]
                                           },
                                           "message": "파스토 출고 목록 조회 성공"
                                         }

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/apidocs/RegisterFasstoDeliveryApiDocs.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/apidocs/RegisterFasstoDeliveryApiDocs.java
@@ -90,6 +90,18 @@ import java.lang.annotation.*;
                 | --- | --- | --- | --- |
                 | dataCount | number | 등록 건수 | 0 |
                 | deliveries | array | 출고 등록 결과 | [ ... ] |
+                
+                ---
+                
+                ### Response > content > deliveries
+                
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | fmsSlipNo | string | 전표번호 | "TESTOO260121000042" |
+                | orderNo | string | 주문번호 | "asdf" |
+                | msg | string | 처리 메시지 | "출고요청 등록 성공" |
+                | code | string | 처리 코드 | "200" |
+                | outOfStockGoodsDetail | object | 품절 상품 상세 | null |
                 """,
         security = {@SecurityRequirement(name = "bearer")},
         parameters = {
@@ -152,8 +164,16 @@ import java.lang.annotation.*;
                                           "code": "SUC01",
                                           "timestamp": "2026-02-11T12:12:30.013",
                                           "content": {
-                                            "dataCount": 0,
-                                            "deliveries": []
+                                            "dataCount": 1,
+                                            "deliveries": [
+                                              {
+                                                "fmsSlipNo": "TESTOO260121000042",
+                                                "orderNo": "asdf",
+                                                "msg": "출고요청 등록 성공",
+                                                "code": "200",
+                                                "outOfStockGoodsDetail": null
+                                              }
+                                            ]
                                           },
                                           "message": "파스토 출고 등록 성공"
                                         }

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/client/FasstoDeliveryClient.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/client/FasstoDeliveryClient.java
@@ -5,11 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.personal.marketnote.common.adapter.out.VendorAdapter;
 import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.common.utility.http.client.CommunicationFailureHandler;
-import com.personal.marketnote.fulfillment.adapter.out.vendor.fassto.response.FasstoDeliveryItemResponse;
-import com.personal.marketnote.fulfillment.adapter.out.vendor.fassto.response.FasstoDeliveryListResponse;
-import com.personal.marketnote.fulfillment.adapter.out.vendor.fassto.response.FasstoErrorResponse;
-import com.personal.marketnote.fulfillment.adapter.out.vendor.fassto.response.RegisterFasstoDeliveryItemResponse;
-import com.personal.marketnote.fulfillment.adapter.out.vendor.fassto.response.RegisterFasstoDeliveryResponse;
+import com.personal.marketnote.fulfillment.adapter.out.vendor.fassto.response.*;
 import com.personal.marketnote.fulfillment.configuration.FasstoAuthProperties;
 import com.personal.marketnote.fulfillment.domain.vendor.fassto.delivery.FasstoDeliveryMapper;
 import com.personal.marketnote.fulfillment.domain.vendor.fassto.delivery.FasstoDeliveryQuery;
@@ -556,10 +552,11 @@ public class FasstoDeliveryClient implements RegisterFasstoDeliveryPort, GetFass
 
     private RegisterFasstoDeliveryItemResult mapDeliveryItem(RegisterFasstoDeliveryItemResponse item) {
         return RegisterFasstoDeliveryItemResult.of(
+                item.fmsSlipNo(),
+                item.orderNo(),
                 item.msg(),
                 item.code(),
-                item.slipNo(),
-                item.ordNo()
+                item.outOfStockGoodsDetail()
         );
     }
 
@@ -569,12 +566,15 @@ public class FasstoDeliveryClient implements RegisterFasstoDeliveryPort, GetFass
                 : List.of();
 
         return FasstoDeliveryInfoResult.of(
+                item.outDt(),
                 item.ordDt(),
                 item.whCd(),
                 item.whNm(),
                 item.slipNo(),
                 item.cstCd(),
                 item.cstNm(),
+                item.shopCd(),
+                item.mapSlipNo(),
                 item.shopNm(),
                 item.sku(),
                 item.ordQty(),
@@ -594,7 +594,6 @@ public class FasstoDeliveryClient implements RegisterFasstoDeliveryPort, GetFass
                 item.invoiceNo(),
                 item.parcelNm(),
                 item.parcelCd(),
-                item.updTime(),
                 item.custNm(),
                 goodsSerialNo,
                 item.custAddr(),
@@ -604,7 +603,8 @@ public class FasstoDeliveryClient implements RegisterFasstoDeliveryPort, GetFass
                 item.remark(),
                 item.sendNm(),
                 item.sendTelNo(),
-                item.updUserNm()
+                item.updUserNm(),
+                item.updTime()
         );
     }
 

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoDeliveryItemResponse.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoDeliveryItemResponse.java
@@ -6,12 +6,15 @@ import java.util.List;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record FasstoDeliveryItemResponse(
+        String outDt,
         String ordDt,
         String whCd,
         String whNm,
         String slipNo,
         String cstCd,
         String cstNm,
+        String shopCd,
+        String mapSlipNo,
         String shopNm,
         Integer sku,
         Integer ordQty,

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/RegisterFasstoDeliveryItemResponse.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/RegisterFasstoDeliveryItemResponse.java
@@ -4,10 +4,11 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record RegisterFasstoDeliveryItemResponse(
+        String fmsSlipNo,
+        String orderNo,
         String msg,
         String code,
-        String slipNo,
-        String ordNo
+        Object outOfStockGoodsDetail
 ) {
     private static final String SUCCESS_CODE = "200";
 

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/result/vendor/FasstoDeliveryInfoResult.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/result/vendor/FasstoDeliveryInfoResult.java
@@ -3,12 +3,15 @@ package com.personal.marketnote.fulfillment.port.in.result.vendor;
 import java.util.List;
 
 public record FasstoDeliveryInfoResult(
+        String outDt,
         String ordDt,
         String whCd,
         String whNm,
         String slipNo,
         String cstCd,
         String cstNm,
+        String shopCd,
+        String mapSlipNo,
         String shopNm,
         Integer sku,
         Integer ordQty,
@@ -28,7 +31,6 @@ public record FasstoDeliveryInfoResult(
         String invoiceNo,
         String parcelNm,
         String parcelCd,
-        String updTime,
         String custNm,
         List<Object> goodsSerialNo,
         String custAddr,
@@ -38,15 +40,19 @@ public record FasstoDeliveryInfoResult(
         String remark,
         String sendNm,
         String sendTelNo,
-        String updUserNm
+        String updUserNm,
+        String updTime
 ) {
     public static FasstoDeliveryInfoResult of(
+            String outDt,
             String ordDt,
             String whCd,
             String whNm,
             String slipNo,
             String cstCd,
             String cstNm,
+            String shopCd,
+            String mapSlipNo,
             String shopNm,
             Integer sku,
             Integer ordQty,
@@ -66,7 +72,6 @@ public record FasstoDeliveryInfoResult(
             String invoiceNo,
             String parcelNm,
             String parcelCd,
-            String updTime,
             String custNm,
             List<Object> goodsSerialNo,
             String custAddr,
@@ -76,15 +81,19 @@ public record FasstoDeliveryInfoResult(
             String remark,
             String sendNm,
             String sendTelNo,
-            String updUserNm
+            String updUserNm,
+            String updTime
     ) {
         return new FasstoDeliveryInfoResult(
+                outDt,
                 ordDt,
                 whCd,
                 whNm,
                 slipNo,
                 cstCd,
                 cstNm,
+                shopCd,
+                mapSlipNo,
                 shopNm,
                 sku,
                 ordQty,
@@ -104,7 +113,6 @@ public record FasstoDeliveryInfoResult(
                 invoiceNo,
                 parcelNm,
                 parcelCd,
-                updTime,
                 custNm,
                 goodsSerialNo,
                 custAddr,
@@ -114,7 +122,8 @@ public record FasstoDeliveryInfoResult(
                 remark,
                 sendNm,
                 sendTelNo,
-                updUserNm
+                updUserNm,
+                updTime
         );
     }
 }

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/result/vendor/RegisterFasstoDeliveryItemResult.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/result/vendor/RegisterFasstoDeliveryItemResult.java
@@ -1,17 +1,25 @@
 package com.personal.marketnote.fulfillment.port.in.result.vendor;
 
 public record RegisterFasstoDeliveryItemResult(
+        String fmsSlipNo,
+        String orderNo,
         String msg,
         String code,
-        String slipNo,
-        String ordNo
+        Object outOfStockGoodsDetail
 ) {
     public static RegisterFasstoDeliveryItemResult of(
+            String fmsSlipNo,
+            String orderNo,
             String msg,
             String code,
-            String slipNo,
-            String ordNo
+            Object outOfStockGoodsDetail
     ) {
-        return new RegisterFasstoDeliveryItemResult(msg, code, slipNo, ordNo);
+        return new RegisterFasstoDeliveryItemResult(
+                fmsSlipNo,
+                orderNo,
+                msg,
+                code,
+                outOfStockGoodsDetail
+        );
     }
 }


### PR DESCRIPTION
## partially addresses #475
## resolves #662

## Task
- [x] 응답 파라미터
- [x] Swagger Docs