### PR TITLE
[#475][#740] feat: 파스토 주문번호 기반 출고중 상품 조회 연동 기능 추가

### DIFF
--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/FasstoDeliveryController.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/FasstoDeliveryController.java
@@ -33,6 +33,7 @@ public class FasstoDeliveryController {
     private final GetFasstoDeliveryStatusesUseCase getFasstoDeliveryStatusesUseCase;
     private final GetFasstoDeliveryDetailUseCase getFasstoDeliveryDetailUseCase;
     private final GetFasstoDeliveryOutOrdGoodsDetailUseCase getFasstoDeliveryOutOrdGoodsDetailUseCase;
+    private final GetFasstoDeliveryOutOrdGoodsByOrdNoUseCase getFasstoDeliveryOutOrdGoodsByOrdNoUseCase;
     private final CancelFasstoDeliveryUseCase cancelFasstoDeliveryUseCase;
 
     /**
@@ -360,6 +361,49 @@ public class FasstoDeliveryController {
                         HttpStatus.OK,
                         DEFAULT_SUCCESS_CODE,
                         "파스토 출고중 상품 송장별 조회 성공"
+                ),
+                HttpStatus.OK
+        );
+    }
+
+    /**
+     * (관리자) 파스토 주문번호 기반 출고중 상품 조회
+     *
+     * @param customerCode 파스토 고객사 코드
+     * @param startDate    조회 시작일(YYYY-MM-DD)
+     * @param endDate      조회 종료일(YYYY-MM-DD)
+     * @param accessToken  파스토 액세스 토큰
+     * @param ordNo        고객사 주문번호
+     * @Author 성효빈
+     * @Date 2026-02-17
+     * @Description 파스토 주문번호 기준 출고중 상품 정보를 조회합니다.
+     */
+    @GetMapping("/out-ord/goods-ord-no/{customerCode}/{startDate}/{endDate}")
+    @PreAuthorize(ADMIN_POINTCUT)
+    @GetFasstoDeliveryOutOrdGoodsByOrdNoApiDocs
+    public ResponseEntity<BaseResponse<GetFasstoDeliveryOutOrdGoodsByOrdNoResponse>> getOutOrdGoodsByOrdNo(
+            @PathVariable String customerCode,
+            @PathVariable String startDate,
+            @PathVariable String endDate,
+            @RequestHeader("accessToken") String accessToken,
+            @RequestParam(required = false) String ordNo
+    ) {
+        GetFasstoDeliveryOutOrdGoodsByOrdNoResult result = getFasstoDeliveryOutOrdGoodsByOrdNoUseCase.getOutOrdGoodsByOrdNo(
+                FasstoDeliveryRequestToCommandMapper.mapToOutOrdGoodsByOrdNoCommand(
+                        customerCode,
+                        accessToken,
+                        startDate,
+                        endDate,
+                        ordNo
+                )
+        );
+
+        return new ResponseEntity<>(
+                BaseResponse.of(
+                        GetFasstoDeliveryOutOrdGoodsByOrdNoResponse.from(result),
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "파스토 주문번호 기반 출고중 상품 조회 성공"
                 ),
                 HttpStatus.OK
         );

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/apidocs/GetFasstoDeliveryOutOrdGoodsByOrdNoApiDocs.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/apidocs/GetFasstoDeliveryOutOrdGoodsByOrdNoApiDocs.java
@@ -1,0 +1,155 @@
+package com.personal.marketnote.fulfillment.adapter.in.web.vendor.controller.apidocs;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Operation(
+        summary = "(관리자) 파스토 주문번호 기반 출고중 상품 조회",
+        description = """
+                작성일자: 2026-02-17
+                
+                작성자: 성효빈
+                
+                ---
+                
+                ## Description
+                
+                파스토 출고중 상품의 주문번호 기준 송장 및 상품 정보를 조회합니다.
+                
+                ---
+                
+                ## Request
+                
+                | **키** | **위치** | **타입** | **설명** | **필수 여부** | **예시** |
+                | --- | --- | --- | --- | --- | --- |
+                | accessToken | header | string | 파스토 액세스 토큰 | Y | 039a797bf66d11f0be620ab49498ff55 |
+                | customerCode | path | string | 파스토 고객사 코드 | Y | 94388 |
+                | startDate | path | string | 조회 시작일(YYYY-MM-DD) | Y | 2026-02-11 |
+                | endDate | path | string | 조회 종료일(YYYY-MM-DD) | Y | 2026-02-13 |
+                | ordNo | query | string | 고객사 주문번호 | N | ORDER-20260130 |
+                
+                ---
+                
+                ## Response
+                
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | statusCode | number | 상태 코드 | 200: 성공 / 400: 클라이언트 요청 오류 / 401: 인증 실패 / 403: 인가 실패 / 500: 그 외 |
+                | code | string | 응답 코드 | "SUC01" / "BAD_REQUEST" / "UNAUTHORIZED" / "FORBIDDEN" / "INTERNAL_SERVER_ERROR" |
+                | timestamp | string(datetime) | 응답 일시 | "2026-02-17T12:12:30.013" |
+                | content | object | 응답 본문 | { ... } |
+                | message | string | 처리 결과 | "파스토 주문번호 기반 출고중 상품 조회 성공" |
+                
+                ---
+                
+                ### Response > content
+                
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | dataCount | number | 조회 건수 | 1 |
+                | goodsByOrdNo | array | 주문번호 기반 상품 정보 | [ ... ] |
+                
+                ---
+                
+                ### Response > content > goodsByOrdNo
+                
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | ordNo | string | 주문번호 | "ORDER-20260130" |
+                | invoiceNo | string | 송장번호 | "1234567890" |
+                | goods | array | 상품 정보 | [ ... ] |
+                
+                ---
+                
+                ### Response > content > goodsByOrdNo > goods
+                
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | cstGodCd | string | 고객사 상품코드 | "1" |
+                | godNm | string | 상품명 | "테스트상품" |
+                | ordQty | number | 상품 수량 | 2 |
+                """,
+        security = {@SecurityRequirement(name = "bearer")},
+        parameters = {
+                @Parameter(
+                        name = "accessToken",
+                        description = "파스토 액세스 토큰",
+                        in = ParameterIn.HEADER,
+                        required = true,
+                        schema = @Schema(type = "string", example = "039a797bf66d11f0be620ab49498ff55")
+                ),
+                @Parameter(
+                        name = "customerCode",
+                        description = "파스토 고객사 코드",
+                        in = ParameterIn.PATH,
+                        required = true,
+                        schema = @Schema(type = "string", example = "94388")
+                ),
+                @Parameter(
+                        name = "startDate",
+                        description = "조회 시작일(YYYY-MM-DD)",
+                        in = ParameterIn.PATH,
+                        required = true,
+                        schema = @Schema(type = "string", example = "2026-02-11")
+                ),
+                @Parameter(
+                        name = "endDate",
+                        description = "조회 종료일(YYYY-MM-DD)",
+                        in = ParameterIn.PATH,
+                        required = true,
+                        schema = @Schema(type = "string", example = "2026-02-13")
+                ),
+                @Parameter(
+                        name = "ordNo",
+                        description = "고객사 주문번호",
+                        in = ParameterIn.QUERY,
+                        required = false,
+                        schema = @Schema(type = "string", example = "ORDER-20260130")
+                )
+        },
+        responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "파스토 주문번호 기반 출고중 상품 조회 성공",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 200,
+                                          "code": "SUC01",
+                                          "timestamp": "2026-02-17T12:12:30.013",
+                                          "content": {
+                                            "dataCount": 1,
+                                            "goodsByOrdNo": [
+                                              {
+                                                "ordNo": "ORDER-20260130",
+                                                "invoiceNo": "1234567890",
+                                                "goods": [
+                                                  {
+                                                    "cstGodCd": "1",
+                                                    "godNm": "테스트상품",
+                                                    "ordQty": 2
+                                                  }
+                                                ]
+                                              }
+                                            ]
+                                          },
+                                          "message": "파스토 주문번호 기반 출고중 상품 조회 성공"
+                                        }
+                                        """)
+                        )
+                )
+        }
+)
+public @interface GetFasstoDeliveryOutOrdGoodsByOrdNoApiDocs {
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/mapper/FasstoDeliveryRequestToCommandMapper.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/mapper/FasstoDeliveryRequestToCommandMapper.java
@@ -113,6 +113,22 @@ public class FasstoDeliveryRequestToCommandMapper {
         return GetFasstoDeliveryOutOrdGoodsDetailCommand.of(customerCode, accessToken, outOrdSlipNo);
     }
 
+    public static GetFasstoDeliveryOutOrdGoodsByOrdNoCommand mapToOutOrdGoodsByOrdNoCommand(
+            String customerCode,
+            String accessToken,
+            String startDate,
+            String endDate,
+            String ordNo
+    ) {
+        return GetFasstoDeliveryOutOrdGoodsByOrdNoCommand.of(
+                customerCode,
+                accessToken,
+                startDate,
+                endDate,
+                ordNo
+        );
+    }
+
     private static RegisterFasstoDeliveryItemCommand mapItem(RegisterFasstoDeliveryRequest item) {
         List<RegisterFasstoDeliveryGoodsCommand> goods = item.getGodCds().stream()
                 .map(FasstoDeliveryRequestToCommandMapper::mapGoods)

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/response/GetFasstoDeliveryOutOrdGoodsByOrdNoResponse.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/response/GetFasstoDeliveryOutOrdGoodsByOrdNoResponse.java
@@ -1,0 +1,15 @@
+package com.personal.marketnote.fulfillment.adapter.in.web.vendor.response;
+
+import com.personal.marketnote.fulfillment.port.in.result.vendor.FasstoDeliveryOutOrdGoodsByOrdNoInfoResult;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.GetFasstoDeliveryOutOrdGoodsByOrdNoResult;
+
+import java.util.List;
+
+public record GetFasstoDeliveryOutOrdGoodsByOrdNoResponse(
+        Integer dataCount,
+        List<FasstoDeliveryOutOrdGoodsByOrdNoInfoResult> goodsByOrdNo
+) {
+    public static GetFasstoDeliveryOutOrdGoodsByOrdNoResponse from(GetFasstoDeliveryOutOrdGoodsByOrdNoResult result) {
+        return new GetFasstoDeliveryOutOrdGoodsByOrdNoResponse(result.dataCount(), result.goodsByOrdNo());
+    }
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/client/FasstoDeliveryClient.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/client/FasstoDeliveryClient.java
@@ -37,7 +37,7 @@ import static com.personal.marketnote.common.utility.ApiConstant.*;
 @VendorAdapter
 @RequiredArgsConstructor
 @Slf4j
-public class FasstoDeliveryClient implements RegisterFasstoDeliveryPort, UpdateFasstoDeliveryPort, RegisterFasstoDeliveryCarPort, UpdateFasstoDeliveryCarPort, GetFasstoDeliveriesPort, GetFasstoDeliveryStatusesPort, GetFasstoDeliveryDetailPort, GetFasstoDeliveryOutOrdGoodsDetailPort, CancelFasstoDeliveryPort {
+public class FasstoDeliveryClient implements RegisterFasstoDeliveryPort, UpdateFasstoDeliveryPort, RegisterFasstoDeliveryCarPort, UpdateFasstoDeliveryCarPort, GetFasstoDeliveriesPort, GetFasstoDeliveryStatusesPort, GetFasstoDeliveryDetailPort, GetFasstoDeliveryOutOrdGoodsDetailPort, GetFasstoDeliveryOutOrdGoodsByOrdNoPort, CancelFasstoDeliveryPort {
     private static final String ACCESS_TOKEN_HEADER = "accessToken";
     private static final String CUSTOMER_CODE_PLACEHOLDER = "{customerCode}";
 
@@ -427,6 +427,124 @@ public class FasstoDeliveryClient implements RegisterFasstoDeliveryPort, UpdateF
 
         log.error("Failed to get Fassto out-ord goods detail: {} with error: {}", uri, error.getMessage(), error);
         throw new GetFasstoDeliveryOutOrdGoodsDetailFailedException(failureMessage, new IOException(error));
+    }
+
+    @Override
+    public GetFasstoDeliveryOutOrdGoodsByOrdNoResult getOutOrdGoodsByOrdNo(FasstoDeliveryOutOrdGoodsByOrdNoQuery query) {
+        if (FormatValidator.hasNoValue(query)) {
+            throw new IllegalArgumentException("Fassto out-ord goods by ordNo query is required.");
+        }
+
+        URI uri = buildOutOrdGoodsByOrdNoUri(
+                query.getCustomerCode(),
+                query.getStartDate(),
+                query.getEndDate(),
+                query.getOrdNo()
+        );
+        HttpEntity<Void> httpEntity = new HttpEntity<>(buildHeaders(query.getAccessToken(), false));
+
+        Exception error = new Exception();
+        String failureMessage = null;
+        long sleepMillis = INTER_SERVER_DEFAULT_RETRIAL_PENDING_MILLI_SECOND;
+        FulfillmentVendorCommunicationTargetType targetType = FulfillmentVendorCommunicationTargetType.DELIVERY;
+        FulfillmentVendorName vendorName = FulfillmentVendorName.FASSTO;
+
+        for (int i = 0; i < INTER_SERVER_MAX_REQUEST_COUNT; i++) {
+            int attempt = i + 1;
+            JsonNode requestPayloadJson = buildOutOrdGoodsByOrdNoRequestPayloadJson(query, uri, attempt);
+            String requestPayload = requestPayloadJson.toString();
+
+            ResponseEntity<String> response;
+            try {
+                response = restTemplate.exchange(
+                        uri,
+                        HttpMethod.GET,
+                        httpEntity,
+                        String.class
+                );
+            } catch (Exception e) {
+                Map<String, Object> errorPayload = new LinkedHashMap<>();
+                errorPayload.put("error", e.getClass().getSimpleName());
+                errorPayload.put("message", e.getMessage());
+                errorPayload.put("attempt", attempt);
+
+                vendorCommunicationFailureHandler.handleFailure(
+                        targetType,
+                        vendorName,
+                        requestPayload,
+                        requestPayloadJson,
+                        errorPayload,
+                        e
+                );
+
+                String vendorMessage = resolveVendorMessageFromException(e);
+                if (FormatValidator.hasValue(vendorMessage)) {
+                    failureMessage = vendorMessage;
+                    error = new Exception(vendorMessage);
+                }
+
+                log.warn("Failed to get Fassto out-ord goods by ordNo: attempt={}, message={}", attempt, e.getMessage(), e);
+                if (i == INTER_SERVER_MAX_REQUEST_COUNT - 1) {
+                    error = e;
+                }
+
+                sleep(sleepMillis);
+                sleepMillis = sleepMillis * INTER_SERVER_DEFAULT_EXPONENTIAL_BACKOFF_VALUE;
+                continue;
+            }
+
+            JsonNode responsePayloadJson = buildResponsePayloadJson(response, attempt);
+            String responsePayload = responsePayloadJson.toString();
+
+            FasstoOutOrdGoodsByOrdNoListResponse parsedResponse = parseOutOrdGoodsByOrdNoResponse(response);
+            boolean isSuccess = isOutOrdGoodsByOrdNoSuccess(response, parsedResponse);
+            String exception = isSuccess ? null : resolveOutOrdGoodsByOrdNoException(response, parsedResponse);
+
+            vendorCommunicationRecorder.record(
+                    targetType,
+                    FulfillmentVendorCommunicationType.REQUEST,
+                    FulfillmentVendorCommunicationSenderType.SERVER,
+                    vendorName,
+                    requestPayload,
+                    requestPayloadJson,
+                    exception
+            );
+            vendorCommunicationRecorder.record(
+                    targetType,
+                    FulfillmentVendorCommunicationType.RESPONSE,
+                    FulfillmentVendorCommunicationSenderType.VENDOR,
+                    vendorName,
+                    responsePayload,
+                    responsePayloadJson,
+                    exception
+            );
+
+            if (isSuccess) {
+                return mapOutOrdGoodsByOrdNoResult(parsedResponse);
+            }
+
+            String vendorMessage = resolveVendorMessage(parsedResponse, FormatValidator.hasValue(response) ? response.getBody() : null);
+            if (FormatValidator.hasValue(vendorMessage)) {
+                failureMessage = vendorMessage;
+                error = new Exception(vendorMessage);
+            }
+
+            log.warn("Fassto out-ord goods by ordNo request failed: attempt={}, status={}, exception={}",
+                    attempt,
+                    FormatValidator.hasValue(response) ? response.getStatusCode() : null,
+                    exception
+            );
+
+            if (CommunicationFailureHandler.isCertainFailure(response)) {
+                break;
+            }
+
+            sleep(sleepMillis);
+            sleepMillis = sleepMillis * INTER_SERVER_DEFAULT_EXPONENTIAL_BACKOFF_VALUE;
+        }
+
+        log.error("Failed to get Fassto out-ord goods by ordNo: {} with error: {}", uri, error.getMessage(), error);
+        throw new GetFasstoDeliveryOutOrdGoodsByOrdNoFailedException(failureMessage, new IOException(error));
     }
 
     @Override
@@ -1027,6 +1145,23 @@ public class FasstoDeliveryClient implements RegisterFasstoDeliveryPort, UpdateF
                 .toUri();
     }
 
+    private URI buildOutOrdGoodsByOrdNoUri(
+            String customerCode,
+            String startDate,
+            String endDate,
+            String ordNo
+    ) {
+        validateDeliveryOutOrdGoodsByOrdNoProperties();
+        UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(properties.getBaseUrl())
+                .path(properties.getDeliveryOutOrdGoodsByOrdNoPath());
+        if (FormatValidator.hasValue(ordNo)) {
+            builder.queryParam("ordNo", ordNo);
+        }
+        return builder
+                .buildAndExpand(customerCode, startDate, endDate)
+                .toUri();
+    }
+
     private URI buildDeliveryCancelUri(String customerCode) {
         validateDeliveryCancelProperties();
         return UriComponentsBuilder.fromUriString(properties.getBaseUrl())
@@ -1146,6 +1281,24 @@ public class FasstoDeliveryClient implements RegisterFasstoDeliveryPort, UpdateF
         }
     }
 
+    private void validateDeliveryOutOrdGoodsByOrdNoProperties() {
+        if (FormatValidator.hasNoValue(properties.getBaseUrl())) {
+            throw new IllegalStateException("Fassto base URL is required.");
+        }
+        if (FormatValidator.hasNoValue(properties.getDeliveryOutOrdGoodsByOrdNoPath())) {
+            throw new IllegalStateException("Fassto delivery out-ord goods by ordNo path is required.");
+        }
+        if (!properties.getDeliveryOutOrdGoodsByOrdNoPath().contains(CUSTOMER_CODE_PLACEHOLDER)) {
+            throw new IllegalStateException("Fassto delivery out-ord goods by ordNo path must include {customerCode}.");
+        }
+        if (!properties.getDeliveryOutOrdGoodsByOrdNoPath().contains("{startDate}")) {
+            throw new IllegalStateException("Fassto delivery out-ord goods by ordNo path must include {startDate}.");
+        }
+        if (!properties.getDeliveryOutOrdGoodsByOrdNoPath().contains("{endDate}")) {
+            throw new IllegalStateException("Fassto delivery out-ord goods by ordNo path must include {endDate}.");
+        }
+    }
+
     private void validateDeliveryCancelProperties() {
         if (FormatValidator.hasNoValue(properties.getBaseUrl())) {
             throw new IllegalStateException("Fassto base URL is required.");
@@ -1248,6 +1401,24 @@ public class FasstoDeliveryClient implements RegisterFasstoDeliveryPort, UpdateF
         }
     }
 
+    private FasstoOutOrdGoodsByOrdNoListResponse parseOutOrdGoodsByOrdNoResponse(ResponseEntity<String> response) {
+        if (FormatValidator.hasNoValue(response)) {
+            return null;
+        }
+
+        String body = response.getBody();
+        if (FormatValidator.hasNoValue(body)) {
+            return null;
+        }
+
+        try {
+            return objectMapper.readValue(body, FasstoOutOrdGoodsByOrdNoListResponse.class);
+        } catch (Exception e) {
+            log.warn("Failed to parse Fassto out-ord goods by ordNo response: {}", e.getMessage(), e);
+            return null;
+        }
+    }
+
     private boolean isSuccessResponse(ResponseEntity<String> response, RegisterFasstoDeliveryResponse parsedResponse) {
         return FormatValidator.hasValue(response)
                 && response.getStatusCode().value() == 200
@@ -1277,6 +1448,13 @@ public class FasstoDeliveryClient implements RegisterFasstoDeliveryPort, UpdateF
     }
 
     private boolean isOutOrdGoodsDetailSuccess(ResponseEntity<String> response, FasstoOutOrdGoodsDetailListResponse parsedResponse) {
+        return FormatValidator.hasValue(response)
+                && response.getStatusCode().value() == 200
+                && FormatValidator.hasValue(parsedResponse)
+                && parsedResponse.isSuccess();
+    }
+
+    private boolean isOutOrdGoodsByOrdNoSuccess(ResponseEntity<String> response, FasstoOutOrdGoodsByOrdNoListResponse parsedResponse) {
         return FormatValidator.hasValue(response)
                 && response.getStatusCode().value() == 200
                 && FormatValidator.hasValue(parsedResponse)
@@ -1359,6 +1537,28 @@ public class FasstoDeliveryClient implements RegisterFasstoDeliveryPort, UpdateF
     private String resolveOutOrdGoodsDetailException(
             ResponseEntity<String> response,
             FasstoOutOrdGoodsDetailListResponse parsedResponse
+    ) {
+        if (FormatValidator.hasNoValue(response)) {
+            return "NO_RESPONSE";
+        }
+        if (response.getStatusCode().value() != 200) {
+            return "HTTP_" + response.getStatusCode().value();
+        }
+        if (FormatValidator.hasNoValue(parsedResponse)) {
+            return "INVALID_RESPONSE";
+        }
+        if (FormatValidator.hasNoValue(parsedResponse.header()) || !parsedResponse.header().isSuccess()) {
+            return "HEADER_FAILURE";
+        }
+        if (FormatValidator.hasNoValue(parsedResponse.data())) {
+            return "DATA_MISSING";
+        }
+        return "UNKNOWN_FAILURE";
+    }
+
+    private String resolveOutOrdGoodsByOrdNoException(
+            ResponseEntity<String> response,
+            FasstoOutOrdGoodsByOrdNoListResponse parsedResponse
     ) {
         if (FormatValidator.hasNoValue(response)) {
             return "NO_RESPONSE";
@@ -1488,6 +1688,25 @@ public class FasstoDeliveryClient implements RegisterFasstoDeliveryPort, UpdateF
         return vendorCommunicationPayloadGenerator.buildPayloadJson(payload);
     }
 
+    private JsonNode buildOutOrdGoodsByOrdNoRequestPayloadJson(
+            FasstoDeliveryOutOrdGoodsByOrdNoQuery query,
+            URI uri,
+            int attempt
+    ) {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("method", HttpMethod.GET.name());
+        payload.put("url", uri.toString());
+        payload.put("customerCode", query.getCustomerCode());
+        payload.put("startDate", query.getStartDate());
+        payload.put("endDate", query.getEndDate());
+        if (FormatValidator.hasValue(query.getOrdNo())) {
+            payload.put("ordNo", query.getOrdNo());
+        }
+        payload.put(ACCESS_TOKEN_HEADER, maskValue(query.getAccessToken()));
+        payload.put("attempt", attempt);
+        return vendorCommunicationPayloadGenerator.buildPayloadJson(payload);
+    }
+
     private JsonNode buildResponsePayloadJson(ResponseEntity<String> response, int attempt) {
         Map<String, Object> payload = new LinkedHashMap<>();
         if (FormatValidator.hasValue(response)) {
@@ -1557,6 +1776,14 @@ public class FasstoDeliveryClient implements RegisterFasstoDeliveryPort, UpdateF
                 : List.of();
         Integer dataCount = FormatValidator.hasValue(response.header()) ? response.header().dataCount() : null;
         return GetFasstoDeliveryOutOrdGoodsDetailResult.of(dataCount, goodsByInvoice);
+    }
+
+    private GetFasstoDeliveryOutOrdGoodsByOrdNoResult mapOutOrdGoodsByOrdNoResult(FasstoOutOrdGoodsByOrdNoListResponse response) {
+        List<FasstoDeliveryOutOrdGoodsByOrdNoInfoResult> goodsByOrdNo = FormatValidator.hasValue(response.data())
+                ? response.data().stream().map(this::mapOutOrdGoodsByOrdNo).toList()
+                : List.of();
+        Integer dataCount = FormatValidator.hasValue(response.header()) ? response.header().dataCount() : null;
+        return GetFasstoDeliveryOutOrdGoodsByOrdNoResult.of(dataCount, goodsByOrdNo);
     }
 
     private RegisterFasstoDeliveryItemResult mapDeliveryItem(RegisterFasstoDeliveryItemResponse item) {
@@ -1769,6 +1996,22 @@ public class FasstoDeliveryClient implements RegisterFasstoDeliveryPort, UpdateF
         );
     }
 
+    private FasstoDeliveryOutOrdGoodsByOrdNoInfoResult mapOutOrdGoodsByOrdNo(FasstoOutOrdGoodsByOrdNoItemResponse item) {
+        List<FasstoDeliveryOutOrdGoodsByOrdNoItemInfoResult> goods = FormatValidator.hasValue(item.goods())
+                ? item.goods().stream().map(this::mapOutOrdGoodsByOrdNoGoods).toList()
+                : List.of();
+
+        return FasstoDeliveryOutOrdGoodsByOrdNoInfoResult.of(item.ordNo(), item.invoiceNo(), goods);
+    }
+
+    private FasstoDeliveryOutOrdGoodsByOrdNoItemInfoResult mapOutOrdGoodsByOrdNoGoods(FasstoOutOrdGoodsByOrdNoGoodsResponse item) {
+        return FasstoDeliveryOutOrdGoodsByOrdNoItemInfoResult.of(
+                item.cstGodCd(),
+                item.godNm(),
+                item.ordQty()
+        );
+    }
+
     private String maskValue(String value) {
         if (FormatValidator.hasNoValue(value)) {
             return value;
@@ -1835,6 +2078,16 @@ public class FasstoDeliveryClient implements RegisterFasstoDeliveryPort, UpdateF
     }
 
     private String resolveVendorMessage(FasstoOutOrdGoodsDetailListResponse response, String rawBody) {
+        if (FormatValidator.hasValue(response)) {
+            String message = response.resolveErrorMessage();
+            if (FormatValidator.hasValue(message)) {
+                return message;
+            }
+        }
+        return resolveVendorMessage(rawBody);
+    }
+
+    private String resolveVendorMessage(FasstoOutOrdGoodsByOrdNoListResponse response, String rawBody) {
         if (FormatValidator.hasValue(response)) {
             String message = response.resolveErrorMessage();
             if (FormatValidator.hasValue(message)) {

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoOutOrdGoodsByOrdNoGoodsResponse.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoOutOrdGoodsByOrdNoGoodsResponse.java
@@ -1,0 +1,11 @@
+package com.personal.marketnote.fulfillment.adapter.out.vendor.fassto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record FasstoOutOrdGoodsByOrdNoGoodsResponse(
+        String cstGodCd,
+        String godNm,
+        Integer ordQty
+) {
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoOutOrdGoodsByOrdNoItemResponse.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoOutOrdGoodsByOrdNoItemResponse.java
@@ -1,0 +1,13 @@
+package com.personal.marketnote.fulfillment.adapter.out.vendor.fassto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record FasstoOutOrdGoodsByOrdNoItemResponse(
+        String ordNo,
+        String invoiceNo,
+        List<FasstoOutOrdGoodsByOrdNoGoodsResponse> goods
+) {
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoOutOrdGoodsByOrdNoListResponse.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoOutOrdGoodsByOrdNoListResponse.java
@@ -1,0 +1,16 @@
+package com.personal.marketnote.fulfillment.adapter.out.vendor.fassto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record FasstoOutOrdGoodsByOrdNoListResponse(
+        FasstoResponseHeader header,
+        List<FasstoOutOrdGoodsByOrdNoItemResponse> data,
+        FasstoErrorInfo errorInfo
+) implements FasstoApiResponse {
+    public boolean isSuccess() {
+        return header != null && header.isSuccess() && data != null;
+    }
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/resources/application.yml
+++ b/fulfillment-service/fulfillment-adapters/src/main/resources/application.yml
@@ -69,6 +69,7 @@ vendor:
       delivery-detail-path: ${FASSTO_DELIVERY_DETAIL_PATH:/api/v1/delivery/detail/{customerCode}/{slipNo}}
       delivery-cancel-path: ${FASSTO_DELIVERY_CANCEL_PATH:/api/v1/delivery/cancel/{customerCode}}
       delivery-out-ord-goods-detail-path: ${FASSTO_DELIVERY_OUT_ORD_GOODS_DETAIL_PATH:/api/v1/delivery/outOrd/goodsDetail/{customerCode}}
+      delivery-out-ord-goods-ord-no-path: ${FASSTO_DELIVERY_OUT_ORD_GOODS_ORD_NO_PATH:/api/v1/delivery/outOrd/ordNo/{customerCode}/{startDate}/{endDate}}
       stock-list-path: ${FASSTO_STOCK_LIST_PATH:/api/v1/stock/list/{customerCode}}
       settlement-daily-cost-path: ${FASSTO_SETTLEMENT_DAILY_COST_PATH:/api/v1/settlement/{yearMonth}/{whCd}/{customerCode}}
       api-cd: ${FASSTO_API_CD:change-me}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/configuration/FasstoAuthProperties.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/configuration/FasstoAuthProperties.java
@@ -33,6 +33,7 @@ public class FasstoAuthProperties {
     private String deliveryDetailPath = "/api/v1/delivery/detail/{customerCode}/{slipNo}";
     private String deliveryCancelPath = "/api/v1/delivery/cancel/{customerCode}";
     private String deliveryOutOrdGoodsDetailPath = "/api/v1/delivery/outOrd/goodsDetail/{customerCode}";
+    private String deliveryOutOrdGoodsByOrdNoPath = "/api/v1/delivery/outOrd/ordNo/{customerCode}/{startDate}/{endDate}";
     private String stockListPath = "/api/v1/stock/list/{customerCode}";
     private String settlementDailyCostPath = "/api/v1/settlement/{yearMonth}/{whCd}/{customerCode}";
 }

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/GetFasstoDeliveryOutOrdGoodsByOrdNoFailedException.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/GetFasstoDeliveryOutOrdGoodsByOrdNoFailedException.java
@@ -1,0 +1,25 @@
+package com.personal.marketnote.fulfillment.exception;
+
+import com.personal.marketnote.common.exception.ExternalOperationFailedException;
+import com.personal.marketnote.common.utility.FormatValidator;
+
+import java.io.IOException;
+
+public class GetFasstoDeliveryOutOrdGoodsByOrdNoFailedException extends ExternalOperationFailedException {
+    private static final String DEFAULT_MESSAGE = "파스토 주문번호 기반 출고중 상품 조회 중 오류가 발생했습니다.";
+
+    public GetFasstoDeliveryOutOrdGoodsByOrdNoFailedException(IOException cause) {
+        super(DEFAULT_MESSAGE, cause);
+    }
+
+    public GetFasstoDeliveryOutOrdGoodsByOrdNoFailedException(String vendorMessage, IOException cause) {
+        super(resolveMessage(vendorMessage), cause);
+    }
+
+    private static String resolveMessage(String vendorMessage) {
+        if (FormatValidator.hasValue(vendorMessage)) {
+            return String.format("파스토 주문번호 기반 출고중 상품 조회 실패: %s", vendorMessage);
+        }
+        return DEFAULT_MESSAGE;
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/mapper/FasstoDeliveryCommandToRequestMapper.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/mapper/FasstoDeliveryCommandToRequestMapper.java
@@ -47,6 +47,18 @@ public class FasstoDeliveryCommandToRequestMapper {
         );
     }
 
+    public static FasstoDeliveryOutOrdGoodsByOrdNoQuery mapToOutOrdGoodsByOrdNoQuery(
+            GetFasstoDeliveryOutOrdGoodsByOrdNoCommand command
+    ) {
+        return FasstoDeliveryOutOrdGoodsByOrdNoQuery.of(
+                command.customerCode(),
+                command.accessToken(),
+                command.startDate(),
+                command.endDate(),
+                command.ordNo()
+        );
+    }
+
     public static FasstoDeliveryCancelMapper mapToCancelRequest(CancelFasstoDeliveryCommand command) {
         List<FasstoDeliveryCancelItemMapper> cancelRequests = command.deliveries().stream()
                 .map(FasstoDeliveryCommandToRequestMapper::mapCancelItem)

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/vendor/GetFasstoDeliveryOutOrdGoodsByOrdNoCommand.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/vendor/GetFasstoDeliveryOutOrdGoodsByOrdNoCommand.java
@@ -1,0 +1,19 @@
+package com.personal.marketnote.fulfillment.port.in.command.vendor;
+
+public record GetFasstoDeliveryOutOrdGoodsByOrdNoCommand(
+        String customerCode,
+        String accessToken,
+        String startDate,
+        String endDate,
+        String ordNo
+) {
+    public static GetFasstoDeliveryOutOrdGoodsByOrdNoCommand of(
+            String customerCode,
+            String accessToken,
+            String startDate,
+            String endDate,
+            String ordNo
+    ) {
+        return new GetFasstoDeliveryOutOrdGoodsByOrdNoCommand(customerCode, accessToken, startDate, endDate, ordNo);
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/result/vendor/FasstoDeliveryOutOrdGoodsByOrdNoInfoResult.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/result/vendor/FasstoDeliveryOutOrdGoodsByOrdNoInfoResult.java
@@ -1,0 +1,17 @@
+package com.personal.marketnote.fulfillment.port.in.result.vendor;
+
+import java.util.List;
+
+public record FasstoDeliveryOutOrdGoodsByOrdNoInfoResult(
+        String ordNo,
+        String invoiceNo,
+        List<FasstoDeliveryOutOrdGoodsByOrdNoItemInfoResult> goods
+) {
+    public static FasstoDeliveryOutOrdGoodsByOrdNoInfoResult of(
+            String ordNo,
+            String invoiceNo,
+            List<FasstoDeliveryOutOrdGoodsByOrdNoItemInfoResult> goods
+    ) {
+        return new FasstoDeliveryOutOrdGoodsByOrdNoInfoResult(ordNo, invoiceNo, goods);
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/result/vendor/FasstoDeliveryOutOrdGoodsByOrdNoItemInfoResult.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/result/vendor/FasstoDeliveryOutOrdGoodsByOrdNoItemInfoResult.java
@@ -1,0 +1,15 @@
+package com.personal.marketnote.fulfillment.port.in.result.vendor;
+
+public record FasstoDeliveryOutOrdGoodsByOrdNoItemInfoResult(
+        String cstGodCd,
+        String godNm,
+        Integer ordQty
+) {
+    public static FasstoDeliveryOutOrdGoodsByOrdNoItemInfoResult of(
+            String cstGodCd,
+            String godNm,
+            Integer ordQty
+    ) {
+        return new FasstoDeliveryOutOrdGoodsByOrdNoItemInfoResult(cstGodCd, godNm, ordQty);
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/result/vendor/GetFasstoDeliveryOutOrdGoodsByOrdNoResult.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/result/vendor/GetFasstoDeliveryOutOrdGoodsByOrdNoResult.java
@@ -1,0 +1,15 @@
+package com.personal.marketnote.fulfillment.port.in.result.vendor;
+
+import java.util.List;
+
+public record GetFasstoDeliveryOutOrdGoodsByOrdNoResult(
+        Integer dataCount,
+        List<FasstoDeliveryOutOrdGoodsByOrdNoInfoResult> goodsByOrdNo
+) {
+    public static GetFasstoDeliveryOutOrdGoodsByOrdNoResult of(
+            Integer dataCount,
+            List<FasstoDeliveryOutOrdGoodsByOrdNoInfoResult> goodsByOrdNo
+    ) {
+        return new GetFasstoDeliveryOutOrdGoodsByOrdNoResult(dataCount, goodsByOrdNo);
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/usecase/vendor/GetFasstoDeliveryOutOrdGoodsByOrdNoUseCase.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/usecase/vendor/GetFasstoDeliveryOutOrdGoodsByOrdNoUseCase.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.fulfillment.port.in.usecase.vendor;
+
+import com.personal.marketnote.fulfillment.port.in.command.vendor.GetFasstoDeliveryOutOrdGoodsByOrdNoCommand;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.GetFasstoDeliveryOutOrdGoodsByOrdNoResult;
+
+public interface GetFasstoDeliveryOutOrdGoodsByOrdNoUseCase {
+    GetFasstoDeliveryOutOrdGoodsByOrdNoResult getOutOrdGoodsByOrdNo(GetFasstoDeliveryOutOrdGoodsByOrdNoCommand command);
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/vendor/GetFasstoDeliveryOutOrdGoodsByOrdNoPort.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/vendor/GetFasstoDeliveryOutOrdGoodsByOrdNoPort.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.fulfillment.port.out.vendor;
+
+import com.personal.marketnote.fulfillment.domain.vendor.fassto.delivery.FasstoDeliveryOutOrdGoodsByOrdNoQuery;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.GetFasstoDeliveryOutOrdGoodsByOrdNoResult;
+
+public interface GetFasstoDeliveryOutOrdGoodsByOrdNoPort {
+    GetFasstoDeliveryOutOrdGoodsByOrdNoResult getOutOrdGoodsByOrdNo(FasstoDeliveryOutOrdGoodsByOrdNoQuery query);
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/vendor/GetFasstoDeliveryOutOrdGoodsByOrdNoService.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/vendor/GetFasstoDeliveryOutOrdGoodsByOrdNoService.java
@@ -1,0 +1,28 @@
+package com.personal.marketnote.fulfillment.service.vendor;
+
+import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.fulfillment.mapper.FasstoDeliveryCommandToRequestMapper;
+import com.personal.marketnote.fulfillment.port.in.command.vendor.GetFasstoDeliveryOutOrdGoodsByOrdNoCommand;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.GetFasstoDeliveryOutOrdGoodsByOrdNoResult;
+import com.personal.marketnote.fulfillment.port.in.usecase.vendor.GetFasstoDeliveryOutOrdGoodsByOrdNoUseCase;
+import com.personal.marketnote.fulfillment.port.out.vendor.GetFasstoDeliveryOutOrdGoodsByOrdNoPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional(isolation = READ_COMMITTED, readOnly = true)
+public class GetFasstoDeliveryOutOrdGoodsByOrdNoService implements GetFasstoDeliveryOutOrdGoodsByOrdNoUseCase {
+    private final GetFasstoDeliveryOutOrdGoodsByOrdNoPort getFasstoDeliveryOutOrdGoodsByOrdNoPort;
+
+    @Override
+    public GetFasstoDeliveryOutOrdGoodsByOrdNoResult getOutOrdGoodsByOrdNo(
+            GetFasstoDeliveryOutOrdGoodsByOrdNoCommand command
+    ) {
+        return getFasstoDeliveryOutOrdGoodsByOrdNoPort.getOutOrdGoodsByOrdNo(
+                FasstoDeliveryCommandToRequestMapper.mapToOutOrdGoodsByOrdNoQuery(command)
+        );
+    }
+}

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/delivery/FasstoDeliveryOutOrdGoodsByOrdNoQuery.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/delivery/FasstoDeliveryOutOrdGoodsByOrdNoQuery.java
@@ -1,0 +1,49 @@
+package com.personal.marketnote.fulfillment.domain.vendor.fassto.delivery;
+
+import com.personal.marketnote.common.utility.FormatValidator;
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+public class FasstoDeliveryOutOrdGoodsByOrdNoQuery {
+    private String customerCode;
+    private String accessToken;
+    private String startDate;
+    private String endDate;
+    private String ordNo;
+
+    public static FasstoDeliveryOutOrdGoodsByOrdNoQuery of(
+            String customerCode,
+            String accessToken,
+            String startDate,
+            String endDate,
+            String ordNo
+    ) {
+        FasstoDeliveryOutOrdGoodsByOrdNoQuery query = FasstoDeliveryOutOrdGoodsByOrdNoQuery.builder()
+                .customerCode(customerCode)
+                .accessToken(accessToken)
+                .startDate(startDate)
+                .endDate(endDate)
+                .ordNo(ordNo)
+                .build();
+        query.validate();
+        return query;
+    }
+
+    private void validate() {
+        if (FormatValidator.hasNoValue(customerCode)) {
+            throw new IllegalArgumentException("customerCode is required.");
+        }
+        if (FormatValidator.hasNoValue(accessToken)) {
+            throw new IllegalArgumentException("accessToken is required.");
+        }
+        if (FormatValidator.hasNoValue(startDate)) {
+            throw new IllegalArgumentException("startDate is required.");
+        }
+        if (FormatValidator.hasNoValue(endDate)) {
+            throw new IllegalArgumentException("endDate is required.");
+        }
+    }
+}


### PR DESCRIPTION
## partially addresses #475
## resolves #740

## Task
- [x] 파스토 주문번호 기반 출고중 상품 조회 연동 요청
- [x] 파스토 주문번호 기반 출고중 상품 조회 연동 비즈니스 로직
- [x] 파스토 서버에 주문번호 기반 출고중 상품 정보 요청
- [x] 200 status code 응답
- [x] Swagger docs