### PR TITLE
[#475][#737] feat: 파스토 입고 검수 상세 정보 조회 연동 기능 추가

### DIFF
--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/FasstoWarehousingController.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/FasstoWarehousingController.java
@@ -29,6 +29,7 @@ public class FasstoWarehousingController {
     private final RegisterFasstoWarehousingUseCase registerFasstoWarehousingUseCase;
     private final GetFasstoWarehousingUseCase getFasstoWarehousingUseCase;
     private final GetFasstoWarehousingDetailUseCase getFasstoWarehousingDetailUseCase;
+    private final GetFasstoWarehousingInspecDetailUseCase getFasstoWarehousingInspecDetailUseCase;
     private final GetFasstoWarehousingAbnormalUseCase getFasstoWarehousingAbnormalUseCase;
     private final GetFasstoWarehousingAbnormalImageUseCase getFasstoWarehousingAbnormalImageUseCase;
     private final UpdateFasstoWarehousingUseCase updateFasstoWarehousingUseCase;
@@ -150,6 +151,46 @@ public class FasstoWarehousingController {
                         HttpStatus.OK,
                         DEFAULT_SUCCESS_CODE,
                         "파스토 상품 입고 상세 조회 성공"
+                ),
+                HttpStatus.OK
+        );
+    }
+
+    /**
+     * (관리자) 파스토 입고 검수 상세 조회
+     *
+     * @param customerCode 파스토 고객사 코드
+     * @param slipNo       파스토 입고요청번호
+     * @param whCd         센터
+     * @param accessToken  파스토 액세스 토큰
+     * @Author 성효빈
+     * @Date 2026-02-17
+     * @Description 파스토 입고 검수 상세 정보를 조회합니다.
+     */
+    @GetMapping("/inspec/{customerCode}/{slipNo}/{whCd}")
+    @PreAuthorize(ADMIN_POINTCUT)
+    @GetFasstoWarehousingInspecDetailApiDocs
+    public ResponseEntity<BaseResponse<GetFasstoWarehousingInspecDetailResponse>> getWarehousingInspecDetail(
+            @PathVariable String customerCode,
+            @PathVariable String slipNo,
+            @PathVariable String whCd,
+            @RequestHeader("accessToken") String accessToken
+    ) {
+        GetFasstoWarehousingInspecDetailResult result = getFasstoWarehousingInspecDetailUseCase.getWarehousingInspecDetail(
+                FasstoWarehousingRequestToCommandMapper.mapToWarehousingInspecDetailCommand(
+                        customerCode,
+                        accessToken,
+                        slipNo,
+                        whCd
+                )
+        );
+
+        return new ResponseEntity<>(
+                BaseResponse.of(
+                        GetFasstoWarehousingInspecDetailResponse.from(result),
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "파스토 입고 검수 상세 조회 성공"
                 ),
                 HttpStatus.OK
         );

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/apidocs/GetFasstoWarehousingInspecDetailApiDocs.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/apidocs/GetFasstoWarehousingInspecDetailApiDocs.java
@@ -1,0 +1,169 @@
+package com.personal.marketnote.fulfillment.adapter.in.web.vendor.controller.apidocs;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Operation(
+        summary = "(관리자) 파스토 입고 검수 상세 조회",
+        description = """
+                작성일자: 2026-02-17
+                
+                작성자: 성효빈
+                
+                ---
+                
+                ## Description
+                
+                파스토 입고 검수 상세 정보를 조회합니다.
+                
+                ---
+                
+                ## Request
+                
+                | **키** | **위치** | **타입** | **설명** | **필수 여부** | **예시** |
+                | --- | --- | --- | --- | --- | --- |
+                | accessToken | header | string | 파스토 액세스 토큰 | Y | eefae1befa4c11f0be620ab49498ff55 |
+                | customerCode | path | string | 파스토 고객사 코드 | Y | 94388 |
+                | slipNo | path | string | 입고요청번호 | Y | TESTIO260130000001 |
+                | whCd | path | string | 센터 | Y | TEST |
+                
+                ---
+                
+                ## Response
+                
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | statusCode | number | 상태 코드 | 200: 성공 / 400: 클라이언트 요청 오류 / 401: 인증 실패 / 403: 인가 실패 / 500: 그 외 |
+                | code | string | 응답 코드 | "SUC01" / "BAD_REQUEST" / "UNAUTHORIZED" / "FORBIDDEN" / "INTERNAL_SERVER_ERROR" |
+                | timestamp | string(datetime) | 응답 일시 | "2026-02-17T10:20:30.013" |
+                | content | object | 응답 본문 | { ... } |
+                | message | string | 처리 결과 | "파스토 입고 검수 상세 조회 성공" |
+                
+                ---
+                
+                ### Response > content
+                
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | dataCount | number | 조회 건수 | 1 |
+                | details | array | 입고 검수 상세 목록 | [ ... ] |
+                
+                ---
+                
+                ### Response > content > details
+                
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | ordDt | string | 입고일자 | "20260130" |
+                | whCd | string | 창고코드 | "TEST" |
+                | whNm | string | 창고명 | "테스트" |
+                | slipNo | string | 전표번호(입고요청번호) | "TESTIO260130000001" |
+                | cstCd | string | 고객사코드 | "94388" |
+                | cstNm | string | 고객사명 | "마켓노트 주식회사 테스트" |
+                | supCd | string | 파스토공급사코드 | "99999999" |
+                | supNm | string | 공급사명 | "미지정 공급사" |
+                | inWay | string | 입고방식(01:택배,02:차량) | "01" |
+                | inWayNm | string | 입고방식명 | "택배" |
+                | godCd | string | 상품코드 | "943881" |
+                | ordQty | number | 입고 요청 수량 | 1 |
+                | totInQty | number | 검수 수량 | 1 |
+                | parcelComp | string | 택배사명 | "" |
+                | parcelInvoiceNo | string | 입고시 송장번호 | "" |
+                | wrkStat | string | 작업상태코드(1:입고 반품 예정(지연),2:입고 검수 진행,3:입고 확정,4:입고 완료,5:입고 취소) | "2" |
+                | wrkStatNm | string | 작업상태명 | "입고 검수 진행" |
+                | remark | string | 입고요청내용 | "" |
+                | goods | array | 상품 정보 | ["943881"] |
+                | goodsSerialNo | array | 상품일련번호 | ["SN-001"] |
+                | externalGodImgUrl | string | 상품이미지url | "https://cdn.personal.marketnote/images/sample.png" |
+                | distTermDt | string | 유통기한 | "2026-12-31" |
+                """,
+        security = {@SecurityRequirement(name = "bearer")},
+        parameters = {
+                @Parameter(
+                        name = "accessToken",
+                        description = "파스토 액세스 토큰",
+                        in = ParameterIn.HEADER,
+                        required = true,
+                        schema = @Schema(type = "string", example = "eefae1befa4c11f0be620ab49498ff55")
+                ),
+                @Parameter(
+                        name = "customerCode",
+                        description = "파스토 고객사 코드",
+                        in = ParameterIn.PATH,
+                        required = true,
+                        schema = @Schema(type = "string", example = "94388")
+                ),
+                @Parameter(
+                        name = "slipNo",
+                        description = "입고요청번호",
+                        in = ParameterIn.PATH,
+                        required = true,
+                        schema = @Schema(type = "string", example = "TESTIO260130000001")
+                ),
+                @Parameter(
+                        name = "whCd",
+                        description = "센터",
+                        in = ParameterIn.PATH,
+                        required = true,
+                        schema = @Schema(type = "string", example = "TEST")
+                )
+        },
+        responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "파스토 입고 검수 상세 조회 성공",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 200,
+                                          "code": "SUC01",
+                                          "timestamp": "2026-02-17T10:20:30.013",
+                                          "content": {
+                                            "dataCount": 1,
+                                            "details": [
+                                              {
+                                                "ordDt": "20260130",
+                                                "whCd": "TEST",
+                                                "whNm": "테스트",
+                                                "slipNo": "TESTIO260130000001",
+                                                "cstCd": "94388",
+                                                "cstNm": "마켓노트 주식회사 테스트",
+                                                "supCd": "99999999",
+                                                "supNm": "미지정 공급사",
+                                                "inWay": "01",
+                                                "inWayNm": "택배",
+                                                "godCd": "943881",
+                                                "ordQty": 1,
+                                                "totInQty": 1,
+                                                "parcelComp": "",
+                                                "parcelInvoiceNo": "",
+                                                "wrkStat": "2",
+                                                "wrkStatNm": "입고 검수 진행",
+                                                "remark": "",
+                                                "goods": ["943881"],
+                                                "goodsSerialNo": ["SN-001"],
+                                                "externalGodImgUrl": "https://cdn.personal.marketnote/images/sample.png",
+                                                "distTermDt": "2026-12-31"
+                                              }
+                                            ]
+                                          },
+                                          "message": "파스토 입고 검수 상세 조회 성공"
+                                        }
+                                        """)
+                        )
+                )
+        }
+)
+public @interface GetFasstoWarehousingInspecDetailApiDocs {
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/mapper/FasstoWarehousingRequestToCommandMapper.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/mapper/FasstoWarehousingRequestToCommandMapper.java
@@ -69,6 +69,15 @@ public class FasstoWarehousingRequestToCommandMapper {
         );
     }
 
+    public static GetFasstoWarehousingInspecDetailCommand mapToWarehousingInspecDetailCommand(
+            String customerCode,
+            String accessToken,
+            String slipNo,
+            String whCd
+    ) {
+        return GetFasstoWarehousingInspecDetailCommand.of(customerCode, accessToken, slipNo, whCd);
+    }
+
     public static UpdateFasstoWarehousingCommand mapToUpdateCommand(
             String customerCode,
             String accessToken,

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/response/GetFasstoWarehousingInspecDetailResponse.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/response/GetFasstoWarehousingInspecDetailResponse.java
@@ -1,0 +1,15 @@
+package com.personal.marketnote.fulfillment.adapter.in.web.vendor.response;
+
+import com.personal.marketnote.fulfillment.port.in.result.vendor.FasstoWarehousingInspecDetailInfoResult;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.GetFasstoWarehousingInspecDetailResult;
+
+import java.util.List;
+
+public record GetFasstoWarehousingInspecDetailResponse(
+        Integer dataCount,
+        List<FasstoWarehousingInspecDetailInfoResult> details
+) {
+    public static GetFasstoWarehousingInspecDetailResponse from(GetFasstoWarehousingInspecDetailResult result) {
+        return new GetFasstoWarehousingInspecDetailResponse(result.dataCount(), result.details());
+    }
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/client/FasstoWarehousingClient.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/client/FasstoWarehousingClient.java
@@ -37,7 +37,7 @@ import static com.personal.marketnote.common.utility.ApiConstant.*;
 @VendorAdapter
 @RequiredArgsConstructor
 @Slf4j
-public class FasstoWarehousingClient implements RegisterFasstoWarehousingPort, GetFasstoWarehousingPort, GetFasstoWarehousingDetailPort, GetFasstoWarehousingAbnormalPort, GetFasstoWarehousingAbnormalImagePort, UpdateFasstoWarehousingPort {
+public class FasstoWarehousingClient implements RegisterFasstoWarehousingPort, GetFasstoWarehousingPort, GetFasstoWarehousingDetailPort, GetFasstoWarehousingInspecDetailPort, GetFasstoWarehousingAbnormalPort, GetFasstoWarehousingAbnormalImagePort, UpdateFasstoWarehousingPort {
     private static final String ACCESS_TOKEN_HEADER = "accessToken";
     private static final String CUSTOMER_CODE_PLACEHOLDER = "{customerCode}";
 
@@ -311,6 +311,123 @@ public class FasstoWarehousingClient implements RegisterFasstoWarehousingPort, G
 
         log.error("Failed to get Fassto warehousing detail: {} with error: {}", uri, error.getMessage(), error);
         throw new GetFasstoWarehousingDetailFailedException(failureMessage, new IOException(error));
+    }
+
+    @Override
+    public GetFasstoWarehousingInspecDetailResult getWarehousingInspecDetail(FasstoWarehousingInspecDetailQuery query) {
+        if (FormatValidator.hasNoValue(query)) {
+            throw new IllegalArgumentException("Fassto warehousing inspection detail query is required.");
+        }
+
+        URI uri = buildWarehousingInspecDetailUri(
+                query.getCustomerCode(),
+                query.getSlipNo(),
+                query.getWhCd()
+        );
+        HttpEntity<Void> httpEntity = new HttpEntity<>(buildHeaders(query.getAccessToken(), false));
+
+        Exception error = new Exception();
+        String failureMessage = null;
+        long sleepMillis = INTER_SERVER_DEFAULT_RETRIAL_PENDING_MILLI_SECOND;
+        FulfillmentVendorCommunicationTargetType targetType = FulfillmentVendorCommunicationTargetType.WAREHOUSING;
+        FulfillmentVendorName vendorName = FulfillmentVendorName.FASSTO;
+
+        for (int i = 0; i < INTER_SERVER_MAX_REQUEST_COUNT; i++) {
+            int attempt = i + 1;
+            JsonNode requestPayloadJson = buildInspecDetailRequestPayloadJson(query, uri, attempt);
+            String requestPayload = requestPayloadJson.toString();
+
+            ResponseEntity<String> response;
+            try {
+                response = restTemplate.exchange(
+                        uri,
+                        HttpMethod.GET,
+                        httpEntity,
+                        String.class
+                );
+            } catch (Exception e) {
+                Map<String, Object> errorPayload = new LinkedHashMap<>();
+                errorPayload.put("error", e.getClass().getSimpleName());
+                errorPayload.put("message", e.getMessage());
+                errorPayload.put("attempt", attempt);
+
+                vendorCommunicationFailureHandler.handleFailure(
+                        targetType,
+                        vendorName,
+                        requestPayload,
+                        requestPayloadJson,
+                        errorPayload,
+                        e
+                );
+
+                String vendorMessage = resolveVendorMessageFromException(e);
+                if (FormatValidator.hasValue(vendorMessage)) {
+                    failureMessage = vendorMessage;
+                    error = new Exception(vendorMessage);
+                }
+
+                log.warn("Failed to get Fassto warehousing inspection detail: attempt={}, message={}", attempt, e.getMessage(), e);
+                if (i == INTER_SERVER_MAX_REQUEST_COUNT - 1) {
+                    error = e;
+                }
+
+                sleep(sleepMillis);
+                sleepMillis = sleepMillis * INTER_SERVER_DEFAULT_EXPONENTIAL_BACKOFF_VALUE;
+                continue;
+            }
+
+            JsonNode responsePayloadJson = buildResponsePayloadJson(response, attempt);
+            String responsePayload = responsePayloadJson.toString();
+
+            FasstoWarehousingInspecDetailListResponse parsedResponse = parseWarehousingInspecDetailResponse(response);
+            boolean isSuccess = isWarehousingInspecDetailSuccess(response, parsedResponse);
+            String exception = isSuccess ? null : resolveWarehousingInspecDetailException(response, parsedResponse);
+
+            vendorCommunicationRecorder.record(
+                    targetType,
+                    FulfillmentVendorCommunicationType.REQUEST,
+                    FulfillmentVendorCommunicationSenderType.SERVER,
+                    vendorName,
+                    requestPayload,
+                    requestPayloadJson,
+                    exception
+            );
+            vendorCommunicationRecorder.record(
+                    targetType,
+                    FulfillmentVendorCommunicationType.RESPONSE,
+                    FulfillmentVendorCommunicationSenderType.VENDOR,
+                    vendorName,
+                    responsePayload,
+                    responsePayloadJson,
+                    exception
+            );
+
+            if (isSuccess) {
+                return mapWarehousingInspecDetailResult(parsedResponse);
+            }
+
+            String vendorMessage = resolveVendorMessage(parsedResponse, FormatValidator.hasValue(response) ? response.getBody() : null);
+            if (FormatValidator.hasValue(vendorMessage)) {
+                failureMessage = vendorMessage;
+                error = new Exception(vendorMessage);
+            }
+
+            log.warn("Fassto warehousing inspection detail request failed: attempt={}, status={}, exception={}",
+                    attempt,
+                    FormatValidator.hasValue(response) ? response.getStatusCode() : null,
+                    exception
+            );
+
+            if (CommunicationFailureHandler.isCertainFailure(response)) {
+                break;
+            }
+
+            sleep(sleepMillis);
+            sleepMillis = sleepMillis * INTER_SERVER_DEFAULT_EXPONENTIAL_BACKOFF_VALUE;
+        }
+
+        log.error("Failed to get Fassto warehousing inspection detail: {} with error: {}", uri, error.getMessage(), error);
+        throw new GetFasstoWarehousingInspecDetailFailedException(failureMessage, new IOException(error));
     }
 
     @Override
@@ -733,6 +850,18 @@ public class FasstoWarehousingClient implements RegisterFasstoWarehousingPort, G
                 .toUri();
     }
 
+    private URI buildWarehousingInspecDetailUri(
+            String customerCode,
+            String slipNo,
+            String whCd
+    ) {
+        validateWarehousingInspecDetailProperties();
+        return UriComponentsBuilder.fromUriString(properties.getBaseUrl())
+                .path(properties.getWarehousingInspecDetailPath())
+                .buildAndExpand(customerCode, slipNo, whCd)
+                .toUri();
+    }
+
     private URI buildWarehousingAbnormalUri(
             String customerCode,
             String whCd,
@@ -815,6 +944,24 @@ public class FasstoWarehousingClient implements RegisterFasstoWarehousingPort, G
         }
         if (!properties.getWarehousingDetailPath().contains("{slipNo}")) {
             throw new IllegalStateException("Fassto warehousing detail path must include {slipNo}.");
+        }
+    }
+
+    private void validateWarehousingInspecDetailProperties() {
+        if (FormatValidator.hasNoValue(properties.getBaseUrl())) {
+            throw new IllegalStateException("Fassto base URL is required.");
+        }
+        if (FormatValidator.hasNoValue(properties.getWarehousingInspecDetailPath())) {
+            throw new IllegalStateException("Fassto warehousing inspection detail path is required.");
+        }
+        if (!properties.getWarehousingInspecDetailPath().contains(CUSTOMER_CODE_PLACEHOLDER)) {
+            throw new IllegalStateException("Fassto warehousing inspection detail path must include {customerCode}.");
+        }
+        if (!properties.getWarehousingInspecDetailPath().contains("{slipNo}")) {
+            throw new IllegalStateException("Fassto warehousing inspection detail path must include {slipNo}.");
+        }
+        if (!properties.getWarehousingInspecDetailPath().contains("{whCd}")) {
+            throw new IllegalStateException("Fassto warehousing inspection detail path must include {whCd}.");
         }
     }
 
@@ -914,6 +1061,24 @@ public class FasstoWarehousingClient implements RegisterFasstoWarehousingPort, G
         }
     }
 
+    private FasstoWarehousingInspecDetailListResponse parseWarehousingInspecDetailResponse(ResponseEntity<String> response) {
+        if (FormatValidator.hasNoValue(response)) {
+            return null;
+        }
+
+        String body = response.getBody();
+        if (FormatValidator.hasNoValue(body)) {
+            return null;
+        }
+
+        try {
+            return objectMapper.readValue(body, FasstoWarehousingInspecDetailListResponse.class);
+        } catch (Exception e) {
+            log.warn("Failed to parse Fassto warehousing inspection detail response: {}", e.getMessage(), e);
+            return null;
+        }
+    }
+
     private FasstoWarehousingAbnormalListResponse parseWarehousingAbnormalResponse(ResponseEntity<String> response) {
         if (FormatValidator.hasNoValue(response)) {
             return null;
@@ -966,6 +1131,16 @@ public class FasstoWarehousingClient implements RegisterFasstoWarehousingPort, G
     }
 
     private boolean isWarehousingDetailSuccess(ResponseEntity<String> response, FasstoWarehousingDetailListResponse parsedResponse) {
+        return FormatValidator.hasValue(response)
+                && response.getStatusCode().value() == 200
+                && FormatValidator.hasValue(parsedResponse)
+                && parsedResponse.isSuccess();
+    }
+
+    private boolean isWarehousingInspecDetailSuccess(
+            ResponseEntity<String> response,
+            FasstoWarehousingInspecDetailListResponse parsedResponse
+    ) {
         return FormatValidator.hasValue(response)
                 && response.getStatusCode().value() == 200
                 && FormatValidator.hasValue(parsedResponse)
@@ -1030,6 +1205,28 @@ public class FasstoWarehousingClient implements RegisterFasstoWarehousingPort, G
     private String resolveWarehousingDetailException(
             ResponseEntity<String> response,
             FasstoWarehousingDetailListResponse parsedResponse
+    ) {
+        if (FormatValidator.hasNoValue(response)) {
+            return "NO_RESPONSE";
+        }
+        if (response.getStatusCode().value() != 200) {
+            return "HTTP_" + response.getStatusCode().value();
+        }
+        if (FormatValidator.hasNoValue(parsedResponse)) {
+            return "INVALID_RESPONSE";
+        }
+        if (FormatValidator.hasNoValue(parsedResponse.header()) || !parsedResponse.header().isSuccess()) {
+            return "HEADER_FAILURE";
+        }
+        if (FormatValidator.hasNoValue(parsedResponse.data())) {
+            return "DATA_MISSING";
+        }
+        return "UNKNOWN_FAILURE";
+    }
+
+    private String resolveWarehousingInspecDetailException(
+            ResponseEntity<String> response,
+            FasstoWarehousingInspecDetailListResponse parsedResponse
     ) {
         if (FormatValidator.hasNoValue(response)) {
             return "NO_RESPONSE";
@@ -1123,6 +1320,18 @@ public class FasstoWarehousingClient implements RegisterFasstoWarehousingPort, G
         if (FormatValidator.hasValue(query.getOrdNo())) {
             payload.put("ordNo", query.getOrdNo());
         }
+        payload.put(ACCESS_TOKEN_HEADER, maskValue(query.getAccessToken()));
+        payload.put("attempt", attempt);
+        return vendorCommunicationPayloadGenerator.buildPayloadJson(payload);
+    }
+
+    private JsonNode buildInspecDetailRequestPayloadJson(FasstoWarehousingInspecDetailQuery query, URI uri, int attempt) {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("method", HttpMethod.GET.name());
+        payload.put("url", uri.toString());
+        payload.put("customerCode", query.getCustomerCode());
+        payload.put("slipNo", query.getSlipNo());
+        payload.put("whCd", query.getWhCd());
         payload.put(ACCESS_TOKEN_HEADER, maskValue(query.getAccessToken()));
         payload.put("attempt", attempt);
         return vendorCommunicationPayloadGenerator.buildPayloadJson(payload);
@@ -1225,6 +1434,16 @@ public class FasstoWarehousingClient implements RegisterFasstoWarehousingPort, G
                 .toList();
         Integer dataCount = FormatValidator.hasValue(response.header()) ? response.header().dataCount() : null;
         return GetFasstoWarehousingDetailResult.of(dataCount, details);
+    }
+
+    private GetFasstoWarehousingInspecDetailResult mapWarehousingInspecDetailResult(
+            FasstoWarehousingInspecDetailListResponse response
+    ) {
+        List<FasstoWarehousingInspecDetailInfoResult> details = response.data().stream()
+                .map(this::mapWarehousingInspecDetailInfo)
+                .toList();
+        Integer dataCount = FormatValidator.hasValue(response.header()) ? response.header().dataCount() : null;
+        return GetFasstoWarehousingInspecDetailResult.of(dataCount, details);
     }
 
     private GetFasstoWarehousingAbnormalResult mapWarehousingAbnormalResult(FasstoWarehousingAbnormalListResponse response) {
@@ -1348,6 +1567,38 @@ public class FasstoWarehousingClient implements RegisterFasstoWarehousingPort, G
         );
     }
 
+    private FasstoWarehousingInspecDetailInfoResult mapWarehousingInspecDetailInfo(
+            FasstoWarehousingInspecDetailItemResponse item
+    ) {
+        List<Object> goods = FormatValidator.hasValue(item.goods()) ? item.goods() : List.of();
+        List<Object> goodsSerialNo = FormatValidator.hasValue(item.goodsSerialNo()) ? item.goodsSerialNo() : List.of();
+
+        return FasstoWarehousingInspecDetailInfoResult.of(
+                item.ordDt(),
+                item.whCd(),
+                item.whNm(),
+                item.slipNo(),
+                item.cstCd(),
+                item.cstNm(),
+                item.supCd(),
+                item.supNm(),
+                item.inWay(),
+                item.inWayNm(),
+                item.godCd(),
+                item.ordQty(),
+                item.totInQty(),
+                item.parcelComp(),
+                item.parcelInvoiceNo(),
+                item.wrkStat(),
+                item.wrkStatNm(),
+                item.remark(),
+                goods,
+                goodsSerialNo,
+                item.externalGodImgUrl(),
+                item.distTermDt()
+        );
+    }
+
     private FasstoWarehousingAbnormalInfoResult mapWarehousingAbnormalInfo(FasstoWarehousingAbnormalItemResponse item) {
         List<Object> imageUrl = FormatValidator.hasValue(item.imageUrl())
                 ? item.imageUrl()
@@ -1420,6 +1671,16 @@ public class FasstoWarehousingClient implements RegisterFasstoWarehousingPort, G
     }
 
     private String resolveVendorMessage(FasstoWarehousingDetailListResponse response, String rawBody) {
+        if (FormatValidator.hasValue(response)) {
+            String message = response.resolveErrorMessage();
+            if (FormatValidator.hasValue(message)) {
+                return message;
+            }
+        }
+        return resolveVendorMessage(rawBody);
+    }
+
+    private String resolveVendorMessage(FasstoWarehousingInspecDetailListResponse response, String rawBody) {
         if (FormatValidator.hasValue(response)) {
             String message = response.resolveErrorMessage();
             if (FormatValidator.hasValue(message)) {

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoWarehousingInspecDetailItemResponse.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoWarehousingInspecDetailItemResponse.java
@@ -1,0 +1,32 @@
+package com.personal.marketnote.fulfillment.adapter.out.vendor.fassto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record FasstoWarehousingInspecDetailItemResponse(
+        String ordDt,
+        String whCd,
+        String whNm,
+        String slipNo,
+        String cstCd,
+        String cstNm,
+        String supCd,
+        String supNm,
+        String inWay,
+        String inWayNm,
+        String godCd,
+        Integer ordQty,
+        Integer totInQty,
+        String parcelComp,
+        String parcelInvoiceNo,
+        String wrkStat,
+        String wrkStatNm,
+        String remark,
+        List<Object> goods,
+        List<Object> goodsSerialNo,
+        String externalGodImgUrl,
+        String distTermDt
+) {
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoWarehousingInspecDetailListResponse.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoWarehousingInspecDetailListResponse.java
@@ -1,0 +1,16 @@
+package com.personal.marketnote.fulfillment.adapter.out.vendor.fassto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record FasstoWarehousingInspecDetailListResponse(
+        FasstoResponseHeader header,
+        List<FasstoWarehousingInspecDetailItemResponse> data,
+        FasstoErrorInfo errorInfo
+) implements FasstoApiResponse {
+    public boolean isSuccess() {
+        return header != null && header.isSuccess() && data != null;
+    }
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/resources/application.yml
+++ b/fulfillment-service/fulfillment-adapters/src/main/resources/application.yml
@@ -59,6 +59,7 @@ vendor:
       warehousing-path: ${FASSTO_WAREHOUSING_PATH:/api/v1/warehousing/{customerCode}}
       warehousing-list-path: ${FASSTO_WAREHOUSING_LIST_PATH:/api/v1/warehousing/{customerCode}/{startDate}/{endDate}}
       warehousing-detail-path: ${FASSTO_WAREHOUSING_DETAIL_PATH:/api/v1/warehousing/detail/{customerCode}/{slipNo}}
+      warehousing-inspec-detail-path: ${FASSTO_WAREHOUSING_INSPEC_DETAIL_PATH:/api/v1/warehousing/inspec/{customerCode}/{slipNo}/{whCd}}
       warehousing-abnormal-path: ${FASSTO_WAREHOUSING_ABNORMAL_PATH:/api/v1/warehousing/abnormal/{customerCode}/{whCd}/{slipNo}}
       warehousing-abnormal-image-path: ${FASSTO_WAREHOUSING_ABNORMAL_IMAGE_PATH:/api/v1/warehousing/{slipNo}/{godCd}/{goodsSerialNo}/{fileSeq}/{imgNo}}
       delivery-path: ${FASSTO_DELIVERY_PATH:/api/v1/delivery/parcel/{customerCode}}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/configuration/FasstoAuthProperties.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/configuration/FasstoAuthProperties.java
@@ -23,6 +23,7 @@ public class FasstoAuthProperties {
     private String warehousingPath = "/api/v1/warehousing/{customerCode}";
     private String warehousingListPath = "/api/v1/warehousing/{customerCode}/{startDate}/{endDate}";
     private String warehousingDetailPath = "/api/v1/warehousing/detail/{customerCode}/{slipNo}";
+    private String warehousingInspecDetailPath = "/api/v1/warehousing/inspec/{customerCode}/{slipNo}/{whCd}";
     private String warehousingAbnormalPath = "/api/v1/warehousing/abnormal/{customerCode}/{whCd}/{slipNo}";
     private String warehousingAbnormalImagePath = "/api/v1/warehousing/{slipNo}/{godCd}/{goodsSerialNo}/{fileSeq}/{imgNo}";
     private String deliveryPath = "/api/v1/delivery/parcel/{customerCode}";

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/GetFasstoWarehousingInspecDetailFailedException.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/GetFasstoWarehousingInspecDetailFailedException.java
@@ -1,0 +1,25 @@
+package com.personal.marketnote.fulfillment.exception;
+
+import com.personal.marketnote.common.exception.ExternalOperationFailedException;
+import com.personal.marketnote.common.utility.FormatValidator;
+
+import java.io.IOException;
+
+public class GetFasstoWarehousingInspecDetailFailedException extends ExternalOperationFailedException {
+    private static final String DEFAULT_MESSAGE = "파스토 입고 검수 상세 조회 중 오류가 발생했습니다.";
+
+    public GetFasstoWarehousingInspecDetailFailedException(IOException cause) {
+        super(DEFAULT_MESSAGE, cause);
+    }
+
+    public GetFasstoWarehousingInspecDetailFailedException(String vendorMessage, IOException cause) {
+        super(resolveMessage(vendorMessage), cause);
+    }
+
+    private static String resolveMessage(String vendorMessage) {
+        if (FormatValidator.hasValue(vendorMessage)) {
+            return String.format("파스토 입고 검수 상세 조회 실패: %s", vendorMessage);
+        }
+        return DEFAULT_MESSAGE;
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/mapper/FasstoWarehousingCommandToRequestMapper.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/mapper/FasstoWarehousingCommandToRequestMapper.java
@@ -61,6 +61,17 @@ public class FasstoWarehousingCommandToRequestMapper {
         );
     }
 
+    public static FasstoWarehousingInspecDetailQuery mapToInspecDetailQuery(
+            GetFasstoWarehousingInspecDetailCommand command
+    ) {
+        return FasstoWarehousingInspecDetailQuery.of(
+                command.customerCode(),
+                command.accessToken(),
+                command.slipNo(),
+                command.whCd()
+        );
+    }
+
     public static FasstoWarehousingMapper mapToUpdateRequest(UpdateFasstoWarehousingCommand command) {
         List<FasstoWarehousingItemMapper> requests = command.warehousingRequests().stream()
                 .map(FasstoWarehousingCommandToRequestMapper::mapUpdateItem)

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/vendor/GetFasstoWarehousingInspecDetailCommand.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/vendor/GetFasstoWarehousingInspecDetailCommand.java
@@ -1,0 +1,17 @@
+package com.personal.marketnote.fulfillment.port.in.command.vendor;
+
+public record GetFasstoWarehousingInspecDetailCommand(
+        String customerCode,
+        String accessToken,
+        String slipNo,
+        String whCd
+) {
+    public static GetFasstoWarehousingInspecDetailCommand of(
+            String customerCode,
+            String accessToken,
+            String slipNo,
+            String whCd
+    ) {
+        return new GetFasstoWarehousingInspecDetailCommand(customerCode, accessToken, slipNo, whCd);
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/result/vendor/FasstoWarehousingInspecDetailInfoResult.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/result/vendor/FasstoWarehousingInspecDetailInfoResult.java
@@ -1,0 +1,78 @@
+package com.personal.marketnote.fulfillment.port.in.result.vendor;
+
+import java.util.List;
+
+public record FasstoWarehousingInspecDetailInfoResult(
+        String ordDt,
+        String whCd,
+        String whNm,
+        String slipNo,
+        String cstCd,
+        String cstNm,
+        String supCd,
+        String supNm,
+        String inWay,
+        String inWayNm,
+        String godCd,
+        Integer ordQty,
+        Integer totInQty,
+        String parcelComp,
+        String parcelInvoiceNo,
+        String wrkStat,
+        String wrkStatNm,
+        String remark,
+        List<Object> goods,
+        List<Object> goodsSerialNo,
+        String externalGodImgUrl,
+        String distTermDt
+) {
+    public static FasstoWarehousingInspecDetailInfoResult of(
+            String ordDt,
+            String whCd,
+            String whNm,
+            String slipNo,
+            String cstCd,
+            String cstNm,
+            String supCd,
+            String supNm,
+            String inWay,
+            String inWayNm,
+            String godCd,
+            Integer ordQty,
+            Integer totInQty,
+            String parcelComp,
+            String parcelInvoiceNo,
+            String wrkStat,
+            String wrkStatNm,
+            String remark,
+            List<Object> goods,
+            List<Object> goodsSerialNo,
+            String externalGodImgUrl,
+            String distTermDt
+    ) {
+        return new FasstoWarehousingInspecDetailInfoResult(
+                ordDt,
+                whCd,
+                whNm,
+                slipNo,
+                cstCd,
+                cstNm,
+                supCd,
+                supNm,
+                inWay,
+                inWayNm,
+                godCd,
+                ordQty,
+                totInQty,
+                parcelComp,
+                parcelInvoiceNo,
+                wrkStat,
+                wrkStatNm,
+                remark,
+                goods,
+                goodsSerialNo,
+                externalGodImgUrl,
+                distTermDt
+        );
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/result/vendor/GetFasstoWarehousingInspecDetailResult.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/result/vendor/GetFasstoWarehousingInspecDetailResult.java
@@ -1,0 +1,15 @@
+package com.personal.marketnote.fulfillment.port.in.result.vendor;
+
+import java.util.List;
+
+public record GetFasstoWarehousingInspecDetailResult(
+        Integer dataCount,
+        List<FasstoWarehousingInspecDetailInfoResult> details
+) {
+    public static GetFasstoWarehousingInspecDetailResult of(
+            Integer dataCount,
+            List<FasstoWarehousingInspecDetailInfoResult> details
+    ) {
+        return new GetFasstoWarehousingInspecDetailResult(dataCount, details);
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/usecase/vendor/GetFasstoWarehousingInspecDetailUseCase.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/usecase/vendor/GetFasstoWarehousingInspecDetailUseCase.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.fulfillment.port.in.usecase.vendor;
+
+import com.personal.marketnote.fulfillment.port.in.command.vendor.GetFasstoWarehousingInspecDetailCommand;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.GetFasstoWarehousingInspecDetailResult;
+
+public interface GetFasstoWarehousingInspecDetailUseCase {
+    GetFasstoWarehousingInspecDetailResult getWarehousingInspecDetail(GetFasstoWarehousingInspecDetailCommand command);
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/vendor/GetFasstoWarehousingInspecDetailPort.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/vendor/GetFasstoWarehousingInspecDetailPort.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.fulfillment.port.out.vendor;
+
+import com.personal.marketnote.fulfillment.domain.vendor.fassto.warehousing.FasstoWarehousingInspecDetailQuery;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.GetFasstoWarehousingInspecDetailResult;
+
+public interface GetFasstoWarehousingInspecDetailPort {
+    GetFasstoWarehousingInspecDetailResult getWarehousingInspecDetail(FasstoWarehousingInspecDetailQuery query);
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/vendor/GetFasstoWarehousingInspecDetailService.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/vendor/GetFasstoWarehousingInspecDetailService.java
@@ -1,0 +1,26 @@
+package com.personal.marketnote.fulfillment.service.vendor;
+
+import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.fulfillment.mapper.FasstoWarehousingCommandToRequestMapper;
+import com.personal.marketnote.fulfillment.port.in.command.vendor.GetFasstoWarehousingInspecDetailCommand;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.GetFasstoWarehousingInspecDetailResult;
+import com.personal.marketnote.fulfillment.port.in.usecase.vendor.GetFasstoWarehousingInspecDetailUseCase;
+import com.personal.marketnote.fulfillment.port.out.vendor.GetFasstoWarehousingInspecDetailPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional(isolation = READ_COMMITTED, readOnly = true)
+public class GetFasstoWarehousingInspecDetailService implements GetFasstoWarehousingInspecDetailUseCase {
+    private final GetFasstoWarehousingInspecDetailPort getFasstoWarehousingInspecDetailPort;
+
+    @Override
+    public GetFasstoWarehousingInspecDetailResult getWarehousingInspecDetail(GetFasstoWarehousingInspecDetailCommand command) {
+        return getFasstoWarehousingInspecDetailPort.getWarehousingInspecDetail(
+                FasstoWarehousingCommandToRequestMapper.mapToInspecDetailQuery(command)
+        );
+    }
+}

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/warehousing/FasstoWarehousingInspecDetailQuery.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/warehousing/FasstoWarehousingInspecDetailQuery.java
@@ -1,0 +1,46 @@
+package com.personal.marketnote.fulfillment.domain.vendor.fassto.warehousing;
+
+import com.personal.marketnote.common.utility.FormatValidator;
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+public class FasstoWarehousingInspecDetailQuery {
+    private String customerCode;
+    private String accessToken;
+    private String slipNo;
+    private String whCd;
+
+    public static FasstoWarehousingInspecDetailQuery of(
+            String customerCode,
+            String accessToken,
+            String slipNo,
+            String whCd
+    ) {
+        FasstoWarehousingInspecDetailQuery query = FasstoWarehousingInspecDetailQuery.builder()
+                .customerCode(customerCode)
+                .accessToken(accessToken)
+                .slipNo(slipNo)
+                .whCd(whCd)
+                .build();
+        query.validate();
+        return query;
+    }
+
+    private void validate() {
+        if (FormatValidator.hasNoValue(customerCode)) {
+            throw new IllegalArgumentException("customerCode is required.");
+        }
+        if (FormatValidator.hasNoValue(accessToken)) {
+            throw new IllegalArgumentException("accessToken is required.");
+        }
+        if (FormatValidator.hasNoValue(slipNo)) {
+            throw new IllegalArgumentException("slipNo is required.");
+        }
+        if (FormatValidator.hasNoValue(whCd)) {
+            throw new IllegalArgumentException("whCd is required.");
+        }
+    }
+}


### PR DESCRIPTION
## partially addresses #475
## resolves #737

## Task
- [x] 파스토 입고 검수 상세 정보 조회 연동 요청
- [x] 파스토 입고 검수 상세 정보 조회 연동 비즈니스 로직
- [x] 파스토 서버에 입고 검수 상세 정보 요청
- [x] 200 status code 응답
- [x] Swagger docs