### PR TITLE
[#475][#765] feat: 파스토 배송 완료 처리(해외) 연동 기능 추가

### DIFF
--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/FasstoDeliveryController.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/FasstoDeliveryController.java
@@ -37,6 +37,7 @@ public class FasstoDeliveryController {
     private final GetFasstoDeliveryOutOrdGoodsByOrdNoUseCase getFasstoDeliveryOutOrdGoodsByOrdNoUseCase;
     private final GetFasstoDeliveryGoodDetailUseCase getFasstoDeliveryGoodDetailUseCase;
     private final CancelFasstoDeliveryUseCase cancelFasstoDeliveryUseCase;
+    private final CompleteFasstoDeliveryIcsUseCase completeFasstoDeliveryIcsUseCase;
 
     /**
      * (관리자) 파스토 출고 등록 요청
@@ -482,6 +483,39 @@ public class FasstoDeliveryController {
                         HttpStatus.OK,
                         DEFAULT_SUCCESS_CODE,
                         "파스토 출고 상품 상세 목록 조회 성공"
+                ),
+                HttpStatus.OK
+        );
+    }
+
+    /**
+     * (관리자) 파스토 배송완료 처리(해외)
+     *
+     * @param customerCode 파스토 고객사 코드
+     * @param accessToken  파스토 액세스 토큰
+     * @param request      배송완료 처리 요청 정보
+     * @Author 성효빈
+     * @Date 2026-02-18
+     * @Description 파스토 해외(ICS) 배송완료 처리를 요청합니다.
+     */
+    @PatchMapping("/ics/completed/{customerCode}")
+    @PreAuthorize(ADMIN_POINTCUT)
+    @CompleteFasstoDeliveryIcsApiDocs
+    public ResponseEntity<BaseResponse<CompleteFasstoDeliveryIcsResponse>> completeDeliveryIcs(
+            @PathVariable String customerCode,
+            @RequestHeader("accessToken") String accessToken,
+            @Valid @RequestBody CompleteFasstoDeliveryIcsRequest request
+    ) {
+        CompleteFasstoDeliveryIcsResult result = completeFasstoDeliveryIcsUseCase.completeDeliveryIcs(
+                FasstoDeliveryRequestToCommandMapper.mapToIcsCompletionCommand(customerCode, accessToken, request)
+        );
+
+        return new ResponseEntity<>(
+                BaseResponse.of(
+                        CompleteFasstoDeliveryIcsResponse.from(result),
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "파스토 배송완료 처리(해외) 성공"
                 ),
                 HttpStatus.OK
         );

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/apidocs/CompleteFasstoDeliveryIcsApiDocs.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/apidocs/CompleteFasstoDeliveryIcsApiDocs.java
@@ -1,0 +1,173 @@
+package com.personal.marketnote.fulfillment.adapter.in.web.vendor.controller.apidocs;
+
+import com.personal.marketnote.fulfillment.adapter.in.web.vendor.request.CompleteFasstoDeliveryIcsRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Operation(
+        summary = "(관리자) 파스토 배송완료 처리(해외)",
+        description = """
+                작성일자: 2026-02-18
+                
+                작성자: 성효빈
+                
+                ---
+                
+                ## Description
+                
+                파스토 해외(ICS) 배송완료 처리를 요청합니다.
+                
+                ---
+                
+                ## Request
+                
+                ### Request Parameters
+                
+                | **키** | **위치** | **타입** | **설명** | **필수 여부** | **예시** |
+                | --- | --- | --- | --- | --- | --- |
+                | accessToken | header | string | 파스토 액세스 토큰 | Y | 039a797bf66d11f0be620ab49498ff55 |
+                | customerCode | path | string | 파스토 고객사 코드 | Y | 94388 |
+                
+                ---
+                
+                ### Request Body
+                
+                | **키** | **타입** | **설명** | **필수 여부** | **예시** |
+                | --- | --- | --- | --- | --- |
+                | ordNoList | array(string) | 배송완료 처리할 주문번호 목록 | Y | ["ORD20260202001", "ORD20260202002"] |
+                
+                ---
+                
+                ## Response
+                
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | statusCode | number | 상태 코드 | 200: 성공 / 400: 클라이언트 요청 오류 / 401: 인증 실패 / 403: 인가 실패 / 500: 그 외 |
+                | code | string | 응답 코드 | "SUC01" / "BAD_REQUEST" / "UNAUTHORIZED" / "FORBIDDEN" / "INTERNAL_SERVER_ERROR" |
+                | timestamp | string(datetime) | 응답 일시 | "2026-02-18T12:00:00.000" |
+                | content | object | 응답 본문 | { ... } |
+                | message | string | 처리 결과 | "파스토 배송완료 처리(해외) 성공" |
+                
+                ---
+                
+                ### Response > content
+                
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | dataCount | number | 처리 건수 | 2 |
+                | completions | array | 배송완료 처리 결과 | [ ... ] |
+                
+                ---
+                
+                ### Response > content > completions
+                
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | code | string | 응답코드 | "200" |
+                | msg | string | 응답결과 | "배송완료 처리 성공" |
+                | ordNo | string | 주문번호 | "ORD20260202001" |
+                """,
+        security = {@SecurityRequirement(name = "bearer")},
+        parameters = {
+                @Parameter(
+                        name = "accessToken",
+                        description = "파스토 액세스 토큰",
+                        in = ParameterIn.HEADER,
+                        required = true,
+                        schema = @Schema(type = "string", example = "039a797bf66d11f0be620ab49498ff55")
+                ),
+                @Parameter(
+                        name = "customerCode",
+                        description = "파스토 고객사 코드",
+                        in = ParameterIn.PATH,
+                        required = true,
+                        schema = @Schema(type = "string", example = "94388")
+                )
+        },
+        requestBody = @RequestBody(
+                required = true,
+                content = @Content(
+                        schema = @Schema(implementation = CompleteFasstoDeliveryIcsRequest.class),
+                        examples = @ExampleObject("""
+                                {
+                                  "ordNoList": ["ORD20260202001", "ORD20260202002"]
+                                }
+                                """)
+                )
+        ),
+        responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "파스토 배송완료 처리(해외) 성공",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 200,
+                                          "code": "SUC01",
+                                          "timestamp": "2026-02-18T12:00:00.000",
+                                          "content": {
+                                            "dataCount": 2,
+                                            "completions": [
+                                              {
+                                                "code": "200",
+                                                "msg": "배송완료 처리 성공",
+                                                "ordNo": "ORD20260202001"
+                                              },
+                                              {
+                                                "code": "200",
+                                                "msg": "배송완료 처리 성공",
+                                                "ordNo": "ORD20260202002"
+                                              }
+                                            ]
+                                          },
+                                          "message": "파스토 배송완료 처리(해외) 성공"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "401",
+                        description = "토큰 인증 실패",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 401,
+                                          "code": "UNAUTHORIZED",
+                                          "timestamp": "2026-02-18T12:00:00.000",
+                                          "content": null,
+                                          "message": "Invalid token"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "403",
+                        description = "토큰 인가 실패",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 403,
+                                          "code": "FORBIDDEN",
+                                          "timestamp": "2026-02-18T12:00:00.000",
+                                          "content": null,
+                                          "message": "Access Denied"
+                                        }
+                                        """)
+                        )
+                )
+        }
+)
+public @interface CompleteFasstoDeliveryIcsApiDocs {
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/mapper/FasstoDeliveryRequestToCommandMapper.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/mapper/FasstoDeliveryRequestToCommandMapper.java
@@ -157,6 +157,15 @@ public class FasstoDeliveryRequestToCommandMapper {
         );
     }
 
+    public static CompleteFasstoDeliveryIcsCommand mapToIcsCompletionCommand(
+            String customerCode,
+            String accessToken,
+            CompleteFasstoDeliveryIcsRequest request
+    ) {
+        CompleteFasstoDeliveryIcsItemCommand itemCommand = CompleteFasstoDeliveryIcsItemCommand.of(request.getOrdNoList());
+        return CompleteFasstoDeliveryIcsCommand.of(customerCode, accessToken, List.of(itemCommand));
+    }
+
     private static RegisterFasstoDeliveryItemCommand mapItem(RegisterFasstoDeliveryRequest item) {
         List<RegisterFasstoDeliveryGoodsCommand> goods = item.getGodCds().stream()
                 .map(FasstoDeliveryRequestToCommandMapper::mapGoods)

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/request/CompleteFasstoDeliveryIcsRequest.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/request/CompleteFasstoDeliveryIcsRequest.java
@@ -1,0 +1,12 @@
+package com.personal.marketnote.fulfillment.adapter.in.web.vendor.request;
+
+import jakarta.validation.constraints.NotEmpty;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class CompleteFasstoDeliveryIcsRequest {
+    @NotEmpty
+    private List<String> ordNoList;
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/response/CompleteFasstoDeliveryIcsResponse.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/response/CompleteFasstoDeliveryIcsResponse.java
@@ -1,0 +1,15 @@
+package com.personal.marketnote.fulfillment.adapter.in.web.vendor.response;
+
+import com.personal.marketnote.fulfillment.port.in.result.vendor.CompleteFasstoDeliveryIcsItemResult;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.CompleteFasstoDeliveryIcsResult;
+
+import java.util.List;
+
+public record CompleteFasstoDeliveryIcsResponse(
+        Integer dataCount,
+        List<CompleteFasstoDeliveryIcsItemResult> completions
+) {
+    public static CompleteFasstoDeliveryIcsResponse from(CompleteFasstoDeliveryIcsResult result) {
+        return new CompleteFasstoDeliveryIcsResponse(result.dataCount(), result.completions());
+    }
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/client/FasstoDeliveryClient.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/client/FasstoDeliveryClient.java
@@ -37,7 +37,7 @@ import static com.personal.marketnote.common.utility.ApiConstant.*;
 @VendorAdapter
 @RequiredArgsConstructor
 @Slf4j
-public class FasstoDeliveryClient implements RegisterFasstoDeliveryPort, UpdateFasstoDeliveryPort, RegisterFasstoDeliveryCarPort, UpdateFasstoDeliveryCarPort, RegisterFasstoDeliveryIcsPort, GetFasstoDeliveriesPort, GetFasstoDeliveryStatusesPort, GetFasstoDeliveryDetailPort, GetFasstoDeliveryOutOrdGoodsDetailPort, GetFasstoDeliveryOutOrdGoodsByOrdNoPort, GetFasstoDeliveryGoodDetailPort, CancelFasstoDeliveryPort {
+public class FasstoDeliveryClient implements RegisterFasstoDeliveryPort, UpdateFasstoDeliveryPort, RegisterFasstoDeliveryCarPort, UpdateFasstoDeliveryCarPort, RegisterFasstoDeliveryIcsPort, CompleteFasstoDeliveryIcsPort, GetFasstoDeliveriesPort, GetFasstoDeliveryStatusesPort, GetFasstoDeliveryDetailPort, GetFasstoDeliveryOutOrdGoodsDetailPort, GetFasstoDeliveryOutOrdGoodsByOrdNoPort, GetFasstoDeliveryGoodDetailPort, CancelFasstoDeliveryPort {
     private static final String ACCESS_TOKEN_HEADER = "accessToken";
     private static final String CUSTOMER_CODE_PLACEHOLDER = "{customerCode}";
 
@@ -70,6 +70,12 @@ public class FasstoDeliveryClient implements RegisterFasstoDeliveryPort, UpdateF
     public RegisterFasstoDeliveryResult registerDeliveryIcs(FasstoDeliveryIcsMapper request) {
         RegisterFasstoDeliveryResponse response = executeDeliveryIcsMutation(request, "REGISTER_ICS", HttpMethod.POST);
         return mapDeliveryResult(response);
+    }
+
+    @Override
+    public CompleteFasstoDeliveryIcsResult completeDeliveryIcs(FasstoDeliveryIcsCompletionMapper request) {
+        FasstoDeliveryIcsCompletionListResponse response = executeDeliveryIcsCompletionMutation(request, "COMPLETE_ICS");
+        return mapDeliveryIcsCompletionResult(response);
     }
 
     @Override
@@ -1197,6 +1203,138 @@ public class FasstoDeliveryClient implements RegisterFasstoDeliveryPort, UpdateF
         throw new RegisterFasstoDeliveryFailedException(failureMessage, new IOException(error));
     }
 
+    private FasstoDeliveryIcsCompletionListResponse executeDeliveryIcsCompletionMutation(
+            FasstoDeliveryIcsCompletionMapper request,
+            String action
+    ) {
+        if (FormatValidator.hasNoValue(request)) {
+            throw new IllegalArgumentException("Fassto delivery ics completion request is required.");
+        }
+
+        URI uri = buildDeliveryIcsCompletedUri(request.getCustomerCode());
+        HttpEntity<List<Map<String, Object>>> httpEntity = new HttpEntity<>(
+                request.toPayload(),
+                buildHeaders(request.getAccessToken())
+        );
+
+        Exception error = new Exception();
+        String failureMessage = null;
+        long sleepMillis = INTER_SERVER_DEFAULT_RETRIAL_PENDING_MILLI_SECOND;
+        FulfillmentVendorCommunicationTargetType targetType = FulfillmentVendorCommunicationTargetType.DELIVERY;
+        FulfillmentVendorName vendorName = FulfillmentVendorName.FASSTO;
+
+        for (int i = 0; i < INTER_SERVER_MAX_REQUEST_COUNT; i++) {
+            int attempt = i + 1;
+            JsonNode requestPayloadJson = buildIcsCompletionRequestPayloadJson(request, uri, attempt, action);
+            String requestPayload = requestPayloadJson.toString();
+
+            ResponseEntity<String> response;
+            try {
+                response = restTemplate.exchange(
+                        uri,
+                        HttpMethod.PATCH,
+                        httpEntity,
+                        String.class
+                );
+            } catch (Exception e) {
+                Map<String, Object> errorPayload = new LinkedHashMap<>();
+                errorPayload.put("error", e.getClass().getSimpleName());
+                errorPayload.put("message", e.getMessage());
+                errorPayload.put("attempt", attempt);
+
+                vendorCommunicationFailureHandler.handleFailure(
+                        targetType,
+                        vendorName,
+                        requestPayload,
+                        requestPayloadJson,
+                        errorPayload,
+                        e
+                );
+
+                String vendorMessage = resolveVendorMessageFromException(e);
+                if (FormatValidator.hasValue(vendorMessage)) {
+                    failureMessage = vendorMessage;
+                    error = new Exception(vendorMessage);
+                }
+
+                log.warn("Failed to {} Fassto delivery ics completion: attempt={}, message={}",
+                        action.toLowerCase(),
+                        attempt,
+                        e.getMessage(),
+                        e
+                );
+                if (i == INTER_SERVER_MAX_REQUEST_COUNT - 1) {
+                    error = e;
+                }
+
+                sleep(sleepMillis);
+                sleepMillis = sleepMillis * INTER_SERVER_DEFAULT_EXPONENTIAL_BACKOFF_VALUE;
+                continue;
+            }
+
+            JsonNode responsePayloadJson = buildResponsePayloadJson(response, attempt);
+            String responsePayload = responsePayloadJson.toString();
+
+            FasstoDeliveryIcsCompletionListResponse parsedResponse = parseDeliveryIcsCompletionResponse(response);
+            boolean isSuccess = isDeliveryIcsCompletionSuccess(response, parsedResponse);
+            String exception = isSuccess
+                    ? null
+                    : resolveDeliveryIcsCompletionException(response, parsedResponse);
+
+            vendorCommunicationRecorder.record(
+                    targetType,
+                    FulfillmentVendorCommunicationType.REQUEST,
+                    FulfillmentVendorCommunicationSenderType.SERVER,
+                    vendorName,
+                    requestPayload,
+                    requestPayloadJson,
+                    exception
+            );
+            vendorCommunicationRecorder.record(
+                    targetType,
+                    FulfillmentVendorCommunicationType.RESPONSE,
+                    FulfillmentVendorCommunicationSenderType.VENDOR,
+                    vendorName,
+                    responsePayload,
+                    responsePayloadJson,
+                    exception
+            );
+
+            if (isSuccess) {
+                return parsedResponse;
+            }
+
+            String vendorMessage = resolveVendorMessage(parsedResponse, FormatValidator.hasValue(response) ? response.getBody() : null);
+            if (FormatValidator.hasValue(vendorMessage)) {
+                failureMessage = vendorMessage;
+                error = new Exception(vendorMessage);
+            }
+
+            log.warn("Fassto delivery ics completion {} failed: attempt={}, status={}, exception={}",
+                    action.toLowerCase(),
+                    attempt,
+                    FormatValidator.hasValue(response) ? response.getStatusCode() : null,
+                    exception
+            );
+
+            if (CommunicationFailureHandler.isCertainFailure(response)) {
+                break;
+            }
+
+            sleep(sleepMillis);
+            sleepMillis = sleepMillis * INTER_SERVER_DEFAULT_EXPONENTIAL_BACKOFF_VALUE;
+        }
+
+        log.error("Failed to {} Fassto delivery ics completion request: {} with error: {}",
+                action.toLowerCase(),
+                uri,
+                error.getMessage(),
+                error
+        );
+
+        throw new CompleteFasstoDeliveryIcsFailedException(failureMessage, new IOException(error));
+    }
+
     private RegisterFasstoDeliveryResponse executeDeliveryCancellation(
             FasstoDeliveryCancelMapper request,
             String action
@@ -1353,6 +1491,14 @@ public class FasstoDeliveryClient implements RegisterFasstoDeliveryPort, UpdateF
                 .toUri();
     }
 
+    private URI buildDeliveryIcsCompletedUri(String customerCode) {
+        validateDeliveryIcsCompletedProperties();
+        return UriComponentsBuilder.fromUriString(properties.getBaseUrl())
+                .path(properties.getDeliveryIcsCompletedPath())
+                .buildAndExpand(customerCode)
+                .toUri();
+    }
+
     private URI buildDeliveryListUri(
             String customerCode,
             String startDate,
@@ -1500,6 +1646,18 @@ public class FasstoDeliveryClient implements RegisterFasstoDeliveryPort, UpdateF
         }
         if (!properties.getDeliveryIcsPath().contains(CUSTOMER_CODE_PLACEHOLDER)) {
             throw new IllegalStateException("Fassto delivery ics path must include {customerCode}.");
+        }
+    }
+
+    private void validateDeliveryIcsCompletedProperties() {
+        if (FormatValidator.hasNoValue(properties.getBaseUrl())) {
+            throw new IllegalStateException("Fassto base URL is required.");
+        }
+        if (FormatValidator.hasNoValue(properties.getDeliveryIcsCompletedPath())) {
+            throw new IllegalStateException("Fassto delivery ics completed path is required.");
+        }
+        if (!properties.getDeliveryIcsCompletedPath().contains(CUSTOMER_CODE_PLACEHOLDER)) {
+            throw new IllegalStateException("Fassto delivery ics completed path must include {customerCode}.");
         }
     }
 
@@ -1749,6 +1907,24 @@ public class FasstoDeliveryClient implements RegisterFasstoDeliveryPort, UpdateF
         }
     }
 
+    private FasstoDeliveryIcsCompletionListResponse parseDeliveryIcsCompletionResponse(ResponseEntity<String> response) {
+        if (FormatValidator.hasNoValue(response)) {
+            return null;
+        }
+
+        String body = response.getBody();
+        if (FormatValidator.hasNoValue(body)) {
+            return null;
+        }
+
+        try {
+            return objectMapper.readValue(body, FasstoDeliveryIcsCompletionListResponse.class);
+        } catch (Exception e) {
+            log.warn("Failed to parse Fassto delivery ics completion response: {}", e.getMessage(), e);
+            return null;
+        }
+    }
+
     private boolean isSuccessResponse(ResponseEntity<String> response, RegisterFasstoDeliveryResponse parsedResponse) {
         return FormatValidator.hasValue(response)
                 && response.getStatusCode().value() == 200
@@ -1792,6 +1968,13 @@ public class FasstoDeliveryClient implements RegisterFasstoDeliveryPort, UpdateF
     }
 
     private boolean isDeliveryGoodDetailSuccess(ResponseEntity<String> response, FasstoDeliveryGoodDetailListResponse parsedResponse) {
+        return FormatValidator.hasValue(response)
+                && response.getStatusCode().value() == 200
+                && FormatValidator.hasValue(parsedResponse)
+                && parsedResponse.isSuccess();
+    }
+
+    private boolean isDeliveryIcsCompletionSuccess(ResponseEntity<String> response, FasstoDeliveryIcsCompletionListResponse parsedResponse) {
         return FormatValidator.hasValue(response)
                 && response.getStatusCode().value() == 200
                 && FormatValidator.hasValue(parsedResponse)
@@ -1937,6 +2120,28 @@ public class FasstoDeliveryClient implements RegisterFasstoDeliveryPort, UpdateF
         return "UNKNOWN_FAILURE";
     }
 
+    private String resolveDeliveryIcsCompletionException(
+            ResponseEntity<String> response,
+            FasstoDeliveryIcsCompletionListResponse parsedResponse
+    ) {
+        if (FormatValidator.hasNoValue(response)) {
+            return "NO_RESPONSE";
+        }
+        if (response.getStatusCode().value() != 200) {
+            return "HTTP_" + response.getStatusCode().value();
+        }
+        if (FormatValidator.hasNoValue(parsedResponse)) {
+            return "INVALID_RESPONSE";
+        }
+        if (FormatValidator.hasNoValue(parsedResponse.header()) || !parsedResponse.header().isSuccess()) {
+            return "HEADER_FAILURE";
+        }
+        if (FormatValidator.hasNoValue(parsedResponse.data())) {
+            return "DATA_MISSING";
+        }
+        return "UNKNOWN_FAILURE";
+    }
+
     private JsonNode buildRequestPayloadJson(
             FasstoDeliveryMapper request,
             URI uri,
@@ -1990,6 +2195,23 @@ public class FasstoDeliveryClient implements RegisterFasstoDeliveryPort, UpdateF
 
     private JsonNode buildCancelRequestPayloadJson(
             FasstoDeliveryCancelMapper request,
+            URI uri,
+            int attempt,
+            String action
+    ) {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("method", HttpMethod.PATCH.name());
+        payload.put("url", uri.toString());
+        payload.put("customerCode", request.getCustomerCode());
+        payload.put(ACCESS_TOKEN_HEADER, maskValue(request.getAccessToken()));
+        payload.put("body", request.toPayload());
+        payload.put("action", action);
+        payload.put("attempt", attempt);
+        return vendorCommunicationPayloadGenerator.buildPayloadJson(payload);
+    }
+
+    private JsonNode buildIcsCompletionRequestPayloadJson(
+            FasstoDeliveryIcsCompletionMapper request,
             URI uri,
             int attempt,
             String action
@@ -2187,6 +2409,14 @@ public class FasstoDeliveryClient implements RegisterFasstoDeliveryPort, UpdateF
                 : List.of();
         Integer dataCount = FormatValidator.hasValue(response.header()) ? response.header().dataCount() : null;
         return GetFasstoDeliveryGoodDetailResult.of(dataCount, goodDetails);
+    }
+
+    private CompleteFasstoDeliveryIcsResult mapDeliveryIcsCompletionResult(FasstoDeliveryIcsCompletionListResponse response) {
+        List<CompleteFasstoDeliveryIcsItemResult> completions = FormatValidator.hasValue(response.data())
+                ? response.data().stream().map(this::mapDeliveryIcsCompletionItem).toList()
+                : List.of();
+        Integer dataCount = FormatValidator.hasValue(response.header()) ? response.header().dataCount() : null;
+        return CompleteFasstoDeliveryIcsResult.of(dataCount, completions);
     }
 
     private RegisterFasstoDeliveryItemResult mapDeliveryItem(RegisterFasstoDeliveryItemResponse item) {
@@ -2438,6 +2668,14 @@ public class FasstoDeliveryClient implements RegisterFasstoDeliveryPort, UpdateF
         );
     }
 
+    private CompleteFasstoDeliveryIcsItemResult mapDeliveryIcsCompletionItem(FasstoDeliveryIcsCompletionItemResponse item) {
+        return CompleteFasstoDeliveryIcsItemResult.of(
+                item.code(),
+                item.msg(),
+                item.ordNo()
+        );
+    }
+
     private String maskValue(String value) {
         if (FormatValidator.hasNoValue(value)) {
             return value;
@@ -2524,6 +2762,16 @@ public class FasstoDeliveryClient implements RegisterFasstoDeliveryPort, UpdateF
     }
 
     private String resolveVendorMessage(FasstoDeliveryGoodDetailListResponse response, String rawBody) {
+        if (FormatValidator.hasValue(response)) {
+            String message = response.resolveErrorMessage();
+            if (FormatValidator.hasValue(message)) {
+                return message;
+            }
+        }
+        return resolveVendorMessage(rawBody);
+    }
+
+    private String resolveVendorMessage(FasstoDeliveryIcsCompletionListResponse response, String rawBody) {
         if (FormatValidator.hasValue(response)) {
             String message = response.resolveErrorMessage();
             if (FormatValidator.hasValue(message)) {

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoDeliveryIcsCompletionItemResponse.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoDeliveryIcsCompletionItemResponse.java
@@ -1,0 +1,16 @@
+package com.personal.marketnote.fulfillment.adapter.out.vendor.fassto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record FasstoDeliveryIcsCompletionItemResponse(
+        String code,
+        String msg,
+        String ordNo
+) {
+    private static final String SUCCESS_CODE = "200";
+
+    public boolean isSuccess() {
+        return SUCCESS_CODE.equals(code);
+    }
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoDeliveryIcsCompletionListResponse.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoDeliveryIcsCompletionListResponse.java
@@ -1,0 +1,16 @@
+package com.personal.marketnote.fulfillment.adapter.out.vendor.fassto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record FasstoDeliveryIcsCompletionListResponse(
+        FasstoResponseHeader header,
+        List<FasstoDeliveryIcsCompletionItemResponse> data,
+        FasstoErrorInfo errorInfo
+) implements FasstoApiResponse {
+    public boolean isSuccess() {
+        return header != null && header.isSuccess() && data != null;
+    }
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/resources/application.yml
+++ b/fulfillment-service/fulfillment-adapters/src/main/resources/application.yml
@@ -72,6 +72,7 @@ vendor:
       delivery-out-ord-goods-detail-path: ${FASSTO_DELIVERY_OUT_ORD_GOODS_DETAIL_PATH:/api/v1/delivery/outOrd/goodsDetail/{customerCode}}
       delivery-out-ord-goods-ord-no-path: ${FASSTO_DELIVERY_OUT_ORD_GOODS_ORD_NO_PATH:/api/v1/delivery/outOrd/ordNo/{customerCode}/{startDate}/{endDate}}
       delivery-good-detail-path: ${FASSTO_DELIVERY_GOOD_DETAIL_PATH:/api/v1/delivery/goodDetail/{customerCode}/{startDate}/{endDate}}
+      delivery-ics-completed-path: ${FASSTO_DELIVERY_ICS_COMPLETED_PATH:/api/v1/delivery/ics/completed/{customerCode}}
       stock-list-path: ${FASSTO_STOCK_LIST_PATH:/api/v1/stock/list/{customerCode}}
       settlement-daily-cost-path: ${FASSTO_SETTLEMENT_DAILY_COST_PATH:/api/v1/settlement/{yearMonth}/{whCd}/{customerCode}}
       api-cd: ${FASSTO_API_CD:change-me}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/configuration/FasstoAuthProperties.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/configuration/FasstoAuthProperties.java
@@ -36,6 +36,7 @@ public class FasstoAuthProperties {
     private String deliveryOutOrdGoodsDetailPath = "/api/v1/delivery/outOrd/goodsDetail/{customerCode}";
     private String deliveryOutOrdGoodsByOrdNoPath = "/api/v1/delivery/outOrd/ordNo/{customerCode}/{startDate}/{endDate}";
     private String deliveryGoodDetailPath = "/api/v1/delivery/goodDetail/{customerCode}/{startDate}/{endDate}";
+    private String deliveryIcsCompletedPath = "/api/v1/delivery/ics/completed/{customerCode}";
     private String stockListPath = "/api/v1/stock/list/{customerCode}";
     private String settlementDailyCostPath = "/api/v1/settlement/{yearMonth}/{whCd}/{customerCode}";
 }

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/CompleteFasstoDeliveryIcsFailedException.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/CompleteFasstoDeliveryIcsFailedException.java
@@ -1,0 +1,25 @@
+package com.personal.marketnote.fulfillment.exception;
+
+import com.personal.marketnote.common.exception.ExternalOperationFailedException;
+import com.personal.marketnote.common.utility.FormatValidator;
+
+import java.io.IOException;
+
+public class CompleteFasstoDeliveryIcsFailedException extends ExternalOperationFailedException {
+    private static final String DEFAULT_MESSAGE = "파스토 배송완료 처리(해외) 중 오류가 발생했습니다.";
+
+    public CompleteFasstoDeliveryIcsFailedException(IOException cause) {
+        super(DEFAULT_MESSAGE, cause);
+    }
+
+    public CompleteFasstoDeliveryIcsFailedException(String vendorMessage, IOException cause) {
+        super(resolveMessage(vendorMessage), cause);
+    }
+
+    private static String resolveMessage(String vendorMessage) {
+        if (FormatValidator.hasValue(vendorMessage)) {
+            return String.format("파스토 배송완료 처리(해외) 실패: %s", vendorMessage);
+        }
+        return DEFAULT_MESSAGE;
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/mapper/FasstoDeliveryCommandToRequestMapper.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/mapper/FasstoDeliveryCommandToRequestMapper.java
@@ -254,6 +254,26 @@ public class FasstoDeliveryCommandToRequestMapper {
         );
     }
 
+    public static FasstoDeliveryIcsCompletionMapper mapToIcsCompletionRequest(
+            CompleteFasstoDeliveryIcsCommand command
+    ) {
+        List<FasstoDeliveryIcsCompletionItemMapper> completionRequests = command.completionRequests().stream()
+                .map(FasstoDeliveryCommandToRequestMapper::mapIcsCompletionItem)
+                .toList();
+
+        return FasstoDeliveryIcsCompletionMapper.of(
+                command.customerCode(),
+                command.accessToken(),
+                completionRequests
+        );
+    }
+
+    private static FasstoDeliveryIcsCompletionItemMapper mapIcsCompletionItem(
+            CompleteFasstoDeliveryIcsItemCommand item
+    ) {
+        return FasstoDeliveryIcsCompletionItemMapper.of(item.ordNoList());
+    }
+
     private static FasstoDeliveryCancelItemMapper mapCancelItem(CancelFasstoDeliveryItemCommand item) {
         return FasstoDeliveryCancelItemMapper.of(
                 item.slipNo(),

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/vendor/CompleteFasstoDeliveryIcsCommand.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/vendor/CompleteFasstoDeliveryIcsCommand.java
@@ -1,0 +1,17 @@
+package com.personal.marketnote.fulfillment.port.in.command.vendor;
+
+import java.util.List;
+
+public record CompleteFasstoDeliveryIcsCommand(
+        String customerCode,
+        String accessToken,
+        List<CompleteFasstoDeliveryIcsItemCommand> completionRequests
+) {
+    public static CompleteFasstoDeliveryIcsCommand of(
+            String customerCode,
+            String accessToken,
+            List<CompleteFasstoDeliveryIcsItemCommand> completionRequests
+    ) {
+        return new CompleteFasstoDeliveryIcsCommand(customerCode, accessToken, completionRequests);
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/vendor/CompleteFasstoDeliveryIcsItemCommand.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/vendor/CompleteFasstoDeliveryIcsItemCommand.java
@@ -1,0 +1,11 @@
+package com.personal.marketnote.fulfillment.port.in.command.vendor;
+
+import java.util.List;
+
+public record CompleteFasstoDeliveryIcsItemCommand(
+        List<String> ordNoList
+) {
+    public static CompleteFasstoDeliveryIcsItemCommand of(List<String> ordNoList) {
+        return new CompleteFasstoDeliveryIcsItemCommand(ordNoList);
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/result/vendor/CompleteFasstoDeliveryIcsItemResult.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/result/vendor/CompleteFasstoDeliveryIcsItemResult.java
@@ -1,0 +1,15 @@
+package com.personal.marketnote.fulfillment.port.in.result.vendor;
+
+public record CompleteFasstoDeliveryIcsItemResult(
+        String code,
+        String msg,
+        String ordNo
+) {
+    public static CompleteFasstoDeliveryIcsItemResult of(
+            String code,
+            String msg,
+            String ordNo
+    ) {
+        return new CompleteFasstoDeliveryIcsItemResult(code, msg, ordNo);
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/result/vendor/CompleteFasstoDeliveryIcsResult.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/result/vendor/CompleteFasstoDeliveryIcsResult.java
@@ -1,0 +1,15 @@
+package com.personal.marketnote.fulfillment.port.in.result.vendor;
+
+import java.util.List;
+
+public record CompleteFasstoDeliveryIcsResult(
+        Integer dataCount,
+        List<CompleteFasstoDeliveryIcsItemResult> completions
+) {
+    public static CompleteFasstoDeliveryIcsResult of(
+            Integer dataCount,
+            List<CompleteFasstoDeliveryIcsItemResult> completions
+    ) {
+        return new CompleteFasstoDeliveryIcsResult(dataCount, completions);
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/usecase/vendor/CompleteFasstoDeliveryIcsUseCase.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/usecase/vendor/CompleteFasstoDeliveryIcsUseCase.java
@@ -1,0 +1,15 @@
+package com.personal.marketnote.fulfillment.port.in.usecase.vendor;
+
+import com.personal.marketnote.fulfillment.port.in.command.vendor.CompleteFasstoDeliveryIcsCommand;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.CompleteFasstoDeliveryIcsResult;
+
+public interface CompleteFasstoDeliveryIcsUseCase {
+    /**
+     * @param command 해외 배송완료 처리 커맨드
+     * @return 해외 배송완료 처리 결과
+     * @Author 성효빈
+     * @Date 2026-02-18
+     * @Description 파스토 배송완료 처리(해외)를 요청합니다.
+     */
+    CompleteFasstoDeliveryIcsResult completeDeliveryIcs(CompleteFasstoDeliveryIcsCommand command);
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/vendor/CompleteFasstoDeliveryIcsPort.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/vendor/CompleteFasstoDeliveryIcsPort.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.fulfillment.port.out.vendor;
+
+import com.personal.marketnote.fulfillment.domain.vendor.fassto.delivery.FasstoDeliveryIcsCompletionMapper;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.CompleteFasstoDeliveryIcsResult;
+
+public interface CompleteFasstoDeliveryIcsPort {
+    CompleteFasstoDeliveryIcsResult completeDeliveryIcs(FasstoDeliveryIcsCompletionMapper request);
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/vendor/CompleteFasstoDeliveryIcsService.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/vendor/CompleteFasstoDeliveryIcsService.java
@@ -1,0 +1,26 @@
+package com.personal.marketnote.fulfillment.service.vendor;
+
+import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.fulfillment.mapper.FasstoDeliveryCommandToRequestMapper;
+import com.personal.marketnote.fulfillment.port.in.command.vendor.CompleteFasstoDeliveryIcsCommand;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.CompleteFasstoDeliveryIcsResult;
+import com.personal.marketnote.fulfillment.port.in.usecase.vendor.CompleteFasstoDeliveryIcsUseCase;
+import com.personal.marketnote.fulfillment.port.out.vendor.CompleteFasstoDeliveryIcsPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional(isolation = READ_COMMITTED, readOnly = true)
+public class CompleteFasstoDeliveryIcsService implements CompleteFasstoDeliveryIcsUseCase {
+    private final CompleteFasstoDeliveryIcsPort completeFasstoDeliveryIcsPort;
+
+    @Override
+    public CompleteFasstoDeliveryIcsResult completeDeliveryIcs(CompleteFasstoDeliveryIcsCommand command) {
+        return completeFasstoDeliveryIcsPort.completeDeliveryIcs(
+                FasstoDeliveryCommandToRequestMapper.mapToIcsCompletionRequest(command)
+        );
+    }
+}

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/delivery/FasstoDeliveryIcsCompletionItemMapper.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/delivery/FasstoDeliveryIcsCompletionItemMapper.java
@@ -1,0 +1,36 @@
+package com.personal.marketnote.fulfillment.domain.vendor.fassto.delivery;
+
+import com.personal.marketnote.common.utility.FormatValidator;
+import lombok.*;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+public class FasstoDeliveryIcsCompletionItemMapper {
+    private List<String> ordNoList;
+
+    public static FasstoDeliveryIcsCompletionItemMapper of(List<String> ordNoList) {
+        FasstoDeliveryIcsCompletionItemMapper mapper = FasstoDeliveryIcsCompletionItemMapper.builder()
+                .ordNoList(ordNoList)
+                .build();
+        mapper.validate();
+        return mapper;
+    }
+
+    public Map<String, Object> toPayload() {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("ordNoList", ordNoList);
+        return payload;
+    }
+
+    private void validate() {
+        if (FormatValidator.hasNoValue(ordNoList)) {
+            throw new IllegalArgumentException("ordNoList is required for delivery ics completion request.");
+        }
+    }
+}

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/delivery/FasstoDeliveryIcsCompletionMapper.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/delivery/FasstoDeliveryIcsCompletionMapper.java
@@ -1,0 +1,49 @@
+package com.personal.marketnote.fulfillment.domain.vendor.fassto.delivery;
+
+import com.personal.marketnote.common.utility.FormatValidator;
+import lombok.*;
+
+import java.util.List;
+import java.util.Map;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+public class FasstoDeliveryIcsCompletionMapper {
+    private String customerCode;
+    private String accessToken;
+    private List<FasstoDeliveryIcsCompletionItemMapper> completionRequests;
+
+    public static FasstoDeliveryIcsCompletionMapper of(
+            String customerCode,
+            String accessToken,
+            List<FasstoDeliveryIcsCompletionItemMapper> completionRequests
+    ) {
+        FasstoDeliveryIcsCompletionMapper mapper = FasstoDeliveryIcsCompletionMapper.builder()
+                .customerCode(customerCode)
+                .accessToken(accessToken)
+                .completionRequests(completionRequests)
+                .build();
+        mapper.validate();
+        return mapper;
+    }
+
+    public List<Map<String, Object>> toPayload() {
+        return completionRequests.stream()
+                .map(FasstoDeliveryIcsCompletionItemMapper::toPayload)
+                .toList();
+    }
+
+    private void validate() {
+        if (FormatValidator.hasNoValue(customerCode)) {
+            throw new IllegalArgumentException("customerCode is required.");
+        }
+        if (FormatValidator.hasNoValue(accessToken)) {
+            throw new IllegalArgumentException("accessToken is required.");
+        }
+        if (FormatValidator.hasNoValue(completionRequests)) {
+            throw new IllegalArgumentException("completionRequests is required.");
+        }
+    }
+}


### PR DESCRIPTION
## partially addresses #475
## resolves #765

## Task
- [x] 파스토 배송 완료 처리(해외) 연동 요청
- [x] 파스토 배송 완료 처리(해외) 연동 비즈니스 로직
- [x] 파스토 서버에 배송 완료 처리 요청
- [x] 200 status code 응답
- [x] Swagger docs