### PR TITLE
[#1][#811] refactor: null 체크 유효성 검사 전체 로직에서 FormatValidator를 사용하도록 변경

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/utility/ServiceCommunicationPayloadGenerator.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/utility/ServiceCommunicationPayloadGenerator.java
@@ -18,7 +18,7 @@ public class ServiceCommunicationPayloadGenerator {
     private final ObjectMapper objectMapper;
 
     public JsonNode buildPayloadJson(Object payload) {
-        if (payload == null) {
+        if (FormatValidator.hasNoValue(payload)) {
             return objectMapper.createObjectNode();
         }
 
@@ -33,7 +33,7 @@ public class ServiceCommunicationPayloadGenerator {
         Map<String, Object> payload = new LinkedHashMap<>();
         payload.put("method", method.name());
         payload.put("url", uri.toString());
-        if (body != null) {
+        if (FormatValidator.hasValue(body)) {
             payload.put("body", body);
         }
         payload.put("attempt", attempt);
@@ -45,7 +45,7 @@ public class ServiceCommunicationPayloadGenerator {
         if (FormatValidator.hasValue(response)) {
             payload.put("status", response.getStatusCode().value());
             Object body = response.getBody();
-            if (body != null) {
+            if (FormatValidator.hasValue(body)) {
                 payload.put("body", body);
             }
         }

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/inventory/GetInventoryUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/inventory/GetInventoryUseCaseTest.java
@@ -4,6 +4,7 @@ import com.personal.marketnote.commerce.domain.inventory.Inventory;
 import com.personal.marketnote.commerce.port.in.command.inventory.RegisterInventoryCommand;
 import com.personal.marketnote.commerce.port.in.usecase.inventory.RegisterInventoryUseCase;
 import com.personal.marketnote.commerce.port.out.inventory.FindInventoryPort;
+import com.personal.marketnote.common.utility.FormatValidator;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -96,7 +97,7 @@ class GetInventoryUseCaseTest {
             assertThat(commands).hasSize(3);
             assertThat(commands).extracting(RegisterInventoryCommand::pricePolicyId)
                     .containsExactlyInAnyOrder(100L, 200L, 300L);
-            assertThat(commands).allMatch(cmd -> cmd.productId() == null);
+            assertThat(commands).allMatch(cmd -> FormatValidator.hasNoValue(cmd.productId()));
         }
 
         @Test

--- a/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/out/web/product/response/ProductsInfoResponse.java
+++ b/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/out/web/product/response/ProductsInfoResponse.java
@@ -2,6 +2,7 @@ package com.personal.marketnote.community.adapter.out.web.product.response;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.personal.marketnote.common.application.file.port.in.result.GetFileResult;
+import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.community.port.out.result.product.ProductOptionInfoResult;
 import com.personal.marketnote.community.port.out.result.product.ProductPricePolicyInfoResult;
 
@@ -17,6 +18,6 @@ public record ProductsInfoResponse(
         GetFileResult catalogImage
 ) {
     public Long getPricePolicyId() {
-        return pricePolicy != null ? pricePolicy.id() : null;
+        return FormatValidator.hasValue(pricePolicy) ? pricePolicy.id() : null;
     }
 }

--- a/community-service/community-adapters/src/main/java/com/personal/marketnote/community/utility/ServiceCommunicationPayloadGenerator.java
+++ b/community-service/community-adapters/src/main/java/com/personal/marketnote/community/utility/ServiceCommunicationPayloadGenerator.java
@@ -18,7 +18,7 @@ public class ServiceCommunicationPayloadGenerator {
     private final ObjectMapper objectMapper;
 
     public JsonNode buildPayloadJson(Object payload) {
-        if (payload == null) {
+        if (FormatValidator.hasNoValue(payload)) {
             return objectMapper.createObjectNode();
         }
 
@@ -33,7 +33,7 @@ public class ServiceCommunicationPayloadGenerator {
         Map<String, Object> payload = new LinkedHashMap<>();
         payload.put("method", method.name());
         payload.put("url", uri.toString());
-        if (body != null) {
+        if (FormatValidator.hasValue(body)) {
             payload.put("body", body);
         }
         payload.put("attempt", attempt);
@@ -45,7 +45,7 @@ public class ServiceCommunicationPayloadGenerator {
         if (FormatValidator.hasValue(response)) {
             payload.put("status", response.getStatusCode().value());
             Object body = response.getBody();
-            if (body != null) {
+            if (FormatValidator.hasValue(body)) {
                 payload.put("body", body);
             }
         }

--- a/community-service/community-application/src/main/java/com/personal/marketnote/community/port/in/result/review/GetReviewsResult.java
+++ b/community-service/community-application/src/main/java/com/personal/marketnote/community/port/in/result/review/GetReviewsResult.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.community.port.in.result.review;
 
 import com.personal.marketnote.common.application.file.port.in.result.GetFileResult;
+import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.community.domain.review.Review;
 
 import java.util.List;
@@ -37,7 +38,7 @@ public record GetReviewsResult(
                 reviews.stream()
                         .map(review -> {
                             Long pricePolicyId = review.getPricePolicyId();
-                            ReviewProductInfoResult productInfo = pricePolicyId != null
+                            ReviewProductInfoResult productInfo = FormatValidator.hasValue(pricePolicyId)
                                     ? productInfoByPricePolicyId.get(pricePolicyId)
                                     : null;
 

--- a/file-service/file-adapters/src/main/java/com/personal/marketnote/file/utility/ServiceCommunicationPayloadGenerator.java
+++ b/file-service/file-adapters/src/main/java/com/personal/marketnote/file/utility/ServiceCommunicationPayloadGenerator.java
@@ -18,7 +18,7 @@ public class ServiceCommunicationPayloadGenerator {
     private final ObjectMapper objectMapper;
 
     public JsonNode buildPayloadJson(Object payload) {
-        if (payload == null) {
+        if (FormatValidator.hasNoValue(payload)) {
             return objectMapper.createObjectNode();
         }
 
@@ -33,7 +33,7 @@ public class ServiceCommunicationPayloadGenerator {
         Map<String, Object> payload = new LinkedHashMap<>();
         payload.put("method", method.name());
         payload.put("url", uri.toString());
-        if (body != null) {
+        if (FormatValidator.hasValue(body)) {
             payload.put("body", body);
         }
         payload.put("attempt", attempt);
@@ -45,7 +45,7 @@ public class ServiceCommunicationPayloadGenerator {
         if (FormatValidator.hasValue(response)) {
             payload.put("status", response.getStatusCode().value());
             Object body = response.getBody();
-            if (body != null) {
+            if (FormatValidator.hasValue(body)) {
                 payload.put("body", body);
             }
         }

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoAuthResponse.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoAuthResponse.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.fulfillment.adapter.out.vendor.fassto.response;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.personal.marketnote.common.utility.FormatValidator;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record FasstoAuthResponse(
@@ -9,6 +10,6 @@ public record FasstoAuthResponse(
         FasstoErrorInfo errorInfo
 ) implements FasstoApiResponse {
     public boolean isSuccess() {
-        return header != null && header.isSuccess();
+        return FormatValidator.hasValue(header) && header.isSuccess();
     }
 }

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoDeliveryDetailListResponse.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoDeliveryDetailListResponse.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.fulfillment.adapter.out.vendor.fassto.response;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.personal.marketnote.common.utility.FormatValidator;
 
 import java.util.List;
 
@@ -11,6 +12,6 @@ public record FasstoDeliveryDetailListResponse(
         FasstoErrorInfo errorInfo
 ) implements FasstoApiResponse {
     public boolean isSuccess() {
-        return header != null && header.isSuccess() && data != null;
+        return FormatValidator.hasValue(header) && header.isSuccess();
     }
 }

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoDeliveryGoodDetailListResponse.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoDeliveryGoodDetailListResponse.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.fulfillment.adapter.out.vendor.fassto.response;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.personal.marketnote.common.utility.FormatValidator;
 
 import java.util.List;
 
@@ -11,6 +12,6 @@ public record FasstoDeliveryGoodDetailListResponse(
         FasstoErrorInfo errorInfo
 ) implements FasstoApiResponse {
     public boolean isSuccess() {
-        return header != null && header.isSuccess() && data != null;
+        return FormatValidator.hasValue(header) && header.isSuccess();
     }
 }

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoDeliveryIcsCompletionListResponse.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoDeliveryIcsCompletionListResponse.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.fulfillment.adapter.out.vendor.fassto.response;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.personal.marketnote.common.utility.FormatValidator;
 
 import java.util.List;
 
@@ -11,6 +12,6 @@ public record FasstoDeliveryIcsCompletionListResponse(
         FasstoErrorInfo errorInfo
 ) implements FasstoApiResponse {
     public boolean isSuccess() {
-        return header != null && header.isSuccess() && data != null;
+        return FormatValidator.hasValue(header) && header.isSuccess();
     }
 }

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoDeliveryListResponse.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoDeliveryListResponse.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.fulfillment.adapter.out.vendor.fassto.response;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.personal.marketnote.common.utility.FormatValidator;
 
 import java.util.List;
 
@@ -11,6 +12,6 @@ public record FasstoDeliveryListResponse(
         FasstoErrorInfo errorInfo
 ) implements FasstoApiResponse {
     public boolean isSuccess() {
-        return header != null && header.isSuccess() && data != null;
+        return FormatValidator.hasValue(header) && header.isSuccess();
     }
 }

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoDeliveryStatusListResponse.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoDeliveryStatusListResponse.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.fulfillment.adapter.out.vendor.fassto.response;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.personal.marketnote.common.utility.FormatValidator;
 
 import java.util.List;
 
@@ -11,6 +12,6 @@ public record FasstoDeliveryStatusListResponse(
         FasstoErrorInfo errorInfo
 ) implements FasstoApiResponse {
     public boolean isSuccess() {
-        return header != null && header.isSuccess() && data != null;
+        return FormatValidator.hasValue(header) && header.isSuccess();
     }
 }

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoGoodsElementsResponse.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoGoodsElementsResponse.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.fulfillment.adapter.out.vendor.fassto.response;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.personal.marketnote.common.utility.FormatValidator;
 
 import java.util.List;
 
@@ -11,6 +12,6 @@ public record FasstoGoodsElementsResponse(
         FasstoErrorInfo errorInfo
 ) implements FasstoApiResponse {
     public boolean isSuccess() {
-        return header != null && header.isSuccess() && data != null;
+        return FormatValidator.hasValue(header) && header.isSuccess();
     }
 }

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoGoodsListResponse.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoGoodsListResponse.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.fulfillment.adapter.out.vendor.fassto.response;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.personal.marketnote.common.utility.FormatValidator;
 
 import java.util.List;
 
@@ -11,6 +12,6 @@ public record FasstoGoodsListResponse(
         FasstoErrorInfo errorInfo
 ) implements FasstoApiResponse {
     public boolean isSuccess() {
-        return header != null && header.isSuccess() && data != null;
+        return FormatValidator.hasValue(header) && header.isSuccess();
     }
 }

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoOutOrdGoodsByOrdNoListResponse.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoOutOrdGoodsByOrdNoListResponse.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.fulfillment.adapter.out.vendor.fassto.response;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.personal.marketnote.common.utility.FormatValidator;
 
 import java.util.List;
 
@@ -11,6 +12,6 @@ public record FasstoOutOrdGoodsByOrdNoListResponse(
         FasstoErrorInfo errorInfo
 ) implements FasstoApiResponse {
     public boolean isSuccess() {
-        return header != null && header.isSuccess() && data != null;
+        return FormatValidator.hasValue(header) && header.isSuccess();
     }
 }

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoOutOrdGoodsDetailListResponse.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoOutOrdGoodsDetailListResponse.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.fulfillment.adapter.out.vendor.fassto.response;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.personal.marketnote.common.utility.FormatValidator;
 
 import java.util.List;
 
@@ -11,6 +12,6 @@ public record FasstoOutOrdGoodsDetailListResponse(
         FasstoErrorInfo errorInfo
 ) implements FasstoApiResponse {
     public boolean isSuccess() {
-        return header != null && header.isSuccess() && data != null;
+        return FormatValidator.hasValue(header) && header.isSuccess();
     }
 }

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoShopsResponse.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoShopsResponse.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.fulfillment.adapter.out.vendor.fassto.response;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.personal.marketnote.common.utility.FormatValidator;
 
 import java.util.List;
 
@@ -11,6 +12,6 @@ public record FasstoShopsResponse(
         FasstoErrorInfo errorInfo
 ) implements FasstoApiResponse {
     public boolean isSuccess() {
-        return header != null && header.isSuccess() && data != null;
+        return FormatValidator.hasValue(header) && header.isSuccess();
     }
 }

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoStockListResponse.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoStockListResponse.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.fulfillment.adapter.out.vendor.fassto.response;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.personal.marketnote.common.utility.FormatValidator;
 
 import java.util.List;
 
@@ -11,6 +12,6 @@ public record FasstoStockListResponse(
         FasstoErrorInfo errorInfo
 ) implements FasstoApiResponse {
     public boolean isSuccess() {
-        return header != null && header.isSuccess() && data != null;
+        return FormatValidator.hasValue(header) && header.isSuccess();
     }
 }

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoSuppliersResponse.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoSuppliersResponse.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.fulfillment.adapter.out.vendor.fassto.response;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.personal.marketnote.common.utility.FormatValidator;
 
 import java.util.List;
 
@@ -11,6 +12,6 @@ public record FasstoSuppliersResponse(
         FasstoErrorInfo errorInfo
 ) implements FasstoApiResponse {
     public boolean isSuccess() {
-        return header != null && header.isSuccess() && data != null;
+        return FormatValidator.hasValue(header) && header.isSuccess();
     }
 }

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoWarehousingAbnormalImageResponse.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoWarehousingAbnormalImageResponse.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.fulfillment.adapter.out.vendor.fassto.response;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.personal.marketnote.common.utility.FormatValidator;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record FasstoWarehousingAbnormalImageResponse(
@@ -9,6 +10,6 @@ public record FasstoWarehousingAbnormalImageResponse(
         FasstoErrorInfo errorInfo
 ) implements FasstoApiResponse {
     public boolean isSuccess() {
-        return header != null && header.isSuccess() && data != null;
+        return FormatValidator.hasValue(header) && header.isSuccess();
     }
 }

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoWarehousingAbnormalListResponse.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoWarehousingAbnormalListResponse.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.fulfillment.adapter.out.vendor.fassto.response;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.personal.marketnote.common.utility.FormatValidator;
 
 import java.util.List;
 
@@ -11,6 +12,6 @@ public record FasstoWarehousingAbnormalListResponse(
         FasstoErrorInfo errorInfo
 ) implements FasstoApiResponse {
     public boolean isSuccess() {
-        return header != null && header.isSuccess() && data != null;
+        return FormatValidator.hasValue(header) && header.isSuccess();
     }
 }

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoWarehousingDetailListResponse.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoWarehousingDetailListResponse.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.fulfillment.adapter.out.vendor.fassto.response;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.personal.marketnote.common.utility.FormatValidator;
 
 import java.util.List;
 
@@ -11,6 +12,6 @@ public record FasstoWarehousingDetailListResponse(
         FasstoErrorInfo errorInfo
 ) implements FasstoApiResponse {
     public boolean isSuccess() {
-        return header != null && header.isSuccess() && data != null;
+        return FormatValidator.hasValue(header) && header.isSuccess();
     }
 }

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoWarehousingInspecDetailListResponse.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoWarehousingInspecDetailListResponse.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.fulfillment.adapter.out.vendor.fassto.response;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.personal.marketnote.common.utility.FormatValidator;
 
 import java.util.List;
 
@@ -11,6 +12,6 @@ public record FasstoWarehousingInspecDetailListResponse(
         FasstoErrorInfo errorInfo
 ) implements FasstoApiResponse {
     public boolean isSuccess() {
-        return header != null && header.isSuccess() && data != null;
+        return FormatValidator.hasValue(header) && header.isSuccess();
     }
 }

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoWarehousingListResponse.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/response/FasstoWarehousingListResponse.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.fulfillment.adapter.out.vendor.fassto.response;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.personal.marketnote.common.utility.FormatValidator;
 
 import java.util.List;
 
@@ -11,6 +12,6 @@ public record FasstoWarehousingListResponse(
         FasstoErrorInfo errorInfo
 ) implements FasstoApiResponse {
     public boolean isSuccess() {
-        return header != null && header.isSuccess() && data != null;
+        return FormatValidator.hasValue(header) && header.isSuccess();
     }
 }

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/utility/ServiceCommunicationPayloadGenerator.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/utility/ServiceCommunicationPayloadGenerator.java
@@ -19,7 +19,7 @@ public class ServiceCommunicationPayloadGenerator {
     private final VendorCommunicationRecorder vendorCommunicationRecorder;
 
     public JsonNode buildPayloadJson(Object payload) {
-        if (payload == null) {
+        if (FormatValidator.hasNoValue(payload)) {
             return objectMapper.createObjectNode();
         }
 
@@ -34,7 +34,7 @@ public class ServiceCommunicationPayloadGenerator {
         Map<String, Object> payload = new LinkedHashMap<>();
         payload.put("method", method.name());
         payload.put("url", uri.toString());
-        if (body != null) {
+        if (FormatValidator.hasValue(body)) {
             payload.put("body", body);
         }
         payload.put("attempt", attempt);
@@ -46,7 +46,7 @@ public class ServiceCommunicationPayloadGenerator {
         if (FormatValidator.hasValue(response)) {
             payload.put("status", response.getStatusCode().value());
             Object body = response.getBody();
-            if (body != null) {
+            if (FormatValidator.hasValue(body)) {
                 payload.put("body", body);
             }
         }

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/utility/VendorCommunicationPayloadGenerator.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/utility/VendorCommunicationPayloadGenerator.java
@@ -13,7 +13,7 @@ public class VendorCommunicationPayloadGenerator {
     private final ObjectMapper objectMapper;
 
     public JsonNode buildPayloadJson(Object payload) {
-        if (payload == null) {
+        if (FormatValidator.hasNoValue(payload)) {
             return objectMapper.createObjectNode();
         }
 

--- a/fulfillment-service/fulfillment-adapters/src/test/java/com/personal/marketnote/fulfillment/adapter/out/scheduler/FasstoWarehousingPollingSchedulerTest.java
+++ b/fulfillment-service/fulfillment-adapters/src/test/java/com/personal/marketnote/fulfillment/adapter/out/scheduler/FasstoWarehousingPollingSchedulerTest.java
@@ -1,5 +1,6 @@
 package com.personal.marketnote.fulfillment.adapter.out.scheduler;
 
+import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.fulfillment.domain.FasstoAccessToken;
 import com.personal.marketnote.fulfillment.port.in.command.vendor.GetFasstoWarehousingCommand;
 import com.personal.marketnote.fulfillment.port.in.command.vendor.SyncFasstoAllStockCommand;
@@ -92,7 +93,7 @@ class FasstoWarehousingPollingSchedulerTest {
         FasstoWarehousingInfoResult item = buildWarehousingInfo("ORD-1", "WH1", "4");
         GetFasstoWarehousingResult result = GetFasstoWarehousingResult.of(1, List.of(item));
         when(getFasstoWarehousingUseCase.getWarehousing(
-                argThat(command -> command != null && "4".equals(command.wrkStat()))
+                argThat(command -> FormatValidator.hasValue(command) && "4".equals(command.wrkStat()))
         ))
                 .thenReturn(result);
         scheduler.schedule(buildCommand("ORD-1"));

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/FasstoAuthDisconnectFailedException.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/FasstoAuthDisconnectFailedException.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.fulfillment.exception;
 
 import com.personal.marketnote.common.exception.ExternalOperationFailedException;
+import com.personal.marketnote.common.utility.FormatValidator;
 
 import java.io.IOException;
 
@@ -17,7 +18,7 @@ public class FasstoAuthDisconnectFailedException extends ExternalOperationFailed
     }
 
     private static String resolveMessage(String vendorMessage) {
-        if (vendorMessage == null || vendorMessage.isBlank()) {
+        if (FormatValidator.hasNoValue(vendorMessage)) {
             return FASSTO_AUTH_DISCONNECT_FAILED_EXCEPTION_MESSAGE;
         }
         return vendorMessage;

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/FasstoAuthRequestFailedException.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/FasstoAuthRequestFailedException.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.fulfillment.exception;
 
 import com.personal.marketnote.common.exception.ExternalOperationFailedException;
+import com.personal.marketnote.common.utility.FormatValidator;
 
 import java.io.IOException;
 
@@ -17,7 +18,7 @@ public class FasstoAuthRequestFailedException extends ExternalOperationFailedExc
     }
 
     private static String resolveMessage(String vendorMessage) {
-        if (vendorMessage == null || vendorMessage.isBlank()) {
+        if (FormatValidator.hasNoValue(vendorMessage)) {
             return FASSTO_AUTH_REQUEST_FAILED_EXCEPTION_MESSAGE;
         }
         return vendorMessage;

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/GetFasstoShopsFailedException.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/GetFasstoShopsFailedException.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.fulfillment.exception;
 
 import com.personal.marketnote.common.exception.ExternalOperationFailedException;
+import com.personal.marketnote.common.utility.FormatValidator;
 
 import java.io.IOException;
 
@@ -17,7 +18,7 @@ public class GetFasstoShopsFailedException extends ExternalOperationFailedExcept
     }
 
     private static String resolveMessage(String vendorMessage) {
-        if (vendorMessage == null || vendorMessage.isBlank()) {
+        if (FormatValidator.hasNoValue(vendorMessage)) {
             return GET_FASSTO_MARKETNOTE_LIST_FAILED_EXCEPTION_MESSAGE;
         }
         return vendorMessage;

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/GetFasstoSuppliersFailedException.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/GetFasstoSuppliersFailedException.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.fulfillment.exception;
 
 import com.personal.marketnote.common.exception.ExternalOperationFailedException;
+import com.personal.marketnote.common.utility.FormatValidator;
 
 import java.io.IOException;
 
@@ -17,7 +18,7 @@ public class GetFasstoSuppliersFailedException extends ExternalOperationFailedEx
     }
 
     private static String resolveMessage(String vendorMessage) {
-        if (vendorMessage == null || vendorMessage.isBlank()) {
+        if (FormatValidator.hasNoValue(vendorMessage)) {
             return GET_FASSTO_SUPPLIER_LIST_FAILED_EXCEPTION_MESSAGE;
         }
         return vendorMessage;

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/RegisterFasstoDeliveryFailedException.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/RegisterFasstoDeliveryFailedException.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.fulfillment.exception;
 
 import com.personal.marketnote.common.exception.ExternalOperationFailedException;
+import com.personal.marketnote.common.utility.FormatValidator;
 
 import java.io.IOException;
 
@@ -17,7 +18,7 @@ public class RegisterFasstoDeliveryFailedException extends ExternalOperationFail
     }
 
     private static String resolveMessage(String vendorMessage) {
-        if (vendorMessage == null || vendorMessage.isBlank()) {
+        if (FormatValidator.hasNoValue(vendorMessage)) {
             return REGISTER_FASSTO_DELIVERY_FAILED_EXCEPTION_MESSAGE;
         }
         return vendorMessage;

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/RegisterFasstoDirectReturnDeliveryFailedException.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/RegisterFasstoDirectReturnDeliveryFailedException.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.fulfillment.exception;
 
 import com.personal.marketnote.common.exception.ExternalOperationFailedException;
+import com.personal.marketnote.common.utility.FormatValidator;
 
 import java.io.IOException;
 
@@ -17,7 +18,7 @@ public class RegisterFasstoDirectReturnDeliveryFailedException extends ExternalO
     }
 
     private static String resolveMessage(String vendorMessage) {
-        if (vendorMessage == null || vendorMessage.isBlank()) {
+        if (FormatValidator.hasNoValue(vendorMessage)) {
             return REGISTER_FASSTO_DIRECT_RETURN_DELIVERY_FAILED_EXCEPTION_MESSAGE;
         }
         return vendorMessage;

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/RegisterFasstoGoodsFailedException.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/RegisterFasstoGoodsFailedException.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.fulfillment.exception;
 
 import com.personal.marketnote.common.exception.ExternalOperationFailedException;
+import com.personal.marketnote.common.utility.FormatValidator;
 
 import java.io.IOException;
 
@@ -17,7 +18,7 @@ public class RegisterFasstoGoodsFailedException extends ExternalOperationFailedE
     }
 
     private static String resolveMessage(String vendorMessage) {
-        if (vendorMessage == null || vendorMessage.isBlank()) {
+        if (FormatValidator.hasNoValue(vendorMessage)) {
             return REGISTER_FASSTO_GOODS_FAILED_EXCEPTION_MESSAGE;
         }
         return vendorMessage;

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/RegisterFasstoReturnDeliveryFailedException.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/RegisterFasstoReturnDeliveryFailedException.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.fulfillment.exception;
 
 import com.personal.marketnote.common.exception.ExternalOperationFailedException;
+import com.personal.marketnote.common.utility.FormatValidator;
 
 import java.io.IOException;
 
@@ -17,7 +18,7 @@ public class RegisterFasstoReturnDeliveryFailedException extends ExternalOperati
     }
 
     private static String resolveMessage(String vendorMessage) {
-        if (vendorMessage == null || vendorMessage.isBlank()) {
+        if (FormatValidator.hasNoValue(vendorMessage)) {
             return REGISTER_FASSTO_RETURN_DELIVERY_FAILED_EXCEPTION_MESSAGE;
         }
         return vendorMessage;

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/RegisterFasstoShopFailedException.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/RegisterFasstoShopFailedException.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.fulfillment.exception;
 
 import com.personal.marketnote.common.exception.ExternalOperationFailedException;
+import com.personal.marketnote.common.utility.FormatValidator;
 
 import java.io.IOException;
 
@@ -17,7 +18,7 @@ public class RegisterFasstoShopFailedException extends ExternalOperationFailedEx
     }
 
     private static String resolveMessage(String vendorMessage) {
-        if (vendorMessage == null || vendorMessage.isBlank()) {
+        if (FormatValidator.hasNoValue(vendorMessage)) {
             return REGISTER_FASSTO_MARKETNOTE_FAILED_EXCEPTION_MESSAGE;
         }
         return vendorMessage;

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/RegisterFasstoSupplierFailedException.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/RegisterFasstoSupplierFailedException.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.fulfillment.exception;
 
 import com.personal.marketnote.common.exception.ExternalOperationFailedException;
+import com.personal.marketnote.common.utility.FormatValidator;
 
 import java.io.IOException;
 
@@ -17,7 +18,7 @@ public class RegisterFasstoSupplierFailedException extends ExternalOperationFail
     }
 
     private static String resolveMessage(String vendorMessage) {
-        if (vendorMessage == null || vendorMessage.isBlank()) {
+        if (FormatValidator.hasNoValue(vendorMessage)) {
             return REGISTER_FASSTO_SUPPLIER_FAILED_EXCEPTION_MESSAGE;
         }
         return vendorMessage;

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/UpdateFasstoShopFailedException.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/UpdateFasstoShopFailedException.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.fulfillment.exception;
 
 import com.personal.marketnote.common.exception.ExternalOperationFailedException;
+import com.personal.marketnote.common.utility.FormatValidator;
 
 import java.io.IOException;
 
@@ -17,7 +18,7 @@ public class UpdateFasstoShopFailedException extends ExternalOperationFailedExce
     }
 
     private static String resolveMessage(String vendorMessage) {
-        if (vendorMessage == null || vendorMessage.isBlank()) {
+        if (FormatValidator.hasNoValue(vendorMessage)) {
             return UPDATE_FASSTO_MARKETNOTE_FAILED_EXCEPTION_MESSAGE;
         }
         return vendorMessage;

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/UpdateFasstoSupplierFailedException.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/UpdateFasstoSupplierFailedException.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.fulfillment.exception;
 
 import com.personal.marketnote.common.exception.ExternalOperationFailedException;
+import com.personal.marketnote.common.utility.FormatValidator;
 
 import java.io.IOException;
 
@@ -17,7 +18,7 @@ public class UpdateFasstoSupplierFailedException extends ExternalOperationFailed
     }
 
     private static String resolveMessage(String vendorMessage) {
-        if (vendorMessage == null || vendorMessage.isBlank()) {
+        if (FormatValidator.hasNoValue(vendorMessage)) {
             return UPDATE_FASSTO_SUPPLIER_FAILED_EXCEPTION_MESSAGE;
         }
         return vendorMessage;

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/mapper/FasstoDirectReturnDeliveryCommandToRequestMapper.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/mapper/FasstoDirectReturnDeliveryCommandToRequestMapper.java
@@ -1,5 +1,6 @@
 package com.personal.marketnote.fulfillment.mapper;
 
+import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.fulfillment.domain.vendor.fassto.delivery.FasstoDeliveryGoodsMapper;
 import com.personal.marketnote.fulfillment.domain.vendor.fassto.returndelivery.FasstoDirectReturnDeliveryItemMapper;
 import com.personal.marketnote.fulfillment.domain.vendor.fassto.returndelivery.FasstoDirectReturnDeliveryMapper;
@@ -24,7 +25,7 @@ public class FasstoDirectReturnDeliveryCommandToRequestMapper {
     }
 
     private static FasstoDirectReturnDeliveryItemMapper mapItem(RegisterFasstoDirectReturnDeliveryItemCommand item) {
-        List<FasstoDeliveryGoodsMapper> goods = item.godCds() != null
+        List<FasstoDeliveryGoodsMapper> goods = FormatValidator.hasValue(item.godCds())
                 ? item.godCds().stream()
                 .map(FasstoDirectReturnDeliveryCommandToRequestMapper::mapGoods)
                 .toList()

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/mapper/FasstoReturnDeliveryCommandToRequestMapper.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/mapper/FasstoReturnDeliveryCommandToRequestMapper.java
@@ -1,5 +1,6 @@
 package com.personal.marketnote.fulfillment.mapper;
 
+import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.fulfillment.domain.vendor.fassto.delivery.FasstoDeliveryGoodsMapper;
 import com.personal.marketnote.fulfillment.domain.vendor.fassto.returndelivery.FasstoReturnDeliveryItemMapper;
 import com.personal.marketnote.fulfillment.domain.vendor.fassto.returndelivery.FasstoReturnDeliveryMapper;
@@ -37,7 +38,7 @@ public class FasstoReturnDeliveryCommandToRequestMapper {
     }
 
     private static FasstoReturnDeliveryItemMapper mapItem(RegisterFasstoReturnDeliveryItemCommand item) {
-        List<FasstoDeliveryGoodsMapper> goods = item.godCds() != null
+        List<FasstoDeliveryGoodsMapper> goods = FormatValidator.hasValue(item.godCds())
                 ? item.godCds().stream()
                 .map(FasstoReturnDeliveryCommandToRequestMapper::mapGoods)
                 .toList()

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/goods/FasstoGoodsItemMapper.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/goods/FasstoGoodsItemMapper.java
@@ -181,7 +181,7 @@ public class FasstoGoodsItemMapper {
     }
 
     private void putIfNotNull(Map<String, Object> payload, String key, String value) {
-        if (value != null) {
+        if (FormatValidator.hasValue(value)) {
             payload.put(key, value);
         }
     }

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/supplier/FasstoSupplierMapper.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/supplier/FasstoSupplierMapper.java
@@ -196,7 +196,7 @@ public class FasstoSupplierMapper {
     }
 
     private void putIfNotNull(Map<String, Object> payload, String key, String value) {
-        if (value != null) {
+        if (FormatValidator.hasValue(value)) {
             payload.put(key, value);
         }
     }

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/warehousing/FasstoWarehousingGoodsMapper.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/warehousing/FasstoWarehousingGoodsMapper.java
@@ -33,7 +33,7 @@ public class FasstoWarehousingGoodsMapper {
         Map<String, Object> payload = new LinkedHashMap<>();
         putIfNotNull(payload, "cstGodCd", cstGodCd);
         putIfNotNull(payload, "distTermDt", distTermDt);
-        if (ordQty != null) {
+        if (FormatValidator.hasValue(ordQty)) {
             payload.put("ordQty", ordQty);
         }
         return payload;
@@ -49,7 +49,7 @@ public class FasstoWarehousingGoodsMapper {
     }
 
     private void putIfNotNull(Map<String, Object> payload, String key, String value) {
-        if (value != null) {
+        if (FormatValidator.hasValue(value)) {
             payload.put(key, value);
         }
     }

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/warehousing/FasstoWarehousingItemMapper.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/warehousing/FasstoWarehousingItemMapper.java
@@ -102,7 +102,7 @@ public class FasstoWarehousingItemMapper {
         putIfNotNull(payload, "distTermDt", distTermDt);
         putIfNotNull(payload, "makeDt", makeDt);
         putIfNotNull(payload, "preArv", preArv);
-        if (godCds != null) {
+        if (FormatValidator.hasValue(godCds)) {
             payload.put("godCds", godCds.stream()
                     .map(FasstoWarehousingGoodsMapper::toPayload)
                     .toList());
@@ -130,7 +130,7 @@ public class FasstoWarehousingItemMapper {
     }
 
     private void putIfNotNull(Map<String, Object> payload, String key, String value) {
-        if (value != null) {
+        if (FormatValidator.hasValue(value)) {
             payload.put(key, value);
         }
     }

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/web/commerce/CommerceServiceClient.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/web/commerce/CommerceServiceClient.java
@@ -76,7 +76,7 @@ public class CommerceServiceClient implements RegisterInventoryPort, FindStockPo
     public void sendRequest(URI uri, HttpEntity<RegisterInventoryRequest> httpEntity, Long pricePolicyId) {
         long sleepMillis = INTER_SERVER_DEFAULT_RETRIAL_PENDING_MILLI_SECOND;
         Exception error = new Exception();
-        String targetId = pricePolicyId != null ? String.valueOf(pricePolicyId) : null;
+        String targetId = FormatValidator.hasValue(pricePolicyId) ? String.valueOf(pricePolicyId) : null;
 
         for (int i = 0; i < INTER_SERVER_MAX_REQUEST_COUNT; i++) {
             int attempt = i + 1;

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/web/community/CommunityServiceClient.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/web/community/CommunityServiceClient.java
@@ -90,7 +90,7 @@ public class CommunityServiceClient implements FindProductReviewAggregatesPort {
                         );
                 BaseResponse<GetProductReviewAggregatesResponse> response = responseEntity.getBody();
 
-                if (response == null || response.getContent() == null) {
+                if (FormatValidator.hasNoValue(response) || FormatValidator.hasNoValue(response.getContent())) {
                     return Map.of();
                 }
 
@@ -102,7 +102,7 @@ public class CommunityServiceClient implements FindProductReviewAggregatesPort {
 
                 return reviewAggregates.stream()
                         .filter(Objects::nonNull)
-                        .filter(item -> item.productId() != null)
+                        .filter(item -> FormatValidator.hasValue(item.productId()))
                         .collect(Collectors.toMap(
                                 ProductReviewAggregateItemResponse::productId,
                                 item -> new ProductReviewAggregateResult(

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/web/fulfillment/response/GetFasstoGoodsElementsResponse.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/web/fulfillment/response/GetFasstoGoodsElementsResponse.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.product.adapter.out.web.fulfillment.response;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.personal.marketnote.common.utility.FormatValidator;
 
 import java.util.List;
 
@@ -10,6 +11,6 @@ public record GetFasstoGoodsElementsResponse(
         List<FasstoGoodsElementResponse> elements
 ) {
     public boolean isSuccess() {
-        return elements != null;
+        return FormatValidator.hasValue(elements);
     }
 }

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/web/fulfillment/response/GetFasstoGoodsResponse.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/web/fulfillment/response/GetFasstoGoodsResponse.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.product.adapter.out.web.fulfillment.response;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.personal.marketnote.common.utility.FormatValidator;
 
 import java.util.List;
 
@@ -10,6 +11,6 @@ public record GetFasstoGoodsResponse(
         List<FasstoGoodsItemResponse> goods
 ) {
     public boolean isSuccess() {
-        return goods != null;
+        return FormatValidator.hasValue(goods);
     }
 }

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/utility/ServiceCommunicationPayloadGenerator.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/utility/ServiceCommunicationPayloadGenerator.java
@@ -18,7 +18,7 @@ public class ServiceCommunicationPayloadGenerator {
     private final ObjectMapper objectMapper;
 
     public JsonNode buildPayloadJson(Object payload) {
-        if (payload == null) {
+        if (FormatValidator.hasNoValue(payload)) {
             return objectMapper.createObjectNode();
         }
 
@@ -33,7 +33,7 @@ public class ServiceCommunicationPayloadGenerator {
         Map<String, Object> payload = new LinkedHashMap<>();
         payload.put("method", method.name());
         payload.put("url", uri.toString());
-        if (body != null) {
+        if (FormatValidator.hasValue(body)) {
             payload.put("body", body);
         }
         payload.put("attempt", attempt);
@@ -45,7 +45,7 @@ public class ServiceCommunicationPayloadGenerator {
         if (FormatValidator.hasValue(response)) {
             payload.put("status", response.getStatusCode().value());
             Object body = response.getBody();
-            if (body != null) {
+            if (FormatValidator.hasValue(body)) {
                 payload.put("body", body);
             }
         }

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/service/product/GetProductService.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/service/product/GetProductService.java
@@ -276,7 +276,7 @@ public class GetProductService implements GetProductUseCase {
         }
 
         ProductReviewAggregateResult result = reviewAggregatesByProductId.get(productId);
-        if (result == null || result.averageRating() == null) {
+        if (FormatValidator.hasNoValue(result) || FormatValidator.hasNoValue(result.averageRating())) {
             return 0f;
         }
 
@@ -293,7 +293,7 @@ public class GetProductService implements GetProductUseCase {
         }
 
         ProductReviewAggregateResult result = reviewAggregatesByProductId.get(productId);
-        if (result == null || result.totalCount() == null) {
+        if (FormatValidator.hasNoValue(result) || FormatValidator.hasNoValue(result.totalCount())) {
             return 0;
         }
 

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/attendance/entity/UserAttendanceJpaEntity.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/attendance/entity/UserAttendanceJpaEntity.java
@@ -64,7 +64,7 @@ public class UserAttendanceJpaEntity {
                 .month(attendance.getMonth())
                 .createdAt(attendance.getCreatedAt())
                 .totalRewardQuantity(attendance.getTotalRewardQuantity())
-                .histories(attendance.getHistories() == null ? null : attendance.getHistories().stream()
+                .histories(FormatValidator.hasNoValue(attendance.getHistories()) ? null : attendance.getHistories().stream()
                         .map(UserAttendanceHistoryJpaEntity::from)
                         .toList())
                 .build();
@@ -79,7 +79,7 @@ public class UserAttendanceJpaEntity {
                         .month(month)
                         .createdAt(createdAt)
                         .totalRewardQuantity(totalRewardQuantity)
-                        .histories(histories == null ? null : histories.stream()
+                        .histories(FormatValidator.hasNoValue(histories) ? null : histories.stream()
                                 .map(UserAttendanceHistoryJpaEntity::toDomain)
                                 .toList())
                         .build()

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/utility/ServiceCommunicationPayloadGenerator.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/utility/ServiceCommunicationPayloadGenerator.java
@@ -18,7 +18,7 @@ public class ServiceCommunicationPayloadGenerator {
     private final ObjectMapper objectMapper;
 
     public JsonNode buildPayloadJson(Object payload) {
-        if (payload == null) {
+        if (FormatValidator.hasNoValue(payload)) {
             return objectMapper.createObjectNode();
         }
 
@@ -33,7 +33,7 @@ public class ServiceCommunicationPayloadGenerator {
         Map<String, Object> payload = new LinkedHashMap<>();
         payload.put("method", method.name());
         payload.put("url", uri.toString());
-        if (body != null) {
+        if (FormatValidator.hasValue(body)) {
             payload.put("body", body);
         }
         payload.put("attempt", attempt);
@@ -45,7 +45,7 @@ public class ServiceCommunicationPayloadGenerator {
         if (FormatValidator.hasValue(response)) {
             payload.put("status", response.getStatusCode().value());
             Object body = response.getBody();
-            if (body != null) {
+            if (FormatValidator.hasValue(body)) {
                 payload.put("body", body);
             }
         }

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/result/attendance/GetMonthlyAttendanceResult.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/result/attendance/GetMonthlyAttendanceResult.java
@@ -1,5 +1,6 @@
 package com.personal.marketnote.reward.port.in.result.attendance;
 
+import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.reward.domain.attendance.UserAttendance;
 import com.personal.marketnote.reward.domain.attendance.UserAttendanceHistory;
 
@@ -14,12 +15,12 @@ public record GetMonthlyAttendanceResult(
         long totalRewardQuantity
 ) {
     public static GetMonthlyAttendanceResult from(UserAttendance attendance) {
-        if (attendance == null) {
+        if (FormatValidator.hasNoValue(attendance)) {
             return empty();
         }
 
         List<UserAttendanceHistory> histories = attendance.getHistories();
-        List<LocalDate> dates = histories == null
+        List<LocalDate> dates = FormatValidator.hasNoValue(histories)
                 ? List.of()
                 : histories.stream()
                 .map(UserAttendanceHistory::getAttendedAt)

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/out/web/reward/RewardServiceClient.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/out/web/reward/RewardServiceClient.java
@@ -70,7 +70,7 @@ public class RewardServiceClient implements ModifyUserPointPort {
                     statusCode = response.getStatusCode();
                 }
 
-                String exception = statusCode != null ? statusCode.toString() : "EmptyResponse";
+                String exception = FormatValidator.hasValue(statusCode) ? statusCode.toString() : "EmptyResponse";
                 JsonNode requestPayloadJson = serviceCommunicationPayloadGenerator.buildRequestPayloadJson(
                         HttpMethod.POST,
                         uri,

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/utility/ServiceCommunicationPayloadGenerator.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/utility/ServiceCommunicationPayloadGenerator.java
@@ -18,7 +18,7 @@ public class ServiceCommunicationPayloadGenerator {
     private final ObjectMapper objectMapper;
 
     public JsonNode buildPayloadJson(Object payload) {
-        if (payload == null) {
+        if (FormatValidator.hasNoValue(payload)) {
             return objectMapper.createObjectNode();
         }
 
@@ -33,7 +33,7 @@ public class ServiceCommunicationPayloadGenerator {
         Map<String, Object> payload = new LinkedHashMap<>();
         payload.put("method", method.name());
         payload.put("url", uri.toString());
-        if (body != null) {
+        if (FormatValidator.hasValue(body)) {
             payload.put("body", body);
         }
         payload.put("attempt", attempt);
@@ -45,7 +45,7 @@ public class ServiceCommunicationPayloadGenerator {
         if (FormatValidator.hasValue(response)) {
             payload.put("status", response.getStatusCode().value());
             Object body = response.getBody();
-            if (body != null) {
+            if (FormatValidator.hasValue(body)) {
                 payload.put("body", body);
             }
         }


### PR DESCRIPTION
## partially addresses #1
## resolves #811

## Task
- [x] null 체크 유효성 검사 전체 로직에서 FormatValidator를 사용하도록 변경