### PR TITLE
[#475][#738] feat: 파스토 출고 등록(차량) 연동 기능 추가

### DIFF
--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/FasstoDeliveryController.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/FasstoDeliveryController.java
@@ -4,6 +4,7 @@ import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
 import com.personal.marketnote.fulfillment.adapter.in.web.vendor.controller.apidocs.*;
 import com.personal.marketnote.fulfillment.adapter.in.web.vendor.mapper.FasstoDeliveryRequestToCommandMapper;
 import com.personal.marketnote.fulfillment.adapter.in.web.vendor.request.CancelFasstoDeliveryRequest;
+import com.personal.marketnote.fulfillment.adapter.in.web.vendor.request.RegisterFasstoDeliveryCarRequest;
 import com.personal.marketnote.fulfillment.adapter.in.web.vendor.request.RegisterFasstoDeliveryRequest;
 import com.personal.marketnote.fulfillment.adapter.in.web.vendor.response.*;
 import com.personal.marketnote.fulfillment.port.in.result.vendor.*;
@@ -27,6 +28,7 @@ import static com.personal.marketnote.common.utility.ApiConstant.ADMIN_POINTCUT;
 @RequiredArgsConstructor
 public class FasstoDeliveryController {
     private final RegisterFasstoDeliveryUseCase registerFasstoDeliveryUseCase;
+    private final RegisterFasstoDeliveryCarUseCase registerFasstoDeliveryCarUseCase;
     private final GetFasstoDeliveriesUseCase getFasstoDeliveriesUseCase;
     private final GetFasstoDeliveryStatusesUseCase getFasstoDeliveryStatusesUseCase;
     private final GetFasstoDeliveryDetailUseCase getFasstoDeliveryDetailUseCase;
@@ -61,6 +63,39 @@ public class FasstoDeliveryController {
                         HttpStatus.CREATED,
                         DEFAULT_SUCCESS_CODE,
                         "파스토 출고 등록 성공"
+                ),
+                HttpStatus.CREATED
+        );
+    }
+
+    /**
+     * (관리자) 파스토 출고 등록(차량) 요청
+     *
+     * @param customerCode 파스토 고객사 코드
+     * @param accessToken  파스토 액세스 토큰
+     * @param request      출고 등록(차량) 요청 정보
+     * @Author 성효빈
+     * @Date 2026-02-17
+     * @Description 파스토 출고 등록(차량)을 요청합니다.
+     */
+    @PostMapping("/car/{customerCode}")
+    @PreAuthorize(ADMIN_POINTCUT)
+    @RegisterFasstoDeliveryCarApiDocs
+    public ResponseEntity<BaseResponse<RegisterFasstoDeliveryResponse>> registerDeliveryCar(
+            @PathVariable String customerCode,
+            @RequestHeader("accessToken") String accessToken,
+            @Valid @RequestBody List<RegisterFasstoDeliveryCarRequest> request
+    ) {
+        RegisterFasstoDeliveryResult result = registerFasstoDeliveryCarUseCase.registerDeliveryCar(
+                FasstoDeliveryRequestToCommandMapper.mapToRegisterCarCommand(customerCode, accessToken, request)
+        );
+
+        return new ResponseEntity<>(
+                BaseResponse.of(
+                        RegisterFasstoDeliveryResponse.from(result),
+                        HttpStatus.CREATED,
+                        DEFAULT_SUCCESS_CODE,
+                        "파스토 출고 등록(차량) 성공"
                 ),
                 HttpStatus.CREATED
         );

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/apidocs/RegisterFasstoDeliveryCarApiDocs.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/apidocs/RegisterFasstoDeliveryCarApiDocs.java
@@ -1,0 +1,170 @@
+package com.personal.marketnote.fulfillment.adapter.in.web.vendor.controller.apidocs;
+
+import com.personal.marketnote.fulfillment.adapter.in.web.vendor.request.RegisterFasstoDeliveryCarRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Operation(
+        summary = "(관리자) 파스토 출고 등록(차량) 요청",
+        description = """
+                작성일자: 2026-02-17
+                
+                작성자: 성효빈
+                
+                ---
+                
+                ## Description
+                
+                파스토 출고 등록(차량)을 요청합니다.
+                
+                ---
+                
+                ## Request
+                
+                | **키** | **위치** | **타입** | **설명** | **필수 여부** | **예시** |
+                | --- | --- | --- | --- | --- | --- |
+                | accessToken | header | string | 파스토 액세스 토큰 | Y | 23ea2ab4f0e111f0be620ab49498ff55 |
+                | customerCode | path | string | 파스토 고객사 코드 | Y | 94388 |
+                
+                ---
+                
+                ## Request Body (Array)
+                
+                | **키** | **타입** | **설명** | **필수 여부** | **예시** |
+                | --- | --- | --- | --- | --- |
+                | ordDt | string | 요청일자(등록/수정시 필수) | Y | "20260130" |
+                | ordNo | string | 주문번호(등록/수정시 필수) | Y | "CAR-001" |
+                | slipNo | string | FMS 출고요청번호(수정시 필수) | N | "" |
+                | outWay | string | 출고방법(1:선입선출,3:유통기한지정)(등록시 필수) | Y | "1" |
+                | cstShopCd | string | 고객사출고처코드(등록시 필수) | Y | "99999999" |
+                | godCds | array | 출고 상품 코드 목록 | Y | [ ... ] |
+                | remark | string | 비고(파스토에 요청하거나 공유할 내용) | N | "" |
+                
+                ---
+                
+                ### Request Body > godCds
+                
+                | **키** | **타입** | **설명** | **필수 여부** | **예시** |
+                | --- | --- | --- | --- | --- |
+                | cstGodCd | string | 고객사상품번호 | Y | "1" |
+                | distTermDt | string | 유통기한 | N | "" |
+                | ordQty | number | 주문수량 | Y | 2 |
+                
+                ---
+                
+                ## Response
+                
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | statusCode | number | 상태 코드 | 200: 성공 / 400: 클라이언트 요청 오류 / 401: 인증 실패 / 403: 인가 실패 / 500: 그 외 |
+                | code | string | 응답 코드 | "SUC01" / "BAD_REQUEST" / "UNAUTHORIZED" / "FORBIDDEN" / "INTERNAL_SERVER_ERROR" |
+                | timestamp | string(datetime) | 응답 일시 | "2026-02-17T12:12:30.013" |
+                | content | object | 응답 본문 | { ... } |
+                | message | string | 처리 결과 | "파스토 출고 등록(차량) 성공" |
+                
+                ---
+                
+                ### Response > content
+                
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | dataCount | number | 등록 건수 | 0 |
+                | deliveries | array | 출고 등록 결과 | [ ... ] |
+                
+                ---
+                
+                ### Response > content > deliveries
+                
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | fmsSlipNo | string | 전표번호 | "CAROO260130000001" |
+                | orderNo | string | 주문번호 | "CAR-001" |
+                | msg | string | 처리 메시지 | "출고요청 등록 성공" |
+                | code | string | 처리 코드 | "200" |
+                | outOfStockGoodsDetail | object | 품절 상품 상세 | null |
+                """,
+        security = {@SecurityRequirement(name = "bearer")},
+        parameters = {
+                @Parameter(
+                        name = "accessToken",
+                        description = "파스토 액세스 토큰",
+                        in = ParameterIn.HEADER,
+                        required = true,
+                        schema = @Schema(type = "string", example = "23ea2ab4f0e111f0be620ab49498ff55")
+                ),
+                @Parameter(
+                        name = "customerCode",
+                        description = "파스토 고객사 코드",
+                        in = ParameterIn.PATH,
+                        required = true,
+                        schema = @Schema(type = "string", example = "94388")
+                )
+        },
+        requestBody = @RequestBody(
+                required = true,
+                content = @Content(
+                        schema = @Schema(implementation = RegisterFasstoDeliveryCarRequest.class),
+                        examples = @ExampleObject("""
+                                [
+                                  {
+                                    "ordDt": "20260130",
+                                    "ordNo": "CAR-001",
+                                    "slipNo": "",
+                                    "outWay": "1",
+                                    "cstShopCd": "99999999",
+                                    "godCds": [
+                                      {
+                                        "cstGodCd": "1",
+                                        "distTermDt": "",
+                                        "ordQty": 2
+                                      }
+                                    ],
+                                    "remark": ""
+                                  }
+                                ]
+                                """)
+                )
+        ),
+        responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "파스토 출고 등록(차량) 성공",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 200,
+                                          "code": "SUC01",
+                                          "timestamp": "2026-02-17T12:12:30.013",
+                                          "content": {
+                                            "dataCount": 0,
+                                            "deliveries": [
+                                              {
+                                                "fmsSlipNo": "CAROO260130000001",
+                                                "orderNo": "CAR-001",
+                                                "msg": "출고요청 등록 성공",
+                                                "code": "200",
+                                                "outOfStockGoodsDetail": null
+                                              }
+                                            ]
+                                          },
+                                          "message": "파스토 출고 등록(차량) 성공"
+                                        }
+                                        """)
+                        )
+                )
+        }
+)
+public @interface RegisterFasstoDeliveryCarApiDocs {
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/mapper/FasstoDeliveryRequestToCommandMapper.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/mapper/FasstoDeliveryRequestToCommandMapper.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.fulfillment.adapter.in.web.vendor.mapper;
 
 import com.personal.marketnote.fulfillment.adapter.in.web.vendor.request.CancelFasstoDeliveryRequest;
+import com.personal.marketnote.fulfillment.adapter.in.web.vendor.request.RegisterFasstoDeliveryCarRequest;
 import com.personal.marketnote.fulfillment.adapter.in.web.vendor.request.RegisterFasstoDeliveryGoodsRequest;
 import com.personal.marketnote.fulfillment.adapter.in.web.vendor.request.RegisterFasstoDeliveryRequest;
 import com.personal.marketnote.fulfillment.port.in.command.vendor.*;
@@ -18,6 +19,18 @@ public class FasstoDeliveryRequestToCommandMapper {
                 .toList();
 
         return RegisterFasstoDeliveryCommand.of(customerCode, accessToken, deliveryRequests);
+    }
+
+    public static RegisterFasstoDeliveryCarCommand mapToRegisterCarCommand(
+            String customerCode,
+            String accessToken,
+            List<RegisterFasstoDeliveryCarRequest> request
+    ) {
+        List<RegisterFasstoDeliveryCarItemCommand> deliveryRequests = request.stream()
+                .map(FasstoDeliveryRequestToCommandMapper::mapCarItem)
+                .toList();
+
+        return RegisterFasstoDeliveryCarCommand.of(customerCode, accessToken, deliveryRequests);
     }
 
     public static GetFasstoDeliveriesCommand mapToDeliveriesCommand(
@@ -99,6 +112,22 @@ public class FasstoDeliveryRequestToCommandMapper {
                 .shipReqTerm(item.getShipReqTerm())
                 .godCds(goods)
                 .oneDayDeliveryCd(item.getOneDayDeliveryCd())
+                .remark(item.getRemark())
+                .build();
+    }
+
+    private static RegisterFasstoDeliveryCarItemCommand mapCarItem(RegisterFasstoDeliveryCarRequest item) {
+        List<RegisterFasstoDeliveryGoodsCommand> goods = item.getGodCds().stream()
+                .map(FasstoDeliveryRequestToCommandMapper::mapGoods)
+                .toList();
+
+        return RegisterFasstoDeliveryCarItemCommand.builder()
+                .ordDt(item.getOrdDt())
+                .ordNo(item.getOrdNo())
+                .slipNo(item.getSlipNo())
+                .outWay(item.getOutWay())
+                .cstShopCd(item.getCstShopCd())
+                .godCds(goods)
                 .remark(item.getRemark())
                 .build();
     }

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/request/RegisterFasstoDeliveryCarRequest.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/request/RegisterFasstoDeliveryCarRequest.java
@@ -1,0 +1,66 @@
+package com.personal.marketnote.fulfillment.adapter.in.web.vendor.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class RegisterFasstoDeliveryCarRequest {
+    @Schema(
+            name = "ordDt",
+            description = "요청일자(등록/수정시 필수)",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    @NotEmpty(message = "요청일자는 필수값입니다.")
+    private String ordDt;
+
+    @Schema(
+            name = "ordNo",
+            description = "주문번호(등록/수정시 필수)",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    @NotEmpty(message = "주문번호는 필수값입니다.")
+    private String ordNo;
+
+    @Schema(
+            name = "slipNo",
+            description = "FMS 출고요청번호(수정시 필수)",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String slipNo;
+
+    @Schema(
+            name = "outWay",
+            description = "출고방법(1:선입선출,3:유통기한지정)(등록시 필수)",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    @NotEmpty(message = "출고방법은 필수값입니다.")
+    private String outWay;
+
+    @Schema(
+            name = "cstShopCd",
+            description = "고객사출고처코드(등록시 필수)",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    @NotEmpty(message = "고객사출고처코드는 필수값입니다.")
+    private String cstShopCd;
+
+    @Schema(
+            name = "godCds",
+            description = "출고 상품 코드 목록",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    @Valid
+    @NotEmpty(message = "출고 상품 목록은 필수값입니다.")
+    private List<RegisterFasstoDeliveryGoodsRequest> godCds;
+
+    @Schema(
+            name = "remark",
+            description = "비고(파스토에 요청하거나 공유할 내용)",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String remark;
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/client/FasstoDeliveryClient.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/client/FasstoDeliveryClient.java
@@ -37,7 +37,7 @@ import static com.personal.marketnote.common.utility.ApiConstant.*;
 @VendorAdapter
 @RequiredArgsConstructor
 @Slf4j
-public class FasstoDeliveryClient implements RegisterFasstoDeliveryPort, GetFasstoDeliveriesPort, GetFasstoDeliveryStatusesPort, GetFasstoDeliveryDetailPort, GetFasstoDeliveryOutOrdGoodsDetailPort, CancelFasstoDeliveryPort {
+public class FasstoDeliveryClient implements RegisterFasstoDeliveryPort, RegisterFasstoDeliveryCarPort, GetFasstoDeliveriesPort, GetFasstoDeliveryStatusesPort, GetFasstoDeliveryDetailPort, GetFasstoDeliveryOutOrdGoodsDetailPort, CancelFasstoDeliveryPort {
     private static final String ACCESS_TOKEN_HEADER = "accessToken";
     private static final String CUSTOMER_CODE_PLACEHOLDER = "{customerCode}";
 
@@ -51,6 +51,12 @@ public class FasstoDeliveryClient implements RegisterFasstoDeliveryPort, GetFass
     @Override
     public RegisterFasstoDeliveryResult registerDelivery(FasstoDeliveryMapper request) {
         RegisterFasstoDeliveryResponse response = executeDeliveryRegistration(request, "REGISTER");
+        return mapDeliveryResult(response);
+    }
+
+    @Override
+    public RegisterFasstoDeliveryResult registerDeliveryCar(FasstoDeliveryCarMapper request) {
+        RegisterFasstoDeliveryResponse response = executeDeliveryCarRegistration(request, "REGISTER_CAR");
         return mapDeliveryResult(response);
     }
 
@@ -662,6 +668,138 @@ public class FasstoDeliveryClient implements RegisterFasstoDeliveryPort, GetFass
         throw new RegisterFasstoDeliveryFailedException(failureMessage, new IOException(error));
     }
 
+    private RegisterFasstoDeliveryResponse executeDeliveryCarRegistration(
+            FasstoDeliveryCarMapper request,
+            String action
+    ) {
+        if (FormatValidator.hasNoValue(request)) {
+            throw new IllegalArgumentException("Fassto delivery car request is required.");
+        }
+
+        URI uri = buildDeliveryCarUri(request.getCustomerCode());
+        HttpEntity<List<Map<String, Object>>> httpEntity = new HttpEntity<>(
+                request.toPayload(),
+                buildHeaders(request.getAccessToken())
+        );
+
+        Exception error = new Exception();
+        String failureMessage = null;
+        long sleepMillis = INTER_SERVER_DEFAULT_RETRIAL_PENDING_MILLI_SECOND;
+        FulfillmentVendorCommunicationTargetType targetType = FulfillmentVendorCommunicationTargetType.DELIVERY;
+        FulfillmentVendorName vendorName = FulfillmentVendorName.FASSTO;
+
+        for (int i = 0; i < INTER_SERVER_MAX_REQUEST_COUNT; i++) {
+            int attempt = i + 1;
+            JsonNode requestPayloadJson = buildCarRequestPayloadJson(request, uri, attempt, action);
+            String requestPayload = requestPayloadJson.toString();
+
+            ResponseEntity<String> response;
+            try {
+                response = restTemplate.exchange(
+                        uri,
+                        HttpMethod.POST,
+                        httpEntity,
+                        String.class
+                );
+            } catch (Exception e) {
+                Map<String, Object> errorPayload = new LinkedHashMap<>();
+                errorPayload.put("error", e.getClass().getSimpleName());
+                errorPayload.put("message", e.getMessage());
+                errorPayload.put("attempt", attempt);
+
+                vendorCommunicationFailureHandler.handleFailure(
+                        targetType,
+                        vendorName,
+                        requestPayload,
+                        requestPayloadJson,
+                        errorPayload,
+                        e
+                );
+
+                String vendorMessage = resolveVendorMessageFromException(e);
+                if (FormatValidator.hasValue(vendorMessage)) {
+                    failureMessage = vendorMessage;
+                    error = new Exception(vendorMessage);
+                }
+
+                log.warn("Failed to {} Fassto delivery car: attempt={}, message={}",
+                        action.toLowerCase(),
+                        attempt,
+                        e.getMessage(),
+                        e
+                );
+                if (i == INTER_SERVER_MAX_REQUEST_COUNT - 1) {
+                    error = e;
+                }
+
+                sleep(sleepMillis);
+                sleepMillis = sleepMillis * INTER_SERVER_DEFAULT_EXPONENTIAL_BACKOFF_VALUE;
+                continue;
+            }
+
+            JsonNode responsePayloadJson = buildResponsePayloadJson(response, attempt);
+            String responsePayload = responsePayloadJson.toString();
+
+            RegisterFasstoDeliveryResponse parsedResponse = parseResponseBody(response);
+            boolean isSuccess = isSuccessResponse(response, parsedResponse);
+            String exception = isSuccess
+                    ? null
+                    : resolveResponseException(response, parsedResponse);
+
+            vendorCommunicationRecorder.record(
+                    targetType,
+                    FulfillmentVendorCommunicationType.REQUEST,
+                    FulfillmentVendorCommunicationSenderType.SERVER,
+                    vendorName,
+                    requestPayload,
+                    requestPayloadJson,
+                    exception
+            );
+            vendorCommunicationRecorder.record(
+                    targetType,
+                    FulfillmentVendorCommunicationType.RESPONSE,
+                    FulfillmentVendorCommunicationSenderType.VENDOR,
+                    vendorName,
+                    responsePayload,
+                    responsePayloadJson,
+                    exception
+            );
+
+            if (isSuccess) {
+                return parsedResponse;
+            }
+
+            String vendorMessage = resolveVendorMessage(parsedResponse, FormatValidator.hasValue(response) ? response.getBody() : null);
+            if (FormatValidator.hasValue(vendorMessage)) {
+                failureMessage = vendorMessage;
+                error = new Exception(vendorMessage);
+            }
+
+            log.warn("Fassto delivery car {} failed: attempt={}, status={}, exception={}",
+                    action.toLowerCase(),
+                    attempt,
+                    FormatValidator.hasValue(response) ? response.getStatusCode() : null,
+                    exception
+            );
+
+            if (CommunicationFailureHandler.isCertainFailure(response)) {
+                break;
+            }
+
+            sleep(sleepMillis);
+            sleepMillis = sleepMillis * INTER_SERVER_DEFAULT_EXPONENTIAL_BACKOFF_VALUE;
+        }
+
+        log.error("Failed to {} Fassto delivery car request: {} with error: {}",
+                action.toLowerCase(),
+                uri,
+                error.getMessage(),
+                error
+        );
+
+        throw new RegisterFasstoDeliveryFailedException(failureMessage, new IOException(error));
+    }
+
     private RegisterFasstoDeliveryResponse executeDeliveryCancellation(
             FasstoDeliveryCancelMapper request,
             String action
@@ -802,6 +940,14 @@ public class FasstoDeliveryClient implements RegisterFasstoDeliveryPort, GetFass
                 .toUri();
     }
 
+    private URI buildDeliveryCarUri(String customerCode) {
+        validateDeliveryCarProperties();
+        return UriComponentsBuilder.fromUriString(properties.getBaseUrl())
+                .path(properties.getDeliveryCarPath())
+                .buildAndExpand(customerCode)
+                .toUri();
+    }
+
     private URI buildDeliveryListUri(
             String customerCode,
             String startDate,
@@ -891,6 +1037,18 @@ public class FasstoDeliveryClient implements RegisterFasstoDeliveryPort, GetFass
         }
         if (!properties.getDeliveryPath().contains(CUSTOMER_CODE_PLACEHOLDER)) {
             throw new IllegalStateException("Fassto delivery path must include {customerCode}.");
+        }
+    }
+
+    private void validateDeliveryCarProperties() {
+        if (FormatValidator.hasNoValue(properties.getBaseUrl())) {
+            throw new IllegalStateException("Fassto base URL is required.");
+        }
+        if (FormatValidator.hasNoValue(properties.getDeliveryCarPath())) {
+            throw new IllegalStateException("Fassto delivery car path is required.");
+        }
+        if (!properties.getDeliveryCarPath().contains(CUSTOMER_CODE_PLACEHOLDER)) {
+            throw new IllegalStateException("Fassto delivery car path must include {customerCode}.");
         }
     }
 
@@ -1200,6 +1358,23 @@ public class FasstoDeliveryClient implements RegisterFasstoDeliveryPort, GetFass
 
     private JsonNode buildRequestPayloadJson(
             FasstoDeliveryMapper request,
+            URI uri,
+            int attempt,
+            String action
+    ) {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("method", HttpMethod.POST.name());
+        payload.put("url", uri.toString());
+        payload.put("customerCode", request.getCustomerCode());
+        payload.put(ACCESS_TOKEN_HEADER, maskValue(request.getAccessToken()));
+        payload.put("body", request.toPayload());
+        payload.put("action", action);
+        payload.put("attempt", attempt);
+        return vendorCommunicationPayloadGenerator.buildPayloadJson(payload);
+    }
+
+    private JsonNode buildCarRequestPayloadJson(
+            FasstoDeliveryCarMapper request,
             URI uri,
             int attempt,
             String action

--- a/fulfillment-service/fulfillment-adapters/src/main/resources/application.yml
+++ b/fulfillment-service/fulfillment-adapters/src/main/resources/application.yml
@@ -63,6 +63,7 @@ vendor:
       warehousing-abnormal-path: ${FASSTO_WAREHOUSING_ABNORMAL_PATH:/api/v1/warehousing/abnormal/{customerCode}/{whCd}/{slipNo}}
       warehousing-abnormal-image-path: ${FASSTO_WAREHOUSING_ABNORMAL_IMAGE_PATH:/api/v1/warehousing/{slipNo}/{godCd}/{goodsSerialNo}/{fileSeq}/{imgNo}}
       delivery-path: ${FASSTO_DELIVERY_PATH:/api/v1/delivery/parcel/{customerCode}}
+      delivery-car-path: ${FASSTO_DELIVERY_CAR_PATH:/api/v1/delivery/car/{customerCode}}
       delivery-list-path: ${FASSTO_DELIVERY_LIST_PATH:/api/v1/delivery/{customerCode}/{startDate}/{endDate}/{status}/{outDiv}}
       delivery-status-path: ${FASSTO_DELIVERY_STATUS_PATH:/api/v1/delivery/parcel/{customerCode}/{startDate}/{endDate}/{outDiv}}
       delivery-detail-path: ${FASSTO_DELIVERY_DETAIL_PATH:/api/v1/delivery/detail/{customerCode}/{slipNo}}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/configuration/FasstoAuthProperties.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/configuration/FasstoAuthProperties.java
@@ -27,6 +27,7 @@ public class FasstoAuthProperties {
     private String warehousingAbnormalPath = "/api/v1/warehousing/abnormal/{customerCode}/{whCd}/{slipNo}";
     private String warehousingAbnormalImagePath = "/api/v1/warehousing/{slipNo}/{godCd}/{goodsSerialNo}/{fileSeq}/{imgNo}";
     private String deliveryPath = "/api/v1/delivery/parcel/{customerCode}";
+    private String deliveryCarPath = "/api/v1/delivery/car/{customerCode}";
     private String deliveryListPath = "/api/v1/delivery/{customerCode}/{startDate}/{endDate}/{status}/{outDiv}";
     private String deliveryStatusPath = "/api/v1/delivery/parcel/{customerCode}/{startDate}/{endDate}/{outDiv}";
     private String deliveryDetailPath = "/api/v1/delivery/detail/{customerCode}/{slipNo}";

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/mapper/FasstoDeliveryCommandToRequestMapper.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/mapper/FasstoDeliveryCommandToRequestMapper.java
@@ -71,6 +71,18 @@ public class FasstoDeliveryCommandToRequestMapper {
         );
     }
 
+    public static FasstoDeliveryCarMapper mapToRegisterCarRequest(RegisterFasstoDeliveryCarCommand command) {
+        List<FasstoDeliveryCarItemMapper> deliveryRequests = command.deliveryRequests().stream()
+                .map(FasstoDeliveryCommandToRequestMapper::mapCarItem)
+                .toList();
+
+        return FasstoDeliveryCarMapper.register(
+                command.customerCode(),
+                command.accessToken(),
+                deliveryRequests
+        );
+    }
+
     private static FasstoDeliveryItemMapper mapItem(RegisterFasstoDeliveryItemCommand item) {
         List<FasstoDeliveryGoodsMapper> goods = item.godCds().stream()
                 .map(FasstoDeliveryCommandToRequestMapper::mapGoods)
@@ -91,6 +103,22 @@ public class FasstoDeliveryCommandToRequestMapper {
                 item.shipReqTerm(),
                 goods,
                 item.oneDayDeliveryCd(),
+                item.remark()
+        );
+    }
+
+    private static FasstoDeliveryCarItemMapper mapCarItem(RegisterFasstoDeliveryCarItemCommand item) {
+        List<FasstoDeliveryGoodsMapper> goods = item.godCds().stream()
+                .map(FasstoDeliveryCommandToRequestMapper::mapGoods)
+                .toList();
+
+        return FasstoDeliveryCarItemMapper.of(
+                item.ordDt(),
+                item.ordNo(),
+                item.slipNo(),
+                item.outWay(),
+                item.cstShopCd(),
+                goods,
                 item.remark()
         );
     }

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/vendor/RegisterFasstoDeliveryCarCommand.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/vendor/RegisterFasstoDeliveryCarCommand.java
@@ -1,0 +1,17 @@
+package com.personal.marketnote.fulfillment.port.in.command.vendor;
+
+import java.util.List;
+
+public record RegisterFasstoDeliveryCarCommand(
+        String customerCode,
+        String accessToken,
+        List<RegisterFasstoDeliveryCarItemCommand> deliveryRequests
+) {
+    public static RegisterFasstoDeliveryCarCommand of(
+            String customerCode,
+            String accessToken,
+            List<RegisterFasstoDeliveryCarItemCommand> deliveryRequests
+    ) {
+        return new RegisterFasstoDeliveryCarCommand(customerCode, accessToken, deliveryRequests);
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/vendor/RegisterFasstoDeliveryCarItemCommand.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/vendor/RegisterFasstoDeliveryCarItemCommand.java
@@ -1,0 +1,17 @@
+package com.personal.marketnote.fulfillment.port.in.command.vendor;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record RegisterFasstoDeliveryCarItemCommand(
+        String ordDt,
+        String ordNo,
+        String slipNo,
+        String outWay,
+        String cstShopCd,
+        List<RegisterFasstoDeliveryGoodsCommand> godCds,
+        String remark
+) {
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/usecase/vendor/RegisterFasstoDeliveryCarUseCase.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/usecase/vendor/RegisterFasstoDeliveryCarUseCase.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.fulfillment.port.in.usecase.vendor;
+
+import com.personal.marketnote.fulfillment.port.in.command.vendor.RegisterFasstoDeliveryCarCommand;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.RegisterFasstoDeliveryResult;
+
+public interface RegisterFasstoDeliveryCarUseCase {
+    RegisterFasstoDeliveryResult registerDeliveryCar(RegisterFasstoDeliveryCarCommand command);
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/vendor/RegisterFasstoDeliveryCarPort.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/vendor/RegisterFasstoDeliveryCarPort.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.fulfillment.port.out.vendor;
+
+import com.personal.marketnote.fulfillment.domain.vendor.fassto.delivery.FasstoDeliveryCarMapper;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.RegisterFasstoDeliveryResult;
+
+public interface RegisterFasstoDeliveryCarPort {
+    RegisterFasstoDeliveryResult registerDeliveryCar(FasstoDeliveryCarMapper request);
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/vendor/RegisterFasstoDeliveryCarService.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/vendor/RegisterFasstoDeliveryCarService.java
@@ -1,0 +1,26 @@
+package com.personal.marketnote.fulfillment.service.vendor;
+
+import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.fulfillment.mapper.FasstoDeliveryCommandToRequestMapper;
+import com.personal.marketnote.fulfillment.port.in.command.vendor.RegisterFasstoDeliveryCarCommand;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.RegisterFasstoDeliveryResult;
+import com.personal.marketnote.fulfillment.port.in.usecase.vendor.RegisterFasstoDeliveryCarUseCase;
+import com.personal.marketnote.fulfillment.port.out.vendor.RegisterFasstoDeliveryCarPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional(isolation = READ_COMMITTED)
+public class RegisterFasstoDeliveryCarService implements RegisterFasstoDeliveryCarUseCase {
+    private final RegisterFasstoDeliveryCarPort registerFasstoDeliveryCarPort;
+
+    @Override
+    public RegisterFasstoDeliveryResult registerDeliveryCar(RegisterFasstoDeliveryCarCommand command) {
+        return registerFasstoDeliveryCarPort.registerDeliveryCar(
+                FasstoDeliveryCommandToRequestMapper.mapToRegisterCarRequest(command)
+        );
+    }
+}

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/delivery/FasstoDeliveryCarItemMapper.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/delivery/FasstoDeliveryCarItemMapper.java
@@ -1,0 +1,84 @@
+package com.personal.marketnote.fulfillment.domain.vendor.fassto.delivery;
+
+import com.personal.marketnote.common.utility.FormatValidator;
+import lombok.*;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+public class FasstoDeliveryCarItemMapper {
+    private String ordDt;
+    private String ordNo;
+    private String slipNo;
+    private String outWay;
+    private String cstShopCd;
+    private List<FasstoDeliveryGoodsMapper> godCds;
+    private String remark;
+
+    public static FasstoDeliveryCarItemMapper of(
+            String ordDt,
+            String ordNo,
+            String slipNo,
+            String outWay,
+            String cstShopCd,
+            List<FasstoDeliveryGoodsMapper> godCds,
+            String remark
+    ) {
+        FasstoDeliveryCarItemMapper mapper = FasstoDeliveryCarItemMapper.builder()
+                .ordDt(ordDt)
+                .ordNo(ordNo)
+                .slipNo(slipNo)
+                .outWay(outWay)
+                .cstShopCd(cstShopCd)
+                .godCds(godCds)
+                .remark(remark)
+                .build();
+        mapper.validate();
+        return mapper;
+    }
+
+    public Map<String, Object> toPayload() {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        putIfHasValue(payload, "ordDt", ordDt);
+        putIfHasValue(payload, "ordNo", ordNo);
+        putIfHasValue(payload, "slipNo", slipNo);
+        putIfHasValue(payload, "outWay", outWay);
+        putIfHasValue(payload, "cstShopCd", cstShopCd);
+        if (FormatValidator.hasValue(godCds)) {
+            payload.put("godCds", godCds.stream()
+                    .map(FasstoDeliveryGoodsMapper::toPayload)
+                    .toList());
+        }
+        putIfHasValue(payload, "remark", remark);
+        return payload;
+    }
+
+    private void validate() {
+        if (FormatValidator.hasNoValue(ordDt)) {
+            throw new IllegalArgumentException("ordDt is required for delivery car request.");
+        }
+        if (FormatValidator.hasNoValue(ordNo)) {
+            throw new IllegalArgumentException("ordNo is required for delivery car request.");
+        }
+        if (FormatValidator.hasNoValue(outWay)) {
+            throw new IllegalArgumentException("outWay is required for delivery car request.");
+        }
+        if (FormatValidator.hasNoValue(cstShopCd)) {
+            throw new IllegalArgumentException("cstShopCd is required for delivery car request.");
+        }
+        if (FormatValidator.hasNoValue(godCds)) {
+            throw new IllegalArgumentException("godCds is required for delivery car request.");
+        }
+    }
+
+    private void putIfHasValue(Map<String, Object> payload, String key, String value) {
+        if (FormatValidator.hasValue(value)) {
+            payload.put(key, value);
+        }
+    }
+}

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/delivery/FasstoDeliveryCarMapper.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/delivery/FasstoDeliveryCarMapper.java
@@ -1,0 +1,56 @@
+package com.personal.marketnote.fulfillment.domain.vendor.fassto.delivery;
+
+import com.personal.marketnote.common.utility.FormatValidator;
+import lombok.*;
+
+import java.util.List;
+import java.util.Map;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+public class FasstoDeliveryCarMapper {
+    private String customerCode;
+    private String accessToken;
+    private List<FasstoDeliveryCarItemMapper> deliveryRequests;
+
+    public static FasstoDeliveryCarMapper register(
+            String customerCode,
+            String accessToken,
+            List<FasstoDeliveryCarItemMapper> deliveryRequests
+    ) {
+        FasstoDeliveryCarMapper mapper = FasstoDeliveryCarMapper.builder()
+                .customerCode(customerCode)
+                .accessToken(accessToken)
+                .deliveryRequests(deliveryRequests)
+                .build();
+        mapper.validate();
+        return mapper;
+    }
+
+    public List<Map<String, Object>> toPayload() {
+        return deliveryRequests.stream()
+                .map(FasstoDeliveryCarItemMapper::toPayload)
+                .toList();
+    }
+
+    public String getOrdNo() {
+        if (FormatValidator.hasNoValue(deliveryRequests)) {
+            return null;
+        }
+        return deliveryRequests.getFirst().getOrdNo();
+    }
+
+    private void validate() {
+        if (FormatValidator.hasNoValue(customerCode)) {
+            throw new IllegalArgumentException("customerCode is required.");
+        }
+        if (FormatValidator.hasNoValue(accessToken)) {
+            throw new IllegalArgumentException("accessToken is required.");
+        }
+        if (FormatValidator.hasNoValue(deliveryRequests)) {
+            throw new IllegalArgumentException("deliveryRequests is required.");
+        }
+    }
+}


### PR DESCRIPTION
## partially addresses #475
## resolves #738

## Task
- [x] 파스토 출고 등록(차량) 연동 요청
- [x] 파스토 출고 등록(차량) 연동 비즈니스 로직
- [x] 파스토 서버에 출고 등록(차량) 요청
- [x] 200 status code 응답
- [x] Swagger docs