### PR TITLE
[#216][#921] feat: 주문 상태 이력 조회 기능 추가

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/AdminOrderController.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/AdminOrderController.java
@@ -1,11 +1,15 @@
 package com.personal.marketnote.commerce.adapter.in.web.order.controller;
 
 import com.personal.marketnote.commerce.adapter.in.web.order.controller.apidocs.GetAdminOrdersApiDocs;
+import com.personal.marketnote.commerce.adapter.in.web.order.controller.apidocs.GetOrderStatusHistoryApiDocs;
 import com.personal.marketnote.commerce.adapter.in.web.order.mapper.AdminOrderRequestToCommandMapper;
 import com.personal.marketnote.commerce.adapter.in.web.order.response.GetAdminOrdersResponse;
+import com.personal.marketnote.commerce.adapter.in.web.order.response.GetOrderStatusHistoryResponse;
 import com.personal.marketnote.commerce.domain.order.OrderStatus;
 import com.personal.marketnote.commerce.port.in.result.order.GetAdminOrdersResult;
+import com.personal.marketnote.commerce.port.in.result.order.GetOrderStatusHistoryResult;
 import com.personal.marketnote.commerce.port.in.usecase.order.GetAdminOrdersUseCase;
+import com.personal.marketnote.commerce.port.in.usecase.order.GetOrderStatusHistoryUseCase;
 import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -13,10 +17,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDateTime;
 
@@ -37,6 +38,7 @@ import static com.personal.marketnote.common.utility.ApiConstant.ADMIN_POINTCUT;
 @Validated
 public class AdminOrderController {
     private final GetAdminOrdersUseCase getAdminOrdersUseCase;
+    private final GetOrderStatusHistoryUseCase getOrderStatusHistoryUseCase;
 
     /**
      * 관리자 주문 내역 조회
@@ -69,6 +71,34 @@ public class AdminOrderController {
                         HttpStatus.OK,
                         DEFAULT_SUCCESS_CODE,
                         "관리자 주문 내역 조회 성공"
+                ),
+                HttpStatus.OK
+        );
+    }
+
+    /**
+     * 주문 상태 이력 조회
+     *
+     * @param id 주문 ID
+     * @return 주문 상태 이력 조회 응답 {@link GetOrderStatusHistoryResponse}
+     * @Author 성효빈
+     * @Date 2026-03-02
+     * @Description 관리자가 특정 주문의 상태 변경 이력을 조회합니다.
+     */
+    @GetMapping("/{id}/status-history")
+    @PreAuthorize(ADMIN_POINTCUT)
+    @GetOrderStatusHistoryApiDocs
+    public ResponseEntity<BaseResponse<GetOrderStatusHistoryResponse>> getOrderStatusHistory(
+            @PathVariable("id") Long id
+    ) {
+        GetOrderStatusHistoryResult result = getOrderStatusHistoryUseCase.getOrderStatusHistory(id);
+
+        return new ResponseEntity<>(
+                BaseResponse.of(
+                        GetOrderStatusHistoryResponse.from(result),
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "주문 상태 이력 조회 성공"
                 ),
                 HttpStatus.OK
         );

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/apidocs/GetOrderStatusHistoryApiDocs.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/apidocs/GetOrderStatusHistoryApiDocs.java
@@ -1,0 +1,100 @@
+package com.personal.marketnote.commerce.adapter.in.web.order.controller.apidocs;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Operation(
+        summary = "(관리자) 주문 상태 이력 조회",
+        description = """
+                작성일자: 2026-03-02
+
+                작성자: 성효빈
+
+                ---
+
+                ## Description
+
+                - 관리자가 특정 주문의 상태 변경 이력을 조회합니다.
+                - CS 대응을 위해 주문의 전체 상태 변경 이력을 시간순(오름차순)으로 반환합니다.
+                - 각 이력에는 변경된 상태, 사유 카테고리, 사유, 변경 시간이 포함됩니다.
+
+                ---
+
+                ## Path Parameters
+
+                | **키** | **타입** | **설명** | **필수 여부** | **예시** |
+                | --- | --- | --- | --- | --- |
+                | id | number | 주문 ID | Y | 1 |
+
+                ---
+
+                ## Response > content
+
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | orderId | number | 주문 ID | 1 |
+                | statusHistory | array | 상태 변경 이력 목록 | - |
+                | statusHistory[].id | number | 이력 ID | 1 |
+                | statusHistory[].orderStatus | string | 주문 상태 | "PAID" |
+                | statusHistory[].orderStatusDescription | string | 주문 상태 설명 | "결제 완료" |
+                | statusHistory[].reasonCategory | string | 사유 카테고리 | "CANCEL_ORDER" |
+                | statusHistory[].reason | string | 변경 사유 | "결제 완료" |
+                | statusHistory[].createdAt | string | 변경 일시 | "2026-03-02T12:00:00" |
+                """,
+        security = {@SecurityRequirement(name = "bearer")},
+        responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "주문 상태 이력 조회 성공",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 200,
+                                          "code": "SUC01",
+                                          "timestamp": "2026-03-02T12:00:00.000",
+                                          "content": {
+                                            "orderId": 1,
+                                            "statusHistory": [
+                                              {
+                                                "id": 1,
+                                                "orderStatus": "PAYMENT_PENDING",
+                                                "orderStatusDescription": "결제 대기",
+                                                "reasonCategory": null,
+                                                "reason": "결제 대기",
+                                                "createdAt": "2026-03-02T10:00:00"
+                                              },
+                                              {
+                                                "id": 2,
+                                                "orderStatus": "PAID",
+                                                "orderStatusDescription": "결제 완료",
+                                                "reasonCategory": null,
+                                                "reason": "결제 완료",
+                                                "createdAt": "2026-03-02T10:05:00"
+                                              },
+                                              {
+                                                "id": 3,
+                                                "orderStatus": "CANCEL_REQUESTED",
+                                                "orderStatusDescription": "주문 취소 요청됨",
+                                                "reasonCategory": "CANCEL_ORDER",
+                                                "reason": "구매 의사 취소",
+                                                "createdAt": "2026-03-02T11:00:00"
+                                              }
+                                            ]
+                                          },
+                                          "message": "주문 상태 이력 조회 성공"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(responseCode = "404", description = "주문을 찾을 수 없음")
+        })
+public @interface GetOrderStatusHistoryApiDocs {
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/response/GetOrderStatusHistoryResponse.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/response/GetOrderStatusHistoryResponse.java
@@ -1,0 +1,24 @@
+package com.personal.marketnote.commerce.adapter.in.web.order.response;
+
+import com.personal.marketnote.commerce.port.in.result.order.GetOrderStatusHistoryResult;
+
+import java.util.List;
+
+/**
+ * 주문 상태 이력 조회 응답 DTO
+ *
+ * @Author 성효빈
+ * @Date 2026-03-02
+ * @Description 주문의 전체 상태 변경 이력 조회 응답 DTO입니다.
+ */
+public record GetOrderStatusHistoryResponse(
+        Long orderId,
+        List<OrderStatusHistoryItemResponse> statusHistory
+) {
+    public static GetOrderStatusHistoryResponse from(GetOrderStatusHistoryResult result) {
+        List<OrderStatusHistoryItemResponse> items = result.statusHistory().stream()
+                .map(OrderStatusHistoryItemResponse::from)
+                .toList();
+        return new GetOrderStatusHistoryResponse(result.orderId(), items);
+    }
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/response/OrderStatusHistoryItemResponse.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/response/OrderStatusHistoryItemResponse.java
@@ -1,0 +1,34 @@
+package com.personal.marketnote.commerce.adapter.in.web.order.response;
+
+import com.personal.marketnote.commerce.domain.order.OrderStatus;
+import com.personal.marketnote.commerce.domain.order.OrderStatusReasonCategory;
+import com.personal.marketnote.commerce.port.in.result.order.OrderStatusHistoryItem;
+
+import java.time.LocalDateTime;
+
+/**
+ * 주문 상태 이력 항목 응답 DTO
+ *
+ * @Author 성효빈
+ * @Date 2026-03-02
+ * @Description 개별 주문 상태 변경 이력 항목의 응답 DTO입니다.
+ */
+public record OrderStatusHistoryItemResponse(
+        Long id,
+        OrderStatus orderStatus,
+        String orderStatusDescription,
+        OrderStatusReasonCategory reasonCategory,
+        String reason,
+        LocalDateTime createdAt
+) {
+    public static OrderStatusHistoryItemResponse from(OrderStatusHistoryItem item) {
+        return new OrderStatusHistoryItemResponse(
+                item.id(),
+                item.orderStatus(),
+                item.orderStatusDescription(),
+                item.reasonCategory(),
+                item.reason(),
+                item.createdAt()
+        );
+    }
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/mapper/OrderJpaEntityToDomainMapper.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/mapper/OrderJpaEntityToDomainMapper.java
@@ -3,10 +3,7 @@ package com.personal.marketnote.commerce.adapter.out.mapper;
 import com.personal.marketnote.commerce.adapter.out.persistence.order.entity.OrderJpaEntity;
 import com.personal.marketnote.commerce.adapter.out.persistence.order.entity.OrderProductJpaEntity;
 import com.personal.marketnote.commerce.adapter.out.persistence.order.entity.OrderStatusHistoryJpaEntity;
-import com.personal.marketnote.commerce.domain.order.Order;
-import com.personal.marketnote.commerce.domain.order.OrderProduct;
-import com.personal.marketnote.commerce.domain.order.OrderProductSnapshotState;
-import com.personal.marketnote.commerce.domain.order.OrderSnapshotState;
+import com.personal.marketnote.commerce.domain.order.*;
 
 import java.util.List;
 import java.util.Optional;
@@ -87,6 +84,21 @@ public class OrderJpaEntityToDomainMapper {
                         .orderStatus(entity.getOrderStatus())
                         .isReviewed(entity.getIsReviewed())
                         .build());
+    }
+
+    public static OrderStatusHistory mapToOrderStatusHistoryDomain(
+            OrderStatusHistoryJpaEntity entity
+    ) {
+        return OrderStatusHistory.from(
+                OrderStatusHistorySnapshotState.builder()
+                        .id(entity.getId())
+                        .orderId(entity.getOrderJpaEntity().getId())
+                        .orderStatus(entity.getOrderStatus())
+                        .reasonCategory(entity.getReasonCategory())
+                        .reason(entity.getReason())
+                        .createdAt(entity.getCreatedAt())
+                        .build()
+        );
     }
 
     public static Optional<OrderProduct> mapToOrderProductDomain(OrderProductJpaEntity orderProductJpaEntity) {

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/order/OrderPersistenceAdapter.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/order/OrderPersistenceAdapter.java
@@ -7,10 +7,7 @@ import com.personal.marketnote.commerce.adapter.out.persistence.order.entity.Ord
 import com.personal.marketnote.commerce.adapter.out.persistence.order.repository.OrderHistoryJpaRepository;
 import com.personal.marketnote.commerce.adapter.out.persistence.order.repository.OrderJpaRepository;
 import com.personal.marketnote.commerce.adapter.out.persistence.order.repository.OrderProductJpaRepository;
-import com.personal.marketnote.commerce.domain.order.Order;
-import com.personal.marketnote.commerce.domain.order.OrderProduct;
-import com.personal.marketnote.commerce.domain.order.OrderStatus;
-import com.personal.marketnote.commerce.domain.order.OrderStatusHistory;
+import com.personal.marketnote.commerce.domain.order.*;
 import com.personal.marketnote.commerce.exception.OrderNotFoundException;
 import com.personal.marketnote.commerce.exception.OrderProductNotFoundException;
 import com.personal.marketnote.commerce.port.out.order.*;
@@ -23,7 +20,7 @@ import java.util.*;
 
 @PersistenceAdapter
 @RequiredArgsConstructor
-public class OrderPersistenceAdapter implements SaveOrderPort, FindOrderPort, FindOrderProductPort, UpdateOrderPort, UpdateOrderProductPort {
+public class OrderPersistenceAdapter implements SaveOrderPort, FindOrderPort, FindOrderProductPort, UpdateOrderPort, UpdateOrderProductPort, FindOrderStatusHistoryPort {
     private final OrderJpaRepository orderJpaRepository;
     private final OrderProductJpaRepository orderProductJpaRepository;
     private final OrderHistoryJpaRepository orderHistoryJpaRepository;
@@ -165,6 +162,20 @@ public class OrderPersistenceAdapter implements SaveOrderPort, FindOrderPort, Fi
         OrderProductJpaEntity orderProductJpaEntity
                 = findEntityByOrderIdAndPricePolicyId(orderProduct.getOrderId(), orderProduct.getPricePolicyId());
         orderProductJpaEntity.updateFrom(orderProduct);
+    }
+
+    @Override
+    public List<OrderStatusHistory> findAllByOrderId(Long orderId) {
+        List<OrderStatusHistoryJpaEntity> entities
+                = orderHistoryJpaRepository.findAllByOrderJpaEntityIdOrderByCreatedAtAsc(orderId);
+
+        if (FormatValidator.hasNoValue(entities)) {
+            return List.of();
+        }
+
+        return entities.stream()
+                .map(OrderJpaEntityToDomainMapper::mapToOrderStatusHistoryDomain)
+                .toList();
     }
 
     private OrderProductJpaEntity findEntityByOrderIdAndPricePolicyId(Long orderId, Long pricePolicyId) throws OrderProductNotFoundException {

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/order/repository/OrderHistoryJpaRepository.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/order/repository/OrderHistoryJpaRepository.java
@@ -3,6 +3,10 @@ package com.personal.marketnote.commerce.adapter.out.persistence.order.repositor
 import com.personal.marketnote.commerce.adapter.out.persistence.order.entity.OrderStatusHistoryJpaEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface OrderHistoryJpaRepository extends JpaRepository<OrderStatusHistoryJpaEntity, Long> {
     OrderStatusHistoryJpaEntity findTopByOrderJpaEntityIdOrderByIdDesc(Long orderId);
+
+    List<OrderStatusHistoryJpaEntity> findAllByOrderJpaEntityIdOrderByCreatedAtAsc(Long orderId);
 }

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/result/order/GetOrderStatusHistoryResult.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/result/order/GetOrderStatusHistoryResult.java
@@ -1,0 +1,24 @@
+package com.personal.marketnote.commerce.port.in.result.order;
+
+import com.personal.marketnote.commerce.domain.order.OrderStatusHistory;
+
+import java.util.List;
+
+/**
+ * 주문 상태 이력 조회 결과
+ *
+ * @Author 성효빈
+ * @Date 2026-03-02
+ * @Description 주문의 전체 상태 변경 이력 목록을 감싸는 결과 record입니다.
+ */
+public record GetOrderStatusHistoryResult(
+        Long orderId,
+        List<OrderStatusHistoryItem> statusHistory
+) {
+    public static GetOrderStatusHistoryResult from(Long orderId, List<OrderStatusHistory> histories) {
+        List<OrderStatusHistoryItem> items = histories.stream()
+                .map(OrderStatusHistoryItem::from)
+                .toList();
+        return new GetOrderStatusHistoryResult(orderId, items);
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/result/order/OrderStatusHistoryItem.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/result/order/OrderStatusHistoryItem.java
@@ -1,0 +1,34 @@
+package com.personal.marketnote.commerce.port.in.result.order;
+
+import com.personal.marketnote.commerce.domain.order.OrderStatus;
+import com.personal.marketnote.commerce.domain.order.OrderStatusHistory;
+import com.personal.marketnote.commerce.domain.order.OrderStatusReasonCategory;
+
+import java.time.LocalDateTime;
+
+/**
+ * 주문 상태 이력 항목
+ *
+ * @Author 성효빈
+ * @Date 2026-03-02
+ * @Description 개별 주문 상태 변경 이력 항목을 표현합니다.
+ */
+public record OrderStatusHistoryItem(
+        Long id,
+        OrderStatus orderStatus,
+        String orderStatusDescription,
+        OrderStatusReasonCategory reasonCategory,
+        String reason,
+        LocalDateTime createdAt
+) {
+    public static OrderStatusHistoryItem from(OrderStatusHistory history) {
+        return new OrderStatusHistoryItem(
+                history.getId(),
+                history.getOrderStatus(),
+                history.getOrderStatus().getDescription(),
+                history.getReasonCategory(),
+                history.getReason(),
+                history.getCreatedAt()
+        );
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/order/GetOrderStatusHistoryUseCase.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/order/GetOrderStatusHistoryUseCase.java
@@ -1,0 +1,14 @@
+package com.personal.marketnote.commerce.port.in.usecase.order;
+
+import com.personal.marketnote.commerce.port.in.result.order.GetOrderStatusHistoryResult;
+
+/**
+ * 주문 상태 이력 조회 유스케이스
+ *
+ * @Author 성효빈
+ * @Date 2026-03-02
+ * @Description 관리자가 특정 주문의 상태 변경 이력을 조회합니다.
+ */
+public interface GetOrderStatusHistoryUseCase {
+    GetOrderStatusHistoryResult getOrderStatusHistory(Long orderId);
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/order/FindOrderStatusHistoryPort.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/order/FindOrderStatusHistoryPort.java
@@ -1,0 +1,23 @@
+package com.personal.marketnote.commerce.port.out.order;
+
+import com.personal.marketnote.commerce.domain.order.OrderStatusHistory;
+
+import java.util.List;
+
+/**
+ * 주문 상태 이력 조회 포트
+ *
+ * @Author 성효빈
+ * @Date 2026-03-02
+ * @Description 주문 상태 변경 이력을 조회하는 기능을 제공합니다.
+ */
+public interface FindOrderStatusHistoryPort {
+    /**
+     * @param orderId 주문 ID
+     * @return 주문 상태 이력 목록 {@link List}
+     * @Date 2026-03-02
+     * @Author 성효빈
+     * @Description 주문 ID로 전체 상태 변경 이력을 생성시간 오름차순으로 조회합니다.
+     */
+    List<OrderStatusHistory> findAllByOrderId(Long orderId);
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/GetOrderStatusHistoryService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/GetOrderStatusHistoryService.java
@@ -1,0 +1,44 @@
+package com.personal.marketnote.commerce.service.order;
+
+import com.personal.marketnote.commerce.domain.order.OrderStatusHistory;
+import com.personal.marketnote.commerce.exception.OrderNotFoundException;
+import com.personal.marketnote.commerce.port.in.result.order.GetOrderStatusHistoryResult;
+import com.personal.marketnote.commerce.port.in.usecase.order.GetOrderStatusHistoryUseCase;
+import com.personal.marketnote.commerce.port.out.order.FindOrderPort;
+import com.personal.marketnote.commerce.port.out.order.FindOrderStatusHistoryPort;
+import com.personal.marketnote.common.application.UseCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+/**
+ * 주문 상태 이력 조회 서비스
+ *
+ * @Author 성효빈
+ * @Date 2026-03-02
+ * @Description 관리자가 특정 주문의 상태 변경 이력을 조회합니다.
+ */
+@UseCase
+@RequiredArgsConstructor
+@Slf4j
+public class GetOrderStatusHistoryService implements GetOrderStatusHistoryUseCase {
+    private final FindOrderPort findOrderPort;
+    private final FindOrderStatusHistoryPort findOrderStatusHistoryPort;
+
+    @Override
+    @Transactional(isolation = READ_COMMITTED, readOnly = true)
+    public GetOrderStatusHistoryResult getOrderStatusHistory(Long orderId) {
+        log.info("주문 상태 이력 조회 - orderId={}", orderId);
+
+        findOrderPort.findById(orderId)
+                .orElseThrow(() -> new OrderNotFoundException(orderId));
+
+        List<OrderStatusHistory> histories = findOrderStatusHistoryPort.findAllByOrderId(orderId);
+
+        return GetOrderStatusHistoryResult.from(orderId, histories);
+    }
+}

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/GetOrderStatusHistoryUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/GetOrderStatusHistoryUseCaseTest.java
@@ -1,0 +1,233 @@
+package com.personal.marketnote.commerce.service.order;
+
+import com.personal.marketnote.commerce.domain.order.*;
+import com.personal.marketnote.commerce.exception.OrderNotFoundException;
+import com.personal.marketnote.commerce.port.in.result.order.GetOrderStatusHistoryResult;
+import com.personal.marketnote.commerce.port.in.result.order.OrderStatusHistoryItem;
+import com.personal.marketnote.commerce.port.out.order.FindOrderPort;
+import com.personal.marketnote.commerce.port.out.order.FindOrderStatusHistoryPort;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GetOrderStatusHistoryUseCase 테스트")
+class GetOrderStatusHistoryUseCaseTest {
+
+    @InjectMocks
+    private GetOrderStatusHistoryService getOrderStatusHistoryService;
+
+    @Mock
+    private FindOrderPort findOrderPort;
+
+    @Mock
+    private FindOrderStatusHistoryPort findOrderStatusHistoryPort;
+
+    private Order createOrder(Long id) {
+        return Order.from(OrderSnapshotState.builder()
+                .id(id)
+                .buyerId(100L)
+                .orderKey(UUID.randomUUID())
+                .orderNumber("ORD" + id)
+                .orderStatus(OrderStatus.PAID)
+                .totalAmount(100000L)
+                .paidAmount(95000L)
+                .couponAmount(3000L)
+                .pointAmount(2000L)
+                .orderProductStates(List.of())
+                .createdAt(LocalDateTime.of(2026, 2, 20, 10, 0))
+                .modifiedAt(LocalDateTime.of(2026, 2, 20, 10, 0))
+                .build());
+    }
+
+    private OrderStatusHistory createHistory(Long id, Long orderId, OrderStatus status,
+                                             OrderStatusReasonCategory reasonCategory,
+                                             String reason, LocalDateTime createdAt) {
+        return OrderStatusHistory.from(OrderStatusHistorySnapshotState.builder()
+                .id(id)
+                .orderId(orderId)
+                .orderStatus(status)
+                .reasonCategory(reasonCategory)
+                .reason(reason)
+                .createdAt(createdAt)
+                .build());
+    }
+
+    @Test
+    @DisplayName("주문이 존재하고 이력이 있으면 이력 목록을 반환한다")
+    void shouldReturnHistoriesWhenOrderExistsAndHasHistory() {
+        // given
+        Long orderId = 1L;
+        when(findOrderPort.findById(orderId)).thenReturn(Optional.of(createOrder(orderId)));
+
+        List<OrderStatusHistory> histories = List.of(
+                createHistory(1L, orderId, OrderStatus.PAYMENT_PENDING, null, "결제 대기",
+                        LocalDateTime.of(2026, 2, 20, 10, 0)),
+                createHistory(2L, orderId, OrderStatus.PAID, null, "결제 완료",
+                        LocalDateTime.of(2026, 2, 20, 10, 5))
+        );
+        when(findOrderStatusHistoryPort.findAllByOrderId(orderId)).thenReturn(histories);
+
+        // when
+        GetOrderStatusHistoryResult result = getOrderStatusHistoryService.getOrderStatusHistory(orderId);
+
+        // then
+        assertThat(result.statusHistory()).hasSize(2);
+        assertThat(result.statusHistory().get(0).orderStatus()).isEqualTo(OrderStatus.PAYMENT_PENDING);
+        assertThat(result.statusHistory().get(1).orderStatus()).isEqualTo(OrderStatus.PAID);
+        verify(findOrderPort).findById(orderId);
+        verify(findOrderStatusHistoryPort).findAllByOrderId(orderId);
+        verifyNoMoreInteractions(findOrderPort, findOrderStatusHistoryPort);
+    }
+
+    @Test
+    @DisplayName("반환된 이력의 orderId가 요청한 orderId와 일치한다")
+    void shouldReturnCorrectOrderId() {
+        // given
+        Long orderId = 5L;
+        when(findOrderPort.findById(orderId)).thenReturn(Optional.of(createOrder(orderId)));
+
+        List<OrderStatusHistory> histories = List.of(
+                createHistory(1L, orderId, OrderStatus.PAID, null, "결제 완료",
+                        LocalDateTime.of(2026, 2, 20, 10, 0))
+        );
+        when(findOrderStatusHistoryPort.findAllByOrderId(orderId)).thenReturn(histories);
+
+        // when
+        GetOrderStatusHistoryResult result = getOrderStatusHistoryService.getOrderStatusHistory(orderId);
+
+        // then
+        assertThat(result.orderId()).isEqualTo(5L);
+    }
+
+    @Test
+    @DisplayName("반환된 이력 항목에 orderStatus, reasonCategory, reason, createdAt이 포함된다")
+    void shouldIncludeAllFieldsInHistoryItem() {
+        // given
+        Long orderId = 1L;
+        when(findOrderPort.findById(orderId)).thenReturn(Optional.of(createOrder(orderId)));
+
+        OrderStatusHistory history = createHistory(
+                3L, orderId, OrderStatus.CANCEL_REQUESTED, OrderStatusReasonCategory.CANCEL_ORDER,
+                "구매 의사 취소", LocalDateTime.of(2026, 2, 20, 11, 0));
+        when(findOrderStatusHistoryPort.findAllByOrderId(orderId)).thenReturn(List.of(history));
+
+        // when
+        GetOrderStatusHistoryResult result = getOrderStatusHistoryService.getOrderStatusHistory(orderId);
+
+        // then
+        OrderStatusHistoryItem item = result.statusHistory().get(0);
+        assertThat(item.id()).isEqualTo(3L);
+        assertThat(item.orderStatus()).isEqualTo(OrderStatus.CANCEL_REQUESTED);
+        assertThat(item.reasonCategory()).isEqualTo(OrderStatusReasonCategory.CANCEL_ORDER);
+        assertThat(item.reason()).isEqualTo("구매 의사 취소");
+        assertThat(item.createdAt()).isEqualTo(LocalDateTime.of(2026, 2, 20, 11, 0));
+    }
+
+    @Test
+    @DisplayName("반환된 이력 항목에 orderStatusDescription이 포함된다")
+    void shouldIncludeOrderStatusDescription() {
+        // given
+        Long orderId = 1L;
+        when(findOrderPort.findById(orderId)).thenReturn(Optional.of(createOrder(orderId)));
+
+        OrderStatusHistory history = createHistory(
+                1L, orderId, OrderStatus.PAID, null, "결제 완료",
+                LocalDateTime.of(2026, 2, 20, 10, 0));
+        when(findOrderStatusHistoryPort.findAllByOrderId(orderId)).thenReturn(List.of(history));
+
+        // when
+        GetOrderStatusHistoryResult result = getOrderStatusHistoryService.getOrderStatusHistory(orderId);
+
+        // then
+        assertThat(result.statusHistory().get(0).orderStatusDescription()).isEqualTo("결제 완료");
+    }
+
+    @Test
+    @DisplayName("주문은 존재하지만 이력이 없으면 빈 이력 목록을 반환한다")
+    void shouldReturnEmptyWhenNoHistory() {
+        // given
+        Long orderId = 1L;
+        when(findOrderPort.findById(orderId)).thenReturn(Optional.of(createOrder(orderId)));
+        when(findOrderStatusHistoryPort.findAllByOrderId(orderId)).thenReturn(List.of());
+
+        // when
+        GetOrderStatusHistoryResult result = getOrderStatusHistoryService.getOrderStatusHistory(orderId);
+
+        // then
+        assertThat(result.orderId()).isEqualTo(orderId);
+        assertThat(result.statusHistory()).isEmpty();
+        verify(findOrderPort).findById(orderId);
+        verify(findOrderStatusHistoryPort).findAllByOrderId(orderId);
+        verifyNoMoreInteractions(findOrderPort, findOrderStatusHistoryPort);
+    }
+
+    @Test
+    @DisplayName("주문이 존재하지 않으면 OrderNotFoundException을 던진다")
+    void shouldThrowWhenOrderNotFound() {
+        // given
+        Long orderId = 999L;
+        when(findOrderPort.findById(orderId)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> getOrderStatusHistoryService.getOrderStatusHistory(orderId))
+                .isInstanceOf(OrderNotFoundException.class);
+        verify(findOrderPort).findById(orderId);
+        verifyNoInteractions(findOrderStatusHistoryPort);
+    }
+
+    @Test
+    @DisplayName("findOrderPort.findById를 정확히 한 번 호출한다")
+    void shouldCallFindOrderPortExactlyOnce() {
+        // given
+        Long orderId = 1L;
+        when(findOrderPort.findById(orderId)).thenReturn(Optional.of(createOrder(orderId)));
+        when(findOrderStatusHistoryPort.findAllByOrderId(orderId)).thenReturn(List.of());
+
+        // when
+        getOrderStatusHistoryService.getOrderStatusHistory(orderId);
+
+        // then
+        verify(findOrderPort, times(1)).findById(orderId);
+    }
+
+    @Test
+    @DisplayName("findOrderStatusHistoryPort.findAllByOrderId를 정확히 한 번 호출한다")
+    void shouldCallFindHistoryPortExactlyOnce() {
+        // given
+        Long orderId = 1L;
+        when(findOrderPort.findById(orderId)).thenReturn(Optional.of(createOrder(orderId)));
+        when(findOrderStatusHistoryPort.findAllByOrderId(orderId)).thenReturn(List.of());
+
+        // when
+        getOrderStatusHistoryService.getOrderStatusHistory(orderId);
+
+        // then
+        verify(findOrderStatusHistoryPort, times(1)).findAllByOrderId(orderId);
+    }
+
+    @Test
+    @DisplayName("주문이 존재하지 않으면 findOrderStatusHistoryPort를 호출하지 않는다")
+    void shouldNotCallHistoryPortWhenOrderNotFound() {
+        // given
+        Long orderId = 999L;
+        when(findOrderPort.findById(orderId)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> getOrderStatusHistoryService.getOrderStatusHistory(orderId))
+                .isInstanceOf(OrderNotFoundException.class);
+        verifyNoInteractions(findOrderStatusHistoryPort);
+    }
+}


### PR DESCRIPTION
## partially addresses #216
## resolves #921

## Task
- [x] GetOrderStatusHistoryUseCase 인터페이스 정의
- [x] FindOrderStatusHistoryPort 정의
- [x] GetOrderStatusHistoryService 구현 (주문 존재 검증 후 이력 조회)
- [x] OrderHistoryJpaRepository에 주문별 전체 이력 조회 쿼리 추가
- [x] GET /api/v1/admin/orders/{id}/status-history 엔드포인트 추가
- [x] @PreAuthorize(ADMIN_POINTCUT) 인가 적용
- [x] OrderStatusHistoryItem/GetOrderStatusHistoryResult Result 정의
- [x] GetOrderStatusHistoryResponse/OrderStatusHistoryItemResponse 응답 DTO 정의
- [x] GetOrderStatusHistoryApiDocs Swagger 문서 추가
- [x] OrderJpaEntityToDomainMapper에 이력 매핑 메서드 추가
- [x] OrderPersistenceAdapter에 FindOrderStatusHistoryPort 구현 추가
- [x] 단위 테스트 9개 작성