### PR TITLE
[#128][#710] fix: 상품 옵션 카테고리 및 하위 옵션 목록 등록 시 409 예외가 발생하는 이슈 대응

### DIFF
--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/pricepolicy/repository/PricePolicyJpaRepository.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/pricepolicy/repository/PricePolicyJpaRepository.java
@@ -3,8 +3,10 @@ package com.personal.marketnote.product.adapter.out.persistence.pricepolicy.repo
 import com.personal.marketnote.product.adapter.out.persistence.pricepolicy.entity.PricePolicyJpaEntity;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
@@ -267,5 +269,7 @@ public interface PricePolicyJpaRepository extends JpaRepository<PricePolicyJpaEn
             DELETE FROM PricePolicyJpaEntity pp
             WHERE pp.productJpaEntity.id = :productId
             """)
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Transactional
     void deleteByProductId(Long productId);
 }


### PR DESCRIPTION
## partially addresses #128
## resolves #710

## Reason
deleteByProductId 메서드의 @Modifying 어노테이션 누락

## Action
deleteByProductId 메서드에 @Modifying 어노테이션 추가