### PR TITLE
[#128][#767] test: 재고 도메인 등록 기능 자동화 테스트 추가

### DIFF
--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/inventory/RegisterInventoryUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/inventory/RegisterInventoryUseCaseTest.java
@@ -1,0 +1,194 @@
+package com.personal.marketnote.commerce.service.inventory;
+
+import com.personal.marketnote.commerce.domain.inventory.Inventory;
+import com.personal.marketnote.commerce.exception.InventoryAlreadyExistsException;
+import com.personal.marketnote.commerce.port.in.command.inventory.RegisterInventoryCommand;
+import com.personal.marketnote.commerce.port.out.inventory.FindInventoryPort;
+import com.personal.marketnote.commerce.port.out.inventory.SaveCacheStockPort;
+import com.personal.marketnote.commerce.port.out.inventory.SaveInventoryPort;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class RegisterInventoryUseCaseTest {
+    @Mock
+    private SaveInventoryPort saveInventoryPort;
+    @Mock
+    private SaveCacheStockPort saveCacheStockPort;
+    @Mock
+    private FindInventoryPort findInventoryPort;
+
+    @InjectMocks
+    private RegisterInventoryService registerInventoryService;
+
+    // ==================================================================================
+    // registerInventory (단건 등록)
+    // ==================================================================================
+
+    @Nested
+    @DisplayName("registerInventory (단건 등록)")
+    class RegisterInventoryTest {
+
+        @Test
+        @DisplayName("재고 등록 시 productId와 pricePolicyId를 갖는 재고를 저장한다")
+        void registerInventory_success_savesInventory() {
+            Long productId = 1L;
+            Long pricePolicyId = 100L;
+            RegisterInventoryCommand command = RegisterInventoryCommand.of(productId, pricePolicyId);
+
+            when(findInventoryPort.existsByPricePolicyId(pricePolicyId)).thenReturn(false);
+
+            registerInventoryService.registerInventory(command);
+
+            ArgumentCaptor<Inventory> captor = ArgumentCaptor.forClass(Inventory.class);
+            verify(saveInventoryPort).save(captor.capture());
+            Inventory saved = captor.getValue();
+
+            assertThat(saved.getProductId()).isEqualTo(productId);
+            assertThat(saved.getPricePolicyId()).isEqualTo(pricePolicyId);
+            assertThat(saved.getStockValue()).isEqualTo(0);
+        }
+
+        @Test
+        @DisplayName("재고 등록 시 캐시에 해당 가격 정책의 재고를 0으로 저장한다")
+        void registerInventory_success_savesCacheWithZeroStock() {
+            Long productId = 2L;
+            Long pricePolicyId = 200L;
+            RegisterInventoryCommand command = RegisterInventoryCommand.of(productId, pricePolicyId);
+
+            when(findInventoryPort.existsByPricePolicyId(pricePolicyId)).thenReturn(false);
+
+            registerInventoryService.registerInventory(command);
+
+            verify(saveCacheStockPort).save(pricePolicyId, 0);
+        }
+
+        @Test
+        @DisplayName("재고 등록 시 중복 여부 확인 -> 재고 저장 -> 캐시 저장 순서로 호출한다")
+        void registerInventory_success_callsPortsInOrder() {
+            Long productId = 3L;
+            Long pricePolicyId = 300L;
+            RegisterInventoryCommand command = RegisterInventoryCommand.of(productId, pricePolicyId);
+
+            when(findInventoryPort.existsByPricePolicyId(pricePolicyId)).thenReturn(false);
+
+            registerInventoryService.registerInventory(command);
+
+            var inOrder = inOrder(findInventoryPort, saveInventoryPort, saveCacheStockPort);
+            inOrder.verify(findInventoryPort).existsByPricePolicyId(pricePolicyId);
+            inOrder.verify(saveInventoryPort).save(any(Inventory.class));
+            inOrder.verify(saveCacheStockPort).save(pricePolicyId, 0);
+            inOrder.verifyNoMoreInteractions();
+        }
+
+        @Test
+        @DisplayName("productId가 null인 커맨드로 재고 등록 시 productId가 null인 재고를 저장한다")
+        void registerInventory_nullProductId_savesWithNullProductId() {
+            Long pricePolicyId = 400L;
+            RegisterInventoryCommand command = RegisterInventoryCommand.of(pricePolicyId);
+
+            when(findInventoryPort.existsByPricePolicyId(pricePolicyId)).thenReturn(false);
+
+            registerInventoryService.registerInventory(command);
+
+            ArgumentCaptor<Inventory> captor = ArgumentCaptor.forClass(Inventory.class);
+            verify(saveInventoryPort).save(captor.capture());
+            Inventory saved = captor.getValue();
+
+            assertThat(saved.getProductId()).isNull();
+            assertThat(saved.getPricePolicyId()).isEqualTo(pricePolicyId);
+            assertThat(saved.getStockValue()).isEqualTo(0);
+        }
+
+        @Test
+        @DisplayName("이미 존재하는 가격 정책 ID로 재고 등록 시 InventoryAlreadyExistsException을 던진다")
+        void registerInventory_alreadyExists_throwsInventoryAlreadyExistsException() {
+            Long productId = 5L;
+            Long pricePolicyId = 500L;
+            RegisterInventoryCommand command = RegisterInventoryCommand.of(productId, pricePolicyId);
+
+            when(findInventoryPort.existsByPricePolicyId(pricePolicyId)).thenReturn(true);
+
+            assertThatThrownBy(() -> registerInventoryService.registerInventory(command))
+                    .isInstanceOf(InventoryAlreadyExistsException.class)
+                    .hasMessageContaining("500");
+        }
+
+        @Test
+        @DisplayName("이미 존재하는 재고로 등록 실패 시 재고 저장과 캐시 저장을 호출하지 않는다")
+        void registerInventory_alreadyExists_doesNotSave() {
+            Long productId = 6L;
+            Long pricePolicyId = 600L;
+            RegisterInventoryCommand command = RegisterInventoryCommand.of(productId, pricePolicyId);
+
+            when(findInventoryPort.existsByPricePolicyId(pricePolicyId)).thenReturn(true);
+
+            assertThatThrownBy(() -> registerInventoryService.registerInventory(command))
+                    .isInstanceOf(InventoryAlreadyExistsException.class);
+
+            verify(saveInventoryPort, never()).save(any(Inventory.class));
+            verify(saveCacheStockPort, never()).save(anyLong(), anyInt());
+        }
+
+        @Test
+        @DisplayName("재고 존재 여부 확인 중 예외 발생 시 예외를 전파한다")
+        void registerInventory_findPortFails_propagates() {
+            Long productId = 7L;
+            Long pricePolicyId = 700L;
+            RegisterInventoryCommand command = RegisterInventoryCommand.of(productId, pricePolicyId);
+            RuntimeException exception = new RuntimeException("find fail");
+
+            when(findInventoryPort.existsByPricePolicyId(pricePolicyId)).thenThrow(exception);
+
+            assertThatThrownBy(() -> registerInventoryService.registerInventory(command))
+                    .isSameAs(exception);
+
+            verifyNoInteractions(saveInventoryPort);
+            verifyNoInteractions(saveCacheStockPort);
+        }
+
+        @Test
+        @DisplayName("재고 저장 중 예외 발생 시 예외를 전파한다")
+        void registerInventory_saveInventoryFails_propagates() {
+            Long productId = 8L;
+            Long pricePolicyId = 800L;
+            RegisterInventoryCommand command = RegisterInventoryCommand.of(productId, pricePolicyId);
+            RuntimeException exception = new RuntimeException("save fail");
+
+            when(findInventoryPort.existsByPricePolicyId(pricePolicyId)).thenReturn(false);
+            doThrow(exception).when(saveInventoryPort).save(any(Inventory.class));
+
+            assertThatThrownBy(() -> registerInventoryService.registerInventory(command))
+                    .isSameAs(exception);
+
+            verifyNoInteractions(saveCacheStockPort);
+        }
+
+        @Test
+        @DisplayName("캐시 저장 중 예외 발생 시 예외를 전파한다")
+        void registerInventory_saveCacheFails_propagates() {
+            Long productId = 9L;
+            Long pricePolicyId = 900L;
+            RegisterInventoryCommand command = RegisterInventoryCommand.of(productId, pricePolicyId);
+            RuntimeException exception = new RuntimeException("cache fail");
+
+            when(findInventoryPort.existsByPricePolicyId(pricePolicyId)).thenReturn(false);
+            doThrow(exception).when(saveCacheStockPort).save(pricePolicyId, 0);
+
+            assertThatThrownBy(() -> registerInventoryService.registerInventory(command))
+                    .isSameAs(exception);
+
+            verify(saveInventoryPort).save(any(Inventory.class));
+        }
+    }
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/apidocs/GetFasstoDeliveryGoodDetailApiDocs.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/apidocs/GetFasstoDeliveryGoodDetailApiDocs.java
@@ -18,19 +18,19 @@ import java.lang.annotation.*;
         summary = "(관리자) 파스토 출고 상품 상세 목록 조회",
         description = """
                 작성일자: 2026-02-18
-
+                
                 작성자: 성효빈
-
+                
                 ---
-
+                
                 ## Description
-
+                
                 파스토 출고 상품의 상세 정보(금액, 배송유형 등)를 조회합니다.
-
+                
                 ---
-
+                
                 ## Request
-
+                
                 | **키** | **위치** | **타입** | **설명** | **필수 여부** | **예시** |
                 | --- | --- | --- | --- | --- | --- |
                 | accessToken | header | string | 파스토 액세스 토큰 | Y | 039a797bf66d11f0be620ab49498ff55 |
@@ -38,11 +38,11 @@ import java.lang.annotation.*;
                 | startDate | path | string | 조회 시작일(YYYY-MM-DD) | Y | 2026-02-01 |
                 | endDate | path | string | 조회 종료일(YYYY-MM-DD) | Y | 2026-02-18 |
                 | ordNo | query | string | 고객사 주문번호 | N | ORDER-20260202 |
-
+                
                 ---
-
+                
                 ## Response
-
+                
                 | **키** | **타입** | **설명** | **예시** |
                 | --- | --- | --- | --- |
                 | statusCode | number | 상태 코드 | 200: 성공 / 400: 클라이언트 요청 오류 / 401: 인증 실패 / 403: 인가 실패 / 500: 그 외 |
@@ -50,20 +50,20 @@ import java.lang.annotation.*;
                 | timestamp | string(datetime) | 응답 일시 | "2026-02-18T12:00:00.000" |
                 | content | object | 응답 본문 | { ... } |
                 | message | string | 처리 결과 | "파스토 출고 상품 상세 목록 조회 성공" |
-
+                
                 ---
-
+                
                 ### Response > content
-
+                
                 | **키** | **타입** | **설명** | **예시** |
                 | --- | --- | --- | --- |
                 | dataCount | number | 조회 건수 | 1 |
                 | goodDetails | array | 출고 상품 상세 정보 | [ ... ] |
-
+                
                 ---
-
+                
                 ### Response > content > goodDetails
-
+                
                 | **키** | **타입** | **설명** | **예시** |
                 | --- | --- | --- | --- |
                 | outDt | string | 출고일 | "2026-02-18" |

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/usecase/servicecommunication/RecordProductServiceCommunicationHistoryUseCase.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/usecase/servicecommunication/RecordProductServiceCommunicationHistoryUseCase.java
@@ -9,7 +9,7 @@ public interface RecordProductServiceCommunicationHistoryUseCase {
      * @return 상품 서비스 통신 기록 {@link ProductServiceCommunicationHistory}
      * @Date 2026-02-18
      * @Author 성효빈
-     * @Description 상품 서비스 통신 기록을 기록합니다.
+     * @Description 상품 서비스 통신 기록을 저장합니다.
      */
     ProductServiceCommunicationHistory record(ProductServiceCommunicationHistoryCommand command);
 }


### PR DESCRIPTION
## partially addresses #128
## resolves #767

## Test Case
- [x]  재고 등록 시 productId와 pricePolicyId를 갖는 재고를 저장한다
- [x]  재고 등록 시 캐시에 해당 가격 정책의 재고를 0으로 저장한다
- [x]  재고 등록 시 중복 여부 확인 -> 재고 저장 -> 캐시 저장 순서로 호출한다
- [x]  productId가 null인 커맨드로 재고 등록 시 productId가 null인 재고를 저장한다
- [x]  이미 존재하는 가격 정책 ID로 재고 등록 시 InventoryAlreadyExistsException을 던진다
- [x]  이미 존재하는 재고로 등록 실패 시 재고 저장과 캐시 저장을 호출하지 않는다
- [x]  재고 존재 여부 확인 중 예외 발생 시 예외를 전파한다
- [x]  재고 저장 중 예외 발생 시 예외를 전파한다
- [x]  캐시 저장 중 예외 발생 시 예외를 전파한다