### PR TITLE
[#128][#819] fix: 상품 등록/수정 기능의 isFindAllOptions 파라미터 NPE 발생 문제 픽스

### DIFF
--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/product/mapper/ProductRequestToCommandMapper.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/product/mapper/ProductRequestToCommandMapper.java
@@ -15,16 +15,16 @@ import java.util.List;
 public class ProductRequestToCommandMapper {
     public static RegisterProductCommand mapToCommand(RegisterProductRequest registerProductRequest) {
         return RegisterProductCommand.builder()
-                .sellerId(registerProductRequest.getSellerId())
-                .name(registerProductRequest.getName())
-                .brandName(registerProductRequest.getBrandName())
-                .detail(registerProductRequest.getDetail())
-                .price(registerProductRequest.getPrice())
-                .discountPrice(registerProductRequest.getDiscountPrice())
-                .accumulatedPoint(registerProductRequest.getAccumulatedPoint())
-                .isFindAllOptions(registerProductRequest.getIsFindAllOptions())
-                .tags(registerProductRequest.getTags())
-                .fulfillmentVendorGoods(mapToCommand(registerProductRequest.getFulfillmentVendorGoods()))
+                .sellerId(registerProductRequest.sellerId())
+                .name(registerProductRequest.name())
+                .brandName(registerProductRequest.brandName())
+                .detail(registerProductRequest.detail())
+                .price(registerProductRequest.price())
+                .discountPrice(registerProductRequest.discountPrice())
+                .accumulatedPoint(registerProductRequest.accumulatedPoint())
+                .isFindAllOptions(registerProductRequest.isFindAllOptions())
+                .tags(registerProductRequest.tags())
+                .fulfillmentVendorGoods(mapToCommand(registerProductRequest.fulfillmentVendorGoods()))
                 .build();
     }
 
@@ -145,12 +145,12 @@ public class ProductRequestToCommandMapper {
     ) {
         return UpdateProductCommand.builder()
                 .id(id)
-                .name(request.getName())
-                .brandName(request.getBrandName())
-                .detail(request.getDetail())
-                .isFindAllOptions(request.getIsFindAllOptions())
-                .tags(request.getTags())
-                .fulfillmentVendorGoods(mapToCommand(request.getFulfillmentVendorGoods()))
+                .name(request.name())
+                .brandName(request.brandName())
+                .detail(request.detail())
+                .isFindAllOptions(request.isFindAllOptions())
+                .tags(request.tags())
+                .fulfillmentVendorGoods(mapToCommand(request.fulfillmentVendorGoods()))
                 .build();
     }
 

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/product/request/RegisterProductRequest.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/product/request/RegisterProductRequest.java
@@ -2,88 +2,100 @@ package com.personal.marketnote.product.adapter.in.web.product.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import lombok.Getter;
+import jakarta.validation.constraints.Size;
 
 import java.util.List;
 
-@Getter
-public class RegisterProductRequest {
-    @Schema(
-            name = "sellerId",
-            description = "판매자 회원 ID",
-            requiredMode = Schema.RequiredMode.REQUIRED
-    )
-    @NotNull(message = "판매자 회원 ID는 필수값입니다.")
-    @Min(value = 1, message = "판매자 회원 ID는 1 이상이어야 합니다.")
-    @Max(value = Long.MAX_VALUE, message = "판매자 회원 ID는 정수형 최대값을 초과할 수 없습니다.")
-    private Long sellerId;
+public record RegisterProductRequest(
+        @Schema(
+                name = "sellerId",
+                description = "판매자 회원 ID",
+                requiredMode = Schema.RequiredMode.REQUIRED
+        )
+        @NotNull(message = "판매자 회원 ID는 필수값입니다.")
+        @Min(value = 1, message = "판매자 회원 ID는 1 이상이어야 합니다.")
+        Long sellerId,
 
-    @Schema(
-            name = "name",
-            description = "상품명",
-            requiredMode = Schema.RequiredMode.REQUIRED
-    )
-    private String name;
+        @Schema(
+                name = "name",
+                description = "상품명",
+                requiredMode = Schema.RequiredMode.REQUIRED
+        )
+        @NotBlank(message = "상품명은 필수값입니다.")
+        @Size(min = 1, max = 255, message = "상품명은 1~255자입니다.")
+        String name,
 
-    @Schema(
-            name = "brandName",
-            description = "브랜드명",
-            requiredMode = Schema.RequiredMode.NOT_REQUIRED
-    )
-    private String brandName;
+        @Schema(
+                name = "brandName",
+                description = "브랜드명",
+                requiredMode = Schema.RequiredMode.NOT_REQUIRED
+        )
+        @Size(max = 255, message = "브랜드명은 최대 255자입니다.")
+        String brandName,
 
-    @Schema(
-            name = "detail",
-            description = "상품 설명",
-            requiredMode = Schema.RequiredMode.NOT_REQUIRED
-    )
-    @NotBlank(message = "상품 설명은 필수값입니다.")
-    private String detail;
+        @Schema(
+                name = "detail",
+                description = "상품 설명",
+                requiredMode = Schema.RequiredMode.REQUIRED
+        )
+        @NotBlank(message = "상품 설명은 필수값입니다.")
+        @Size(max = 1023, message = "상품 설명은 최대 1023자입니다.")
+        String detail,
 
-    @Schema(
-            name = "price",
-            description = "상품 기본 판매 가격(원)",
-            requiredMode = Schema.RequiredMode.REQUIRED
-    )
-    private Long price;
+        @Schema(
+                name = "price",
+                description = "상품 기본 판매 가격(원)",
+                requiredMode = Schema.RequiredMode.REQUIRED
+        )
+        @NotNull(message = "상품 기본 판매 가격은 필수값입니다.")
+        @Min(value = 0, message = "상품 기본 판매 가격은 0 이상이어야 합니다.")
+        Long price,
 
-    @Schema(
-            name = "discountPrice",
-            description = "상품 할인 판매 가격(원)",
-            requiredMode = Schema.RequiredMode.REQUIRED
-    )
-    private Long discountPrice;
+        @Schema(
+                name = "discountPrice",
+                description = "상품 할인 판매 가격(원)",
+                requiredMode = Schema.RequiredMode.REQUIRED
+        )
+        @NotNull(message = "상품 할인 판매 가격은 필수값입니다.")
+        @Min(value = 0, message = "상품 할인 판매 가격은 0 이상이어야 합니다.")
+        Long discountPrice,
 
-    @Schema(
-            name = "accumulatedPoint",
-            description = "상품 적립 포인트(원)",
-            requiredMode = Schema.RequiredMode.REQUIRED
-    )
-    private Long accumulatedPoint;
+        @Schema(
+                name = "accumulatedPoint",
+                description = "상품 적립 포인트(원)",
+                requiredMode = Schema.RequiredMode.REQUIRED
+        )
+        @NotNull(message = "상품 적립 포인트는 필수값입니다.")
+        @Min(value = 0, message = "상품 적립 포인트는 0 이상이어야 합니다.")
+        Long accumulatedPoint,
 
-    @Schema(
-            name = "isFindAllOptions",
-            description = "상품 목록 조회 시 옵션마다 개별 상품으로 조회 여부",
-            requiredMode = Schema.RequiredMode.REQUIRED
-    )
-    private Boolean isFindAllOptions;
+        @Schema(
+                name = "isFindAllOptions",
+                description = "상품 목록 조회 시 옵션마다 개별 상품으로 조회 여부",
+                requiredMode = Schema.RequiredMode.NOT_REQUIRED
+        )
+        Boolean isFindAllOptions,
 
-    @Schema(
-            name = "tags",
-            description = "상품 태그 목록",
-            requiredMode = Schema.RequiredMode.REQUIRED
-    )
-    private List<String> tags;
+        @Schema(
+                name = "tags",
+                description = "상품 태그 목록",
+                requiredMode = Schema.RequiredMode.REQUIRED
+        )
+        @NotNull(message = "상품 태그 목록은 필수값입니다.")
+        List<String> tags,
 
-    @Schema(
-            name = "fulfillmentVendorGoods",
-            description = "풀필먼트 서비스 벤더(현재 fassto) 상품 등록 옵션 정보",
-            requiredMode = Schema.RequiredMode.NOT_REQUIRED
-    )
-    @Valid
-    private RegisterProductFulfillmentVendorGoodsRequest fulfillmentVendorGoods;
+        @Schema(
+                name = "fulfillmentVendorGoods",
+                description = "풀필먼트 서비스 벤더(현재 fassto) 상품 등록 옵션 정보",
+                requiredMode = Schema.RequiredMode.NOT_REQUIRED
+        )
+        @Valid
+        RegisterProductFulfillmentVendorGoodsRequest fulfillmentVendorGoods
+) {
+    public RegisterProductRequest {
+        isFindAllOptions = isFindAllOptions != null ? isFindAllOptions : true;
+    }
 }

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/product/request/UpdateProductRequest.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/product/request/UpdateProductRequest.java
@@ -2,56 +2,64 @@ package com.personal.marketnote.product.adapter.in.web.product.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
-import lombok.Getter;
 
 import java.util.List;
 
-@Getter
-public class UpdateProductRequest {
-    @Schema(
-            name = "name",
-            description = "상품명",
-            requiredMode = Schema.RequiredMode.REQUIRED
-    )
-    @Size(min = 1, max = 255, message = "상품명은 1~255자입니다.")
-    private String name;
+public record UpdateProductRequest(
+        @Schema(
+                name = "name",
+                description = "상품명",
+                requiredMode = Schema.RequiredMode.REQUIRED
+        )
+        @NotBlank(message = "상품명은 필수값입니다.")
+        @Size(min = 1, max = 255, message = "상품명은 1~255자입니다.")
+        String name,
 
-    @Schema(
-            name = "brandName",
-            description = "브랜드명",
-            requiredMode = Schema.RequiredMode.REQUIRED
-    )
-    @Size(max = 255, message = "브랜드명은 최대 255자입니다.")
-    private String brandName;
+        @Schema(
+                name = "brandName",
+                description = "브랜드명",
+                requiredMode = Schema.RequiredMode.REQUIRED
+        )
+        @NotNull(message = "브랜드명은 필수값입니다.")
+        @Size(max = 255, message = "브랜드명은 최대 255자입니다.")
+        String brandName,
 
-    @Schema(
-            name = "detail",
-            description = "상품 설명",
-            requiredMode = Schema.RequiredMode.REQUIRED
-    )
-    @Size(max = 1023, message = "상품 설명은 최대 1023자입니다.")
-    private String detail;
+        @Schema(
+                name = "detail",
+                description = "상품 설명",
+                requiredMode = Schema.RequiredMode.REQUIRED
+        )
+        @NotBlank(message = "상품 설명은 필수값입니다.")
+        @Size(max = 1023, message = "상품 설명은 최대 1023자입니다.")
+        String detail,
 
-    @Schema(
-            name = "isFindAllOptions",
-            description = "상품 목록 조회 시 옵션마다 개별 상품으로 조회 여부",
-            requiredMode = Schema.RequiredMode.REQUIRED
-    )
-    private Boolean isFindAllOptions;
+        @Schema(
+                name = "isFindAllOptions",
+                description = "상품 목록 조회 시 옵션마다 개별 상품으로 조회 여부",
+                requiredMode = Schema.RequiredMode.NOT_REQUIRED
+        )
+        Boolean isFindAllOptions,
 
-    @Schema(
-            name = "tags",
-            description = "상품 태그 목록",
-            requiredMode = Schema.RequiredMode.REQUIRED
-    )
-    private List<String> tags;
+        @Schema(
+                name = "tags",
+                description = "상품 태그 목록",
+                requiredMode = Schema.RequiredMode.REQUIRED
+        )
+        @NotNull(message = "상품 태그 목록은 필수값입니다.")
+        List<String> tags,
 
-    @Schema(
-            name = "fulfillmentVendorGoods",
-            description = "파스토 상품 수정 파라미터",
-            requiredMode = Schema.RequiredMode.NOT_REQUIRED
-    )
-    @Valid
-    private UpdateProductFulfillmentVendorGoodsRequest fulfillmentVendorGoods;
+        @Schema(
+                name = "fulfillmentVendorGoods",
+                description = "파스토 상품 수정 파라미터",
+                requiredMode = Schema.RequiredMode.NOT_REQUIRED
+        )
+        @Valid
+        UpdateProductFulfillmentVendorGoodsRequest fulfillmentVendorGoods
+) {
+    public UpdateProductRequest {
+        isFindAllOptions = isFindAllOptions != null ? isFindAllOptions : true;
+    }
 }

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/mapper/ProductCommandToStateMapper.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/mapper/ProductCommandToStateMapper.java
@@ -20,7 +20,7 @@ public class ProductCommandToStateMapper {
                 .name(command.name())
                 .brandName(command.brandName())
                 .detail(command.detail())
-                .findAllOptionsYn(command.isFindAllOptions())
+                .findAllOptionsYn(Boolean.TRUE.equals(command.isFindAllOptions()))
                 .tags(
                         command.tags()
                                 .stream()

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/service/product/UpdateProductService.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/service/product/UpdateProductService.java
@@ -38,7 +38,8 @@ public class UpdateProductService implements UpdateProductUseCase {
 
         Product product = getProductUseCase.getProduct(id);
         product.update(
-                command.name(), command.brandName(), command.detail(), command.isFindAllOptions(), command.tags()
+                command.name(), command.brandName(), command.detail(),
+                Boolean.TRUE.equals(command.isFindAllOptions()), command.tags()
         );
 
         updateProductPort.update(product);


### PR DESCRIPTION
## partially addresses #128
## resolves #819

## Reason
클라이언트에서 isFindAllOptions 값 미전송 시 Boolean → boolean 언박싱에서 NullPointerException 발생 (500 에러)

## Action
- [x] RegisterProductRequest.isFindAllOptions 기본값 true 설정
- [x] UpdateProductRequest.isFindAllOptions 기본값 true 설정
- [x] requiredMode를 NOT_REQUIRED로 변경