### PR TITLE
[#216][#900] feat: 정산 조회 기능 추가

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/settlement/controller/SettlementController.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/settlement/controller/SettlementController.java
@@ -1,0 +1,134 @@
+package com.personal.marketnote.commerce.adapter.in.web.settlement.controller;
+
+import com.personal.marketnote.commerce.adapter.in.web.settlement.controller.apidocs.ExecuteSettlementApiDocs;
+import com.personal.marketnote.commerce.adapter.in.web.settlement.controller.apidocs.GetSettlementApiDocs;
+import com.personal.marketnote.commerce.adapter.in.web.settlement.controller.apidocs.GetSettlementsApiDocs;
+import com.personal.marketnote.commerce.adapter.in.web.settlement.mapper.SettlementRequestToCommandMapper;
+import com.personal.marketnote.commerce.adapter.in.web.settlement.request.ExecuteSettlementRequest;
+import com.personal.marketnote.commerce.adapter.in.web.settlement.response.GetSettlementResponse;
+import com.personal.marketnote.commerce.adapter.in.web.settlement.response.GetSettlementsResponse;
+import com.personal.marketnote.commerce.port.in.result.settlement.GetSettlementResult;
+import com.personal.marketnote.commerce.port.in.result.settlement.GetSettlementsResult;
+import com.personal.marketnote.commerce.port.in.usecase.settlement.ExecuteSettlementUseCase;
+import com.personal.marketnote.commerce.port.in.usecase.settlement.GetSettlementUseCase;
+import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import static com.personal.marketnote.common.domain.exception.ExceptionCode.DEFAULT_SUCCESS_CODE;
+import static com.personal.marketnote.common.utility.ApiConstant.ADMIN_POINTCUT;
+
+/**
+ * 정산 컨트롤러 (관리자 전용)
+ *
+ * @Author 성효빈
+ * @Date 2026-02-16
+ * @Description 정산 관련 관리자 API를 제공합니다.
+ */
+@RestController
+@RequestMapping("/api/v1/admin/settlements")
+@Tag(name = "(관리자) 정산 API", description = "관리자 정산 관련 API")
+@RequiredArgsConstructor
+@Validated
+public class SettlementController {
+    private final ExecuteSettlementUseCase executeSettlementUseCase;
+    private final GetSettlementUseCase getSettlementUseCase;
+
+    /**
+     * 정산 실행
+     *
+     * @param request 정산 실행 요청
+     * @Author 성효빈
+     * @Date 2026-02-16
+     * @Description 지정된 연/월에 대해 판매자별 정산을 실행합니다.
+     */
+    @PostMapping
+    @PreAuthorize(ADMIN_POINTCUT)
+    @ExecuteSettlementApiDocs
+    public ResponseEntity<BaseResponse<Void>> executeSettlement(
+            @Valid @RequestBody ExecuteSettlementRequest request
+    ) {
+        executeSettlementUseCase.executeSettlement(
+                SettlementRequestToCommandMapper.mapToCommand(request)
+        );
+
+        return new ResponseEntity<>(
+                BaseResponse.of(
+                        null,
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "정산 실행 성공"
+                ),
+                HttpStatus.OK
+        );
+    }
+
+    /**
+     * 정산 목록 조회
+     *
+     * @param year  정산 연도
+     * @param month 정산 월
+     * @return 정산 목록 조회 응답 {@link GetSettlementsResponse}
+     * @Author 성효빈
+     * @Date 2026-02-16
+     * @Description 연/월 기준으로 정산 목록을 조회합니다.
+     */
+    @GetMapping
+    @PreAuthorize(ADMIN_POINTCUT)
+    @GetSettlementsApiDocs
+    public ResponseEntity<BaseResponse<GetSettlementsResponse>> getSettlements(
+            @RequestParam @NotNull @Min(2020) @Max(2100) Integer year,
+            @RequestParam @NotNull @Min(1) @Max(12) Integer month
+    ) {
+        GetSettlementsResult result = getSettlementUseCase.getSettlements(
+                SettlementRequestToCommandMapper.mapToQuery(year, month)
+        );
+
+        return new ResponseEntity<>(
+                BaseResponse.of(
+                        GetSettlementsResponse.from(result),
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "정산 목록 조회 성공"
+                ),
+                HttpStatus.OK
+        );
+    }
+
+    /**
+     * 정산 단건 조회
+     *
+     * @param id 정산 ID
+     * @return 정산 단건 조회 응답 {@link GetSettlementResponse}
+     * @Author 성효빈
+     * @Date 2026-02-16
+     * @Description 정산 ID로 정산 상세 정보를 조회합니다.
+     */
+    @GetMapping("/{id}")
+    @PreAuthorize(ADMIN_POINTCUT)
+    @GetSettlementApiDocs
+    public ResponseEntity<BaseResponse<GetSettlementResponse>> getSettlement(
+            @PathVariable("id") Long id
+    ) {
+        GetSettlementResult result = getSettlementUseCase.getSettlement(id);
+
+        return new ResponseEntity<>(
+                BaseResponse.of(
+                        GetSettlementResponse.from(result),
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "정산 단건 조회 성공"
+                ),
+                HttpStatus.OK
+        );
+    }
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/settlement/controller/apidocs/ExecuteSettlementApiDocs.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/settlement/controller/apidocs/ExecuteSettlementApiDocs.java
@@ -1,0 +1,78 @@
+package com.personal.marketnote.commerce.adapter.in.web.settlement.controller.apidocs;
+
+import com.personal.marketnote.commerce.adapter.in.web.settlement.request.ExecuteSettlementRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Operation(
+        summary = "(관리자) 정산 실행",
+        description = """
+                작성일자: 2026-02-16
+
+                작성자: 성효빈
+
+                ---
+
+                ## Description
+
+                - 지정된 연/월에 대해 판매자별 정산을 실행합니다.
+
+                - PG 수수료율과 플랫폼 수수료율은 basis point (1/10000) 단위입니다.
+
+                - 예: pgFeeRate=300은 3%, platformFeeRate=500은 5%
+
+                ---
+
+                ## Request
+
+                | **키** | **타입** | **설명** | **필수 여부** | **예시** |
+                | --- | --- | --- | --- | --- |
+                | year | number | 정산 연도 | Y | 2026 |
+                | month | number | 정산 월 | Y | 2 |
+                | pgFeeRate | number | PG 수수료율 (basis point) | Y | 300 |
+                | platformFeeRate | number | 플랫폼 수수료율 (basis point) | Y | 500 |
+                """,
+        security = {@SecurityRequirement(name = "bearer")},
+        requestBody = @RequestBody(
+                required = true,
+                content = @Content(
+                        schema = @Schema(implementation = ExecuteSettlementRequest.class),
+                        examples = @ExampleObject("""
+                                {
+                                  "year": 2026,
+                                  "month": 2,
+                                  "pgFeeRate": 300,
+                                  "platformFeeRate": 500
+                                }
+                                """)
+                )
+        ),
+        responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "정산 실행 성공",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 200,
+                                          "code": "SUC01",
+                                          "timestamp": "2026-02-16T12:00:00.000",
+                                          "content": null,
+                                          "message": "정산 실행 성공"
+                                        }
+                                        """)
+                        )
+                )
+        })
+public @interface ExecuteSettlementApiDocs {
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/settlement/controller/apidocs/GetSettlementApiDocs.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/settlement/controller/apidocs/GetSettlementApiDocs.java
@@ -1,0 +1,84 @@
+package com.personal.marketnote.commerce.adapter.in.web.settlement.controller.apidocs;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Operation(
+        summary = "(관리자) 정산 단건 조회",
+        description = """
+                작성일자: 2026-02-16
+
+                작성자: 성효빈
+
+                ---
+
+                ## Description
+
+                - 정산 ID로 정산 상세 정보를 조회합니다.
+
+                ---
+
+                ## Path Variable
+
+                | **키** | **타입** | **설명** | **필수 여부** | **예시** |
+                | --- | --- | --- | --- | --- |
+                | id | number | 정산 ID | Y | 1 |
+
+                ---
+
+                ## Response > content
+
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | id | number | 정산 ID | 1 |
+                | sellerId | number | 판매자 ID | 10 |
+                | year | number | 정산 연도 | 2026 |
+                | month | number | 정산 월 | 2 |
+                | totalAllocatedAmount | number | 총 배분 금액 | 100000 |
+                | pgFeeAmount | number | PG 수수료 | 3000 |
+                | platformFeeAmount | number | 플랫폼 수수료 | 5000 |
+                | sellerPayoutAmount | number | 판매자 지급액 | 92000 |
+                | status | string | 정산 상태 | "COMPLETED" |
+                | createdAt | string | 생성일시 | "2026-02-16T10:00:00" |
+                | modifiedAt | string | 수정일시 | "2026-02-16T10:00:00" |
+                """,
+        security = {@SecurityRequirement(name = "bearer")},
+        responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "정산 단건 조회 성공",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 200,
+                                          "code": "SUC01",
+                                          "timestamp": "2026-02-16T12:00:00.000",
+                                          "content": {
+                                            "id": 1,
+                                            "sellerId": 10,
+                                            "year": 2026,
+                                            "month": 2,
+                                            "totalAllocatedAmount": 100000,
+                                            "pgFeeAmount": 3000,
+                                            "platformFeeAmount": 5000,
+                                            "sellerPayoutAmount": 92000,
+                                            "status": "COMPLETED",
+                                            "createdAt": "2026-02-16T10:00:00",
+                                            "modifiedAt": "2026-02-16T10:00:00"
+                                          },
+                                          "message": "정산 단건 조회 성공"
+                                        }
+                                        """)
+                        )
+                )
+        })
+public @interface GetSettlementApiDocs {
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/settlement/controller/apidocs/GetSettlementsApiDocs.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/settlement/controller/apidocs/GetSettlementsApiDocs.java
@@ -1,0 +1,98 @@
+package com.personal.marketnote.commerce.adapter.in.web.settlement.controller.apidocs;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Operation(
+        summary = "(관리자) 정산 목록 조회",
+        description = """
+                작성일자: 2026-02-16
+
+                작성자: 성효빈
+
+                ---
+
+                ## Description
+
+                - 연/월 기준으로 정산 목록을 조회합니다.
+
+                ---
+
+                ## Query Parameters
+
+                | **키** | **타입** | **설명** | **필수 여부** | **예시** |
+                | --- | --- | --- | --- | --- |
+                | year | number | 정산 연도 | Y | 2026 |
+                | month | number | 정산 월 | Y | 2 |
+
+                ---
+
+                ## Response > content
+
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | settlements | array | 정산 목록 | [ ... ] |
+                """,
+        security = {@SecurityRequirement(name = "bearer")},
+        parameters = {
+                @Parameter(
+                        name = "year",
+                        in = ParameterIn.QUERY,
+                        required = true,
+                        description = "정산 연도",
+                        schema = @Schema(type = "integer", example = "2026")
+                ),
+                @Parameter(
+                        name = "month",
+                        in = ParameterIn.QUERY,
+                        required = true,
+                        description = "정산 월",
+                        schema = @Schema(type = "integer", example = "2")
+                )
+        },
+        responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "정산 목록 조회 성공",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 200,
+                                          "code": "SUC01",
+                                          "timestamp": "2026-02-16T12:00:00.000",
+                                          "content": {
+                                            "settlements": [
+                                              {
+                                                "id": 1,
+                                                "sellerId": 10,
+                                                "year": 2026,
+                                                "month": 2,
+                                                "totalAllocatedAmount": 100000,
+                                                "pgFeeAmount": 3000,
+                                                "platformFeeAmount": 5000,
+                                                "sellerPayoutAmount": 92000,
+                                                "status": "COMPLETED",
+                                                "createdAt": "2026-02-16T10:00:00",
+                                                "modifiedAt": "2026-02-16T10:00:00"
+                                              }
+                                            ]
+                                          },
+                                          "message": "정산 목록 조회 성공"
+                                        }
+                                        """)
+                        )
+                )
+        })
+public @interface GetSettlementsApiDocs {
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/settlement/mapper/SettlementRequestToCommandMapper.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/settlement/mapper/SettlementRequestToCommandMapper.java
@@ -1,0 +1,23 @@
+package com.personal.marketnote.commerce.adapter.in.web.settlement.mapper;
+
+import com.personal.marketnote.commerce.adapter.in.web.settlement.request.ExecuteSettlementRequest;
+import com.personal.marketnote.commerce.port.in.command.settlement.ExecuteSettlementCommand;
+import com.personal.marketnote.commerce.port.in.command.settlement.GetSettlementsQuery;
+
+public class SettlementRequestToCommandMapper {
+    private SettlementRequestToCommandMapper() {
+    }
+
+    public static ExecuteSettlementCommand mapToCommand(ExecuteSettlementRequest request) {
+        return ExecuteSettlementCommand.builder()
+                .year(request.getYear())
+                .month(request.getMonth())
+                .pgFeeRate(request.getPgFeeRate())
+                .platformFeeRate(request.getPlatformFeeRate())
+                .build();
+    }
+
+    public static GetSettlementsQuery mapToQuery(Integer year, Integer month) {
+        return GetSettlementsQuery.of(year, month);
+    }
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/settlement/request/ExecuteSettlementRequest.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/settlement/request/ExecuteSettlementRequest.java
@@ -1,0 +1,32 @@
+package com.personal.marketnote.commerce.adapter.in.web.settlement.request;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ExecuteSettlementRequest {
+    @NotNull(message = "정산 연도는 필수입니다")
+    @Min(value = 2020, message = "연도는 2020 이상이어야 합니다")
+    @Max(value = 2100, message = "연도는 2100 이하여야 합니다")
+    private Integer year;
+
+    @NotNull(message = "정산 월은 필수입니다")
+    @Min(value = 1, message = "월은 1 이상이어야 합니다")
+    @Max(value = 12, message = "월은 12 이하여야 합니다")
+    private Integer month;
+
+    @NotNull(message = "PG 수수료율은 필수입니다")
+    @Min(value = 0, message = "PG 수수료율은 0 이상이어야 합니다")
+    @Max(value = 10000, message = "PG 수수료율은 10000(100%) 이하여야 합니다")
+    private Integer pgFeeRate;
+
+    @NotNull(message = "플랫폼 수수료율은 필수입니다")
+    @Min(value = 0, message = "플랫폼 수수료율은 0 이상이어야 합니다")
+    @Max(value = 10000, message = "플랫폼 수수료율은 10000(100%) 이하여야 합니다")
+    private Integer platformFeeRate;
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/settlement/response/GetSettlementResponse.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/settlement/response/GetSettlementResponse.java
@@ -1,0 +1,39 @@
+package com.personal.marketnote.commerce.adapter.in.web.settlement.response;
+
+import com.personal.marketnote.commerce.domain.settlement.SettlementStatus;
+import com.personal.marketnote.commerce.port.in.result.settlement.GetSettlementResult;
+import lombok.AccessLevel;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder(access = AccessLevel.PRIVATE)
+public record GetSettlementResponse(
+        Long id,
+        Long sellerId,
+        Integer year,
+        Integer month,
+        Long totalAllocatedAmount,
+        Long pgFeeAmount,
+        Long platformFeeAmount,
+        Long sellerPayoutAmount,
+        SettlementStatus status,
+        LocalDateTime createdAt,
+        LocalDateTime modifiedAt
+) {
+    public static GetSettlementResponse from(GetSettlementResult result) {
+        return GetSettlementResponse.builder()
+                .id(result.id())
+                .sellerId(result.sellerId())
+                .year(result.year())
+                .month(result.month())
+                .totalAllocatedAmount(result.totalAllocatedAmount())
+                .pgFeeAmount(result.pgFeeAmount())
+                .platformFeeAmount(result.platformFeeAmount())
+                .sellerPayoutAmount(result.sellerPayoutAmount())
+                .status(result.status())
+                .createdAt(result.createdAt())
+                .modifiedAt(result.modifiedAt())
+                .build();
+    }
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/settlement/response/GetSettlementsResponse.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/settlement/response/GetSettlementsResponse.java
@@ -1,0 +1,16 @@
+package com.personal.marketnote.commerce.adapter.in.web.settlement.response;
+
+import com.personal.marketnote.commerce.port.in.result.settlement.GetSettlementsResult;
+
+import java.util.List;
+
+public record GetSettlementsResponse(
+        List<GetSettlementResponse> settlements
+) {
+    public static GetSettlementsResponse from(GetSettlementsResult result) {
+        List<GetSettlementResponse> responses = result.settlements().stream()
+                .map(GetSettlementResponse::from)
+                .toList();
+        return new GetSettlementsResponse(responses);
+    }
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/settlement/repository/PaymentAllocationJpaRepository.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/settlement/repository/PaymentAllocationJpaRepository.java
@@ -16,6 +16,6 @@ public interface PaymentAllocationJpaRepository extends JpaRepository<PaymentAll
     List<PaymentAllocationJpaEntity> findAllUnsettledByPeriod(@Param("year") Integer year, @Param("month") Integer month);
 
     @Modifying
-    @Query("UPDATE PaymentAllocationJpaEntity pa SET pa.settlementId = :settlementId WHERE pa.id IN :ids")
+    @Query("UPDATE PaymentAllocationJpaEntity pa SET pa.settlementId = :settlementId WHERE pa.id IN :ids AND pa.settlementId IS NULL")
     int bulkAssignSettlement(@Param("ids") List<Long> ids, @Param("settlementId") Long settlementId);
 }

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/command/settlement/GetSettlementsQuery.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/command/settlement/GetSettlementsQuery.java
@@ -1,0 +1,10 @@
+package com.personal.marketnote.commerce.port.in.command.settlement;
+
+public record GetSettlementsQuery(
+        Integer year,
+        Integer month
+) {
+    public static GetSettlementsQuery of(Integer year, Integer month) {
+        return new GetSettlementsQuery(year, month);
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/result/settlement/GetSettlementResult.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/result/settlement/GetSettlementResult.java
@@ -1,0 +1,38 @@
+package com.personal.marketnote.commerce.port.in.result.settlement;
+
+import com.personal.marketnote.commerce.domain.settlement.Settlement;
+import com.personal.marketnote.commerce.domain.settlement.SettlementStatus;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record GetSettlementResult(
+        Long id,
+        Long sellerId,
+        Integer year,
+        Integer month,
+        Long totalAllocatedAmount,
+        Long pgFeeAmount,
+        Long platformFeeAmount,
+        Long sellerPayoutAmount,
+        SettlementStatus status,
+        LocalDateTime createdAt,
+        LocalDateTime modifiedAt
+) {
+    public static GetSettlementResult from(Settlement settlement) {
+        return GetSettlementResult.builder()
+                .id(settlement.getId())
+                .sellerId(settlement.getSellerId())
+                .year(settlement.getYear())
+                .month(settlement.getMonth())
+                .totalAllocatedAmount(settlement.getTotalAllocatedAmount())
+                .pgFeeAmount(settlement.getPgFeeAmount())
+                .platformFeeAmount(settlement.getPlatformFeeAmount())
+                .sellerPayoutAmount(settlement.getSellerPayoutAmount())
+                .status(settlement.getStatus())
+                .createdAt(settlement.getCreatedAt())
+                .modifiedAt(settlement.getModifiedAt())
+                .build();
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/result/settlement/GetSettlementsResult.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/result/settlement/GetSettlementsResult.java
@@ -1,0 +1,16 @@
+package com.personal.marketnote.commerce.port.in.result.settlement;
+
+import com.personal.marketnote.commerce.domain.settlement.Settlement;
+
+import java.util.List;
+
+public record GetSettlementsResult(
+        List<GetSettlementResult> settlements
+) {
+    public static GetSettlementsResult from(List<Settlement> settlements) {
+        List<GetSettlementResult> results = settlements.stream()
+                .map(GetSettlementResult::from)
+                .toList();
+        return new GetSettlementsResult(results);
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/settlement/GetSettlementUseCase.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/settlement/GetSettlementUseCase.java
@@ -1,0 +1,11 @@
+package com.personal.marketnote.commerce.port.in.usecase.settlement;
+
+import com.personal.marketnote.commerce.port.in.command.settlement.GetSettlementsQuery;
+import com.personal.marketnote.commerce.port.in.result.settlement.GetSettlementResult;
+import com.personal.marketnote.commerce.port.in.result.settlement.GetSettlementsResult;
+
+public interface GetSettlementUseCase {
+    GetSettlementResult getSettlement(Long id);
+
+    GetSettlementsResult getSettlements(GetSettlementsQuery query);
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/settlement/GetSettlementService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/settlement/GetSettlementService.java
@@ -1,0 +1,38 @@
+package com.personal.marketnote.commerce.service.settlement;
+
+import com.personal.marketnote.commerce.domain.settlement.Settlement;
+import com.personal.marketnote.commerce.exception.SettlementNotFoundException;
+import com.personal.marketnote.commerce.port.in.command.settlement.GetSettlementsQuery;
+import com.personal.marketnote.commerce.port.in.result.settlement.GetSettlementResult;
+import com.personal.marketnote.commerce.port.in.result.settlement.GetSettlementsResult;
+import com.personal.marketnote.commerce.port.in.usecase.settlement.GetSettlementUseCase;
+import com.personal.marketnote.commerce.port.out.settlement.FindSettlementPort;
+import com.personal.marketnote.common.application.UseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@UseCase
+@RequiredArgsConstructor
+public class GetSettlementService implements GetSettlementUseCase {
+    private final FindSettlementPort findSettlementPort;
+
+    @Override
+    @Transactional(isolation = READ_COMMITTED, readOnly = true)
+    public GetSettlementResult getSettlement(Long id) {
+        Settlement settlement = findSettlementPort.findById(id)
+                .orElseThrow(() -> new SettlementNotFoundException(id));
+        return GetSettlementResult.from(settlement);
+    }
+
+    @Override
+    @Transactional(isolation = READ_COMMITTED, readOnly = true)
+    public GetSettlementsResult getSettlements(GetSettlementsQuery query) {
+        List<Settlement> settlements = findSettlementPort.findAllByYearAndMonth(
+                query.year(), query.month());
+        return GetSettlementsResult.from(settlements);
+    }
+}

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/settlement/GetSettlementUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/settlement/GetSettlementUseCaseTest.java
@@ -1,0 +1,228 @@
+package com.personal.marketnote.commerce.service.settlement;
+
+import com.personal.marketnote.commerce.domain.settlement.Settlement;
+import com.personal.marketnote.commerce.domain.settlement.SettlementSnapshotState;
+import com.personal.marketnote.commerce.domain.settlement.SettlementStatus;
+import com.personal.marketnote.commerce.exception.SettlementNotFoundException;
+import com.personal.marketnote.commerce.port.in.command.settlement.GetSettlementsQuery;
+import com.personal.marketnote.commerce.port.in.result.settlement.GetSettlementResult;
+import com.personal.marketnote.commerce.port.in.result.settlement.GetSettlementsResult;
+import com.personal.marketnote.commerce.port.out.settlement.FindSettlementPort;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GetSettlementUseCase 테스트")
+class GetSettlementUseCaseTest {
+
+    @InjectMocks
+    private GetSettlementService getSettlementService;
+
+    @Mock
+    private FindSettlementPort findSettlementPort;
+
+    private Settlement createSettlement(Long id, Long sellerId, Integer year, Integer month,
+                                        Long totalAllocated, Long pgFee, Long platformFee,
+                                        Long sellerPayout, SettlementStatus status) {
+        return Settlement.from(SettlementSnapshotState.builder()
+                .id(id)
+                .sellerId(sellerId)
+                .year(year)
+                .month(month)
+                .totalAllocatedAmount(totalAllocated)
+                .pgFeeAmount(pgFee)
+                .platformFeeAmount(platformFee)
+                .sellerPayoutAmount(sellerPayout)
+                .status(status)
+                .version(0L)
+                .createdAt(LocalDateTime.of(2026, 2, 16, 10, 0))
+                .modifiedAt(LocalDateTime.of(2026, 2, 16, 10, 0))
+                .build());
+    }
+
+    @Nested
+    @DisplayName("정산 단건 조회")
+    class GetSettlementTest {
+
+        @Test
+        @DisplayName("정산 ID로 COMPLETED 상태의 정산 정보를 조회한다")
+        void shouldReturnCompletedSettlementById() {
+            // given
+            Settlement settlement = createSettlement(1L, 10L, 2026, 2,
+                    100000L, 3000L, 5000L, 92000L, SettlementStatus.COMPLETED);
+            when(findSettlementPort.findById(1L)).thenReturn(Optional.of(settlement));
+
+            // when
+            GetSettlementResult result = getSettlementService.getSettlement(1L);
+
+            // then
+            assertThat(result.id()).isEqualTo(1L);
+            assertThat(result.sellerId()).isEqualTo(10L);
+            assertThat(result.year()).isEqualTo(2026);
+            assertThat(result.month()).isEqualTo(2);
+            assertThat(result.totalAllocatedAmount()).isEqualTo(100000L);
+            assertThat(result.pgFeeAmount()).isEqualTo(3000L);
+            assertThat(result.platformFeeAmount()).isEqualTo(5000L);
+            assertThat(result.sellerPayoutAmount()).isEqualTo(92000L);
+            assertThat(result.status()).isEqualTo(SettlementStatus.COMPLETED);
+            assertThat(result.createdAt()).isNotNull();
+            assertThat(result.modifiedAt()).isNotNull();
+            verify(findSettlementPort).findById(1L);
+        }
+
+        @Test
+        @DisplayName("PENDING 상태의 정산을 조회한다")
+        void shouldReturnPendingSettlement() {
+            // given
+            Settlement settlement = createSettlement(2L, 20L, 2026, 1,
+                    50000L, 1500L, 2500L, 46000L, SettlementStatus.PENDING);
+            when(findSettlementPort.findById(2L)).thenReturn(Optional.of(settlement));
+
+            // when
+            GetSettlementResult result = getSettlementService.getSettlement(2L);
+
+            // then
+            assertThat(result.id()).isEqualTo(2L);
+            assertThat(result.status()).isEqualTo(SettlementStatus.PENDING);
+            verify(findSettlementPort).findById(2L);
+        }
+
+        @Test
+        @DisplayName("FAILED 상태의 정산을 조회한다")
+        void shouldReturnFailedSettlement() {
+            // given
+            Settlement settlement = createSettlement(3L, 30L, 2026, 1,
+                    80000L, 2400L, 4000L, 73600L, SettlementStatus.FAILED);
+            when(findSettlementPort.findById(3L)).thenReturn(Optional.of(settlement));
+
+            // when
+            GetSettlementResult result = getSettlementService.getSettlement(3L);
+
+            // then
+            assertThat(result.status()).isEqualTo(SettlementStatus.FAILED);
+            verify(findSettlementPort).findById(3L);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 정산 ID로 조회하면 SettlementNotFoundException이 발생한다")
+        void shouldThrowWhenSettlementNotFound() {
+            // given
+            when(findSettlementPort.findById(999L)).thenReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> getSettlementService.getSettlement(999L))
+                    .isInstanceOf(SettlementNotFoundException.class)
+                    .hasMessageContaining("999");
+            verify(findSettlementPort).findById(999L);
+        }
+    }
+
+    @Nested
+    @DisplayName("정산 목록 조회")
+    class GetSettlementsTest {
+
+        @Test
+        @DisplayName("연/월 기준으로 정산 목록을 조회한다")
+        void shouldReturnSettlementsByYearAndMonth() {
+            // given
+            Settlement settlement1 = createSettlement(1L, 10L, 2026, 2,
+                    100000L, 3000L, 5000L, 92000L, SettlementStatus.COMPLETED);
+            Settlement settlement2 = createSettlement(2L, 20L, 2026, 2,
+                    200000L, 6000L, 10000L, 184000L, SettlementStatus.COMPLETED);
+
+            when(findSettlementPort.findAllByYearAndMonth(2026, 2))
+                    .thenReturn(List.of(settlement1, settlement2));
+
+            GetSettlementsQuery query = GetSettlementsQuery.of(2026, 2);
+
+            // when
+            GetSettlementsResult result = getSettlementService.getSettlements(query);
+
+            // then
+            assertThat(result.settlements()).hasSize(2);
+            assertThat(result.settlements().get(0).sellerId()).isEqualTo(10L);
+            assertThat(result.settlements().get(1).sellerId()).isEqualTo(20L);
+            verify(findSettlementPort).findAllByYearAndMonth(2026, 2);
+        }
+
+        @Test
+        @DisplayName("해당 연/월에 정산이 없으면 빈 목록을 반환한다")
+        void shouldReturnEmptyListWhenNoSettlements() {
+            // given
+            when(findSettlementPort.findAllByYearAndMonth(2025, 12))
+                    .thenReturn(List.of());
+
+            GetSettlementsQuery query = GetSettlementsQuery.of(2025, 12);
+
+            // when
+            GetSettlementsResult result = getSettlementService.getSettlements(query);
+
+            // then
+            assertThat(result.settlements()).isEmpty();
+            verify(findSettlementPort).findAllByYearAndMonth(2025, 12);
+        }
+
+        @Test
+        @DisplayName("단일 판매자 정산만 있는 경우 목록에 1건이 반환된다")
+        void shouldReturnSingleSettlement() {
+            // given
+            Settlement settlement = createSettlement(1L, 10L, 2026, 1,
+                    50000L, 1500L, 2500L, 46000L, SettlementStatus.COMPLETED);
+
+            when(findSettlementPort.findAllByYearAndMonth(2026, 1))
+                    .thenReturn(List.of(settlement));
+
+            GetSettlementsQuery query = GetSettlementsQuery.of(2026, 1);
+
+            // when
+            GetSettlementsResult result = getSettlementService.getSettlements(query);
+
+            // then
+            assertThat(result.settlements()).hasSize(1);
+            assertThat(result.settlements().get(0).id()).isEqualTo(1L);
+            assertThat(result.settlements().get(0).totalAllocatedAmount()).isEqualTo(50000L);
+        }
+
+        @Test
+        @DisplayName("정산 목록의 각 항목 필드가 정확히 매핑된다")
+        void shouldMapAllFieldsCorrectly() {
+            // given
+            Settlement settlement = createSettlement(5L, 15L, 2026, 3,
+                    150000L, 4500L, 7500L, 138000L, SettlementStatus.COMPLETED);
+
+            when(findSettlementPort.findAllByYearAndMonth(2026, 3))
+                    .thenReturn(List.of(settlement));
+
+            GetSettlementsQuery query = GetSettlementsQuery.of(2026, 3);
+
+            // when
+            GetSettlementsResult result = getSettlementService.getSettlements(query);
+
+            // then
+            GetSettlementResult item = result.settlements().get(0);
+            assertThat(item.id()).isEqualTo(5L);
+            assertThat(item.sellerId()).isEqualTo(15L);
+            assertThat(item.year()).isEqualTo(2026);
+            assertThat(item.month()).isEqualTo(3);
+            assertThat(item.totalAllocatedAmount()).isEqualTo(150000L);
+            assertThat(item.pgFeeAmount()).isEqualTo(4500L);
+            assertThat(item.platformFeeAmount()).isEqualTo(7500L);
+            assertThat(item.sellerPayoutAmount()).isEqualTo(138000L);
+            assertThat(item.status()).isEqualTo(SettlementStatus.COMPLETED);
+        }
+    }
+}


### PR DESCRIPTION
## partially addresses #216
## resolves #900

## Task
- [x] GetSettlementsQuery 목록 조회용 Query record 생성
- [x] GetSettlementResult, GetSettlementsResult 조회 결과 record 생성
- [x] GetSettlementUseCase 인터페이스 생성 (getSettlement, getSettlements)
- [x] GetSettlementService 구현 (@transactional readOnly, FindSettlementPort 활용)
- [x] ExecuteSettlementRequest DTO 생성 (@Valid + Bean Validation, basis point 수수료율)
- [x] GetSettlementResponse, GetSettlementsResponse 응답 DTO 생성
- [x] SettlementRequestToCommandMapper 정적 매퍼 생성
- [x] ExecuteSettlementApiDocs, GetSettlementApiDocs, GetSettlementsApiDocs 합성 애노테이션 생성
- [x] SettlementController 관리자 전용 REST API 3개 엔드포인트 (POST, GET 목록, GET 단건)
- [x] 모든 엔드포인트에 @PreAuthorize(ADMIN_POINTCUT) 적용
- [x] 쿼리 파라미터 year/month @validated + @Min/@max 검증 추가
- [x] 수수료율 pgFeeRate/platformFeeRate @max(10000) 상한 검증 추가
- [x] year @max(2100) 상한 검증 추가
- [x] bulkAssignSettlement WHERE settlementId IS NULL 조건 추가 (이중 할당 방지)
- [x] GetSettlementUseCaseTest 8개 테스트 케이스 (단건 4 + 목록 4)