### PR TITLE
[#475][#793] feat: (관리자) 파스토 반품 택배사 미지정 등록 연동 기능 추가

### DIFF
--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/FasstoDirectReturnDeliveryController.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/FasstoDirectReturnDeliveryController.java
@@ -1,0 +1,62 @@
+package com.personal.marketnote.fulfillment.adapter.in.web.vendor.controller;
+
+import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
+import com.personal.marketnote.fulfillment.adapter.in.web.vendor.controller.apidocs.RegisterFasstoDirectReturnDeliveryApiDocs;
+import com.personal.marketnote.fulfillment.adapter.in.web.vendor.mapper.FasstoDirectReturnDeliveryRequestToCommandMapper;
+import com.personal.marketnote.fulfillment.adapter.in.web.vendor.request.RegisterFasstoDirectReturnDeliveryRequest;
+import com.personal.marketnote.fulfillment.adapter.in.web.vendor.response.RegisterFasstoDirectReturnDeliveryResponse;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.RegisterFasstoDeliveryResult;
+import com.personal.marketnote.fulfillment.port.in.usecase.vendor.RegisterFasstoDirectReturnDeliveryUseCase;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+import static com.personal.marketnote.common.domain.exception.ExceptionCode.DEFAULT_SUCCESS_CODE;
+import static com.personal.marketnote.common.utility.ApiConstant.ADMIN_POINTCUT;
+
+@RestController
+@RequestMapping("/api/v1/vendors/fassto/direct-return-deliveries")
+@Tag(name = "파스토 반품(택배사 미지정) API", description = "파스토 반품 택배사 미지정 관련 API")
+@RequiredArgsConstructor
+public class FasstoDirectReturnDeliveryController {
+    private final RegisterFasstoDirectReturnDeliveryUseCase registerFasstoDirectReturnDeliveryUseCase;
+
+    /**
+     * (관리자) 파스토 반품 택배사 미지정 등록 요청
+     *
+     * @param customerCode 파스토 고객사 코드
+     * @param accessToken  파스토 액세스 토큰
+     * @param request      반품 택배사 미지정 등록 요청 정보
+     * @Author Claude
+     * @Date 2026-02-20
+     * @Description 파스토 반품 택배사 미지정 등록(택배사 예약 없거나 다른 택배사 사용 시)을 요청합니다.
+     */
+    @PostMapping("/{customerCode}")
+    @PreAuthorize(ADMIN_POINTCUT)
+    @RegisterFasstoDirectReturnDeliveryApiDocs
+    public ResponseEntity<BaseResponse<RegisterFasstoDirectReturnDeliveryResponse>> registerDirectReturnDelivery(
+            @PathVariable String customerCode,
+            @RequestHeader("accessToken") String accessToken,
+            @Valid @RequestBody List<RegisterFasstoDirectReturnDeliveryRequest> request
+    ) {
+        RegisterFasstoDeliveryResult result = registerFasstoDirectReturnDeliveryUseCase.registerDirectReturnDelivery(
+                FasstoDirectReturnDeliveryRequestToCommandMapper.mapToRegisterCommand(customerCode, accessToken, request)
+        );
+
+        return new ResponseEntity<>(
+                BaseResponse.of(
+                        RegisterFasstoDirectReturnDeliveryResponse.from(result),
+                        HttpStatus.CREATED,
+                        DEFAULT_SUCCESS_CODE,
+                        "파스토 반품 택배사 미지정 등록 성공"
+                ),
+                HttpStatus.CREATED
+        );
+    }
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/apidocs/RegisterFasstoDirectReturnDeliveryApiDocs.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/controller/apidocs/RegisterFasstoDirectReturnDeliveryApiDocs.java
@@ -1,0 +1,229 @@
+package com.personal.marketnote.fulfillment.adapter.in.web.vendor.controller.apidocs;
+
+import com.personal.marketnote.fulfillment.adapter.in.web.vendor.request.RegisterFasstoDirectReturnDeliveryRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Operation(
+        summary = "(관리자) 파스토 반품 택배사 미지정 등록 요청",
+        description = """
+                작성일자: 2026-02-20
+                
+                작성자: Claude
+                
+                ---
+                
+                ## Description
+                
+                파스토 반품 택배사 미지정 등록(택배사 예약 없거나 다른 택배사 사용 시)을 요청합니다.
+                
+                ---
+                
+                ## Request
+                
+                | **키** | **위치** | **타입** | **설명** | **필수 여부** | **예시** |
+                | --- | --- | --- | --- | --- | --- |
+                | accessToken | header | string | 파스토 액세스 토큰 | Y | 23ea2ab4f0e111f0be620ab49498ff55 |
+                | customerCode | path | string | 파스토 고객사 코드 | Y | 94388 |
+                
+                ---
+                
+                ## Request Body (Array)
+                
+                | **키** | **타입** | **설명** | **필수 여부** | **예시** |
+                | --- | --- | --- | --- | --- |
+                | ordDt | string | 반품예정일 | Y | "20260204" |
+                | supCd | string | 공급처코드 | N | "SUP001" |
+                | orgParcelCd | string | 원택배사코드 | Y | "04" |
+                | orgInvoiceNo | string | 원송장번호 | Y | "1234567890" |
+                | inWay | string | 반품방식(01:택배, 02:차량) | Y | "01" |
+                | custNm | string | 고객명 | Y | "홍길동" |
+                | rtnParcelComp | string | 반품택배사명(택배사코드 사용하지 않음) | N | "CJ대한통운" |
+                | rtnInvoiceNo | string | 반품송장번호 | N | "9876543210" |
+                | rtnGubun | string | 반품 구분코드(01:반품, 02:교환, 03:환불) | Y | "01" |
+                | rtnReason | string | 반품 사유 코드(01~10, 99) | Y | "07" |
+                | rtnDetailReason | string | 반품 사유 상세내용 | N | "상품 파손" |
+                | remark | string | 비고 | N | "취급주의" |
+                | godCds | array | 반품 대상 상품 목록 | N | [ ... ] |
+                
+                ---
+                
+                ### Request Body > godCds
+                
+                | **키** | **타입** | **설명** | **필수 여부** | **예시** |
+                | --- | --- | --- | --- | --- |
+                | cstGodCd | string | 고객사상품번호 | Y | "PROD001" |
+                | distTermDt | string | 유통기한 | N | "" |
+                | ordQty | number | 주문수량 | Y | 1 |
+                
+                ---
+                
+                ## 반품 사유 코드 참조
+                
+                | **코드** | **설명** |
+                | --- | --- |
+                | 01 | 구매 의사 취소 |
+                | 02 | 색상 및 사이즈 변경 |
+                | 03 | 다른 상품 잘못 주문 |
+                | 04 | 서비스 불만족 |
+                | 05 | 배송 지연 |
+                | 06 | 배송 누락 |
+                | 07 | 상품 파손 |
+                | 08 | 상품 정보 상이 |
+                | 09 | 배송 주소 상이 |
+                | 10 | 색상 등 다른상품 잘못 배송 |
+                | 99 | 기타 |
+                
+                ---
+                
+                ## Response
+                
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | statusCode | number | 상태 코드 | 201: 성공 / 400: 클라이언트 요청 오류 / 401: 인증 실패 / 403: 인가 실패 / 500: 그 외 |
+                | code | string | 응답 코드 | "SUC01" / "BAD_REQUEST" / "UNAUTHORIZED" / "FORBIDDEN" / "INTERNAL_SERVER_ERROR" |
+                | timestamp | string(datetime) | 응답 일시 | "2026-02-20T12:00:00.000" |
+                | content | object | 응답 본문 | { ... } |
+                | message | string | 처리 결과 | "파스토 반품 택배사 미지정 등록 성공" |
+                
+                ---
+                
+                ### Response > content
+                
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | dataCount | number | 등록 건수 | 1 |
+                | deliveries | array | 반품 등록 결과 | [ ... ] |
+                
+                ---
+                
+                ### Response > content > deliveries
+                
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | fmsSlipNo | string | FMS 요청번호 | "TESTRI260204000001" |
+                | orderNo | string | 주문번호 | "" |
+                | msg | string | 처리 메시지 | "반품요청 등록 성공" |
+                | code | string | 처리 코드 | "200" |
+                | outOfStockGoodsDetail | object | 재고부족 상품 상세 | null |
+                """,
+        security = {@SecurityRequirement(name = "bearer")},
+        parameters = {
+                @Parameter(
+                        name = "accessToken",
+                        description = "파스토 액세스 토큰",
+                        in = ParameterIn.HEADER,
+                        required = true,
+                        schema = @Schema(type = "string", example = "23ea2ab4f0e111f0be620ab49498ff55")
+                ),
+                @Parameter(
+                        name = "customerCode",
+                        description = "파스토 고객사 코드",
+                        in = ParameterIn.PATH,
+                        required = true,
+                        schema = @Schema(type = "string", example = "94388")
+                )
+        },
+        requestBody = @RequestBody(
+                required = true,
+                content = @Content(
+                        schema = @Schema(implementation = RegisterFasstoDirectReturnDeliveryRequest.class),
+                        examples = @ExampleObject("""
+                                [
+                                  {
+                                    "ordDt": "20260204",
+                                    "supCd": "SUP001",
+                                    "orgParcelCd": "04",
+                                    "orgInvoiceNo": "1234567890",
+                                    "inWay": "01",
+                                    "custNm": "홍길동",
+                                    "rtnParcelComp": "CJ대한통운",
+                                    "rtnInvoiceNo": "9876543210",
+                                    "rtnGubun": "01",
+                                    "rtnReason": "07",
+                                    "rtnDetailReason": "상품 파손",
+                                    "remark": "취급주의",
+                                    "godCds": [
+                                      {
+                                        "cstGodCd": "PROD001",
+                                        "distTermDt": "",
+                                        "ordQty": 1
+                                      }
+                                    ]
+                                  }
+                                ]
+                                """)
+                )
+        ),
+        responses = {
+                @ApiResponse(
+                        responseCode = "201",
+                        description = "파스토 반품 택배사 미지정 등록 성공",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 201,
+                                          "code": "SUC01",
+                                          "timestamp": "2026-02-20T12:00:00.000",
+                                          "content": {
+                                            "dataCount": 1,
+                                            "deliveries": [
+                                              {
+                                                "fmsSlipNo": "TESTRI260204000001",
+                                                "orderNo": "",
+                                                "msg": "반품요청 등록 성공",
+                                                "code": "200",
+                                                "outOfStockGoodsDetail": null
+                                              }
+                                            ]
+                                          },
+                                          "message": "파스토 반품 택배사 미지정 등록 성공"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "401",
+                        description = "토큰 인증 실패",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 401,
+                                          "code": "UNAUTHORIZED",
+                                          "timestamp": "2026-02-20T12:00:00.000",
+                                          "content": null,
+                                          "message": "Invalid token"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "403",
+                        description = "토큰 인가 실패",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 403,
+                                          "code": "FORBIDDEN",
+                                          "timestamp": "2026-02-20T12:00:00.000",
+                                          "content": null,
+                                          "message": "Access Denied"
+                                        }
+                                        """)
+                        )
+                )
+        })
+public @interface RegisterFasstoDirectReturnDeliveryApiDocs {
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/mapper/FasstoDirectReturnDeliveryRequestToCommandMapper.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/mapper/FasstoDirectReturnDeliveryRequestToCommandMapper.java
@@ -1,0 +1,57 @@
+package com.personal.marketnote.fulfillment.adapter.in.web.vendor.mapper;
+
+import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.fulfillment.adapter.in.web.vendor.request.RegisterFasstoDeliveryGoodsRequest;
+import com.personal.marketnote.fulfillment.adapter.in.web.vendor.request.RegisterFasstoDirectReturnDeliveryRequest;
+import com.personal.marketnote.fulfillment.port.in.command.vendor.RegisterFasstoDeliveryGoodsCommand;
+import com.personal.marketnote.fulfillment.port.in.command.vendor.RegisterFasstoDirectReturnDeliveryCommand;
+import com.personal.marketnote.fulfillment.port.in.command.vendor.RegisterFasstoDirectReturnDeliveryItemCommand;
+
+import java.util.List;
+
+public class FasstoDirectReturnDeliveryRequestToCommandMapper {
+
+    public static RegisterFasstoDirectReturnDeliveryCommand mapToRegisterCommand(
+            String customerCode,
+            String accessToken,
+            List<RegisterFasstoDirectReturnDeliveryRequest> request
+    ) {
+        List<RegisterFasstoDirectReturnDeliveryItemCommand> directReturnDeliveryRequests = request.stream()
+                .map(FasstoDirectReturnDeliveryRequestToCommandMapper::mapItem)
+                .toList();
+
+        return RegisterFasstoDirectReturnDeliveryCommand.of(customerCode, accessToken, directReturnDeliveryRequests);
+    }
+
+    private static RegisterFasstoDirectReturnDeliveryItemCommand mapItem(RegisterFasstoDirectReturnDeliveryRequest item) {
+        List<RegisterFasstoDeliveryGoodsCommand> goods = FormatValidator.hasValue(item.getGodCds())
+                ? item.getGodCds().stream()
+                .map(FasstoDirectReturnDeliveryRequestToCommandMapper::mapGoods)
+                .toList()
+                : List.of();
+
+        return RegisterFasstoDirectReturnDeliveryItemCommand.builder()
+                .ordDt(item.getOrdDt())
+                .supCd(item.getSupCd())
+                .orgParcelCd(item.getOrgParcelCd())
+                .orgInvoiceNo(item.getOrgInvoiceNo())
+                .inWay(item.getInWay())
+                .custNm(item.getCustNm())
+                .rtnParcelComp(item.getRtnParcelComp())
+                .rtnInvoiceNo(item.getRtnInvoiceNo())
+                .rtnGubun(item.getRtnGubun())
+                .rtnReason(item.getRtnReason())
+                .rtnDetailReason(item.getRtnDetailReason())
+                .remark(item.getRemark())
+                .godCds(goods)
+                .build();
+    }
+
+    private static RegisterFasstoDeliveryGoodsCommand mapGoods(RegisterFasstoDeliveryGoodsRequest item) {
+        return RegisterFasstoDeliveryGoodsCommand.of(
+                item.getCstGodCd(),
+                item.getDistTermDt(),
+                item.getOrdQty()
+        );
+    }
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/request/RegisterFasstoDirectReturnDeliveryRequest.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/request/RegisterFasstoDirectReturnDeliveryRequest.java
@@ -1,0 +1,110 @@
+package com.personal.marketnote.fulfillment.adapter.in.web.vendor.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class RegisterFasstoDirectReturnDeliveryRequest {
+    @Schema(
+            name = "ordDt",
+            description = "반품예정일(필수)",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    @NotEmpty(message = "반품예정일은 필수값입니다.")
+    private String ordDt;
+
+    @Schema(
+            name = "supCd",
+            description = "공급처코드",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String supCd;
+
+    @Schema(
+            name = "orgParcelCd",
+            description = "원택배사코드(필수)",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    @NotEmpty(message = "원택배사코드는 필수값입니다.")
+    private String orgParcelCd;
+
+    @Schema(
+            name = "orgInvoiceNo",
+            description = "원송장번호(필수)",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    @NotEmpty(message = "원송장번호는 필수값입니다.")
+    private String orgInvoiceNo;
+
+    @Schema(
+            name = "inWay",
+            description = "반품방식(필수, 01:택배, 02:차량)",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    @NotEmpty(message = "반품방식은 필수값입니다.")
+    private String inWay;
+
+    @Schema(
+            name = "custNm",
+            description = "고객명(필수)",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    @NotEmpty(message = "고객명은 필수값입니다.")
+    private String custNm;
+
+    @Schema(
+            name = "rtnParcelComp",
+            description = "반품택배사명(택배사코드 사용하지 않음)",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String rtnParcelComp;
+
+    @Schema(
+            name = "rtnInvoiceNo",
+            description = "반품송장번호",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String rtnInvoiceNo;
+
+    @Schema(
+            name = "rtnGubun",
+            description = "반품 구분코드(필수, 01:반품, 02:교환, 03:환불)",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    @NotEmpty(message = "반품 구분코드는 필수값입니다.")
+    private String rtnGubun;
+
+    @Schema(
+            name = "rtnReason",
+            description = "반품 사유 코드(필수, 01:구매 의사 취소, 02:색상 및 사이즈 변경, 03:다른 상품 잘못 주문, 04:서비스 불만족, 05:배송 지연, 06:배송 누락, 07:상품 파손, 08:상품 정보 상이, 09:배송 주소 상이, 10:색상 등 다른상품 잘못 배송, 99:기타)",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    @NotEmpty(message = "반품 사유 코드는 필수값입니다.")
+    private String rtnReason;
+
+    @Schema(
+            name = "rtnDetailReason",
+            description = "반품 사유 상세내용",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String rtnDetailReason;
+
+    @Schema(
+            name = "remark",
+            description = "비고",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private String remark;
+
+    @Schema(
+            name = "godCds",
+            description = "반품 대상 상품 목록",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    @Valid
+    private List<RegisterFasstoDeliveryGoodsRequest> godCds;
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/response/RegisterFasstoDirectReturnDeliveryResponse.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/response/RegisterFasstoDirectReturnDeliveryResponse.java
@@ -1,0 +1,15 @@
+package com.personal.marketnote.fulfillment.adapter.in.web.vendor.response;
+
+import com.personal.marketnote.fulfillment.port.in.result.vendor.RegisterFasstoDeliveryItemResult;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.RegisterFasstoDeliveryResult;
+
+import java.util.List;
+
+public record RegisterFasstoDirectReturnDeliveryResponse(
+        Integer dataCount,
+        List<RegisterFasstoDeliveryItemResult> deliveries
+) {
+    public static RegisterFasstoDirectReturnDeliveryResponse from(RegisterFasstoDeliveryResult result) {
+        return new RegisterFasstoDirectReturnDeliveryResponse(result.dataCount(), result.deliveries());
+    }
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/client/FasstoDirectReturnDeliveryClient.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/client/FasstoDirectReturnDeliveryClient.java
@@ -1,0 +1,375 @@
+package com.personal.marketnote.fulfillment.adapter.out.vendor.fassto.client;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.common.adapter.out.VendorAdapter;
+import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.common.utility.http.client.CommunicationFailureHandler;
+import com.personal.marketnote.fulfillment.adapter.out.vendor.fassto.response.RegisterFasstoDeliveryResponse;
+import com.personal.marketnote.fulfillment.configuration.FasstoAuthProperties;
+import com.personal.marketnote.fulfillment.domain.vendor.fassto.returndelivery.FasstoDirectReturnDeliveryMapper;
+import com.personal.marketnote.fulfillment.domain.vendorcommunication.FulfillmentVendorCommunicationSenderType;
+import com.personal.marketnote.fulfillment.domain.vendorcommunication.FulfillmentVendorCommunicationTargetType;
+import com.personal.marketnote.fulfillment.domain.vendorcommunication.FulfillmentVendorCommunicationType;
+import com.personal.marketnote.fulfillment.domain.vendorcommunication.FulfillmentVendorName;
+import com.personal.marketnote.fulfillment.exception.RegisterFasstoDirectReturnDeliveryFailedException;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.RegisterFasstoDeliveryItemResult;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.RegisterFasstoDeliveryResult;
+import com.personal.marketnote.fulfillment.port.out.vendor.RegisterFasstoDirectReturnDeliveryPort;
+import com.personal.marketnote.fulfillment.utility.VendorCommunicationFailureHandler;
+import com.personal.marketnote.fulfillment.utility.VendorCommunicationPayloadGenerator;
+import com.personal.marketnote.fulfillment.utility.VendorCommunicationRecorder;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.*;
+import org.springframework.web.client.RestClientResponseException;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
+
+import static com.personal.marketnote.common.utility.ApiConstant.*;
+
+@VendorAdapter
+@RequiredArgsConstructor
+@Slf4j
+public class FasstoDirectReturnDeliveryClient implements RegisterFasstoDirectReturnDeliveryPort {
+    private static final String ACCESS_TOKEN_HEADER = "accessToken";
+    private static final String CUSTOMER_CODE_PLACEHOLDER = "{customerCode}";
+
+    private final RestTemplate restTemplate;
+    private final ObjectMapper objectMapper;
+    private final FasstoAuthProperties properties;
+    private final VendorCommunicationRecorder vendorCommunicationRecorder;
+    private final VendorCommunicationPayloadGenerator vendorCommunicationPayloadGenerator;
+    private final VendorCommunicationFailureHandler vendorCommunicationFailureHandler;
+
+    @Override
+    public RegisterFasstoDeliveryResult registerDirectReturnDelivery(FasstoDirectReturnDeliveryMapper request) {
+        RegisterFasstoDeliveryResponse response = executeDirectReturnDeliveryMutation(request, "REGISTER_DIRECT_RETURN");
+        return mapDeliveryResult(response);
+    }
+
+    private RegisterFasstoDeliveryResponse executeDirectReturnDeliveryMutation(
+            FasstoDirectReturnDeliveryMapper request,
+            String action
+    ) {
+        if (FormatValidator.hasNoValue(request)) {
+            throw new IllegalArgumentException("Fassto direct return delivery request is required.");
+        }
+
+        URI uri = buildDirectReturnDeliveryUri(request.getCustomerCode());
+        HttpEntity<List<Map<String, Object>>> httpEntity = new HttpEntity<>(
+                request.toPayload(),
+                buildHeaders(request.getAccessToken())
+        );
+
+        Exception error = new Exception();
+        String failureMessage = null;
+        long sleepMillis = INTER_SERVER_DEFAULT_RETRIAL_PENDING_MILLI_SECOND;
+        FulfillmentVendorCommunicationTargetType targetType = FulfillmentVendorCommunicationTargetType.RETURN_DELIVERY;
+        FulfillmentVendorName vendorName = FulfillmentVendorName.FASSTO;
+
+        for (int i = 0; i < INTER_SERVER_MAX_REQUEST_COUNT; i++) {
+            int attempt = i + 1;
+            JsonNode requestPayloadJson = buildRequestPayloadJson(request, uri, attempt, action);
+            String requestPayload = requestPayloadJson.toString();
+
+            ResponseEntity<String> response;
+            try {
+                response = restTemplate.exchange(
+                        uri,
+                        HttpMethod.POST,
+                        httpEntity,
+                        String.class
+                );
+            } catch (Exception e) {
+                Map<String, Object> errorPayload = new LinkedHashMap<>();
+                errorPayload.put("error", e.getClass().getSimpleName());
+                errorPayload.put("message", e.getMessage());
+                errorPayload.put("attempt", attempt);
+
+                vendorCommunicationFailureHandler.handleFailure(
+                        targetType,
+                        vendorName,
+                        requestPayload,
+                        requestPayloadJson,
+                        errorPayload,
+                        e
+                );
+
+                String vendorMessage = resolveVendorMessageFromException(e);
+                if (FormatValidator.hasValue(vendorMessage)) {
+                    failureMessage = vendorMessage;
+                    error = new Exception(vendorMessage);
+                }
+
+                log.warn("Failed to {} Fassto direct return delivery: attempt={}, message={}",
+                        action.toLowerCase(),
+                        attempt,
+                        e.getMessage(),
+                        e
+                );
+                if (i == INTER_SERVER_MAX_REQUEST_COUNT - 1) {
+                    error = e;
+                }
+
+                sleep(sleepMillis);
+                sleepMillis = sleepMillis * INTER_SERVER_DEFAULT_EXPONENTIAL_BACKOFF_VALUE;
+                continue;
+            }
+
+            JsonNode responsePayloadJson = buildResponsePayloadJson(response, attempt);
+            String responsePayload = responsePayloadJson.toString();
+
+            RegisterFasstoDeliveryResponse parsedResponse = parseResponseBody(response);
+            boolean isSuccess = isSuccessResponse(response, parsedResponse);
+            String exception = isSuccess
+                    ? null
+                    : resolveResponseException(response, parsedResponse);
+
+            vendorCommunicationRecorder.record(
+                    targetType,
+                    FulfillmentVendorCommunicationType.REQUEST,
+                    FulfillmentVendorCommunicationSenderType.SERVER,
+                    vendorName,
+                    requestPayload,
+                    requestPayloadJson,
+                    exception
+            );
+            vendorCommunicationRecorder.record(
+                    targetType,
+                    FulfillmentVendorCommunicationType.RESPONSE,
+                    FulfillmentVendorCommunicationSenderType.VENDOR,
+                    vendorName,
+                    responsePayload,
+                    responsePayloadJson,
+                    exception
+            );
+
+            if (isSuccess) {
+                return parsedResponse;
+            }
+
+            String vendorMessage = resolveVendorMessage(parsedResponse, FormatValidator.hasValue(response) ? response.getBody() : null);
+            if (FormatValidator.hasValue(vendorMessage)) {
+                failureMessage = vendorMessage;
+                error = new Exception(vendorMessage);
+            }
+
+            log.warn("Fassto direct return delivery {} failed: attempt={}, status={}, exception={}",
+                    action.toLowerCase(),
+                    attempt,
+                    FormatValidator.hasValue(response) ? response.getStatusCode() : null,
+                    exception
+            );
+
+            if (CommunicationFailureHandler.isCertainFailure(response)) {
+                break;
+            }
+
+            sleep(sleepMillis);
+            sleepMillis = sleepMillis * INTER_SERVER_DEFAULT_EXPONENTIAL_BACKOFF_VALUE;
+        }
+
+        log.error("Failed to {} Fassto direct return delivery request: {} with error: {}",
+                action.toLowerCase(),
+                uri,
+                error.getMessage(),
+                error
+        );
+
+        throw new RegisterFasstoDirectReturnDeliveryFailedException(failureMessage, new IOException(error));
+    }
+
+    private URI buildDirectReturnDeliveryUri(String customerCode) {
+        validateDirectReturnDeliveryProperties();
+        return UriComponentsBuilder.fromUriString(properties.getBaseUrl())
+                .path(properties.getReturnDirectDeliveryPath())
+                .buildAndExpand(customerCode)
+                .toUri();
+    }
+
+    private HttpHeaders buildHeaders(String accessToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setAccept(List.of(MediaType.APPLICATION_JSON));
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.add(ACCESS_TOKEN_HEADER, accessToken);
+        return headers;
+    }
+
+    private void validateDirectReturnDeliveryProperties() {
+        if (FormatValidator.hasNoValue(properties.getBaseUrl())) {
+            throw new IllegalStateException("Fassto base URL is required.");
+        }
+        if (FormatValidator.hasNoValue(properties.getReturnDirectDeliveryPath())) {
+            throw new IllegalStateException("Fassto direct return delivery path is required.");
+        }
+        if (!properties.getReturnDirectDeliveryPath().contains(CUSTOMER_CODE_PLACEHOLDER)) {
+            throw new IllegalStateException("Fassto direct return delivery path must include {customerCode}.");
+        }
+    }
+
+    private RegisterFasstoDeliveryResponse parseResponseBody(ResponseEntity<String> response) {
+        if (FormatValidator.hasNoValue(response)) {
+            return null;
+        }
+
+        String body = response.getBody();
+        if (FormatValidator.hasNoValue(body)) {
+            return null;
+        }
+
+        try {
+            return objectMapper.readValue(body, RegisterFasstoDeliveryResponse.class);
+        } catch (Exception e) {
+            log.warn("Failed to parse Fassto direct return delivery response: {}", e.getMessage(), e);
+            return null;
+        }
+    }
+
+    private boolean isSuccessResponse(ResponseEntity<String> response, RegisterFasstoDeliveryResponse parsedResponse) {
+        return FormatValidator.hasValue(response)
+                && response.getStatusCode().value() == 200
+                && FormatValidator.hasValue(parsedResponse)
+                && parsedResponse.isSuccess();
+    }
+
+    private String resolveResponseException(ResponseEntity<String> response, RegisterFasstoDeliveryResponse parsedResponse) {
+        if (FormatValidator.hasNoValue(response)) {
+            return "NO_RESPONSE";
+        }
+        if (response.getStatusCode().value() != 200) {
+            return "HTTP_" + response.getStatusCode().value();
+        }
+        if (FormatValidator.hasNoValue(parsedResponse)) {
+            return "INVALID_RESPONSE";
+        }
+        if (FormatValidator.hasNoValue(parsedResponse.header()) || !parsedResponse.header().isSuccess()) {
+            return "HEADER_FAILURE";
+        }
+        return "UNKNOWN_FAILURE";
+    }
+
+    private RegisterFasstoDeliveryResult mapDeliveryResult(RegisterFasstoDeliveryResponse response) {
+        List<RegisterFasstoDeliveryItemResult> deliveries = FormatValidator.hasValue(response.data())
+                ? response.data().stream().map(this::mapDeliveryItem).toList()
+                : List.of();
+        Integer dataCount = FormatValidator.hasValue(response.header()) ? response.header().dataCount() : null;
+        return RegisterFasstoDeliveryResult.of(dataCount, deliveries);
+    }
+
+    private RegisterFasstoDeliveryItemResult mapDeliveryItem(
+            com.personal.marketnote.fulfillment.adapter.out.vendor.fassto.response.RegisterFasstoDeliveryItemResponse item
+    ) {
+        return RegisterFasstoDeliveryItemResult.of(
+                item.fmsSlipNo(),
+                item.orderNo(),
+                item.msg(),
+                item.code(),
+                item.outOfStockGoodsDetail()
+        );
+    }
+
+    private JsonNode buildRequestPayloadJson(
+            FasstoDirectReturnDeliveryMapper request,
+            URI uri,
+            int attempt,
+            String action
+    ) {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("method", HttpMethod.POST.name());
+        payload.put("url", uri.toString());
+        payload.put("customerCode", request.getCustomerCode());
+        payload.put(ACCESS_TOKEN_HEADER, maskValue(request.getAccessToken()));
+        payload.put("body", request.toPayload());
+        payload.put("action", action);
+        payload.put("attempt", attempt);
+        return vendorCommunicationPayloadGenerator.buildPayloadJson(payload);
+    }
+
+    private JsonNode buildResponsePayloadJson(ResponseEntity<String> response, int attempt) {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        if (FormatValidator.hasValue(response)) {
+            payload.put("status", response.getStatusCode().value());
+            payload.put("headers", toSingleValueMap(response.getHeaders()));
+
+            String body = response.getBody();
+            if (FormatValidator.hasValue(body)) {
+                payload.put("body", body);
+            }
+        }
+        payload.put("attempt", attempt);
+        return vendorCommunicationPayloadGenerator.buildPayloadJson(payload);
+    }
+
+    private Map<String, String> toSingleValueMap(HttpHeaders headers) {
+        if (FormatValidator.hasNoValue(headers)) {
+            return Map.of();
+        }
+        return headers.toSingleValueMap();
+    }
+
+    private String resolveVendorMessage(RegisterFasstoDeliveryResponse parsedResponse, String rawBody) {
+        if (FormatValidator.hasValue(parsedResponse)) {
+            String message = parsedResponse.resolveErrorMessage();
+            if (FormatValidator.hasValue(message)) {
+                return message;
+            }
+        }
+
+        if (FormatValidator.hasValue(rawBody)) {
+            try {
+                var errorResponse = objectMapper.readValue(
+                        rawBody,
+                        com.personal.marketnote.fulfillment.adapter.out.vendor.fassto.response.FasstoErrorResponse.class
+                );
+                return errorResponse.resolveErrorMessage();
+            } catch (Exception ignored) {
+            }
+        }
+
+        return null;
+    }
+
+    private String resolveVendorMessageFromException(Exception e) {
+        if (e instanceof RestClientResponseException responseException) {
+            String body = responseException.getResponseBodyAsString();
+            if (FormatValidator.hasNoValue(body)) {
+                return null;
+            }
+            try {
+                var parsedResponse = objectMapper.readValue(
+                        body,
+                        com.personal.marketnote.fulfillment.adapter.out.vendor.fassto.response.FasstoErrorResponse.class
+                );
+                return parsedResponse.resolveErrorMessage();
+            } catch (Exception ignored) {
+            }
+        }
+        return null;
+    }
+
+    private String maskValue(String value) {
+        if (FormatValidator.hasNoValue(value)) {
+            return value;
+        }
+        if (value.length() <= 4) {
+            return "****";
+        }
+        return value.substring(0, 4) + "****";
+    }
+
+    private void sleep(long millis) {
+        try {
+            Thread.sleep(millis + ThreadLocalRandom.current().nextLong(500));
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/configuration/FasstoAuthProperties.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/configuration/FasstoAuthProperties.java
@@ -39,5 +39,6 @@ public class FasstoAuthProperties {
     private String deliveryIcsCompletedPath = "/api/v1/delivery/ics/completed/{customerCode}";
     private String stockListPath = "/api/v1/stock/list/{customerCode}";
     private String returnDeliveryPath = "/api/v1/return/parcel/{customerCode}";
+    private String returnDirectDeliveryPath = "/api/v1/return/direct/{customerCode}";
     private String settlementDailyCostPath = "/api/v1/settlement/{yearMonth}/{whCd}/{customerCode}";
 }

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/RegisterFasstoDirectReturnDeliveryFailedException.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/RegisterFasstoDirectReturnDeliveryFailedException.java
@@ -1,0 +1,25 @@
+package com.personal.marketnote.fulfillment.exception;
+
+import com.personal.marketnote.common.exception.ExternalOperationFailedException;
+
+import java.io.IOException;
+
+public class RegisterFasstoDirectReturnDeliveryFailedException extends ExternalOperationFailedException {
+    private static final String REGISTER_FASSTO_DIRECT_RETURN_DELIVERY_FAILED_EXCEPTION_MESSAGE =
+            "Fassto direct return delivery registration request failed.";
+
+    public RegisterFasstoDirectReturnDeliveryFailedException(IOException cause) {
+        super(REGISTER_FASSTO_DIRECT_RETURN_DELIVERY_FAILED_EXCEPTION_MESSAGE, cause);
+    }
+
+    public RegisterFasstoDirectReturnDeliveryFailedException(String vendorMessage, IOException cause) {
+        super(resolveMessage(vendorMessage), cause);
+    }
+
+    private static String resolveMessage(String vendorMessage) {
+        if (vendorMessage == null || vendorMessage.isBlank()) {
+            return REGISTER_FASSTO_DIRECT_RETURN_DELIVERY_FAILED_EXCEPTION_MESSAGE;
+        }
+        return vendorMessage;
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/mapper/FasstoDirectReturnDeliveryCommandToRequestMapper.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/mapper/FasstoDirectReturnDeliveryCommandToRequestMapper.java
@@ -1,0 +1,57 @@
+package com.personal.marketnote.fulfillment.mapper;
+
+import com.personal.marketnote.fulfillment.domain.vendor.fassto.delivery.FasstoDeliveryGoodsMapper;
+import com.personal.marketnote.fulfillment.domain.vendor.fassto.returndelivery.FasstoDirectReturnDeliveryItemMapper;
+import com.personal.marketnote.fulfillment.domain.vendor.fassto.returndelivery.FasstoDirectReturnDeliveryMapper;
+import com.personal.marketnote.fulfillment.port.in.command.vendor.RegisterFasstoDeliveryGoodsCommand;
+import com.personal.marketnote.fulfillment.port.in.command.vendor.RegisterFasstoDirectReturnDeliveryCommand;
+import com.personal.marketnote.fulfillment.port.in.command.vendor.RegisterFasstoDirectReturnDeliveryItemCommand;
+
+import java.util.List;
+
+public class FasstoDirectReturnDeliveryCommandToRequestMapper {
+
+    public static FasstoDirectReturnDeliveryMapper mapToRegisterRequest(RegisterFasstoDirectReturnDeliveryCommand command) {
+        List<FasstoDirectReturnDeliveryItemMapper> directReturnDeliveryRequests = command.directReturnDeliveryRequests().stream()
+                .map(FasstoDirectReturnDeliveryCommandToRequestMapper::mapItem)
+                .toList();
+
+        return FasstoDirectReturnDeliveryMapper.register(
+                command.customerCode(),
+                command.accessToken(),
+                directReturnDeliveryRequests
+        );
+    }
+
+    private static FasstoDirectReturnDeliveryItemMapper mapItem(RegisterFasstoDirectReturnDeliveryItemCommand item) {
+        List<FasstoDeliveryGoodsMapper> goods = item.godCds() != null
+                ? item.godCds().stream()
+                .map(FasstoDirectReturnDeliveryCommandToRequestMapper::mapGoods)
+                .toList()
+                : List.of();
+
+        return FasstoDirectReturnDeliveryItemMapper.of(
+                item.ordDt(),
+                item.supCd(),
+                item.orgParcelCd(),
+                item.orgInvoiceNo(),
+                item.inWay(),
+                item.custNm(),
+                item.rtnParcelComp(),
+                item.rtnInvoiceNo(),
+                item.rtnGubun(),
+                item.rtnReason(),
+                item.rtnDetailReason(),
+                item.remark(),
+                goods
+        );
+    }
+
+    private static FasstoDeliveryGoodsMapper mapGoods(RegisterFasstoDeliveryGoodsCommand item) {
+        return FasstoDeliveryGoodsMapper.of(
+                item.cstGodCd(),
+                item.distTermDt(),
+                item.ordQty()
+        );
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/mapper/FulfillmentServiceCommunicationHistoryCommandToStateMapper.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/mapper/FulfillmentServiceCommunicationHistoryCommandToStateMapper.java
@@ -11,13 +11,13 @@ public class FulfillmentServiceCommunicationHistoryCommandToStateMapper {
             FulfillmentServiceCommunicationHistoryCommand command
     ) {
         return FulfillmentServiceCommunicationHistoryCreateState.builder()
-                .targetType(command.getTargetType())
-                .targetId(command.getTargetId())
-                .communicationType(command.getCommunicationType())
-                .sender(command.getSender())
-                .exception(command.getException())
-                .payload(command.getPayload())
-                .payloadJson(command.getPayloadJson())
+                .targetType(command.targetType())
+                .targetId(command.targetId())
+                .communicationType(command.communicationType())
+                .sender(command.sender())
+                .exception(command.exception())
+                .payload(command.payload())
+                .payloadJson(command.payloadJson())
                 .build();
     }
 }

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/mapper/FulfillmentVendorCommunicationHistoryCommandToStateMapper.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/mapper/FulfillmentVendorCommunicationHistoryCommandToStateMapper.java
@@ -11,14 +11,14 @@ public class FulfillmentVendorCommunicationHistoryCommandToStateMapper {
             FulfillmentVendorCommunicationHistoryCommand command
     ) {
         return FulfillmentVendorCommunicationHistoryCreateState.builder()
-                .targetType(command.getTargetType())
-                .targetId(command.getTargetId())
-                .vendorName(command.getVendorName())
-                .communicationType(command.getCommunicationType())
-                .sender(command.getSender())
-                .exception(command.getException())
-                .payload(command.getPayload())
-                .payloadJson(command.getPayloadJson())
+                .targetType(command.targetType())
+                .targetId(command.targetId())
+                .vendorName(command.vendorName())
+                .communicationType(command.communicationType())
+                .sender(command.sender())
+                .exception(command.exception())
+                .payload(command.payload())
+                .payloadJson(command.payloadJson())
                 .build();
     }
 }

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/servicecommunication/FulfillmentServiceCommunicationHistoryCommand.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/servicecommunication/FulfillmentServiceCommunicationHistoryCommand.java
@@ -5,16 +5,15 @@ import com.personal.marketnote.fulfillment.domain.servicecommunication.Fulfillme
 import com.personal.marketnote.fulfillment.domain.servicecommunication.FulfillmentServiceCommunicationTargetType;
 import com.personal.marketnote.fulfillment.domain.servicecommunication.FulfillmentServiceCommunicationType;
 import lombok.Builder;
-import lombok.Getter;
 
-@Getter
 @Builder
-public class FulfillmentServiceCommunicationHistoryCommand {
-    private final FulfillmentServiceCommunicationTargetType targetType;
-    private final String targetId;
-    private final FulfillmentServiceCommunicationType communicationType;
-    private final FulfillmentServiceCommunicationSenderType sender;
-    private final String exception;
-    private final String payload;
-    private final JsonNode payloadJson;
+public record FulfillmentServiceCommunicationHistoryCommand(
+        FulfillmentServiceCommunicationTargetType targetType,
+        String targetId,
+        FulfillmentServiceCommunicationType communicationType,
+        FulfillmentServiceCommunicationSenderType sender,
+        String exception,
+        String payload,
+        JsonNode payloadJson
+) {
 }

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/vendor/RegisterFasstoDirectReturnDeliveryCommand.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/vendor/RegisterFasstoDirectReturnDeliveryCommand.java
@@ -1,0 +1,17 @@
+package com.personal.marketnote.fulfillment.port.in.command.vendor;
+
+import java.util.List;
+
+public record RegisterFasstoDirectReturnDeliveryCommand(
+        String customerCode,
+        String accessToken,
+        List<RegisterFasstoDirectReturnDeliveryItemCommand> directReturnDeliveryRequests
+) {
+    public static RegisterFasstoDirectReturnDeliveryCommand of(
+            String customerCode,
+            String accessToken,
+            List<RegisterFasstoDirectReturnDeliveryItemCommand> directReturnDeliveryRequests
+    ) {
+        return new RegisterFasstoDirectReturnDeliveryCommand(customerCode, accessToken, directReturnDeliveryRequests);
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/vendor/RegisterFasstoDirectReturnDeliveryItemCommand.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/vendor/RegisterFasstoDirectReturnDeliveryItemCommand.java
@@ -1,0 +1,23 @@
+package com.personal.marketnote.fulfillment.port.in.command.vendor;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record RegisterFasstoDirectReturnDeliveryItemCommand(
+        String ordDt,
+        String supCd,
+        String orgParcelCd,
+        String orgInvoiceNo,
+        String inWay,
+        String custNm,
+        String rtnParcelComp,
+        String rtnInvoiceNo,
+        String rtnGubun,
+        String rtnReason,
+        String rtnDetailReason,
+        String remark,
+        List<RegisterFasstoDeliveryGoodsCommand> godCds
+) {
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/vendorcommunication/FulfillmentVendorCommunicationHistoryCommand.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/vendorcommunication/FulfillmentVendorCommunicationHistoryCommand.java
@@ -6,17 +6,16 @@ import com.personal.marketnote.fulfillment.domain.vendorcommunication.Fulfillmen
 import com.personal.marketnote.fulfillment.domain.vendorcommunication.FulfillmentVendorCommunicationType;
 import com.personal.marketnote.fulfillment.domain.vendorcommunication.FulfillmentVendorName;
 import lombok.Builder;
-import lombok.Getter;
 
-@Getter
 @Builder
-public class FulfillmentVendorCommunicationHistoryCommand {
-    private final FulfillmentVendorCommunicationTargetType targetType;
-    private final String targetId;
-    private final FulfillmentVendorName vendorName;
-    private final FulfillmentVendorCommunicationType communicationType;
-    private final FulfillmentVendorCommunicationSenderType sender;
-    private final String exception;
-    private final String payload;
-    private final JsonNode payloadJson;
+public record FulfillmentVendorCommunicationHistoryCommand(
+        FulfillmentVendorCommunicationTargetType targetType,
+        String targetId,
+        FulfillmentVendorName vendorName,
+        FulfillmentVendorCommunicationType communicationType,
+        FulfillmentVendorCommunicationSenderType sender,
+        String exception,
+        String payload,
+        JsonNode payloadJson
+) {
 }

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/usecase/vendor/RegisterFasstoDirectReturnDeliveryUseCase.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/usecase/vendor/RegisterFasstoDirectReturnDeliveryUseCase.java
@@ -1,0 +1,15 @@
+package com.personal.marketnote.fulfillment.port.in.usecase.vendor;
+
+import com.personal.marketnote.fulfillment.port.in.command.vendor.RegisterFasstoDirectReturnDeliveryCommand;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.RegisterFasstoDeliveryResult;
+
+public interface RegisterFasstoDirectReturnDeliveryUseCase {
+    /**
+     * @param command 반품 택배사 미지정 등록 커맨드
+     * @return 반품 택배사 미지정 등록 결과 {@link RegisterFasstoDeliveryResult}
+     * @Author Claude
+     * @Date 2026-02-20
+     * @Description 파스토 반품 택배사 미지정 등록을 요청합니다.
+     */
+    RegisterFasstoDeliveryResult registerDirectReturnDelivery(RegisterFasstoDirectReturnDeliveryCommand command);
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/vendor/RegisterFasstoDirectReturnDeliveryPort.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/vendor/RegisterFasstoDirectReturnDeliveryPort.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.fulfillment.port.out.vendor;
+
+import com.personal.marketnote.fulfillment.domain.vendor.fassto.returndelivery.FasstoDirectReturnDeliveryMapper;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.RegisterFasstoDeliveryResult;
+
+public interface RegisterFasstoDirectReturnDeliveryPort {
+    RegisterFasstoDeliveryResult registerDirectReturnDelivery(FasstoDirectReturnDeliveryMapper request);
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/vendor/RegisterFasstoDirectReturnDeliveryService.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/vendor/RegisterFasstoDirectReturnDeliveryService.java
@@ -1,0 +1,26 @@
+package com.personal.marketnote.fulfillment.service.vendor;
+
+import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.fulfillment.mapper.FasstoDirectReturnDeliveryCommandToRequestMapper;
+import com.personal.marketnote.fulfillment.port.in.command.vendor.RegisterFasstoDirectReturnDeliveryCommand;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.RegisterFasstoDeliveryResult;
+import com.personal.marketnote.fulfillment.port.in.usecase.vendor.RegisterFasstoDirectReturnDeliveryUseCase;
+import com.personal.marketnote.fulfillment.port.out.vendor.RegisterFasstoDirectReturnDeliveryPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional(isolation = READ_COMMITTED, readOnly = true)
+public class RegisterFasstoDirectReturnDeliveryService implements RegisterFasstoDirectReturnDeliveryUseCase {
+    private final RegisterFasstoDirectReturnDeliveryPort registerFasstoDirectReturnDeliveryPort;
+
+    @Override
+    public RegisterFasstoDeliveryResult registerDirectReturnDelivery(RegisterFasstoDirectReturnDeliveryCommand command) {
+        return registerFasstoDirectReturnDeliveryPort.registerDirectReturnDelivery(
+                FasstoDirectReturnDeliveryCommandToRequestMapper.mapToRegisterRequest(command)
+        );
+    }
+}

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/returndelivery/FasstoDirectReturnDeliveryItemMapper.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/returndelivery/FasstoDirectReturnDeliveryItemMapper.java
@@ -1,0 +1,115 @@
+package com.personal.marketnote.fulfillment.domain.vendor.fassto.returndelivery;
+
+import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.fulfillment.domain.vendor.fassto.delivery.FasstoDeliveryGoodsMapper;
+import lombok.*;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+public class FasstoDirectReturnDeliveryItemMapper {
+    private String ordDt;
+    private String supCd;
+    private String orgParcelCd;
+    private String orgInvoiceNo;
+    private String inWay;
+    private String custNm;
+    private String rtnParcelComp;
+    private String rtnInvoiceNo;
+    private String rtnGubun;
+    private String rtnReason;
+    private String rtnDetailReason;
+    private String remark;
+    private List<FasstoDeliveryGoodsMapper> godCds;
+
+    public static FasstoDirectReturnDeliveryItemMapper of(
+            String ordDt,
+            String supCd,
+            String orgParcelCd,
+            String orgInvoiceNo,
+            String inWay,
+            String custNm,
+            String rtnParcelComp,
+            String rtnInvoiceNo,
+            String rtnGubun,
+            String rtnReason,
+            String rtnDetailReason,
+            String remark,
+            List<FasstoDeliveryGoodsMapper> godCds
+    ) {
+        FasstoDirectReturnDeliveryItemMapper mapper = FasstoDirectReturnDeliveryItemMapper.builder()
+                .ordDt(ordDt)
+                .supCd(supCd)
+                .orgParcelCd(orgParcelCd)
+                .orgInvoiceNo(orgInvoiceNo)
+                .inWay(inWay)
+                .custNm(custNm)
+                .rtnParcelComp(rtnParcelComp)
+                .rtnInvoiceNo(rtnInvoiceNo)
+                .rtnGubun(rtnGubun)
+                .rtnReason(rtnReason)
+                .rtnDetailReason(rtnDetailReason)
+                .remark(remark)
+                .godCds(godCds)
+                .build();
+        mapper.validate();
+        return mapper;
+    }
+
+    public Map<String, Object> toPayload() {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        putIfHasValue(payload, "ordDt", ordDt);
+        putIfHasValue(payload, "supCd", supCd);
+        putIfHasValue(payload, "orgParcelCd", orgParcelCd);
+        putIfHasValue(payload, "orgInvoiceNo", orgInvoiceNo);
+        putIfHasValue(payload, "inWay", inWay);
+        putIfHasValue(payload, "custNm", custNm);
+        putIfHasValue(payload, "rtnParcelComp", rtnParcelComp);
+        putIfHasValue(payload, "rtnInvoiceNo", rtnInvoiceNo);
+        putIfHasValue(payload, "rtnGubun", rtnGubun);
+        putIfHasValue(payload, "rtnReason", rtnReason);
+        putIfHasValue(payload, "rtnDetailReason", rtnDetailReason);
+        putIfHasValue(payload, "remark", remark);
+        if (FormatValidator.hasValue(godCds)) {
+            payload.put("godCds", godCds.stream()
+                    .map(FasstoDeliveryGoodsMapper::toPayload)
+                    .toList());
+        }
+        return payload;
+    }
+
+    private void validate() {
+        if (FormatValidator.hasNoValue(ordDt)) {
+            throw new IllegalArgumentException("ordDt is required for direct return delivery request.");
+        }
+        if (FormatValidator.hasNoValue(orgParcelCd)) {
+            throw new IllegalArgumentException("orgParcelCd is required for direct return delivery request.");
+        }
+        if (FormatValidator.hasNoValue(orgInvoiceNo)) {
+            throw new IllegalArgumentException("orgInvoiceNo is required for direct return delivery request.");
+        }
+        if (FormatValidator.hasNoValue(inWay)) {
+            throw new IllegalArgumentException("inWay is required for direct return delivery request.");
+        }
+        if (FormatValidator.hasNoValue(custNm)) {
+            throw new IllegalArgumentException("custNm is required for direct return delivery request.");
+        }
+        if (FormatValidator.hasNoValue(rtnGubun)) {
+            throw new IllegalArgumentException("rtnGubun is required for direct return delivery request.");
+        }
+        if (FormatValidator.hasNoValue(rtnReason)) {
+            throw new IllegalArgumentException("rtnReason is required for direct return delivery request.");
+        }
+    }
+
+    private void putIfHasValue(Map<String, Object> payload, String key, String value) {
+        if (FormatValidator.hasValue(value)) {
+            payload.put(key, value);
+        }
+    }
+}

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/returndelivery/FasstoDirectReturnDeliveryMapper.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/returndelivery/FasstoDirectReturnDeliveryMapper.java
@@ -1,0 +1,49 @@
+package com.personal.marketnote.fulfillment.domain.vendor.fassto.returndelivery;
+
+import com.personal.marketnote.common.utility.FormatValidator;
+import lombok.*;
+
+import java.util.List;
+import java.util.Map;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+public class FasstoDirectReturnDeliveryMapper {
+    private String customerCode;
+    private String accessToken;
+    private List<FasstoDirectReturnDeliveryItemMapper> directReturnDeliveryRequests;
+
+    public static FasstoDirectReturnDeliveryMapper register(
+            String customerCode,
+            String accessToken,
+            List<FasstoDirectReturnDeliveryItemMapper> directReturnDeliveryRequests
+    ) {
+        FasstoDirectReturnDeliveryMapper mapper = FasstoDirectReturnDeliveryMapper.builder()
+                .customerCode(customerCode)
+                .accessToken(accessToken)
+                .directReturnDeliveryRequests(directReturnDeliveryRequests)
+                .build();
+        mapper.validate();
+        return mapper;
+    }
+
+    public List<Map<String, Object>> toPayload() {
+        return directReturnDeliveryRequests.stream()
+                .map(FasstoDirectReturnDeliveryItemMapper::toPayload)
+                .toList();
+    }
+
+    private void validate() {
+        if (FormatValidator.hasNoValue(customerCode)) {
+            throw new IllegalArgumentException("customerCode is required.");
+        }
+        if (FormatValidator.hasNoValue(accessToken)) {
+            throw new IllegalArgumentException("accessToken is required.");
+        }
+        if (FormatValidator.hasNoValue(directReturnDeliveryRequests)) {
+            throw new IllegalArgumentException("directReturnDeliveryRequests is required.");
+        }
+    }
+}


### PR DESCRIPTION
## partially addresses #475
## resolves #793

## Task
- [x] 파스토 반품 택배사 미지정 등록 연동 요청
- [x] 파스토 반품 택배사 미지정 등록 연동 비즈니스 로직
- [x] 파스토 서버에 반품 택배사 미지정 등록 요청
- [x] 200 status code 응답
- [x] Swagger docs