### PR TITLE
[#128][#714] fix: 상품 태그 조회 시 Lazy Initialization 이슈 대응

### DIFF
--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/RegisterOrderService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/RegisterOrderService.java
@@ -1,10 +1,13 @@
 package com.personal.marketnote.commerce.service.order;
 
+import com.personal.marketnote.commerce.domain.inventory.Inventory;
 import com.personal.marketnote.commerce.domain.order.Order;
 import com.personal.marketnote.commerce.domain.order.OrderCreateState;
 import com.personal.marketnote.commerce.domain.order.OrderProductCreateState;
+import com.personal.marketnote.commerce.port.in.command.order.OrderProductItemCommand;
 import com.personal.marketnote.commerce.port.in.command.order.RegisterOrderCommand;
 import com.personal.marketnote.commerce.port.in.result.order.RegisterOrderResult;
+import com.personal.marketnote.commerce.port.in.usecase.inventory.GetInventoryUseCase;
 import com.personal.marketnote.commerce.port.in.usecase.order.RegisterOrderUseCase;
 import com.personal.marketnote.commerce.port.out.order.SaveOrderPort;
 import com.personal.marketnote.common.application.UseCase;
@@ -12,6 +15,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Set;
 
 import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
 
@@ -19,10 +23,26 @@ import static org.springframework.transaction.annotation.Isolation.READ_COMMITTE
 @RequiredArgsConstructor
 @Transactional(isolation = READ_COMMITTED)
 public class RegisterOrderService implements RegisterOrderUseCase {
+    private final GetInventoryUseCase getInventoryUseCase;
     private final SaveOrderPort saveOrderPort;
 
     @Override
     public RegisterOrderResult registerOrder(RegisterOrderCommand command) {
+        Set<Inventory> inventories = getInventoryUseCase.getInventories(
+                command.orderProducts()
+                        .stream()
+                        .map(OrderProductItemCommand::pricePolicyId)
+                        .toList()
+        );
+        inventories.forEach(inventory -> {
+            int orderQuantity = command.orderProducts().stream()
+                    .filter(item -> item.pricePolicyId().equals(inventory.getPricePolicyId()))
+                    .map(OrderProductItemCommand::quantity)
+                    .reduce(0, Integer::sum);
+
+            inventory.validateIsSufficient(orderQuantity);
+        });
+
         List<OrderProductCreateState> orderProductStates = command.orderProducts().stream()
                 .map(item -> OrderProductCreateState.builder()
                         .sellerId(item.sellerId())

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/inventory/Inventory.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/inventory/Inventory.java
@@ -60,4 +60,8 @@ public class Inventory {
     public boolean isMe(Long pricePolicyId) {
         return FormatValidator.equals(pricePolicyId, pricePolicyId);
     }
+
+    public void validateIsSufficient(int orderQuantity) {
+        stock.validateIsSufficient(orderQuantity);
+    }
 }

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/inventory/Stock.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/inventory/Stock.java
@@ -1,5 +1,6 @@
 package com.personal.marketnote.commerce.domain.inventory;
 
+import com.personal.marketnote.common.domain.exception.illegalargument.invalidvalue.InsufficientQuantityException;
 import com.personal.marketnote.common.domain.exception.illegalargument.invalidvalue.InvalidQuantityException;
 import com.personal.marketnote.common.domain.exception.illegalargument.novalue.QuantityNoValueException;
 import com.personal.marketnote.common.utility.FormatConverter;
@@ -67,5 +68,11 @@ public class Stock {
 
     public Integer reduce(int stock) {
         return this.stock - stock;
+    }
+
+    public void validateIsSufficient(int orderQuantity) {
+        if (stock < orderQuantity) {
+            throw new InsufficientQuantityException(stock, orderQuantity);
+        }
     }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,7 @@ services:
       - FASSTO_BASE_URL=${FASSTO_BASE_URL:-http://localhost:1234}
       - FASSTO_API_CD=${FASSTO_API_CD:-abc}
       - FASSTO_API_KEY=${FASSTO_API_KEY:-def}
+      - COMMERCE_SERVICE_SERVER_ORIGIN=https://commerce.marketnote.store
 
 networks:
   shop_network:

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/mapper/ProductJpaEntityToDomainMapper.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/mapper/ProductJpaEntityToDomainMapper.java
@@ -165,4 +165,60 @@ public class ProductJpaEntityToDomainMapper {
                     );
                 });
     }
+
+    public static Optional<ProductOptionCategory> mapToDomainWithoutProductTags(
+            ProductOptionCategoryJpaEntity productOptionCategoryJpaEntity
+    ) {
+        return Optional.ofNullable(productOptionCategoryJpaEntity)
+                .map(entity -> {
+                    Product product = mapToDomainWithoutProductTags(entity.getProductJpaEntity());
+                    ProductOptionCategory productOptionCategory = ProductOptionCategory.from(
+                            ProductOptionCategorySnapshotState.builder()
+                                    .id(entity.getId())
+                                    .product(product)
+                                    .name(entity.getName())
+                                    .options(null)
+                                    .orderNum(entity.getOrderNum())
+                                    .status(entity.getStatus())
+                                    .build()
+                    );
+
+                    List<ProductOption> options = entity.getProductOptionJpaEntities()
+                            .stream()
+                            .map(optEntity -> mapToDomain(optEntity, productOptionCategory))
+                            .filter(Optional::isPresent)
+                            .map(Optional::get)
+                            .toList();
+
+                    return ProductOptionCategory.from(
+                            ProductOptionCategorySnapshotState.builder()
+                                    .id(entity.getId())
+                                    .product(product)
+                                    .name(entity.getName())
+                                    .options(options)
+                                    .orderNum(entity.getOrderNum())
+                                    .status(entity.getStatus())
+                                    .build()
+                    );
+                });
+    }
+
+    private static Product mapToDomainWithoutProductTags(ProductJpaEntity productJpaEntity) {
+        return Product.from(
+                ProductSnapshotState.builder()
+                        .id(productJpaEntity.getId())
+                        .sellerId(productJpaEntity.getSellerId())
+                        .name(productJpaEntity.getName())
+                        .brandName(productJpaEntity.getBrandName())
+                        .detail(productJpaEntity.getDetail())
+                        .sales(productJpaEntity.getSales())
+                        .viewCount(productJpaEntity.getViewCount())
+                        .popularity(productJpaEntity.getPopularity())
+                        .findAllOptionsYn(productJpaEntity.isFindAllOptionsYn())
+                        .productTags(List.of())
+                        .orderNum(productJpaEntity.getOrderNum())
+                        .status(productJpaEntity.getStatus())
+                        .build()
+        );
+    }
 }

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/pricepolicy/repository/PricePolicyJpaRepository.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/pricepolicy/repository/PricePolicyJpaRepository.java
@@ -3,8 +3,10 @@ package com.personal.marketnote.product.adapter.out.persistence.pricepolicy.repo
 import com.personal.marketnote.product.adapter.out.persistence.pricepolicy.entity.PricePolicyJpaEntity;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
@@ -264,8 +266,11 @@ public interface PricePolicyJpaRepository extends JpaRepository<PricePolicyJpaEn
     );
 
     @Query("""
-            DELETE FROM PricePolicyJpaEntity pp
+            UPDATE PricePolicyJpaEntity pp
+            SET pp.status = com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus.INACTIVE
             WHERE pp.productJpaEntity.id = :productId
             """)
-    void deleteByProductId(Long productId);
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Transactional
+    void deactivateByProductId(@Param("productId") Long productId);
 }

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/productoption/ProductOptionPersistenceAdapter.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/productoption/ProductOptionPersistenceAdapter.java
@@ -59,8 +59,19 @@ public class ProductOptionPersistenceAdapter implements SaveProductOptionsPort, 
         List<ProductOptionPricePolicyJpaEntity> newOptionPolicies = new ArrayList<>();
         registerPricePoliciesToOptionCombinations(allCategories, savedCategory, newPolicies, newOptionPolicies, product);
 
