### PR TITLE
[#723][#128][#724] fix: 상품 서비스 관련 이슈 대응

### DIFF
--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/pricepolicy/PricePolicyPersistenceAdapter.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/pricepolicy/PricePolicyPersistenceAdapter.java
@@ -128,8 +128,7 @@ public class PricePolicyPersistenceAdapter implements SavePricePolicyPort, FindP
     @Override
     public Optional<PricePolicy> findByOptionIds(List<Long> optionIds) {
         return pricePolicyJpaRepository.findOneByOptionIds(optionIds)
-                .map(PricePolicyJpaEntityToDomainMapper::mapToDomain)
-                .orElse(null);
+                .flatMap(PricePolicyJpaEntityToDomainMapper::mapToDomain);
     }
 
     @Override

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/pricepolicy/entity/PricePolicyJpaEntity.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/pricepolicy/entity/PricePolicyJpaEntity.java
@@ -61,6 +61,6 @@ public class PricePolicyJpaEntity extends BaseOrderedGeneralEntity {
     }
 
     public void deactivate() {
-        deactivate();
+        super.deactivate();
     }
 }

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/pricepolicy/repository/PricePolicyJpaRepository.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/pricepolicy/repository/PricePolicyJpaRepository.java
@@ -74,8 +74,8 @@ public interface PricePolicyJpaRepository extends JpaRepository<PricePolicyJpaEn
                  OR NOT EXISTS (SELECT 1 FROM PricePolicyJpaEntity pp0 WHERE pp0.id = :cursor)
                  OR (
                         (:sortProperty = 'orderNum' AND (
-                              pp.orderNum > (SELECT pp2.orderNum FROM PricePolicyJpaEntity pp2 WHERE pp2.id = :cursor)
-                           OR (pp.orderNum = (SELECT pp2.orderNum FROM PricePolicyJpaEntity pp2 WHERE pp2.id = :cursor)
+                              p.orderNum > (SELECT pp2.productJpaEntity.orderNum FROM PricePolicyJpaEntity pp2 WHERE pp2.id = :cursor)
+                           OR (p.orderNum = (SELECT pp2.productJpaEntity.orderNum FROM PricePolicyJpaEntity pp2 WHERE pp2.id = :cursor)
                                AND pp.id > :cursor)
                         ))
                      OR (:sortProperty = 'popularity' AND (
@@ -96,7 +96,7 @@ public interface PricePolicyJpaRepository extends JpaRepository<PricePolicyJpaEn
                  )
               )
             ORDER BY
-                CASE WHEN :sortProperty = 'orderNum' THEN pp.orderNum END ASC,
+                CASE WHEN :sortProperty = 'orderNum' THEN p.orderNum END ASC,
                 CASE WHEN :sortProperty = 'popularity' THEN pp.popularity END ASC,
                 CASE WHEN :sortProperty = 'discountPrice' THEN pp.discountPrice END ASC,
                 CASE WHEN :sortProperty = 'accumulatedPoint' THEN pp.accumulatedPoint END ASC,
@@ -142,13 +142,13 @@ public interface PricePolicyJpaRepository extends JpaRepository<PricePolicyJpaEn
                  OR NOT EXISTS (SELECT 1 FROM PricePolicyJpaEntity pp0 WHERE pp0.id = :cursor)
                  OR (
                         (:sortProperty = 'orderNum' AND (
-                              pp.orderNum < (
-                                  SELECT pp2.orderNum
+                              p.orderNum < (
+                                  SELECT pp2.productJpaEntity.orderNum
                                   FROM PricePolicyJpaEntity pp2
                                   WHERE pp2.id = :cursor
                               )
-                           OR (pp.orderNum = (
-                                    SELECT pp2.orderNum
+                           OR (p.orderNum = (
+                                    SELECT pp2.productJpaEntity.orderNum
                                     FROM PricePolicyJpaEntity pp2
                                     WHERE pp2.id = :cursor
                                 )
@@ -196,7 +196,7 @@ public interface PricePolicyJpaRepository extends JpaRepository<PricePolicyJpaEn
                  )
               )
             ORDER BY
-                CASE WHEN :sortProperty = 'orderNum' THEN pp.orderNum END DESC,
+                CASE WHEN :sortProperty = 'orderNum' THEN p.orderNum END DESC,
                 CASE WHEN :sortProperty = 'popularity' THEN pp.popularity END DESC,
                 CASE WHEN :sortProperty = 'discountPrice' THEN pp.discountPrice END DESC,
                 CASE WHEN :sortProperty = 'accumulatedPoint' THEN pp.accumulatedPoint END DESC,

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/product/repository/ProductJpaRepository.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/product/repository/ProductJpaRepository.java
@@ -442,8 +442,8 @@ public interface ProductJpaRepository extends JpaRepository<ProductJpaEntity, Lo
             ORDER BY
                 CASE WHEN :sortProperty = 'orderNum' THEN p.orderNum END DESC,
                 CASE WHEN :sortProperty = 'popularity' THEN p.sales END DESC,
-                CASE WHEN :sortProperty = 'name' THEN COALESCE(pp.discountPrice, 0) END DESC,
-                CASE WHEN :sortProperty = 'brandName' THEN COALESCE(pp.accumulatedPoint, 0) END DESC,
+                CASE WHEN :sortProperty = 'discountPrice' THEN COALESCE(pp.discountPrice, 0) END DESC,
+                CASE WHEN :sortProperty = 'accumulatedPoint' THEN COALESCE(pp.accumulatedPoint, 0) END DESC,
                 p.id DESC
             """)
     List<ProductJpaEntity> findAllActiveByCategoryIdCursorDesc(

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/productoption/ProductOptionPersistenceAdapter.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/productoption/ProductOptionPersistenceAdapter.java
@@ -213,7 +213,7 @@ public class ProductOptionPersistenceAdapter implements SaveProductOptionsPort, 
 
     @Override
     @CacheEvict(value = "product:detail", key = "#productId")
-    public void assignPricePolicyToOptions(Long pricePolicyId, List<Long> optionIds) {
+    public void assignPricePolicyToOptions(Long productId, Long pricePolicyId, List<Long> optionIds) {
         // 기존 동일 옵션 조합 가격 정책 삭제
         List<PricePolicyJpaEntity> existentPricePolicies = pricePolicyJpaRepository.findByOptionIds(optionIds);
         existentPricePolicies.forEach(PricePolicyJpaEntity::deactivate);

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/usecase/option/DeleteProductOptionsUseCase.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/usecase/option/DeleteProductOptionsUseCase.java
@@ -1,6 +1,15 @@
 package com.personal.marketnote.product.port.in.usecase.option;
 
 public interface DeleteProductOptionsUseCase {
+    /**
+     * @param userId           사용자 ID
+     * @param isAdmin          관리자 여부
+     * @param productId        상품 ID
+     * @param optionCategoryId 옵션 카테고리 ID
+     * @Date 2026-02-16
+     * @Author 성효빈
+     * @Description 상품 옵션을 삭제합니다.
+     */
     void deleteProductOptions(
             Long userId, boolean isAdmin, Long productId, Long optionCategoryId
     );

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/usecase/option/UpdateProductOptionsUseCase.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/usecase/option/UpdateProductOptionsUseCase.java
@@ -4,6 +4,15 @@ import com.personal.marketnote.product.port.in.command.UpdateProductOptionsComma
 import com.personal.marketnote.product.port.in.result.option.UpdateProductOptionsResult;
 
 public interface UpdateProductOptionsUseCase {
+    /**
+     * @param userId  사용자 ID
+     * @param isAdmin 관리자 여부
+     * @param command 상품 옵션 수정 커맨드
+     * @return 상품 옵션 수정 결과 {@link UpdateProductOptionsResult}
+     * @Date 2026-02-16
+     * @Author 성효빈
+     * @Description 상품 옵션을 수정합니다.
+     */
     UpdateProductOptionsResult updateProductOptions(
             Long userId, boolean isAdmin, UpdateProductOptionsCommand command
     );

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/out/productoption/UpdateOptionPricePolicyPort.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/out/productoption/UpdateOptionPricePolicyPort.java
@@ -3,7 +3,6 @@ package com.personal.marketnote.product.port.out.productoption;
 import java.util.List;
 
 public interface UpdateOptionPricePolicyPort {
-    void assignPricePolicyToOptions(Long pricePolicyId, List<Long> optionIds);
+    void assignPricePolicyToOptions(Long productId, Long pricePolicyId, List<Long> optionIds);
 }
-
 

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/service/cart/UpdateCartProductOptionsService.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/service/cart/UpdateCartProductOptionsService.java
@@ -4,14 +4,12 @@ import com.personal.marketnote.common.application.UseCase;
 import com.personal.marketnote.product.domain.cart.CartProduct;
 import com.personal.marketnote.product.domain.pricepolicy.PricePolicy;
 import com.personal.marketnote.product.exception.CartProductAlreadyExistsException;
-import com.personal.marketnote.product.exception.PricePolicyNotFoundException;
 import com.personal.marketnote.product.port.in.command.UpdateCartProductOptionCommand;
 import com.personal.marketnote.product.port.in.usecase.cart.GetCartProductUseCase;
 import com.personal.marketnote.product.port.in.usecase.cart.UpdateCartProductOptionsUseCase;
 import com.personal.marketnote.product.port.in.usecase.pricepolicy.GetPricePolicyUseCase;
 import com.personal.marketnote.product.port.out.cart.UpdateCartProductPort;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.transaction.annotation.Transactional;
 
 import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
@@ -19,7 +17,6 @@ import static org.springframework.transaction.annotation.Isolation.READ_COMMITTE
 @UseCase
 @RequiredArgsConstructor
 @Transactional(isolation = READ_COMMITTED)
-@Slf4j
 public class UpdateCartProductOptionsService implements UpdateCartProductOptionsUseCase {
     private final GetCartProductUseCase getCartProductUseCase;
     private final GetPricePolicyUseCase getPricePolicyUseCase;
@@ -28,20 +25,18 @@ public class UpdateCartProductOptionsService implements UpdateCartProductOptions
     @Override
     public void updateCartProductOptions(UpdateCartProductOptionCommand command) {
         Long userId = command.userId();
-        Long policyId = command.pricePolicyId();
-        CartProduct cartProduct = getCartProductUseCase.getCartProduct(userId, policyId);
+        Long originalPolicyId = command.pricePolicyId();
+        CartProduct cartProduct = getCartProductUseCase.getCartProduct(userId, originalPolicyId);
 
-        try {
-            PricePolicy pricePolicy = getPricePolicyUseCase.getPricePolicy(command.newOptionIds());
-            cartProduct.updatePricePolicy(pricePolicy);
+        PricePolicy pricePolicy = getPricePolicyUseCase.getPricePolicy(command.newOptionIds());
+        cartProduct.updatePricePolicy(pricePolicy);
 
-            if (getCartProductUseCase.existsByUserIdAndPolicyId(userId, policyId)) {
-                throw new CartProductAlreadyExistsException(userId, policyId);
-            }
-
-            updateCartProductPort.update(cartProduct, policyId);
-        } catch (PricePolicyNotFoundException e) {
-            log.warn("Price policy not found for options: {}", command.newOptionIds());
+        Long newPolicyId = pricePolicy.getId();
+        boolean pricePolicyChanged = !originalPolicyId.equals(newPolicyId);
+        if (pricePolicyChanged && getCartProductUseCase.existsByUserIdAndPolicyId(userId, newPolicyId)) {
+            throw new CartProductAlreadyExistsException(userId, newPolicyId);
         }
+
+        updateCartProductPort.update(cartProduct, originalPolicyId);
     }
 }

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/service/pricepolicy/RegisterPricePolicyService.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/service/pricepolicy/RegisterPricePolicyService.java
@@ -50,7 +50,7 @@ public class RegisterPricePolicyService implements RegisterPricePolicyUseCase {
 
         List<Long> optionIds = command.optionIds();
         if (FormatValidator.hasValue(optionIds)) {
-            updateOptionPricePolicyPort.assignPricePolicyToOptions(id, optionIds);
+            updateOptionPricePolicyPort.assignPricePolicyToOptions(productId, id, optionIds);
         }
 
         registerInventoryAfterCommit(productId, id);

--- a/product-service/product-application/src/test/java/com/personal/marketnote/product/service/pricepolicy/RegisterPricePolicyUseCaseTest.java
+++ b/product-service/product-application/src/test/java/com/personal/marketnote/product/service/pricepolicy/RegisterPricePolicyUseCaseTest.java
@@ -99,7 +99,7 @@ class RegisterPricePolicyUseCaseTest {
         assertThat(saved.getAccumulationRate())
                 .isEqualByComparingTo(calculateAccumulationRate(command.accumulatedPoint(), command.discountPrice()));
 
-        verify(updateOptionPricePolicyPort).assignPricePolicyToOptions(100L, optionIds);
+        verify(updateOptionPricePolicyPort).assignPricePolicyToOptions(productId, 100L, optionIds);
         verify(registerInventoryPort).registerInventory(productId, 100L);
     }
 
@@ -118,7 +118,7 @@ class RegisterPricePolicyUseCaseTest {
 
         assertThat(result.id()).isEqualTo(200L);
         verify(registerInventoryPort).registerInventory(productId, 200L);
-        verify(updateOptionPricePolicyPort, never()).assignPricePolicyToOptions(anyLong(), anyList());
+        verify(updateOptionPricePolicyPort, never()).assignPricePolicyToOptions(anyLong(), anyLong(), anyList());
         verifyNoInteractions(findProductPort);
     }
 
@@ -136,7 +136,7 @@ class RegisterPricePolicyUseCaseTest {
 
         registerPricePolicyService.registerPricePolicy(userId, false, command);
 
-        verify(updateOptionPricePolicyPort, never()).assignPricePolicyToOptions(anyLong(), anyList());
+        verify(updateOptionPricePolicyPort, never()).assignPricePolicyToOptions(anyLong(), anyLong(), anyList());
         verify(registerInventoryPort).registerInventory(productId, 250L);
     }
 
@@ -174,7 +174,7 @@ class RegisterPricePolicyUseCaseTest {
         assertThatThrownBy(() -> registerPricePolicyService.registerPricePolicy(userId, false, command))
                 .isSameAs(exception);
 
-        verify(updateOptionPricePolicyPort, never()).assignPricePolicyToOptions(anyLong(), anyList());
+        verify(updateOptionPricePolicyPort, never()).assignPricePolicyToOptions(anyLong(), anyLong(), anyList());
         verifyNoInteractions(registerInventoryPort);
     }
 
@@ -191,7 +191,7 @@ class RegisterPricePolicyUseCaseTest {
         when(findProductPort.existsByIdAndSellerId(productId, userId)).thenReturn(true);
         when(getProductUseCase.getProduct(productId)).thenReturn(product);
         when(savePricePolicyPort.save(any(PricePolicy.class))).thenReturn(300L);
-        doThrow(exception).when(updateOptionPricePolicyPort).assignPricePolicyToOptions(300L, optionIds);
+        doThrow(exception).when(updateOptionPricePolicyPort).assignPricePolicyToOptions(productId, 300L, optionIds);
 
         assertThatThrownBy(() -> registerPricePolicyService.registerPricePolicy(userId, false, command))
                 .isSameAs(exception);
@@ -217,7 +217,7 @@ class RegisterPricePolicyUseCaseTest {
         assertThatThrownBy(() -> registerPricePolicyService.registerPricePolicy(userId, false, command))
                 .isSameAs(exception);
 
-        verify(updateOptionPricePolicyPort).assignPricePolicyToOptions(400L, optionIds);
+        verify(updateOptionPricePolicyPort).assignPricePolicyToOptions(productId, 400L, optionIds);
     }
 
     private RegisterPricePolicyCommand buildCommand(Long productId, List<Long> optionIds) {


### PR DESCRIPTION
## partially addresses #723
## partially addresses #128
## resolves #724

## Task
- [x] 옵션 가격정책 Cache Key가 null로 반환되는 버그 픽스
- [x] 가격 정책 튜플 논리적 삭제 시 PricePolicyJpaEntity 클래스의 deactivate 메서드를 재귀 호출하는 버그 픽스
- [x] 상품 정렬 시 ORDER_NUM 기준을 PricePolicy 엔티티에서 Product 엔티티로 변경
- [x] 카테고리 DESC 정렬 쿼리의 타이포 픽스(name/brandName → discountPrice/accumulatedPoint)
- [x] PricePolicyPersistenceAdapter.findByOptionIds() 메서드가 Optional 대신 null 반환하던 버그 픽스
- [x] 장바구니 상품 옵션 수정 시 새로운 옵션 조합으로 계산된 pricePolicyId 기준으로 중복 체크 로직 추가