### PR TITLE
[#723][#823] fix: 비활성화(삭제) 상품 공개 상세 조회 API 노출 문제 픽스

### DIFF
--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/product/ProductPersistenceAdapter.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/product/ProductPersistenceAdapter.java
@@ -52,6 +52,11 @@ public class ProductPersistenceAdapter implements SaveProductPort, FindProductPo
     }
 
     @Override
+    public Optional<Product> findActiveById(Long id) {
+        return findById(id).filter(Product::isActive);
+    }
+
+    @Override
     public List<Product> findAll() {
         return loadProductsWithAssociations(productJpaRepository.findAll()).stream()
                 .map(entity -> ProductJpaEntityToDomainMapper.mapToDomain(entity).get())

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/usecase/product/GetProductUseCase.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/usecase/product/GetProductUseCase.java
@@ -34,9 +34,19 @@ public interface GetProductUseCase {
      * @return 상품 상세 정보 응답 {@link GetProductInfoWithOptionsResult}
      * @Date 2025-12-31
      * @Author 성효빈
-     * @Description 상품 상세 정보를 조회합니다.
+     * @Description 활성화 상태의 상품 상세 정보를 조회합니다.
      */
     GetProductInfoWithOptionsResult getProductInfo(Long id, List<Long> selectedOptionIds);
+
+    /**
+     * @param id                상품 ID
+     * @param selectedOptionIds 선택된 옵션 ID 목록
+     * @return 상품 상세 정보 응답 {@link GetProductInfoWithOptionsResult}
+     * @Date 2026-02-23
+     * @Author 성효빈
+     * @Description 비활성화/비노출 상품을 포함하여 상품 상세 정보를 조회합니다. (관리자용)
+     */
+    GetProductInfoWithOptionsResult getProductInfoIncludingInactive(Long id, List<Long> selectedOptionIds);
 
     /**
      * @param categoryId     카테고리 ID

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/out/product/FindProductPort.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/out/product/FindProductPort.java
@@ -29,6 +29,15 @@ public interface FindProductPort {
     Optional<Product> findById(Long productId);
 
     /**
+     * @param productId 상품 ID
+     * @return 활성화 상태의 상품 도메인 {@link Product}
+     * @Date 2026-02-23
+     * @Author 성효빈
+     * @Description 활성화 상태의 상품만 조회합니다.
+     */
+    Optional<Product> findActiveById(Long productId);
+
+    /**
      * @return 모든 상품 목록 {@link List<Product>}
      * @Date 2025-12-31
      * @Author 성효빈

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/service/product/GetAdminProductDetailService.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/service/product/GetAdminProductDetailService.java
@@ -35,7 +35,7 @@ public class GetAdminProductDetailService implements GetAdminProductDetailUseCas
                 ? selectedOptionIds
                 : List.of();
 
-        GetProductInfoWithOptionsResult productInfo = getProductUseCase.getProductInfo(id, options);
+        GetProductInfoWithOptionsResult productInfo = getProductUseCase.getProductInfoIncludingInactive(id, options);
 
         GetFulfillmentVendorGoodsResult goodsResult = getFulfillmentVendorGoodsPort.getFulfillmentVendorGoods(
                 String.valueOf(id)

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/service/product/GetProductService.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/service/product/GetProductService.java
@@ -72,6 +72,20 @@ public class GetProductService implements GetProductUseCase {
 
     @Override
     public GetProductInfoWithOptionsResult getProductInfo(Long id, List<Long> selectedOptionIds) {
+        Product product = findProductPort.findActiveById(id)
+                .orElseThrow(() -> new ProductNotFoundException(id));
+        return buildProductInfo(product, id, selectedOptionIds);
+    }
+
+    @Override
+    public GetProductInfoWithOptionsResult getProductInfoIncludingInactive(Long id, List<Long> selectedOptionIds) {
+        Product product = getProduct(id);
+        return buildProductInfo(product, id, selectedOptionIds);
+    }
+
+    private GetProductInfoWithOptionsResult buildProductInfo(
+            Product product, Long id, List<Long> selectedOptionIds
+    ) {
         // 상단 대표 이미지 목록, 본문 이미지 목록 조회 시작
         CompletableFuture<GetFilesResult> representativeFuture =
                 CompletableFuture.supplyAsync(
@@ -90,7 +104,6 @@ public class GetProductService implements GetProductUseCase {
                 );
 
         // 상품 조회 (병렬 진행)
-        Product product = getProduct(id);
         List<ProductOptionCategory> categories
                 = findProductOptionCategoryPort.findActiveWithOptionsByProductId(product.getId());
         List<PricePolicy> pricePolicies


### PR DESCRIPTION
## partially addresses #723
## resolves #823

## Reason
FindProductPort.findById()가 EntityStatus 필터 없이 JPA 기본 findById()를 사용하여, 삭제(INACTIVE) 처리된 상품이 비인증 사용자에게 200으로 조회됨. 상품 목록 조회는 ACTIVE 필터가 적용되어 있으나 상세 조회에는 누락

## Action
- [x] FindProductPort에 findActiveById() 포트 메서드 추가
- [x] ProductPersistenceAdapter에서 기존 캐시 재활용 + isActive 필터로 구현
- [x] GetProductService.getProductInfo()에서 findActiveById() 사용 (공개 조회)
- [x] GetProductUseCase에 getProductInfoIncludingInactive() 추가 (관리자용)
- [x] GetAdminProductDetailService가 관리자용 메서드를 호출하도록 변경