### PR TITLE
[#475][#794] fix: 파스토 반품 상세 목록 조회 시 빈 배열의 응답이 오더라도 성공으로 처리하도록 변경

### DIFF
--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoReturnGodDetailListResponse.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoReturnGodDetailListResponse.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.fulfillment.adapter.out.vendor.fassto.response;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.personal.marketnote.common.utility.FormatValidator;
 
 import java.util.List;
 
@@ -11,6 +12,6 @@ public record FasstoReturnGodDetailListResponse(
         FasstoErrorInfo errorInfo
 ) implements FasstoApiResponse {
     public boolean isSuccess() {
-        return header != null && header.isSuccess() && data != null;
+        return FormatValidator.hasValue(header) && header.isSuccess();
     }
 }


### PR DESCRIPTION
## partially addresses #475
## resolves #794

## Task
- [x] 파스토 반품 상세 목록 조회 시 빈 배열의 응답이 오더라도 성공으로 처리하도록 변경