### PR TITLE
[#216][#917] feat: 계정과목 조회 기능 캐싱 적용

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/ledger/AccountPersistenceAdapter.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/ledger/AccountPersistenceAdapter.java
@@ -6,6 +6,7 @@ import com.personal.marketnote.commerce.domain.ledger.Account;
 import com.personal.marketnote.commerce.port.out.ledger.FindAccountPort;
 import com.personal.marketnote.common.adapter.out.PersistenceAdapter;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 
 import java.util.Optional;
 
@@ -15,12 +16,22 @@ public class AccountPersistenceAdapter implements FindAccountPort {
     private final AccountJpaRepository accountJpaRepository;
 
     @Override
+    @Cacheable(
+            value = "account:detail",
+            key = "#id",
+            unless = "#result == null || T(java.util.Optional).empty().equals(#result)"
+    )
     public Optional<Account> findById(Long id) {
         return accountJpaRepository.findById(id)
                 .map(AccountEntityToDomainMapper::toDomain);
     }
 
     @Override
+    @Cacheable(
+            value = "account:name",
+            key = "#name",
+            unless = "#result == null || T(java.util.Optional).empty().equals(#result)"
+    )
     public Optional<Account> findByName(String name) {
         return accountJpaRepository.findByName(name)
                 .map(AccountEntityToDomainMapper::toDomain);

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/configuration/CacheConfig.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/configuration/CacheConfig.java
@@ -1,0 +1,89 @@
+package com.personal.marketnote.commerce.configuration;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.hibernate5.jakarta.Hibernate5JakartaModule;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.springframework.data.redis.cache.RedisCacheConfiguration.defaultCacheConfig;
+
+@Configuration
+@EnableCaching
+@RequiredArgsConstructor
+public class CacheConfig {
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Value("${spring.data.redis.password}")
+    private String password;
+
+    private ObjectMapper objectMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+
+        mapper.enableDefaultTyping(ObjectMapper.DefaultTyping.NON_FINAL, JsonTypeInfo.As.PROPERTY);
+        mapper.setVisibility(PropertyAccessor.GETTER, JsonAutoDetect.Visibility.NONE);
+        mapper.setVisibility(PropertyAccessor.IS_GETTER, JsonAutoDetect.Visibility.NONE);
+        mapper.setVisibility(PropertyAccessor.SETTER, JsonAutoDetect.Visibility.NONE);
+        mapper.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        mapper.registerModule(new Jdk8Module());
+        mapper.registerModule(new Hibernate5JakartaModule());
+        mapper.registerModule(new JavaTimeModule());
+
+        return mapper;
+    }
+
+    @Bean
+    public CacheManager redisCacheManager(RedisConnectionFactory redisConnectionFactory) {
+        RedisCacheConfiguration redisCacheConfiguration = defaultCacheConfig()
+                .serializeKeysWith(RedisSerializationContext
+                        .SerializationPair.fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(RedisSerializationContext
+                        .SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer(objectMapper())))
+                .entryTtl(Duration.ofMinutes(10));
+
+        Map<String, RedisCacheConfiguration> perCacheTtl = new HashMap<>();
+        perCacheTtl.put("account:detail", redisCacheConfiguration.entryTtl(Duration.ofMinutes(30)));
+        perCacheTtl.put("account:name", redisCacheConfiguration.entryTtl(Duration.ofMinutes(30)));
+
+        return RedisCacheManager.builder(redisConnectionFactory)
+                .cacheDefaults(redisCacheConfiguration)
+                .withInitialCacheConfigurations(perCacheTtl)
+                .build();
+    }
+
+    @Bean
+    public RedisConnectionFactory redisCacheManagerFactory() {
+        RedisStandaloneConfiguration standalone = new RedisStandaloneConfiguration();
+        standalone.setHostName(host);
+        standalone.setPort(port);
+        standalone.setPassword(password);
+
+        return new LettuceConnectionFactory(standalone);
+    }
+}


### PR DESCRIPTION
## partially addresses #216
## resolves #917

## Task
- [x] AccountPersistenceAdapter.findByName: @Cacheable(account:name) 적용
- [x] AccountPersistenceAdapter.findById: @Cacheable(account:detail) 적용
- [x] CacheConfig: 캐시 설정 및 TTL 관리