### PR TITLE
[#216][#861] feat: 결제 승인 기능 프로덕션/자동화 테스트 추가

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/configuration/CommerceSwaggerConfig.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/configuration/CommerceSwaggerConfig.java
@@ -33,6 +33,7 @@ public class CommerceSwaggerConfig {
     private static final List<String> TAGS_ORDER = List.of(
             "재고 API",
             "주문 API",
+            "결제 API",
             "주문 상품 API",
             "서버 정보 API"
     );

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/payment/controller/PaymentController.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/payment/controller/PaymentController.java
@@ -1,0 +1,94 @@
+package com.personal.marketnote.commerce.adapter.in.web.payment.controller;
+
+import com.personal.marketnote.commerce.adapter.in.web.payment.controller.apidocs.ApprovePaymentApiDocs;
+import com.personal.marketnote.commerce.adapter.in.web.payment.controller.apidocs.ReadyPaymentApiDocs;
+import com.personal.marketnote.commerce.adapter.in.web.payment.mapper.PaymentRequestToCommandMapper;
+import com.personal.marketnote.commerce.adapter.in.web.payment.request.ApprovePaymentRequest;
+import com.personal.marketnote.commerce.adapter.in.web.payment.request.ReadyPaymentRequest;
+import com.personal.marketnote.commerce.adapter.in.web.payment.response.ApprovePaymentResponse;
+import com.personal.marketnote.commerce.adapter.in.web.payment.response.ReadyPaymentResponse;
+import com.personal.marketnote.commerce.port.in.result.payment.ApprovePaymentResult;
+import com.personal.marketnote.commerce.port.in.result.payment.ReadyPaymentResult;
+import com.personal.marketnote.commerce.port.in.usecase.payment.ApprovePaymentUseCase;
+import com.personal.marketnote.commerce.port.in.usecase.payment.ReadyPaymentUseCase;
+import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
+import com.personal.marketnote.common.utility.ElementExtractor;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.core.OAuth2AuthenticatedPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import static com.personal.marketnote.common.domain.exception.ExceptionCode.DEFAULT_SUCCESS_CODE;
+
+@RestController
+@RequestMapping("/api/v1/payments")
+@Tag(name = "결제 API", description = "결제 관련 API")
+@RequiredArgsConstructor
+public class PaymentController {
+    private final ReadyPaymentUseCase readyPaymentUseCase;
+    private final ApprovePaymentUseCase approvePaymentUseCase;
+
+    /**
+     * 거래 등록 (Mobile)
+     *
+     * @param request 거래등록 요청
+     * @return 거래등록 응답 {@link ReadyPaymentResponse}
+     * @Author 성효빈
+     * @Date 2026-02-25
+     * @Description KCP 거래등록 API를 호출하여 결제 준비를 수행합니다.
+     */
+    @PostMapping("/ready")
+    @ReadyPaymentApiDocs
+    public ResponseEntity<BaseResponse<ReadyPaymentResponse>> readyPayment(
+            @Valid @RequestBody ReadyPaymentRequest request
+    ) {
+        ReadyPaymentResult result = readyPaymentUseCase.ready(
+                PaymentRequestToCommandMapper.mapToCommand(request)
+        );
+
+        return new ResponseEntity<>(
+                BaseResponse.of(
+                        ReadyPaymentResponse.from(result),
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "거래 등록 성공"
+                ),
+                HttpStatus.OK
+        );
+    }
+
+    /**
+     * 결제 승인
+     *
+     * @param request 결제 승인 요청
+     * @return 결제 승인 응답 {@link ApprovePaymentResponse}
+     * @Author 성효빈
+     * @Date 2026-02-25
+     * @Description KCP 결제 승인 API를 호출합니다.
+     */
+    @PostMapping("/approve")
+    @ApprovePaymentApiDocs
+    public ResponseEntity<BaseResponse<ApprovePaymentResponse>> approvePayment(
+            @AuthenticationPrincipal OAuth2AuthenticatedPrincipal principal,
+            @Valid @RequestBody ApprovePaymentRequest request
+    ) {
+        Long buyerId = ElementExtractor.extractUserId(principal);
+        ApprovePaymentResult result = approvePaymentUseCase.approve(
+                PaymentRequestToCommandMapper.mapToCommand(request, buyerId)
+        );
+
+        return new ResponseEntity<>(
+                BaseResponse.of(
+                        ApprovePaymentResponse.from(result),
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "결제 승인 성공"
+                ),
+                HttpStatus.OK
+        );
+    }
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/payment/controller/apidocs/ApprovePaymentApiDocs.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/payment/controller/apidocs/ApprovePaymentApiDocs.java
@@ -1,0 +1,100 @@
+package com.personal.marketnote.commerce.adapter.in.web.payment.controller.apidocs;
+
+import com.personal.marketnote.commerce.adapter.in.web.payment.request.ApprovePaymentRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Operation(
+        summary = "결제 승인",
+        description = """
+                작성일자: 2026-02-25
+                
+                작성자: 성효빈
+                
+                ---
+                
+                ## Description
+                
+                - KCP 결제 승인 API를 호출합니다.
+                
+                - 서버 DB 금액으로 위변조 검증 후 승인을 수행합니다.
+                
+                - 승인 성공 시 주문 상태를 PAID로 변경합니다.
+                
+                ---
+                
+                ## Request
+                
+                | **키** | **타입** | **설명** | **필수 여부** | **예시** |
+                | --- | --- | --- | --- | --- |
+                | orderKey | string | 주문 키 (UUID) | Y | "550e8400-e29b-41d4-a716-446655440000" |
+                | encData | string | KCP 결제창 인증결과 암호화 데이터 | Y | "..." |
+                | encInfo | string | KCP 결제창 인증결과 암호화 정보 | Y | "..." |
+                | payType | string | 결제수단 (PACA: 신용카드, PABK: 계좌이체, PAMC: 휴대폰) | Y | "PACA" |
+                
+                ---
+                
+                ## Response > content
+                
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | orderId | number | 주문 ID | 1 |
+                | orderKey | string | 주문 키 (UUID) | "550e8400-..." |
+                | pgPaymentKey | string | PG사 거래번호 (tno) | "KCP000001" |
+                | amount | number | 결제 금액 | 100000 |
+                | resultCode | string | 결과 코드 | "0000" |
+                | resultMessage | string | 결과 메시지 | "성공" |
+                | payMethod | string | 결제 수단 | "PACA" |
+                """,
+        security = {@SecurityRequirement(name = "bearer")},
+        requestBody = @RequestBody(
+                required = true,
+                content = @Content(
+                        schema = @Schema(implementation = ApprovePaymentRequest.class),
+                        examples = @ExampleObject("""
+                                {
+                                  "orderKey": "550e8400-e29b-41d4-a716-446655440000",
+                                  "encData": "encrypted_data_from_kcp",
+                                  "encInfo": "encrypted_info_from_kcp",
+                                  "payType": "PACA"
+                                }
+                                """)
+                )
+        ),
+        responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "결제 승인 성공",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 200,
+                                          "code": "SUC01",
+                                          "timestamp": "2026-02-25T12:00:00.000",
+                                          "content": {
+                                            "orderId": 1,
+                                            "orderKey": "550e8400-e29b-41d4-a716-446655440000",
+                                            "pgPaymentKey": "KCP000001",
+                                            "amount": 100000,
+                                            "resultCode": "0000",
+                                            "resultMessage": "성공",
+                                            "payMethod": "PACA"
+                                          },
+                                          "message": "결제 승인 성공"
+                                        }
+                                        """)
+                        )
+                )
+        })
+public @interface ApprovePaymentApiDocs {
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/payment/mapper/PaymentRequestToCommandMapper.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/payment/mapper/PaymentRequestToCommandMapper.java
@@ -1,0 +1,29 @@
+package com.personal.marketnote.commerce.adapter.in.web.payment.mapper;
+
+import com.personal.marketnote.commerce.adapter.in.web.payment.request.ApprovePaymentRequest;
+import com.personal.marketnote.commerce.adapter.in.web.payment.request.ReadyPaymentRequest;
+import com.personal.marketnote.commerce.port.in.command.payment.ApprovePaymentCommand;
+import com.personal.marketnote.commerce.port.in.command.payment.ReadyPaymentCommand;
+
+public class PaymentRequestToCommandMapper {
+    private PaymentRequestToCommandMapper() {
+    }
+
+    public static ReadyPaymentCommand mapToCommand(ReadyPaymentRequest request) {
+        return ReadyPaymentCommand.builder()
+                .orderKey(request.getOrderKey())
+                .payMethod(request.getPayMethod())
+                .goodName(request.getGoodName())
+                .build();
+    }
+
+    public static ApprovePaymentCommand mapToCommand(ApprovePaymentRequest request, Long buyerId) {
+        return ApprovePaymentCommand.builder()
+                .buyerId(buyerId)
+                .orderKey(request.getOrderKey())
+                .encData(request.getEncData())
+                .encInfo(request.getEncInfo())
+                .payType(request.getPayType())
+                .build();
+    }
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/payment/request/ApprovePaymentRequest.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/payment/request/ApprovePaymentRequest.java
@@ -1,0 +1,26 @@
+package com.personal.marketnote.commerce.adapter.in.web.payment.request;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ApprovePaymentRequest {
+    @Schema(name = "orderKey", description = "주문 키 (UUID)", requiredMode = Schema.RequiredMode.REQUIRED)
+    @NotBlank
+    private String orderKey;
+
+    @Schema(name = "encData", description = "KCP 결제창 인증결과 암호화 데이터", requiredMode = Schema.RequiredMode.REQUIRED)
+    @NotBlank
+    private String encData;
+
+    @Schema(name = "encInfo", description = "KCP 결제창 인증결과 암호화 정보", requiredMode = Schema.RequiredMode.REQUIRED)
+    @NotBlank
+    private String encInfo;
+
+    @Schema(name = "payType", description = "결제수단 (PACA: 신용카드, PABK: 계좌이체, PAMC: 휴대폰, PAPT: 포인트, PATK: 상품권)", requiredMode = Schema.RequiredMode.REQUIRED)
+    @NotBlank
+    private String payType;
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/payment/response/ApprovePaymentResponse.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/payment/response/ApprovePaymentResponse.java
@@ -1,0 +1,28 @@
+package com.personal.marketnote.commerce.adapter.in.web.payment.response;
+
+import com.personal.marketnote.commerce.port.in.result.payment.ApprovePaymentResult;
+import lombok.AccessLevel;
+import lombok.Builder;
+
+@Builder(access = AccessLevel.PRIVATE)
+public record ApprovePaymentResponse(
+        Long orderId,
+        String orderKey,
+        String pgPaymentKey,
+        Long amount,
+        String resultCode,
+        String resultMessage,
+        String payMethod
+) {
+    public static ApprovePaymentResponse from(ApprovePaymentResult result) {
+        return ApprovePaymentResponse.builder()
+                .orderId(result.orderId())
+                .orderKey(result.orderKey())
+                .pgPaymentKey(result.pgPaymentKey())
+                .amount(result.amount())
+                .resultCode(result.resultCode())
+                .resultMessage(result.resultMessage())
+                .payMethod(result.payMethod())
+                .build();
+    }
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/vendor/kcp/KcpApiClient.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/vendor/kcp/KcpApiClient.java
@@ -2,8 +2,7 @@ package com.personal.marketnote.commerce.adapter.out.vendor.kcp;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.personal.marketnote.commerce.adapter.out.vendor.kcp.dto.KcpTradeRegisterRequest;
-import com.personal.marketnote.commerce.adapter.out.vendor.kcp.dto.KcpTradeRegisterResponse;
+import com.personal.marketnote.commerce.adapter.out.vendor.kcp.dto.*;
 import com.personal.marketnote.commerce.adapter.out.vendor.kcp.exception.KcpCommunicationException;
 import com.personal.marketnote.commerce.configuration.KcpProperties;
 import com.personal.marketnote.common.utility.FormatValidator;
@@ -43,7 +42,7 @@ public class KcpApiClient {
         log.debug("KCP 거래등록 응답 Content-Type={}, body={}", rawResponse.getHeaders().getContentType(), responseBody);
 
         if (FormatValidator.hasNoValue(responseBody)) {
-            throw new KcpCommunicationException("KCP 거래등록 응답 본문이 비어있습니다");
+            throw new KcpCommunicationException("KCP 거래등록 응답 본문이 비어 있습니다.");
         }
 
         try {
@@ -51,6 +50,37 @@ public class KcpApiClient {
         } catch (Exception e) {
             log.error("KCP 거래등록 응답 파싱 실패: {}", e.getMessage());
             throw new KcpCommunicationException("KCP 거래등록 응답 파싱 실패", e);
+        }
+    }
+
+    public KcpPaymentApprovalResponse approvePayment(KcpPaymentApprovalRequest request) {
+        String url = kcpProperties.getApi().getPaymentApprovalUrl();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        HttpEntity<KcpPaymentApprovalRequest> httpEntity = new HttpEntity<>(request, headers);
+
+        log.info("KCP 결제승인 요청: url={}, ordrNo={}", url, request.ordrNo());
+
+        ResponseEntity<String> rawResponse = restTemplate.exchange(
+                url,
+                HttpMethod.POST,
+                httpEntity,
+                String.class
+        );
+
+        String responseBody = rawResponse.getBody();
+        log.debug("KCP 결제승인 응답 Content-Type={}, body={}", rawResponse.getHeaders().getContentType(), responseBody);
+
+        if (FormatValidator.hasNoValue(responseBody)) {
+            throw new KcpCommunicationException("KCP 결제승인 응답 본문이 비어 있습니다.");
+        }
+
+        try {
+            return objectMapper.readValue(responseBody, KcpPaymentApprovalResponse.class);
+        } catch (Exception e) {
+            log.error("KCP 결제승인 응답 파싱 실패: {}", e.getMessage());
+            throw new KcpCommunicationException("KCP 결제승인 응답 파싱 실패", e);
         }
     }
 

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/vendor/kcp/KcpPaymentVendorAdapter.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/vendor/kcp/KcpPaymentVendorAdapter.java
@@ -2,8 +2,7 @@ package com.personal.marketnote.commerce.adapter.out.vendor.kcp;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.personal.marketnote.commerce.adapter.out.vendor.kcp.dto.KcpTradeRegisterRequest;
-import com.personal.marketnote.commerce.adapter.out.vendor.kcp.dto.KcpTradeRegisterResponse;
+import com.personal.marketnote.commerce.adapter.out.vendor.kcp.dto.*;
 import com.personal.marketnote.commerce.adapter.out.vendor.kcp.exception.KcpCommunicationException;
 import com.personal.marketnote.commerce.configuration.KcpProperties;
 import com.personal.marketnote.commerce.domain.payment.PaymentMethod;
@@ -12,8 +11,7 @@ import com.personal.marketnote.commerce.domain.vendorcommunication.CommerceVendo
 import com.personal.marketnote.commerce.domain.vendorcommunication.CommerceVendorCommunicationType;
 import com.personal.marketnote.commerce.domain.vendorcommunication.CommerceVendorName;
 import com.personal.marketnote.commerce.port.out.payment.PaymentVendorPort;
-import com.personal.marketnote.commerce.port.out.payment.vendor.TradeRegisterVendorCommand;
-import com.personal.marketnote.commerce.port.out.payment.vendor.TradeRegisterVendorResult;
+import com.personal.marketnote.commerce.port.out.payment.vendor.*;
 import com.personal.marketnote.commerce.utility.VendorCommunicationRecorder;
 import com.personal.marketnote.common.adapter.out.ServiceAdapter;
 import lombok.RequiredArgsConstructor;
@@ -27,6 +25,7 @@ import java.util.Set;
 @Slf4j
 public class KcpPaymentVendorAdapter implements PaymentVendorPort {
     private static final CommerceVendorName VENDOR_NAME = CommerceVendorName.NHN_KCP;
+    private static final String PAYMENT_APPROVAL_TRAN_CD = "00100000";
     private static final String MASKED = "***MASKED***";
     private static final Set<String> SENSITIVE_FIELDS = Set.of(
             "kcp_cert_info", "kcp_sign_data", "enc_data", "enc_info"
@@ -76,6 +75,55 @@ public class KcpPaymentVendorAdapter implements PaymentVendorPort {
                     .build();
         } catch (KcpCommunicationException e) {
             recordError(CommerceVendorCommunicationTargetType.TRADE_REGISTER, command.orderKey(), e);
+            throw e;
+        }
+    }
+
+    @Override
+    public PaymentApprovalVendorResult approvePayment(PaymentApprovalVendorCommand command) {
+        String certInfo = kcpCertificateLoader.loadCertInfo();
+
+        KcpPaymentApprovalRequest request = KcpPaymentApprovalRequest.builder()
+                .siteCd(kcpProperties.getSiteCd())
+                .encData(command.encData())
+                .encInfo(command.encInfo())
+                .tranCd(PAYMENT_APPROVAL_TRAN_CD)
+                .kcpCertInfo(certInfo)
+                .ordrMony(command.ordrMony())
+                .ordrNo(command.ordrNo())
+                .payType(command.payType())
+                .build();
+
+        recordRequest(CommerceVendorCommunicationTargetType.PAYMENT_APPROVAL, command.ordrNo(), request);
+
+        try {
+            KcpPaymentApprovalResponse response = kcpApiClient.approvePayment(request);
+            recordResponse(CommerceVendorCommunicationTargetType.PAYMENT_APPROVAL, command.ordrNo(), response);
+
+            return PaymentApprovalVendorResult.builder()
+                    .resCd(response.resCd())
+                    .resMsg(response.resMsg())
+                    .resEnMsg(response.resEnMsg())
+                    .tno(response.tno())
+                    .amount(response.amount())
+                    .payMethod(response.payMethod())
+                    .cardCd(response.cardCd())
+                    .cardName(response.cardName())
+                    .cardNo(response.cardNo())
+                    .appNo(response.appNo())
+                    .appTime(response.appTime())
+                    .noinf(response.noinf())
+                    .noinfType(response.noinfType())
+                    .quota(response.quota())
+                    .cardMny(response.cardMny())
+                    .couponMny(response.couponMny())
+                    .partcancYn(response.partcancYn())
+                    .cardBinType01(response.cardBinType01())
+                    .cardBinType02(response.cardBinType02())
+                    .rawResponse(kcpApiClient.toJsonNode(response).toString())
+                    .build();
+        } catch (KcpCommunicationException e) {
+            recordError(CommerceVendorCommunicationTargetType.PAYMENT_APPROVAL, command.ordrNo(), e);
             throw e;
         }
     }

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/vendor/kcp/dto/KcpPaymentApprovalRequest.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/vendor/kcp/dto/KcpPaymentApprovalRequest.java
@@ -1,0 +1,17 @@
+package com.personal.marketnote.commerce.adapter.out.vendor.kcp.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+
+@Builder
+public record KcpPaymentApprovalRequest(
+        @JsonProperty("site_cd") String siteCd,
+        @JsonProperty("enc_data") String encData,
+        @JsonProperty("enc_info") String encInfo,
+        @JsonProperty("tran_cd") String tranCd,
+        @JsonProperty("kcp_cert_info") String kcpCertInfo,
+        @JsonProperty("ordr_mony") String ordrMony,
+        @JsonProperty("ordr_no") String ordrNo,
+        @JsonProperty("pay_type") String payType
+) {
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/vendor/kcp/dto/KcpPaymentApprovalResponse.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/vendor/kcp/dto/KcpPaymentApprovalResponse.java
@@ -1,0 +1,31 @@
+package com.personal.marketnote.commerce.adapter.out.vendor.kcp.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record KcpPaymentApprovalResponse(
+        @JsonProperty("res_cd") String resCd,
+        @JsonProperty("res_msg") String resMsg,
+        @JsonProperty("res_en_msg") String resEnMsg,
+        @JsonProperty("tno") String tno,
+        @JsonProperty("amount") String amount,
+        @JsonProperty("pay_method") String payMethod,
+        @JsonProperty("card_cd") String cardCd,
+        @JsonProperty("card_name") String cardName,
+        @JsonProperty("card_no") String cardNo,
+        @JsonProperty("app_no") String appNo,
+        @JsonProperty("app_time") String appTime,
+        @JsonProperty("noinf") String noinf,
+        @JsonProperty("noinf_type") String noinfType,
+        @JsonProperty("quota") String quota,
+        @JsonProperty("card_mny") String cardMny,
+        @JsonProperty("coupon_mny") String couponMny,
+        @JsonProperty("partcanc_yn") String partcancYn,
+        @JsonProperty("card_bin_type_01") String cardBinType01,
+        @JsonProperty("card_bin_type_02") String cardBinType02
+) {
+    public boolean isSuccess() {
+        return "0000".equals(resCd);
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/command/payment/ApprovePaymentCommand.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/command/payment/ApprovePaymentCommand.java
@@ -1,0 +1,13 @@
+package com.personal.marketnote.commerce.port.in.command.payment;
+
+import lombok.Builder;
+
+@Builder
+public record ApprovePaymentCommand(
+        Long buyerId,
+        String orderKey,
+        String encData,
+        String encInfo,
+        String payType
+) {
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/result/payment/ApprovePaymentResult.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/result/payment/ApprovePaymentResult.java
@@ -1,0 +1,15 @@
+package com.personal.marketnote.commerce.port.in.result.payment;
+
+import lombok.Builder;
+
+@Builder
+public record ApprovePaymentResult(
+        Long orderId,
+        String orderKey,
+        String pgPaymentKey,
+        Long amount,
+        String resultCode,
+        String resultMessage,
+        String payMethod
+) {
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/payment/ApprovePaymentUseCase.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/payment/ApprovePaymentUseCase.java
@@ -1,0 +1,15 @@
+package com.personal.marketnote.commerce.port.in.usecase.payment;
+
+import com.personal.marketnote.commerce.port.in.command.payment.ApprovePaymentCommand;
+import com.personal.marketnote.commerce.port.in.result.payment.ApprovePaymentResult;
+
+public interface ApprovePaymentUseCase {
+    /**
+     * @param command 결제 승인 커맨드
+     * @return 결제 승인 결과 {@link ApprovePaymentResult}
+     * @Date 2026-02-25
+     * @Author 성효빈
+     * @Description 결제 대행사에 결제 승인을 요청합니다.
+     */
+    ApprovePaymentResult approve(ApprovePaymentCommand command);
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/payment/PaymentVendorPort.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/payment/PaymentVendorPort.java
@@ -1,7 +1,6 @@
 package com.personal.marketnote.commerce.port.out.payment;
 
-import com.personal.marketnote.commerce.port.out.payment.vendor.TradeRegisterVendorCommand;
-import com.personal.marketnote.commerce.port.out.payment.vendor.TradeRegisterVendorResult;
+import com.personal.marketnote.commerce.port.out.payment.vendor.*;
 
 public interface PaymentVendorPort {
     /**
@@ -20,4 +19,13 @@ public interface PaymentVendorPort {
      * @Description 결제 대행사에 거래를 등록합니다.
      */
     TradeRegisterVendorResult registerTrade(TradeRegisterVendorCommand command);
+
+    /**
+     * @param command 결제 승인 요청 정보 {@link PaymentApprovalVendorCommand}
+     * @return 결제 승인 결과 {@link PaymentApprovalVendorResult}
+     * @Date 2026-02-25
+     * @Author 성효빈
+     * @Description 결제 대행사에 결제 승인을 요청합니다.
+     */
+    PaymentApprovalVendorResult approvePayment(PaymentApprovalVendorCommand command);
 }

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/payment/vendor/PaymentApprovalVendorCommand.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/payment/vendor/PaymentApprovalVendorCommand.java
@@ -1,0 +1,13 @@
+package com.personal.marketnote.commerce.port.out.payment.vendor;
+
+import lombok.Builder;
+
+@Builder
+public record PaymentApprovalVendorCommand(
+        String encData,
+        String encInfo,
+        String ordrMony,
+        String ordrNo,
+        String payType
+) {
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/payment/vendor/PaymentApprovalVendorResult.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/payment/vendor/PaymentApprovalVendorResult.java
@@ -1,0 +1,31 @@
+package com.personal.marketnote.commerce.port.out.payment.vendor;
+
+import lombok.Builder;
+
+@Builder
+public record PaymentApprovalVendorResult(
+        String resCd,
+        String resMsg,
+        String resEnMsg,
+        String tno,
+        String amount,
+        String payMethod,
+        String cardCd,
+        String cardName,
+        String cardNo,
+        String appNo,
+        String appTime,
+        String noinf,
+        String noinfType,
+        String quota,
+        String cardMny,
+        String couponMny,
+        String partcancYn,
+        String cardBinType01,
+        String cardBinType02,
+        String rawResponse
+) {
+    public boolean isSuccess() {
+        return "0000".equals(resCd);
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/ApprovePaymentService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/ApprovePaymentService.java
@@ -1,0 +1,171 @@
+package com.personal.marketnote.commerce.service.payment;
+
+import com.personal.marketnote.commerce.domain.order.Order;
+import com.personal.marketnote.commerce.domain.order.OrderStatus;
+import com.personal.marketnote.commerce.domain.payment.Payment;
+import com.personal.marketnote.commerce.domain.payment.PaymentApprovalInfo;
+import com.personal.marketnote.commerce.domain.payment.PspPaymentEvent;
+import com.personal.marketnote.commerce.exception.PaymentApprovalException;
+import com.personal.marketnote.commerce.exception.PaymentNotFoundException;
+import com.personal.marketnote.commerce.port.in.command.order.ChangeOrderStatusCommand;
+import com.personal.marketnote.commerce.port.in.command.payment.ApprovePaymentCommand;
+import com.personal.marketnote.commerce.port.in.result.payment.ApprovePaymentResult;
+import com.personal.marketnote.commerce.port.in.usecase.order.ChangeOrderStatusUseCase;
+import com.personal.marketnote.commerce.port.in.usecase.payment.ApprovePaymentUseCase;
+import com.personal.marketnote.commerce.port.out.order.FindOrderPort;
+import com.personal.marketnote.commerce.port.out.payment.*;
+import com.personal.marketnote.commerce.port.out.payment.vendor.PaymentApprovalVendorCommand;
+import com.personal.marketnote.commerce.port.out.payment.vendor.PaymentApprovalVendorResult;
+import com.personal.marketnote.common.application.UseCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional(isolation = READ_COMMITTED)
+@Slf4j
+public class ApprovePaymentService implements ApprovePaymentUseCase {
+    private final FindOrderPort findOrderPort;
+    private final FindPaymentPort findPaymentPort;
+    private final UpdatePaymentPort updatePaymentPort;
+    private final SavePspPaymentEventPort savePspPaymentEventPort;
+    private final FindPspPaymentEventPort findPspPaymentEventPort;
+    private final UpdatePspPaymentEventPort updatePspPaymentEventPort;
+    private final PaymentVendorPort paymentVendorPort;
+    private final ChangeOrderStatusUseCase changeOrderStatusUseCase;
+
+    @Override
+    public ApprovePaymentResult approve(ApprovePaymentCommand command) {
+        UUID orderKeyUuid = UUID.fromString(command.orderKey());
+
+        Payment payment = findPaymentPort.findByOrderKey(orderKeyUuid)
+                .orElseThrow(() -> new PaymentNotFoundException(command.orderKey()));
+
+        Order order = findVerifiedOrder(payment.getOrderId(), command.buyerId());
+        verifyPaymentAmount(order, payment);
+
+        String vendorSiteCd = paymentVendorPort.getVendorSiteCd();
+        PspPaymentEvent event = findPspPaymentEventPort.findByOrderKey(command.orderKey())
+                .orElseGet(() -> PspPaymentEvent.createReady(payment, vendorSiteCd, command.payType()));
+        event.startExecution();
+        savePspPaymentEventPort.save(event);
+
+        Long serverAmount = payment.getPaymentAmount();
+
+        PaymentApprovalVendorCommand vendorCommand = PaymentApprovalVendorCommand.builder()
+                .encData(command.encData())
+                .encInfo(command.encInfo())
+                .ordrMony(String.valueOf(serverAmount))
+                .ordrNo(command.orderKey())
+                .payType(command.payType())
+                .build();
+
+        PaymentApprovalVendorResult vendorResult;
+        try {
+            vendorResult = paymentVendorPort.approvePayment(vendorCommand);
+        } catch (Exception e) {
+            handleFailure(payment, event, "KCP 통신 오류: " + e.getMessage());
+            throw PaymentApprovalException.kcpApprovalRequestFailed(e);
+        }
+
+        if (vendorResult.isSuccess()) {
+            return handleSuccess(payment, event, vendorResult);
+        }
+
+        handleFailure(payment, event, vendorResult.resMsg());
+        throw PaymentApprovalException.kcpApprovalFailed(vendorResult.resCd(), vendorResult.resMsg());
+    }
+
+    private ApprovePaymentResult handleSuccess(
+            Payment payment, PspPaymentEvent event, PaymentApprovalVendorResult vendorResult
+    ) {
+        payment.markAsSuccess(vendorResult.tno());
+        updatePaymentPort.update(payment);
+
+        Short installment = parseInstallment(vendorResult.quota());
+        PaymentApprovalInfo approvalInfo = PaymentApprovalInfo.builder()
+                .pgPaymentKey(vendorResult.tno())
+                .method(vendorResult.payMethod())
+                .cardNumber(vendorResult.cardNo())
+                .approvalNumber(vendorResult.appNo())
+                .installment(installment)
+                .issueCompanyCode(vendorResult.cardCd())
+                .issueCompanyName(vendorResult.cardName())
+                .resultCode(vendorResult.resCd())
+                .resultMessage(vendorResult.resMsg())
+                .pgApprovalResult(vendorResult.rawResponse())
+                .appTime(vendorResult.appTime())
+                .build();
+        event.completeWithApproval(approvalInfo);
+        updatePspPaymentEventPort.update(event);
+
+        changeOrderStatusUseCase.changeOrderStatus(
+                ChangeOrderStatusCommand.builder()
+                        .id(payment.getOrderId())
+                        .orderStatus(OrderStatus.PAID)
+                        .build()
+        );
+
+        return ApprovePaymentResult.builder()
+                .orderId(payment.getOrderId())
+                .orderKey(payment.getOrderKey().toString())
+                .pgPaymentKey(vendorResult.tno())
+                .amount(payment.getPaymentAmount())
+                .resultCode(vendorResult.resCd())
+                .resultMessage(vendorResult.resMsg())
+                .payMethod(vendorResult.payMethod())
+                .build();
+    }
+
+    private void handleFailure(Payment payment, PspPaymentEvent event, String reason) {
+        payment.markAsFailed();
+        updatePaymentPort.update(payment);
+
+        event.failExecution("FAIL", reason);
+        updatePspPaymentEventPort.update(event);
+
+        changeOrderStatusUseCase.changeOrderStatus(
+                ChangeOrderStatusCommand.builder()
+                        .id(payment.getOrderId())
+                        .orderStatus(OrderStatus.FAILED)
+                        .build()
+        );
+    }
+
+    private Order findVerifiedOrder(Long orderId, Long buyerId) {
+        Order order = findOrderPort.findById(orderId)
+                .orElseThrow(() -> new IllegalStateException("주문 정보를 찾을 수 없습니다: " + orderId));
+        if (!order.getBuyerId().equals(buyerId)) {
+            throw new IllegalStateException("해당 주문에 대한 권한이 없습니다");
+        }
+        return order;
+    }
+
+    private void verifyPaymentAmount(Order order, Payment payment) {
+        Long couponAmount = order.getCouponAmount() != null ? order.getCouponAmount() : 0L;
+        Long pointAmount = order.getPointAmount() != null ? order.getPointAmount() : 0L;
+        Long expectedAmount = order.getTotalAmount() - couponAmount - pointAmount;
+
+        if (!expectedAmount.equals(payment.getPaymentAmount())) {
+            log.error("결제 금액 불일치: orderId={}, 주문금액={}, 쿠폰={}, 포인트={}, 예상결제금액={}, 실제결제금액={}",
+                    order.getId(), order.getTotalAmount(), couponAmount, pointAmount,
+                    expectedAmount, payment.getPaymentAmount());
+            throw new IllegalStateException(
+                    "주문 금액과 결제 금액이 일치하지 않습니다. 예상: " + expectedAmount + ", 실제: " + payment.getPaymentAmount()
+            );
+        }
+    }
+
+    private Short parseInstallment(String quota) {
+        try {
+            return Short.parseShort(quota);
+        } catch (NumberFormatException e) {
+            return (short) 0;
+        }
+    }
+}

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/payment/ApprovePaymentUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/payment/ApprovePaymentUseCaseTest.java
@@ -1,0 +1,349 @@
+package com.personal.marketnote.commerce.service.payment;
+
+import com.personal.marketnote.commerce.domain.order.Order;
+import com.personal.marketnote.commerce.domain.order.OrderSnapshotState;
+import com.personal.marketnote.commerce.domain.order.OrderStatus;
+import com.personal.marketnote.commerce.domain.payment.Payment;
+import com.personal.marketnote.commerce.domain.payment.PaymentCreateState;
+import com.personal.marketnote.commerce.domain.payment.PaymentEventStatus;
+import com.personal.marketnote.commerce.domain.payment.PspPaymentEvent;
+import com.personal.marketnote.commerce.exception.PaymentApprovalException;
+import com.personal.marketnote.commerce.exception.PaymentNotFoundException;
+import com.personal.marketnote.commerce.port.in.command.payment.ApprovePaymentCommand;
+import com.personal.marketnote.commerce.port.in.result.payment.ApprovePaymentResult;
+import com.personal.marketnote.commerce.port.in.usecase.order.ChangeOrderStatusUseCase;
+import com.personal.marketnote.commerce.port.out.order.FindOrderPort;
+import com.personal.marketnote.commerce.port.out.payment.*;
+import com.personal.marketnote.commerce.port.out.payment.vendor.PaymentApprovalVendorResult;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ApprovePaymentUseCase 테스트")
+class ApprovePaymentUseCaseTest {
+
+    @InjectMocks
+    private ApprovePaymentService approvePaymentService;
+
+    @Mock
+    private FindOrderPort findOrderPort;
+
+    @Mock
+    private FindPaymentPort findPaymentPort;
+
+    @Mock
+    private UpdatePaymentPort updatePaymentPort;
+
+    @Mock
+    private SavePspPaymentEventPort savePspPaymentEventPort;
+
+    @Mock
+    private FindPspPaymentEventPort findPspPaymentEventPort;
+
+    @Mock
+    private UpdatePspPaymentEventPort updatePspPaymentEventPort;
+
+    @Mock
+    private PaymentVendorPort paymentVendorPort;
+
+    @Mock
+    private ChangeOrderStatusUseCase changeOrderStatusUseCase;
+
+    private static final Long BUYER_ID = 100L;
+    private static final UUID ORDER_KEY = UUID.randomUUID();
+    private static final String ORDER_KEY_STR = ORDER_KEY.toString();
+
+    @Nested
+    @DisplayName("결제 승인 성공")
+    class ApproveSuccessTest {
+
+        @Test
+        @DisplayName("KCP 승인 성공 시 Payment가 성공 상태로 변경되고 주문이 PAID가 된다")
+        void shouldApprovePaymentSuccessfully() {
+            Payment payment = createPayment(1L, ORDER_KEY, 50000L);
+            ApprovePaymentCommand command = createApproveCommand(ORDER_KEY_STR);
+            PaymentApprovalVendorResult vendorResult = createSuccessVendorResult("tno_123", "50000");
+
+            when(findPaymentPort.findByOrderKey(ORDER_KEY)).thenReturn(Optional.of(payment));
+            when(findOrderPort.findById(1L)).thenReturn(Optional.of(createOrder(1L, BUYER_ID)));
+            when(findPspPaymentEventPort.findByOrderKey(ORDER_KEY_STR)).thenReturn(Optional.empty());
+            when(paymentVendorPort.getVendorSiteCd()).thenReturn("T0000");
+            when(savePspPaymentEventPort.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+            when(paymentVendorPort.approvePayment(any())).thenReturn(vendorResult);
+
+            ApprovePaymentResult result = approvePaymentService.approve(command);
+
+            assertThat(result.pgPaymentKey()).isEqualTo("tno_123");
+            assertThat(result.resultCode()).isEqualTo("0000");
+            assertThat(result.orderId()).isEqualTo(1L);
+
+            verify(updatePaymentPort).update(argThat(p -> p.getSuccessYn() && "tno_123".equals(p.getPgPaymentKey())));
+            verify(changeOrderStatusUseCase).changeOrderStatus(argThat(c -> c.orderStatus() == OrderStatus.PAID));
+        }
+
+        @Test
+        @DisplayName("서버 DB의 금액이 KCP 승인 요청에 사용된다")
+        void shouldUseServerAmountForApproval() {
+            Payment payment = createPayment(1L, ORDER_KEY, 99000L);
+            ApprovePaymentCommand command = createApproveCommand(ORDER_KEY_STR);
+            PaymentApprovalVendorResult vendorResult = createSuccessVendorResult("tno_456", "99000");
+
+            when(findPaymentPort.findByOrderKey(ORDER_KEY)).thenReturn(Optional.of(payment));
+            when(findOrderPort.findById(1L)).thenReturn(Optional.of(createOrder(1L, BUYER_ID, 99000L, 0L, 0L)));
+            when(findPspPaymentEventPort.findByOrderKey(ORDER_KEY_STR)).thenReturn(Optional.empty());
+            when(paymentVendorPort.getVendorSiteCd()).thenReturn("T0000");
+            when(savePspPaymentEventPort.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+            when(paymentVendorPort.approvePayment(any())).thenReturn(vendorResult);
+
+            approvePaymentService.approve(command);
+
+            verify(paymentVendorPort).approvePayment(argThat(c -> "99000".equals(c.ordrMony())));
+        }
+    }
+
+    @Nested
+    @DisplayName("결제 승인 실패")
+    class ApproveFailureTest {
+
+        @Test
+        @DisplayName("KCP 승인 응답 res_cd가 0000이 아닌 경우 Payment가 실패 상태로 변경된다")
+        void shouldMarkFailedWhenKcpReturnsError() {
+            Payment payment = createPayment(1L, ORDER_KEY, 50000L);
+            ApprovePaymentCommand command = createApproveCommand(ORDER_KEY_STR);
+            PaymentApprovalVendorResult vendorResult = PaymentApprovalVendorResult.builder()
+                    .resCd("8001")
+                    .resMsg("카드 인증 실패")
+                    .rawResponse("{}")
+                    .build();
+
+            when(findPaymentPort.findByOrderKey(ORDER_KEY)).thenReturn(Optional.of(payment));
+            when(findOrderPort.findById(1L)).thenReturn(Optional.of(createOrder(1L, BUYER_ID)));
+            when(findPspPaymentEventPort.findByOrderKey(ORDER_KEY_STR)).thenReturn(Optional.empty());
+            when(paymentVendorPort.getVendorSiteCd()).thenReturn("T0000");
+            when(savePspPaymentEventPort.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+            when(paymentVendorPort.approvePayment(any())).thenReturn(vendorResult);
+
+            assertThatThrownBy(() -> approvePaymentService.approve(command))
+                    .isInstanceOf(PaymentApprovalException.class);
+
+            verify(updatePaymentPort).update(argThat(p -> Boolean.FALSE.equals(p.getSuccessYn())));
+            verify(changeOrderStatusUseCase).changeOrderStatus(argThat(c -> c.orderStatus() == OrderStatus.FAILED));
+        }
+
+        @Test
+        @DisplayName("KCP 통신 중 예외 발생 시 결제 실패 처리된다")
+        void shouldHandleVendorCommunicationException() {
+            Payment payment = createPayment(1L, ORDER_KEY, 50000L);
+            ApprovePaymentCommand command = createApproveCommand(ORDER_KEY_STR);
+
+            when(findPaymentPort.findByOrderKey(ORDER_KEY)).thenReturn(Optional.of(payment));
+            when(findOrderPort.findById(1L)).thenReturn(Optional.of(createOrder(1L, BUYER_ID)));
+            when(findPspPaymentEventPort.findByOrderKey(ORDER_KEY_STR)).thenReturn(Optional.empty());
+            when(paymentVendorPort.getVendorSiteCd()).thenReturn("T0000");
+            when(savePspPaymentEventPort.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+            when(paymentVendorPort.approvePayment(any())).thenThrow(new RuntimeException("Connection timeout"));
+
+            assertThatThrownBy(() -> approvePaymentService.approve(command))
+                    .isInstanceOf(PaymentApprovalException.class);
+
+            verify(updatePaymentPort).update(argThat(p -> Boolean.FALSE.equals(p.getSuccessYn())));
+        }
+    }
+
+    @Nested
+    @DisplayName("결제 미존재")
+    class PaymentNotFoundTest {
+
+        @Test
+        @DisplayName("orderKey에 해당하는 결제가 없으면 PaymentNotFoundException이 발생한다")
+        void shouldThrowWhenPaymentNotFound() {
+            ApprovePaymentCommand command = createApproveCommand(ORDER_KEY_STR);
+
+            when(findPaymentPort.findByOrderKey(ORDER_KEY)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> approvePaymentService.approve(command))
+                    .isInstanceOf(PaymentNotFoundException.class);
+
+            verify(paymentVendorPort, never()).approvePayment(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("결제 금액 검증")
+    class PaymentAmountVerificationTest {
+
+        @Test
+        @DisplayName("주문 금액과 결제 금액이 불일치하면 예외가 발생한다")
+        void shouldThrowWhenAmountMismatch() {
+            Payment payment = createPayment(1L, ORDER_KEY, 50000L);
+            ApprovePaymentCommand command = createApproveCommand(ORDER_KEY_STR);
+            Order order = createOrder(1L, BUYER_ID, 60000L, 0L, 0L);
+
+            when(findPaymentPort.findByOrderKey(ORDER_KEY)).thenReturn(Optional.of(payment));
+            when(findOrderPort.findById(1L)).thenReturn(Optional.of(order));
+
+            assertThatThrownBy(() -> approvePaymentService.approve(command))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("주문 금액과 결제 금액이 일치하지 않습니다");
+
+            verify(paymentVendorPort, never()).approvePayment(any());
+        }
+
+        @Test
+        @DisplayName("쿠폰/포인트 할인 적용 후 금액이 일치하면 승인이 진행된다")
+        void shouldProceedWhenDiscountedAmountMatches() {
+            Payment payment = createPayment(1L, ORDER_KEY, 40000L);
+            ApprovePaymentCommand command = createApproveCommand(ORDER_KEY_STR);
+            Order order = createOrder(1L, BUYER_ID, 50000L, 5000L, 5000L);
+            PaymentApprovalVendorResult vendorResult = createSuccessVendorResult("tno_disc", "40000");
+
+            when(findPaymentPort.findByOrderKey(ORDER_KEY)).thenReturn(Optional.of(payment));
+            when(findOrderPort.findById(1L)).thenReturn(Optional.of(order));
+            when(findPspPaymentEventPort.findByOrderKey(ORDER_KEY_STR)).thenReturn(Optional.empty());
+            when(paymentVendorPort.getVendorSiteCd()).thenReturn("T0000");
+            when(savePspPaymentEventPort.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+            when(paymentVendorPort.approvePayment(any())).thenReturn(vendorResult);
+
+            ApprovePaymentResult result = approvePaymentService.approve(command);
+
+            assertThat(result.pgPaymentKey()).isEqualTo("tno_disc");
+            verify(paymentVendorPort).approvePayment(argThat(c -> "40000".equals(c.ordrMony())));
+        }
+
+        @Test
+        @DisplayName("쿠폰/포인트 할인 적용 후 금액이 불일치하면 예외가 발생한다")
+        void shouldThrowWhenDiscountedAmountMismatch() {
+            Payment payment = createPayment(1L, ORDER_KEY, 50000L);
+            ApprovePaymentCommand command = createApproveCommand(ORDER_KEY_STR);
+            Order order = createOrder(1L, BUYER_ID, 60000L, 5000L, 3000L);
+
+            when(findPaymentPort.findByOrderKey(ORDER_KEY)).thenReturn(Optional.of(payment));
+            when(findOrderPort.findById(1L)).thenReturn(Optional.of(order));
+
+            assertThatThrownBy(() -> approvePaymentService.approve(command))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("주문 금액과 결제 금액이 일치하지 않습니다");
+
+            verify(paymentVendorPort, never()).approvePayment(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("PspPaymentEvent 상태 전이 검증")
+    class EventStatusTransitionTest {
+
+        @Test
+        @DisplayName("기존 이벤트가 없으면 새로 생성하고 save가 호출된다")
+        void shouldCreateNewEventWhenNotExists() {
+            Payment payment = createPayment(1L, ORDER_KEY, 50000L);
+            ApprovePaymentCommand command = createApproveCommand(ORDER_KEY_STR);
+            PaymentApprovalVendorResult vendorResult = createSuccessVendorResult("tno_789", "50000");
+
+            java.util.concurrent.atomic.AtomicReference<PaymentEventStatus> statusAtSave = new java.util.concurrent.atomic.AtomicReference<>();
+            when(findPaymentPort.findByOrderKey(ORDER_KEY)).thenReturn(Optional.of(payment));
+            when(findOrderPort.findById(1L)).thenReturn(Optional.of(createOrder(1L, BUYER_ID)));
+            when(findPspPaymentEventPort.findByOrderKey(ORDER_KEY_STR)).thenReturn(Optional.empty());
+            when(paymentVendorPort.getVendorSiteCd()).thenReturn("T0000");
+            when(savePspPaymentEventPort.save(any())).thenAnswer(invocation -> {
+                PspPaymentEvent e = invocation.getArgument(0);
+                statusAtSave.set(e.getPoStatus());
+                return e;
+            });
+            when(paymentVendorPort.approvePayment(any())).thenReturn(vendorResult);
+
+            approvePaymentService.approve(command);
+
+            verify(savePspPaymentEventPort).save(any());
+            assertThat(statusAtSave.get()).isEqualTo(PaymentEventStatus.EXECUTING);
+        }
+
+        @Test
+        @DisplayName("승인 성공 시 이벤트가 COMPLETE 상태로 업데이트된다")
+        void shouldUpdateEventToCompleteOnSuccess() {
+            Payment payment = createPayment(1L, ORDER_KEY, 50000L);
+            ApprovePaymentCommand command = createApproveCommand(ORDER_KEY_STR);
+            PaymentApprovalVendorResult vendorResult = createSuccessVendorResult("tno_999", "50000");
+
+            when(findPaymentPort.findByOrderKey(ORDER_KEY)).thenReturn(Optional.of(payment));
+            when(findOrderPort.findById(1L)).thenReturn(Optional.of(createOrder(1L, BUYER_ID)));
+            when(findPspPaymentEventPort.findByOrderKey(ORDER_KEY_STR)).thenReturn(Optional.empty());
+            when(paymentVendorPort.getVendorSiteCd()).thenReturn("T0000");
+            when(savePspPaymentEventPort.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+            when(paymentVendorPort.approvePayment(any())).thenReturn(vendorResult);
+
+            approvePaymentService.approve(command);
+
+            verify(updatePspPaymentEventPort).update(argThat(e ->
+                    e.getPoStatus() == PaymentEventStatus.COMPLETE
+                            && "tno_999".equals(e.getPgPaymentKey())
+            ));
+        }
+    }
+
+    private Payment createPayment(Long orderId, UUID orderKey, Long amount) {
+        PaymentCreateState state = PaymentCreateState.builder()
+                .orderId(orderId)
+                .orderKey(orderKey)
+                .paymentAmount(amount)
+                .build();
+        return Payment.from(state);
+    }
+
+    private ApprovePaymentCommand createApproveCommand(String orderKey) {
+        return ApprovePaymentCommand.builder()
+                .buyerId(BUYER_ID)
+                .orderKey(orderKey)
+                .encData("enc_data_test")
+                .encInfo("enc_info_test")
+                .payType("PACA")
+                .build();
+    }
+
+    private Order createOrder(Long orderId, Long buyerId) {
+        return createOrder(orderId, buyerId, 50000L, 0L, 0L);
+    }
+
+    private Order createOrder(Long orderId, Long buyerId, Long totalAmount, Long couponAmount, Long pointAmount) {
+        OrderSnapshotState state = OrderSnapshotState.builder()
+                .id(orderId)
+                .buyerId(buyerId)
+                .orderKey(ORDER_KEY)
+                .orderStatus(OrderStatus.PAYMENT_PENDING)
+                .totalAmount(totalAmount)
+                .couponAmount(couponAmount)
+                .pointAmount(pointAmount)
+                .build();
+        return Order.from(state);
+    }
+
+    private PaymentApprovalVendorResult createSuccessVendorResult(String tno, String amount) {
+        return PaymentApprovalVendorResult.builder()
+                .resCd("0000")
+                .resMsg("승인 성공")
+                .tno(tno)
+                .amount(amount)
+                .payMethod("PACA")
+                .cardCd("CCLG")
+                .cardName("신한카드")
+                .cardNo("1234-****-****-5678")
+                .appNo("12345678")
+                .appTime("20260210153000")
+                .quota("00")
+                .partcancYn("Y")
+                .rawResponse("{\"res_cd\":\"0000\"}")
+                .build();
+    }
+}


### PR DESCRIPTION
## partially addresses #216
## resolves #861

## Task
- [x] 결제 승인 UseCase/Service/Command/Result 구현 (ApprovePaymentUseCase, ApprovePaymentService)
- [x] 결제 승인 단위 테스트 추가 (ApprovePaymentUseCaseTest - 9개 테스트)
- [x] 결제 승인 Vendor Command/Result 추가 (PaymentApprovalVendorCommand, PaymentApprovalVendorResult)
- [x] KCP 결제 승인 DTO 추가 (KcpPaymentApprovalRequest, KcpPaymentApprovalResponse)
- [x] PaymentVendorPort에 approvePayment() 메서드 추가
- [x] KcpApiClient에 approvePayment() 메서드 추가
- [x] KcpPaymentVendorAdapter에 approvePayment() 메서드 추가
- [x] 결제 승인 REST API DTO 추가 (ApprovePaymentRequest, ApprovePaymentResponse, ApprovePaymentApiDocs)
- [x] PaymentController에 거래 등록 + 결제 승인 엔드포인트 추가
- [x] PaymentRequestToCommandMapper에 거래 등록 + 결제 승인 매핑 메서드 추가