### PR TITLE
[#216][#913] feat: 할인 비례 배분 기능 추가

### DIFF
--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/RegisterOrderService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/RegisterOrderService.java
@@ -32,6 +32,9 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -118,21 +121,26 @@ public class RegisterOrderService implements RegisterOrderUseCase {
                 )
         );
 
-        createPaymentAllocations(savedOrder.getId(), command.orderProducts());
+        long totalDiscount = Math.addExact(couponAmount, pointAmount);
+        createPaymentAllocations(savedOrder.getId(), command.orderProducts(), totalDiscount);
 
         return RegisterOrderResult.from(savedOrder);
     }
 
-    private void createPaymentAllocations(Long orderId, List<OrderProductItemCommand> orderProducts) {
-        // allocatedAmount = 할인 전 판매자별 소계 (Phase 5에서 할인 배분 처리)
-        Map<Long, Long> sellerAmounts = orderProducts.stream()
+    private void createPaymentAllocations(Long orderId, List<OrderProductItemCommand> orderProducts,
+                                          long totalDiscount) {
+        Map<Long, Long> sellerGrossAmounts = orderProducts.stream()
                 .collect(Collectors.groupingBy(
                         OrderProductItemCommand::sellerId,
                         Collectors.summingLong(item ->
                                 Math.multiplyExact(item.unitAmount(), (long) item.quantity()))
                 ));
 
-        List<PaymentAllocation> allocations = sellerAmounts.entrySet().stream()
+        Map<Long, Long> sellerAllocatedAmounts = totalDiscount > 0
+                ? distributeDiscountAndAllocate(sellerGrossAmounts, totalDiscount)
+                : sellerGrossAmounts;
+
+        List<PaymentAllocation> allocations = sellerAllocatedAmounts.entrySet().stream()
                 .filter(entry -> entry.getValue() > 0)
                 .map(entry -> PaymentAllocation.from(
                         PaymentAllocationCreateState.builder()
@@ -149,6 +157,55 @@ public class RegisterOrderService implements RegisterOrderUseCase {
         if (!allocations.isEmpty()) {
             savePaymentAllocationPort.saveAll(allocations);
         }
+    }
+
+    private Map<Long, Long> distributeDiscountAndAllocate(Map<Long, Long> sellerGrossAmounts, long totalDiscount) {
+        long totalGross = sellerGrossAmounts.values().stream().mapToLong(Long::longValue).sum();
+        if (totalGross <= 0) {
+            return sellerGrossAmounts;
+        }
+
+        Map<Long, Long> sellerDiscounts = new LinkedHashMap<>();
+        long allocatedDiscount = 0L;
+        Long largestSellerId = null;
+        long largestGross = Long.MIN_VALUE;
+
+        for (Map.Entry<Long, Long> entry : sellerGrossAmounts.entrySet()) {
+            Long sellerId = entry.getKey();
+            long gross = entry.getValue();
+            long discount = calculateProportionalDiscount(totalDiscount, gross, totalGross);
+            sellerDiscounts.put(sellerId, discount);
+            allocatedDiscount = Math.addExact(allocatedDiscount, discount);
+
+            if (gross > largestGross) {
+                largestGross = gross;
+                largestSellerId = sellerId;
+            }
+        }
+
+        long remainder = totalDiscount - allocatedDiscount;
+        if (remainder < 0) {
+            log.error("할인 배분 오류 - totalDiscount: {}, allocatedDiscount: {}", totalDiscount, allocatedDiscount);
+        }
+        if (remainder > 0 && FormatValidator.hasValue(largestSellerId)) {
+            sellerDiscounts.merge(largestSellerId, remainder, Long::sum);
+        }
+
+        Map<Long, Long> result = new LinkedHashMap<>();
+        for (Map.Entry<Long, Long> entry : sellerGrossAmounts.entrySet()) {
+            Long sellerId = entry.getKey();
+            long gross = entry.getValue();
+            long discount = sellerDiscounts.getOrDefault(sellerId, 0L);
+            result.put(sellerId, gross - discount);
+        }
+        return result;
+    }
+
+    private long calculateProportionalDiscount(long totalDiscount, long sellerGross, long totalGross) {
+        return BigDecimal.valueOf(totalDiscount)
+                .multiply(BigDecimal.valueOf(sellerGross))
+                .divide(BigDecimal.valueOf(totalGross), 0, RoundingMode.DOWN)
+                .longValueExact();
     }
 
     private void validateTotalAmountConsistency(RegisterOrderCommand command) {

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/RegisterOrderUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/RegisterOrderUseCaseTest.java
@@ -39,6 +39,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
@@ -2274,6 +2275,344 @@ class RegisterOrderUseCaseTest {
             registerOrderService.registerOrder(command);
 
             verifyNoInteractions(savePaymentAllocationPort);
+        }
+    }
+
+    // ==================================================================================
+    // 할인 비례 배분 검증
+    // ==================================================================================
+
+    @Nested
+    @DisplayName("할인 비례 배분 검증")
+    class DiscountAllocationTest {
+
+        @Test
+        @DisplayName("할인이 있는 단일 판매자 주문 시 할인이 전액 해당 판매자에게 배분된다")
+        @SuppressWarnings("unchecked")
+        void registerOrder_singleSellerWithDiscount_allocatesFullDiscount() {
+            Long pricePolicyId = 100L;
+            RegisterOrderCommand command = RegisterOrderCommand.builder()
+                    .buyerId(1L)
+                    .totalAmount(50000L)
+                    .couponAmount(5000L)
+                    .pointAmount(0L)
+                    .orderProducts(List.of(
+                            OrderProductItemCommand.builder()
+                                    .productId(100L)
+                                    .sellerId(10L)
+                                    .pricePolicyId(pricePolicyId)
+                                    .quantity(1)
+                                    .unitAmount(50000L)
+                                    .build()
+                    ))
+                    .build();
+
+            mockProductPrice(pricePolicyId, 50000L);
+            mockInventoryAndSave(pricePolicyId, 100, 1L);
+
+            registerOrderService.registerOrder(command);
+
+            ArgumentCaptor<List<PaymentAllocation>> captor = ArgumentCaptor.forClass(List.class);
+            verify(savePaymentAllocationPort).saveAll(captor.capture());
+            List<PaymentAllocation> allocations = captor.getValue();
+            assertThat(allocations).hasSize(1);
+            assertThat(allocations.get(0).getSellerId()).isEqualTo(10L);
+            assertThat(allocations.get(0).getAllocatedAmount()).isEqualTo(45000L);
+        }
+
+        @Test
+        @DisplayName("할인이 있는 복수 판매자 주문 시 총액 비례로 할인이 배분된다")
+        @SuppressWarnings("unchecked")
+        void registerOrder_multipleSellerWithDiscount_distributesProportionally() {
+            Long pricePolicyId1 = 100L;
+            Long pricePolicyId2 = 200L;
+            // 판매자A(10): 70,000 (70%), 판매자B(20): 30,000 (30%)
+            // 할인 10,000 → A: 7,000, B: 3,000
+            RegisterOrderCommand command = RegisterOrderCommand.builder()
+                    .buyerId(1L)
+                    .totalAmount(100000L)
+                    .couponAmount(10000L)
+                    .pointAmount(0L)
+                    .orderProducts(List.of(
+                            OrderProductItemCommand.builder()
+                                    .productId(100L)
+                                    .sellerId(10L)
+                                    .pricePolicyId(pricePolicyId1)
+                                    .quantity(1)
+                                    .unitAmount(70000L)
+                                    .build(),
+                            OrderProductItemCommand.builder()
+                                    .productId(200L)
+                                    .sellerId(20L)
+                                    .pricePolicyId(pricePolicyId2)
+                                    .quantity(1)
+                                    .unitAmount(30000L)
+                                    .build()
+                    ))
+                    .build();
+
+            mockProductPricesWithSellerIds(Map.of(
+                    pricePolicyId1, Map.entry(70000L, 10L),
+                    pricePolicyId2, Map.entry(30000L, 20L)
+            ));
+            mockInventoryMultiple(Map.of(pricePolicyId1, 100, pricePolicyId2, 100));
+            Order savedOrder = mockSavedOrder(1L);
+            when(saveOrderPort.save(any(Order.class))).thenReturn(savedOrder);
+
+            registerOrderService.registerOrder(command);
+
+            ArgumentCaptor<List<PaymentAllocation>> captor = ArgumentCaptor.forClass(List.class);
+            verify(savePaymentAllocationPort).saveAll(captor.capture());
+            List<PaymentAllocation> allocations = captor.getValue();
+            assertThat(allocations).hasSize(2);
+
+            Map<Long, Long> sellerToAllocation = allocations.stream()
+                    .collect(Collectors.toMap(PaymentAllocation::getSellerId, PaymentAllocation::getAllocatedAmount));
+            assertThat(sellerToAllocation.get(10L)).isEqualTo(63000L);
+            assertThat(sellerToAllocation.get(20L)).isEqualTo(27000L);
+        }
+
+        @Test
+        @DisplayName("할인 비례 배분 시 끝전(나머지)이 최대 금액 판매자에게 할당된다")
+        @SuppressWarnings("unchecked")
+        void registerOrder_discountWithRemainder_assignsToLargestSeller() {
+            Long pricePolicyId1 = 100L;
+            Long pricePolicyId2 = 200L;
+            Long pricePolicyId3 = 300L;
+            // 판매자A(10): 50,000, 판매자B(20): 30,000, 판매자C(30): 20,000 → 총 100,000
+            // 할인 10,001원 → 비례배분: A=floor(10001*50000/100000)=5000, B=floor(10001*30000/100000)=3000, C=floor(10001*20000/100000)=2000
+            // 합계 = 10,000 → 나머지 1원 → 최대 금액 판매자A에게
+            // 최종: A=50000-5001=44999, B=30000-3000=27000, C=20000-2000=18000
+            RegisterOrderCommand command = RegisterOrderCommand.builder()
+                    .buyerId(1L)
+                    .totalAmount(100000L)
+                    .couponAmount(10001L)
+                    .pointAmount(0L)
+                    .orderProducts(List.of(
+                            OrderProductItemCommand.builder()
+                                    .productId(100L)
+                                    .sellerId(10L)
+                                    .pricePolicyId(pricePolicyId1)
+                                    .quantity(1)
+                                    .unitAmount(50000L)
+                                    .build(),
+                            OrderProductItemCommand.builder()
+                                    .productId(200L)
+                                    .sellerId(20L)
+                                    .pricePolicyId(pricePolicyId2)
+                                    .quantity(1)
+                                    .unitAmount(30000L)
+                                    .build(),
+                            OrderProductItemCommand.builder()
+                                    .productId(300L)
+                                    .sellerId(30L)
+                                    .pricePolicyId(pricePolicyId3)
+                                    .quantity(1)
+                                    .unitAmount(20000L)
+                                    .build()
+                    ))
+                    .build();
+
+            mockProductPricesWithSellerIds(Map.of(
+                    pricePolicyId1, Map.entry(50000L, 10L),
+                    pricePolicyId2, Map.entry(30000L, 20L),
+                    pricePolicyId3, Map.entry(20000L, 30L)
+            ));
+            mockInventoryMultiple(Map.of(pricePolicyId1, 100, pricePolicyId2, 100, pricePolicyId3, 100));
+            Order savedOrder = mockSavedOrder(1L);
+            when(saveOrderPort.save(any(Order.class))).thenReturn(savedOrder);
+
+            registerOrderService.registerOrder(command);
+
+            ArgumentCaptor<List<PaymentAllocation>> captor = ArgumentCaptor.forClass(List.class);
+            verify(savePaymentAllocationPort).saveAll(captor.capture());
+            List<PaymentAllocation> allocations = captor.getValue();
+            assertThat(allocations).hasSize(3);
+
+            Map<Long, Long> sellerToAllocation = allocations.stream()
+                    .collect(Collectors.toMap(PaymentAllocation::getSellerId, PaymentAllocation::getAllocatedAmount));
+            long totalAllocated = sellerToAllocation.values().stream().mapToLong(Long::longValue).sum();
+            assertThat(totalAllocated).isEqualTo(100000L - 10001L);
+            assertThat(sellerToAllocation.get(10L)).isEqualTo(44999L);
+            assertThat(sellerToAllocation.get(20L)).isEqualTo(27000L);
+            assertThat(sellerToAllocation.get(30L)).isEqualTo(18000L);
+        }
+
+        @Test
+        @DisplayName("100% 할인 시 allocatedAmount가 0인 판매자는 배분에서 제외된다")
+        void registerOrder_fullDiscount_skipsZeroAllocations() {
+            Long pricePolicyId = 100L;
+            RegisterOrderCommand command = RegisterOrderCommand.builder()
+                    .buyerId(1L)
+                    .totalAmount(10000L)
+                    .couponAmount(10000L)
+                    .pointAmount(0L)
+                    .orderProducts(List.of(
+                            OrderProductItemCommand.builder()
+                                    .productId(100L)
+                                    .sellerId(10L)
+                                    .pricePolicyId(pricePolicyId)
+                                    .quantity(1)
+                                    .unitAmount(10000L)
+                                    .build()
+                    ))
+                    .build();
+
+            mockProductPrice(pricePolicyId, 10000L);
+            mockInventoryAndSave(pricePolicyId, 100, 1L);
+
+            registerOrderService.registerOrder(command);
+
+            verifyNoInteractions(savePaymentAllocationPort);
+        }
+
+        @Test
+        @DisplayName("쿠폰과 포인트가 모두 사용된 주문의 할인 합계가 올바르게 배분된다")
+        @SuppressWarnings("unchecked")
+        void registerOrder_couponAndPointCombined_distributesCorrectly() {
+            Long pricePolicyId1 = 100L;
+            Long pricePolicyId2 = 200L;
+            // 판매자A(10): 60,000 (60%), 판매자B(20): 40,000 (40%)
+            // 쿠폰 3,000 + 포인트 2,000 = 할인 5,000
+            // A: floor(5000*60000/100000) = 3000, B: floor(5000*40000/100000) = 2000
+            // 최종: A=60000-3000=57000, B=40000-2000=38000
+            RegisterOrderCommand command = RegisterOrderCommand.builder()
+                    .buyerId(1L)
+                    .totalAmount(100000L)
+                    .couponAmount(3000L)
+                    .pointAmount(2000L)
+                    .orderProducts(List.of(
+                            OrderProductItemCommand.builder()
+                                    .productId(100L)
+                                    .sellerId(10L)
+                                    .pricePolicyId(pricePolicyId1)
+                                    .quantity(2)
+                                    .unitAmount(30000L)
+                                    .build(),
+                            OrderProductItemCommand.builder()
+                                    .productId(200L)
+                                    .sellerId(20L)
+                                    .pricePolicyId(pricePolicyId2)
+                                    .quantity(2)
+                                    .unitAmount(20000L)
+                                    .build()
+                    ))
+                    .build();
+
+            mockProductPricesWithSellerIds(Map.of(
+                    pricePolicyId1, Map.entry(30000L, 10L),
+                    pricePolicyId2, Map.entry(20000L, 20L)
+            ));
+            mockInventoryMultiple(Map.of(pricePolicyId1, 100, pricePolicyId2, 100));
+            Order savedOrder = mockSavedOrder(1L);
+            when(saveOrderPort.save(any(Order.class))).thenReturn(savedOrder);
+            when(modifyUserPointPort.getAvailablePoints(1L)).thenReturn(999999L);
+
+            registerOrderService.registerOrder(command);
+
+            ArgumentCaptor<List<PaymentAllocation>> captor = ArgumentCaptor.forClass(List.class);
+            verify(savePaymentAllocationPort).saveAll(captor.capture());
+            List<PaymentAllocation> allocations = captor.getValue();
+            assertThat(allocations).hasSize(2);
+
+            Map<Long, Long> sellerToAllocation = allocations.stream()
+                    .collect(Collectors.toMap(PaymentAllocation::getSellerId, PaymentAllocation::getAllocatedAmount));
+            assertThat(sellerToAllocation.get(10L)).isEqualTo(57000L);
+            assertThat(sellerToAllocation.get(20L)).isEqualTo(38000L);
+
+            long totalAllocated = sellerToAllocation.values().stream().mapToLong(Long::longValue).sum();
+            assertThat(totalAllocated).isEqualTo(100000L - 5000L);
+        }
+
+        @Test
+        @DisplayName("복수 판매자에서 100% 할인 시 모든 allocatedAmount가 0이 되어 배분이 생략된다")
+        void registerOrder_multipleSellerFullDiscount_skipsAllAllocations() {
+            Long pricePolicyId1 = 100L;
+            Long pricePolicyId2 = 200L;
+            RegisterOrderCommand command = RegisterOrderCommand.builder()
+                    .buyerId(1L)
+                    .totalAmount(100000L)
+                    .couponAmount(100000L)
+                    .pointAmount(0L)
+                    .orderProducts(List.of(
+                            OrderProductItemCommand.builder()
+                                    .productId(100L)
+                                    .sellerId(10L)
+                                    .pricePolicyId(pricePolicyId1)
+                                    .quantity(1)
+                                    .unitAmount(60000L)
+                                    .build(),
+                            OrderProductItemCommand.builder()
+                                    .productId(200L)
+                                    .sellerId(20L)
+                                    .pricePolicyId(pricePolicyId2)
+                                    .quantity(1)
+                                    .unitAmount(40000L)
+                                    .build()
+                    ))
+                    .build();
+
+            mockProductPricesWithSellerIds(Map.of(
+                    pricePolicyId1, Map.entry(60000L, 10L),
+                    pricePolicyId2, Map.entry(40000L, 20L)
+            ));
+            mockInventoryMultiple(Map.of(pricePolicyId1, 100, pricePolicyId2, 100));
+            Order savedOrder = mockSavedOrder(1L);
+            when(saveOrderPort.save(any(Order.class))).thenReturn(savedOrder);
+
+            registerOrderService.registerOrder(command);
+
+            verifyNoInteractions(savePaymentAllocationPort);
+        }
+
+        @Test
+        @DisplayName("할인 없이 주문 시 판매자별 총액이 그대로 배분된다")
+        @SuppressWarnings("unchecked")
+        void registerOrder_noDiscount_allocatesGrossAmounts() {
+            Long pricePolicyId1 = 100L;
+            Long pricePolicyId2 = 200L;
+            RegisterOrderCommand command = RegisterOrderCommand.builder()
+                    .buyerId(1L)
+                    .totalAmount(80000L)
+                    .couponAmount(0L)
+                    .pointAmount(0L)
+                    .orderProducts(List.of(
+                            OrderProductItemCommand.builder()
+                                    .productId(100L)
+                                    .sellerId(10L)
+                                    .pricePolicyId(pricePolicyId1)
+                                    .quantity(1)
+                                    .unitAmount(50000L)
+                                    .build(),
+                            OrderProductItemCommand.builder()
+                                    .productId(200L)
+                                    .sellerId(20L)
+                                    .pricePolicyId(pricePolicyId2)
+                                    .quantity(1)
+                                    .unitAmount(30000L)
+                                    .build()
+                    ))
+                    .build();
+
+            mockProductPricesWithSellerIds(Map.of(
+                    pricePolicyId1, Map.entry(50000L, 10L),
+                    pricePolicyId2, Map.entry(30000L, 20L)
+            ));
+            mockInventoryMultiple(Map.of(pricePolicyId1, 100, pricePolicyId2, 100));
+            Order savedOrder = mockSavedOrder(1L);
+            when(saveOrderPort.save(any(Order.class))).thenReturn(savedOrder);
+
+            registerOrderService.registerOrder(command);
+
+            ArgumentCaptor<List<PaymentAllocation>> captor = ArgumentCaptor.forClass(List.class);
+            verify(savePaymentAllocationPort).saveAll(captor.capture());
+            List<PaymentAllocation> allocations = captor.getValue();
+            assertThat(allocations).hasSize(2);
+
+            Map<Long, Long> sellerToAllocation = allocations.stream()
+                    .collect(Collectors.toMap(PaymentAllocation::getSellerId, PaymentAllocation::getAllocatedAmount));
+            assertThat(sellerToAllocation.get(10L)).isEqualTo(50000L);
+            assertThat(sellerToAllocation.get(20L)).isEqualTo(30000L);
         }
     }
 


### PR DESCRIPTION
## partially addresses #216
## resolves #913

## Task
- [x] createPaymentAllocations에 totalDiscount 파라미터 추가
- [x] distributeDiscountAndAllocate: 판매자별 총액 비례로 할인 배분
- [x] calculateProportionalDiscount: BigDecimal 기반 오버플로 안전 계산
- [x] 끝전(나머지) 처리: 최대 금액 판매자에게 귀속
- [x] allocatedAmount <= 0인 판매자 필터링 (100% 할인 대응)
- [x] remainder 음수 방어 로그 추가
- [x] 할인 비례 배분 테스트 7개 추가