### PR TITLE
[#723][#881] fix: 거래 등록 API(readyPayment) IDOR 보안 취약점 수정

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/request/ChangeOrderStatusRequest.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/request/ChangeOrderStatusRequest.java
@@ -3,6 +3,8 @@ package com.personal.marketnote.commerce.adapter.in.web.order.request;
 import com.personal.marketnote.commerce.domain.order.OrderStatus;
 import com.personal.marketnote.commerce.domain.order.OrderStatusReasonCategory;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 
 import java.util.List;
@@ -16,6 +18,7 @@ public class ChangeOrderStatusRequest {
     )
     private List<Long> pricePolicyIds;
 
+    @NotNull(message = "주문 상태는 필수값입니다.")
     @Schema(
             name = "orderStatus",
             description = "주문 상태",
@@ -35,5 +38,6 @@ public class ChangeOrderStatusRequest {
             description = "변경 사유",
             requiredMode = Schema.RequiredMode.NOT_REQUIRED
     )
+    @Size(max = 500, message = "변경 사유는 500자 이내여야 합니다.")
     private String reason;
 }

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/request/OrderProductItemRequest.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/request/OrderProductItemRequest.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 
 @Getter
@@ -70,5 +71,6 @@ public class OrderProductItemRequest {
             description = "상품 이미지 URL",
             requiredMode = Schema.RequiredMode.NOT_REQUIRED
     )
+    @Size(max = 2048, message = "이미지 URL은 2048자 이내여야 합니다.")
     private String imageUrl;
 }

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/payment/controller/PaymentController.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/payment/controller/PaymentController.java
@@ -60,10 +60,12 @@ public class PaymentController {
     @PostMapping("/ready")
     @ReadyPaymentApiDocs
     public ResponseEntity<BaseResponse<ReadyPaymentResponse>> readyPayment(
+            @AuthenticationPrincipal OAuth2AuthenticatedPrincipal principal,
             @Valid @RequestBody ReadyPaymentRequest request
     ) {
+        Long buyerId = ElementExtractor.extractUserId(principal);
         ReadyPaymentResult result = readyPaymentUseCase.ready(
-                PaymentRequestToCommandMapper.mapToCommand(request)
+                PaymentRequestToCommandMapper.mapToCommand(request, buyerId)
         );
 
         return new ResponseEntity<>(

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/payment/mapper/PaymentRequestToCommandMapper.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/payment/mapper/PaymentRequestToCommandMapper.java
@@ -11,8 +11,9 @@ public class PaymentRequestToCommandMapper {
     private PaymentRequestToCommandMapper() {
     }
 
-    public static ReadyPaymentCommand mapToCommand(ReadyPaymentRequest request) {
+    public static ReadyPaymentCommand mapToCommand(ReadyPaymentRequest request, Long buyerId) {
         return ReadyPaymentCommand.builder()
+                .buyerId(buyerId)
                 .orderKey(request.getOrderKey())
                 .payMethod(request.getPayMethod())
                 .goodName(request.getGoodName())

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/payment/request/ReadyPaymentRequest.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/payment/request/ReadyPaymentRequest.java
@@ -2,6 +2,7 @@ package com.personal.marketnote.commerce.adapter.in.web.payment.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 
 @Getter
@@ -16,5 +17,6 @@ public class ReadyPaymentRequest {
 
     @Schema(name = "goodName", description = "상품명", requiredMode = Schema.RequiredMode.REQUIRED)
     @NotBlank
+    @Size(max = 100, message = "상품명은 100자 이내여야 합니다.")
     private String goodName;
 }

--- a/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/web/order/request/ChangeOrderStatusRequestValidationTest.java
+++ b/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/web/order/request/ChangeOrderStatusRequestValidationTest.java
@@ -1,0 +1,38 @@
+package com.personal.marketnote.commerce.adapter.in.web.order.request;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("ChangeOrderStatusRequest 유효성 검증 테스트")
+class ChangeOrderStatusRequestValidationTest {
+
+    private static Validator validator;
+
+    @BeforeAll
+    static void setUp() {
+        ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+        validator = factory.getValidator();
+    }
+
+    @Test
+    @DisplayName("orderStatus가 null이면 유효성 검증에 실패한다")
+    void shouldFailValidationWhenOrderStatusIsNull() {
+        ChangeOrderStatusRequest request = new ChangeOrderStatusRequest();
+
+        Set<ConstraintViolation<ChangeOrderStatusRequest>> violations = validator.validate(request);
+
+        assertThat(violations).isNotEmpty();
+        assertThat(violations).anyMatch(v ->
+                v.getPropertyPath().toString().equals("orderStatus")
+                        && v.getMessage().equals("주문 상태는 필수값입니다."));
+    }
+}

--- a/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/web/order/request/InputLengthValidationTest.java
+++ b/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/web/order/request/InputLengthValidationTest.java
@@ -1,0 +1,104 @@
+package com.personal.marketnote.commerce.adapter.in.web.order.request;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("입력값 길이 제한 검증 테스트")
+class InputLengthValidationTest {
+
+    private static Validator validator;
+
+    @BeforeAll
+    static void setUp() {
+        ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+        validator = factory.getValidator();
+    }
+
+    @Nested
+    @DisplayName("OrderProductItemRequest.imageUrl 길이 제한")
+    class ImageUrlLengthTest {
+
+        @Test
+        @DisplayName("imageUrl이 2048자를 초과하면 유효성 검증에 실패한다")
+        void shouldFailValidationWhenImageUrlExceeds2048Characters() {
+            OrderProductItemRequest request = new OrderProductItemRequest();
+            setField(request, "productId", 1L);
+            setField(request, "sellerId", 1L);
+            setField(request, "pricePolicyId", 1L);
+            setField(request, "quantity", 1);
+            setField(request, "unitAmount", 50000L);
+            setField(request, "imageUrl", "https://example.com/" + "a".repeat(2030));
+
+            Set<ConstraintViolation<OrderProductItemRequest>> violations = validator.validate(request);
+
+            assertThat(violations).anyMatch(v ->
+                    v.getPropertyPath().toString().equals("imageUrl"));
+        }
+
+        @Test
+        @DisplayName("imageUrl이 2048자 이내이면 imageUrl 길이 검증에 성공한다")
+        void shouldPassValidationWhenImageUrlIsWithin2048Characters() {
+            OrderProductItemRequest request = new OrderProductItemRequest();
+            setField(request, "productId", 1L);
+            setField(request, "sellerId", 1L);
+            setField(request, "pricePolicyId", 1L);
+            setField(request, "quantity", 1);
+            setField(request, "unitAmount", 50000L);
+            setField(request, "imageUrl", "https://example.com/image.jpg");
+
+            Set<ConstraintViolation<OrderProductItemRequest>> violations = validator.validate(request);
+
+            assertThat(violations).noneMatch(v ->
+                    v.getPropertyPath().toString().equals("imageUrl"));
+        }
+    }
+
+    @Nested
+    @DisplayName("ChangeOrderStatusRequest.reason 길이 제한")
+    class ReasonLengthTest {
+
+        @Test
+        @DisplayName("reason이 500자를 초과하면 유효성 검증에 실패한다")
+        void shouldFailValidationWhenReasonExceeds500Characters() {
+            ChangeOrderStatusRequest request = new ChangeOrderStatusRequest();
+            setField(request, "reason", "가".repeat(501));
+
+            Set<ConstraintViolation<ChangeOrderStatusRequest>> violations = validator.validate(request);
+
+            assertThat(violations).anyMatch(v ->
+                    v.getPropertyPath().toString().equals("reason"));
+        }
+
+        @Test
+        @DisplayName("reason이 500자 이내이면 reason 길이 검증에 성공한다")
+        void shouldPassValidationWhenReasonIsWithin500Characters() {
+            ChangeOrderStatusRequest request = new ChangeOrderStatusRequest();
+            setField(request, "reason", "가".repeat(500));
+
+            Set<ConstraintViolation<ChangeOrderStatusRequest>> violations = validator.validate(request);
+
+            assertThat(violations).noneMatch(v ->
+                    v.getPropertyPath().toString().equals("reason"));
+        }
+    }
+
+    private void setField(Object target, String fieldName, Object value) {
+        try {
+            java.lang.reflect.Field field = target.getClass().getDeclaredField(fieldName);
+            field.setAccessible(true);
+            field.set(target, value);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/web/payment/request/ReadyPaymentRequestValidationTest.java
+++ b/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/web/payment/request/ReadyPaymentRequestValidationTest.java
@@ -1,0 +1,64 @@
+package com.personal.marketnote.commerce.adapter.in.web.payment.request;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("ReadyPaymentRequest 유효성 검증 테스트")
+class ReadyPaymentRequestValidationTest {
+
+    private static Validator validator;
+
+    @BeforeAll
+    static void setUp() {
+        ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+        validator = factory.getValidator();
+    }
+
+    @Test
+    @DisplayName("goodName이 100자를 초과하면 유효성 검증에 실패한다")
+    void shouldFailValidationWhenGoodNameExceeds100Characters() {
+        ReadyPaymentRequest request = new ReadyPaymentRequest();
+        setField(request, "orderKey", "valid-order-key");
+        setField(request, "payMethod", "CARD");
+        setField(request, "goodName", "가".repeat(101));
+
+        Set<ConstraintViolation<ReadyPaymentRequest>> violations = validator.validate(request);
+
+        assertThat(violations).anyMatch(v ->
+                v.getPropertyPath().toString().equals("goodName"));
+    }
+
+    @Test
+    @DisplayName("goodName이 100자 이내이면 goodName 길이 검증에 성공한다")
+    void shouldPassValidationWhenGoodNameIsWithin100Characters() {
+        ReadyPaymentRequest request = new ReadyPaymentRequest();
+        setField(request, "orderKey", "valid-order-key");
+        setField(request, "payMethod", "CARD");
+        setField(request, "goodName", "가".repeat(100));
+
+        Set<ConstraintViolation<ReadyPaymentRequest>> violations = validator.validate(request);
+
+        assertThat(violations).noneMatch(v ->
+                v.getPropertyPath().toString().equals("goodName")
+                        && v.getMessage().contains("100"));
+    }
+
+    private void setField(Object target, String fieldName, Object value) {
+        try {
+            java.lang.reflect.Field field = target.getClass().getDeclaredField(fieldName);
+            field.setAccessible(true);
+            field.set(target, value);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/command/payment/ReadyPaymentCommand.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/command/payment/ReadyPaymentCommand.java
@@ -4,6 +4,7 @@ import lombok.Builder;
 
 @Builder
 public record ReadyPaymentCommand(
+        Long buyerId,
         String orderKey,
         String payMethod,
         String goodName

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/ReadyPaymentService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/ReadyPaymentService.java
@@ -8,6 +8,7 @@ import com.personal.marketnote.commerce.exception.InvalidOrderStatusForPaymentEx
 import com.personal.marketnote.commerce.exception.OrderNotFoundException;
 import com.personal.marketnote.commerce.exception.PaymentApprovalException;
 import com.personal.marketnote.commerce.exception.PaymentNotFoundException;
+import com.personal.marketnote.commerce.exception.UnauthorizedOrderAccessException;
 import com.personal.marketnote.commerce.port.in.command.payment.ReadyPaymentCommand;
 import com.personal.marketnote.commerce.port.in.result.payment.ReadyPaymentResult;
 import com.personal.marketnote.commerce.port.in.usecase.payment.ReadyPaymentUseCase;
@@ -46,7 +47,7 @@ public class ReadyPaymentService implements ReadyPaymentUseCase {
         Payment payment = findPaymentPort.findByOrderKey(orderKey)
                 .orElseThrow(() -> new PaymentNotFoundException(command.orderKey()));
 
-        verifyOrderStatusForPayment(payment.getOrderId());
+        verifyOrderForPayment(payment.getOrderId(), command.buyerId());
         verifyNoDuplicatePaymentReady(command.orderKey());
         saveReadyEvent(payment, command.payMethod());
 
@@ -71,9 +72,15 @@ public class ReadyPaymentService implements ReadyPaymentUseCase {
                 .build();
     }
 
-    private void verifyOrderStatusForPayment(Long orderId) {
+    private void verifyOrderForPayment(Long orderId, Long buyerId) {
         Order order = findOrderPort.findById(orderId)
                 .orElseThrow(() -> new OrderNotFoundException(orderId));
+
+        if (!order.getBuyerId().equals(buyerId)) {
+            log.warn("거래 등록 소유자 불일치 - orderId: {}, 주문소유자: {}, 요청자: {}",
+                    orderId, order.getBuyerId(), buyerId);
+            throw new UnauthorizedOrderAccessException();
+        }
 
         if (!order.isPaymentPending()) {
             log.warn("결제 불가 주문 상태에서 거래 등록 시도 - orderId: {}, 주문 상태: {}",

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/payment/ReadyPaymentUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/payment/ReadyPaymentUseCaseTest.java
@@ -8,6 +8,7 @@ import com.personal.marketnote.commerce.exception.DuplicatePaymentReadyException
 import com.personal.marketnote.commerce.exception.InvalidOrderStatusForPaymentException;
 import com.personal.marketnote.commerce.exception.OrderNotFoundException;
 import com.personal.marketnote.commerce.exception.PaymentNotFoundException;
+import com.personal.marketnote.commerce.exception.UnauthorizedOrderAccessException;
 import com.personal.marketnote.commerce.port.in.command.payment.ReadyPaymentCommand;
 import com.personal.marketnote.commerce.port.in.result.payment.ReadyPaymentResult;
 import com.personal.marketnote.commerce.port.out.order.FindOrderPort;
@@ -56,6 +57,7 @@ class ReadyPaymentUseCaseTest {
     @Mock
     private PaymentVendorPort paymentVendorPort;
 
+    private static final Long BUYER_ID = 1L;
     private static final UUID ORDER_KEY = UUID.randomUUID();
     private static final String ORDER_KEY_STR = ORDER_KEY.toString();
 
@@ -111,6 +113,7 @@ class ReadyPaymentUseCaseTest {
         void shouldPassPayMethodAndGoodName() {
             Payment payment = createPayment(1L, ORDER_KEY, 50000L);
             ReadyPaymentCommand command = ReadyPaymentCommand.builder()
+                    .buyerId(BUYER_ID)
                     .orderKey(ORDER_KEY_STR)
                     .payMethod("CARD")
                     .goodName("테스트 상품")
@@ -309,6 +312,55 @@ class ReadyPaymentUseCaseTest {
     }
 
     @Nested
+    @DisplayName("주문 소유자 검증 실패 (IDOR 방어)")
+    class UnauthorizedAccessTest {
+
+        @Test
+        @DisplayName("요청자의 buyerId와 주문 소유자가 다르면 UnauthorizedOrderAccessException이 발생한다")
+        void shouldThrowWhenBuyerIdMismatch() {
+            Payment payment = createPayment(1L, ORDER_KEY, 50000L);
+            ReadyPaymentCommand command = ReadyPaymentCommand.builder()
+                    .buyerId(999L)
+                    .orderKey(ORDER_KEY_STR)
+                    .payMethod("CARD")
+                    .goodName("테스트 상품")
+                    .build();
+            Order order = createOrder(1L, OrderStatus.PAYMENT_PENDING);
+
+            when(findPaymentPort.findByOrderKey(ORDER_KEY)).thenReturn(Optional.of(payment));
+            when(findOrderPort.findById(1L)).thenReturn(Optional.of(order));
+
+            assertThatThrownBy(() -> readyPaymentService.ready(command))
+                    .isInstanceOf(UnauthorizedOrderAccessException.class);
+
+            verify(paymentVendorPort, never()).registerTrade(any());
+            verify(findPspPaymentEventPort, never()).findByOrderKey(any());
+        }
+
+        @Test
+        @DisplayName("소유자 검증 실패 시 주문 상태 검증 및 중복 거래 검증이 실행되지 않는다")
+        void shouldNotProceedToStatusCheckWhenBuyerMismatch() {
+            Payment payment = createPayment(1L, ORDER_KEY, 50000L);
+            ReadyPaymentCommand command = ReadyPaymentCommand.builder()
+                    .buyerId(888L)
+                    .orderKey(ORDER_KEY_STR)
+                    .payMethod("CARD")
+                    .goodName("테스트 상품")
+                    .build();
+            Order order = createOrder(1L, OrderStatus.CANCELLED);
+
+            when(findPaymentPort.findByOrderKey(ORDER_KEY)).thenReturn(Optional.of(payment));
+            when(findOrderPort.findById(1L)).thenReturn(Optional.of(order));
+
+            assertThatThrownBy(() -> readyPaymentService.ready(command))
+                    .isInstanceOf(UnauthorizedOrderAccessException.class);
+
+            verify(findPspPaymentEventPort, never()).findByOrderKey(any());
+            verify(paymentVendorPort, never()).registerTrade(any());
+        }
+    }
+
+    @Nested
     @DisplayName("KCP 통신 실패")
     class VendorFailureTest {
 
@@ -388,7 +440,7 @@ class ReadyPaymentUseCaseTest {
     private Order createOrder(Long orderId, OrderStatus orderStatus) {
         OrderSnapshotState state = OrderSnapshotState.builder()
                 .id(orderId)
-                .buyerId(1L)
+                .buyerId(BUYER_ID)
                 .orderKey(ORDER_KEY)
                 .orderNumber("ORD-TEST-001")
                 .orderStatus(orderStatus)
@@ -409,6 +461,7 @@ class ReadyPaymentUseCaseTest {
 
     private ReadyPaymentCommand createReadyCommand(String orderKey) {
         return ReadyPaymentCommand.builder()
+                .buyerId(BUYER_ID)
                 .orderKey(orderKey)
                 .payMethod("CARD")
                 .goodName("테스트 상품")

--- a/common/src/main/java/com/personal/marketnote/common/domain/exception/GlobalExceptionHandler.java
+++ b/common/src/main/java/com/personal/marketnote/common/domain/exception/GlobalExceptionHandler.java
@@ -76,7 +76,7 @@ public class GlobalExceptionHandler {
     ResponseEntity<ErrorResponse> handleNullPointerException(NullPointerException e) {
         HttpStatus httpStatus = HttpStatus.INTERNAL_SERVER_ERROR;
         log.error(LOG_ERROR_MESSAGE, e.getMessage(), e);
-        return buildErrorResponse(httpStatus, e.getMessage());
+        return buildErrorResponse(httpStatus, httpStatus.name(), "서버 내부 오류가 발생했습니다.");
     }
 
     @ExceptionHandler(EntityNotFoundException.class)

--- a/common/src/test/java/com/personal/marketnote/common/domain/exception/GlobalExceptionHandlerTest.java
+++ b/common/src/test/java/com/personal/marketnote/common/domain/exception/GlobalExceptionHandlerTest.java
@@ -104,6 +104,47 @@ class GlobalExceptionHandlerTest {
     }
 
     @Nested
+    @DisplayName("NPE 핸들러 정보 노출 방지")
+    class NpeInfoLeakPreventionTest {
+
+        @Test
+        @DisplayName("NPE 핸들러는 500을 반환한다")
+        void shouldReturn500ForNullPointerException() {
+            NullPointerException exception =
+                    new NullPointerException("Cannot invoke \"com.personal.marketnote.commerce.domain.order.OrderStatus.isMe()\" because \"status\" is null");
+
+            ResponseEntity<ErrorResponse> response = handler.handleNullPointerException(exception);
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+
+        @Test
+        @DisplayName("NPE 핸들러는 응답에 내부 패키지/클래스 정보를 노출하지 않는다")
+        void shouldNotExposeInternalInfoInNpeResponse() {
+            NullPointerException exception =
+                    new NullPointerException("Cannot invoke \"com.personal.marketnote.commerce.domain.order.OrderStatus.isMe()\" because \"status\" is null");
+
+            ResponseEntity<ErrorResponse> response = handler.handleNullPointerException(exception);
+
+            assertThat(response.getBody()).isNotNull();
+            assertThat(response.getBody().getMessage()).doesNotContain("com.personal");
+            assertThat(response.getBody().getMessage()).doesNotContain("OrderStatus");
+            assertThat(response.getBody().getMessage()).isEqualTo("서버 내부 오류가 발생했습니다.");
+        }
+
+        @Test
+        @DisplayName("NPE 핸들러는 null 메시지에도 고정 문자열을 반환한다")
+        void shouldReturnGenericMessageForNullNpeMessage() {
+            NullPointerException exception = new NullPointerException();
+
+            ResponseEntity<ErrorResponse> response = handler.handleNullPointerException(exception);
+
+            assertThat(response.getBody()).isNotNull();
+            assertThat(response.getBody().getMessage()).isEqualTo("서버 내부 오류가 발생했습니다.");
+        }
+    }
+
+    @Nested
     @DisplayName("스레드 안전성")
     class ThreadSafetyTest {
 


### PR DESCRIPTION
## partially addresses #723
## resolves #881

## Reason
PaymentController의 readyPayment() 메서드에 @AuthenticationPrincipal이 누락되어 있고, ReadyPaymentCommand/ReadyPaymentService에 buyerId 기반 소유자 검증이 없어 인증된 사용자라면 타 사용자의 주문에 대해 거래 등록이
가능한 IDOR(Insecure Direct Object Reference) 취약점이 존재함. 동일 컨트롤러의 나머지 3개 API(approve, get, cancel)는 모두 소유자 검증을 수행 중이었으나 readyPayment만 누락됨.

## Action
- ReadyPaymentCommand에 buyerId 필드 추가
- ReadyPaymentService.verifyOrderForPayment()에 주문 소유자 검증 로직 추가 (buyerId 불일치 시 UnauthorizedOrderAccessException)
- PaymentRequestToCommandMapper의 mapToCommand에 buyerId 파라미터 추가
- PaymentController.readyPayment()에 @AuthenticationPrincipal 추가 및 buyerId 추출
- 기존 테스트 buyerId 반영 수정 + 소유자 검증 실패 테스트 2건 추가
- ChangeOrderStatusRequest @NotNull import 누락 수정 (기존 병합 이슈)
