### PR TITLE
[#475][#644] fix: 파스토 정산 연동 요청 시 빈 배열의 응답이 오더라도 성공으로 처리하도록 변경

### DIFF
--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/client/FasstoSettlementClient.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/client/FasstoSettlementClient.java
@@ -281,9 +281,9 @@ public class FasstoSettlementClient implements GetFasstoSettlementDailyCostsPort
     }
 
     private GetFasstoSettlementDailyCostsResult mapDailyCostListResult(FasstoSettlementDailyCostListResponse response) {
-        List<FasstoSettlementDailyCostInfoResult> dailyCosts = response.data().stream()
-                .map(this::mapDailyCostInfo)
-                .toList();
+        List<FasstoSettlementDailyCostInfoResult> dailyCosts = FormatValidator.hasValue(response.data())
+                ? response.data().stream().map(this::mapDailyCostInfo).toList()
+                : List.of();
         Integer dataCount = FormatValidator.hasValue(response.header()) ? response.header().dataCount() : null;
         return GetFasstoSettlementDailyCostsResult.of(dataCount, dailyCosts);
     }

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoSettlementDailyCostListResponse.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoSettlementDailyCostListResponse.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.fulfillment.adapter.out.vendor.fassto.response;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.personal.marketnote.common.utility.FormatValidator;
 
 import java.util.List;
 
@@ -11,6 +12,6 @@ public record FasstoSettlementDailyCostListResponse(
         FasstoErrorInfo errorInfo
 ) implements FasstoApiResponse {
     public boolean isSuccess() {
-        return header != null && header.isSuccess() && data != null;
+        return FormatValidator.hasValue(header) && header.isSuccess();
     }
 }


### PR DESCRIPTION
## partially addresses #475
## resolves #644

## Task
- [x] 파스토 정산 연동 요청 시 빈 배열의 응답이 오더라도 성공으로 처리하도록 변경