### PR TITLE
[#216][#892] feat: 결제 승인 시 자동 분개 기능 추가

### DIFF
--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/ledger/RecordLedgerEntryUseCase.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/ledger/RecordLedgerEntryUseCase.java
@@ -4,4 +4,6 @@ import com.personal.marketnote.commerce.port.in.command.ledger.RecordLedgerEntry
 
 public interface RecordLedgerEntryUseCase {
     void record(RecordLedgerEntryCommand command);
+
+    void recordPaymentApproval(Long orderId, long paymentAmount);
 }

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/ledger/RecordLedgerEntryService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/ledger/RecordLedgerEntryService.java
@@ -13,6 +13,7 @@ import com.personal.marketnote.commerce.port.out.ledger.SaveLedgerTransactionPor
 import com.personal.marketnote.common.application.UseCase;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
@@ -22,14 +23,17 @@ import static org.springframework.transaction.annotation.Isolation.READ_COMMITTE
 
 @UseCase
 @RequiredArgsConstructor
-@Transactional(isolation = READ_COMMITTED)
 @Slf4j
 public class RecordLedgerEntryService implements RecordLedgerEntryUseCase {
+    private static final String ACCOUNT_PG_RECEIVABLE = "매출채권_PG";
+    private static final String ACCOUNT_SELLER_PAYABLE = "미지급금_판매자";
+
     private final FindAccountPort findAccountPort;
     private final SaveLedgerTransactionPort saveLedgerTransactionPort;
     private final SaveLedgerEntryPort saveLedgerEntryPort;
 
     @Override
+    @Transactional(propagation = Propagation.REQUIRES_NEW, isolation = READ_COMMITTED)
     public void record(RecordLedgerEntryCommand command) {
         validateEntryLines(command.entries());
         validateIdempotency(command.idempotencyKey());
@@ -48,6 +52,37 @@ public class RecordLedgerEntryService implements RecordLedgerEntryUseCase {
         log.info("장부 거래 기록 완료 - transactionId: {}, type: {}, targetType: {}, targetId: {}, idempotencyKey: {}",
                 savedTransaction.getId(), command.transactionType(),
                 command.targetType(), command.targetId(), command.idempotencyKey());
+    }
+
+    @Override
+    @Transactional(propagation = Propagation.REQUIRES_NEW, isolation = READ_COMMITTED)
+    public void recordPaymentApproval(Long orderId, long paymentAmount) {
+        Account pgReceivable = findAccountPort.findByName(ACCOUNT_PG_RECEIVABLE)
+                .orElseThrow(() -> new AccountNotFoundException(ACCOUNT_PG_RECEIVABLE));
+        Account sellerPayable = findAccountPort.findByName(ACCOUNT_SELLER_PAYABLE)
+                .orElseThrow(() -> new AccountNotFoundException(ACCOUNT_SELLER_PAYABLE));
+
+        RecordLedgerEntryCommand command = RecordLedgerEntryCommand.builder()
+                .transactionType(LedgerTransactionType.PAYMENT_APPROVAL)
+                .targetType("PAYMENT")
+                .targetId(orderId)
+                .description("결제 승인 분개")
+                .idempotencyKey("PAYMENT_APPROVAL:" + orderId)
+                .entries(List.of(
+                        RecordLedgerEntryCommand.EntryLine.builder()
+                                .accountId(pgReceivable.getId())
+                                .amount(paymentAmount)
+                                .transactionType(TransactionType.DEBIT)
+                                .build(),
+                        RecordLedgerEntryCommand.EntryLine.builder()
+                                .accountId(sellerPayable.getId())
+                                .amount(paymentAmount)
+                                .transactionType(TransactionType.CREDIT)
+                                .build()
+                ))
+                .build();
+
+        record(command);
     }
 
     private void validateEntryLines(List<RecordLedgerEntryCommand.EntryLine> entryLines) {

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/ApprovePaymentService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/ApprovePaymentService.java
@@ -12,6 +12,7 @@ import com.personal.marketnote.commerce.exception.UnauthorizedOrderAccessExcepti
 import com.personal.marketnote.commerce.port.in.command.order.ChangeOrderStatusCommand;
 import com.personal.marketnote.commerce.port.in.command.payment.ApprovePaymentCommand;
 import com.personal.marketnote.commerce.port.in.result.payment.ApprovePaymentResult;
+import com.personal.marketnote.commerce.port.in.usecase.ledger.RecordLedgerEntryUseCase;
 import com.personal.marketnote.commerce.port.in.usecase.order.ChangeOrderStatusUseCase;
 import com.personal.marketnote.commerce.port.in.usecase.payment.ApprovePaymentUseCase;
 import com.personal.marketnote.commerce.port.out.order.FindOrderPort;
@@ -41,6 +42,7 @@ public class ApprovePaymentService implements ApprovePaymentUseCase {
     private final UpdatePspPaymentEventPort updatePspPaymentEventPort;
     private final PaymentVendorPort paymentVendorPort;
     private final ChangeOrderStatusUseCase changeOrderStatusUseCase;
+    private final RecordLedgerEntryUseCase recordLedgerEntryUseCase;
 
     @Override
     public ApprovePaymentResult approve(ApprovePaymentCommand command) {
@@ -119,6 +121,8 @@ public class ApprovePaymentService implements ApprovePaymentUseCase {
                         .build()
         );
 
+        recordLedgerEntryForPaymentApproval(payment);
+
         return ApprovePaymentResult.builder()
                 .orderId(payment.getOrderId())
                 .orderKey(payment.getOrderKey().toString())
@@ -143,6 +147,16 @@ public class ApprovePaymentService implements ApprovePaymentUseCase {
                         .orderStatus(OrderStatus.FAILED)
                         .build()
         );
+    }
+
+    private void recordLedgerEntryForPaymentApproval(Payment payment) {
+        try {
+            recordLedgerEntryUseCase.recordPaymentApproval(
+                    payment.getOrderId(), payment.getPaymentAmount()
+            );
+        } catch (Exception e) {
+            log.error("결제 승인 분개 기록 실패 - orderId: {}, error: {}", payment.getOrderId(), e.getMessage(), e);
+        }
     }
 
     private Order findVerifiedOrder(Long orderId, Long buyerId) {

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/ledger/RecordLedgerEntryUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/ledger/RecordLedgerEntryUseCaseTest.java
@@ -402,4 +402,92 @@ class RecordLedgerEntryUseCaseTest {
             verify(saveLedgerEntryPort, never()).saveAll(any());
         }
     }
+
+    @Nested
+    @DisplayName("결제 승인 분개 편의 메서드")
+    class RecordPaymentApprovalTest {
+
+        @Test
+        @DisplayName("결제 승인 분개 시 매출채권_PG 차변, 미지급금_판매자 대변으로 기록된다")
+        void shouldRecordPaymentApprovalWithCorrectAccounts() {
+            // given
+            Account pgReceivable = createActiveAccount(1L, "매출채권_PG", AccountType.ASSET);
+            Account sellerPayable = createActiveAccount(3L, "미지급금_판매자", AccountType.LIABILITY);
+
+            when(findAccountPort.findByName("매출채권_PG")).thenReturn(Optional.of(pgReceivable));
+            when(findAccountPort.findByName("미지급금_판매자")).thenReturn(Optional.of(sellerPayable));
+            when(saveLedgerTransactionPort.existsByIdempotencyKey(anyString())).thenReturn(false);
+            when(findAccountPort.findById(1L)).thenReturn(Optional.of(pgReceivable));
+            when(findAccountPort.findById(3L)).thenReturn(Optional.of(sellerPayable));
+            when(saveLedgerTransactionPort.save(any())).thenAnswer(invocation -> {
+                LedgerTransaction tx = invocation.getArgument(0);
+                return LedgerTransaction.from(LedgerTransactionSnapshotState.builder()
+                        .id(100L)
+                        .transactionType(tx.getTransactionType())
+                        .targetType(tx.getTargetType())
+                        .targetId(tx.getTargetId())
+                        .description(tx.getDescription())
+                        .idempotencyKey(tx.getIdempotencyKey())
+                        .build());
+            });
+
+            // when
+            recordLedgerEntryService.recordPaymentApproval(1L, 50000L);
+
+            // then
+            verify(findAccountPort).findByName("매출채권_PG");
+            verify(findAccountPort).findByName("미지급금_판매자");
+            verify(saveLedgerTransactionPort).save(argThat(tx ->
+                    tx.getTransactionType() == LedgerTransactionType.PAYMENT_APPROVAL
+                            && "PAYMENT_APPROVAL:1".equals(tx.getIdempotencyKey())
+                            && "PAYMENT".equals(tx.getTargetType())
+            ));
+
+            ArgumentCaptor<List<LedgerEntry>> entriesCaptor = ArgumentCaptor.forClass(List.class);
+            verify(saveLedgerEntryPort).saveAll(entriesCaptor.capture());
+
+            List<LedgerEntry> savedEntries = entriesCaptor.getValue();
+            assertThat(savedEntries).hasSize(2);
+
+            LedgerEntry debitEntry = savedEntries.stream()
+                    .filter(e -> e.getTransactionType().isDebit())
+                    .findFirst().orElseThrow();
+            assertThat(debitEntry.getAccountId()).isEqualTo(1L);
+            assertThat(debitEntry.getAmount()).isEqualTo(50000L);
+
+            LedgerEntry creditEntry = savedEntries.stream()
+                    .filter(e -> e.getTransactionType().isCredit())
+                    .findFirst().orElseThrow();
+            assertThat(creditEntry.getAccountId()).isEqualTo(3L);
+            assertThat(creditEntry.getAmount()).isEqualTo(50000L);
+        }
+
+        @Test
+        @DisplayName("매출채권_PG 계정이 없으면 AccountNotFoundException이 발생한다")
+        void shouldThrowWhenPgReceivableAccountNotFound() {
+            // given
+            when(findAccountPort.findByName("매출채권_PG")).thenReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> recordLedgerEntryService.recordPaymentApproval(1L, 50000L))
+                    .isInstanceOf(AccountNotFoundException.class);
+
+            verify(saveLedgerTransactionPort, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("미지급금_판매자 계정이 없으면 AccountNotFoundException이 발생한다")
+        void shouldThrowWhenSellerPayableAccountNotFound() {
+            // given
+            Account pgReceivable = createActiveAccount(1L, "매출채권_PG", AccountType.ASSET);
+            when(findAccountPort.findByName("매출채권_PG")).thenReturn(Optional.of(pgReceivable));
+            when(findAccountPort.findByName("미지급금_판매자")).thenReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> recordLedgerEntryService.recordPaymentApproval(1L, 50000L))
+                    .isInstanceOf(AccountNotFoundException.class);
+
+            verify(saveLedgerTransactionPort, never()).save(any());
+        }
+    }
 }

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/payment/ApprovePaymentUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/payment/ApprovePaymentUseCaseTest.java
@@ -12,6 +12,7 @@ import com.personal.marketnote.commerce.exception.PaymentNotFoundException;
 import com.personal.marketnote.commerce.exception.UnauthorizedOrderAccessException;
 import com.personal.marketnote.commerce.port.in.command.payment.ApprovePaymentCommand;
 import com.personal.marketnote.commerce.port.in.result.payment.ApprovePaymentResult;
+import com.personal.marketnote.commerce.port.in.usecase.ledger.RecordLedgerEntryUseCase;
 import com.personal.marketnote.commerce.port.in.usecase.order.ChangeOrderStatusUseCase;
 import com.personal.marketnote.commerce.port.out.order.FindOrderPort;
 import com.personal.marketnote.commerce.port.out.payment.*;
@@ -62,6 +63,9 @@ class ApprovePaymentUseCaseTest {
 
     @Mock
     private ChangeOrderStatusUseCase changeOrderStatusUseCase;
+
+    @Mock
+    private RecordLedgerEntryUseCase recordLedgerEntryUseCase;
 
     private static final Long BUYER_ID = 100L;
     private static final UUID ORDER_KEY = UUID.randomUUID();
@@ -333,6 +337,71 @@ class ApprovePaymentUseCaseTest {
                     e.getPoStatus() == PaymentEventStatus.COMPLETE
                             && "tno_999".equals(e.getPgPaymentKey())
             ));
+        }
+    }
+
+    @Nested
+    @DisplayName("결제 승인 시 자동 분개")
+    class LedgerEntryRecordingTest {
+
+        private void setupSuccessScenario(Payment payment) {
+            when(findPaymentPort.findByOrderKey(ORDER_KEY)).thenReturn(Optional.of(payment));
+            when(findOrderPort.findById(1L)).thenReturn(Optional.of(createOrder(1L, BUYER_ID)));
+            when(findPspPaymentEventPort.findByOrderKey(ORDER_KEY_STR)).thenReturn(Optional.empty());
+            when(paymentVendorPort.getVendorSiteCd()).thenReturn("T0000");
+            when(savePspPaymentEventPort.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+        }
+
+        @Test
+        @DisplayName("결제 승인 성공 시 recordPaymentApproval이 orderId와 결제금액으로 호출된다")
+        void shouldRecordLedgerEntryOnPaymentApproval() {
+            Payment payment = createPayment(1L, ORDER_KEY, 50000L);
+            ApprovePaymentCommand command = createApproveCommand(ORDER_KEY_STR);
+            PaymentApprovalVendorResult vendorResult = createSuccessVendorResult("tno_ledger", "50000");
+            setupSuccessScenario(payment);
+            when(paymentVendorPort.approvePayment(any())).thenReturn(vendorResult);
+
+            approvePaymentService.approve(command);
+
+            verify(recordLedgerEntryUseCase).recordPaymentApproval(1L, 50000L);
+        }
+
+        @Test
+        @DisplayName("분개 기록 실패 시에도 결제 승인은 정상적으로 완료된다")
+        void shouldCompletePaymentEvenWhenLedgerRecordingFails() {
+            Payment payment = createPayment(1L, ORDER_KEY, 50000L);
+            ApprovePaymentCommand command = createApproveCommand(ORDER_KEY_STR);
+            PaymentApprovalVendorResult vendorResult = createSuccessVendorResult("tno_fail", "50000");
+            setupSuccessScenario(payment);
+            when(paymentVendorPort.approvePayment(any())).thenReturn(vendorResult);
+
+            doThrow(new RuntimeException("분개 기록 실패"))
+                    .when(recordLedgerEntryUseCase).recordPaymentApproval(anyLong(), anyLong());
+
+            ApprovePaymentResult result = approvePaymentService.approve(command);
+
+            assertThat(result.pgPaymentKey()).isEqualTo("tno_fail");
+            verify(updatePaymentPort).update(argThat(p -> p.getSuccessYn()));
+            verify(changeOrderStatusUseCase).changeOrderStatus(argThat(c -> c.orderStatus() == OrderStatus.PAID));
+        }
+
+        @Test
+        @DisplayName("결제 실패 시 분개가 기록되지 않는다")
+        void shouldNotRecordLedgerEntryOnPaymentFailure() {
+            Payment payment = createPayment(1L, ORDER_KEY, 50000L);
+            ApprovePaymentCommand command = createApproveCommand(ORDER_KEY_STR);
+            PaymentApprovalVendorResult vendorResult = PaymentApprovalVendorResult.builder()
+                    .resCd("8001")
+                    .resMsg("카드 인증 실패")
+                    .rawResponse("{}")
+                    .build();
+            setupSuccessScenario(payment);
+            when(paymentVendorPort.approvePayment(any())).thenReturn(vendorResult);
+
+            assertThatThrownBy(() -> approvePaymentService.approve(command))
+                    .isInstanceOf(PaymentApprovalException.class);
+
+            verify(recordLedgerEntryUseCase, never()).recordPaymentApproval(anyLong(), anyLong());
         }
     }
 


### PR DESCRIPTION
## partially addresses #216
## resolves #892

## Task
- [x] RecordLedgerEntryUseCase에 결제 승인 전용 메서드(recordPaymentApproval) 추가
- [x] RecordLedgerEntryService에 REQUIRES_NEW 트랜잭션 전파 적용
- [x] ApprovePaymentService.handleSuccess()에서 분개 호출
- [x] ApprovePaymentUseCaseTest 분개 검증 테스트 3개 추가
- [x] RecordLedgerEntryUseCaseTest 결제 승인 분개 테스트 3개 추가