### PR TITLE
[#128][#708] fix: 카테고리 등록 시 상위 카테고리가 존재하지 않는 케이스의 예외 처리 메시지 포맷이 깨지는 이슈 대응

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,26 @@ out/
 ### VS Code ###
 .vscode/
 logs/
+.github/
+commerce-openapi.json
+community-openapi.json
+files-openapi.json
+fulfillment-openapi.json
+products-openapi.json
+rewards-openapi.json
+users-openapi.json
+tools/qa/auto_qa.py
+tools/qa/README.md
+tools/qa/__pycache__/auto_qa.cpython-313.pyc
+tools/qa/output/qa-report-20260123-172813.json
+tools/qa/output/qa-report-20260123-172813.md
+tools/qa/output/qa-report-20260123-174726.json
+tools/qa/output/qa-report-20260123-174726.md
+tools/qa/output/qa-report-20260123-175740.json
+tools/qa/output/qa-report-20260123-175740.md
+tools/qa/output/qa-report-20260123-180045.json
+tools/qa/output/qa-report-20260123-180045.md
+tools/qa/output/qa-report-20260123-180330.json
+tools/qa/output/qa-report-20260123-180330.md
+tools/qa/output/qa-report-20260123-180645.json
+tools/qa/output/qa-report-20260123-180645.md

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/service/category/RegisterCategoryService.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/service/category/RegisterCategoryService.java
@@ -34,7 +34,7 @@ public class RegisterCategoryService implements RegisterCategoryUseCase {
                         && findCategoryPort.findAllActiveByIds(List.of(parentCategoryId)).isEmpty()
         ) {
             throw new CategoryNotFoundException(
-                    "%s::존재하지 않는 상위 카테고리 ID입니다. 전송된 상위 카테고리 ID: %d",
+                    "존재하지 않는 상위 카테고리 ID입니다. 전송된 상위 카테고리 ID: %d",
                     parentCategoryId
             );
         }


### PR DESCRIPTION
## partially addresses #128
## resolves #708

## Reason
String.format 메서드의 인자에 더 많은 %s가 삽입됨

## Action
%s 제거
