### PR TITLE
[#216][#920] feat: 판매자 정산 내역 조회 기능 추가

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/settlement/controller/SellerSettlementController.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/settlement/controller/SellerSettlementController.java
@@ -1,0 +1,79 @@
+package com.personal.marketnote.commerce.adapter.in.web.settlement.controller;
+
+import com.personal.marketnote.commerce.adapter.in.web.settlement.controller.apidocs.GetSellerSettlementsApiDocs;
+import com.personal.marketnote.commerce.adapter.in.web.settlement.mapper.SellerSettlementRequestToQueryMapper;
+import com.personal.marketnote.commerce.adapter.in.web.settlement.response.GetSellerSettlementsResponse;
+import com.personal.marketnote.commerce.port.in.result.settlement.GetSettlementsResult;
+import com.personal.marketnote.commerce.port.in.usecase.settlement.GetSellerSettlementsUseCase;
+import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
+import com.personal.marketnote.common.utility.ElementExtractor;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.core.OAuth2AuthenticatedPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import static com.personal.marketnote.common.domain.exception.ExceptionCode.DEFAULT_SUCCESS_CODE;
+import static com.personal.marketnote.common.utility.ApiConstant.ADMIN_OR_SELLER_POINTCUT;
+
+/**
+ * 판매자 정산 컨트롤러
+ *
+ * @Author 성효빈
+ * @Date 2026-03-02
+ * @Description 판매자 본인의 정산 내역 조회 API를 제공합니다.
+ */
+@RestController
+@RequestMapping("/api/v1/sellers/me/settlements")
+@Tag(name = "(판매자) 정산 API", description = "판매자 정산 관련 API")
+@RequiredArgsConstructor
+@Validated
+public class SellerSettlementController {
+    private final GetSellerSettlementsUseCase getSellerSettlementsUseCase;
+
+    /**
+     * 나의 정산 내역 조회
+     *
+     * @param year      정산 연도
+     * @param month     정산 월 (선택)
+     * @param principal 인증된 사용자 정보
+     * @return 판매자 정산 내역 조회 응답 {@link GetSellerSettlementsResponse}
+     * @Author 성효빈
+     * @Date 2026-03-02
+     * @Description 판매자 본인의 정산 내역을 조회합니다.
+     */
+    @GetMapping
+    @PreAuthorize(ADMIN_OR_SELLER_POINTCUT)
+    @GetSellerSettlementsApiDocs
+    public ResponseEntity<BaseResponse<GetSellerSettlementsResponse>> getMySettlements(
+            @RequestParam @NotNull @Min(2020) @Max(2100) Integer year,
+            @RequestParam(required = false) @Min(1) @Max(12) Integer month,
+            @AuthenticationPrincipal OAuth2AuthenticatedPrincipal principal
+    ) {
+        Long sellerId = ElementExtractor.extractUserId(principal);
+
+        GetSettlementsResult result = getSellerSettlementsUseCase.getSellerSettlements(
+                SellerSettlementRequestToQueryMapper.mapToQuery(sellerId, year, month)
+        );
+
+        return new ResponseEntity<>(
+                BaseResponse.of(
+                        GetSellerSettlementsResponse.from(result),
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "나의 정산 내역 조회 성공"
+                ),
+                HttpStatus.OK
+        );
+    }
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/settlement/controller/apidocs/GetSellerSettlementsApiDocs.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/settlement/controller/apidocs/GetSellerSettlementsApiDocs.java
@@ -1,0 +1,100 @@
+package com.personal.marketnote.commerce.adapter.in.web.settlement.controller.apidocs;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Operation(
+        summary = "(판매자) 나의 정산 내역 조회",
+        description = """
+                작성일자: 2026-03-02
+
+                작성자: 성효빈
+
+                ---
+
+                ## Description
+
+                - 판매자 본인의 정산 내역을 조회합니다.
+                - year는 필수, month는 선택입니다.
+                - month를 지정하면 해당 월의 정산만, 미지정 시 해당 연도 전체 정산을 조회합니다.
+
+                ---
+
+                ## Query Parameters
+
+                | **키** | **타입** | **설명** | **필수 여부** | **예시** |
+                | --- | --- | --- | --- | --- |
+                | year | number | 정산 연도 | Y | 2026 |
+                | month | number | 정산 월 | N | 2 |
+
+                ---
+
+                ## Response > content
+
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | settlements | array | 정산 목록 | [ ... ] |
+                """,
+        security = {@SecurityRequirement(name = "bearer")},
+        parameters = {
+                @Parameter(
+                        name = "year",
+                        in = ParameterIn.QUERY,
+                        required = true,
+                        description = "정산 연도",
+                        schema = @Schema(type = "integer", example = "2026")
+                ),
+                @Parameter(
+                        name = "month",
+                        in = ParameterIn.QUERY,
+                        required = false,
+                        description = "정산 월 (미지정 시 해당 연도 전체)",
+                        schema = @Schema(type = "integer", example = "2")
+                )
+        },
+        responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "나의 정산 내역 조회 성공",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 200,
+                                          "code": "SUC01",
+                                          "timestamp": "2026-03-02T12:00:00.000",
+                                          "content": {
+                                            "settlements": [
+                                              {
+                                                "id": 1,
+                                                "sellerId": 10,
+                                                "year": 2026,
+                                                "month": 1,
+                                                "totalAllocatedAmount": 100000,
+                                                "pgFeeAmount": 3000,
+                                                "platformFeeAmount": 5000,
+                                                "sellerPayoutAmount": 92000,
+                                                "status": "COMPLETED",
+                                                "createdAt": "2026-02-16T10:00:00",
+                                                "modifiedAt": "2026-02-16T10:00:00"
+                                              }
+                                            ]
+                                          },
+                                          "message": "나의 정산 내역 조회 성공"
+                                        }
+                                        """)
+                        )
+                )
+        })
+public @interface GetSellerSettlementsApiDocs {
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/settlement/mapper/SellerSettlementRequestToQueryMapper.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/settlement/mapper/SellerSettlementRequestToQueryMapper.java
@@ -1,0 +1,12 @@
+package com.personal.marketnote.commerce.adapter.in.web.settlement.mapper;
+
+import com.personal.marketnote.commerce.port.in.command.settlement.GetSellerSettlementsQuery;
+
+public class SellerSettlementRequestToQueryMapper {
+    private SellerSettlementRequestToQueryMapper() {
+    }
+
+    public static GetSellerSettlementsQuery mapToQuery(Long sellerId, Integer year, Integer month) {
+        return GetSellerSettlementsQuery.of(sellerId, year, month);
+    }
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/settlement/response/GetSellerSettlementsResponse.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/settlement/response/GetSellerSettlementsResponse.java
@@ -1,0 +1,16 @@
+package com.personal.marketnote.commerce.adapter.in.web.settlement.response;
+
+import com.personal.marketnote.commerce.port.in.result.settlement.GetSettlementsResult;
+
+import java.util.List;
+
+public record GetSellerSettlementsResponse(
+        List<GetSettlementResponse> settlements
+) {
+    public static GetSellerSettlementsResponse from(GetSettlementsResult result) {
+        List<GetSettlementResponse> responses = result.settlements().stream()
+                .map(GetSettlementResponse::from)
+                .toList();
+        return new GetSellerSettlementsResponse(responses);
+    }
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/settlement/SettlementPersistenceAdapter.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/settlement/SettlementPersistenceAdapter.java
@@ -50,6 +50,13 @@ public class SettlementPersistenceAdapter implements SaveSettlementPort, FindSet
     }
 
     @Override
+    public List<Settlement> findAllBySellerIdAndYear(Long sellerId, Integer year) {
+        return settlementJpaRepository.findAllBySellerIdAndYear(sellerId, year).stream()
+                .map(SettlementEntityToDomainMapper::toDomain)
+                .toList();
+    }
+
+    @Override
     public Settlement update(Settlement settlement) {
         SettlementJpaEntity entity = SettlementJpaEntity.from(settlement);
         SettlementJpaEntity updated = settlementJpaRepository.save(entity);

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/settlement/repository/SettlementJpaRepository.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/settlement/repository/SettlementJpaRepository.java
@@ -13,4 +13,6 @@ public interface SettlementJpaRepository extends JpaRepository<SettlementJpaEnti
     List<SettlementJpaEntity> findAllByYearAndMonth(Integer year, Integer month);
 
     boolean existsBySellerIdAndYearAndMonth(Long sellerId, Integer year, Integer month);
+
+    List<SettlementJpaEntity> findAllBySellerIdAndYear(Long sellerId, Integer year);
 }

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/command/settlement/GetSellerSettlementsQuery.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/command/settlement/GetSellerSettlementsQuery.java
@@ -1,0 +1,18 @@
+package com.personal.marketnote.commerce.port.in.command.settlement;
+
+/**
+ * 판매자 정산 내역 조회 쿼리
+ *
+ * @Author 성효빈
+ * @Date 2026-03-02
+ * @Description 판매자 본인의 정산 내역 조회에 필요한 조건을 개입화합니다.
+ */
+public record GetSellerSettlementsQuery(
+        Long sellerId,
+        Integer year,
+        Integer month
+) {
+    public static GetSellerSettlementsQuery of(Long sellerId, Integer year, Integer month) {
+        return new GetSellerSettlementsQuery(sellerId, year, month);
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/settlement/GetSellerSettlementsUseCase.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/settlement/GetSellerSettlementsUseCase.java
@@ -1,0 +1,15 @@
+package com.personal.marketnote.commerce.port.in.usecase.settlement;
+
+import com.personal.marketnote.commerce.port.in.command.settlement.GetSellerSettlementsQuery;
+import com.personal.marketnote.commerce.port.in.result.settlement.GetSettlementsResult;
+
+/**
+ * 판매자 정산 내역 조회 유스케이스
+ *
+ * @Author 성효빈
+ * @Date 2026-03-02
+ * @Description 판매자가 본인의 정산 내역을 연도/월 기준으로 조회합니다.
+ */
+public interface GetSellerSettlementsUseCase {
+    GetSettlementsResult getSellerSettlements(GetSellerSettlementsQuery query);
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/settlement/FindSettlementPort.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/settlement/FindSettlementPort.java
@@ -13,4 +13,14 @@ public interface FindSettlementPort {
     List<Settlement> findAllByYearAndMonth(Integer year, Integer month);
 
     boolean existsBySellerIdAndYearAndMonth(Long sellerId, Integer year, Integer month);
+
+    /**
+     * @param sellerId 판매자 ID
+     * @param year     정산 연도
+     * @return 해당 판매자의 해당 연도 정산 목록 {@link List}
+     * @Date 2026-03-02
+     * @Author 성효빈
+     * @Description 판매자 ID와 연도로 정산 목록을 조회합니다.
+     */
+    List<Settlement> findAllBySellerIdAndYear(Long sellerId, Integer year);
 }

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/settlement/GetSellerSettlementsService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/settlement/GetSellerSettlementsService.java
@@ -1,0 +1,51 @@
+package com.personal.marketnote.commerce.service.settlement;
+
+import com.personal.marketnote.commerce.domain.settlement.Settlement;
+import com.personal.marketnote.commerce.port.in.command.settlement.GetSellerSettlementsQuery;
+import com.personal.marketnote.commerce.port.in.result.settlement.GetSettlementsResult;
+import com.personal.marketnote.commerce.port.in.usecase.settlement.GetSellerSettlementsUseCase;
+import com.personal.marketnote.commerce.port.out.settlement.FindSettlementPort;
+import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.common.utility.FormatValidator;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+/**
+ * 판매자 정산 내역 조회 서비스
+ *
+ * @Author 성효빈
+ * @Date 2026-03-02
+ * @Description 판매자가 본인의 정산 내역을 연도/월 기준으로 조회합니다.
+ */
+@UseCase
+@RequiredArgsConstructor
+@Slf4j
+public class GetSellerSettlementsService implements GetSellerSettlementsUseCase {
+    private final FindSettlementPort findSettlementPort;
+
+    @Override
+    @Transactional(isolation = READ_COMMITTED, readOnly = true)
+    public GetSettlementsResult getSellerSettlements(GetSellerSettlementsQuery query) {
+        log.info("판매자 정산 조회 - sellerId={}, year={}, month={}",
+                query.sellerId(), query.year(), query.month());
+
+        List<Settlement> settlements;
+
+        if (FormatValidator.hasValue(query.month())) {
+            Optional<Settlement> settlement = findSettlementPort.findBySellerIdAndYearAndMonth(
+                    query.sellerId(), query.year(), query.month());
+            settlements = settlement.map(List::of).orElse(List.of());
+        } else {
+            settlements = findSettlementPort.findAllBySellerIdAndYear(
+                    query.sellerId(), query.year());
+        }
+
+        return GetSettlementsResult.from(settlements);
+    }
+}

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/settlement/GetSellerSettlementsUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/settlement/GetSellerSettlementsUseCaseTest.java
@@ -1,0 +1,187 @@
+package com.personal.marketnote.commerce.service.settlement;
+
+import com.personal.marketnote.commerce.domain.settlement.Settlement;
+import com.personal.marketnote.commerce.domain.settlement.SettlementSnapshotState;
+import com.personal.marketnote.commerce.domain.settlement.SettlementStatus;
+import com.personal.marketnote.commerce.port.in.command.settlement.GetSellerSettlementsQuery;
+import com.personal.marketnote.commerce.port.in.result.settlement.GetSettlementResult;
+import com.personal.marketnote.commerce.port.in.result.settlement.GetSettlementsResult;
+import com.personal.marketnote.commerce.port.out.settlement.FindSettlementPort;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GetSellerSettlementsUseCase 테스트")
+class GetSellerSettlementsUseCaseTest {
+
+    @InjectMocks
+    private GetSellerSettlementsService getSellerSettlementsService;
+
+    @Mock
+    private FindSettlementPort findSettlementPort;
+
+    private Settlement createSettlement(Long id, Long sellerId, Integer year, Integer month,
+                                        Long totalAllocated, Long pgFee, Long platformFee,
+                                        Long sellerPayout, SettlementStatus status) {
+        return Settlement.from(SettlementSnapshotState.builder()
+                .id(id)
+                .sellerId(sellerId)
+                .year(year)
+                .month(month)
+                .totalAllocatedAmount(totalAllocated)
+                .pgFeeAmount(pgFee)
+                .platformFeeAmount(platformFee)
+                .sellerPayoutAmount(sellerPayout)
+                .status(status)
+                .version(0L)
+                .createdAt(LocalDateTime.of(2026, 2, 16, 10, 0))
+                .modifiedAt(LocalDateTime.of(2026, 2, 16, 10, 0))
+                .build());
+    }
+
+    @Test
+    @DisplayName("연도와 월을 지정하면 해당 판매자의 특정 월 정산을 반환한다")
+    void shouldReturnSettlementForSpecificMonth() {
+        // given
+        Long sellerId = 10L;
+        Settlement settlement = createSettlement(1L, sellerId, 2026, 2,
+                100000L, 3000L, 5000L, 92000L, SettlementStatus.COMPLETED);
+        when(findSettlementPort.findBySellerIdAndYearAndMonth(sellerId, 2026, 2))
+                .thenReturn(Optional.of(settlement));
+
+        GetSellerSettlementsQuery query = GetSellerSettlementsQuery.of(sellerId, 2026, 2);
+
+        // when
+        GetSettlementsResult result = getSellerSettlementsService.getSellerSettlements(query);
+
+        // then
+        assertThat(result.settlements()).hasSize(1);
+        assertThat(result.settlements().get(0).id()).isEqualTo(1L);
+        assertThat(result.settlements().get(0).sellerId()).isEqualTo(sellerId);
+        assertThat(result.settlements().get(0).year()).isEqualTo(2026);
+        assertThat(result.settlements().get(0).month()).isEqualTo(2);
+        verify(findSettlementPort).findBySellerIdAndYearAndMonth(sellerId, 2026, 2);
+        verifyNoMoreInteractions(findSettlementPort);
+    }
+
+    @Test
+    @DisplayName("연도와 월을 지정했지만 정산이 없으면 빈 목록을 반환한다")
+    void shouldReturnEmptyWhenNoSettlementForMonth() {
+        // given
+        Long sellerId = 10L;
+        when(findSettlementPort.findBySellerIdAndYearAndMonth(sellerId, 2026, 3))
+                .thenReturn(Optional.empty());
+
+        GetSellerSettlementsQuery query = GetSellerSettlementsQuery.of(sellerId, 2026, 3);
+
+        // when
+        GetSettlementsResult result = getSellerSettlementsService.getSellerSettlements(query);
+
+        // then
+        assertThat(result.settlements()).isEmpty();
+        verify(findSettlementPort).findBySellerIdAndYearAndMonth(sellerId, 2026, 3);
+        verifyNoMoreInteractions(findSettlementPort);
+    }
+
+    @Test
+    @DisplayName("연도만 지정하면 해당 판매자의 해당 연도 전체 정산을 반환한다")
+    void shouldReturnAllSettlementsForYear() {
+        // given
+        Long sellerId = 10L;
+        Settlement jan = createSettlement(1L, sellerId, 2026, 1,
+                100000L, 3000L, 5000L, 92000L, SettlementStatus.COMPLETED);
+        Settlement feb = createSettlement(2L, sellerId, 2026, 2,
+                200000L, 6000L, 10000L, 184000L, SettlementStatus.COMPLETED);
+        when(findSettlementPort.findAllBySellerIdAndYear(sellerId, 2026))
+                .thenReturn(List.of(jan, feb));
+
+        GetSellerSettlementsQuery query = GetSellerSettlementsQuery.of(sellerId, 2026, null);
+
+        // when
+        GetSettlementsResult result = getSellerSettlementsService.getSellerSettlements(query);
+
+        // then
+        assertThat(result.settlements()).hasSize(2);
+        assertThat(result.settlements().get(0).month()).isEqualTo(1);
+        assertThat(result.settlements().get(1).month()).isEqualTo(2);
+        verify(findSettlementPort).findAllBySellerIdAndYear(sellerId, 2026);
+        verifyNoMoreInteractions(findSettlementPort);
+    }
+
+    @Test
+    @DisplayName("연도만 지정했지만 정산이 없으면 빈 목록을 반환한다")
+    void shouldReturnEmptyWhenNoSettlementsForYear() {
+        // given
+        Long sellerId = 10L;
+        when(findSettlementPort.findAllBySellerIdAndYear(sellerId, 2025))
+                .thenReturn(List.of());
+
+        GetSellerSettlementsQuery query = GetSellerSettlementsQuery.of(sellerId, 2025, null);
+
+        // when
+        GetSettlementsResult result = getSellerSettlementsService.getSellerSettlements(query);
+
+        // then
+        assertThat(result.settlements()).isEmpty();
+        verify(findSettlementPort).findAllBySellerIdAndYear(sellerId, 2025);
+        verifyNoMoreInteractions(findSettlementPort);
+    }
+
+    @Test
+    @DisplayName("정산 결과의 모든 필드가 정확히 매핑된다")
+    void shouldMapAllFieldsCorrectly() {
+        // given
+        Long sellerId = 15L;
+        Settlement settlement = createSettlement(5L, sellerId, 2026, 3,
+                150000L, 4500L, 7500L, 138000L, SettlementStatus.COMPLETED);
+        when(findSettlementPort.findBySellerIdAndYearAndMonth(sellerId, 2026, 3))
+                .thenReturn(Optional.of(settlement));
+
+        GetSellerSettlementsQuery query = GetSellerSettlementsQuery.of(sellerId, 2026, 3);
+
+        // when
+        GetSettlementsResult result = getSellerSettlementsService.getSellerSettlements(query);
+
+        // then
+        GetSettlementResult item = result.settlements().get(0);
+        assertThat(item.id()).isEqualTo(5L);
+        assertThat(item.sellerId()).isEqualTo(15L);
+        assertThat(item.year()).isEqualTo(2026);
+        assertThat(item.month()).isEqualTo(3);
+        assertThat(item.totalAllocatedAmount()).isEqualTo(150000L);
+        assertThat(item.pgFeeAmount()).isEqualTo(4500L);
+        assertThat(item.platformFeeAmount()).isEqualTo(7500L);
+        assertThat(item.sellerPayoutAmount()).isEqualTo(138000L);
+        assertThat(item.status()).isEqualTo(SettlementStatus.COMPLETED);
+        assertThat(item.createdAt()).isNotNull();
+        assertThat(item.modifiedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("findAllBySellerIdAndYear가 판매자 ID를 정확히 전달한다")
+    void shouldPassCorrectSellerIdToPort() {
+        // given
+        Long sellerId = 99L;
+        when(findSettlementPort.findAllBySellerIdAndYear(sellerId, 2026))
+                .thenReturn(List.of());
+
+        GetSellerSettlementsQuery query = GetSellerSettlementsQuery.of(sellerId, 2026, null);
+
+        // when
+        getSellerSettlementsService.getSellerSettlements(query);
+
+        // then
+        verify(findSettlementPort).findAllBySellerIdAndYear(99L, 2026);
+    }
+}


### PR DESCRIPTION
## partially addresses #216
## resolves #920

## Task
- [x] GetSellerSettlementsUseCase 인터페이스 정의
- [x] GetSellerSettlementsQuery Command 정의 (sellerId, year, month 필터)
- [x] GetSellerSettlementsService 구현 (month 유무에 따라 조회 분기)
- [x] FindSettlementPort에 findAllBySellerIdAndYear 메서드 추가
- [x] SettlementJpaRepository/PersistenceAdapter 구현
- [x] GET /api/v1/sellers/me/settlements 엔드포인트 추가
- [x] @PreAuthorize(ADMIN_OR_SELLER_POINTCUT) 인가 적용
- [x] GetSellerSettlementsApiDocs 합성 애노테이션 추가
- [x] GetSellerSettlementsUseCaseTest 유닛 테스트 6건 추가