### PR TITLE
[#128][#820] fix: 상품 옵션 카테고리 API Swagger 스키마 필드명 불일치 문제 픽스

### DIFF
--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/option/request/UpdateProductOptionsRequest.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/option/request/UpdateProductOptionsRequest.java
@@ -15,7 +15,7 @@ public class UpdateProductOptionsRequest {
     @NotBlank(message = "옵션 카테고리명은 필수입니다.")
     private String categoryName;
 
-    @Schema(name = "selectedOptions", description = "해당 카테고리에 등록할 옵션 목록", requiredMode = Schema.RequiredMode.REQUIRED)
+    @Schema(name = "options", description = "해당 카테고리에 등록할 옵션 목록", requiredMode = Schema.RequiredMode.REQUIRED)
     @NotNull(message = "옵션 목록은 필수입니다.")
     @Size(min = 1, message = "각 옵션 카테고리는 최소 1개 이상의 옵션을 가져야 합니다.")
     private List<@Valid RegisterProductOptionRequest> options;


### PR DESCRIPTION
## partially addresses #128
## resolves #820

## Reason
@Schema 애노테이션에 name="selectedOptions"로 정의되어 있으나 실제 필드명은 options로, 클라이언트 개발 시 혼란 유발

## Action
- [x] UpdateProductOptionsRequest의 @Schema name을 "options"로 변경