### PR TITLE
[#475][#792] feat: (관리자) 파스토 반품 예약 등록 연동 기능 추가

### DIFF
--- a/common/src/main/java/com/personal/marketnote/common/domain/exception/GlobalExceptionHandler.java
+++ b/common/src/main/java/com/personal/marketnote/common/domain/exception/GlobalExceptionHandler.java
@@ -165,9 +165,12 @@ public class GlobalExceptionHandler {
         httpStatus = HttpStatus.BAD_REQUEST;
 
         String fieldErrorMessage = e.getBindingResult().getFieldErrors().stream()
-                .findFirst()
                 .map(fieldError -> fieldError.getDefaultMessage())
-                .orElse("요청 값이 올바르지 않습니다.");
+                .collect(java.util.stream.Collectors.joining(", "));
+
+        if (fieldErrorMessage.isEmpty()) {
+            fieldErrorMessage = "요청 값이 올바르지 않습니다.";
+        }
 
         initializeMessage(fieldErrorMessage);
 

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/FasstoReturnDeliveryController.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/FasstoReturnDeliveryController.java
@@ -1,0 +1,62 @@
+package com.personal.marketnote.fulfillment.adapter.in.web.vendor.controller;
+
+import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
+import com.personal.marketnote.fulfillment.adapter.in.web.vendor.controller.apidocs.RegisterFasstoReturnDeliveryApiDocs;
+import com.personal.marketnote.fulfillment.adapter.in.web.vendor.mapper.FasstoReturnDeliveryRequestToCommandMapper;
+import com.personal.marketnote.fulfillment.adapter.in.web.vendor.request.RegisterFasstoReturnDeliveryRequest;
+import com.personal.marketnote.fulfillment.adapter.in.web.vendor.response.RegisterFasstoReturnDeliveryResponse;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.RegisterFasstoDeliveryResult;
+import com.personal.marketnote.fulfillment.port.in.usecase.vendor.RegisterFasstoReturnDeliveryUseCase;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+import static com.personal.marketnote.common.domain.exception.ExceptionCode.DEFAULT_SUCCESS_CODE;
+import static com.personal.marketnote.common.utility.ApiConstant.ADMIN_POINTCUT;
+
+@RestController
+@RequestMapping("/api/v1/vendors/fassto/return-deliveries")
+@Tag(name = "파스토 반품 API", description = "파스토 반품 관련 API")
+@RequiredArgsConstructor
+public class FasstoReturnDeliveryController {
+    private final RegisterFasstoReturnDeliveryUseCase registerFasstoReturnDeliveryUseCase;
+
+    /**
+     * (관리자) 파스토 반품 예약 등록 요청
+     *
+     * @param customerCode 파스토 고객사 코드
+     * @param accessToken  파스토 액세스 토큰
+     * @param request      반품 예약 등록 요청 정보
+     * @Author Claude
+     * @Date 2026-02-20
+     * @Description 파스토 반품 예약 등록(택배반품등록/예약진행)을 요청합니다.
+     */
+    @PostMapping("/{customerCode}")
+    @PreAuthorize(ADMIN_POINTCUT)
+    @RegisterFasstoReturnDeliveryApiDocs
+    public ResponseEntity<BaseResponse<RegisterFasstoReturnDeliveryResponse>> registerReturnDelivery(
+            @PathVariable String customerCode,
+            @RequestHeader("accessToken") String accessToken,
+            @Valid @RequestBody List<RegisterFasstoReturnDeliveryRequest> request
+    ) {
+        RegisterFasstoDeliveryResult result = registerFasstoReturnDeliveryUseCase.registerReturnDelivery(
+                FasstoReturnDeliveryRequestToCommandMapper.mapToRegisterCommand(customerCode, accessToken, request)
+        );
+
+        return new ResponseEntity<>(
+                BaseResponse.of(
+                        RegisterFasstoReturnDeliveryResponse.from(result),
+                        HttpStatus.CREATED,
+                        DEFAULT_SUCCESS_CODE,
+                        "파스토 반품 예약 등록 성공"
+                ),
+                HttpStatus.CREATED
+        );
+    }
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/apidocs/RegisterFasstoReturnDeliveryApiDocs.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/apidocs/RegisterFasstoReturnDeliveryApiDocs.java
@@ -1,0 +1,219 @@
+package com.personal.marketnote.fulfillment.adapter.in.web.vendor.controller.apidocs;
+
+import com.personal.marketnote.fulfillment.adapter.in.web.vendor.request.RegisterFasstoReturnDeliveryRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Operation(
+        summary = "(관리자) 파스토 반품 예약 등록 요청",
+        description = """
+                작성일자: 2026-02-20
+                
+                작성자: Claude
+                
+                ---
+                
+                ## Description
+                
+                파스토 반품 예약 등록(택배반품등록/예약진행)을 요청합니다.
+                
+                ---
+                
+                ## Request
+                
+                | **키** | **위치** | **타입** | **설명** | **필수 여부** | **예시** |
+                | --- | --- | --- | --- | --- | --- |
+                | accessToken | header | string | 파스토 액세스 토큰 | Y | 23ea2ab4f0e111f0be620ab49498ff55 |
+                | customerCode | path | string | 파스토 고객사 코드 | Y | 94388 |
+                
+                ---
+                
+                ## Request Body (Array)
+                
+                | **키** | **타입** | **설명** | **필수 여부** | **예시** |
+                | --- | --- | --- | --- | --- |
+                | ordDt | string | 반품예정일 | Y | "20260204" |
+                | ordNo | string | 주문번호 | N | "RTN20260204001" |
+                | parcelCd | string | 원택배사코드 | Y | "04" |
+                | invoiceNo | string | 원송장번호 | Y | "1234567890" |
+                | custNm | string | 고객명 | Y | "홍길동" |
+                | custTelNo | string | 고객 전화번호 | Y | "01012345678" |
+                | custAddr | string | 고객 주소 | Y | "서울특별시 강남구 테헤란로 123" |
+                | rtnEmpNm | string | 담당자명 | N | "김담당" |
+                | rtnTelNo | string | 반품 전화번호(공백시 센터로) | N | "0212345678" |
+                | rtnZipCd | string | 반품 우편번호(공백시 센터로) | N | "06234" |
+                | rtnAddr1 | string | 반품 주소1(공백시 센터로) | N | "서울특별시 강남구" |
+                | rtnAddr2 | string | 반품 주소2(공백시 센터로) | N | "테헤란로 456 물류센터" |
+                | rtnGubun | string | 반품 구분코드(01:반품, 02:교환, 03:환불) | N | "01" |
+                | rtnReason | string | 반품 사유 코드 | N | "01" |
+                | getRtnDetailReason | string | 반품 사유 상세 | N | "상품 불량" |
+                | rtnShipReqTerm | string | 반품 배송요청사항 | N | "부재시 경비실에 맡겨주세요" |
+                | godCds | array | 반품 상품 코드 목록 | N | [ ... ] |
+                
+                ---
+                
+                ### Request Body > godCds
+                
+                | **키** | **타입** | **설명** | **필수 여부** | **예시** |
+                | --- | --- | --- | --- | --- |
+                | cstGodCd | string | 고객사상품번호 | Y | "PROD001" |
+                | distTermDt | string | 유통기한 | N | "" |
+                | ordQty | number | 주문수량 | Y | 1 |
+                
+                ---
+                
+                ## Response
+                
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | statusCode | number | 상태 코드 | 201: 성공 / 400: 클라이언트 요청 오류 / 401: 인증 실패 / 403: 인가 실패 / 500: 그 외 |
+                | code | string | 응답 코드 | "SUC01" / "BAD_REQUEST" / "UNAUTHORIZED" / "FORBIDDEN" / "INTERNAL_SERVER_ERROR" |
+                | timestamp | string(datetime) | 응답 일시 | "2026-02-20T12:00:00.000" |
+                | content | object | 응답 본문 | { ... } |
+                | message | string | 처리 결과 | "파스토 반품 예약 등록 성공" |
+                
+                ---
+                
+                ### Response > content
+                
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | dataCount | number | 등록 건수 | 1 |
+                | deliveries | array | 반품 등록 결과 | [ ... ] |
+                
+                ---
+                
+                ### Response > content > deliveries
+                
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | fmsSlipNo | string | FMS 요청번호 | "TESTRI260204000001" |
+                | orderNo | string | 주문번호 | "RTN20260204001" |
+                | msg | string | 처리 메시지 | "반품요청 등록 성공" |
+                | code | string | 처리 코드 | "200" |
+                | outOfStockGoodsDetail | object | 재고부족 상품 상세 | null |
+                """,
+        security = {@SecurityRequirement(name = "bearer")},
+        parameters = {
+                @Parameter(
+                        name = "accessToken",
+                        description = "파스토 액세스 토큰",
+                        in = ParameterIn.HEADER,
+                        required = true,
+                        schema = @Schema(type = "string", example = "23ea2ab4f0e111f0be620ab49498ff55")
+                ),
+                @Parameter(
+                        name = "customerCode",
+                        description = "파스토 고객사 코드",
+                        in = ParameterIn.PATH,
+                        required = true,
+                        schema = @Schema(type = "string", example = "94388")
+                )
+        },
+        requestBody = @RequestBody(
+                required = true,
+                content = @Content(
+                        schema = @Schema(implementation = RegisterFasstoReturnDeliveryRequest.class),
+                        examples = @ExampleObject("""
+                                [
+                                  {
+                                    "ordDt": "20260204",
+                                    "ordNo": "RTN20260204001",
+                                    "parcelCd": "04",
+                                    "invoiceNo": "1234567890",
+                                    "custNm": "홍길동",
+                                    "custTelNo": "01012345678",
+                                    "custAddr": "서울특별시 강남구 테헤란로 123",
+                                    "rtnEmpNm": "김담당",
+                                    "rtnTelNo": "0212345678",
+                                    "rtnZipCd": "06234",
+                                    "rtnAddr1": "서울특별시 강남구",
+                                    "rtnAddr2": "테헤란로 456 물류센터",
+                                    "rtnGubun": "01",
+                                    "rtnReason": "01",
+                                    "getRtnDetailReason": "상품 불량",
+                                    "rtnShipReqTerm": "부재시 경비실에 맡겨주세요",
+                                    "godCds": [
+                                      {
+                                        "cstGodCd": "PROD001",
+                                        "distTermDt": "",
+                                        "ordQty": 1
+                                      }
+                                    ]
+                                  }
+                                ]
+                                """)
+                )
+        ),
+        responses = {
+                @ApiResponse(
+                        responseCode = "201",
+                        description = "파스토 반품 예약 등록 성공",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 201,
+                                          "code": "SUC01",
+                                          "timestamp": "2026-02-20T12:00:00.000",
+                                          "content": {
+                                            "dataCount": 1,
+                                            "deliveries": [
+                                              {
+                                                "fmsSlipNo": "TESTRI260204000001",
+                                                "orderNo": "RTN20260204001",
+                                                "msg": "반품요청 등록 성공",
+                                                "code": "200",
+                                                "outOfStockGoodsDetail": null
+                                              }
+                                            ]
+                                          },
+                                          "message": "파스토 반품 예약 등록 성공"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "401",
+                        description = "토큰 인증 실패",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 401,
+                                          "code": "UNAUTHORIZED",
+                                          "timestamp": "2026-02-20T12:00:00.000",
+                                          "content": null,
+                                          "message": "Invalid token"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "403",
+                        description = "토큰 인가 실패",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 403,
+                                          "code": "FORBIDDEN",
+                                          "timestamp": "2026-02-20T12:00:00.000",
+                                          "content": null,
+                                          "message": "Access Denied"
+                                        }
+                                        """)
+                        )
+                )
+        })
+public @interface RegisterFasstoReturnDeliveryApiDocs {
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/mapper/FasstoReturnDeliveryRequestToCommandMapper.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/mapper/FasstoReturnDeliveryRequestToCommandMapper.java
@@ -1,0 +1,61 @@
+package com.personal.marketnote.fulfillment.adapter.in.web.vendor.mapper;
+
+import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.fulfillment.adapter.in.web.vendor.request.RegisterFasstoDeliveryGoodsRequest;
+import com.personal.marketnote.fulfillment.adapter.in.web.vendor.request.RegisterFasstoReturnDeliveryRequest;
+import com.personal.marketnote.fulfillment.port.in.command.vendor.RegisterFasstoDeliveryGoodsCommand;
+import com.personal.marketnote.fulfillment.port.in.command.vendor.RegisterFasstoReturnDeliveryCommand;
+import com.personal.marketnote.fulfillment.port.in.command.vendor.RegisterFasstoReturnDeliveryItemCommand;
+
+import java.util.List;
+
+public class FasstoReturnDeliveryRequestToCommandMapper {
+
+    public static RegisterFasstoReturnDeliveryCommand mapToRegisterCommand(
+            String customerCode,
+            String accessToken,
+            List<RegisterFasstoReturnDeliveryRequest> request
+    ) {
+        List<RegisterFasstoReturnDeliveryItemCommand> returnDeliveryRequests = request.stream()
+                .map(FasstoReturnDeliveryRequestToCommandMapper::mapItem)
+                .toList();
+
+        return RegisterFasstoReturnDeliveryCommand.of(customerCode, accessToken, returnDeliveryRequests);
+    }
+
+    private static RegisterFasstoReturnDeliveryItemCommand mapItem(RegisterFasstoReturnDeliveryRequest item) {
+        List<RegisterFasstoDeliveryGoodsCommand> goods = FormatValidator.hasValue(item.getGodCds())
+                ? item.getGodCds().stream()
+                .map(FasstoReturnDeliveryRequestToCommandMapper::mapGoods)
+                .toList()
+                : List.of();
+
+        return RegisterFasstoReturnDeliveryItemCommand.builder()
+                .ordDt(item.getOrdDt())
+                .ordNo(item.getOrdNo())
+                .parcelCd(item.getParcelCd())
+                .invoiceNo(item.getInvoiceNo())
+                .custNm(item.getCustNm())
+                .custTelNo(item.getCustTelNo())
+                .custAddr(item.getCustAddr())
+                .rtnEmpNm(item.getRtnEmpNm())
+                .rtnTelNo(item.getRtnTelNo())
+                .rtnZipCd(item.getRtnZipCd())
+                .rtnAddr1(item.getRtnAddr1())
+                .rtnAddr2(item.getRtnAddr2())
+                .rtnGubun(item.getRtnGubun())
+                .rtnReason(item.getRtnReason())
+                .getRtnDetailReason(item.getGetRtnDetailReason())
+                .rtnShipReqTerm(item.getRtnShipReqTerm())
+                .godCds(goods)
+                .build();
+    }
+
+    private static RegisterFasstoDeliveryGoodsCommand mapGoods(RegisterFasstoDeliveryGoodsRequest item) {
+        return RegisterFasstoDeliveryGoodsCommand.of(
+                item.getCstGodCd(),
+                item.getDistTermDt(),
+                item.getOrdQty()
+        );
+    }
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/request/RegisterFasstoReturnDeliveryRequest.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/request/RegisterFasstoReturnDeliveryRequest.java
@@ -1,0 +1,137 @@
+package com.personal.marketnote.fulfillment.adapter.in.web.vendor.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class RegisterFasstoReturnDeliveryRequest {
+    @Schema(
+            name = "ordDt",
+            description = "반품예정일(필수)",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    @NotEmpty(message = "반품예정일은 필수값입니다.")
+    private String ordDt;
+
+    @Schema(
+            name = "ordNo",
+            description = "주문번호",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String ordNo;
+
+    @Schema(
+            name = "parcelCd",
+            description = "원택배사코드(필수)",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    @NotEmpty(message = "원택배사코드는 필수값입니다.")
+    private String parcelCd;
+
+    @Schema(
+            name = "invoiceNo",
+            description = "원송장번호(필수)",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    @NotEmpty(message = "원송장번호는 필수값입니다.")
+    private String invoiceNo;
+
+    @Schema(
+            name = "custNm",
+            description = "고객명(필수)",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    @NotEmpty(message = "고객명은 필수값입니다.")
+    private String custNm;
+
+    @Schema(
+            name = "custTelNo",
+            description = "고객 전화번호(필수)",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    @NotEmpty(message = "고객 전화번호는 필수값입니다.")
+    private String custTelNo;
+
+    @Schema(
+            name = "custAddr",
+            description = "고객 주소(필수)",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    @NotEmpty(message = "고객 주소는 필수값입니다.")
+    private String custAddr;
+
+    @Schema(
+            name = "rtnEmpNm",
+            description = "담당자명",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String rtnEmpNm;
+
+    @Schema(
+            name = "rtnTelNo",
+            description = "반품 전화번호(공백시 센터로)",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String rtnTelNo;
+
+    @Schema(
+            name = "rtnZipCd",
+            description = "반품 우편번호(공백시 센터로)",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String rtnZipCd;
+
+    @Schema(
+            name = "rtnAddr1",
+            description = "반품 주소1(공백시 센터로)",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String rtnAddr1;
+
+    @Schema(
+            name = "rtnAddr2",
+            description = "반품 주소2(공백시 센터로)",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String rtnAddr2;
+
+    @Schema(
+            name = "rtnGubun",
+            description = "반품 구분코드(01:반품, 02:교환, 03:환불)",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String rtnGubun;
+
+    @Schema(
+            name = "rtnReason",
+            description = "반품 사유 코드",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String rtnReason;
+
+    @Schema(
+            name = "getRtnDetailReason",
+            description = "반품 사유 상세",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String getRtnDetailReason;
+
+    @Schema(
+            name = "rtnShipReqTerm",
+            description = "반품 배송요청사항",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String rtnShipReqTerm;
+
+    @Schema(
+            name = "godCds",
+            description = "반품 상품 코드 목록",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    @Valid
+    private List<RegisterFasstoDeliveryGoodsRequest> godCds;
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/response/RegisterFasstoReturnDeliveryResponse.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/response/RegisterFasstoReturnDeliveryResponse.java
@@ -1,0 +1,15 @@
+package com.personal.marketnote.fulfillment.adapter.in.web.vendor.response;
+
+import com.personal.marketnote.fulfillment.port.in.result.vendor.RegisterFasstoDeliveryItemResult;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.RegisterFasstoDeliveryResult;
+
+import java.util.List;
+
+public record RegisterFasstoReturnDeliveryResponse(
+        Integer dataCount,
+        List<RegisterFasstoDeliveryItemResult> deliveries
+) {
+    public static RegisterFasstoReturnDeliveryResponse from(RegisterFasstoDeliveryResult result) {
+        return new RegisterFasstoReturnDeliveryResponse(result.dataCount(), result.deliveries());
+    }
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/client/FasstoReturnDeliveryClient.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/client/FasstoReturnDeliveryClient.java
@@ -1,0 +1,375 @@
+package com.personal.marketnote.fulfillment.adapter.out.vendor.fassto.client;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.common.adapter.out.VendorAdapter;
+import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.common.utility.http.client.CommunicationFailureHandler;
+import com.personal.marketnote.fulfillment.adapter.out.vendor.fassto.response.RegisterFasstoDeliveryResponse;
+import com.personal.marketnote.fulfillment.configuration.FasstoAuthProperties;
+import com.personal.marketnote.fulfillment.domain.vendor.fassto.returndelivery.FasstoReturnDeliveryMapper;
+import com.personal.marketnote.fulfillment.domain.vendorcommunication.FulfillmentVendorCommunicationSenderType;
+import com.personal.marketnote.fulfillment.domain.vendorcommunication.FulfillmentVendorCommunicationTargetType;
+import com.personal.marketnote.fulfillment.domain.vendorcommunication.FulfillmentVendorCommunicationType;
+import com.personal.marketnote.fulfillment.domain.vendorcommunication.FulfillmentVendorName;
+import com.personal.marketnote.fulfillment.exception.RegisterFasstoReturnDeliveryFailedException;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.RegisterFasstoDeliveryItemResult;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.RegisterFasstoDeliveryResult;
+import com.personal.marketnote.fulfillment.port.out.vendor.RegisterFasstoReturnDeliveryPort;
+import com.personal.marketnote.fulfillment.utility.VendorCommunicationFailureHandler;
+import com.personal.marketnote.fulfillment.utility.VendorCommunicationPayloadGenerator;
+import com.personal.marketnote.fulfillment.utility.VendorCommunicationRecorder;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.*;
+import org.springframework.web.client.RestClientResponseException;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
+
+import static com.personal.marketnote.common.utility.ApiConstant.*;
+
+@VendorAdapter
+@RequiredArgsConstructor
+@Slf4j
+public class FasstoReturnDeliveryClient implements RegisterFasstoReturnDeliveryPort {
+    private static final String ACCESS_TOKEN_HEADER = "accessToken";
+    private static final String CUSTOMER_CODE_PLACEHOLDER = "{customerCode}";
+
+    private final RestTemplate restTemplate;
+    private final ObjectMapper objectMapper;
+    private final FasstoAuthProperties properties;
+    private final VendorCommunicationRecorder vendorCommunicationRecorder;
+    private final VendorCommunicationPayloadGenerator vendorCommunicationPayloadGenerator;
+    private final VendorCommunicationFailureHandler vendorCommunicationFailureHandler;
+
+    @Override
+    public RegisterFasstoDeliveryResult registerReturnDelivery(FasstoReturnDeliveryMapper request) {
+        RegisterFasstoDeliveryResponse response = executeReturnDeliveryMutation(request, "REGISTER_RETURN");
+        return mapDeliveryResult(response);
+    }
+
+    private RegisterFasstoDeliveryResponse executeReturnDeliveryMutation(
+            FasstoReturnDeliveryMapper request,
+            String action
+    ) {
+        if (FormatValidator.hasNoValue(request)) {
+            throw new IllegalArgumentException("Fassto return delivery request is required.");
+        }
+
+        URI uri = buildReturnDeliveryUri(request.getCustomerCode());
+        HttpEntity<List<Map<String, Object>>> httpEntity = new HttpEntity<>(
+                request.toPayload(),
+                buildHeaders(request.getAccessToken())
+        );
+
+        Exception error = new Exception();
+        String failureMessage = null;
+        long sleepMillis = INTER_SERVER_DEFAULT_RETRIAL_PENDING_MILLI_SECOND;
+        FulfillmentVendorCommunicationTargetType targetType = FulfillmentVendorCommunicationTargetType.RETURN_DELIVERY;
+        FulfillmentVendorName vendorName = FulfillmentVendorName.FASSTO;
+
+        for (int i = 0; i < INTER_SERVER_MAX_REQUEST_COUNT; i++) {
+            int attempt = i + 1;
+            JsonNode requestPayloadJson = buildRequestPayloadJson(request, uri, attempt, action);
+            String requestPayload = requestPayloadJson.toString();
+
+            ResponseEntity<String> response;
+            try {
+                response = restTemplate.exchange(
+                        uri,
+                        HttpMethod.POST,
+                        httpEntity,
+                        String.class
+                );
+            } catch (Exception e) {
+                Map<String, Object> errorPayload = new LinkedHashMap<>();
+                errorPayload.put("error", e.getClass().getSimpleName());
+                errorPayload.put("message", e.getMessage());
+                errorPayload.put("attempt", attempt);
+
+                vendorCommunicationFailureHandler.handleFailure(
+                        targetType,
+                        vendorName,
+                        requestPayload,
+                        requestPayloadJson,
+                        errorPayload,
+                        e
+                );
+
+                String vendorMessage = resolveVendorMessageFromException(e);
+                if (FormatValidator.hasValue(vendorMessage)) {
+                    failureMessage = vendorMessage;
+                    error = new Exception(vendorMessage);
+                }
+
+                log.warn("Failed to {} Fassto return delivery: attempt={}, message={}",
+                        action.toLowerCase(),
+                        attempt,
+                        e.getMessage(),
+                        e
+                );
+                if (i == INTER_SERVER_MAX_REQUEST_COUNT - 1) {
+                    error = e;
+                }
+
+                sleep(sleepMillis);
+                sleepMillis = sleepMillis * INTER_SERVER_DEFAULT_EXPONENTIAL_BACKOFF_VALUE;
+                continue;
+            }
+
+            JsonNode responsePayloadJson = buildResponsePayloadJson(response, attempt);
+            String responsePayload = responsePayloadJson.toString();
+
+            RegisterFasstoDeliveryResponse parsedResponse = parseResponseBody(response);
+            boolean isSuccess = isSuccessResponse(response, parsedResponse);
+            String exception = isSuccess
+                    ? null
+                    : resolveResponseException(response, parsedResponse);
+
+            vendorCommunicationRecorder.record(
+                    targetType,
+                    FulfillmentVendorCommunicationType.REQUEST,
+                    FulfillmentVendorCommunicationSenderType.SERVER,
+                    vendorName,
+                    requestPayload,
+                    requestPayloadJson,
+                    exception
+            );
+            vendorCommunicationRecorder.record(
+                    targetType,
+                    FulfillmentVendorCommunicationType.RESPONSE,
+                    FulfillmentVendorCommunicationSenderType.VENDOR,
+                    vendorName,
+                    responsePayload,
+                    responsePayloadJson,
+                    exception
+            );
+
+            if (isSuccess) {
+                return parsedResponse;
+            }
+
+            String vendorMessage = resolveVendorMessage(parsedResponse, FormatValidator.hasValue(response) ? response.getBody() : null);
+            if (FormatValidator.hasValue(vendorMessage)) {
+                failureMessage = vendorMessage;
+                error = new Exception(vendorMessage);
+            }
+
+            log.warn("Fassto return delivery {} failed: attempt={}, status={}, exception={}",
+                    action.toLowerCase(),
+                    attempt,
+                    FormatValidator.hasValue(response) ? response.getStatusCode() : null,
+                    exception
+            );
+
+            if (CommunicationFailureHandler.isCertainFailure(response)) {
+                break;
+            }
+
+            sleep(sleepMillis);
+            sleepMillis = sleepMillis * INTER_SERVER_DEFAULT_EXPONENTIAL_BACKOFF_VALUE;
+        }
+
+        log.error("Failed to {} Fassto return delivery request: {} with error: {}",
+                action.toLowerCase(),
+                uri,
+                error.getMessage(),
+                error
+        );
+
+        throw new RegisterFasstoReturnDeliveryFailedException(failureMessage, new IOException(error));
+    }
+
+    private URI buildReturnDeliveryUri(String customerCode) {
+        validateReturnDeliveryProperties();
+        return UriComponentsBuilder.fromUriString(properties.getBaseUrl())
+                .path(properties.getReturnDeliveryPath())
+                .buildAndExpand(customerCode)
+                .toUri();
+    }
+
+    private HttpHeaders buildHeaders(String accessToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setAccept(List.of(MediaType.APPLICATION_JSON));
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.add(ACCESS_TOKEN_HEADER, accessToken);
+        return headers;
+    }
+
+    private void validateReturnDeliveryProperties() {
+        if (FormatValidator.hasNoValue(properties.getBaseUrl())) {
+            throw new IllegalStateException("Fassto base URL is required.");
+        }
+        if (FormatValidator.hasNoValue(properties.getReturnDeliveryPath())) {
+            throw new IllegalStateException("Fassto return delivery path is required.");
+        }
+        if (!properties.getReturnDeliveryPath().contains(CUSTOMER_CODE_PLACEHOLDER)) {
+            throw new IllegalStateException("Fassto return delivery path must include {customerCode}.");
+        }
+    }
+
+    private RegisterFasstoDeliveryResponse parseResponseBody(ResponseEntity<String> response) {
+        if (FormatValidator.hasNoValue(response)) {
+            return null;
+        }
+
+        String body = response.getBody();
+        if (FormatValidator.hasNoValue(body)) {
+            return null;
+        }
+
+        try {
+            return objectMapper.readValue(body, RegisterFasstoDeliveryResponse.class);
+        } catch (Exception e) {
+            log.warn("Failed to parse Fassto return delivery response: {}", e.getMessage(), e);
+            return null;
+        }
+    }
+
+    private boolean isSuccessResponse(ResponseEntity<String> response, RegisterFasstoDeliveryResponse parsedResponse) {
+        return FormatValidator.hasValue(response)
+                && response.getStatusCode().value() == 200
+                && FormatValidator.hasValue(parsedResponse)
+                && parsedResponse.isSuccess();
+    }
+
+    private String resolveResponseException(ResponseEntity<String> response, RegisterFasstoDeliveryResponse parsedResponse) {
+        if (FormatValidator.hasNoValue(response)) {
+            return "NO_RESPONSE";
+        }
+        if (response.getStatusCode().value() != 200) {
+            return "HTTP_" + response.getStatusCode().value();
+        }
+        if (FormatValidator.hasNoValue(parsedResponse)) {
+            return "INVALID_RESPONSE";
+        }
+        if (FormatValidator.hasNoValue(parsedResponse.header()) || !parsedResponse.header().isSuccess()) {
+            return "HEADER_FAILURE";
+        }
+        return "UNKNOWN_FAILURE";
+    }
+
+    private RegisterFasstoDeliveryResult mapDeliveryResult(RegisterFasstoDeliveryResponse response) {
+        List<RegisterFasstoDeliveryItemResult> deliveries = FormatValidator.hasValue(response.data())
+                ? response.data().stream().map(this::mapDeliveryItem).toList()
+                : List.of();
+        Integer dataCount = FormatValidator.hasValue(response.header()) ? response.header().dataCount() : null;
+        return RegisterFasstoDeliveryResult.of(dataCount, deliveries);
+    }
+
+    private RegisterFasstoDeliveryItemResult mapDeliveryItem(
+            com.personal.marketnote.fulfillment.adapter.out.vendor.fassto.response.RegisterFasstoDeliveryItemResponse item
+    ) {
+        return RegisterFasstoDeliveryItemResult.of(
+                item.fmsSlipNo(),
+                item.orderNo(),
+                item.msg(),
+                item.code(),
+                item.outOfStockGoodsDetail()
+        );
+    }
+
+    private JsonNode buildRequestPayloadJson(
+            FasstoReturnDeliveryMapper request,
+            URI uri,
+            int attempt,
+            String action
+    ) {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("method", HttpMethod.POST.name());
+        payload.put("url", uri.toString());
+        payload.put("customerCode", request.getCustomerCode());
+        payload.put(ACCESS_TOKEN_HEADER, maskValue(request.getAccessToken()));
+        payload.put("body", request.toPayload());
+        payload.put("action", action);
+        payload.put("attempt", attempt);
+        return vendorCommunicationPayloadGenerator.buildPayloadJson(payload);
+    }
+
+    private JsonNode buildResponsePayloadJson(ResponseEntity<String> response, int attempt) {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        if (FormatValidator.hasValue(response)) {
+            payload.put("status", response.getStatusCode().value());
+            payload.put("headers", toSingleValueMap(response.getHeaders()));
+
+            String body = response.getBody();
+            if (FormatValidator.hasValue(body)) {
+                payload.put("body", body);
+            }
+        }
+        payload.put("attempt", attempt);
+        return vendorCommunicationPayloadGenerator.buildPayloadJson(payload);
+    }
+
+    private Map<String, String> toSingleValueMap(HttpHeaders headers) {
+        if (FormatValidator.hasNoValue(headers)) {
+            return Map.of();
+        }
+        return headers.toSingleValueMap();
+    }
+
+    private String resolveVendorMessage(RegisterFasstoDeliveryResponse parsedResponse, String rawBody) {
+        if (FormatValidator.hasValue(parsedResponse)) {
+            String message = parsedResponse.resolveErrorMessage();
+            if (FormatValidator.hasValue(message)) {
+                return message;
+            }
+        }
+
+        if (FormatValidator.hasValue(rawBody)) {
+            try {
+                var errorResponse = objectMapper.readValue(
+                        rawBody,
+                        com.personal.marketnote.fulfillment.adapter.out.vendor.fassto.response.FasstoErrorResponse.class
+                );
+                return errorResponse.resolveErrorMessage();
+            } catch (Exception ignored) {
+            }
+        }
+
+        return null;
+    }
+
+    private String resolveVendorMessageFromException(Exception e) {
+        if (e instanceof RestClientResponseException responseException) {
+            String body = responseException.getResponseBodyAsString();
+            if (FormatValidator.hasNoValue(body)) {
+                return null;
+            }
+            try {
+                var parsedResponse = objectMapper.readValue(
+                        body,
+                        com.personal.marketnote.fulfillment.adapter.out.vendor.fassto.response.FasstoErrorResponse.class
+                );
+                return parsedResponse.resolveErrorMessage();
+            } catch (Exception ignored) {
+            }
+        }
+        return null;
+    }
+
+    private String maskValue(String value) {
+        if (FormatValidator.hasNoValue(value)) {
+            return value;
+        }
+        if (value.length() <= 4) {
+            return "****";
+        }
+        return value.substring(0, 4) + "****";
+    }
+
+    private void sleep(long millis) {
+        try {
+            Thread.sleep(millis + ThreadLocalRandom.current().nextLong(500));
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/configuration/FasstoAuthProperties.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/configuration/FasstoAuthProperties.java
@@ -38,5 +38,6 @@ public class FasstoAuthProperties {
     private String deliveryGoodDetailPath = "/api/v1/delivery/goodDetail/{customerCode}/{startDate}/{endDate}";
     private String deliveryIcsCompletedPath = "/api/v1/delivery/ics/completed/{customerCode}";
     private String stockListPath = "/api/v1/stock/list/{customerCode}";
+    private String returnDeliveryPath = "/api/v1/return/parcel/{customerCode}";
     private String settlementDailyCostPath = "/api/v1/settlement/{yearMonth}/{whCd}/{customerCode}";
 }

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/RegisterFasstoReturnDeliveryFailedException.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/RegisterFasstoReturnDeliveryFailedException.java
@@ -1,0 +1,25 @@
+package com.personal.marketnote.fulfillment.exception;
+
+import com.personal.marketnote.common.exception.ExternalOperationFailedException;
+
+import java.io.IOException;
+
+public class RegisterFasstoReturnDeliveryFailedException extends ExternalOperationFailedException {
+    private static final String REGISTER_FASSTO_RETURN_DELIVERY_FAILED_EXCEPTION_MESSAGE =
+            "Fassto return delivery registration request failed.";
+
+    public RegisterFasstoReturnDeliveryFailedException(IOException cause) {
+        super(REGISTER_FASSTO_RETURN_DELIVERY_FAILED_EXCEPTION_MESSAGE, cause);
+    }
+
+    public RegisterFasstoReturnDeliveryFailedException(String vendorMessage, IOException cause) {
+        super(resolveMessage(vendorMessage), cause);
+    }
+
+    private static String resolveMessage(String vendorMessage) {
+        if (vendorMessage == null || vendorMessage.isBlank()) {
+            return REGISTER_FASSTO_RETURN_DELIVERY_FAILED_EXCEPTION_MESSAGE;
+        }
+        return vendorMessage;
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/mapper/FasstoReturnDeliveryCommandToRequestMapper.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/mapper/FasstoReturnDeliveryCommandToRequestMapper.java
@@ -1,0 +1,61 @@
+package com.personal.marketnote.fulfillment.mapper;
+
+import com.personal.marketnote.fulfillment.domain.vendor.fassto.delivery.FasstoDeliveryGoodsMapper;
+import com.personal.marketnote.fulfillment.domain.vendor.fassto.returndelivery.FasstoReturnDeliveryItemMapper;
+import com.personal.marketnote.fulfillment.domain.vendor.fassto.returndelivery.FasstoReturnDeliveryMapper;
+import com.personal.marketnote.fulfillment.port.in.command.vendor.RegisterFasstoDeliveryGoodsCommand;
+import com.personal.marketnote.fulfillment.port.in.command.vendor.RegisterFasstoReturnDeliveryCommand;
+import com.personal.marketnote.fulfillment.port.in.command.vendor.RegisterFasstoReturnDeliveryItemCommand;
+
+import java.util.List;
+
+public class FasstoReturnDeliveryCommandToRequestMapper {
+
+    public static FasstoReturnDeliveryMapper mapToRegisterRequest(RegisterFasstoReturnDeliveryCommand command) {
+        List<FasstoReturnDeliveryItemMapper> returnDeliveryRequests = command.returnDeliveryRequests().stream()
+                .map(FasstoReturnDeliveryCommandToRequestMapper::mapItem)
+                .toList();
+
+        return FasstoReturnDeliveryMapper.register(
+                command.customerCode(),
+                command.accessToken(),
+                returnDeliveryRequests
+        );
+    }
+
+    private static FasstoReturnDeliveryItemMapper mapItem(RegisterFasstoReturnDeliveryItemCommand item) {
+        List<FasstoDeliveryGoodsMapper> goods = item.godCds() != null
+                ? item.godCds().stream()
+                .map(FasstoReturnDeliveryCommandToRequestMapper::mapGoods)
+                .toList()
+                : List.of();
+
+        return FasstoReturnDeliveryItemMapper.of(
+                item.ordDt(),
+                item.ordNo(),
+                item.parcelCd(),
+                item.invoiceNo(),
+                item.custNm(),
+                item.custTelNo(),
+                item.custAddr(),
+                item.rtnEmpNm(),
+                item.rtnTelNo(),
+                item.rtnZipCd(),
+                item.rtnAddr1(),
+                item.rtnAddr2(),
+                item.rtnGubun(),
+                item.rtnReason(),
+                item.getRtnDetailReason(),
+                item.rtnShipReqTerm(),
+                goods
+        );
+    }
+
+    private static FasstoDeliveryGoodsMapper mapGoods(RegisterFasstoDeliveryGoodsCommand item) {
+        return FasstoDeliveryGoodsMapper.of(
+                item.cstGodCd(),
+                item.distTermDt(),
+                item.ordQty()
+        );
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/vendor/RegisterFasstoReturnDeliveryCommand.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/vendor/RegisterFasstoReturnDeliveryCommand.java
@@ -1,0 +1,17 @@
+package com.personal.marketnote.fulfillment.port.in.command.vendor;
+
+import java.util.List;
+
+public record RegisterFasstoReturnDeliveryCommand(
+        String customerCode,
+        String accessToken,
+        List<RegisterFasstoReturnDeliveryItemCommand> returnDeliveryRequests
+) {
+    public static RegisterFasstoReturnDeliveryCommand of(
+            String customerCode,
+            String accessToken,
+            List<RegisterFasstoReturnDeliveryItemCommand> returnDeliveryRequests
+    ) {
+        return new RegisterFasstoReturnDeliveryCommand(customerCode, accessToken, returnDeliveryRequests);
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/vendor/RegisterFasstoReturnDeliveryItemCommand.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/vendor/RegisterFasstoReturnDeliveryItemCommand.java
@@ -1,0 +1,27 @@
+package com.personal.marketnote.fulfillment.port.in.command.vendor;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record RegisterFasstoReturnDeliveryItemCommand(
+        String ordDt,
+        String ordNo,
+        String parcelCd,
+        String invoiceNo,
+        String custNm,
+        String custTelNo,
+        String custAddr,
+        String rtnEmpNm,
+        String rtnTelNo,
+        String rtnZipCd,
+        String rtnAddr1,
+        String rtnAddr2,
+        String rtnGubun,
+        String rtnReason,
+        String getRtnDetailReason,
+        String rtnShipReqTerm,
+        List<RegisterFasstoDeliveryGoodsCommand> godCds
+) {
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/usecase/vendor/RegisterFasstoReturnDeliveryUseCase.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/usecase/vendor/RegisterFasstoReturnDeliveryUseCase.java
@@ -1,0 +1,15 @@
+package com.personal.marketnote.fulfillment.port.in.usecase.vendor;
+
+import com.personal.marketnote.fulfillment.port.in.command.vendor.RegisterFasstoReturnDeliveryCommand;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.RegisterFasstoDeliveryResult;
+
+public interface RegisterFasstoReturnDeliveryUseCase {
+    /**
+     * @param command 반품 예약 등록 커맨드
+     * @return 반품 예약 등록 결과 {@link RegisterFasstoDeliveryResult}
+     * @Author Claude
+     * @Date 2026-02-20
+     * @Description 파스토 반품 예약 등록을 요청합니다.
+     */
+    RegisterFasstoDeliveryResult registerReturnDelivery(RegisterFasstoReturnDeliveryCommand command);
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/vendor/RegisterFasstoReturnDeliveryPort.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/vendor/RegisterFasstoReturnDeliveryPort.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.fulfillment.port.out.vendor;
+
+import com.personal.marketnote.fulfillment.domain.vendor.fassto.returndelivery.FasstoReturnDeliveryMapper;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.RegisterFasstoDeliveryResult;
+
+public interface RegisterFasstoReturnDeliveryPort {
+    RegisterFasstoDeliveryResult registerReturnDelivery(FasstoReturnDeliveryMapper request);
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/vendor/RegisterFasstoReturnDeliveryService.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/vendor/RegisterFasstoReturnDeliveryService.java
@@ -1,0 +1,26 @@
+package com.personal.marketnote.fulfillment.service.vendor;
+
+import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.fulfillment.mapper.FasstoReturnDeliveryCommandToRequestMapper;
+import com.personal.marketnote.fulfillment.port.in.command.vendor.RegisterFasstoReturnDeliveryCommand;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.RegisterFasstoDeliveryResult;
+import com.personal.marketnote.fulfillment.port.in.usecase.vendor.RegisterFasstoReturnDeliveryUseCase;
+import com.personal.marketnote.fulfillment.port.out.vendor.RegisterFasstoReturnDeliveryPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional(isolation = READ_COMMITTED, readOnly = true)
+public class RegisterFasstoReturnDeliveryService implements RegisterFasstoReturnDeliveryUseCase {
+    private final RegisterFasstoReturnDeliveryPort registerFasstoReturnDeliveryPort;
+
+    @Override
+    public RegisterFasstoDeliveryResult registerReturnDelivery(RegisterFasstoReturnDeliveryCommand command) {
+        return registerFasstoReturnDeliveryPort.registerReturnDelivery(
+                FasstoReturnDeliveryCommandToRequestMapper.mapToRegisterRequest(command)
+        );
+    }
+}

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/returndelivery/FasstoReturnDeliveryItemMapper.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/returndelivery/FasstoReturnDeliveryItemMapper.java
@@ -1,0 +1,128 @@
+package com.personal.marketnote.fulfillment.domain.vendor.fassto.returndelivery;
+
+import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.fulfillment.domain.vendor.fassto.delivery.FasstoDeliveryGoodsMapper;
+import lombok.*;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+public class FasstoReturnDeliveryItemMapper {
+    private String ordDt;
+    private String ordNo;
+    private String parcelCd;
+    private String invoiceNo;
+    private String custNm;
+    private String custTelNo;
+    private String custAddr;
+    private String rtnEmpNm;
+    private String rtnTelNo;
+    private String rtnZipCd;
+    private String rtnAddr1;
+    private String rtnAddr2;
+    private String rtnGubun;
+    private String rtnReason;
+    private String getRtnDetailReason;
+    private String rtnShipReqTerm;
+    private List<FasstoDeliveryGoodsMapper> godCds;
+
+    public static FasstoReturnDeliveryItemMapper of(
+            String ordDt,
+            String ordNo,
+            String parcelCd,
+            String invoiceNo,
+            String custNm,
+            String custTelNo,
+            String custAddr,
+            String rtnEmpNm,
+            String rtnTelNo,
+            String rtnZipCd,
+            String rtnAddr1,
+            String rtnAddr2,
+            String rtnGubun,
+            String rtnReason,
+            String getRtnDetailReason,
+            String rtnShipReqTerm,
+            List<FasstoDeliveryGoodsMapper> godCds
+    ) {
+        FasstoReturnDeliveryItemMapper mapper = FasstoReturnDeliveryItemMapper.builder()
+                .ordDt(ordDt)
+                .ordNo(ordNo)
+                .parcelCd(parcelCd)
+                .invoiceNo(invoiceNo)
+                .custNm(custNm)
+                .custTelNo(custTelNo)
+                .custAddr(custAddr)
+                .rtnEmpNm(rtnEmpNm)
+                .rtnTelNo(rtnTelNo)
+                .rtnZipCd(rtnZipCd)
+                .rtnAddr1(rtnAddr1)
+                .rtnAddr2(rtnAddr2)
+                .rtnGubun(rtnGubun)
+                .rtnReason(rtnReason)
+                .getRtnDetailReason(getRtnDetailReason)
+                .rtnShipReqTerm(rtnShipReqTerm)
+                .godCds(godCds)
+                .build();
+        mapper.validate();
+        return mapper;
+    }
+
+    public Map<String, Object> toPayload() {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        putIfHasValue(payload, "ordDt", ordDt);
+        putIfHasValue(payload, "ordNo", ordNo);
+        putIfHasValue(payload, "parcelCd", parcelCd);
+        putIfHasValue(payload, "invoiceNo", invoiceNo);
+        putIfHasValue(payload, "custNm", custNm);
+        putIfHasValue(payload, "custTelNo", custTelNo);
+        putIfHasValue(payload, "custAddr", custAddr);
+        putIfHasValue(payload, "rtnEmpNm", rtnEmpNm);
+        putIfHasValue(payload, "rtnTelNo", rtnTelNo);
+        putIfHasValue(payload, "rtnZipCd", rtnZipCd);
+        putIfHasValue(payload, "rtnAddr1", rtnAddr1);
+        putIfHasValue(payload, "rtnAddr2", rtnAddr2);
+        putIfHasValue(payload, "rtnGubun", rtnGubun);
+        putIfHasValue(payload, "rtnReason", rtnReason);
+        putIfHasValue(payload, "getRtnDetailReason", getRtnDetailReason);
+        putIfHasValue(payload, "rtnShipReqTerm", rtnShipReqTerm);
+        if (FormatValidator.hasValue(godCds)) {
+            payload.put("godCds", godCds.stream()
+                    .map(FasstoDeliveryGoodsMapper::toPayload)
+                    .toList());
+        }
+        return payload;
+    }
+
+    private void validate() {
+        if (FormatValidator.hasNoValue(ordDt)) {
+            throw new IllegalArgumentException("ordDt is required for return delivery request.");
+        }
+        if (FormatValidator.hasNoValue(parcelCd)) {
+            throw new IllegalArgumentException("parcelCd is required for return delivery request.");
+        }
+        if (FormatValidator.hasNoValue(invoiceNo)) {
+            throw new IllegalArgumentException("invoiceNo is required for return delivery request.");
+        }
+        if (FormatValidator.hasNoValue(custNm)) {
+            throw new IllegalArgumentException("custNm is required for return delivery request.");
+        }
+        if (FormatValidator.hasNoValue(custTelNo)) {
+            throw new IllegalArgumentException("custTelNo is required for return delivery request.");
+        }
+        if (FormatValidator.hasNoValue(custAddr)) {
+            throw new IllegalArgumentException("custAddr is required for return delivery request.");
+        }
+    }
+
+    private void putIfHasValue(Map<String, Object> payload, String key, String value) {
+        if (FormatValidator.hasValue(value)) {
+            payload.put(key, value);
+        }
+    }
+}

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/returndelivery/FasstoReturnDeliveryMapper.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/returndelivery/FasstoReturnDeliveryMapper.java
@@ -1,0 +1,56 @@
+package com.personal.marketnote.fulfillment.domain.vendor.fassto.returndelivery;
+
+import com.personal.marketnote.common.utility.FormatValidator;
+import lombok.*;
+
+import java.util.List;
+import java.util.Map;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+public class FasstoReturnDeliveryMapper {
+    private String customerCode;
+    private String accessToken;
+    private List<FasstoReturnDeliveryItemMapper> returnDeliveryRequests;
+
+    public static FasstoReturnDeliveryMapper register(
+            String customerCode,
+            String accessToken,
+            List<FasstoReturnDeliveryItemMapper> returnDeliveryRequests
+    ) {
+        FasstoReturnDeliveryMapper mapper = FasstoReturnDeliveryMapper.builder()
+                .customerCode(customerCode)
+                .accessToken(accessToken)
+                .returnDeliveryRequests(returnDeliveryRequests)
+                .build();
+        mapper.validate();
+        return mapper;
+    }
+
+    public List<Map<String, Object>> toPayload() {
+        return returnDeliveryRequests.stream()
+                .map(FasstoReturnDeliveryItemMapper::toPayload)
+                .toList();
+    }
+
+    public String getOrdNo() {
+        if (FormatValidator.hasNoValue(returnDeliveryRequests)) {
+            return null;
+        }
+        return returnDeliveryRequests.getFirst().getOrdNo();
+    }
+
+    private void validate() {
+        if (FormatValidator.hasNoValue(customerCode)) {
+            throw new IllegalArgumentException("customerCode is required.");
+        }
+        if (FormatValidator.hasNoValue(accessToken)) {
+            throw new IllegalArgumentException("accessToken is required.");
+        }
+        if (FormatValidator.hasNoValue(returnDeliveryRequests)) {
+            throw new IllegalArgumentException("returnDeliveryRequests is required.");
+        }
+    }
+}

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendorcommunication/FulfillmentVendorCommunicationTargetType.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendorcommunication/FulfillmentVendorCommunicationTargetType.java
@@ -10,6 +10,7 @@ public enum FulfillmentVendorCommunicationTargetType {
     GOODS("상품"),
     WAREHOUSING("입고"),
     DELIVERY("출고"),
+    RETURN_DELIVERY("반품"),
     STOCK("재고"),
     SETTLEMENT("정산");
 

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/shippingaddress/request/RegisterShippingAddressRequest.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/shippingaddress/request/RegisterShippingAddressRequest.java
@@ -5,6 +5,7 @@ import com.personal.marketnote.user.domain.shippingaddress.ShippingAddressType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 
 @Getter
@@ -14,32 +15,39 @@ public class RegisterShippingAddressRequest {
     @NotNull(message = "배송지 타입은 필수값입니다.")
     private ShippingAddressType addressType;
 
-    @Schema(name = "address", description = "도로명 주소", requiredMode = Schema.RequiredMode.REQUIRED)
+    @Schema(name = "address", description = "도로명 주소 (최대 255자)", requiredMode = Schema.RequiredMode.REQUIRED)
     @NotBlank(message = "주소는 필수값입니다.")
+    @Size(max = 255, message = "주소는 최대 255자까지 입력할 수 있습니다.")
     private String address;
 
-    @Schema(name = "addressDetail", description = "상세주소", requiredMode = Schema.RequiredMode.REQUIRED)
+    @Schema(name = "addressDetail", description = "상세주소 (최대 255자)", requiredMode = Schema.RequiredMode.REQUIRED)
     @NotBlank(message = "상세주소는 필수값입니다.")
+    @Size(max = 255, message = "상세주소는 최대 255자까지 입력할 수 있습니다.")
     private String addressDetail;
 
-    @Schema(name = "companyName", description = "회사명 (COMPANY 타입일 때 필수)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @Schema(name = "companyName", description = "회사명 (COMPANY 타입일 때 필수, 최대 63자)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @Size(max = 63, message = "회사명은 최대 63자까지 입력할 수 있습니다.")
     private String companyName;
 
-    @Schema(name = "addressAlias", description = "주소 별명 (OTHER 타입일 때 필수)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @Schema(name = "addressAlias", description = "주소 별명 (OTHER 타입일 때 필수, 최대 31자)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @Size(max = 31, message = "주소 별명은 최대 31자까지 입력할 수 있습니다.")
     private String addressAlias;
 
-    @Schema(name = "recipientName", description = "받는 분", requiredMode = Schema.RequiredMode.REQUIRED)
+    @Schema(name = "recipientName", description = "받는 분 (최대 31자)", requiredMode = Schema.RequiredMode.REQUIRED)
     @NotBlank(message = "받는 분은 필수값입니다.")
+    @Size(max = 31, message = "받는 분은 최대 31자까지 입력할 수 있습니다.")
     private String recipientName;
 
-    @Schema(name = "recipientPhoneNumber", description = "휴대폰 번호", requiredMode = Schema.RequiredMode.REQUIRED)
+    @Schema(name = "recipientPhoneNumber", description = "휴대폰 번호 (최대 15자)", requiredMode = Schema.RequiredMode.REQUIRED)
     @NotBlank(message = "휴대폰 번호는 필수값입니다.")
+    @Size(max = 15, message = "휴대폰 번호는 최대 15자까지 입력할 수 있습니다.")
     private String recipientPhoneNumber;
 
     @Schema(name = "deliveryRequestType", description = "배송 요청사항 타입", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private DeliveryRequestType deliveryRequestType;
 
     @Schema(name = "deliveryRequestMessage", description = "배송 요청사항 직접입력 메시지 (최대 30자, CUSTOM 타입일 때 필수)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @Size(max = 30, message = "배송 요청사항 메시지는 최대 30자까지 입력할 수 있습니다.")
     private String deliveryRequestMessage;
 
     @Schema(name = "isDefault", description = "기본 배송지 여부", requiredMode = Schema.RequiredMode.NOT_REQUIRED)

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/shippingaddress/request/UpdateShippingAddressRequest.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/shippingaddress/request/UpdateShippingAddressRequest.java
@@ -3,36 +3,44 @@ package com.personal.marketnote.user.adapter.in.web.shippingaddress.request;
 import com.personal.marketnote.user.domain.shippingaddress.DeliveryRequestType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 
 @Getter
 public class UpdateShippingAddressRequest {
 
-    @Schema(name = "address", description = "도로명 주소", requiredMode = Schema.RequiredMode.REQUIRED)
+    @Schema(name = "address", description = "도로명 주소 (최대 255자)", requiredMode = Schema.RequiredMode.REQUIRED)
     @NotBlank(message = "주소는 필수값입니다.")
+    @Size(max = 255, message = "주소는 최대 255자까지 입력할 수 있습니다.")
     private String address;
 
-    @Schema(name = "addressDetail", description = "상세주소", requiredMode = Schema.RequiredMode.REQUIRED)
+    @Schema(name = "addressDetail", description = "상세주소 (최대 255자)", requiredMode = Schema.RequiredMode.REQUIRED)
     @NotBlank(message = "상세주소는 필수값입니다.")
+    @Size(max = 255, message = "상세주소는 최대 255자까지 입력할 수 있습니다.")
     private String addressDetail;
 
-    @Schema(name = "companyName", description = "회사명 (COMPANY 타입일 때 필수)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @Schema(name = "companyName", description = "회사명 (COMPANY 타입일 때 필수, 최대 63자)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @Size(max = 63, message = "회사명은 최대 63자까지 입력할 수 있습니다.")
     private String companyName;
 
-    @Schema(name = "addressAlias", description = "주소 별명 (OTHER 타입일 때 필수)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @Schema(name = "addressAlias", description = "주소 별명 (OTHER 타입일 때 필수, 최대 31자)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @Size(max = 31, message = "주소 별명은 최대 31자까지 입력할 수 있습니다.")
     private String addressAlias;
 
-    @Schema(name = "recipientName", description = "받는 분", requiredMode = Schema.RequiredMode.REQUIRED)
+    @Schema(name = "recipientName", description = "받는 분 (최대 31자)", requiredMode = Schema.RequiredMode.REQUIRED)
     @NotBlank(message = "받는 분은 필수값입니다.")
+    @Size(max = 31, message = "받는 분은 최대 31자까지 입력할 수 있습니다.")
     private String recipientName;
 
-    @Schema(name = "recipientPhoneNumber", description = "휴대폰 번호", requiredMode = Schema.RequiredMode.REQUIRED)
+    @Schema(name = "recipientPhoneNumber", description = "휴대폰 번호 (최대 15자)", requiredMode = Schema.RequiredMode.REQUIRED)
     @NotBlank(message = "휴대폰 번호는 필수값입니다.")
+    @Size(max = 15, message = "휴대폰 번호는 최대 15자까지 입력할 수 있습니다.")
     private String recipientPhoneNumber;
 
     @Schema(name = "deliveryRequestType", description = "배송 요청사항 타입", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private DeliveryRequestType deliveryRequestType;
 
     @Schema(name = "deliveryRequestMessage", description = "배송 요청사항 직접입력 메시지 (최대 30자, CUSTOM 타입일 때 필수)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @Size(max = 30, message = "배송 요청사항 메시지는 최대 30자까지 입력할 수 있습니다.")
     private String deliveryRequestMessage;
 }

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/out/persistence/shippingaddress/ShippingAddressPersistenceAdapter.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/out/persistence/shippingaddress/ShippingAddressPersistenceAdapter.java
@@ -62,9 +62,11 @@ public class ShippingAddressPersistenceAdapter implements FindShippingAddressPor
     }
 
     @Override
-    public Optional<ShippingAddress> findDefaultByUserId(Long userId) {
-        return shippingAddressJpaRepository.findByUserIdAndIsDefaultAndStatus(userId, true, EntityStatus.ACTIVE)
-                .map(ShippingAddressJpaEntityToDomainMapper::mapToDomain);
+    public List<ShippingAddress> findDefaultsByUserId(Long userId) {
+        return shippingAddressJpaRepository.findAllByUserIdAndIsDefaultAndStatus(userId, true, EntityStatus.ACTIVE)
+                .stream()
+                .map(ShippingAddressJpaEntityToDomainMapper::mapToDomain)
+                .toList();
     }
 
     @Override

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/out/persistence/shippingaddress/repository/ShippingAddressJpaRepository.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/out/persistence/shippingaddress/repository/ShippingAddressJpaRepository.java
@@ -20,5 +20,5 @@ public interface ShippingAddressJpaRepository extends JpaRepository<ShippingAddr
 
     Optional<ShippingAddressJpaEntity> findByIdAndUserIdAndStatus(Long id, Long userId, EntityStatus status);
 
-    Optional<ShippingAddressJpaEntity> findByUserIdAndIsDefaultAndStatus(Long userId, Boolean isDefault, EntityStatus status);
+    List<ShippingAddressJpaEntity> findAllByUserIdAndIsDefaultAndStatus(Long userId, Boolean isDefault, EntityStatus status);
 }

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/port/out/shippingaddress/FindShippingAddressPort.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/port/out/shippingaddress/FindShippingAddressPort.java
@@ -17,5 +17,5 @@ public interface FindShippingAddressPort {
 
     Optional<ShippingAddress> findByIdAndUserId(Long id, Long userId);
 
-    Optional<ShippingAddress> findDefaultByUserId(Long userId);
+    List<ShippingAddress> findDefaultsByUserId(Long userId);
 }

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/service/shippingaddress/RegisterShippingAddressService.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/service/shippingaddress/RegisterShippingAddressService.java
@@ -41,8 +41,8 @@ public class RegisterShippingAddressService implements RegisterShippingAddressUs
         boolean isDefault = isFirstAddress || Boolean.TRUE.equals(command.isDefault());
 
         if (isDefault && !isFirstAddress) {
-            findShippingAddressPort.findDefaultByUserId(userId)
-                    .ifPresent(currentDefault -> {
+            findShippingAddressPort.findDefaultsByUserId(userId)
+                    .forEach(currentDefault -> {
                         currentDefault.unsetAsDefault();
                         updateShippingAddressPort.update(currentDefault);
                     });

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/service/shippingaddress/SetDefaultShippingAddressService.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/service/shippingaddress/SetDefaultShippingAddressService.java
@@ -27,8 +27,8 @@ public class SetDefaultShippingAddressService implements SetDefaultShippingAddre
             return;
         }
 
-        findShippingAddressPort.findDefaultByUserId(userId)
-                .ifPresent(currentDefault -> {
+        findShippingAddressPort.findDefaultsByUserId(userId)
+                .forEach(currentDefault -> {
                     currentDefault.unsetAsDefault();
                     updateShippingAddressPort.update(currentDefault);
                 });


### PR DESCRIPTION
## partially addresses #475
## resolves #792

## Task
- [x] 파스토 반품 예약 등록 연동 요청
- [x] 파스토 반품 예약 등록 연동 비즈니스 로직
- [x] 파스토 서버에 반품 예약 등록 요청
- [x] 201 status code 응답
- [x] Swagger docs