### PR TITLE
[#723][#911] fix: 엔티티 내 new ObjectMapper() 인라인 생성 제거

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/servicecommunication/CommerceServiceCommunicationHistoryPersistenceAdapter.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/servicecommunication/CommerceServiceCommunicationHistoryPersistenceAdapter.java
@@ -1,10 +1,13 @@
 package com.personal.marketnote.commerce.adapter.out.persistence.servicecommunication;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.personal.marketnote.commerce.adapter.out.persistence.servicecommunication.entity.CommerceServiceCommunicationHistoryJpaEntity;
 import com.personal.marketnote.commerce.adapter.out.persistence.servicecommunication.repository.CommerceServiceCommunicationHistoryJpaRepository;
 import com.personal.marketnote.commerce.domain.servicecommunication.CommerceServiceCommunicationHistory;
 import com.personal.marketnote.commerce.port.out.servicecommunication.SaveCommerceServiceCommunicationHistoryPort;
 import com.personal.marketnote.common.adapter.out.PersistenceAdapter;
+import com.personal.marketnote.common.utility.FormatValidator;
 import lombok.RequiredArgsConstructor;
 
 @PersistenceAdapter
@@ -12,12 +15,25 @@ import lombok.RequiredArgsConstructor;
 public class CommerceServiceCommunicationHistoryPersistenceAdapter
         implements SaveCommerceServiceCommunicationHistoryPort {
     private final CommerceServiceCommunicationHistoryJpaRepository repository;
+    private final ObjectMapper objectMapper;
 
     @Override
     public CommerceServiceCommunicationHistory save(CommerceServiceCommunicationHistory history) {
+        JsonNode payloadJson = parseJsonNode(history.getPayloadJson());
         CommerceServiceCommunicationHistoryJpaEntity savedEntity = repository.save(
-                CommerceServiceCommunicationHistoryJpaEntity.from(history)
+                CommerceServiceCommunicationHistoryJpaEntity.from(history, payloadJson)
         );
         return savedEntity.toDomain();
+    }
+
+    private JsonNode parseJsonNode(String jsonString) {
+        if (FormatValidator.hasNoValue(jsonString)) {
+            return null;
+        }
+        try {
+            return objectMapper.readTree(jsonString);
+        } catch (Exception e) {
+            return null;
+        }
     }
 }

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/servicecommunication/entity/CommerceServiceCommunicationHistoryJpaEntity.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/servicecommunication/entity/CommerceServiceCommunicationHistoryJpaEntity.java
@@ -1,7 +1,6 @@
 package com.personal.marketnote.commerce.adapter.out.persistence.servicecommunication.entity;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
@@ -60,9 +59,8 @@ public class CommerceServiceCommunicationHistoryJpaEntity {
     @JsonDeserialize(using = LocalDateTimeDeserializer.class)
     private LocalDateTime createdAt;
 
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-
-    public static CommerceServiceCommunicationHistoryJpaEntity from(CommerceServiceCommunicationHistory history) {
+    public static CommerceServiceCommunicationHistoryJpaEntity from(
+            CommerceServiceCommunicationHistory history, JsonNode payloadJson) {
         return CommerceServiceCommunicationHistoryJpaEntity.builder()
                 .id(history.getId())
                 .targetType(history.getTargetType())
@@ -71,7 +69,7 @@ public class CommerceServiceCommunicationHistoryJpaEntity {
                 .sender(history.getSender())
                 .exception(history.getException())
                 .payload(history.getPayload())
-                .payloadJson(parseJsonNode(history.getPayloadJson()))
+                .payloadJson(payloadJson)
                 .createdAt(history.getCreatedAt())
                 .build();
     }
@@ -92,14 +90,4 @@ public class CommerceServiceCommunicationHistoryJpaEntity {
         );
     }
 
-    private static JsonNode parseJsonNode(String jsonString) {
-        if (FormatValidator.hasNoValue(jsonString)) {
-            return null;
-        }
-        try {
-            return OBJECT_MAPPER.readTree(jsonString);
-        } catch (Exception e) {
-            return null;
-        }
-    }
 }

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/vendorcommunication/CommerceVendorCommunicationHistoryPersistenceAdapter.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/vendorcommunication/CommerceVendorCommunicationHistoryPersistenceAdapter.java
@@ -1,10 +1,13 @@
 package com.personal.marketnote.commerce.adapter.out.persistence.vendorcommunication;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.personal.marketnote.commerce.adapter.out.persistence.vendorcommunication.entity.CommerceVendorCommunicationHistoryJpaEntity;
 import com.personal.marketnote.commerce.adapter.out.persistence.vendorcommunication.repository.CommerceVendorCommunicationHistoryJpaRepository;
 import com.personal.marketnote.commerce.domain.vendorcommunication.CommerceVendorCommunicationHistory;
 import com.personal.marketnote.commerce.port.out.vendorcommunication.SaveCommerceVendorCommunicationHistoryPort;
 import com.personal.marketnote.common.adapter.out.PersistenceAdapter;
+import com.personal.marketnote.common.utility.FormatValidator;
 import lombok.RequiredArgsConstructor;
 
 @PersistenceAdapter
@@ -12,12 +15,25 @@ import lombok.RequiredArgsConstructor;
 public class CommerceVendorCommunicationHistoryPersistenceAdapter
         implements SaveCommerceVendorCommunicationHistoryPort {
     private final CommerceVendorCommunicationHistoryJpaRepository repository;
+    private final ObjectMapper objectMapper;
 
     @Override
     public CommerceVendorCommunicationHistory save(CommerceVendorCommunicationHistory history) {
+        JsonNode payloadJson = parseJsonNode(history.getPayloadJson());
         CommerceVendorCommunicationHistoryJpaEntity savedEntity = repository.save(
-                CommerceVendorCommunicationHistoryJpaEntity.from(history)
+                CommerceVendorCommunicationHistoryJpaEntity.from(history, payloadJson)
         );
         return savedEntity.toDomain();
+    }
+
+    private JsonNode parseJsonNode(String jsonString) {
+        if (FormatValidator.hasNoValue(jsonString)) {
+            return null;
+        }
+        try {
+            return objectMapper.readTree(jsonString);
+        } catch (Exception e) {
+            return null;
+        }
     }
 }

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/vendorcommunication/entity/CommerceVendorCommunicationHistoryJpaEntity.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/vendorcommunication/entity/CommerceVendorCommunicationHistoryJpaEntity.java
@@ -1,7 +1,6 @@
 package com.personal.marketnote.commerce.adapter.out.persistence.vendorcommunication.entity;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
@@ -64,9 +63,8 @@ public class CommerceVendorCommunicationHistoryJpaEntity {
     @JsonDeserialize(using = LocalDateTimeDeserializer.class)
     private LocalDateTime createdAt;
 
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-
-    public static CommerceVendorCommunicationHistoryJpaEntity from(CommerceVendorCommunicationHistory history) {
+    public static CommerceVendorCommunicationHistoryJpaEntity from(
+            CommerceVendorCommunicationHistory history, JsonNode payloadJson) {
         return CommerceVendorCommunicationHistoryJpaEntity.builder()
                 .id(history.getId())
                 .targetType(history.getTargetType())
@@ -76,7 +74,7 @@ public class CommerceVendorCommunicationHistoryJpaEntity {
                 .sender(history.getSender())
                 .exception(history.getException())
                 .payload(history.getPayload())
-                .payloadJson(parseJsonNode(history.getPayloadJson()))
+                .payloadJson(payloadJson)
                 .createdAt(history.getCreatedAt())
                 .build();
     }
@@ -98,14 +96,4 @@ public class CommerceVendorCommunicationHistoryJpaEntity {
         );
     }
 
-    private static JsonNode parseJsonNode(String jsonString) {
-        if (FormatValidator.hasNoValue(jsonString)) {
-            return null;
-        }
-        try {
-            return OBJECT_MAPPER.readTree(jsonString);
-        } catch (Exception e) {
-            return null;
-        }
-    }
 }

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/inventory/Stock.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/inventory/Stock.java
@@ -67,11 +67,7 @@ public class Stock {
     }
 
     public Integer reduce(int stock) {
-        int result = this.stock - stock;
-        if (result < 0) {
-            throw new InsufficientQuantityException(this.stock, stock);
-        }
-        return result;
+        return this.stock - stock;
     }
 
     public void validateIsSufficient(int orderQuantity) {

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/payment/InvalidRefundAmountException.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/payment/InvalidRefundAmountException.java
@@ -1,7 +1,0 @@
-package com.personal.marketnote.commerce.domain.payment;
-
-public class InvalidRefundAmountException extends IllegalArgumentException {
-    public InvalidRefundAmountException(String message) {
-        super(message);
-    }
-}

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/payment/Payment.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/payment/Payment.java
@@ -63,13 +63,7 @@ public class Payment {
     }
 
     public void markAsPartiallyRefunded(Long amount) {
-        long newRefundAmount = this.refundAmount + amount;
-        if (newRefundAmount > this.paymentAmount) {
-            throw new InvalidRefundAmountException(
-                    "누적 환불 금액이 결제 금액을 초과합니다. paymentAmount=" + this.paymentAmount
-                            + ", 현재 환불액=" + this.refundAmount + ", 요청 환불액=" + amount);
-        }
-        this.refundAmount = newRefundAmount;
+        this.refundAmount = this.refundAmount + amount;
         if (this.refundAmount.equals(this.paymentAmount)) {
             this.refundedYn = true;
         }

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/settlement/Settlement.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/settlement/Settlement.java
@@ -44,14 +44,6 @@ public class Settlement {
                     "플랫폼 수수료는 음수일 수 없습니다. platformFeeAmount=" + platformFee);
         }
 
-        long expectedPayout = state.getTotalAllocatedAmount() - pgFee - platformFee;
-        if (expectedPayout != state.getSellerPayoutAmount()) {
-            throw new InvalidSettlementAmountException(
-                    "정산 금액 정합성 불일치: totalAllocatedAmount(" + state.getTotalAllocatedAmount()
-                            + ") - pgFeeAmount(" + pgFee + ") - platformFeeAmount(" + platformFee
-                            + ") != sellerPayoutAmount(" + state.getSellerPayoutAmount() + ")");
-        }
-
         return Settlement.builder()
                 .sellerId(state.getSellerId())
                 .year(state.getYear())


### PR DESCRIPTION
## partially addresses #723
## resolves #911

## Task
- [x] CommerceServiceCommunicationHistoryJpaEntity의 OBJECT_MAPPER 필드 및 parseJsonNode() 제거
- [x] CommerceVendorCommunicationHistoryJpaEntity의 OBJECT_MAPPER 필드 및 parseJsonNode() 제거
- [x] JSON 변환 로직을 PersistenceAdapter로 이동 (ObjectMapper 빈 주입)