### PR TITLE
[#723][#886] fix: 주문 등록 시 sellerId 교차 검증 누락 수정

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/web/product/ProductServiceClient.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/web/product/ProductServiceClient.java
@@ -182,6 +182,7 @@ public class ProductServiceClient implements FindProductByPricePolicyPort {
                     pricePolicyId,
                     new ProductInfoResult(
                             productInfo.id(),
+                            productInfo.sellerId(),
                             productInfo.name(),
                             productInfo.brandName(),
                             productInfo.pricePolicy().price(),

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/web/product/response/ProductsInfoResponse.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/web/product/response/ProductsInfoResponse.java
@@ -9,6 +9,7 @@ import java.util.List;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record ProductsInfoResponse(
         Long id,
+        Long sellerId,
         String name,
         String brandName,
         ProductPricePolicyInfoResult pricePolicy,

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/exception/SellerMismatchException.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/exception/SellerMismatchException.java
@@ -1,0 +1,19 @@
+package com.personal.marketnote.commerce.exception;
+
+import com.personal.marketnote.common.domain.exception.illegalargument.invalidvalue.InvalidValueException;
+
+/**
+ * 주문 상품의 판매자 ID가 실제 상품의 판매자 ID와 불일치할 때 발생하는 예외
+ *
+ * @Author 성효빈
+ * @Date 2026-02-27
+ * @Description 주문 등록 시 sellerId가 product-service의 실제 판매자 ID와 일치하지 않으면 발생합니다.
+ */
+public class SellerMismatchException extends InvalidValueException {
+    private static final String MESSAGE =
+            "ERR_ORDER_SELLER_01::주문 상품의 판매자가 실제 상품의 판매자와 일치하지 않습니다.";
+
+    public SellerMismatchException(Long pricePolicyId, Long requestedSellerId, Long actualSellerId) {
+        super(MESSAGE);
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/result/product/ProductInfoResult.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/result/product/ProductInfoResult.java
@@ -7,6 +7,7 @@ import java.util.List;
 
 public record ProductInfoResult(
         Long id,
+        Long sellerId,
         String name,
         String brandName,
         Long price,

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/RegisterOrderService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/RegisterOrderService.java
@@ -9,6 +9,7 @@ import com.personal.marketnote.commerce.domain.payment.PaymentCreateState;
 import com.personal.marketnote.commerce.exception.ExcessiveDiscountException;
 import com.personal.marketnote.commerce.exception.OrderAmountMismatchException;
 import com.personal.marketnote.commerce.exception.PriceMismatchException;
+import com.personal.marketnote.commerce.exception.SellerMismatchException;
 import com.personal.marketnote.commerce.port.in.command.order.OrderProductItemCommand;
 import com.personal.marketnote.commerce.port.in.command.order.RegisterOrderCommand;
 import com.personal.marketnote.commerce.port.in.result.order.RegisterOrderResult;
@@ -160,16 +161,23 @@ public class RegisterOrderService implements RegisterOrderUseCase {
         Map<Long, ProductInfoResult> productInfoMap = findProductByPricePolicyPort.findByPricePolicyIds(pricePolicyIds);
 
         if (productInfoMap.isEmpty()) {
-            log.warn("[PRICE_VALIDATION_SKIPPED] product-service 응답 없음 - 가격 검증 생략. pricePolicyIds: {}", pricePolicyIds);
+            log.warn("[PRODUCT_VALIDATION_SKIPPED] product-service 응답 없음 - 가격/판매자 검증 생략. pricePolicyIds: {}", pricePolicyIds);
             return;
         }
 
         for (OrderProductItemCommand item : command.orderProducts()) {
             ProductInfoResult productInfo = productInfoMap.get(item.pricePolicyId());
             if (FormatValidator.hasNoValue(productInfo)) {
-                log.warn("[PRICE_VALIDATION_SKIPPED] 상품 정보 누락 - pricePolicyId: {}, 전송된 단가: {}",
+                log.warn("[PRODUCT_VALIDATION_SKIPPED] 상품 정보 누락 - pricePolicyId: {}, 전송된 단가: {}",
                         item.pricePolicyId(), item.unitAmount());
                 continue;
+            }
+
+            Long actualSellerId = productInfo.sellerId();
+            if (FormatValidator.hasValue(actualSellerId) && !actualSellerId.equals(item.sellerId())) {
+                log.warn("판매자 불일치 - pricePolicyId: {}, 전송된 sellerId: {} (실제 판매자와 불일치)",
+                        item.pricePolicyId(), item.sellerId());
+                throw new SellerMismatchException(item.pricePolicyId(), item.sellerId(), actualSellerId);
             }
 
             Long actualPrice = productInfo.getSellingPrice();

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/GetBuyerOrderCountUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/GetBuyerOrderCountUseCaseTest.java
@@ -1018,6 +1018,6 @@ class GetBuyerOrderCountUseCaseTest {
     }
 
     private ProductInfoResult createProductInfo(Long id, String name) {
-        return new ProductInfoResult(id, name, "브랜드", null, null, List.of());
+        return new ProductInfoResult(id, null, name, "브랜드", null, null, List.of());
     }
 }

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/GetBuyerOrderHistoryUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/GetBuyerOrderHistoryUseCaseTest.java
@@ -1129,6 +1129,6 @@ class GetBuyerOrderHistoryUseCaseTest {
     }
 
     private ProductInfoResult createProductInfo(Long id, String name) {
-        return new ProductInfoResult(id, name, "브랜드", null, null, List.of());
+        return new ProductInfoResult(id, null, name, "브랜드", null, null, List.of());
     }
 }

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/GetBuyerOrderProductsUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/GetBuyerOrderProductsUseCaseTest.java
@@ -475,7 +475,7 @@ class GetBuyerOrderProductsUseCaseTest {
             when(findOrderPort.findByBuyerId(eq(buyerId), isNull(), isNull(), eq(List.of())))
                     .thenReturn(List.of(order));
             when(findProductByPricePolicyPort.findByPricePolicyIds(anyList()))
-                    .thenReturn(Map.of(100L, new ProductInfoResult(100L, "상품A", "나이키", null, null, List.of())));
+                    .thenReturn(Map.of(100L, new ProductInfoResult(100L, null, "상품A", "나이키", null, null, List.of())));
 
             GetBuyerOrderProductsResult result = getOrderService.getBuyerOrderProducts(query);
 
@@ -988,6 +988,6 @@ class GetBuyerOrderProductsUseCaseTest {
     }
 
     private ProductInfoResult createProductInfo(Long id, String name) {
-        return new ProductInfoResult(id, name, "브랜드", null, null, List.of());
+        return new ProductInfoResult(id, null, name, "브랜드", null, null, List.of());
     }
 }

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/GetOrderAndOrderProductsUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/GetOrderAndOrderProductsUseCaseTest.java
@@ -58,7 +58,7 @@ class GetOrderAndOrderProductsUseCaseTest {
             when(findOrderPort.findById(orderId)).thenReturn(Optional.of(order));
 
             ProductInfoResult productInfo = new ProductInfoResult(
-                    1L, "테스트 상품", "테스트 브랜드", null, null, List.of()
+                    1L, null, "테스트 상품", "테스트 브랜드", null, null, List.of()
             );
             when(findProductByPricePolicyPort.findByPricePolicyIds(List.of(pricePolicyId)))
                     .thenReturn(Map.of(pricePolicyId, productInfo));
@@ -86,9 +86,9 @@ class GetOrderAndOrderProductsUseCaseTest {
             when(findOrderPort.findById(orderId)).thenReturn(Optional.of(order));
 
             Map<Long, ProductInfoResult> productInfoMap = Map.of(
-                    pricePolicyId1, new ProductInfoResult(1L, "상품1", "브랜드1", null, null, List.of()),
-                    pricePolicyId2, new ProductInfoResult(2L, "상품2", "브랜드2", null, null, List.of()),
-                    pricePolicyId3, new ProductInfoResult(3L, "상품3", "브랜드3", null, null, List.of())
+                    pricePolicyId1, new ProductInfoResult(1L, null, "상품1", "브랜드1", null, null, List.of()),
+                    pricePolicyId2, new ProductInfoResult(2L, null, "상품2", "브랜드2", null, null, List.of()),
+                    pricePolicyId3, new ProductInfoResult(3L, null, "상품3", "브랜드3", null, null, List.of())
             );
             when(findProductByPricePolicyPort.findByPricePolicyIds(anyList()))
                     .thenReturn(productInfoMap);
@@ -134,7 +134,7 @@ class GetOrderAndOrderProductsUseCaseTest {
             when(findOrderPort.findById(orderId)).thenReturn(Optional.of(order));
 
             Map<Long, ProductInfoResult> productInfoMap = new HashMap<>();
-            productInfoMap.put(pricePolicyId1, new ProductInfoResult(1L, "상품1", "브랜드1", null, null, List.of()));
+            productInfoMap.put(pricePolicyId1, new ProductInfoResult(1L, null, "상품1", "브랜드1", null, null, List.of()));
             when(findProductByPricePolicyPort.findByPricePolicyIds(anyList()))
                     .thenReturn(productInfoMap);
 
@@ -173,7 +173,7 @@ class GetOrderAndOrderProductsUseCaseTest {
                     new ProductOptionInfoResult(2L, "사이즈: L", "ACTIVE")
             );
             ProductInfoResult productInfo = new ProductInfoResult(
-                    1L, "테스트 상품", "테스트 브랜드", null, null, options
+                    1L, null, "테스트 상품", "테스트 브랜드", null, null, options
             );
             when(findProductByPricePolicyPort.findByPricePolicyIds(List.of(pricePolicyId)))
                     .thenReturn(Map.of(pricePolicyId, productInfo));
@@ -607,7 +607,7 @@ class GetOrderAndOrderProductsUseCaseTest {
             when(findOrderPort.findById(orderId)).thenReturn(Optional.of(order));
 
             ProductInfoResult productInfo = new ProductInfoResult(
-                    productId, "테스트 상품", "테스트 브랜드", null, null, List.of()
+                    productId, null, "테스트 상품", "테스트 브랜드", null, null, List.of()
             );
             when(findProductByPricePolicyPort.findByPricePolicyIds(List.of(pricePolicyId)))
                     .thenReturn(Map.of(pricePolicyId, productInfo));
@@ -630,7 +630,7 @@ class GetOrderAndOrderProductsUseCaseTest {
             when(findOrderPort.findById(orderId)).thenReturn(Optional.of(order));
 
             ProductInfoResult productInfo = new ProductInfoResult(
-                    1L, productName, "테스트 브랜드", null, null, List.of()
+                    1L, null, productName, "테스트 브랜드", null, null, List.of()
             );
             when(findProductByPricePolicyPort.findByPricePolicyIds(List.of(pricePolicyId)))
                     .thenReturn(Map.of(pricePolicyId, productInfo));
@@ -653,7 +653,7 @@ class GetOrderAndOrderProductsUseCaseTest {
             when(findOrderPort.findById(orderId)).thenReturn(Optional.of(order));
 
             ProductInfoResult productInfo = new ProductInfoResult(
-                    1L, "테스트 상품", brandName, null, null, List.of()
+                    1L, null, "테스트 상품", brandName, null, null, List.of()
             );
             when(findProductByPricePolicyPort.findByPricePolicyIds(List.of(pricePolicyId)))
                     .thenReturn(Map.of(pricePolicyId, productInfo));
@@ -680,7 +680,7 @@ class GetOrderAndOrderProductsUseCaseTest {
                     new ProductOptionInfoResult(3L, "소재: 면", "ACTIVE")
             );
             ProductInfoResult productInfo = new ProductInfoResult(
-                    1L, "테스트 상품", "테스트 브랜드", null, null, options
+                    1L, null, "테스트 상품", "테스트 브랜드", null, null, options
             );
             when(findProductByPricePolicyPort.findByPricePolicyIds(List.of(pricePolicyId)))
                     .thenReturn(Map.of(pricePolicyId, productInfo));
@@ -949,7 +949,7 @@ class GetOrderAndOrderProductsUseCaseTest {
             when(findOrderPort.findById(orderId)).thenReturn(Optional.of(order));
 
             ProductInfoResult productInfo = new ProductInfoResult(
-                    1L, "테스트 상품", "테스트 브랜드", null, null, List.of()
+                    1L, null, "테스트 상품", "테스트 브랜드", null, null, List.of()
             );
             when(findProductByPricePolicyPort.findByPricePolicyIds(anyList()))
                     .thenReturn(Map.of(pricePolicyId, productInfo));

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/GetOrderWithBuyerVerificationUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/GetOrderWithBuyerVerificationUseCaseTest.java
@@ -80,7 +80,7 @@ class GetOrderWithBuyerVerificationUseCaseTest {
 
             when(findOrderPort.findById(orderId)).thenReturn(Optional.of(order));
 
-            ProductInfoResult productInfo = new ProductInfoResult(1L, "테스트 상품", "테스트 브랜드", null, null, List.of());
+            ProductInfoResult productInfo = new ProductInfoResult(1L, null, "테스트 상품", "테스트 브랜드", null, null, List.of());
             when(findProductByPricePolicyPort.findByPricePolicyIds(List.of(pricePolicyId)))
                     .thenReturn(Map.of(pricePolicyId, productInfo));
 

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/RegisterOrderUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/RegisterOrderUseCaseTest.java
@@ -8,6 +8,7 @@ import com.personal.marketnote.commerce.domain.payment.Payment;
 import com.personal.marketnote.commerce.exception.ExcessiveDiscountException;
 import com.personal.marketnote.commerce.exception.OrderAmountMismatchException;
 import com.personal.marketnote.commerce.exception.PriceMismatchException;
+import com.personal.marketnote.commerce.exception.SellerMismatchException;
 import com.personal.marketnote.commerce.port.in.command.order.OrderProductItemCommand;
 import com.personal.marketnote.commerce.port.in.command.order.RegisterOrderCommand;
 import com.personal.marketnote.commerce.port.in.result.order.RegisterOrderResult;
@@ -134,7 +135,10 @@ class RegisterOrderUseCaseTest {
                     ))
                     .build();
 
-            mockProductPrices(Map.of(pricePolicyId1, 25000L, pricePolicyId2, 50000L));
+            mockProductPricesWithSellerIds(Map.of(
+                    pricePolicyId1, Map.entry(25000L, 10L),
+                    pricePolicyId2, Map.entry(50000L, 20L)
+            ));
 
             Inventory inventory1 = Inventory.of(1L, pricePolicyId1, 100);
             Inventory inventory2 = Inventory.of(2L, pricePolicyId2, 50);
@@ -559,7 +563,7 @@ class RegisterOrderUseCaseTest {
                     ))
                     .build();
 
-            mockProductPrice(pricePolicyId, 50000L);
+            mockProductPriceWithSellerId(pricePolicyId, 50000L, sellerId);
             mockInventoryAndSave(pricePolicyId, 100, 1L);
 
             registerOrderService.registerOrder(command);
@@ -961,7 +965,7 @@ class RegisterOrderUseCaseTest {
 
             when(findProductByPricePolicyPort.findByPricePolicyIds(anyList()))
                     .thenReturn(Map.of(pricePolicyId,
-                            new ProductInfoResult(1L, "상품", "브랜드", 50000L, 40000L, List.of())));
+                            new ProductInfoResult(1L, 10L, "상품", "브랜드", 50000L, 40000L, List.of())));
             mockInventoryAndSave(pricePolicyId, 100, 1L);
 
             assertThatCode(() -> registerOrderService.registerOrder(command))
@@ -976,7 +980,7 @@ class RegisterOrderUseCaseTest {
 
             when(findProductByPricePolicyPort.findByPricePolicyIds(anyList()))
                     .thenReturn(Map.of(pricePolicyId,
-                            new ProductInfoResult(1L, "상품", "브랜드", 50000L, null, List.of())));
+                            new ProductInfoResult(1L, 10L, "상품", "브랜드", 50000L, null, List.of())));
             mockInventoryAndSave(pricePolicyId, 100, 1L);
 
             assertThatCode(() -> registerOrderService.registerOrder(command))
@@ -1009,6 +1013,165 @@ class RegisterOrderUseCaseTest {
                     .isInstanceOf(PriceMismatchException.class);
 
             verifyNoInteractions(getInventoryUseCase, saveOrderPort, savePaymentPort);
+        }
+    }
+
+    // ==================================================================================
+    // sellerId 교차 검증
+    // ==================================================================================
+
+    @Nested
+    @DisplayName("sellerId 교차 검증")
+    class SellerIdValidationTest {
+
+        @Test
+        @DisplayName("sellerId가 실제 상품의 판매자와 일치하면 주문이 성공한다")
+        void registerOrder_matchingSellerId_succeeds() {
+            Long pricePolicyId = 100L;
+            Long sellerId = 10L;
+            RegisterOrderCommand command = RegisterOrderCommand.builder()
+                    .buyerId(1L)
+                    .totalAmount(50000L)
+                    .couponAmount(0L)
+                    .pointAmount(0L)
+                    .orderProducts(List.of(
+                            OrderProductItemCommand.builder()
+                                    .productId(100L)
+                                    .sellerId(sellerId)
+                                    .pricePolicyId(pricePolicyId)
+                                    .quantity(1)
+                                    .unitAmount(50000L)
+                                    .build()
+                    ))
+                    .build();
+
+            mockProductPriceWithSellerId(pricePolicyId, 50000L, sellerId);
+            mockInventoryAndSave(pricePolicyId, 100, 1L);
+
+            assertThatCode(() -> registerOrderService.registerOrder(command))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("sellerId가 실제 상품의 판매자와 다르면 SellerMismatchException이 발생한다")
+        void registerOrder_mismatchingSellerId_throwsException() {
+            Long pricePolicyId = 100L;
+            Long requestedSellerId = 999L;
+            Long actualSellerId = 10L;
+            RegisterOrderCommand command = RegisterOrderCommand.builder()
+                    .buyerId(1L)
+                    .totalAmount(50000L)
+                    .couponAmount(0L)
+                    .pointAmount(0L)
+                    .orderProducts(List.of(
+                            OrderProductItemCommand.builder()
+                                    .productId(100L)
+                                    .sellerId(requestedSellerId)
+                                    .pricePolicyId(pricePolicyId)
+                                    .quantity(1)
+                                    .unitAmount(50000L)
+                                    .build()
+                    ))
+                    .build();
+
+            mockProductPriceWithSellerId(pricePolicyId, 50000L, actualSellerId);
+
+            assertThatThrownBy(() -> registerOrderService.registerOrder(command))
+                    .isInstanceOf(SellerMismatchException.class)
+                    .hasMessageContaining("판매자가 실제 상품의 판매자와 일치하지 않습니다");
+        }
+
+        @Test
+        @DisplayName("product-service 응답의 sellerId가 null이면 검증을 건너뛴다")
+        void registerOrder_nullActualSellerId_skipsValidation() {
+            Long pricePolicyId = 100L;
+            RegisterOrderCommand command = RegisterOrderCommand.builder()
+                    .buyerId(1L)
+                    .totalAmount(50000L)
+                    .couponAmount(0L)
+                    .pointAmount(0L)
+                    .orderProducts(List.of(
+                            OrderProductItemCommand.builder()
+                                    .productId(100L)
+                                    .sellerId(999L)
+                                    .pricePolicyId(pricePolicyId)
+                                    .quantity(1)
+                                    .unitAmount(50000L)
+                                    .build()
+                    ))
+                    .build();
+
+            mockProductPriceWithSellerId(pricePolicyId, 50000L, null);
+            mockInventoryAndSave(pricePolicyId, 100, 1L);
+
+            assertThatCode(() -> registerOrderService.registerOrder(command))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("sellerId 불일치 시 재고 검증/주문 저장이 호출되지 않는다")
+        void registerOrder_sellerMismatch_doesNotCallSubsequentPorts() {
+            Long pricePolicyId = 100L;
+            RegisterOrderCommand command = RegisterOrderCommand.builder()
+                    .buyerId(1L)
+                    .totalAmount(50000L)
+                    .couponAmount(0L)
+                    .pointAmount(0L)
+                    .orderProducts(List.of(
+                            OrderProductItemCommand.builder()
+                                    .productId(100L)
+                                    .sellerId(999L)
+                                    .pricePolicyId(pricePolicyId)
+                                    .quantity(1)
+                                    .unitAmount(50000L)
+                                    .build()
+                    ))
+                    .build();
+
+            mockProductPriceWithSellerId(pricePolicyId, 50000L, 10L);
+
+            assertThatThrownBy(() -> registerOrderService.registerOrder(command))
+                    .isInstanceOf(SellerMismatchException.class);
+
+            verifyNoInteractions(getInventoryUseCase, saveOrderPort, savePaymentPort);
+        }
+
+        @Test
+        @DisplayName("복수 상품 중 하나의 sellerId가 불일치하면 SellerMismatchException이 발생한다")
+        void registerOrder_oneSellerMismatch_throwsException() {
+            Long pricePolicyId1 = 100L;
+            Long pricePolicyId2 = 200L;
+            RegisterOrderCommand command = RegisterOrderCommand.builder()
+                    .buyerId(1L)
+                    .totalAmount(100000L)
+                    .couponAmount(0L)
+                    .pointAmount(0L)
+                    .orderProducts(List.of(
+                            OrderProductItemCommand.builder()
+                                    .productId(100L)
+                                    .sellerId(10L)
+                                    .pricePolicyId(pricePolicyId1)
+                                    .quantity(1)
+                                    .unitAmount(50000L)
+                                    .build(),
+                            OrderProductItemCommand.builder()
+                                    .productId(200L)
+                                    .sellerId(999L)
+                                    .pricePolicyId(pricePolicyId2)
+                                    .quantity(1)
+                                    .unitAmount(50000L)
+                                    .build()
+                    ))
+                    .build();
+
+            java.util.HashMap<Long, ProductInfoResult> productInfoMap = new java.util.HashMap<>();
+            productInfoMap.put(pricePolicyId1, new ProductInfoResult(1L, 10L, "상품1", "브랜드1", 50000L, null, List.of()));
+            productInfoMap.put(pricePolicyId2, new ProductInfoResult(2L, 20L, "상품2", "브랜드2", 50000L, null, List.of()));
+            when(findProductByPricePolicyPort.findByPricePolicyIds(anyList()))
+                    .thenReturn(productInfoMap);
+
+            assertThatThrownBy(() -> registerOrderService.registerOrder(command))
+                    .isInstanceOf(SellerMismatchException.class);
         }
     }
 
@@ -1164,7 +1327,10 @@ class RegisterOrderUseCaseTest {
                     ))
                     .build();
 
-            mockProductPrices(Map.of(pricePolicyId1, 50000L, pricePolicyId2, 50000L));
+            mockProductPricesWithSellerIds(Map.of(
+                    pricePolicyId1, Map.entry(50000L, 10L),
+                    pricePolicyId2, Map.entry(50000L, 20L)
+            ));
 
             Inventory inventory1 = Inventory.of(1L, pricePolicyId1, 100);
             Inventory inventory2 = Inventory.of(2L, pricePolicyId2, 100);
@@ -1330,7 +1496,10 @@ class RegisterOrderUseCaseTest {
                     ))
                     .build();
 
-            mockProductPrices(Map.of(pricePolicyId1, 10000L, pricePolicyId2, 5000L));
+            mockProductPricesWithSellerIds(Map.of(
+                    pricePolicyId1, Map.entry(10000L, 10L),
+                    pricePolicyId2, Map.entry(5000L, 20L)
+            ));
 
             Inventory inventory1 = Inventory.of(1L, pricePolicyId1, 100);
             Inventory inventory2 = Inventory.of(2L, pricePolicyId2, 5);
@@ -1600,7 +1769,7 @@ class RegisterOrderUseCaseTest {
                     .orderProducts(List.of(
                             OrderProductItemCommand.builder()
                                     .productId(100L)
-                                    .sellerId(20L)
+                                    .sellerId(10L)
                                     .pricePolicyId(pricePolicyId)
                                     .quantity(2)
                                     .unitAmount(50000L)
@@ -1799,7 +1968,11 @@ class RegisterOrderUseCaseTest {
                     ))
                     .build();
 
-            mockProductPrices(Map.of(pricePolicyId1, 50000L, pricePolicyId2, 100000L, pricePolicyId3, 100000L));
+            mockProductPricesWithSellerIds(Map.of(
+                    pricePolicyId1, Map.entry(50000L, 10L),
+                    pricePolicyId2, Map.entry(100000L, 20L),
+                    pricePolicyId3, Map.entry(100000L, 30L)
+            ));
 
             Inventory inventory1 = Inventory.of(1L, pricePolicyId1, 100);
             Inventory inventory2 = Inventory.of(2L, pricePolicyId2, 50);
@@ -1856,17 +2029,37 @@ class RegisterOrderUseCaseTest {
 
     private void mockProductPrice(Long pricePolicyId, Long price) {
         ProductInfoResult productInfo = new ProductInfoResult(
-                1L, "테스트 상품", "테스트 브랜드", price, null, List.of()
+                1L, 10L, "테스트 상품", "테스트 브랜드", price, null, List.of()
         );
         when(findProductByPricePolicyPort.findByPricePolicyIds(anyList()))
                 .thenReturn(Map.of(pricePolicyId, productInfo));
+    }
+
+    private void mockProductPriceWithSellerId(Long pricePolicyId, Long price, Long sellerId) {
+        ProductInfoResult productInfo = new ProductInfoResult(
+                1L, sellerId, "테스트 상품", "테스트 브랜드", price, null, List.of()
+        );
+        when(findProductByPricePolicyPort.findByPricePolicyIds(anyList()))
+                .thenReturn(Map.of(pricePolicyId, productInfo));
+    }
+
+    private void mockProductPricesWithSellerIds(Map<Long, Map.Entry<Long, Long>> pricePolicyIdToPriceAndSellerId) {
+        java.util.HashMap<Long, ProductInfoResult> result = new java.util.HashMap<>();
+        pricePolicyIdToPriceAndSellerId.forEach((pricePolicyId, priceAndSellerId) ->
+                result.put(pricePolicyId, new ProductInfoResult(
+                        pricePolicyId, priceAndSellerId.getValue(), "테스트 상품", "테스트 브랜드",
+                        priceAndSellerId.getKey(), null, List.of()
+                ))
+        );
+        when(findProductByPricePolicyPort.findByPricePolicyIds(anyList()))
+                .thenReturn(result);
     }
 
     private void mockProductPrices(Map<Long, Long> pricePolicyIdToPrice) {
         java.util.HashMap<Long, ProductInfoResult> result = new java.util.HashMap<>();
         pricePolicyIdToPrice.forEach((pricePolicyId, price) ->
                 result.put(pricePolicyId, new ProductInfoResult(
-                        pricePolicyId, "테스트 상품", "테스트 브랜드", price, null, List.of()
+                        pricePolicyId, 10L, "테스트 상품", "테스트 브랜드", price, null, List.of()
                 ))
         );
         when(findProductByPricePolicyPort.findByPricePolicyIds(anyList()))


### PR DESCRIPTION
## partially addresses #723
## resolves #886

## Reason
QA에서 sellerId=99999(미존재) 또는 다른 판매자의 ID를 임의 지정해도
주문이 성공하는 것이 확인됨. 검증되지 않은 sellerId가 OrderProduct에
저장되어 정산 오류 가능성이 있음.

## Action
- ProductsInfoResponse에 sellerId 필드 추가 (Product Service 응답에서 수신)
- ProductInfoResult에 sellerId 필드 추가
- ProductServiceClient.generateResult()에 sellerId 매핑 추가
- RegisterOrderService.validateUnitAmountsAgainstActualPrices()에 sellerId 교차 검증 추가
- SellerMismatchException 예외 클래스 생성
- sellerId 검증을 가격 검증보다 먼저 수행 (보안 강화)
- 로그에서 실제 sellerId 미노출 (정보 열거 방지)