### PR TITLE
[#723][#907] refactor: Inventory 도메인 Hibernate 의존성 제거

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/order/repository/OrderProductJpaRepository.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/order/repository/OrderProductJpaRepository.java
@@ -2,7 +2,7 @@ package com.personal.marketnote.commerce.adapter.out.persistence.order.repositor
 
 import com.personal.marketnote.commerce.adapter.out.persistence.order.entity.OrderProductId;
 import com.personal.marketnote.commerce.adapter.out.persistence.order.entity.OrderProductJpaEntity;
-import org.springframework.data.repository.query.Param;
+import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/inventory/RegisterInventoryService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/inventory/RegisterInventoryService.java
@@ -14,7 +14,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static org.hibernate.type.descriptor.java.IntegerJavaType.ZERO;
 import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
 import static org.springframework.transaction.annotation.Propagation.REQUIRES_NEW;
 
@@ -36,7 +35,7 @@ public class RegisterInventoryService implements RegisterInventoryUseCase {
         Inventory inventory = Inventory.of(command.productId(), command.pricePolicyId());
         saveInventoryPort.save(inventory);
 
-        saveCacheStockPort.save(command.pricePolicyId(), ZERO);
+        saveCacheStockPort.save(command.pricePolicyId(), 0);
     }
 
     @Override

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/inventory/Inventory.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/inventory/Inventory.java
@@ -3,8 +3,6 @@ package com.personal.marketnote.commerce.domain.inventory;
 import com.personal.marketnote.common.utility.FormatValidator;
 import lombok.*;
 
-import static org.hibernate.type.descriptor.java.IntegerJavaType.ZERO;
-
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder(access = AccessLevel.PRIVATE)
@@ -20,7 +18,7 @@ public class Inventory {
                 .productId(productId)
                 .pricePolicyId(pricePolicyId)
                 .stock(Stock.of(
-                        ZERO.toString()
+                        "0"
                 ))
                 .build();
     }


### PR DESCRIPTION
## partially addresses #723
## resolves #907

## Task
- [x] Inventory.java에서 IntegerJavaType.ZERO → "0" 문자열 리터럴로 교체
- [x] RegisterInventoryService.java에서 IntegerJavaType.ZERO → 0 정수 리터럴로 교체
- [x] Hibernate static import 제거