### PR TITLE
[#216][#899] feat: 정산 실행 기능 추가

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/settlement/PaymentAllocationPersistenceAdapter.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/settlement/PaymentAllocationPersistenceAdapter.java
@@ -1,9 +1,12 @@
 package com.personal.marketnote.commerce.adapter.out.persistence.settlement;
 
 import com.personal.marketnote.commerce.adapter.out.persistence.settlement.entity.PaymentAllocationJpaEntity;
+import com.personal.marketnote.commerce.adapter.out.persistence.settlement.mapper.PaymentAllocationEntityToDomainMapper;
 import com.personal.marketnote.commerce.adapter.out.persistence.settlement.repository.PaymentAllocationJpaRepository;
 import com.personal.marketnote.commerce.domain.settlement.PaymentAllocation;
+import com.personal.marketnote.commerce.port.out.settlement.FindPaymentAllocationPort;
 import com.personal.marketnote.commerce.port.out.settlement.SavePaymentAllocationPort;
+import com.personal.marketnote.commerce.port.out.settlement.UpdatePaymentAllocationPort;
 import com.personal.marketnote.common.adapter.out.PersistenceAdapter;
 import lombok.RequiredArgsConstructor;
 
@@ -11,7 +14,8 @@ import java.util.List;
 
 @PersistenceAdapter
 @RequiredArgsConstructor
-public class PaymentAllocationPersistenceAdapter implements SavePaymentAllocationPort {
+public class PaymentAllocationPersistenceAdapter
+        implements SavePaymentAllocationPort, FindPaymentAllocationPort, UpdatePaymentAllocationPort {
     private final PaymentAllocationJpaRepository paymentAllocationJpaRepository;
 
     @Override
@@ -20,5 +24,17 @@ public class PaymentAllocationPersistenceAdapter implements SavePaymentAllocatio
                 .map(PaymentAllocationJpaEntity::from)
                 .toList();
         paymentAllocationJpaRepository.saveAll(entities);
+    }
+
+    @Override
+    public List<PaymentAllocation> findUnsettledAllocations(Integer year, Integer month) {
+        return paymentAllocationJpaRepository.findAllUnsettledByPeriod(year, month).stream()
+                .map(PaymentAllocationEntityToDomainMapper::toDomain)
+                .toList();
+    }
+
+    @Override
+    public void assignSettlement(List<Long> allocationIds, Long settlementId) {
+        paymentAllocationJpaRepository.bulkAssignSettlement(allocationIds, settlementId);
     }
 }

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/settlement/SettlementPersistenceAdapter.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/settlement/SettlementPersistenceAdapter.java
@@ -6,6 +6,7 @@ import com.personal.marketnote.commerce.adapter.out.persistence.settlement.repos
 import com.personal.marketnote.commerce.domain.settlement.Settlement;
 import com.personal.marketnote.commerce.port.out.settlement.FindSettlementPort;
 import com.personal.marketnote.commerce.port.out.settlement.SaveSettlementPort;
+import com.personal.marketnote.commerce.port.out.settlement.UpdateSettlementPort;
 import com.personal.marketnote.common.adapter.out.PersistenceAdapter;
 import lombok.RequiredArgsConstructor;
 
@@ -14,7 +15,7 @@ import java.util.Optional;
 
 @PersistenceAdapter
 @RequiredArgsConstructor
-public class SettlementPersistenceAdapter implements SaveSettlementPort, FindSettlementPort {
+public class SettlementPersistenceAdapter implements SaveSettlementPort, FindSettlementPort, UpdateSettlementPort {
     private final SettlementJpaRepository settlementJpaRepository;
 
     @Override
@@ -46,5 +47,12 @@ public class SettlementPersistenceAdapter implements SaveSettlementPort, FindSet
     @Override
     public boolean existsBySellerIdAndYearAndMonth(Long sellerId, Integer year, Integer month) {
         return settlementJpaRepository.existsBySellerIdAndYearAndMonth(sellerId, year, month);
+    }
+
+    @Override
+    public Settlement update(Settlement settlement) {
+        SettlementJpaEntity entity = SettlementJpaEntity.from(settlement);
+        SettlementJpaEntity updated = settlementJpaRepository.save(entity);
+        return SettlementEntityToDomainMapper.toDomain(updated);
     }
 }

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/settlement/entity/SettlementJpaEntity.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/settlement/entity/SettlementJpaEntity.java
@@ -74,6 +74,8 @@ public class SettlementJpaEntity {
                 .sellerPayoutAmount(settlement.getSellerPayoutAmount())
                 .status(settlement.getStatus())
                 .version(settlement.getVersion())
+                .createdAt(settlement.getCreatedAt())
+                .modifiedAt(settlement.getModifiedAt())
                 .build();
     }
 }

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/settlement/repository/PaymentAllocationJpaRepository.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/settlement/repository/PaymentAllocationJpaRepository.java
@@ -2,7 +2,20 @@ package com.personal.marketnote.commerce.adapter.out.persistence.settlement.repo
 
 import com.personal.marketnote.commerce.adapter.out.persistence.settlement.entity.PaymentAllocationJpaEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface PaymentAllocationJpaRepository extends JpaRepository<PaymentAllocationJpaEntity, Long> {
     boolean existsByIdempotencyKey(String idempotencyKey);
+
+    @Query("SELECT pa FROM PaymentAllocationJpaEntity pa WHERE pa.settlementId IS NULL " +
+            "AND YEAR(pa.createdAt) = :year AND MONTH(pa.createdAt) = :month")
+    List<PaymentAllocationJpaEntity> findAllUnsettledByPeriod(@Param("year") Integer year, @Param("month") Integer month);
+
+    @Modifying
+    @Query("UPDATE PaymentAllocationJpaEntity pa SET pa.settlementId = :settlementId WHERE pa.id IN :ids")
+    int bulkAssignSettlement(@Param("ids") List<Long> ids, @Param("settlementId") Long settlementId);
 }

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/exception/NoUnsettledAllocationException.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/exception/NoUnsettledAllocationException.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.commerce.exception;
+
+public class NoUnsettledAllocationException extends IllegalStateException {
+    public NoUnsettledAllocationException() {
+        super("미정산 배분이 존재하지 않습니다.");
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/exception/SettlementAlreadyExistsException.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/exception/SettlementAlreadyExistsException.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.commerce.exception;
+
+public class SettlementAlreadyExistsException extends IllegalStateException {
+    public SettlementAlreadyExistsException(Long sellerId, Integer year, Integer month) {
+        super("이미 해당 기간의 정산이 존재합니다. sellerId=" + sellerId + ", year=" + year + ", month=" + month);
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/exception/SettlementNotFoundException.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/exception/SettlementNotFoundException.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.commerce.exception;
+
+import jakarta.persistence.EntityNotFoundException;
+
+public class SettlementNotFoundException extends EntityNotFoundException {
+    public SettlementNotFoundException(Long id) {
+        super("정산을 찾을 수 없습니다. ID: " + id);
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/command/settlement/ExecuteSettlementCommand.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/command/settlement/ExecuteSettlementCommand.java
@@ -1,0 +1,12 @@
+package com.personal.marketnote.commerce.port.in.command.settlement;
+
+import lombok.Builder;
+
+@Builder
+public record ExecuteSettlementCommand(
+        Integer year,
+        Integer month,
+        Integer pgFeeRate,
+        Integer platformFeeRate
+) {
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/ledger/RecordLedgerEntryUseCase.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/ledger/RecordLedgerEntryUseCase.java
@@ -8,4 +8,8 @@ public interface RecordLedgerEntryUseCase {
     void recordPaymentApproval(Long orderId, long paymentAmount);
 
     void recordPaymentCancellation(Long orderId, long cancelAmount, String idempotencyKey);
+
+    void recordPgSettlement(Long settlementId, long totalAmount, long pgFeeAmount);
+
+    void recordSellerSettlement(Long settlementId, long totalAmount, long sellerPayoutAmount, long platformFeeAmount);
 }

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/settlement/ExecuteSettlementUseCase.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/settlement/ExecuteSettlementUseCase.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.commerce.port.in.usecase.settlement;
+
+import com.personal.marketnote.commerce.port.in.command.settlement.ExecuteSettlementCommand;
+
+public interface ExecuteSettlementUseCase {
+    void executeSettlement(ExecuteSettlementCommand command);
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/settlement/FindPaymentAllocationPort.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/settlement/FindPaymentAllocationPort.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.commerce.port.out.settlement;
+
+import com.personal.marketnote.commerce.domain.settlement.PaymentAllocation;
+
+import java.util.List;
+
+public interface FindPaymentAllocationPort {
+    List<PaymentAllocation> findUnsettledAllocations(Integer year, Integer month);
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/settlement/UpdatePaymentAllocationPort.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/settlement/UpdatePaymentAllocationPort.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.commerce.port.out.settlement;
+
+import java.util.List;
+
+public interface UpdatePaymentAllocationPort {
+    void assignSettlement(List<Long> allocationIds, Long settlementId);
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/settlement/UpdateSettlementPort.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/settlement/UpdateSettlementPort.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.commerce.port.out.settlement;
+
+import com.personal.marketnote.commerce.domain.settlement.Settlement;
+
+public interface UpdateSettlementPort {
+    Settlement update(Settlement settlement);
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/ledger/RecordLedgerEntryService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/ledger/RecordLedgerEntryService.java
@@ -27,6 +27,9 @@ import static org.springframework.transaction.annotation.Isolation.READ_COMMITTE
 public class RecordLedgerEntryService implements RecordLedgerEntryUseCase {
     private static final String ACCOUNT_PG_RECEIVABLE = "매출채권_PG";
     private static final String ACCOUNT_SELLER_PAYABLE = "미지급금_판매자";
+    private static final String ACCOUNT_CASH = "보통예금";
+    private static final String ACCOUNT_PG_FEE = "PG수수료비용";
+    private static final String ACCOUNT_PLATFORM_FEE_REVENUE = "플랫폼수수료수익";
 
     private final FindAccountPort findAccountPort;
     private final SaveLedgerTransactionPort saveLedgerTransactionPort;
@@ -111,6 +114,95 @@ public class RecordLedgerEntryService implements RecordLedgerEntryUseCase {
                                 .transactionType(TransactionType.CREDIT)
                                 .build()
                 ))
+                .build();
+
+        record(command);
+    }
+
+    @Override
+    @Transactional(propagation = Propagation.REQUIRES_NEW, isolation = READ_COMMITTED)
+    public void recordPgSettlement(Long settlementId, long totalAmount, long pgFeeAmount) {
+        Account cashAccount = findAccountPort.findByName(ACCOUNT_CASH)
+                .orElseThrow(() -> new AccountNotFoundException(ACCOUNT_CASH));
+        Account pgFeeAccount = findAccountPort.findByName(ACCOUNT_PG_FEE)
+                .orElseThrow(() -> new AccountNotFoundException(ACCOUNT_PG_FEE));
+        Account pgReceivable = findAccountPort.findByName(ACCOUNT_PG_RECEIVABLE)
+                .orElseThrow(() -> new AccountNotFoundException(ACCOUNT_PG_RECEIVABLE));
+
+        List<RecordLedgerEntryCommand.EntryLine> entries = new ArrayList<>();
+
+        long cashAmount = totalAmount - pgFeeAmount;
+        entries.add(RecordLedgerEntryCommand.EntryLine.builder()
+                .accountId(cashAccount.getId())
+                .amount(cashAmount)
+                .transactionType(TransactionType.DEBIT)
+                .build());
+
+        if (pgFeeAmount > 0) {
+            entries.add(RecordLedgerEntryCommand.EntryLine.builder()
+                    .accountId(pgFeeAccount.getId())
+                    .amount(pgFeeAmount)
+                    .transactionType(TransactionType.DEBIT)
+                    .build());
+        }
+
+        entries.add(RecordLedgerEntryCommand.EntryLine.builder()
+                .accountId(pgReceivable.getId())
+                .amount(totalAmount)
+                .transactionType(TransactionType.CREDIT)
+                .build());
+
+        RecordLedgerEntryCommand command = RecordLedgerEntryCommand.builder()
+                .transactionType(LedgerTransactionType.PG_SETTLEMENT)
+                .targetType("SETTLEMENT")
+                .targetId(settlementId)
+                .description("PG 정산 입금 분개")
+                .idempotencyKey("PG_SETTLEMENT:" + settlementId)
+                .entries(entries)
+                .build();
+
+        record(command);
+    }
+
+    @Override
+    @Transactional(propagation = Propagation.REQUIRES_NEW, isolation = READ_COMMITTED)
+    public void recordSellerSettlement(Long settlementId, long totalAmount, long sellerPayoutAmount, long platformFeeAmount) {
+        Account sellerPayable = findAccountPort.findByName(ACCOUNT_SELLER_PAYABLE)
+                .orElseThrow(() -> new AccountNotFoundException(ACCOUNT_SELLER_PAYABLE));
+        Account cashAccount = findAccountPort.findByName(ACCOUNT_CASH)
+                .orElseThrow(() -> new AccountNotFoundException(ACCOUNT_CASH));
+        Account platformFeeAccount = findAccountPort.findByName(ACCOUNT_PLATFORM_FEE_REVENUE)
+                .orElseThrow(() -> new AccountNotFoundException(ACCOUNT_PLATFORM_FEE_REVENUE));
+
+        List<RecordLedgerEntryCommand.EntryLine> entries = new ArrayList<>();
+
+        entries.add(RecordLedgerEntryCommand.EntryLine.builder()
+                .accountId(sellerPayable.getId())
+                .amount(totalAmount)
+                .transactionType(TransactionType.DEBIT)
+                .build());
+
+        entries.add(RecordLedgerEntryCommand.EntryLine.builder()
+                .accountId(cashAccount.getId())
+                .amount(sellerPayoutAmount)
+                .transactionType(TransactionType.CREDIT)
+                .build());
+
+        if (platformFeeAmount > 0) {
+            entries.add(RecordLedgerEntryCommand.EntryLine.builder()
+                    .accountId(platformFeeAccount.getId())
+                    .amount(platformFeeAmount)
+                    .transactionType(TransactionType.CREDIT)
+                    .build());
+        }
+
+        RecordLedgerEntryCommand command = RecordLedgerEntryCommand.builder()
+                .transactionType(LedgerTransactionType.SELLER_SETTLEMENT)
+                .targetType("SETTLEMENT")
+                .targetId(settlementId)
+                .description("판매자 정산 분개")
+                .idempotencyKey("SELLER_SETTLEMENT:" + settlementId)
+                .entries(entries)
                 .build();
 
         record(command);

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/settlement/ExecuteSettlementService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/settlement/ExecuteSettlementService.java
@@ -1,0 +1,119 @@
+package com.personal.marketnote.commerce.service.settlement;
+
+import com.personal.marketnote.commerce.domain.settlement.PaymentAllocation;
+import com.personal.marketnote.commerce.domain.settlement.Settlement;
+import com.personal.marketnote.commerce.domain.settlement.SettlementCreateState;
+import com.personal.marketnote.commerce.exception.NoUnsettledAllocationException;
+import com.personal.marketnote.commerce.exception.SettlementAlreadyExistsException;
+import com.personal.marketnote.commerce.port.in.command.settlement.ExecuteSettlementCommand;
+import com.personal.marketnote.commerce.port.in.usecase.ledger.RecordLedgerEntryUseCase;
+import com.personal.marketnote.commerce.port.in.usecase.settlement.ExecuteSettlementUseCase;
+import com.personal.marketnote.commerce.port.out.settlement.*;
+import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.common.utility.FormatValidator;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@UseCase
+@RequiredArgsConstructor
+@Slf4j
+public class ExecuteSettlementService implements ExecuteSettlementUseCase {
+    private static final int BASIS_POINT_DENOMINATOR = 10000;
+
+    private final FindPaymentAllocationPort findPaymentAllocationPort;
+    private final FindSettlementPort findSettlementPort;
+    private final SaveSettlementPort saveSettlementPort;
+    private final UpdateSettlementPort updateSettlementPort;
+    private final UpdatePaymentAllocationPort updatePaymentAllocationPort;
+    private final RecordLedgerEntryUseCase recordLedgerEntryUseCase;
+
+    @Override
+    @Transactional(isolation = READ_COMMITTED)
+    public void executeSettlement(ExecuteSettlementCommand command) {
+        validateFeeRates(command);
+
+        List<PaymentAllocation> unsettledAllocations = findPaymentAllocationPort.findUnsettledAllocations(
+                command.year(), command.month());
+
+        if (unsettledAllocations.isEmpty()) {
+            throw new NoUnsettledAllocationException();
+        }
+
+        Map<Long, List<PaymentAllocation>> allocationsBySeller = unsettledAllocations.stream()
+                .collect(Collectors.groupingBy(PaymentAllocation::getSellerId));
+
+        for (Map.Entry<Long, List<PaymentAllocation>> entry : allocationsBySeller.entrySet()) {
+            Long sellerId = entry.getKey();
+            List<PaymentAllocation> sellerAllocations = entry.getValue();
+
+            processSellerSettlement(command, sellerId, sellerAllocations);
+        }
+    }
+
+    private void validateFeeRates(ExecuteSettlementCommand command) {
+        if (FormatValidator.hasNoValue(command.pgFeeRate()) || command.pgFeeRate() < 0) {
+            throw new IllegalArgumentException("PG 수수료율은 0 이상이어야 합니다. pgFeeRate=" + command.pgFeeRate());
+        }
+        if (FormatValidator.hasNoValue(command.platformFeeRate()) || command.platformFeeRate() < 0) {
+            throw new IllegalArgumentException("플랫폼 수수료율은 0 이상이어야 합니다. platformFeeRate=" + command.platformFeeRate());
+        }
+        if (command.pgFeeRate() + command.platformFeeRate() > BASIS_POINT_DENOMINATOR) {
+            throw new IllegalArgumentException("수수료율 합계가 100%를 초과합니다. pgFeeRate=" + command.pgFeeRate()
+                    + ", platformFeeRate=" + command.platformFeeRate());
+        }
+    }
+
+    private void processSellerSettlement(ExecuteSettlementCommand command, Long sellerId,
+                                          List<PaymentAllocation> sellerAllocations) {
+        Integer year = command.year();
+        Integer month = command.month();
+
+        if (findSettlementPort.existsBySellerIdAndYearAndMonth(sellerId, year, month)) {
+            throw new SettlementAlreadyExistsException(sellerId, year, month);
+        }
+
+        long totalAllocatedAmount = sellerAllocations.stream()
+                .mapToLong(PaymentAllocation::getAllocatedAmount)
+                .sum();
+
+        long pgFeeAmount = Math.multiplyExact(totalAllocatedAmount, command.pgFeeRate()) / BASIS_POINT_DENOMINATOR;
+        long platformFeeAmount = Math.multiplyExact(totalAllocatedAmount, command.platformFeeRate()) / BASIS_POINT_DENOMINATOR;
+        long sellerPayoutAmount = totalAllocatedAmount - pgFeeAmount - platformFeeAmount;
+
+        Settlement settlement = Settlement.from(SettlementCreateState.builder()
+                .sellerId(sellerId)
+                .year(year)
+                .month(month)
+                .totalAllocatedAmount(totalAllocatedAmount)
+                .pgFeeAmount(pgFeeAmount)
+                .platformFeeAmount(platformFeeAmount)
+                .sellerPayoutAmount(sellerPayoutAmount)
+                .build());
+
+        Settlement savedSettlement = saveSettlementPort.save(settlement);
+        Long settlementId = savedSettlement.getId();
+
+        List<Long> allocationIds = sellerAllocations.stream()
+                .map(PaymentAllocation::getId)
+                .toList();
+        updatePaymentAllocationPort.assignSettlement(allocationIds, settlementId);
+
+        recordLedgerEntryUseCase.recordPgSettlement(settlementId, totalAllocatedAmount, pgFeeAmount);
+
+        long sellerSettlementDebit = sellerPayoutAmount + platformFeeAmount;
+        recordLedgerEntryUseCase.recordSellerSettlement(settlementId, sellerSettlementDebit, sellerPayoutAmount, platformFeeAmount);
+
+        savedSettlement.complete();
+        updateSettlementPort.update(savedSettlement);
+
+        log.info("정산 완료 - settlementId: {}, sellerId: {}, year: {}, month: {}, total: {}, pgFee: {}, platformFee: {}, sellerPayout: {}",
+                settlementId, sellerId, year, month, totalAllocatedAmount, pgFeeAmount, platformFeeAmount, sellerPayoutAmount);
+    }
+}

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/ledger/RecordLedgerEntryUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/ledger/RecordLedgerEntryUseCaseTest.java
@@ -617,4 +617,261 @@ class RecordLedgerEntryUseCaseTest {
             verify(saveLedgerTransactionPort, never()).save(any());
         }
     }
+
+    @Nested
+    @DisplayName("PG 정산 입금 분개 편의 메서드")
+    class RecordPgSettlementTest {
+
+        @Test
+        @DisplayName("PG 정산 입금 분개 시 보통예금 차변, PG수수료비용 차변, 매출채권_PG 대변으로 기록된다")
+        void shouldRecordPgSettlementWithCorrectAccounts() {
+            // given
+            Account cashAccount = createActiveAccount(2L, "보통예금", AccountType.ASSET);
+            Account pgFeeAccount = createActiveAccount(5L, "PG수수료비용", AccountType.EXPENSE);
+            Account pgReceivable = createActiveAccount(1L, "매출채권_PG", AccountType.ASSET);
+
+            when(findAccountPort.findByName("보통예금")).thenReturn(Optional.of(cashAccount));
+            when(findAccountPort.findByName("PG수수료비용")).thenReturn(Optional.of(pgFeeAccount));
+            when(findAccountPort.findByName("매출채권_PG")).thenReturn(Optional.of(pgReceivable));
+            when(saveLedgerTransactionPort.existsByIdempotencyKey(anyString())).thenReturn(false);
+            when(findAccountPort.findById(2L)).thenReturn(Optional.of(cashAccount));
+            when(findAccountPort.findById(5L)).thenReturn(Optional.of(pgFeeAccount));
+            when(findAccountPort.findById(1L)).thenReturn(Optional.of(pgReceivable));
+            when(saveLedgerTransactionPort.save(any())).thenAnswer(invocation -> {
+                LedgerTransaction tx = invocation.getArgument(0);
+                return LedgerTransaction.from(LedgerTransactionSnapshotState.builder()
+                        .id(400L)
+                        .transactionType(tx.getTransactionType())
+                        .targetType(tx.getTargetType())
+                        .targetId(tx.getTargetId())
+                        .description(tx.getDescription())
+                        .idempotencyKey(tx.getIdempotencyKey())
+                        .build());
+            });
+
+            // when
+            recordLedgerEntryService.recordPgSettlement(1L, 10000L, 300L);
+
+            // then
+            verify(saveLedgerTransactionPort).save(argThat(tx ->
+                    tx.getTransactionType() == LedgerTransactionType.PG_SETTLEMENT
+                            && "PG_SETTLEMENT:1".equals(tx.getIdempotencyKey())
+                            && "SETTLEMENT".equals(tx.getTargetType())
+            ));
+
+            ArgumentCaptor<List<LedgerEntry>> entriesCaptor = ArgumentCaptor.forClass(List.class);
+            verify(saveLedgerEntryPort).saveAll(entriesCaptor.capture());
+
+            List<LedgerEntry> savedEntries = entriesCaptor.getValue();
+            assertThat(savedEntries).hasSize(3);
+
+            // DEBIT 보통예금 = 10000 - 300 = 9700
+            LedgerEntry cashDebit = savedEntries.stream()
+                    .filter(e -> e.getTransactionType().isDebit() && e.getAccountId().equals(2L))
+                    .findFirst().orElseThrow();
+            assertThat(cashDebit.getAmount()).isEqualTo(9700L);
+
+            // DEBIT PG수수료비용 = 300
+            LedgerEntry pgFeeDebit = savedEntries.stream()
+                    .filter(e -> e.getTransactionType().isDebit() && e.getAccountId().equals(5L))
+                    .findFirst().orElseThrow();
+            assertThat(pgFeeDebit.getAmount()).isEqualTo(300L);
+
+            // CREDIT 매출채권_PG = 10000
+            LedgerEntry pgReceivableCredit = savedEntries.stream()
+                    .filter(e -> e.getTransactionType().isCredit())
+                    .findFirst().orElseThrow();
+            assertThat(pgReceivableCredit.getAccountId()).isEqualTo(1L);
+            assertThat(pgReceivableCredit.getAmount()).isEqualTo(10000L);
+        }
+
+        @Test
+        @DisplayName("PG 수수료 0일 때 보통예금 차변 = totalAmount, PG수수료비용 Entry 생략")
+        void shouldSkipPgFeeEntryWhenZero() {
+            // given
+            Account cashAccount = createActiveAccount(2L, "보통예금", AccountType.ASSET);
+            Account pgFeeAccount = createActiveAccount(5L, "PG수수료비용", AccountType.EXPENSE);
+            Account pgReceivable = createActiveAccount(1L, "매출채권_PG", AccountType.ASSET);
+
+            when(findAccountPort.findByName("보통예금")).thenReturn(Optional.of(cashAccount));
+            when(findAccountPort.findByName("PG수수료비용")).thenReturn(Optional.of(pgFeeAccount));
+            when(findAccountPort.findByName("매출채권_PG")).thenReturn(Optional.of(pgReceivable));
+            when(saveLedgerTransactionPort.existsByIdempotencyKey(anyString())).thenReturn(false);
+            when(findAccountPort.findById(2L)).thenReturn(Optional.of(cashAccount));
+            when(findAccountPort.findById(1L)).thenReturn(Optional.of(pgReceivable));
+            when(saveLedgerTransactionPort.save(any())).thenAnswer(invocation -> {
+                LedgerTransaction tx = invocation.getArgument(0);
+                return LedgerTransaction.from(LedgerTransactionSnapshotState.builder()
+                        .id(401L)
+                        .transactionType(tx.getTransactionType())
+                        .targetType(tx.getTargetType())
+                        .targetId(tx.getTargetId())
+                        .description(tx.getDescription())
+                        .idempotencyKey(tx.getIdempotencyKey())
+                        .build());
+            });
+
+            // when
+            recordLedgerEntryService.recordPgSettlement(1L, 10000L, 0L);
+
+            // then
+            ArgumentCaptor<List<LedgerEntry>> entriesCaptor = ArgumentCaptor.forClass(List.class);
+            verify(saveLedgerEntryPort).saveAll(entriesCaptor.capture());
+
+            List<LedgerEntry> savedEntries = entriesCaptor.getValue();
+            assertThat(savedEntries).hasSize(2); // PG수수료비용 Entry 생략
+
+            LedgerEntry cashDebit = savedEntries.stream()
+                    .filter(e -> e.getTransactionType().isDebit())
+                    .findFirst().orElseThrow();
+            assertThat(cashDebit.getAccountId()).isEqualTo(2L);
+            assertThat(cashDebit.getAmount()).isEqualTo(10000L);
+        }
+
+        @Test
+        @DisplayName("보통예금 계정 미존재 시 AccountNotFoundException이 발생한다")
+        void shouldThrowWhenCashAccountNotFound() {
+            // given
+            when(findAccountPort.findByName("보통예금")).thenReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> recordLedgerEntryService.recordPgSettlement(1L, 10000L, 300L))
+                    .isInstanceOf(AccountNotFoundException.class);
+
+            verify(saveLedgerTransactionPort, never()).save(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("판매자 정산 분개 편의 메서드")
+    class RecordSellerSettlementTest {
+
+        @Test
+        @DisplayName("판매자 정산 분개 시 미지급금_판매자 차변, 보통예금 대변, 플랫폼수수료수익 대변으로 기록된다")
+        void shouldRecordSellerSettlementWithCorrectAccounts() {
+            // given
+            Account sellerPayable = createActiveAccount(3L, "미지급금_판매자", AccountType.LIABILITY);
+            Account cashAccount = createActiveAccount(2L, "보통예금", AccountType.ASSET);
+            Account platformFeeAccount = createActiveAccount(4L, "플랫폼수수료수익", AccountType.REVENUE);
+
+            when(findAccountPort.findByName("미지급금_판매자")).thenReturn(Optional.of(sellerPayable));
+            when(findAccountPort.findByName("보통예금")).thenReturn(Optional.of(cashAccount));
+            when(findAccountPort.findByName("플랫폼수수료수익")).thenReturn(Optional.of(platformFeeAccount));
+            when(saveLedgerTransactionPort.existsByIdempotencyKey(anyString())).thenReturn(false);
+            when(findAccountPort.findById(3L)).thenReturn(Optional.of(sellerPayable));
+            when(findAccountPort.findById(2L)).thenReturn(Optional.of(cashAccount));
+            when(findAccountPort.findById(4L)).thenReturn(Optional.of(platformFeeAccount));
+            when(saveLedgerTransactionPort.save(any())).thenAnswer(invocation -> {
+                LedgerTransaction tx = invocation.getArgument(0);
+                return LedgerTransaction.from(LedgerTransactionSnapshotState.builder()
+                        .id(500L)
+                        .transactionType(tx.getTransactionType())
+                        .targetType(tx.getTargetType())
+                        .targetId(tx.getTargetId())
+                        .description(tx.getDescription())
+                        .idempotencyKey(tx.getIdempotencyKey())
+                        .build());
+            });
+
+            // when
+            recordLedgerEntryService.recordSellerSettlement(1L, 9700L, 9200L, 500L); // 9700 = 9200 + 500
+
+            // then
+            verify(saveLedgerTransactionPort).save(argThat(tx ->
+                    tx.getTransactionType() == LedgerTransactionType.SELLER_SETTLEMENT
+                            && "SELLER_SETTLEMENT:1".equals(tx.getIdempotencyKey())
+                            && "SETTLEMENT".equals(tx.getTargetType())
+            ));
+
+            ArgumentCaptor<List<LedgerEntry>> entriesCaptor = ArgumentCaptor.forClass(List.class);
+            verify(saveLedgerEntryPort).saveAll(entriesCaptor.capture());
+
+            List<LedgerEntry> savedEntries = entriesCaptor.getValue();
+            assertThat(savedEntries).hasSize(3);
+
+            // 판매자 정산 분개: DEBIT 미지급금(sellerPayout+platformFee) = CREDIT 보통예금(sellerPayout) + CREDIT 플랫폼수수료수익(platformFee)
+            LedgerEntry sellerDebit = savedEntries.stream()
+                    .filter(e -> e.getTransactionType().isDebit())
+                    .findFirst().orElseThrow();
+            assertThat(sellerDebit.getAccountId()).isEqualTo(3L);
+            assertThat(sellerDebit.getAmount()).isEqualTo(9700L); // sellerPayout + platformFee
+
+            List<LedgerEntry> credits = savedEntries.stream()
+                    .filter(e -> e.getTransactionType().isCredit())
+                    .toList();
+            assertThat(credits).hasSize(2);
+
+            LedgerEntry cashCredit = credits.stream()
+                    .filter(e -> e.getAccountId().equals(2L))
+                    .findFirst().orElseThrow();
+            assertThat(cashCredit.getAmount()).isEqualTo(9200L);
+
+            LedgerEntry platformFeeCredit = credits.stream()
+                    .filter(e -> e.getAccountId().equals(4L))
+                    .findFirst().orElseThrow();
+            assertThat(platformFeeCredit.getAmount()).isEqualTo(500L);
+        }
+
+        @Test
+        @DisplayName("플랫폼 수수료 0일 때 플랫폼수수료수익 Entry 생략")
+        void shouldSkipPlatformFeeEntryWhenZero() {
+            // given
+            Account sellerPayable = createActiveAccount(3L, "미지급금_판매자", AccountType.LIABILITY);
+            Account cashAccount = createActiveAccount(2L, "보통예금", AccountType.ASSET);
+            Account platformFeeAccount = createActiveAccount(4L, "플랫폼수수료수익", AccountType.REVENUE);
+
+            when(findAccountPort.findByName("미지급금_판매자")).thenReturn(Optional.of(sellerPayable));
+            when(findAccountPort.findByName("보통예금")).thenReturn(Optional.of(cashAccount));
+            when(findAccountPort.findByName("플랫폼수수료수익")).thenReturn(Optional.of(platformFeeAccount));
+            when(saveLedgerTransactionPort.existsByIdempotencyKey(anyString())).thenReturn(false);
+            when(findAccountPort.findById(3L)).thenReturn(Optional.of(sellerPayable));
+            when(findAccountPort.findById(2L)).thenReturn(Optional.of(cashAccount));
+            when(saveLedgerTransactionPort.save(any())).thenAnswer(invocation -> {
+                LedgerTransaction tx = invocation.getArgument(0);
+                return LedgerTransaction.from(LedgerTransactionSnapshotState.builder()
+                        .id(501L)
+                        .transactionType(tx.getTransactionType())
+                        .targetType(tx.getTargetType())
+                        .targetId(tx.getTargetId())
+                        .description(tx.getDescription())
+                        .idempotencyKey(tx.getIdempotencyKey())
+                        .build());
+            });
+
+            // when — totalAmount = sellerPayout + platformFee = 9500 + 0 = 9500
+            recordLedgerEntryService.recordSellerSettlement(1L, 9500L, 9500L, 0L);
+
+            // then
+            ArgumentCaptor<List<LedgerEntry>> entriesCaptor = ArgumentCaptor.forClass(List.class);
+            verify(saveLedgerEntryPort).saveAll(entriesCaptor.capture());
+
+            List<LedgerEntry> savedEntries = entriesCaptor.getValue();
+            assertThat(savedEntries).hasSize(2); // 플랫폼수수료수익 Entry 생략
+
+            LedgerEntry sellerDebit = savedEntries.stream()
+                    .filter(e -> e.getTransactionType().isDebit())
+                    .findFirst().orElseThrow();
+            assertThat(sellerDebit.getAccountId()).isEqualTo(3L);
+            assertThat(sellerDebit.getAmount()).isEqualTo(9500L);
+
+            LedgerEntry cashCredit = savedEntries.stream()
+                    .filter(e -> e.getTransactionType().isCredit())
+                    .findFirst().orElseThrow();
+            assertThat(cashCredit.getAccountId()).isEqualTo(2L);
+            assertThat(cashCredit.getAmount()).isEqualTo(9500L);
+        }
+
+        @Test
+        @DisplayName("미지급금_판매자 계정 미존재 시 AccountNotFoundException이 발생한다")
+        void shouldThrowWhenSellerPayableNotFound() {
+            // given
+            when(findAccountPort.findByName("미지급금_판매자")).thenReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> recordLedgerEntryService.recordSellerSettlement(1L, 9700L, 9200L, 500L))
+                    .isInstanceOf(AccountNotFoundException.class);
+
+            verify(saveLedgerTransactionPort, never()).save(any());
+        }
+    }
 }

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/settlement/ExecuteSettlementUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/settlement/ExecuteSettlementUseCaseTest.java
@@ -1,0 +1,406 @@
+package com.personal.marketnote.commerce.service.settlement;
+
+import com.personal.marketnote.commerce.domain.settlement.*;
+import com.personal.marketnote.commerce.exception.NoUnsettledAllocationException;
+import com.personal.marketnote.commerce.exception.SettlementAlreadyExistsException;
+import com.personal.marketnote.commerce.port.in.command.settlement.ExecuteSettlementCommand;
+import com.personal.marketnote.commerce.port.in.usecase.ledger.RecordLedgerEntryUseCase;
+import com.personal.marketnote.commerce.port.out.settlement.*;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ExecuteSettlementUseCase 테스트")
+class ExecuteSettlementUseCaseTest {
+
+    @InjectMocks
+    private ExecuteSettlementService executeSettlementService;
+
+    @Mock
+    private FindPaymentAllocationPort findPaymentAllocationPort;
+
+    @Mock
+    private FindSettlementPort findSettlementPort;
+
+    @Mock
+    private SaveSettlementPort saveSettlementPort;
+
+    @Mock
+    private UpdateSettlementPort updateSettlementPort;
+
+    @Mock
+    private UpdatePaymentAllocationPort updatePaymentAllocationPort;
+
+    @Mock
+    private RecordLedgerEntryUseCase recordLedgerEntryUseCase;
+
+    @Captor
+    private ArgumentCaptor<Settlement> settlementCaptor;
+
+    @Captor
+    private ArgumentCaptor<List<Long>> allocationIdsCaptor;
+
+    private PaymentAllocation createAllocation(Long id, Long sellerId, Long allocatedAmount) {
+        return PaymentAllocation.from(PaymentAllocationSnapshotState.builder()
+                .id(id)
+                .orderId(100L)
+                .sellerId(sellerId)
+                .allocatedAmount(allocatedAmount)
+                .transactionType(PaymentAllocationTransactionType.ORDER_REGISTRATION)
+                .targetType(PaymentAllocationTargetType.ORDER)
+                .idempotencyKey("TEST:" + id)
+                .createdAt(LocalDateTime.of(2026, 2, 15, 10, 0))
+                .build());
+    }
+
+    private Settlement createSavedSettlement(Long id, Long sellerId, Integer year, Integer month,
+                                              Long totalAllocatedAmount, Long pgFeeAmount,
+                                              Long platformFeeAmount, Long sellerPayoutAmount) {
+        return Settlement.from(SettlementSnapshotState.builder()
+                .id(id)
+                .sellerId(sellerId)
+                .year(year)
+                .month(month)
+                .totalAllocatedAmount(totalAllocatedAmount)
+                .pgFeeAmount(pgFeeAmount)
+                .platformFeeAmount(platformFeeAmount)
+                .sellerPayoutAmount(sellerPayoutAmount)
+                .status(SettlementStatus.PENDING)
+                .version(0L)
+                .createdAt(LocalDateTime.now())
+                .modifiedAt(LocalDateTime.now())
+                .build());
+    }
+
+    @Nested
+    @DisplayName("정상 정산 실행")
+    class SuccessfulSettlement {
+
+        @Test
+        @DisplayName("단일 판매자 정산을 정상 처리한다")
+        void shouldExecuteSettlementForSingleSeller() {
+            // given
+            PaymentAllocation allocation1 = createAllocation(1L, 10L, 5000L);
+            PaymentAllocation allocation2 = createAllocation(2L, 10L, 3000L);
+
+            when(findPaymentAllocationPort.findUnsettledAllocations(2026, 2))
+                    .thenReturn(List.of(allocation1, allocation2));
+            when(findSettlementPort.existsBySellerIdAndYearAndMonth(10L, 2026, 2))
+                    .thenReturn(false);
+            when(saveSettlementPort.save(any(Settlement.class)))
+                    .thenAnswer(invocation -> {
+                        Settlement s = invocation.getArgument(0);
+                        return createSavedSettlement(1L, s.getSellerId(), s.getYear(), s.getMonth(),
+                                s.getTotalAllocatedAmount(), s.getPgFeeAmount(),
+                                s.getPlatformFeeAmount(), s.getSellerPayoutAmount());
+                    });
+            when(updateSettlementPort.update(any(Settlement.class)))
+                    .thenAnswer(invocation -> invocation.getArgument(0));
+
+            ExecuteSettlementCommand command = ExecuteSettlementCommand.builder()
+                    .year(2026).month(2).pgFeeRate(300).platformFeeRate(500).build();
+
+            // when
+            executeSettlementService.executeSettlement(command);
+
+            // then
+            verify(saveSettlementPort).save(settlementCaptor.capture());
+            Settlement savedSettlement = settlementCaptor.getValue();
+            assertThat(savedSettlement.getSellerId()).isEqualTo(10L);
+            assertThat(savedSettlement.getTotalAllocatedAmount()).isEqualTo(8000L);
+            assertThat(savedSettlement.getPgFeeAmount()).isEqualTo(240L);      // 8000 * 300 / 10000
+            assertThat(savedSettlement.getPlatformFeeAmount()).isEqualTo(400L); // 8000 * 500 / 10000
+            assertThat(savedSettlement.getSellerPayoutAmount()).isEqualTo(7360L); // 8000 - 240 - 400
+
+            verify(updatePaymentAllocationPort).assignSettlement(allocationIdsCaptor.capture(), eq(1L));
+            assertThat(allocationIdsCaptor.getValue()).containsExactlyInAnyOrder(1L, 2L);
+
+            verify(recordLedgerEntryUseCase).recordPgSettlement(1L, 8000L, 240L);
+            verify(recordLedgerEntryUseCase).recordSellerSettlement(1L, 7760L, 7360L, 400L); // 7760 = 7360 + 400
+            verify(updateSettlementPort).update(argThat(Settlement::isCompleted));
+        }
+
+        @Test
+        @DisplayName("다중 판매자 정산 시 각각 독립 Settlement를 생성한다")
+        void shouldExecuteSettlementForMultipleSellers() {
+            // given
+            PaymentAllocation seller10Alloc = createAllocation(1L, 10L, 10000L);
+            PaymentAllocation seller20Alloc = createAllocation(2L, 20L, 20000L);
+
+            when(findPaymentAllocationPort.findUnsettledAllocations(2026, 2))
+                    .thenReturn(List.of(seller10Alloc, seller20Alloc));
+            when(findSettlementPort.existsBySellerIdAndYearAndMonth(anyLong(), eq(2026), eq(2)))
+                    .thenReturn(false);
+            when(saveSettlementPort.save(any(Settlement.class)))
+                    .thenAnswer(invocation -> {
+                        Settlement s = invocation.getArgument(0);
+                        Long id = s.getSellerId().equals(10L) ? 1L : 2L;
+                        return createSavedSettlement(id, s.getSellerId(), s.getYear(), s.getMonth(),
+                                s.getTotalAllocatedAmount(), s.getPgFeeAmount(),
+                                s.getPlatformFeeAmount(), s.getSellerPayoutAmount());
+                    });
+            when(updateSettlementPort.update(any(Settlement.class)))
+                    .thenAnswer(invocation -> invocation.getArgument(0));
+
+            ExecuteSettlementCommand command = ExecuteSettlementCommand.builder()
+                    .year(2026).month(2).pgFeeRate(300).platformFeeRate(500).build();
+
+            // when
+            executeSettlementService.executeSettlement(command);
+
+            // then
+            verify(saveSettlementPort, times(2)).save(any(Settlement.class));
+            verify(recordLedgerEntryUseCase, times(2)).recordPgSettlement(anyLong(), anyLong(), anyLong());
+            verify(recordLedgerEntryUseCase, times(2)).recordSellerSettlement(anyLong(), anyLong(), anyLong(), anyLong());
+            verify(updateSettlementPort, times(2)).update(argThat(Settlement::isCompleted));
+        }
+
+        @Test
+        @DisplayName("PG 수수료가 0인 경우 정상 처리한다")
+        void shouldHandleZeroPgFee() {
+            // given
+            PaymentAllocation allocation = createAllocation(1L, 10L, 10000L);
+
+            when(findPaymentAllocationPort.findUnsettledAllocations(2026, 2))
+                    .thenReturn(List.of(allocation));
+            when(findSettlementPort.existsBySellerIdAndYearAndMonth(10L, 2026, 2))
+                    .thenReturn(false);
+            when(saveSettlementPort.save(any(Settlement.class)))
+                    .thenAnswer(invocation -> {
+                        Settlement s = invocation.getArgument(0);
+                        return createSavedSettlement(1L, s.getSellerId(), s.getYear(), s.getMonth(),
+                                s.getTotalAllocatedAmount(), s.getPgFeeAmount(),
+                                s.getPlatformFeeAmount(), s.getSellerPayoutAmount());
+                    });
+            when(updateSettlementPort.update(any(Settlement.class)))
+                    .thenAnswer(invocation -> invocation.getArgument(0));
+
+            ExecuteSettlementCommand command = ExecuteSettlementCommand.builder()
+                    .year(2026).month(2).pgFeeRate(0).platformFeeRate(500).build();
+
+            // when
+            executeSettlementService.executeSettlement(command);
+
+            // then
+            verify(saveSettlementPort).save(settlementCaptor.capture());
+            Settlement saved = settlementCaptor.getValue();
+            assertThat(saved.getPgFeeAmount()).isEqualTo(0L);
+            assertThat(saved.getPlatformFeeAmount()).isEqualTo(500L);
+            assertThat(saved.getSellerPayoutAmount()).isEqualTo(9500L);
+
+            verify(recordLedgerEntryUseCase).recordPgSettlement(1L, 10000L, 0L);
+        }
+    }
+
+    @Nested
+    @DisplayName("수수료 계산 정합성")
+    class FeeCalculation {
+
+        @Test
+        @DisplayName("수수료 역산 정합성: totalAllocated = pgFee + platformFee + sellerPayout")
+        void shouldMaintainFeeIntegrity() {
+            // given
+            PaymentAllocation allocation = createAllocation(1L, 10L, 10001L);
+
+            when(findPaymentAllocationPort.findUnsettledAllocations(2026, 2))
+                    .thenReturn(List.of(allocation));
+            when(findSettlementPort.existsBySellerIdAndYearAndMonth(10L, 2026, 2))
+                    .thenReturn(false);
+            when(saveSettlementPort.save(any(Settlement.class)))
+                    .thenAnswer(invocation -> {
+                        Settlement s = invocation.getArgument(0);
+                        return createSavedSettlement(1L, s.getSellerId(), s.getYear(), s.getMonth(),
+                                s.getTotalAllocatedAmount(), s.getPgFeeAmount(),
+                                s.getPlatformFeeAmount(), s.getSellerPayoutAmount());
+                    });
+            when(updateSettlementPort.update(any(Settlement.class)))
+                    .thenAnswer(invocation -> invocation.getArgument(0));
+
+            ExecuteSettlementCommand command = ExecuteSettlementCommand.builder()
+                    .year(2026).month(2).pgFeeRate(300).platformFeeRate(500).build();
+
+            // when
+            executeSettlementService.executeSettlement(command);
+
+            // then
+            verify(saveSettlementPort).save(settlementCaptor.capture());
+            Settlement saved = settlementCaptor.getValue();
+
+            long pgFee = saved.getPgFeeAmount();
+            long platformFee = saved.getPlatformFeeAmount();
+            long sellerPayout = saved.getSellerPayoutAmount();
+            long total = saved.getTotalAllocatedAmount();
+
+            // 역산 정합성: pgFee + platformFee + sellerPayout == totalAllocatedAmount
+            assertThat(pgFee + platformFee + sellerPayout).isEqualTo(total);
+
+            // basis point 내림: 10001 * 300 / 10000 = 300 (not 300.03)
+            assertThat(pgFee).isEqualTo(300L);
+            // 10001 * 500 / 10000 = 500
+            assertThat(platformFee).isEqualTo(500L);
+            // 10001 - 300 - 500 = 9201
+            assertThat(sellerPayout).isEqualTo(9201L);
+        }
+
+        @Test
+        @DisplayName("수수료율 합계가 100%일 때 판매자 지급액이 0이 되지 않고 정합성 유지")
+        void shouldHandleHighFeeRates() {
+            // given
+            PaymentAllocation allocation = createAllocation(1L, 10L, 10000L);
+
+            when(findPaymentAllocationPort.findUnsettledAllocations(2026, 2))
+                    .thenReturn(List.of(allocation));
+            when(findSettlementPort.existsBySellerIdAndYearAndMonth(10L, 2026, 2))
+                    .thenReturn(false);
+            when(saveSettlementPort.save(any(Settlement.class)))
+                    .thenAnswer(invocation -> {
+                        Settlement s = invocation.getArgument(0);
+                        return createSavedSettlement(1L, s.getSellerId(), s.getYear(), s.getMonth(),
+                                s.getTotalAllocatedAmount(), s.getPgFeeAmount(),
+                                s.getPlatformFeeAmount(), s.getSellerPayoutAmount());
+                    });
+            when(updateSettlementPort.update(any(Settlement.class)))
+                    .thenAnswer(invocation -> invocation.getArgument(0));
+
+            // pgFeeRate=3000 (30%) + platformFeeRate=2000 (20%) = 50%
+            ExecuteSettlementCommand command = ExecuteSettlementCommand.builder()
+                    .year(2026).month(2).pgFeeRate(3000).platformFeeRate(2000).build();
+
+            // when
+            executeSettlementService.executeSettlement(command);
+
+            // then
+            verify(saveSettlementPort).save(settlementCaptor.capture());
+            Settlement saved = settlementCaptor.getValue();
+            assertThat(saved.getPgFeeAmount()).isEqualTo(3000L);
+            assertThat(saved.getPlatformFeeAmount()).isEqualTo(2000L);
+            assertThat(saved.getSellerPayoutAmount()).isEqualTo(5000L);
+            assertThat(saved.getPgFeeAmount() + saved.getPlatformFeeAmount() + saved.getSellerPayoutAmount())
+                    .isEqualTo(saved.getTotalAllocatedAmount());
+        }
+    }
+
+    @Nested
+    @DisplayName("예외 처리")
+    class ExceptionHandling {
+
+        @Test
+        @DisplayName("미정산 배분이 없으면 NoUnsettledAllocationException을 던진다")
+        void shouldThrowWhenNoUnsettledAllocations() {
+            // given
+            when(findPaymentAllocationPort.findUnsettledAllocations(2026, 2))
+                    .thenReturn(List.of());
+
+            ExecuteSettlementCommand command = ExecuteSettlementCommand.builder()
+                    .year(2026).month(2).pgFeeRate(300).platformFeeRate(500).build();
+
+            // when & then
+            assertThatThrownBy(() -> executeSettlementService.executeSettlement(command))
+                    .isInstanceOf(NoUnsettledAllocationException.class);
+
+            verify(saveSettlementPort, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("이미 해당 기간 정산이 존재하면 SettlementAlreadyExistsException을 던진다")
+        void shouldThrowWhenSettlementAlreadyExists() {
+            // given
+            PaymentAllocation allocation = createAllocation(1L, 10L, 10000L);
+
+            when(findPaymentAllocationPort.findUnsettledAllocations(2026, 2))
+                    .thenReturn(List.of(allocation));
+            when(findSettlementPort.existsBySellerIdAndYearAndMonth(10L, 2026, 2))
+                    .thenReturn(true);
+
+            ExecuteSettlementCommand command = ExecuteSettlementCommand.builder()
+                    .year(2026).month(2).pgFeeRate(300).platformFeeRate(500).build();
+
+            // when & then
+            assertThatThrownBy(() -> executeSettlementService.executeSettlement(command))
+                    .isInstanceOf(SettlementAlreadyExistsException.class)
+                    .hasMessageContaining("10")
+                    .hasMessageContaining("2026")
+                    .hasMessageContaining("2");
+
+            verify(saveSettlementPort, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("PG 수수료율이 음수이면 IllegalArgumentException을 던진다")
+        void shouldThrowWhenNegativePgFeeRate() {
+            // given
+            ExecuteSettlementCommand command = ExecuteSettlementCommand.builder()
+                    .year(2026).month(2).pgFeeRate(-1).platformFeeRate(500).build();
+
+            // when & then
+            assertThatThrownBy(() -> executeSettlementService.executeSettlement(command))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("PG 수수료율");
+        }
+
+        @Test
+        @DisplayName("수수료율 합계가 100%를 초과하면 IllegalArgumentException을 던진다")
+        void shouldThrowWhenFeeRatesExceed100Percent() {
+            // given
+            ExecuteSettlementCommand command = ExecuteSettlementCommand.builder()
+                    .year(2026).month(2).pgFeeRate(6000).platformFeeRate(5000).build();
+
+            // when & then
+            assertThatThrownBy(() -> executeSettlementService.executeSettlement(command))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("100%");
+        }
+    }
+
+    @Nested
+    @DisplayName("PaymentAllocation 정산 할당")
+    class AllocationAssignment {
+
+        @Test
+        @DisplayName("정산 완료 후 PaymentAllocation에 settlementId를 할당한다")
+        void shouldAssignSettlementIdToAllocations() {
+            // given
+            PaymentAllocation alloc1 = createAllocation(1L, 10L, 3000L);
+            PaymentAllocation alloc2 = createAllocation(2L, 10L, 7000L);
+
+            when(findPaymentAllocationPort.findUnsettledAllocations(2026, 2))
+                    .thenReturn(List.of(alloc1, alloc2));
+            when(findSettlementPort.existsBySellerIdAndYearAndMonth(10L, 2026, 2))
+                    .thenReturn(false);
+            when(saveSettlementPort.save(any(Settlement.class)))
+                    .thenAnswer(invocation -> {
+                        Settlement s = invocation.getArgument(0);
+                        return createSavedSettlement(99L, s.getSellerId(), s.getYear(), s.getMonth(),
+                                s.getTotalAllocatedAmount(), s.getPgFeeAmount(),
+                                s.getPlatformFeeAmount(), s.getSellerPayoutAmount());
+                    });
+            when(updateSettlementPort.update(any(Settlement.class)))
+                    .thenAnswer(invocation -> invocation.getArgument(0));
+
+            ExecuteSettlementCommand command = ExecuteSettlementCommand.builder()
+                    .year(2026).month(2).pgFeeRate(300).platformFeeRate(500).build();
+
+            // when
+            executeSettlementService.executeSettlement(command);
+
+            // then
+            verify(updatePaymentAllocationPort).assignSettlement(allocationIdsCaptor.capture(), eq(99L));
+            assertThat(allocationIdsCaptor.getValue()).containsExactlyInAnyOrder(1L, 2L);
+        }
+    }
+}

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/settlement/Settlement.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/settlement/Settlement.java
@@ -82,10 +82,18 @@ public class Settlement {
     }
 
     public void complete() {
+        if (!isPending()) {
+            throw new IllegalStateException(
+                    "PENDING 상태에서만 완료 처리할 수 있습니다. 현재 상태: " + status);
+        }
         this.status = SettlementStatus.COMPLETED;
     }
 
     public void fail() {
+        if (!isPending()) {
+            throw new IllegalStateException(
+                    "PENDING 상태에서만 실패 처리할 수 있습니다. 현재 상태: " + status);
+        }
         this.status = SettlementStatus.FAILED;
     }
 }

--- a/commerce-service/commerce-domain/src/test/java/com/personal/marketnote/commerce/domain/settlement/SettlementTest.java
+++ b/commerce-service/commerce-domain/src/test/java/com/personal/marketnote/commerce/domain/settlement/SettlementTest.java
@@ -217,5 +217,43 @@ class SettlementTest {
             assertThat(settlement.isPending()).isFalse();
             assertThat(settlement.isCompleted()).isFalse();
         }
+
+        @Test
+        @DisplayName("COMPLETED 상태에서 complete() 호출 시 IllegalStateException을 던진다")
+        void shouldThrowWhenCompleteFromCompleted() {
+            // given
+            Settlement settlement = Settlement.from(
+                    SettlementCreateState.builder()
+                            .sellerId(10L).year(2026).month(2)
+                            .totalAllocatedAmount(100000L).pgFeeAmount(3000L)
+                            .platformFeeAmount(5000L).sellerPayoutAmount(92000L)
+                            .build()
+            );
+            settlement.complete();
+
+            // when & then
+            assertThatThrownBy(settlement::complete)
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("PENDING");
+        }
+
+        @Test
+        @DisplayName("COMPLETED 상태에서 fail() 호출 시 IllegalStateException을 던진다")
+        void shouldThrowWhenFailFromCompleted() {
+            // given
+            Settlement settlement = Settlement.from(
+                    SettlementCreateState.builder()
+                            .sellerId(10L).year(2026).month(2)
+                            .totalAllocatedAmount(100000L).pgFeeAmount(3000L)
+                            .platformFeeAmount(5000L).sellerPayoutAmount(92000L)
+                            .build()
+            );
+            settlement.complete();
+
+            // when & then
+            assertThatThrownBy(settlement::fail)
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("PENDING");
+        }
     }
 }


### PR DESCRIPTION
## partially addresses #216
## resolves #899

## Task
- [x] 예외 3개 추가 (SettlementNotFoundException, SettlementAlreadyExistsException, NoUnsettledAllocationException)
- [x] Out Port 3개 추가 (FindPaymentAllocationPort, UpdatePaymentAllocationPort, UpdateSettlementPort)
- [x] ExecuteSettlementCommand, ExecuteSettlementUseCase 정의
- [x] ExecuteSettlementService 구현 — 미정산 배분 조회, 판매자별 그룹핑, Settlement 생성, 분개, complete
- [x] RecordLedgerEntryUseCase 확장 — recordPgSettlement(), recordSellerSettlement()
- [x] RecordLedgerEntryService PG 정산/판매자 정산 분개 구현
- [x] PaymentAllocationJpaRepository 미정산 조회(기간 필터) + 벌크 할당 JPQL 추가
- [x] PaymentAllocationPersistenceAdapter FindPaymentAllocationPort, UpdatePaymentAllocationPort 구현
- [x] SettlementPersistenceAdapter UpdateSettlementPort 구현
- [x] Settlement 도메인 complete()/fail() 상태 가드 추가
- [x] SettlementJpaEntity.from() createdAt/modifiedAt 매핑 추가
- [x] 수수료율 검증 (null, 음수, 합계 100% 초과)
- [x] Math.multiplyExact() 오버플로 방지
- [x] ExecuteSettlementUseCaseTest 10개 테스트 케이스
- [x] RecordLedgerEntryUseCaseTest PG/판매자 정산 6개 테스트 케이스
- [x] SettlementTest 상태 가드 2개 테스트 케이스