### PR TITLE
[#723][#871] fix: 주문 조회/변경 API IDOR 보안 취약점 수정 및 구매자 역할 기반 접근 제어 추가

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/OrderController.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/OrderController.java
@@ -82,18 +82,21 @@ public class OrderController {
     /**
      * 주문 키 조회
      *
-     * @param id 주문 ID
+     * @param id        주문 ID
+     * @param principal 인증된 사용자 정보
      * @return 주문 키 조회 응답 {@link GetOrderKeyResponse}
      * @Author 성효빈
      * @Date 2026-02-25
-     * @Description 주문 ID로 주문 키를 조회합니다.
+     * @Description 주문 ID로 주문 키를 조회합니다. 구매자 소유자 검증을 수행합니다.
      */
     @GetMapping("/{id}/order-key")
     @GetOrderKeyApiDocs
     public ResponseEntity<BaseResponse<GetOrderKeyResponse>> getOrderKey(
-            @PathVariable("id") Long id
+            @PathVariable("id") Long id,
+            @AuthenticationPrincipal OAuth2AuthenticatedPrincipal principal
     ) {
-        GetOrderKeyResult getOrderKeyResult = getOrderUseCase.getOrderKey(id);
+        Long buyerId = ElementExtractor.extractUserId(principal);
+        GetOrderKeyResult getOrderKeyResult = getOrderUseCase.getOrderKey(id, buyerId);
 
         return new ResponseEntity<>(
                 BaseResponse.of(
@@ -109,16 +112,21 @@ public class OrderController {
     /**
      * 주문 정보 조회
      *
-     * @param id 주문 ID
+     * @param id        주문 ID
+     * @param principal 인증된 사용자 정보
      * @return 주문 정보 조회 응답 {@link GetOrderResponse}
      * @Author 성효빈
      * @Date 2026-01-05
-     * @Description 주문 정보를 조회합니다.
+     * @Description 주문 정보를 조회합니다. 구매자 소유자 검증을 수행합니다.
      */
     @GetMapping("/{id}")
     @GetOrderInfoApiDocs
-    public ResponseEntity<BaseResponse<GetOrderResponse>> getOrder(@PathVariable("id") Long id) {
-        GetOrderResult getOrderResult = getOrderUseCase.getOrderAndOrderProducts(id);
+    public ResponseEntity<BaseResponse<GetOrderResponse>> getOrder(
+            @PathVariable("id") Long id,
+            @AuthenticationPrincipal OAuth2AuthenticatedPrincipal principal
+    ) {
+        Long buyerId = ElementExtractor.extractUserId(principal);
+        GetOrderResult getOrderResult = getOrderUseCase.getOrderAndOrderProducts(id, buyerId);
 
         return new ResponseEntity<>(
                 BaseResponse.of(
@@ -212,19 +220,25 @@ public class OrderController {
     /**
      * 주문 상태 변경
      *
-     * @param request 주문 상태 변겅 요청
+     * @param id        주문 ID
+     * @param request   주문 상태 변경 요청
+     * @param principal 인증된 사용자 정보
      * @Author 성효빈
      * @Date 2026-01-05
-     * @Description 주문 상태를 변경합니다.
+     * @Description 주문 상태를 변경합니다. 구매자 역할일 경우 허용된 상태만 변경 가능합니다.
      */
     @PatchMapping("/{id}")
     @ChangeOrderStatusApiDocs
     public ResponseEntity<BaseResponse<Void>> changeOrderStatus(
             @PathVariable("id") Long id,
-            @Valid @RequestBody ChangeOrderStatusRequest request
+            @Valid @RequestBody ChangeOrderStatusRequest request,
+            @AuthenticationPrincipal OAuth2AuthenticatedPrincipal principal
     ) {
+        Long buyerId = ElementExtractor.extractUserId(principal);
+        String role = ElementExtractor.extractRole(principal);
+
         changeOrderStatusUseCase.changeOrderStatus(
-                OrderRequestToCommandMapper.mapToCommand(id, request)
+                OrderRequestToCommandMapper.mapToCommand(id, request, role, buyerId)
         );
 
         return new ResponseEntity<>(

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/mapper/OrderRequestToCommandMapper.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/mapper/OrderRequestToCommandMapper.java
@@ -34,13 +34,15 @@ public class OrderRequestToCommandMapper {
                 .build();
     }
 
-    public static ChangeOrderStatusCommand mapToCommand(Long id, ChangeOrderStatusRequest request) {
+    public static ChangeOrderStatusCommand mapToCommand(Long id, ChangeOrderStatusRequest request, String role, Long buyerId) {
         return ChangeOrderStatusCommand.builder()
                 .id(id)
                 .pricePolicyIds(request.getPricePolicyIds())
                 .orderStatus(request.getOrderStatus())
                 .reasonCategory(request.getReasonCategory())
                 .reason(request.getReason())
+                .role(role)
+                .buyerId(buyerId)
                 .build();
     }
 }

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/exception/UnauthorizedOrderAccessException.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/exception/UnauthorizedOrderAccessException.java
@@ -1,0 +1,19 @@
+package com.personal.marketnote.commerce.exception;
+
+import com.personal.marketnote.common.domain.exception.BusinessSecurityException;
+
+/**
+ * 주문에 대한 접근 권한이 없는 경우 발생하는 예외
+ *
+ * @Author 성효빈
+ * @Date 2026-02-27
+ * @Description 타 사용자의 주문에 접근하려 할 때 발생합니다.
+ */
+public class UnauthorizedOrderAccessException extends BusinessSecurityException {
+    private static final String UNAUTHORIZED_ORDER_ACCESS_EXCEPTION_MESSAGE
+            = "ERR_ORDER_AUTH_01::해당 주문에 대한 접근 권한이 없습니다.";
+
+    public UnauthorizedOrderAccessException() {
+        super(UNAUTHORIZED_ORDER_ACCESS_EXCEPTION_MESSAGE);
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/exception/UnauthorizedOrderStatusChangeException.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/exception/UnauthorizedOrderStatusChangeException.java
@@ -1,0 +1,19 @@
+package com.personal.marketnote.commerce.exception;
+
+import com.personal.marketnote.common.domain.exception.BusinessSecurityException;
+
+/**
+ * 주문 상태 변경 권한이 없는 경우 발생하는 예외
+ *
+ * @Author 성효빈
+ * @Date 2026-02-27
+ * @Description 구매자가 허용되지 않은 상태로 주문 상태를 변경하려 할 때 발생합니다.
+ */
+public class UnauthorizedOrderStatusChangeException extends BusinessSecurityException {
+    private static final String UNAUTHORIZED_ORDER_STATUS_CHANGE_EXCEPTION_MESSAGE
+            = "ERR_ORDER_AUTH_02::해당 상태로 변경할 권한이 없습니다.";
+
+    public UnauthorizedOrderStatusChangeException() {
+        super(UNAUTHORIZED_ORDER_STATUS_CHANGE_EXCEPTION_MESSAGE);
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/command/order/ChangeOrderStatusCommand.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/command/order/ChangeOrderStatusCommand.java
@@ -13,10 +13,32 @@ public record ChangeOrderStatusCommand(
         List<Long> pricePolicyIds,
         OrderStatus orderStatus,
         OrderStatusReasonCategory reasonCategory,
-        String reason
+        String reason,
+        String role,
+        Long buyerId
 ) {
+    private static final String BUYER_ROLE = "BUYER";
+
     public boolean isPartialProductChange() {
         return FormatValidator.hasValue(pricePolicyIds);
     }
-}
 
+    /**
+     * 구매자 역할인지 확인한다.
+     *
+     * @return role이 BUYER이면 true
+     */
+    public boolean isBuyerRole() {
+        return BUYER_ROLE.equals(role);
+    }
+
+    /**
+     * 서비스 내부 호출인지 확인한다.
+     * role이 null이면 서비스 내부 호출로 간주한다.
+     *
+     * @return role이 null이면 true
+     */
+    public boolean isInternalCall() {
+        return FormatValidator.hasNoValue(role);
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/inventory/GetInventoryUseCase.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/inventory/GetInventoryUseCase.java
@@ -26,7 +26,7 @@ public interface GetInventoryUseCase {
     /**
      * @param productIdsByPricePolicyId 가격 정책 ID → 상품 ID 매핑
      * @return 상품 재고 목록 {@link Set<Inventory>}
-     * @Date 2026-02-12
+     * @Date 2026-02-27
      * @Author 성효빈
      * @Description 상품 재고 목록을 조회합니다. 존재하지 않는 재고는 productId와 함께 자동 생성합니다.
      */

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/order/GetOrderUseCase.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/order/GetOrderUseCase.java
@@ -19,9 +19,19 @@ public interface GetOrderUseCase {
      * @return 주문 조회 결과 {@link GetOrderResult}
      * @Date 2026-01-05
      * @Author 성효빈
-     * @Description 주문과 주문 상품 정보를 조회합니다.
+     * @Description 주문과 주문 상품 정보를 조회합니다. (내부용, 소유자 검증 없음)
      */
     GetOrderResult getOrderAndOrderProducts(Long id);
+
+    /**
+     * @param id      주문 ID
+     * @param buyerId 요청 구매자 ID
+     * @return 주문 조회 결과 {@link GetOrderResult}
+     * @Date 2026-02-27
+     * @Author 성효빈
+     * @Description 구매자 소유자 검증 후 주문과 주문 상품 정보를 조회합니다.
+     */
+    GetOrderResult getOrderAndOrderProducts(Long id, Long buyerId);
 
     /**
      * @param id 주문 ID
@@ -64,9 +74,19 @@ public interface GetOrderUseCase {
      * @return 주문 키 조회 결과 {@link GetOrderKeyResult}
      * @Date 2026-02-25
      * @Author 성효빈
-     * @Description 주문 키를 조회합니다.
+     * @Description 주문 키를 조회합니다. (내부용, 소유자 검증 없음)
      */
     GetOrderKeyResult getOrderKey(Long id);
+
+    /**
+     * @param id      주문 ID
+     * @param buyerId 요청 구매자 ID
+     * @return 주문 키 조회 결과 {@link GetOrderKeyResult}
+     * @Date 2026-02-27
+     * @Author 성효빈
+     * @Description 구매자 소유자 검증 후 주문 키를 조회합니다.
+     */
+    GetOrderKeyResult getOrderKey(Long id, Long buyerId);
 
     /**
      * @param orderId       주문 ID

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/ChangeOrderStatusService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/ChangeOrderStatusService.java
@@ -6,6 +6,8 @@ import com.personal.marketnote.commerce.domain.order.OrderStatus;
 import com.personal.marketnote.commerce.domain.order.OrderStatusHistory;
 import com.personal.marketnote.commerce.exception.InvalidOrderStatusTransitionException;
 import com.personal.marketnote.commerce.exception.OrderStatusAlreadyChangedException;
+import com.personal.marketnote.commerce.exception.UnauthorizedOrderAccessException;
+import com.personal.marketnote.commerce.exception.UnauthorizedOrderStatusChangeException;
 import com.personal.marketnote.commerce.mapper.OrderCommandToStateMapper;
 import com.personal.marketnote.commerce.port.in.command.order.ChangeOrderStatusCommand;
 import com.personal.marketnote.commerce.port.in.usecase.inventory.ReduceProductInventoryUseCase;
@@ -16,6 +18,7 @@ import com.personal.marketnote.commerce.port.out.order.UpdateOrderPort;
 import com.personal.marketnote.commerce.port.out.reward.ModifyUserPointPort;
 import com.personal.marketnote.common.application.UseCase;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
@@ -28,6 +31,7 @@ import static org.springframework.transaction.annotation.Isolation.READ_COMMITTE
 @UseCase
 @RequiredArgsConstructor
 @Transactional(isolation = READ_COMMITTED)
+@Slf4j
 public class ChangeOrderStatusService implements ChangeOrderStatusUseCase {
     private final ReduceProductInventoryUseCase reduceProductInventoryUseCase;
     private final GetOrderUseCase getOrderUseCase;
@@ -39,6 +43,9 @@ public class ChangeOrderStatusService implements ChangeOrderStatusUseCase {
     public void changeOrderStatus(ChangeOrderStatusCommand command) {
         Order order = getOrderUseCase.getOrder(command.id());
         OrderStatus status = command.orderStatus();
+
+        validateBuyerRoleRestriction(command);
+        validateBuyerOwnership(command, order);
 
         if (status.isMe(order.getOrderStatus()) && status.isNotPartialChanged()) {
             throw new OrderStatusAlreadyChangedException(status);
@@ -70,6 +77,30 @@ public class ChangeOrderStatusService implements ChangeOrderStatusUseCase {
                 // 링크 공유 회원 포인트 적립
                 modifyUserPointPort.accrueSharedPurchasePoints(sharerIds);
             });
+        }
+    }
+
+    private void validateBuyerRoleRestriction(ChangeOrderStatusCommand command) {
+        if (command.isBuyerRole() && !command.orderStatus().isBuyerAllowed()) {
+            log.warn("구매자 허용되지 않은 상태 변경 시도 - orderId: {}, targetStatus: {}, role: {}",
+                    command.id(), command.orderStatus(), command.role());
+            throw new UnauthorizedOrderStatusChangeException();
+        }
+    }
+
+    private void validateBuyerOwnership(ChangeOrderStatusCommand command, Order order) {
+        if (command.isInternalCall()) {
+            return;
+        }
+
+        if (!command.isBuyerRole()) {
+            return;
+        }
+
+        if (!order.getBuyerId().equals(command.buyerId())) {
+            log.warn("주문 소유자 불일치 - orderId: {}, 주문소유자: {}, 요청자: {}",
+                    command.id(), order.getBuyerId(), command.buyerId());
+            throw new UnauthorizedOrderAccessException();
         }
     }
 

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/GetOrderService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/GetOrderService.java
@@ -4,6 +4,7 @@ import com.personal.marketnote.commerce.domain.order.Order;
 import com.personal.marketnote.commerce.domain.order.OrderProduct;
 import com.personal.marketnote.commerce.exception.OrderNotFoundException;
 import com.personal.marketnote.commerce.exception.OrderProductNotFoundException;
+import com.personal.marketnote.commerce.exception.UnauthorizedOrderAccessException;
 import com.personal.marketnote.commerce.port.in.command.order.GetBuyerOrderHistoryQuery;
 import com.personal.marketnote.commerce.port.in.command.order.GetBuyerOrderProductsQuery;
 import com.personal.marketnote.commerce.port.in.result.order.*;
@@ -15,6 +16,7 @@ import com.personal.marketnote.commerce.port.out.result.product.ProductInfoResul
 import com.personal.marketnote.common.application.UseCase;
 import com.personal.marketnote.common.utility.FormatValidator;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
@@ -29,6 +31,7 @@ import static org.springframework.transaction.annotation.Isolation.READ_COMMITTE
 @UseCase
 @RequiredArgsConstructor
 @Transactional(isolation = READ_COMMITTED, readOnly = true)
+@Slf4j
 public class GetOrderService implements GetOrderUseCase {
     private final FindOrderPort findOrderPort;
     private final FindOrderProductPort findOrderProductPort;
@@ -36,7 +39,17 @@ public class GetOrderService implements GetOrderUseCase {
 
     @Override
     public GetOrderResult getOrderAndOrderProducts(Long id) {
-        Order order = getOrder(id);
+        return getOrderAndOrderProductsInternal(getOrder(id));
+    }
+
+    @Override
+    public GetOrderResult getOrderAndOrderProducts(Long id, Long buyerId) {
+        Order order = getOrderAndVerifyOwner(id, buyerId);
+
+        return getOrderAndOrderProductsInternal(order);
+    }
+
+    private GetOrderResult getOrderAndOrderProductsInternal(Order order) {
         Map<Long, ProductInfoResult> orderedProductsByPricePolicyId = Optional.ofNullable(
                         findProductByPricePolicyPort.findByPricePolicyIds(
                                 order.getOrderProducts()
@@ -112,9 +125,27 @@ public class GetOrderService implements GetOrderUseCase {
     }
 
     @Override
+    public GetOrderKeyResult getOrderKey(Long id, Long buyerId) {
+        Order order = getOrderAndVerifyOwner(id, buyerId);
+
+        return GetOrderKeyResult.from(order);
+    }
+
+    @Override
     public OrderProduct getOrderProduct(Long orderId, Long pricePolicyId) {
         return findOrderProductPort.findByOrderIdAndPricePolicyId(orderId, pricePolicyId)
                 .orElseThrow(() -> new OrderProductNotFoundException(orderId, pricePolicyId));
+    }
+
+    private Order getOrderAndVerifyOwner(Long id, Long buyerId) {
+        Order order = getOrder(id);
+
+        if (!order.getBuyerId().equals(buyerId)) {
+            log.warn("주문 소유자 불일치 - orderId: {}, 주문소유자: {}, 요청자: {}", id, order.getBuyerId(), buyerId);
+            throw new UnauthorizedOrderAccessException();
+        }
+
+        return order;
     }
 
     private BuyerOrdersAndProductsResult findBuyerOrders(GetBuyerOrderHistoryQuery query, boolean includeProductDetails) {

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/ApprovePaymentService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/ApprovePaymentService.java
@@ -5,8 +5,10 @@ import com.personal.marketnote.commerce.domain.order.OrderStatus;
 import com.personal.marketnote.commerce.domain.payment.Payment;
 import com.personal.marketnote.commerce.domain.payment.PaymentApprovalInfo;
 import com.personal.marketnote.commerce.domain.payment.PspPaymentEvent;
+import com.personal.marketnote.commerce.exception.OrderNotFoundException;
 import com.personal.marketnote.commerce.exception.PaymentApprovalException;
 import com.personal.marketnote.commerce.exception.PaymentNotFoundException;
+import com.personal.marketnote.commerce.exception.UnauthorizedOrderAccessException;
 import com.personal.marketnote.commerce.port.in.command.order.ChangeOrderStatusCommand;
 import com.personal.marketnote.commerce.port.in.command.payment.ApprovePaymentCommand;
 import com.personal.marketnote.commerce.port.in.result.payment.ApprovePaymentResult;
@@ -140,9 +142,11 @@ public class ApprovePaymentService implements ApprovePaymentUseCase {
 
     private Order findVerifiedOrder(Long orderId, Long buyerId) {
         Order order = findOrderPort.findById(orderId)
-                .orElseThrow(() -> new IllegalStateException("주문 정보를 찾을 수 없습니다: " + orderId));
+                .orElseThrow(() -> new OrderNotFoundException(orderId));
         if (!order.getBuyerId().equals(buyerId)) {
-            throw new IllegalStateException("해당 주문에 대한 권한이 없습니다");
+            log.warn("결제 승인 소유자 불일치 - orderId: {}, 주문소유자: {}, 요청자: {}",
+                    orderId, order.getBuyerId(), buyerId);
+            throw new UnauthorizedOrderAccessException();
         }
         return order;
     }

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/CancelPaymentService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/CancelPaymentService.java
@@ -4,8 +4,10 @@ import com.personal.marketnote.commerce.domain.order.Order;
 import com.personal.marketnote.commerce.domain.order.OrderStatus;
 import com.personal.marketnote.commerce.domain.payment.Payment;
 import com.personal.marketnote.commerce.domain.payment.PspPaymentEvent;
+import com.personal.marketnote.commerce.exception.OrderNotFoundException;
 import com.personal.marketnote.commerce.exception.PaymentCancelException;
 import com.personal.marketnote.commerce.exception.PaymentNotFoundException;
+import com.personal.marketnote.commerce.exception.UnauthorizedOrderAccessException;
 import com.personal.marketnote.commerce.port.in.command.order.ChangeOrderStatusCommand;
 import com.personal.marketnote.commerce.port.in.command.payment.CancelPaymentCommand;
 import com.personal.marketnote.commerce.port.in.usecase.order.ChangeOrderStatusUseCase;
@@ -112,9 +114,11 @@ public class CancelPaymentService implements CancelPaymentUseCase {
 
     private void verifyOrderOwnership(Long orderId, Long buyerId) {
         Order order = findOrderPort.findById(orderId)
-                .orElseThrow(() -> new IllegalStateException("주문 정보를 찾을 수 없습니다: " + orderId));
+                .orElseThrow(() -> new OrderNotFoundException(orderId));
         if (!order.getBuyerId().equals(buyerId)) {
-            throw new IllegalStateException("해당 주문에 대한 권한이 없습니다");
+            log.warn("결제 취소 소유자 불일치 - orderId: {}, 주문소유자: {}, 요청자: {}",
+                    orderId, order.getBuyerId(), buyerId);
+            throw new UnauthorizedOrderAccessException();
         }
     }
 }

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/GetPaymentService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/GetPaymentService.java
@@ -3,7 +3,9 @@ package com.personal.marketnote.commerce.service.payment;
 import com.personal.marketnote.commerce.domain.order.Order;
 import com.personal.marketnote.commerce.domain.payment.Payment;
 import com.personal.marketnote.commerce.domain.payment.PspPaymentEvent;
+import com.personal.marketnote.commerce.exception.OrderNotFoundException;
 import com.personal.marketnote.commerce.exception.PaymentNotFoundException;
+import com.personal.marketnote.commerce.exception.UnauthorizedOrderAccessException;
 import com.personal.marketnote.commerce.port.in.result.payment.GetPaymentResult;
 import com.personal.marketnote.commerce.port.in.usecase.payment.GetPaymentUseCase;
 import com.personal.marketnote.commerce.port.out.order.FindOrderPort;
@@ -11,6 +13,7 @@ import com.personal.marketnote.commerce.port.out.payment.FindPaymentPort;
 import com.personal.marketnote.commerce.port.out.payment.FindPspPaymentEventPort;
 import com.personal.marketnote.common.application.UseCase;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.UUID;
@@ -20,6 +23,7 @@ import static org.springframework.transaction.annotation.Isolation.READ_COMMITTE
 @UseCase
 @RequiredArgsConstructor
 @Transactional(readOnly = true, isolation = READ_COMMITTED)
+@Slf4j
 public class GetPaymentService implements GetPaymentUseCase {
     private final FindOrderPort findOrderPort;
     private final FindPaymentPort findPaymentPort;
@@ -42,9 +46,11 @@ public class GetPaymentService implements GetPaymentUseCase {
 
     private void verifyOrderOwnership(Long orderId, Long buyerId) {
         Order order = findOrderPort.findById(orderId)
-                .orElseThrow(() -> new IllegalStateException("주문 정보를 찾을 수 없습니다: " + orderId));
+                .orElseThrow(() -> new OrderNotFoundException(orderId));
         if (!order.getBuyerId().equals(buyerId)) {
-            throw new IllegalStateException("해당 주문에 대한 권한이 없습니다");
+            log.warn("결제 조회 소유자 불일치 - orderId: {}, 주문소유자: {}, 요청자: {}",
+                    orderId, order.getBuyerId(), buyerId);
+            throw new UnauthorizedOrderAccessException();
         }
     }
 }

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/exception/UnauthorizedOrderAccessExceptionTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/exception/UnauthorizedOrderAccessExceptionTest.java
@@ -1,0 +1,59 @@
+package com.personal.marketnote.commerce.exception;
+
+import com.personal.marketnote.common.domain.exception.BusinessSecurityException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UnauthorizedOrderAccessExceptionTest {
+
+    @Nested
+    @DisplayName("UnauthorizedOrderAccessException 생성 검증")
+    class CreateExceptionTest {
+
+        @Test
+        @DisplayName("예외 메시지에 에러 코드 ERR_ORDER_AUTH_01이 포함된다")
+        void exceptionMessage_containsErrorCode() {
+            UnauthorizedOrderAccessException exception = new UnauthorizedOrderAccessException();
+
+            assertThat(exception.getMessage()).contains("ERR_ORDER_AUTH_01");
+        }
+
+        @Test
+        @DisplayName("예외 메시지에 접근 권한 안내 문구가 포함된다")
+        void exceptionMessage_containsGuideMessage() {
+            UnauthorizedOrderAccessException exception = new UnauthorizedOrderAccessException();
+
+            assertThat(exception.getMessage()).contains("해당 주문에 대한 접근 권한이 없습니다");
+        }
+
+        @Test
+        @DisplayName("예외 메시지에 내부 ID가 노출되지 않는다")
+        void exceptionMessage_doesNotContainInternalId() {
+            UnauthorizedOrderAccessException exception = new UnauthorizedOrderAccessException();
+
+            assertThat(exception.getMessage()).doesNotContain("123");
+            assertThat(exception.getMessage()).doesNotContain("456");
+            assertThat(exception.getMessage()).doesNotContain("주문 ID");
+            assertThat(exception.getMessage()).doesNotContain("구매자 ID");
+        }
+
+        @Test
+        @DisplayName("BusinessSecurityException을 상속한다")
+        void exception_isBusinessSecurityException() {
+            UnauthorizedOrderAccessException exception = new UnauthorizedOrderAccessException();
+
+            assertThat(exception).isInstanceOf(BusinessSecurityException.class);
+        }
+
+        @Test
+        @DisplayName("RuntimeException을 상속한다")
+        void exception_isRuntimeException() {
+            UnauthorizedOrderAccessException exception = new UnauthorizedOrderAccessException();
+
+            assertThat(exception).isInstanceOf(RuntimeException.class);
+        }
+    }
+}

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/exception/UnauthorizedOrderStatusChangeExceptionTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/exception/UnauthorizedOrderStatusChangeExceptionTest.java
@@ -1,0 +1,73 @@
+package com.personal.marketnote.commerce.exception;
+
+import com.personal.marketnote.common.domain.exception.BusinessSecurityException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UnauthorizedOrderStatusChangeExceptionTest {
+
+    @Nested
+    @DisplayName("UnauthorizedOrderStatusChangeException 생성 검증")
+    class CreateExceptionTest {
+
+        @Test
+        @DisplayName("예외 메시지에 에러 코드 ERR_ORDER_AUTH_02가 포함된다")
+        void exceptionMessage_containsErrorCode() {
+            UnauthorizedOrderStatusChangeException exception
+                    = new UnauthorizedOrderStatusChangeException();
+
+            assertThat(exception.getMessage()).contains("ERR_ORDER_AUTH_02");
+        }
+
+        @Test
+        @DisplayName("예외 메시지에 권한 안내 문구가 포함된다")
+        void exceptionMessage_containsGuideMessage() {
+            UnauthorizedOrderStatusChangeException exception
+                    = new UnauthorizedOrderStatusChangeException();
+
+            assertThat(exception.getMessage()).contains("해당 상태로 변경할 권한이 없습니다");
+        }
+
+        @Test
+        @DisplayName("예외 메시지에 역할 정보가 노출되지 않는다")
+        void exceptionMessage_doesNotContainRole() {
+            UnauthorizedOrderStatusChangeException exception
+                    = new UnauthorizedOrderStatusChangeException();
+
+            assertThat(exception.getMessage()).doesNotContain("BUYER");
+            assertThat(exception.getMessage()).doesNotContain("ADMIN");
+            assertThat(exception.getMessage()).doesNotContain("SELLER");
+        }
+
+        @Test
+        @DisplayName("예외 메시지에 상태 설명이 노출되지 않는다")
+        void exceptionMessage_doesNotContainStatusDescription() {
+            UnauthorizedOrderStatusChangeException exception
+                    = new UnauthorizedOrderStatusChangeException();
+
+            assertThat(exception.getMessage()).doesNotContain("결제 완료");
+            assertThat(exception.getMessage()).doesNotContain("상품 준비중");
+        }
+
+        @Test
+        @DisplayName("BusinessSecurityException을 상속한다")
+        void exception_isBusinessSecurityException() {
+            UnauthorizedOrderStatusChangeException exception
+                    = new UnauthorizedOrderStatusChangeException();
+
+            assertThat(exception).isInstanceOf(BusinessSecurityException.class);
+        }
+
+        @Test
+        @DisplayName("RuntimeException을 상속한다")
+        void exception_isRuntimeException() {
+            UnauthorizedOrderStatusChangeException exception
+                    = new UnauthorizedOrderStatusChangeException();
+
+            assertThat(exception).isInstanceOf(RuntimeException.class);
+        }
+    }
+}

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/port/in/command/order/ChangeOrderStatusCommandTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/port/in/command/order/ChangeOrderStatusCommandTest.java
@@ -1,0 +1,161 @@
+package com.personal.marketnote.commerce.port.in.command.order;
+
+import com.personal.marketnote.commerce.domain.order.OrderStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ChangeOrderStatusCommandTest {
+
+    @Nested
+    @DisplayName("역할 기반 검증 메서드")
+    class RoleBasedValidationTest {
+
+        @Test
+        @DisplayName("role이 BUYER이면 isBuyerRole()은 true를 반환한다")
+        void isBuyerRole_buyer_returnsTrue() {
+            ChangeOrderStatusCommand command = ChangeOrderStatusCommand.builder()
+                    .id(1L)
+                    .orderStatus(OrderStatus.CANCEL_REQUESTED)
+                    .role("BUYER")
+                    .build();
+
+            assertThat(command.isBuyerRole()).isTrue();
+        }
+
+        @Test
+        @DisplayName("role이 ADMIN이면 isBuyerRole()은 false를 반환한다")
+        void isBuyerRole_admin_returnsFalse() {
+            ChangeOrderStatusCommand command = ChangeOrderStatusCommand.builder()
+                    .id(1L)
+                    .orderStatus(OrderStatus.PREPARING)
+                    .role("ADMIN")
+                    .build();
+
+            assertThat(command.isBuyerRole()).isFalse();
+        }
+
+        @Test
+        @DisplayName("role이 SELLER이면 isBuyerRole()은 false를 반환한다")
+        void isBuyerRole_seller_returnsFalse() {
+            ChangeOrderStatusCommand command = ChangeOrderStatusCommand.builder()
+                    .id(1L)
+                    .orderStatus(OrderStatus.PREPARING)
+                    .role("SELLER")
+                    .build();
+
+            assertThat(command.isBuyerRole()).isFalse();
+        }
+
+        @Test
+        @DisplayName("role이 null이면 isBuyerRole()은 false를 반환한다 (서비스 내부 호출)")
+        void isBuyerRole_null_returnsFalse() {
+            ChangeOrderStatusCommand command = ChangeOrderStatusCommand.builder()
+                    .id(1L)
+                    .orderStatus(OrderStatus.PAID)
+                    .build();
+
+            assertThat(command.isBuyerRole()).isFalse();
+        }
+
+        @Test
+        @DisplayName("role이 null이면 isInternalCall()은 true를 반환한다")
+        void isInternalCall_nullRole_returnsTrue() {
+            ChangeOrderStatusCommand command = ChangeOrderStatusCommand.builder()
+                    .id(1L)
+                    .orderStatus(OrderStatus.PAID)
+                    .build();
+
+            assertThat(command.isInternalCall()).isTrue();
+        }
+
+        @Test
+        @DisplayName("role이 존재하면 isInternalCall()은 false를 반환한다")
+        void isInternalCall_withRole_returnsFalse() {
+            ChangeOrderStatusCommand command = ChangeOrderStatusCommand.builder()
+                    .id(1L)
+                    .orderStatus(OrderStatus.CANCEL_REQUESTED)
+                    .role("BUYER")
+                    .build();
+
+            assertThat(command.isInternalCall()).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("buyerId 필드 검증")
+    class BuyerIdFieldTest {
+
+        @Test
+        @DisplayName("buyerId를 포함하여 빌드하면 buyerId가 설정된다")
+        void buildWithBuyerId_setsBuyerId() {
+            ChangeOrderStatusCommand command = ChangeOrderStatusCommand.builder()
+                    .id(1L)
+                    .orderStatus(OrderStatus.CANCEL_REQUESTED)
+                    .role("BUYER")
+                    .buyerId(100L)
+                    .build();
+
+            assertThat(command.buyerId()).isEqualTo(100L);
+        }
+
+        @Test
+        @DisplayName("buyerId 없이 빌드하면 buyerId가 null이다 (서비스 내부 호출)")
+        void buildWithoutBuyerId_buyerIdIsNull() {
+            ChangeOrderStatusCommand command = ChangeOrderStatusCommand.builder()
+                    .id(1L)
+                    .orderStatus(OrderStatus.PAID)
+                    .build();
+
+            assertThat(command.buyerId()).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("기존 기능 호환성 검증")
+    class BackwardCompatibilityTest {
+
+        @Test
+        @DisplayName("role 없이 빌드해도 정상 동작한다 (기존 서비스 내부 호출 호환)")
+        void buildWithoutRole_succeeds() {
+            ChangeOrderStatusCommand command = ChangeOrderStatusCommand.builder()
+                    .id(1L)
+                    .orderStatus(OrderStatus.PAID)
+                    .build();
+
+            assertThat(command.id()).isEqualTo(1L);
+            assertThat(command.orderStatus()).isEqualTo(OrderStatus.PAID);
+            assertThat(command.role()).isNull();
+            assertThat(command.buyerId()).isNull();
+        }
+
+        @Test
+        @DisplayName("isPartialProductChange는 pricePolicyIds가 있으면 true를 반환한다")
+        void isPartialProductChange_withPricePolicyIds_returnsTrue() {
+            ChangeOrderStatusCommand command = ChangeOrderStatusCommand.builder()
+                    .id(1L)
+                    .pricePolicyIds(List.of(100L, 200L))
+                    .orderStatus(OrderStatus.CONFIRMED)
+                    .role("BUYER")
+                    .build();
+
+            assertThat(command.isPartialProductChange()).isTrue();
+        }
+
+        @Test
+        @DisplayName("isPartialProductChange는 pricePolicyIds가 null이면 false를 반환한다")
+        void isPartialProductChange_nullPricePolicyIds_returnsFalse() {
+            ChangeOrderStatusCommand command = ChangeOrderStatusCommand.builder()
+                    .id(1L)
+                    .orderStatus(OrderStatus.CANCEL_REQUESTED)
+                    .role("BUYER")
+                    .build();
+
+            assertThat(command.isPartialProductChange()).isFalse();
+        }
+    }
+}

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/ChangeOrderStatusRoleValidationUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/ChangeOrderStatusRoleValidationUseCaseTest.java
@@ -1,0 +1,510 @@
+package com.personal.marketnote.commerce.service.order;
+
+import com.personal.marketnote.commerce.domain.order.Order;
+import com.personal.marketnote.commerce.domain.order.OrderProductSnapshotState;
+import com.personal.marketnote.commerce.domain.order.OrderSnapshotState;
+import com.personal.marketnote.commerce.domain.order.OrderStatus;
+import com.personal.marketnote.commerce.exception.UnauthorizedOrderAccessException;
+import com.personal.marketnote.commerce.exception.UnauthorizedOrderStatusChangeException;
+import com.personal.marketnote.commerce.port.in.command.order.ChangeOrderStatusCommand;
+import com.personal.marketnote.commerce.port.in.usecase.inventory.ReduceProductInventoryUseCase;
+import com.personal.marketnote.commerce.port.in.usecase.order.GetOrderUseCase;
+import com.personal.marketnote.commerce.port.out.order.DeleteOrderedCartProductsPort;
+import com.personal.marketnote.commerce.port.out.order.UpdateOrderPort;
+import com.personal.marketnote.commerce.port.out.reward.ModifyUserPointPort;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ChangeOrderStatusRoleValidationUseCaseTest {
+    @Mock
+    private ReduceProductInventoryUseCase reduceProductInventoryUseCase;
+    @Mock
+    private GetOrderUseCase getOrderUseCase;
+    @Mock
+    private UpdateOrderPort updateOrderPort;
+    @Mock
+    private DeleteOrderedCartProductsPort deleteOrderedCartProductsPort;
+    @Mock
+    private ModifyUserPointPort modifyUserPointPort;
+
+    @InjectMocks
+    private ChangeOrderStatusService changeOrderStatusService;
+
+    // ==================================================================================
+    // 구매자 역할 - 허용 상태 변경 테스트
+    // ==================================================================================
+
+    @Nested
+    @DisplayName("구매자 역할 - 허용 상태 변경")
+    class BuyerAllowedStatusChangeTest {
+
+        @Test
+        @DisplayName("구매자가 CANCEL_REQUESTED로 변경하면 정상 처리된다")
+        void buyer_cancelRequested_succeeds() {
+            Order order = createOrder(1L, OrderStatus.PAYMENT_PENDING);
+            when(getOrderUseCase.getOrder(1L)).thenReturn(order);
+
+            ChangeOrderStatusCommand command = ChangeOrderStatusCommand.builder()
+                    .id(1L)
+                    .orderStatus(OrderStatus.CANCEL_REQUESTED)
+                    .role("BUYER")
+                    .buyerId(1L)
+                    .build();
+
+            assertThatCode(() -> changeOrderStatusService.changeOrderStatus(command))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("구매자가 CONFIRMED로 변경하면 정상 처리된다")
+        void buyer_confirmed_succeeds() {
+            Order order = createOrder(1L, OrderStatus.DELIVERED);
+            when(getOrderUseCase.getOrder(1L)).thenReturn(order);
+
+            ChangeOrderStatusCommand command = ChangeOrderStatusCommand.builder()
+                    .id(1L)
+                    .orderStatus(OrderStatus.CONFIRMED)
+                    .role("BUYER")
+                    .buyerId(1L)
+                    .build();
+
+            assertThatCode(() -> changeOrderStatusService.changeOrderStatus(command))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("구매자가 EXCHANGE_REQUESTED로 변경하면 정상 처리된다")
+        void buyer_exchangeRequested_succeeds() {
+            Order order = createOrder(1L, OrderStatus.DELIVERED);
+            when(getOrderUseCase.getOrder(1L)).thenReturn(order);
+
+            ChangeOrderStatusCommand command = ChangeOrderStatusCommand.builder()
+                    .id(1L)
+                    .orderStatus(OrderStatus.EXCHANGE_REQUESTED)
+                    .role("BUYER")
+                    .buyerId(1L)
+                    .build();
+
+            assertThatCode(() -> changeOrderStatusService.changeOrderStatus(command))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("구매자가 REFUND_REQUESTED로 변경하면 정상 처리된다")
+        void buyer_refundRequested_succeeds() {
+            Order order = createOrder(1L, OrderStatus.DELIVERED);
+            when(getOrderUseCase.getOrder(1L)).thenReturn(order);
+
+            ChangeOrderStatusCommand command = ChangeOrderStatusCommand.builder()
+                    .id(1L)
+                    .orderStatus(OrderStatus.REFUND_REQUESTED)
+                    .role("BUYER")
+                    .buyerId(1L)
+                    .build();
+
+            assertThatCode(() -> changeOrderStatusService.changeOrderStatus(command))
+                    .doesNotThrowAnyException();
+        }
+    }
+
+    // ==================================================================================
+    // 구매자 역할 - 차단 상태 변경 테스트
+    // ==================================================================================
+
+    @Nested
+    @DisplayName("구매자 역할 - 차단 상태 변경")
+    class BuyerBlockedStatusChangeTest {
+
+        @Test
+        @DisplayName("구매자가 PAID로 변경하면 UnauthorizedOrderStatusChangeException이 발생한다")
+        void buyer_paid_throwsException() {
+            Order order = createOrder(1L, OrderStatus.PAYMENT_PENDING);
+            when(getOrderUseCase.getOrder(1L)).thenReturn(order);
+
+            ChangeOrderStatusCommand command = ChangeOrderStatusCommand.builder()
+                    .id(1L)
+                    .orderStatus(OrderStatus.PAID)
+                    .role("BUYER")
+                    .buyerId(1L)
+                    .build();
+
+            assertThatThrownBy(() -> changeOrderStatusService.changeOrderStatus(command))
+                    .isInstanceOf(UnauthorizedOrderStatusChangeException.class);
+        }
+
+        @Test
+        @DisplayName("구매자가 PREPARING으로 변경하면 UnauthorizedOrderStatusChangeException이 발생한다")
+        void buyer_preparing_throwsException() {
+            Order order = createOrder(1L, OrderStatus.PAID);
+            when(getOrderUseCase.getOrder(1L)).thenReturn(order);
+
+            ChangeOrderStatusCommand command = ChangeOrderStatusCommand.builder()
+                    .id(1L)
+                    .orderStatus(OrderStatus.PREPARING)
+                    .role("BUYER")
+                    .buyerId(1L)
+                    .build();
+
+            assertThatThrownBy(() -> changeOrderStatusService.changeOrderStatus(command))
+                    .isInstanceOf(UnauthorizedOrderStatusChangeException.class);
+        }
+
+        @Test
+        @DisplayName("구매자가 SHIPPING으로 변경하면 UnauthorizedOrderStatusChangeException이 발생한다")
+        void buyer_shipping_throwsException() {
+            Order order = createOrder(1L, OrderStatus.PREPARED);
+            when(getOrderUseCase.getOrder(1L)).thenReturn(order);
+
+            ChangeOrderStatusCommand command = ChangeOrderStatusCommand.builder()
+                    .id(1L)
+                    .orderStatus(OrderStatus.SHIPPING)
+                    .role("BUYER")
+                    .buyerId(1L)
+                    .build();
+
+            assertThatThrownBy(() -> changeOrderStatusService.changeOrderStatus(command))
+                    .isInstanceOf(UnauthorizedOrderStatusChangeException.class);
+        }
+
+        @Test
+        @DisplayName("구매자가 DELIVERED로 변경하면 UnauthorizedOrderStatusChangeException이 발생한다")
+        void buyer_delivered_throwsException() {
+            Order order = createOrder(1L, OrderStatus.SHIPPING);
+            when(getOrderUseCase.getOrder(1L)).thenReturn(order);
+
+            ChangeOrderStatusCommand command = ChangeOrderStatusCommand.builder()
+                    .id(1L)
+                    .orderStatus(OrderStatus.DELIVERED)
+                    .role("BUYER")
+                    .buyerId(1L)
+                    .build();
+
+            assertThatThrownBy(() -> changeOrderStatusService.changeOrderStatus(command))
+                    .isInstanceOf(UnauthorizedOrderStatusChangeException.class);
+        }
+
+        @Test
+        @DisplayName("구매자가 CANCELLED로 변경하면 UnauthorizedOrderStatusChangeException이 발생한다")
+        void buyer_cancelled_throwsException() {
+            Order order = createOrder(1L, OrderStatus.CANCEL_REQUESTED);
+            when(getOrderUseCase.getOrder(1L)).thenReturn(order);
+
+            ChangeOrderStatusCommand command = ChangeOrderStatusCommand.builder()
+                    .id(1L)
+                    .orderStatus(OrderStatus.CANCELLED)
+                    .role("BUYER")
+                    .buyerId(1L)
+                    .build();
+
+            assertThatThrownBy(() -> changeOrderStatusService.changeOrderStatus(command))
+                    .isInstanceOf(UnauthorizedOrderStatusChangeException.class);
+        }
+
+        @Test
+        @DisplayName("구매자가 차단된 상태 변경 시 UpdateOrderPort를 호출하지 않는다")
+        void buyer_blockedStatus_doesNotCallUpdatePort() {
+            Order order = createOrder(1L, OrderStatus.PAYMENT_PENDING);
+            when(getOrderUseCase.getOrder(1L)).thenReturn(order);
+
+            ChangeOrderStatusCommand command = ChangeOrderStatusCommand.builder()
+                    .id(1L)
+                    .orderStatus(OrderStatus.PAID)
+                    .role("BUYER")
+                    .buyerId(1L)
+                    .build();
+
+            assertThatThrownBy(() -> changeOrderStatusService.changeOrderStatus(command))
+                    .isInstanceOf(UnauthorizedOrderStatusChangeException.class);
+
+            verifyNoInteractions(updateOrderPort);
+        }
+    }
+
+    // ==================================================================================
+    // 서비스 내부 호출 (role == null) - 모든 상태 변경 허용
+    // ==================================================================================
+
+    @Nested
+    @DisplayName("서비스 내부 호출 (role == null) - 모든 상태 변경 허용")
+    class InternalCallTest {
+
+        @Test
+        @DisplayName("서비스 내부에서 PAID로 변경하면 정상 처리된다")
+        void internalCall_paid_succeeds() {
+            Order order = createOrder(1L, OrderStatus.PAYMENT_PENDING);
+            when(getOrderUseCase.getOrder(1L)).thenReturn(order);
+
+            ChangeOrderStatusCommand command = ChangeOrderStatusCommand.builder()
+                    .id(1L)
+                    .orderStatus(OrderStatus.PAID)
+                    .build();
+
+            assertThatCode(() -> changeOrderStatusService.changeOrderStatus(command))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("서비스 내부에서 FAILED로 변경하면 정상 처리된다")
+        void internalCall_failed_succeeds() {
+            Order order = createOrder(1L, OrderStatus.PAYMENT_PENDING);
+            when(getOrderUseCase.getOrder(1L)).thenReturn(order);
+
+            ChangeOrderStatusCommand command = ChangeOrderStatusCommand.builder()
+                    .id(1L)
+                    .orderStatus(OrderStatus.FAILED)
+                    .build();
+
+            assertThatCode(() -> changeOrderStatusService.changeOrderStatus(command))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("서비스 내부에서 PREPARING으로 변경하면 정상 처리된다")
+        void internalCall_preparing_succeeds() {
+            Order order = createOrder(1L, OrderStatus.PAID);
+            when(getOrderUseCase.getOrder(1L)).thenReturn(order);
+
+            ChangeOrderStatusCommand command = ChangeOrderStatusCommand.builder()
+                    .id(1L)
+                    .orderStatus(OrderStatus.PREPARING)
+                    .build();
+
+            assertThatCode(() -> changeOrderStatusService.changeOrderStatus(command))
+                    .doesNotThrowAnyException();
+        }
+    }
+
+    // ==================================================================================
+    // 관리자/판매자 역할 - 모든 상태 변경 허용
+    // ==================================================================================
+
+    @Nested
+    @DisplayName("관리자/판매자 역할 - 모든 상태 변경 허용")
+    class AdminSellerTest {
+
+        @Test
+        @DisplayName("ADMIN이 PAID로 변경하면 정상 처리된다")
+        void admin_paid_succeeds() {
+            Order order = createOrder(1L, OrderStatus.PAYMENT_PENDING);
+            when(getOrderUseCase.getOrder(1L)).thenReturn(order);
+
+            ChangeOrderStatusCommand command = ChangeOrderStatusCommand.builder()
+                    .id(1L)
+                    .orderStatus(OrderStatus.PAID)
+                    .role("ADMIN")
+                    .build();
+
+            assertThatCode(() -> changeOrderStatusService.changeOrderStatus(command))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("SELLER가 PREPARING으로 변경하면 정상 처리된다")
+        void seller_preparing_succeeds() {
+            Order order = createOrder(1L, OrderStatus.PAID);
+            when(getOrderUseCase.getOrder(1L)).thenReturn(order);
+
+            ChangeOrderStatusCommand command = ChangeOrderStatusCommand.builder()
+                    .id(1L)
+                    .orderStatus(OrderStatus.PREPARING)
+                    .role("SELLER")
+                    .build();
+
+            assertThatCode(() -> changeOrderStatusService.changeOrderStatus(command))
+                    .doesNotThrowAnyException();
+        }
+    }
+
+    // ==================================================================================
+    // 구매자 역할 - 소유자 검증 (IDOR 방어)
+    // ==================================================================================
+
+    @Nested
+    @DisplayName("구매자 역할 - 소유자 검증 (IDOR 방어)")
+    class BuyerOwnerVerificationTest {
+
+        @Test
+        @DisplayName("구매자가 자신의 주문 상태를 변경하면 정상 처리된다")
+        void buyer_ownOrder_succeeds() {
+            Long orderId = 1L;
+            Long buyerId = 100L;
+            Order order = createOrderWithBuyerId(orderId, buyerId, OrderStatus.PAYMENT_PENDING);
+            when(getOrderUseCase.getOrder(orderId)).thenReturn(order);
+
+            ChangeOrderStatusCommand command = ChangeOrderStatusCommand.builder()
+                    .id(orderId)
+                    .orderStatus(OrderStatus.CANCEL_REQUESTED)
+                    .role("BUYER")
+                    .buyerId(buyerId)
+                    .build();
+
+            assertThatCode(() -> changeOrderStatusService.changeOrderStatus(command))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("구매자가 타인의 주문 상태를 변경하면 UnauthorizedOrderAccessException이 발생한다")
+        void buyer_otherOrder_throwsException() {
+            Long orderId = 1L;
+            Long ownerBuyerId = 100L;
+            Long attackerBuyerId = 999L;
+            Order order = createOrderWithBuyerId(orderId, ownerBuyerId, OrderStatus.PAYMENT_PENDING);
+            when(getOrderUseCase.getOrder(orderId)).thenReturn(order);
+
+            ChangeOrderStatusCommand command = ChangeOrderStatusCommand.builder()
+                    .id(orderId)
+                    .orderStatus(OrderStatus.CANCEL_REQUESTED)
+                    .role("BUYER")
+                    .buyerId(attackerBuyerId)
+                    .build();
+
+            assertThatThrownBy(() -> changeOrderStatusService.changeOrderStatus(command))
+                    .isInstanceOf(UnauthorizedOrderAccessException.class);
+        }
+
+        @Test
+        @DisplayName("구매자가 타인의 주문 상태 변경 시 UpdateOrderPort를 호출하지 않는다")
+        void buyer_otherOrder_doesNotCallUpdatePort() {
+            Long orderId = 1L;
+            Long ownerBuyerId = 100L;
+            Long attackerBuyerId = 999L;
+            Order order = createOrderWithBuyerId(orderId, ownerBuyerId, OrderStatus.PAYMENT_PENDING);
+            when(getOrderUseCase.getOrder(orderId)).thenReturn(order);
+
+            ChangeOrderStatusCommand command = ChangeOrderStatusCommand.builder()
+                    .id(orderId)
+                    .orderStatus(OrderStatus.CANCEL_REQUESTED)
+                    .role("BUYER")
+                    .buyerId(attackerBuyerId)
+                    .build();
+
+            assertThatThrownBy(() -> changeOrderStatusService.changeOrderStatus(command))
+                    .isInstanceOf(UnauthorizedOrderAccessException.class);
+
+            verifyNoInteractions(updateOrderPort);
+        }
+
+        @Test
+        @DisplayName("서비스 내부 호출(isInternalCall)이면 소유자 검증을 스킵한다")
+        void internalCall_skipsOwnerVerification() {
+            Long orderId = 1L;
+            Order order = createOrderWithBuyerId(orderId, 100L, OrderStatus.PAYMENT_PENDING);
+            when(getOrderUseCase.getOrder(orderId)).thenReturn(order);
+
+            ChangeOrderStatusCommand command = ChangeOrderStatusCommand.builder()
+                    .id(orderId)
+                    .orderStatus(OrderStatus.PAID)
+                    .build();
+
+            assertThatCode(() -> changeOrderStatusService.changeOrderStatus(command))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("ADMIN 역할이면 소유자 검증을 수행하지 않는다")
+        void admin_skipsOwnerVerification() {
+            Long orderId = 1L;
+            Order order = createOrderWithBuyerId(orderId, 100L, OrderStatus.PAYMENT_PENDING);
+            when(getOrderUseCase.getOrder(orderId)).thenReturn(order);
+
+            ChangeOrderStatusCommand command = ChangeOrderStatusCommand.builder()
+                    .id(orderId)
+                    .orderStatus(OrderStatus.PAID)
+                    .role("ADMIN")
+                    .build();
+
+            assertThatCode(() -> changeOrderStatusService.changeOrderStatus(command))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("SELLER 역할이면 소유자 검증을 수행하지 않는다")
+        void seller_skipsOwnerVerification() {
+            Long orderId = 1L;
+            Order order = createOrderWithBuyerId(orderId, 100L, OrderStatus.PAID);
+            when(getOrderUseCase.getOrder(orderId)).thenReturn(order);
+
+            ChangeOrderStatusCommand command = ChangeOrderStatusCommand.builder()
+                    .id(orderId)
+                    .orderStatus(OrderStatus.PREPARING)
+                    .role("SELLER")
+                    .build();
+
+            assertThatCode(() -> changeOrderStatusService.changeOrderStatus(command))
+                    .doesNotThrowAnyException();
+        }
+    }
+
+    // ==================================================================================
+    // 헬퍼 메서드
+    // ==================================================================================
+
+    private Order createOrderWithBuyerId(Long orderId, Long buyerId, OrderStatus status) {
+        List<OrderProductSnapshotState> productStates = List.of(
+                OrderProductSnapshotState.builder()
+                        .orderId(orderId)
+                        .sellerId(10L)
+                        .pricePolicyId(100L)
+                        .quantity(1)
+                        .unitAmount(50000L)
+                        .orderStatus(status)
+                        .build()
+        );
+
+        return Order.from(OrderSnapshotState.builder()
+                .id(orderId)
+                .buyerId(buyerId)
+                .orderKey(UUID.randomUUID())
+                .orderNumber("ORD-" + orderId)
+                .orderStatus(status)
+                .totalAmount(50000L)
+                .couponAmount(0L)
+                .pointAmount(0L)
+                .orderProductStates(productStates)
+                .createdAt(LocalDateTime.now())
+                .modifiedAt(LocalDateTime.now())
+                .build());
+    }
+
+    private Order createOrder(Long orderId, OrderStatus status) {
+        List<OrderProductSnapshotState> productStates = List.of(
+                OrderProductSnapshotState.builder()
+                        .orderId(orderId)
+                        .sellerId(10L)
+                        .pricePolicyId(100L)
+                        .quantity(1)
+                        .unitAmount(50000L)
+                        .orderStatus(status)
+                        .build()
+        );
+
+        return Order.from(OrderSnapshotState.builder()
+                .id(orderId)
+                .buyerId(1L)
+                .orderKey(UUID.randomUUID())
+                .orderNumber("ORD-" + orderId)
+                .orderStatus(status)
+                .totalAmount(50000L)
+                .couponAmount(0L)
+                .pointAmount(0L)
+                .orderProductStates(productStates)
+                .createdAt(LocalDateTime.now())
+                .modifiedAt(LocalDateTime.now())
+                .build());
+    }
+}

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/GetOrderWithBuyerVerificationUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/GetOrderWithBuyerVerificationUseCaseTest.java
@@ -1,0 +1,281 @@
+package com.personal.marketnote.commerce.service.order;
+
+import com.personal.marketnote.commerce.domain.order.Order;
+import com.personal.marketnote.commerce.domain.order.OrderProductSnapshotState;
+import com.personal.marketnote.commerce.domain.order.OrderSnapshotState;
+import com.personal.marketnote.commerce.domain.order.OrderStatus;
+import com.personal.marketnote.commerce.exception.OrderNotFoundException;
+import com.personal.marketnote.commerce.exception.UnauthorizedOrderAccessException;
+import com.personal.marketnote.commerce.port.in.result.order.GetOrderKeyResult;
+import com.personal.marketnote.commerce.port.in.result.order.GetOrderResult;
+import com.personal.marketnote.commerce.port.out.order.FindOrderPort;
+import com.personal.marketnote.commerce.port.out.order.FindOrderProductPort;
+import com.personal.marketnote.commerce.port.out.product.FindProductByPricePolicyPort;
+import com.personal.marketnote.commerce.port.out.result.product.ProductInfoResult;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class GetOrderWithBuyerVerificationUseCaseTest {
+    @Mock
+    private FindOrderPort findOrderPort;
+    @Mock
+    private FindOrderProductPort findOrderProductPort;
+    @Mock
+    private FindProductByPricePolicyPort findProductByPricePolicyPort;
+
+    @InjectMocks
+    private GetOrderService getOrderService;
+
+    // ==================================================================================
+    // getOrderAndOrderProducts(id, buyerId) - 소유자 검증 포함
+    // ==================================================================================
+
+    @Nested
+    @DisplayName("getOrderAndOrderProducts(id, buyerId) - 소유자 검증 성공")
+    class GetOrderAndOrderProductsWithBuyerIdSuccessTest {
+
+        @Test
+        @DisplayName("주문 소유자와 요청 buyerId가 일치하면 주문 정보를 반환한다")
+        void ownerMatches_returnsOrderResult() {
+            Long orderId = 1L;
+            Long buyerId = 100L;
+            Order order = createOrderWithBuyerId(orderId, buyerId);
+
+            when(findOrderPort.findById(orderId)).thenReturn(Optional.of(order));
+            when(findProductByPricePolicyPort.findByPricePolicyIds(anyList()))
+                    .thenReturn(Map.of());
+
+            GetOrderResult result = getOrderService.getOrderAndOrderProducts(orderId, buyerId);
+
+            assertThat(result).isNotNull();
+            assertThat(result.id()).isEqualTo(orderId);
+            assertThat(result.buyerId()).isEqualTo(buyerId);
+        }
+
+        @Test
+        @DisplayName("소유자 검증 통과 후 상품 정보를 포함한 결과를 반환한다")
+        void ownerMatches_returnsOrderWithProducts() {
+            Long orderId = 1L;
+            Long buyerId = 100L;
+            Long pricePolicyId = 200L;
+            Order order = createOrderWithBuyerIdAndProducts(orderId, buyerId, List.of(pricePolicyId));
+
+            when(findOrderPort.findById(orderId)).thenReturn(Optional.of(order));
+
+            ProductInfoResult productInfo = new ProductInfoResult(1L, "테스트 상품", "테스트 브랜드", List.of());
+            when(findProductByPricePolicyPort.findByPricePolicyIds(List.of(pricePolicyId)))
+                    .thenReturn(Map.of(pricePolicyId, productInfo));
+
+            GetOrderResult result = getOrderService.getOrderAndOrderProducts(orderId, buyerId);
+
+            assertThat(result.orderProducts()).hasSize(1);
+        }
+    }
+
+    @Nested
+    @DisplayName("getOrderAndOrderProducts(id, buyerId) - 소유자 검증 실패")
+    class GetOrderAndOrderProductsWithBuyerIdFailureTest {
+
+        @Test
+        @DisplayName("주문 소유자와 요청 buyerId가 다르면 UnauthorizedOrderAccessException이 발생한다")
+        void ownerMismatch_throwsUnauthorizedOrderAccessException() {
+            Long orderId = 1L;
+            Long ownerBuyerId = 100L;
+            Long requestedBuyerId = 999L;
+            Order order = createOrderWithBuyerId(orderId, ownerBuyerId);
+
+            when(findOrderPort.findById(orderId)).thenReturn(Optional.of(order));
+
+            assertThatThrownBy(() -> getOrderService.getOrderAndOrderProducts(orderId, requestedBuyerId))
+                    .isInstanceOf(UnauthorizedOrderAccessException.class);
+        }
+
+        @Test
+        @DisplayName("소유자 검증 실패 시 예외 메시지에 내부 ID가 노출되지 않는다")
+        void ownerMismatch_exceptionDoesNotContainInternalId() {
+            Long orderId = 123L;
+            Long ownerBuyerId = 100L;
+            Long requestedBuyerId = 999L;
+            Order order = createOrderWithBuyerId(orderId, ownerBuyerId);
+
+            when(findOrderPort.findById(orderId)).thenReturn(Optional.of(order));
+
+            assertThatThrownBy(() -> getOrderService.getOrderAndOrderProducts(orderId, requestedBuyerId))
+                    .isInstanceOf(UnauthorizedOrderAccessException.class)
+                    .hasMessageContaining("ERR_ORDER_AUTH_01")
+                    .hasMessageNotContaining("123")
+                    .hasMessageNotContaining("999");
+        }
+
+        @Test
+        @DisplayName("소유자 검증 실패 시 상품 정보 조회를 수행하지 않는다")
+        void ownerMismatch_doesNotCallProductPort() {
+            Long orderId = 1L;
+            Long ownerBuyerId = 100L;
+            Long requestedBuyerId = 999L;
+            Order order = createOrderWithBuyerId(orderId, ownerBuyerId);
+
+            when(findOrderPort.findById(orderId)).thenReturn(Optional.of(order));
+
+            assertThatThrownBy(() -> getOrderService.getOrderAndOrderProducts(orderId, requestedBuyerId))
+                    .isInstanceOf(UnauthorizedOrderAccessException.class);
+
+            verifyNoInteractions(findProductByPricePolicyPort);
+        }
+
+        @Test
+        @DisplayName("주문이 존재하지 않으면 OrderNotFoundException이 발생한다")
+        void orderNotFound_throwsOrderNotFoundException() {
+            Long orderId = 999L;
+            Long buyerId = 100L;
+
+            when(findOrderPort.findById(orderId)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> getOrderService.getOrderAndOrderProducts(orderId, buyerId))
+                    .isInstanceOf(OrderNotFoundException.class);
+        }
+    }
+
+    // ==================================================================================
+    // getOrderKey(id, buyerId) - 소유자 검증 포함
+    // ==================================================================================
+
+    @Nested
+    @DisplayName("getOrderKey(id, buyerId) - 소유자 검증 성공")
+    class GetOrderKeyWithBuyerIdSuccessTest {
+
+        @Test
+        @DisplayName("주문 소유자와 요청 buyerId가 일치하면 주문 키를 반환한다")
+        void ownerMatches_returnsOrderKey() {
+            Long orderId = 1L;
+            Long buyerId = 100L;
+            Order order = createOrderWithBuyerId(orderId, buyerId);
+
+            when(findOrderPort.findById(orderId)).thenReturn(Optional.of(order));
+
+            GetOrderKeyResult result = getOrderService.getOrderKey(orderId, buyerId);
+
+            assertThat(result).isNotNull();
+            assertThat(result.orderKey()).isNotNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("getOrderKey(id, buyerId) - 소유자 검증 실패")
+    class GetOrderKeyWithBuyerIdFailureTest {
+
+        @Test
+        @DisplayName("주문 소유자와 요청 buyerId가 다르면 UnauthorizedOrderAccessException이 발생한다")
+        void ownerMismatch_throwsUnauthorizedOrderAccessException() {
+            Long orderId = 1L;
+            Long ownerBuyerId = 100L;
+            Long requestedBuyerId = 999L;
+            Order order = createOrderWithBuyerId(orderId, ownerBuyerId);
+
+            when(findOrderPort.findById(orderId)).thenReturn(Optional.of(order));
+
+            assertThatThrownBy(() -> getOrderService.getOrderKey(orderId, requestedBuyerId))
+                    .isInstanceOf(UnauthorizedOrderAccessException.class);
+        }
+
+        @Test
+        @DisplayName("주문이 존재하지 않으면 OrderNotFoundException이 발생한다")
+        void orderNotFound_throwsOrderNotFoundException() {
+            Long orderId = 999L;
+            Long buyerId = 100L;
+
+            when(findOrderPort.findById(orderId)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> getOrderService.getOrderKey(orderId, buyerId))
+                    .isInstanceOf(OrderNotFoundException.class);
+        }
+    }
+
+    // ==================================================================================
+    // 기존 getOrder(id) 검증 없음 확인
+    // ==================================================================================
+
+    @Nested
+    @DisplayName("getOrder(id) - 기존 내부용 메서드는 소유자 검증 없음")
+    class GetOrderInternalTest {
+
+        @Test
+        @DisplayName("getOrder(id)는 buyerId 검증 없이 주문을 반환한다")
+        void getOrder_noBuyerVerification_returnsOrder() {
+            Long orderId = 1L;
+            Order order = createOrderWithBuyerId(orderId, 100L);
+
+            when(findOrderPort.findById(orderId)).thenReturn(Optional.of(order));
+
+            Order result = getOrderService.getOrder(orderId);
+
+            assertThat(result).isNotNull();
+            assertThat(result.getId()).isEqualTo(orderId);
+        }
+    }
+
+    // ==================================================================================
+    // 헬퍼 메서드
+    // ==================================================================================
+
+    private Order createOrderWithBuyerId(Long orderId, Long buyerId) {
+        return Order.from(OrderSnapshotState.builder()
+                .id(orderId)
+                .buyerId(buyerId)
+                .orderKey(UUID.randomUUID())
+                .orderNumber("ORD-" + orderId)
+                .orderStatus(OrderStatus.PAID)
+                .totalAmount(100000L)
+                .couponAmount(0L)
+                .pointAmount(0L)
+                .orderProductStates(List.of())
+                .createdAt(LocalDateTime.now())
+                .modifiedAt(LocalDateTime.now())
+                .build());
+    }
+
+    private Order createOrderWithBuyerIdAndProducts(Long orderId, Long buyerId, List<Long> pricePolicyIds) {
+        List<OrderProductSnapshotState> productStates = pricePolicyIds.stream()
+                .map(pricePolicyId -> OrderProductSnapshotState.builder()
+                        .orderId(orderId)
+                        .sellerId(10L)
+                        .pricePolicyId(pricePolicyId)
+                        .quantity(1)
+                        .unitAmount(50000L)
+                        .orderStatus(OrderStatus.PAID)
+                        .build())
+                .toList();
+
+        return Order.from(OrderSnapshotState.builder()
+                .id(orderId)
+                .buyerId(buyerId)
+                .orderKey(UUID.randomUUID())
+                .orderNumber("ORD-" + orderId)
+                .orderStatus(OrderStatus.PAID)
+                .totalAmount(100000L)
+                .couponAmount(0L)
+                .pointAmount(0L)
+                .orderProductStates(productStates)
+                .createdAt(LocalDateTime.now())
+                .modifiedAt(LocalDateTime.now())
+                .build());
+    }
+}

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/payment/ApprovePaymentUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/payment/ApprovePaymentUseCaseTest.java
@@ -9,6 +9,7 @@ import com.personal.marketnote.commerce.domain.payment.PaymentEventStatus;
 import com.personal.marketnote.commerce.domain.payment.PspPaymentEvent;
 import com.personal.marketnote.commerce.exception.PaymentApprovalException;
 import com.personal.marketnote.commerce.exception.PaymentNotFoundException;
+import com.personal.marketnote.commerce.exception.UnauthorizedOrderAccessException;
 import com.personal.marketnote.commerce.port.in.command.payment.ApprovePaymentCommand;
 import com.personal.marketnote.commerce.port.in.result.payment.ApprovePaymentResult;
 import com.personal.marketnote.commerce.port.in.usecase.order.ChangeOrderStatusUseCase;
@@ -176,6 +177,48 @@ class ApprovePaymentUseCaseTest {
 
             assertThatThrownBy(() -> approvePaymentService.approve(command))
                     .isInstanceOf(PaymentNotFoundException.class);
+
+            verify(paymentVendorPort, never()).approvePayment(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("주문 소유자 검증")
+    class OrderOwnerVerificationTest {
+
+        @Test
+        @DisplayName("주문 소유자가 아닌 사용자가 결제 승인 시 UnauthorizedOrderAccessException이 발생한다")
+        void shouldThrowWhenBuyerIsNotOrderOwner() {
+            Payment payment = createPayment(1L, ORDER_KEY, 50000L);
+            Long attackerBuyerId = 999L;
+            ApprovePaymentCommand command = ApprovePaymentCommand.builder()
+                    .buyerId(attackerBuyerId)
+                    .orderKey(ORDER_KEY_STR)
+                    .encData("enc_data_test")
+                    .encInfo("enc_info_test")
+                    .payType("PACA")
+                    .build();
+
+            when(findPaymentPort.findByOrderKey(ORDER_KEY)).thenReturn(Optional.of(payment));
+            when(findOrderPort.findById(1L)).thenReturn(Optional.of(createOrder(1L, BUYER_ID)));
+
+            assertThatThrownBy(() -> approvePaymentService.approve(command))
+                    .isInstanceOf(UnauthorizedOrderAccessException.class);
+
+            verify(paymentVendorPort, never()).approvePayment(any());
+        }
+
+        @Test
+        @DisplayName("주문을 찾을 수 없으면 OrderNotFoundException이 발생한다")
+        void shouldThrowWhenOrderNotFound() {
+            Payment payment = createPayment(1L, ORDER_KEY, 50000L);
+            ApprovePaymentCommand command = createApproveCommand(ORDER_KEY_STR);
+
+            when(findPaymentPort.findByOrderKey(ORDER_KEY)).thenReturn(Optional.of(payment));
+            when(findOrderPort.findById(1L)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> approvePaymentService.approve(command))
+                    .isInstanceOf(com.personal.marketnote.commerce.exception.OrderNotFoundException.class);
 
             verify(paymentVendorPort, never()).approvePayment(any());
         }

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/payment/CancelPaymentUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/payment/CancelPaymentUseCaseTest.java
@@ -6,6 +6,7 @@ import com.personal.marketnote.commerce.domain.order.OrderStatus;
 import com.personal.marketnote.commerce.domain.payment.*;
 import com.personal.marketnote.commerce.exception.PaymentCancelException;
 import com.personal.marketnote.commerce.exception.PaymentNotFoundException;
+import com.personal.marketnote.commerce.exception.UnauthorizedOrderAccessException;
 import com.personal.marketnote.commerce.port.in.command.payment.CancelPaymentCommand;
 import com.personal.marketnote.commerce.port.in.usecase.order.ChangeOrderStatusUseCase;
 import com.personal.marketnote.commerce.port.out.order.FindOrderPort;
@@ -310,6 +311,47 @@ class CancelPaymentUseCaseTest {
             assertThatThrownBy(() -> cancelPaymentService.cancel(command))
                     .isInstanceOf(IllegalArgumentException.class)
                     .hasMessageContaining("환불 가능 금액");
+
+            verify(paymentVendorPort, never()).cancelPayment(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("주문 소유자 검증")
+    class OrderOwnerVerificationTest {
+
+        @Test
+        @DisplayName("주문 소유자가 아닌 사용자가 결제 취소 시 UnauthorizedOrderAccessException이 발생한다")
+        void shouldThrowWhenBuyerIsNotOrderOwner() {
+            Payment payment = createSuccessPayment(1L, ORDER_KEY, 50000L, "tno_123");
+            Long attackerBuyerId = 999L;
+            CancelPaymentCommand command = CancelPaymentCommand.builder()
+                    .buyerId(attackerBuyerId)
+                    .orderKey(ORDER_KEY_STR)
+                    .cancelType(CancelPaymentCommand.CancelType.FULL)
+                    .cancelReason("고객 요청")
+                    .build();
+
+            when(findPaymentPort.findByOrderKey(ORDER_KEY)).thenReturn(Optional.of(payment));
+            when(findOrderPort.findById(1L)).thenReturn(Optional.of(createOrder(1L, BUYER_ID)));
+
+            assertThatThrownBy(() -> cancelPaymentService.cancel(command))
+                    .isInstanceOf(UnauthorizedOrderAccessException.class);
+
+            verify(paymentVendorPort, never()).cancelPayment(any());
+        }
+
+        @Test
+        @DisplayName("주문을 찾을 수 없으면 OrderNotFoundException이 발생한다")
+        void shouldThrowWhenOrderNotFound() {
+            Payment payment = createSuccessPayment(1L, ORDER_KEY, 50000L, "tno_123");
+            CancelPaymentCommand command = createFullCancelCommand(ORDER_KEY_STR);
+
+            when(findPaymentPort.findByOrderKey(ORDER_KEY)).thenReturn(Optional.of(payment));
+            when(findOrderPort.findById(1L)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> cancelPaymentService.cancel(command))
+                    .isInstanceOf(com.personal.marketnote.commerce.exception.OrderNotFoundException.class);
 
             verify(paymentVendorPort, never()).cancelPayment(any());
         }

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/payment/GetPaymentUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/payment/GetPaymentUseCaseTest.java
@@ -5,6 +5,7 @@ import com.personal.marketnote.commerce.domain.order.OrderSnapshotState;
 import com.personal.marketnote.commerce.domain.order.OrderStatus;
 import com.personal.marketnote.commerce.domain.payment.*;
 import com.personal.marketnote.commerce.exception.PaymentNotFoundException;
+import com.personal.marketnote.commerce.exception.UnauthorizedOrderAccessException;
 import com.personal.marketnote.commerce.port.in.result.payment.GetPaymentResult;
 import com.personal.marketnote.commerce.port.out.order.FindOrderPort;
 import com.personal.marketnote.commerce.port.out.payment.FindPaymentPort;
@@ -109,6 +110,40 @@ class GetPaymentUseCaseTest {
 
             assertThat(result.refundedYn()).isTrue();
             assertThat(result.refundAmount()).isEqualTo(50000L);
+        }
+    }
+
+    @Nested
+    @DisplayName("주문 소유자 검증")
+    class OrderOwnerVerificationTest {
+
+        @Test
+        @DisplayName("주문 소유자가 아닌 사용자가 결제 조회 시 UnauthorizedOrderAccessException이 발생한다")
+        void shouldThrowWhenBuyerIsNotOrderOwner() {
+            Long attackerBuyerId = 999L;
+            Payment payment = createPayment(1L, ORDER_KEY, 50000L);
+
+            when(findPaymentPort.findByOrderKey(ORDER_KEY)).thenReturn(Optional.of(payment));
+            when(findOrderPort.findById(1L)).thenReturn(Optional.of(createOrder(1L, BUYER_ID)));
+
+            assertThatThrownBy(() -> getPaymentService.getPayment(attackerBuyerId, ORDER_KEY_STR))
+                    .isInstanceOf(UnauthorizedOrderAccessException.class);
+
+            verify(findPspPaymentEventPort, never()).findByOrderKey(any());
+        }
+
+        @Test
+        @DisplayName("주문을 찾을 수 없으면 OrderNotFoundException이 발생한다")
+        void shouldThrowWhenOrderNotFound() {
+            Payment payment = createPayment(1L, ORDER_KEY, 50000L);
+
+            when(findPaymentPort.findByOrderKey(ORDER_KEY)).thenReturn(Optional.of(payment));
+            when(findOrderPort.findById(1L)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> getPaymentService.getPayment(BUYER_ID, ORDER_KEY_STR))
+                    .isInstanceOf(com.personal.marketnote.commerce.exception.OrderNotFoundException.class);
+
+            verify(findPspPaymentEventPort, never()).findByOrderKey(any());
         }
     }
 

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/order/OrderStatus.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/order/OrderStatus.java
@@ -35,6 +35,9 @@ public enum OrderStatus {
     private final String description;
 
     private static final Map<OrderStatus, Set<OrderStatus>> ALLOWED_TRANSITIONS = new EnumMap<>(OrderStatus.class);
+    private static final Set<OrderStatus> BUYER_ALLOWED_STATUSES = EnumSet.of(
+            CANCEL_REQUESTED, CONFIRMED, EXCHANGE_REQUESTED, REFUND_REQUESTED
+    );
 
     static {
         ALLOWED_TRANSITIONS.put(PAYMENT_PENDING, EnumSet.of(PAID, FAILED, CANCEL_REQUESTED, CANCELLED));
@@ -97,5 +100,17 @@ public enum OrderStatus {
 
     public boolean isNotPartialChanged() {
         return this != PARTIALLY_CONFIRMED && this != PARTIALLY_REFUNDED;
+    }
+
+    /**
+     * 구매자가 직접 변경할 수 있는 주문 상태인지 확인한다.
+     * <p>
+     * 구매자 허용 상태: CANCEL_REQUESTED, CONFIRMED, EXCHANGE_REQUESTED, REFUND_REQUESTED
+     * </p>
+     *
+     * @return 구매자가 변경 가능한 상태이면 true
+     */
+    public boolean isBuyerAllowed() {
+        return BUYER_ALLOWED_STATUSES.contains(this);
     }
 }

--- a/commerce-service/commerce-domain/src/test/java/com/personal/marketnote/commerce/domain/order/OrderStatusTest.java
+++ b/commerce-service/commerce-domain/src/test/java/com/personal/marketnote/commerce/domain/order/OrderStatusTest.java
@@ -1,0 +1,135 @@
+package com.personal.marketnote.commerce.domain.order;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OrderStatusTest {
+
+    @Nested
+    @DisplayName("구매자 허용 상태 검증 (isBuyerAllowed)")
+    class IsBuyerAllowedTest {
+
+        @Test
+        @DisplayName("CANCEL_REQUESTED는 구매자가 변경 가능한 상태이다")
+        void cancelRequested_isBuyerAllowed() {
+            assertThat(OrderStatus.CANCEL_REQUESTED.isBuyerAllowed()).isTrue();
+        }
+
+        @Test
+        @DisplayName("CONFIRMED는 구매자가 변경 가능한 상태이다")
+        void confirmed_isBuyerAllowed() {
+            assertThat(OrderStatus.CONFIRMED.isBuyerAllowed()).isTrue();
+        }
+
+        @Test
+        @DisplayName("EXCHANGE_REQUESTED는 구매자가 변경 가능한 상태이다")
+        void exchangeRequested_isBuyerAllowed() {
+            assertThat(OrderStatus.EXCHANGE_REQUESTED.isBuyerAllowed()).isTrue();
+        }
+
+        @Test
+        @DisplayName("REFUND_REQUESTED는 구매자가 변경 가능한 상태이다")
+        void refundRequested_isBuyerAllowed() {
+            assertThat(OrderStatus.REFUND_REQUESTED.isBuyerAllowed()).isTrue();
+        }
+
+        @Test
+        @DisplayName("PAID는 구매자가 변경할 수 없는 상태이다")
+        void paid_isNotBuyerAllowed() {
+            assertThat(OrderStatus.PAID.isBuyerAllowed()).isFalse();
+        }
+
+        @Test
+        @DisplayName("PAYMENT_PENDING는 구매자가 변경할 수 없는 상태이다")
+        void paymentPending_isNotBuyerAllowed() {
+            assertThat(OrderStatus.PAYMENT_PENDING.isBuyerAllowed()).isFalse();
+        }
+
+        @Test
+        @DisplayName("FAILED는 구매자가 변경할 수 없는 상태이다")
+        void failed_isNotBuyerAllowed() {
+            assertThat(OrderStatus.FAILED.isBuyerAllowed()).isFalse();
+        }
+
+        @Test
+        @DisplayName("PREPARING는 구매자가 변경할 수 없는 상태이다")
+        void preparing_isNotBuyerAllowed() {
+            assertThat(OrderStatus.PREPARING.isBuyerAllowed()).isFalse();
+        }
+
+        @Test
+        @DisplayName("PREPARED는 구매자가 변경할 수 없는 상태이다")
+        void prepared_isNotBuyerAllowed() {
+            assertThat(OrderStatus.PREPARED.isBuyerAllowed()).isFalse();
+        }
+
+        @Test
+        @DisplayName("CANCELLED는 구매자가 변경할 수 없는 상태이다")
+        void cancelled_isNotBuyerAllowed() {
+            assertThat(OrderStatus.CANCELLED.isBuyerAllowed()).isFalse();
+        }
+
+        @Test
+        @DisplayName("SHIPPING는 구매자가 변경할 수 없는 상태이다")
+        void shipping_isNotBuyerAllowed() {
+            assertThat(OrderStatus.SHIPPING.isBuyerAllowed()).isFalse();
+        }
+
+        @Test
+        @DisplayName("DELIVERED는 구매자가 변경할 수 없는 상태이다")
+        void delivered_isNotBuyerAllowed() {
+            assertThat(OrderStatus.DELIVERED.isBuyerAllowed()).isFalse();
+        }
+
+        @Test
+        @DisplayName("PARTIALLY_CONFIRMED는 구매자가 변경할 수 없는 상태이다")
+        void partiallyConfirmed_isNotBuyerAllowed() {
+            assertThat(OrderStatus.PARTIALLY_CONFIRMED.isBuyerAllowed()).isFalse();
+        }
+
+        @Test
+        @DisplayName("EXCHANGE_RECALLING는 구매자가 변경할 수 없는 상태이다")
+        void exchangeRecalling_isNotBuyerAllowed() {
+            assertThat(OrderStatus.EXCHANGE_RECALLING.isBuyerAllowed()).isFalse();
+        }
+
+        @Test
+        @DisplayName("EXCHANGE_SHIPPING는 구매자가 변경할 수 없는 상태이다")
+        void exchangeShipping_isNotBuyerAllowed() {
+            assertThat(OrderStatus.EXCHANGE_SHIPPING.isBuyerAllowed()).isFalse();
+        }
+
+        @Test
+        @DisplayName("EXCHANGED는 구매자가 변경할 수 없는 상태이다")
+        void exchanged_isNotBuyerAllowed() {
+            assertThat(OrderStatus.EXCHANGED.isBuyerAllowed()).isFalse();
+        }
+
+        @Test
+        @DisplayName("REFUND_RECALLING는 구매자가 변경할 수 없는 상태이다")
+        void refundRecalling_isNotBuyerAllowed() {
+            assertThat(OrderStatus.REFUND_RECALLING.isBuyerAllowed()).isFalse();
+        }
+
+        @Test
+        @DisplayName("REFUND_SHIPPING는 구매자가 변경할 수 없는 상태이다")
+        void refundShipping_isNotBuyerAllowed() {
+            assertThat(OrderStatus.REFUND_SHIPPING.isBuyerAllowed()).isFalse();
+        }
+
+        @Test
+        @DisplayName("PARTIALLY_REFUNDED는 구매자가 변경할 수 없는 상태이다")
+        void partiallyRefunded_isNotBuyerAllowed() {
+            assertThat(OrderStatus.PARTIALLY_REFUNDED.isBuyerAllowed()).isFalse();
+        }
+
+        @Test
+        @DisplayName("REFUNDED는 구매자가 변경할 수 없는 상태이다")
+        void refunded_isNotBuyerAllowed() {
+            assertThat(OrderStatus.REFUNDED.isBuyerAllowed()).isFalse();
+        }
+    }
+}

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -69,6 +69,10 @@ dependencies {
     testImplementation("org.springframework.boot:spring-boot-starter-test")
 }
 
+tasks.withType<Test> {
+    useJUnitPlatform()
+}
+
 tasks.named("bootJar") {
     enabled = false
 }

--- a/common/src/main/java/com/personal/marketnote/common/domain/exception/BusinessSecurityException.java
+++ b/common/src/main/java/com/personal/marketnote/common/domain/exception/BusinessSecurityException.java
@@ -1,0 +1,16 @@
+package com.personal.marketnote.common.domain.exception;
+
+/**
+ * 비즈니스 보안 예외 추상 클래스
+ *
+ * <p>도메인에서 발생하는 인가/접근 제어 관련 예외의 공통 부모 클래스입니다.
+ * java.lang.SecurityException 대신 이 클래스를 상속하여 비즈니스 보안 예외를 정의합니다.</p>
+ *
+ * @Author 성효빈
+ * @Date 2026-02-27
+ */
+public abstract class BusinessSecurityException extends RuntimeException {
+    protected BusinessSecurityException(String message) {
+        super(message);
+    }
+}

--- a/common/src/main/java/com/personal/marketnote/common/domain/exception/GlobalExceptionHandler.java
+++ b/common/src/main/java/com/personal/marketnote/common/domain/exception/GlobalExceptionHandler.java
@@ -34,138 +34,90 @@ public class GlobalExceptionHandler {
     private static final String LOG_WARN_MESSAGE = "Warning exception occurred: {}";
     private static final String LOG_INFO_MESSAGE = "Exception occurred: {}";
 
-    private HttpStatus httpStatus;
-    private String code;
-    private String message;
+    private record ParsedMessage(String code, String message) {
+        static ParsedMessage from(String errorMessage, HttpStatus httpStatus) {
+            if (FormatValidator.hasNoValue(errorMessage)) {
+                return new ParsedMessage(httpStatus.name(), "");
+            }
 
-    private void initializeMessage(String errorMessage) {
-        if (FormatValidator.hasNoValue(errorMessage)) {
-            return;
+            String[] messages = errorMessage.split("::");
+            if (messages.length > 1) {
+                return new ParsedMessage(messages[0].trim(), messages[1].trim());
+            }
+
+            return new ParsedMessage(httpStatus.name(), messages[0]);
         }
+    }
 
-        String[] messages = errorMessage.split("::");
-        if (messages.length > 1) {
-            code = messages[0].trim();
-            message = messages[1].trim();
-            return;
-        }
+    private ResponseEntity<ErrorResponse> buildErrorResponse(HttpStatus httpStatus, String code, String message) {
+        ErrorResponse errorResponse = ErrorResponse.builder()
+                .statusCode(httpStatus.value())
+                .timestamp(LocalDateTime.now())
+                .code(code)
+                .message(message)
+                .build();
 
-        code = httpStatus.name();
-        message = messages[0];
+        return new ResponseEntity<>(errorResponse, HttpStatus.resolve(errorResponse.getStatusCode()));
+    }
+
+    private ResponseEntity<ErrorResponse> buildErrorResponse(HttpStatus httpStatus, String errorMessage) {
+        ParsedMessage parsed = ParsedMessage.from(errorMessage, httpStatus);
+        return buildErrorResponse(httpStatus, parsed.code(), parsed.message());
     }
 
     @ExceptionHandler(IOException.class)
-    private ResponseEntity<ErrorResponse> handleIOException
-            (IOException e) {
-        httpStatus = HttpStatus.INTERNAL_SERVER_ERROR;
-        initializeMessage(e.getMessage());
-
+    ResponseEntity<ErrorResponse> handleIOException(IOException e) {
+        HttpStatus httpStatus = HttpStatus.INTERNAL_SERVER_ERROR;
         log.error(LOG_ERROR_MESSAGE, e.getMessage(), e);
-
-        ErrorResponse errorResponse = ErrorResponse.builder()
-                .statusCode(httpStatus.value())
-                .timestamp(LocalDateTime.now())
-                .code(code)
-                .message(message)
-                .build();
-
-        return new ResponseEntity<>(errorResponse, HttpStatus.resolve(errorResponse.getStatusCode()));
+        return buildErrorResponse(httpStatus, e.getMessage());
     }
 
     @ExceptionHandler(NullPointerException.class)
-    private ResponseEntity<ErrorResponse> handleNullPointerException
-            (NullPointerException e) {
-        httpStatus = HttpStatus.INTERNAL_SERVER_ERROR;
-        initializeMessage(e.getMessage());
-
+    ResponseEntity<ErrorResponse> handleNullPointerException(NullPointerException e) {
+        HttpStatus httpStatus = HttpStatus.INTERNAL_SERVER_ERROR;
         log.error(LOG_ERROR_MESSAGE, e.getMessage(), e);
-
-        ErrorResponse errorResponse = ErrorResponse.builder()
-                .statusCode(httpStatus.value())
-                .timestamp(LocalDateTime.now())
-                .code(code)
-                .message(message)
-                .build();
-
-        return new ResponseEntity<>(errorResponse, HttpStatus.resolve(errorResponse.getStatusCode()));
+        return buildErrorResponse(httpStatus, e.getMessage());
     }
 
     @ExceptionHandler(EntityNotFoundException.class)
-    private ResponseEntity<ErrorResponse> handleEntityNotFoundException
-            (EntityNotFoundException e) {
-        httpStatus = HttpStatus.NOT_FOUND;
-        initializeMessage(e.getMessage());
-
+    ResponseEntity<ErrorResponse> handleEntityNotFoundException(EntityNotFoundException e) {
+        HttpStatus httpStatus = HttpStatus.NOT_FOUND;
         log.warn(LOG_WARN_MESSAGE, e.getMessage(), e);
-
-        ErrorResponse errorResponse = ErrorResponse.builder()
-                .statusCode(httpStatus.value())
-                .timestamp(LocalDateTime.now())
-                .code(code)
-                .message(message)
-                .build();
-
-        return new ResponseEntity<>(errorResponse, HttpStatus.resolve(errorResponse.getStatusCode()));
+        return buildErrorResponse(httpStatus, e.getMessage());
     }
 
     @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
-    private ResponseEntity<ErrorResponse> handleHttpRequestMethodNotSupportedException
-            (HttpRequestMethodNotSupportedException e) {
-        httpStatus = HttpStatus.METHOD_NOT_ALLOWED;
-        initializeMessage(e.getMessage());
-
+    ResponseEntity<ErrorResponse> handleHttpRequestMethodNotSupportedException(
+            HttpRequestMethodNotSupportedException e) {
+        HttpStatus httpStatus = HttpStatus.METHOD_NOT_ALLOWED;
         log.warn(LOG_WARN_MESSAGE, e.getMessage(), e);
-
-        ErrorResponse errorResponse = ErrorResponse.builder()
-                .statusCode(httpStatus.value())
-                .timestamp(LocalDateTime.now())
-                .code(code)
-                .message(message)
-                .build();
-
-        return new ResponseEntity<>(errorResponse, HttpStatus.resolve(errorResponse.getStatusCode()));
+        return buildErrorResponse(httpStatus, e.getMessage());
     }
 
     @ExceptionHandler(AuthenticationException.class)
-    private ResponseEntity<ErrorResponse> handleAuthenticationException
-            (AuthenticationException e) {
-        httpStatus = HttpStatus.UNAUTHORIZED;
-        initializeMessage(e.getMessage());
-
+    ResponseEntity<ErrorResponse> handleAuthenticationException(AuthenticationException e) {
+        HttpStatus httpStatus = HttpStatus.UNAUTHORIZED;
         log.warn(LOG_WARN_MESSAGE, e.getMessage(), e);
-
-        ErrorResponse errorResponse = ErrorResponse.builder()
-                .statusCode(httpStatus.value())
-                .timestamp(LocalDateTime.now())
-                .code(code)
-                .message(message)
-                .build();
-
-        return new ResponseEntity<>(errorResponse, HttpStatus.resolve(errorResponse.getStatusCode()));
+        return buildErrorResponse(httpStatus, e.getMessage());
     }
 
     @ExceptionHandler(AccessDeniedException.class)
-    private ResponseEntity<ErrorResponse> handleAccessDeniedException
-            (AccessDeniedException e) {
-        httpStatus = HttpStatus.FORBIDDEN;
-        initializeMessage(e.getMessage());
-
+    ResponseEntity<ErrorResponse> handleAccessDeniedException(AccessDeniedException e) {
+        HttpStatus httpStatus = HttpStatus.FORBIDDEN;
         log.warn(LOG_WARN_MESSAGE, e.getMessage(), e);
+        return buildErrorResponse(httpStatus, e.getMessage());
+    }
 
-        ErrorResponse errorResponse = ErrorResponse.builder()
-                .statusCode(httpStatus.value())
-                .timestamp(LocalDateTime.now())
-                .code(code)
-                .message(message)
-                .build();
-
-        return new ResponseEntity<>(errorResponse, HttpStatus.resolve(errorResponse.getStatusCode()));
+    @ExceptionHandler(BusinessSecurityException.class)
+    ResponseEntity<ErrorResponse> handleBusinessSecurityException(BusinessSecurityException e) {
+        HttpStatus httpStatus = HttpStatus.FORBIDDEN;
+        log.warn(LOG_WARN_MESSAGE, e.getMessage(), e);
+        return buildErrorResponse(httpStatus, e.getMessage());
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    private ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException
-            (MethodArgumentNotValidException e) {
-        httpStatus = HttpStatus.BAD_REQUEST;
+    ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+        HttpStatus httpStatus = HttpStatus.BAD_REQUEST;
 
         String fieldErrorMessage = e.getBindingResult().getFieldErrors().stream()
                 .map(fieldError -> fieldError.getDefaultMessage())
@@ -175,223 +127,97 @@ public class GlobalExceptionHandler {
             fieldErrorMessage = "요청 값이 올바르지 않습니다.";
         }
 
-        initializeMessage(fieldErrorMessage);
-
         log.info(LOG_INFO_MESSAGE, e.getMessage(), e);
-
-        ErrorResponse errorResponse = ErrorResponse.builder()
-                .statusCode(httpStatus.value())
-                .timestamp(LocalDateTime.now())
-                .code(code)
-                .message(message)
-                .build();
-
-        return new ResponseEntity<>(errorResponse, HttpStatus.resolve(errorResponse.getStatusCode()));
+        return buildErrorResponse(httpStatus, fieldErrorMessage);
     }
 
     @ExceptionHandler(IllegalArgumentException.class)
-    private ResponseEntity<ErrorResponse> handleIllegalArgumentException
-            (IllegalArgumentException e) {
-        httpStatus = HttpStatus.BAD_REQUEST;
-        initializeMessage(e.getMessage());
-
+    ResponseEntity<ErrorResponse> handleIllegalArgumentException(IllegalArgumentException e) {
+        HttpStatus httpStatus = HttpStatus.BAD_REQUEST;
         log.info(LOG_INFO_MESSAGE, e.getMessage(), e);
-
-        ErrorResponse errorResponse = ErrorResponse.builder()
-                .statusCode(httpStatus.value())
-                .timestamp(LocalDateTime.now())
-                .code(code)
-                .message(message)
-                .build();
-
-        return new ResponseEntity<>(errorResponse, HttpStatus.resolve(errorResponse.getStatusCode()));
+        return buildErrorResponse(httpStatus, e.getMessage());
     }
 
     @ExceptionHandler(HttpMessageNotReadableException.class)
-    private ResponseEntity<ErrorResponse> handleHttpMessageNotReadableException
-            (HttpMessageNotReadableException e) {
-        httpStatus = HttpStatus.BAD_REQUEST;
-        code = httpStatus.name();
-        message = "요청 본문을 읽을 수 없습니다.";
-
+    ResponseEntity<ErrorResponse> handleHttpMessageNotReadableException(HttpMessageNotReadableException e) {
+        HttpStatus httpStatus = HttpStatus.BAD_REQUEST;
         log.info(LOG_INFO_MESSAGE, e.getMessage(), e);
-
-        ErrorResponse errorResponse = ErrorResponse.builder()
-                .statusCode(httpStatus.value())
-                .timestamp(LocalDateTime.now())
-                .code(code)
-                .message(message)
-                .build();
-
-        return new ResponseEntity<>(errorResponse, HttpStatus.resolve(errorResponse.getStatusCode()));
+        return buildErrorResponse(httpStatus, httpStatus.name(), "요청 본문을 읽을 수 없습니다.");
     }
 
     @ExceptionHandler(HttpMediaTypeNotSupportedException.class)
-    private ResponseEntity<ErrorResponse> handleHttpMediaTypeNotSupportedException
-            (HttpMediaTypeNotSupportedException e) {
-        httpStatus = HttpStatus.UNSUPPORTED_MEDIA_TYPE;
-        initializeMessage(e.getMessage());
-
+    ResponseEntity<ErrorResponse> handleHttpMediaTypeNotSupportedException(
+            HttpMediaTypeNotSupportedException e) {
+        HttpStatus httpStatus = HttpStatus.UNSUPPORTED_MEDIA_TYPE;
         log.info(LOG_INFO_MESSAGE, e.getMessage(), e);
-
-        ErrorResponse errorResponse = ErrorResponse.builder()
-                .statusCode(httpStatus.value())
-                .timestamp(LocalDateTime.now())
-                .code(code)
-                .message(message)
-                .build();
-        return new ResponseEntity<>(errorResponse, HttpStatus.resolve(errorResponse.getStatusCode()));
+        return buildErrorResponse(httpStatus, e.getMessage());
     }
 
     @ExceptionHandler(MalformedJwtException.class)
-    private ResponseEntity<ErrorResponse> handleMalformedJwtException(MalformedJwtException e) {
-        httpStatus = HttpStatus.BAD_REQUEST;
-        initializeMessage(e.getMessage());
-
+    ResponseEntity<ErrorResponse> handleMalformedJwtException(MalformedJwtException e) {
+        HttpStatus httpStatus = HttpStatus.BAD_REQUEST;
         log.info(LOG_INFO_MESSAGE, e.getMessage(), e);
-
-        ErrorResponse errorResponse = ErrorResponse.builder()
-                .statusCode(httpStatus.value())
-                .timestamp(LocalDateTime.now())
-                .code(code)
-                .message(message)
-                .build();
-        return new ResponseEntity<>(errorResponse, HttpStatus.resolve(errorResponse.getStatusCode()));
+        return buildErrorResponse(httpStatus, e.getMessage());
     }
 
     @ExceptionHandler(UnsupportedJwtException.class)
-    private ResponseEntity<ErrorResponse> handleUnsupportedJwtException(UnsupportedJwtException e) {
-        httpStatus = HttpStatus.BAD_REQUEST;
-        initializeMessage(e.getMessage());
-
+    ResponseEntity<ErrorResponse> handleUnsupportedJwtException(UnsupportedJwtException e) {
+        HttpStatus httpStatus = HttpStatus.BAD_REQUEST;
         log.info(LOG_INFO_MESSAGE, e.getMessage(), e);
-
-        ErrorResponse errorResponse = ErrorResponse.builder()
-                .statusCode(httpStatus.value())
-                .timestamp(LocalDateTime.now())
-                .code(code)
-                .message(message)
-                .build();
-        return new ResponseEntity<>(errorResponse, HttpStatus.resolve(errorResponse.getStatusCode()));
+        return buildErrorResponse(httpStatus, e.getMessage());
     }
 
     @ExceptionHandler(EntityExistsException.class)
-    private ResponseEntity<ErrorResponse> handleEntityExistsException(EntityExistsException e) {
-        httpStatus = HttpStatus.CONFLICT;
-        initializeMessage(e.getMessage());
-
+    ResponseEntity<ErrorResponse> handleEntityExistsException(EntityExistsException e) {
+        HttpStatus httpStatus = HttpStatus.CONFLICT;
         log.info(LOG_INFO_MESSAGE, e.getMessage(), e);
-
-        ErrorResponse errorResponse = ErrorResponse.builder()
-                .statusCode(httpStatus.value())
-                .timestamp(LocalDateTime.now())
-                .code(code)
-                .message(message)
-                .build();
-        return new ResponseEntity<>(errorResponse, HttpStatus.resolve(errorResponse.getStatusCode()));
+        return buildErrorResponse(httpStatus, e.getMessage());
     }
 
     @ExceptionHandler(IllegalStateException.class)
-    private ResponseEntity<ErrorResponse> handleIllegalStateException(IllegalStateException e) {
-        httpStatus = HttpStatus.CONFLICT;
-        initializeMessage(e.getMessage());
-
+    ResponseEntity<ErrorResponse> handleIllegalStateException(IllegalStateException e) {
+        HttpStatus httpStatus = HttpStatus.CONFLICT;
         log.info(LOG_INFO_MESSAGE, e.getMessage(), e);
-
-        ErrorResponse errorResponse = ErrorResponse.builder()
-                .statusCode(httpStatus.value())
-                .timestamp(LocalDateTime.now())
-                .code(code)
-                .message(message)
-                .build();
-        return new ResponseEntity<>(errorResponse, HttpStatus.resolve(errorResponse.getStatusCode()));
+        return buildErrorResponse(httpStatus, e.getMessage());
     }
 
     @ExceptionHandler(MailException.class)
-    private ResponseEntity<ErrorResponse> handleMailException(MailException e) {
-        httpStatus = HttpStatus.BAD_GATEWAY;
-        initializeMessage(e.getMessage());
-
+    ResponseEntity<ErrorResponse> handleMailException(MailException e) {
+        HttpStatus httpStatus = HttpStatus.BAD_GATEWAY;
         log.info(LOG_INFO_MESSAGE, e.getMessage(), e);
-
-        ErrorResponse errorResponse = ErrorResponse.builder()
-                .statusCode(httpStatus.value())
-                .timestamp(LocalDateTime.now())
-                .code(code)
-                .message(message)
-                .build();
-
-        return new ResponseEntity<>(errorResponse, HttpStatus.resolve(errorResponse.getStatusCode()));
+        return buildErrorResponse(httpStatus, e.getMessage());
     }
 
     @ExceptionHandler(UncheckedIOException.class)
-    private ResponseEntity<ErrorResponse> handleUncheckedIOException(UncheckedIOException e) {
-        httpStatus = HttpStatus.BAD_GATEWAY;
-        initializeMessage(e.getMessage());
-
+    ResponseEntity<ErrorResponse> handleUncheckedIOException(UncheckedIOException e) {
+        HttpStatus httpStatus = HttpStatus.BAD_GATEWAY;
         log.info(LOG_INFO_MESSAGE, e.getMessage(), e);
-
-        ErrorResponse errorResponse = ErrorResponse.builder()
-                .statusCode(httpStatus.value())
-                .timestamp(LocalDateTime.now())
-                .code(code)
-                .message(message)
-                .build();
-
-        return new ResponseEntity<>(errorResponse, HttpStatus.resolve(errorResponse.getStatusCode()));
+        return buildErrorResponse(httpStatus, e.getMessage());
     }
 
     @ExceptionHandler(MissingServletRequestParameterException.class)
-    private ResponseEntity<ErrorResponse> handleMissingServletRequestParameterException(
+    ResponseEntity<ErrorResponse> handleMissingServletRequestParameterException(
             MissingServletRequestParameterException e) {
-        httpStatus = HttpStatus.BAD_REQUEST;
-        code = httpStatus.name();
-        message = "필수 요청 파라미터 '" + e.getParameterName() + "'이(가) 누락되었습니다.";
-
+        HttpStatus httpStatus = HttpStatus.BAD_REQUEST;
+        String message = "필수 요청 파라미터 '" + e.getParameterName() + "'이(가) 누락되었습니다.";
         log.info(LOG_INFO_MESSAGE, e.getMessage(), e);
-
-        ErrorResponse errorResponse = ErrorResponse.builder()
-                .statusCode(httpStatus.value())
-                .timestamp(LocalDateTime.now())
-                .code(code)
-                .message(message)
-                .build();
-        return new ResponseEntity<>(errorResponse, HttpStatus.resolve(errorResponse.getStatusCode()));
+        return buildErrorResponse(httpStatus, httpStatus.name(), message);
     }
 
     @ExceptionHandler(MethodArgumentTypeMismatchException.class)
-    private ResponseEntity<ErrorResponse> handleMethodArgumentTypeMismatchException(
+    ResponseEntity<ErrorResponse> handleMethodArgumentTypeMismatchException(
             MethodArgumentTypeMismatchException e) {
-        httpStatus = HttpStatus.BAD_REQUEST;
-        code = httpStatus.name();
-        message = "요청 파라미터 '" + e.getName() + "'의 타입이 올바르지 않습니다.";
-
+        HttpStatus httpStatus = HttpStatus.BAD_REQUEST;
+        String message = "요청 파라미터 '" + e.getName() + "'의 타입이 올바르지 않습니다.";
         log.info(LOG_INFO_MESSAGE, e.getMessage(), e);
-
-        ErrorResponse errorResponse = ErrorResponse.builder()
-                .statusCode(httpStatus.value())
-                .timestamp(LocalDateTime.now())
-                .code(code)
-                .message(message)
-                .build();
-        return new ResponseEntity<>(errorResponse, HttpStatus.resolve(errorResponse.getStatusCode()));
+        return buildErrorResponse(httpStatus, httpStatus.name(), message);
     }
 
     @ExceptionHandler(DataIntegrityViolationException.class)
-    private ResponseEntity<ErrorResponse> handleDataIntegrityViolationException(
+    ResponseEntity<ErrorResponse> handleDataIntegrityViolationException(
             DataIntegrityViolationException e) {
-        httpStatus = HttpStatus.CONFLICT;
-        code = httpStatus.name();
-        message = "데이터 무결성 제약 조건을 위반했습니다.";
-
+        HttpStatus httpStatus = HttpStatus.CONFLICT;
         log.error(LOG_ERROR_MESSAGE, e.getMessage(), e);
-
-        ErrorResponse errorResponse = ErrorResponse.builder()
-                .statusCode(httpStatus.value())
-                .timestamp(LocalDateTime.now())
-                .code(code)
-                .message(message)
-                .build();
-        return new ResponseEntity<>(errorResponse, HttpStatus.resolve(errorResponse.getStatusCode()));
+        return buildErrorResponse(httpStatus, httpStatus.name(), "데이터 무결성 제약 조건을 위반했습니다.");
     }
 }

--- a/common/src/main/java/com/personal/marketnote/common/utility/ElementExtractor.java
+++ b/common/src/main/java/com/personal/marketnote/common/utility/ElementExtractor.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.common.utility;
 
 import com.personal.marketnote.common.domain.exception.token.AuthenticationFailedException;
+import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.oauth2.core.OAuth2AuthenticatedPrincipal;
 
 import static com.personal.marketnote.common.domain.exception.ExceptionMessage.INVALID_ACCESS_TOKEN_EXCEPTION_MESSAGE;
@@ -12,5 +13,30 @@ public class ElementExtractor {
         }
 
         return FormatConverter.parseId(principal.getName());
+    }
+
+    private static final String DEFAULT_ROLE = "BUYER";
+
+    /**
+     * principal의 authorities에서 첫 번째 역할명을 추출한다.
+     * ROLE_ 접두사를 제거하여 BUYER, SELLER, ADMIN 등으로 반환한다.
+     * 역할을 찾지 못하면 가장 제한적인 역할인 BUYER를 기본값으로 반환하여,
+     * 외부 요청이 서비스 내부 호출로 오인되는 것을 방지한다.
+     *
+     * @param principal 인증된 사용자 정보
+     * @return 역할명 (BUYER, SELLER, ADMIN 등), 역할이 없으면 BUYER (기본값)
+     */
+    public static String extractRole(OAuth2AuthenticatedPrincipal principal) {
+        if (FormatValidator.hasNoValue(principal) || FormatValidator.hasNoValue(principal.getAuthorities())) {
+            return DEFAULT_ROLE;
+        }
+
+        return principal.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .filter(FormatValidator::hasValue)
+                .filter(authority -> authority.startsWith("ROLE_"))
+                .map(authority -> authority.substring("ROLE_".length()))
+                .findFirst()
+                .orElse(DEFAULT_ROLE);
     }
 }

--- a/common/src/test/java/com/personal/marketnote/common/domain/exception/GlobalExceptionHandlerTest.java
+++ b/common/src/test/java/com/personal/marketnote/common/domain/exception/GlobalExceptionHandlerTest.java
@@ -1,0 +1,155 @@
+package com.personal.marketnote.common.domain.exception;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("GlobalExceptionHandler 테스트")
+class GlobalExceptionHandlerTest {
+
+    private final GlobalExceptionHandler handler = new GlobalExceptionHandler();
+
+    @Nested
+    @DisplayName("에러 메시지 파싱")
+    class ErrorMessageParsingTest {
+
+        @Test
+        @DisplayName("ERR_CODE::메시지 형식이면 코드와 메시지가 분리된다")
+        void shouldParseCodeAndMessageFromFormattedError() {
+            IllegalArgumentException exception = new IllegalArgumentException("ERR_TEST_01::테스트 에러 메시지");
+
+            ResponseEntity<ErrorResponse> response = handler.handleIllegalArgumentException(exception);
+
+            assertThat(response.getBody()).isNotNull();
+            assertThat(response.getBody().getCode()).isEqualTo("ERR_TEST_01");
+            assertThat(response.getBody().getMessage()).isEqualTo("테스트 에러 메시지");
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        }
+
+        @Test
+        @DisplayName("일반 메시지이면 HTTP 상태명이 코드로 사용된다")
+        void shouldUseHttpStatusNameAsCodeForPlainMessage() {
+            IllegalArgumentException exception = new IllegalArgumentException("잘못된 요청입니다");
+
+            ResponseEntity<ErrorResponse> response = handler.handleIllegalArgumentException(exception);
+
+            assertThat(response.getBody()).isNotNull();
+            assertThat(response.getBody().getCode()).isEqualTo("BAD_REQUEST");
+            assertThat(response.getBody().getMessage()).isEqualTo("잘못된 요청입니다");
+        }
+
+        @Test
+        @DisplayName("EntityNotFoundException 핸들러는 404를 반환한다")
+        void shouldReturn404ForEntityNotFoundException() {
+            jakarta.persistence.EntityNotFoundException exception =
+                    new jakarta.persistence.EntityNotFoundException("ERR_ENTITY_01::엔티티를 찾을 수 없습니다");
+
+            ResponseEntity<ErrorResponse> response = handler.handleEntityNotFoundException(exception);
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+            assertThat(response.getBody()).isNotNull();
+            assertThat(response.getBody().getCode()).isEqualTo("ERR_ENTITY_01");
+            assertThat(response.getBody().getMessage()).isEqualTo("엔티티를 찾을 수 없습니다");
+        }
+
+        @Test
+        @DisplayName("IOException 핸들러는 500을 반환한다")
+        void shouldReturn500ForIOException() {
+            IOException exception = new IOException("ERR_IO_01::파일 처리 실패");
+
+            ResponseEntity<ErrorResponse> response = handler.handleIOException(exception);
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+            assertThat(response.getBody()).isNotNull();
+            assertThat(response.getBody().getCode()).isEqualTo("ERR_IO_01");
+        }
+
+        @Test
+        @DisplayName("IllegalStateException 핸들러는 409를 반환한다")
+        void shouldReturn409ForIllegalStateException() {
+            IllegalStateException exception = new IllegalStateException("ERR_STATE_01::상태 충돌");
+
+            ResponseEntity<ErrorResponse> response = handler.handleIllegalStateException(exception);
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
+            assertThat(response.getBody()).isNotNull();
+            assertThat(response.getBody().getCode()).isEqualTo("ERR_STATE_01");
+        }
+
+        @Test
+        @DisplayName("BusinessSecurityException 핸들러는 403을 반환한다")
+        void shouldReturn403ForBusinessSecurityException() {
+            BusinessSecurityException exception = new BusinessSecurityException("ERR_AUTH_01::접근 권한 없음") {
+            };
+
+            ResponseEntity<ErrorResponse> response = handler.handleBusinessSecurityException(exception);
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+            assertThat(response.getBody()).isNotNull();
+            assertThat(response.getBody().getCode()).isEqualTo("ERR_AUTH_01");
+            assertThat(response.getBody().getMessage()).isEqualTo("접근 권한 없음");
+        }
+    }
+
+    @Nested
+    @DisplayName("스레드 안전성")
+    class ThreadSafetyTest {
+
+        @Test
+        @DisplayName("동시 요청 시 각 핸들러가 올바른 코드와 메시지를 반환한다")
+        void shouldHandleConcurrentRequestsWithCorrectResponses() throws Exception {
+            int threadCount = 50;
+            ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+            CountDownLatch startLatch = new CountDownLatch(1);
+            List<Future<ResponseEntity<ErrorResponse>>> futures = new ArrayList<>();
+
+            for (int i = 0; i < threadCount; i++) {
+                int index = i;
+                futures.add(executor.submit(() -> {
+                    startLatch.await();
+
+                    if (index % 2 == 0) {
+                        IllegalArgumentException exception =
+                                new IllegalArgumentException("ERR_ARG_" + index + "::인자 에러 " + index);
+                        return handler.handleIllegalArgumentException(exception);
+                    } else {
+                        IllegalStateException exception =
+                                new IllegalStateException("ERR_STATE_" + index + "::상태 에러 " + index);
+                        return handler.handleIllegalStateException(exception);
+                    }
+                }));
+            }
+
+            startLatch.countDown();
+
+            for (int i = 0; i < threadCount; i++) {
+                ResponseEntity<ErrorResponse> response = futures.get(i).get();
+                ErrorResponse body = response.getBody();
+
+                assertThat(body).isNotNull();
+                assertThat(body.getCode()).isEqualTo(i % 2 == 0 ? "ERR_ARG_" + i : "ERR_STATE_" + i);
+                assertThat(body.getMessage()).isEqualTo(i % 2 == 0 ? "인자 에러 " + i : "상태 에러 " + i);
+
+                if (i % 2 == 0) {
+                    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+                } else {
+                    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
+                }
+            }
+
+            executor.shutdown();
+        }
+    }
+}

--- a/common/src/test/java/com/personal/marketnote/common/utility/ElementExtractorTest.java
+++ b/common/src/test/java/com/personal/marketnote/common/utility/ElementExtractorTest.java
@@ -1,0 +1,121 @@
+package com.personal.marketnote.common.utility;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.core.OAuth2AuthenticatedPrincipal;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+@DisplayName("ElementExtractor 테스트")
+class ElementExtractorTest {
+
+    @Nested
+    @DisplayName("extractRole 테스트")
+    class ExtractRoleTest {
+
+        @Test
+        @DisplayName("ROLE_BUYER authority가 있으면 BUYER를 반환한다")
+        void shouldReturnBuyerWhenRoleBuyerAuthorityExists() {
+            OAuth2AuthenticatedPrincipal principal = mock(OAuth2AuthenticatedPrincipal.class);
+            Collection<GrantedAuthority> authorities = List.of(new SimpleGrantedAuthority("ROLE_BUYER"));
+            doReturn(authorities).when(principal).getAuthorities();
+
+            String role = ElementExtractor.extractRole(principal);
+
+            assertThat(role).isEqualTo("BUYER");
+        }
+
+        @Test
+        @DisplayName("ROLE_ADMIN authority가 있으면 ADMIN을 반환한다")
+        void shouldReturnAdminWhenRoleAdminAuthorityExists() {
+            OAuth2AuthenticatedPrincipal principal = mock(OAuth2AuthenticatedPrincipal.class);
+            Collection<GrantedAuthority> authorities = List.of(new SimpleGrantedAuthority("ROLE_ADMIN"));
+            doReturn(authorities).when(principal).getAuthorities();
+
+            String role = ElementExtractor.extractRole(principal);
+
+            assertThat(role).isEqualTo("ADMIN");
+        }
+
+        @Test
+        @DisplayName("ROLE_SELLER authority가 있으면 SELLER를 반환한다")
+        void shouldReturnSellerWhenRoleSellerAuthorityExists() {
+            OAuth2AuthenticatedPrincipal principal = mock(OAuth2AuthenticatedPrincipal.class);
+            Collection<GrantedAuthority> authorities = List.of(new SimpleGrantedAuthority("ROLE_SELLER"));
+            doReturn(authorities).when(principal).getAuthorities();
+
+            String role = ElementExtractor.extractRole(principal);
+
+            assertThat(role).isEqualTo("SELLER");
+        }
+
+        @Test
+        @DisplayName("principal이 null이면 기본값 BUYER를 반환한다")
+        void shouldReturnBuyerWhenPrincipalIsNull() {
+            String role = ElementExtractor.extractRole(null);
+
+            assertThat(role).isEqualTo("BUYER");
+        }
+
+        @Test
+        @DisplayName("authorities가 비어있으면 기본값 BUYER를 반환한다")
+        void shouldReturnBuyerWhenAuthoritiesEmpty() {
+            OAuth2AuthenticatedPrincipal principal = mock(OAuth2AuthenticatedPrincipal.class);
+            doReturn(Collections.emptyList()).when(principal).getAuthorities();
+
+            String role = ElementExtractor.extractRole(principal);
+
+            assertThat(role).isEqualTo("BUYER");
+        }
+
+        @Test
+        @DisplayName("ROLE_ 접두사가 없는 authority만 있으면 기본값 BUYER를 반환한다")
+        void shouldReturnBuyerWhenNoRolePrefixedAuthority() {
+            OAuth2AuthenticatedPrincipal principal = mock(OAuth2AuthenticatedPrincipal.class);
+            Collection<GrantedAuthority> authorities = List.of(
+                    new SimpleGrantedAuthority("SCOPE_read"),
+                    new SimpleGrantedAuthority("SCOPE_write")
+            );
+            doReturn(authorities).when(principal).getAuthorities();
+
+            String role = ElementExtractor.extractRole(principal);
+
+            assertThat(role).isEqualTo("BUYER");
+        }
+
+        @Test
+        @DisplayName("여러 ROLE_ authority가 있으면 첫 번째를 반환한다")
+        void shouldReturnFirstRoleWhenMultipleRolesExist() {
+            OAuth2AuthenticatedPrincipal principal = mock(OAuth2AuthenticatedPrincipal.class);
+            Collection<GrantedAuthority> authorities = List.of(
+                    new SimpleGrantedAuthority("ROLE_ADMIN"),
+                    new SimpleGrantedAuthority("ROLE_SELLER")
+            );
+            doReturn(authorities).when(principal).getAuthorities();
+
+            String role = ElementExtractor.extractRole(principal);
+
+            assertThat(role).isEqualTo("ADMIN");
+        }
+
+        @Test
+        @DisplayName("authorities가 null이면 기본값 BUYER를 반환한다")
+        void shouldReturnBuyerWhenAuthoritiesNull() {
+            OAuth2AuthenticatedPrincipal principal = mock(OAuth2AuthenticatedPrincipal.class);
+            doReturn(null).when(principal).getAuthorities();
+
+            String role = ElementExtractor.extractRole(principal);
+
+            assertThat(role).isEqualTo("BUYER");
+        }
+    }
+}


### PR DESCRIPTION
## partially addresses #723
## resolves #871
## resolves #872

## Reason
NHN KCP 결제 연동 통합 QA에서 buyerId 불일치 시에도 타 사용자 주문 조회/변경/취소가 가능한 IDOR 취약점이 발견됨 구매자가 PATCH /orders/{id}로 PAID 상태를 직접 설정하여 결제 없이 결제 완료 처리 가능한 권한 검증 누락이 발견됨

## Action
- [x] GET /orders/{id}, GET /orders/{id}/order-key, PATCH /orders/{id}에 @AuthenticationPrincipal 추가
- [x] GetOrderService, ChangeOrderStatusService에 buyerId 소유자 검증 추가
- [x] UnauthorizedOrderAccessException, UnauthorizedOrderStatusChangeException 예외 클래스 생성
- [x] OrderStatus에 구매자 허용 상태 정의 (CANCEL_REQUESTED, CONFIRMED, EXCHANGE_REQUESTED, REFUND_REQUESTED)
- [x] ChangeOrderStatusCommand에 role, buyerId 필드 추가 및 역할 기반 상태 전이 검증
- [x] 예외 메시지에서 내부 ID 제거 — ERR_ORDER_AUTH_01/02 에러 코드 형식 적용
- [x] BusinessSecurityException 추상 클래스 도입 (java.lang.SecurityException 캐치 범위 축소)
- [x] ApprovePaymentService, CancelPaymentService, GetPaymentService 소유자 검증 예외 통일
- [x] ElementExtractor.extractRole() null 반환 시 기본값 "BUYER" 적용 (보안 우회 방지)
- [x] GlobalExceptionHandler Thread-safety 수정 (인스턴스 필드 제거, ParsedMessage record 도입)

## Test Case
- [x] 주문 소유자와 요청 buyerId가 일치하면 주문 정보를 반환한다
- [x] 주문 소유자와 요청 buyerId가 다르면 UnauthorizedOrderAccessException이 발생한다
- [x] 구매자가 PAID로 변경하면 UnauthorizedOrderStatusChangeException이 발생한다
- [x] 구매자가 CANCEL_REQUESTED로 변경하면 정상 처리된다
- [x] 서비스 내부 호출(role=null)이면 소유자/역할 검증을 스킵한다
- [x] ADMIN/SELLER 역할이면 모든 상태 변경 가능
- [x] 예외 메시지에 내부 ID가 노출되지 않는다
- [x] 결제 승인/취소/조회 시 소유자 불일치하면 UnauthorizedOrderAccessException이 발생한다
- [x] 동시 요청 시 GlobalExceptionHandler가 올바른 응답을 반환한다