### PR TITLE
[#216][#804] feat: 주문 상태 변경 시 무결성을 유지할 수 있는 일부 상태에 대해서만 허용하는 로직 추가

### DIFF
--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/exception/InvalidOrderStatusTransitionException.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/exception/InvalidOrderStatusTransitionException.java
@@ -1,0 +1,16 @@
+package com.personal.marketnote.commerce.exception;
+
+import com.personal.marketnote.commerce.domain.order.OrderStatus;
+
+public class InvalidOrderStatusTransitionException extends IllegalStateException {
+    private static final String INVALID_ORDER_STATUS_TRANSITION_EXCEPTION_MESSAGE
+            = "주문 상태를 %s에서 %s(으)로 변경할 수 없습니다.";
+
+    public InvalidOrderStatusTransitionException(OrderStatus from, OrderStatus to) {
+        super(String.format(
+                INVALID_ORDER_STATUS_TRANSITION_EXCEPTION_MESSAGE,
+                from.getDescription(),
+                to.getDescription()
+        ));
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/ChangeOrderStatusService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/ChangeOrderStatusService.java
@@ -4,6 +4,7 @@ import com.personal.marketnote.commerce.domain.order.Order;
 import com.personal.marketnote.commerce.domain.order.OrderProduct;
 import com.personal.marketnote.commerce.domain.order.OrderStatus;
 import com.personal.marketnote.commerce.domain.order.OrderStatusHistory;
+import com.personal.marketnote.commerce.exception.InvalidOrderStatusTransitionException;
 import com.personal.marketnote.commerce.exception.OrderStatusAlreadyChangedException;
 import com.personal.marketnote.commerce.mapper.OrderCommandToStateMapper;
 import com.personal.marketnote.commerce.port.in.command.order.ChangeOrderStatusCommand;
@@ -41,6 +42,10 @@ public class ChangeOrderStatusService implements ChangeOrderStatusUseCase {
 
         if (status.isMe(order.getOrderStatus()) && status.isNotPartialChanged()) {
             throw new OrderStatusAlreadyChangedException(status);
+        }
+
+        if (!command.isPartialProductChange() && !order.getOrderStatus().canTransitionTo(status)) {
+            throw new InvalidOrderStatusTransitionException(order.getOrderStatus(), status);
         }
 
         changeOrderStatus(command, order);

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/order/OrderProduct.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/order/OrderProduct.java
@@ -44,6 +44,15 @@ public class OrderProduct {
     }
 
     public void changeOrderStatus(OrderStatus orderStatus) {
+        if (this.orderStatus == orderStatus) {
+            return;
+        }
+        if (!this.orderStatus.canTransitionTo(orderStatus)) {
+            throw new IllegalStateException(
+                    String.format("주문 상품 상태를 %s에서 %s(으)로 변경할 수 없습니다.",
+                            this.orderStatus.getDescription(), orderStatus.getDescription())
+            );
+        }
         this.orderStatus = orderStatus;
     }
 

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/order/OrderStatus.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/order/OrderStatus.java
@@ -3,6 +3,11 @@ package com.personal.marketnote.commerce.domain.order;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+import java.util.EnumMap;
+import java.util.EnumSet;
+import java.util.Map;
+import java.util.Set;
+
 @RequiredArgsConstructor
 @Getter
 public enum OrderStatus {
@@ -28,6 +33,39 @@ public enum OrderStatus {
     REFUNDED("환불 완료");
 
     private final String description;
+
+    private static final Map<OrderStatus, Set<OrderStatus>> ALLOWED_TRANSITIONS = new EnumMap<>(OrderStatus.class);
+
+    static {
+        ALLOWED_TRANSITIONS.put(PAYMENT_PENDING, EnumSet.of(PAID, FAILED, CANCEL_REQUESTED, CANCELLED));
+        ALLOWED_TRANSITIONS.put(PAID, EnumSet.of(PREPARING, CANCEL_REQUESTED, CANCELLED));
+        ALLOWED_TRANSITIONS.put(FAILED, EnumSet.noneOf(OrderStatus.class));
+        ALLOWED_TRANSITIONS.put(PREPARING, EnumSet.of(PREPARED, CANCEL_REQUESTED, CANCELLED));
+        ALLOWED_TRANSITIONS.put(PREPARED, EnumSet.of(SHIPPING, CANCEL_REQUESTED, CANCELLED));
+        ALLOWED_TRANSITIONS.put(CANCEL_REQUESTED, EnumSet.of(CANCELLED));
+        ALLOWED_TRANSITIONS.put(CANCELLED, EnumSet.noneOf(OrderStatus.class));
+        ALLOWED_TRANSITIONS.put(SHIPPING, EnumSet.of(DELIVERED));
+        ALLOWED_TRANSITIONS.put(DELIVERED, EnumSet.of(CONFIRMED, PARTIALLY_CONFIRMED, EXCHANGE_REQUESTED, REFUND_REQUESTED));
+        ALLOWED_TRANSITIONS.put(PARTIALLY_CONFIRMED, EnumSet.of(CONFIRMED, EXCHANGE_REQUESTED, REFUND_REQUESTED));
+        ALLOWED_TRANSITIONS.put(CONFIRMED, EnumSet.noneOf(OrderStatus.class));
+        ALLOWED_TRANSITIONS.put(EXCHANGE_REQUESTED, EnumSet.of(EXCHANGE_RECALLING));
+        ALLOWED_TRANSITIONS.put(EXCHANGE_RECALLING, EnumSet.of(EXCHANGE_SHIPPING));
+        ALLOWED_TRANSITIONS.put(EXCHANGE_SHIPPING, EnumSet.of(EXCHANGED));
+        ALLOWED_TRANSITIONS.put(EXCHANGED, EnumSet.noneOf(OrderStatus.class));
+        ALLOWED_TRANSITIONS.put(REFUND_REQUESTED, EnumSet.of(REFUND_RECALLING));
+        ALLOWED_TRANSITIONS.put(REFUND_RECALLING, EnumSet.of(REFUND_SHIPPING));
+        ALLOWED_TRANSITIONS.put(REFUND_SHIPPING, EnumSet.of(REFUNDED, PARTIALLY_REFUNDED));
+        ALLOWED_TRANSITIONS.put(PARTIALLY_REFUNDED, EnumSet.of(REFUND_REQUESTED, REFUNDED));
+        ALLOWED_TRANSITIONS.put(REFUNDED, EnumSet.noneOf(OrderStatus.class));
+    }
+
+    public boolean canTransitionTo(OrderStatus target) {
+        return ALLOWED_TRANSITIONS.getOrDefault(this, EnumSet.noneOf(OrderStatus.class)).contains(target);
+    }
+
+    public boolean isTerminal() {
+        return ALLOWED_TRANSITIONS.getOrDefault(this, EnumSet.noneOf(OrderStatus.class)).isEmpty();
+    }
 
     public boolean isRefunded() {
         return this == REFUNDED;


### PR DESCRIPTION
## partially addresses #216
## resolves #804

## Task
- [x] PAYMENT_PENDING → PAID, FAILED, CANCEL_REQUESTED, CANCELLED
- [x] PAID → PREPARING, CANCEL_REQUESTED, CANCELLED
- [x] FAILED → (종료)
- [x] PREPARING → PREPARED, CANCEL_REQUESTED, CANCELLED
- [x] PREPARED → SHIPPING, CANCEL_REQUESTED, CANCELLED
- [x] CANCEL_REQUESTED → CANCELLED
- [x] CANCELLED → (종료)
- [x] SHIPPING → DELIVERED
- [x] DELIVERED → CONFIRMED, PARTIALLY_CONFIRMED, EXCHANGE_REQUESTED, REFUND_REQUESTED
- [x] PARTIALLY_CONFIRMED → CONFIRMED, EXCHANGE_REQUESTED, REFUND_REQUESTED
- [x] CONFIRMED → (종료)
- [x] EXCHANGE_REQUESTED → EXCHANGE_RECALLING
- [x] EXCHANGE_RECALLING → EXCHANGE_SHIPPING
- [x] EXCHANGE_SHIPPING → EXCHANGED
- [x] EXCHANGED → (종료)
- [x] REFUND_REQUESTED → REFUND_RECALLING
- [x] REFUND_RECALLING → REFUND_SHIPPING
- [x] REFUND_SHIPPING → REFUNDED, PARTIALLY_REFUNDED
- [x] PARTIALLY_REFUNDED → REFUND_REQUESTED, REFUNDED
- [x] REFUNDED → (종료)