### PR TITLE
[#723][#908] fix: 재고 도메인 패키지 선언 오류 수정

### DIFF
--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/inventory/RegisterInventoryService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/inventory/RegisterInventoryService.java
@@ -14,6 +14,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static org.hibernate.type.descriptor.java.IntegerJavaType.ZERO;
 import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
 import static org.springframework.transaction.annotation.Propagation.REQUIRES_NEW;
 
@@ -35,7 +36,7 @@ public class RegisterInventoryService implements RegisterInventoryUseCase {
         Inventory inventory = Inventory.of(command.productId(), command.pricePolicyId());
         saveInventoryPort.save(inventory);
 
-        saveCacheStockPort.save(command.pricePolicyId(), 0);
+        saveCacheStockPort.save(command.pricePolicyId(), ZERO);
     }
 
     @Override

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/inventory/FulfillmentMapper.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/inventory/FulfillmentMapper.java
@@ -1,4 +1,4 @@
-package com.personal.marketnote.product.domain.inventory;
+package com.personal.marketnote.commerce.domain.inventory;
 
 import com.personal.marketnote.commerce.domain.inventory.FulfillmentMapperCreateState;
 import com.personal.marketnote.commerce.domain.inventory.FulfillmentMapperSnapshotState;

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/inventory/Inventory.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/inventory/Inventory.java
@@ -3,6 +3,8 @@ package com.personal.marketnote.commerce.domain.inventory;
 import com.personal.marketnote.common.utility.FormatValidator;
 import lombok.*;
 
+import static org.hibernate.type.descriptor.java.IntegerJavaType.ZERO;
+
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder(access = AccessLevel.PRIVATE)
@@ -18,7 +20,7 @@ public class Inventory {
                 .productId(productId)
                 .pricePolicyId(pricePolicyId)
                 .stock(Stock.of(
-                        "0"
+                        ZERO.toString()
                 ))
                 .build();
     }

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/inventory/InventoryAdditionHistory.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/inventory/InventoryAdditionHistory.java
@@ -1,4 +1,4 @@
-package com.personal.marketnote.product.domain.inventory;
+package com.personal.marketnote.commerce.domain.inventory;
 
 import com.personal.marketnote.commerce.domain.inventory.InventoryAdditionHistoryCreateState;
 import com.personal.marketnote.commerce.domain.inventory.InventoryAdditionHistorySnapshotState;


### PR DESCRIPTION
## partially addresses #723
## resolves #908

## Reason
- commerce-service 도메인 파일의 package 선언이 product 패키지로 잘못 지정됨

## Action
- [x] InventoryAdditionHistory.java 패키지 선언을 commerce.domain.inventory로 수정
- [x] FulfillmentMapper.java 패키지 선언을 commerce.domain.inventory로 수정