### PR TITLE
[#475][#683] feat: 파스토 출고중인 상품의 송장번호, 상품정보 조회 연동 기능 추가

### DIFF
--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/FasstoDeliveryController.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/FasstoDeliveryController.java
@@ -1,25 +1,13 @@
 package com.personal.marketnote.fulfillment.adapter.in.web.vendor.controller;
 
 import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
-import com.personal.marketnote.fulfillment.adapter.in.web.vendor.controller.apidocs.CancelFasstoDeliveryApiDocs;
-import com.personal.marketnote.fulfillment.adapter.in.web.vendor.controller.apidocs.GetFasstoDeliveriesApiDocs;
-import com.personal.marketnote.fulfillment.adapter.in.web.vendor.controller.apidocs.GetFasstoDeliveryDetailApiDocs;
-import com.personal.marketnote.fulfillment.adapter.in.web.vendor.controller.apidocs.RegisterFasstoDeliveryApiDocs;
+import com.personal.marketnote.fulfillment.adapter.in.web.vendor.controller.apidocs.*;
 import com.personal.marketnote.fulfillment.adapter.in.web.vendor.mapper.FasstoDeliveryRequestToCommandMapper;
 import com.personal.marketnote.fulfillment.adapter.in.web.vendor.request.CancelFasstoDeliveryRequest;
 import com.personal.marketnote.fulfillment.adapter.in.web.vendor.request.RegisterFasstoDeliveryRequest;
-import com.personal.marketnote.fulfillment.adapter.in.web.vendor.response.CancelFasstoDeliveryResponse;
-import com.personal.marketnote.fulfillment.adapter.in.web.vendor.response.GetFasstoDeliveriesResponse;
-import com.personal.marketnote.fulfillment.adapter.in.web.vendor.response.GetFasstoDeliveryDetailResponse;
-import com.personal.marketnote.fulfillment.adapter.in.web.vendor.response.RegisterFasstoDeliveryResponse;
-import com.personal.marketnote.fulfillment.port.in.result.vendor.CancelFasstoDeliveryResult;
-import com.personal.marketnote.fulfillment.port.in.result.vendor.GetFasstoDeliveriesResult;
-import com.personal.marketnote.fulfillment.port.in.result.vendor.GetFasstoDeliveryDetailResult;
-import com.personal.marketnote.fulfillment.port.in.result.vendor.RegisterFasstoDeliveryResult;
-import com.personal.marketnote.fulfillment.port.in.usecase.vendor.CancelFasstoDeliveryUseCase;
-import com.personal.marketnote.fulfillment.port.in.usecase.vendor.GetFasstoDeliveriesUseCase;
-import com.personal.marketnote.fulfillment.port.in.usecase.vendor.GetFasstoDeliveryDetailUseCase;
-import com.personal.marketnote.fulfillment.port.in.usecase.vendor.RegisterFasstoDeliveryUseCase;
+import com.personal.marketnote.fulfillment.adapter.in.web.vendor.response.*;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.*;
+import com.personal.marketnote.fulfillment.port.in.usecase.vendor.*;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -41,6 +29,7 @@ public class FasstoDeliveryController {
     private final RegisterFasstoDeliveryUseCase registerFasstoDeliveryUseCase;
     private final GetFasstoDeliveriesUseCase getFasstoDeliveriesUseCase;
     private final GetFasstoDeliveryDetailUseCase getFasstoDeliveryDetailUseCase;
+    private final GetFasstoDeliveryOutOrdGoodsDetailUseCase getFasstoDeliveryOutOrdGoodsDetailUseCase;
     private final CancelFasstoDeliveryUseCase cancelFasstoDeliveryUseCase;
 
     /**
@@ -189,6 +178,43 @@ public class FasstoDeliveryController {
                         HttpStatus.OK,
                         DEFAULT_SUCCESS_CODE,
                         "파스토 출고 상세 조회 성공"
+                ),
+                HttpStatus.OK
+        );
+    }
+
+    /**
+     * (관리자) 파스토 출고중 상품 송장별 조회
+     *
+     * @param customerCode 파스토 고객사 코드
+     * @param accessToken  파스토 액세스 토큰
+     * @param outOrdSlipNo 파스토 출고요청번호
+     * @Author 성효빈
+     * @Date 2026-02-12
+     * @Description 파스토 출고중 상품의 송장별 상품 정보를 조회합니다.
+     */
+    @GetMapping("/out-ord/goods-detail/{customerCode}")
+    @PreAuthorize(ADMIN_POINTCUT)
+    @GetFasstoDeliveryOutOrdGoodsDetailApiDocs
+    public ResponseEntity<BaseResponse<GetFasstoDeliveryOutOrdGoodsDetailResponse>> getOutOrdGoodsDetail(
+            @PathVariable String customerCode,
+            @RequestHeader("accessToken") String accessToken,
+            @RequestParam("outOrdSlipNo") String outOrdSlipNo
+    ) {
+        GetFasstoDeliveryOutOrdGoodsDetailResult result = getFasstoDeliveryOutOrdGoodsDetailUseCase.getOutOrdGoodsDetail(
+                FasstoDeliveryRequestToCommandMapper.mapToOutOrdGoodsDetailCommand(
+                        customerCode,
+                        accessToken,
+                        outOrdSlipNo
+                )
+        );
+
+        return new ResponseEntity<>(
+                BaseResponse.of(
+                        GetFasstoDeliveryOutOrdGoodsDetailResponse.from(result),
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "파스토 출고중 상품 송장별 조회 성공"
                 ),
                 HttpStatus.OK
         );

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/apidocs/GetFasstoDeliveryOutOrdGoodsDetailApiDocs.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/apidocs/GetFasstoDeliveryOutOrdGoodsDetailApiDocs.java
@@ -1,0 +1,137 @@
+package com.personal.marketnote.fulfillment.adapter.in.web.vendor.controller.apidocs;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Operation(
+        summary = "(관리자) 파스토 출고중 상품 송장별 상품 조회",
+        description = """
+                작성일자: 2026-02-12
+                
+                작성자: 성효빈
+                
+                ---
+                
+                ## Description
+                
+                파스토 출고중인 상품의 송장번호 기준 상품 정보를 조회합니다.
+                
+                ---
+                
+                ## Request
+                
+                | **키** | **위치** | **타입** | **설명** | **필수 여부** | **예시** |
+                | --- | --- | --- | --- | --- | --- |
+                | accessToken | header | string | 파스토 액세스 토큰 | Y | 039a797bf66d11f0be620ab49498ff55 |
+                | customerCode | path | string | 파스토 고객사 코드 | Y | 94388 |
+                | outOrdSlipNo | query | string | 파스토 출고요청번호 | Y | 123 |
+                
+                ---
+                
+                ## Response
+                
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | statusCode | number | 상태 코드 | 200: 성공 / 400: 클라이언트 요청 오류 / 401: 인증 실패 / 403: 인가 실패 / 500: 그 외 |
+                | code | string | 응답 코드 | "SUC01" / "BAD_REQUEST" / "UNAUTHORIZED" / "FORBIDDEN" / "INTERNAL_SERVER_ERROR" |
+                | timestamp | string(datetime) | 응답 일시 | "2026-02-12T12:12:30.013" |
+                | content | object | 응답 본문 | { ... } |
+                | message | string | 처리 결과 | "파스토 출고중 상품 송장별 조회 성공" |
+                
+                ---
+                
+                ### Response > content
+                
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | dataCount | number | 조회 건수 | 1 |
+                | goodsByInvoice | array | 송장별 상품 정보 | [ ... ] |
+                
+                ---
+                
+                ### Response > content > goodsByInvoice
+                
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | invoiceNo | string | 송장번호 | "1234567890" |
+                | goodsDeliveredList | array | 상품 정보 | [ ... ] |
+                
+                ---
+                
+                ### Response > content > goodsByInvoice > goodsDeliveredList
+                
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | cstGodCd | string | 고객사 상품코드 | "1" |
+                | godNm | string | 상품명 | "테스트상품" |
+                | packQty | number | 상품 수량 | 2 |
+                """,
+        security = {@SecurityRequirement(name = "bearer")},
+        parameters = {
+                @Parameter(
+                        name = "accessToken",
+                        description = "파스토 액세스 토큰",
+                        in = ParameterIn.HEADER,
+                        required = true,
+                        schema = @Schema(type = "string", example = "039a797bf66d11f0be620ab49498ff55")
+                ),
+                @Parameter(
+                        name = "customerCode",
+                        description = "파스토 고객사 코드",
+                        in = ParameterIn.PATH,
+                        required = true,
+                        schema = @Schema(type = "string", example = "94388")
+                ),
+                @Parameter(
+                        name = "outOrdSlipNo",
+                        description = "파스토 출고요청번호",
+                        in = ParameterIn.QUERY,
+                        required = true,
+                        schema = @Schema(type = "string", example = "123")
+                )
+        },
+        responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "파스토 출고중 상품 송장별 조회 성공",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 200,
+                                          "code": "SUC01",
+                                          "timestamp": "2026-02-12T12:12:30.013",
+                                          "content": {
+                                            "dataCount": 1,
+                                            "goodsByInvoice": [
+                                              {
+                                                "invoiceNo": "1234567890",
+                                                "goodsDeliveredList": [
+                                                  {
+                                                    "cstGodCd": "1",
+                                                    "godNm": "테스트상품",
+                                                    "packQty": 2
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          "message": "파스토 출고중 상품 송장별 조회 성공"
+                                        }
+                                        """)
+                        )
+                )
+        }
+)
+public @interface GetFasstoDeliveryOutOrdGoodsDetailApiDocs {
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/mapper/FasstoDeliveryRequestToCommandMapper.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/mapper/FasstoDeliveryRequestToCommandMapper.java
@@ -61,6 +61,14 @@ public class FasstoDeliveryRequestToCommandMapper {
         return CancelFasstoDeliveryCommand.of(customerCode, accessToken, cancelRequests);
     }
 
+    public static GetFasstoDeliveryOutOrdGoodsDetailCommand mapToOutOrdGoodsDetailCommand(
+            String customerCode,
+            String accessToken,
+            String outOrdSlipNo
+    ) {
+        return GetFasstoDeliveryOutOrdGoodsDetailCommand.of(customerCode, accessToken, outOrdSlipNo);
+    }
+
     private static RegisterFasstoDeliveryItemCommand mapItem(RegisterFasstoDeliveryRequest item) {
         List<RegisterFasstoDeliveryGoodsCommand> goods = item.getGodCds().stream()
                 .map(FasstoDeliveryRequestToCommandMapper::mapGoods)

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/response/GetFasstoDeliveryOutOrdGoodsDetailResponse.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/response/GetFasstoDeliveryOutOrdGoodsDetailResponse.java
@@ -1,0 +1,15 @@
+package com.personal.marketnote.fulfillment.adapter.in.web.vendor.response;
+
+import com.personal.marketnote.fulfillment.port.in.result.vendor.FasstoDeliveryOutOrdGoodsInfoResult;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.GetFasstoDeliveryOutOrdGoodsDetailResult;
+
+import java.util.List;
+
+public record GetFasstoDeliveryOutOrdGoodsDetailResponse(
+        Integer dataCount,
+        List<FasstoDeliveryOutOrdGoodsInfoResult> goodsByInvoice
+) {
+    public static GetFasstoDeliveryOutOrdGoodsDetailResponse from(GetFasstoDeliveryOutOrdGoodsDetailResult result) {
+        return new GetFasstoDeliveryOutOrdGoodsDetailResponse(result.dataCount(), result.goodsByInvoice());
+    }
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoOutOrdGoodsByInvoiceResponse.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoOutOrdGoodsByInvoiceResponse.java
@@ -1,0 +1,12 @@
+package com.personal.marketnote.fulfillment.adapter.out.vendor.fassto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record FasstoOutOrdGoodsByInvoiceResponse(
+        String invoiceNo,
+        List<FasstoOutOrdGoodsDeliveredResponse> goodsDeliveredList
+) {
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoOutOrdGoodsDeliveredResponse.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoOutOrdGoodsDeliveredResponse.java
@@ -1,0 +1,11 @@
+package com.personal.marketnote.fulfillment.adapter.out.vendor.fassto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record FasstoOutOrdGoodsDeliveredResponse(
+        String cstGodCd,
+        String godNm,
+        Integer packQty
+) {
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoOutOrdGoodsDetailListResponse.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoOutOrdGoodsDetailListResponse.java
@@ -1,0 +1,16 @@
+package com.personal.marketnote.fulfillment.adapter.out.vendor.fassto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record FasstoOutOrdGoodsDetailListResponse(
+        FasstoResponseHeader header,
+        List<FasstoOutOrdGoodsByInvoiceResponse> data,
+        FasstoErrorInfo errorInfo
+) implements FasstoApiResponse {
+    public boolean isSuccess() {
+        return header != null && header.isSuccess() && data != null;
+    }
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/resources/application.yml
+++ b/fulfillment-service/fulfillment-adapters/src/main/resources/application.yml
@@ -62,6 +62,7 @@ vendor:
       delivery-list-path: ${FASSTO_DELIVERY_LIST_PATH:/api/v1/delivery/{customerCode}/{startDate}/{endDate}/{status}/{outDiv}}
       delivery-detail-path: ${FASSTO_DELIVERY_DETAIL_PATH:/api/v1/delivery/detail/{customerCode}/{slipNo}}
       delivery-cancel-path: ${FASSTO_DELIVERY_CANCEL_PATH:/api/v1/delivery/cancel/{customerCode}}
+      delivery-out-ord-goods-detail-path: ${FASSTO_DELIVERY_OUT_ORD_GOODS_DETAIL_PATH:/api/v1/delivery/outOrd/goodsDetail/{customerCode}}
       stock-list-path: ${FASSTO_STOCK_LIST_PATH:/api/v1/stock/list/{customerCode}}
       settlement-daily-cost-path: ${FASSTO_SETTLEMENT_DAILY_COST_PATH:/api/v1/settlement/{yearMonth}/{whCd}/{customerCode}}
       api-cd: ${FASSTO_API_CD:change-me}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/configuration/FasstoAuthProperties.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/configuration/FasstoAuthProperties.java
@@ -26,6 +26,7 @@ public class FasstoAuthProperties {
     private String deliveryListPath = "/api/v1/delivery/{customerCode}/{startDate}/{endDate}/{status}/{outDiv}";
     private String deliveryDetailPath = "/api/v1/delivery/detail/{customerCode}/{slipNo}";
     private String deliveryCancelPath = "/api/v1/delivery/cancel/{customerCode}";
+    private String deliveryOutOrdGoodsDetailPath = "/api/v1/delivery/outOrd/goodsDetail/{customerCode}";
     private String stockListPath = "/api/v1/stock/list/{customerCode}";
     private String settlementDailyCostPath = "/api/v1/settlement/{yearMonth}/{whCd}/{customerCode}";
 }

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/GetFasstoDeliveryOutOrdGoodsDetailFailedException.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/GetFasstoDeliveryOutOrdGoodsDetailFailedException.java
@@ -1,0 +1,25 @@
+package com.personal.marketnote.fulfillment.exception;
+
+import com.personal.marketnote.common.exception.ExternalOperationFailedException;
+import com.personal.marketnote.common.utility.FormatValidator;
+
+import java.io.IOException;
+
+public class GetFasstoDeliveryOutOrdGoodsDetailFailedException extends ExternalOperationFailedException {
+    private static final String DEFAULT_MESSAGE = "파스토 송장별 상품 정보 조회 중 오류가 발생했습니다.";
+
+    public GetFasstoDeliveryOutOrdGoodsDetailFailedException(IOException cause) {
+        super(DEFAULT_MESSAGE, cause);
+    }
+
+    public GetFasstoDeliveryOutOrdGoodsDetailFailedException(String vendorMessage, IOException cause) {
+        super(resolveMessage(vendorMessage), cause);
+    }
+
+    private static String resolveMessage(String vendorMessage) {
+        if (FormatValidator.hasValue(vendorMessage)) {
+            return String.format("파스토 송장별 상품 정보 조회 실패: %s", vendorMessage);
+        }
+        return DEFAULT_MESSAGE;
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/mapper/FasstoDeliveryCommandToRequestMapper.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/mapper/FasstoDeliveryCommandToRequestMapper.java
@@ -27,6 +27,16 @@ public class FasstoDeliveryCommandToRequestMapper {
         );
     }
 
+    public static FasstoDeliveryOutOrdGoodsDetailQuery mapToOutOrdGoodsDetailQuery(
+            GetFasstoDeliveryOutOrdGoodsDetailCommand command
+    ) {
+        return FasstoDeliveryOutOrdGoodsDetailQuery.of(
+                command.customerCode(),
+                command.accessToken(),
+                command.outOrdSlipNo()
+        );
+    }
+
     public static FasstoDeliveryCancelMapper mapToCancelRequest(CancelFasstoDeliveryCommand command) {
         List<FasstoDeliveryCancelItemMapper> cancelRequests = command.deliveries().stream()
                 .map(FasstoDeliveryCommandToRequestMapper::mapCancelItem)

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/vendor/GetFasstoDeliveryOutOrdGoodsDetailCommand.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/vendor/GetFasstoDeliveryOutOrdGoodsDetailCommand.java
@@ -1,0 +1,15 @@
+package com.personal.marketnote.fulfillment.port.in.command.vendor;
+
+public record GetFasstoDeliveryOutOrdGoodsDetailCommand(
+        String customerCode,
+        String accessToken,
+        String outOrdSlipNo
+) {
+    public static GetFasstoDeliveryOutOrdGoodsDetailCommand of(
+            String customerCode,
+            String accessToken,
+            String outOrdSlipNo
+    ) {
+        return new GetFasstoDeliveryOutOrdGoodsDetailCommand(customerCode, accessToken, outOrdSlipNo);
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/result/vendor/FasstoDeliveryOutOrdGoodsInfoResult.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/result/vendor/FasstoDeliveryOutOrdGoodsInfoResult.java
@@ -1,0 +1,15 @@
+package com.personal.marketnote.fulfillment.port.in.result.vendor;
+
+import java.util.List;
+
+public record FasstoDeliveryOutOrdGoodsInfoResult(
+        String invoiceNo,
+        List<FasstoDeliveryOutOrdGoodsItemInfoResult> goodsDeliveredList
+) {
+    public static FasstoDeliveryOutOrdGoodsInfoResult of(
+            String invoiceNo,
+            List<FasstoDeliveryOutOrdGoodsItemInfoResult> goodsDeliveredList
+    ) {
+        return new FasstoDeliveryOutOrdGoodsInfoResult(invoiceNo, goodsDeliveredList);
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/result/vendor/FasstoDeliveryOutOrdGoodsItemInfoResult.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/result/vendor/FasstoDeliveryOutOrdGoodsItemInfoResult.java
@@ -1,0 +1,15 @@
+package com.personal.marketnote.fulfillment.port.in.result.vendor;
+
+public record FasstoDeliveryOutOrdGoodsItemInfoResult(
+        String cstGodCd,
+        String godNm,
+        Integer packQty
+) {
+    public static FasstoDeliveryOutOrdGoodsItemInfoResult of(
+            String cstGodCd,
+            String godNm,
+            Integer packQty
+    ) {
+        return new FasstoDeliveryOutOrdGoodsItemInfoResult(cstGodCd, godNm, packQty);
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/result/vendor/GetFasstoDeliveryOutOrdGoodsDetailResult.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/result/vendor/GetFasstoDeliveryOutOrdGoodsDetailResult.java
@@ -1,0 +1,15 @@
+package com.personal.marketnote.fulfillment.port.in.result.vendor;
+
+import java.util.List;
+
+public record GetFasstoDeliveryOutOrdGoodsDetailResult(
+        Integer dataCount,
+        List<FasstoDeliveryOutOrdGoodsInfoResult> goodsByInvoice
+) {
+    public static GetFasstoDeliveryOutOrdGoodsDetailResult of(
+            Integer dataCount,
+            List<FasstoDeliveryOutOrdGoodsInfoResult> goodsByInvoice
+    ) {
+        return new GetFasstoDeliveryOutOrdGoodsDetailResult(dataCount, goodsByInvoice);
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/usecase/vendor/GetFasstoDeliveryOutOrdGoodsDetailUseCase.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/usecase/vendor/GetFasstoDeliveryOutOrdGoodsDetailUseCase.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.fulfillment.port.in.usecase.vendor;
+
+import com.personal.marketnote.fulfillment.port.in.command.vendor.GetFasstoDeliveryOutOrdGoodsDetailCommand;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.GetFasstoDeliveryOutOrdGoodsDetailResult;
+
+public interface GetFasstoDeliveryOutOrdGoodsDetailUseCase {
+    GetFasstoDeliveryOutOrdGoodsDetailResult getOutOrdGoodsDetail(GetFasstoDeliveryOutOrdGoodsDetailCommand command);
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/vendor/GetFasstoDeliveryOutOrdGoodsDetailPort.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/vendor/GetFasstoDeliveryOutOrdGoodsDetailPort.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.fulfillment.port.out.vendor;
+
+import com.personal.marketnote.fulfillment.domain.vendor.fassto.delivery.FasstoDeliveryOutOrdGoodsDetailQuery;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.GetFasstoDeliveryOutOrdGoodsDetailResult;
+
+public interface GetFasstoDeliveryOutOrdGoodsDetailPort {
+    GetFasstoDeliveryOutOrdGoodsDetailResult getOutOrdGoodsDetail(FasstoDeliveryOutOrdGoodsDetailQuery query);
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/vendor/GetFasstoDeliveryOutOrdGoodsDetailService.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/vendor/GetFasstoDeliveryOutOrdGoodsDetailService.java
@@ -1,0 +1,26 @@
+package com.personal.marketnote.fulfillment.service.vendor;
+
+import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.fulfillment.mapper.FasstoDeliveryCommandToRequestMapper;
+import com.personal.marketnote.fulfillment.port.in.command.vendor.GetFasstoDeliveryOutOrdGoodsDetailCommand;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.GetFasstoDeliveryOutOrdGoodsDetailResult;
+import com.personal.marketnote.fulfillment.port.in.usecase.vendor.GetFasstoDeliveryOutOrdGoodsDetailUseCase;
+import com.personal.marketnote.fulfillment.port.out.vendor.GetFasstoDeliveryOutOrdGoodsDetailPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional(isolation = READ_COMMITTED, readOnly = true)
+public class GetFasstoDeliveryOutOrdGoodsDetailService implements GetFasstoDeliveryOutOrdGoodsDetailUseCase {
+    private final GetFasstoDeliveryOutOrdGoodsDetailPort getFasstoDeliveryOutOrdGoodsDetailPort;
+
+    @Override
+    public GetFasstoDeliveryOutOrdGoodsDetailResult getOutOrdGoodsDetail(GetFasstoDeliveryOutOrdGoodsDetailCommand command) {
+        return getFasstoDeliveryOutOrdGoodsDetailPort.getOutOrdGoodsDetail(
+                FasstoDeliveryCommandToRequestMapper.mapToOutOrdGoodsDetailQuery(command)
+        );
+    }
+}

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/delivery/FasstoDeliveryOutOrdGoodsDetailQuery.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/delivery/FasstoDeliveryOutOrdGoodsDetailQuery.java
@@ -1,0 +1,40 @@
+package com.personal.marketnote.fulfillment.domain.vendor.fassto.delivery;
+
+import com.personal.marketnote.common.utility.FormatValidator;
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+public class FasstoDeliveryOutOrdGoodsDetailQuery {
+    private String customerCode;
+    private String accessToken;
+    private String outOrdSlipNo;
+
+    public static FasstoDeliveryOutOrdGoodsDetailQuery of(
+            String customerCode,
+            String accessToken,
+            String outOrdSlipNo
+    ) {
+        FasstoDeliveryOutOrdGoodsDetailQuery query = FasstoDeliveryOutOrdGoodsDetailQuery.builder()
+                .customerCode(customerCode)
+                .accessToken(accessToken)
+                .outOrdSlipNo(outOrdSlipNo)
+                .build();
+        query.validate();
+        return query;
+    }
+
+    private void validate() {
+        if (FormatValidator.hasNoValue(customerCode)) {
+            throw new IllegalArgumentException("customerCode is required.");
+        }
+        if (FormatValidator.hasNoValue(accessToken)) {
+            throw new IllegalArgumentException("accessToken is required.");
+        }
+        if (FormatValidator.hasNoValue(outOrdSlipNo)) {
+            throw new IllegalArgumentException("outOrdSlipNo is required.");
+        }
+    }
+}


### PR DESCRIPTION
## partially addresses #475
## resolves #683

## Task
- [x] 파스토 출고중인 상품 조회 연동 요청
- [x] 파스토 출고중인 상품 조회 연동 비즈니스 로직
- [x] 파스토 서버에 출고중인 상품 정보 요청
- [x] 200 status code 응답
- [x] Swagger docs