### PR TITLE
[#723][#843] test: 새로 추가된 로직들의 사이드 이펙트로 인해 실패하는 기존 자동화 테스트 로직 픽스

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -261,7 +261,7 @@ pipeline {
 		stage('Test') {
             steps {
                 sh "chmod u+x ${WORKSPACE}/gradlew"
-                sh "./gradlew -p ${env.SERVICE_DIRECTORY} clean test"
+                sh "./gradlew -p ${env.SERVICE_NAME} clean test"
                 echo "Tests complete"
             }
         }

--- a/product-service/product-application/src/test/java/com/personal/marketnote/product/service/product/GetAdminProductDetailUseCaseTest.java
+++ b/product-service/product-application/src/test/java/com/personal/marketnote/product/service/product/GetAdminProductDetailUseCaseTest.java
@@ -17,6 +17,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Arrays;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -46,7 +47,7 @@ class GetAdminProductDetailUseCaseTest {
         FulfillmentVendorGoodsInfoResult goodsInfo = goodsInfoWithCstGodCd(String.valueOf(id));
         FulfillmentVendorGoodsElementInfoResult elementInfo = elementInfoWithCstGodCd(String.valueOf(id));
 
-        when(getProductUseCase.getProductInfo(id, selectedOptionIds)).thenReturn(productInfo);
+        when(getProductUseCase.getProductInfoIncludingInactive(id, selectedOptionIds)).thenReturn(productInfo);
         when(getFulfillmentVendorGoodsPort.getFulfillmentVendorGoods(String.valueOf(id)))
                 .thenReturn(GetFulfillmentVendorGoodsResult.of(1, List.of(goodsInfo)));
         when(getFulfillmentVendorGoodsElementsPort.getFulfillmentVendorGoodsElements())
@@ -59,7 +60,7 @@ class GetAdminProductDetailUseCaseTest {
         assertThat(result.product()).isSameAs(productInfo);
         assertThat(result.fasstoGoods()).isSameAs(goodsInfo);
         assertThat(result.fasstoGoodsElement()).isSameAs(elementInfo);
-        verify(getProductUseCase).getProductInfo(id, selectedOptionIds);
+        verify(getProductUseCase).getProductInfoIncludingInactive(id, selectedOptionIds);
         verify(getFulfillmentVendorGoodsPort).getFulfillmentVendorGoods(String.valueOf(id));
         verify(getFulfillmentVendorGoodsElementsPort).getFulfillmentVendorGoodsElements();
     }
@@ -70,7 +71,7 @@ class GetAdminProductDetailUseCaseTest {
         Long id = 200L;
         GetProductInfoWithOptionsResult productInfo = mock(GetProductInfoWithOptionsResult.class);
 
-        when(getProductUseCase.getProductInfo(eq(id), anyList())).thenReturn(productInfo);
+        when(getProductUseCase.getProductInfoIncludingInactive(eq(id), anyList())).thenReturn(productInfo);
         when(getFulfillmentVendorGoodsPort.getFulfillmentVendorGoods(String.valueOf(id)))
                 .thenReturn(GetFulfillmentVendorGoodsResult.of(0, List.of()));
         when(getFulfillmentVendorGoodsElementsPort.getFulfillmentVendorGoodsElements())
@@ -79,7 +80,7 @@ class GetAdminProductDetailUseCaseTest {
         GetAdminProductDetailResult result = getAdminProductDetailService.getAdminProductDetail(id, null);
 
         ArgumentCaptor<List<Long>> optionsCaptor = ArgumentCaptor.forClass(List.class);
-        verify(getProductUseCase).getProductInfo(eq(id), optionsCaptor.capture());
+        verify(getProductUseCase).getProductInfoIncludingInactive(eq(id), optionsCaptor.capture());
         assertThat(optionsCaptor.getValue()).isEmpty();
         assertThat(result.fasstoGoods()).isNull();
         assertThat(result.fasstoGoodsElement()).isNull();
@@ -95,11 +96,11 @@ class GetAdminProductDetailUseCaseTest {
         FulfillmentVendorGoodsElementInfoResult invalidElement = elementInfoWithCstGodCd(null);
         FulfillmentVendorGoodsElementInfoResult validElement = elementInfoWithCstGodCd(String.valueOf(id));
 
-        when(getProductUseCase.getProductInfo(id, List.of())).thenReturn(productInfo);
+        when(getProductUseCase.getProductInfoIncludingInactive(id, List.of())).thenReturn(productInfo);
         when(getFulfillmentVendorGoodsPort.getFulfillmentVendorGoods(String.valueOf(id)))
-                .thenReturn(GetFulfillmentVendorGoodsResult.of(2, List.of(null, invalidGoods, validGoods)));
+                .thenReturn(GetFulfillmentVendorGoodsResult.of(2, Arrays.asList(null, invalidGoods, validGoods)));
         when(getFulfillmentVendorGoodsElementsPort.getFulfillmentVendorGoodsElements())
-                .thenReturn(GetFulfillmentVendorGoodsElementsResult.of(2, List.of(null, invalidElement, validElement)));
+                .thenReturn(GetFulfillmentVendorGoodsElementsResult.of(2, Arrays.asList(null, invalidElement, validElement)));
 
         GetAdminProductDetailResult result = getAdminProductDetailService.getAdminProductDetail(id, List.of());
 
@@ -117,7 +118,7 @@ class GetAdminProductDetailUseCaseTest {
         FulfillmentVendorGoodsElementInfoResult firstElement = elementInfoWithCstGodCd(String.valueOf(id));
         FulfillmentVendorGoodsElementInfoResult secondElement = elementInfoWithCstGodCd(String.valueOf(id));
 
-        when(getProductUseCase.getProductInfo(id, List.of())).thenReturn(productInfo);
+        when(getProductUseCase.getProductInfoIncludingInactive(id, List.of())).thenReturn(productInfo);
         when(getFulfillmentVendorGoodsPort.getFulfillmentVendorGoods(String.valueOf(id)))
                 .thenReturn(GetFulfillmentVendorGoodsResult.of(2, List.of(firstGoods, secondGoods)));
         when(getFulfillmentVendorGoodsElementsPort.getFulfillmentVendorGoodsElements())
@@ -135,7 +136,7 @@ class GetAdminProductDetailUseCaseTest {
         Long id = 500L;
         RuntimeException exception = new RuntimeException("product info fail");
 
-        when(getProductUseCase.getProductInfo(id, List.of())).thenThrow(exception);
+        when(getProductUseCase.getProductInfoIncludingInactive(id, List.of())).thenThrow(exception);
 
         assertThatThrownBy(() -> getAdminProductDetailService.getAdminProductDetail(id, List.of()))
                 .isSameAs(exception);
@@ -150,7 +151,7 @@ class GetAdminProductDetailUseCaseTest {
         GetProductInfoWithOptionsResult productInfo = mock(GetProductInfoWithOptionsResult.class);
         RuntimeException exception = new RuntimeException("goods fail");
 
-        when(getProductUseCase.getProductInfo(id, List.of())).thenReturn(productInfo);
+        when(getProductUseCase.getProductInfoIncludingInactive(id, List.of())).thenReturn(productInfo);
         when(getFulfillmentVendorGoodsPort.getFulfillmentVendorGoods(String.valueOf(id))).thenThrow(exception);
 
         assertThatThrownBy(() -> getAdminProductDetailService.getAdminProductDetail(id, List.of()))
@@ -166,7 +167,7 @@ class GetAdminProductDetailUseCaseTest {
         GetProductInfoWithOptionsResult productInfo = mock(GetProductInfoWithOptionsResult.class);
         RuntimeException exception = new RuntimeException("elements fail");
 
-        when(getProductUseCase.getProductInfo(id, List.of())).thenReturn(productInfo);
+        when(getProductUseCase.getProductInfoIncludingInactive(id, List.of())).thenReturn(productInfo);
         when(getFulfillmentVendorGoodsPort.getFulfillmentVendorGoods(String.valueOf(id)))
                 .thenReturn(GetFulfillmentVendorGoodsResult.of(0, List.of()));
         when(getFulfillmentVendorGoodsElementsPort.getFulfillmentVendorGoodsElements()).thenThrow(exception);

--- a/product-service/product-application/src/test/java/com/personal/marketnote/product/service/product/GetProductUseCaseTest.java
+++ b/product-service/product-application/src/test/java/com/personal/marketnote/product/service/product/GetProductUseCaseTest.java
@@ -123,7 +123,7 @@ class GetProductUseCaseTest {
         when(getPricePoliciesUseCase.getPricePoliciesAndOptions(List.of(500L)))
                 .thenReturn(List.of(policyForLookup));
 
-        when(findProductPort.findById(1L)).thenReturn(Optional.of(product));
+        when(findProductPort.findActiveById(1L)).thenReturn(Optional.of(product));
         ProductOptionCategory category = buildOptionCategory(11L, product, optionList);
         when(findProductOptionCategoryPort.findActiveWithOptionsByProductId(1L))
                 .thenReturn(List.of(category));
@@ -164,7 +164,7 @@ class GetProductUseCaseTest {
         Product product = buildProduct(2L, false);
         PricePolicy optionPolicy = buildPricePolicy(900L, product, List.of(1L), List.of());
 
-        when(findProductPort.findById(2L)).thenReturn(Optional.of(product));
+        when(findProductPort.findActiveById(2L)).thenReturn(Optional.of(product));
         when(findProductOptionCategoryPort.findActiveWithOptionsByProductId(2L))
                 .thenReturn(List.of());
         when(findPricePoliciesPort.findByProductId(2L)).thenReturn(List.of(optionPolicy));
@@ -181,15 +181,13 @@ class GetProductUseCaseTest {
     @Test
     @DisplayName("상품 상세 정보 조회 시 상품이 없으면 예외를 던진다")
     void getProductInfo_productNotFound_throws() {
-        stubProductImageExecutor();
-        stubProductImagesEmpty(77L);
-        when(findProductPort.findById(77L)).thenReturn(Optional.empty());
+        when(findProductPort.findActiveById(77L)).thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> getProductService.getProductInfo(77L, List.of()))
                 .isInstanceOf(ProductNotFoundException.class)
                 .hasMessageContaining("상품을 찾을 수 없습니다");
 
-        verify(findProductPort).findById(77L);
+        verify(findProductPort).findActiveById(77L);
         verifyNoInteractions(findProductOptionCategoryPort, findPricePoliciesPort, getProductInventoryUseCase);
     }
 
@@ -203,7 +201,7 @@ class GetProductUseCaseTest {
         PricePolicy defaultPolicy = buildPricePolicy(700L, product, null, List.of());
         PricePolicy optionPolicy = buildPricePolicy(701L, product, List.of(202L), List.of());
 
-        when(findProductPort.findById(3L)).thenReturn(Optional.of(product));
+        when(findProductPort.findActiveById(3L)).thenReturn(Optional.of(product));
         when(findProductOptionCategoryPort.findActiveWithOptionsByProductId(3L))
                 .thenReturn(List.of(category));
         when(findPricePoliciesPort.findByProductId(3L)).thenReturn(List.of(defaultPolicy, optionPolicy));
@@ -232,7 +230,7 @@ class GetProductUseCaseTest {
         PricePolicy defaultPolicy = buildPricePolicy(800L, product, null, List.of());
         PricePolicy optionPolicy = buildPricePolicy(801L, product, selectedOptionIds, List.of());
 
-        when(findProductPort.findById(4L)).thenReturn(Optional.of(product));
+        when(findProductPort.findActiveById(4L)).thenReturn(Optional.of(product));
         when(findProductOptionCategoryPort.findActiveWithOptionsByProductId(4L))
                 .thenReturn(List.of(category));
         when(findPricePoliciesPort.findByProductId(4L)).thenReturn(List.of(defaultPolicy, optionPolicy));
@@ -256,7 +254,7 @@ class GetProductUseCaseTest {
         PricePolicy defaultPolicy = buildPricePolicy(810L, product, null, List.of());
         PricePolicy optionPolicy = buildPricePolicy(811L, product, List.of(401L), List.of());
 
-        when(findProductPort.findById(5L)).thenReturn(Optional.of(product));
+        when(findProductPort.findActiveById(5L)).thenReturn(Optional.of(product));
         when(findProductOptionCategoryPort.findActiveWithOptionsByProductId(5L))
                 .thenReturn(List.of(category));
         when(findPricePoliciesPort.findByProductId(5L)).thenReturn(List.of(defaultPolicy, optionPolicy));
@@ -281,7 +279,7 @@ class GetProductUseCaseTest {
         PricePolicy defaultPolicy = buildPricePolicy(820L, product, null, List.of());
         PricePolicy optionPolicy = buildPricePolicy(821L, product, selectedOptionIds, List.of());
 
-        when(findProductPort.findById(6L)).thenReturn(Optional.of(product));
+        when(findProductPort.findActiveById(6L)).thenReturn(Optional.of(product));
         when(findProductOptionCategoryPort.findActiveWithOptionsByProductId(6L))
                 .thenReturn(List.of());
         when(findPricePoliciesPort.findByProductId(6L)).thenReturn(List.of(defaultPolicy, optionPolicy));


### PR DESCRIPTION
## partially addresses #723
## resolves #843

## Reason
새로 추가된 로직들의 사이드 이펙트로 인해 기존 자동화 테스트 실패

## Action
- [x] GetProductUseCaseTest
    - [x] 가격 정책 ID로 상품 상세 정보 조회 시 옵션 가격 정책을 선택한다
    - [x] 상품 상세 정보 조회 시 상품이 없으면 예외를 던진다
    - [x] 상품 상세 정보 조회 시 기본 가격 정책이 없으면 예외를 던진다
    - [x] 상품 상세 정보 조회 시 옵션 개별 노출이 꺼진 상품은 기본 가격 정책을 사용한다
    - [x] 상품 상세 정보 조회 시 옵션 카테고리가 없으면 기본 가격 정책을 사용한다
    - [x] 상품 상세 정보 조회 시 선택된 옵션이 가격 정책과 불일치하면 기본 가격 정책을 사용한다
    - [x] 상품 상세 정보 조회 시 선택된 옵션이 없으면 기본 가격 정책을 사용한다
- [x] GetAdminProductDetailUseCaseTest
    - [x] 풀필먼트 정보가 중복될 경우 최초 항목을 반환한다
    - [x] 관리자 상품 상세 정보 조회 시 선택 옵션 목록을 그대로 전달하고 풀필먼트 정보를 매핑한다
    - [x] 풀필먼트 정보에서 유효하지 않은 항목은 무시하고 매칭된 항목만 반환한다
    - [x] 관리자 상품 상세 정보 조회 중 풀필먼트 상품 조회가 실패하면 예외를 전파한다
    - [x] 관리자 상품 상세 정보 조회 중 풀필먼트 구성 조회가 실패하면 예외를 전파한다
    - [x] 상품 상세 정보 조회 시 선택 옵션이 없으면 빈 목록으로 조회한다
    - [x] 관리자 상품 상세 정보 조회 중 상품 상세 조회가 실패하면 예외를 전파한다