### PR TITLE
[#475][#739] feat: 파스토 출고 수정(택배) 연동 기능 추가

### DIFF
--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/FasstoDeliveryController.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/FasstoDeliveryController.java
@@ -3,10 +3,7 @@ package com.personal.marketnote.fulfillment.adapter.in.web.vendor.controller;
 import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
 import com.personal.marketnote.fulfillment.adapter.in.web.vendor.controller.apidocs.*;
 import com.personal.marketnote.fulfillment.adapter.in.web.vendor.mapper.FasstoDeliveryRequestToCommandMapper;
-import com.personal.marketnote.fulfillment.adapter.in.web.vendor.request.CancelFasstoDeliveryRequest;
-import com.personal.marketnote.fulfillment.adapter.in.web.vendor.request.RegisterFasstoDeliveryCarRequest;
-import com.personal.marketnote.fulfillment.adapter.in.web.vendor.request.RegisterFasstoDeliveryRequest;
-import com.personal.marketnote.fulfillment.adapter.in.web.vendor.request.UpdateFasstoDeliveryCarRequest;
+import com.personal.marketnote.fulfillment.adapter.in.web.vendor.request.*;
 import com.personal.marketnote.fulfillment.adapter.in.web.vendor.response.*;
 import com.personal.marketnote.fulfillment.port.in.result.vendor.*;
 import com.personal.marketnote.fulfillment.port.in.usecase.vendor.*;
@@ -29,6 +26,7 @@ import static com.personal.marketnote.common.utility.ApiConstant.ADMIN_POINTCUT;
 @RequiredArgsConstructor
 public class FasstoDeliveryController {
     private final RegisterFasstoDeliveryUseCase registerFasstoDeliveryUseCase;
+    private final UpdateFasstoDeliveryUseCase updateFasstoDeliveryUseCase;
     private final RegisterFasstoDeliveryCarUseCase registerFasstoDeliveryCarUseCase;
     private final UpdateFasstoDeliveryCarUseCase updateFasstoDeliveryCarUseCase;
     private final GetFasstoDeliveriesUseCase getFasstoDeliveriesUseCase;
@@ -67,6 +65,39 @@ public class FasstoDeliveryController {
                         "파스토 출고 등록 성공"
                 ),
                 HttpStatus.CREATED
+        );
+    }
+
+    /**
+     * (관리자) 파스토 출고 수정(택배) 요청
+     *
+     * @param customerCode 파스토 고객사 코드
+     * @param accessToken  파스토 액세스 토큰
+     * @param request      출고 수정(택배) 요청 정보
+     * @Author 성효빈
+     * @Date 2026-02-17
+     * @Description 파스토 출고 수정(택배)을 요청합니다.
+     */
+    @PatchMapping("/{customerCode}")
+    @PreAuthorize(ADMIN_POINTCUT)
+    @UpdateFasstoDeliveryApiDocs
+    public ResponseEntity<BaseResponse<RegisterFasstoDeliveryResponse>> updateDelivery(
+            @PathVariable String customerCode,
+            @RequestHeader("accessToken") String accessToken,
+            @Valid @RequestBody List<UpdateFasstoDeliveryRequest> request
+    ) {
+        RegisterFasstoDeliveryResult result = updateFasstoDeliveryUseCase.updateDelivery(
+                FasstoDeliveryRequestToCommandMapper.mapToUpdateCommand(customerCode, accessToken, request)
+        );
+
+        return new ResponseEntity<>(
+                BaseResponse.of(
+                        RegisterFasstoDeliveryResponse.from(result),
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "파스토 출고 수정(택배) 성공"
+                ),
+                HttpStatus.OK
         );
     }
 

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/apidocs/UpdateFasstoDeliveryApiDocs.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/apidocs/UpdateFasstoDeliveryApiDocs.java
@@ -1,0 +1,186 @@
+package com.personal.marketnote.fulfillment.adapter.in.web.vendor.controller.apidocs;
+
+import com.personal.marketnote.fulfillment.adapter.in.web.vendor.request.UpdateFasstoDeliveryRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Operation(
+        summary = "(관리자) 파스토 출고 수정(택배) 요청",
+        description = """
+                작성일자: 2026-02-17
+                
+                작성자: 성효빈
+                
+                ---
+                
+                ## Description
+                
+                파스토 출고 수정(택배)을 요청합니다.
+                
+                ---
+                
+                ## Request
+                
+                | **키** | **위치** | **타입** | **설명** | **필수 여부** | **예시** |
+                | --- | --- | --- | --- | --- | --- |
+                | accessToken | header | string | 파스토 액세스 토큰 | Y | 23ea2ab4f0e111f0be620ab49498ff55 |
+                | customerCode | path | string | 파스토 고객사 코드 | Y | 94388 |
+                
+                ---
+                
+                ## Request Body (Array)
+                
+                | **키** | **타입** | **설명** | **필수 여부** | **예시** |
+                | --- | --- | --- | --- | --- |
+                | ordDt | string | 요청일자(등록/수정시 필수) | Y | "20260130" |
+                | ordNo | string | 주문번호(등록/수정시 필수) | Y | "PARCEL-001" |
+                | ordSeq | number | FMS 요청번호 순번 | N | 0 |
+                | slipNo | string | FMS 출고요청번호(수정시 필수) | Y | "TESTOO260130000001" |
+                | custNm | string | 배송 고객명(등록시 필수) | Y | "홍길동" |
+                | custTelNo | string | 배송 고객번호(등록시 필수) | Y | "01012345678" |
+                | custAddr | string | 배송주소(등록시 필수) | Y | "서울" |
+                | outWay | string | 출고방법(1:선입선출,3:유통기한지정)(등록시 필수) | Y | "1" |
+                | sendNm | string | 보내는분 | N | "" |
+                | sendTelNo | string | 보내는분전화번호 | N | "" |
+                | salChanel | string | 판매채널 | N | "" |
+                | shipReqTerm | string | 배송요청사항 | N | "" |
+                | godCds | array | 출고 상품 코드 목록 | Y | [ ... ] |
+                | oneDayDeliveryCd | string | 원데이배송회사 코드 | N | "" |
+                | remark | string | 비고(파스토에 요청하거나 공유할 내용) | N | "" |
+                
+                ---
+                
+                ### Request Body > godCds
+                
+                | **키** | **타입** | **설명** | **필수 여부** | **예시** |
+                | --- | --- | --- | --- | --- |
+                | cstGodCd | string | 고객사상품번호 | Y | "1" |
+                | distTermDt | string | 유통기한 | N | "" |
+                | ordQty | number | 주문수량 | Y | 2 |
+                
+                ---
+                
+                ## Response
+                
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | statusCode | number | 상태 코드 | 200: 성공 / 400: 클라이언트 요청 오류 / 401: 인증 실패 / 403: 인가 실패 / 500: 그 외 |
+                | code | string | 응답 코드 | "SUC01" / "BAD_REQUEST" / "UNAUTHORIZED" / "FORBIDDEN" / "INTERNAL_SERVER_ERROR" |
+                | timestamp | string(datetime) | 응답 일시 | "2026-02-17T12:12:30.013" |
+                | content | object | 응답 본문 | { ... } |
+                | message | string | 처리 결과 | "파스토 출고 수정(택배) 성공" |
+                
+                ---
+                
+                ### Response > content
+                
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | dataCount | number | 수정 건수 | 1 |
+                | deliveries | array | 출고 수정 결과 | [ ... ] |
+                
+                ---
+                
+                ### Response > content > deliveries
+                
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | fmsSlipNo | string | 전표번호 | "TESTOO260130000001" |
+                | orderNo | string | 주문번호 | "PARCEL-001" |
+                | msg | string | 처리 메시지 | "출고요청 수정 성공" |
+                | code | string | 처리 코드 | "200" |
+                | outOfStockGoodsDetail | object | 품절 상품 상세 | null |
+                """,
+        security = {@SecurityRequirement(name = "bearer")},
+        parameters = {
+                @Parameter(
+                        name = "accessToken",
+                        description = "파스토 액세스 토큰",
+                        in = ParameterIn.HEADER,
+                        required = true,
+                        schema = @Schema(type = "string", example = "23ea2ab4f0e111f0be620ab49498ff55")
+                ),
+                @Parameter(
+                        name = "customerCode",
+                        description = "파스토 고객사 코드",
+                        in = ParameterIn.PATH,
+                        required = true,
+                        schema = @Schema(type = "string", example = "94388")
+                )
+        },
+        requestBody = @RequestBody(
+                required = true,
+                content = @Content(
+                        schema = @Schema(implementation = UpdateFasstoDeliveryRequest.class),
+                        examples = @ExampleObject("""
+                                [
+                                  {
+                                    "ordDt": "20260130",
+                                    "ordNo": "PARCEL-001",
+                                    "ordSeq": 0,
+                                    "slipNo": "TESTOO260130000001",
+                                    "custNm": "홍길동",
+                                    "custTelNo": "01012345678",
+                                    "custAddr": "서울",
+                                    "outWay": "1",
+                                    "sendNm": "",
+                                    "sendTelNo": "",
+                                    "salChanel": "",
+                                    "shipReqTerm": "",
+                                    "godCds": [
+                                      {
+                                        "cstGodCd": "1",
+                                        "distTermDt": "",
+                                        "ordQty": 2
+                                      }
+                                    ],
+                                    "oneDayDeliveryCd": "",
+                                    "remark": ""
+                                  }
+                                ]
+                                """)
+                )
+        ),
+        responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "파스토 출고 수정(택배) 성공",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 200,
+                                          "code": "SUC01",
+                                          "timestamp": "2026-02-17T12:12:30.013",
+                                          "content": {
+                                            "dataCount": 1,
+                                            "deliveries": [
+                                              {
+                                                "fmsSlipNo": "TESTOO260130000001",
+                                                "orderNo": "PARCEL-001",
+                                                "msg": "출고요청 수정 성공",
+                                                "code": "200",
+                                                "outOfStockGoodsDetail": null
+                                              }
+                                            ]
+                                          },
+                                          "message": "파스토 출고 수정(택배) 성공"
+                                        }
+                                        """)
+                        )
+                )
+        }
+)
+public @interface UpdateFasstoDeliveryApiDocs {
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/mapper/FasstoDeliveryRequestToCommandMapper.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/mapper/FasstoDeliveryRequestToCommandMapper.java
@@ -1,10 +1,6 @@
 package com.personal.marketnote.fulfillment.adapter.in.web.vendor.mapper;
 
-import com.personal.marketnote.fulfillment.adapter.in.web.vendor.request.CancelFasstoDeliveryRequest;
-import com.personal.marketnote.fulfillment.adapter.in.web.vendor.request.RegisterFasstoDeliveryCarRequest;
-import com.personal.marketnote.fulfillment.adapter.in.web.vendor.request.RegisterFasstoDeliveryGoodsRequest;
-import com.personal.marketnote.fulfillment.adapter.in.web.vendor.request.RegisterFasstoDeliveryRequest;
-import com.personal.marketnote.fulfillment.adapter.in.web.vendor.request.UpdateFasstoDeliveryCarRequest;
+import com.personal.marketnote.fulfillment.adapter.in.web.vendor.request.*;
 import com.personal.marketnote.fulfillment.port.in.command.vendor.*;
 
 import java.util.List;
@@ -20,6 +16,18 @@ public class FasstoDeliveryRequestToCommandMapper {
                 .toList();
 
         return RegisterFasstoDeliveryCommand.of(customerCode, accessToken, deliveryRequests);
+    }
+
+    public static UpdateFasstoDeliveryCommand mapToUpdateCommand(
+            String customerCode,
+            String accessToken,
+            List<UpdateFasstoDeliveryRequest> request
+    ) {
+        List<UpdateFasstoDeliveryItemCommand> deliveryRequests = request.stream()
+                .map(FasstoDeliveryRequestToCommandMapper::mapUpdateItem)
+                .toList();
+
+        return UpdateFasstoDeliveryCommand.of(customerCode, accessToken, deliveryRequests);
     }
 
     public static RegisterFasstoDeliveryCarCommand mapToRegisterCarCommand(
@@ -111,6 +119,30 @@ public class FasstoDeliveryRequestToCommandMapper {
                 .toList();
 
         return RegisterFasstoDeliveryItemCommand.builder()
+                .ordDt(item.getOrdDt())
+                .ordNo(item.getOrdNo())
+                .ordSeq(item.getOrdSeq())
+                .slipNo(item.getSlipNo())
+                .custNm(item.getCustNm())
+                .custTelNo(item.getCustTelNo())
+                .custAddr(item.getCustAddr())
+                .outWay(item.getOutWay())
+                .sendNm(item.getSendNm())
+                .sendTelNo(item.getSendTelNo())
+                .salChanel(item.getSalChanel())
+                .shipReqTerm(item.getShipReqTerm())
+                .godCds(goods)
+                .oneDayDeliveryCd(item.getOneDayDeliveryCd())
+                .remark(item.getRemark())
+                .build();
+    }
+
+    private static UpdateFasstoDeliveryItemCommand mapUpdateItem(UpdateFasstoDeliveryRequest item) {
+        List<RegisterFasstoDeliveryGoodsCommand> goods = item.getGodCds().stream()
+                .map(FasstoDeliveryRequestToCommandMapper::mapGoods)
+                .toList();
+
+        return UpdateFasstoDeliveryItemCommand.builder()
                 .ordDt(item.getOrdDt())
                 .ordNo(item.getOrdNo())
                 .ordSeq(item.getOrdSeq())

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/request/UpdateFasstoDeliveryRequest.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/request/UpdateFasstoDeliveryRequest.java
@@ -1,0 +1,125 @@
+package com.personal.marketnote.fulfillment.adapter.in.web.vendor.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class UpdateFasstoDeliveryRequest {
+    @Schema(
+            name = "ordDt",
+            description = "요청일자(등록/수정시 필수)",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    @NotEmpty(message = "요청일자는 필수값입니다.")
+    private String ordDt;
+
+    @Schema(
+            name = "ordNo",
+            description = "주문번호(등록/수정시 필수)",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    @NotEmpty(message = "주문번호는 필수값입니다.")
+    private String ordNo;
+
+    @Schema(
+            name = "ordSeq",
+            description = "FMS 요청번호 순번",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private Integer ordSeq;
+
+    @Schema(
+            name = "slipNo",
+            description = "FMS 출고요청번호(수정시 필수)",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    @NotEmpty(message = "출고요청번호는 필수값입니다.")
+    private String slipNo;
+
+    @Schema(
+            name = "custNm",
+            description = "배송 고객명(등록시 필수)",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    @NotEmpty(message = "배송 고객명은 필수값입니다.")
+    private String custNm;
+
+    @Schema(
+            name = "custTelNo",
+            description = "배송 고객번호(등록시 필수)",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    @NotEmpty(message = "배송 고객번호는 필수값입니다.")
+    private String custTelNo;
+
+    @Schema(
+            name = "custAddr",
+            description = "배송주소(등록시 필수)",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    @NotEmpty(message = "배송주소는 필수값입니다.")
+    private String custAddr;
+
+    @Schema(
+            name = "outWay",
+            description = "출고방법(1:선입선출,3:유통기한지정)(등록시 필수)",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    @NotEmpty(message = "출고방법은 필수값입니다.")
+    private String outWay;
+
+    @Schema(
+            name = "sendNm",
+            description = "보내는분",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String sendNm;
+
+    @Schema(
+            name = "sendTelNo",
+            description = "보내는분전화번호",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String sendTelNo;
+
+    @Schema(
+            name = "salChanel",
+            description = "판매채널",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String salChanel;
+
+    @Schema(
+            name = "shipReqTerm",
+            description = "배송요청사항",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String shipReqTerm;
+
+    @Schema(
+            name = "godCds",
+            description = "출고 상품 코드 목록",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    @Valid
+    @NotEmpty(message = "출고 상품 목록은 필수값입니다.")
+    private List<RegisterFasstoDeliveryGoodsRequest> godCds;
+
+    @Schema(
+            name = "oneDayDeliveryCd",
+            description = "원데이배송회사 코드(NULL:사용안함, VROONG:부릉, CHAINLOGIS:체인로지스)",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String oneDayDeliveryCd;
+
+    @Schema(
+            name = "remark",
+            description = "비고(파스토에 요청하거나 공유할 내용)",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String remark;
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/client/FasstoDeliveryClient.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/client/FasstoDeliveryClient.java
@@ -37,7 +37,7 @@ import static com.personal.marketnote.common.utility.ApiConstant.*;
 @VendorAdapter
 @RequiredArgsConstructor
 @Slf4j
-public class FasstoDeliveryClient implements RegisterFasstoDeliveryPort, RegisterFasstoDeliveryCarPort, UpdateFasstoDeliveryCarPort, GetFasstoDeliveriesPort, GetFasstoDeliveryStatusesPort, GetFasstoDeliveryDetailPort, GetFasstoDeliveryOutOrdGoodsDetailPort, CancelFasstoDeliveryPort {
+public class FasstoDeliveryClient implements RegisterFasstoDeliveryPort, UpdateFasstoDeliveryPort, RegisterFasstoDeliveryCarPort, UpdateFasstoDeliveryCarPort, GetFasstoDeliveriesPort, GetFasstoDeliveryStatusesPort, GetFasstoDeliveryDetailPort, GetFasstoDeliveryOutOrdGoodsDetailPort, CancelFasstoDeliveryPort {
     private static final String ACCESS_TOKEN_HEADER = "accessToken";
     private static final String CUSTOMER_CODE_PLACEHOLDER = "{customerCode}";
 
@@ -50,7 +50,13 @@ public class FasstoDeliveryClient implements RegisterFasstoDeliveryPort, Registe
 
     @Override
     public RegisterFasstoDeliveryResult registerDelivery(FasstoDeliveryMapper request) {
-        RegisterFasstoDeliveryResponse response = executeDeliveryRegistration(request, "REGISTER");
+        RegisterFasstoDeliveryResponse response = executeDeliveryMutation(request, "REGISTER", HttpMethod.POST, false);
+        return mapDeliveryResult(response);
+    }
+
+    @Override
+    public RegisterFasstoDeliveryResult updateDelivery(FasstoDeliveryMapper request) {
+        RegisterFasstoDeliveryResponse response = executeDeliveryMutation(request, "UPDATE", HttpMethod.PATCH, true);
         return mapDeliveryResult(response);
     }
 
@@ -540,9 +546,11 @@ public class FasstoDeliveryClient implements RegisterFasstoDeliveryPort, Registe
         throw new GetFasstoDeliveryDetailFailedException(failureMessage, new IOException(error));
     }
 
-    private RegisterFasstoDeliveryResponse executeDeliveryRegistration(
+    private RegisterFasstoDeliveryResponse executeDeliveryMutation(
             FasstoDeliveryMapper request,
-            String action
+            String action,
+            HttpMethod method,
+            boolean isUpdate
     ) {
         if (FormatValidator.hasNoValue(request)) {
             throw new IllegalArgumentException("Fassto delivery request is required.");
@@ -569,7 +577,7 @@ public class FasstoDeliveryClient implements RegisterFasstoDeliveryPort, Registe
             try {
                 response = restTemplate.exchange(
                         uri,
-                        HttpMethod.POST,
+                        method,
                         httpEntity,
                         String.class
                 );
@@ -671,6 +679,9 @@ public class FasstoDeliveryClient implements RegisterFasstoDeliveryPort, Registe
                 error
         );
 
+        if (isUpdate) {
+            throw new UpdateFasstoDeliveryFailedException(failureMessage, new IOException(error));
+        }
         throw new RegisterFasstoDeliveryFailedException(failureMessage, new IOException(error));
     }
 

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/UpdateFasstoDeliveryFailedException.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/UpdateFasstoDeliveryFailedException.java
@@ -1,0 +1,25 @@
+package com.personal.marketnote.fulfillment.exception;
+
+import com.personal.marketnote.common.exception.ExternalOperationFailedException;
+import com.personal.marketnote.common.utility.FormatValidator;
+
+import java.io.IOException;
+
+public class UpdateFasstoDeliveryFailedException extends ExternalOperationFailedException {
+    private static final String DEFAULT_MESSAGE = "파스토 출고 수정(택배) 중 오류가 발생했습니다.";
+
+    public UpdateFasstoDeliveryFailedException(IOException cause) {
+        super(DEFAULT_MESSAGE, cause);
+    }
+
+    public UpdateFasstoDeliveryFailedException(String vendorMessage, IOException cause) {
+        super(resolveMessage(vendorMessage), cause);
+    }
+
+    private static String resolveMessage(String vendorMessage) {
+        if (FormatValidator.hasValue(vendorMessage)) {
+            return String.format("파스토 출고 수정(택배) 실패: %s", vendorMessage);
+        }
+        return DEFAULT_MESSAGE;
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/mapper/FasstoDeliveryCommandToRequestMapper.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/mapper/FasstoDeliveryCommandToRequestMapper.java
@@ -71,6 +71,18 @@ public class FasstoDeliveryCommandToRequestMapper {
         );
     }
 
+    public static FasstoDeliveryMapper mapToUpdateRequest(UpdateFasstoDeliveryCommand command) {
+        List<FasstoDeliveryItemMapper> deliveryRequests = command.deliveryRequests().stream()
+                .map(FasstoDeliveryCommandToRequestMapper::mapUpdateItem)
+                .toList();
+
+        return FasstoDeliveryMapper.update(
+                command.customerCode(),
+                command.accessToken(),
+                deliveryRequests
+        );
+    }
+
     public static FasstoDeliveryCarMapper mapToRegisterCarRequest(RegisterFasstoDeliveryCarCommand command) {
         List<FasstoDeliveryCarItemMapper> deliveryRequests = command.deliveryRequests().stream()
                 .map(FasstoDeliveryCommandToRequestMapper::mapCarItem)
@@ -101,6 +113,30 @@ public class FasstoDeliveryCommandToRequestMapper {
                 .toList();
 
         return FasstoDeliveryItemMapper.of(
+                item.ordDt(),
+                item.ordNo(),
+                item.ordSeq(),
+                item.slipNo(),
+                item.custNm(),
+                item.custTelNo(),
+                item.custAddr(),
+                item.outWay(),
+                item.sendNm(),
+                item.sendTelNo(),
+                item.salChanel(),
+                item.shipReqTerm(),
+                goods,
+                item.oneDayDeliveryCd(),
+                item.remark()
+        );
+    }
+
+    private static FasstoDeliveryItemMapper mapUpdateItem(UpdateFasstoDeliveryItemCommand item) {
+        List<FasstoDeliveryGoodsMapper> goods = item.godCds().stream()
+                .map(FasstoDeliveryCommandToRequestMapper::mapGoods)
+                .toList();
+
+        return FasstoDeliveryItemMapper.update(
                 item.ordDt(),
                 item.ordNo(),
                 item.ordSeq(),

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/vendor/UpdateFasstoDeliveryCommand.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/vendor/UpdateFasstoDeliveryCommand.java
@@ -1,0 +1,17 @@
+package com.personal.marketnote.fulfillment.port.in.command.vendor;
+
+import java.util.List;
+
+public record UpdateFasstoDeliveryCommand(
+        String customerCode,
+        String accessToken,
+        List<UpdateFasstoDeliveryItemCommand> deliveryRequests
+) {
+    public static UpdateFasstoDeliveryCommand of(
+            String customerCode,
+            String accessToken,
+            List<UpdateFasstoDeliveryItemCommand> deliveryRequests
+    ) {
+        return new UpdateFasstoDeliveryCommand(customerCode, accessToken, deliveryRequests);
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/vendor/UpdateFasstoDeliveryItemCommand.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/vendor/UpdateFasstoDeliveryItemCommand.java
@@ -1,0 +1,25 @@
+package com.personal.marketnote.fulfillment.port.in.command.vendor;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record UpdateFasstoDeliveryItemCommand(
+        String ordDt,
+        String ordNo,
+        Integer ordSeq,
+        String slipNo,
+        String custNm,
+        String custTelNo,
+        String custAddr,
+        String outWay,
+        String sendNm,
+        String sendTelNo,
+        String salChanel,
+        String shipReqTerm,
+        List<RegisterFasstoDeliveryGoodsCommand> godCds,
+        String oneDayDeliveryCd,
+        String remark
+) {
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/usecase/vendor/UpdateFasstoDeliveryUseCase.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/usecase/vendor/UpdateFasstoDeliveryUseCase.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.fulfillment.port.in.usecase.vendor;
+
+import com.personal.marketnote.fulfillment.port.in.command.vendor.UpdateFasstoDeliveryCommand;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.RegisterFasstoDeliveryResult;
+
+public interface UpdateFasstoDeliveryUseCase {
+    RegisterFasstoDeliveryResult updateDelivery(UpdateFasstoDeliveryCommand command);
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/vendor/UpdateFasstoDeliveryPort.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/vendor/UpdateFasstoDeliveryPort.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.fulfillment.port.out.vendor;
+
+import com.personal.marketnote.fulfillment.domain.vendor.fassto.delivery.FasstoDeliveryMapper;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.RegisterFasstoDeliveryResult;
+
+public interface UpdateFasstoDeliveryPort {
+    RegisterFasstoDeliveryResult updateDelivery(FasstoDeliveryMapper request);
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/vendor/UpdateFasstoDeliveryService.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/vendor/UpdateFasstoDeliveryService.java
@@ -1,0 +1,26 @@
+package com.personal.marketnote.fulfillment.service.vendor;
+
+import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.fulfillment.mapper.FasstoDeliveryCommandToRequestMapper;
+import com.personal.marketnote.fulfillment.port.in.command.vendor.UpdateFasstoDeliveryCommand;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.RegisterFasstoDeliveryResult;
+import com.personal.marketnote.fulfillment.port.in.usecase.vendor.UpdateFasstoDeliveryUseCase;
+import com.personal.marketnote.fulfillment.port.out.vendor.UpdateFasstoDeliveryPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional(isolation = READ_COMMITTED)
+public class UpdateFasstoDeliveryService implements UpdateFasstoDeliveryUseCase {
+    private final UpdateFasstoDeliveryPort updateFasstoDeliveryPort;
+
+    @Override
+    public RegisterFasstoDeliveryResult updateDelivery(UpdateFasstoDeliveryCommand command) {
+        return updateFasstoDeliveryPort.updateDelivery(
+                FasstoDeliveryCommandToRequestMapper.mapToUpdateRequest(command)
+        );
+    }
+}

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/delivery/FasstoDeliveryItemMapper.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/delivery/FasstoDeliveryItemMapper.java
@@ -66,6 +66,44 @@ public class FasstoDeliveryItemMapper {
         return mapper;
     }
 
+    public static FasstoDeliveryItemMapper update(
+            String ordDt,
+            String ordNo,
+            Integer ordSeq,
+            String slipNo,
+            String custNm,
+            String custTelNo,
+            String custAddr,
+            String outWay,
+            String sendNm,
+            String sendTelNo,
+            String salChanel,
+            String shipReqTerm,
+            List<FasstoDeliveryGoodsMapper> godCds,
+            String oneDayDeliveryCd,
+            String remark
+    ) {
+        FasstoDeliveryItemMapper mapper = FasstoDeliveryItemMapper.builder()
+                .ordDt(ordDt)
+                .ordNo(ordNo)
+                .ordSeq(ordSeq)
+                .slipNo(slipNo)
+                .custNm(custNm)
+                .custTelNo(custTelNo)
+                .custAddr(custAddr)
+                .outWay(outWay)
+                .sendNm(sendNm)
+                .sendTelNo(sendTelNo)
+                .salChanel(salChanel)
+                .shipReqTerm(shipReqTerm)
+                .godCds(godCds)
+                .oneDayDeliveryCd(oneDayDeliveryCd)
+                .remark(remark)
+                .build();
+        mapper.validateForUpdate();
+        return mapper;
+    }
+
     public Map<String, Object> toPayload() {
         Map<String, Object> payload = new LinkedHashMap<>();
         putIfHasValue(payload, "ordDt", ordDt);
@@ -113,6 +151,13 @@ public class FasstoDeliveryItemMapper {
         }
         if (FormatValidator.hasNoValue(godCds)) {
             throw new IllegalArgumentException("godCds is required for delivery request.");
+        }
+    }
+
+    private void validateForUpdate() {
+        validate();
+        if (FormatValidator.hasNoValue(slipNo)) {
+            throw new IllegalArgumentException("slipNo is required for delivery update request.");
         }
     }
 

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/delivery/FasstoDeliveryMapper.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/delivery/FasstoDeliveryMapper.java
@@ -29,6 +29,20 @@ public class FasstoDeliveryMapper {
         return mapper;
     }
 
+    public static FasstoDeliveryMapper update(
+            String customerCode,
+            String accessToken,
+            List<FasstoDeliveryItemMapper> deliveryRequests
+    ) {
+        FasstoDeliveryMapper mapper = FasstoDeliveryMapper.builder()
+                .customerCode(customerCode)
+                .accessToken(accessToken)
+                .deliveryRequests(deliveryRequests)
+                .build();
+        mapper.validate();
+        return mapper;
+    }
+
     public List<Map<String, Object>> toPayload() {
         return deliveryRequests.stream()
                 .map(FasstoDeliveryItemMapper::toPayload)


### PR DESCRIPTION
## partially addresses #475
## resolves #739

## Task
- [x] 파스토 출고 수정(택배) 연동 요청
- [x] 파스토 출고 수정(택배) 연동 비즈니스 로직
- [x] 파스토 서버에 출고 수정(택배) 요청
- [x] 200 status code 응답
- [x] Swagger docs