### PR TITLE
[#723][#824] fix: 예외 발생 시 스택 트레이스가 응답에 노출되는 보안 취약점에 대해 GlobalExceptionHandler 예외 처리 보강

### DIFF
--- a/commerce-service/commerce-adapters/src/main/resources/application.yml
+++ b/commerce-service/commerce-adapters/src/main/resources/application.yml
@@ -46,8 +46,8 @@ client:
 server:
   origin: ${SERVER_ORIGIN:http://localhost:8082}
   error:
-    include-exception: true
-    include-stacktrace: ALWAYS
+    include-exception: false
+    include-stacktrace: NEVER
     whitelabel:
       enabled: false
 

--- a/common/src/main/java/com/personal/marketnote/common/domain/exception/GlobalExceptionHandler.java
+++ b/common/src/main/java/com/personal/marketnote/common/domain/exception/GlobalExceptionHandler.java
@@ -7,6 +7,7 @@ import jakarta.persistence.EntityExistsException;
 import jakarta.persistence.EntityNotFoundException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -16,8 +17,10 @@ import org.springframework.security.core.AuthenticationException;
 import org.springframework.web.HttpMediaTypeNotSupportedException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -335,6 +338,60 @@ public class GlobalExceptionHandler {
                 .message(message)
                 .build();
 
+        return new ResponseEntity<>(errorResponse, HttpStatus.resolve(errorResponse.getStatusCode()));
+    }
+
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    private ResponseEntity<ErrorResponse> handleMissingServletRequestParameterException(
+            MissingServletRequestParameterException e) {
+        httpStatus = HttpStatus.BAD_REQUEST;
+        code = httpStatus.name();
+        message = "필수 요청 파라미터 '" + e.getParameterName() + "'이(가) 누락되었습니다.";
+
+        log.info(LOG_INFO_MESSAGE, e.getMessage(), e);
+
+        ErrorResponse errorResponse = ErrorResponse.builder()
+                .statusCode(httpStatus.value())
+                .timestamp(LocalDateTime.now())
+                .code(code)
+                .message(message)
+                .build();
+        return new ResponseEntity<>(errorResponse, HttpStatus.resolve(errorResponse.getStatusCode()));
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    private ResponseEntity<ErrorResponse> handleMethodArgumentTypeMismatchException(
+            MethodArgumentTypeMismatchException e) {
+        httpStatus = HttpStatus.BAD_REQUEST;
+        code = httpStatus.name();
+        message = "요청 파라미터 '" + e.getName() + "'의 타입이 올바르지 않습니다.";
+
+        log.info(LOG_INFO_MESSAGE, e.getMessage(), e);
+
+        ErrorResponse errorResponse = ErrorResponse.builder()
+                .statusCode(httpStatus.value())
+                .timestamp(LocalDateTime.now())
+                .code(code)
+                .message(message)
+                .build();
+        return new ResponseEntity<>(errorResponse, HttpStatus.resolve(errorResponse.getStatusCode()));
+    }
+
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    private ResponseEntity<ErrorResponse> handleDataIntegrityViolationException(
+            DataIntegrityViolationException e) {
+        httpStatus = HttpStatus.CONFLICT;
+        code = httpStatus.name();
+        message = "데이터 무결성 제약 조건을 위반했습니다.";
+
+        log.error(LOG_ERROR_MESSAGE, e.getMessage(), e);
+
+        ErrorResponse errorResponse = ErrorResponse.builder()
+                .statusCode(httpStatus.value())
+                .timestamp(LocalDateTime.now())
+                .code(code)
+                .message(message)
+                .build();
         return new ResponseEntity<>(errorResponse, HttpStatus.resolve(errorResponse.getStatusCode()));
     }
 }

--- a/community-service/community-adapters/src/main/resources/application.yml
+++ b/community-service/community-adapters/src/main/resources/application.yml
@@ -46,8 +46,8 @@ client:
 server:
   origin: ${SERVER_ORIGIN:http://localhost:8083}
   error:
-    include-exception: true
-    include-stacktrace: ALWAYS
+    include-exception: false
+    include-stacktrace: NEVER
     whitelabel:
       enabled: false
 

--- a/file-service/file-adapters/src/main/resources/application.yml
+++ b/file-service/file-adapters/src/main/resources/application.yml
@@ -44,8 +44,8 @@ client:
 server:
   origin: ${SERVER_ORIGIN:http://localhost:9000}
   error:
-    include-exception: true
-    include-stacktrace: ALWAYS
+    include-exception: false
+    include-stacktrace: NEVER
     whitelabel:
       enabled: false
 

--- a/fulfillment-service/fulfillment-adapters/src/main/resources/application.yml
+++ b/fulfillment-service/fulfillment-adapters/src/main/resources/application.yml
@@ -40,8 +40,8 @@ client:
 server:
   origin: ${SERVER_ORIGIN:http://localhost:8085}
   error:
-    include-exception: true
-    include-stacktrace: ALWAYS
+    include-exception: false
+    include-stacktrace: NEVER
     whitelabel:
       enabled: false
 

--- a/product-service/product-adapters/src/main/resources/application.yml
+++ b/product-service/product-adapters/src/main/resources/application.yml
@@ -46,8 +46,8 @@ client:
 server:
   origin: ${SERVER_ORIGIN:http://localhost:8081}
   error:
-    include-exception: true
-    include-stacktrace: ALWAYS
+    include-exception: false
+    include-stacktrace: NEVER
     whitelabel:
       enabled: false
 

--- a/reward-service/reward-adapters/src/main/resources/application.yml
+++ b/reward-service/reward-adapters/src/main/resources/application.yml
@@ -46,8 +46,8 @@ client:
 server:
   origin: ${SERVER_ORIGIN:http://localhost:8084}
   error:
-    include-exception: true
-    include-stacktrace: ALWAYS
+    include-exception: false
+    include-stacktrace: NEVER
     whitelabel:
       enabled: false
 


### PR DESCRIPTION
## partially addresses #723
## resolves #824

## Reason
API 에러 응답에 예외 스택 트레이스가 그대로 노출되어 내부 패키지 구조, 클래스명, 프레임워크 버전 등이 유출됨

## Action
- [x] 6개 서비스 application.yml에 `include-exception: false`, `include-stacktrace: NEVER` 적용
- [x] GlobalExceptionHandler에 MissingServletRequestParameterException 핸들러 추가 (400)
- [x] GlobalExceptionHandler에 MethodArgumentTypeMismatchException 핸들러 추가 (400)
- [x] GlobalExceptionHandler에 DataIntegrityViolationException 핸들러 추가 (409)
- [x] 사용자에게는 안전한 메시지만 전달, 내부 로그는 상세 유지