### PR TITLE
[#216][#918] feat: 정산 내역 상세 조회 기능 추가

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/settlement/controller/SettlementController.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/settlement/controller/SettlementController.java
@@ -2,14 +2,18 @@ package com.personal.marketnote.commerce.adapter.in.web.settlement.controller;
 
 import com.personal.marketnote.commerce.adapter.in.web.settlement.controller.apidocs.ExecuteSettlementApiDocs;
 import com.personal.marketnote.commerce.adapter.in.web.settlement.controller.apidocs.GetSettlementApiDocs;
+import com.personal.marketnote.commerce.adapter.in.web.settlement.controller.apidocs.GetSettlementDetailApiDocs;
 import com.personal.marketnote.commerce.adapter.in.web.settlement.controller.apidocs.GetSettlementsApiDocs;
 import com.personal.marketnote.commerce.adapter.in.web.settlement.mapper.SettlementRequestToCommandMapper;
 import com.personal.marketnote.commerce.adapter.in.web.settlement.request.ExecuteSettlementRequest;
+import com.personal.marketnote.commerce.adapter.in.web.settlement.response.GetSettlementDetailResponse;
 import com.personal.marketnote.commerce.adapter.in.web.settlement.response.GetSettlementResponse;
 import com.personal.marketnote.commerce.adapter.in.web.settlement.response.GetSettlementsResponse;
+import com.personal.marketnote.commerce.port.in.result.settlement.GetSettlementDetailResult;
 import com.personal.marketnote.commerce.port.in.result.settlement.GetSettlementResult;
 import com.personal.marketnote.commerce.port.in.result.settlement.GetSettlementsResult;
 import com.personal.marketnote.commerce.port.in.usecase.settlement.ExecuteSettlementUseCase;
+import com.personal.marketnote.commerce.port.in.usecase.settlement.GetSettlementDetailUseCase;
 import com.personal.marketnote.commerce.port.in.usecase.settlement.GetSettlementUseCase;
 import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -23,6 +27,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 import static com.personal.marketnote.common.domain.exception.ExceptionCode.DEFAULT_SUCCESS_CODE;
 import static com.personal.marketnote.common.utility.ApiConstant.ADMIN_POINTCUT;
@@ -42,6 +48,7 @@ import static com.personal.marketnote.common.utility.ApiConstant.ADMIN_POINTCUT;
 public class SettlementController {
     private final ExecuteSettlementUseCase executeSettlementUseCase;
     private final GetSettlementUseCase getSettlementUseCase;
+    private final GetSettlementDetailUseCase getSettlementDetailUseCase;
 
     /**
      * 정산 실행
@@ -127,6 +134,34 @@ public class SettlementController {
                         HttpStatus.OK,
                         DEFAULT_SUCCESS_CODE,
                         "정산 단건 조회 성공"
+                ),
+                HttpStatus.OK
+        );
+    }
+
+    /**
+     * 정산 내역 상세 조회
+     *
+     * @param id 정산 ID
+     * @return 정산에 포함된 결제 배분 목록 {@link GetSettlementDetailResponse}
+     * @Author 성효빈
+     * @Date 2026-03-02
+     * @Description 정산 ID로 해당 정산에 포함된 결제 배분(PaymentAllocation) 목록을 조회합니다.
+     */
+    @GetMapping("/{id}/allocations")
+    @PreAuthorize(ADMIN_POINTCUT)
+    @GetSettlementDetailApiDocs
+    public ResponseEntity<BaseResponse<List<GetSettlementDetailResponse>>> getSettlementAllocations(
+            @PathVariable("id") Long id
+    ) {
+        List<GetSettlementDetailResult> results = getSettlementDetailUseCase.getSettlementAllocations(id);
+
+        return new ResponseEntity<>(
+                BaseResponse.of(
+                        GetSettlementDetailResponse.fromList(results),
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "정산 내역 상세 조회 성공"
                 ),
                 HttpStatus.OK
         );

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/settlement/controller/apidocs/GetSettlementDetailApiDocs.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/settlement/controller/apidocs/GetSettlementDetailApiDocs.java
@@ -1,0 +1,87 @@
+package com.personal.marketnote.commerce.adapter.in.web.settlement.controller.apidocs;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Operation(
+        summary = "(관리자) 정산 내역 상세 조회",
+        description = """
+                작성일자: 2026-03-02
+
+                작성자: 성효빈
+
+                ---
+
+                ## Description
+
+                - 정산 ID로 해당 정산에 포함된 결제 배분(PaymentAllocation) 목록을 조회합니다.
+
+                ---
+
+                ## Path Variable
+
+                | **키** | **타입** | **설명** | **필수 여부** | **예시** |
+                | --- | --- | --- | --- | --- |
+                | id | number | 정산 ID | Y | 1 |
+
+                ---
+
+                ## Response > content
+
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | id | number | 배분 ID | 1 |
+                | orderId | number | 주문 ID | 100 |
+                | sellerId | number | 판매자 ID | 10 |
+                | allocatedAmount | number | 배분 금액 | 50000 |
+                | transactionType | string | 거래 유형 | "ORDER_REGISTRATION" |
+                | targetType | string | 대상 유형 | "ORDER" |
+                | createdAt | string | 생성일시 | "2026-02-15T14:30:00" |
+                """,
+        security = {@SecurityRequirement(name = "bearer")},
+        responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "정산 내역 상세 조회 성공",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 200,
+                                          "code": "SUC01",
+                                          "timestamp": "2026-03-02T12:00:00.000",
+                                          "content": [
+                                            {
+                                              "id": 1,
+                                              "orderId": 100,
+                                              "sellerId": 10,
+                                              "allocatedAmount": 50000,
+                                              "transactionType": "ORDER_REGISTRATION",
+                                              "targetType": "ORDER",
+                                              "createdAt": "2026-02-15T14:30:00"
+                                            },
+                                            {
+                                              "id": 2,
+                                              "orderId": 101,
+                                              "sellerId": 10,
+                                              "allocatedAmount": 30000,
+                                              "transactionType": "ORDER_REGISTRATION",
+                                              "targetType": "ORDER",
+                                              "createdAt": "2026-02-15T15:00:00"
+                                            }
+                                          ],
+                                          "message": "정산 내역 상세 조회 성공"
+                                        }
+                                        """)
+                        )
+                )
+        })
+public @interface GetSettlementDetailApiDocs {
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/settlement/response/GetSettlementDetailResponse.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/settlement/response/GetSettlementDetailResponse.java
@@ -1,0 +1,39 @@
+package com.personal.marketnote.commerce.adapter.in.web.settlement.response;
+
+import com.personal.marketnote.commerce.domain.settlement.PaymentAllocationTargetType;
+import com.personal.marketnote.commerce.domain.settlement.PaymentAllocationTransactionType;
+import com.personal.marketnote.commerce.port.in.result.settlement.GetSettlementDetailResult;
+import lombok.AccessLevel;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Builder(access = AccessLevel.PRIVATE)
+public record GetSettlementDetailResponse(
+        Long id,
+        Long orderId,
+        Long sellerId,
+        Long allocatedAmount,
+        PaymentAllocationTransactionType transactionType,
+        PaymentAllocationTargetType targetType,
+        LocalDateTime createdAt
+) {
+    public static GetSettlementDetailResponse from(GetSettlementDetailResult result) {
+        return GetSettlementDetailResponse.builder()
+                .id(result.id())
+                .orderId(result.orderId())
+                .sellerId(result.sellerId())
+                .allocatedAmount(result.allocatedAmount())
+                .transactionType(result.transactionType())
+                .targetType(result.targetType())
+                .createdAt(result.createdAt())
+                .build();
+    }
+
+    public static List<GetSettlementDetailResponse> fromList(List<GetSettlementDetailResult> results) {
+        return results.stream()
+                .map(GetSettlementDetailResponse::from)
+                .toList();
+    }
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/settlement/PaymentAllocationPersistenceAdapter.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/settlement/PaymentAllocationPersistenceAdapter.java
@@ -34,6 +34,13 @@ public class PaymentAllocationPersistenceAdapter
     }
 
     @Override
+    public List<PaymentAllocation> findBySettlementId(Long settlementId) {
+        return paymentAllocationJpaRepository.findAllBySettlementId(settlementId).stream()
+                .map(PaymentAllocationEntityToDomainMapper::toDomain)
+                .toList();
+    }
+
+    @Override
     public void assignSettlement(List<Long> allocationIds, Long settlementId) {
         paymentAllocationJpaRepository.bulkAssignSettlement(allocationIds, settlementId);
     }

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/settlement/repository/PaymentAllocationJpaRepository.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/settlement/repository/PaymentAllocationJpaRepository.java
@@ -18,4 +18,6 @@ public interface PaymentAllocationJpaRepository extends JpaRepository<PaymentAll
     @Modifying
     @Query("UPDATE PaymentAllocationJpaEntity pa SET pa.settlementId = :settlementId WHERE pa.id IN :ids AND pa.settlementId IS NULL")
     int bulkAssignSettlement(@Param("ids") List<Long> ids, @Param("settlementId") Long settlementId);
+
+    List<PaymentAllocationJpaEntity> findAllBySettlementId(Long settlementId);
 }

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/exception/InsufficientPointException.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/exception/InsufficientPointException.java
@@ -6,7 +6,7 @@ import com.personal.marketnote.common.domain.exception.illegalargument.invalidva
  * 포인트 잔액이 부족할 때 발생하는 예외
  *
  * @Author 성효빈
- * @Date 2026-02-20
+ * @Date 2026-03-02
  * @Description 주문 등록 시 요청 포인트가 보유 포인트를 초과하면 발생합니다.
  */
 public class InsufficientPointException extends InvalidValueException {

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/result/settlement/GetSettlementDetailResult.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/result/settlement/GetSettlementDetailResult.java
@@ -1,0 +1,38 @@
+package com.personal.marketnote.commerce.port.in.result.settlement;
+
+import com.personal.marketnote.commerce.domain.settlement.PaymentAllocation;
+import com.personal.marketnote.commerce.domain.settlement.PaymentAllocationTargetType;
+import com.personal.marketnote.commerce.domain.settlement.PaymentAllocationTransactionType;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Builder
+public record GetSettlementDetailResult(
+        Long id,
+        Long orderId,
+        Long sellerId,
+        Long allocatedAmount,
+        PaymentAllocationTransactionType transactionType,
+        PaymentAllocationTargetType targetType,
+        LocalDateTime createdAt
+) {
+    public static GetSettlementDetailResult from(PaymentAllocation allocation) {
+        return GetSettlementDetailResult.builder()
+                .id(allocation.getId())
+                .orderId(allocation.getOrderId())
+                .sellerId(allocation.getSellerId())
+                .allocatedAmount(allocation.getAllocatedAmount())
+                .transactionType(allocation.getTransactionType())
+                .targetType(allocation.getTargetType())
+                .createdAt(allocation.getCreatedAt())
+                .build();
+    }
+
+    public static List<GetSettlementDetailResult> fromList(List<PaymentAllocation> allocations) {
+        return allocations.stream()
+                .map(GetSettlementDetailResult::from)
+                .toList();
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/settlement/GetSettlementDetailUseCase.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/settlement/GetSettlementDetailUseCase.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.commerce.port.in.usecase.settlement;
+
+import com.personal.marketnote.commerce.port.in.result.settlement.GetSettlementDetailResult;
+
+import java.util.List;
+
+public interface GetSettlementDetailUseCase {
+    List<GetSettlementDetailResult> getSettlementAllocations(Long settlementId);
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/reward/ModifyUserPointPort.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/reward/ModifyUserPointPort.java
@@ -21,7 +21,7 @@ public interface ModifyUserPointPort {
     /**
      * @param userId 회원 ID
      * @return 사용 가능한 포인트 잔액
-     * @Date 2026-02-20
+     * @Date 2026-03-02
      * @Author 성효빈
      * @Description 회원의 사용 가능한 포인트 잔액을 조회합니다.
      */
@@ -31,7 +31,7 @@ public interface ModifyUserPointPort {
      * @param userId  회원 ID
      * @param amount  차감할 포인트
      * @param orderId 주문 ID
-     * @Date 2026-02-20
+     * @Date 2026-03-02
      * @Author 성효빈
      * @Description 주문 결제 시 포인트를 차감합니다.
      */
@@ -41,7 +41,7 @@ public interface ModifyUserPointPort {
      * @param userId  회원 ID
      * @param amount  환불할 포인트
      * @param orderId 주문 ID
-     * @Date 2026-02-20
+     * @Date 2026-03-02
      * @Author 성효빈
      * @Description 주문 취소 시 포인트를 환불합니다.
      */

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/settlement/FindPaymentAllocationPort.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/settlement/FindPaymentAllocationPort.java
@@ -6,4 +6,6 @@ import java.util.List;
 
 public interface FindPaymentAllocationPort {
     List<PaymentAllocation> findUnsettledAllocations(Integer year, Integer month);
+
+    List<PaymentAllocation> findBySettlementId(Long settlementId);
 }

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/settlement/GetSettlementDetailService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/settlement/GetSettlementDetailService.java
@@ -1,0 +1,32 @@
+package com.personal.marketnote.commerce.service.settlement;
+
+import com.personal.marketnote.commerce.domain.settlement.PaymentAllocation;
+import com.personal.marketnote.commerce.exception.SettlementNotFoundException;
+import com.personal.marketnote.commerce.port.in.result.settlement.GetSettlementDetailResult;
+import com.personal.marketnote.commerce.port.in.usecase.settlement.GetSettlementDetailUseCase;
+import com.personal.marketnote.commerce.port.out.settlement.FindPaymentAllocationPort;
+import com.personal.marketnote.commerce.port.out.settlement.FindSettlementPort;
+import com.personal.marketnote.common.application.UseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@UseCase
+@RequiredArgsConstructor
+public class GetSettlementDetailService implements GetSettlementDetailUseCase {
+    private final FindSettlementPort findSettlementPort;
+    private final FindPaymentAllocationPort findPaymentAllocationPort;
+
+    @Override
+    @Transactional(isolation = READ_COMMITTED, readOnly = true)
+    public List<GetSettlementDetailResult> getSettlementAllocations(Long settlementId) {
+        findSettlementPort.findById(settlementId)
+                .orElseThrow(() -> new SettlementNotFoundException(settlementId));
+
+        List<PaymentAllocation> allocations = findPaymentAllocationPort.findBySettlementId(settlementId);
+        return GetSettlementDetailResult.fromList(allocations);
+    }
+}

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/settlement/GetSettlementDetailUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/settlement/GetSettlementDetailUseCaseTest.java
@@ -1,0 +1,181 @@
+package com.personal.marketnote.commerce.service.settlement;
+
+import com.personal.marketnote.commerce.domain.settlement.*;
+import com.personal.marketnote.commerce.exception.SettlementNotFoundException;
+import com.personal.marketnote.commerce.port.in.result.settlement.GetSettlementDetailResult;
+import com.personal.marketnote.commerce.port.out.settlement.FindPaymentAllocationPort;
+import com.personal.marketnote.commerce.port.out.settlement.FindSettlementPort;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GetSettlementDetailUseCase 테스트")
+class GetSettlementDetailUseCaseTest {
+
+    @InjectMocks
+    private GetSettlementDetailService getSettlementDetailService;
+
+    @Mock
+    private FindSettlementPort findSettlementPort;
+
+    @Mock
+    private FindPaymentAllocationPort findPaymentAllocationPort;
+
+    private Settlement createSettlement(Long id) {
+        return Settlement.from(SettlementSnapshotState.builder()
+                .id(id)
+                .sellerId(10L)
+                .year(2026)
+                .month(2)
+                .totalAllocatedAmount(100000L)
+                .pgFeeAmount(3000L)
+                .platformFeeAmount(5000L)
+                .sellerPayoutAmount(92000L)
+                .status(SettlementStatus.COMPLETED)
+                .version(0L)
+                .createdAt(LocalDateTime.of(2026, 2, 16, 10, 0))
+                .modifiedAt(LocalDateTime.of(2026, 2, 16, 10, 0))
+                .build());
+    }
+
+    private PaymentAllocation createAllocation(Long id, Long orderId, Long sellerId,
+                                                Long allocatedAmount, Long settlementId,
+                                                PaymentAllocationTransactionType transactionType,
+                                                PaymentAllocationTargetType targetType) {
+        return PaymentAllocation.from(PaymentAllocationSnapshotState.builder()
+                .id(id)
+                .orderId(orderId)
+                .sellerId(sellerId)
+                .allocatedAmount(allocatedAmount)
+                .settlementId(settlementId)
+                .transactionType(transactionType)
+                .targetType(targetType)
+                .idempotencyKey("key-" + id)
+                .createdAt(LocalDateTime.of(2026, 2, 15, 14, 30))
+                .build());
+    }
+
+    @Test
+    @DisplayName("정산 ID로 배분 목록을 조회하면 해당 정산에 포함된 배분 내역을 반환한다")
+    void shouldReturnAllocationsForSettlement() {
+        // given
+        Long settlementId = 1L;
+        Settlement settlement = createSettlement(settlementId);
+        PaymentAllocation allocation1 = createAllocation(1L, 100L, 10L, 50000L, settlementId,
+                PaymentAllocationTransactionType.ORDER_REGISTRATION, PaymentAllocationTargetType.ORDER);
+        PaymentAllocation allocation2 = createAllocation(2L, 101L, 10L, 50000L, settlementId,
+                PaymentAllocationTransactionType.ORDER_REGISTRATION, PaymentAllocationTargetType.ORDER);
+
+        when(findSettlementPort.findById(settlementId)).thenReturn(Optional.of(settlement));
+        when(findPaymentAllocationPort.findBySettlementId(settlementId))
+                .thenReturn(List.of(allocation1, allocation2));
+
+        // when
+        List<GetSettlementDetailResult> results = getSettlementDetailService.getSettlementAllocations(settlementId);
+
+        // then
+        assertThat(results).hasSize(2);
+        assertThat(results.get(0).orderId()).isEqualTo(100L);
+        assertThat(results.get(0).allocatedAmount()).isEqualTo(50000L);
+        assertThat(results.get(1).orderId()).isEqualTo(101L);
+        assertThat(results.get(1).allocatedAmount()).isEqualTo(50000L);
+        verify(findSettlementPort).findById(settlementId);
+        verify(findPaymentAllocationPort).findBySettlementId(settlementId);
+    }
+
+    @Test
+    @DisplayName("정산에 배분 내역이 없으면 빈 목록을 반환한다")
+    void shouldReturnEmptyListWhenNoAllocations() {
+        // given
+        Long settlementId = 1L;
+        Settlement settlement = createSettlement(settlementId);
+
+        when(findSettlementPort.findById(settlementId)).thenReturn(Optional.of(settlement));
+        when(findPaymentAllocationPort.findBySettlementId(settlementId)).thenReturn(List.of());
+
+        // when
+        List<GetSettlementDetailResult> results = getSettlementDetailService.getSettlementAllocations(settlementId);
+
+        // then
+        assertThat(results).isEmpty();
+        verify(findSettlementPort).findById(settlementId);
+        verify(findPaymentAllocationPort).findBySettlementId(settlementId);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 정산 ID로 조회하면 SettlementNotFoundException이 발생한다")
+    void shouldThrowWhenSettlementNotFound() {
+        // given
+        Long settlementId = 999L;
+        when(findSettlementPort.findById(settlementId)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> getSettlementDetailService.getSettlementAllocations(settlementId))
+                .isInstanceOf(SettlementNotFoundException.class)
+                .hasMessageContaining("999");
+        verify(findSettlementPort).findById(settlementId);
+        verifyNoInteractions(findPaymentAllocationPort);
+    }
+
+    @Test
+    @DisplayName("배분 내역의 모든 필드가 정확히 매핑된다")
+    void shouldMapAllFieldsCorrectly() {
+        // given
+        Long settlementId = 1L;
+        Settlement settlement = createSettlement(settlementId);
+        PaymentAllocation allocation = createAllocation(5L, 200L, 15L, 75000L, settlementId,
+                PaymentAllocationTransactionType.ORDER_REGISTRATION, PaymentAllocationTargetType.ORDER);
+
+        when(findSettlementPort.findById(settlementId)).thenReturn(Optional.of(settlement));
+        when(findPaymentAllocationPort.findBySettlementId(settlementId)).thenReturn(List.of(allocation));
+
+        // when
+        List<GetSettlementDetailResult> results = getSettlementDetailService.getSettlementAllocations(settlementId);
+
+        // then
+        GetSettlementDetailResult result = results.get(0);
+        assertThat(result.id()).isEqualTo(5L);
+        assertThat(result.orderId()).isEqualTo(200L);
+        assertThat(result.sellerId()).isEqualTo(15L);
+        assertThat(result.allocatedAmount()).isEqualTo(75000L);
+        assertThat(result.transactionType()).isEqualTo(PaymentAllocationTransactionType.ORDER_REGISTRATION);
+        assertThat(result.targetType()).isEqualTo(PaymentAllocationTargetType.ORDER);
+        assertThat(result.createdAt()).isEqualTo(LocalDateTime.of(2026, 2, 15, 14, 30));
+    }
+
+    @Test
+    @DisplayName("취소 거래가 포함된 배분 내역을 조회한다")
+    void shouldReturnAllocationsWithCancellationType() {
+        // given
+        Long settlementId = 1L;
+        Settlement settlement = createSettlement(settlementId);
+        PaymentAllocation orderAllocation = createAllocation(1L, 100L, 10L, 50000L, settlementId,
+                PaymentAllocationTransactionType.ORDER_REGISTRATION, PaymentAllocationTargetType.ORDER);
+        PaymentAllocation cancelAllocation = createAllocation(2L, 100L, 10L, 50000L, settlementId,
+                PaymentAllocationTransactionType.CANCELLATION, PaymentAllocationTargetType.ORDER);
+
+        when(findSettlementPort.findById(settlementId)).thenReturn(Optional.of(settlement));
+        when(findPaymentAllocationPort.findBySettlementId(settlementId))
+                .thenReturn(List.of(orderAllocation, cancelAllocation));
+
+        // when
+        List<GetSettlementDetailResult> results = getSettlementDetailService.getSettlementAllocations(settlementId);
+
+        // then
+        assertThat(results).hasSize(2);
+        assertThat(results.get(0).transactionType()).isEqualTo(PaymentAllocationTransactionType.ORDER_REGISTRATION);
+        assertThat(results.get(1).transactionType()).isEqualTo(PaymentAllocationTransactionType.CANCELLATION);
+    }
+}

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/point/PointController.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/point/PointController.java
@@ -117,7 +117,7 @@ public class PointController {
      * @param userId 회원 ID
      * @return 회원 포인트 정보 조회 응답 {@link GetUserPointByIdResponse}
      * @Author 성효빈
-     * @Date 2026-02-20
+     * @Date 2026-03-02
      * @Description 관리자가 특정 회원의 포인트 정보를 조회합니다.
      */
     @GetMapping("/{userId}/points")

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/point/apidocs/GetUserPointByIdApiDocs.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/point/apidocs/GetUserPointByIdApiDocs.java
@@ -18,7 +18,7 @@ import java.lang.annotation.*;
 @Operation(
         summary = "(관리자) 회원 포인트 정보 조회",
         description = """
-                작성일자: 2026-02-20
+                작성일자: 2026-03-02
 
                 작성자: 성효빈
 
@@ -45,7 +45,7 @@ import java.lang.annotation.*;
                 | --- | --- | --- | --- |
                 | statusCode | number | HTTP 상태 코드 | 200 |
                 | code | string | 응답 코드 | "SUC01" |
-                | timestamp | string(datetime) | 응답 시간 | "2026-02-20T12:00:00.000" |
+                | timestamp | string(datetime) | 응답 시간 | "2026-03-02T12:00:00.000" |
                 | content | object | 응답 본문 | { ... } |
                 | message | string | 처리 결과 | "회원 포인트 정보 조회 성공" |
 
@@ -82,14 +82,14 @@ import java.lang.annotation.*;
                                         {
                                           "statusCode": 200,
                                           "code": "SUC01",
-                                          "timestamp": "2026-02-20T18:01:50.214036",
+                                          "timestamp": "2026-03-02T18:01:50.214036",
                                           "content": {
                                             "userId": 100,
                                             "amount": 5000,
                                             "addExpectedAmount": 0,
                                             "expireExpectedAmount": 0,
                                             "createdAt": "2026-01-17T05:27:21.418776",
-                                            "modifiedAt": "2026-02-20T14:28:00.973419"
+                                            "modifiedAt": "2026-03-02T14:28:00.973419"
                                           },
                                           "message": "회원 포인트 정보 조회 성공"
                                         }
@@ -104,7 +104,7 @@ import java.lang.annotation.*;
                                         {
                                           "statusCode": 401,
                                           "code": "UNAUTHORIZED",
-                                          "timestamp": "2026-02-20T12:12:30.013",
+                                          "timestamp": "2026-03-02T12:12:30.013",
                                           "content": null,
                                           "message": "Invalid token"
                                         }
@@ -119,7 +119,7 @@ import java.lang.annotation.*;
                                         {
                                           "statusCode": 403,
                                           "code": "FORBIDDEN",
-                                          "timestamp": "2026-02-20T12:12:30.013",
+                                          "timestamp": "2026-03-02T12:12:30.013",
                                           "content": null,
                                           "message": "Access Denied"
                                         }


### PR DESCRIPTION
## partially addresses #216
## resolves #918

## Task
- [x] GetSettlementDetailUseCase 인터페이스 정의
- [x] FindPaymentAllocationPort에 정산 ID 기반 조회 메서드 추가
- [x] GetSettlementDetailService 구현 (정산 존재 확인 + 배분 목록 조회)
- [x] GET /api/v1/admin/settlements/{id}/allocations 엔드포인트 추가
- [x] GetSettlementDetailResponse 응답 DTO 추가
- [x] GetSettlementDetailApiDocs 합성 애노테이션 추가
- [x] GetSettlementDetailUseCaseTest 단위 테스트 5개 추가