### PR TITLE
[#216][#912] feat: 포인트 기반 결제 기능 추가

### DIFF
--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/inventory/RestoreProductInventoryUseCase.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/inventory/RestoreProductInventoryUseCase.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.commerce.port.in.usecase.inventory;
+
+import com.personal.marketnote.commerce.domain.order.OrderProduct;
+
+import java.util.List;
+
+public interface RestoreProductInventoryUseCase {
+    void restore(List<OrderProduct> orderProducts, String reason);
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/inventory/RestoreProductInventoryService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/inventory/RestoreProductInventoryService.java
@@ -1,0 +1,49 @@
+package com.personal.marketnote.commerce.service.inventory;
+
+import com.personal.marketnote.commerce.domain.inventory.Inventory;
+import com.personal.marketnote.commerce.domain.order.OrderProduct;
+import com.personal.marketnote.commerce.port.in.usecase.inventory.RestoreProductInventoryUseCase;
+import com.personal.marketnote.commerce.port.out.inventory.FindInventoryPort;
+import com.personal.marketnote.commerce.port.out.inventory.InventoryLockPort;
+import com.personal.marketnote.commerce.port.out.inventory.SaveCacheStockPort;
+import com.personal.marketnote.commerce.port.out.inventory.UpdateInventoryPort;
+import com.personal.marketnote.common.application.UseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional(isolation = READ_COMMITTED)
+public class RestoreProductInventoryService implements RestoreProductInventoryUseCase {
+    private final FindInventoryPort findInventoryPort;
+    private final UpdateInventoryPort updateInventoryPort;
+    private final SaveCacheStockPort saveCacheStockPort;
+    private final InventoryLockPort inventoryLockPort;
+
+    @Override
+    public void restore(List<OrderProduct> orderProducts, String reason) {
+        Map<Long, Integer> stocksByPricePolicyId = orderProducts.stream()
+                .collect(
+                        Collectors.groupingBy(
+                                OrderProduct::getPricePolicyId, Collectors.summingInt(OrderProduct::getQuantity)
+                        )
+                );
+
+        inventoryLockPort.executeWithLock(stocksByPricePolicyId.keySet(), () -> {
+            Set<Inventory> inventories = findInventoryPort.findByPricePolicyIds(stocksByPricePolicyId.keySet());
+            inventories.forEach(inventory -> inventory.restore(
+                    stocksByPricePolicyId.get(inventory.getPricePolicyId())
+            ));
+
+            updateInventoryPort.update(inventories);
+            saveCacheStockPort.save(inventories);
+        });
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/CancelPaymentService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/CancelPaymentService.java
@@ -11,6 +11,7 @@ import com.personal.marketnote.commerce.exception.PaymentNotFoundException;
 import com.personal.marketnote.commerce.exception.UnauthorizedOrderAccessException;
 import com.personal.marketnote.commerce.port.in.command.order.ChangeOrderStatusCommand;
 import com.personal.marketnote.commerce.port.in.command.payment.CancelPaymentCommand;
+import com.personal.marketnote.commerce.port.in.usecase.inventory.RestoreProductInventoryUseCase;
 import com.personal.marketnote.commerce.port.in.usecase.ledger.RecordLedgerEntryUseCase;
 import com.personal.marketnote.commerce.port.in.usecase.order.ChangeOrderStatusUseCase;
 import com.personal.marketnote.commerce.port.in.usecase.payment.CancelPaymentUseCase;
@@ -41,6 +42,7 @@ public class CancelPaymentService implements CancelPaymentUseCase {
     private final PaymentVendorPort paymentVendorPort;
     private final ChangeOrderStatusUseCase changeOrderStatusUseCase;
     private final RecordLedgerEntryUseCase recordLedgerEntryUseCase;
+    private final RestoreProductInventoryUseCase restoreProductInventoryUseCase;
 
     @Override
     public void cancel(CancelPaymentCommand command) {
@@ -49,7 +51,7 @@ public class CancelPaymentService implements CancelPaymentUseCase {
         Payment payment = findPaymentPort.findByOrderKey(orderKeyUuid)
                 .orElseThrow(() -> new PaymentNotFoundException(command.orderKey()));
 
-        verifyOrderOwnership(payment.getOrderId(), command.buyerId());
+        Order order = findVerifiedOrder(payment.getOrderId(), command.buyerId());
 
         PspPaymentEvent event = findPspPaymentEventPort.findByOrderKey(command.orderKey())
                 .orElseThrow(() -> new PaymentNotFoundException(command.orderKey()));
@@ -112,6 +114,7 @@ public class CancelPaymentService implements CancelPaymentUseCase {
                             .orderStatus(OrderStatus.CANCEL_REQUESTED)
                             .build()
             );
+            restoreInventory(order);
         }
 
         recordLedgerEntryForCancellation(payment, isFullCancel, cancelAmount, alreadyRefunded);
@@ -137,13 +140,25 @@ public class CancelPaymentService implements CancelPaymentUseCase {
         }
     }
 
-    private void verifyOrderOwnership(Long orderId, Long buyerId) {
+    private Order findVerifiedOrder(Long orderId, Long buyerId) {
         Order order = findOrderPort.findById(orderId)
                 .orElseThrow(() -> new OrderNotFoundException(orderId));
         if (!order.getBuyerId().equals(buyerId)) {
             log.warn("결제 취소 소유자 불일치 - orderId: {}, 주문소유자: {}, 요청자: {}",
                     orderId, order.getBuyerId(), buyerId);
             throw new UnauthorizedOrderAccessException();
+        }
+        return order;
+    }
+
+    private void restoreInventory(Order order) {
+        try {
+            restoreProductInventoryUseCase.restore(
+                    order.getOrderProducts(), "주문 전액 취소에 의한 재고 복구"
+            );
+        } catch (Exception e) {
+            log.error("재고 복구 실패 - orderId: {}, error: {}",
+                    order.getId(), e.getMessage(), e);
         }
     }
 }

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/inventory/RestoreProductInventoryUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/inventory/RestoreProductInventoryUseCaseTest.java
@@ -1,0 +1,200 @@
+package com.personal.marketnote.commerce.service.inventory;
+
+import com.personal.marketnote.commerce.domain.inventory.Inventory;
+import com.personal.marketnote.commerce.domain.order.OrderProduct;
+import com.personal.marketnote.commerce.domain.order.OrderProductSnapshotState;
+import com.personal.marketnote.commerce.port.out.inventory.FindInventoryPort;
+import com.personal.marketnote.commerce.port.out.inventory.InventoryLockPort;
+import com.personal.marketnote.commerce.port.out.inventory.SaveCacheStockPort;
+import com.personal.marketnote.commerce.port.out.inventory.UpdateInventoryPort;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class RestoreProductInventoryUseCaseTest {
+    @Mock
+    private FindInventoryPort findInventoryPort;
+    @Mock
+    private UpdateInventoryPort updateInventoryPort;
+    @Mock
+    private SaveCacheStockPort saveCacheStockPort;
+    @Mock
+    private InventoryLockPort inventoryLockPort;
+
+    @InjectMocks
+    private RestoreProductInventoryService restoreProductInventoryService;
+
+    @Nested
+    @DisplayName("restore (재고 복구)")
+    class RestoreTest {
+
+        @Test
+        @DisplayName("단일 주문 상품 재고 복구 시 재고가 올바르게 증가한다")
+        void restore_singleOrderProduct_increasesInventoryStock() {
+            List<OrderProduct> orderProducts = List.of(buildOrderProduct(100L, 3));
+            Inventory inventory = buildInventory(1L, 100L, 7);
+
+            stubLockToExecuteTask();
+            when(findInventoryPort.findByPricePolicyIds(any())).thenReturn(Set.of(inventory));
+
+            restoreProductInventoryService.restore(orderProducts, "주문 취소");
+
+            assertThat(inventory.getStockValue()).isEqualTo(10);
+        }
+
+        @Test
+        @DisplayName("서로 다른 가격 정책의 복수 주문 상품 재고 복구 시 각각의 재고가 올바르게 증가한다")
+        void restore_differentPolicies_restoresEachInventory() {
+            List<OrderProduct> orderProducts = List.of(
+                    buildOrderProduct(100L, 2),
+                    buildOrderProduct(200L, 5)
+            );
+            Inventory inventory1 = buildInventory(1L, 100L, 8);
+            Inventory inventory2 = buildInventory(2L, 200L, 15);
+
+            stubLockToExecuteTask();
+            when(findInventoryPort.findByPricePolicyIds(any())).thenReturn(Set.of(inventory1, inventory2));
+
+            restoreProductInventoryService.restore(orderProducts, "주문 취소");
+
+            assertThat(inventory1.getStockValue()).isEqualTo(10);
+            assertThat(inventory2.getStockValue()).isEqualTo(20);
+        }
+
+        @Test
+        @DisplayName("동일 가격 정책의 복수 주문 상품 재고 복구 시 수량을 합산하여 복구한다")
+        void restore_samePolicyMultipleProducts_sumsQuantityAndRestores() {
+            List<OrderProduct> orderProducts = List.of(
+                    buildOrderProduct(100L, 2),
+                    buildOrderProduct(100L, 3)
+            );
+            Inventory inventory = buildInventory(1L, 100L, 5);
+
+            stubLockToExecuteTask();
+            when(findInventoryPort.findByPricePolicyIds(any())).thenReturn(Set.of(inventory));
+
+            restoreProductInventoryService.restore(orderProducts, "주문 취소");
+
+            assertThat(inventory.getStockValue()).isEqualTo(10);
+        }
+
+        @Test
+        @DisplayName("재고 복구 시 분산 락에 올바른 가격 정책 ID Set을 전달한다")
+        @SuppressWarnings("unchecked")
+        void restore_success_passesCorrectPricePolicyIdsToLock() {
+            List<OrderProduct> orderProducts = List.of(
+                    buildOrderProduct(100L, 2),
+                    buildOrderProduct(200L, 3)
+            );
+
+            stubLockToExecuteTask();
+            when(findInventoryPort.findByPricePolicyIds(any())).thenReturn(Set.of(
+                    buildInventory(1L, 100L, 8),
+                    buildInventory(2L, 200L, 17)
+            ));
+
+            restoreProductInventoryService.restore(orderProducts, "주문 취소");
+
+            ArgumentCaptor<Set<Long>> lockKeysCaptor = ArgumentCaptor.forClass(Set.class);
+            verify(inventoryLockPort).executeWithLock(lockKeysCaptor.capture(), any());
+            assertThat(lockKeysCaptor.getValue()).containsExactlyInAnyOrder(100L, 200L);
+        }
+
+        @Test
+        @DisplayName("재고 복구 시 재고 조회 → 업데이트 → 캐시 저장 순서로 호출한다")
+        @SuppressWarnings("unchecked")
+        void restore_success_callsPortsInCorrectOrder() {
+            List<OrderProduct> orderProducts = List.of(buildOrderProduct(100L, 3));
+            Inventory inventory = buildInventory(1L, 100L, 7);
+
+            stubLockToExecuteTask();
+            when(findInventoryPort.findByPricePolicyIds(any())).thenReturn(Set.of(inventory));
+
+            restoreProductInventoryService.restore(orderProducts, "주문 취소");
+
+            InOrder inOrder = inOrder(findInventoryPort, updateInventoryPort, saveCacheStockPort);
+            inOrder.verify(findInventoryPort).findByPricePolicyIds(any());
+            inOrder.verify(updateInventoryPort).update(any());
+            inOrder.verify(saveCacheStockPort).save(any(Set.class));
+            inOrder.verifyNoMoreInteractions();
+        }
+
+        @Test
+        @DisplayName("분산 락이 작업을 실행하지 않으면 내부 Port를 호출하지 않는다")
+        void restore_lockNotExecuted_doesNotCallInternalPorts() {
+            List<OrderProduct> orderProducts = List.of(buildOrderProduct(100L, 3));
+
+            restoreProductInventoryService.restore(orderProducts, "주문 취소");
+
+            verify(inventoryLockPort).executeWithLock(any(), any());
+            verifyNoInteractions(findInventoryPort);
+            verifyNoInteractions(updateInventoryPort);
+            verifyNoInteractions(saveCacheStockPort);
+        }
+
+        @Test
+        @DisplayName("재고 조회 중 예외 발생 시 예외를 전파한다")
+        void restore_findPortFails_propagates() {
+            List<OrderProduct> orderProducts = List.of(buildOrderProduct(100L, 3));
+            RuntimeException exception = new RuntimeException("find fail");
+
+            stubLockToExecuteTask();
+            when(findInventoryPort.findByPricePolicyIds(any())).thenThrow(exception);
+
+            assertThatThrownBy(() -> restoreProductInventoryService.restore(orderProducts, "주문 취소"))
+                    .isSameAs(exception);
+        }
+
+        @Test
+        @DisplayName("재고 업데이트 중 예외 발생 시 캐시 저장을 호출하지 않는다")
+        void restore_updatePortFails_doesNotSaveCache() {
+            List<OrderProduct> orderProducts = List.of(buildOrderProduct(100L, 3));
+            Inventory inventory = buildInventory(1L, 100L, 7);
+
+            stubLockToExecuteTask();
+            when(findInventoryPort.findByPricePolicyIds(any())).thenReturn(Set.of(inventory));
+            doThrow(new RuntimeException("update fail")).when(updateInventoryPort).update(any());
+
+            assertThatThrownBy(() -> restoreProductInventoryService.restore(orderProducts, "주문 취소"))
+                    .isInstanceOf(RuntimeException.class);
+
+            verifyNoInteractions(saveCacheStockPort);
+        }
+    }
+
+    private void stubLockToExecuteTask() {
+        doAnswer(invocation -> {
+            Runnable task = invocation.getArgument(1);
+            task.run();
+            return null;
+        }).when(inventoryLockPort).executeWithLock(any(), any());
+    }
+
+    private OrderProduct buildOrderProduct(Long pricePolicyId, int quantity) {
+        return OrderProduct.from(
+                OrderProductSnapshotState.builder()
+                        .pricePolicyId(pricePolicyId)
+                        .quantity(quantity)
+                        .build()
+        );
+    }
+
+    private Inventory buildInventory(Long productId, Long pricePolicyId, int stock) {
+        return Inventory.of(productId, pricePolicyId, stock, 0L);
+    }
+}

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/payment/CancelPaymentUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/payment/CancelPaymentUseCaseTest.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.commerce.service.payment;
 
 import com.personal.marketnote.commerce.domain.order.Order;
+import com.personal.marketnote.commerce.domain.order.OrderProductSnapshotState;
 import com.personal.marketnote.commerce.domain.order.OrderSnapshotState;
 import com.personal.marketnote.commerce.domain.order.OrderStatus;
 import com.personal.marketnote.commerce.domain.payment.*;
@@ -8,6 +9,7 @@ import com.personal.marketnote.commerce.exception.PaymentCancelException;
 import com.personal.marketnote.commerce.exception.PaymentNotFoundException;
 import com.personal.marketnote.commerce.exception.UnauthorizedOrderAccessException;
 import com.personal.marketnote.commerce.port.in.command.payment.CancelPaymentCommand;
+import com.personal.marketnote.commerce.port.in.usecase.inventory.RestoreProductInventoryUseCase;
 import com.personal.marketnote.commerce.port.in.usecase.ledger.RecordLedgerEntryUseCase;
 import com.personal.marketnote.commerce.port.in.usecase.order.ChangeOrderStatusUseCase;
 import com.personal.marketnote.commerce.port.out.order.FindOrderPort;
@@ -22,6 +24,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -59,6 +62,9 @@ class CancelPaymentUseCaseTest {
 
     @Mock
     private RecordLedgerEntryUseCase recordLedgerEntryUseCase;
+
+    @Mock
+    private RestoreProductInventoryUseCase restoreProductInventoryUseCase;
 
     private static final Long BUYER_ID = 100L;
     private static final UUID ORDER_KEY = UUID.randomUUID();
@@ -449,6 +455,69 @@ class CancelPaymentUseCaseTest {
     }
 
     @Nested
+    @DisplayName("재고 복구 검증")
+    class InventoryRestoreTest {
+
+        @Test
+        @DisplayName("전체 취소 성공 시 재고 복구가 호출된다")
+        void shouldRestoreInventoryOnFullCancel() {
+            Payment payment = createSuccessPayment(1L, ORDER_KEY, 50000L, "tno_123");
+            PspPaymentEvent event = createCompleteEvent(ORDER_KEY_STR, "tno_123", 50000L);
+            CancelPaymentCommand command = createFullCancelCommand(ORDER_KEY_STR);
+            PaymentCancelVendorResult vendorResult = createSuccessVendorResult();
+
+            when(findPaymentPort.findByOrderKey(ORDER_KEY)).thenReturn(Optional.of(payment));
+            when(findOrderPort.findById(1L)).thenReturn(Optional.of(createOrder(1L, BUYER_ID)));
+            when(findPspPaymentEventPort.findByOrderKey(ORDER_KEY_STR)).thenReturn(Optional.of(event));
+            when(paymentVendorPort.cancelPayment(any())).thenReturn(vendorResult);
+
+            cancelPaymentService.cancel(command);
+
+            verify(restoreProductInventoryUseCase).restore(anyList(), anyString());
+        }
+
+        @Test
+        @DisplayName("부분 취소 시 재고 복구가 호출되지 않는다")
+        void shouldNotRestoreInventoryOnPartialCancel() {
+            Payment payment = createSuccessPayment(1L, ORDER_KEY, 50000L, "tno_123");
+            PspPaymentEvent event = createCompleteEvent(ORDER_KEY_STR, "tno_123", 50000L);
+            CancelPaymentCommand command = createPartialCancelCommand(ORDER_KEY_STR, 20000L);
+            PaymentCancelVendorResult vendorResult = createSuccessVendorResult();
+
+            when(findPaymentPort.findByOrderKey(ORDER_KEY)).thenReturn(Optional.of(payment));
+            when(findOrderPort.findById(1L)).thenReturn(Optional.of(createOrder(1L, BUYER_ID)));
+            when(findPspPaymentEventPort.findByOrderKey(ORDER_KEY_STR)).thenReturn(Optional.of(event));
+            when(paymentVendorPort.cancelPayment(any())).thenReturn(vendorResult);
+
+            cancelPaymentService.cancel(command);
+
+            verify(restoreProductInventoryUseCase, never()).restore(anyList(), anyString());
+        }
+
+        @Test
+        @DisplayName("재고 복구 실패 시에도 결제 취소는 정상 완료된다")
+        void shouldCompleteCancelEvenWhenInventoryRestoreFails() {
+            Payment payment = createSuccessPayment(1L, ORDER_KEY, 50000L, "tno_123");
+            PspPaymentEvent event = createCompleteEvent(ORDER_KEY_STR, "tno_123", 50000L);
+            CancelPaymentCommand command = createFullCancelCommand(ORDER_KEY_STR);
+            PaymentCancelVendorResult vendorResult = createSuccessVendorResult();
+
+            when(findPaymentPort.findByOrderKey(ORDER_KEY)).thenReturn(Optional.of(payment));
+            when(findOrderPort.findById(1L)).thenReturn(Optional.of(createOrder(1L, BUYER_ID)));
+            when(findPspPaymentEventPort.findByOrderKey(ORDER_KEY_STR)).thenReturn(Optional.of(event));
+            when(paymentVendorPort.cancelPayment(any())).thenReturn(vendorResult);
+            doThrow(new RuntimeException("재고 복구 실패")).when(restoreProductInventoryUseCase)
+                    .restore(anyList(), anyString());
+
+            cancelPaymentService.cancel(command);
+
+            verify(updatePaymentPort).update(any());
+            verify(updatePspPaymentEventPort).update(any());
+            verify(changeOrderStatusUseCase).changeOrderStatus(any());
+        }
+    }
+
+    @Nested
     @DisplayName("KCP 취소 실패")
     class VendorFailureTest {
 
@@ -539,11 +608,18 @@ class CancelPaymentUseCaseTest {
     }
 
     private Order createOrder(Long orderId, Long buyerId) {
+        OrderProductSnapshotState productState = OrderProductSnapshotState.builder()
+                .pricePolicyId(100L)
+                .quantity(2)
+                .sellerId(10L)
+                .unitAmount(25000L)
+                .build();
         OrderSnapshotState state = OrderSnapshotState.builder()
                 .id(orderId)
                 .buyerId(buyerId)
                 .orderKey(ORDER_KEY)
                 .orderStatus(OrderStatus.PAID)
+                .orderProductStates(List.of(productState))
                 .build();
         return Order.from(state);
     }

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/inventory/Inventory.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/inventory/Inventory.java
@@ -51,6 +51,13 @@ public class Inventory {
         );
     }
 
+    public void restore(int quantity) {
+        Integer increasedStock = stock.increase(quantity);
+        stock = Stock.of(
+                String.valueOf(increasedStock)
+        );
+    }
+
     public Integer getStockValue() {
         return stock.getValue();
     }

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/inventory/Stock.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/inventory/Stock.java
@@ -67,7 +67,20 @@ public class Stock {
     }
 
     public Integer reduce(int stock) {
-        return this.stock - stock;
+        int result = this.stock - stock;
+        if (result < 0) {
+            throw new InsufficientQuantityException(this.stock, stock);
+        }
+        return result;
+    }
+
+    public Integer increase(int quantity) {
+        if (quantity <= 0) {
+            throw new InvalidQuantityException(
+                    String.format(STOCK_INVALID_EXCEPTION, quantity)
+            );
+        }
+        return this.stock + quantity;
     }
 
     public void validateIsSufficient(int orderQuantity) {

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/payment/InvalidRefundAmountException.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/payment/InvalidRefundAmountException.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.commerce.domain.payment;
+
+public class InvalidRefundAmountException extends IllegalArgumentException {
+    public InvalidRefundAmountException(String message) {
+        super(message);
+    }
+}

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/payment/Payment.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/payment/Payment.java
@@ -63,7 +63,13 @@ public class Payment {
     }
 
     public void markAsPartiallyRefunded(Long amount) {
-        this.refundAmount = this.refundAmount + amount;
+        long newRefundAmount = this.refundAmount + amount;
+        if (newRefundAmount > this.paymentAmount) {
+            throw new InvalidRefundAmountException(
+                    "누적 환불 금액이 결제 금액을 초과합니다. paymentAmount=" + this.paymentAmount
+                            + ", 현재 환불액=" + this.refundAmount + ", 요청 환불액=" + amount);
+        }
+        this.refundAmount = newRefundAmount;
         if (this.refundAmount.equals(this.paymentAmount)) {
             this.refundedYn = true;
         }

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/settlement/Settlement.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/settlement/Settlement.java
@@ -44,6 +44,14 @@ public class Settlement {
                     "플랫폼 수수료는 음수일 수 없습니다. platformFeeAmount=" + platformFee);
         }
 
+        long expectedPayout = state.getTotalAllocatedAmount() - pgFee - platformFee;
+        if (expectedPayout != state.getSellerPayoutAmount()) {
+            throw new InvalidSettlementAmountException(
+                    "정산 금액 정합성 불일치: totalAllocatedAmount(" + state.getTotalAllocatedAmount()
+                            + ") - pgFeeAmount(" + pgFee + ") - platformFeeAmount(" + platformFee
+                            + ") != sellerPayoutAmount(" + state.getSellerPayoutAmount() + ")");
+        }
+
         return Settlement.builder()
                 .sellerId(state.getSellerId())
                 .year(state.getYear())


### PR DESCRIPTION
## partially addresses #216
## resolves #912

## Task
- [x] reward-service: 관리자용 회원 포인트 조회 API 추가 (GET /{userId}/points)
- [x] commerce-service: ModifyUserPointPort에 잔액 조회/차감 메서드 추가
- [x] commerce-service: 주문 등록 시 포인트 잔액 검증 (RegisterOrderService)
- [x] commerce-service: 결제 완료 후 포인트 차감 (ChangeOrderStatusService, afterCommit)
- [x] commerce-service: RewardServiceClient에 잔액 조회/차감 HTTP 클라이언트 구현
- [x] commerce-service: InsufficientPointException 커스텀 예외 추가
- [x] commerce-service: 포인트 잔액 검증 테스트 5건 추가