### PR TITLE
[#475][#752] feat: 파스토 출고 수정(차량) 연동 기능 추가

### DIFF
--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/FasstoDeliveryController.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/FasstoDeliveryController.java
@@ -6,6 +6,7 @@ import com.personal.marketnote.fulfillment.adapter.in.web.vendor.mapper.FasstoDe
 import com.personal.marketnote.fulfillment.adapter.in.web.vendor.request.CancelFasstoDeliveryRequest;
 import com.personal.marketnote.fulfillment.adapter.in.web.vendor.request.RegisterFasstoDeliveryCarRequest;
 import com.personal.marketnote.fulfillment.adapter.in.web.vendor.request.RegisterFasstoDeliveryRequest;
+import com.personal.marketnote.fulfillment.adapter.in.web.vendor.request.UpdateFasstoDeliveryCarRequest;
 import com.personal.marketnote.fulfillment.adapter.in.web.vendor.response.*;
 import com.personal.marketnote.fulfillment.port.in.result.vendor.*;
 import com.personal.marketnote.fulfillment.port.in.usecase.vendor.*;
@@ -29,6 +30,7 @@ import static com.personal.marketnote.common.utility.ApiConstant.ADMIN_POINTCUT;
 public class FasstoDeliveryController {
     private final RegisterFasstoDeliveryUseCase registerFasstoDeliveryUseCase;
     private final RegisterFasstoDeliveryCarUseCase registerFasstoDeliveryCarUseCase;
+    private final UpdateFasstoDeliveryCarUseCase updateFasstoDeliveryCarUseCase;
     private final GetFasstoDeliveriesUseCase getFasstoDeliveriesUseCase;
     private final GetFasstoDeliveryStatusesUseCase getFasstoDeliveryStatusesUseCase;
     private final GetFasstoDeliveryDetailUseCase getFasstoDeliveryDetailUseCase;
@@ -98,6 +100,39 @@ public class FasstoDeliveryController {
                         "파스토 출고 등록(차량) 성공"
                 ),
                 HttpStatus.CREATED
+        );
+    }
+
+    /**
+     * (관리자) 파스토 출고 수정(차량) 요청
+     *
+     * @param customerCode 파스토 고객사 코드
+     * @param accessToken  파스토 액세스 토큰
+     * @param request      출고 수정(차량) 요청 정보
+     * @Author 성효빈
+     * @Date 2026-02-17
+     * @Description 파스토 출고 수정(차량)을 요청합니다.
+     */
+    @PatchMapping("/car/{customerCode}")
+    @PreAuthorize(ADMIN_POINTCUT)
+    @UpdateFasstoDeliveryCarApiDocs
+    public ResponseEntity<BaseResponse<RegisterFasstoDeliveryResponse>> updateDeliveryCar(
+            @PathVariable String customerCode,
+            @RequestHeader("accessToken") String accessToken,
+            @Valid @RequestBody List<UpdateFasstoDeliveryCarRequest> request
+    ) {
+        RegisterFasstoDeliveryResult result = updateFasstoDeliveryCarUseCase.updateDeliveryCar(
+                FasstoDeliveryRequestToCommandMapper.mapToUpdateCarCommand(customerCode, accessToken, request)
+        );
+
+        return new ResponseEntity<>(
+                BaseResponse.of(
+                        RegisterFasstoDeliveryResponse.from(result),
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "파스토 출고 수정(차량) 성공"
+                ),
+                HttpStatus.OK
         );
     }
 

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/apidocs/UpdateFasstoDeliveryCarApiDocs.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/apidocs/UpdateFasstoDeliveryCarApiDocs.java
@@ -1,0 +1,170 @@
+package com.personal.marketnote.fulfillment.adapter.in.web.vendor.controller.apidocs;
+
+import com.personal.marketnote.fulfillment.adapter.in.web.vendor.request.UpdateFasstoDeliveryCarRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Operation(
+        summary = "(관리자) 파스토 출고 수정(차량) 요청",
+        description = """
+                작성일자: 2026-02-17
+                
+                작성자: 성효빈
+                
+                ---
+                
+                ## Description
+                
+                파스토 출고 수정(차량)을 요청합니다.
+                
+                ---
+                
+                ## Request
+                
+                | **키** | **위치** | **타입** | **설명** | **필수 여부** | **예시** |
+                | --- | --- | --- | --- | --- | --- |
+                | accessToken | header | string | 파스토 액세스 토큰 | Y | 23ea2ab4f0e111f0be620ab49498ff55 |
+                | customerCode | path | string | 파스토 고객사 코드 | Y | 94388 |
+                
+                ---
+                
+                ## Request Body (Array)
+                
+                | **키** | **타입** | **설명** | **필수 여부** | **예시** |
+                | --- | --- | --- | --- | --- |
+                | ordDt | string | 요청일자(등록/수정시 필수) | Y | "20260130" |
+                | ordNo | string | 주문번호(등록/수정시 필수) | Y | "CAR-001" |
+                | slipNo | string | FMS 출고요청번호(수정시 필수) | Y | "CAROO260130000001" |
+                | outWay | string | 출고방법(1:선입선출,3:유통기한지정)(등록시 필수) | Y | "1" |
+                | cstShopCd | string | 고객사출고처코드(등록시 필수) | Y | "99999999" |
+                | godCds | array | 출고 상품 코드 목록 | Y | [ ... ] |
+                | remark | string | 비고(파스토에 요청하거나 공유할 내용) | N | "" |
+                
+                ---
+                
+                ### Request Body > godCds
+                
+                | **키** | **타입** | **설명** | **필수 여부** | **예시** |
+                | --- | --- | --- | --- | --- |
+                | cstGodCd | string | 고객사상품번호 | Y | "1" |
+                | distTermDt | string | 유통기한 | N | "" |
+                | ordQty | number | 주문수량 | Y | 2 |
+                
+                ---
+                
+                ## Response
+                
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | statusCode | number | 상태 코드 | 200: 성공 / 400: 클라이언트 요청 오류 / 401: 인증 실패 / 403: 인가 실패 / 500: 그 외 |
+                | code | string | 응답 코드 | "SUC01" / "BAD_REQUEST" / "UNAUTHORIZED" / "FORBIDDEN" / "INTERNAL_SERVER_ERROR" |
+                | timestamp | string(datetime) | 응답 일시 | "2026-02-17T12:12:30.013" |
+                | content | object | 응답 본문 | { ... } |
+                | message | string | 처리 결과 | "파스토 출고 수정(차량) 성공" |
+                
+                ---
+                
+                ### Response > content
+                
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | dataCount | number | 수정 건수 | 1 |
+                | deliveries | array | 출고 수정 결과 | [ ... ] |
+                
+                ---
+                
+                ### Response > content > deliveries
+                
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | fmsSlipNo | string | 전표번호 | "CAROO260130000001" |
+                | orderNo | string | 주문번호 | "CAR-001" |
+                | msg | string | 처리 메시지 | "출고요청 수정 성공" |
+                | code | string | 처리 코드 | "200" |
+                | outOfStockGoodsDetail | object | 품절 상품 상세 | null |
+                """,
+        security = {@SecurityRequirement(name = "bearer")},
+        parameters = {
+                @Parameter(
+                        name = "accessToken",
+                        description = "파스토 액세스 토큰",
+                        in = ParameterIn.HEADER,
+                        required = true,
+                        schema = @Schema(type = "string", example = "23ea2ab4f0e111f0be620ab49498ff55")
+                ),
+                @Parameter(
+                        name = "customerCode",
+                        description = "파스토 고객사 코드",
+                        in = ParameterIn.PATH,
+                        required = true,
+                        schema = @Schema(type = "string", example = "94388")
+                )
+        },
+        requestBody = @RequestBody(
+                required = true,
+                content = @Content(
+                        schema = @Schema(implementation = UpdateFasstoDeliveryCarRequest.class),
+                        examples = @ExampleObject("""
+                                [
+                                  {
+                                    "ordDt": "20260130",
+                                    "ordNo": "CAR-001",
+                                    "slipNo": "CAROO260130000001",
+                                    "outWay": "1",
+                                    "cstShopCd": "99999999",
+                                    "godCds": [
+                                      {
+                                        "cstGodCd": "1",
+                                        "distTermDt": "",
+                                        "ordQty": 2
+                                      }
+                                    ],
+                                    "remark": ""
+                                  }
+                                ]
+                                """)
+                )
+        ),
+        responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "파스토 출고 수정(차량) 성공",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 200,
+                                          "code": "SUC01",
+                                          "timestamp": "2026-02-17T12:12:30.013",
+                                          "content": {
+                                            "dataCount": 1,
+                                            "deliveries": [
+                                              {
+                                                "fmsSlipNo": "CAROO260130000001",
+                                                "orderNo": "CAR-001",
+                                                "msg": "출고요청 수정 성공",
+                                                "code": "200",
+                                                "outOfStockGoodsDetail": null
+                                              }
+                                            ]
+                                          },
+                                          "message": "파스토 출고 수정(차량) 성공"
+                                        }
+                                        """)
+                        )
+                )
+        }
+)
+public @interface UpdateFasstoDeliveryCarApiDocs {
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/mapper/FasstoDeliveryRequestToCommandMapper.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/mapper/FasstoDeliveryRequestToCommandMapper.java
@@ -4,6 +4,7 @@ import com.personal.marketnote.fulfillment.adapter.in.web.vendor.request.CancelF
 import com.personal.marketnote.fulfillment.adapter.in.web.vendor.request.RegisterFasstoDeliveryCarRequest;
 import com.personal.marketnote.fulfillment.adapter.in.web.vendor.request.RegisterFasstoDeliveryGoodsRequest;
 import com.personal.marketnote.fulfillment.adapter.in.web.vendor.request.RegisterFasstoDeliveryRequest;
+import com.personal.marketnote.fulfillment.adapter.in.web.vendor.request.UpdateFasstoDeliveryCarRequest;
 import com.personal.marketnote.fulfillment.port.in.command.vendor.*;
 
 import java.util.List;
@@ -31,6 +32,18 @@ public class FasstoDeliveryRequestToCommandMapper {
                 .toList();
 
         return RegisterFasstoDeliveryCarCommand.of(customerCode, accessToken, deliveryRequests);
+    }
+
+    public static UpdateFasstoDeliveryCarCommand mapToUpdateCarCommand(
+            String customerCode,
+            String accessToken,
+            List<UpdateFasstoDeliveryCarRequest> request
+    ) {
+        List<UpdateFasstoDeliveryCarItemCommand> deliveryRequests = request.stream()
+                .map(FasstoDeliveryRequestToCommandMapper::mapUpdateCarItem)
+                .toList();
+
+        return UpdateFasstoDeliveryCarCommand.of(customerCode, accessToken, deliveryRequests);
     }
 
     public static GetFasstoDeliveriesCommand mapToDeliveriesCommand(
@@ -122,6 +135,22 @@ public class FasstoDeliveryRequestToCommandMapper {
                 .toList();
 
         return RegisterFasstoDeliveryCarItemCommand.builder()
+                .ordDt(item.getOrdDt())
+                .ordNo(item.getOrdNo())
+                .slipNo(item.getSlipNo())
+                .outWay(item.getOutWay())
+                .cstShopCd(item.getCstShopCd())
+                .godCds(goods)
+                .remark(item.getRemark())
+                .build();
+    }
+
+    private static UpdateFasstoDeliveryCarItemCommand mapUpdateCarItem(UpdateFasstoDeliveryCarRequest item) {
+        List<RegisterFasstoDeliveryGoodsCommand> goods = item.getGodCds().stream()
+                .map(FasstoDeliveryRequestToCommandMapper::mapGoods)
+                .toList();
+
+        return UpdateFasstoDeliveryCarItemCommand.builder()
                 .ordDt(item.getOrdDt())
                 .ordNo(item.getOrdNo())
                 .slipNo(item.getSlipNo())

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/request/UpdateFasstoDeliveryCarRequest.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/request/UpdateFasstoDeliveryCarRequest.java
@@ -1,0 +1,67 @@
+package com.personal.marketnote.fulfillment.adapter.in.web.vendor.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class UpdateFasstoDeliveryCarRequest {
+    @Schema(
+            name = "ordDt",
+            description = "요청일자(등록/수정시 필수)",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    @NotEmpty(message = "요청일자는 필수값입니다.")
+    private String ordDt;
+
+    @Schema(
+            name = "ordNo",
+            description = "주문번호(등록/수정시 필수)",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    @NotEmpty(message = "주문번호는 필수값입니다.")
+    private String ordNo;
+
+    @Schema(
+            name = "slipNo",
+            description = "FMS 출고요청번호(수정시 필수)",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    @NotEmpty(message = "출고요청번호는 필수값입니다.")
+    private String slipNo;
+
+    @Schema(
+            name = "outWay",
+            description = "출고방법(1:선입선출,3:유통기한지정)(등록시 필수)",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    @NotEmpty(message = "출고방법은 필수값입니다.")
+    private String outWay;
+
+    @Schema(
+            name = "cstShopCd",
+            description = "고객사출고처코드(등록시 필수)",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    @NotEmpty(message = "고객사출고처코드는 필수값입니다.")
+    private String cstShopCd;
+
+    @Schema(
+            name = "godCds",
+            description = "출고 상품 코드 목록",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    @Valid
+    @NotEmpty(message = "출고 상품 목록은 필수값입니다.")
+    private List<RegisterFasstoDeliveryGoodsRequest> godCds;
+
+    @Schema(
+            name = "remark",
+            description = "비고(파스토에 요청하거나 공유할 내용)",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String remark;
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/client/FasstoDeliveryClient.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/client/FasstoDeliveryClient.java
@@ -37,7 +37,7 @@ import static com.personal.marketnote.common.utility.ApiConstant.*;
 @VendorAdapter
 @RequiredArgsConstructor
 @Slf4j
-public class FasstoDeliveryClient implements RegisterFasstoDeliveryPort, RegisterFasstoDeliveryCarPort, GetFasstoDeliveriesPort, GetFasstoDeliveryStatusesPort, GetFasstoDeliveryDetailPort, GetFasstoDeliveryOutOrdGoodsDetailPort, CancelFasstoDeliveryPort {
+public class FasstoDeliveryClient implements RegisterFasstoDeliveryPort, RegisterFasstoDeliveryCarPort, UpdateFasstoDeliveryCarPort, GetFasstoDeliveriesPort, GetFasstoDeliveryStatusesPort, GetFasstoDeliveryDetailPort, GetFasstoDeliveryOutOrdGoodsDetailPort, CancelFasstoDeliveryPort {
     private static final String ACCESS_TOKEN_HEADER = "accessToken";
     private static final String CUSTOMER_CODE_PLACEHOLDER = "{customerCode}";
 
@@ -56,7 +56,13 @@ public class FasstoDeliveryClient implements RegisterFasstoDeliveryPort, Registe
 
     @Override
     public RegisterFasstoDeliveryResult registerDeliveryCar(FasstoDeliveryCarMapper request) {
-        RegisterFasstoDeliveryResponse response = executeDeliveryCarRegistration(request, "REGISTER_CAR");
+        RegisterFasstoDeliveryResponse response = executeDeliveryCarMutation(request, "REGISTER_CAR", HttpMethod.POST, false);
+        return mapDeliveryResult(response);
+    }
+
+    @Override
+    public RegisterFasstoDeliveryResult updateDeliveryCar(FasstoDeliveryCarMapper request) {
+        RegisterFasstoDeliveryResponse response = executeDeliveryCarMutation(request, "UPDATE_CAR", HttpMethod.PATCH, true);
         return mapDeliveryResult(response);
     }
 
@@ -668,9 +674,11 @@ public class FasstoDeliveryClient implements RegisterFasstoDeliveryPort, Registe
         throw new RegisterFasstoDeliveryFailedException(failureMessage, new IOException(error));
     }
 
-    private RegisterFasstoDeliveryResponse executeDeliveryCarRegistration(
+    private RegisterFasstoDeliveryResponse executeDeliveryCarMutation(
             FasstoDeliveryCarMapper request,
-            String action
+            String action,
+            HttpMethod method,
+            boolean isUpdate
     ) {
         if (FormatValidator.hasNoValue(request)) {
             throw new IllegalArgumentException("Fassto delivery car request is required.");
@@ -697,7 +705,7 @@ public class FasstoDeliveryClient implements RegisterFasstoDeliveryPort, Registe
             try {
                 response = restTemplate.exchange(
                         uri,
-                        HttpMethod.POST,
+                        method,
                         httpEntity,
                         String.class
                 );
@@ -797,6 +805,9 @@ public class FasstoDeliveryClient implements RegisterFasstoDeliveryPort, Registe
                 error
         );
 
+        if (isUpdate) {
+            throw new UpdateFasstoDeliveryCarFailedException(failureMessage, new IOException(error));
+        }
         throw new RegisterFasstoDeliveryFailedException(failureMessage, new IOException(error));
     }
 

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/UpdateFasstoDeliveryCarFailedException.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/UpdateFasstoDeliveryCarFailedException.java
@@ -1,0 +1,25 @@
+package com.personal.marketnote.fulfillment.exception;
+
+import com.personal.marketnote.common.exception.ExternalOperationFailedException;
+import com.personal.marketnote.common.utility.FormatValidator;
+
+import java.io.IOException;
+
+public class UpdateFasstoDeliveryCarFailedException extends ExternalOperationFailedException {
+    private static final String DEFAULT_MESSAGE = "파스토 출고 수정(차량) 중 오류가 발생했습니다.";
+
+    public UpdateFasstoDeliveryCarFailedException(IOException cause) {
+        super(DEFAULT_MESSAGE, cause);
+    }
+
+    public UpdateFasstoDeliveryCarFailedException(String vendorMessage, IOException cause) {
+        super(resolveMessage(vendorMessage), cause);
+    }
+
+    private static String resolveMessage(String vendorMessage) {
+        if (FormatValidator.hasValue(vendorMessage)) {
+            return String.format("파스토 출고 수정(차량) 실패: %s", vendorMessage);
+        }
+        return DEFAULT_MESSAGE;
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/mapper/FasstoDeliveryCommandToRequestMapper.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/mapper/FasstoDeliveryCommandToRequestMapper.java
@@ -83,6 +83,18 @@ public class FasstoDeliveryCommandToRequestMapper {
         );
     }
 
+    public static FasstoDeliveryCarMapper mapToUpdateCarRequest(UpdateFasstoDeliveryCarCommand command) {
+        List<FasstoDeliveryCarItemMapper> deliveryRequests = command.deliveryRequests().stream()
+                .map(FasstoDeliveryCommandToRequestMapper::mapUpdateCarItem)
+                .toList();
+
+        return FasstoDeliveryCarMapper.update(
+                command.customerCode(),
+                command.accessToken(),
+                deliveryRequests
+        );
+    }
+
     private static FasstoDeliveryItemMapper mapItem(RegisterFasstoDeliveryItemCommand item) {
         List<FasstoDeliveryGoodsMapper> goods = item.godCds().stream()
                 .map(FasstoDeliveryCommandToRequestMapper::mapGoods)
@@ -113,6 +125,22 @@ public class FasstoDeliveryCommandToRequestMapper {
                 .toList();
 
         return FasstoDeliveryCarItemMapper.of(
+                item.ordDt(),
+                item.ordNo(),
+                item.slipNo(),
+                item.outWay(),
+                item.cstShopCd(),
+                goods,
+                item.remark()
+        );
+    }
+
+    private static FasstoDeliveryCarItemMapper mapUpdateCarItem(UpdateFasstoDeliveryCarItemCommand item) {
+        List<FasstoDeliveryGoodsMapper> goods = item.godCds().stream()
+                .map(FasstoDeliveryCommandToRequestMapper::mapGoods)
+                .toList();
+
+        return FasstoDeliveryCarItemMapper.update(
                 item.ordDt(),
                 item.ordNo(),
                 item.slipNo(),

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/vendor/UpdateFasstoDeliveryCarCommand.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/vendor/UpdateFasstoDeliveryCarCommand.java
@@ -1,0 +1,17 @@
+package com.personal.marketnote.fulfillment.port.in.command.vendor;
+
+import java.util.List;
+
+public record UpdateFasstoDeliveryCarCommand(
+        String customerCode,
+        String accessToken,
+        List<UpdateFasstoDeliveryCarItemCommand> deliveryRequests
+) {
+    public static UpdateFasstoDeliveryCarCommand of(
+            String customerCode,
+            String accessToken,
+            List<UpdateFasstoDeliveryCarItemCommand> deliveryRequests
+    ) {
+        return new UpdateFasstoDeliveryCarCommand(customerCode, accessToken, deliveryRequests);
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/vendor/UpdateFasstoDeliveryCarItemCommand.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/vendor/UpdateFasstoDeliveryCarItemCommand.java
@@ -1,0 +1,17 @@
+package com.personal.marketnote.fulfillment.port.in.command.vendor;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record UpdateFasstoDeliveryCarItemCommand(
+        String ordDt,
+        String ordNo,
+        String slipNo,
+        String outWay,
+        String cstShopCd,
+        List<RegisterFasstoDeliveryGoodsCommand> godCds,
+        String remark
+) {
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/usecase/vendor/UpdateFasstoDeliveryCarUseCase.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/usecase/vendor/UpdateFasstoDeliveryCarUseCase.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.fulfillment.port.in.usecase.vendor;
+
+import com.personal.marketnote.fulfillment.port.in.command.vendor.UpdateFasstoDeliveryCarCommand;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.RegisterFasstoDeliveryResult;
+
+public interface UpdateFasstoDeliveryCarUseCase {
+    RegisterFasstoDeliveryResult updateDeliveryCar(UpdateFasstoDeliveryCarCommand command);
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/vendor/UpdateFasstoDeliveryCarPort.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/vendor/UpdateFasstoDeliveryCarPort.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.fulfillment.port.out.vendor;
+
+import com.personal.marketnote.fulfillment.domain.vendor.fassto.delivery.FasstoDeliveryCarMapper;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.RegisterFasstoDeliveryResult;
+
+public interface UpdateFasstoDeliveryCarPort {
+    RegisterFasstoDeliveryResult updateDeliveryCar(FasstoDeliveryCarMapper request);
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/vendor/UpdateFasstoDeliveryCarService.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/vendor/UpdateFasstoDeliveryCarService.java
@@ -1,0 +1,26 @@
+package com.personal.marketnote.fulfillment.service.vendor;
+
+import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.fulfillment.mapper.FasstoDeliveryCommandToRequestMapper;
+import com.personal.marketnote.fulfillment.port.in.command.vendor.UpdateFasstoDeliveryCarCommand;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.RegisterFasstoDeliveryResult;
+import com.personal.marketnote.fulfillment.port.in.usecase.vendor.UpdateFasstoDeliveryCarUseCase;
+import com.personal.marketnote.fulfillment.port.out.vendor.UpdateFasstoDeliveryCarPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional(isolation = READ_COMMITTED)
+public class UpdateFasstoDeliveryCarService implements UpdateFasstoDeliveryCarUseCase {
+    private final UpdateFasstoDeliveryCarPort updateFasstoDeliveryCarPort;
+
+    @Override
+    public RegisterFasstoDeliveryResult updateDeliveryCar(UpdateFasstoDeliveryCarCommand command) {
+        return updateFasstoDeliveryCarPort.updateDeliveryCar(
+                FasstoDeliveryCommandToRequestMapper.mapToUpdateCarRequest(command)
+        );
+    }
+}

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/delivery/FasstoDeliveryCarItemMapper.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/delivery/FasstoDeliveryCarItemMapper.java
@@ -42,6 +42,28 @@ public class FasstoDeliveryCarItemMapper {
         return mapper;
     }
 
+    public static FasstoDeliveryCarItemMapper update(
+            String ordDt,
+            String ordNo,
+            String slipNo,
+            String outWay,
+            String cstShopCd,
+            List<FasstoDeliveryGoodsMapper> godCds,
+            String remark
+    ) {
+        FasstoDeliveryCarItemMapper mapper = FasstoDeliveryCarItemMapper.builder()
+                .ordDt(ordDt)
+                .ordNo(ordNo)
+                .slipNo(slipNo)
+                .outWay(outWay)
+                .cstShopCd(cstShopCd)
+                .godCds(godCds)
+                .remark(remark)
+                .build();
+        mapper.validateForUpdate();
+        return mapper;
+    }
+
     public Map<String, Object> toPayload() {
         Map<String, Object> payload = new LinkedHashMap<>();
         putIfHasValue(payload, "ordDt", ordDt);
@@ -73,6 +95,13 @@ public class FasstoDeliveryCarItemMapper {
         }
         if (FormatValidator.hasNoValue(godCds)) {
             throw new IllegalArgumentException("godCds is required for delivery car request.");
+        }
+    }
+
+    private void validateForUpdate() {
+        validate();
+        if (FormatValidator.hasNoValue(slipNo)) {
+            throw new IllegalArgumentException("slipNo is required for delivery car update request.");
         }
     }
 

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/delivery/FasstoDeliveryCarMapper.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/delivery/FasstoDeliveryCarMapper.java
@@ -29,6 +29,20 @@ public class FasstoDeliveryCarMapper {
         return mapper;
     }
 
+    public static FasstoDeliveryCarMapper update(
+            String customerCode,
+            String accessToken,
+            List<FasstoDeliveryCarItemMapper> deliveryRequests
+    ) {
+        FasstoDeliveryCarMapper mapper = FasstoDeliveryCarMapper.builder()
+                .customerCode(customerCode)
+                .accessToken(accessToken)
+                .deliveryRequests(deliveryRequests)
+                .build();
+        mapper.validate();
+        return mapper;
+    }
+
     public List<Map<String, Object>> toPayload() {
         return deliveryRequests.stream()
                 .map(FasstoDeliveryCarItemMapper::toPayload)


### PR DESCRIPTION
## partially addresses #475
## resolves #752

## Task
- [x] 파스토 출고 수정(차량) 연동 요청
- [x] 파스토 출고 수정(차량) 연동 비즈니스 로직
- [x] 파스토 서버에 출고 수정(차량) 요청
- [x] 200 status code 응답
- [x] Swagger docs