### PR TITLE
[#216][#894] feat: 결제 취소/환불 시 역분개 자동 기록 기능 추가

### DIFF
--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/ledger/RecordLedgerEntryUseCase.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/ledger/RecordLedgerEntryUseCase.java
@@ -6,4 +6,6 @@ public interface RecordLedgerEntryUseCase {
     void record(RecordLedgerEntryCommand command);
 
     void recordPaymentApproval(Long orderId, long paymentAmount);
+
+    void recordPaymentCancellation(Long orderId, long cancelAmount, String idempotencyKey);
 }

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/ledger/RecordLedgerEntryService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/ledger/RecordLedgerEntryService.java
@@ -85,6 +85,37 @@ public class RecordLedgerEntryService implements RecordLedgerEntryUseCase {
         record(command);
     }
 
+    @Override
+    @Transactional(propagation = Propagation.REQUIRES_NEW, isolation = READ_COMMITTED)
+    public void recordPaymentCancellation(Long orderId, long cancelAmount, String idempotencyKey) {
+        Account pgReceivable = findAccountPort.findByName(ACCOUNT_PG_RECEIVABLE)
+                .orElseThrow(() -> new AccountNotFoundException(ACCOUNT_PG_RECEIVABLE));
+        Account sellerPayable = findAccountPort.findByName(ACCOUNT_SELLER_PAYABLE)
+                .orElseThrow(() -> new AccountNotFoundException(ACCOUNT_SELLER_PAYABLE));
+
+        RecordLedgerEntryCommand command = RecordLedgerEntryCommand.builder()
+                .transactionType(LedgerTransactionType.PAYMENT_CANCELLATION)
+                .targetType("PAYMENT")
+                .targetId(orderId)
+                .description("결제 취소/환불 역분개")
+                .idempotencyKey(idempotencyKey)
+                .entries(List.of(
+                        RecordLedgerEntryCommand.EntryLine.builder()
+                                .accountId(sellerPayable.getId())
+                                .amount(cancelAmount)
+                                .transactionType(TransactionType.DEBIT)
+                                .build(),
+                        RecordLedgerEntryCommand.EntryLine.builder()
+                                .accountId(pgReceivable.getId())
+                                .amount(cancelAmount)
+                                .transactionType(TransactionType.CREDIT)
+                                .build()
+                ))
+                .build();
+
+        record(command);
+    }
+
     private void validateEntryLines(List<RecordLedgerEntryCommand.EntryLine> entryLines) {
         if (FormatValidator.hasNoValue(entryLines) || entryLines.isEmpty()) {
             throw new IllegalArgumentException("분개 항목이 비어있습니다.");

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/CancelPaymentService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/CancelPaymentService.java
@@ -10,6 +10,7 @@ import com.personal.marketnote.commerce.exception.PaymentNotFoundException;
 import com.personal.marketnote.commerce.exception.UnauthorizedOrderAccessException;
 import com.personal.marketnote.commerce.port.in.command.order.ChangeOrderStatusCommand;
 import com.personal.marketnote.commerce.port.in.command.payment.CancelPaymentCommand;
+import com.personal.marketnote.commerce.port.in.usecase.ledger.RecordLedgerEntryUseCase;
 import com.personal.marketnote.commerce.port.in.usecase.order.ChangeOrderStatusUseCase;
 import com.personal.marketnote.commerce.port.in.usecase.payment.CancelPaymentUseCase;
 import com.personal.marketnote.commerce.port.out.order.FindOrderPort;
@@ -38,6 +39,7 @@ public class CancelPaymentService implements CancelPaymentUseCase {
     private final UpdatePspPaymentEventPort updatePspPaymentEventPort;
     private final PaymentVendorPort paymentVendorPort;
     private final ChangeOrderStatusUseCase changeOrderStatusUseCase;
+    private final RecordLedgerEntryUseCase recordLedgerEntryUseCase;
 
     @Override
     public void cancel(CancelPaymentCommand command) {
@@ -109,6 +111,28 @@ public class CancelPaymentService implements CancelPaymentUseCase {
                             .orderStatus(OrderStatus.CANCEL_REQUESTED)
                             .build()
             );
+        }
+
+        recordLedgerEntryForCancellation(payment, isFullCancel, cancelAmount, alreadyRefunded);
+    }
+
+    private void recordLedgerEntryForCancellation(
+            Payment payment, boolean isFullCancel, Long cancelAmount, Long alreadyRefunded
+    ) {
+        try {
+            String idempotencyKey;
+            if (isFullCancel) {
+                idempotencyKey = "PAYMENT_CANCELLATION:" + payment.getOrderId();
+            } else {
+                idempotencyKey = "PAYMENT_PARTIAL_REFUND:" + payment.getOrderId()
+                        + ":" + cancelAmount + ":" + alreadyRefunded;
+            }
+            recordLedgerEntryUseCase.recordPaymentCancellation(
+                    payment.getOrderId(), cancelAmount, idempotencyKey
+            );
+        } catch (Exception e) {
+            log.error("결제 취소 역분개 기록 실패 - orderId: {}, error: {}",
+                    payment.getOrderId(), e.getMessage(), e);
         }
     }
 

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/ledger/RecordLedgerEntryUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/ledger/RecordLedgerEntryUseCaseTest.java
@@ -490,4 +490,131 @@ class RecordLedgerEntryUseCaseTest {
             verify(saveLedgerTransactionPort, never()).save(any());
         }
     }
+
+    @Nested
+    @DisplayName("결제 취소/환불 역분개 편의 메서드")
+    class RecordPaymentCancellationTest {
+
+        @Test
+        @DisplayName("결제 취소 역분개 시 미지급금_판매자 차변, 매출채권_PG 대변으로 기록된다")
+        void shouldRecordReverseLedgerEntriesForCancellation() {
+            // given
+            Account pgReceivable = createActiveAccount(1L, "매출채권_PG", AccountType.ASSET);
+            Account sellerPayable = createActiveAccount(3L, "미지급금_판매자", AccountType.LIABILITY);
+
+            when(findAccountPort.findByName("매출채권_PG")).thenReturn(Optional.of(pgReceivable));
+            when(findAccountPort.findByName("미지급금_판매자")).thenReturn(Optional.of(sellerPayable));
+            when(saveLedgerTransactionPort.existsByIdempotencyKey(anyString())).thenReturn(false);
+            when(findAccountPort.findById(3L)).thenReturn(Optional.of(sellerPayable));
+            when(findAccountPort.findById(1L)).thenReturn(Optional.of(pgReceivable));
+            when(saveLedgerTransactionPort.save(any())).thenAnswer(invocation -> {
+                LedgerTransaction tx = invocation.getArgument(0);
+                return LedgerTransaction.from(LedgerTransactionSnapshotState.builder()
+                        .id(300L)
+                        .transactionType(tx.getTransactionType())
+                        .targetType(tx.getTargetType())
+                        .targetId(tx.getTargetId())
+                        .description(tx.getDescription())
+                        .idempotencyKey(tx.getIdempotencyKey())
+                        .build());
+            });
+
+            // when
+            recordLedgerEntryService.recordPaymentCancellation(1L, 50000L, "PAYMENT_CANCELLATION:1");
+
+            // then
+            verify(saveLedgerTransactionPort).save(argThat(tx ->
+                    tx.getTransactionType() == LedgerTransactionType.PAYMENT_CANCELLATION
+                            && "PAYMENT_CANCELLATION:1".equals(tx.getIdempotencyKey())
+                            && "PAYMENT".equals(tx.getTargetType())
+            ));
+
+            ArgumentCaptor<List<LedgerEntry>> entriesCaptor = ArgumentCaptor.forClass(List.class);
+            verify(saveLedgerEntryPort).saveAll(entriesCaptor.capture());
+
+            List<LedgerEntry> savedEntries = entriesCaptor.getValue();
+            assertThat(savedEntries).hasSize(2);
+
+            LedgerEntry debitEntry = savedEntries.stream()
+                    .filter(e -> e.getTransactionType().isDebit())
+                    .findFirst().orElseThrow();
+            assertThat(debitEntry.getAccountId()).isEqualTo(3L);
+            assertThat(debitEntry.getAmount()).isEqualTo(50000L);
+
+            LedgerEntry creditEntry = savedEntries.stream()
+                    .filter(e -> e.getTransactionType().isCredit())
+                    .findFirst().orElseThrow();
+            assertThat(creditEntry.getAccountId()).isEqualTo(1L);
+            assertThat(creditEntry.getAmount()).isEqualTo(50000L);
+        }
+
+        @Test
+        @DisplayName("부분 환불 역분개 시 환불 금액만큼만 기록된다")
+        void shouldRecordPartialRefundWithCorrectAmount() {
+            // given
+            Account pgReceivable = createActiveAccount(1L, "매출채권_PG", AccountType.ASSET);
+            Account sellerPayable = createActiveAccount(3L, "미지급금_판매자", AccountType.LIABILITY);
+
+            when(findAccountPort.findByName("매출채권_PG")).thenReturn(Optional.of(pgReceivable));
+            when(findAccountPort.findByName("미지급금_판매자")).thenReturn(Optional.of(sellerPayable));
+            when(saveLedgerTransactionPort.existsByIdempotencyKey(anyString())).thenReturn(false);
+            when(findAccountPort.findById(3L)).thenReturn(Optional.of(sellerPayable));
+            when(findAccountPort.findById(1L)).thenReturn(Optional.of(pgReceivable));
+            when(saveLedgerTransactionPort.save(any())).thenAnswer(invocation -> {
+                LedgerTransaction tx = invocation.getArgument(0);
+                return LedgerTransaction.from(LedgerTransactionSnapshotState.builder()
+                        .id(301L)
+                        .transactionType(tx.getTransactionType())
+                        .targetType(tx.getTargetType())
+                        .targetId(tx.getTargetId())
+                        .description(tx.getDescription())
+                        .idempotencyKey(tx.getIdempotencyKey())
+                        .build());
+            });
+
+            // when
+            recordLedgerEntryService.recordPaymentCancellation(1L, 20000L, "PAYMENT_PARTIAL_REFUND:1:20000:0");
+
+            // then
+            verify(saveLedgerTransactionPort).save(argThat(tx ->
+                    tx.getTransactionType() == LedgerTransactionType.PAYMENT_CANCELLATION
+                            && "PAYMENT_PARTIAL_REFUND:1:20000:0".equals(tx.getIdempotencyKey())
+            ));
+
+            ArgumentCaptor<List<LedgerEntry>> entriesCaptor = ArgumentCaptor.forClass(List.class);
+            verify(saveLedgerEntryPort).saveAll(entriesCaptor.capture());
+
+            List<LedgerEntry> savedEntries = entriesCaptor.getValue();
+            assertThat(savedEntries).hasSize(2);
+            savedEntries.forEach(entry -> assertThat(entry.getAmount()).isEqualTo(20000L));
+        }
+
+        @Test
+        @DisplayName("매출채권_PG 계정이 없으면 AccountNotFoundException이 발생한다")
+        void shouldThrowWhenPgReceivableNotFoundForCancellation() {
+            // given
+            when(findAccountPort.findByName("매출채권_PG")).thenReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> recordLedgerEntryService.recordPaymentCancellation(1L, 50000L, "PAYMENT_CANCELLATION:1"))
+                    .isInstanceOf(AccountNotFoundException.class);
+
+            verify(saveLedgerTransactionPort, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("미지급금_판매자 계정이 없으면 AccountNotFoundException이 발생한다")
+        void shouldThrowWhenSellerPayableNotFoundForCancellation() {
+            // given
+            Account pgReceivable = createActiveAccount(1L, "매출채권_PG", AccountType.ASSET);
+            when(findAccountPort.findByName("매출채권_PG")).thenReturn(Optional.of(pgReceivable));
+            when(findAccountPort.findByName("미지급금_판매자")).thenReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> recordLedgerEntryService.recordPaymentCancellation(1L, 50000L, "PAYMENT_CANCELLATION:1"))
+                    .isInstanceOf(AccountNotFoundException.class);
+
+            verify(saveLedgerTransactionPort, never()).save(any());
+        }
+    }
 }

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/payment/CancelPaymentUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/payment/CancelPaymentUseCaseTest.java
@@ -8,6 +8,7 @@ import com.personal.marketnote.commerce.exception.PaymentCancelException;
 import com.personal.marketnote.commerce.exception.PaymentNotFoundException;
 import com.personal.marketnote.commerce.exception.UnauthorizedOrderAccessException;
 import com.personal.marketnote.commerce.port.in.command.payment.CancelPaymentCommand;
+import com.personal.marketnote.commerce.port.in.usecase.ledger.RecordLedgerEntryUseCase;
 import com.personal.marketnote.commerce.port.in.usecase.order.ChangeOrderStatusUseCase;
 import com.personal.marketnote.commerce.port.out.order.FindOrderPort;
 import com.personal.marketnote.commerce.port.out.payment.*;
@@ -25,8 +26,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -56,6 +56,9 @@ class CancelPaymentUseCaseTest {
 
     @Mock
     private ChangeOrderStatusUseCase changeOrderStatusUseCase;
+
+    @Mock
+    private RecordLedgerEntryUseCase recordLedgerEntryUseCase;
 
     private static final Long BUYER_ID = 100L;
     private static final UUID ORDER_KEY = UUID.randomUUID();
@@ -354,6 +357,94 @@ class CancelPaymentUseCaseTest {
                     .isInstanceOf(com.personal.marketnote.commerce.exception.OrderNotFoundException.class);
 
             verify(paymentVendorPort, never()).cancelPayment(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("분개 기록 검증")
+    class LedgerEntryRecordingTest {
+
+        @Test
+        @DisplayName("전체 취소 성공 시 역분개가 기록된다")
+        void shouldRecordReverseLedgerEntryOnFullCancel() {
+            Payment payment = createSuccessPayment(1L, ORDER_KEY, 50000L, "tno_123");
+            PspPaymentEvent event = createCompleteEvent(ORDER_KEY_STR, "tno_123", 50000L);
+            CancelPaymentCommand command = createFullCancelCommand(ORDER_KEY_STR);
+            PaymentCancelVendorResult vendorResult = createSuccessVendorResult();
+
+            when(findPaymentPort.findByOrderKey(ORDER_KEY)).thenReturn(Optional.of(payment));
+            when(findOrderPort.findById(1L)).thenReturn(Optional.of(createOrder(1L, BUYER_ID)));
+            when(findPspPaymentEventPort.findByOrderKey(ORDER_KEY_STR)).thenReturn(Optional.of(event));
+            when(paymentVendorPort.cancelPayment(any())).thenReturn(vendorResult);
+
+            cancelPaymentService.cancel(command);
+
+            verify(recordLedgerEntryUseCase).recordPaymentCancellation(
+                    eq(1L), eq(50000L), eq("PAYMENT_CANCELLATION:1")
+            );
+        }
+
+        @Test
+        @DisplayName("부분 취소 성공 시 부분 환불 역분개가 기록된다")
+        void shouldRecordReverseLedgerEntryOnPartialCancel() {
+            Payment payment = createSuccessPayment(1L, ORDER_KEY, 50000L, "tno_123");
+            PspPaymentEvent event = createCompleteEvent(ORDER_KEY_STR, "tno_123", 50000L);
+            CancelPaymentCommand command = createPartialCancelCommand(ORDER_KEY_STR, 20000L);
+            PaymentCancelVendorResult vendorResult = createSuccessVendorResult();
+
+            when(findPaymentPort.findByOrderKey(ORDER_KEY)).thenReturn(Optional.of(payment));
+            when(findOrderPort.findById(1L)).thenReturn(Optional.of(createOrder(1L, BUYER_ID)));
+            when(findPspPaymentEventPort.findByOrderKey(ORDER_KEY_STR)).thenReturn(Optional.of(event));
+            when(paymentVendorPort.cancelPayment(any())).thenReturn(vendorResult);
+
+            cancelPaymentService.cancel(command);
+
+            verify(recordLedgerEntryUseCase).recordPaymentCancellation(
+                    eq(1L), eq(20000L), eq("PAYMENT_PARTIAL_REFUND:1:20000:0")
+            );
+        }
+
+        @Test
+        @DisplayName("이미 부분환불된 상태에서 추가 부분 취소 시 누적 환불액이 멱등성 키에 포함된다")
+        void shouldIncludeAccumulatedRefundInIdempotencyKey() {
+            Payment payment = createSuccessPayment(1L, ORDER_KEY, 50000L, "tno_123");
+            payment.markAsPartiallyRefunded(10000L);
+            PspPaymentEvent event = createCompleteEvent(ORDER_KEY_STR, "tno_123", 50000L);
+            CancelPaymentCommand command = createPartialCancelCommand(ORDER_KEY_STR, 20000L);
+            PaymentCancelVendorResult vendorResult = createSuccessVendorResult();
+
+            when(findPaymentPort.findByOrderKey(ORDER_KEY)).thenReturn(Optional.of(payment));
+            when(findOrderPort.findById(1L)).thenReturn(Optional.of(createOrder(1L, BUYER_ID)));
+            when(findPspPaymentEventPort.findByOrderKey(ORDER_KEY_STR)).thenReturn(Optional.of(event));
+            when(paymentVendorPort.cancelPayment(any())).thenReturn(vendorResult);
+
+            cancelPaymentService.cancel(command);
+
+            verify(recordLedgerEntryUseCase).recordPaymentCancellation(
+                    eq(1L), eq(20000L), eq("PAYMENT_PARTIAL_REFUND:1:20000:10000")
+            );
+        }
+
+        @Test
+        @DisplayName("역분개 실패 시에도 결제 취소는 정상 완료된다")
+        void shouldCompleteCancelEvenWhenLedgerRecordingFails() {
+            Payment payment = createSuccessPayment(1L, ORDER_KEY, 50000L, "tno_123");
+            PspPaymentEvent event = createCompleteEvent(ORDER_KEY_STR, "tno_123", 50000L);
+            CancelPaymentCommand command = createFullCancelCommand(ORDER_KEY_STR);
+            PaymentCancelVendorResult vendorResult = createSuccessVendorResult();
+
+            when(findPaymentPort.findByOrderKey(ORDER_KEY)).thenReturn(Optional.of(payment));
+            when(findOrderPort.findById(1L)).thenReturn(Optional.of(createOrder(1L, BUYER_ID)));
+            when(findPspPaymentEventPort.findByOrderKey(ORDER_KEY_STR)).thenReturn(Optional.of(event));
+            when(paymentVendorPort.cancelPayment(any())).thenReturn(vendorResult);
+            doThrow(new RuntimeException("분개 실패")).when(recordLedgerEntryUseCase)
+                    .recordPaymentCancellation(anyLong(), anyLong(), anyString());
+
+            cancelPaymentService.cancel(command);
+
+            verify(updatePaymentPort).update(any());
+            verify(updatePspPaymentEventPort).update(any());
+            verify(changeOrderStatusUseCase).changeOrderStatus(any());
         }
     }
 


### PR DESCRIPTION
## partially addresses #216
## resolves #894

## Task
- [x] RecordLedgerEntryUseCase에 recordPaymentCancellation() 메서드 추가
- [x] RecordLedgerEntryService에 역분개 구현 (DEBIT 미지급금_판매자 / CREDIT 매출채권_PG)
- [x] CancelPaymentService에서 KCP 취소 성공 후 역분개 호출
- [x] 전체 취소 멱등성 키: PAYMENT_CANCELLATION:{orderId}
- [x] 부분 환불 멱등성 키: PAYMENT_PARTIAL_REFUND:{orderId}:{cancelAmount}:{alreadyRefunded}
- [x] 분개 실패 시에도 결제 취소는 정상 완료 (fault isolation)
- [x] RecordLedgerEntryUseCaseTest에 역분개 테스트 5개 추가
- [x] CancelPaymentUseCaseTest에 분개 호출 검증 테스트 4개 추가