### PR TITLE
[#216][#915] feat: 주문 취소 시 포인트 환불 기능 추가

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/web/reward/RewardServiceClient.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/web/reward/RewardServiceClient.java
@@ -35,6 +35,7 @@ public class RewardServiceClient implements ModifyUserPointPort {
     private static final String CHANGE_TYPE_DEDUCTION = "DEDUCTION";
     private static final String SHARE_PURCHASE_REASON = "링크 공유 회원 상품 구매";
     private static final String ORDER_POINT_DEDUCTION_REASON = "주문 포인트 사용";
+    private static final String ORDER_POINT_REFUND_REASON = "주문 취소 포인트 환불";
     private static final CommerceServiceCommunicationTargetType TARGET_TYPE =
             CommerceServiceCommunicationTargetType.USER_POINT;
     private static final CommerceServiceCommunicationSenderType REQUEST_SENDER =
@@ -101,6 +102,21 @@ public class RewardServiceClient implements ModifyUserPointPort {
         HttpHeaders headers = buildHeaders();
 
         ModifyUserPointRequest request = ModifyUserPointRequest.deduction(amount, orderId);
+        HttpEntity<ModifyUserPointRequest> httpEntity = new HttpEntity<>(request, headers);
+
+        sendDeductionRequest(uri, httpEntity, userId);
+    }
+
+    @Override
+    public void refundOrderPoints(Long userId, Long amount, Long orderId) {
+        if (FormatValidator.hasNoValue(amount) || amount <= 0) {
+            return;
+        }
+
+        URI uri = buildUserPointUri(userId);
+        HttpHeaders headers = buildHeaders();
+
+        ModifyUserPointRequest request = ModifyUserPointRequest.refund(amount, orderId);
         HttpEntity<ModifyUserPointRequest> httpEntity = new HttpEntity<>(request, headers);
 
         sendDeductionRequest(uri, httpEntity, userId);
@@ -344,6 +360,16 @@ public class RewardServiceClient implements ModifyUserPointPort {
                     SOURCE_TYPE_ORDER,
                     orderId,
                     ORDER_POINT_DEDUCTION_REASON
+            );
+        }
+
+        private static ModifyUserPointRequest refund(long amount, Long orderId) {
+            return new ModifyUserPointRequest(
+                    CHANGE_TYPE_ACCRUAL,
+                    Math.abs(amount),
+                    SOURCE_TYPE_ORDER,
+                    orderId,
+                    ORDER_POINT_REFUND_REASON
             );
         }
     }

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/inventory/RestoreProductInventoryUseCase.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/inventory/RestoreProductInventoryUseCase.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.commerce.port.in.usecase.inventory;
+
+import com.personal.marketnote.commerce.domain.order.OrderProduct;
+
+import java.util.List;
+
+public interface RestoreProductInventoryUseCase {
+    void restore(List<OrderProduct> orderProducts, String reason);
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/reward/ModifyUserPointPort.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/reward/ModifyUserPointPort.java
@@ -36,4 +36,14 @@ public interface ModifyUserPointPort {
      * @Description 주문 결제 시 포인트를 차감합니다.
      */
     void deductOrderPoints(Long userId, Long amount, Long orderId);
+
+    /**
+     * @param userId  회원 ID
+     * @param amount  환불할 포인트
+     * @param orderId 주문 ID
+     * @Date 2026-02-20
+     * @Author 성효빈
+     * @Description 주문 취소 시 포인트를 환불합니다.
+     */
+    void refundOrderPoints(Long userId, Long amount, Long orderId);
 }

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/inventory/RestoreProductInventoryService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/inventory/RestoreProductInventoryService.java
@@ -1,0 +1,49 @@
+package com.personal.marketnote.commerce.service.inventory;
+
+import com.personal.marketnote.commerce.domain.inventory.Inventory;
+import com.personal.marketnote.commerce.domain.order.OrderProduct;
+import com.personal.marketnote.commerce.port.in.usecase.inventory.RestoreProductInventoryUseCase;
+import com.personal.marketnote.commerce.port.out.inventory.FindInventoryPort;
+import com.personal.marketnote.commerce.port.out.inventory.InventoryLockPort;
+import com.personal.marketnote.commerce.port.out.inventory.SaveCacheStockPort;
+import com.personal.marketnote.commerce.port.out.inventory.UpdateInventoryPort;
+import com.personal.marketnote.common.application.UseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional(isolation = READ_COMMITTED)
+public class RestoreProductInventoryService implements RestoreProductInventoryUseCase {
+    private final FindInventoryPort findInventoryPort;
+    private final UpdateInventoryPort updateInventoryPort;
+    private final SaveCacheStockPort saveCacheStockPort;
+    private final InventoryLockPort inventoryLockPort;
+
+    @Override
+    public void restore(List<OrderProduct> orderProducts, String reason) {
+        Map<Long, Integer> stocksByPricePolicyId = orderProducts.stream()
+                .collect(
+                        Collectors.groupingBy(
+                                OrderProduct::getPricePolicyId, Collectors.summingInt(OrderProduct::getQuantity)
+                        )
+                );
+
+        inventoryLockPort.executeWithLock(stocksByPricePolicyId.keySet(), () -> {
+            Set<Inventory> inventories = findInventoryPort.findByPricePolicyIds(stocksByPricePolicyId.keySet());
+            inventories.forEach(inventory -> inventory.restore(
+                    stocksByPricePolicyId.get(inventory.getPricePolicyId())
+            ));
+
+            updateInventoryPort.update(inventories);
+            saveCacheStockPort.save(inventories);
+        });
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/CancelPaymentService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/CancelPaymentService.java
@@ -11,11 +11,13 @@ import com.personal.marketnote.commerce.exception.PaymentNotFoundException;
 import com.personal.marketnote.commerce.exception.UnauthorizedOrderAccessException;
 import com.personal.marketnote.commerce.port.in.command.order.ChangeOrderStatusCommand;
 import com.personal.marketnote.commerce.port.in.command.payment.CancelPaymentCommand;
+import com.personal.marketnote.commerce.port.in.usecase.inventory.RestoreProductInventoryUseCase;
 import com.personal.marketnote.commerce.port.in.usecase.ledger.RecordLedgerEntryUseCase;
 import com.personal.marketnote.commerce.port.in.usecase.order.ChangeOrderStatusUseCase;
 import com.personal.marketnote.commerce.port.in.usecase.payment.CancelPaymentUseCase;
 import com.personal.marketnote.commerce.port.out.order.FindOrderPort;
 import com.personal.marketnote.commerce.port.out.payment.*;
+import com.personal.marketnote.commerce.port.out.reward.ModifyUserPointPort;
 import com.personal.marketnote.commerce.port.out.payment.vendor.PaymentCancelVendorCommand;
 import com.personal.marketnote.commerce.port.out.payment.vendor.PaymentCancelVendorResult;
 import com.personal.marketnote.common.application.UseCase;
@@ -41,6 +43,8 @@ public class CancelPaymentService implements CancelPaymentUseCase {
     private final PaymentVendorPort paymentVendorPort;
     private final ChangeOrderStatusUseCase changeOrderStatusUseCase;
     private final RecordLedgerEntryUseCase recordLedgerEntryUseCase;
+    private final RestoreProductInventoryUseCase restoreProductInventoryUseCase;
+    private final ModifyUserPointPort modifyUserPointPort;
 
     @Override
     public void cancel(CancelPaymentCommand command) {
@@ -49,7 +53,7 @@ public class CancelPaymentService implements CancelPaymentUseCase {
         Payment payment = findPaymentPort.findByOrderKey(orderKeyUuid)
                 .orElseThrow(() -> new PaymentNotFoundException(command.orderKey()));
 
-        verifyOrderOwnership(payment.getOrderId(), command.buyerId());
+        Order order = findVerifiedOrder(payment.getOrderId(), command.buyerId());
 
         PspPaymentEvent event = findPspPaymentEventPort.findByOrderKey(command.orderKey())
                 .orElseThrow(() -> new PaymentNotFoundException(command.orderKey()));
@@ -112,6 +116,8 @@ public class CancelPaymentService implements CancelPaymentUseCase {
                             .orderStatus(OrderStatus.CANCEL_REQUESTED)
                             .build()
             );
+            restoreInventory(order);
+            refundPoints(order);
         }
 
         recordLedgerEntryForCancellation(payment, isFullCancel, cancelAmount, alreadyRefunded);
@@ -137,13 +143,39 @@ public class CancelPaymentService implements CancelPaymentUseCase {
         }
     }
 
-    private void verifyOrderOwnership(Long orderId, Long buyerId) {
+    private Order findVerifiedOrder(Long orderId, Long buyerId) {
         Order order = findOrderPort.findById(orderId)
                 .orElseThrow(() -> new OrderNotFoundException(orderId));
         if (!order.getBuyerId().equals(buyerId)) {
             log.warn("결제 취소 소유자 불일치 - orderId: {}, 주문소유자: {}, 요청자: {}",
                     orderId, order.getBuyerId(), buyerId);
             throw new UnauthorizedOrderAccessException();
+        }
+        return order;
+    }
+
+    private void restoreInventory(Order order) {
+        try {
+            restoreProductInventoryUseCase.restore(
+                    order.getOrderProducts(), "주문 전액 취소에 의한 재고 복구"
+            );
+        } catch (Exception e) {
+            log.error("재고 복구 실패 - orderId: {}, error: {}",
+                    order.getId(), e.getMessage(), e);
+        }
+    }
+
+    private void refundPoints(Order order) {
+        Long pointAmount = order.getPointAmount();
+        if (FormatValidator.hasNoValue(pointAmount) || pointAmount <= 0) {
+            return;
+        }
+
+        try {
+            modifyUserPointPort.refundOrderPoints(order.getBuyerId(), pointAmount, order.getId());
+        } catch (Exception e) {
+            log.error("포인트 환불 실패 - orderId: {}, buyerId: {}, pointAmount: {}, error: {}",
+                    order.getId(), order.getBuyerId(), pointAmount, e.getMessage(), e);
         }
     }
 }

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/inventory/RestoreProductInventoryUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/inventory/RestoreProductInventoryUseCaseTest.java
@@ -1,0 +1,200 @@
+package com.personal.marketnote.commerce.service.inventory;
+
+import com.personal.marketnote.commerce.domain.inventory.Inventory;
+import com.personal.marketnote.commerce.domain.order.OrderProduct;
+import com.personal.marketnote.commerce.domain.order.OrderProductSnapshotState;
+import com.personal.marketnote.commerce.port.out.inventory.FindInventoryPort;
+import com.personal.marketnote.commerce.port.out.inventory.InventoryLockPort;
+import com.personal.marketnote.commerce.port.out.inventory.SaveCacheStockPort;
+import com.personal.marketnote.commerce.port.out.inventory.UpdateInventoryPort;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class RestoreProductInventoryUseCaseTest {
+    @Mock
+    private FindInventoryPort findInventoryPort;
+    @Mock
+    private UpdateInventoryPort updateInventoryPort;
+    @Mock
+    private SaveCacheStockPort saveCacheStockPort;
+    @Mock
+    private InventoryLockPort inventoryLockPort;
+
+    @InjectMocks
+    private RestoreProductInventoryService restoreProductInventoryService;
+
+    @Nested
+    @DisplayName("restore (재고 복구)")
+    class RestoreTest {
+
+        @Test
+        @DisplayName("단일 주문 상품 재고 복구 시 재고가 올바르게 증가한다")
+        void restore_singleOrderProduct_increasesInventoryStock() {
+            List<OrderProduct> orderProducts = List.of(buildOrderProduct(100L, 3));
+            Inventory inventory = buildInventory(1L, 100L, 7);
+
+            stubLockToExecuteTask();
+            when(findInventoryPort.findByPricePolicyIds(any())).thenReturn(Set.of(inventory));
+
+            restoreProductInventoryService.restore(orderProducts, "주문 취소");
+
+            assertThat(inventory.getStockValue()).isEqualTo(10);
+        }
+
+        @Test
+        @DisplayName("서로 다른 가격 정책의 복수 주문 상품 재고 복구 시 각각의 재고가 올바르게 증가한다")
+        void restore_differentPolicies_restoresEachInventory() {
+            List<OrderProduct> orderProducts = List.of(
+                    buildOrderProduct(100L, 2),
+                    buildOrderProduct(200L, 5)
+            );
+            Inventory inventory1 = buildInventory(1L, 100L, 8);
+            Inventory inventory2 = buildInventory(2L, 200L, 15);
+
+            stubLockToExecuteTask();
+            when(findInventoryPort.findByPricePolicyIds(any())).thenReturn(Set.of(inventory1, inventory2));
+
+            restoreProductInventoryService.restore(orderProducts, "주문 취소");
+
+            assertThat(inventory1.getStockValue()).isEqualTo(10);
+            assertThat(inventory2.getStockValue()).isEqualTo(20);
+        }
+
+        @Test
+        @DisplayName("동일 가격 정책의 복수 주문 상품 재고 복구 시 수량을 합산하여 복구한다")
+        void restore_samePolicyMultipleProducts_sumsQuantityAndRestores() {
+            List<OrderProduct> orderProducts = List.of(
+                    buildOrderProduct(100L, 2),
+                    buildOrderProduct(100L, 3)
+            );
+            Inventory inventory = buildInventory(1L, 100L, 5);
+
+            stubLockToExecuteTask();
+            when(findInventoryPort.findByPricePolicyIds(any())).thenReturn(Set.of(inventory));
+
+            restoreProductInventoryService.restore(orderProducts, "주문 취소");
+
+            assertThat(inventory.getStockValue()).isEqualTo(10);
+        }
+
+        @Test
+        @DisplayName("재고 복구 시 분산 락에 올바른 가격 정책 ID Set을 전달한다")
+        @SuppressWarnings("unchecked")
+        void restore_success_passesCorrectPricePolicyIdsToLock() {
+            List<OrderProduct> orderProducts = List.of(
+                    buildOrderProduct(100L, 2),
+                    buildOrderProduct(200L, 3)
+            );
+
+            stubLockToExecuteTask();
+            when(findInventoryPort.findByPricePolicyIds(any())).thenReturn(Set.of(
+                    buildInventory(1L, 100L, 8),
+                    buildInventory(2L, 200L, 17)
+            ));
+
+            restoreProductInventoryService.restore(orderProducts, "주문 취소");
+
+            ArgumentCaptor<Set<Long>> lockKeysCaptor = ArgumentCaptor.forClass(Set.class);
+            verify(inventoryLockPort).executeWithLock(lockKeysCaptor.capture(), any());
+            assertThat(lockKeysCaptor.getValue()).containsExactlyInAnyOrder(100L, 200L);
+        }
+
+        @Test
+        @DisplayName("재고 복구 시 재고 조회 → 업데이트 → 캐시 저장 순서로 호출한다")
+        @SuppressWarnings("unchecked")
+        void restore_success_callsPortsInCorrectOrder() {
+            List<OrderProduct> orderProducts = List.of(buildOrderProduct(100L, 3));
+            Inventory inventory = buildInventory(1L, 100L, 7);
+
+            stubLockToExecuteTask();
+            when(findInventoryPort.findByPricePolicyIds(any())).thenReturn(Set.of(inventory));
+
+            restoreProductInventoryService.restore(orderProducts, "주문 취소");
+
+            InOrder inOrder = inOrder(findInventoryPort, updateInventoryPort, saveCacheStockPort);
+            inOrder.verify(findInventoryPort).findByPricePolicyIds(any());
+            inOrder.verify(updateInventoryPort).update(any());
+            inOrder.verify(saveCacheStockPort).save(any(Set.class));
+            inOrder.verifyNoMoreInteractions();
+        }
+
+        @Test
+        @DisplayName("분산 락이 작업을 실행하지 않으면 내부 Port를 호출하지 않는다")
+        void restore_lockNotExecuted_doesNotCallInternalPorts() {
+            List<OrderProduct> orderProducts = List.of(buildOrderProduct(100L, 3));
+
+            restoreProductInventoryService.restore(orderProducts, "주문 취소");
+
+            verify(inventoryLockPort).executeWithLock(any(), any());
+            verifyNoInteractions(findInventoryPort);
+            verifyNoInteractions(updateInventoryPort);
+            verifyNoInteractions(saveCacheStockPort);
+        }
+
+        @Test
+        @DisplayName("재고 조회 중 예외 발생 시 예외를 전파한다")
+        void restore_findPortFails_propagates() {
+            List<OrderProduct> orderProducts = List.of(buildOrderProduct(100L, 3));
+            RuntimeException exception = new RuntimeException("find fail");
+
+            stubLockToExecuteTask();
+            when(findInventoryPort.findByPricePolicyIds(any())).thenThrow(exception);
+
+            assertThatThrownBy(() -> restoreProductInventoryService.restore(orderProducts, "주문 취소"))
+                    .isSameAs(exception);
+        }
+
+        @Test
+        @DisplayName("재고 업데이트 중 예외 발생 시 캐시 저장을 호출하지 않는다")
+        void restore_updatePortFails_doesNotSaveCache() {
+            List<OrderProduct> orderProducts = List.of(buildOrderProduct(100L, 3));
+            Inventory inventory = buildInventory(1L, 100L, 7);
+
+            stubLockToExecuteTask();
+            when(findInventoryPort.findByPricePolicyIds(any())).thenReturn(Set.of(inventory));
+            doThrow(new RuntimeException("update fail")).when(updateInventoryPort).update(any());
+
+            assertThatThrownBy(() -> restoreProductInventoryService.restore(orderProducts, "주문 취소"))
+                    .isInstanceOf(RuntimeException.class);
+
+            verifyNoInteractions(saveCacheStockPort);
+        }
+    }
+
+    private void stubLockToExecuteTask() {
+        doAnswer(invocation -> {
+            Runnable task = invocation.getArgument(1);
+            task.run();
+            return null;
+        }).when(inventoryLockPort).executeWithLock(any(), any());
+    }
+
+    private OrderProduct buildOrderProduct(Long pricePolicyId, int quantity) {
+        return OrderProduct.from(
+                OrderProductSnapshotState.builder()
+                        .pricePolicyId(pricePolicyId)
+                        .quantity(quantity)
+                        .build()
+        );
+    }
+
+    private Inventory buildInventory(Long productId, Long pricePolicyId, int stock) {
+        return Inventory.of(productId, pricePolicyId, stock, 0L);
+    }
+}

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/payment/CancelPaymentUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/payment/CancelPaymentUseCaseTest.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.commerce.service.payment;
 
 import com.personal.marketnote.commerce.domain.order.Order;
+import com.personal.marketnote.commerce.domain.order.OrderProductSnapshotState;
 import com.personal.marketnote.commerce.domain.order.OrderSnapshotState;
 import com.personal.marketnote.commerce.domain.order.OrderStatus;
 import com.personal.marketnote.commerce.domain.payment.*;
@@ -8,10 +9,12 @@ import com.personal.marketnote.commerce.exception.PaymentCancelException;
 import com.personal.marketnote.commerce.exception.PaymentNotFoundException;
 import com.personal.marketnote.commerce.exception.UnauthorizedOrderAccessException;
 import com.personal.marketnote.commerce.port.in.command.payment.CancelPaymentCommand;
+import com.personal.marketnote.commerce.port.in.usecase.inventory.RestoreProductInventoryUseCase;
 import com.personal.marketnote.commerce.port.in.usecase.ledger.RecordLedgerEntryUseCase;
 import com.personal.marketnote.commerce.port.in.usecase.order.ChangeOrderStatusUseCase;
 import com.personal.marketnote.commerce.port.out.order.FindOrderPort;
 import com.personal.marketnote.commerce.port.out.payment.*;
+import com.personal.marketnote.commerce.port.out.reward.ModifyUserPointPort;
 import com.personal.marketnote.commerce.port.out.payment.vendor.PaymentCancelVendorResult;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -22,6 +25,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -59,6 +63,12 @@ class CancelPaymentUseCaseTest {
 
     @Mock
     private RecordLedgerEntryUseCase recordLedgerEntryUseCase;
+
+    @Mock
+    private RestoreProductInventoryUseCase restoreProductInventoryUseCase;
+
+    @Mock
+    private ModifyUserPointPort modifyUserPointPort;
 
     private static final Long BUYER_ID = 100L;
     private static final UUID ORDER_KEY = UUID.randomUUID();
@@ -449,6 +459,69 @@ class CancelPaymentUseCaseTest {
     }
 
     @Nested
+    @DisplayName("재고 복구 검증")
+    class InventoryRestoreTest {
+
+        @Test
+        @DisplayName("전체 취소 성공 시 재고 복구가 호출된다")
+        void shouldRestoreInventoryOnFullCancel() {
+            Payment payment = createSuccessPayment(1L, ORDER_KEY, 50000L, "tno_123");
+            PspPaymentEvent event = createCompleteEvent(ORDER_KEY_STR, "tno_123", 50000L);
+            CancelPaymentCommand command = createFullCancelCommand(ORDER_KEY_STR);
+            PaymentCancelVendorResult vendorResult = createSuccessVendorResult();
+
+            when(findPaymentPort.findByOrderKey(ORDER_KEY)).thenReturn(Optional.of(payment));
+            when(findOrderPort.findById(1L)).thenReturn(Optional.of(createOrder(1L, BUYER_ID)));
+            when(findPspPaymentEventPort.findByOrderKey(ORDER_KEY_STR)).thenReturn(Optional.of(event));
+            when(paymentVendorPort.cancelPayment(any())).thenReturn(vendorResult);
+
+            cancelPaymentService.cancel(command);
+
+            verify(restoreProductInventoryUseCase).restore(anyList(), anyString());
+        }
+
+        @Test
+        @DisplayName("부분 취소 시 재고 복구가 호출되지 않는다")
+        void shouldNotRestoreInventoryOnPartialCancel() {
+            Payment payment = createSuccessPayment(1L, ORDER_KEY, 50000L, "tno_123");
+            PspPaymentEvent event = createCompleteEvent(ORDER_KEY_STR, "tno_123", 50000L);
+            CancelPaymentCommand command = createPartialCancelCommand(ORDER_KEY_STR, 20000L);
+            PaymentCancelVendorResult vendorResult = createSuccessVendorResult();
+
+            when(findPaymentPort.findByOrderKey(ORDER_KEY)).thenReturn(Optional.of(payment));
+            when(findOrderPort.findById(1L)).thenReturn(Optional.of(createOrder(1L, BUYER_ID)));
+            when(findPspPaymentEventPort.findByOrderKey(ORDER_KEY_STR)).thenReturn(Optional.of(event));
+            when(paymentVendorPort.cancelPayment(any())).thenReturn(vendorResult);
+
+            cancelPaymentService.cancel(command);
+
+            verify(restoreProductInventoryUseCase, never()).restore(anyList(), anyString());
+        }
+
+        @Test
+        @DisplayName("재고 복구 실패 시에도 결제 취소는 정상 완료된다")
+        void shouldCompleteCancelEvenWhenInventoryRestoreFails() {
+            Payment payment = createSuccessPayment(1L, ORDER_KEY, 50000L, "tno_123");
+            PspPaymentEvent event = createCompleteEvent(ORDER_KEY_STR, "tno_123", 50000L);
+            CancelPaymentCommand command = createFullCancelCommand(ORDER_KEY_STR);
+            PaymentCancelVendorResult vendorResult = createSuccessVendorResult();
+
+            when(findPaymentPort.findByOrderKey(ORDER_KEY)).thenReturn(Optional.of(payment));
+            when(findOrderPort.findById(1L)).thenReturn(Optional.of(createOrder(1L, BUYER_ID)));
+            when(findPspPaymentEventPort.findByOrderKey(ORDER_KEY_STR)).thenReturn(Optional.of(event));
+            when(paymentVendorPort.cancelPayment(any())).thenReturn(vendorResult);
+            doThrow(new RuntimeException("재고 복구 실패")).when(restoreProductInventoryUseCase)
+                    .restore(anyList(), anyString());
+
+            cancelPaymentService.cancel(command);
+
+            verify(updatePaymentPort).update(any());
+            verify(updatePspPaymentEventPort).update(any());
+            verify(changeOrderStatusUseCase).changeOrderStatus(any());
+        }
+    }
+
+    @Nested
     @DisplayName("KCP 취소 실패")
     class VendorFailureTest {
 
@@ -510,6 +583,89 @@ class CancelPaymentUseCaseTest {
         }
     }
 
+    @Nested
+    @DisplayName("포인트 환불 검증")
+    class PointRefundTest {
+
+        @Test
+        @DisplayName("전체 취소 시 포인트가 사용된 주문이면 포인트 환불이 호출된다")
+        void shouldRefundPointsOnFullCancelWhenPointUsed() {
+            Long pointAmount = 5000L;
+            Payment payment = createSuccessPayment(1L, ORDER_KEY, 45000L, "tno_123");
+            PspPaymentEvent event = createCompleteEvent(ORDER_KEY_STR, "tno_123", 45000L);
+            CancelPaymentCommand command = createFullCancelCommand(ORDER_KEY_STR);
+            PaymentCancelVendorResult vendorResult = createSuccessVendorResult();
+
+            when(findPaymentPort.findByOrderKey(ORDER_KEY)).thenReturn(Optional.of(payment));
+            when(findOrderPort.findById(1L)).thenReturn(Optional.of(createOrder(1L, BUYER_ID, pointAmount)));
+            when(findPspPaymentEventPort.findByOrderKey(ORDER_KEY_STR)).thenReturn(Optional.of(event));
+            when(paymentVendorPort.cancelPayment(any())).thenReturn(vendorResult);
+
+            cancelPaymentService.cancel(command);
+
+            verify(modifyUserPointPort).refundOrderPoints(BUYER_ID, pointAmount, 1L);
+        }
+
+        @Test
+        @DisplayName("전체 취소 시 포인트 미사용 주문이면 포인트 환불이 호출되지 않는다")
+        void shouldNotRefundPointsWhenNoPointUsed() {
+            Payment payment = createSuccessPayment(1L, ORDER_KEY, 50000L, "tno_123");
+            PspPaymentEvent event = createCompleteEvent(ORDER_KEY_STR, "tno_123", 50000L);
+            CancelPaymentCommand command = createFullCancelCommand(ORDER_KEY_STR);
+            PaymentCancelVendorResult vendorResult = createSuccessVendorResult();
+
+            when(findPaymentPort.findByOrderKey(ORDER_KEY)).thenReturn(Optional.of(payment));
+            when(findOrderPort.findById(1L)).thenReturn(Optional.of(createOrder(1L, BUYER_ID, 0L)));
+            when(findPspPaymentEventPort.findByOrderKey(ORDER_KEY_STR)).thenReturn(Optional.of(event));
+            when(paymentVendorPort.cancelPayment(any())).thenReturn(vendorResult);
+
+            cancelPaymentService.cancel(command);
+
+            verify(modifyUserPointPort, never()).refundOrderPoints(anyLong(), anyLong(), anyLong());
+        }
+
+        @Test
+        @DisplayName("부분 취소 시 포인트 환불이 호출되지 않는다")
+        void shouldNotRefundPointsOnPartialCancel() {
+            Payment payment = createSuccessPayment(1L, ORDER_KEY, 50000L, "tno_123");
+            PspPaymentEvent event = createCompleteEvent(ORDER_KEY_STR, "tno_123", 50000L);
+            CancelPaymentCommand command = createPartialCancelCommand(ORDER_KEY_STR, 20000L);
+            PaymentCancelVendorResult vendorResult = createSuccessVendorResult();
+
+            when(findPaymentPort.findByOrderKey(ORDER_KEY)).thenReturn(Optional.of(payment));
+            when(findOrderPort.findById(1L)).thenReturn(Optional.of(createOrder(1L, BUYER_ID, 5000L)));
+            when(findPspPaymentEventPort.findByOrderKey(ORDER_KEY_STR)).thenReturn(Optional.of(event));
+            when(paymentVendorPort.cancelPayment(any())).thenReturn(vendorResult);
+
+            cancelPaymentService.cancel(command);
+
+            verify(modifyUserPointPort, never()).refundOrderPoints(anyLong(), anyLong(), anyLong());
+        }
+
+        @Test
+        @DisplayName("포인트 환불 실패 시에도 결제 취소는 정상 완료된다")
+        void shouldCompleteCancelEvenWhenPointRefundFails() {
+            Long pointAmount = 5000L;
+            Payment payment = createSuccessPayment(1L, ORDER_KEY, 45000L, "tno_123");
+            PspPaymentEvent event = createCompleteEvent(ORDER_KEY_STR, "tno_123", 45000L);
+            CancelPaymentCommand command = createFullCancelCommand(ORDER_KEY_STR);
+            PaymentCancelVendorResult vendorResult = createSuccessVendorResult();
+
+            when(findPaymentPort.findByOrderKey(ORDER_KEY)).thenReturn(Optional.of(payment));
+            when(findOrderPort.findById(1L)).thenReturn(Optional.of(createOrder(1L, BUYER_ID, pointAmount)));
+            when(findPspPaymentEventPort.findByOrderKey(ORDER_KEY_STR)).thenReturn(Optional.of(event));
+            when(paymentVendorPort.cancelPayment(any())).thenReturn(vendorResult);
+            doThrow(new RuntimeException("포인트 환불 실패")).when(modifyUserPointPort)
+                    .refundOrderPoints(anyLong(), anyLong(), anyLong());
+
+            cancelPaymentService.cancel(command);
+
+            verify(updatePaymentPort).update(any());
+            verify(updatePspPaymentEventPort).update(any());
+            verify(changeOrderStatusUseCase).changeOrderStatus(any());
+        }
+    }
+
     private Payment createSuccessPayment(Long orderId, UUID orderKey, Long amount, String pgPaymentKey) {
         PaymentCreateState state = PaymentCreateState.builder()
                 .orderId(orderId)
@@ -539,11 +695,24 @@ class CancelPaymentUseCaseTest {
     }
 
     private Order createOrder(Long orderId, Long buyerId) {
+        return createOrder(orderId, buyerId, 0L);
+    }
+
+    private Order createOrder(Long orderId, Long buyerId, Long pointAmount) {
+        OrderProductSnapshotState productState = OrderProductSnapshotState.builder()
+                .pricePolicyId(100L)
+                .quantity(2)
+                .sellerId(10L)
+                .unitAmount(25000L)
+                .build();
         OrderSnapshotState state = OrderSnapshotState.builder()
                 .id(orderId)
                 .buyerId(buyerId)
                 .orderKey(ORDER_KEY)
                 .orderStatus(OrderStatus.PAID)
+                .totalAmount(50000L)
+                .pointAmount(pointAmount)
+                .orderProductStates(List.of(productState))
                 .build();
         return Order.from(state);
     }


### PR DESCRIPTION
## partially addresses #216
## resolves #915

## Task
- [x] ModifyUserPointPort에 refundOrderPoints() 추가
- [x] CancelPaymentService 전액 취소 시 포인트 환불 호출
- [x] RewardServiceClient에 환불 HTTP 클라이언트 구현
- [x] 포인트 환불 단위 테스트 4개 추가