### PR TITLE
[#216][#919] feat: 관리자 주문 내역 조회 기능 추가

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/AdminOrderController.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/AdminOrderController.java
@@ -1,0 +1,76 @@
+package com.personal.marketnote.commerce.adapter.in.web.order.controller;
+
+import com.personal.marketnote.commerce.adapter.in.web.order.controller.apidocs.GetAdminOrdersApiDocs;
+import com.personal.marketnote.commerce.adapter.in.web.order.mapper.AdminOrderRequestToCommandMapper;
+import com.personal.marketnote.commerce.adapter.in.web.order.response.GetAdminOrdersResponse;
+import com.personal.marketnote.commerce.domain.order.OrderStatus;
+import com.personal.marketnote.commerce.port.in.result.order.GetAdminOrdersResult;
+import com.personal.marketnote.commerce.port.in.usecase.order.GetAdminOrdersUseCase;
+import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDateTime;
+
+import static com.personal.marketnote.common.domain.exception.ExceptionCode.DEFAULT_SUCCESS_CODE;
+import static com.personal.marketnote.common.utility.ApiConstant.ADMIN_POINTCUT;
+
+/**
+ * 관리자 주문 컨트롤러
+ *
+ * @Author 성효빈
+ * @Date 2026-03-02
+ * @Description 관리자 주문 관련 API를 제공합니다.
+ */
+@RestController
+@RequestMapping("/api/v1/admin/orders")
+@Tag(name = "(관리자) 주문 API", description = "관리자 주문 관련 API")
+@RequiredArgsConstructor
+@Validated
+public class AdminOrderController {
+    private final GetAdminOrdersUseCase getAdminOrdersUseCase;
+
+    /**
+     * 관리자 주문 내역 조회
+     *
+     * @param sellerId    판매자 ID (선택)
+     * @param startDate   조회 시작 일시 (선택)
+     * @param endDate     조회 종료 일시 (선택)
+     * @param orderStatus 주문 상태 (선택)
+     * @return 주문 내역 조회 응답 {@link GetAdminOrdersResponse}
+     * @Author 성효빈
+     * @Date 2026-03-02
+     * @Description 관리자가 전체 주문 내역을 판매자별, 기간별, 상태별로 조회합니다.
+     */
+    @GetMapping
+    @PreAuthorize(ADMIN_POINTCUT)
+    @GetAdminOrdersApiDocs
+    public ResponseEntity<BaseResponse<GetAdminOrdersResponse>> getAdminOrders(
+            @RequestParam(required = false) Long sellerId,
+            @RequestParam(required = false) LocalDateTime startDate,
+            @RequestParam(required = false) LocalDateTime endDate,
+            @RequestParam(required = false) OrderStatus orderStatus
+    ) {
+        GetAdminOrdersResult result = getAdminOrdersUseCase.getAdminOrders(
+                AdminOrderRequestToCommandMapper.mapToQuery(sellerId, startDate, endDate, orderStatus)
+        );
+
+        return new ResponseEntity<>(
+                BaseResponse.of(
+                        GetAdminOrdersResponse.from(result),
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "관리자 주문 내역 조회 성공"
+                ),
+                HttpStatus.OK
+        );
+    }
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/apidocs/GetAdminOrdersApiDocs.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/apidocs/GetAdminOrdersApiDocs.java
@@ -1,0 +1,100 @@
+package com.personal.marketnote.commerce.adapter.in.web.order.controller.apidocs;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Operation(
+        summary = "(관리자) 주문 내역 조회",
+        description = """
+                작성일자: 2026-03-02
+
+                작성자: 성효빈
+
+                ---
+
+                ## Description
+
+                - 관리자가 전체 주문 내역을 판매자별, 기간별, 상태별로 조회합니다.
+                - 모든 필터는 선택 사항이며, 필터를 지정하지 않으면 전체 주문을 조회합니다.
+                - PAYMENT_PENDING 상태의 주문은 제외됩니다.
+
+                ---
+
+                ## Query Parameters
+
+                | **키** | **타입** | **설명** | **필수 여부** | **예시** |
+                | --- | --- | --- | --- | --- |
+                | sellerId | number | 판매자 ID | N | 10 |
+                | startDate | string (ISO DateTime) | 조회 시작 일시 | N | 2026-02-01T00:00:00 |
+                | endDate | string (ISO DateTime) | 조회 종료 일시 | N | 2026-02-28T23:59:59 |
+                | orderStatus | string (enum) | 주문 상태 | N | PAID |
+
+                ---
+
+                ## Response > content
+
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | orders | array | 주문 목록 | - |
+                | orders[].orderInfo.id | number | 주문 ID | 1 |
+                | orders[].orderInfo.buyerId | number | 구매자 ID | 100 |
+                | orders[].orderInfo.orderNumber | string | 주문 번호 | "ORD20260220001" |
+                | orders[].orderInfo.orderStatus | string | 주문 상태 | "PAID" |
+                | orders[].orderInfo.totalAmount | number | 총 금액 | 100000 |
+                | orders[].orderInfo.paidAmount | number | 결제 금액 | 95000 |
+                | orders[].orderInfo.orderProducts | array | 주문 상품 목록 | - |
+                """,
+        security = {@SecurityRequirement(name = "bearer")},
+        responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "관리자 주문 내역 조회 성공",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 200,
+                                          "code": "SUC01",
+                                          "timestamp": "2026-03-02T12:00:00.000",
+                                          "content": {
+                                            "orders": [
+                                              {
+                                                "orderInfo": {
+                                                  "id": 1,
+                                                  "buyerId": 100,
+                                                  "orderNumber": "ORD20260220001",
+                                                  "orderStatus": "PAID",
+                                                  "totalAmount": 100000,
+                                                  "paidAmount": 95000,
+                                                  "couponAmount": 3000,
+                                                  "pointAmount": 2000,
+                                                  "orderProducts": [
+                                                    {
+                                                      "sellerId": 10,
+                                                      "productId": 50,
+                                                      "pricePolicyId": 30,
+                                                      "quantity": 2,
+                                                      "unitAmount": 50000,
+                                                      "brandName": "테스트 브랜드",
+                                                      "productName": "테스트 상품"
+                                                    }
+                                                  ]
+                                                }
+                                              }
+                                            ]
+                                          },
+                                          "message": "관리자 주문 내역 조회 성공"
+                                        }
+                                        """)
+                        )
+                )
+        })
+public @interface GetAdminOrdersApiDocs {
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/mapper/AdminOrderRequestToCommandMapper.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/mapper/AdminOrderRequestToCommandMapper.java
@@ -1,0 +1,20 @@
+package com.personal.marketnote.commerce.adapter.in.web.order.mapper;
+
+import com.personal.marketnote.commerce.domain.order.OrderStatus;
+import com.personal.marketnote.commerce.port.in.command.order.GetAdminOrdersQuery;
+
+import java.time.LocalDateTime;
+
+public class AdminOrderRequestToCommandMapper {
+    private AdminOrderRequestToCommandMapper() {
+    }
+
+    public static GetAdminOrdersQuery mapToQuery(
+            Long sellerId,
+            LocalDateTime startDate,
+            LocalDateTime endDate,
+            OrderStatus orderStatus
+    ) {
+        return GetAdminOrdersQuery.of(sellerId, startDate, endDate, orderStatus);
+    }
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/response/GetAdminOrdersResponse.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/response/GetAdminOrdersResponse.java
@@ -1,0 +1,16 @@
+package com.personal.marketnote.commerce.adapter.in.web.order.response;
+
+import com.personal.marketnote.commerce.port.in.result.order.GetAdminOrdersResult;
+
+import java.util.List;
+
+public record GetAdminOrdersResponse(
+        List<GetOrderResponse> orders
+) {
+    public static GetAdminOrdersResponse from(GetAdminOrdersResult result) {
+        List<GetOrderResponse> responses = result.orders().stream()
+                .map(GetOrderResponse::from)
+                .toList();
+        return new GetAdminOrdersResponse(responses);
+    }
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/order/OrderPersistenceAdapter.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/order/OrderPersistenceAdapter.java
@@ -103,6 +103,45 @@ public class OrderPersistenceAdapter implements SaveOrderPort, FindOrderPort, Fi
     }
 
     @Override
+    public List<Order> findAllWithFilters(
+            Long sellerId,
+            LocalDateTime startDate,
+            LocalDateTime endDate,
+            OrderStatus orderStatus
+    ) {
+        String orderStatusParam = FormatValidator.hasValue(orderStatus)
+                ? orderStatus.name()
+                : "";
+
+        List<Long> orderIds = orderJpaRepository.findIdsByAdminFilters(
+                sellerId,
+                startDate,
+                endDate,
+                orderStatusParam
+        );
+
+        if (FormatValidator.hasNoValue(orderIds)) {
+            return List.of();
+        }
+
+        List<OrderJpaEntity> entities = orderJpaRepository.findWithProductsByIds(orderIds);
+
+        Map<Long, Integer> orderIndex = new HashMap<>();
+        for (int i = 0; i < orderIds.size(); i++) {
+            orderIndex.put(orderIds.get(i), i);
+        }
+
+        return entities.stream()
+                .sorted(Comparator.comparingInt(
+                        entity -> orderIndex.getOrDefault(entity.getId(), Integer.MAX_VALUE))
+                )
+                .map(OrderJpaEntityToDomainMapper::mapToDomain)
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .toList();
+    }
+
+    @Override
     public void update(Order order, OrderStatusHistory orderStatusHistory) throws OrderNotFoundException {
         OrderJpaEntity orderJpaEntity = findEntityById(order.getId());
         orderJpaEntity.updateFrom(order);

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/order/repository/OrderJpaRepository.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/order/repository/OrderJpaRepository.java
@@ -26,6 +26,25 @@ public interface OrderJpaRepository extends JpaRepository<OrderJpaEntity, Long> 
             @Param("statusSize") int statusSize
     );
 
+    @Query(value = """
+            SELECT DISTINCT o.id
+            FROM orders o
+            LEFT JOIN order_product op ON o.id = op.order_id
+            WHERE o.order_status <> 'PAYMENT_PENDING'
+              AND (CAST(:sellerId AS BIGINT) IS NULL OR op.seller_id = :sellerId)
+              AND (CAST(:startDate AS timestamp) IS NULL OR o.created_at >= CAST(:startDate AS timestamp))
+              AND (CAST(:endDate   AS timestamp) IS NULL OR o.created_at <  CAST(:endDate   AS timestamp))
+              AND (:orderStatus = '' OR o.order_status = :orderStatus)
+            ORDER BY o.id DESC
+            LIMIT 1000
+            """, nativeQuery = true)
+    List<Long> findIdsByAdminFilters(
+            @Param("sellerId") Long sellerId,
+            @Param("startDate") java.time.LocalDateTime startDate,
+            @Param("endDate") java.time.LocalDateTime endDate,
+            @Param("orderStatus") String orderStatus
+    );
+
     @Query("""
             SELECT DISTINCT o
             FROM OrderJpaEntity o

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/command/order/GetAdminOrdersQuery.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/command/order/GetAdminOrdersQuery.java
@@ -1,0 +1,27 @@
+package com.personal.marketnote.commerce.port.in.command.order;
+
+import com.personal.marketnote.commerce.domain.order.OrderStatus;
+import com.personal.marketnote.common.utility.FormatValidator;
+
+import java.time.LocalDateTime;
+
+public record GetAdminOrdersQuery(
+        Long sellerId,
+        LocalDateTime startDate,
+        LocalDateTime endDate,
+        OrderStatus orderStatus
+) {
+    public static GetAdminOrdersQuery of(
+            Long sellerId,
+            LocalDateTime startDate,
+            LocalDateTime endDate,
+            OrderStatus orderStatus
+    ) {
+        if (FormatValidator.hasValue(startDate)
+                && FormatValidator.hasValue(endDate)
+                && endDate.isBefore(startDate)) {
+            throw new IllegalArgumentException("종료일은 시작일 이후여야 합니다.");
+        }
+        return new GetAdminOrdersQuery(sellerId, startDate, endDate, orderStatus);
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/result/order/GetAdminOrdersResult.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/result/order/GetAdminOrdersResult.java
@@ -1,0 +1,25 @@
+package com.personal.marketnote.commerce.port.in.result.order;
+
+import com.personal.marketnote.commerce.domain.order.Order;
+import com.personal.marketnote.commerce.port.out.result.product.ProductInfoResult;
+
+import java.util.List;
+import java.util.Map;
+
+public record GetAdminOrdersResult(
+        List<GetOrderResult> orders
+) {
+    public static GetAdminOrdersResult from(
+            List<Order> orders,
+            Map<Long, ProductInfoResult> productInfoResultsByPricePolicyId
+    ) {
+        List<GetOrderResult> results = orders.stream()
+                .map(order -> GetOrderResult.from(order, productInfoResultsByPricePolicyId))
+                .toList();
+        return new GetAdminOrdersResult(results);
+    }
+
+    public static GetAdminOrdersResult empty() {
+        return new GetAdminOrdersResult(List.of());
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/order/GetAdminOrdersUseCase.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/order/GetAdminOrdersUseCase.java
@@ -1,0 +1,15 @@
+package com.personal.marketnote.commerce.port.in.usecase.order;
+
+import com.personal.marketnote.commerce.port.in.command.order.GetAdminOrdersQuery;
+import com.personal.marketnote.commerce.port.in.result.order.GetAdminOrdersResult;
+
+/**
+ * 관리자 주문 내역 조회 유스케이스
+ *
+ * @Author 성효빈
+ * @Date 2026-03-02
+ * @Description 관리자가 전체 주문 내역을 판매자별, 기간별, 상태별로 조회합니다.
+ */
+public interface GetAdminOrdersUseCase {
+    GetAdminOrdersResult getAdminOrders(GetAdminOrdersQuery query);
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/order/FindOrderPort.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/order/FindOrderPort.java
@@ -40,4 +40,21 @@ public interface FindOrderPort {
             LocalDateTime endDate,
             List<OrderStatus> statuses
     );
+
+    /**
+     * @param sellerId    판매자 ID (null이면 전체)
+     * @param startDate   조회 시작 일시 (null이면 제한 없음)
+     * @param endDate     조회 종료 일시 (null이면 제한 없음)
+     * @param orderStatus 주문 상태 (null이면 전체)
+     * @return 주문 목록 {@link List}
+     * @Date 2026-03-02
+     * @Author 성효빈
+     * @Description 관리자용 전체 주문 조회. 판매자별, 기간별, 상태별 필터링을 지원합니다.
+     */
+    List<Order> findAllWithFilters(
+            Long sellerId,
+            LocalDateTime startDate,
+            LocalDateTime endDate,
+            OrderStatus orderStatus
+    );
 }

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/GetAdminOrdersService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/GetAdminOrdersService.java
@@ -1,0 +1,68 @@
+package com.personal.marketnote.commerce.service.order;
+
+import com.personal.marketnote.commerce.domain.order.Order;
+import com.personal.marketnote.commerce.domain.order.OrderProduct;
+import com.personal.marketnote.commerce.port.in.command.order.GetAdminOrdersQuery;
+import com.personal.marketnote.commerce.port.in.result.order.GetAdminOrdersResult;
+import com.personal.marketnote.commerce.port.in.usecase.order.GetAdminOrdersUseCase;
+import com.personal.marketnote.commerce.port.out.order.FindOrderPort;
+import com.personal.marketnote.commerce.port.out.product.FindProductByPricePolicyPort;
+import com.personal.marketnote.commerce.port.out.result.product.ProductInfoResult;
+import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.common.utility.FormatValidator;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+/**
+ * 관리자 주문 내역 조회 서비스
+ *
+ * @Author 성효빈
+ * @Date 2026-03-02
+ * @Description 관리자가 전체 주문 내역을 판매자별, 기간별, 상태별로 조회합니다.
+ */
+@UseCase
+@RequiredArgsConstructor
+@Transactional(isolation = READ_COMMITTED, readOnly = true)
+@Slf4j
+public class GetAdminOrdersService implements GetAdminOrdersUseCase {
+    private final FindOrderPort findOrderPort;
+    private final FindProductByPricePolicyPort findProductByPricePolicyPort;
+
+    @Override
+    public GetAdminOrdersResult getAdminOrders(GetAdminOrdersQuery query) {
+        log.info("관리자 주문 조회 - sellerId={}, startDate={}, endDate={}, status={}",
+                query.sellerId(), query.startDate(), query.endDate(), query.orderStatus());
+
+        List<Order> orders = findOrderPort.findAllWithFilters(
+                query.sellerId(),
+                query.startDate(),
+                query.endDate(),
+                query.orderStatus()
+        );
+
+        if (FormatValidator.hasNoValue(orders)) {
+            return GetAdminOrdersResult.empty();
+        }
+
+        List<Long> pricePolicyIds = orders.stream()
+                .flatMap(order -> order.getOrderProducts().stream())
+                .map(OrderProduct::getPricePolicyId)
+                .filter(FormatValidator::hasValue)
+                .distinct()
+                .toList();
+
+        Map<Long, ProductInfoResult> productInfoMap = FormatValidator.hasNoValue(pricePolicyIds)
+                ? Map.of()
+                : Optional.ofNullable(findProductByPricePolicyPort.findByPricePolicyIds(pricePolicyIds))
+                .orElse(Map.of());
+
+        return GetAdminOrdersResult.from(orders, productInfoMap);
+    }
+}

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/GetAdminOrdersUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/GetAdminOrdersUseCaseTest.java
@@ -1,0 +1,328 @@
+package com.personal.marketnote.commerce.service.order;
+
+import com.personal.marketnote.commerce.domain.order.*;
+import com.personal.marketnote.commerce.port.in.command.order.GetAdminOrdersQuery;
+import com.personal.marketnote.commerce.port.in.result.order.GetAdminOrdersResult;
+import com.personal.marketnote.commerce.port.out.order.FindOrderPort;
+import com.personal.marketnote.commerce.port.out.product.FindProductByPricePolicyPort;
+import com.personal.marketnote.commerce.port.out.result.product.ProductInfoResult;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GetAdminOrdersUseCase 테스트")
+class GetAdminOrdersUseCaseTest {
+
+    @InjectMocks
+    private GetAdminOrdersService getAdminOrdersService;
+
+    @Mock
+    private FindOrderPort findOrderPort;
+
+    @Mock
+    private FindProductByPricePolicyPort findProductByPricePolicyPort;
+
+    private Order createOrder(Long id, Long buyerId, OrderStatus status, Long pricePolicyId) {
+        return Order.from(OrderSnapshotState.builder()
+                .id(id)
+                .buyerId(buyerId)
+                .orderKey(UUID.randomUUID())
+                .orderNumber("ORD" + id)
+                .orderStatus(status)
+                .totalAmount(100000L)
+                .paidAmount(95000L)
+                .couponAmount(3000L)
+                .pointAmount(2000L)
+                .orderProductStates(List.of(
+                        OrderProductSnapshotState.builder()
+                                .orderId(id)
+                                .sellerId(10L)
+                                .pricePolicyId(pricePolicyId)
+                                .quantity(1)
+                                .unitAmount(50000L)
+                                .imageUrl("https://example.com/image.jpg")
+                                .orderStatus(status)
+                                .isReviewed(false)
+                                .build()
+                ))
+                .createdAt(LocalDateTime.of(2026, 2, 20, 10, 0))
+                .modifiedAt(LocalDateTime.of(2026, 2, 20, 10, 0))
+                .build());
+    }
+
+    private ProductInfoResult createProductInfo(Long id, String name, String brandName) {
+        return new ProductInfoResult(id, 10L, name, brandName, 50000L, null, List.of());
+    }
+
+    @Test
+    @DisplayName("주문이 존재하면 주문 목록과 상품 정보를 반환한다")
+    void shouldReturnOrdersWithProductInfo() {
+        // given
+        GetAdminOrdersQuery query = GetAdminOrdersQuery.of(null, null, null, null);
+        Order order = createOrder(1L, 100L, OrderStatus.PAID, 30L);
+
+        when(findOrderPort.findAllWithFilters(null, null, null, null))
+                .thenReturn(List.of(order));
+        when(findProductByPricePolicyPort.findByPricePolicyIds(List.of(30L)))
+                .thenReturn(Map.of(30L, createProductInfo(50L, "테스트 상품", "테스트 브랜드")));
+
+        // when
+        GetAdminOrdersResult result = getAdminOrdersService.getAdminOrders(query);
+
+        // then
+        assertThat(result.orders()).hasSize(1);
+        assertThat(result.orders().get(0).id()).isEqualTo(1L);
+        assertThat(result.orders().get(0).buyerId()).isEqualTo(100L);
+        assertThat(result.orders().get(0).orderStatus()).isEqualTo(OrderStatus.PAID);
+        assertThat(result.orders().get(0).orderProducts()).hasSize(1);
+        assertThat(result.orders().get(0).orderProducts().get(0).productName()).isEqualTo("테스트 상품");
+        verify(findOrderPort).findAllWithFilters(null, null, null, null);
+        verify(findProductByPricePolicyPort).findByPricePolicyIds(List.of(30L));
+    }
+
+    @Test
+    @DisplayName("여러 주문이 존재하면 모든 주문을 반환한다")
+    void shouldReturnMultipleOrders() {
+        // given
+        GetAdminOrdersQuery query = GetAdminOrdersQuery.of(null, null, null, null);
+        Order order1 = createOrder(1L, 100L, OrderStatus.PAID, 30L);
+        Order order2 = createOrder(2L, 101L, OrderStatus.PREPARING, 31L);
+
+        when(findOrderPort.findAllWithFilters(null, null, null, null))
+                .thenReturn(List.of(order1, order2));
+        when(findProductByPricePolicyPort.findByPricePolicyIds(List.of(30L, 31L)))
+                .thenReturn(Map.of(
+                        30L, createProductInfo(50L, "상품A", "브랜드A"),
+                        31L, createProductInfo(51L, "상품B", "브랜드B")
+                ));
+
+        // when
+        GetAdminOrdersResult result = getAdminOrdersService.getAdminOrders(query);
+
+        // then
+        assertThat(result.orders()).hasSize(2);
+        assertThat(result.orders().get(0).id()).isEqualTo(1L);
+        assertThat(result.orders().get(1).id()).isEqualTo(2L);
+    }
+
+    @Test
+    @DisplayName("주문이 없으면 빈 목록을 반환한다")
+    void shouldReturnEmptyWhenNoOrders() {
+        // given
+        GetAdminOrdersQuery query = GetAdminOrdersQuery.of(null, null, null, null);
+
+        when(findOrderPort.findAllWithFilters(null, null, null, null))
+                .thenReturn(List.of());
+
+        // when
+        GetAdminOrdersResult result = getAdminOrdersService.getAdminOrders(query);
+
+        // then
+        assertThat(result.orders()).isEmpty();
+        verify(findOrderPort).findAllWithFilters(null, null, null, null);
+        verifyNoInteractions(findProductByPricePolicyPort);
+    }
+
+    @Test
+    @DisplayName("findOrderPort가 null을 반환하면 빈 목록을 반환한다")
+    void shouldReturnEmptyWhenPortReturnsNull() {
+        // given
+        GetAdminOrdersQuery query = GetAdminOrdersQuery.of(null, null, null, null);
+
+        when(findOrderPort.findAllWithFilters(null, null, null, null))
+                .thenReturn(null);
+
+        // when
+        GetAdminOrdersResult result = getAdminOrdersService.getAdminOrders(query);
+
+        // then
+        assertThat(result.orders()).isEmpty();
+        verifyNoInteractions(findProductByPricePolicyPort);
+    }
+
+    @Test
+    @DisplayName("sellerId 필터를 정확히 전달한다")
+    void shouldPassSellerIdFilter() {
+        // given
+        Long sellerId = 10L;
+        GetAdminOrdersQuery query = GetAdminOrdersQuery.of(sellerId, null, null, null);
+
+        when(findOrderPort.findAllWithFilters(sellerId, null, null, null))
+                .thenReturn(List.of());
+
+        // when
+        getAdminOrdersService.getAdminOrders(query);
+
+        // then
+        verify(findOrderPort).findAllWithFilters(sellerId, null, null, null);
+    }
+
+    @Test
+    @DisplayName("기간 필터를 정확히 전달한다")
+    void shouldPassDateFilters() {
+        // given
+        LocalDateTime startDate = LocalDateTime.of(2026, 2, 1, 0, 0);
+        LocalDateTime endDate = LocalDateTime.of(2026, 2, 28, 23, 59, 59);
+        GetAdminOrdersQuery query = GetAdminOrdersQuery.of(null, startDate, endDate, null);
+
+        when(findOrderPort.findAllWithFilters(null, startDate, endDate, null))
+                .thenReturn(List.of());
+
+        // when
+        getAdminOrdersService.getAdminOrders(query);
+
+        // then
+        verify(findOrderPort).findAllWithFilters(null, startDate, endDate, null);
+    }
+
+    @Test
+    @DisplayName("orderStatus 필터를 정확히 전달한다")
+    void shouldPassOrderStatusFilter() {
+        // given
+        GetAdminOrdersQuery query = GetAdminOrdersQuery.of(null, null, null, OrderStatus.PAID);
+
+        when(findOrderPort.findAllWithFilters(null, null, null, OrderStatus.PAID))
+                .thenReturn(List.of());
+
+        // when
+        getAdminOrdersService.getAdminOrders(query);
+
+        // then
+        verify(findOrderPort).findAllWithFilters(null, null, null, OrderStatus.PAID);
+    }
+
+    @Test
+    @DisplayName("모든 필터를 동시에 전달한다")
+    void shouldPassAllFilters() {
+        // given
+        Long sellerId = 10L;
+        LocalDateTime startDate = LocalDateTime.of(2026, 2, 1, 0, 0);
+        LocalDateTime endDate = LocalDateTime.of(2026, 2, 28, 23, 59, 59);
+        OrderStatus status = OrderStatus.CANCELLED;
+        GetAdminOrdersQuery query = GetAdminOrdersQuery.of(sellerId, startDate, endDate, status);
+
+        when(findOrderPort.findAllWithFilters(sellerId, startDate, endDate, status))
+                .thenReturn(List.of());
+
+        // when
+        getAdminOrdersService.getAdminOrders(query);
+
+        // then
+        verify(findOrderPort).findAllWithFilters(sellerId, startDate, endDate, status);
+    }
+
+    @Test
+    @DisplayName("주문이 없으면 상품 정보 포트를 호출하지 않는다")
+    void shouldNotCallProductPortWhenNoOrders() {
+        // given
+        GetAdminOrdersQuery query = GetAdminOrdersQuery.of(null, null, null, null);
+
+        when(findOrderPort.findAllWithFilters(null, null, null, null))
+                .thenReturn(List.of());
+
+        // when
+        getAdminOrdersService.getAdminOrders(query);
+
+        // then
+        verifyNoInteractions(findProductByPricePolicyPort);
+    }
+
+    @Test
+    @DisplayName("findProductByPricePolicyPort가 null을 반환하면 빈 맵으로 처리한다")
+    void shouldHandleNullProductInfoMap() {
+        // given
+        GetAdminOrdersQuery query = GetAdminOrdersQuery.of(null, null, null, null);
+        Order order = createOrder(1L, 100L, OrderStatus.PAID, 30L);
+
+        when(findOrderPort.findAllWithFilters(null, null, null, null))
+                .thenReturn(List.of(order));
+        when(findProductByPricePolicyPort.findByPricePolicyIds(List.of(30L)))
+                .thenReturn(null);
+
+        // when
+        GetAdminOrdersResult result = getAdminOrdersService.getAdminOrders(query);
+
+        // then
+        assertThat(result.orders()).hasSize(1);
+        assertThat(result.orders().get(0).orderProducts().get(0).productName()).isNull();
+    }
+
+    @Test
+    @DisplayName("주문 상품이 없는 주문도 정상 반환한다")
+    void shouldHandleOrderWithNoProducts() {
+        // given
+        GetAdminOrdersQuery query = GetAdminOrdersQuery.of(null, null, null, null);
+        Order order = Order.from(OrderSnapshotState.builder()
+                .id(1L)
+                .buyerId(100L)
+                .orderKey(UUID.randomUUID())
+                .orderNumber("ORD1")
+                .orderStatus(OrderStatus.PAID)
+                .totalAmount(100000L)
+                .paidAmount(95000L)
+                .couponAmount(3000L)
+                .pointAmount(2000L)
+                .orderProductStates(List.of())
+                .createdAt(LocalDateTime.of(2026, 2, 20, 10, 0))
+                .modifiedAt(LocalDateTime.of(2026, 2, 20, 10, 0))
+                .build());
+
+        when(findOrderPort.findAllWithFilters(null, null, null, null))
+                .thenReturn(List.of(order));
+
+        // when
+        GetAdminOrdersResult result = getAdminOrdersService.getAdminOrders(query);
+
+        // then
+        assertThat(result.orders()).hasSize(1);
+        assertThat(result.orders().get(0).orderProducts()).isEmpty();
+        verifyNoInteractions(findProductByPricePolicyPort);
+    }
+
+    @Test
+    @DisplayName("endDate가 startDate보다 이전이면 IllegalArgumentException이 발생한다")
+    void shouldThrowWhenEndDateBeforeStartDate() {
+        // given
+        LocalDateTime startDate = LocalDateTime.of(2026, 2, 28, 0, 0);
+        LocalDateTime endDate = LocalDateTime.of(2026, 2, 1, 0, 0);
+
+        // when & then
+        assertThatThrownBy(() -> GetAdminOrdersQuery.of(null, startDate, endDate, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("종료일은 시작일 이후여야 합니다");
+    }
+
+    @Test
+    @DisplayName("여러 주문의 pricePolicyId가 중복되면 distinct하여 조회한다")
+    void shouldDeduplicatePricePolicyIds() {
+        // given
+        GetAdminOrdersQuery query = GetAdminOrdersQuery.of(null, null, null, null);
+        Order order1 = createOrder(1L, 100L, OrderStatus.PAID, 30L);
+        Order order2 = createOrder(2L, 101L, OrderStatus.PAID, 30L);
+
+        when(findOrderPort.findAllWithFilters(null, null, null, null))
+                .thenReturn(List.of(order1, order2));
+        when(findProductByPricePolicyPort.findByPricePolicyIds(List.of(30L)))
+                .thenReturn(Map.of(30L, createProductInfo(50L, "테스트 상품", "테스트 브랜드")));
+
+        // when
+        GetAdminOrdersResult result = getAdminOrdersService.getAdminOrders(query);
+
+        // then
+        assertThat(result.orders()).hasSize(2);
+        verify(findProductByPricePolicyPort).findByPricePolicyIds(List.of(30L));
+    }
+}


### PR DESCRIPTION
## partially addresses #216
## resolves #919

## Task
- [x] GetAdminOrdersUseCase 인터페이스 정의
- [x] GetAdminOrdersQuery Command 정의 (sellerId, startDate, endDate, orderStatus 필터)
- [x] GetAdminOrdersService 구현 (조회 + 상품 정보 매핑)
- [x] FindOrderPort에 findAllWithFilters 메서드 추가
- [x] OrderJpaRepository에 findIdsByAdminFilters 네이티브 쿼리 추가 (LIMIT 1000)
- [x] OrderPersistenceAdapter에 findAllWithFilters 구현
- [x] GET /api/v1/admin/orders 엔드포인트 추가 (@PreAuthorize ADMIN_POINTCUT)
- [x] GetAdminOrdersResponse, AdminOrderRequestToCommandMapper 작성
- [x] GetAdminOrdersApiDocs 합성 애노테이션 추가
- [x] 날짜 범위 역전 검증 추가 (endDate < startDate 시 예외)
- [x] 관리자 조회 감사 로그 추가
- [x] GetAdminOrdersUseCaseTest 단위 테스트 13개 작성