### PR TITLE
[#475][#764] feat: 파스토 출고 상품 상세 목록 조회 연동 기능 추가

### DIFF
--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/FasstoDeliveryController.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/FasstoDeliveryController.java
@@ -35,6 +35,7 @@ public class FasstoDeliveryController {
     private final GetFasstoDeliveryDetailUseCase getFasstoDeliveryDetailUseCase;
     private final GetFasstoDeliveryOutOrdGoodsDetailUseCase getFasstoDeliveryOutOrdGoodsDetailUseCase;
     private final GetFasstoDeliveryOutOrdGoodsByOrdNoUseCase getFasstoDeliveryOutOrdGoodsByOrdNoUseCase;
+    private final GetFasstoDeliveryGoodDetailUseCase getFasstoDeliveryGoodDetailUseCase;
     private final CancelFasstoDeliveryUseCase cancelFasstoDeliveryUseCase;
 
     /**
@@ -438,6 +439,49 @@ public class FasstoDeliveryController {
                         HttpStatus.OK,
                         DEFAULT_SUCCESS_CODE,
                         "파스토 주문번호 기반 출고중 상품 조회 성공"
+                ),
+                HttpStatus.OK
+        );
+    }
+
+    /**
+     * (관리자) 파스토 출고 상품 상세 목록 조회
+     *
+     * @param customerCode 파스토 고객사 코드
+     * @param startDate    조회 시작일(YYYY-MM-DD)
+     * @param endDate      조회 종료일(YYYY-MM-DD)
+     * @param accessToken  파스토 액세스 토큰
+     * @param ordNo        고객사 주문번호
+     * @Author 성효빈
+     * @Date 2026-02-18
+     * @Description 파스토 출고 상품의 상세 정보(금액, 배송유형 등)를 조회합니다.
+     */
+    @GetMapping("/good-detail/{customerCode}/{startDate}/{endDate}")
+    @PreAuthorize(ADMIN_POINTCUT)
+    @GetFasstoDeliveryGoodDetailApiDocs
+    public ResponseEntity<BaseResponse<GetFasstoDeliveryGoodDetailResponse>> getDeliveryGoodDetail(
+            @PathVariable String customerCode,
+            @PathVariable String startDate,
+            @PathVariable String endDate,
+            @RequestHeader("accessToken") String accessToken,
+            @RequestParam(required = false) String ordNo
+    ) {
+        GetFasstoDeliveryGoodDetailResult result = getFasstoDeliveryGoodDetailUseCase.getDeliveryGoodDetail(
+                FasstoDeliveryRequestToCommandMapper.mapToDeliveryGoodDetailCommand(
+                        customerCode,
+                        accessToken,
+                        startDate,
+                        endDate,
+                        ordNo
+                )
+        );
+
+        return new ResponseEntity<>(
+                BaseResponse.of(
+                        GetFasstoDeliveryGoodDetailResponse.from(result),
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "파스토 출고 상품 상세 목록 조회 성공"
                 ),
                 HttpStatus.OK
         );

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/apidocs/GetFasstoDeliveryGoodDetailApiDocs.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/apidocs/GetFasstoDeliveryGoodDetailApiDocs.java
@@ -1,0 +1,169 @@
+package com.personal.marketnote.fulfillment.adapter.in.web.vendor.controller.apidocs;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Operation(
+        summary = "(관리자) 파스토 출고 상품 상세 목록 조회",
+        description = """
+                작성일자: 2026-02-18
+
+                작성자: 성효빈
+
+                ---
+
+                ## Description
+
+                파스토 출고 상품의 상세 정보(금액, 배송유형 등)를 조회합니다.
+
+                ---
+
+                ## Request
+
+                | **키** | **위치** | **타입** | **설명** | **필수 여부** | **예시** |
+                | --- | --- | --- | --- | --- | --- |
+                | accessToken | header | string | 파스토 액세스 토큰 | Y | 039a797bf66d11f0be620ab49498ff55 |
+                | customerCode | path | string | 파스토 고객사 코드 | Y | 94388 |
+                | startDate | path | string | 조회 시작일(YYYY-MM-DD) | Y | 2026-02-01 |
+                | endDate | path | string | 조회 종료일(YYYY-MM-DD) | Y | 2026-02-18 |
+                | ordNo | query | string | 고객사 주문번호 | N | ORDER-20260202 |
+
+                ---
+
+                ## Response
+
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | statusCode | number | 상태 코드 | 200: 성공 / 400: 클라이언트 요청 오류 / 401: 인증 실패 / 403: 인가 실패 / 500: 그 외 |
+                | code | string | 응답 코드 | "SUC01" / "BAD_REQUEST" / "UNAUTHORIZED" / "FORBIDDEN" / "INTERNAL_SERVER_ERROR" |
+                | timestamp | string(datetime) | 응답 일시 | "2026-02-18T12:00:00.000" |
+                | content | object | 응답 본문 | { ... } |
+                | message | string | 처리 결과 | "파스토 출고 상품 상세 목록 조회 성공" |
+
+                ---
+
+                ### Response > content
+
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | dataCount | number | 조회 건수 | 1 |
+                | goodDetails | array | 출고 상품 상세 정보 | [ ... ] |
+
+                ---
+
+                ### Response > content > goodDetails
+
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | outDt | string | 출고일 | "2026-02-18" |
+                | slipNo | string | 출고요청번호 | "SLP20260202001" |
+                | outOrdSlipNo | string | 출고지시번호 | "OUT20260202001" |
+                | orderNo | string | 주문번호 | "ORDER-20260202" |
+                | productOrderNo | string | 상품주문번호 | "PROD-20260202" |
+                | ordDiv | string | 주문구분 | "1" |
+                | invoiceNo | string | 송장번호 | "1234567890" |
+                | sellerChannel | string | 판매채널 | "NAVER" |
+                | custNm | string | 수하인명 | "홍길동" |
+                | godCd | string | 상품코드 | "GOD001" |
+                | cstGodCd | string | 고객사 상품코드 | "CST001" |
+                | godNm | string | 상품명 | "테스트상품" |
+                | outQty | number | 출고수량 | 2 |
+                | markedPrAmount | number | 정가금액 | 15000.00 |
+                | sellingPrAmount | number | 판매금액 | 12000.00 |
+                | dcAmount | number | 할인금액 | 3000.00 |
+                | sellerDcAmount | number | 판매자할인금액 | 1000.00 |
+                | naverDcAmount | number | 네이버할인금액 | 2000.00 |
+                """,
+        security = {@SecurityRequirement(name = "bearer")},
+        parameters = {
+                @Parameter(
+                        name = "accessToken",
+                        description = "파스토 액세스 토큰",
+                        in = ParameterIn.HEADER,
+                        required = true,
+                        schema = @Schema(type = "string", example = "039a797bf66d11f0be620ab49498ff55")
+                ),
+                @Parameter(
+                        name = "customerCode",
+                        description = "파스토 고객사 코드",
+                        in = ParameterIn.PATH,
+                        required = true,
+                        schema = @Schema(type = "string", example = "94388")
+                ),
+                @Parameter(
+                        name = "startDate",
+                        description = "조회 시작일(YYYY-MM-DD)",
+                        in = ParameterIn.PATH,
+                        required = true,
+                        schema = @Schema(type = "string", example = "2026-02-01")
+                ),
+                @Parameter(
+                        name = "endDate",
+                        description = "조회 종료일(YYYY-MM-DD)",
+                        in = ParameterIn.PATH,
+                        required = true,
+                        schema = @Schema(type = "string", example = "2026-02-18")
+                ),
+                @Parameter(
+                        name = "ordNo",
+                        description = "고객사 주문번호",
+                        in = ParameterIn.QUERY,
+                        required = false,
+                        schema = @Schema(type = "string", example = "ORDER-20260202")
+                )
+        },
+        responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "파스토 출고 상품 상세 목록 조회 성공",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 200,
+                                          "code": "SUC01",
+                                          "timestamp": "2026-02-18T12:00:00.000",
+                                          "content": {
+                                            "dataCount": 1,
+                                            "goodDetails": [
+                                              {
+                                                "outDt": "2026-02-18",
+                                                "slipNo": "SLP20260202001",
+                                                "outOrdSlipNo": "OUT20260202001",
+                                                "orderNo": "ORDER-20260202",
+                                                "productOrderNo": "PROD-20260202",
+                                                "ordDiv": "1",
+                                                "invoiceNo": "1234567890",
+                                                "sellerChannel": "NAVER",
+                                                "custNm": "홍길동",
+                                                "godCd": "GOD001",
+                                                "cstGodCd": "CST001",
+                                                "godNm": "테스트상품",
+                                                "outQty": 2,
+                                                "markedPrAmount": 15000.00,
+                                                "sellingPrAmount": 12000.00,
+                                                "dcAmount": 3000.00,
+                                                "sellerDcAmount": 1000.00,
+                                                "naverDcAmount": 2000.00
+                                              }
+                                            ]
+                                          },
+                                          "message": "파스토 출고 상품 상세 목록 조회 성공"
+                                        }
+                                        """)
+                        )
+                )
+        }
+)
+public @interface GetFasstoDeliveryGoodDetailApiDocs {
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/mapper/FasstoDeliveryRequestToCommandMapper.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/mapper/FasstoDeliveryRequestToCommandMapper.java
@@ -141,6 +141,22 @@ public class FasstoDeliveryRequestToCommandMapper {
         );
     }
 
+    public static GetFasstoDeliveryGoodDetailCommand mapToDeliveryGoodDetailCommand(
+            String customerCode,
+            String accessToken,
+            String startDate,
+            String endDate,
+            String ordNo
+    ) {
+        return GetFasstoDeliveryGoodDetailCommand.of(
+                customerCode,
+                accessToken,
+                startDate,
+                endDate,
+                ordNo
+        );
+    }
+
     private static RegisterFasstoDeliveryItemCommand mapItem(RegisterFasstoDeliveryRequest item) {
         List<RegisterFasstoDeliveryGoodsCommand> goods = item.getGodCds().stream()
                 .map(FasstoDeliveryRequestToCommandMapper::mapGoods)

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/response/GetFasstoDeliveryGoodDetailResponse.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/response/GetFasstoDeliveryGoodDetailResponse.java
@@ -1,0 +1,15 @@
+package com.personal.marketnote.fulfillment.adapter.in.web.vendor.response;
+
+import com.personal.marketnote.fulfillment.port.in.result.vendor.FasstoDeliveryGoodDetailInfoResult;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.GetFasstoDeliveryGoodDetailResult;
+
+import java.util.List;
+
+public record GetFasstoDeliveryGoodDetailResponse(
+        Integer dataCount,
+        List<FasstoDeliveryGoodDetailInfoResult> goodDetails
+) {
+    public static GetFasstoDeliveryGoodDetailResponse from(GetFasstoDeliveryGoodDetailResult result) {
+        return new GetFasstoDeliveryGoodDetailResponse(result.dataCount(), result.goodDetails());
+    }
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/client/FasstoDeliveryClient.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/client/FasstoDeliveryClient.java
@@ -37,7 +37,7 @@ import static com.personal.marketnote.common.utility.ApiConstant.*;
 @VendorAdapter
 @RequiredArgsConstructor
 @Slf4j
-public class FasstoDeliveryClient implements RegisterFasstoDeliveryPort, UpdateFasstoDeliveryPort, RegisterFasstoDeliveryCarPort, UpdateFasstoDeliveryCarPort, RegisterFasstoDeliveryIcsPort, GetFasstoDeliveriesPort, GetFasstoDeliveryStatusesPort, GetFasstoDeliveryDetailPort, GetFasstoDeliveryOutOrdGoodsDetailPort, GetFasstoDeliveryOutOrdGoodsByOrdNoPort, CancelFasstoDeliveryPort {
+public class FasstoDeliveryClient implements RegisterFasstoDeliveryPort, UpdateFasstoDeliveryPort, RegisterFasstoDeliveryCarPort, UpdateFasstoDeliveryCarPort, RegisterFasstoDeliveryIcsPort, GetFasstoDeliveriesPort, GetFasstoDeliveryStatusesPort, GetFasstoDeliveryDetailPort, GetFasstoDeliveryOutOrdGoodsDetailPort, GetFasstoDeliveryOutOrdGoodsByOrdNoPort, GetFasstoDeliveryGoodDetailPort, CancelFasstoDeliveryPort {
     private static final String ACCESS_TOKEN_HEADER = "accessToken";
     private static final String CUSTOMER_CODE_PLACEHOLDER = "{customerCode}";
 
@@ -551,6 +551,124 @@ public class FasstoDeliveryClient implements RegisterFasstoDeliveryPort, UpdateF
 
         log.error("Failed to get Fassto out-ord goods by ordNo: {} with error: {}", uri, error.getMessage(), error);
         throw new GetFasstoDeliveryOutOrdGoodsByOrdNoFailedException(failureMessage, new IOException(error));
+    }
+
+    @Override
+    public GetFasstoDeliveryGoodDetailResult getDeliveryGoodDetail(FasstoDeliveryGoodDetailQuery query) {
+        if (FormatValidator.hasNoValue(query)) {
+            throw new IllegalArgumentException("Fassto delivery good detail query is required.");
+        }
+
+        URI uri = buildDeliveryGoodDetailUri(
+                query.getCustomerCode(),
+                query.getStartDate(),
+                query.getEndDate(),
+                query.getOrdNo()
+        );
+        HttpEntity<Void> httpEntity = new HttpEntity<>(buildHeaders(query.getAccessToken(), false));
+
+        Exception error = new Exception();
+        String failureMessage = null;
+        long sleepMillis = INTER_SERVER_DEFAULT_RETRIAL_PENDING_MILLI_SECOND;
+        FulfillmentVendorCommunicationTargetType targetType = FulfillmentVendorCommunicationTargetType.DELIVERY;
+        FulfillmentVendorName vendorName = FulfillmentVendorName.FASSTO;
+
+        for (int i = 0; i < INTER_SERVER_MAX_REQUEST_COUNT; i++) {
+            int attempt = i + 1;
+            JsonNode requestPayloadJson = buildDeliveryGoodDetailRequestPayloadJson(query, uri, attempt);
+            String requestPayload = requestPayloadJson.toString();
+
+            ResponseEntity<String> response;
+            try {
+                response = restTemplate.exchange(
+                        uri,
+                        HttpMethod.GET,
+                        httpEntity,
+                        String.class
+                );
+            } catch (Exception e) {
+                Map<String, Object> errorPayload = new LinkedHashMap<>();
+                errorPayload.put("error", e.getClass().getSimpleName());
+                errorPayload.put("message", e.getMessage());
+                errorPayload.put("attempt", attempt);
+
+                vendorCommunicationFailureHandler.handleFailure(
+                        targetType,
+                        vendorName,
+                        requestPayload,
+                        requestPayloadJson,
+                        errorPayload,
+                        e
+                );
+
+                String vendorMessage = resolveVendorMessageFromException(e);
+                if (FormatValidator.hasValue(vendorMessage)) {
+                    failureMessage = vendorMessage;
+                    error = new Exception(vendorMessage);
+                }
+
+                log.warn("Failed to get Fassto delivery good detail: attempt={}, message={}", attempt, e.getMessage(), e);
+                if (i == INTER_SERVER_MAX_REQUEST_COUNT - 1) {
+                    error = e;
+                }
+
+                sleep(sleepMillis);
+                sleepMillis = sleepMillis * INTER_SERVER_DEFAULT_EXPONENTIAL_BACKOFF_VALUE;
+                continue;
+            }
+
+            JsonNode responsePayloadJson = buildResponsePayloadJson(response, attempt);
+            String responsePayload = responsePayloadJson.toString();
+
+            FasstoDeliveryGoodDetailListResponse parsedResponse = parseDeliveryGoodDetailResponse(response);
+            boolean isSuccess = isDeliveryGoodDetailSuccess(response, parsedResponse);
+            String exception = isSuccess ? null : resolveDeliveryGoodDetailException(response, parsedResponse);
+
+            vendorCommunicationRecorder.record(
+                    targetType,
+                    FulfillmentVendorCommunicationType.REQUEST,
+                    FulfillmentVendorCommunicationSenderType.SERVER,
+                    vendorName,
+                    requestPayload,
+                    requestPayloadJson,
+                    exception
+            );
+            vendorCommunicationRecorder.record(
+                    targetType,
+                    FulfillmentVendorCommunicationType.RESPONSE,
+                    FulfillmentVendorCommunicationSenderType.VENDOR,
+                    vendorName,
+                    responsePayload,
+                    responsePayloadJson,
+                    exception
+            );
+
+            if (isSuccess) {
+                return mapDeliveryGoodDetailResult(parsedResponse);
+            }
+
+            String vendorMessage = resolveVendorMessage(parsedResponse, FormatValidator.hasValue(response) ? response.getBody() : null);
+            if (FormatValidator.hasValue(vendorMessage)) {
+                failureMessage = vendorMessage;
+                error = new Exception(vendorMessage);
+            }
+
+            log.warn("Fassto delivery good detail request failed: attempt={}, status={}, exception={}",
+                    attempt,
+                    FormatValidator.hasValue(response) ? response.getStatusCode() : null,
+                    exception
+            );
+
+            if (CommunicationFailureHandler.isCertainFailure(response)) {
+                break;
+            }
+
+            sleep(sleepMillis);
+            sleepMillis = sleepMillis * INTER_SERVER_DEFAULT_EXPONENTIAL_BACKOFF_VALUE;
+        }
+
+        log.error("Failed to get Fassto delivery good detail: {} with error: {}", uri, error.getMessage(), error);
+        throw new GetFasstoDeliveryGoodDetailFailedException(failureMessage, new IOException(error));
     }
 
     @Override
@@ -1309,6 +1427,23 @@ public class FasstoDeliveryClient implements RegisterFasstoDeliveryPort, UpdateF
                 .toUri();
     }
 
+    private URI buildDeliveryGoodDetailUri(
+            String customerCode,
+            String startDate,
+            String endDate,
+            String ordNo
+    ) {
+        validateDeliveryGoodDetailProperties();
+        UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(properties.getBaseUrl())
+                .path(properties.getDeliveryGoodDetailPath());
+        if (FormatValidator.hasValue(ordNo)) {
+            builder.queryParam("ordNo", ordNo);
+        }
+        return builder
+                .buildAndExpand(customerCode, startDate, endDate)
+                .toUri();
+    }
+
     private URI buildDeliveryCancelUri(String customerCode) {
         validateDeliveryCancelProperties();
         return UriComponentsBuilder.fromUriString(properties.getBaseUrl())
@@ -1458,6 +1593,24 @@ public class FasstoDeliveryClient implements RegisterFasstoDeliveryPort, UpdateF
         }
     }
 
+    private void validateDeliveryGoodDetailProperties() {
+        if (FormatValidator.hasNoValue(properties.getBaseUrl())) {
+            throw new IllegalStateException("Fassto base URL is required.");
+        }
+        if (FormatValidator.hasNoValue(properties.getDeliveryGoodDetailPath())) {
+            throw new IllegalStateException("Fassto delivery good detail path is required.");
+        }
+        if (!properties.getDeliveryGoodDetailPath().contains(CUSTOMER_CODE_PLACEHOLDER)) {
+            throw new IllegalStateException("Fassto delivery good detail path must include {customerCode}.");
+        }
+        if (!properties.getDeliveryGoodDetailPath().contains("{startDate}")) {
+            throw new IllegalStateException("Fassto delivery good detail path must include {startDate}.");
+        }
+        if (!properties.getDeliveryGoodDetailPath().contains("{endDate}")) {
+            throw new IllegalStateException("Fassto delivery good detail path must include {endDate}.");
+        }
+    }
+
     private void validateDeliveryCancelProperties() {
         if (FormatValidator.hasNoValue(properties.getBaseUrl())) {
             throw new IllegalStateException("Fassto base URL is required.");
@@ -1578,6 +1731,24 @@ public class FasstoDeliveryClient implements RegisterFasstoDeliveryPort, UpdateF
         }
     }
 
+    private FasstoDeliveryGoodDetailListResponse parseDeliveryGoodDetailResponse(ResponseEntity<String> response) {
+        if (FormatValidator.hasNoValue(response)) {
+            return null;
+        }
+
+        String body = response.getBody();
+        if (FormatValidator.hasNoValue(body)) {
+            return null;
+        }
+
+        try {
+            return objectMapper.readValue(body, FasstoDeliveryGoodDetailListResponse.class);
+        } catch (Exception e) {
+            log.warn("Failed to parse Fassto delivery good detail response: {}", e.getMessage(), e);
+            return null;
+        }
+    }
+
     private boolean isSuccessResponse(ResponseEntity<String> response, RegisterFasstoDeliveryResponse parsedResponse) {
         return FormatValidator.hasValue(response)
                 && response.getStatusCode().value() == 200
@@ -1614,6 +1785,13 @@ public class FasstoDeliveryClient implements RegisterFasstoDeliveryPort, UpdateF
     }
 
     private boolean isOutOrdGoodsByOrdNoSuccess(ResponseEntity<String> response, FasstoOutOrdGoodsByOrdNoListResponse parsedResponse) {
+        return FormatValidator.hasValue(response)
+                && response.getStatusCode().value() == 200
+                && FormatValidator.hasValue(parsedResponse)
+                && parsedResponse.isSuccess();
+    }
+
+    private boolean isDeliveryGoodDetailSuccess(ResponseEntity<String> response, FasstoDeliveryGoodDetailListResponse parsedResponse) {
         return FormatValidator.hasValue(response)
                 && response.getStatusCode().value() == 200
                 && FormatValidator.hasValue(parsedResponse)
@@ -1718,6 +1896,28 @@ public class FasstoDeliveryClient implements RegisterFasstoDeliveryPort, UpdateF
     private String resolveOutOrdGoodsByOrdNoException(
             ResponseEntity<String> response,
             FasstoOutOrdGoodsByOrdNoListResponse parsedResponse
+    ) {
+        if (FormatValidator.hasNoValue(response)) {
+            return "NO_RESPONSE";
+        }
+        if (response.getStatusCode().value() != 200) {
+            return "HTTP_" + response.getStatusCode().value();
+        }
+        if (FormatValidator.hasNoValue(parsedResponse)) {
+            return "INVALID_RESPONSE";
+        }
+        if (FormatValidator.hasNoValue(parsedResponse.header()) || !parsedResponse.header().isSuccess()) {
+            return "HEADER_FAILURE";
+        }
+        if (FormatValidator.hasNoValue(parsedResponse.data())) {
+            return "DATA_MISSING";
+        }
+        return "UNKNOWN_FAILURE";
+    }
+
+    private String resolveDeliveryGoodDetailException(
+            ResponseEntity<String> response,
+            FasstoDeliveryGoodDetailListResponse parsedResponse
     ) {
         if (FormatValidator.hasNoValue(response)) {
             return "NO_RESPONSE";
@@ -1883,6 +2083,25 @@ public class FasstoDeliveryClient implements RegisterFasstoDeliveryPort, UpdateF
         return vendorCommunicationPayloadGenerator.buildPayloadJson(payload);
     }
 
+    private JsonNode buildDeliveryGoodDetailRequestPayloadJson(
+            FasstoDeliveryGoodDetailQuery query,
+            URI uri,
+            int attempt
+    ) {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("method", HttpMethod.GET.name());
+        payload.put("url", uri.toString());
+        payload.put("customerCode", query.getCustomerCode());
+        payload.put("startDate", query.getStartDate());
+        payload.put("endDate", query.getEndDate());
+        if (FormatValidator.hasValue(query.getOrdNo())) {
+            payload.put("ordNo", query.getOrdNo());
+        }
+        payload.put(ACCESS_TOKEN_HEADER, maskValue(query.getAccessToken()));
+        payload.put("attempt", attempt);
+        return vendorCommunicationPayloadGenerator.buildPayloadJson(payload);
+    }
+
     private JsonNode buildResponsePayloadJson(ResponseEntity<String> response, int attempt) {
         Map<String, Object> payload = new LinkedHashMap<>();
         if (FormatValidator.hasValue(response)) {
@@ -1960,6 +2179,14 @@ public class FasstoDeliveryClient implements RegisterFasstoDeliveryPort, UpdateF
                 : List.of();
         Integer dataCount = FormatValidator.hasValue(response.header()) ? response.header().dataCount() : null;
         return GetFasstoDeliveryOutOrdGoodsByOrdNoResult.of(dataCount, goodsByOrdNo);
+    }
+
+    private GetFasstoDeliveryGoodDetailResult mapDeliveryGoodDetailResult(FasstoDeliveryGoodDetailListResponse response) {
+        List<FasstoDeliveryGoodDetailInfoResult> goodDetails = FormatValidator.hasValue(response.data())
+                ? response.data().stream().map(this::mapDeliveryGoodDetailItem).toList()
+                : List.of();
+        Integer dataCount = FormatValidator.hasValue(response.header()) ? response.header().dataCount() : null;
+        return GetFasstoDeliveryGoodDetailResult.of(dataCount, goodDetails);
     }
 
     private RegisterFasstoDeliveryItemResult mapDeliveryItem(RegisterFasstoDeliveryItemResponse item) {
@@ -2188,6 +2415,29 @@ public class FasstoDeliveryClient implements RegisterFasstoDeliveryPort, UpdateF
         );
     }
 
+    private FasstoDeliveryGoodDetailInfoResult mapDeliveryGoodDetailItem(FasstoDeliveryGoodDetailItemResponse item) {
+        return FasstoDeliveryGoodDetailInfoResult.of(
+                item.outDt(),
+                item.slipNo(),
+                item.outOrdSlipNo(),
+                item.orderNo(),
+                item.productOrderNo(),
+                item.ordDiv(),
+                item.invoiceNo(),
+                item.sellerChannel(),
+                item.custNm(),
+                item.godCd(),
+                item.cstGodCd(),
+                item.godNm(),
+                item.outQty(),
+                item.markedPrAmount(),
+                item.sellingPrAmount(),
+                item.dcAmount(),
+                item.sellerDcAmount(),
+                item.naverDcAmount()
+        );
+    }
+
     private String maskValue(String value) {
         if (FormatValidator.hasNoValue(value)) {
             return value;
@@ -2264,6 +2514,16 @@ public class FasstoDeliveryClient implements RegisterFasstoDeliveryPort, UpdateF
     }
 
     private String resolveVendorMessage(FasstoOutOrdGoodsByOrdNoListResponse response, String rawBody) {
+        if (FormatValidator.hasValue(response)) {
+            String message = response.resolveErrorMessage();
+            if (FormatValidator.hasValue(message)) {
+                return message;
+            }
+        }
+        return resolveVendorMessage(rawBody);
+    }
+
+    private String resolveVendorMessage(FasstoDeliveryGoodDetailListResponse response, String rawBody) {
         if (FormatValidator.hasValue(response)) {
             String message = response.resolveErrorMessage();
             if (FormatValidator.hasValue(message)) {

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoDeliveryGoodDetailItemResponse.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoDeliveryGoodDetailItemResponse.java
@@ -1,0 +1,28 @@
+package com.personal.marketnote.fulfillment.adapter.out.vendor.fassto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.math.BigDecimal;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record FasstoDeliveryGoodDetailItemResponse(
+        String outDt,
+        String slipNo,
+        String outOrdSlipNo,
+        String orderNo,
+        String productOrderNo,
+        String ordDiv,
+        String invoiceNo,
+        String sellerChannel,
+        String custNm,
+        String godCd,
+        String cstGodCd,
+        String godNm,
+        Integer outQty,
+        BigDecimal markedPrAmount,
+        BigDecimal sellingPrAmount,
+        BigDecimal dcAmount,
+        BigDecimal sellerDcAmount,
+        BigDecimal naverDcAmount
+) {
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoDeliveryGoodDetailListResponse.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoDeliveryGoodDetailListResponse.java
@@ -1,0 +1,16 @@
+package com.personal.marketnote.fulfillment.adapter.out.vendor.fassto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record FasstoDeliveryGoodDetailListResponse(
+        FasstoResponseHeader header,
+        List<FasstoDeliveryGoodDetailItemResponse> data,
+        FasstoErrorInfo errorInfo
+) implements FasstoApiResponse {
+    public boolean isSuccess() {
+        return header != null && header.isSuccess() && data != null;
+    }
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/resources/application.yml
+++ b/fulfillment-service/fulfillment-adapters/src/main/resources/application.yml
@@ -71,6 +71,7 @@ vendor:
       delivery-cancel-path: ${FASSTO_DELIVERY_CANCEL_PATH:/api/v1/delivery/cancel/{customerCode}}
       delivery-out-ord-goods-detail-path: ${FASSTO_DELIVERY_OUT_ORD_GOODS_DETAIL_PATH:/api/v1/delivery/outOrd/goodsDetail/{customerCode}}
       delivery-out-ord-goods-ord-no-path: ${FASSTO_DELIVERY_OUT_ORD_GOODS_ORD_NO_PATH:/api/v1/delivery/outOrd/ordNo/{customerCode}/{startDate}/{endDate}}
+      delivery-good-detail-path: ${FASSTO_DELIVERY_GOOD_DETAIL_PATH:/api/v1/delivery/goodDetail/{customerCode}/{startDate}/{endDate}}
       stock-list-path: ${FASSTO_STOCK_LIST_PATH:/api/v1/stock/list/{customerCode}}
       settlement-daily-cost-path: ${FASSTO_SETTLEMENT_DAILY_COST_PATH:/api/v1/settlement/{yearMonth}/{whCd}/{customerCode}}
       api-cd: ${FASSTO_API_CD:change-me}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/configuration/FasstoAuthProperties.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/configuration/FasstoAuthProperties.java
@@ -35,6 +35,7 @@ public class FasstoAuthProperties {
     private String deliveryCancelPath = "/api/v1/delivery/cancel/{customerCode}";
     private String deliveryOutOrdGoodsDetailPath = "/api/v1/delivery/outOrd/goodsDetail/{customerCode}";
     private String deliveryOutOrdGoodsByOrdNoPath = "/api/v1/delivery/outOrd/ordNo/{customerCode}/{startDate}/{endDate}";
+    private String deliveryGoodDetailPath = "/api/v1/delivery/goodDetail/{customerCode}/{startDate}/{endDate}";
     private String stockListPath = "/api/v1/stock/list/{customerCode}";
     private String settlementDailyCostPath = "/api/v1/settlement/{yearMonth}/{whCd}/{customerCode}";
 }

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/GetFasstoDeliveryGoodDetailFailedException.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/GetFasstoDeliveryGoodDetailFailedException.java
@@ -1,0 +1,25 @@
+package com.personal.marketnote.fulfillment.exception;
+
+import com.personal.marketnote.common.exception.ExternalOperationFailedException;
+import com.personal.marketnote.common.utility.FormatValidator;
+
+import java.io.IOException;
+
+public class GetFasstoDeliveryGoodDetailFailedException extends ExternalOperationFailedException {
+    private static final String DEFAULT_MESSAGE = "파스토 출고 상품 상세 목록 조회 중 오류가 발생했습니다.";
+
+    public GetFasstoDeliveryGoodDetailFailedException(IOException cause) {
+        super(DEFAULT_MESSAGE, cause);
+    }
+
+    public GetFasstoDeliveryGoodDetailFailedException(String vendorMessage, IOException cause) {
+        super(resolveMessage(vendorMessage), cause);
+    }
+
+    private static String resolveMessage(String vendorMessage) {
+        if (FormatValidator.hasValue(vendorMessage)) {
+            return String.format("파스토 출고 상품 상세 목록 조회 실패: %s", vendorMessage);
+        }
+        return DEFAULT_MESSAGE;
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/mapper/FasstoDeliveryCommandToRequestMapper.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/mapper/FasstoDeliveryCommandToRequestMapper.java
@@ -59,6 +59,18 @@ public class FasstoDeliveryCommandToRequestMapper {
         );
     }
 
+    public static FasstoDeliveryGoodDetailQuery mapToDeliveryGoodDetailQuery(
+            GetFasstoDeliveryGoodDetailCommand command
+    ) {
+        return FasstoDeliveryGoodDetailQuery.of(
+                command.customerCode(),
+                command.accessToken(),
+                command.startDate(),
+                command.endDate(),
+                command.ordNo()
+        );
+    }
+
     public static FasstoDeliveryCancelMapper mapToCancelRequest(CancelFasstoDeliveryCommand command) {
         List<FasstoDeliveryCancelItemMapper> cancelRequests = command.deliveries().stream()
                 .map(FasstoDeliveryCommandToRequestMapper::mapCancelItem)

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/vendor/GetFasstoDeliveryGoodDetailCommand.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/vendor/GetFasstoDeliveryGoodDetailCommand.java
@@ -1,0 +1,19 @@
+package com.personal.marketnote.fulfillment.port.in.command.vendor;
+
+public record GetFasstoDeliveryGoodDetailCommand(
+        String customerCode,
+        String accessToken,
+        String startDate,
+        String endDate,
+        String ordNo
+) {
+    public static GetFasstoDeliveryGoodDetailCommand of(
+            String customerCode,
+            String accessToken,
+            String startDate,
+            String endDate,
+            String ordNo
+    ) {
+        return new GetFasstoDeliveryGoodDetailCommand(customerCode, accessToken, startDate, endDate, ordNo);
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/result/vendor/FasstoDeliveryGoodDetailInfoResult.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/result/vendor/FasstoDeliveryGoodDetailInfoResult.java
@@ -1,0 +1,52 @@
+package com.personal.marketnote.fulfillment.port.in.result.vendor;
+
+import java.math.BigDecimal;
+
+public record FasstoDeliveryGoodDetailInfoResult(
+        String outDt,
+        String slipNo,
+        String outOrdSlipNo,
+        String orderNo,
+        String productOrderNo,
+        String ordDiv,
+        String invoiceNo,
+        String sellerChannel,
+        String custNm,
+        String godCd,
+        String cstGodCd,
+        String godNm,
+        Integer outQty,
+        BigDecimal markedPrAmount,
+        BigDecimal sellingPrAmount,
+        BigDecimal dcAmount,
+        BigDecimal sellerDcAmount,
+        BigDecimal naverDcAmount
+) {
+    public static FasstoDeliveryGoodDetailInfoResult of(
+            String outDt,
+            String slipNo,
+            String outOrdSlipNo,
+            String orderNo,
+            String productOrderNo,
+            String ordDiv,
+            String invoiceNo,
+            String sellerChannel,
+            String custNm,
+            String godCd,
+            String cstGodCd,
+            String godNm,
+            Integer outQty,
+            BigDecimal markedPrAmount,
+            BigDecimal sellingPrAmount,
+            BigDecimal dcAmount,
+            BigDecimal sellerDcAmount,
+            BigDecimal naverDcAmount
+    ) {
+        return new FasstoDeliveryGoodDetailInfoResult(
+                outDt, slipNo, outOrdSlipNo, orderNo, productOrderNo,
+                ordDiv, invoiceNo, sellerChannel, custNm, godCd,
+                cstGodCd, godNm, outQty, markedPrAmount, sellingPrAmount,
+                dcAmount, sellerDcAmount, naverDcAmount
+        );
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/result/vendor/GetFasstoDeliveryGoodDetailResult.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/result/vendor/GetFasstoDeliveryGoodDetailResult.java
@@ -1,0 +1,15 @@
+package com.personal.marketnote.fulfillment.port.in.result.vendor;
+
+import java.util.List;
+
+public record GetFasstoDeliveryGoodDetailResult(
+        Integer dataCount,
+        List<FasstoDeliveryGoodDetailInfoResult> goodDetails
+) {
+    public static GetFasstoDeliveryGoodDetailResult of(
+            Integer dataCount,
+            List<FasstoDeliveryGoodDetailInfoResult> goodDetails
+    ) {
+        return new GetFasstoDeliveryGoodDetailResult(dataCount, goodDetails);
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/usecase/vendor/GetFasstoDeliveryGoodDetailUseCase.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/usecase/vendor/GetFasstoDeliveryGoodDetailUseCase.java
@@ -1,0 +1,14 @@
+package com.personal.marketnote.fulfillment.port.in.usecase.vendor;
+
+import com.personal.marketnote.fulfillment.port.in.command.vendor.GetFasstoDeliveryGoodDetailCommand;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.GetFasstoDeliveryGoodDetailResult;
+
+/**
+ * 파스토 출고 상품 상세 목록 조회 UseCase
+ *
+ * @Author 성효빈
+ * @Date 2026-02-18
+ */
+public interface GetFasstoDeliveryGoodDetailUseCase {
+    GetFasstoDeliveryGoodDetailResult getDeliveryGoodDetail(GetFasstoDeliveryGoodDetailCommand command);
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/vendor/GetFasstoDeliveryGoodDetailPort.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/vendor/GetFasstoDeliveryGoodDetailPort.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.fulfillment.port.out.vendor;
+
+import com.personal.marketnote.fulfillment.domain.vendor.fassto.delivery.FasstoDeliveryGoodDetailQuery;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.GetFasstoDeliveryGoodDetailResult;
+
+public interface GetFasstoDeliveryGoodDetailPort {
+    GetFasstoDeliveryGoodDetailResult getDeliveryGoodDetail(FasstoDeliveryGoodDetailQuery query);
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/vendor/GetFasstoDeliveryGoodDetailService.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/vendor/GetFasstoDeliveryGoodDetailService.java
@@ -1,0 +1,28 @@
+package com.personal.marketnote.fulfillment.service.vendor;
+
+import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.fulfillment.mapper.FasstoDeliveryCommandToRequestMapper;
+import com.personal.marketnote.fulfillment.port.in.command.vendor.GetFasstoDeliveryGoodDetailCommand;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.GetFasstoDeliveryGoodDetailResult;
+import com.personal.marketnote.fulfillment.port.in.usecase.vendor.GetFasstoDeliveryGoodDetailUseCase;
+import com.personal.marketnote.fulfillment.port.out.vendor.GetFasstoDeliveryGoodDetailPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional(isolation = READ_COMMITTED, readOnly = true)
+public class GetFasstoDeliveryGoodDetailService implements GetFasstoDeliveryGoodDetailUseCase {
+    private final GetFasstoDeliveryGoodDetailPort getFasstoDeliveryGoodDetailPort;
+
+    @Override
+    public GetFasstoDeliveryGoodDetailResult getDeliveryGoodDetail(
+            GetFasstoDeliveryGoodDetailCommand command
+    ) {
+        return getFasstoDeliveryGoodDetailPort.getDeliveryGoodDetail(
+                FasstoDeliveryCommandToRequestMapper.mapToDeliveryGoodDetailQuery(command)
+        );
+    }
+}

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/delivery/FasstoDeliveryGoodDetailQuery.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/delivery/FasstoDeliveryGoodDetailQuery.java
@@ -1,0 +1,49 @@
+package com.personal.marketnote.fulfillment.domain.vendor.fassto.delivery;
+
+import com.personal.marketnote.common.utility.FormatValidator;
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+public class FasstoDeliveryGoodDetailQuery {
+    private String customerCode;
+    private String accessToken;
+    private String startDate;
+    private String endDate;
+    private String ordNo;
+
+    public static FasstoDeliveryGoodDetailQuery of(
+            String customerCode,
+            String accessToken,
+            String startDate,
+            String endDate,
+            String ordNo
+    ) {
+        FasstoDeliveryGoodDetailQuery query = FasstoDeliveryGoodDetailQuery.builder()
+                .customerCode(customerCode)
+                .accessToken(accessToken)
+                .startDate(startDate)
+                .endDate(endDate)
+                .ordNo(ordNo)
+                .build();
+        query.validate();
+        return query;
+    }
+
+    private void validate() {
+        if (FormatValidator.hasNoValue(customerCode)) {
+            throw new IllegalArgumentException("customerCode is required.");
+        }
+        if (FormatValidator.hasNoValue(accessToken)) {
+            throw new IllegalArgumentException("accessToken is required.");
+        }
+        if (FormatValidator.hasNoValue(startDate)) {
+            throw new IllegalArgumentException("startDate is required.");
+        }
+        if (FormatValidator.hasNoValue(endDate)) {
+            throw new IllegalArgumentException("endDate is required.");
+        }
+    }
+}


### PR DESCRIPTION
## partially addresses #475
## resolves #764

## Task
- [x] 파스토 출고 상품 상세 목록 조회 연동 요청
- [x] 파스토 출고 상품 상세 목록 조회 연동 비즈니스 로직
- [x] 파스토 서버에 출고 상품 상세 목록 요청
- [x] 200 status code 응답
- [x] Swagger docs