### PR TITLE
[#723][#790] fix: 배송지 관련 기능 버그 픽스

### DIFF
--- a/common/src/main/java/com/personal/marketnote/common/domain/exception/GlobalExceptionHandler.java
+++ b/common/src/main/java/com/personal/marketnote/common/domain/exception/GlobalExceptionHandler.java
@@ -163,7 +163,13 @@ public class GlobalExceptionHandler {
     private ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException
             (MethodArgumentNotValidException e) {
         httpStatus = HttpStatus.BAD_REQUEST;
-        initializeMessage(e.getMessage());
+
+        String fieldErrorMessage = e.getBindingResult().getFieldErrors().stream()
+                .findFirst()
+                .map(fieldError -> fieldError.getDefaultMessage())
+                .orElse("요청 값이 올바르지 않습니다.");
+
+        initializeMessage(fieldErrorMessage);
 
         log.info(LOG_INFO_MESSAGE, e.getMessage(), e);
 
@@ -199,7 +205,8 @@ public class GlobalExceptionHandler {
     private ResponseEntity<ErrorResponse> handleHttpMessageNotReadableException
             (HttpMessageNotReadableException e) {
         httpStatus = HttpStatus.BAD_REQUEST;
-        initializeMessage(e.getMessage());
+        code = httpStatus.name();
+        message = "요청 본문을 읽을 수 없습니다.";
 
         log.info(LOG_INFO_MESSAGE, e.getMessage(), e);
 

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/shippingaddress/request/RegisterShippingAddressRequest.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/shippingaddress/request/RegisterShippingAddressRequest.java
@@ -3,7 +3,7 @@ package com.personal.marketnote.user.adapter.in.web.shippingaddress.request;
 import com.personal.marketnote.user.domain.shippingaddress.DeliveryRequestType;
 import com.personal.marketnote.user.domain.shippingaddress.ShippingAddressType;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 
@@ -15,11 +15,11 @@ public class RegisterShippingAddressRequest {
     private ShippingAddressType addressType;
 
     @Schema(name = "address", description = "도로명 주소", requiredMode = Schema.RequiredMode.REQUIRED)
-    @NotEmpty(message = "주소는 필수값입니다.")
+    @NotBlank(message = "주소는 필수값입니다.")
     private String address;
 
     @Schema(name = "addressDetail", description = "상세주소", requiredMode = Schema.RequiredMode.REQUIRED)
-    @NotEmpty(message = "상세주소는 필수값입니다.")
+    @NotBlank(message = "상세주소는 필수값입니다.")
     private String addressDetail;
 
     @Schema(name = "companyName", description = "회사명 (COMPANY 타입일 때 필수)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
@@ -29,11 +29,11 @@ public class RegisterShippingAddressRequest {
     private String addressAlias;
 
     @Schema(name = "recipientName", description = "받는 분", requiredMode = Schema.RequiredMode.REQUIRED)
-    @NotEmpty(message = "받는 분은 필수값입니다.")
+    @NotBlank(message = "받는 분은 필수값입니다.")
     private String recipientName;
 
     @Schema(name = "recipientPhoneNumber", description = "휴대폰 번호", requiredMode = Schema.RequiredMode.REQUIRED)
-    @NotEmpty(message = "휴대폰 번호는 필수값입니다.")
+    @NotBlank(message = "휴대폰 번호는 필수값입니다.")
     private String recipientPhoneNumber;
 
     @Schema(name = "deliveryRequestType", description = "배송 요청사항 타입", requiredMode = Schema.RequiredMode.NOT_REQUIRED)

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/shippingaddress/request/UpdateShippingAddressRequest.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/shippingaddress/request/UpdateShippingAddressRequest.java
@@ -2,18 +2,18 @@ package com.personal.marketnote.user.adapter.in.web.shippingaddress.request;
 
 import com.personal.marketnote.user.domain.shippingaddress.DeliveryRequestType;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 
 @Getter
 public class UpdateShippingAddressRequest {
 
     @Schema(name = "address", description = "도로명 주소", requiredMode = Schema.RequiredMode.REQUIRED)
-    @NotEmpty(message = "주소는 필수값입니다.")
+    @NotBlank(message = "주소는 필수값입니다.")
     private String address;
 
     @Schema(name = "addressDetail", description = "상세주소", requiredMode = Schema.RequiredMode.REQUIRED)
-    @NotEmpty(message = "상세주소는 필수값입니다.")
+    @NotBlank(message = "상세주소는 필수값입니다.")
     private String addressDetail;
 
     @Schema(name = "companyName", description = "회사명 (COMPANY 타입일 때 필수)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
@@ -23,11 +23,11 @@ public class UpdateShippingAddressRequest {
     private String addressAlias;
 
     @Schema(name = "recipientName", description = "받는 분", requiredMode = Schema.RequiredMode.REQUIRED)
-    @NotEmpty(message = "받는 분은 필수값입니다.")
+    @NotBlank(message = "받는 분은 필수값입니다.")
     private String recipientName;
 
     @Schema(name = "recipientPhoneNumber", description = "휴대폰 번호", requiredMode = Schema.RequiredMode.REQUIRED)
-    @NotEmpty(message = "휴대폰 번호는 필수값입니다.")
+    @NotBlank(message = "휴대폰 번호는 필수값입니다.")
     private String recipientPhoneNumber;
 
     @Schema(name = "deliveryRequestType", description = "배송 요청사항 타입", requiredMode = Schema.RequiredMode.NOT_REQUIRED)

--- a/user-service/user-adapters/src/main/resources/application.yml
+++ b/user-service/user-adapters/src/main/resources/application.yml
@@ -66,8 +66,8 @@ client:
 server:
   origin: ${SERVER_ORIGIN:http://localhost:8080}
   error:
-    include-exception: true
-    include-stacktrace: ALWAYS
+    include-exception: false
+    include-stacktrace: NEVER
     whitelabel:
       enabled: false
 

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/service/shippingaddress/GetMyShippingAddressesService.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/service/shippingaddress/GetMyShippingAddressesService.java
@@ -8,6 +8,7 @@ import com.personal.marketnote.user.port.out.shippingaddress.FindShippingAddress
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 
@@ -21,7 +22,7 @@ public class GetMyShippingAddressesService implements GetMyShippingAddressesUseC
 
     @Override
     public GetMyShippingAddressesResult getMyShippingAddresses(Long userId) {
-        List<ShippingAddress> shippingAddresses = findShippingAddressPort.findAllByUserId(userId);
+        List<ShippingAddress> shippingAddresses = new ArrayList<>(findShippingAddressPort.findAllByUserId(userId));
 
         shippingAddresses.sort(
                 Comparator.comparing(ShippingAddress::isDefault, Comparator.reverseOrder())

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/service/shippingaddress/RegisterShippingAddressService.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/service/shippingaddress/RegisterShippingAddressService.java
@@ -11,6 +11,7 @@ import com.personal.marketnote.user.port.in.result.shippingaddress.RegisterShipp
 import com.personal.marketnote.user.port.in.usecase.shippingaddress.RegisterShippingAddressUseCase;
 import com.personal.marketnote.user.port.out.shippingaddress.FindShippingAddressPort;
 import com.personal.marketnote.user.port.out.shippingaddress.SaveShippingAddressPort;
+import com.personal.marketnote.user.port.out.shippingaddress.UpdateShippingAddressPort;
 import jakarta.persistence.EntityExistsException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
@@ -27,6 +28,7 @@ public class RegisterShippingAddressService implements RegisterShippingAddressUs
 
     private final FindShippingAddressPort findShippingAddressPort;
     private final SaveShippingAddressPort saveShippingAddressPort;
+    private final UpdateShippingAddressPort updateShippingAddressPort;
 
     @Override
     public RegisterShippingAddressResult registerShippingAddress(RegisterShippingAddressCommand command) {
@@ -37,6 +39,14 @@ public class RegisterShippingAddressService implements RegisterShippingAddressUs
 
         boolean isFirstAddress = !findShippingAddressPort.existsByUserId(userId);
         boolean isDefault = isFirstAddress || Boolean.TRUE.equals(command.isDefault());
+
+        if (isDefault && !isFirstAddress) {
+            findShippingAddressPort.findDefaultByUserId(userId)
+                    .ifPresent(currentDefault -> {
+                        currentDefault.unsetAsDefault();
+                        updateShippingAddressPort.update(currentDefault);
+                    });
+        }
 
         ShippingAddress shippingAddress = ShippingAddress.from(
                 ShippingAddressCreateState.builder()


### PR DESCRIPTION
## partially addresses #723
## resolves #790

## Reason
테스트 과정에서 배송지 관련 기능 버그 확인

## Action
- [x] GetMyShippingAddressesService: .toList()로 반환된 불변 리스트를 new ArrayList<>()로 감싸서 가변 리스트로 변환 후 정렬
- [x] RegisterShippingAddressService: UpdateShippingAddressPort 주입 추가
- [x] RegisterShippingAddressService: isDefault=true이고 첫 배송지가 아닌 경우 findDefaultByUserId()로 기존 기본 배송지를 찾아 unsetAsDefault() + update() 호출하여 기존 기본 배송지 해제
- [x] RegisterShippingAddressRequest: @notempty → @notblank로 변경 (공백만 있는 문자열도 거부)
- [x] UpdateShippingAddressRequest: @notempty → @notblank로 변경 (공백만 있는 문자열도 거부)
- [x] GlobalExceptionHandler:
    - [x] `MethodArgumentNotValidException`: `e.getMessage()` 대신 `e.getBindingResult().getFieldErrors()`에서 첫 번째 필드 에러의 `defaultMessage` 추출
    - [x] `HttpMessageNotReadableException`: 고정 메시지 `"요청 본문을 읽을 수 없습니다."` 반환
- [x] application.yml:
    - [x] include-exception: false로 변경
    - [x] include-stacktrace: NEVER로 변경