### PR TITLE
[#723][#888] fix: 에러 응답 형식 불일치 이슈 대응

### DIFF
--- a/common/src/main/java/com/personal/marketnote/common/domain/exception/GlobalExceptionHandler.java
+++ b/common/src/main/java/com/personal/marketnote/common/domain/exception/GlobalExceptionHandler.java
@@ -21,6 +21,8 @@ import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.servlet.NoHandlerFoundException;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -92,6 +94,20 @@ public class GlobalExceptionHandler {
         HttpStatus httpStatus = HttpStatus.METHOD_NOT_ALLOWED;
         log.warn(LOG_WARN_MESSAGE, e.getMessage(), e);
         return buildErrorResponse(httpStatus, e.getMessage());
+    }
+
+    @ExceptionHandler(NoHandlerFoundException.class)
+    ResponseEntity<ErrorResponse> handleNoHandlerFoundException(NoHandlerFoundException e) {
+        HttpStatus httpStatus = HttpStatus.NOT_FOUND;
+        log.info(LOG_INFO_MESSAGE, e.getMessage());
+        return buildErrorResponse(httpStatus, httpStatus.name(), "요청한 경로를 찾을 수 없습니다.");
+    }
+
+    @ExceptionHandler(NoResourceFoundException.class)
+    ResponseEntity<ErrorResponse> handleNoResourceFoundException(NoResourceFoundException e) {
+        HttpStatus httpStatus = HttpStatus.NOT_FOUND;
+        log.info(LOG_INFO_MESSAGE, e.getMessage());
+        return buildErrorResponse(httpStatus, httpStatus.name(), "요청한 리소스를 찾을 수 없습니다.");
     }
 
     @ExceptionHandler(AuthenticationException.class)

--- a/common/src/test/java/com/personal/marketnote/common/domain/exception/GlobalExceptionHandlerTest.java
+++ b/common/src/test/java/com/personal/marketnote/common/domain/exception/GlobalExceptionHandlerTest.java
@@ -3,8 +3,11 @@ package com.personal.marketnote.common.domain.exception;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.servlet.NoHandlerFoundException;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -141,6 +144,63 @@ class GlobalExceptionHandlerTest {
 
             assertThat(response.getBody()).isNotNull();
             assertThat(response.getBody().getMessage()).isEqualTo("서버 내부 오류가 발생했습니다.");
+        }
+    }
+
+    @Nested
+    @DisplayName("404 Not Found 핸들러")
+    class NotFoundHandlerTest {
+
+        @Test
+        @DisplayName("NoHandlerFoundException 핸들러는 404를 반환한다")
+        void shouldReturn404ForNoHandlerFoundException() {
+            NoHandlerFoundException exception =
+                    new NoHandlerFoundException("GET", "/api/v1/nonexistent", null);
+
+            ResponseEntity<ErrorResponse> response = handler.handleNoHandlerFoundException(exception);
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+            assertThat(response.getBody()).isNotNull();
+            assertThat(response.getBody().getCode()).isEqualTo("NOT_FOUND");
+            assertThat(response.getBody().getMessage()).isEqualTo("요청한 경로를 찾을 수 없습니다.");
+        }
+
+        @Test
+        @DisplayName("NoHandlerFoundException 응답에 요청 경로가 노출되지 않는다")
+        void shouldNotExposeRequestPathInNoHandlerResponse() {
+            NoHandlerFoundException exception =
+                    new NoHandlerFoundException("GET", "/api/v1/internal/secret", null);
+
+            ResponseEntity<ErrorResponse> response = handler.handleNoHandlerFoundException(exception);
+
+            assertThat(response.getBody()).isNotNull();
+            assertThat(response.getBody().getMessage()).doesNotContain("/api/v1/internal/secret");
+        }
+
+        @Test
+        @DisplayName("NoResourceFoundException 핸들러는 404를 반환한다")
+        void shouldReturn404ForNoResourceFoundException() {
+            NoResourceFoundException exception =
+                    new NoResourceFoundException(HttpMethod.GET, "/static/missing.js");
+
+            ResponseEntity<ErrorResponse> response = handler.handleNoResourceFoundException(exception);
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+            assertThat(response.getBody()).isNotNull();
+            assertThat(response.getBody().getCode()).isEqualTo("NOT_FOUND");
+            assertThat(response.getBody().getMessage()).isEqualTo("요청한 리소스를 찾을 수 없습니다.");
+        }
+
+        @Test
+        @DisplayName("NoResourceFoundException 응답에 리소스 경로가 노출되지 않는다")
+        void shouldNotExposeResourcePathInNoResourceResponse() {
+            NoResourceFoundException exception =
+                    new NoResourceFoundException(HttpMethod.GET, "/internal/config.json");
+
+            ResponseEntity<ErrorResponse> response = handler.handleNoResourceFoundException(exception);
+
+            assertThat(response.getBody()).isNotNull();
+            assertThat(response.getBody().getMessage()).doesNotContain("/internal/config.json");
         }
     }
 


### PR DESCRIPTION
## partially addresses #723
## resolves #888

## Task
## Reason
NHN KCP 결제 연동 통합 QA에서 존재하지 않는 URL 요청 시 Spring 기본 404 응답 (timestamp, status, error, path 형태)이 반환되어 GlobalExceptionHandler의 ErrorResponse 형식(statusCode, code, timestamp, content, message)과 불일치하는 것이 확인됨

## Action
- GlobalExceptionHandler에 NoHandlerFoundException 핸들러 추가 (404, 고정 메시지)
- GlobalExceptionHandler에 NoResourceFoundException 핸들러 추가 (404, 고정 메시지)
- 응답에 요청 경로/리소스 경로 비노출 (정보 노출 방지)
- 404 로그에서 불필요한 스택 트레이스 제외 (로그 노이즈 방지)
- GlobalExceptionHandlerTest에 테스트 4개 추가