### PR TITLE
[#475][#696] feat: 파스토 비정상 입고 상품 정보 조회 기능 추가

### DIFF
--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/FasstoWarehousingController.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/FasstoWarehousingController.java
@@ -1,25 +1,13 @@
 package com.personal.marketnote.fulfillment.adapter.in.web.vendor.controller;
 
 import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
-import com.personal.marketnote.fulfillment.adapter.in.web.vendor.controller.apidocs.GetFasstoWarehousingApiDocs;
-import com.personal.marketnote.fulfillment.adapter.in.web.vendor.controller.apidocs.GetFasstoWarehousingDetailApiDocs;
-import com.personal.marketnote.fulfillment.adapter.in.web.vendor.controller.apidocs.RegisterFasstoWarehousingApiDocs;
-import com.personal.marketnote.fulfillment.adapter.in.web.vendor.controller.apidocs.UpdateFasstoWarehousingApiDocs;
+import com.personal.marketnote.fulfillment.adapter.in.web.vendor.controller.apidocs.*;
 import com.personal.marketnote.fulfillment.adapter.in.web.vendor.mapper.FasstoWarehousingRequestToCommandMapper;
 import com.personal.marketnote.fulfillment.adapter.in.web.vendor.request.RegisterFasstoWarehousingRequest;
 import com.personal.marketnote.fulfillment.adapter.in.web.vendor.request.UpdateFasstoWarehousingRequest;
-import com.personal.marketnote.fulfillment.adapter.in.web.vendor.response.GetFasstoWarehousingDetailResponse;
-import com.personal.marketnote.fulfillment.adapter.in.web.vendor.response.GetFasstoWarehousingResponse;
-import com.personal.marketnote.fulfillment.adapter.in.web.vendor.response.RegisterFasstoWarehousingResponse;
-import com.personal.marketnote.fulfillment.adapter.in.web.vendor.response.UpdateFasstoWarehousingResponse;
-import com.personal.marketnote.fulfillment.port.in.result.vendor.GetFasstoWarehousingDetailResult;
-import com.personal.marketnote.fulfillment.port.in.result.vendor.GetFasstoWarehousingResult;
-import com.personal.marketnote.fulfillment.port.in.result.vendor.RegisterFasstoWarehousingResult;
-import com.personal.marketnote.fulfillment.port.in.result.vendor.UpdateFasstoWarehousingResult;
-import com.personal.marketnote.fulfillment.port.in.usecase.vendor.GetFasstoWarehousingDetailUseCase;
-import com.personal.marketnote.fulfillment.port.in.usecase.vendor.GetFasstoWarehousingUseCase;
-import com.personal.marketnote.fulfillment.port.in.usecase.vendor.RegisterFasstoWarehousingUseCase;
-import com.personal.marketnote.fulfillment.port.in.usecase.vendor.UpdateFasstoWarehousingUseCase;
+import com.personal.marketnote.fulfillment.adapter.in.web.vendor.response.*;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.*;
+import com.personal.marketnote.fulfillment.port.in.usecase.vendor.*;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -41,6 +29,7 @@ public class FasstoWarehousingController {
     private final RegisterFasstoWarehousingUseCase registerFasstoWarehousingUseCase;
     private final GetFasstoWarehousingUseCase getFasstoWarehousingUseCase;
     private final GetFasstoWarehousingDetailUseCase getFasstoWarehousingDetailUseCase;
+    private final GetFasstoWarehousingAbnormalUseCase getFasstoWarehousingAbnormalUseCase;
     private final UpdateFasstoWarehousingUseCase updateFasstoWarehousingUseCase;
 
     /**
@@ -160,6 +149,46 @@ public class FasstoWarehousingController {
                         HttpStatus.OK,
                         DEFAULT_SUCCESS_CODE,
                         "파스토 상품 입고 상세 조회 성공"
+                ),
+                HttpStatus.OK
+        );
+    }
+
+    /**
+     * (관리자) 파스토 비정상 입고 상품 정보 조회
+     *
+     * @param customerCode 파스토 고객사 코드
+     * @param whCd         센터
+     * @param slipNo       파스토 입고요청번호
+     * @param accessToken  파스토 액세스 토큰
+     * @Author 성효빈
+     * @Date 2026-02-14
+     * @Description 파스토 비정상 입고 상품 정보를 조회합니다.
+     */
+    @GetMapping("/abnormal/{customerCode}/{whCd}/{slipNo}")
+    @PreAuthorize(ADMIN_POINTCUT)
+    @GetFasstoWarehousingAbnormalApiDocs
+    public ResponseEntity<BaseResponse<GetFasstoWarehousingAbnormalResponse>> getWarehousingAbnormal(
+            @PathVariable String customerCode,
+            @PathVariable String whCd,
+            @PathVariable String slipNo,
+            @RequestHeader("accessToken") String accessToken
+    ) {
+        GetFasstoWarehousingAbnormalResult result = getFasstoWarehousingAbnormalUseCase.getWarehousingAbnormal(
+                FasstoWarehousingRequestToCommandMapper.mapToWarehousingAbnormalCommand(
+                        customerCode,
+                        accessToken,
+                        whCd,
+                        slipNo
+                )
+        );
+
+        return new ResponseEntity<>(
+                BaseResponse.of(
+                        GetFasstoWarehousingAbnormalResponse.from(result),
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "파스토 비정상 입고 상품 조회 성공"
                 ),
                 HttpStatus.OK
         );

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/apidocs/GetFasstoWarehousingAbnormalApiDocs.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/apidocs/GetFasstoWarehousingAbnormalApiDocs.java
@@ -1,0 +1,139 @@
+package com.personal.marketnote.fulfillment.adapter.in.web.vendor.controller.apidocs;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Operation(
+        summary = "(관리자) 파스토 비정상 입고 상품 정보 조회",
+        description = """
+                작성일자: 2026-02-14
+                
+                작성자: 성효빈
+                
+                ---
+                
+                ## Description
+                
+                파스토 비정상 입고 상품 정보를 조회합니다.
+                
+                ---
+                
+                ## Request
+                
+                | **키** | **위치** | **타입** | **설명** | **필수 여부** | **예시** |
+                | --- | --- | --- | --- | --- | --- |
+                | accessToken | header | string | 파스토 액세스 토큰 | Y | eefae1befa4c11f0be620ab49498ff55 |
+                | customerCode | path | string | 파스토 고객사 코드 | Y | 94388 |
+                | whCd | path | string | 센터 | Y | TEST |
+                | slipNo | path | string | 입고요청번호 | Y | TESTIO260119000005 |
+                
+                ---
+                
+                ## Response
+                
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | statusCode | number | 상태 코드 | 200: 성공 / 400: 클라이언트 요청 오류 / 401: 인증 실패 / 403: 인가 실패 / 500: 그 외 |
+                | code | string | 응답 코드 | "SUC01" / "BAD_REQUEST" / "UNAUTHORIZED" / "FORBIDDEN" / "INTERNAL_SERVER_ERROR" |
+                | timestamp | string(datetime) | 응답 일시 | "2026-02-14T12:12:30.013" |
+                | content | object | 응답 본문 | { ... } |
+                | message | string | 처리 결과 | "파스토 비정상 입고 상품 조회 성공" |
+                
+                ---
+                
+                ### Response > content
+                
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | dataCount | number | 조회 건수 | 0 |
+                | abnormals | array | 비정상 입고 목록 | [ ... ] |
+                
+                ---
+                
+                ### Response > content > abnormals
+                
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | slipNo | string | 입고요청번호 | "TESTIO260119000005" |
+                | goodsSerialNo | string | 상품일련번호 | "" |
+                | goodsSerialStatus | string | 상품일련번호상태 | "" |
+                | whCd | string | 센터 | "TEST" |
+                | cstCd | string | 고객사코드 | "94388" |
+                | cstNm | string | 고객사명 | "마켓노트 주식회사 테스트" |
+                | godCd | string | 상품코드 | "943881" |
+                | description | string | 설명 | "" |
+                | remark | string | 기타메모 | "" |
+                | fileSeq | string | 파일seq | "" |
+                | lastFileSeqNo | number | 마지막파일no | 0 |
+                | regDate | string | 비정상입고등록일자 | "" |
+                | regNM | string | 비정상입고등록자 | "" |
+                | updDate | string | 비정상입고수정일자 | "" |
+                | updNm | string | 비정상입고수정자 | "" |
+                | fileNo | string | 파일하위seq | "" |
+                | imageUrl | array | 이미지 URL | [] |
+                """,
+        security = {@SecurityRequirement(name = "bearer")},
+        parameters = {
+                @Parameter(
+                        name = "accessToken",
+                        description = "파스토 액세스 토큰",
+                        in = ParameterIn.HEADER,
+                        required = true,
+                        schema = @Schema(type = "string", example = "eefae1befa4c11f0be620ab49498ff55")
+                ),
+                @Parameter(
+                        name = "customerCode",
+                        description = "파스토 고객사 코드",
+                        in = ParameterIn.PATH,
+                        required = true,
+                        schema = @Schema(type = "string", example = "94388")
+                ),
+                @Parameter(
+                        name = "whCd",
+                        description = "센터",
+                        in = ParameterIn.PATH,
+                        required = true,
+                        schema = @Schema(type = "string", example = "TEST")
+                ),
+                @Parameter(
+                        name = "slipNo",
+                        description = "입고요청번호",
+                        in = ParameterIn.PATH,
+                        required = true,
+                        schema = @Schema(type = "string", example = "TESTIO260119000005")
+                )
+        },
+        responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "파스토 비정상 입고 상품 조회 성공",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 200,
+                                          "code": "SUC01",
+                                          "timestamp": "2026-02-14T12:12:30.013",
+                                          "content": {
+                                            "dataCount": 0,
+                                            "abnormals": []
+                                          },
+                                          "message": "파스토 비정상 입고 상품 조회 성공"
+                                        }
+                                        """)
+                        )
+                )
+        }
+)
+public @interface GetFasstoWarehousingAbnormalApiDocs {
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/mapper/FasstoWarehousingRequestToCommandMapper.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/mapper/FasstoWarehousingRequestToCommandMapper.java
@@ -42,6 +42,15 @@ public class FasstoWarehousingRequestToCommandMapper {
         return GetFasstoWarehousingDetailCommand.of(customerCode, accessToken, slipNo, ordNo);
     }
 
+    public static GetFasstoWarehousingAbnormalCommand mapToWarehousingAbnormalCommand(
+            String customerCode,
+            String accessToken,
+            String whCd,
+            String slipNo
+    ) {
+        return GetFasstoWarehousingAbnormalCommand.of(customerCode, accessToken, whCd, slipNo);
+    }
+
     public static UpdateFasstoWarehousingCommand mapToUpdateCommand(
             String customerCode,
             String accessToken,

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/response/GetFasstoWarehousingAbnormalResponse.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/response/GetFasstoWarehousingAbnormalResponse.java
@@ -1,0 +1,15 @@
+package com.personal.marketnote.fulfillment.adapter.in.web.vendor.response;
+
+import com.personal.marketnote.fulfillment.port.in.result.vendor.FasstoWarehousingAbnormalInfoResult;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.GetFasstoWarehousingAbnormalResult;
+
+import java.util.List;
+
+public record GetFasstoWarehousingAbnormalResponse(
+        Integer dataCount,
+        List<FasstoWarehousingAbnormalInfoResult> abnormals
+) {
+    public static GetFasstoWarehousingAbnormalResponse from(GetFasstoWarehousingAbnormalResult result) {
+        return new GetFasstoWarehousingAbnormalResponse(result.dataCount(), result.abnormals());
+    }
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/client/FasstoWarehousingClient.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/client/FasstoWarehousingClient.java
@@ -7,6 +7,7 @@ import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.common.utility.http.client.CommunicationFailureHandler;
 import com.personal.marketnote.fulfillment.adapter.out.vendor.fassto.response.*;
 import com.personal.marketnote.fulfillment.configuration.FasstoAuthProperties;
+import com.personal.marketnote.fulfillment.domain.vendor.fassto.warehousing.FasstoWarehousingAbnormalQuery;
 import com.personal.marketnote.fulfillment.domain.vendor.fassto.warehousing.FasstoWarehousingDetailQuery;
 import com.personal.marketnote.fulfillment.domain.vendor.fassto.warehousing.FasstoWarehousingMapper;
 import com.personal.marketnote.fulfillment.domain.vendor.fassto.warehousing.FasstoWarehousingQuery;
@@ -14,15 +15,9 @@ import com.personal.marketnote.fulfillment.domain.vendorcommunication.Fulfillmen
 import com.personal.marketnote.fulfillment.domain.vendorcommunication.FulfillmentVendorCommunicationTargetType;
 import com.personal.marketnote.fulfillment.domain.vendorcommunication.FulfillmentVendorCommunicationType;
 import com.personal.marketnote.fulfillment.domain.vendorcommunication.FulfillmentVendorName;
-import com.personal.marketnote.fulfillment.exception.GetFasstoWarehousingDetailFailedException;
-import com.personal.marketnote.fulfillment.exception.GetFasstoWarehousingFailedException;
-import com.personal.marketnote.fulfillment.exception.RegisterFasstoWarehousingFailedException;
-import com.personal.marketnote.fulfillment.exception.UpdateFasstoWarehousingFailedException;
+import com.personal.marketnote.fulfillment.exception.*;
 import com.personal.marketnote.fulfillment.port.in.result.vendor.*;
-import com.personal.marketnote.fulfillment.port.out.vendor.GetFasstoWarehousingDetailPort;
-import com.personal.marketnote.fulfillment.port.out.vendor.GetFasstoWarehousingPort;
-import com.personal.marketnote.fulfillment.port.out.vendor.RegisterFasstoWarehousingPort;
-import com.personal.marketnote.fulfillment.port.out.vendor.UpdateFasstoWarehousingPort;
+import com.personal.marketnote.fulfillment.port.out.vendor.*;
 import com.personal.marketnote.fulfillment.utility.VendorCommunicationFailureHandler;
 import com.personal.marketnote.fulfillment.utility.VendorCommunicationPayloadGenerator;
 import com.personal.marketnote.fulfillment.utility.VendorCommunicationRecorder;
@@ -45,7 +40,7 @@ import static com.personal.marketnote.common.utility.ApiConstant.*;
 @VendorAdapter
 @RequiredArgsConstructor
 @Slf4j
-public class FasstoWarehousingClient implements RegisterFasstoWarehousingPort, GetFasstoWarehousingPort, GetFasstoWarehousingDetailPort, UpdateFasstoWarehousingPort {
+public class FasstoWarehousingClient implements RegisterFasstoWarehousingPort, GetFasstoWarehousingPort, GetFasstoWarehousingDetailPort, GetFasstoWarehousingAbnormalPort, UpdateFasstoWarehousingPort {
     private static final String ACCESS_TOKEN_HEADER = "accessToken";
     private static final String CUSTOMER_CODE_PLACEHOLDER = "{customerCode}";
 
@@ -321,6 +316,119 @@ public class FasstoWarehousingClient implements RegisterFasstoWarehousingPort, G
         throw new GetFasstoWarehousingDetailFailedException(failureMessage, new IOException(error));
     }
 
+    @Override
+    public GetFasstoWarehousingAbnormalResult getWarehousingAbnormal(FasstoWarehousingAbnormalQuery query) {
+        if (FormatValidator.hasNoValue(query)) {
+            throw new IllegalArgumentException("Fassto warehousing abnormal query is required.");
+        }
+
+        URI uri = buildWarehousingAbnormalUri(query.getCustomerCode(), query.getWhCd(), query.getSlipNo());
+        HttpEntity<Void> httpEntity = new HttpEntity<>(buildHeaders(query.getAccessToken(), false));
+
+        Exception error = new Exception();
+        String failureMessage = null;
+        long sleepMillis = INTER_SERVER_DEFAULT_RETRIAL_PENDING_MILLI_SECOND;
+        FulfillmentVendorCommunicationTargetType targetType = FulfillmentVendorCommunicationTargetType.WAREHOUSING;
+        FulfillmentVendorName vendorName = FulfillmentVendorName.FASSTO;
+
+        for (int i = 0; i < INTER_SERVER_MAX_REQUEST_COUNT; i++) {
+            int attempt = i + 1;
+            JsonNode requestPayloadJson = buildAbnormalRequestPayloadJson(query, uri, attempt);
+            String requestPayload = requestPayloadJson.toString();
+
+            ResponseEntity<String> response;
+            try {
+                response = restTemplate.exchange(
+                        uri,
+                        HttpMethod.GET,
+                        httpEntity,
+                        String.class
+                );
+            } catch (Exception e) {
+                Map<String, Object> errorPayload = new LinkedHashMap<>();
+                errorPayload.put("error", e.getClass().getSimpleName());
+                errorPayload.put("message", e.getMessage());
+                errorPayload.put("attempt", attempt);
+
+                vendorCommunicationFailureHandler.handleFailure(
+                        targetType,
+                        vendorName,
+                        requestPayload,
+                        requestPayloadJson,
+                        errorPayload,
+                        e
+                );
+
+                String vendorMessage = resolveVendorMessageFromException(e);
+                if (FormatValidator.hasValue(vendorMessage)) {
+                    failureMessage = vendorMessage;
+                    error = new Exception(vendorMessage);
+                }
+
+                log.warn("Failed to get Fassto warehousing abnormal: attempt={}, message={}", attempt, e.getMessage(), e);
+                if (i == INTER_SERVER_MAX_REQUEST_COUNT - 1) {
+                    error = e;
+                }
+
+                sleep(sleepMillis);
+                sleepMillis = sleepMillis * INTER_SERVER_DEFAULT_EXPONENTIAL_BACKOFF_VALUE;
+                continue;
+            }
+
+            JsonNode responsePayloadJson = buildResponsePayloadJson(response, attempt);
+            String responsePayload = responsePayloadJson.toString();
+
+            FasstoWarehousingAbnormalListResponse parsedResponse = parseWarehousingAbnormalResponse(response);
+            boolean isSuccess = isWarehousingAbnormalSuccess(response, parsedResponse);
+            String exception = isSuccess ? null : resolveWarehousingAbnormalException(response, parsedResponse);
+
+            vendorCommunicationRecorder.record(
+                    targetType,
+                    FulfillmentVendorCommunicationType.REQUEST,
+                    FulfillmentVendorCommunicationSenderType.SERVER,
+                    vendorName,
+                    requestPayload,
+                    requestPayloadJson,
+                    exception
+            );
+            vendorCommunicationRecorder.record(
+                    targetType,
+                    FulfillmentVendorCommunicationType.RESPONSE,
+                    FulfillmentVendorCommunicationSenderType.VENDOR,
+                    vendorName,
+                    responsePayload,
+                    responsePayloadJson,
+                    exception
+            );
+
+            if (isSuccess) {
+                return mapWarehousingAbnormalResult(parsedResponse);
+            }
+
+            String vendorMessage = resolveVendorMessage(parsedResponse, FormatValidator.hasValue(response) ? response.getBody() : null);
+            if (FormatValidator.hasValue(vendorMessage)) {
+                failureMessage = vendorMessage;
+                error = new Exception(vendorMessage);
+            }
+
+            log.warn("Fassto warehousing abnormal request failed: attempt={}, status={}, exception={}",
+                    attempt,
+                    FormatValidator.hasValue(response) ? response.getStatusCode() : null,
+                    exception
+            );
+
+            if (CommunicationFailureHandler.isCertainFailure(response)) {
+                break;
+            }
+
+            sleep(sleepMillis);
+            sleepMillis = sleepMillis * INTER_SERVER_DEFAULT_EXPONENTIAL_BACKOFF_VALUE;
+        }
+
+        log.error("Failed to get Fassto warehousing abnormal: {} with error: {}", uri, error.getMessage(), error);
+        throw new GetFasstoWarehousingAbnormalFailedException(failureMessage, new IOException(error));
+    }
+
     private RegisterFasstoWarehousingResponse executeWarehousingMutation(
             FasstoWarehousingMapper request,
             String action,
@@ -509,6 +617,18 @@ public class FasstoWarehousingClient implements RegisterFasstoWarehousingPort, G
                 .toUri();
     }
 
+    private URI buildWarehousingAbnormalUri(
+            String customerCode,
+            String whCd,
+            String slipNo
+    ) {
+        validateWarehousingAbnormalProperties();
+        return UriComponentsBuilder.fromUriString(properties.getBaseUrl())
+                .path(properties.getWarehousingAbnormalPath())
+                .buildAndExpand(customerCode, whCd, slipNo)
+                .toUri();
+    }
+
     private HttpHeaders buildHeaders(String accessToken) {
         return buildHeaders(accessToken, true);
     }
@@ -568,6 +688,24 @@ public class FasstoWarehousingClient implements RegisterFasstoWarehousingPort, G
         }
     }
 
+    private void validateWarehousingAbnormalProperties() {
+        if (FormatValidator.hasNoValue(properties.getBaseUrl())) {
+            throw new IllegalStateException("Fassto base URL is required.");
+        }
+        if (FormatValidator.hasNoValue(properties.getWarehousingAbnormalPath())) {
+            throw new IllegalStateException("Fassto warehousing abnormal path is required.");
+        }
+        if (!properties.getWarehousingAbnormalPath().contains(CUSTOMER_CODE_PLACEHOLDER)) {
+            throw new IllegalStateException("Fassto warehousing abnormal path must include {customerCode}.");
+        }
+        if (!properties.getWarehousingAbnormalPath().contains("{whCd}")) {
+            throw new IllegalStateException("Fassto warehousing abnormal path must include {whCd}.");
+        }
+        if (!properties.getWarehousingAbnormalPath().contains("{slipNo}")) {
+            throw new IllegalStateException("Fassto warehousing abnormal path must include {slipNo}.");
+        }
+    }
+
     private RegisterFasstoWarehousingResponse parseResponseBody(ResponseEntity<String> response) {
         if (FormatValidator.hasNoValue(response)) {
             return null;
@@ -622,6 +760,24 @@ public class FasstoWarehousingClient implements RegisterFasstoWarehousingPort, G
         }
     }
 
+    private FasstoWarehousingAbnormalListResponse parseWarehousingAbnormalResponse(ResponseEntity<String> response) {
+        if (FormatValidator.hasNoValue(response)) {
+            return null;
+        }
+
+        String body = response.getBody();
+        if (FormatValidator.hasNoValue(body)) {
+            return null;
+        }
+
+        try {
+            return objectMapper.readValue(body, FasstoWarehousingAbnormalListResponse.class);
+        } catch (Exception e) {
+            log.warn("Failed to parse Fassto warehousing abnormal response: {}", e.getMessage(), e);
+            return null;
+        }
+    }
+
     private boolean isSuccessResponse(ResponseEntity<String> response, RegisterFasstoWarehousingResponse parsedResponse) {
         return FormatValidator.hasValue(response)
                 && response.getStatusCode().value() == 200
@@ -638,6 +794,13 @@ public class FasstoWarehousingClient implements RegisterFasstoWarehousingPort, G
     }
 
     private boolean isWarehousingDetailSuccess(ResponseEntity<String> response, FasstoWarehousingDetailListResponse parsedResponse) {
+        return FormatValidator.hasValue(response)
+                && response.getStatusCode().value() == 200
+                && FormatValidator.hasValue(parsedResponse)
+                && parsedResponse.isSuccess();
+    }
+
+    private boolean isWarehousingAbnormalSuccess(ResponseEntity<String> response, FasstoWarehousingAbnormalListResponse parsedResponse) {
         return FormatValidator.hasValue(response)
                 && response.getStatusCode().value() == 200
                 && FormatValidator.hasValue(parsedResponse)
@@ -707,6 +870,28 @@ public class FasstoWarehousingClient implements RegisterFasstoWarehousingPort, G
         return "UNKNOWN_FAILURE";
     }
 
+    private String resolveWarehousingAbnormalException(
+            ResponseEntity<String> response,
+            FasstoWarehousingAbnormalListResponse parsedResponse
+    ) {
+        if (FormatValidator.hasNoValue(response)) {
+            return "NO_RESPONSE";
+        }
+        if (response.getStatusCode().value() != 200) {
+            return "HTTP_" + response.getStatusCode().value();
+        }
+        if (FormatValidator.hasNoValue(parsedResponse)) {
+            return "INVALID_RESPONSE";
+        }
+        if (FormatValidator.hasNoValue(parsedResponse.header()) || !parsedResponse.header().isSuccess()) {
+            return "HEADER_FAILURE";
+        }
+        if (FormatValidator.hasNoValue(parsedResponse.data())) {
+            return "DATA_MISSING";
+        }
+        return "UNKNOWN_FAILURE";
+    }
+
     private JsonNode buildListRequestPayloadJson(FasstoWarehousingQuery query, URI uri, int attempt) {
         Map<String, Object> payload = new LinkedHashMap<>();
         payload.put("method", HttpMethod.GET.name());
@@ -737,6 +922,18 @@ public class FasstoWarehousingClient implements RegisterFasstoWarehousingPort, G
         if (FormatValidator.hasValue(query.getOrdNo())) {
             payload.put("ordNo", query.getOrdNo());
         }
+        payload.put(ACCESS_TOKEN_HEADER, maskValue(query.getAccessToken()));
+        payload.put("attempt", attempt);
+        return vendorCommunicationPayloadGenerator.buildPayloadJson(payload);
+    }
+
+    private JsonNode buildAbnormalRequestPayloadJson(FasstoWarehousingAbnormalQuery query, URI uri, int attempt) {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("method", HttpMethod.GET.name());
+        payload.put("url", uri.toString());
+        payload.put("customerCode", query.getCustomerCode());
+        payload.put("whCd", query.getWhCd());
+        payload.put("slipNo", query.getSlipNo());
         payload.put(ACCESS_TOKEN_HEADER, maskValue(query.getAccessToken()));
         payload.put("attempt", attempt);
         return vendorCommunicationPayloadGenerator.buildPayloadJson(payload);
@@ -813,6 +1010,14 @@ public class FasstoWarehousingClient implements RegisterFasstoWarehousingPort, G
                 .toList();
         Integer dataCount = FormatValidator.hasValue(response.header()) ? response.header().dataCount() : null;
         return GetFasstoWarehousingDetailResult.of(dataCount, details);
+    }
+
+    private GetFasstoWarehousingAbnormalResult mapWarehousingAbnormalResult(FasstoWarehousingAbnormalListResponse response) {
+        List<FasstoWarehousingAbnormalInfoResult> abnormals = response.data().stream()
+                .map(this::mapWarehousingAbnormalInfo)
+                .toList();
+        Integer dataCount = FormatValidator.hasValue(response.header()) ? response.header().dataCount() : null;
+        return GetFasstoWarehousingAbnormalResult.of(dataCount, abnormals);
     }
 
     private RegisterFasstoWarehousingItemResult mapWarehousingItem(RegisterFasstoWarehousingItemResponse item) {
@@ -921,6 +1126,32 @@ public class FasstoWarehousingClient implements RegisterFasstoWarehousingPort, G
         );
     }
 
+    private FasstoWarehousingAbnormalInfoResult mapWarehousingAbnormalInfo(FasstoWarehousingAbnormalItemResponse item) {
+        List<Object> imageUrl = FormatValidator.hasValue(item.imageUrl())
+                ? item.imageUrl()
+                : List.of();
+
+        return FasstoWarehousingAbnormalInfoResult.of(
+                item.slipNo(),
+                item.goodsSerialNo(),
+                item.goodsSerialStatus(),
+                item.whCd(),
+                item.cstCd(),
+                item.cstNm(),
+                item.godCd(),
+                item.description(),
+                item.remark(),
+                item.fileSeq(),
+                item.lastFileSeqNo(),
+                item.regDate(),
+                item.regNM(),
+                item.updDate(),
+                item.updNm(),
+                item.fileNo(),
+                imageUrl
+        );
+    }
+
     private String maskValue(String value) {
         if (FormatValidator.hasNoValue(value)) {
             return value;
@@ -967,6 +1198,16 @@ public class FasstoWarehousingClient implements RegisterFasstoWarehousingPort, G
     }
 
     private String resolveVendorMessage(FasstoWarehousingDetailListResponse response, String rawBody) {
+        if (FormatValidator.hasValue(response)) {
+            String message = response.resolveErrorMessage();
+            if (FormatValidator.hasValue(message)) {
+                return message;
+            }
+        }
+        return resolveVendorMessage(rawBody);
+    }
+
+    private String resolveVendorMessage(FasstoWarehousingAbnormalListResponse response, String rawBody) {
         if (FormatValidator.hasValue(response)) {
             String message = response.resolveErrorMessage();
             if (FormatValidator.hasValue(message)) {

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoWarehousingAbnormalItemResponse.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoWarehousingAbnormalItemResponse.java
@@ -1,0 +1,27 @@
+package com.personal.marketnote.fulfillment.adapter.out.vendor.fassto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record FasstoWarehousingAbnormalItemResponse(
+        String slipNo,
+        String goodsSerialNo,
+        String goodsSerialStatus,
+        String whCd,
+        String cstCd,
+        String cstNm,
+        String godCd,
+        String description,
+        String remark,
+        String fileSeq,
+        Integer lastFileSeqNo,
+        String regDate,
+        String regNM,
+        String updDate,
+        String updNm,
+        String fileNo,
+        List<Object> imageUrl
+) {
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoWarehousingAbnormalListResponse.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoWarehousingAbnormalListResponse.java
@@ -1,0 +1,16 @@
+package com.personal.marketnote.fulfillment.adapter.out.vendor.fassto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record FasstoWarehousingAbnormalListResponse(
+        FasstoResponseHeader header,
+        List<FasstoWarehousingAbnormalItemResponse> data,
+        FasstoErrorInfo errorInfo
+) implements FasstoApiResponse {
+    public boolean isSuccess() {
+        return header != null && header.isSuccess() && data != null;
+    }
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/resources/application.yml
+++ b/fulfillment-service/fulfillment-adapters/src/main/resources/application.yml
@@ -59,6 +59,7 @@ vendor:
       warehousing-path: ${FASSTO_WAREHOUSING_PATH:/api/v1/warehousing/{customerCode}}
       warehousing-list-path: ${FASSTO_WAREHOUSING_LIST_PATH:/api/v1/warehousing/{customerCode}/{startDate}/{endDate}}
       warehousing-detail-path: ${FASSTO_WAREHOUSING_DETAIL_PATH:/api/v1/warehousing/detail/{customerCode}/{slipNo}}
+      warehousing-abnormal-path: ${FASSTO_WAREHOUSING_ABNORMAL_PATH:/api/v1/warehousing/abnormal/{customerCode}/{whCd}/{slipNo}}
       delivery-path: ${FASSTO_DELIVERY_PATH:/api/v1/delivery/parcel/{customerCode}}
       delivery-list-path: ${FASSTO_DELIVERY_LIST_PATH:/api/v1/delivery/{customerCode}/{startDate}/{endDate}/{status}/{outDiv}}
       delivery-status-path: ${FASSTO_DELIVERY_STATUS_PATH:/api/v1/delivery/parcel/{customerCode}/{startDate}/{endDate}/{outDiv}}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/configuration/FasstoAuthProperties.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/configuration/FasstoAuthProperties.java
@@ -23,6 +23,7 @@ public class FasstoAuthProperties {
     private String warehousingPath = "/api/v1/warehousing/{customerCode}";
     private String warehousingListPath = "/api/v1/warehousing/{customerCode}/{startDate}/{endDate}";
     private String warehousingDetailPath = "/api/v1/warehousing/detail/{customerCode}/{slipNo}";
+    private String warehousingAbnormalPath = "/api/v1/warehousing/abnormal/{customerCode}/{whCd}/{slipNo}";
     private String deliveryPath = "/api/v1/delivery/parcel/{customerCode}";
     private String deliveryListPath = "/api/v1/delivery/{customerCode}/{startDate}/{endDate}/{status}/{outDiv}";
     private String deliveryStatusPath = "/api/v1/delivery/parcel/{customerCode}/{startDate}/{endDate}/{outDiv}";

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/GetFasstoWarehousingAbnormalFailedException.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/GetFasstoWarehousingAbnormalFailedException.java
@@ -1,0 +1,25 @@
+package com.personal.marketnote.fulfillment.exception;
+
+import com.personal.marketnote.common.exception.ExternalOperationFailedException;
+import com.personal.marketnote.common.utility.FormatValidator;
+
+import java.io.IOException;
+
+public class GetFasstoWarehousingAbnormalFailedException extends ExternalOperationFailedException {
+    private static final String DEFAULT_MESSAGE = "파스토 비정상 입고 조회 중 오류가 발생했습니다.";
+
+    public GetFasstoWarehousingAbnormalFailedException(IOException cause) {
+        super(DEFAULT_MESSAGE, cause);
+    }
+
+    public GetFasstoWarehousingAbnormalFailedException(String vendorMessage, IOException cause) {
+        super(resolveMessage(vendorMessage), cause);
+    }
+
+    private static String resolveMessage(String vendorMessage) {
+        if (FormatValidator.hasValue(vendorMessage)) {
+            return String.format("파스토 비정상 입고 조회 실패: %s", vendorMessage);
+        }
+        return DEFAULT_MESSAGE;
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/mapper/FasstoWarehousingCommandToRequestMapper.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/mapper/FasstoWarehousingCommandToRequestMapper.java
@@ -39,6 +39,15 @@ public class FasstoWarehousingCommandToRequestMapper {
         );
     }
 
+    public static FasstoWarehousingAbnormalQuery mapToAbnormalQuery(GetFasstoWarehousingAbnormalCommand command) {
+        return FasstoWarehousingAbnormalQuery.of(
+                command.customerCode(),
+                command.accessToken(),
+                command.whCd(),
+                command.slipNo()
+        );
+    }
+
     public static FasstoWarehousingMapper mapToUpdateRequest(UpdateFasstoWarehousingCommand command) {
         List<FasstoWarehousingItemMapper> requests = command.warehousingRequests().stream()
                 .map(FasstoWarehousingCommandToRequestMapper::mapUpdateItem)

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/vendor/GetFasstoWarehousingAbnormalCommand.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/vendor/GetFasstoWarehousingAbnormalCommand.java
@@ -1,0 +1,17 @@
+package com.personal.marketnote.fulfillment.port.in.command.vendor;
+
+public record GetFasstoWarehousingAbnormalCommand(
+        String customerCode,
+        String accessToken,
+        String whCd,
+        String slipNo
+) {
+    public static GetFasstoWarehousingAbnormalCommand of(
+            String customerCode,
+            String accessToken,
+            String whCd,
+            String slipNo
+    ) {
+        return new GetFasstoWarehousingAbnormalCommand(customerCode, accessToken, whCd, slipNo);
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/result/vendor/FasstoWarehousingAbnormalInfoResult.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/result/vendor/FasstoWarehousingAbnormalInfoResult.java
@@ -1,0 +1,63 @@
+package com.personal.marketnote.fulfillment.port.in.result.vendor;
+
+import java.util.List;
+
+public record FasstoWarehousingAbnormalInfoResult(
+        String slipNo,
+        String goodsSerialNo,
+        String goodsSerialStatus,
+        String whCd,
+        String cstCd,
+        String cstNm,
+        String godCd,
+        String description,
+        String remark,
+        String fileSeq,
+        Integer lastFileSeqNo,
+        String regDate,
+        String regNM,
+        String updDate,
+        String updNm,
+        String fileNo,
+        List<Object> imageUrl
+) {
+    public static FasstoWarehousingAbnormalInfoResult of(
+            String slipNo,
+            String goodsSerialNo,
+            String goodsSerialStatus,
+            String whCd,
+            String cstCd,
+            String cstNm,
+            String godCd,
+            String description,
+            String remark,
+            String fileSeq,
+            Integer lastFileSeqNo,
+            String regDate,
+            String regNM,
+            String updDate,
+            String updNm,
+            String fileNo,
+            List<Object> imageUrl
+    ) {
+        return new FasstoWarehousingAbnormalInfoResult(
+                slipNo,
+                goodsSerialNo,
+                goodsSerialStatus,
+                whCd,
+                cstCd,
+                cstNm,
+                godCd,
+                description,
+                remark,
+                fileSeq,
+                lastFileSeqNo,
+                regDate,
+                regNM,
+                updDate,
+                updNm,
+                fileNo,
+                imageUrl
+        );
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/result/vendor/GetFasstoWarehousingAbnormalResult.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/result/vendor/GetFasstoWarehousingAbnormalResult.java
@@ -1,0 +1,15 @@
+package com.personal.marketnote.fulfillment.port.in.result.vendor;
+
+import java.util.List;
+
+public record GetFasstoWarehousingAbnormalResult(
+        Integer dataCount,
+        List<FasstoWarehousingAbnormalInfoResult> abnormals
+) {
+    public static GetFasstoWarehousingAbnormalResult of(
+            Integer dataCount,
+            List<FasstoWarehousingAbnormalInfoResult> abnormals
+    ) {
+        return new GetFasstoWarehousingAbnormalResult(dataCount, abnormals);
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/usecase/vendor/GetFasstoWarehousingAbnormalUseCase.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/usecase/vendor/GetFasstoWarehousingAbnormalUseCase.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.fulfillment.port.in.usecase.vendor;
+
+import com.personal.marketnote.fulfillment.port.in.command.vendor.GetFasstoWarehousingAbnormalCommand;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.GetFasstoWarehousingAbnormalResult;
+
+public interface GetFasstoWarehousingAbnormalUseCase {
+    GetFasstoWarehousingAbnormalResult getWarehousingAbnormal(GetFasstoWarehousingAbnormalCommand command);
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/vendor/GetFasstoWarehousingAbnormalPort.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/vendor/GetFasstoWarehousingAbnormalPort.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.fulfillment.port.out.vendor;
+
+import com.personal.marketnote.fulfillment.domain.vendor.fassto.warehousing.FasstoWarehousingAbnormalQuery;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.GetFasstoWarehousingAbnormalResult;
+
+public interface GetFasstoWarehousingAbnormalPort {
+    GetFasstoWarehousingAbnormalResult getWarehousingAbnormal(FasstoWarehousingAbnormalQuery query);
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/vendor/GetFasstoWarehousingAbnormalService.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/vendor/GetFasstoWarehousingAbnormalService.java
@@ -1,0 +1,26 @@
+package com.personal.marketnote.fulfillment.service.vendor;
+
+import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.fulfillment.mapper.FasstoWarehousingCommandToRequestMapper;
+import com.personal.marketnote.fulfillment.port.in.command.vendor.GetFasstoWarehousingAbnormalCommand;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.GetFasstoWarehousingAbnormalResult;
+import com.personal.marketnote.fulfillment.port.in.usecase.vendor.GetFasstoWarehousingAbnormalUseCase;
+import com.personal.marketnote.fulfillment.port.out.vendor.GetFasstoWarehousingAbnormalPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional(isolation = READ_COMMITTED, readOnly = true)
+public class GetFasstoWarehousingAbnormalService implements GetFasstoWarehousingAbnormalUseCase {
+    private final GetFasstoWarehousingAbnormalPort getFasstoWarehousingAbnormalPort;
+
+    @Override
+    public GetFasstoWarehousingAbnormalResult getWarehousingAbnormal(GetFasstoWarehousingAbnormalCommand command) {
+        return getFasstoWarehousingAbnormalPort.getWarehousingAbnormal(
+                FasstoWarehousingCommandToRequestMapper.mapToAbnormalQuery(command)
+        );
+    }
+}

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/warehousing/FasstoWarehousingAbnormalQuery.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/warehousing/FasstoWarehousingAbnormalQuery.java
@@ -1,0 +1,46 @@
+package com.personal.marketnote.fulfillment.domain.vendor.fassto.warehousing;
+
+import com.personal.marketnote.common.utility.FormatValidator;
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+public class FasstoWarehousingAbnormalQuery {
+    private String customerCode;
+    private String accessToken;
+    private String whCd;
+    private String slipNo;
+
+    public static FasstoWarehousingAbnormalQuery of(
+            String customerCode,
+            String accessToken,
+            String whCd,
+            String slipNo
+    ) {
+        FasstoWarehousingAbnormalQuery query = FasstoWarehousingAbnormalQuery.builder()
+                .customerCode(customerCode)
+                .accessToken(accessToken)
+                .whCd(whCd)
+                .slipNo(slipNo)
+                .build();
+        query.validate();
+        return query;
+    }
+
+    private void validate() {
+        if (FormatValidator.hasNoValue(customerCode)) {
+            throw new IllegalArgumentException("customerCode is required.");
+        }
+        if (FormatValidator.hasNoValue(accessToken)) {
+            throw new IllegalArgumentException("accessToken is required.");
+        }
+        if (FormatValidator.hasNoValue(whCd)) {
+            throw new IllegalArgumentException("whCd is required.");
+        }
+        if (FormatValidator.hasNoValue(slipNo)) {
+            throw new IllegalArgumentException("slipNo is required.");
+        }
+    }
+}


### PR DESCRIPTION
## partially addresses #475
## resolves #696

## Task
- [x] 파스토 비정상 입고 상품 정보 조회 연동 요청
- [x] 파스토 비정상 입고 상품 정보 조회 연동 비즈니스 로직
- [x] 파스토 서버에 비정상 입고 상품 정보 요청
- [x] 200 status code 응답
- [x] Swagger docs