### PR TITLE
[#475][#695] feat: 파스토 입고 상세 정보 조회 기능 추가

### DIFF
--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/FasstoWarehousingController.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/FasstoWarehousingController.java
@@ -2,17 +2,21 @@ package com.personal.marketnote.fulfillment.adapter.in.web.vendor.controller;
 
 import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
 import com.personal.marketnote.fulfillment.adapter.in.web.vendor.controller.apidocs.GetFasstoWarehousingApiDocs;
+import com.personal.marketnote.fulfillment.adapter.in.web.vendor.controller.apidocs.GetFasstoWarehousingDetailApiDocs;
 import com.personal.marketnote.fulfillment.adapter.in.web.vendor.controller.apidocs.RegisterFasstoWarehousingApiDocs;
 import com.personal.marketnote.fulfillment.adapter.in.web.vendor.controller.apidocs.UpdateFasstoWarehousingApiDocs;
 import com.personal.marketnote.fulfillment.adapter.in.web.vendor.mapper.FasstoWarehousingRequestToCommandMapper;
 import com.personal.marketnote.fulfillment.adapter.in.web.vendor.request.RegisterFasstoWarehousingRequest;
 import com.personal.marketnote.fulfillment.adapter.in.web.vendor.request.UpdateFasstoWarehousingRequest;
+import com.personal.marketnote.fulfillment.adapter.in.web.vendor.response.GetFasstoWarehousingDetailResponse;
 import com.personal.marketnote.fulfillment.adapter.in.web.vendor.response.GetFasstoWarehousingResponse;
 import com.personal.marketnote.fulfillment.adapter.in.web.vendor.response.RegisterFasstoWarehousingResponse;
 import com.personal.marketnote.fulfillment.adapter.in.web.vendor.response.UpdateFasstoWarehousingResponse;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.GetFasstoWarehousingDetailResult;
 import com.personal.marketnote.fulfillment.port.in.result.vendor.GetFasstoWarehousingResult;
 import com.personal.marketnote.fulfillment.port.in.result.vendor.RegisterFasstoWarehousingResult;
 import com.personal.marketnote.fulfillment.port.in.result.vendor.UpdateFasstoWarehousingResult;
+import com.personal.marketnote.fulfillment.port.in.usecase.vendor.GetFasstoWarehousingDetailUseCase;
 import com.personal.marketnote.fulfillment.port.in.usecase.vendor.GetFasstoWarehousingUseCase;
 import com.personal.marketnote.fulfillment.port.in.usecase.vendor.RegisterFasstoWarehousingUseCase;
 import com.personal.marketnote.fulfillment.port.in.usecase.vendor.UpdateFasstoWarehousingUseCase;
@@ -36,6 +40,7 @@ import static com.personal.marketnote.common.utility.ApiConstant.ADMIN_POINTCUT;
 public class FasstoWarehousingController {
     private final RegisterFasstoWarehousingUseCase registerFasstoWarehousingUseCase;
     private final GetFasstoWarehousingUseCase getFasstoWarehousingUseCase;
+    private final GetFasstoWarehousingDetailUseCase getFasstoWarehousingDetailUseCase;
     private final UpdateFasstoWarehousingUseCase updateFasstoWarehousingUseCase;
 
     /**
@@ -115,6 +120,46 @@ public class FasstoWarehousingController {
                         HttpStatus.OK,
                         DEFAULT_SUCCESS_CODE,
                         "파스토 상품 입고 목록 조회 성공"
+                ),
+                HttpStatus.OK
+        );
+    }
+
+    /**
+     * (관리자) 파스토 상품 입고 상세 조회
+     *
+     * @param customerCode 파스토 고객사 코드
+     * @param slipNo       파스토 입고요청번호
+     * @param accessToken  파스토 액세스 토큰
+     * @param ordNo        주문번호
+     * @Author 성효빈
+     * @Date 2026-02-14
+     * @Description 파스토 상품 입고 상세 정보를 조회합니다.
+     */
+    @GetMapping("/detail/{customerCode}/{slipNo}")
+    @PreAuthorize(ADMIN_POINTCUT)
+    @GetFasstoWarehousingDetailApiDocs
+    public ResponseEntity<BaseResponse<GetFasstoWarehousingDetailResponse>> getWarehousingDetail(
+            @PathVariable String customerCode,
+            @PathVariable String slipNo,
+            @RequestHeader("accessToken") String accessToken,
+            @RequestParam(required = false) String ordNo
+    ) {
+        GetFasstoWarehousingDetailResult result = getFasstoWarehousingDetailUseCase.getWarehousingDetail(
+                FasstoWarehousingRequestToCommandMapper.mapToWarehousingDetailCommand(
+                        customerCode,
+                        accessToken,
+                        slipNo,
+                        ordNo
+                )
+        );
+
+        return new ResponseEntity<>(
+                BaseResponse.of(
+                        GetFasstoWarehousingDetailResponse.from(result),
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "파스토 상품 입고 상세 조회 성공"
                 ),
                 HttpStatus.OK
         );

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/apidocs/GetFasstoDeliveryStatusesApiDocs.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/apidocs/GetFasstoDeliveryStatusesApiDocs.java
@@ -9,11 +9,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Inherited;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+import java.lang.annotation.*;
 
 @Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
 @Retention(RetentionPolicy.RUNTIME)

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/apidocs/GetFasstoWarehousingDetailApiDocs.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/apidocs/GetFasstoWarehousingDetailApiDocs.java
@@ -1,0 +1,221 @@
+package com.personal.marketnote.fulfillment.adapter.in.web.vendor.controller.apidocs;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Operation(
+        summary = "(관리자) 파스토 상품 입고 상세 조회",
+        description = """
+                작성일자: 2026-02-14
+                
+                작성자: 성효빈
+                
+                ---
+                
+                ## Description
+                
+                파스토 상품 입고 상세 정보를 조회합니다.
+                
+                ---
+                
+                ## Request
+                
+                | **키** | **위치** | **타입** | **설명** | **필수 여부** | **예시** |
+                | --- | --- | --- | --- | --- | --- |
+                | accessToken | header | string | 파스토 액세스 토큰 | Y | eefae1befa4c11f0be620ab49498ff55 |
+                | customerCode | path | string | 파스토 고객사 코드 | Y | 94388 |
+                | slipNo | path | string | 입고요청번호 | Y | TESTIO260119000005 |
+                | ordNo | query | string | 주문번호 | N | 12345 |
+                
+                ---
+                
+                ## Response
+                
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | statusCode | number | 상태 코드 | 200: 성공 / 400: 클라이언트 요청 오류 / 401: 인증 실패 / 403: 인가 실패 / 500: 그 외 |
+                | code | string | 응답 코드 | "SUC01" / "BAD_REQUEST" / "UNAUTHORIZED" / "FORBIDDEN" / "INTERNAL_SERVER_ERROR" |
+                | timestamp | string(datetime) | 응답 일시 | "2026-02-14T12:12:30.013" |
+                | content | object | 응답 본문 | { ... } |
+                | message | string | 처리 결과 | "파스토 상품 입고 상세 조회 성공" |
+                
+                ---
+                
+                ### Response > content
+                
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | dataCount | number | 조회 건수 | 1 |
+                | details | array | 입고 상세 목록 | [ ... ] |
+                
+                ---
+                
+                ### Response > content > details
+                
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | ordDt | string | 입고일자 | "20260119" |
+                | whCd | string | 창고코드 | "TEST" |
+                | whNm | string | 창고명 | "테스트" |
+                | slipNo | string | 전표번호(입고요청번호) | "TESTIO260119000005" |
+                | ordNo | string | 주문번호 | "" |
+                | cstCd | string | 고객사코드 | "94388" |
+                | cstNm | string | 고객사명 | "마켓노트 주식회사 테스트" |
+                | supCd | string | FSS공급사코드 | "99999999" |
+                | supNm | string | 공급사명 | "미지정 공급사" |
+                | cstSupCd | string | 고객사공급사코드 | null |
+                | sku | number | sku(상품 종류수) | 1 |
+                | ordQty | number | 입고 요청 수량 | 1 |
+                | inQty | number | 입고 완료 수량 | 0 |
+                | tarQty | number | 대상 수량 | 1 |
+                | inWay | string | 입고방식(01:택배,02:차량) | "01" |
+                | inWayNm | string | 입고방식명 | "택배" |
+                | parcelComp | string | 택배사명 | "" |
+                | parcelInvoiceNo | string | 입고시 송장번호 | "" |
+                | wrkStat | string | 작업상태코드(1:입고요청,2:검수중,3:검수완료,4:입고완료,5:입고취소) | "1" |
+                | wrkStatNm | string | 작업상태명 | "입고요청" |
+                | emgrYn | string | 긴급입고여부 | null |
+                | remark | string | 입고요청내용 | "" |
+                | goods | array | 입고 상품 목록 | [ ... ] |
+                
+                ---
+                
+                ### Response > content > details > goods
+                
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | ordDt | string | 입고일자 | "20260119" |
+                | whCd | string | 창고코드 | "TEST" |
+                | slipNo | string | 전표번호(입고요청번호) | "TESTIO260119000005" |
+                | cstCd | string | 고객사코드 | "94388" |
+                | shopCd | string | 공급사코드 | null |
+                | supCd | string | FSS공급사코드 | "99999999" |
+                | godCd | string | 상품코드 | "943881" |
+                | cstGodCd | string | 고객사상품코드 | "1" |
+                | godNm | string | 상품명 | "테스트 상품1" |
+                | orgGodCd | string | 원상품코드 | null |
+                | godType | string | 상품유형 | null |
+                | godTypeNm | string | 상품유형명 | null |
+                | distTermDt | string | 유통기한 | "" |
+                | stockQty | number | 재고수량 | 0 |
+                | ordQty | number | 지시수량 | 1 |
+                | addGodOrdQty | number | 딸린상품 지시수량 | 0 |
+                | ordQtySum | number | 지시수량 합계 | 1 |
+                | giftDiv | string | 사은품구분 | "01" |
+                | addType | string | 추가타입 | null |
+                | emgrYn | string | 긴급여부 | null |
+                """,
+        security = {@SecurityRequirement(name = "bearer")},
+        parameters = {
+                @Parameter(
+                        name = "accessToken",
+                        description = "파스토 액세스 토큰",
+                        in = ParameterIn.HEADER,
+                        required = true,
+                        schema = @Schema(type = "string", example = "eefae1befa4c11f0be620ab49498ff55")
+                ),
+                @Parameter(
+                        name = "customerCode",
+                        description = "파스토 고객사 코드",
+                        in = ParameterIn.PATH,
+                        required = true,
+                        schema = @Schema(type = "string", example = "94388")
+                ),
+                @Parameter(
+                        name = "slipNo",
+                        description = "입고요청번호",
+                        in = ParameterIn.PATH,
+                        required = true,
+                        schema = @Schema(type = "string", example = "TESTIO260119000005")
+                ),
+                @Parameter(
+                        name = "ordNo",
+                        description = "주문번호",
+                        in = ParameterIn.QUERY,
+                        required = false,
+                        schema = @Schema(type = "string", example = "12345")
+                )
+        },
+        responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "파스토 상품 입고 상세 조회 성공",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 200,
+                                          "code": "SUC01",
+                                          "timestamp": "2026-02-14T12:12:30.013",
+                                          "content": {
+                                            "dataCount": 1,
+                                            "details": [
+                                              {
+                                                "ordDt": "20260119",
+                                                "whCd": "TEST",
+                                                "whNm": "테스트",
+                                                "slipNo": "TESTIO260119000005",
+                                                "ordNo": "",
+                                                "cstCd": "94388",
+                                                "cstNm": "마켓노트 주식회사 테스트",
+                                                "supCd": "99999999",
+                                                "supNm": "미지정 공급사",
+                                                "cstSupCd": null,
+                                                "sku": 1,
+                                                "ordQty": 1,
+                                                "inQty": 0,
+                                                "tarQty": 1,
+                                                "inWay": "01",
+                                                "inWayNm": "택배",
+                                                "parcelComp": "",
+                                                "parcelInvoiceNo": "",
+                                                "wrkStat": "1",
+                                                "wrkStatNm": "입고요청",
+                                                "emgrYn": null,
+                                                "remark": "",
+                                                "goods": [
+                                                  {
+                                                    "ordDt": "20260119",
+                                                    "whCd": "TEST",
+                                                    "slipNo": "TESTIO260119000005",
+                                                    "cstCd": "94388",
+                                                    "shopCd": null,
+                                                    "supCd": "99999999",
+                                                    "godCd": "943881",
+                                                    "cstGodCd": "1",
+                                                    "godNm": "테스트 상품1",
+                                                    "orgGodCd": null,
+                                                    "godType": null,
+                                                    "godTypeNm": null,
+                                                    "distTermDt": "",
+                                                    "stockQty": 0,
+                                                    "ordQty": 1,
+                                                    "addGodOrdQty": 0,
+                                                    "ordQtySum": 1,
+                                                    "giftDiv": "01",
+                                                    "addType": null,
+                                                    "emgrYn": null
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          "message": "파스토 상품 입고 상세 조회 성공"
+                                        }
+                                        """)
+                        )
+                )
+        }
+)
+public @interface GetFasstoWarehousingDetailApiDocs {
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/mapper/FasstoWarehousingRequestToCommandMapper.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/mapper/FasstoWarehousingRequestToCommandMapper.java
@@ -33,6 +33,15 @@ public class FasstoWarehousingRequestToCommandMapper {
         return GetFasstoWarehousingCommand.of(customerCode, accessToken, startDate, endDate, inWay, ordNo, wrkStat);
     }
 
+    public static GetFasstoWarehousingDetailCommand mapToWarehousingDetailCommand(
+            String customerCode,
+            String accessToken,
+            String slipNo,
+            String ordNo
+    ) {
+        return GetFasstoWarehousingDetailCommand.of(customerCode, accessToken, slipNo, ordNo);
+    }
+
     public static UpdateFasstoWarehousingCommand mapToUpdateCommand(
             String customerCode,
             String accessToken,

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/response/GetFasstoWarehousingDetailResponse.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/response/GetFasstoWarehousingDetailResponse.java
@@ -1,0 +1,15 @@
+package com.personal.marketnote.fulfillment.adapter.in.web.vendor.response;
+
+import com.personal.marketnote.fulfillment.port.in.result.vendor.FasstoWarehousingDetailInfoResult;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.GetFasstoWarehousingDetailResult;
+
+import java.util.List;
+
+public record GetFasstoWarehousingDetailResponse(
+        Integer dataCount,
+        List<FasstoWarehousingDetailInfoResult> details
+) {
+    public static GetFasstoWarehousingDetailResponse from(GetFasstoWarehousingDetailResult result) {
+        return new GetFasstoWarehousingDetailResponse(result.dataCount(), result.details());
+    }
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoWarehousingDetailGoodsResponse.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoWarehousingDetailGoodsResponse.java
@@ -1,0 +1,28 @@
+package com.personal.marketnote.fulfillment.adapter.out.vendor.fassto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record FasstoWarehousingDetailGoodsResponse(
+        String ordDt,
+        String whCd,
+        String slipNo,
+        String cstCd,
+        String shopCd,
+        String supCd,
+        String godCd,
+        String cstGodCd,
+        String godNm,
+        String orgGodCd,
+        String godType,
+        String godTypeNm,
+        String distTermDt,
+        Integer stockQty,
+        Integer ordQty,
+        Integer addGodOrdQty,
+        Integer ordQtySum,
+        String giftDiv,
+        String addType,
+        String emgrYn
+) {
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoWarehousingDetailItemResponse.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoWarehousingDetailItemResponse.java
@@ -1,0 +1,33 @@
+package com.personal.marketnote.fulfillment.adapter.out.vendor.fassto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record FasstoWarehousingDetailItemResponse(
+        String ordDt,
+        String whCd,
+        String whNm,
+        String slipNo,
+        String ordNo,
+        String cstCd,
+        String cstNm,
+        String supCd,
+        String supNm,
+        String cstSupCd,
+        Integer sku,
+        Integer ordQty,
+        Integer inQty,
+        Integer tarQty,
+        String inWay,
+        String inWayNm,
+        String parcelComp,
+        String parcelInvoiceNo,
+        String wrkStat,
+        String wrkStatNm,
+        String emgrYn,
+        String remark,
+        List<FasstoWarehousingDetailGoodsResponse> goods
+) {
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoWarehousingDetailListResponse.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoWarehousingDetailListResponse.java
@@ -1,0 +1,16 @@
+package com.personal.marketnote.fulfillment.adapter.out.vendor.fassto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record FasstoWarehousingDetailListResponse(
+        FasstoResponseHeader header,
+        List<FasstoWarehousingDetailItemResponse> data,
+        FasstoErrorInfo errorInfo
+) implements FasstoApiResponse {
+    public boolean isSuccess() {
+        return header != null && header.isSuccess() && data != null;
+    }
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/resources/application.yml
+++ b/fulfillment-service/fulfillment-adapters/src/main/resources/application.yml
@@ -58,6 +58,7 @@ vendor:
       goods-element-path: ${FASSTO_GOODS_ELEMENT_PATH:/api/v1/goods/element/{customerCode}}
       warehousing-path: ${FASSTO_WAREHOUSING_PATH:/api/v1/warehousing/{customerCode}}
       warehousing-list-path: ${FASSTO_WAREHOUSING_LIST_PATH:/api/v1/warehousing/{customerCode}/{startDate}/{endDate}}
+      warehousing-detail-path: ${FASSTO_WAREHOUSING_DETAIL_PATH:/api/v1/warehousing/detail/{customerCode}/{slipNo}}
       delivery-path: ${FASSTO_DELIVERY_PATH:/api/v1/delivery/parcel/{customerCode}}
       delivery-list-path: ${FASSTO_DELIVERY_LIST_PATH:/api/v1/delivery/{customerCode}/{startDate}/{endDate}/{status}/{outDiv}}
       delivery-status-path: ${FASSTO_DELIVERY_STATUS_PATH:/api/v1/delivery/parcel/{customerCode}/{startDate}/{endDate}/{outDiv}}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/configuration/FasstoAuthProperties.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/configuration/FasstoAuthProperties.java
@@ -22,6 +22,7 @@ public class FasstoAuthProperties {
     private String goodsElementPath = "/api/v1/goods/element/{customerCode}";
     private String warehousingPath = "/api/v1/warehousing/{customerCode}";
     private String warehousingListPath = "/api/v1/warehousing/{customerCode}/{startDate}/{endDate}";
+    private String warehousingDetailPath = "/api/v1/warehousing/detail/{customerCode}/{slipNo}";
     private String deliveryPath = "/api/v1/delivery/parcel/{customerCode}";
     private String deliveryListPath = "/api/v1/delivery/{customerCode}/{startDate}/{endDate}/{status}/{outDiv}";
     private String deliveryStatusPath = "/api/v1/delivery/parcel/{customerCode}/{startDate}/{endDate}/{outDiv}";

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/GetFasstoWarehousingDetailFailedException.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/GetFasstoWarehousingDetailFailedException.java
@@ -1,0 +1,25 @@
+package com.personal.marketnote.fulfillment.exception;
+
+import com.personal.marketnote.common.exception.ExternalOperationFailedException;
+import com.personal.marketnote.common.utility.FormatValidator;
+
+import java.io.IOException;
+
+public class GetFasstoWarehousingDetailFailedException extends ExternalOperationFailedException {
+    private static final String DEFAULT_MESSAGE = "파스토 입고 상세 조회 중 오류가 발생했습니다.";
+
+    public GetFasstoWarehousingDetailFailedException(IOException cause) {
+        super(DEFAULT_MESSAGE, cause);
+    }
+
+    public GetFasstoWarehousingDetailFailedException(String vendorMessage, IOException cause) {
+        super(resolveMessage(vendorMessage), cause);
+    }
+
+    private static String resolveMessage(String vendorMessage) {
+        if (FormatValidator.hasValue(vendorMessage)) {
+            return String.format("파스토 입고 상세 조회 실패: %s", vendorMessage);
+        }
+        return DEFAULT_MESSAGE;
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/mapper/FasstoWarehousingCommandToRequestMapper.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/mapper/FasstoWarehousingCommandToRequestMapper.java
@@ -1,9 +1,6 @@
 package com.personal.marketnote.fulfillment.mapper;
 
-import com.personal.marketnote.fulfillment.domain.vendor.fassto.warehousing.FasstoWarehousingGoodsMapper;
-import com.personal.marketnote.fulfillment.domain.vendor.fassto.warehousing.FasstoWarehousingItemMapper;
-import com.personal.marketnote.fulfillment.domain.vendor.fassto.warehousing.FasstoWarehousingMapper;
-import com.personal.marketnote.fulfillment.domain.vendor.fassto.warehousing.FasstoWarehousingQuery;
+import com.personal.marketnote.fulfillment.domain.vendor.fassto.warehousing.*;
 import com.personal.marketnote.fulfillment.port.in.command.vendor.*;
 
 import java.util.List;
@@ -30,6 +27,15 @@ public class FasstoWarehousingCommandToRequestMapper {
                 command.inWay(),
                 command.ordNo(),
                 command.wrkStat()
+        );
+    }
+
+    public static FasstoWarehousingDetailQuery mapToDetailQuery(GetFasstoWarehousingDetailCommand command) {
+        return FasstoWarehousingDetailQuery.of(
+                command.customerCode(),
+                command.accessToken(),
+                command.slipNo(),
+                command.ordNo()
         );
     }
 

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/vendor/GetFasstoWarehousingDetailCommand.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/vendor/GetFasstoWarehousingDetailCommand.java
@@ -1,0 +1,17 @@
+package com.personal.marketnote.fulfillment.port.in.command.vendor;
+
+public record GetFasstoWarehousingDetailCommand(
+        String customerCode,
+        String accessToken,
+        String slipNo,
+        String ordNo
+) {
+    public static GetFasstoWarehousingDetailCommand of(
+            String customerCode,
+            String accessToken,
+            String slipNo,
+            String ordNo
+    ) {
+        return new GetFasstoWarehousingDetailCommand(customerCode, accessToken, slipNo, ordNo);
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/result/vendor/FasstoWarehousingDetailGoodsInfoResult.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/result/vendor/FasstoWarehousingDetailGoodsInfoResult.java
@@ -1,0 +1,70 @@
+package com.personal.marketnote.fulfillment.port.in.result.vendor;
+
+public record FasstoWarehousingDetailGoodsInfoResult(
+        String ordDt,
+        String whCd,
+        String slipNo,
+        String cstCd,
+        String shopCd,
+        String supCd,
+        String godCd,
+        String cstGodCd,
+        String godNm,
+        String orgGodCd,
+        String godType,
+        String godTypeNm,
+        String distTermDt,
+        Integer stockQty,
+        Integer ordQty,
+        Integer addGodOrdQty,
+        Integer ordQtySum,
+        String giftDiv,
+        String addType,
+        String emgrYn
+) {
+    public static FasstoWarehousingDetailGoodsInfoResult of(
+            String ordDt,
+            String whCd,
+            String slipNo,
+            String cstCd,
+            String shopCd,
+            String supCd,
+            String godCd,
+            String cstGodCd,
+            String godNm,
+            String orgGodCd,
+            String godType,
+            String godTypeNm,
+            String distTermDt,
+            Integer stockQty,
+            Integer ordQty,
+            Integer addGodOrdQty,
+            Integer ordQtySum,
+            String giftDiv,
+            String addType,
+            String emgrYn
+    ) {
+        return new FasstoWarehousingDetailGoodsInfoResult(
+                ordDt,
+                whCd,
+                slipNo,
+                cstCd,
+                shopCd,
+                supCd,
+                godCd,
+                cstGodCd,
+                godNm,
+                orgGodCd,
+                godType,
+                godTypeNm,
+                distTermDt,
+                stockQty,
+                ordQty,
+                addGodOrdQty,
+                ordQtySum,
+                giftDiv,
+                addType,
+                emgrYn
+        );
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/result/vendor/FasstoWarehousingDetailInfoResult.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/result/vendor/FasstoWarehousingDetailInfoResult.java
@@ -1,0 +1,81 @@
+package com.personal.marketnote.fulfillment.port.in.result.vendor;
+
+import java.util.List;
+
+public record FasstoWarehousingDetailInfoResult(
+        String ordDt,
+        String whCd,
+        String whNm,
+        String slipNo,
+        String ordNo,
+        String cstCd,
+        String cstNm,
+        String supCd,
+        String supNm,
+        String cstSupCd,
+        Integer sku,
+        Integer ordQty,
+        Integer inQty,
+        Integer tarQty,
+        String inWay,
+        String inWayNm,
+        String parcelComp,
+        String parcelInvoiceNo,
+        String wrkStat,
+        String wrkStatNm,
+        String emgrYn,
+        String remark,
+        List<FasstoWarehousingDetailGoodsInfoResult> goods
+) {
+    public static FasstoWarehousingDetailInfoResult of(
+            String ordDt,
+            String whCd,
+            String whNm,
+            String slipNo,
+            String ordNo,
+            String cstCd,
+            String cstNm,
+            String supCd,
+            String supNm,
+            String cstSupCd,
+            Integer sku,
+            Integer ordQty,
+            Integer inQty,
+            Integer tarQty,
+            String inWay,
+            String inWayNm,
+            String parcelComp,
+            String parcelInvoiceNo,
+            String wrkStat,
+            String wrkStatNm,
+            String emgrYn,
+            String remark,
+            List<FasstoWarehousingDetailGoodsInfoResult> goods
+    ) {
+        return new FasstoWarehousingDetailInfoResult(
+                ordDt,
+                whCd,
+                whNm,
+                slipNo,
+                ordNo,
+                cstCd,
+                cstNm,
+                supCd,
+                supNm,
+                cstSupCd,
+                sku,
+                ordQty,
+                inQty,
+                tarQty,
+                inWay,
+                inWayNm,
+                parcelComp,
+                parcelInvoiceNo,
+                wrkStat,
+                wrkStatNm,
+                emgrYn,
+                remark,
+                goods
+        );
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/result/vendor/GetFasstoWarehousingDetailResult.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/result/vendor/GetFasstoWarehousingDetailResult.java
@@ -1,0 +1,15 @@
+package com.personal.marketnote.fulfillment.port.in.result.vendor;
+
+import java.util.List;
+
+public record GetFasstoWarehousingDetailResult(
+        Integer dataCount,
+        List<FasstoWarehousingDetailInfoResult> details
+) {
+    public static GetFasstoWarehousingDetailResult of(
+            Integer dataCount,
+            List<FasstoWarehousingDetailInfoResult> details
+    ) {
+        return new GetFasstoWarehousingDetailResult(dataCount, details);
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/usecase/vendor/GetFasstoWarehousingDetailUseCase.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/usecase/vendor/GetFasstoWarehousingDetailUseCase.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.fulfillment.port.in.usecase.vendor;
+
+import com.personal.marketnote.fulfillment.port.in.command.vendor.GetFasstoWarehousingDetailCommand;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.GetFasstoWarehousingDetailResult;
+
+public interface GetFasstoWarehousingDetailUseCase {
+    GetFasstoWarehousingDetailResult getWarehousingDetail(GetFasstoWarehousingDetailCommand command);
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/vendor/GetFasstoWarehousingDetailPort.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/vendor/GetFasstoWarehousingDetailPort.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.fulfillment.port.out.vendor;
+
+import com.personal.marketnote.fulfillment.domain.vendor.fassto.warehousing.FasstoWarehousingDetailQuery;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.GetFasstoWarehousingDetailResult;
+
+public interface GetFasstoWarehousingDetailPort {
+    GetFasstoWarehousingDetailResult getWarehousingDetail(FasstoWarehousingDetailQuery query);
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/vendor/GetFasstoWarehousingDetailService.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/vendor/GetFasstoWarehousingDetailService.java
@@ -1,0 +1,26 @@
+package com.personal.marketnote.fulfillment.service.vendor;
+
+import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.fulfillment.mapper.FasstoWarehousingCommandToRequestMapper;
+import com.personal.marketnote.fulfillment.port.in.command.vendor.GetFasstoWarehousingDetailCommand;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.GetFasstoWarehousingDetailResult;
+import com.personal.marketnote.fulfillment.port.in.usecase.vendor.GetFasstoWarehousingDetailUseCase;
+import com.personal.marketnote.fulfillment.port.out.vendor.GetFasstoWarehousingDetailPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional(isolation = READ_COMMITTED, readOnly = true)
+public class GetFasstoWarehousingDetailService implements GetFasstoWarehousingDetailUseCase {
+    private final GetFasstoWarehousingDetailPort getFasstoWarehousingDetailPort;
+
+    @Override
+    public GetFasstoWarehousingDetailResult getWarehousingDetail(GetFasstoWarehousingDetailCommand command) {
+        return getFasstoWarehousingDetailPort.getWarehousingDetail(
+                FasstoWarehousingCommandToRequestMapper.mapToDetailQuery(command)
+        );
+    }
+}

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/warehousing/FasstoWarehousingDetailQuery.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/warehousing/FasstoWarehousingDetailQuery.java
@@ -1,0 +1,43 @@
+package com.personal.marketnote.fulfillment.domain.vendor.fassto.warehousing;
+
+import com.personal.marketnote.common.utility.FormatValidator;
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+public class FasstoWarehousingDetailQuery {
+    private String customerCode;
+    private String accessToken;
+    private String slipNo;
+    private String ordNo;
+
+    public static FasstoWarehousingDetailQuery of(
+            String customerCode,
+            String accessToken,
+            String slipNo,
+            String ordNo
+    ) {
+        FasstoWarehousingDetailQuery query = FasstoWarehousingDetailQuery.builder()
+                .customerCode(customerCode)
+                .accessToken(accessToken)
+                .slipNo(slipNo)
+                .ordNo(ordNo)
+                .build();
+        query.validate();
+        return query;
+    }
+
+    private void validate() {
+        if (FormatValidator.hasNoValue(customerCode)) {
+            throw new IllegalArgumentException("customerCode is required.");
+        }
+        if (FormatValidator.hasNoValue(accessToken)) {
+            throw new IllegalArgumentException("accessToken is required.");
+        }
+        if (FormatValidator.hasNoValue(slipNo)) {
+            throw new IllegalArgumentException("slipNo is required.");
+        }
+    }
+}

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/usecase/option/RegisterProductOptionsUseCase.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/usecase/option/RegisterProductOptionsUseCase.java
@@ -4,6 +4,14 @@ import com.personal.marketnote.product.port.in.command.RegisterProductOptionsCom
 import com.personal.marketnote.product.port.in.result.option.UpdateProductOptionsResult;
 
 public interface RegisterProductOptionsUseCase {
+    /**
+     * 상품 옵션 등록
+     *
+     * @param userId  사용자 ID
+     * @param isAdmin 관리자 여부
+     * @param command 상품 옵션 등록 커맨드
+     * @return 상품 옵션 등록 결과 {@link UpdateProductOptionsResult}
+     */
     UpdateProductOptionsResult registerProductOptions(
             Long userId, boolean isAdmin, RegisterProductOptionsCommand command
     );

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/usecase/pricepolicy/DeletePricePolicyUseCase.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/usecase/pricepolicy/DeletePricePolicyUseCase.java
@@ -1,7 +1,13 @@
 package com.personal.marketnote.product.port.in.usecase.pricepolicy;
 
 public interface DeletePricePolicyUseCase {
+    /**
+     * 가격 정책 삭제
+     *
+     * @param userId        사용자 ID
+     * @param isAdmin       관리자 여부
+     * @param productId     상품 ID
+     * @param pricePolicyId 가격 정책 ID
+     */
     void delete(Long userId, boolean isAdmin, Long productId, Long pricePolicyId);
 }
-
-

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/usecase/pricepolicy/RegisterPricePolicyUseCase.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/usecase/pricepolicy/RegisterPricePolicyUseCase.java
@@ -5,7 +5,7 @@ import com.personal.marketnote.product.port.in.result.pricepolicy.RegisterPriceP
 
 public interface RegisterPricePolicyUseCase {
     /**
-     * @param userId 사용자 ID
+     * @param userId  사용자 ID
      * @param isAdmin 관리자 여부
      * @param command 가격 정책 등록 커맨드
      * @return 가격 정책 등록 결과 {@link RegisterPricePolicyResult}

--- a/product-service/product-application/src/test/java/com/personal/marketnote/product/service/pricepolicy/GetPricePoliciesUseCaseTest.java
+++ b/product-service/product-application/src/test/java/com/personal/marketnote/product/service/pricepolicy/GetPricePoliciesUseCaseTest.java
@@ -18,7 +18,8 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class GetPricePoliciesUseCaseTest {


### PR DESCRIPTION
## partially addresses #475
## resolves #695

## Task
- [x] 파스토 출고중인 상품 조회 연동 요청
- [x] 파스토 출고중인 상품 조회 연동 비즈니스 로직
- [x] 파스토 서버에 출고중인 상품 정보 요청
- [x] 200 status code 응답
- [x] Swagger docs