### PR TITLE
[#475][#736] feat: 파스토 비정상 입고 상품 이미지 조회 연동 기능 추가

### DIFF
--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/FasstoWarehousingController.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/FasstoWarehousingController.java
@@ -30,6 +30,7 @@ public class FasstoWarehousingController {
     private final GetFasstoWarehousingUseCase getFasstoWarehousingUseCase;
     private final GetFasstoWarehousingDetailUseCase getFasstoWarehousingDetailUseCase;
     private final GetFasstoWarehousingAbnormalUseCase getFasstoWarehousingAbnormalUseCase;
+    private final GetFasstoWarehousingAbnormalImageUseCase getFasstoWarehousingAbnormalImageUseCase;
     private final UpdateFasstoWarehousingUseCase updateFasstoWarehousingUseCase;
 
     /**
@@ -189,6 +190,52 @@ public class FasstoWarehousingController {
                         HttpStatus.OK,
                         DEFAULT_SUCCESS_CODE,
                         "파스토 비정상 입고 상품 조회 성공"
+                ),
+                HttpStatus.OK
+        );
+    }
+
+    /**
+     * (관리자) 파스토 비정상 입고 상품 이미지 조회
+     *
+     * @param slipNo        입고요청번호
+     * @param godCd         상품코드
+     * @param goodsSerialNo 상품일련번호
+     * @param fileSeq       파일seq
+     * @param imgNo         이미지순서
+     * @param accessToken   파스토 액세스 토큰
+     * @Author 성효빈
+     * @Date 2026-02-17
+     * @Description 파스토 비정상 입고 상품 이미지를 조회합니다.
+     */
+    @GetMapping("/abnormal/image/{slipNo}/{godCd}/{goodsSerialNo}/{fileSeq}/{imgNo}")
+    @PreAuthorize(ADMIN_POINTCUT)
+    @GetFasstoWarehousingAbnormalImageApiDocs
+    public ResponseEntity<BaseResponse<GetFasstoWarehousingAbnormalImageResponse>> getWarehousingAbnormalImage(
+            @PathVariable String slipNo,
+            @PathVariable String godCd,
+            @PathVariable String goodsSerialNo,
+            @PathVariable String fileSeq,
+            @PathVariable String imgNo,
+            @RequestHeader("accessToken") String accessToken
+    ) {
+        GetFasstoWarehousingAbnormalImageResult result = getFasstoWarehousingAbnormalImageUseCase.getWarehousingAbnormalImage(
+                FasstoWarehousingRequestToCommandMapper.mapToWarehousingAbnormalImageCommand(
+                        accessToken,
+                        slipNo,
+                        godCd,
+                        goodsSerialNo,
+                        fileSeq,
+                        imgNo
+                )
+        );
+
+        return new ResponseEntity<>(
+                BaseResponse.of(
+                        GetFasstoWarehousingAbnormalImageResponse.from(result),
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "파스토 비정상 입고 상품 이미지 조회 성공"
                 ),
                 HttpStatus.OK
         );

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/apidocs/GetFasstoWarehousingAbnormalImageApiDocs.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/apidocs/GetFasstoWarehousingAbnormalImageApiDocs.java
@@ -1,0 +1,122 @@
+package com.personal.marketnote.fulfillment.adapter.in.web.vendor.controller.apidocs;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Operation(
+        summary = "(관리자) 파스토 비정상 입고 상품 이미지 조회",
+        description = """
+                작성일자: 2026-02-17
+                
+                작성자: 성효빈
+                
+                ---
+                
+                ## Description
+                
+                파스토 비정상 입고 상품의 이미지 정보를 조회합니다.
+                
+                ---
+                
+                ## Request
+                
+                | **키** | **위치** | **타입** | **설명** | **필수 여부** | **예시** |
+                | --- | --- | --- | --- | --- | --- |
+                | accessToken | header | string | 파스토 액세스 토큰 | Y | eefae1befa4c11f0be620ab49498ff55 |
+                | slipNo | path | string | 입고요청번호 | Y | TESTIO260119000005 |
+                | godCd | path | string | 상품코드 | Y | 943881 |
+                | goodsSerialNo | path | string | 상품일련번호 | Y | SERIAL-0001 |
+                | fileSeq | path | string | 파일seq | Y | 1 |
+                | imgNo | path | string | 이미지순서 | Y | 1 |
+                
+                ---
+                
+                ## Response
+                
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | statusCode | number | 상태 코드 | 200: 성공 / 400: 클라이언트 요청 오류 / 401: 인증 실패 / 403: 인가 실패 / 500: 그 외 |
+                | code | string | 응답 코드 | "SUC01" / "BAD_REQUEST" / "UNAUTHORIZED" / "FORBIDDEN" / "INTERNAL_SERVER_ERROR" |
+                | timestamp | string(datetime) | 응답 일시 | "2026-02-17T12:12:30.013" |
+                | content | object | 응답 본문 | { ... } |
+                | message | string | 처리 결과 | "파스토 비정상 입고 상품 이미지 조회 성공" |
+                """,
+        security = {@SecurityRequirement(name = "bearer")},
+        parameters = {
+                @Parameter(
+                        name = "accessToken",
+                        description = "파스토 액세스 토큰",
+                        in = ParameterIn.HEADER,
+                        required = true,
+                        schema = @Schema(type = "string", example = "eefae1befa4c11f0be620ab49498ff55")
+                ),
+                @Parameter(
+                        name = "slipNo",
+                        description = "입고요청번호",
+                        in = ParameterIn.PATH,
+                        required = true,
+                        schema = @Schema(type = "string", example = "TESTIO260119000005")
+                ),
+                @Parameter(
+                        name = "godCd",
+                        description = "상품코드",
+                        in = ParameterIn.PATH,
+                        required = true,
+                        schema = @Schema(type = "string", example = "943881")
+                ),
+                @Parameter(
+                        name = "goodsSerialNo",
+                        description = "상품일련번호",
+                        in = ParameterIn.PATH,
+                        required = true,
+                        schema = @Schema(type = "string", example = "SERIAL-0001")
+                ),
+                @Parameter(
+                        name = "fileSeq",
+                        description = "파일seq",
+                        in = ParameterIn.PATH,
+                        required = true,
+                        schema = @Schema(type = "string", example = "1")
+                ),
+                @Parameter(
+                        name = "imgNo",
+                        description = "이미지순서",
+                        in = ParameterIn.PATH,
+                        required = true,
+                        schema = @Schema(type = "string", example = "1")
+                )
+        },
+        responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "파스토 비정상 입고 상품 이미지 조회 성공",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 200,
+                                          "code": "SUC01",
+                                          "timestamp": "2026-02-17T12:12:30.013",
+                                          "content": {
+                                            "dataCount": 1,
+                                            "data": {}
+                                          },
+                                          "message": "파스토 비정상 입고 상품 이미지 조회 성공"
+                                        }
+                                        """)
+                        )
+                )
+        }
+)
+public @interface GetFasstoWarehousingAbnormalImageApiDocs {
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/mapper/FasstoWarehousingRequestToCommandMapper.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/mapper/FasstoWarehousingRequestToCommandMapper.java
@@ -51,6 +51,24 @@ public class FasstoWarehousingRequestToCommandMapper {
         return GetFasstoWarehousingAbnormalCommand.of(customerCode, accessToken, whCd, slipNo);
     }
 
+    public static GetFasstoWarehousingAbnormalImageCommand mapToWarehousingAbnormalImageCommand(
+            String accessToken,
+            String slipNo,
+            String godCd,
+            String goodsSerialNo,
+            String fileSeq,
+            String imgNo
+    ) {
+        return GetFasstoWarehousingAbnormalImageCommand.of(
+                accessToken,
+                slipNo,
+                godCd,
+                goodsSerialNo,
+                fileSeq,
+                imgNo
+        );
+    }
+
     public static UpdateFasstoWarehousingCommand mapToUpdateCommand(
             String customerCode,
             String accessToken,

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/response/GetFasstoWarehousingAbnormalImageResponse.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/response/GetFasstoWarehousingAbnormalImageResponse.java
@@ -1,0 +1,12 @@
+package com.personal.marketnote.fulfillment.adapter.in.web.vendor.response;
+
+import com.personal.marketnote.fulfillment.port.in.result.vendor.GetFasstoWarehousingAbnormalImageResult;
+
+public record GetFasstoWarehousingAbnormalImageResponse(
+        Integer dataCount,
+        Object data
+) {
+    public static GetFasstoWarehousingAbnormalImageResponse from(GetFasstoWarehousingAbnormalImageResult result) {
+        return new GetFasstoWarehousingAbnormalImageResponse(result.dataCount(), result.data());
+    }
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/client/FasstoWarehousingClient.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/client/FasstoWarehousingClient.java
@@ -7,10 +7,7 @@ import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.common.utility.http.client.CommunicationFailureHandler;
 import com.personal.marketnote.fulfillment.adapter.out.vendor.fassto.response.*;
 import com.personal.marketnote.fulfillment.configuration.FasstoAuthProperties;
-import com.personal.marketnote.fulfillment.domain.vendor.fassto.warehousing.FasstoWarehousingAbnormalQuery;
-import com.personal.marketnote.fulfillment.domain.vendor.fassto.warehousing.FasstoWarehousingDetailQuery;
-import com.personal.marketnote.fulfillment.domain.vendor.fassto.warehousing.FasstoWarehousingMapper;
-import com.personal.marketnote.fulfillment.domain.vendor.fassto.warehousing.FasstoWarehousingQuery;
+import com.personal.marketnote.fulfillment.domain.vendor.fassto.warehousing.*;
 import com.personal.marketnote.fulfillment.domain.vendorcommunication.FulfillmentVendorCommunicationSenderType;
 import com.personal.marketnote.fulfillment.domain.vendorcommunication.FulfillmentVendorCommunicationTargetType;
 import com.personal.marketnote.fulfillment.domain.vendorcommunication.FulfillmentVendorCommunicationType;
@@ -40,7 +37,7 @@ import static com.personal.marketnote.common.utility.ApiConstant.*;
 @VendorAdapter
 @RequiredArgsConstructor
 @Slf4j
-public class FasstoWarehousingClient implements RegisterFasstoWarehousingPort, GetFasstoWarehousingPort, GetFasstoWarehousingDetailPort, GetFasstoWarehousingAbnormalPort, UpdateFasstoWarehousingPort {
+public class FasstoWarehousingClient implements RegisterFasstoWarehousingPort, GetFasstoWarehousingPort, GetFasstoWarehousingDetailPort, GetFasstoWarehousingAbnormalPort, GetFasstoWarehousingAbnormalImagePort, UpdateFasstoWarehousingPort {
     private static final String ACCESS_TOKEN_HEADER = "accessToken";
     private static final String CUSTOMER_CODE_PLACEHOLDER = "{customerCode}";
 
@@ -429,6 +426,125 @@ public class FasstoWarehousingClient implements RegisterFasstoWarehousingPort, G
         throw new GetFasstoWarehousingAbnormalFailedException(failureMessage, new IOException(error));
     }
 
+    @Override
+    public GetFasstoWarehousingAbnormalImageResult getWarehousingAbnormalImage(FasstoWarehousingAbnormalImageQuery query) {
+        if (FormatValidator.hasNoValue(query)) {
+            throw new IllegalArgumentException("Fassto warehousing abnormal image query is required.");
+        }
+
+        URI uri = buildWarehousingAbnormalImageUri(
+                query.getSlipNo(),
+                query.getGodCd(),
+                query.getGoodsSerialNo(),
+                query.getFileSeq(),
+                query.getImgNo()
+        );
+        HttpEntity<Void> httpEntity = new HttpEntity<>(buildHeaders(query.getAccessToken(), false));
+
+        Exception error = new Exception();
+        String failureMessage = null;
+        long sleepMillis = INTER_SERVER_DEFAULT_RETRIAL_PENDING_MILLI_SECOND;
+        FulfillmentVendorCommunicationTargetType targetType = FulfillmentVendorCommunicationTargetType.WAREHOUSING;
+        FulfillmentVendorName vendorName = FulfillmentVendorName.FASSTO;
+
+        for (int i = 0; i < INTER_SERVER_MAX_REQUEST_COUNT; i++) {
+            int attempt = i + 1;
+            JsonNode requestPayloadJson = buildAbnormalImageRequestPayloadJson(query, uri, attempt);
+            String requestPayload = requestPayloadJson.toString();
+
+            ResponseEntity<String> response;
+            try {
+                response = restTemplate.exchange(
+                        uri,
+                        HttpMethod.GET,
+                        httpEntity,
+                        String.class
+                );
+            } catch (Exception e) {
+                Map<String, Object> errorPayload = new LinkedHashMap<>();
+                errorPayload.put("error", e.getClass().getSimpleName());
+                errorPayload.put("message", e.getMessage());
+                errorPayload.put("attempt", attempt);
+
+                vendorCommunicationFailureHandler.handleFailure(
+                        targetType,
+                        vendorName,
+                        requestPayload,
+                        requestPayloadJson,
+                        errorPayload,
+                        e
+                );
+
+                String vendorMessage = resolveVendorMessageFromException(e);
+                if (FormatValidator.hasValue(vendorMessage)) {
+                    failureMessage = vendorMessage;
+                    error = new Exception(vendorMessage);
+                }
+
+                log.warn("Failed to get Fassto warehousing abnormal image: attempt={}, message={}", attempt, e.getMessage(), e);
+                if (i == INTER_SERVER_MAX_REQUEST_COUNT - 1) {
+                    error = e;
+                }
+
+                sleep(sleepMillis);
+                sleepMillis = sleepMillis * INTER_SERVER_DEFAULT_EXPONENTIAL_BACKOFF_VALUE;
+                continue;
+            }
+
+            JsonNode responsePayloadJson = buildResponsePayloadJson(response, attempt);
+            String responsePayload = responsePayloadJson.toString();
+
+            FasstoWarehousingAbnormalImageResponse parsedResponse = parseWarehousingAbnormalImageResponse(response);
+            boolean isSuccess = isWarehousingAbnormalImageSuccess(response, parsedResponse);
+            String exception = isSuccess ? null : resolveWarehousingAbnormalImageException(response, parsedResponse);
+
+            vendorCommunicationRecorder.record(
+                    targetType,
+                    FulfillmentVendorCommunicationType.REQUEST,
+                    FulfillmentVendorCommunicationSenderType.SERVER,
+                    vendorName,
+                    requestPayload,
+                    requestPayloadJson,
+                    exception
+            );
+            vendorCommunicationRecorder.record(
+                    targetType,
+                    FulfillmentVendorCommunicationType.RESPONSE,
+                    FulfillmentVendorCommunicationSenderType.VENDOR,
+                    vendorName,
+                    responsePayload,
+                    responsePayloadJson,
+                    exception
+            );
+
+            if (isSuccess) {
+                return mapWarehousingAbnormalImageResult(parsedResponse);
+            }
+
+            String vendorMessage = resolveVendorMessage(parsedResponse, FormatValidator.hasValue(response) ? response.getBody() : null);
+            if (FormatValidator.hasValue(vendorMessage)) {
+                failureMessage = vendorMessage;
+                error = new Exception(vendorMessage);
+            }
+
+            log.warn("Fassto warehousing abnormal image request failed: attempt={}, status={}, exception={}",
+                    attempt,
+                    FormatValidator.hasValue(response) ? response.getStatusCode() : null,
+                    exception
+            );
+
+            if (CommunicationFailureHandler.isCertainFailure(response)) {
+                break;
+            }
+
+            sleep(sleepMillis);
+            sleepMillis = sleepMillis * INTER_SERVER_DEFAULT_EXPONENTIAL_BACKOFF_VALUE;
+        }
+
+        log.error("Failed to get Fassto warehousing abnormal image: {} with error: {}", uri, error.getMessage(), error);
+        throw new GetFasstoWarehousingAbnormalImageFailedException(failureMessage, new IOException(error));
+    }
+
     private RegisterFasstoWarehousingResponse executeWarehousingMutation(
             FasstoWarehousingMapper request,
             String action,
@@ -629,6 +745,20 @@ public class FasstoWarehousingClient implements RegisterFasstoWarehousingPort, G
                 .toUri();
     }
 
+    private URI buildWarehousingAbnormalImageUri(
+            String slipNo,
+            String godCd,
+            String goodsSerialNo,
+            String fileSeq,
+            String imgNo
+    ) {
+        validateWarehousingAbnormalImageProperties();
+        return UriComponentsBuilder.fromUriString(properties.getBaseUrl())
+                .path(properties.getWarehousingAbnormalImagePath())
+                .buildAndExpand(slipNo, godCd, goodsSerialNo, fileSeq, imgNo)
+                .toUri();
+    }
+
     private HttpHeaders buildHeaders(String accessToken) {
         return buildHeaders(accessToken, true);
     }
@@ -706,6 +836,30 @@ public class FasstoWarehousingClient implements RegisterFasstoWarehousingPort, G
         }
     }
 
+    private void validateWarehousingAbnormalImageProperties() {
+        if (FormatValidator.hasNoValue(properties.getBaseUrl())) {
+            throw new IllegalStateException("Fassto base URL is required.");
+        }
+        if (FormatValidator.hasNoValue(properties.getWarehousingAbnormalImagePath())) {
+            throw new IllegalStateException("Fassto warehousing abnormal image path is required.");
+        }
+        if (!properties.getWarehousingAbnormalImagePath().contains("{slipNo}")) {
+            throw new IllegalStateException("Fassto warehousing abnormal image path must include {slipNo}.");
+        }
+        if (!properties.getWarehousingAbnormalImagePath().contains("{godCd}")) {
+            throw new IllegalStateException("Fassto warehousing abnormal image path must include {godCd}.");
+        }
+        if (!properties.getWarehousingAbnormalImagePath().contains("{goodsSerialNo}")) {
+            throw new IllegalStateException("Fassto warehousing abnormal image path must include {goodsSerialNo}.");
+        }
+        if (!properties.getWarehousingAbnormalImagePath().contains("{fileSeq}")) {
+            throw new IllegalStateException("Fassto warehousing abnormal image path must include {fileSeq}.");
+        }
+        if (!properties.getWarehousingAbnormalImagePath().contains("{imgNo}")) {
+            throw new IllegalStateException("Fassto warehousing abnormal image path must include {imgNo}.");
+        }
+    }
+
     private RegisterFasstoWarehousingResponse parseResponseBody(ResponseEntity<String> response) {
         if (FormatValidator.hasNoValue(response)) {
             return null;
@@ -778,6 +932,24 @@ public class FasstoWarehousingClient implements RegisterFasstoWarehousingPort, G
         }
     }
 
+    private FasstoWarehousingAbnormalImageResponse parseWarehousingAbnormalImageResponse(ResponseEntity<String> response) {
+        if (FormatValidator.hasNoValue(response)) {
+            return null;
+        }
+
+        String body = response.getBody();
+        if (FormatValidator.hasNoValue(body)) {
+            return null;
+        }
+
+        try {
+            return objectMapper.readValue(body, FasstoWarehousingAbnormalImageResponse.class);
+        } catch (Exception e) {
+            log.warn("Failed to parse Fassto warehousing abnormal image response: {}", e.getMessage(), e);
+            return null;
+        }
+    }
+
     private boolean isSuccessResponse(ResponseEntity<String> response, RegisterFasstoWarehousingResponse parsedResponse) {
         return FormatValidator.hasValue(response)
                 && response.getStatusCode().value() == 200
@@ -801,6 +973,13 @@ public class FasstoWarehousingClient implements RegisterFasstoWarehousingPort, G
     }
 
     private boolean isWarehousingAbnormalSuccess(ResponseEntity<String> response, FasstoWarehousingAbnormalListResponse parsedResponse) {
+        return FormatValidator.hasValue(response)
+                && response.getStatusCode().value() == 200
+                && FormatValidator.hasValue(parsedResponse)
+                && parsedResponse.isSuccess();
+    }
+
+    private boolean isWarehousingAbnormalImageSuccess(ResponseEntity<String> response, FasstoWarehousingAbnormalImageResponse parsedResponse) {
         return FormatValidator.hasValue(response)
                 && response.getStatusCode().value() == 200
                 && FormatValidator.hasValue(parsedResponse)
@@ -892,6 +1071,28 @@ public class FasstoWarehousingClient implements RegisterFasstoWarehousingPort, G
         return "UNKNOWN_FAILURE";
     }
 
+    private String resolveWarehousingAbnormalImageException(
+            ResponseEntity<String> response,
+            FasstoWarehousingAbnormalImageResponse parsedResponse
+    ) {
+        if (FormatValidator.hasNoValue(response)) {
+            return "NO_RESPONSE";
+        }
+        if (response.getStatusCode().value() != 200) {
+            return "HTTP_" + response.getStatusCode().value();
+        }
+        if (FormatValidator.hasNoValue(parsedResponse)) {
+            return "INVALID_RESPONSE";
+        }
+        if (FormatValidator.hasNoValue(parsedResponse.header()) || !parsedResponse.header().isSuccess()) {
+            return "HEADER_FAILURE";
+        }
+        if (FormatValidator.hasNoValue(parsedResponse.data())) {
+            return "DATA_MISSING";
+        }
+        return "UNKNOWN_FAILURE";
+    }
+
     private JsonNode buildListRequestPayloadJson(FasstoWarehousingQuery query, URI uri, int attempt) {
         Map<String, Object> payload = new LinkedHashMap<>();
         payload.put("method", HttpMethod.GET.name());
@@ -934,6 +1135,20 @@ public class FasstoWarehousingClient implements RegisterFasstoWarehousingPort, G
         payload.put("customerCode", query.getCustomerCode());
         payload.put("whCd", query.getWhCd());
         payload.put("slipNo", query.getSlipNo());
+        payload.put(ACCESS_TOKEN_HEADER, maskValue(query.getAccessToken()));
+        payload.put("attempt", attempt);
+        return vendorCommunicationPayloadGenerator.buildPayloadJson(payload);
+    }
+
+    private JsonNode buildAbnormalImageRequestPayloadJson(FasstoWarehousingAbnormalImageQuery query, URI uri, int attempt) {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("method", HttpMethod.GET.name());
+        payload.put("url", uri.toString());
+        payload.put("slipNo", query.getSlipNo());
+        payload.put("godCd", query.getGodCd());
+        payload.put("goodsSerialNo", query.getGoodsSerialNo());
+        payload.put("fileSeq", query.getFileSeq());
+        payload.put("imgNo", query.getImgNo());
         payload.put(ACCESS_TOKEN_HEADER, maskValue(query.getAccessToken()));
         payload.put("attempt", attempt);
         return vendorCommunicationPayloadGenerator.buildPayloadJson(payload);
@@ -1018,6 +1233,13 @@ public class FasstoWarehousingClient implements RegisterFasstoWarehousingPort, G
                 .toList();
         Integer dataCount = FormatValidator.hasValue(response.header()) ? response.header().dataCount() : null;
         return GetFasstoWarehousingAbnormalResult.of(dataCount, abnormals);
+    }
+
+    private GetFasstoWarehousingAbnormalImageResult mapWarehousingAbnormalImageResult(
+            FasstoWarehousingAbnormalImageResponse response
+    ) {
+        Integer dataCount = FormatValidator.hasValue(response.header()) ? response.header().dataCount() : null;
+        return GetFasstoWarehousingAbnormalImageResult.of(dataCount, response.data());
     }
 
     private RegisterFasstoWarehousingItemResult mapWarehousingItem(RegisterFasstoWarehousingItemResponse item) {
@@ -1208,6 +1430,16 @@ public class FasstoWarehousingClient implements RegisterFasstoWarehousingPort, G
     }
 
     private String resolveVendorMessage(FasstoWarehousingAbnormalListResponse response, String rawBody) {
+        if (FormatValidator.hasValue(response)) {
+            String message = response.resolveErrorMessage();
+            if (FormatValidator.hasValue(message)) {
+                return message;
+            }
+        }
+        return resolveVendorMessage(rawBody);
+    }
+
+    private String resolveVendorMessage(FasstoWarehousingAbnormalImageResponse response, String rawBody) {
         if (FormatValidator.hasValue(response)) {
             String message = response.resolveErrorMessage();
             if (FormatValidator.hasValue(message)) {

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoWarehousingAbnormalImageResponse.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoWarehousingAbnormalImageResponse.java
@@ -1,0 +1,14 @@
+package com.personal.marketnote.fulfillment.adapter.out.vendor.fassto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record FasstoWarehousingAbnormalImageResponse(
+        FasstoResponseHeader header,
+        Object data,
+        FasstoErrorInfo errorInfo
+) implements FasstoApiResponse {
+    public boolean isSuccess() {
+        return header != null && header.isSuccess() && data != null;
+    }
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/resources/application.yml
+++ b/fulfillment-service/fulfillment-adapters/src/main/resources/application.yml
@@ -60,6 +60,7 @@ vendor:
       warehousing-list-path: ${FASSTO_WAREHOUSING_LIST_PATH:/api/v1/warehousing/{customerCode}/{startDate}/{endDate}}
       warehousing-detail-path: ${FASSTO_WAREHOUSING_DETAIL_PATH:/api/v1/warehousing/detail/{customerCode}/{slipNo}}
       warehousing-abnormal-path: ${FASSTO_WAREHOUSING_ABNORMAL_PATH:/api/v1/warehousing/abnormal/{customerCode}/{whCd}/{slipNo}}
+      warehousing-abnormal-image-path: ${FASSTO_WAREHOUSING_ABNORMAL_IMAGE_PATH:/api/v1/warehousing/{slipNo}/{godCd}/{goodsSerialNo}/{fileSeq}/{imgNo}}
       delivery-path: ${FASSTO_DELIVERY_PATH:/api/v1/delivery/parcel/{customerCode}}
       delivery-list-path: ${FASSTO_DELIVERY_LIST_PATH:/api/v1/delivery/{customerCode}/{startDate}/{endDate}/{status}/{outDiv}}
       delivery-status-path: ${FASSTO_DELIVERY_STATUS_PATH:/api/v1/delivery/parcel/{customerCode}/{startDate}/{endDate}/{outDiv}}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/configuration/FasstoAuthProperties.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/configuration/FasstoAuthProperties.java
@@ -24,6 +24,7 @@ public class FasstoAuthProperties {
     private String warehousingListPath = "/api/v1/warehousing/{customerCode}/{startDate}/{endDate}";
     private String warehousingDetailPath = "/api/v1/warehousing/detail/{customerCode}/{slipNo}";
     private String warehousingAbnormalPath = "/api/v1/warehousing/abnormal/{customerCode}/{whCd}/{slipNo}";
+    private String warehousingAbnormalImagePath = "/api/v1/warehousing/{slipNo}/{godCd}/{goodsSerialNo}/{fileSeq}/{imgNo}";
     private String deliveryPath = "/api/v1/delivery/parcel/{customerCode}";
     private String deliveryListPath = "/api/v1/delivery/{customerCode}/{startDate}/{endDate}/{status}/{outDiv}";
     private String deliveryStatusPath = "/api/v1/delivery/parcel/{customerCode}/{startDate}/{endDate}/{outDiv}";

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/GetFasstoWarehousingAbnormalImageFailedException.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/GetFasstoWarehousingAbnormalImageFailedException.java
@@ -1,0 +1,25 @@
+package com.personal.marketnote.fulfillment.exception;
+
+import com.personal.marketnote.common.exception.ExternalOperationFailedException;
+import com.personal.marketnote.common.utility.FormatValidator;
+
+import java.io.IOException;
+
+public class GetFasstoWarehousingAbnormalImageFailedException extends ExternalOperationFailedException {
+    private static final String DEFAULT_MESSAGE = "파스토 비정상 입고 상품 이미지 조회 중 오류가 발생했습니다.";
+
+    public GetFasstoWarehousingAbnormalImageFailedException(IOException cause) {
+        super(DEFAULT_MESSAGE, cause);
+    }
+
+    public GetFasstoWarehousingAbnormalImageFailedException(String vendorMessage, IOException cause) {
+        super(resolveMessage(vendorMessage), cause);
+    }
+
+    private static String resolveMessage(String vendorMessage) {
+        if (FormatValidator.hasValue(vendorMessage)) {
+            return String.format("파스토 비정상 입고 상품 이미지 조회 실패: %s", vendorMessage);
+        }
+        return DEFAULT_MESSAGE;
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/mapper/FasstoWarehousingCommandToRequestMapper.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/mapper/FasstoWarehousingCommandToRequestMapper.java
@@ -48,6 +48,19 @@ public class FasstoWarehousingCommandToRequestMapper {
         );
     }
 
+    public static FasstoWarehousingAbnormalImageQuery mapToAbnormalImageQuery(
+            GetFasstoWarehousingAbnormalImageCommand command
+    ) {
+        return FasstoWarehousingAbnormalImageQuery.of(
+                command.accessToken(),
+                command.slipNo(),
+                command.godCd(),
+                command.goodsSerialNo(),
+                command.fileSeq(),
+                command.imgNo()
+        );
+    }
+
     public static FasstoWarehousingMapper mapToUpdateRequest(UpdateFasstoWarehousingCommand command) {
         List<FasstoWarehousingItemMapper> requests = command.warehousingRequests().stream()
                 .map(FasstoWarehousingCommandToRequestMapper::mapUpdateItem)

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/vendor/GetFasstoWarehousingAbnormalImageCommand.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/vendor/GetFasstoWarehousingAbnormalImageCommand.java
@@ -1,0 +1,21 @@
+package com.personal.marketnote.fulfillment.port.in.command.vendor;
+
+public record GetFasstoWarehousingAbnormalImageCommand(
+        String accessToken,
+        String slipNo,
+        String godCd,
+        String goodsSerialNo,
+        String fileSeq,
+        String imgNo
+) {
+    public static GetFasstoWarehousingAbnormalImageCommand of(
+            String accessToken,
+            String slipNo,
+            String godCd,
+            String goodsSerialNo,
+            String fileSeq,
+            String imgNo
+    ) {
+        return new GetFasstoWarehousingAbnormalImageCommand(accessToken, slipNo, godCd, goodsSerialNo, fileSeq, imgNo);
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/result/vendor/GetFasstoWarehousingAbnormalImageResult.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/result/vendor/GetFasstoWarehousingAbnormalImageResult.java
@@ -1,0 +1,13 @@
+package com.personal.marketnote.fulfillment.port.in.result.vendor;
+
+public record GetFasstoWarehousingAbnormalImageResult(
+        Integer dataCount,
+        Object data
+) {
+    public static GetFasstoWarehousingAbnormalImageResult of(
+            Integer dataCount,
+            Object data
+    ) {
+        return new GetFasstoWarehousingAbnormalImageResult(dataCount, data);
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/usecase/vendor/GetFasstoWarehousingAbnormalImageUseCase.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/usecase/vendor/GetFasstoWarehousingAbnormalImageUseCase.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.fulfillment.port.in.usecase.vendor;
+
+import com.personal.marketnote.fulfillment.port.in.command.vendor.GetFasstoWarehousingAbnormalImageCommand;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.GetFasstoWarehousingAbnormalImageResult;
+
+public interface GetFasstoWarehousingAbnormalImageUseCase {
+    GetFasstoWarehousingAbnormalImageResult getWarehousingAbnormalImage(GetFasstoWarehousingAbnormalImageCommand command);
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/vendor/GetFasstoWarehousingAbnormalImagePort.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/vendor/GetFasstoWarehousingAbnormalImagePort.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.fulfillment.port.out.vendor;
+
+import com.personal.marketnote.fulfillment.domain.vendor.fassto.warehousing.FasstoWarehousingAbnormalImageQuery;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.GetFasstoWarehousingAbnormalImageResult;
+
+public interface GetFasstoWarehousingAbnormalImagePort {
+    GetFasstoWarehousingAbnormalImageResult getWarehousingAbnormalImage(FasstoWarehousingAbnormalImageQuery query);
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/vendor/GetFasstoWarehousingAbnormalImageService.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/vendor/GetFasstoWarehousingAbnormalImageService.java
@@ -1,0 +1,28 @@
+package com.personal.marketnote.fulfillment.service.vendor;
+
+import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.fulfillment.mapper.FasstoWarehousingCommandToRequestMapper;
+import com.personal.marketnote.fulfillment.port.in.command.vendor.GetFasstoWarehousingAbnormalImageCommand;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.GetFasstoWarehousingAbnormalImageResult;
+import com.personal.marketnote.fulfillment.port.in.usecase.vendor.GetFasstoWarehousingAbnormalImageUseCase;
+import com.personal.marketnote.fulfillment.port.out.vendor.GetFasstoWarehousingAbnormalImagePort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional(isolation = READ_COMMITTED, readOnly = true)
+public class GetFasstoWarehousingAbnormalImageService implements GetFasstoWarehousingAbnormalImageUseCase {
+    private final GetFasstoWarehousingAbnormalImagePort getFasstoWarehousingAbnormalImagePort;
+
+    @Override
+    public GetFasstoWarehousingAbnormalImageResult getWarehousingAbnormalImage(
+            GetFasstoWarehousingAbnormalImageCommand command
+    ) {
+        return getFasstoWarehousingAbnormalImagePort.getWarehousingAbnormalImage(
+                FasstoWarehousingCommandToRequestMapper.mapToAbnormalImageQuery(command)
+        );
+    }
+}

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/warehousing/FasstoWarehousingAbnormalImageQuery.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/warehousing/FasstoWarehousingAbnormalImageQuery.java
@@ -1,0 +1,58 @@
+package com.personal.marketnote.fulfillment.domain.vendor.fassto.warehousing;
+
+import com.personal.marketnote.common.utility.FormatValidator;
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+public class FasstoWarehousingAbnormalImageQuery {
+    private String accessToken;
+    private String slipNo;
+    private String godCd;
+    private String goodsSerialNo;
+    private String fileSeq;
+    private String imgNo;
+
+    public static FasstoWarehousingAbnormalImageQuery of(
+            String accessToken,
+            String slipNo,
+            String godCd,
+            String goodsSerialNo,
+            String fileSeq,
+            String imgNo
+    ) {
+        FasstoWarehousingAbnormalImageQuery query = FasstoWarehousingAbnormalImageQuery.builder()
+                .accessToken(accessToken)
+                .slipNo(slipNo)
+                .godCd(godCd)
+                .goodsSerialNo(goodsSerialNo)
+                .fileSeq(fileSeq)
+                .imgNo(imgNo)
+                .build();
+        query.validate();
+        return query;
+    }
+
+    private void validate() {
+        if (FormatValidator.hasNoValue(accessToken)) {
+            throw new IllegalArgumentException("accessToken is required.");
+        }
+        if (FormatValidator.hasNoValue(slipNo)) {
+            throw new IllegalArgumentException("slipNo is required.");
+        }
+        if (FormatValidator.hasNoValue(godCd)) {
+            throw new IllegalArgumentException("godCd is required.");
+        }
+        if (FormatValidator.hasNoValue(goodsSerialNo)) {
+            throw new IllegalArgumentException("goodsSerialNo is required.");
+        }
+        if (FormatValidator.hasNoValue(fileSeq)) {
+            throw new IllegalArgumentException("fileSeq is required.");
+        }
+        if (FormatValidator.hasNoValue(imgNo)) {
+            throw new IllegalArgumentException("imgNo is required.");
+        }
+    }
+}

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/service/cart/GetMyCartProductsService.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/service/cart/GetMyCartProductsService.java
@@ -3,7 +3,6 @@ package com.personal.marketnote.product.service.cart;
 import com.personal.marketnote.common.application.UseCase;
 import com.personal.marketnote.product.domain.cart.CartProduct;
 import com.personal.marketnote.product.port.in.result.cart.GetMyCartProductsResult;
-import com.personal.marketnote.product.port.in.usecase.cart.GetMyCartProductsUseCase;
 import com.personal.marketnote.product.port.in.usecase.product.GetProductInventoryUseCase;
 import com.personal.marketnote.product.port.out.cart.FindCartProductsPort;
 import lombok.RequiredArgsConstructor;

--- a/product-service/product-application/src/test/java/com/personal/marketnote/product/service/category/GetCategoryUseCaseTest.java
+++ b/product-service/product-application/src/test/java/com/personal/marketnote/product/service/category/GetCategoryUseCaseTest.java
@@ -1,0 +1,77 @@
+package com.personal.marketnote.product.service.category;
+
+import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.product.domain.category.Category;
+import com.personal.marketnote.product.domain.category.CategorySnapshotState;
+import com.personal.marketnote.product.exception.CategoryNotFoundException;
+import com.personal.marketnote.product.port.out.category.FindCategoryPort;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class GetCategoryUseCaseTest {
+    @Mock
+    private FindCategoryPort findCategoryPort;
+
+    @InjectMocks
+    private GetCategoryService getCategoryService;
+
+    @Test
+    @DisplayName("카테고리 ID로 조회하면 카테고리를 반환한다")
+    void getCategory_byId_returnsCategory() {
+        Long categoryId = 10L;
+        Category category = buildCategory(categoryId, null, "카테고리");
+
+        when(findCategoryPort.findById(categoryId)).thenReturn(Optional.of(category));
+
+        Category result = getCategoryService.getCategory(categoryId);
+
+        assertThat(result).isSameAs(category);
+        verify(findCategoryPort).findById(categoryId);
+    }
+
+    @Test
+    @DisplayName("카테고리 ID로 조회 시 없으면 예외를 던진다")
+    void getCategory_byId_notFound() {
+        Long categoryId = 11L;
+
+        when(findCategoryPort.findById(categoryId)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> getCategoryService.getCategory(categoryId))
+                .isInstanceOf(CategoryNotFoundException.class)
+                .hasMessageContaining("카테고리 ID: 11");
+    }
+
+    @Test
+    @DisplayName("카테고리 ID로 조회 시 포트 예외를 전파한다")
+    void getCategory_byId_portFails_propagates() {
+        Long categoryId = 12L;
+        RuntimeException exception = new RuntimeException("find fail");
+
+        when(findCategoryPort.findById(categoryId)).thenThrow(exception);
+
+        assertThatThrownBy(() -> getCategoryService.getCategory(categoryId))
+                .isSameAs(exception);
+    }
+
+    private Category buildCategory(Long id, Long parentId, String name) {
+        return Category.from(
+                CategorySnapshotState.builder()
+                        .id(id)
+                        .parentCategoryId(parentId)
+                        .name(name)
+                        .status(EntityStatus.ACTIVE)
+                        .build()
+        );
+    }
+}


### PR DESCRIPTION
## partially addresses #475
## resolves #736

## Task
- [x] 파스토 비정상 입고 상품 이미지 조회 연동 요청
- [x] 파스토 비정상 입고 상품 이미지 조회 연동 비즈니스 로직
- [x] 파스토 서버에 비정상 입고 상품 이미지 정보 요청
- [x] 200 status code 응답
- [x] Swagger docs