### PR TITLE
[#723][#910] feat: 도메인 모델 방어 로직 강화

### DIFF
--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/inventory/Stock.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/inventory/Stock.java
@@ -67,7 +67,11 @@ public class Stock {
     }
 
     public Integer reduce(int stock) {
-        return this.stock - stock;
+        int result = this.stock - stock;
+        if (result < 0) {
+            throw new InsufficientQuantityException(this.stock, stock);
+        }
+        return result;
     }
 
     public void validateIsSufficient(int orderQuantity) {

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/payment/InvalidRefundAmountException.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/payment/InvalidRefundAmountException.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.commerce.domain.payment;
+
+public class InvalidRefundAmountException extends IllegalArgumentException {
+    public InvalidRefundAmountException(String message) {
+        super(message);
+    }
+}

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/payment/Payment.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/payment/Payment.java
@@ -63,7 +63,13 @@ public class Payment {
     }
 
     public void markAsPartiallyRefunded(Long amount) {
-        this.refundAmount = this.refundAmount + amount;
+        long newRefundAmount = this.refundAmount + amount;
+        if (newRefundAmount > this.paymentAmount) {
+            throw new InvalidRefundAmountException(
+                    "누적 환불 금액이 결제 금액을 초과합니다. paymentAmount=" + this.paymentAmount
+                            + ", 현재 환불액=" + this.refundAmount + ", 요청 환불액=" + amount);
+        }
+        this.refundAmount = newRefundAmount;
         if (this.refundAmount.equals(this.paymentAmount)) {
             this.refundedYn = true;
         }

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/settlement/Settlement.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/settlement/Settlement.java
@@ -44,6 +44,14 @@ public class Settlement {
                     "플랫폼 수수료는 음수일 수 없습니다. platformFeeAmount=" + platformFee);
         }
 
+        long expectedPayout = state.getTotalAllocatedAmount() - pgFee - platformFee;
+        if (expectedPayout != state.getSellerPayoutAmount()) {
+            throw new InvalidSettlementAmountException(
+                    "정산 금액 정합성 불일치: totalAllocatedAmount(" + state.getTotalAllocatedAmount()
+                            + ") - pgFeeAmount(" + pgFee + ") - platformFeeAmount(" + platformFee
+                            + ") != sellerPayoutAmount(" + state.getSellerPayoutAmount() + ")");
+        }
+
         return Settlement.builder()
                 .sellerId(state.getSellerId())
                 .year(state.getYear())


### PR DESCRIPTION
## partially addresses #723
## resolves #910

## Task
- [x] Stock.reduce() 차감 후 음수 결과 방지 검증 추가 (InsufficientQuantityException)
- [x] Settlement.from() 정산 금액 정합성 검증 추가 (totalAllocated - pgFee - platformFee = sellerPayout)
- [x] Payment.markAsPartiallyRefunded() 누적 환불 금액 초과 방지 검증 추가
- [x] InvalidRefundAmountException 커스텀 예외 생성