### PR TITLE
[#216][#706] feat: 주문 등록 시 현재 재고 검증 로직 추가

### DIFF
--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/RegisterOrderService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/RegisterOrderService.java
@@ -1,10 +1,13 @@
 package com.personal.marketnote.commerce.service.order;
 
+import com.personal.marketnote.commerce.domain.inventory.Inventory;
 import com.personal.marketnote.commerce.domain.order.Order;
 import com.personal.marketnote.commerce.domain.order.OrderCreateState;
 import com.personal.marketnote.commerce.domain.order.OrderProductCreateState;
+import com.personal.marketnote.commerce.port.in.command.order.OrderProductItemCommand;
 import com.personal.marketnote.commerce.port.in.command.order.RegisterOrderCommand;
 import com.personal.marketnote.commerce.port.in.result.order.RegisterOrderResult;
+import com.personal.marketnote.commerce.port.in.usecase.inventory.GetInventoryUseCase;
 import com.personal.marketnote.commerce.port.in.usecase.order.RegisterOrderUseCase;
 import com.personal.marketnote.commerce.port.out.order.SaveOrderPort;
 import com.personal.marketnote.common.application.UseCase;
@@ -12,6 +15,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Set;
 
 import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
 
@@ -19,10 +23,26 @@ import static org.springframework.transaction.annotation.Isolation.READ_COMMITTE
 @RequiredArgsConstructor
 @Transactional(isolation = READ_COMMITTED)
 public class RegisterOrderService implements RegisterOrderUseCase {
+    private final GetInventoryUseCase getInventoryUseCase;
     private final SaveOrderPort saveOrderPort;
 
     @Override
     public RegisterOrderResult registerOrder(RegisterOrderCommand command) {
+        Set<Inventory> inventories = getInventoryUseCase.getInventories(
+                command.orderProducts()
+                        .stream()
+                        .map(OrderProductItemCommand::pricePolicyId)
+                        .toList()
+        );
+        inventories.forEach(inventory -> {
+            int orderQuantity = command.orderProducts().stream()
+                    .filter(item -> item.pricePolicyId().equals(inventory.getPricePolicyId()))
+                    .map(OrderProductItemCommand::quantity)
+                    .reduce(0, Integer::sum);
+
+            inventory.validateIsSufficient(orderQuantity);
+        });
+
         List<OrderProductCreateState> orderProductStates = command.orderProducts().stream()
                 .map(item -> OrderProductCreateState.builder()
                         .sellerId(item.sellerId())

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/inventory/Inventory.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/inventory/Inventory.java
@@ -60,4 +60,8 @@ public class Inventory {
     public boolean isMe(Long pricePolicyId) {
         return FormatValidator.equals(pricePolicyId, pricePolicyId);
     }
+
+    public void validateIsSufficient(int orderQuantity) {
+        stock.validateIsSufficient(orderQuantity);
+    }
 }

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/inventory/Stock.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/inventory/Stock.java
@@ -1,5 +1,6 @@
 package com.personal.marketnote.commerce.domain.inventory;
 
+import com.personal.marketnote.common.domain.exception.illegalargument.invalidvalue.InsufficientQuantityException;
 import com.personal.marketnote.common.domain.exception.illegalargument.invalidvalue.InvalidQuantityException;
 import com.personal.marketnote.common.domain.exception.illegalargument.novalue.QuantityNoValueException;
 import com.personal.marketnote.common.utility.FormatConverter;
@@ -67,5 +68,11 @@ public class Stock {
 
     public Integer reduce(int stock) {
         return this.stock - stock;
+    }
+
+    public void validateIsSufficient(int orderQuantity) {
+        if (stock < orderQuantity) {
+            throw new InsufficientQuantityException(stock, orderQuantity);
+        }
     }
 }

--- a/common/src/main/java/com/personal/marketnote/common/domain/exception/illegalargument/invalidvalue/InsufficientQuantityException.java
+++ b/common/src/main/java/com/personal/marketnote/common/domain/exception/illegalargument/invalidvalue/InsufficientQuantityException.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.common.domain.exception.illegalargument.invalidvalue;
+
+public class InsufficientQuantityException extends InvalidValueException {
+    private static final String MESSAGE = "재고 수량이 부족합니다. 현재 재고 수량: %d, 주문 수량: %d";
+
+    public InsufficientQuantityException(Integer currentStock, Integer orderQuantity) {
+        super(String.format(MESSAGE, currentStock, orderQuantity));
+    }
+}


### PR DESCRIPTION
## partially addresses #216
## resolves #706

## Task
- [x] 가격 정책 ID가 중복되지 않는 경우: 각각의 주문 등록 상품에 대해 재고 검증
- [x] 가격 정책 ID가 중복되는 경우: 동일 가격 정책 ID를 가진 주문 등록 상품에 대해 재고 합산 후 검증