### PR TITLE
[#723][#874] fix: 거래 등록 시 주문 상태 검증 누락 수정 및 중복 거래 등록 방지 로직 추가

### DIFF
--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/exception/DuplicatePaymentReadyException.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/exception/DuplicatePaymentReadyException.java
@@ -1,0 +1,10 @@
+package com.personal.marketnote.commerce.exception;
+
+public class DuplicatePaymentReadyException extends IllegalStateException {
+    private static final String DUPLICATE_PAYMENT_READY_EXCEPTION_MESSAGE
+            = "이미 거래 등록이 진행 중인 주문입니다. 주문 키: %s";
+
+    public DuplicatePaymentReadyException(String orderKey) {
+        super(String.format(DUPLICATE_PAYMENT_READY_EXCEPTION_MESSAGE, orderKey));
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/exception/InvalidOrderStatusForPaymentException.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/exception/InvalidOrderStatusForPaymentException.java
@@ -1,0 +1,12 @@
+package com.personal.marketnote.commerce.exception;
+
+import com.personal.marketnote.commerce.domain.order.OrderStatus;
+
+public class InvalidOrderStatusForPaymentException extends IllegalStateException {
+    private static final String INVALID_ORDER_STATUS_FOR_PAYMENT_EXCEPTION_MESSAGE
+            = "결제 대기 상태에서만 거래를 등록할 수 있습니다. 현재 주문 상태: %s";
+
+    public InvalidOrderStatusForPaymentException(OrderStatus currentStatus) {
+        super(String.format(INVALID_ORDER_STATUS_FOR_PAYMENT_EXCEPTION_MESSAGE, currentStatus.getDescription()));
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/ReadyPaymentService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/ReadyPaymentService.java
@@ -1,12 +1,19 @@
 package com.personal.marketnote.commerce.service.payment;
 
+import com.personal.marketnote.commerce.domain.order.Order;
 import com.personal.marketnote.commerce.domain.payment.Payment;
+import com.personal.marketnote.commerce.domain.payment.PspPaymentEvent;
+import com.personal.marketnote.commerce.exception.DuplicatePaymentReadyException;
+import com.personal.marketnote.commerce.exception.InvalidOrderStatusForPaymentException;
+import com.personal.marketnote.commerce.exception.OrderNotFoundException;
 import com.personal.marketnote.commerce.exception.PaymentApprovalException;
 import com.personal.marketnote.commerce.exception.PaymentNotFoundException;
 import com.personal.marketnote.commerce.port.in.command.payment.ReadyPaymentCommand;
 import com.personal.marketnote.commerce.port.in.result.payment.ReadyPaymentResult;
 import com.personal.marketnote.commerce.port.in.usecase.payment.ReadyPaymentUseCase;
+import com.personal.marketnote.commerce.port.out.order.FindOrderPort;
 import com.personal.marketnote.commerce.port.out.payment.FindPaymentPort;
+import com.personal.marketnote.commerce.port.out.payment.FindPspPaymentEventPort;
 import com.personal.marketnote.commerce.port.out.payment.PaymentVendorPort;
 import com.personal.marketnote.commerce.port.out.payment.vendor.TradeRegisterVendorCommand;
 import com.personal.marketnote.commerce.port.out.payment.vendor.TradeRegisterVendorResult;
@@ -24,7 +31,9 @@ import static org.springframework.transaction.annotation.Isolation.READ_COMMITTE
 @Transactional(isolation = READ_COMMITTED)
 @Slf4j
 public class ReadyPaymentService implements ReadyPaymentUseCase {
+    private final FindOrderPort findOrderPort;
     private final FindPaymentPort findPaymentPort;
+    private final FindPspPaymentEventPort findPspPaymentEventPort;
     private final PaymentVendorPort paymentVendorPort;
 
     @Override
@@ -33,6 +42,9 @@ public class ReadyPaymentService implements ReadyPaymentUseCase {
 
         Payment payment = findPaymentPort.findByOrderKey(orderKey)
                 .orElseThrow(() -> new PaymentNotFoundException(command.orderKey()));
+
+        verifyOrderStatusForPayment(payment.getOrderId());
+        verifyNoDuplicatePaymentReady(command.orderKey());
 
         TradeRegisterVendorCommand vendorCommand = TradeRegisterVendorCommand.builder()
                 .orderKey(payment.getOrderKey().toString())
@@ -53,5 +65,26 @@ public class ReadyPaymentService implements ReadyPaymentUseCase {
                 .payUrl(vendorResult.payUrl())
                 .traceNo(vendorResult.traceNo())
                 .build();
+    }
+
+    private void verifyOrderStatusForPayment(Long orderId) {
+        Order order = findOrderPort.findById(orderId)
+                .orElseThrow(() -> new OrderNotFoundException(orderId));
+
+        if (!order.isPaymentPending()) {
+            log.warn("결제 불가 주문 상태에서 거래 등록 시도 - orderId: {}, 주문 상태: {}",
+                    orderId, order.getOrderStatus());
+            throw new InvalidOrderStatusForPaymentException(order.getOrderStatus());
+        }
+    }
+
+    private void verifyNoDuplicatePaymentReady(String orderKey) {
+        findPspPaymentEventPort.findByOrderKey(orderKey)
+                .filter(PspPaymentEvent::isActiveEvent)
+                .ifPresent(event -> {
+                    log.warn("중복 거래 등록 시도 - orderKey: {}, 기존 이벤트 상태: {}",
+                            orderKey, event.getPoStatus());
+                    throw new DuplicatePaymentReadyException(orderKey);
+                });
     }
 }

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/payment/ReadyPaymentUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/payment/ReadyPaymentUseCaseTest.java
@@ -1,11 +1,18 @@
 package com.personal.marketnote.commerce.service.payment;
 
-import com.personal.marketnote.commerce.domain.payment.Payment;
-import com.personal.marketnote.commerce.domain.payment.PaymentCreateState;
+import com.personal.marketnote.commerce.domain.order.Order;
+import com.personal.marketnote.commerce.domain.order.OrderSnapshotState;
+import com.personal.marketnote.commerce.domain.order.OrderStatus;
+import com.personal.marketnote.commerce.domain.payment.*;
+import com.personal.marketnote.commerce.exception.DuplicatePaymentReadyException;
+import com.personal.marketnote.commerce.exception.InvalidOrderStatusForPaymentException;
+import com.personal.marketnote.commerce.exception.OrderNotFoundException;
 import com.personal.marketnote.commerce.exception.PaymentNotFoundException;
 import com.personal.marketnote.commerce.port.in.command.payment.ReadyPaymentCommand;
 import com.personal.marketnote.commerce.port.in.result.payment.ReadyPaymentResult;
+import com.personal.marketnote.commerce.port.out.order.FindOrderPort;
 import com.personal.marketnote.commerce.port.out.payment.FindPaymentPort;
+import com.personal.marketnote.commerce.port.out.payment.FindPspPaymentEventPort;
 import com.personal.marketnote.commerce.port.out.payment.PaymentVendorPort;
 import com.personal.marketnote.commerce.port.out.payment.vendor.TradeRegisterVendorResult;
 import org.junit.jupiter.api.DisplayName;
@@ -33,7 +40,13 @@ class ReadyPaymentUseCaseTest {
     private ReadyPaymentService readyPaymentService;
 
     @Mock
+    private FindOrderPort findOrderPort;
+
+    @Mock
     private FindPaymentPort findPaymentPort;
+
+    @Mock
+    private FindPspPaymentEventPort findPspPaymentEventPort;
 
     @Mock
     private PaymentVendorPort paymentVendorPort;
@@ -51,8 +64,11 @@ class ReadyPaymentUseCaseTest {
             Payment payment = createPayment(1L, ORDER_KEY, 50000L);
             ReadyPaymentCommand command = createReadyCommand(ORDER_KEY_STR);
             TradeRegisterVendorResult vendorResult = createVendorResult();
+            Order order = createOrder(1L, OrderStatus.PAYMENT_PENDING);
 
             when(findPaymentPort.findByOrderKey(ORDER_KEY)).thenReturn(Optional.of(payment));
+            when(findOrderPort.findById(1L)).thenReturn(Optional.of(order));
+            when(findPspPaymentEventPort.findByOrderKey(ORDER_KEY_STR)).thenReturn(Optional.empty());
             when(paymentVendorPort.registerTrade(any())).thenReturn(vendorResult);
 
             ReadyPaymentResult result = readyPaymentService.ready(command);
@@ -69,8 +85,11 @@ class ReadyPaymentUseCaseTest {
             Payment payment = createPayment(1L, ORDER_KEY, 77000L);
             ReadyPaymentCommand command = createReadyCommand(ORDER_KEY_STR);
             TradeRegisterVendorResult vendorResult = createVendorResult();
+            Order order = createOrder(1L, OrderStatus.PAYMENT_PENDING);
 
             when(findPaymentPort.findByOrderKey(ORDER_KEY)).thenReturn(Optional.of(payment));
+            when(findOrderPort.findById(1L)).thenReturn(Optional.of(order));
+            when(findPspPaymentEventPort.findByOrderKey(ORDER_KEY_STR)).thenReturn(Optional.empty());
             when(paymentVendorPort.registerTrade(any())).thenReturn(vendorResult);
 
             readyPaymentService.ready(command);
@@ -90,8 +109,11 @@ class ReadyPaymentUseCaseTest {
                     .goodName("테스트 상품")
                     .build();
             TradeRegisterVendorResult vendorResult = createVendorResult();
+            Order order = createOrder(1L, OrderStatus.PAYMENT_PENDING);
 
             when(findPaymentPort.findByOrderKey(ORDER_KEY)).thenReturn(Optional.of(payment));
+            when(findOrderPort.findById(1L)).thenReturn(Optional.of(order));
+            when(findPspPaymentEventPort.findByOrderKey(ORDER_KEY_STR)).thenReturn(Optional.empty());
             when(paymentVendorPort.registerTrade(any())).thenReturn(vendorResult);
 
             readyPaymentService.ready(command);
@@ -121,6 +143,164 @@ class ReadyPaymentUseCaseTest {
     }
 
     @Nested
+    @DisplayName("주문 미존재")
+    class OrderNotFoundTest {
+
+        @Test
+        @DisplayName("orderId에 해당하는 주문이 없으면 OrderNotFoundException이 발생한다")
+        void shouldThrowWhenOrderNotFound() {
+            Payment payment = createPayment(1L, ORDER_KEY, 50000L);
+            ReadyPaymentCommand command = createReadyCommand(ORDER_KEY_STR);
+
+            when(findPaymentPort.findByOrderKey(ORDER_KEY)).thenReturn(Optional.of(payment));
+            when(findOrderPort.findById(1L)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> readyPaymentService.ready(command))
+                    .isInstanceOf(OrderNotFoundException.class);
+
+            verify(paymentVendorPort, never()).registerTrade(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("주문 상태 검증 실패")
+    class InvalidOrderStatusTest {
+
+        @Test
+        @DisplayName("주문이 CANCELLED 상태이면 InvalidOrderStatusForPaymentException이 발생한다")
+        void shouldThrowWhenOrderIsCancelled() {
+            Payment payment = createPayment(1L, ORDER_KEY, 50000L);
+            ReadyPaymentCommand command = createReadyCommand(ORDER_KEY_STR);
+            Order order = createOrder(1L, OrderStatus.CANCELLED);
+
+            when(findPaymentPort.findByOrderKey(ORDER_KEY)).thenReturn(Optional.of(payment));
+            when(findOrderPort.findById(1L)).thenReturn(Optional.of(order));
+
+            assertThatThrownBy(() -> readyPaymentService.ready(command))
+                    .isInstanceOf(InvalidOrderStatusForPaymentException.class)
+                    .hasMessageContaining("주문 취소");
+
+            verify(paymentVendorPort, never()).registerTrade(any());
+        }
+
+        @Test
+        @DisplayName("주문이 PAID 상태이면 InvalidOrderStatusForPaymentException이 발생한다")
+        void shouldThrowWhenOrderIsPaid() {
+            Payment payment = createPayment(1L, ORDER_KEY, 50000L);
+            ReadyPaymentCommand command = createReadyCommand(ORDER_KEY_STR);
+            Order order = createOrder(1L, OrderStatus.PAID);
+
+            when(findPaymentPort.findByOrderKey(ORDER_KEY)).thenReturn(Optional.of(payment));
+            when(findOrderPort.findById(1L)).thenReturn(Optional.of(order));
+
+            assertThatThrownBy(() -> readyPaymentService.ready(command))
+                    .isInstanceOf(InvalidOrderStatusForPaymentException.class)
+                    .hasMessageContaining("결제 완료");
+
+            verify(paymentVendorPort, never()).registerTrade(any());
+        }
+
+        @Test
+        @DisplayName("주문 상태 검증 실패 시 KCP 거래등록이 호출되지 않는다")
+        void shouldNotCallVendorWhenOrderStatusInvalid() {
+            Payment payment = createPayment(1L, ORDER_KEY, 50000L);
+            ReadyPaymentCommand command = createReadyCommand(ORDER_KEY_STR);
+            Order order = createOrder(1L, OrderStatus.PREPARING);
+
+            when(findPaymentPort.findByOrderKey(ORDER_KEY)).thenReturn(Optional.of(payment));
+            when(findOrderPort.findById(1L)).thenReturn(Optional.of(order));
+
+            assertThatThrownBy(() -> readyPaymentService.ready(command))
+                    .isInstanceOf(InvalidOrderStatusForPaymentException.class);
+
+            verify(paymentVendorPort, never()).registerTrade(any());
+            verify(findPspPaymentEventPort, never()).findByOrderKey(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("중복 거래 등록 방지")
+    class DuplicatePaymentReadyTest {
+
+        @Test
+        @DisplayName("이미 READY 상태의 PspPaymentEvent가 존재하면 DuplicatePaymentReadyException이 발생한다")
+        void shouldThrowWhenReadyEventExists() {
+            Payment payment = createPayment(1L, ORDER_KEY, 50000L);
+            ReadyPaymentCommand command = createReadyCommand(ORDER_KEY_STR);
+            Order order = createOrder(1L, OrderStatus.PAYMENT_PENDING);
+            PspPaymentEvent activeEvent = createPspPaymentEvent(PaymentEventStatus.READY);
+
+            when(findPaymentPort.findByOrderKey(ORDER_KEY)).thenReturn(Optional.of(payment));
+            when(findOrderPort.findById(1L)).thenReturn(Optional.of(order));
+            when(findPspPaymentEventPort.findByOrderKey(ORDER_KEY_STR)).thenReturn(Optional.of(activeEvent));
+
+            assertThatThrownBy(() -> readyPaymentService.ready(command))
+                    .isInstanceOf(DuplicatePaymentReadyException.class)
+                    .hasMessageContaining(ORDER_KEY_STR);
+
+            verify(paymentVendorPort, never()).registerTrade(any());
+        }
+
+        @Test
+        @DisplayName("이미 EXECUTING 상태의 PspPaymentEvent가 존재하면 DuplicatePaymentReadyException이 발생한다")
+        void shouldThrowWhenExecutingEventExists() {
+            Payment payment = createPayment(1L, ORDER_KEY, 50000L);
+            ReadyPaymentCommand command = createReadyCommand(ORDER_KEY_STR);
+            Order order = createOrder(1L, OrderStatus.PAYMENT_PENDING);
+            PspPaymentEvent activeEvent = createPspPaymentEvent(PaymentEventStatus.EXECUTING);
+
+            when(findPaymentPort.findByOrderKey(ORDER_KEY)).thenReturn(Optional.of(payment));
+            when(findOrderPort.findById(1L)).thenReturn(Optional.of(order));
+            when(findPspPaymentEventPort.findByOrderKey(ORDER_KEY_STR)).thenReturn(Optional.of(activeEvent));
+
+            assertThatThrownBy(() -> readyPaymentService.ready(command))
+                    .isInstanceOf(DuplicatePaymentReadyException.class);
+
+            verify(paymentVendorPort, never()).registerTrade(any());
+        }
+
+        @Test
+        @DisplayName("COMPLETE 상태의 PspPaymentEvent가 존재해도 거래 등록은 정상 진행된다")
+        void shouldProceedWhenCompleteEventExists() {
+            Payment payment = createPayment(1L, ORDER_KEY, 50000L);
+            ReadyPaymentCommand command = createReadyCommand(ORDER_KEY_STR);
+            TradeRegisterVendorResult vendorResult = createVendorResult();
+            Order order = createOrder(1L, OrderStatus.PAYMENT_PENDING);
+            PspPaymentEvent completedEvent = createPspPaymentEvent(PaymentEventStatus.COMPLETE);
+
+            when(findPaymentPort.findByOrderKey(ORDER_KEY)).thenReturn(Optional.of(payment));
+            when(findOrderPort.findById(1L)).thenReturn(Optional.of(order));
+            when(findPspPaymentEventPort.findByOrderKey(ORDER_KEY_STR)).thenReturn(Optional.of(completedEvent));
+            when(paymentVendorPort.registerTrade(any())).thenReturn(vendorResult);
+
+            ReadyPaymentResult result = readyPaymentService.ready(command);
+
+            assertThat(result.orderKey()).isEqualTo(ORDER_KEY_STR);
+            verify(paymentVendorPort).registerTrade(any());
+        }
+
+        @Test
+        @DisplayName("CANCELLED 상태의 PspPaymentEvent가 존재해도 거래 등록은 정상 진행된다")
+        void shouldProceedWhenCancelledEventExists() {
+            Payment payment = createPayment(1L, ORDER_KEY, 50000L);
+            ReadyPaymentCommand command = createReadyCommand(ORDER_KEY_STR);
+            TradeRegisterVendorResult vendorResult = createVendorResult();
+            Order order = createOrder(1L, OrderStatus.PAYMENT_PENDING);
+            PspPaymentEvent cancelledEvent = createPspPaymentEvent(PaymentEventStatus.CANCELLED);
+
+            when(findPaymentPort.findByOrderKey(ORDER_KEY)).thenReturn(Optional.of(payment));
+            when(findOrderPort.findById(1L)).thenReturn(Optional.of(order));
+            when(findPspPaymentEventPort.findByOrderKey(ORDER_KEY_STR)).thenReturn(Optional.of(cancelledEvent));
+            when(paymentVendorPort.registerTrade(any())).thenReturn(vendorResult);
+
+            ReadyPaymentResult result = readyPaymentService.ready(command);
+
+            assertThat(result.orderKey()).isEqualTo(ORDER_KEY_STR);
+            verify(paymentVendorPort).registerTrade(any());
+        }
+    }
+
+    @Nested
     @DisplayName("KCP 통신 실패")
     class VendorFailureTest {
 
@@ -129,8 +309,11 @@ class ReadyPaymentUseCaseTest {
         void shouldPropagateVendorException() {
             Payment payment = createPayment(1L, ORDER_KEY, 50000L);
             ReadyPaymentCommand command = createReadyCommand(ORDER_KEY_STR);
+            Order order = createOrder(1L, OrderStatus.PAYMENT_PENDING);
 
             when(findPaymentPort.findByOrderKey(ORDER_KEY)).thenReturn(Optional.of(payment));
+            when(findOrderPort.findById(1L)).thenReturn(Optional.of(order));
+            when(findPspPaymentEventPort.findByOrderKey(ORDER_KEY_STR)).thenReturn(Optional.empty());
             when(paymentVendorPort.registerTrade(any())).thenThrow(new RuntimeException("KCP 거래등록 실패"));
 
             assertThatThrownBy(() -> readyPaymentService.ready(command))
@@ -146,6 +329,28 @@ class ReadyPaymentUseCaseTest {
                 .paymentAmount(amount)
                 .build();
         return Payment.from(state);
+    }
+
+    private Order createOrder(Long orderId, OrderStatus orderStatus) {
+        OrderSnapshotState state = OrderSnapshotState.builder()
+                .id(orderId)
+                .buyerId(1L)
+                .orderKey(ORDER_KEY)
+                .orderNumber("ORD-TEST-001")
+                .orderStatus(orderStatus)
+                .totalAmount(50000L)
+                .build();
+        return Order.from(state);
+    }
+
+    private PspPaymentEvent createPspPaymentEvent(PaymentEventStatus status) {
+        PspPaymentEventSnapshotState state = PspPaymentEventSnapshotState.builder()
+                .id(1L)
+                .orderId(1L)
+                .orderKey(ORDER_KEY_STR)
+                .poStatus(status)
+                .build();
+        return PspPaymentEvent.from(state);
     }
 
     private ReadyPaymentCommand createReadyCommand(String orderKey) {

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/order/Order.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/order/Order.java
@@ -72,6 +72,10 @@ public class Order {
                 .build();
     }
 
+    public boolean isPaymentPending() {
+        return this.orderStatus.isPending();
+    }
+
     public void changeProductsStatus(List<Long> pricePolicyIds, OrderStatus orderStatus) {
         orderProducts.stream()
                 .filter(orderProduct -> pricePolicyIds.contains(orderProduct.getPricePolicyId()))

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/payment/PspPaymentEvent.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/payment/PspPaymentEvent.java
@@ -141,6 +141,14 @@ public class PspPaymentEvent {
         this.resultMessage = resultMessage;
     }
 
+    /**
+     * 거래 등록이 진행 중인 활성 상태인지 확인한다.
+     * READY 또는 EXECUTING 상태면 true를 반환한다.
+     */
+    public boolean isActiveEvent() {
+        return this.poStatus.isReady() || this.poStatus.isExecuting();
+    }
+
     public void cancel(String pgCancelApprovalResult) {
         if (!this.poStatus.isComplete()) {
             throw new IllegalStateException("COMPLETE 상태에서만 취소할 수 있습니다. 현재 상태: " + this.poStatus);


### PR DESCRIPTION
## partially addresses #723
## resolves #874

## Reason
QA에서 CANCELLED/PAID 상태 주문에 대해 KCP 거래 등록이 성공하고,
동일 주문에 거래 등록을 무한 반복하여 매번 새 approvalKey가 발급되는
것이 확인됨

## Action
- ReadyPaymentService에 FindOrderPort 의존성 추가, Order 조회 후 orderStatus.isPending() 검증으로 결제 대기 상태만 거래 등록 허용
- ReadyPaymentService에 FindPspPaymentEventPort 의존성 추가, READY/EXECUTING 상태의 기존 이벤트 존재 시 중복 거래 등록 차단
- PspPaymentEvent에 isActiveEvent() 술어 메서드 추가
- Order에 isPaymentPending() 술어 메서드 추가 (Tell, Don't Ask)
- InvalidOrderStatusForPaymentException 예외 클래스 생성
- DuplicatePaymentReadyException 예외 클래스 생성
- ReadyPaymentUseCaseTest에 주문 상태 검증/중복 방지 테스트 8개 추가