### PR TITLE
[#216][#862] feat: 결제 정보 조회 기능 프로덕션/자동화 테스트 추가

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/payment/controller/PaymentController.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/payment/controller/PaymentController.java
@@ -1,15 +1,19 @@
 package com.personal.marketnote.commerce.adapter.in.web.payment.controller;
 
 import com.personal.marketnote.commerce.adapter.in.web.payment.controller.apidocs.ApprovePaymentApiDocs;
+import com.personal.marketnote.commerce.adapter.in.web.payment.controller.apidocs.GetPaymentApiDocs;
 import com.personal.marketnote.commerce.adapter.in.web.payment.controller.apidocs.ReadyPaymentApiDocs;
 import com.personal.marketnote.commerce.adapter.in.web.payment.mapper.PaymentRequestToCommandMapper;
 import com.personal.marketnote.commerce.adapter.in.web.payment.request.ApprovePaymentRequest;
 import com.personal.marketnote.commerce.adapter.in.web.payment.request.ReadyPaymentRequest;
 import com.personal.marketnote.commerce.adapter.in.web.payment.response.ApprovePaymentResponse;
+import com.personal.marketnote.commerce.adapter.in.web.payment.response.GetPaymentResponse;
 import com.personal.marketnote.commerce.adapter.in.web.payment.response.ReadyPaymentResponse;
 import com.personal.marketnote.commerce.port.in.result.payment.ApprovePaymentResult;
+import com.personal.marketnote.commerce.port.in.result.payment.GetPaymentResult;
 import com.personal.marketnote.commerce.port.in.result.payment.ReadyPaymentResult;
 import com.personal.marketnote.commerce.port.in.usecase.payment.ApprovePaymentUseCase;
+import com.personal.marketnote.commerce.port.in.usecase.payment.GetPaymentUseCase;
 import com.personal.marketnote.commerce.port.in.usecase.payment.ReadyPaymentUseCase;
 import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
 import com.personal.marketnote.common.utility.ElementExtractor;
@@ -31,6 +35,7 @@ import static com.personal.marketnote.common.domain.exception.ExceptionCode.DEFA
 public class PaymentController {
     private final ReadyPaymentUseCase readyPaymentUseCase;
     private final ApprovePaymentUseCase approvePaymentUseCase;
+    private final GetPaymentUseCase getPaymentUseCase;
 
     /**
      * 거래 등록 (Mobile)
@@ -87,6 +92,35 @@ public class PaymentController {
                         HttpStatus.OK,
                         DEFAULT_SUCCESS_CODE,
                         "결제 승인 성공"
+                ),
+                HttpStatus.OK
+        );
+    }
+
+    /**
+     * 결제 정보 조회
+     *
+     * @param orderKey 주문 키 (UUID)
+     * @return 결제 정보 조회 응답 {@link GetPaymentResponse}
+     * @Author 성효빈
+     * @Date 2026-02-25
+     * @Description 주문 키로 결제 정보를 조회합니다.
+     */
+    @GetMapping("/{orderKey}")
+    @GetPaymentApiDocs
+    public ResponseEntity<BaseResponse<GetPaymentResponse>> getPayment(
+            @AuthenticationPrincipal OAuth2AuthenticatedPrincipal principal,
+            @PathVariable("orderKey") String orderKey
+    ) {
+        Long buyerId = ElementExtractor.extractUserId(principal);
+        GetPaymentResult result = getPaymentUseCase.getPayment(buyerId, orderKey);
+
+        return new ResponseEntity<>(
+                BaseResponse.of(
+                        GetPaymentResponse.from(result),
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "결제 정보 조회 성공"
                 ),
                 HttpStatus.OK
         );

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/payment/controller/apidocs/GetPaymentApiDocs.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/payment/controller/apidocs/GetPaymentApiDocs.java
@@ -1,0 +1,92 @@
+package com.personal.marketnote.commerce.adapter.in.web.payment.controller.apidocs;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Operation(
+        summary = "결제 정보 조회",
+        description = """
+                작성일자: 2026-02-25
+                
+                작성자: 성효빈
+                
+                ---
+                
+                ## Description
+                
+                - 주문 키로 결제 정보를 조회합니다.
+                
+                ---
+                
+                ## Path Variable
+                
+                | **키** | **타입** | **설명** | **필수 여부** | **예시** |
+                | --- | --- | --- | --- | --- |
+                | orderKey | string | 주문 키 (UUID) | Y | "550e8400-e29b-41d4-a716-446655440000" |
+                
+                ---
+                
+                ## Response > content
+                
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | orderId | number | 주문 ID | 1 |
+                | orderKey | string | 주문 키 (UUID) | "550e8400-..." |
+                | paymentAmount | number | 결제 금액 | 100000 |
+                | successYn | boolean | 결제 성공 여부 | true |
+                | refundedYn | boolean | 환불 여부 | false |
+                | refundAmount | number | 환불 금액 | 0 |
+                | pgPaymentKey | string | PG사 거래번호 | "KCP000001" |
+                | pgCompanyKey | string | PG사 식별 키 | "NHN_KCP" |
+                | method | string | 결제 수단 | "PACA" |
+                | cardNumber | string | 카드번호 (마스킹) | "5200********1234" |
+                | approvalNumber | string | 승인번호 | "12345678" |
+                | installment | number | 할부 개월수 | 0 |
+                | issueCompanyName | string | 발급사명 | "신한카드" |
+                | resultCode | string | 결과 코드 | "0000" |
+                | resultMessage | string | 결과 메시지 | "성공" |
+                """,
+        security = {@SecurityRequirement(name = "bearer")},
+        responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "결제 정보 조회 성공",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 200,
+                                          "code": "SUC01",
+                                          "timestamp": "2026-02-25T12:00:00.000",
+                                          "content": {
+                                            "orderId": 1,
+                                            "orderKey": "550e8400-e29b-41d4-a716-446655440000",
+                                            "paymentAmount": 100000,
+                                            "successYn": true,
+                                            "refundedYn": false,
+                                            "refundAmount": 0,
+                                            "pgPaymentKey": "KCP000001",
+                                            "pgCompanyKey": "NHN_KCP",
+                                            "method": "PACA",
+                                            "cardNumber": "5200********1234",
+                                            "approvalNumber": "12345678",
+                                            "installment": 0,
+                                            "issueCompanyName": "신한카드",
+                                            "resultCode": "0000",
+                                            "resultMessage": "성공"
+                                          },
+                                          "message": "결제 정보 조회 성공"
+                                        }
+                                        """)
+                        )
+                )
+        })
+public @interface GetPaymentApiDocs {
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/payment/response/GetPaymentResponse.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/payment/response/GetPaymentResponse.java
@@ -1,0 +1,44 @@
+package com.personal.marketnote.commerce.adapter.in.web.payment.response;
+
+import com.personal.marketnote.commerce.port.in.result.payment.GetPaymentResult;
+import lombok.AccessLevel;
+import lombok.Builder;
+
+@Builder(access = AccessLevel.PRIVATE)
+public record GetPaymentResponse(
+        Long orderId,
+        String orderKey,
+        Long paymentAmount,
+        Boolean successYn,
+        Boolean refundedYn,
+        Long refundAmount,
+        String pgPaymentKey,
+        String pgCompanyKey,
+        String method,
+        String cardNumber,
+        String approvalNumber,
+        Short installment,
+        String issueCompanyName,
+        String resultCode,
+        String resultMessage
+) {
+    public static GetPaymentResponse from(GetPaymentResult result) {
+        return GetPaymentResponse.builder()
+                .orderId(result.orderId())
+                .orderKey(result.orderKey())
+                .paymentAmount(result.paymentAmount())
+                .successYn(result.successYn())
+                .refundedYn(result.refundedYn())
+                .refundAmount(result.refundAmount())
+                .pgPaymentKey(result.pgPaymentKey())
+                .pgCompanyKey(result.pgCompanyKey())
+                .method(result.method())
+                .cardNumber(result.cardNumber())
+                .approvalNumber(result.approvalNumber())
+                .installment(result.installment())
+                .issueCompanyName(result.issueCompanyName())
+                .resultCode(result.resultCode())
+                .resultMessage(result.resultMessage())
+                .build();
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/result/payment/GetPaymentResult.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/result/payment/GetPaymentResult.java
@@ -1,0 +1,49 @@
+package com.personal.marketnote.commerce.port.in.result.payment;
+
+import com.personal.marketnote.commerce.domain.payment.Payment;
+import com.personal.marketnote.commerce.domain.payment.PspPaymentEvent;
+import com.personal.marketnote.common.utility.FormatValidator;
+import lombok.Builder;
+
+@Builder
+public record GetPaymentResult(
+        Long orderId,
+        String orderKey,
+        Long paymentAmount,
+        Boolean successYn,
+        Boolean refundedYn,
+        Long refundAmount,
+        String pgPaymentKey,
+        String pgCompanyKey,
+        String method,
+        String cardNumber,
+        String approvalNumber,
+        Short installment,
+        String issueCompanyName,
+        String resultCode,
+        String resultMessage
+) {
+    public static GetPaymentResult of(Payment payment, PspPaymentEvent event) {
+        GetPaymentResultBuilder builder = GetPaymentResult.builder()
+                .orderId(payment.getOrderId())
+                .orderKey(payment.getOrderKey().toString())
+                .paymentAmount(payment.getPaymentAmount())
+                .successYn(payment.getSuccessYn())
+                .refundedYn(payment.getRefundedYn())
+                .refundAmount(payment.getRefundAmount())
+                .pgPaymentKey(payment.getPgPaymentKey());
+
+        if (FormatValidator.hasValue(event)) {
+            builder.pgCompanyKey(event.getPgCompanyKey())
+                    .method(event.getMethod())
+                    .cardNumber(event.getCardNumber())
+                    .approvalNumber(event.getApprovalNumber())
+                    .installment(event.getInstallment())
+                    .issueCompanyName(event.getIssueCompanyName())
+                    .resultCode(event.getResultCode())
+                    .resultMessage(event.getResultMessage());
+        }
+
+        return builder.build();
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/payment/GetPaymentUseCase.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/payment/GetPaymentUseCase.java
@@ -1,0 +1,15 @@
+package com.personal.marketnote.commerce.port.in.usecase.payment;
+
+import com.personal.marketnote.commerce.port.in.result.payment.GetPaymentResult;
+
+public interface GetPaymentUseCase {
+    /**
+     * @param buyerId  구매자 ID
+     * @param orderKey 주문 키
+     * @return 결제 조회 결과 {@link GetPaymentResult}
+     * @Date 2026-02-25
+     * @Author 성효빈
+     * @Description 구매자 ID와 주문 키로 결제 정보를 조회합니다.
+     */
+    GetPaymentResult getPayment(Long buyerId, String orderKey);
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/GetPaymentService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/GetPaymentService.java
@@ -1,0 +1,50 @@
+package com.personal.marketnote.commerce.service.payment;
+
+import com.personal.marketnote.commerce.domain.order.Order;
+import com.personal.marketnote.commerce.domain.payment.Payment;
+import com.personal.marketnote.commerce.domain.payment.PspPaymentEvent;
+import com.personal.marketnote.commerce.exception.PaymentNotFoundException;
+import com.personal.marketnote.commerce.port.in.result.payment.GetPaymentResult;
+import com.personal.marketnote.commerce.port.in.usecase.payment.GetPaymentUseCase;
+import com.personal.marketnote.commerce.port.out.order.FindOrderPort;
+import com.personal.marketnote.commerce.port.out.payment.FindPaymentPort;
+import com.personal.marketnote.commerce.port.out.payment.FindPspPaymentEventPort;
+import com.personal.marketnote.common.application.UseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional(readOnly = true, isolation = READ_COMMITTED)
+public class GetPaymentService implements GetPaymentUseCase {
+    private final FindOrderPort findOrderPort;
+    private final FindPaymentPort findPaymentPort;
+    private final FindPspPaymentEventPort findPspPaymentEventPort;
+
+    @Override
+    public GetPaymentResult getPayment(Long buyerId, String orderKey) {
+        UUID orderKeyUuid = UUID.fromString(orderKey);
+
+        Payment payment = findPaymentPort.findByOrderKey(orderKeyUuid)
+                .orElseThrow(() -> new PaymentNotFoundException(orderKey));
+
+        verifyOrderOwnership(payment.getOrderId(), buyerId);
+
+        PspPaymentEvent event = findPspPaymentEventPort.findByOrderKey(orderKey)
+                .orElse(null);
+
+        return GetPaymentResult.of(payment, event);
+    }
+
+    private void verifyOrderOwnership(Long orderId, Long buyerId) {
+        Order order = findOrderPort.findById(orderId)
+                .orElseThrow(() -> new IllegalStateException("주문 정보를 찾을 수 없습니다: " + orderId));
+        if (!order.getBuyerId().equals(buyerId)) {
+            throw new IllegalStateException("해당 주문에 대한 권한이 없습니다");
+        }
+    }
+}

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/payment/GetPaymentUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/payment/GetPaymentUseCaseTest.java
@@ -1,0 +1,177 @@
+package com.personal.marketnote.commerce.service.payment;
+
+import com.personal.marketnote.commerce.domain.order.Order;
+import com.personal.marketnote.commerce.domain.order.OrderSnapshotState;
+import com.personal.marketnote.commerce.domain.order.OrderStatus;
+import com.personal.marketnote.commerce.domain.payment.*;
+import com.personal.marketnote.commerce.exception.PaymentNotFoundException;
+import com.personal.marketnote.commerce.port.in.result.payment.GetPaymentResult;
+import com.personal.marketnote.commerce.port.out.order.FindOrderPort;
+import com.personal.marketnote.commerce.port.out.payment.FindPaymentPort;
+import com.personal.marketnote.commerce.port.out.payment.FindPspPaymentEventPort;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GetPaymentUseCase 테스트")
+class GetPaymentUseCaseTest {
+
+    @InjectMocks
+    private GetPaymentService getPaymentService;
+
+    @Mock
+    private FindOrderPort findOrderPort;
+
+    @Mock
+    private FindPaymentPort findPaymentPort;
+
+    @Mock
+    private FindPspPaymentEventPort findPspPaymentEventPort;
+
+    private static final Long BUYER_ID = 100L;
+    private static final UUID ORDER_KEY = UUID.randomUUID();
+    private static final String ORDER_KEY_STR = ORDER_KEY.toString();
+
+    @Nested
+    @DisplayName("결제 조회 성공")
+    class GetPaymentSuccessTest {
+
+        @Test
+        @DisplayName("PspPaymentEvent가 있으면 결제 정보와 이벤트 정보가 함께 반환된다")
+        void shouldReturnPaymentWithEvent() {
+            Payment payment = createSuccessPayment(1L, ORDER_KEY, 50000L, "tno_123");
+            PspPaymentEvent event = createCompleteEvent(ORDER_KEY_STR, "tno_123");
+
+            when(findPaymentPort.findByOrderKey(ORDER_KEY)).thenReturn(Optional.of(payment));
+            when(findOrderPort.findById(1L)).thenReturn(Optional.of(createOrder(1L, BUYER_ID)));
+            when(findPspPaymentEventPort.findByOrderKey(ORDER_KEY_STR)).thenReturn(Optional.of(event));
+
+            GetPaymentResult result = getPaymentService.getPayment(BUYER_ID, ORDER_KEY_STR);
+
+            assertThat(result.orderId()).isEqualTo(1L);
+            assertThat(result.orderKey()).isEqualTo(ORDER_KEY_STR);
+            assertThat(result.paymentAmount()).isEqualTo(50000L);
+            assertThat(result.successYn()).isTrue();
+            assertThat(result.pgPaymentKey()).isEqualTo("tno_123");
+            assertThat(result.pgCompanyKey()).isEqualTo("NHN_KCP");
+            assertThat(result.method()).isEqualTo("CARD");
+            assertThat(result.cardNumber()).isEqualTo("1234-****-****-5678");
+            assertThat(result.approvalNumber()).isEqualTo("12345678");
+            assertThat(result.installment()).isEqualTo((short) 0);
+            assertThat(result.issueCompanyName()).isEqualTo("신한카드");
+            assertThat(result.resultCode()).isEqualTo("0000");
+        }
+
+        @Test
+        @DisplayName("PspPaymentEvent가 없으면 결제 기본 정보만 반환된다")
+        void shouldReturnPaymentWithoutEvent() {
+            Payment payment = createPayment(1L, ORDER_KEY, 50000L);
+
+            when(findPaymentPort.findByOrderKey(ORDER_KEY)).thenReturn(Optional.of(payment));
+            when(findOrderPort.findById(1L)).thenReturn(Optional.of(createOrder(1L, BUYER_ID)));
+            when(findPspPaymentEventPort.findByOrderKey(ORDER_KEY_STR)).thenReturn(Optional.empty());
+
+            GetPaymentResult result = getPaymentService.getPayment(BUYER_ID, ORDER_KEY_STR);
+
+            assertThat(result.orderId()).isEqualTo(1L);
+            assertThat(result.paymentAmount()).isEqualTo(50000L);
+            assertThat(result.pgCompanyKey()).isNull();
+            assertThat(result.method()).isNull();
+            assertThat(result.cardNumber()).isNull();
+            assertThat(result.approvalNumber()).isNull();
+        }
+
+        @Test
+        @DisplayName("환불된 결제 정보가 정확히 반환된다")
+        void shouldReturnRefundedPayment() {
+            Payment payment = createSuccessPayment(1L, ORDER_KEY, 50000L, "tno_123");
+            payment.markAsRefunded();
+            PspPaymentEvent event = createCompleteEvent(ORDER_KEY_STR, "tno_123");
+
+            when(findPaymentPort.findByOrderKey(ORDER_KEY)).thenReturn(Optional.of(payment));
+            when(findOrderPort.findById(1L)).thenReturn(Optional.of(createOrder(1L, BUYER_ID)));
+            when(findPspPaymentEventPort.findByOrderKey(ORDER_KEY_STR)).thenReturn(Optional.of(event));
+
+            GetPaymentResult result = getPaymentService.getPayment(BUYER_ID, ORDER_KEY_STR);
+
+            assertThat(result.refundedYn()).isTrue();
+            assertThat(result.refundAmount()).isEqualTo(50000L);
+        }
+    }
+
+    @Nested
+    @DisplayName("결제 미존재")
+    class PaymentNotFoundTest {
+
+        @Test
+        @DisplayName("orderKey에 해당하는 결제가 없으면 PaymentNotFoundException이 발생한다")
+        void shouldThrowWhenPaymentNotFound() {
+            when(findPaymentPort.findByOrderKey(ORDER_KEY)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> getPaymentService.getPayment(BUYER_ID, ORDER_KEY_STR))
+                    .isInstanceOf(PaymentNotFoundException.class);
+
+            verify(findPspPaymentEventPort, never()).findByOrderKey(any());
+        }
+    }
+
+    private Order createOrder(Long orderId, Long buyerId) {
+        OrderSnapshotState state = OrderSnapshotState.builder()
+                .id(orderId)
+                .buyerId(buyerId)
+                .orderKey(ORDER_KEY)
+                .orderStatus(OrderStatus.PAYMENT_PENDING)
+                .build();
+        return Order.from(state);
+    }
+
+    private Payment createPayment(Long orderId, UUID orderKey, Long amount) {
+        PaymentCreateState state = PaymentCreateState.builder()
+                .orderId(orderId)
+                .orderKey(orderKey)
+                .paymentAmount(amount)
+                .build();
+        return Payment.from(state);
+    }
+
+    private Payment createSuccessPayment(Long orderId, UUID orderKey, Long amount, String pgPaymentKey) {
+        Payment payment = createPayment(orderId, orderKey, amount);
+        payment.markAsSuccess(pgPaymentKey);
+        return payment;
+    }
+
+    private PspPaymentEvent createCompleteEvent(String orderKey, String tno) {
+        PspPaymentEventSnapshotState state = PspPaymentEventSnapshotState.builder()
+                .id(1L)
+                .orderId(1L)
+                .orderKey(orderKey)
+                .pgCompanyKey("NHN_KCP")
+                .pgPaymentKey(tno)
+                .poStatus(PaymentEventStatus.COMPLETE)
+                .method("CARD")
+                .amount(50000L)
+                .cardNumber("1234-****-****-5678")
+                .approvalNumber("12345678")
+                .installment((short) 0)
+                .issueCompanyCode("CCLG")
+                .issueCompanyName("신한카드")
+                .resultCode("0000")
+                .resultMessage("승인 성공")
+                .paidAt(LocalDateTime.of(2026, 2, 10, 15, 30, 0))
+                .build();
+        return PspPaymentEvent.from(state);
+    }
+}


### PR DESCRIPTION
## partially addresses #216
## resolves #862

## Task
- [x] 결제 정보 조회 UseCase/Service/Result 구현 (GetPaymentUseCase, GetPaymentService, GetPaymentResult)
- [x] 결제 정보 조회 단위 테스트 추가 (GetPaymentUseCaseTest - 3개 테스트)
- [x] 결제 정보 조회 REST API DTO 추가 (GetPaymentResponse, GetPaymentApiDocs)
- [x] PaymentController에 결제 정보 조회 엔드포인트 추가