### PR TITLE
[#216][#797] test: 커머스 서비스 통신 기록 저장 기능 자동화 테스트 추가

### DIFF
--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/mapper/CommerceServiceCommunicationHistoryCommandToStateMapperTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/mapper/CommerceServiceCommunicationHistoryCommandToStateMapperTest.java
@@ -1,0 +1,250 @@
+package com.personal.marketnote.commerce.mapper;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.personal.marketnote.commerce.domain.servicecommunication.CommerceServiceCommunicationHistoryCreateState;
+import com.personal.marketnote.commerce.domain.servicecommunication.CommerceServiceCommunicationSenderType;
+import com.personal.marketnote.commerce.domain.servicecommunication.CommerceServiceCommunicationTargetType;
+import com.personal.marketnote.commerce.domain.servicecommunication.CommerceServiceCommunicationType;
+import com.personal.marketnote.commerce.port.in.command.servicecommunication.CommerceServiceCommunicationHistoryCommand;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CommerceServiceCommunicationHistoryCommandToStateMapperTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    @DisplayName("커맨드의 모든 필드가 CreateState로 정확히 매핑된다")
+    void mapToCreateState_allFields_mapsCorrectly() {
+        // given
+        JsonNode payloadJson = objectMapper.createObjectNode().put("key", "value");
+        CommerceServiceCommunicationHistoryCommand command = CommerceServiceCommunicationHistoryCommand.builder()
+                .targetType(CommerceServiceCommunicationTargetType.PRODUCT_INFO)
+                .targetId("target-123")
+                .communicationType(CommerceServiceCommunicationType.REQUEST)
+                .sender(CommerceServiceCommunicationSenderType.COMMERCE)
+                .exception("RuntimeException")
+                .payload("payload text")
+                .payloadJson(payloadJson)
+                .build();
+
+        // when
+        CommerceServiceCommunicationHistoryCreateState state =
+                CommerceServiceCommunicationHistoryCommandToStateMapper.mapToCreateState(command);
+
+        // then
+        assertThat(state.getTargetType()).isEqualTo(CommerceServiceCommunicationTargetType.PRODUCT_INFO);
+        assertThat(state.getTargetId()).isEqualTo("target-123");
+        assertThat(state.getCommunicationType()).isEqualTo(CommerceServiceCommunicationType.REQUEST);
+        assertThat(state.getSender()).isEqualTo(CommerceServiceCommunicationSenderType.COMMERCE);
+        assertThat(state.getException()).isEqualTo("RuntimeException");
+        assertThat(state.getPayload()).isEqualTo("payload text");
+        assertThat(state.getPayloadJson()).isEqualTo(payloadJson);
+    }
+
+    @Test
+    @DisplayName("커맨드의 선택 필드가 null이면 CreateState에도 null로 매핑된다")
+    void mapToCreateState_nullOptionalFields_mapsNulls() {
+        // given
+        CommerceServiceCommunicationHistoryCommand command = CommerceServiceCommunicationHistoryCommand.builder()
+                .targetType(CommerceServiceCommunicationTargetType.USER_POINT)
+                .targetId(null)
+                .communicationType(CommerceServiceCommunicationType.RESPONSE)
+                .sender(CommerceServiceCommunicationSenderType.USER)
+                .exception(null)
+                .payload(null)
+                .payloadJson(null)
+                .build();
+
+        // when
+        CommerceServiceCommunicationHistoryCreateState state =
+                CommerceServiceCommunicationHistoryCommandToStateMapper.mapToCreateState(command);
+
+        // then
+        assertThat(state.getTargetType()).isEqualTo(CommerceServiceCommunicationTargetType.USER_POINT);
+        assertThat(state.getCommunicationType()).isEqualTo(CommerceServiceCommunicationType.RESPONSE);
+        assertThat(state.getSender()).isEqualTo(CommerceServiceCommunicationSenderType.USER);
+        assertThat(state.getTargetId()).isNull();
+        assertThat(state.getException()).isNull();
+        assertThat(state.getPayload()).isNull();
+        assertThat(state.getPayloadJson()).isNull();
+    }
+
+    @Test
+    @DisplayName("각 TargetType이 정확히 매핑된다")
+    void mapToCreateState_eachTargetType_mapsCorrectly() {
+        for (CommerceServiceCommunicationTargetType targetType : CommerceServiceCommunicationTargetType.values()) {
+            // given
+            CommerceServiceCommunicationHistoryCommand command = CommerceServiceCommunicationHistoryCommand.builder()
+                    .targetType(targetType)
+                    .communicationType(CommerceServiceCommunicationType.REQUEST)
+                    .sender(CommerceServiceCommunicationSenderType.COMMERCE)
+                    .build();
+
+            // when
+            CommerceServiceCommunicationHistoryCreateState state =
+                    CommerceServiceCommunicationHistoryCommandToStateMapper.mapToCreateState(command);
+
+            // then
+            assertThat(state.getTargetType()).isEqualTo(targetType);
+        }
+    }
+
+    @Test
+    @DisplayName("각 SenderType이 정확히 매핑된다")
+    void mapToCreateState_eachSenderType_mapsCorrectly() {
+        for (CommerceServiceCommunicationSenderType senderType : CommerceServiceCommunicationSenderType.values()) {
+            // given
+            CommerceServiceCommunicationHistoryCommand command = CommerceServiceCommunicationHistoryCommand.builder()
+                    .targetType(CommerceServiceCommunicationTargetType.PRODUCT_INFO)
+                    .communicationType(CommerceServiceCommunicationType.REQUEST)
+                    .sender(senderType)
+                    .build();
+
+            // when
+            CommerceServiceCommunicationHistoryCreateState state =
+                    CommerceServiceCommunicationHistoryCommandToStateMapper.mapToCreateState(command);
+
+            // then
+            assertThat(state.getSender()).isEqualTo(senderType);
+        }
+    }
+
+    @Test
+    @DisplayName("각 CommunicationType이 정확히 매핑된다")
+    void mapToCreateState_eachCommunicationType_mapsCorrectly() {
+        for (CommerceServiceCommunicationType commType : CommerceServiceCommunicationType.values()) {
+            // given
+            CommerceServiceCommunicationHistoryCommand command = CommerceServiceCommunicationHistoryCommand.builder()
+                    .targetType(CommerceServiceCommunicationTargetType.PRODUCT_INFO)
+                    .communicationType(commType)
+                    .sender(CommerceServiceCommunicationSenderType.COMMERCE)
+                    .build();
+
+            // when
+            CommerceServiceCommunicationHistoryCreateState state =
+                    CommerceServiceCommunicationHistoryCommandToStateMapper.mapToCreateState(command);
+
+            // then
+            assertThat(state.getCommunicationType()).isEqualTo(commType);
+        }
+    }
+
+    @Test
+    @DisplayName("복합 JSON payloadJson이 정확히 매핑된다")
+    void mapToCreateState_complexJsonPayload_mapsCorrectly() {
+        // given
+        ObjectNode body = objectMapper.createObjectNode();
+        body.put("productId", 100);
+        body.put("quantity", 5);
+        ObjectNode complexJson = objectMapper.createObjectNode();
+        complexJson.put("method", "POST");
+        complexJson.put("url", "http://api.example.com");
+        complexJson.put("attempt", 3);
+        complexJson.set("body", body);
+
+        CommerceServiceCommunicationHistoryCommand command = CommerceServiceCommunicationHistoryCommand.builder()
+                .targetType(CommerceServiceCommunicationTargetType.CART_PRODUCT)
+                .communicationType(CommerceServiceCommunicationType.REQUEST)
+                .sender(CommerceServiceCommunicationSenderType.COMMERCE)
+                .payloadJson(complexJson)
+                .build();
+
+        // when
+        CommerceServiceCommunicationHistoryCreateState state =
+                CommerceServiceCommunicationHistoryCommandToStateMapper.mapToCreateState(command);
+
+        // then
+        assertThat(state.getPayloadJson()).isEqualTo(complexJson);
+        assertThat(state.getPayloadJson().get("method").asText()).isEqualTo("POST");
+        assertThat(state.getPayloadJson().get("url").asText()).isEqualTo("http://api.example.com");
+        assertThat(state.getPayloadJson().get("attempt").asInt()).isEqualTo(3);
+        assertThat(state.getPayloadJson().get("body").get("productId").asInt()).isEqualTo(100);
+        assertThat(state.getPayloadJson().get("body").get("quantity").asInt()).isEqualTo(5);
+    }
+
+    @Test
+    @DisplayName("payload만 있고 payloadJson이 null이면 독립적으로 매핑된다")
+    void mapToCreateState_payloadOnlyWithoutJson_mapsIndependently() {
+        // given
+        CommerceServiceCommunicationHistoryCommand command = CommerceServiceCommunicationHistoryCommand.builder()
+                .targetType(CommerceServiceCommunicationTargetType.CART_PRODUCT)
+                .communicationType(CommerceServiceCommunicationType.RESPONSE)
+                .sender(CommerceServiceCommunicationSenderType.PRODUCT)
+                .payload("text payload")
+                .payloadJson(null)
+                .build();
+
+        // when
+        CommerceServiceCommunicationHistoryCreateState state =
+                CommerceServiceCommunicationHistoryCommandToStateMapper.mapToCreateState(command);
+
+        // then
+        assertThat(state.getPayload()).isEqualTo("text payload");
+        assertThat(state.getPayloadJson()).isNull();
+    }
+
+    @Test
+    @DisplayName("payloadJson만 있고 payload가 null이면 독립적으로 매핑된다")
+    void mapToCreateState_payloadJsonOnlyWithoutText_mapsIndependently() {
+        // given
+        JsonNode json = objectMapper.createObjectNode().put("status", 200);
+        CommerceServiceCommunicationHistoryCommand command = CommerceServiceCommunicationHistoryCommand.builder()
+                .targetType(CommerceServiceCommunicationTargetType.USER_POINT)
+                .communicationType(CommerceServiceCommunicationType.RESPONSE)
+                .sender(CommerceServiceCommunicationSenderType.USER)
+                .payload(null)
+                .payloadJson(json)
+                .build();
+
+        // when
+        CommerceServiceCommunicationHistoryCreateState state =
+                CommerceServiceCommunicationHistoryCommandToStateMapper.mapToCreateState(command);
+
+        // then
+        assertThat(state.getPayload()).isNull();
+        assertThat(state.getPayloadJson()).isEqualTo(json);
+    }
+
+    @Test
+    @DisplayName("targetId가 빈 문자열이면 빈 문자열 그대로 매핑된다")
+    void mapToCreateState_emptyTargetId_mapsAsEmptyString() {
+        // given
+        CommerceServiceCommunicationHistoryCommand command = CommerceServiceCommunicationHistoryCommand.builder()
+                .targetType(CommerceServiceCommunicationTargetType.PRODUCT_INFO)
+                .targetId("")
+                .communicationType(CommerceServiceCommunicationType.REQUEST)
+                .sender(CommerceServiceCommunicationSenderType.COMMERCE)
+                .build();
+
+        // when
+        CommerceServiceCommunicationHistoryCreateState state =
+                CommerceServiceCommunicationHistoryCommandToStateMapper.mapToCreateState(command);
+
+        // then
+        assertThat(state.getTargetId()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("exception이 빈 문자열이면 빈 문자열 그대로 매핑된다")
+    void mapToCreateState_emptyException_mapsAsEmptyString() {
+        // given
+        CommerceServiceCommunicationHistoryCommand command = CommerceServiceCommunicationHistoryCommand.builder()
+                .targetType(CommerceServiceCommunicationTargetType.PRODUCT_INFO)
+                .communicationType(CommerceServiceCommunicationType.REQUEST)
+                .sender(CommerceServiceCommunicationSenderType.COMMERCE)
+                .exception("")
+                .build();
+
+        // when
+        CommerceServiceCommunicationHistoryCreateState state =
+                CommerceServiceCommunicationHistoryCommandToStateMapper.mapToCreateState(command);
+
+        // then
+        assertThat(state.getException()).isEmpty();
+    }
+}

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/servicecommunication/RecordCommerceServiceCommunicationHistoryUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/servicecommunication/RecordCommerceServiceCommunicationHistoryUseCaseTest.java
@@ -1,0 +1,763 @@
+package com.personal.marketnote.commerce.service.servicecommunication;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.personal.marketnote.commerce.domain.servicecommunication.*;
+import com.personal.marketnote.commerce.port.in.command.servicecommunication.CommerceServiceCommunicationHistoryCommand;
+import com.personal.marketnote.commerce.port.out.servicecommunication.SaveCommerceServiceCommunicationHistoryPort;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class RecordCommerceServiceCommunicationHistoryUseCaseTest {
+
+    @Mock
+    private SaveCommerceServiceCommunicationHistoryPort saveServiceCommunicationHistoryPort;
+
+    @InjectMocks
+    private RecordCommerceServiceCommunicationHistoryService recordService;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    @DisplayName("커머스 서비스 통신 기록 저장 시 모든 필드가 정확히 매핑되어 저장된다")
+    void record_withAllFields_savesWithAllFieldsMapped() {
+        // given
+        JsonNode payloadJson = objectMapper.createObjectNode().put("key", "value");
+        CommerceServiceCommunicationHistoryCommand command = buildCommand(
+                CommerceServiceCommunicationTargetType.PRODUCT_INFO,
+                "target-123",
+                CommerceServiceCommunicationType.REQUEST,
+                CommerceServiceCommunicationSenderType.COMMERCE,
+                "NullPointerException",
+                "payload text",
+                payloadJson
+        );
+        CommerceServiceCommunicationHistory savedHistory = buildHistory(
+                1L,
+                CommerceServiceCommunicationTargetType.PRODUCT_INFO,
+                "target-123",
+                CommerceServiceCommunicationType.REQUEST,
+                CommerceServiceCommunicationSenderType.COMMERCE,
+                "NullPointerException",
+                "payload text",
+                payloadJson,
+                LocalDateTime.of(2026, 2, 3, 12, 0, 0)
+        );
+        when(saveServiceCommunicationHistoryPort.save(any(CommerceServiceCommunicationHistory.class)))
+                .thenReturn(savedHistory);
+
+        // when
+        CommerceServiceCommunicationHistory result = recordService.record(command);
+
+        // then
+        ArgumentCaptor<CommerceServiceCommunicationHistory> captor =
+                ArgumentCaptor.forClass(CommerceServiceCommunicationHistory.class);
+        verify(saveServiceCommunicationHistoryPort).save(captor.capture());
+
+        CommerceServiceCommunicationHistory captured = captor.getValue();
+        assertThat(captured.getTargetType()).isEqualTo(CommerceServiceCommunicationTargetType.PRODUCT_INFO);
+        assertThat(captured.getTargetId()).isEqualTo("target-123");
+        assertThat(captured.getCommunicationType()).isEqualTo(CommerceServiceCommunicationType.REQUEST);
+        assertThat(captured.getSender()).isEqualTo(CommerceServiceCommunicationSenderType.COMMERCE);
+        assertThat(captured.getException()).isEqualTo("NullPointerException");
+        assertThat(captured.getPayload()).isEqualTo("payload text");
+        assertThat(captured.getPayloadJson()).isEqualTo(payloadJson);
+        assertThat(result).isSameAs(savedHistory);
+    }
+
+    @Test
+    @DisplayName("커머스 서비스 통신 기록 저장 시 선택 필드가 null이면 null로 저장된다")
+    void record_withRequiredFieldsOnly_savesWithNullOptionalFields() {
+        // given
+        CommerceServiceCommunicationHistoryCommand command = buildCommand(
+                CommerceServiceCommunicationTargetType.USER_POINT,
+                null,
+                CommerceServiceCommunicationType.RESPONSE,
+                CommerceServiceCommunicationSenderType.USER,
+                null,
+                null,
+                null
+        );
+        when(saveServiceCommunicationHistoryPort.save(any(CommerceServiceCommunicationHistory.class)))
+                .thenReturn(buildMinimalHistory());
+
+        // when
+        recordService.record(command);
+
+        // then
+        ArgumentCaptor<CommerceServiceCommunicationHistory> captor =
+                ArgumentCaptor.forClass(CommerceServiceCommunicationHistory.class);
+        verify(saveServiceCommunicationHistoryPort).save(captor.capture());
+
+        CommerceServiceCommunicationHistory captured = captor.getValue();
+        assertThat(captured.getTargetType()).isEqualTo(CommerceServiceCommunicationTargetType.USER_POINT);
+        assertThat(captured.getCommunicationType()).isEqualTo(CommerceServiceCommunicationType.RESPONSE);
+        assertThat(captured.getSender()).isEqualTo(CommerceServiceCommunicationSenderType.USER);
+        assertThat(captured.getTargetId()).isNull();
+        assertThat(captured.getException()).isNull();
+        assertThat(captured.getPayload()).isNull();
+        assertThat(captured.getPayloadJson()).isNull();
+    }
+
+    @Test
+    @DisplayName("커머스 서비스 통신 기록 저장 시 REQUEST 통신 타입이 정확히 매핑된다")
+    void record_requestCommunicationType_mapsCorrectly() {
+        // given
+        CommerceServiceCommunicationHistoryCommand command = buildCommand(
+                CommerceServiceCommunicationTargetType.PRODUCT_INFO,
+                null,
+                CommerceServiceCommunicationType.REQUEST,
+                CommerceServiceCommunicationSenderType.COMMERCE,
+                null,
+                null,
+                null
+        );
+        when(saveServiceCommunicationHistoryPort.save(any(CommerceServiceCommunicationHistory.class)))
+                .thenReturn(buildMinimalHistory());
+
+        // when
+        recordService.record(command);
+
+        // then
+        ArgumentCaptor<CommerceServiceCommunicationHistory> captor =
+                ArgumentCaptor.forClass(CommerceServiceCommunicationHistory.class);
+        verify(saveServiceCommunicationHistoryPort).save(captor.capture());
+        assertThat(captor.getValue().getCommunicationType()).isEqualTo(CommerceServiceCommunicationType.REQUEST);
+    }
+
+    @Test
+    @DisplayName("커머스 서비스 통신 기록 저장 시 RESPONSE 통신 타입이 정확히 매핑된다")
+    void record_responseCommunicationType_mapsCorrectly() {
+        // given
+        CommerceServiceCommunicationHistoryCommand command = buildCommand(
+                CommerceServiceCommunicationTargetType.PRODUCT_INFO,
+                null,
+                CommerceServiceCommunicationType.RESPONSE,
+                CommerceServiceCommunicationSenderType.PRODUCT,
+                null,
+                null,
+                null
+        );
+        when(saveServiceCommunicationHistoryPort.save(any(CommerceServiceCommunicationHistory.class)))
+                .thenReturn(buildMinimalHistory());
+
+        // when
+        recordService.record(command);
+
+        // then
+        ArgumentCaptor<CommerceServiceCommunicationHistory> captor =
+                ArgumentCaptor.forClass(CommerceServiceCommunicationHistory.class);
+        verify(saveServiceCommunicationHistoryPort).save(captor.capture());
+        assertThat(captor.getValue().getCommunicationType()).isEqualTo(CommerceServiceCommunicationType.RESPONSE);
+    }
+
+    @Test
+    @DisplayName("커머스 서비스 통신 기록 저장 시 각 발신자 타입이 정확히 매핑된다")
+    void record_eachSenderType_mapsCorrectly() {
+        for (CommerceServiceCommunicationSenderType senderType : CommerceServiceCommunicationSenderType.values()) {
+            // given
+            CommerceServiceCommunicationHistoryCommand command = buildCommand(
+                    CommerceServiceCommunicationTargetType.PRODUCT_INFO,
+                    null,
+                    CommerceServiceCommunicationType.REQUEST,
+                    senderType,
+                    null,
+                    null,
+                    null
+            );
+            when(saveServiceCommunicationHistoryPort.save(any(CommerceServiceCommunicationHistory.class)))
+                    .thenReturn(buildMinimalHistory());
+
+            // when
+            recordService.record(command);
+
+            // then
+            ArgumentCaptor<CommerceServiceCommunicationHistory> captor =
+                    ArgumentCaptor.forClass(CommerceServiceCommunicationHistory.class);
+            verify(saveServiceCommunicationHistoryPort, atLeastOnce()).save(captor.capture());
+            assertThat(captor.getValue().getSender()).isEqualTo(senderType);
+            clearInvocations(saveServiceCommunicationHistoryPort);
+        }
+    }
+
+    @Test
+    @DisplayName("커머스 서비스 통신 기록 저장 시 각 대상 타입이 정확히 매핑된다")
+    void record_eachTargetType_mapsCorrectly() {
+        for (CommerceServiceCommunicationTargetType targetType : CommerceServiceCommunicationTargetType.values()) {
+            // given
+            CommerceServiceCommunicationHistoryCommand command = buildCommand(
+                    targetType,
+                    null,
+                    CommerceServiceCommunicationType.REQUEST,
+                    CommerceServiceCommunicationSenderType.COMMERCE,
+                    null,
+                    null,
+                    null
+            );
+            when(saveServiceCommunicationHistoryPort.save(any(CommerceServiceCommunicationHistory.class)))
+                    .thenReturn(buildMinimalHistory());
+
+            // when
+            recordService.record(command);
+
+            // then
+            ArgumentCaptor<CommerceServiceCommunicationHistory> captor =
+                    ArgumentCaptor.forClass(CommerceServiceCommunicationHistory.class);
+            verify(saveServiceCommunicationHistoryPort, atLeastOnce()).save(captor.capture());
+            assertThat(captor.getValue().getTargetType()).isEqualTo(targetType);
+            clearInvocations(saveServiceCommunicationHistoryPort);
+        }
+    }
+
+    @Test
+    @DisplayName("커머스 서비스 통신 기록 저장 시 payload만 있고 payloadJson이 null이면 정상 저장된다")
+    void record_withPayloadOnly_savesCorrectly() {
+        // given
+        CommerceServiceCommunicationHistoryCommand command = buildCommand(
+                CommerceServiceCommunicationTargetType.CART_PRODUCT,
+                null,
+                CommerceServiceCommunicationType.RESPONSE,
+                CommerceServiceCommunicationSenderType.PRODUCT,
+                null,
+                "text payload only",
+                null
+        );
+        when(saveServiceCommunicationHistoryPort.save(any(CommerceServiceCommunicationHistory.class)))
+                .thenReturn(buildMinimalHistory());
+
+        // when
+        recordService.record(command);
+
+        // then
+        ArgumentCaptor<CommerceServiceCommunicationHistory> captor =
+                ArgumentCaptor.forClass(CommerceServiceCommunicationHistory.class);
+        verify(saveServiceCommunicationHistoryPort).save(captor.capture());
+
+        CommerceServiceCommunicationHistory captured = captor.getValue();
+        assertThat(captured.getPayload()).isEqualTo("text payload only");
+        assertThat(captured.getPayloadJson()).isNull();
+    }
+
+    @Test
+    @DisplayName("커머스 서비스 통신 기록 저장 시 payloadJson만 있고 payload가 null이면 정상 저장된다")
+    void record_withPayloadJsonOnly_savesCorrectly() {
+        // given
+        JsonNode json = objectMapper.createObjectNode().put("status", 500);
+        CommerceServiceCommunicationHistoryCommand command = buildCommand(
+                CommerceServiceCommunicationTargetType.USER_POINT,
+                null,
+                CommerceServiceCommunicationType.RESPONSE,
+                CommerceServiceCommunicationSenderType.USER,
+                null,
+                null,
+                json
+        );
+        when(saveServiceCommunicationHistoryPort.save(any(CommerceServiceCommunicationHistory.class)))
+                .thenReturn(buildMinimalHistory());
+
+        // when
+        recordService.record(command);
+
+        // then
+        ArgumentCaptor<CommerceServiceCommunicationHistory> captor =
+                ArgumentCaptor.forClass(CommerceServiceCommunicationHistory.class);
+        verify(saveServiceCommunicationHistoryPort).save(captor.capture());
+
+        CommerceServiceCommunicationHistory captured = captor.getValue();
+        assertThat(captured.getPayload()).isNull();
+        assertThat(captured.getPayloadJson()).isEqualTo(json);
+    }
+
+    @Test
+    @DisplayName("커머스 서비스 통신 기록 저장 시 targetId가 존재하면 정확히 매핑된다")
+    void record_withTargetId_mapsTargetIdCorrectly() {
+        // given
+        CommerceServiceCommunicationHistoryCommand command = buildCommand(
+                CommerceServiceCommunicationTargetType.CART_PRODUCT,
+                "cart-456",
+                CommerceServiceCommunicationType.REQUEST,
+                CommerceServiceCommunicationSenderType.COMMERCE,
+                null,
+                null,
+                null
+        );
+        when(saveServiceCommunicationHistoryPort.save(any(CommerceServiceCommunicationHistory.class)))
+                .thenReturn(buildMinimalHistory());
+
+        // when
+        recordService.record(command);
+
+        // then
+        ArgumentCaptor<CommerceServiceCommunicationHistory> captor =
+                ArgumentCaptor.forClass(CommerceServiceCommunicationHistory.class);
+        verify(saveServiceCommunicationHistoryPort).save(captor.capture());
+        assertThat(captor.getValue().getTargetId()).isEqualTo("cart-456");
+    }
+
+    @Test
+    @DisplayName("커머스 서비스 통신 기록 저장 시 exception이 존재하면 정확히 매핑된다")
+    void record_withException_mapsExceptionCorrectly() {
+        // given
+        CommerceServiceCommunicationHistoryCommand command = buildCommand(
+                CommerceServiceCommunicationTargetType.PRODUCT_INFO,
+                null,
+                CommerceServiceCommunicationType.REQUEST,
+                CommerceServiceCommunicationSenderType.COMMERCE,
+                "HttpClientErrorException",
+                null,
+                null
+        );
+        when(saveServiceCommunicationHistoryPort.save(any(CommerceServiceCommunicationHistory.class)))
+                .thenReturn(buildMinimalHistory());
+
+        // when
+        recordService.record(command);
+
+        // then
+        ArgumentCaptor<CommerceServiceCommunicationHistory> captor =
+                ArgumentCaptor.forClass(CommerceServiceCommunicationHistory.class);
+        verify(saveServiceCommunicationHistoryPort).save(captor.capture());
+        assertThat(captor.getValue().getException()).isEqualTo("HttpClientErrorException");
+    }
+
+    @Test
+    @DisplayName("커머스 서비스 통신 기록 저장 시 SavePort가 정확히 한 번 호출된다")
+    void record_callsSavePortExactlyOnce() {
+        // given
+        CommerceServiceCommunicationHistoryCommand command = buildCommand(
+                CommerceServiceCommunicationTargetType.PRODUCT_INFO,
+                null,
+                CommerceServiceCommunicationType.REQUEST,
+                CommerceServiceCommunicationSenderType.COMMERCE,
+                null,
+                null,
+                null
+        );
+        when(saveServiceCommunicationHistoryPort.save(any(CommerceServiceCommunicationHistory.class)))
+                .thenReturn(buildMinimalHistory());
+
+        // when
+        recordService.record(command);
+
+        // then
+        verify(saveServiceCommunicationHistoryPort, times(1)).save(any(CommerceServiceCommunicationHistory.class));
+        verifyNoMoreInteractions(saveServiceCommunicationHistoryPort);
+    }
+
+    @Test
+    @DisplayName("커머스 서비스 통신 기록 저장 시 SavePort의 반환값이 그대로 반환된다")
+    void record_returnsExactResultFromPort() {
+        // given
+        JsonNode payloadJson = objectMapper.createObjectNode().put("method", "GET");
+        CommerceServiceCommunicationHistoryCommand command = buildCommand(
+                CommerceServiceCommunicationTargetType.PRODUCT_INFO,
+                "product-789",
+                CommerceServiceCommunicationType.REQUEST,
+                CommerceServiceCommunicationSenderType.COMMERCE,
+                null,
+                "GET /api/products/info",
+                payloadJson
+        );
+        CommerceServiceCommunicationHistory expectedResult = buildHistory(
+                100L,
+                CommerceServiceCommunicationTargetType.PRODUCT_INFO,
+                "product-789",
+                CommerceServiceCommunicationType.REQUEST,
+                CommerceServiceCommunicationSenderType.COMMERCE,
+                null,
+                "GET /api/products/info",
+                payloadJson,
+                LocalDateTime.of(2026, 2, 3, 15, 30, 0)
+        );
+        when(saveServiceCommunicationHistoryPort.save(any(CommerceServiceCommunicationHistory.class)))
+                .thenReturn(expectedResult);
+
+        // when
+        CommerceServiceCommunicationHistory result = recordService.record(command);
+
+        // then
+        assertThat(result).isSameAs(expectedResult);
+        assertThat(result.getId()).isEqualTo(100L);
+        assertThat(result.getCreatedAt()).isEqualTo(LocalDateTime.of(2026, 2, 3, 15, 30, 0));
+    }
+
+    @Test
+    @DisplayName("커머스 서비스 통신 기록 저장 시 저장 전 도메인 객체에는 id와 createdAt이 null이다")
+    void record_historyBeforeSave_hasNoIdAndCreatedAt() {
+        // given
+        CommerceServiceCommunicationHistoryCommand command = buildCommand(
+                CommerceServiceCommunicationTargetType.PRODUCT_INFO,
+                null,
+                CommerceServiceCommunicationType.REQUEST,
+                CommerceServiceCommunicationSenderType.COMMERCE,
+                null,
+                null,
+                null
+        );
+        when(saveServiceCommunicationHistoryPort.save(any(CommerceServiceCommunicationHistory.class)))
+                .thenReturn(buildMinimalHistory());
+
+        // when
+        recordService.record(command);
+
+        // then
+        ArgumentCaptor<CommerceServiceCommunicationHistory> captor =
+                ArgumentCaptor.forClass(CommerceServiceCommunicationHistory.class);
+        verify(saveServiceCommunicationHistoryPort).save(captor.capture());
+
+        CommerceServiceCommunicationHistory captured = captor.getValue();
+        assertThat(captured.getId()).isNull();
+        assertThat(captured.getCreatedAt()).isNull();
+    }
+
+    @Test
+    @DisplayName("커머스 서비스 통신 기록 저장 시 복합 JSON payload가 정확히 매핑된다")
+    void record_withComplexJsonPayload_mapsCorrectly() {
+        // given
+        ObjectNode body = objectMapper.createObjectNode();
+        body.put("productId", 100);
+        body.put("quantity", 5);
+        ObjectNode complexJson = objectMapper.createObjectNode();
+        complexJson.put("method", "POST");
+        complexJson.put("url", "http://api.example.com/products/info");
+        complexJson.put("attempt", 3);
+        complexJson.set("body", body);
+
+        CommerceServiceCommunicationHistoryCommand command = buildCommand(
+                CommerceServiceCommunicationTargetType.PRODUCT_INFO,
+                "100",
+                CommerceServiceCommunicationType.REQUEST,
+                CommerceServiceCommunicationSenderType.COMMERCE,
+                null,
+                "{\"method\":\"POST\",\"url\":\"http://api.example.com/products/info\"}",
+                complexJson
+        );
+        when(saveServiceCommunicationHistoryPort.save(any(CommerceServiceCommunicationHistory.class)))
+                .thenReturn(buildMinimalHistory());
+
+        // when
+        recordService.record(command);
+
+        // then
+        ArgumentCaptor<CommerceServiceCommunicationHistory> captor =
+                ArgumentCaptor.forClass(CommerceServiceCommunicationHistory.class);
+        verify(saveServiceCommunicationHistoryPort).save(captor.capture());
+
+        CommerceServiceCommunicationHistory captured = captor.getValue();
+        assertThat(captured.getPayloadJson()).isEqualTo(complexJson);
+        assertThat(captured.getPayloadJson().get("method").asText()).isEqualTo("POST");
+        assertThat(captured.getPayloadJson().get("attempt").asInt()).isEqualTo(3);
+        assertThat(captured.getPayloadJson().get("body").get("productId").asInt()).isEqualTo(100);
+        assertThat(captured.getPayloadJson().get("body").get("quantity").asInt()).isEqualTo(5);
+    }
+
+    @Test
+    @DisplayName("상품 서비스 상품 정보 조회 실패 응답 기록이 정확히 저장된다")
+    void record_productInfoFailureResponse_savesCorrectly() {
+        // given
+        ObjectNode errorPayload = objectMapper.createObjectNode();
+        errorPayload.put("error", "Not Found");
+        errorPayload.put("message", "상품을 찾을 수 없습니다");
+        errorPayload.put("attempt", 1);
+
+        CommerceServiceCommunicationHistoryCommand command = buildCommand(
+                CommerceServiceCommunicationTargetType.PRODUCT_INFO,
+                "product-100",
+                CommerceServiceCommunicationType.RESPONSE,
+                CommerceServiceCommunicationSenderType.PRODUCT,
+                "HttpClientErrorException",
+                "404 Not Found",
+                errorPayload
+        );
+        CommerceServiceCommunicationHistory savedHistory = buildHistory(
+                50L,
+                CommerceServiceCommunicationTargetType.PRODUCT_INFO,
+                "product-100",
+                CommerceServiceCommunicationType.RESPONSE,
+                CommerceServiceCommunicationSenderType.PRODUCT,
+                "HttpClientErrorException",
+                "404 Not Found",
+                errorPayload,
+                LocalDateTime.of(2026, 2, 3, 10, 0, 0)
+        );
+        when(saveServiceCommunicationHistoryPort.save(any(CommerceServiceCommunicationHistory.class)))
+                .thenReturn(savedHistory);
+
+        // when
+        CommerceServiceCommunicationHistory result = recordService.record(command);
+
+        // then
+        ArgumentCaptor<CommerceServiceCommunicationHistory> captor =
+                ArgumentCaptor.forClass(CommerceServiceCommunicationHistory.class);
+        verify(saveServiceCommunicationHistoryPort).save(captor.capture());
+
+        CommerceServiceCommunicationHistory captured = captor.getValue();
+        assertThat(captured.getTargetType()).isEqualTo(CommerceServiceCommunicationTargetType.PRODUCT_INFO);
+        assertThat(captured.getTargetId()).isEqualTo("product-100");
+        assertThat(captured.getCommunicationType()).isEqualTo(CommerceServiceCommunicationType.RESPONSE);
+        assertThat(captured.getSender()).isEqualTo(CommerceServiceCommunicationSenderType.PRODUCT);
+        assertThat(captured.getException()).isEqualTo("HttpClientErrorException");
+        assertThat(captured.getPayload()).isEqualTo("404 Not Found");
+        assertThat(result.getId()).isEqualTo(50L);
+        assertThat(result.getCreatedAt()).isEqualTo(LocalDateTime.of(2026, 2, 3, 10, 0, 0));
+    }
+
+    @Test
+    @DisplayName("유저 서비스 포인트 차감 요청 기록이 정확히 저장된다")
+    void record_userPointDeductionRequest_savesCorrectly() {
+        // given
+        ObjectNode requestPayload = objectMapper.createObjectNode();
+        requestPayload.put("method", "POST");
+        requestPayload.put("url", "http://user/api/points/deduct");
+        requestPayload.put("attempt", 1);
+
+        CommerceServiceCommunicationHistoryCommand command = buildCommand(
+                CommerceServiceCommunicationTargetType.USER_POINT,
+                "user-200",
+                CommerceServiceCommunicationType.REQUEST,
+                CommerceServiceCommunicationSenderType.COMMERCE,
+                null,
+                "POST /api/points/deduct",
+                requestPayload
+        );
+        when(saveServiceCommunicationHistoryPort.save(any(CommerceServiceCommunicationHistory.class)))
+                .thenReturn(buildMinimalHistory());
+
+        // when
+        recordService.record(command);
+
+        // then
+        ArgumentCaptor<CommerceServiceCommunicationHistory> captor =
+                ArgumentCaptor.forClass(CommerceServiceCommunicationHistory.class);
+        verify(saveServiceCommunicationHistoryPort).save(captor.capture());
+
+        CommerceServiceCommunicationHistory captured = captor.getValue();
+        assertThat(captured.getTargetType()).isEqualTo(CommerceServiceCommunicationTargetType.USER_POINT);
+        assertThat(captured.getTargetId()).isEqualTo("user-200");
+        assertThat(captured.getCommunicationType()).isEqualTo(CommerceServiceCommunicationType.REQUEST);
+        assertThat(captured.getSender()).isEqualTo(CommerceServiceCommunicationSenderType.COMMERCE);
+        assertThat(captured.getException()).isNull();
+    }
+
+    @Test
+    @DisplayName("유저 서비스 포인트 조회 실패 응답 기록이 정확히 저장된다")
+    void record_userPointQueryFailureResponse_savesCorrectly() {
+        // given
+        ObjectNode errorPayload = objectMapper.createObjectNode();
+        errorPayload.put("error", "RestClientException");
+        errorPayload.put("message", "Connection refused");
+        errorPayload.put("attempt", 3);
+
+        CommerceServiceCommunicationHistoryCommand command = buildCommand(
+                CommerceServiceCommunicationTargetType.USER_POINT,
+                "user-300",
+                CommerceServiceCommunicationType.RESPONSE,
+                CommerceServiceCommunicationSenderType.USER,
+                "RestClientException",
+                "GET /api/points",
+                errorPayload
+        );
+        when(saveServiceCommunicationHistoryPort.save(any(CommerceServiceCommunicationHistory.class)))
+                .thenReturn(buildMinimalHistory());
+
+        // when
+        recordService.record(command);
+
+        // then
+        ArgumentCaptor<CommerceServiceCommunicationHistory> captor =
+                ArgumentCaptor.forClass(CommerceServiceCommunicationHistory.class);
+        verify(saveServiceCommunicationHistoryPort).save(captor.capture());
+
+        CommerceServiceCommunicationHistory captured = captor.getValue();
+        assertThat(captured.getTargetType()).isEqualTo(CommerceServiceCommunicationTargetType.USER_POINT);
+        assertThat(captured.getTargetId()).isEqualTo("user-300");
+        assertThat(captured.getSender()).isEqualTo(CommerceServiceCommunicationSenderType.USER);
+        assertThat(captured.getException()).isEqualTo("RestClientException");
+        assertThat(captured.getPayload()).isEqualTo("GET /api/points");
+    }
+
+    @Test
+    @DisplayName("장바구니 상품 조회 실패 응답 기록이 정확히 저장된다")
+    void record_cartProductQueryFailureResponse_savesCorrectly() {
+        // given
+        ObjectNode responsePayload = objectMapper.createObjectNode();
+        responsePayload.put("status", 500);
+        responsePayload.put("message", "Internal Server Error");
+
+        CommerceServiceCommunicationHistoryCommand command = buildCommand(
+                CommerceServiceCommunicationTargetType.CART_PRODUCT,
+                "cart-400",
+                CommerceServiceCommunicationType.RESPONSE,
+                CommerceServiceCommunicationSenderType.PRODUCT,
+                "HttpServerErrorException",
+                "500 Internal Server Error",
+                responsePayload
+        );
+        when(saveServiceCommunicationHistoryPort.save(any(CommerceServiceCommunicationHistory.class)))
+                .thenReturn(buildMinimalHistory());
+
+        // when
+        recordService.record(command);
+
+        // then
+        ArgumentCaptor<CommerceServiceCommunicationHistory> captor =
+                ArgumentCaptor.forClass(CommerceServiceCommunicationHistory.class);
+        verify(saveServiceCommunicationHistoryPort).save(captor.capture());
+
+        CommerceServiceCommunicationHistory captured = captor.getValue();
+        assertThat(captured.getTargetType()).isEqualTo(CommerceServiceCommunicationTargetType.CART_PRODUCT);
+        assertThat(captured.getTargetId()).isEqualTo("cart-400");
+        assertThat(captured.getCommunicationType()).isEqualTo(CommerceServiceCommunicationType.RESPONSE);
+        assertThat(captured.getSender()).isEqualTo(CommerceServiceCommunicationSenderType.PRODUCT);
+        assertThat(captured.getException()).isEqualTo("HttpServerErrorException");
+    }
+
+    @Test
+    @DisplayName("상품 정보 동기화 요청 기록이 정확히 저장된다")
+    void record_productInfoSyncRequest_savesCorrectly() {
+        // given
+        ObjectNode requestBody = objectMapper.createObjectNode();
+        requestBody.put("productName", "테스트 상품");
+        requestBody.put("price", 15000);
+        ObjectNode requestPayload = objectMapper.createObjectNode();
+        requestPayload.put("method", "POST");
+        requestPayload.put("url", "http://product/api/products/info");
+        requestPayload.put("attempt", 1);
+        requestPayload.set("body", requestBody);
+
+        CommerceServiceCommunicationHistoryCommand command = buildCommand(
+                CommerceServiceCommunicationTargetType.PRODUCT_INFO,
+                "product-500",
+                CommerceServiceCommunicationType.REQUEST,
+                CommerceServiceCommunicationSenderType.COMMERCE,
+                null,
+                "POST /api/products/info",
+                requestPayload
+        );
+        when(saveServiceCommunicationHistoryPort.save(any(CommerceServiceCommunicationHistory.class)))
+                .thenReturn(buildMinimalHistory());
+
+        // when
+        recordService.record(command);
+
+        // then
+        ArgumentCaptor<CommerceServiceCommunicationHistory> captor =
+                ArgumentCaptor.forClass(CommerceServiceCommunicationHistory.class);
+        verify(saveServiceCommunicationHistoryPort).save(captor.capture());
+
+        CommerceServiceCommunicationHistory captured = captor.getValue();
+        assertThat(captured.getTargetType()).isEqualTo(CommerceServiceCommunicationTargetType.PRODUCT_INFO);
+        assertThat(captured.getTargetId()).isEqualTo("product-500");
+        assertThat(captured.getCommunicationType()).isEqualTo(CommerceServiceCommunicationType.REQUEST);
+        assertThat(captured.getSender()).isEqualTo(CommerceServiceCommunicationSenderType.COMMERCE);
+        assertThat(captured.getException()).isNull();
+        assertThat(captured.getPayloadJson().get("body").get("productName").asText()).isEqualTo("테스트 상품");
+    }
+
+    @Test
+    @DisplayName("장바구니 상품 가격 업데이트 실패 기록이 정확히 저장된다")
+    void record_cartProductPriceUpdateFailure_savesCorrectly() {
+        // given
+        CommerceServiceCommunicationHistoryCommand command = buildCommand(
+                CommerceServiceCommunicationTargetType.CART_PRODUCT,
+                "cart-600",
+                CommerceServiceCommunicationType.RESPONSE,
+                CommerceServiceCommunicationSenderType.PRODUCT,
+                "ResourceAccessException",
+                "I/O error on PATCH request",
+                null
+        );
+        when(saveServiceCommunicationHistoryPort.save(any(CommerceServiceCommunicationHistory.class)))
+                .thenReturn(buildMinimalHistory());
+
+        // when
+        recordService.record(command);
+
+        // then
+        ArgumentCaptor<CommerceServiceCommunicationHistory> captor =
+                ArgumentCaptor.forClass(CommerceServiceCommunicationHistory.class);
+        verify(saveServiceCommunicationHistoryPort).save(captor.capture());
+
+        CommerceServiceCommunicationHistory captured = captor.getValue();
+        assertThat(captured.getTargetType()).isEqualTo(CommerceServiceCommunicationTargetType.CART_PRODUCT);
+        assertThat(captured.getTargetId()).isEqualTo("cart-600");
+        assertThat(captured.getCommunicationType()).isEqualTo(CommerceServiceCommunicationType.RESPONSE);
+        assertThat(captured.getSender()).isEqualTo(CommerceServiceCommunicationSenderType.PRODUCT);
+        assertThat(captured.getException()).isEqualTo("ResourceAccessException");
+        assertThat(captured.getPayload()).isEqualTo("I/O error on PATCH request");
+        assertThat(captured.getPayloadJson()).isNull();
+    }
+
+    // --- Helper Methods ---
+
+    private CommerceServiceCommunicationHistoryCommand buildCommand(
+            CommerceServiceCommunicationTargetType targetType,
+            String targetId,
+            CommerceServiceCommunicationType communicationType,
+            CommerceServiceCommunicationSenderType sender,
+            String exception,
+            String payload,
+            JsonNode payloadJson
+    ) {
+        return CommerceServiceCommunicationHistoryCommand.builder()
+                .targetType(targetType)
+                .targetId(targetId)
+                .communicationType(communicationType)
+                .sender(sender)
+                .exception(exception)
+                .payload(payload)
+                .payloadJson(payloadJson)
+                .build();
+    }
+
+    private CommerceServiceCommunicationHistory buildHistory(
+            Long id,
+            CommerceServiceCommunicationTargetType targetType,
+            String targetId,
+            CommerceServiceCommunicationType communicationType,
+            CommerceServiceCommunicationSenderType sender,
+            String exception,
+            String payload,
+            JsonNode payloadJson,
+            LocalDateTime createdAt
+    ) {
+        return CommerceServiceCommunicationHistory.from(
+                CommerceServiceCommunicationHistorySnapshotState.builder()
+                        .id(id)
+                        .targetType(targetType)
+                        .targetId(targetId)
+                        .communicationType(communicationType)
+                        .sender(sender)
+                        .exception(exception)
+                        .payload(payload)
+                        .payloadJson(payloadJson)
+                        .createdAt(createdAt)
+                        .build()
+        );
+    }
+
+    private CommerceServiceCommunicationHistory buildMinimalHistory() {
+        return CommerceServiceCommunicationHistory.from(
+                CommerceServiceCommunicationHistorySnapshotState.builder()
+                        .id(1L)
+                        .targetType(CommerceServiceCommunicationTargetType.PRODUCT_INFO)
+                        .communicationType(CommerceServiceCommunicationType.REQUEST)
+                        .sender(CommerceServiceCommunicationSenderType.COMMERCE)
+                        .createdAt(LocalDateTime.now())
+                        .build()
+        );
+    }
+}


### PR DESCRIPTION
## partially addresses #216
## resolves #797

## Test Case
- [x] null 커맨드 입력 시 IllegalArgumentException을 던진다
- [x] inventories가 null인 커맨드 입력 시 IllegalArgumentException을 던진다
- [x] null 커맨드 입력 시 어떤 Port도 호출하지 않는다
- [x] 단일 상품 재고 동기화 시 새 재고 값으로 업데이트 포트에 전달한다
- [x] 복수 상품 재고 동기화 시 각 상품의 새 재고 값을 업데이트 포트에 전달한다
- [x] 재고 0으로 동기화 시 0으로 업데이트 포트에 전달한다
- [x] 커맨드의 상품 ID Set으로 findByProductIds를 정확히 한 번 호출한다
- [x] 요청한 상품 ID 중 일부가 존재하지 않으면 InventoryProductNotFoundException을 던진다
- [x] 요청한 상품 ID가 전부 존재하지 않으면 InventoryProductNotFoundException을 던진다
- [x] 상품 미존재 시 분산 락과 후속 Port를 호출하지 않는다
- [x] 재고 동기화 시 조회된 재고의 가격 정책 ID Set을 분산 락에 전달한다
- [x] 분산 락이 작업을 실행하지 않으면 락 내부 Port를 호출하지 않는다
- [x] 분산 락 획득 실패 시 InventoryLockAcquisitionException을 전파한다
- [x] 분산 락 획득 실패 시 락 내부 Port를 호출하지 않는다
- [x] 분산 락 처리 중 인터럽트 발생 시 InventoryLockInterruptedException을 전파한다
- [x] 재고 동기화 시 상품 조회 → 락 내 재고 재조회 → 업데이트 → 캐시 저장 순서로 호출한다
- [x] 락 내부에서 가격 정책 ID Set으로 재고를 재조회한다
- [x] 락 내부 재조회 재고에 동기화 대상이 아닌 상품이 포함되면 업데이트에서 제외된다
- [x] 업데이트되는 Inventory에 올바른 productId와 pricePolicyId가 설정된다
- [x] 업데이트되는 Inventory에 커맨드의 재고 수량이 설정된다
- [x] 업데이트되는 Inventory에 락 내부 재조회된 재고의 version이 보존된다
- [x] 동기화된 재고를 캐시에 저장한다
- [x] 업데이트 포트와 캐시 저장 포트에 동일한 Inventory Set을 전달한다
- [x] findByProductIds 중 예외 발생 시 예외를 전파한다
- [x] findByProductIds 중 예외 발생 시 후속 Port를 호출하지 않는다
- [x] findByPricePolicyIds 중 예외 발생 시 예외를 전파한다
- [x] findByPricePolicyIds 중 예외 발생 시 후속 Port를 호출하지 않는다
- [x] 업데이트 중 예외 발생 시 예외를 전파한다
- [x] 업데이트 중 예외 발생 시 캐시 저장을 호출하지 않는다
- [x] 캐시 저장 중 예외 발생 시 예외를 전파한다
- [x] 캐시 저장 중 예외 발생 시 업데이트는 이미 호출되었다
- [x] 복수 상품이 동일 가격 정책을 가지면 중복 없는 가격 정책 ID Set으로 락을 요청한다
- [x] 커맨드에 중복 상품 ID가 있으면 마지막 재고 값이 사용된다
- [x] 대량 재고 값으로 동기화 시 올바르게 업데이트된다