### PR TITLE
[#475][#674] feat: 파스토 출고 취소 연동 기능 추가

### DIFF
--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/FasstoDeliveryController.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/FasstoDeliveryController.java
@@ -1,17 +1,22 @@
 package com.personal.marketnote.fulfillment.adapter.in.web.vendor.controller;
 
 import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
+import com.personal.marketnote.fulfillment.adapter.in.web.vendor.controller.apidocs.CancelFasstoDeliveryApiDocs;
 import com.personal.marketnote.fulfillment.adapter.in.web.vendor.controller.apidocs.GetFasstoDeliveriesApiDocs;
 import com.personal.marketnote.fulfillment.adapter.in.web.vendor.controller.apidocs.GetFasstoDeliveryDetailApiDocs;
 import com.personal.marketnote.fulfillment.adapter.in.web.vendor.controller.apidocs.RegisterFasstoDeliveryApiDocs;
 import com.personal.marketnote.fulfillment.adapter.in.web.vendor.mapper.FasstoDeliveryRequestToCommandMapper;
+import com.personal.marketnote.fulfillment.adapter.in.web.vendor.request.CancelFasstoDeliveryRequest;
 import com.personal.marketnote.fulfillment.adapter.in.web.vendor.request.RegisterFasstoDeliveryRequest;
+import com.personal.marketnote.fulfillment.adapter.in.web.vendor.response.CancelFasstoDeliveryResponse;
 import com.personal.marketnote.fulfillment.adapter.in.web.vendor.response.GetFasstoDeliveriesResponse;
 import com.personal.marketnote.fulfillment.adapter.in.web.vendor.response.GetFasstoDeliveryDetailResponse;
 import com.personal.marketnote.fulfillment.adapter.in.web.vendor.response.RegisterFasstoDeliveryResponse;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.CancelFasstoDeliveryResult;
 import com.personal.marketnote.fulfillment.port.in.result.vendor.GetFasstoDeliveriesResult;
 import com.personal.marketnote.fulfillment.port.in.result.vendor.GetFasstoDeliveryDetailResult;
 import com.personal.marketnote.fulfillment.port.in.result.vendor.RegisterFasstoDeliveryResult;
+import com.personal.marketnote.fulfillment.port.in.usecase.vendor.CancelFasstoDeliveryUseCase;
 import com.personal.marketnote.fulfillment.port.in.usecase.vendor.GetFasstoDeliveriesUseCase;
 import com.personal.marketnote.fulfillment.port.in.usecase.vendor.GetFasstoDeliveryDetailUseCase;
 import com.personal.marketnote.fulfillment.port.in.usecase.vendor.RegisterFasstoDeliveryUseCase;
@@ -36,6 +41,7 @@ public class FasstoDeliveryController {
     private final RegisterFasstoDeliveryUseCase registerFasstoDeliveryUseCase;
     private final GetFasstoDeliveriesUseCase getFasstoDeliveriesUseCase;
     private final GetFasstoDeliveryDetailUseCase getFasstoDeliveryDetailUseCase;
+    private final CancelFasstoDeliveryUseCase cancelFasstoDeliveryUseCase;
 
     /**
      * (관리자) 파스토 출고 등록 요청
@@ -67,6 +73,39 @@ public class FasstoDeliveryController {
                         "파스토 출고 등록 성공"
                 ),
                 HttpStatus.CREATED
+        );
+    }
+
+    /**
+     * (관리자) 파스토 출고 취소 요청
+     *
+     * @param customerCode 파스토 고객사 코드
+     * @param accessToken  파스토 액세스 토큰
+     * @param request      출고 취소 요청 정보
+     * @Author 성효빈
+     * @Date 2026-02-12
+     * @Description 파스토 출고 요청을 취소합니다.
+     */
+    @PatchMapping("/cancel/{customerCode}")
+    @PreAuthorize(ADMIN_POINTCUT)
+    @CancelFasstoDeliveryApiDocs
+    public ResponseEntity<BaseResponse<CancelFasstoDeliveryResponse>> cancelDelivery(
+            @PathVariable String customerCode,
+            @RequestHeader("accessToken") String accessToken,
+            @Valid @RequestBody List<CancelFasstoDeliveryRequest> request
+    ) {
+        CancelFasstoDeliveryResult result = cancelFasstoDeliveryUseCase.cancelDelivery(
+                FasstoDeliveryRequestToCommandMapper.mapToCancelCommand(customerCode, accessToken, request)
+        );
+
+        return new ResponseEntity<>(
+                BaseResponse.of(
+                        CancelFasstoDeliveryResponse.from(result),
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "파스토 출고 취소 성공"
+                ),
+                HttpStatus.OK
         );
     }
 

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/apidocs/CancelFasstoDeliveryApiDocs.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/apidocs/CancelFasstoDeliveryApiDocs.java
@@ -1,0 +1,174 @@
+package com.personal.marketnote.fulfillment.adapter.in.web.vendor.controller.apidocs;
+
+import com.personal.marketnote.fulfillment.adapter.in.web.vendor.request.CancelFasstoDeliveryRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Operation(
+        summary = "(관리자) 파스토 출고 취소 요청",
+        description = """
+                작성일자: 2026-02-12
+                
+                작성자: 성효빈
+                
+                ---
+                
+                ## Description
+                
+                파스토 출고 요청을 취소합니다.
+                
+                ---
+                
+                ## Request
+                
+                | **키** | **위치** | **타입** | **설명** | **필수 여부** | **예시** |
+                | --- | --- | --- | --- | --- | --- |
+                | accessToken | header | string | 파스토 액세스 토큰 | Y | 039a797bf66d11f0be620ab49498ff55 |
+                | customerCode | path | string | 파스토 고객사 코드 | Y | 94388 |
+                
+                ---
+                
+                ## Request Body (Array)
+                
+                | **키** | **타입** | **설명** | **필수 여부** | **예시** |
+                | --- | --- | --- | --- | --- |
+                | slipNo | string | 출고요청번호 | Y | "TESTOO260121000042" |
+                | ordNo | string | 주문번호 | Y | "asdf" |
+                
+                ---
+                
+                ## Response
+                
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | statusCode | number | 상태 코드 | 200: 성공 / 400: 클라이언트 요청 오류 / 401: 인증 실패 / 403: 인가 실패 / 500: 그 외 |
+                | code | string | 응답 코드 | "SUC01" / "BAD_REQUEST" / "UNAUTHORIZED" / "FORBIDDEN" / "INTERNAL_SERVER_ERROR" |
+                | timestamp | string(datetime) | 응답 일시 | "2026-02-12T12:12:30.013" |
+                | content | object | 응답 본문 | { ... } |
+                | message | string | 처리 결과 | "파스토 출고 취소 성공" |
+                
+                ---
+                
+                ### Response > content
+                
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | dataCount | number | 취소 건수 | 0 |
+                | deliveries | array | 출고 취소 결과 | [ ... ] |
+                
+                ---
+                
+                ### Response > content > deliveries
+                
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | fmsSlipNo | string | 전표번호 | "TESTOO260121000042" |
+                | orderNo | string | 주문번호 | "asdf" |
+                | msg | string | 처리 메시지 | "출고요청 삭제 성공" |
+                | code | string | 처리 코드 | "200" |
+                | outOfStockGoodsDetail | object | 품절 상품 상세 | null |
+                """,
+        security = {@SecurityRequirement(name = "bearer")},
+        parameters = {
+                @Parameter(
+                        name = "accessToken",
+                        description = "파스토 액세스 토큰",
+                        in = ParameterIn.HEADER,
+                        required = true,
+                        schema = @Schema(type = "string", example = "039a797bf66d11f0be620ab49498ff55")
+                ),
+                @Parameter(
+                        name = "customerCode",
+                        description = "파스토 고객사 코드",
+                        in = ParameterIn.PATH,
+                        required = true,
+                        schema = @Schema(type = "string", example = "94388")
+                )
+        },
+        requestBody = @RequestBody(
+                required = true,
+                content = @Content(
+                        schema = @Schema(implementation = CancelFasstoDeliveryRequest.class),
+                        examples = @ExampleObject("""
+                                [
+                                  {
+                                    "slipNo": "TESTOO260121000042",
+                                    "ordNo": "asdf"
+                                  }
+                                ]
+                                """)
+                )
+        ),
+        responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "파스토 출고 취소 성공",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 200,
+                                          "code": "SUC01",
+                                          "timestamp": "2026-02-12T12:12:30.013",
+                                          "content": {
+                                            "dataCount": 0,
+                                            "deliveries": [
+                                              {
+                                                "fmsSlipNo": "TESTOO260121000042",
+                                                "orderNo": "asdf",
+                                                "msg": "출고요청 삭제 성공",
+                                                "code": "200",
+                                                "outOfStockGoodsDetail": null
+                                              }
+                                            ]
+                                          },
+                                          "message": "파스토 출고 취소 성공"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "401",
+                        description = "토큰 인증 실패",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 401,
+                                          "code": "UNAUTHORIZED",
+                                          "timestamp": "2026-02-12T12:12:30.013",
+                                          "content": null,
+                                          "message": "Invalid token"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "403",
+                        description = "토큰 인가 실패",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 403,
+                                          "code": "FORBIDDEN",
+                                          "timestamp": "2026-02-12T12:12:30.013",
+                                          "content": null,
+                                          "message": "Access Denied"
+                                        }
+                                        """)
+                        )
+                )
+        }
+)
+public @interface CancelFasstoDeliveryApiDocs {
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/mapper/FasstoDeliveryRequestToCommandMapper.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/mapper/FasstoDeliveryRequestToCommandMapper.java
@@ -1,5 +1,6 @@
 package com.personal.marketnote.fulfillment.adapter.in.web.vendor.mapper;
 
+import com.personal.marketnote.fulfillment.adapter.in.web.vendor.request.CancelFasstoDeliveryRequest;
 import com.personal.marketnote.fulfillment.adapter.in.web.vendor.request.RegisterFasstoDeliveryGoodsRequest;
 import com.personal.marketnote.fulfillment.adapter.in.web.vendor.request.RegisterFasstoDeliveryRequest;
 import com.personal.marketnote.fulfillment.port.in.command.vendor.*;
@@ -46,6 +47,18 @@ public class FasstoDeliveryRequestToCommandMapper {
             String ordNo
     ) {
         return GetFasstoDeliveryDetailCommand.of(customerCode, accessToken, slipNo, ordNo);
+    }
+
+    public static CancelFasstoDeliveryCommand mapToCancelCommand(
+            String customerCode,
+            String accessToken,
+            List<CancelFasstoDeliveryRequest> request
+    ) {
+        List<CancelFasstoDeliveryItemCommand> cancelRequests = request.stream()
+                .map(item -> CancelFasstoDeliveryItemCommand.of(item.getSlipNo(), item.getOrdNo()))
+                .toList();
+
+        return CancelFasstoDeliveryCommand.of(customerCode, accessToken, cancelRequests);
     }
 
     private static RegisterFasstoDeliveryItemCommand mapItem(RegisterFasstoDeliveryRequest item) {

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/request/CancelFasstoDeliveryRequest.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/request/CancelFasstoDeliveryRequest.java
@@ -1,0 +1,24 @@
+package com.personal.marketnote.fulfillment.adapter.in.web.vendor.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+import lombok.Getter;
+
+@Getter
+public class CancelFasstoDeliveryRequest {
+    @Schema(
+            name = "slipNo",
+            description = "출고요청번호",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    @NotEmpty(message = "출고요청번호는 필수값입니다.")
+    private String slipNo;
+
+    @Schema(
+            name = "ordNo",
+            description = "주문번호",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    @NotEmpty(message = "주문번호는 필수값입니다.")
+    private String ordNo;
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/response/CancelFasstoDeliveryResponse.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/response/CancelFasstoDeliveryResponse.java
@@ -1,0 +1,15 @@
+package com.personal.marketnote.fulfillment.adapter.in.web.vendor.response;
+
+import com.personal.marketnote.fulfillment.port.in.result.vendor.CancelFasstoDeliveryItemResult;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.CancelFasstoDeliveryResult;
+
+import java.util.List;
+
+public record CancelFasstoDeliveryResponse(
+        Integer dataCount,
+        List<CancelFasstoDeliveryItemResult> deliveries
+) {
+    public static CancelFasstoDeliveryResponse from(CancelFasstoDeliveryResult result) {
+        return new CancelFasstoDeliveryResponse(result.dataCount(), result.deliveries());
+    }
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/resources/application.yml
+++ b/fulfillment-service/fulfillment-adapters/src/main/resources/application.yml
@@ -61,6 +61,7 @@ vendor:
       delivery-path: ${FASSTO_DELIVERY_PATH:/api/v1/delivery/parcel/{customerCode}}
       delivery-list-path: ${FASSTO_DELIVERY_LIST_PATH:/api/v1/delivery/{customerCode}/{startDate}/{endDate}/{status}/{outDiv}}
       delivery-detail-path: ${FASSTO_DELIVERY_DETAIL_PATH:/api/v1/delivery/detail/{customerCode}/{slipNo}}
+      delivery-cancel-path: ${FASSTO_DELIVERY_CANCEL_PATH:/api/v1/delivery/cancel/{customerCode}}
       stock-list-path: ${FASSTO_STOCK_LIST_PATH:/api/v1/stock/list/{customerCode}}
       settlement-daily-cost-path: ${FASSTO_SETTLEMENT_DAILY_COST_PATH:/api/v1/settlement/{yearMonth}/{whCd}/{customerCode}}
       api-cd: ${FASSTO_API_CD:change-me}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/configuration/FasstoAuthProperties.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/configuration/FasstoAuthProperties.java
@@ -25,6 +25,7 @@ public class FasstoAuthProperties {
     private String deliveryPath = "/api/v1/delivery/parcel/{customerCode}";
     private String deliveryListPath = "/api/v1/delivery/{customerCode}/{startDate}/{endDate}/{status}/{outDiv}";
     private String deliveryDetailPath = "/api/v1/delivery/detail/{customerCode}/{slipNo}";
+    private String deliveryCancelPath = "/api/v1/delivery/cancel/{customerCode}";
     private String stockListPath = "/api/v1/stock/list/{customerCode}";
     private String settlementDailyCostPath = "/api/v1/settlement/{yearMonth}/{whCd}/{customerCode}";
 }

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/CancelFasstoDeliveryFailedException.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/CancelFasstoDeliveryFailedException.java
@@ -1,0 +1,25 @@
+package com.personal.marketnote.fulfillment.exception;
+
+import com.personal.marketnote.common.exception.ExternalOperationFailedException;
+import com.personal.marketnote.common.utility.FormatValidator;
+
+import java.io.IOException;
+
+public class CancelFasstoDeliveryFailedException extends ExternalOperationFailedException {
+    private static final String DEFAULT_MESSAGE = "파스토 출고 취소 요청 중 오류가 발생했습니다.";
+
+    public CancelFasstoDeliveryFailedException(IOException cause) {
+        super(DEFAULT_MESSAGE, cause);
+    }
+
+    public CancelFasstoDeliveryFailedException(String vendorMessage, IOException cause) {
+        super(resolveMessage(vendorMessage), cause);
+    }
+
+    private static String resolveMessage(String vendorMessage) {
+        if (FormatValidator.hasValue(vendorMessage)) {
+            return String.format("파스토 출고 취소 실패: %s", vendorMessage);
+        }
+        return DEFAULT_MESSAGE;
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/mapper/FasstoDeliveryCommandToRequestMapper.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/mapper/FasstoDeliveryCommandToRequestMapper.java
@@ -27,6 +27,18 @@ public class FasstoDeliveryCommandToRequestMapper {
         );
     }
 
+    public static FasstoDeliveryCancelMapper mapToCancelRequest(CancelFasstoDeliveryCommand command) {
+        List<FasstoDeliveryCancelItemMapper> cancelRequests = command.deliveries().stream()
+                .map(FasstoDeliveryCommandToRequestMapper::mapCancelItem)
+                .toList();
+
+        return FasstoDeliveryCancelMapper.of(
+                command.customerCode(),
+                command.accessToken(),
+                cancelRequests
+        );
+    }
+
     public static FasstoDeliveryMapper mapToRegisterRequest(RegisterFasstoDeliveryCommand command) {
         List<FasstoDeliveryItemMapper> deliveryRequests = command.deliveryRequests().stream()
                 .map(FasstoDeliveryCommandToRequestMapper::mapItem)
@@ -68,6 +80,13 @@ public class FasstoDeliveryCommandToRequestMapper {
                 item.cstGodCd(),
                 item.distTermDt(),
                 item.ordQty()
+        );
+    }
+
+    private static FasstoDeliveryCancelItemMapper mapCancelItem(CancelFasstoDeliveryItemCommand item) {
+        return FasstoDeliveryCancelItemMapper.of(
+                item.slipNo(),
+                item.ordNo()
         );
     }
 }

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/vendor/CancelFasstoDeliveryCommand.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/vendor/CancelFasstoDeliveryCommand.java
@@ -1,0 +1,17 @@
+package com.personal.marketnote.fulfillment.port.in.command.vendor;
+
+import java.util.List;
+
+public record CancelFasstoDeliveryCommand(
+        String customerCode,
+        String accessToken,
+        List<CancelFasstoDeliveryItemCommand> deliveries
+) {
+    public static CancelFasstoDeliveryCommand of(
+            String customerCode,
+            String accessToken,
+            List<CancelFasstoDeliveryItemCommand> deliveries
+    ) {
+        return new CancelFasstoDeliveryCommand(customerCode, accessToken, deliveries);
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/vendor/CancelFasstoDeliveryItemCommand.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/vendor/CancelFasstoDeliveryItemCommand.java
@@ -1,0 +1,13 @@
+package com.personal.marketnote.fulfillment.port.in.command.vendor;
+
+public record CancelFasstoDeliveryItemCommand(
+        String slipNo,
+        String ordNo
+) {
+    public static CancelFasstoDeliveryItemCommand of(
+            String slipNo,
+            String ordNo
+    ) {
+        return new CancelFasstoDeliveryItemCommand(slipNo, ordNo);
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/result/vendor/CancelFasstoDeliveryItemResult.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/result/vendor/CancelFasstoDeliveryItemResult.java
@@ -1,0 +1,19 @@
+package com.personal.marketnote.fulfillment.port.in.result.vendor;
+
+public record CancelFasstoDeliveryItemResult(
+        String fmsSlipNo,
+        String orderNo,
+        String msg,
+        String code,
+        Object outOfStockGoodsDetail
+) {
+    public static CancelFasstoDeliveryItemResult of(
+            String fmsSlipNo,
+            String orderNo,
+            String msg,
+            String code,
+            Object outOfStockGoodsDetail
+    ) {
+        return new CancelFasstoDeliveryItemResult(fmsSlipNo, orderNo, msg, code, outOfStockGoodsDetail);
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/result/vendor/CancelFasstoDeliveryResult.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/result/vendor/CancelFasstoDeliveryResult.java
@@ -1,0 +1,15 @@
+package com.personal.marketnote.fulfillment.port.in.result.vendor;
+
+import java.util.List;
+
+public record CancelFasstoDeliveryResult(
+        Integer dataCount,
+        List<CancelFasstoDeliveryItemResult> deliveries
+) {
+    public static CancelFasstoDeliveryResult of(
+            Integer dataCount,
+            List<CancelFasstoDeliveryItemResult> deliveries
+    ) {
+        return new CancelFasstoDeliveryResult(dataCount, deliveries);
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/usecase/vendor/CancelFasstoDeliveryUseCase.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/usecase/vendor/CancelFasstoDeliveryUseCase.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.fulfillment.port.in.usecase.vendor;
+
+import com.personal.marketnote.fulfillment.port.in.command.vendor.CancelFasstoDeliveryCommand;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.CancelFasstoDeliveryResult;
+
+public interface CancelFasstoDeliveryUseCase {
+    CancelFasstoDeliveryResult cancelDelivery(CancelFasstoDeliveryCommand command);
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/vendor/CancelFasstoDeliveryPort.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/vendor/CancelFasstoDeliveryPort.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.fulfillment.port.out.vendor;
+
+import com.personal.marketnote.fulfillment.domain.vendor.fassto.delivery.FasstoDeliveryCancelMapper;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.CancelFasstoDeliveryResult;
+
+public interface CancelFasstoDeliveryPort {
+    CancelFasstoDeliveryResult cancelDelivery(FasstoDeliveryCancelMapper request);
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/vendor/CancelFasstoDeliveryService.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/vendor/CancelFasstoDeliveryService.java
@@ -1,0 +1,26 @@
+package com.personal.marketnote.fulfillment.service.vendor;
+
+import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.fulfillment.mapper.FasstoDeliveryCommandToRequestMapper;
+import com.personal.marketnote.fulfillment.port.in.command.vendor.CancelFasstoDeliveryCommand;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.CancelFasstoDeliveryResult;
+import com.personal.marketnote.fulfillment.port.in.usecase.vendor.CancelFasstoDeliveryUseCase;
+import com.personal.marketnote.fulfillment.port.out.vendor.CancelFasstoDeliveryPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional(isolation = READ_COMMITTED)
+public class CancelFasstoDeliveryService implements CancelFasstoDeliveryUseCase {
+    private final CancelFasstoDeliveryPort cancelFasstoDeliveryPort;
+
+    @Override
+    public CancelFasstoDeliveryResult cancelDelivery(CancelFasstoDeliveryCommand command) {
+        return cancelFasstoDeliveryPort.cancelDelivery(
+                FasstoDeliveryCommandToRequestMapper.mapToCancelRequest(command)
+        );
+    }
+}

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/delivery/FasstoDeliveryCancelItemMapper.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/delivery/FasstoDeliveryCancelItemMapper.java
@@ -1,0 +1,44 @@
+package com.personal.marketnote.fulfillment.domain.vendor.fassto.delivery;
+
+import com.personal.marketnote.common.utility.FormatValidator;
+import lombok.*;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+public class FasstoDeliveryCancelItemMapper {
+    private String slipNo;
+    private String ordNo;
+
+    public static FasstoDeliveryCancelItemMapper of(
+            String slipNo,
+            String ordNo
+    ) {
+        FasstoDeliveryCancelItemMapper mapper = FasstoDeliveryCancelItemMapper.builder()
+                .slipNo(slipNo)
+                .ordNo(ordNo)
+                .build();
+        mapper.validate();
+        return mapper;
+    }
+
+    public Map<String, Object> toPayload() {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("slipNo", slipNo);
+        payload.put("ordNo", ordNo);
+        return payload;
+    }
+
+    private void validate() {
+        if (FormatValidator.hasNoValue(slipNo)) {
+            throw new IllegalArgumentException("slipNo is required for delivery cancel request.");
+        }
+        if (FormatValidator.hasNoValue(ordNo)) {
+            throw new IllegalArgumentException("ordNo is required for delivery cancel request.");
+        }
+    }
+}

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/delivery/FasstoDeliveryCancelMapper.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/delivery/FasstoDeliveryCancelMapper.java
@@ -1,0 +1,49 @@
+package com.personal.marketnote.fulfillment.domain.vendor.fassto.delivery;
+
+import com.personal.marketnote.common.utility.FormatValidator;
+import lombok.*;
+
+import java.util.List;
+import java.util.Map;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+public class FasstoDeliveryCancelMapper {
+    private String customerCode;
+    private String accessToken;
+    private List<FasstoDeliveryCancelItemMapper> cancelRequests;
+
+    public static FasstoDeliveryCancelMapper of(
+            String customerCode,
+            String accessToken,
+            List<FasstoDeliveryCancelItemMapper> cancelRequests
+    ) {
+        FasstoDeliveryCancelMapper mapper = FasstoDeliveryCancelMapper.builder()
+                .customerCode(customerCode)
+                .accessToken(accessToken)
+                .cancelRequests(cancelRequests)
+                .build();
+        mapper.validate();
+        return mapper;
+    }
+
+    public List<Map<String, Object>> toPayload() {
+        return cancelRequests.stream()
+                .map(FasstoDeliveryCancelItemMapper::toPayload)
+                .toList();
+    }
+
+    private void validate() {
+        if (FormatValidator.hasNoValue(customerCode)) {
+            throw new IllegalArgumentException("customerCode is required.");
+        }
+        if (FormatValidator.hasNoValue(accessToken)) {
+            throw new IllegalArgumentException("accessToken is required.");
+        }
+        if (FormatValidator.hasNoValue(cancelRequests)) {
+            throw new IllegalArgumentException("cancelRequests is required.");
+        }
+    }
+}


### PR DESCRIPTION
## partially addresses #475
## resolves #674

## Task
- [x] 파스토 출고 취소 연동 요청
- [x] 파스토 출고 취소 연동 비즈니스 로직
- [x] 파스토 서버에 출고 취소 요청
- [x] 200 status code 응답
- [x] Swagger docs