### PR TITLE
[#128][#387][#218][#674] docs: 장바구니 상품 추가 및 파스토 출고 취소 연동 기능 Swagger Docs 업데이트

### DIFF
--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/apidocs/CancelFasstoDeliveryApiDocs.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/apidocs/CancelFasstoDeliveryApiDocs.java
@@ -33,6 +33,8 @@ import java.lang.annotation.*;
                 
                 ## Request
                 
+                ### Request Parameters
+                
                 | **키** | **위치** | **타입** | **설명** | **필수 여부** | **예시** |
                 | --- | --- | --- | --- | --- | --- |
                 | accessToken | header | string | 파스토 액세스 토큰 | Y | 039a797bf66d11f0be620ab49498ff55 |
@@ -40,7 +42,7 @@ import java.lang.annotation.*;
                 
                 ---
                 
-                ## Request Body (Array)
+                ### Request Body (Array)
                 
                 | **키** | **타입** | **설명** | **필수 여부** | **예시** |
                 | --- | --- | --- | --- | --- |

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/apidocs/GetFasstoDeliveriesApiDocs.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/apidocs/GetFasstoDeliveriesApiDocs.java
@@ -17,7 +17,7 @@ import java.lang.annotation.*;
 @Operation(
         summary = "(관리자) 파스토 출고 목록 조회",
         description = """
-                작성일자: 2026-02-12
+                작성일자: 2026-02-11
                 
                 작성자: 성효빈
                 

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/cart/controller/apidocs/AddCartProductApiDocs.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/cart/controller/apidocs/AddCartProductApiDocs.java
@@ -110,7 +110,7 @@ import java.lang.annotation.*;
                                 examples = @ExampleObject("""
                                         {
                                           "statusCode": 403,
-                                          "code": "FORBIDDEN",«
+                                          "code": "FORBIDDEN",
                                           "timestamp": "2025-12-30T12:12:30.013",
                                           "content": null,
                                           "message": "Access Denied"


### PR DESCRIPTION
## partially addresses #128
## partially addresses #387
## resolves #218
## resolves #674

## Task
- [x] 장바구니 상품 추가
- [x] 파스토 출고 취소 연동