### PR TITLE
[#723][#875] fix: NPE 발생 시 내부 패키지/클래스 정보 응답 노출 방지 기능 추가

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/request/ChangeOrderStatusRequest.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/request/ChangeOrderStatusRequest.java
@@ -3,6 +3,7 @@ package com.personal.marketnote.commerce.adapter.in.web.order.request;
 import com.personal.marketnote.commerce.domain.order.OrderStatus;
 import com.personal.marketnote.commerce.domain.order.OrderStatusReasonCategory;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 
 import java.util.List;
@@ -16,6 +17,7 @@ public class ChangeOrderStatusRequest {
     )
     private List<Long> pricePolicyIds;
 
+    @NotNull(message = "주문 상태는 필수값입니다.")
     @Schema(
             name = "orderStatus",
             description = "주문 상태",

--- a/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/web/order/request/ChangeOrderStatusRequestValidationTest.java
+++ b/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/web/order/request/ChangeOrderStatusRequestValidationTest.java
@@ -1,0 +1,38 @@
+package com.personal.marketnote.commerce.adapter.in.web.order.request;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("ChangeOrderStatusRequest 유효성 검증 테스트")
+class ChangeOrderStatusRequestValidationTest {
+
+    private static Validator validator;
+
+    @BeforeAll
+    static void setUp() {
+        ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+        validator = factory.getValidator();
+    }
+
+    @Test
+    @DisplayName("orderStatus가 null이면 유효성 검증에 실패한다")
+    void shouldFailValidationWhenOrderStatusIsNull() {
+        ChangeOrderStatusRequest request = new ChangeOrderStatusRequest();
+
+        Set<ConstraintViolation<ChangeOrderStatusRequest>> violations = validator.validate(request);
+
+        assertThat(violations).isNotEmpty();
+        assertThat(violations).anyMatch(v ->
+                v.getPropertyPath().toString().equals("orderStatus")
+                        && v.getMessage().equals("주문 상태는 필수값입니다."));
+    }
+}

--- a/common/src/main/java/com/personal/marketnote/common/domain/exception/GlobalExceptionHandler.java
+++ b/common/src/main/java/com/personal/marketnote/common/domain/exception/GlobalExceptionHandler.java
@@ -76,7 +76,7 @@ public class GlobalExceptionHandler {
     ResponseEntity<ErrorResponse> handleNullPointerException(NullPointerException e) {
         HttpStatus httpStatus = HttpStatus.INTERNAL_SERVER_ERROR;
         log.error(LOG_ERROR_MESSAGE, e.getMessage(), e);
-        return buildErrorResponse(httpStatus, e.getMessage());
+        return buildErrorResponse(httpStatus, httpStatus.name(), "서버 내부 오류가 발생했습니다.");
     }
 
     @ExceptionHandler(EntityNotFoundException.class)

--- a/common/src/test/java/com/personal/marketnote/common/domain/exception/GlobalExceptionHandlerTest.java
+++ b/common/src/test/java/com/personal/marketnote/common/domain/exception/GlobalExceptionHandlerTest.java
@@ -104,6 +104,47 @@ class GlobalExceptionHandlerTest {
     }
 
     @Nested
+    @DisplayName("NPE 핸들러 정보 노출 방지")
+    class NpeInfoLeakPreventionTest {
+
+        @Test
+        @DisplayName("NPE 핸들러는 500을 반환한다")
+        void shouldReturn500ForNullPointerException() {
+            NullPointerException exception =
+                    new NullPointerException("Cannot invoke \"com.personal.marketnote.commerce.domain.order.OrderStatus.isMe()\" because \"status\" is null");
+
+            ResponseEntity<ErrorResponse> response = handler.handleNullPointerException(exception);
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+
+        @Test
+        @DisplayName("NPE 핸들러는 응답에 내부 패키지/클래스 정보를 노출하지 않는다")
+        void shouldNotExposeInternalInfoInNpeResponse() {
+            NullPointerException exception =
+                    new NullPointerException("Cannot invoke \"com.personal.marketnote.commerce.domain.order.OrderStatus.isMe()\" because \"status\" is null");
+
+            ResponseEntity<ErrorResponse> response = handler.handleNullPointerException(exception);
+
+            assertThat(response.getBody()).isNotNull();
+            assertThat(response.getBody().getMessage()).doesNotContain("com.personal");
+            assertThat(response.getBody().getMessage()).doesNotContain("OrderStatus");
+            assertThat(response.getBody().getMessage()).isEqualTo("서버 내부 오류가 발생했습니다.");
+        }
+
+        @Test
+        @DisplayName("NPE 핸들러는 null 메시지에도 고정 문자열을 반환한다")
+        void shouldReturnGenericMessageForNullNpeMessage() {
+            NullPointerException exception = new NullPointerException();
+
+            ResponseEntity<ErrorResponse> response = handler.handleNullPointerException(exception);
+
+            assertThat(response.getBody()).isNotNull();
+            assertThat(response.getBody().getMessage()).isEqualTo("서버 내부 오류가 발생했습니다.");
+        }
+    }
+
+    @Nested
     @DisplayName("스레드 안전성")
     class ThreadSafetyTest {
 


### PR DESCRIPTION
## partially addresses #723
## resolves #875

## Reason
QA에서 PATCH /orders/{id}에 빈 body 전송 시 NPE 메시지에 패키지/클래스/메서드명 (com.oponiti.shop.commerce.domain.order.OrderStatus.isMe())이 응답에 그대로 노출됨

## Action
- ChangeOrderStatusRequest.orderStatus에 @NotNull 추가 (NPE 근본 차단)
- GlobalExceptionHandler NPE 핸들러에서 응답 메시지를 고정 문자열로 교체