-        // 기존 가격 정책 전체 삭제
-        pricePolicyJpaRepository.deleteByProductId(productId);
+        // 기존 가격 정책 비활성화 및 옵션-가격 정책 매핑 삭제 (장바구니 참조 보호)
+        List<PricePolicyJpaEntity> existingPolicies
+                = pricePolicyJpaRepository.findAllByProductJpaEntity_IdOrderByIdDesc(productId);
+        if (FormatValidator.hasNoValue(existingPolicies)) {
+            existingPolicies = List.of();
+        }
+        List<Long> existingPolicyIds = existingPolicies.stream()
+                .map(PricePolicyJpaEntity::getId)
+                .toList();
+        if (FormatValidator.hasValue(existingPolicyIds)) {
+            productOptionPricePolicyJpaRepository.deleteByPricePolicyIds(existingPolicyIds);
+        }
+        pricePolicyJpaRepository.deactivateByProductId(productId);
 
         // endregion
 
@@ -68,7 +79,7 @@ public class ProductOptionPersistenceAdapter implements SaveProductOptionsPort, 
         savedPricePolicyJpaEntities.forEach(PricePolicyJpaEntity::setIdToOrderNum);
         productOptionPricePolicyJpaRepository.saveAll(newOptionPolicies);
 
-        return ProductJpaEntityToDomainMapper.mapToDomain(savedCategory).orElse(null);
+        return ProductJpaEntityToDomainMapper.mapToDomainWithoutProductTags(savedCategory).orElse(null);
     }
 
     private void registerPricePoliciesToOptionCombinations(

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/productoption/repository/ProductOptionPricePolicyJpaRepository.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/productoption/repository/ProductOptionPricePolicyJpaRepository.java
@@ -43,6 +43,13 @@ public interface ProductOptionPricePolicyJpaRepository extends JpaRepository<Pro
             where popp.id.pricePolicyId = :pricePolicyId
             """)
     void deleteByPricePolicyId(@Param("pricePolicyId") Long pricePolicyId);
-}
 
+    @Modifying
+    @Query("""
+            delete
+            from com.personal.marketnote.product.adapter.out.persistence.productoption.entity.ProductOptionPricePolicyJpaEntity popp
+            where popp.id.pricePolicyId in :pricePolicyIds
+            """)
+    void deleteByPricePolicyIds(@Param("pricePolicyIds") List<Long> pricePolicyIds);
+}
 

--- a/product-service/product-adapters/src/test/java/com/personal/marketnote/product/adapter/out/persistence/productoption/ProductOptionPersistenceAdapterTest.java
+++ b/product-service/product-adapters/src/test/java/com/personal/marketnote/product/adapter/out/persistence/productoption/ProductOptionPersistenceAdapterTest.java
@@ -51,7 +51,7 @@ class ProductOptionPersistenceAdapterTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    void save_whenTwoExistingCategoriesAndNewOne_createsOnlyFullCombinationsAndDeletesOldPolicies() {
+    void save_whenTwoExistingCategoriesAndNewOne_createsOnlyFullCombinationsAndDeactivatesOldPolicies() {
         long productId = 1L;
         Product product = buildProduct(productId);
         ProductOptionCategory newCategory = buildCategory(product, "C", 4);
@@ -73,7 +73,7 @@ class ProductOptionPersistenceAdapterTest {
 
         adapter.save(newCategory);
 
-        verify(pricePolicyJpaRepository).deleteByProductId(productId);
+        verify(pricePolicyJpaRepository).deactivateByProductId(productId);
 
         ArgumentCaptor<List<PricePolicyJpaEntity>> policiesCaptor = ArgumentCaptor.forClass(List.class);
         verify(pricePolicyJpaRepository).saveAll(policiesCaptor.capture());
@@ -96,7 +96,7 @@ class ProductOptionPersistenceAdapterTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    void save_whenOnlyOneCategory_createsSingleOptionPoliciesAndDeletesOldPolicies() {
+    void save_whenOnlyOneCategory_createsSingleOptionPoliciesAndDeactivatesOldPolicies() {
         long productId = 2L;
         Product product = buildProduct(productId);
         ProductOptionCategory newCategory = buildCategory(product, "A", 3);
@@ -115,7 +115,7 @@ class ProductOptionPersistenceAdapterTest {
 
         adapter.save(newCategory);
 
-        verify(pricePolicyJpaRepository).deleteByProductId(productId);
+        verify(pricePolicyJpaRepository).deactivateByProductId(productId);
 
         ArgumentCaptor<List<PricePolicyJpaEntity>> policiesCaptor = ArgumentCaptor.forClass(List.class);
         verify(pricePolicyJpaRepository).saveAll(policiesCaptor.capture());

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/service/category/RegisterCategoryService.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/service/category/RegisterCategoryService.java
@@ -34,7 +34,7 @@ public class RegisterCategoryService implements RegisterCategoryUseCase {
                         && findCategoryPort.findAllActiveByIds(List.of(parentCategoryId)).isEmpty()
         ) {
             throw new CategoryNotFoundException(
-                    "%s::존재하지 않는 상위 카테고리 ID입니다. 전송된 상위 카테고리 ID: %d",
+                    "존재하지 않는 상위 카테고리 ID입니다. 전송된 상위 카테고리 ID: %d",
                     parentCategoryId
             );
         }

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/UserApplication.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/UserApplication.java
@@ -1,22 +1,11 @@
 package com.personal.marketnote.user;
 
-import com.personal.marketnote.common.configuration.security.OpaqueTokenIntrospectorConfig;
-import com.personal.marketnote.common.configuration.security.OpaqueTokenIntrospectorProvider;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.FilterType;
 
 @SpringBootApplication(scanBasePackages = {
         "com.personal.marketnote"
 })
-@ComponentScan(
-        basePackages = "com.personal.marketnote",
-        excludeFilters = {
-                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = OpaqueTokenIntrospectorConfig.class),
-                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = OpaqueTokenIntrospectorProvider.class)
-        }
-)
 public class UserApplication {
     public static void main(String[] args) {
         SpringApplication.run(UserApplication.class, args);


### PR DESCRIPTION
## partially addresses #128
## resolves #714

## Task
## Reason
불필요한 상황에서도 상품 태그 엔티티에 접근 로직 존재

## Action
상품 태그 관련 조회 제외한 DB I/O 과정에서 상품 태그 엔티티 접근 로직 제거