### PR TITLE
[#723][#909] refactor: 커스텀 예외 미사용 코드 수정

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/order/repository/OrderProductJpaRepository.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/order/repository/OrderProductJpaRepository.java
@@ -2,7 +2,7 @@ package com.personal.marketnote.commerce.adapter.out.persistence.order.repositor
 
 import com.personal.marketnote.commerce.adapter.out.persistence.order.entity.OrderProductId;
 import com.personal.marketnote.commerce.adapter.out.persistence.order.entity.OrderProductJpaEntity;
-import io.lettuce.core.dynamic.annotation.Param;
+import org.springframework.data.repository.query.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/exception/EmptyLedgerEntriesException.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/exception/EmptyLedgerEntriesException.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.commerce.exception;
+
+public class EmptyLedgerEntriesException extends IllegalArgumentException {
+    private static final String MESSAGE = "분개 항목이 비어있습니다.";
+
+    public EmptyLedgerEntriesException() {
+        super(MESSAGE);
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/exception/InvalidCancelAmountException.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/exception/InvalidCancelAmountException.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.commerce.exception;
+
+public class InvalidCancelAmountException extends IllegalArgumentException {
+    public InvalidCancelAmountException(String message) {
+        super(message);
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/exception/InvalidFeeRateException.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/exception/InvalidFeeRateException.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.commerce.exception;
+
+public class InvalidFeeRateException extends IllegalArgumentException {
+    public InvalidFeeRateException(String message) {
+        super(message);
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/exception/InvalidFulfillmentSyncCommandException.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/exception/InvalidFulfillmentSyncCommandException.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.commerce.exception;
+
+public class InvalidFulfillmentSyncCommandException extends IllegalArgumentException {
+    private static final String MESSAGE = "Sync fulfillment vendor inventory command is required.";
+
+    public InvalidFulfillmentSyncCommandException() {
+        super(MESSAGE);
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/exception/PaymentAmountMismatchException.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/exception/PaymentAmountMismatchException.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.commerce.exception;
+
+public class PaymentAmountMismatchException extends IllegalStateException {
+    public PaymentAmountMismatchException(Long expectedAmount, Long actualAmount) {
+        super("주문 금액과 결제 금액이 일치하지 않습니다. 예상: " + expectedAmount + ", 실제: " + actualAmount);
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/inventory/RegisterInventoryService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/inventory/RegisterInventoryService.java
@@ -14,7 +14,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static org.hibernate.type.descriptor.java.IntegerJavaType.ZERO;
 import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
 import static org.springframework.transaction.annotation.Propagation.REQUIRES_NEW;
 
@@ -36,7 +35,7 @@ public class RegisterInventoryService implements RegisterInventoryUseCase {
         Inventory inventory = Inventory.of(command.productId(), command.pricePolicyId());
         saveInventoryPort.save(inventory);
 
-        saveCacheStockPort.save(command.pricePolicyId(), ZERO);
+        saveCacheStockPort.save(command.pricePolicyId(), 0);
     }
 
     @Override

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/inventory/SyncFulfillmentVendorInventoryService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/inventory/SyncFulfillmentVendorInventoryService.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.commerce.service.inventory;
 
 import com.personal.marketnote.commerce.domain.inventory.Inventory;
+import com.personal.marketnote.commerce.exception.InvalidFulfillmentSyncCommandException;
 import com.personal.marketnote.commerce.exception.InventoryProductNotFoundException;
 import com.personal.marketnote.commerce.port.in.command.inventory.SyncFulfillmentVendorInventoryCommand;
 import com.personal.marketnote.commerce.port.in.command.inventory.SyncFulfillmentVendorInventoryItemCommand;
@@ -33,7 +34,7 @@ public class SyncFulfillmentVendorInventoryService implements SyncFulfillmentVen
     @Override
     public void syncInventories(SyncFulfillmentVendorInventoryCommand command) {
         if (FormatValidator.hasNoValue(command) || FormatValidator.hasNoValue(command.inventories())) {
-            throw new IllegalArgumentException("Sync fulfillment vendor inventory command is required.");
+            throw new InvalidFulfillmentSyncCommandException();
         }
 
         Map<Long, Integer> stocksByProductId = resolveStocksByProductId(command.inventories());

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/ledger/RecordLedgerEntryService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/ledger/RecordLedgerEntryService.java
@@ -3,6 +3,7 @@ package com.personal.marketnote.commerce.service.ledger;
 import com.personal.marketnote.commerce.domain.ledger.*;
 import com.personal.marketnote.commerce.exception.AccountNotFoundException;
 import com.personal.marketnote.commerce.exception.DuplicateLedgerTransactionException;
+import com.personal.marketnote.commerce.exception.EmptyLedgerEntriesException;
 import com.personal.marketnote.commerce.exception.InactiveAccountException;
 import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.commerce.port.in.command.ledger.RecordLedgerEntryCommand;
@@ -210,7 +211,7 @@ public class RecordLedgerEntryService implements RecordLedgerEntryUseCase {
 
     private void validateEntryLines(List<RecordLedgerEntryCommand.EntryLine> entryLines) {
         if (FormatValidator.hasNoValue(entryLines) || entryLines.isEmpty()) {
-            throw new IllegalArgumentException("분개 항목이 비어있습니다.");
+            throw new EmptyLedgerEntriesException();
         }
     }
 

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/ApprovePaymentService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/ApprovePaymentService.java
@@ -6,6 +6,7 @@ import com.personal.marketnote.commerce.domain.payment.Payment;
 import com.personal.marketnote.commerce.domain.payment.PaymentApprovalInfo;
 import com.personal.marketnote.commerce.domain.payment.PspPaymentEvent;
 import com.personal.marketnote.commerce.exception.OrderNotFoundException;
+import com.personal.marketnote.commerce.exception.PaymentAmountMismatchException;
 import com.personal.marketnote.commerce.exception.PaymentApprovalException;
 import com.personal.marketnote.commerce.exception.PaymentNotFoundException;
 import com.personal.marketnote.commerce.exception.UnauthorizedOrderAccessException;
@@ -179,9 +180,7 @@ public class ApprovePaymentService implements ApprovePaymentUseCase {
             log.error("결제 금액 불일치: orderId={}, 주문금액={}, 쿠폰={}, 포인트={}, 예상결제금액={}, 실제결제금액={}",
                     order.getId(), order.getTotalAmount(), couponAmount, pointAmount,
                     expectedAmount, payment.getPaymentAmount());
-            throw new IllegalStateException(
-                    "주문 금액과 결제 금액이 일치하지 않습니다. 예상: " + expectedAmount + ", 실제: " + payment.getPaymentAmount()
-            );
+            throw new PaymentAmountMismatchException(expectedAmount, payment.getPaymentAmount());
         }
     }
 

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/CancelPaymentService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/CancelPaymentService.java
@@ -4,6 +4,7 @@ import com.personal.marketnote.commerce.domain.order.Order;
 import com.personal.marketnote.commerce.domain.order.OrderStatus;
 import com.personal.marketnote.commerce.domain.payment.Payment;
 import com.personal.marketnote.commerce.domain.payment.PspPaymentEvent;
+import com.personal.marketnote.commerce.exception.InvalidCancelAmountException;
 import com.personal.marketnote.commerce.exception.OrderNotFoundException;
 import com.personal.marketnote.commerce.exception.PaymentCancelException;
 import com.personal.marketnote.commerce.exception.PaymentNotFoundException;
@@ -66,10 +67,10 @@ public class CancelPaymentService implements CancelPaymentUseCase {
         } else {
             cancelAmount = command.cancelAmount();
             if (FormatValidator.hasNoValue(cancelAmount) || cancelAmount <= 0L) {
-                throw new IllegalArgumentException("부분취소 금액은 0보다 커야 합니다");
+                throw new InvalidCancelAmountException("부분취소 금액은 0보다 커야 합니다");
             }
             if (cancelAmount > refundableAmount) {
-                throw new IllegalArgumentException(
+                throw new InvalidCancelAmountException(
                         "취소 금액(" + cancelAmount + ")이 환불 가능 금액(" + refundableAmount + ")을 초과합니다"
                 );
             }

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/settlement/ExecuteSettlementService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/settlement/ExecuteSettlementService.java
@@ -3,6 +3,7 @@ package com.personal.marketnote.commerce.service.settlement;
 import com.personal.marketnote.commerce.domain.settlement.PaymentAllocation;
 import com.personal.marketnote.commerce.domain.settlement.Settlement;
 import com.personal.marketnote.commerce.domain.settlement.SettlementCreateState;
+import com.personal.marketnote.commerce.exception.InvalidFeeRateException;
 import com.personal.marketnote.commerce.exception.NoUnsettledAllocationException;
 import com.personal.marketnote.commerce.exception.SettlementAlreadyExistsException;
 import com.personal.marketnote.commerce.port.in.command.settlement.ExecuteSettlementCommand;
@@ -59,13 +60,13 @@ public class ExecuteSettlementService implements ExecuteSettlementUseCase {
 
     private void validateFeeRates(ExecuteSettlementCommand command) {
         if (FormatValidator.hasNoValue(command.pgFeeRate()) || command.pgFeeRate() < 0) {
-            throw new IllegalArgumentException("PG 수수료율은 0 이상이어야 합니다. pgFeeRate=" + command.pgFeeRate());
+            throw new InvalidFeeRateException("PG 수수료율은 0 이상이어야 합니다. pgFeeRate=" + command.pgFeeRate());
         }
         if (FormatValidator.hasNoValue(command.platformFeeRate()) || command.platformFeeRate() < 0) {
-            throw new IllegalArgumentException("플랫폼 수수료율은 0 이상이어야 합니다. platformFeeRate=" + command.platformFeeRate());
+            throw new InvalidFeeRateException("플랫폼 수수료율은 0 이상이어야 합니다. platformFeeRate=" + command.platformFeeRate());
         }
         if (command.pgFeeRate() + command.platformFeeRate() > BASIS_POINT_DENOMINATOR) {
-            throw new IllegalArgumentException("수수료율 합계가 100%를 초과합니다. pgFeeRate=" + command.pgFeeRate()
+            throw new InvalidFeeRateException("수수료율 합계가 100%를 초과합니다. pgFeeRate=" + command.pgFeeRate()
                     + ", platformFeeRate=" + command.platformFeeRate());
         }
     }

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/inventory/Inventory.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/inventory/Inventory.java
@@ -3,8 +3,6 @@ package com.personal.marketnote.commerce.domain.inventory;
 import com.personal.marketnote.common.utility.FormatValidator;
 import lombok.*;
 
-import static org.hibernate.type.descriptor.java.IntegerJavaType.ZERO;
-
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder(access = AccessLevel.PRIVATE)
@@ -20,7 +18,7 @@ public class Inventory {
                 .productId(productId)
                 .pricePolicyId(pricePolicyId)
                 .stock(Stock.of(
-                        ZERO.toString()
+                        "0"
                 ))
                 .build();
     }

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/ledger/InvalidLedgerEntryAmountException.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/ledger/InvalidLedgerEntryAmountException.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.commerce.domain.ledger;
+
+public class InvalidLedgerEntryAmountException extends IllegalStateException {
+    private static final String MESSAGE = "분개 금액은 0보다 커야 합니다.";
+
+    public InvalidLedgerEntryAmountException() {
+        super(MESSAGE);
+    }
+}

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/ledger/LedgerEntryImbalanceException.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/ledger/LedgerEntryImbalanceException.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.commerce.domain.ledger;
+
+public class LedgerEntryImbalanceException extends IllegalStateException {
+    public LedgerEntryImbalanceException(long debitTotal, long creditTotal) {
+        super("차변 합계(" + debitTotal + ")와 대변 합계(" + creditTotal + ")가 일치하지 않습니다.");
+    }
+}

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/ledger/LedgerTransaction.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/ledger/LedgerTransaction.java
@@ -44,7 +44,7 @@ public class LedgerTransaction {
         boolean hasNegativeOrZeroAmount = entries.stream()
                 .anyMatch(entry -> entry.getAmount() <= 0);
         if (hasNegativeOrZeroAmount) {
-            throw new IllegalStateException("분개 금액은 0보다 커야 합니다.");
+            throw new InvalidLedgerEntryAmountException();
         }
 
         long debitTotal = 0L;
@@ -62,9 +62,7 @@ public class LedgerTransaction {
         }
 
         if (debitTotal != creditTotal) {
-            throw new IllegalStateException(
-                    "차변 합계(" + debitTotal + ")와 대변 합계(" + creditTotal + ")가 일치하지 않습니다."
-            );
+            throw new LedgerEntryImbalanceException(debitTotal, creditTotal);
         }
     }
 }

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/order/InvalidOrderProductStatusTransitionException.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/order/InvalidOrderProductStatusTransitionException.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.commerce.domain.order;
+
+public class InvalidOrderProductStatusTransitionException extends IllegalStateException {
+    public InvalidOrderProductStatusTransitionException(OrderStatus from, OrderStatus to) {
+        super(String.format("주문 상품 상태를 %s에서 %s(으)로 변경할 수 없습니다.",
+                from.getDescription(), to.getDescription()));
+    }
+}

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/order/OrderProduct.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/order/OrderProduct.java
@@ -48,10 +48,7 @@ public class OrderProduct {
             return;
         }
         if (!this.orderStatus.canTransitionTo(orderStatus)) {
-            throw new IllegalStateException(
-                    String.format("주문 상품 상태를 %s에서 %s(으)로 변경할 수 없습니다.",
-                            this.orderStatus.getDescription(), orderStatus.getDescription())
-            );
+            throw new InvalidOrderProductStatusTransitionException(this.orderStatus, orderStatus);
         }
         this.orderStatus = orderStatus;
     }

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/payment/InvalidPaymentStatusTransitionException.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/payment/InvalidPaymentStatusTransitionException.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.commerce.domain.payment;
+
+public class InvalidPaymentStatusTransitionException extends IllegalStateException {
+    public InvalidPaymentStatusTransitionException(String expectedStatus, PaymentEventStatus currentStatus) {
+        super(expectedStatus + " 현재 상태: " + currentStatus);
+    }
+}

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/payment/PaymentMethod.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/payment/PaymentMethod.java
@@ -21,6 +21,6 @@ public enum PaymentMethod {
                 return method;
             }
         }
-        throw new IllegalArgumentException("알 수 없는 KCP 결제수단 코드: " + kcpCode);
+        throw new UnknownPaymentMethodCodeException(kcpCode);
     }
 }

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/payment/PspPaymentEvent.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/payment/PspPaymentEvent.java
@@ -97,14 +97,14 @@ public class PspPaymentEvent {
 
     public void startExecution() {
         if (!this.poStatus.isReady()) {
-            throw new IllegalStateException("READY 상태에서만 EXECUTING으로 전이할 수 있습니다. 현재 상태: " + this.poStatus);
+            throw new InvalidPaymentStatusTransitionException("READY 상태에서만 EXECUTING으로 전이할 수 있습니다.", this.poStatus);
         }
         this.poStatus = PaymentEventStatus.EXECUTING;
     }
 
     public void completeWithApproval(PaymentApprovalInfo info) {
         if (!this.poStatus.isExecuting()) {
-            throw new IllegalStateException("EXECUTING 상태에서만 승인 완료 처리할 수 있습니다. 현재 상태: " + this.poStatus);
+            throw new InvalidPaymentStatusTransitionException("EXECUTING 상태에서만 승인 완료 처리할 수 있습니다.", this.poStatus);
         }
         this.poStatus = PaymentEventStatus.COMPLETE;
         this.pgPaymentKey = info.getPgPaymentKey();
@@ -134,7 +134,7 @@ public class PspPaymentEvent {
 
     public void failExecution(String resultCode, String resultMessage) {
         if (!this.poStatus.isExecuting()) {
-            throw new IllegalStateException("EXECUTING 상태에서만 실행 실패 처리할 수 있습니다. 현재 상태: " + this.poStatus);
+            throw new InvalidPaymentStatusTransitionException("EXECUTING 상태에서만 실행 실패 처리할 수 있습니다.", this.poStatus);
         }
         this.poStatus = PaymentEventStatus.READY;
         this.resultCode = resultCode;
@@ -151,7 +151,7 @@ public class PspPaymentEvent {
 
     public void cancel(String pgCancelApprovalResult) {
         if (!this.poStatus.isComplete()) {
-            throw new IllegalStateException("COMPLETE 상태에서만 취소할 수 있습니다. 현재 상태: " + this.poStatus);
+            throw new InvalidPaymentStatusTransitionException("COMPLETE 상태에서만 취소할 수 있습니다.", this.poStatus);
         }
         this.poStatus = PaymentEventStatus.CANCELLED;
         this.pgCancelApprovalResult = pgCancelApprovalResult;
@@ -159,7 +159,7 @@ public class PspPaymentEvent {
 
     public void partialRefund(String pgCancelApprovalResult) {
         if (!this.poStatus.isRefundable()) {
-            throw new IllegalStateException("COMPLETE 또는 PARTIALLY_REFUNDED 상태에서만 부분 환불할 수 있습니다. 현재 상태: " + this.poStatus);
+            throw new InvalidPaymentStatusTransitionException("COMPLETE 또는 PARTIALLY_REFUNDED 상태에서만 부분 환불할 수 있습니다.", this.poStatus);
         }
         this.poStatus = PaymentEventStatus.PARTIALLY_REFUNDED;
         this.pgCancelApprovalResult = pgCancelApprovalResult;
@@ -167,7 +167,7 @@ public class PspPaymentEvent {
 
     public void refund(String pgCancelApprovalResult) {
         if (!this.poStatus.isRefundable()) {
-            throw new IllegalStateException("COMPLETE 또는 PARTIALLY_REFUNDED 상태에서만 환불할 수 있습니다. 현재 상태: " + this.poStatus);
+            throw new InvalidPaymentStatusTransitionException("COMPLETE 또는 PARTIALLY_REFUNDED 상태에서만 환불할 수 있습니다.", this.poStatus);
         }
         this.poStatus = PaymentEventStatus.REFUNDED;
         this.pgCancelApprovalResult = pgCancelApprovalResult;

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/payment/UnknownPaymentMethodCodeException.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/payment/UnknownPaymentMethodCodeException.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.commerce.domain.payment;
+
+public class UnknownPaymentMethodCodeException extends IllegalArgumentException {
+    public UnknownPaymentMethodCodeException(String kcpCode) {
+        super("알 수 없는 KCP 결제수단 코드: " + kcpCode);
+    }
+}

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/settlement/InvalidSettlementAmountException.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/settlement/InvalidSettlementAmountException.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.commerce.domain.settlement;
+
+public class InvalidSettlementAmountException extends IllegalArgumentException {
+    public InvalidSettlementAmountException(String message) {
+        super(message);
+    }
+}

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/settlement/InvalidSettlementStatusTransitionException.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/settlement/InvalidSettlementStatusTransitionException.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.commerce.domain.settlement;
+
+public class InvalidSettlementStatusTransitionException extends IllegalStateException {
+    public InvalidSettlementStatusTransitionException(SettlementStatus currentStatus) {
+        super("PENDING 상태에서만 처리할 수 있습니다. 현재 상태: " + currentStatus);
+    }
+}

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/settlement/PaymentAllocation.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/settlement/PaymentAllocation.java
@@ -22,7 +22,7 @@ public class PaymentAllocation {
 
     public static PaymentAllocation from(PaymentAllocationCreateState state) {
         if (FormatValidator.hasNoValue(state.getAllocatedAmount()) || state.getAllocatedAmount() <= 0) {
-            throw new IllegalArgumentException(
+            throw new InvalidSettlementAmountException(
                     "배분 금액은 0보다 커야 합니다. allocatedAmount=" + state.getAllocatedAmount());
         }
 

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/settlement/Settlement.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/settlement/Settlement.java
@@ -25,22 +25,22 @@ public class Settlement {
 
     public static Settlement from(SettlementCreateState state) {
         if (FormatValidator.hasNoValue(state.getTotalAllocatedAmount()) || state.getTotalAllocatedAmount() <= 0) {
-            throw new IllegalArgumentException(
+            throw new InvalidSettlementAmountException(
                     "총 배분 금액은 0보다 커야 합니다. totalAllocatedAmount=" + state.getTotalAllocatedAmount());
         }
         if (FormatValidator.hasNoValue(state.getSellerPayoutAmount()) || state.getSellerPayoutAmount() <= 0) {
-            throw new IllegalArgumentException(
+            throw new InvalidSettlementAmountException(
                     "판매자 지급액은 0보다 커야 합니다. sellerPayoutAmount=" + state.getSellerPayoutAmount());
         }
         long pgFee = state.getPgFeeAmount() != null ? state.getPgFeeAmount() : 0L;
         long platformFee = state.getPlatformFeeAmount() != null ? state.getPlatformFeeAmount() : 0L;
 
         if (pgFee < 0) {
-            throw new IllegalArgumentException(
+            throw new InvalidSettlementAmountException(
                     "PG 수수료는 음수일 수 없습니다. pgFeeAmount=" + pgFee);
         }
         if (platformFee < 0) {
-            throw new IllegalArgumentException(
+            throw new InvalidSettlementAmountException(
                     "플랫폼 수수료는 음수일 수 없습니다. platformFeeAmount=" + platformFee);
         }
 
@@ -83,16 +83,14 @@ public class Settlement {
 
     public void complete() {
         if (!isPending()) {
-            throw new IllegalStateException(
-                    "PENDING 상태에서만 완료 처리할 수 있습니다. 현재 상태: " + status);
+            throw new InvalidSettlementStatusTransitionException(status);
         }
         this.status = SettlementStatus.COMPLETED;
     }
 
     public void fail() {
         if (!isPending()) {
-            throw new IllegalStateException(
-                    "PENDING 상태에서만 실패 처리할 수 있습니다. 현재 상태: " + status);
+            throw new InvalidSettlementStatusTransitionException(status);
         }
         this.status = SettlementStatus.FAILED;
     }


### PR DESCRIPTION
## partially addresses #723
## resolves #909

## Task
- [x] Settlement 도메인 IllegalArgumentException 4건 → InvalidSettlementAmountException
- [x] Settlement 도메인 IllegalStateException 2건 → InvalidSettlementStatusTransitionException
- [x] PaymentAllocation 도메인 IllegalArgumentException 1건 → InvalidSettlementAmountException
- [x] LedgerTransaction 도메인 IllegalStateException 2건 → InvalidLedgerEntryAmountException, LedgerEntryImbalanceException
- [x] PaymentMethod 도메인 IllegalArgumentException 1건 → UnknownPaymentMethodCodeException
- [x] PspPaymentEvent 도메인 IllegalStateException 7건 → InvalidPaymentStatusTransitionException
- [x] OrderProduct 도메인 IllegalStateException 1건 → InvalidOrderProductStatusTransitionException
- [x] ExecuteSettlementService IllegalArgumentException 3건 → InvalidFeeRateException
- [x] CancelPaymentService IllegalArgumentException 2건 → InvalidCancelAmountException
- [x] ApprovePaymentService IllegalStateException 1건 → PaymentAmountMismatchException
- [x] SyncFulfillmentVendorInventoryService IllegalArgumentException 1건 → InvalidFulfillmentSyncCommandException
- [x] RecordLedgerEntryService IllegalArgumentException 1건 → EmptyLedgerEntriesException