### PR TITLE
[#723][#821] fix: 파스토 출고 상품 상세 목록 조회 시 빈 배열의 응답이 오더라도 성공으로 처리하도록 변경

### DIFF
--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/client/FasstoDeliveryClient.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/client/FasstoDeliveryClient.java
@@ -417,6 +417,10 @@ public class FasstoDeliveryClient implements RegisterFasstoDeliveryPort, UpdateF
                 return mapOutOrdGoodsDetailResult(parsedResponse);
             }
 
+            if (isOutOrdGoodsDetailEmptyDataResponse(response, parsedResponse)) {
+                return mapOutOrdGoodsDetailResult(parsedResponse);
+            }
+
             String vendorMessage = resolveVendorMessage(parsedResponse, FormatValidator.hasValue(response) ? response.getBody() : null);
             if (FormatValidator.hasValue(vendorMessage)) {
                 failureMessage = vendorMessage;
@@ -1958,6 +1962,14 @@ public class FasstoDeliveryClient implements RegisterFasstoDeliveryPort, UpdateF
                 && response.getStatusCode().value() == 200
                 && FormatValidator.hasValue(parsedResponse)
                 && parsedResponse.isSuccess();
+    }
+
+    private boolean isOutOrdGoodsDetailEmptyDataResponse(ResponseEntity<String> response, FasstoOutOrdGoodsDetailListResponse parsedResponse) {
+        return FormatValidator.hasValue(response)
+                && response.getStatusCode().value() == 200
+                && FormatValidator.hasValue(parsedResponse)
+                && FormatValidator.hasValue(parsedResponse.header())
+                && FormatValidator.hasNoValue(parsedResponse.data());
     }
 
     private boolean isOutOrdGoodsByOrdNoSuccess(ResponseEntity<String> response, FasstoOutOrdGoodsByOrdNoListResponse parsedResponse) {


### PR DESCRIPTION
## partially addresses #723
## resolves #821

## Task
- [x] 빈 배열의 응답에 대해 200으로 처리하도록 변경