### PR TITLE
[#216][#863] feat: 결제 취소 기능 프로덕션/자동화 테스트 추가

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/apidocs/RegisterOrderApiDocs.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/apidocs/RegisterOrderApiDocs.java
@@ -68,7 +68,7 @@ import java.lang.annotation.*;
                 ---
                 
                 ### Response > content
-
+                
                 | **키** | **타입** | **설명** | **예시** |
                 | --- | --- | --- | --- |
                 | id | number | 생성된 주문 ID | 1 |

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/payment/controller/PaymentController.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/payment/controller/PaymentController.java
@@ -1,10 +1,12 @@
 package com.personal.marketnote.commerce.adapter.in.web.payment.controller;
 
 import com.personal.marketnote.commerce.adapter.in.web.payment.controller.apidocs.ApprovePaymentApiDocs;
+import com.personal.marketnote.commerce.adapter.in.web.payment.controller.apidocs.CancelPaymentApiDocs;
 import com.personal.marketnote.commerce.adapter.in.web.payment.controller.apidocs.GetPaymentApiDocs;
 import com.personal.marketnote.commerce.adapter.in.web.payment.controller.apidocs.ReadyPaymentApiDocs;
 import com.personal.marketnote.commerce.adapter.in.web.payment.mapper.PaymentRequestToCommandMapper;
 import com.personal.marketnote.commerce.adapter.in.web.payment.request.ApprovePaymentRequest;
+import com.personal.marketnote.commerce.adapter.in.web.payment.request.CancelPaymentRequest;
 import com.personal.marketnote.commerce.adapter.in.web.payment.request.ReadyPaymentRequest;
 import com.personal.marketnote.commerce.adapter.in.web.payment.response.ApprovePaymentResponse;
 import com.personal.marketnote.commerce.adapter.in.web.payment.response.GetPaymentResponse;
@@ -13,6 +15,7 @@ import com.personal.marketnote.commerce.port.in.result.payment.ApprovePaymentRes
 import com.personal.marketnote.commerce.port.in.result.payment.GetPaymentResult;
 import com.personal.marketnote.commerce.port.in.result.payment.ReadyPaymentResult;
 import com.personal.marketnote.commerce.port.in.usecase.payment.ApprovePaymentUseCase;
+import com.personal.marketnote.commerce.port.in.usecase.payment.CancelPaymentUseCase;
 import com.personal.marketnote.commerce.port.in.usecase.payment.GetPaymentUseCase;
 import com.personal.marketnote.commerce.port.in.usecase.payment.ReadyPaymentUseCase;
 import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
@@ -35,6 +38,7 @@ import static com.personal.marketnote.common.domain.exception.ExceptionCode.DEFA
 public class PaymentController {
     private final ReadyPaymentUseCase readyPaymentUseCase;
     private final ApprovePaymentUseCase approvePaymentUseCase;
+    private final CancelPaymentUseCase cancelPaymentUseCase;
     private final GetPaymentUseCase getPaymentUseCase;
 
     /**
@@ -121,6 +125,38 @@ public class PaymentController {
                         HttpStatus.OK,
                         DEFAULT_SUCCESS_CODE,
                         "결제 정보 조회 성공"
+                ),
+                HttpStatus.OK
+        );
+    }
+
+    /**
+     * 결제 취소
+     *
+     * @param orderKey 주문 키 (UUID)
+     * @param request  결제 취소 요청
+     * @Author 성효빈
+     * @Date 2026-02-25
+     * @Description KCP 결제 취소 API를 호출합니다.
+     */
+    @PostMapping("/{orderKey}/cancel")
+    @CancelPaymentApiDocs
+    public ResponseEntity<BaseResponse<Void>> cancelPayment(
+            @AuthenticationPrincipal OAuth2AuthenticatedPrincipal principal,
+            @PathVariable("orderKey") String orderKey,
+            @Valid @RequestBody CancelPaymentRequest request
+    ) {
+        Long buyerId = ElementExtractor.extractUserId(principal);
+        cancelPaymentUseCase.cancel(
+                PaymentRequestToCommandMapper.mapToCommand(orderKey, request, buyerId)
+        );
+
+        return new ResponseEntity<>(
+                BaseResponse.of(
+                        null,
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "결제 취소 성공"
                 ),
                 HttpStatus.OK
         );

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/payment/controller/apidocs/CancelPaymentApiDocs.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/payment/controller/apidocs/CancelPaymentApiDocs.java
@@ -1,0 +1,82 @@
+package com.personal.marketnote.commerce.adapter.in.web.payment.controller.apidocs;
+
+import com.personal.marketnote.commerce.adapter.in.web.payment.request.CancelPaymentRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Operation(
+        summary = "결제 취소",
+        description = """
+                작성일자: 2026-02-25
+                
+                작성자: 성효빈
+                
+                ---
+                
+                ## Description
+                
+                - KCP 결제 취소 API를 호출합니다.
+                
+                - 전체취소(FULL)와 부분취소(PARTIAL) 모두 지원합니다.
+                
+                ---
+                
+                ## Path Variable
+                
+                | **키** | **타입** | **설명** | **필수 여부** | **예시** |
+                | --- | --- | --- | --- | --- |
+                | orderKey | string | 주문 키 (UUID) | Y | "550e8400-e29b-41d4-a716-446655440000" |
+                
+                ---
+                
+                ## Request
+                
+                | **키** | **타입** | **설명** | **필수 여부** | **예시** |
+                | --- | --- | --- | --- | --- |
+                | cancelType | string | 취소 유형 (FULL/PARTIAL) | Y | "FULL" |
+                | cancelAmount | number | 취소 금액 (부분취소 시 필수) | N | 50000 |
+                | cancelReason | string | 취소 사유 | N | "고객 변심" |
+                """,
+        security = {@SecurityRequirement(name = "bearer")},
+        requestBody = @RequestBody(
+                required = true,
+                content = @Content(
+                        schema = @Schema(implementation = CancelPaymentRequest.class),
+                        examples = @ExampleObject("""
+                                {
+                                  "cancelType": "FULL",
+                                  "cancelAmount": null,
+                                  "cancelReason": "고객 변심"
+                                }
+                                """)
+                )
+        ),
+        responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "결제 취소 성공",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 200,
+                                          "code": "SUC01",
+                                          "timestamp": "2026-02-25T12:00:00.000",
+                                          "content": null,
+                                          "message": "결제 취소 성공"
+                                        }
+                                        """)
+                        )
+                )
+        })
+public @interface CancelPaymentApiDocs {
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/payment/mapper/PaymentRequestToCommandMapper.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/payment/mapper/PaymentRequestToCommandMapper.java
@@ -1,8 +1,10 @@
 package com.personal.marketnote.commerce.adapter.in.web.payment.mapper;
 
 import com.personal.marketnote.commerce.adapter.in.web.payment.request.ApprovePaymentRequest;
+import com.personal.marketnote.commerce.adapter.in.web.payment.request.CancelPaymentRequest;
 import com.personal.marketnote.commerce.adapter.in.web.payment.request.ReadyPaymentRequest;
 import com.personal.marketnote.commerce.port.in.command.payment.ApprovePaymentCommand;
+import com.personal.marketnote.commerce.port.in.command.payment.CancelPaymentCommand;
 import com.personal.marketnote.commerce.port.in.command.payment.ReadyPaymentCommand;
 
 public class PaymentRequestToCommandMapper {
@@ -24,6 +26,16 @@ public class PaymentRequestToCommandMapper {
                 .encData(request.getEncData())
                 .encInfo(request.getEncInfo())
                 .payType(request.getPayType())
+                .build();
+    }
+
+    public static CancelPaymentCommand mapToCommand(String orderKey, CancelPaymentRequest request, Long buyerId) {
+        return CancelPaymentCommand.builder()
+                .buyerId(buyerId)
+                .orderKey(orderKey)
+                .cancelType(request.getCancelType())
+                .cancelAmount(request.getCancelAmount())
+                .cancelReason(request.getCancelReason())
                 .build();
     }
 }

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/payment/request/CancelPaymentRequest.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/payment/request/CancelPaymentRequest.java
@@ -1,0 +1,19 @@
+package com.personal.marketnote.commerce.adapter.in.web.payment.request;
+
+import com.personal.marketnote.commerce.port.in.command.payment.CancelPaymentCommand;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class CancelPaymentRequest {
+    @Schema(name = "cancelType", description = "취소 유형 (FULL: 전체취소, PARTIAL: 부분취소)", requiredMode = Schema.RequiredMode.REQUIRED)
+    @NotNull
+    private CancelPaymentCommand.CancelType cancelType;
+
+    @Schema(name = "cancelAmount", description = "취소 금액 (부분취소 시 필수)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private Long cancelAmount;
+
+    @Schema(name = "cancelReason", description = "취소 사유", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private String cancelReason;
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/vendor/kcp/KcpApiClient.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/vendor/kcp/KcpApiClient.java
@@ -84,6 +84,37 @@ public class KcpApiClient {
         }
     }
 
+    public KcpPaymentCancelResponse cancelPayment(KcpPaymentCancelRequest request) {
+        String url = kcpProperties.getApi().getPaymentCancelUrl();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        HttpEntity<KcpPaymentCancelRequest> httpEntity = new HttpEntity<>(request, headers);
+
+        log.info("KCP 결제취소 요청: url={}, tno={}", url, request.tno());
+
+        ResponseEntity<String> rawResponse = restTemplate.exchange(
+                url,
+                HttpMethod.POST,
+                httpEntity,
+                String.class
+        );
+
+        String responseBody = rawResponse.getBody();
+        log.debug("KCP 결제취소 응답 Content-Type={}, body={}", rawResponse.getHeaders().getContentType(), responseBody);
+
+        if (FormatValidator.hasNoValue(responseBody)) {
+            throw new KcpCommunicationException("KCP 결제취소 응답 본문이 비어 있습니다.");
+        }
+
+        try {
+            return objectMapper.readValue(responseBody, KcpPaymentCancelResponse.class);
+        } catch (Exception e) {
+            log.error("KCP 결제취소 응답 파싱 실패: {}", e.getMessage());
+            throw new KcpCommunicationException("KCP 결제취소 응답 파싱 실패", e);
+        }
+    }
+
     public JsonNode toJsonNode(Object object) {
         return objectMapper.valueToTree(object);
     }

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/vendor/kcp/KcpPaymentVendorAdapter.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/vendor/kcp/KcpPaymentVendorAdapter.java
@@ -128,6 +128,48 @@ public class KcpPaymentVendorAdapter implements PaymentVendorPort {
         }
     }
 
+    @Override
+    public PaymentCancelVendorResult cancelPayment(PaymentCancelVendorCommand command) {
+        String certInfo = kcpCertificateLoader.loadCertInfo();
+        String signData = kcpSignatureGenerator.generateSignData(
+                kcpProperties.getSiteCd(),
+                command.tno(),
+                command.modType()
+        );
+
+        KcpPaymentCancelRequest request = KcpPaymentCancelRequest.builder()
+                .siteCd(kcpProperties.getSiteCd())
+                .tno(command.tno())
+                .kcpCertInfo(certInfo)
+                .kcpSignData(signData)
+                .modType(command.modType())
+                .modMny(String.valueOf(command.modMny()))
+                .remMny(String.valueOf(command.remMny()))
+                .modDesc(command.modDesc())
+                .build();
+
+        recordRequest(CommerceVendorCommunicationTargetType.PAYMENT_CANCEL, command.tno(), request);
+
+        try {
+            KcpPaymentCancelResponse response = kcpApiClient.cancelPayment(request);
+            recordResponse(CommerceVendorCommunicationTargetType.PAYMENT_CANCEL, command.tno(), response);
+
+            if (!response.isSuccess()) {
+                log.error("KCP 결제취소 실패: resCd={}, resMsg={}", response.resCd(), response.resMsg());
+            }
+
+            return PaymentCancelVendorResult.builder()
+                    .resCd(response.resCd())
+                    .resMsg(response.resMsg())
+                    .amount(response.amount())
+                    .rawResponse(kcpApiClient.toJsonNode(response).toString())
+                    .build();
+        } catch (KcpCommunicationException e) {
+            recordError(CommerceVendorCommunicationTargetType.PAYMENT_CANCEL, command.tno(), e);
+            throw e;
+        }
+    }
+
     private void recordRequest(CommerceVendorCommunicationTargetType targetType, String targetId, Object request) {
         JsonNode payloadJson = maskSensitiveFields(kcpApiClient.toJsonNode(request));
         vendorCommunicationRecorder.record(

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/vendor/kcp/dto/KcpPaymentCancelRequest.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/vendor/kcp/dto/KcpPaymentCancelRequest.java
@@ -1,0 +1,17 @@
+package com.personal.marketnote.commerce.adapter.out.vendor.kcp.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+
+@Builder
+public record KcpPaymentCancelRequest(
+        @JsonProperty("site_cd") String siteCd,
+        @JsonProperty("tno") String tno,
+        @JsonProperty("kcp_cert_info") String kcpCertInfo,
+        @JsonProperty("kcp_sign_data") String kcpSignData,
+        @JsonProperty("mod_type") String modType,
+        @JsonProperty("mod_mny") String modMny,
+        @JsonProperty("rem_mny") String remMny,
+        @JsonProperty("mod_desc") String modDesc
+) {
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/vendor/kcp/dto/KcpPaymentCancelResponse.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/vendor/kcp/dto/KcpPaymentCancelResponse.java
@@ -1,0 +1,15 @@
+package com.personal.marketnote.commerce.adapter.out.vendor.kcp.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record KcpPaymentCancelResponse(
+        @JsonProperty("res_cd") String resCd,
+        @JsonProperty("res_msg") String resMsg,
+        @JsonProperty("amount") String amount
+) {
+    public boolean isSuccess() {
+        return "0000".equals(resCd);
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/exception/PaymentCancelException.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/exception/PaymentCancelException.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.commerce.exception;
+
+public class PaymentCancelException extends IllegalStateException {
+    public PaymentCancelException(String message) {
+        super(message);
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/command/payment/CancelPaymentCommand.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/command/payment/CancelPaymentCommand.java
@@ -1,0 +1,20 @@
+package com.personal.marketnote.commerce.port.in.command.payment;
+
+import lombok.Builder;
+
+@Builder
+public record CancelPaymentCommand(
+        Long buyerId,
+        String orderKey,
+        CancelType cancelType,
+        Long cancelAmount,
+        String cancelReason
+) {
+    public enum CancelType {
+        FULL, PARTIAL
+    }
+
+    public boolean isFullCancel() {
+        return cancelType == CancelType.FULL;
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/payment/CancelPaymentUseCase.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/payment/CancelPaymentUseCase.java
@@ -1,0 +1,13 @@
+package com.personal.marketnote.commerce.port.in.usecase.payment;
+
+import com.personal.marketnote.commerce.port.in.command.payment.CancelPaymentCommand;
+
+public interface CancelPaymentUseCase {
+    /**
+     * @param command 결제 취소 커맨드
+     * @Date 2026-02-25
+     * @Author 성효빈
+     * @Description 결제 대행사에 결제 취소를 요청합니다.
+     */
+    void cancel(CancelPaymentCommand command);
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/payment/PaymentVendorPort.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/payment/PaymentVendorPort.java
@@ -28,4 +28,13 @@ public interface PaymentVendorPort {
      * @Description 결제 대행사에 결제 승인을 요청합니다.
      */
     PaymentApprovalVendorResult approvePayment(PaymentApprovalVendorCommand command);
+
+    /**
+     * @param command 결제 취소 요청 정보 {@link PaymentCancelVendorCommand}
+     * @return 결제 취소 결과 {@link PaymentCancelVendorResult}
+     * @Date 2026-02-25
+     * @Author 성효빈
+     * @Description 결제 대행사에 결제 취소를 요청합니다.
+     */
+    PaymentCancelVendorResult cancelPayment(PaymentCancelVendorCommand command);
 }

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/payment/vendor/PaymentCancelVendorCommand.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/payment/vendor/PaymentCancelVendorCommand.java
@@ -1,0 +1,13 @@
+package com.personal.marketnote.commerce.port.out.payment.vendor;
+
+import lombok.Builder;
+
+@Builder
+public record PaymentCancelVendorCommand(
+        String tno,
+        String modType,
+        Long modMny,
+        Long remMny,
+        String modDesc
+) {
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/payment/vendor/PaymentCancelVendorResult.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/payment/vendor/PaymentCancelVendorResult.java
@@ -1,0 +1,15 @@
+package com.personal.marketnote.commerce.port.out.payment.vendor;
+
+import lombok.Builder;
+
+@Builder
+public record PaymentCancelVendorResult(
+        String resCd,
+        String resMsg,
+        String amount,
+        String rawResponse
+) {
+    public boolean isSuccess() {
+        return "0000".equals(resCd);
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/CancelPaymentService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/CancelPaymentService.java
@@ -1,0 +1,120 @@
+package com.personal.marketnote.commerce.service.payment;
+
+import com.personal.marketnote.commerce.domain.order.Order;
+import com.personal.marketnote.commerce.domain.order.OrderStatus;
+import com.personal.marketnote.commerce.domain.payment.Payment;
+import com.personal.marketnote.commerce.domain.payment.PspPaymentEvent;
+import com.personal.marketnote.commerce.exception.PaymentCancelException;
+import com.personal.marketnote.commerce.exception.PaymentNotFoundException;
+import com.personal.marketnote.commerce.port.in.command.order.ChangeOrderStatusCommand;
+import com.personal.marketnote.commerce.port.in.command.payment.CancelPaymentCommand;
+import com.personal.marketnote.commerce.port.in.usecase.order.ChangeOrderStatusUseCase;
+import com.personal.marketnote.commerce.port.in.usecase.payment.CancelPaymentUseCase;
+import com.personal.marketnote.commerce.port.out.order.FindOrderPort;
+import com.personal.marketnote.commerce.port.out.payment.*;
+import com.personal.marketnote.commerce.port.out.payment.vendor.PaymentCancelVendorCommand;
+import com.personal.marketnote.commerce.port.out.payment.vendor.PaymentCancelVendorResult;
+import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.common.utility.FormatValidator;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional(isolation = READ_COMMITTED)
+@Slf4j
+public class CancelPaymentService implements CancelPaymentUseCase {
+    private final FindOrderPort findOrderPort;
+    private final FindPaymentPort findPaymentPort;
+    private final UpdatePaymentPort updatePaymentPort;
+    private final FindPspPaymentEventPort findPspPaymentEventPort;
+    private final UpdatePspPaymentEventPort updatePspPaymentEventPort;
+    private final PaymentVendorPort paymentVendorPort;
+    private final ChangeOrderStatusUseCase changeOrderStatusUseCase;
+
+    @Override
+    public void cancel(CancelPaymentCommand command) {
+        UUID orderKeyUuid = UUID.fromString(command.orderKey());
+
+        Payment payment = findPaymentPort.findByOrderKey(orderKeyUuid)
+                .orElseThrow(() -> new PaymentNotFoundException(command.orderKey()));
+
+        verifyOrderOwnership(payment.getOrderId(), command.buyerId());
+
+        PspPaymentEvent event = findPspPaymentEventPort.findByOrderKey(command.orderKey())
+                .orElseThrow(() -> new PaymentNotFoundException(command.orderKey()));
+
+        String tno = event.getPgPaymentKey();
+        boolean isFullCancel = command.isFullCancel();
+        String modType = isFullCancel ? "STSC" : "STPC";
+
+        Long alreadyRefunded = FormatValidator.hasValue(payment.getRefundAmount()) ? payment.getRefundAmount() : 0L;
+        Long refundableAmount = payment.getPaymentAmount() - alreadyRefunded;
+
+        Long cancelAmount;
+        if (isFullCancel) {
+            cancelAmount = refundableAmount;
+        } else {
+            cancelAmount = command.cancelAmount();
+            if (FormatValidator.hasNoValue(cancelAmount) || cancelAmount <= 0L) {
+                throw new IllegalArgumentException("부분취소 금액은 0보다 커야 합니다");
+            }
+            if (cancelAmount > refundableAmount) {
+                throw new IllegalArgumentException(
+                        "취소 금액(" + cancelAmount + ")이 환불 가능 금액(" + refundableAmount + ")을 초과합니다"
+                );
+            }
+        }
+
+        Long remainAmount = refundableAmount - cancelAmount;
+
+        PaymentCancelVendorCommand vendorCommand = PaymentCancelVendorCommand.builder()
+                .tno(tno)
+                .modType(modType)
+                .modMny(cancelAmount)
+                .remMny(remainAmount)
+                .modDesc(command.cancelReason())
+                .build();
+
+        PaymentCancelVendorResult vendorResult = paymentVendorPort.cancelPayment(vendorCommand);
+
+        if (!vendorResult.isSuccess()) {
+            throw new PaymentCancelException(
+                    "KCP 결제 취소 실패 [" + vendorResult.resCd() + "]: " + vendorResult.resMsg()
+            );
+        }
+
+        if (isFullCancel) {
+            payment.markAsRefunded();
+            event.cancel(vendorResult.rawResponse());
+        } else {
+            payment.markAsPartiallyRefunded(cancelAmount);
+            event.partialRefund(vendorResult.rawResponse());
+        }
+
+        updatePaymentPort.update(payment);
+        updatePspPaymentEventPort.update(event);
+
+        if (isFullCancel) {
+            changeOrderStatusUseCase.changeOrderStatus(
+                    ChangeOrderStatusCommand.builder()
+                            .id(payment.getOrderId())
+                            .orderStatus(OrderStatus.CANCEL_REQUESTED)
+                            .build()
+            );
+        }
+    }
+
+    private void verifyOrderOwnership(Long orderId, Long buyerId) {
+        Order order = findOrderPort.findById(orderId)
+                .orElseThrow(() -> new IllegalStateException("주문 정보를 찾을 수 없습니다: " + orderId));
+        if (!order.getBuyerId().equals(buyerId)) {
+            throw new IllegalStateException("해당 주문에 대한 권한이 없습니다");
+        }
+    }
+}

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/payment/CancelPaymentUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/payment/CancelPaymentUseCaseTest.java
@@ -1,0 +1,445 @@
+package com.personal.marketnote.commerce.service.payment;
+
+import com.personal.marketnote.commerce.domain.order.Order;
+import com.personal.marketnote.commerce.domain.order.OrderSnapshotState;
+import com.personal.marketnote.commerce.domain.order.OrderStatus;
+import com.personal.marketnote.commerce.domain.payment.*;
+import com.personal.marketnote.commerce.exception.PaymentCancelException;
+import com.personal.marketnote.commerce.exception.PaymentNotFoundException;
+import com.personal.marketnote.commerce.port.in.command.payment.CancelPaymentCommand;
+import com.personal.marketnote.commerce.port.in.usecase.order.ChangeOrderStatusUseCase;
+import com.personal.marketnote.commerce.port.out.order.FindOrderPort;
+import com.personal.marketnote.commerce.port.out.payment.*;
+import com.personal.marketnote.commerce.port.out.payment.vendor.PaymentCancelVendorResult;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("CancelPaymentUseCase 테스트")
+class CancelPaymentUseCaseTest {
+
+    @InjectMocks
+    private CancelPaymentService cancelPaymentService;
+
+    @Mock
+    private FindOrderPort findOrderPort;
+
+    @Mock
+    private FindPaymentPort findPaymentPort;
+
+    @Mock
+    private UpdatePaymentPort updatePaymentPort;
+
+    @Mock
+    private FindPspPaymentEventPort findPspPaymentEventPort;
+
+    @Mock
+    private UpdatePspPaymentEventPort updatePspPaymentEventPort;
+
+    @Mock
+    private PaymentVendorPort paymentVendorPort;
+
+    @Mock
+    private ChangeOrderStatusUseCase changeOrderStatusUseCase;
+
+    private static final Long BUYER_ID = 100L;
+    private static final UUID ORDER_KEY = UUID.randomUUID();
+    private static final String ORDER_KEY_STR = ORDER_KEY.toString();
+
+    @Nested
+    @DisplayName("전체 취소 성공")
+    class FullCancelSuccessTest {
+
+        @Test
+        @DisplayName("전체 취소 성공 시 Payment가 환불 상태로 변경된다")
+        void shouldMarkPaymentAsRefunded() {
+            Payment payment = createSuccessPayment(1L, ORDER_KEY, 50000L, "tno_123");
+            PspPaymentEvent event = createCompleteEvent(ORDER_KEY_STR, "tno_123", 50000L);
+            CancelPaymentCommand command = createFullCancelCommand(ORDER_KEY_STR);
+            PaymentCancelVendorResult vendorResult = createSuccessVendorResult();
+
+            when(findPaymentPort.findByOrderKey(ORDER_KEY)).thenReturn(Optional.of(payment));
+            when(findOrderPort.findById(1L)).thenReturn(Optional.of(createOrder(1L, BUYER_ID)));
+            when(findPspPaymentEventPort.findByOrderKey(ORDER_KEY_STR)).thenReturn(Optional.of(event));
+            when(paymentVendorPort.cancelPayment(any())).thenReturn(vendorResult);
+
+            cancelPaymentService.cancel(command);
+
+            verify(updatePaymentPort).update(argThat(p ->
+                    Boolean.TRUE.equals(p.getRefundedYn()) && p.getRefundAmount().equals(50000L)
+            ));
+        }
+
+        @Test
+        @DisplayName("전체 취소 시 KCP에 STSC 모드와 전체 금액이 전송된다")
+        void shouldSendFullCancelToVendor() {
+            Payment payment = createSuccessPayment(1L, ORDER_KEY, 50000L, "tno_123");
+            PspPaymentEvent event = createCompleteEvent(ORDER_KEY_STR, "tno_123", 50000L);
+            CancelPaymentCommand command = createFullCancelCommand(ORDER_KEY_STR);
+            PaymentCancelVendorResult vendorResult = createSuccessVendorResult();
+
+            when(findPaymentPort.findByOrderKey(ORDER_KEY)).thenReturn(Optional.of(payment));
+            when(findOrderPort.findById(1L)).thenReturn(Optional.of(createOrder(1L, BUYER_ID)));
+            when(findPspPaymentEventPort.findByOrderKey(ORDER_KEY_STR)).thenReturn(Optional.of(event));
+            when(paymentVendorPort.cancelPayment(any())).thenReturn(vendorResult);
+
+            cancelPaymentService.cancel(command);
+
+            verify(paymentVendorPort).cancelPayment(argThat(c ->
+                    "STSC".equals(c.modType())
+                            && c.modMny().equals(50000L)
+                            && c.remMny().equals(0L)
+                            && "tno_123".equals(c.tno())
+            ));
+        }
+
+        @Test
+        @DisplayName("전체 취소 성공 시 주문 상태가 CANCEL_REQUESTED로 변경된다")
+        void shouldChangeOrderStatusToCancelRequested() {
+            Payment payment = createSuccessPayment(1L, ORDER_KEY, 50000L, "tno_123");
+            PspPaymentEvent event = createCompleteEvent(ORDER_KEY_STR, "tno_123", 50000L);
+            CancelPaymentCommand command = createFullCancelCommand(ORDER_KEY_STR);
+            PaymentCancelVendorResult vendorResult = createSuccessVendorResult();
+
+            when(findPaymentPort.findByOrderKey(ORDER_KEY)).thenReturn(Optional.of(payment));
+            when(findOrderPort.findById(1L)).thenReturn(Optional.of(createOrder(1L, BUYER_ID)));
+            when(findPspPaymentEventPort.findByOrderKey(ORDER_KEY_STR)).thenReturn(Optional.of(event));
+            when(paymentVendorPort.cancelPayment(any())).thenReturn(vendorResult);
+
+            cancelPaymentService.cancel(command);
+
+            verify(changeOrderStatusUseCase).changeOrderStatus(argThat(c ->
+                    c.orderStatus() == OrderStatus.CANCEL_REQUESTED && c.id().equals(1L)
+            ));
+        }
+
+        @Test
+        @DisplayName("이미 부분환불된 결제의 전체 취소 시 잔여액만 취소된다")
+        void shouldCancelOnlyRemainingAmountWhenPartiallyRefunded() {
+            Payment payment = createSuccessPayment(1L, ORDER_KEY, 50000L, "tno_123");
+            payment.markAsPartiallyRefunded(10000L);
+            PspPaymentEvent event = createCompleteEvent(ORDER_KEY_STR, "tno_123", 50000L);
+            CancelPaymentCommand command = createFullCancelCommand(ORDER_KEY_STR);
+            PaymentCancelVendorResult vendorResult = createSuccessVendorResult();
+
+            when(findPaymentPort.findByOrderKey(ORDER_KEY)).thenReturn(Optional.of(payment));
+            when(findOrderPort.findById(1L)).thenReturn(Optional.of(createOrder(1L, BUYER_ID)));
+            when(findPspPaymentEventPort.findByOrderKey(ORDER_KEY_STR)).thenReturn(Optional.of(event));
+            when(paymentVendorPort.cancelPayment(any())).thenReturn(vendorResult);
+
+            cancelPaymentService.cancel(command);
+
+            verify(paymentVendorPort).cancelPayment(argThat(c ->
+                    c.modMny().equals(40000L) && c.remMny().equals(0L)
+            ));
+        }
+    }
+
+    @Nested
+    @DisplayName("부분 취소 성공")
+    class PartialCancelSuccessTest {
+
+        @Test
+        @DisplayName("부분 취소 성공 시 환불 금액이 누적된다")
+        void shouldAccumulateRefundAmount() {
+            Payment payment = createSuccessPayment(1L, ORDER_KEY, 50000L, "tno_123");
+            PspPaymentEvent event = createCompleteEvent(ORDER_KEY_STR, "tno_123", 50000L);
+            CancelPaymentCommand command = createPartialCancelCommand(ORDER_KEY_STR, 20000L);
+            PaymentCancelVendorResult vendorResult = createSuccessVendorResult();
+
+            when(findPaymentPort.findByOrderKey(ORDER_KEY)).thenReturn(Optional.of(payment));
+            when(findOrderPort.findById(1L)).thenReturn(Optional.of(createOrder(1L, BUYER_ID)));
+            when(findPspPaymentEventPort.findByOrderKey(ORDER_KEY_STR)).thenReturn(Optional.of(event));
+            when(paymentVendorPort.cancelPayment(any())).thenReturn(vendorResult);
+
+            cancelPaymentService.cancel(command);
+
+            verify(updatePaymentPort).update(argThat(p ->
+                    p.getRefundAmount().equals(20000L) && Boolean.FALSE.equals(p.getRefundedYn())
+            ));
+        }
+
+        @Test
+        @DisplayName("부분 취소 시 KCP에 STPC 모드와 부분 금액이 전송된다")
+        void shouldSendPartialCancelToVendor() {
+            Payment payment = createSuccessPayment(1L, ORDER_KEY, 50000L, "tno_123");
+            PspPaymentEvent event = createCompleteEvent(ORDER_KEY_STR, "tno_123", 50000L);
+            CancelPaymentCommand command = createPartialCancelCommand(ORDER_KEY_STR, 20000L);
+            PaymentCancelVendorResult vendorResult = createSuccessVendorResult();
+
+            when(findPaymentPort.findByOrderKey(ORDER_KEY)).thenReturn(Optional.of(payment));
+            when(findOrderPort.findById(1L)).thenReturn(Optional.of(createOrder(1L, BUYER_ID)));
+            when(findPspPaymentEventPort.findByOrderKey(ORDER_KEY_STR)).thenReturn(Optional.of(event));
+            when(paymentVendorPort.cancelPayment(any())).thenReturn(vendorResult);
+
+            cancelPaymentService.cancel(command);
+
+            verify(paymentVendorPort).cancelPayment(argThat(c ->
+                    "STPC".equals(c.modType())
+                            && c.modMny().equals(20000L)
+                            && c.remMny().equals(30000L)
+            ));
+        }
+
+        @Test
+        @DisplayName("부분 취소 시 주문 상태는 변경되지 않는다")
+        void shouldNotChangeOrderStatusOnPartialCancel() {
+            Payment payment = createSuccessPayment(1L, ORDER_KEY, 50000L, "tno_123");
+            PspPaymentEvent event = createCompleteEvent(ORDER_KEY_STR, "tno_123", 50000L);
+            CancelPaymentCommand command = createPartialCancelCommand(ORDER_KEY_STR, 20000L);
+            PaymentCancelVendorResult vendorResult = createSuccessVendorResult();
+
+            when(findPaymentPort.findByOrderKey(ORDER_KEY)).thenReturn(Optional.of(payment));
+            when(findOrderPort.findById(1L)).thenReturn(Optional.of(createOrder(1L, BUYER_ID)));
+            when(findPspPaymentEventPort.findByOrderKey(ORDER_KEY_STR)).thenReturn(Optional.of(event));
+            when(paymentVendorPort.cancelPayment(any())).thenReturn(vendorResult);
+
+            cancelPaymentService.cancel(command);
+
+            verify(changeOrderStatusUseCase, never()).changeOrderStatus(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("부분 취소 금액 검증")
+    class PartialCancelValidationTest {
+
+        @Test
+        @DisplayName("부분 취소 금액이 null이면 IllegalArgumentException이 발생한다")
+        void shouldThrowWhenCancelAmountIsNull() {
+            Payment payment = createSuccessPayment(1L, ORDER_KEY, 50000L, "tno_123");
+            PspPaymentEvent event = createCompleteEvent(ORDER_KEY_STR, "tno_123", 50000L);
+            CancelPaymentCommand command = CancelPaymentCommand.builder()
+                    .buyerId(BUYER_ID)
+                    .orderKey(ORDER_KEY_STR)
+                    .cancelType(CancelPaymentCommand.CancelType.PARTIAL)
+                    .cancelAmount(null)
+                    .build();
+
+            when(findPaymentPort.findByOrderKey(ORDER_KEY)).thenReturn(Optional.of(payment));
+            when(findOrderPort.findById(1L)).thenReturn(Optional.of(createOrder(1L, BUYER_ID)));
+            when(findPspPaymentEventPort.findByOrderKey(ORDER_KEY_STR)).thenReturn(Optional.of(event));
+
+            assertThatThrownBy(() -> cancelPaymentService.cancel(command))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("0보다 커야 합니다");
+
+            verify(paymentVendorPort, never()).cancelPayment(any());
+        }
+
+        @Test
+        @DisplayName("부분 취소 금액이 0이면 IllegalArgumentException이 발생한다")
+        void shouldThrowWhenCancelAmountIsZero() {
+            Payment payment = createSuccessPayment(1L, ORDER_KEY, 50000L, "tno_123");
+            PspPaymentEvent event = createCompleteEvent(ORDER_KEY_STR, "tno_123", 50000L);
+            CancelPaymentCommand command = createPartialCancelCommand(ORDER_KEY_STR, 0L);
+
+            when(findPaymentPort.findByOrderKey(ORDER_KEY)).thenReturn(Optional.of(payment));
+            when(findOrderPort.findById(1L)).thenReturn(Optional.of(createOrder(1L, BUYER_ID)));
+            when(findPspPaymentEventPort.findByOrderKey(ORDER_KEY_STR)).thenReturn(Optional.of(event));
+
+            assertThatThrownBy(() -> cancelPaymentService.cancel(command))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("0보다 커야 합니다");
+
+            verify(paymentVendorPort, never()).cancelPayment(any());
+        }
+
+        @Test
+        @DisplayName("부분 취소 금액이 음수이면 IllegalArgumentException이 발생한다")
+        void shouldThrowWhenCancelAmountIsNegative() {
+            Payment payment = createSuccessPayment(1L, ORDER_KEY, 50000L, "tno_123");
+            PspPaymentEvent event = createCompleteEvent(ORDER_KEY_STR, "tno_123", 50000L);
+            CancelPaymentCommand command = createPartialCancelCommand(ORDER_KEY_STR, -10000L);
+
+            when(findPaymentPort.findByOrderKey(ORDER_KEY)).thenReturn(Optional.of(payment));
+            when(findOrderPort.findById(1L)).thenReturn(Optional.of(createOrder(1L, BUYER_ID)));
+            when(findPspPaymentEventPort.findByOrderKey(ORDER_KEY_STR)).thenReturn(Optional.of(event));
+
+            assertThatThrownBy(() -> cancelPaymentService.cancel(command))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("0보다 커야 합니다");
+
+            verify(paymentVendorPort, never()).cancelPayment(any());
+        }
+
+        @Test
+        @DisplayName("부분 취소 금액이 환불 가능 금액을 초과하면 IllegalArgumentException이 발생한다")
+        void shouldThrowWhenCancelAmountExceedsRefundable() {
+            Payment payment = createSuccessPayment(1L, ORDER_KEY, 50000L, "tno_123");
+            PspPaymentEvent event = createCompleteEvent(ORDER_KEY_STR, "tno_123", 50000L);
+            CancelPaymentCommand command = createPartialCancelCommand(ORDER_KEY_STR, 60000L);
+
+            when(findPaymentPort.findByOrderKey(ORDER_KEY)).thenReturn(Optional.of(payment));
+            when(findOrderPort.findById(1L)).thenReturn(Optional.of(createOrder(1L, BUYER_ID)));
+            when(findPspPaymentEventPort.findByOrderKey(ORDER_KEY_STR)).thenReturn(Optional.of(event));
+
+            assertThatThrownBy(() -> cancelPaymentService.cancel(command))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("환불 가능 금액");
+
+            verify(paymentVendorPort, never()).cancelPayment(any());
+        }
+
+        @Test
+        @DisplayName("이미 부분환불된 상태에서 잔여액을 초과하는 부분 취소는 실패한다")
+        void shouldThrowWhenCancelAmountExceedsRemainingAfterPartialRefund() {
+            Payment payment = createSuccessPayment(1L, ORDER_KEY, 50000L, "tno_123");
+            payment.markAsPartiallyRefunded(30000L);
+            PspPaymentEvent event = createCompleteEvent(ORDER_KEY_STR, "tno_123", 50000L);
+            CancelPaymentCommand command = createPartialCancelCommand(ORDER_KEY_STR, 25000L);
+
+            when(findPaymentPort.findByOrderKey(ORDER_KEY)).thenReturn(Optional.of(payment));
+            when(findOrderPort.findById(1L)).thenReturn(Optional.of(createOrder(1L, BUYER_ID)));
+            when(findPspPaymentEventPort.findByOrderKey(ORDER_KEY_STR)).thenReturn(Optional.of(event));
+
+            assertThatThrownBy(() -> cancelPaymentService.cancel(command))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("환불 가능 금액");
+
+            verify(paymentVendorPort, never()).cancelPayment(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("KCP 취소 실패")
+    class VendorFailureTest {
+
+        @Test
+        @DisplayName("KCP 취소 응답이 실패이면 PaymentCancelException이 발생한다")
+        void shouldThrowWhenVendorReturnsError() {
+            Payment payment = createSuccessPayment(1L, ORDER_KEY, 50000L, "tno_123");
+            PspPaymentEvent event = createCompleteEvent(ORDER_KEY_STR, "tno_123", 50000L);
+            CancelPaymentCommand command = createFullCancelCommand(ORDER_KEY_STR);
+            PaymentCancelVendorResult vendorResult = PaymentCancelVendorResult.builder()
+                    .resCd("8001")
+                    .resMsg("취소 불가")
+                    .rawResponse("{}")
+                    .build();
+
+            when(findPaymentPort.findByOrderKey(ORDER_KEY)).thenReturn(Optional.of(payment));
+            when(findOrderPort.findById(1L)).thenReturn(Optional.of(createOrder(1L, BUYER_ID)));
+            when(findPspPaymentEventPort.findByOrderKey(ORDER_KEY_STR)).thenReturn(Optional.of(event));
+            when(paymentVendorPort.cancelPayment(any())).thenReturn(vendorResult);
+
+            assertThatThrownBy(() -> cancelPaymentService.cancel(command))
+                    .isInstanceOf(PaymentCancelException.class);
+
+            verify(updatePaymentPort, never()).update(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("결제 미존재")
+    class PaymentNotFoundTest {
+
+        @Test
+        @DisplayName("orderKey에 해당하는 결제가 없으면 PaymentNotFoundException이 발생한다")
+        void shouldThrowWhenPaymentNotFound() {
+            CancelPaymentCommand command = createFullCancelCommand(ORDER_KEY_STR);
+
+            when(findPaymentPort.findByOrderKey(ORDER_KEY)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> cancelPaymentService.cancel(command))
+                    .isInstanceOf(PaymentNotFoundException.class);
+
+            verify(paymentVendorPort, never()).cancelPayment(any());
+        }
+
+        @Test
+        @DisplayName("PspPaymentEvent가 없으면 PaymentNotFoundException이 발생한다")
+        void shouldThrowWhenEventNotFound() {
+            Payment payment = createSuccessPayment(1L, ORDER_KEY, 50000L, "tno_123");
+            CancelPaymentCommand command = createFullCancelCommand(ORDER_KEY_STR);
+
+            when(findPaymentPort.findByOrderKey(ORDER_KEY)).thenReturn(Optional.of(payment));
+            when(findOrderPort.findById(1L)).thenReturn(Optional.of(createOrder(1L, BUYER_ID)));
+            when(findPspPaymentEventPort.findByOrderKey(ORDER_KEY_STR)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> cancelPaymentService.cancel(command))
+                    .isInstanceOf(PaymentNotFoundException.class);
+
+            verify(paymentVendorPort, never()).cancelPayment(any());
+        }
+    }
+
+    private Payment createSuccessPayment(Long orderId, UUID orderKey, Long amount, String pgPaymentKey) {
+        PaymentCreateState state = PaymentCreateState.builder()
+                .orderId(orderId)
+                .orderKey(orderKey)
+                .paymentAmount(amount)
+                .build();
+        Payment payment = Payment.from(state);
+        payment.markAsSuccess(pgPaymentKey);
+        return payment;
+    }
+
+    private PspPaymentEvent createCompleteEvent(String orderKey, String tno, Long amount) {
+        PspPaymentEventSnapshotState state = PspPaymentEventSnapshotState.builder()
+                .id(1L)
+                .orderId(1L)
+                .orderKey(orderKey)
+                .pgCompanyKey("NHN_KCP")
+                .pgPaymentKey(tno)
+                .poStatus(PaymentEventStatus.COMPLETE)
+                .method("CARD")
+                .amount(amount)
+                .resultCode("0000")
+                .resultMessage("승인 성공")
+                .paidAt(LocalDateTime.of(2026, 2, 10, 15, 30, 0))
+                .build();
+        return PspPaymentEvent.from(state);
+    }
+
+    private Order createOrder(Long orderId, Long buyerId) {
+        OrderSnapshotState state = OrderSnapshotState.builder()
+                .id(orderId)
+                .buyerId(buyerId)
+                .orderKey(ORDER_KEY)
+                .orderStatus(OrderStatus.PAID)
+                .build();
+        return Order.from(state);
+    }
+
+    private CancelPaymentCommand createFullCancelCommand(String orderKey) {
+        return CancelPaymentCommand.builder()
+                .buyerId(BUYER_ID)
+                .orderKey(orderKey)
+                .cancelType(CancelPaymentCommand.CancelType.FULL)
+                .cancelReason("고객 요청")
+                .build();
+    }
+
+    private CancelPaymentCommand createPartialCancelCommand(String orderKey, Long cancelAmount) {
+        return CancelPaymentCommand.builder()
+                .buyerId(BUYER_ID)
+                .orderKey(orderKey)
+                .cancelType(CancelPaymentCommand.CancelType.PARTIAL)
+                .cancelAmount(cancelAmount)
+                .cancelReason("부분 취소")
+                .build();
+    }
+
+    private PaymentCancelVendorResult createSuccessVendorResult() {
+        return PaymentCancelVendorResult.builder()
+                .resCd("0000")
+                .resMsg("취소 성공")
+                .amount("50000")
+                .rawResponse("{\"res_cd\":\"0000\"}")
+                .build();
+    }
+}


### PR DESCRIPTION
## partially addresses #216
## resolves #863

## Task
- [x] 결제 취소 UseCase/Service/Command 구현 (CancelPaymentUseCase, CancelPaymentService, CancelPaymentCommand)
- [x] 결제 취소 단위 테스트 추가 (CancelPaymentUseCaseTest)
- [x] 결제 취소 Vendor Command/Result 추가 (PaymentCancelVendorCommand, PaymentCancelVendorResult)
- [x] 결제 취소 예외 클래스 추가 (PaymentCancelException)
- [x] KCP 결제 취소 DTO 추가 (KcpPaymentCancelRequest, KcpPaymentCancelResponse)
- [x] PaymentVendorPort에 cancelPayment() 메서드 추가
- [x] KcpApiClient에 cancelPayment() 메서드 추가
- [x] KcpPaymentVendorAdapter에 cancelPayment() 메서드 추가
- [x] 결제 취소 REST API DTO 추가 (CancelPaymentRequest, CancelPaymentApiDocs)
- [x] PaymentController에 결제 취소 엔드포인트 추가
- [x] PaymentRequestToCommandMapper에 결제 취소 매핑 메서드 추가