### PR TITLE
[#216][#923] feat: 환불 상세 도메인 기능 추가

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/refund/controller/AdminRefundController.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/refund/controller/AdminRefundController.java
@@ -1,0 +1,63 @@
+package com.personal.marketnote.commerce.adapter.in.web.refund.controller;
+
+import com.personal.marketnote.commerce.adapter.in.web.refund.controller.apidocs.GetAdminRefundsApiDocs;
+import com.personal.marketnote.commerce.adapter.in.web.refund.response.GetAdminRefundResponse;
+import com.personal.marketnote.commerce.port.in.result.refund.GetAdminRefundResult;
+import com.personal.marketnote.commerce.port.in.usecase.refund.GetAdminRefundsUseCase;
+import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+import static com.personal.marketnote.common.domain.exception.ExceptionCode.DEFAULT_SUCCESS_CODE;
+import static com.personal.marketnote.common.utility.ApiConstant.ADMIN_POINTCUT;
+
+/**
+ * 관리자 환불 조회 컨트롤러.
+ *
+ * @author 성효빈
+ * @since 2026-03-02
+ */
+@RestController
+@RequestMapping("/api/v1/admin/refunds")
+@Tag(name = "(관리자) 환불 API", description = "관리자 환불 조회 API")
+@RequiredArgsConstructor
+@Validated
+public class AdminRefundController {
+    private final GetAdminRefundsUseCase getAdminRefundsUseCase;
+
+    /**
+     * 주문별 환불 목록을 조회한다.
+     *
+     * @param orderId 주문 ID
+     * @return 환불 목록 응답
+     * @author 성효빈
+     * @since 2026-03-02
+     */
+    @GetMapping
+    @PreAuthorize(ADMIN_POINTCUT)
+    @GetAdminRefundsApiDocs
+    public ResponseEntity<BaseResponse<List<GetAdminRefundResponse>>> getRefundsByOrderId(
+            @RequestParam("order-id") @NotNull @Min(1) Long orderId
+    ) {
+        List<GetAdminRefundResult> results = getAdminRefundsUseCase.getRefundsByOrderId(orderId);
+        List<GetAdminRefundResponse> responses = results.stream()
+                .map(GetAdminRefundResponse::from)
+                .toList();
+        return new ResponseEntity<>(
+                BaseResponse.of(responses, HttpStatus.OK, DEFAULT_SUCCESS_CODE, "환불 목록 조회 성공"),
+                HttpStatus.OK
+        );
+    }
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/refund/controller/apidocs/GetAdminRefundsApiDocs.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/refund/controller/apidocs/GetAdminRefundsApiDocs.java
@@ -1,0 +1,51 @@
+package com.personal.marketnote.commerce.adapter.in.web.refund.controller.apidocs;
+
+import com.personal.marketnote.commerce.adapter.in.web.refund.response.GetAdminRefundResponse;
+import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.List;
+
+/**
+ * 관리자 환불 목록 조회 API 문서 애노테이션.
+ *
+ * @author 성효빈
+ * @since 2026-03-02
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Operation(
+        summary = "주문별 환불 목록 조회",
+        description = "주문 ID에 해당하는 환불 상세 목록을 조회합니다.",
+        security = @SecurityRequirement(name = "bearer"),
+        parameters = {
+                @Parameter(name = "order-id", description = "주문 ID", required = true, example = "1")
+        }
+)
+@ApiResponses(value = {
+        @ApiResponse(
+                responseCode = "200",
+                description = "환불 목록 조회 성공",
+                content = @Content(schema = @Schema(implementation = BaseResponse.class))
+        ),
+        @ApiResponse(
+                responseCode = "401",
+                description = "인증 실패"
+        ),
+        @ApiResponse(
+                responseCode = "403",
+                description = "관리자 권한 없음"
+        )
+})
+public @interface GetAdminRefundsApiDocs {
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/refund/response/GetAdminRefundResponse.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/refund/response/GetAdminRefundResponse.java
@@ -1,0 +1,40 @@
+package com.personal.marketnote.commerce.adapter.in.web.refund.response;
+
+import com.personal.marketnote.commerce.domain.refund.RefundType;
+import com.personal.marketnote.commerce.port.in.result.refund.GetAdminRefundResult;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+/**
+ * 관리자 환불 조회 응답 DTO.
+ *
+ * @author 성효빈
+ * @since 2026-03-02
+ */
+@Builder
+public record GetAdminRefundResponse(
+        Long id,
+        Long paymentId,
+        Long orderId,
+        RefundType refundType,
+        Long refundAmount,
+        String cancelReason,
+        String processedBy,
+        String pgRefundKey,
+        LocalDateTime createdAt
+) {
+    public static GetAdminRefundResponse from(GetAdminRefundResult result) {
+        return GetAdminRefundResponse.builder()
+                .id(result.id())
+                .paymentId(result.paymentId())
+                .orderId(result.orderId())
+                .refundType(result.refundType())
+                .refundAmount(result.refundAmount())
+                .cancelReason(result.cancelReason())
+                .processedBy(result.processedBy())
+                .pgRefundKey(result.pgRefundKey())
+                .createdAt(result.createdAt())
+                .build();
+    }
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/refund/RefundPersistenceAdapter.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/refund/RefundPersistenceAdapter.java
@@ -1,0 +1,45 @@
+package com.personal.marketnote.commerce.adapter.out.persistence.refund;
+
+import com.personal.marketnote.commerce.adapter.out.persistence.refund.entity.RefundJpaEntity;
+import com.personal.marketnote.commerce.adapter.out.persistence.refund.mapper.RefundJpaEntityToDomainMapper;
+import com.personal.marketnote.commerce.adapter.out.persistence.refund.repository.RefundJpaRepository;
+import com.personal.marketnote.commerce.domain.refund.Refund;
+import com.personal.marketnote.commerce.port.out.refund.FindRefundPort;
+import com.personal.marketnote.commerce.port.out.refund.SaveRefundPort;
+import com.personal.marketnote.common.adapter.out.PersistenceAdapter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+/**
+ * 환불 퍼시스턴스 어댑터.
+ *
+ * @author 성효빈
+ * @since 2026-03-02
+ */
+@PersistenceAdapter
+@RequiredArgsConstructor
+public class RefundPersistenceAdapter implements SaveRefundPort, FindRefundPort {
+    private final RefundJpaRepository refundJpaRepository;
+
+    @Override
+    public Refund save(Refund refund) {
+        RefundJpaEntity entity = RefundJpaEntity.from(refund);
+        RefundJpaEntity savedEntity = refundJpaRepository.save(entity);
+        return RefundJpaEntityToDomainMapper.toDomain(savedEntity);
+    }
+
+    @Override
+    public List<Refund> findByOrderId(Long orderId) {
+        return refundJpaRepository.findByOrderIdOrderByCreatedAtDesc(orderId).stream()
+                .map(RefundJpaEntityToDomainMapper::toDomain)
+                .toList();
+    }
+
+    @Override
+    public List<Refund> findByPaymentId(Long paymentId) {
+        return refundJpaRepository.findByPaymentIdOrderByCreatedAtDesc(paymentId).stream()
+                .map(RefundJpaEntityToDomainMapper::toDomain)
+                .toList();
+    }
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/refund/entity/RefundJpaEntity.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/refund/entity/RefundJpaEntity.java
@@ -1,0 +1,68 @@
+package com.personal.marketnote.commerce.adapter.out.persistence.refund.entity;
+
+import com.personal.marketnote.commerce.domain.refund.Refund;
+import com.personal.marketnote.commerce.domain.refund.RefundType;
+import com.personal.marketnote.common.adapter.out.persistence.audit.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+/**
+ * 환불 JPA 엔티티.
+ *
+ * @author 성효빈
+ * @since 2026-03-02
+ */
+@Entity
+@Table(name = "refund",
+        indexes = {
+                @Index(name = "idx_refund_order_id", columnList = "order_id"),
+                @Index(name = "idx_refund_payment_id", columnList = "payment_id")
+        })
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+@Getter
+public class RefundJpaEntity extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "payment_id", nullable = false)
+    private Long paymentId;
+
+    @Column(name = "order_id", nullable = false)
+    private Long orderId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "refund_type", nullable = false, length = 20)
+    private RefundType refundType;
+
+    @Column(name = "refund_amount", nullable = false)
+    private Long refundAmount;
+
+    @Column(name = "cancel_reason", length = 500)
+    private String cancelReason;
+
+    @Column(name = "processed_by", length = 100)
+    private String processedBy;
+
+    @Column(name = "pg_refund_key", length = 200)
+    private String pgRefundKey;
+
+    @Column(name = "pg_raw_response", columnDefinition = "TEXT")
+    private String pgRawResponse;
+
+    public static RefundJpaEntity from(Refund refund) {
+        return RefundJpaEntity.builder()
+                .paymentId(refund.getPaymentId())
+                .orderId(refund.getOrderId())
+                .refundType(refund.getRefundType())
+                .refundAmount(refund.getRefundAmount())
+                .cancelReason(refund.getCancelReason())
+                .processedBy(refund.getProcessedBy())
+                .pgRefundKey(refund.getPgRefundKey())
+                .pgRawResponse(refund.getPgRawResponse())
+                .build();
+    }
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/refund/mapper/RefundJpaEntityToDomainMapper.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/refund/mapper/RefundJpaEntityToDomainMapper.java
@@ -1,0 +1,32 @@
+package com.personal.marketnote.commerce.adapter.out.persistence.refund.mapper;
+
+import com.personal.marketnote.commerce.adapter.out.persistence.refund.entity.RefundJpaEntity;
+import com.personal.marketnote.commerce.domain.refund.Refund;
+import com.personal.marketnote.commerce.domain.refund.RefundSnapshotState;
+
+/**
+ * 환불 JPA 엔티티 → 도메인 매퍼.
+ *
+ * @author 성효빈
+ * @since 2026-03-02
+ */
+public class RefundJpaEntityToDomainMapper {
+
+    private RefundJpaEntityToDomainMapper() {
+    }
+
+    public static Refund toDomain(RefundJpaEntity entity) {
+        return Refund.from(RefundSnapshotState.builder()
+                .id(entity.getId())
+                .paymentId(entity.getPaymentId())
+                .orderId(entity.getOrderId())
+                .refundType(entity.getRefundType())
+                .refundAmount(entity.getRefundAmount())
+                .cancelReason(entity.getCancelReason())
+                .processedBy(entity.getProcessedBy())
+                .pgRefundKey(entity.getPgRefundKey())
+                .pgRawResponse(entity.getPgRawResponse())
+                .createdAt(entity.getCreatedAt())
+                .build());
+    }
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/refund/repository/RefundJpaRepository.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/refund/repository/RefundJpaRepository.java
@@ -1,0 +1,19 @@
+package com.personal.marketnote.commerce.adapter.out.persistence.refund.repository;
+
+import com.personal.marketnote.commerce.adapter.out.persistence.refund.entity.RefundJpaEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+/**
+ * 환불 JPA 리포지토리.
+ *
+ * @author 성효빈
+ * @since 2026-03-02
+ */
+public interface RefundJpaRepository extends JpaRepository<RefundJpaEntity, Long> {
+
+    List<RefundJpaEntity> findByOrderIdOrderByCreatedAtDesc(Long orderId);
+
+    List<RefundJpaEntity> findByPaymentIdOrderByCreatedAtDesc(Long paymentId);
+}

--- a/commerce-service/commerce-adapters/src/main/resources/db/migration/V894__create_refund_table.sql
+++ b/commerce-service/commerce-adapters/src/main/resources/db/migration/V894__create_refund_table.sql
@@ -1,0 +1,16 @@
+CREATE TABLE refund (
+    id              BIGSERIAL       PRIMARY KEY,
+    payment_id      BIGINT          NOT NULL,
+    order_id        BIGINT          NOT NULL,
+    refund_type     VARCHAR(20)     NOT NULL,
+    refund_amount   BIGINT          NOT NULL,
+    cancel_reason   VARCHAR(500),
+    processed_by    VARCHAR(100),
+    pg_refund_key   VARCHAR(200),
+    pg_raw_response TEXT,
+    created_at      TIMESTAMP       NOT NULL DEFAULT NOW(),
+    modified_at     TIMESTAMP       NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_refund_order_id ON refund (order_id);
+CREATE INDEX idx_refund_payment_id ON refund (payment_id);

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/result/refund/GetAdminRefundResult.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/result/refund/GetAdminRefundResult.java
@@ -1,0 +1,48 @@
+package com.personal.marketnote.commerce.port.in.result.refund;
+
+import com.personal.marketnote.commerce.domain.refund.Refund;
+import com.personal.marketnote.commerce.domain.refund.RefundType;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+/**
+ * 관리자 환불 조회 결과 레코드.
+ *
+ * @author 성효빈
+ * @since 2026-03-02
+ */
+@Builder
+public record GetAdminRefundResult(
+        Long id,
+        Long paymentId,
+        Long orderId,
+        RefundType refundType,
+        Long refundAmount,
+        String cancelReason,
+        String processedBy,
+        String pgRefundKey,
+        String pgRawResponse,
+        LocalDateTime createdAt
+) {
+    /**
+     * 환불 도메인 객체로부터 조회 결과를 생성한다.
+     *
+     * @param refund 환불 도메인 객체
+     * @return 관리자 환불 조회 결과
+     */
+    public static GetAdminRefundResult from(Refund refund) {
+        return GetAdminRefundResult.builder()
+                .id(refund.getId())
+                .paymentId(refund.getPaymentId())
+                .orderId(refund.getOrderId())
+                .refundType(refund.getRefundType())
+                .refundAmount(refund.getRefundAmount())
+                .cancelReason(refund.getCancelReason())
+                .processedBy(refund.getProcessedBy())
+                .pgRefundKey(refund.getPgRefundKey())
+                .pgRawResponse(refund.getPgRawResponse())
+                .createdAt(refund.getCreatedAt())
+                .build();
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/refund/GetAdminRefundsUseCase.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/refund/GetAdminRefundsUseCase.java
@@ -1,0 +1,22 @@
+package com.personal.marketnote.commerce.port.in.usecase.refund;
+
+import com.personal.marketnote.commerce.port.in.result.refund.GetAdminRefundResult;
+
+import java.util.List;
+
+/**
+ * 관리자 환불 목록 조회 유스케이스.
+ *
+ * @author 성효빈
+ * @since 2026-03-02
+ */
+public interface GetAdminRefundsUseCase {
+
+    /**
+     * 주문 ID에 해당하는 환불 목록을 조회한다.
+     *
+     * @param orderId 주문 ID
+     * @return 환불 결과 목록
+     */
+    List<GetAdminRefundResult> getRefundsByOrderId(Long orderId);
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/refund/FindRefundPort.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/refund/FindRefundPort.java
@@ -1,0 +1,30 @@
+package com.personal.marketnote.commerce.port.out.refund;
+
+import com.personal.marketnote.commerce.domain.refund.Refund;
+
+import java.util.List;
+
+/**
+ * 환불 조회 아웃바운드 포트.
+ *
+ * @author 성효빈
+ * @since 2026-03-02
+ */
+public interface FindRefundPort {
+
+    /**
+     * 주문 ID로 환불 목록을 조회한다.
+     *
+     * @param orderId 주문 ID
+     * @return 해당 주문의 환불 목록
+     */
+    List<Refund> findByOrderId(Long orderId);
+
+    /**
+     * 결제 ID로 환불 목록을 조회한다.
+     *
+     * @param paymentId 결제 ID
+     * @return 해당 결제의 환불 목록
+     */
+    List<Refund> findByPaymentId(Long paymentId);
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/refund/SaveRefundPort.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/refund/SaveRefundPort.java
@@ -1,0 +1,20 @@
+package com.personal.marketnote.commerce.port.out.refund;
+
+import com.personal.marketnote.commerce.domain.refund.Refund;
+
+/**
+ * 환불 저장 아웃바운드 포트.
+ *
+ * @author 성효빈
+ * @since 2026-03-02
+ */
+public interface SaveRefundPort {
+
+    /**
+     * 환불 정보를 저장한다.
+     *
+     * @param refund 저장할 환불 도메인 객체
+     * @return 저장된 환불 도메인 객체 (ID 포함)
+     */
+    Refund save(Refund refund);
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/CancelPaymentService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/CancelPaymentService.java
@@ -4,6 +4,9 @@ import com.personal.marketnote.commerce.domain.order.Order;
 import com.personal.marketnote.commerce.domain.order.OrderStatus;
 import com.personal.marketnote.commerce.domain.payment.Payment;
 import com.personal.marketnote.commerce.domain.payment.PspPaymentEvent;
+import com.personal.marketnote.commerce.domain.refund.Refund;
+import com.personal.marketnote.commerce.domain.refund.RefundCreateState;
+import com.personal.marketnote.commerce.domain.refund.RefundType;
 import com.personal.marketnote.commerce.exception.*;
 import com.personal.marketnote.commerce.port.in.command.order.ChangeOrderStatusCommand;
 import com.personal.marketnote.commerce.port.in.command.payment.CancelPaymentCommand;
@@ -15,6 +18,7 @@ import com.personal.marketnote.commerce.port.out.order.FindOrderPort;
 import com.personal.marketnote.commerce.port.out.payment.*;
 import com.personal.marketnote.commerce.port.out.payment.vendor.PaymentCancelVendorCommand;
 import com.personal.marketnote.commerce.port.out.payment.vendor.PaymentCancelVendorResult;
+import com.personal.marketnote.commerce.port.out.refund.SaveRefundPort;
 import com.personal.marketnote.commerce.port.out.reward.ModifyUserPointPort;
 import com.personal.marketnote.common.application.UseCase;
 import com.personal.marketnote.common.utility.FormatValidator;
@@ -41,6 +45,7 @@ public class CancelPaymentService implements CancelPaymentUseCase {
     private final RecordLedgerEntryUseCase recordLedgerEntryUseCase;
     private final RestoreProductInventoryUseCase restoreProductInventoryUseCase;
     private final ModifyUserPointPort modifyUserPointPort;
+    private final SaveRefundPort saveRefundPort;
 
     @Override
     public void cancel(CancelPaymentCommand command) {
@@ -105,6 +110,8 @@ public class CancelPaymentService implements CancelPaymentUseCase {
         updatePaymentPort.update(payment);
         updatePspPaymentEventPort.update(event);
 
+        saveRefundRecord(payment, isFullCancel, cancelAmount, command.cancelReason(), vendorResult);
+
         if (isFullCancel) {
             changeOrderStatusUseCase.changeOrderStatus(
                     ChangeOrderStatusCommand.builder()
@@ -117,6 +124,30 @@ public class CancelPaymentService implements CancelPaymentUseCase {
         }
 
         recordLedgerEntryForCancellation(payment, isFullCancel, cancelAmount, alreadyRefunded);
+    }
+
+    private void saveRefundRecord(
+            Payment payment, boolean isFullCancel, Long cancelAmount,
+            String cancelReason, PaymentCancelVendorResult vendorResult
+    ) {
+        try {
+            RefundType refundType = isFullCancel ? RefundType.FULL_REFUND : RefundType.PARTIAL_REFUND;
+            RefundCreateState createState = RefundCreateState.builder()
+                    .paymentId(payment.getId())
+                    .orderId(payment.getOrderId())
+                    .refundType(refundType)
+                    .refundAmount(cancelAmount)
+                    .cancelReason(cancelReason)
+                    .processedBy("SYSTEM")
+                    .pgRefundKey(payment.getPgPaymentKey())
+                    .pgRawResponse(vendorResult.rawResponse())
+                    .build();
+            Refund refund = Refund.from(createState);
+            saveRefundPort.save(refund);
+        } catch (Exception e) {
+            log.error("환불 상세 기록 저장 실패 - orderId: {}, error: {}",
+                    payment.getOrderId(), e.getMessage(), e);
+        }
     }
 
     private void recordLedgerEntryForCancellation(

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/refund/GetAdminRefundsService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/refund/GetAdminRefundsService.java
@@ -1,0 +1,34 @@
+package com.personal.marketnote.commerce.service.refund;
+
+import com.personal.marketnote.commerce.domain.refund.Refund;
+import com.personal.marketnote.commerce.port.in.result.refund.GetAdminRefundResult;
+import com.personal.marketnote.commerce.port.in.usecase.refund.GetAdminRefundsUseCase;
+import com.personal.marketnote.commerce.port.out.refund.FindRefundPort;
+import com.personal.marketnote.common.application.UseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+/**
+ * 관리자 환불 목록 조회 서비스.
+ *
+ * @author 성효빈
+ * @since 2026-03-02
+ */
+@UseCase
+@RequiredArgsConstructor
+@Transactional(isolation = READ_COMMITTED, readOnly = true)
+public class GetAdminRefundsService implements GetAdminRefundsUseCase {
+    private final FindRefundPort findRefundPort;
+
+    @Override
+    public List<GetAdminRefundResult> getRefundsByOrderId(Long orderId) {
+        List<Refund> refunds = findRefundPort.findByOrderId(orderId);
+        return refunds.stream()
+                .map(GetAdminRefundResult::from)
+                .toList();
+    }
+}

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/payment/CancelPaymentUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/payment/CancelPaymentUseCaseTest.java
@@ -5,6 +5,8 @@ import com.personal.marketnote.commerce.domain.order.OrderProductSnapshotState;
 import com.personal.marketnote.commerce.domain.order.OrderSnapshotState;
 import com.personal.marketnote.commerce.domain.order.OrderStatus;
 import com.personal.marketnote.commerce.domain.payment.*;
+import com.personal.marketnote.commerce.domain.refund.Refund;
+import com.personal.marketnote.commerce.domain.refund.RefundType;
 import com.personal.marketnote.commerce.exception.PaymentCancelException;
 import com.personal.marketnote.commerce.exception.PaymentNotFoundException;
 import com.personal.marketnote.commerce.exception.UnauthorizedOrderAccessException;
@@ -15,6 +17,7 @@ import com.personal.marketnote.commerce.port.in.usecase.order.ChangeOrderStatusU
 import com.personal.marketnote.commerce.port.out.order.FindOrderPort;
 import com.personal.marketnote.commerce.port.out.payment.*;
 import com.personal.marketnote.commerce.port.out.payment.vendor.PaymentCancelVendorResult;
+import com.personal.marketnote.commerce.port.out.refund.SaveRefundPort;
 import com.personal.marketnote.commerce.port.out.reward.ModifyUserPointPort;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -69,6 +72,9 @@ class CancelPaymentUseCaseTest {
 
     @Mock
     private ModifyUserPointPort modifyUserPointPort;
+
+    @Mock
+    private SaveRefundPort saveRefundPort;
 
     private static final Long BUYER_ID = 100L;
     private static final UUID ORDER_KEY = UUID.randomUUID();
@@ -657,6 +663,112 @@ class CancelPaymentUseCaseTest {
             when(paymentVendorPort.cancelPayment(any())).thenReturn(vendorResult);
             doThrow(new RuntimeException("포인트 환불 실패")).when(modifyUserPointPort)
                     .refundOrderPoints(anyLong(), anyLong(), anyLong());
+
+            cancelPaymentService.cancel(command);
+
+            verify(updatePaymentPort).update(any());
+            verify(updatePspPaymentEventPort).update(any());
+            verify(changeOrderStatusUseCase).changeOrderStatus(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("환불 상세 기록 검증")
+    class RefundRecordTest {
+
+        private Payment createPaymentWithId(Long paymentId, Long orderId, UUID orderKey, Long amount, String pgPaymentKey) {
+            PaymentSnapshotState state = PaymentSnapshotState.builder()
+                    .id(paymentId)
+                    .orderId(orderId)
+                    .orderKey(orderKey)
+                    .pgPaymentKey(pgPaymentKey)
+                    .paymentAmount(amount)
+                    .successYn(true)
+                    .refundedYn(false)
+                    .refundAmount(0L)
+                    .createdAt(LocalDateTime.of(2026, 2, 24, 10, 0))
+                    .modifiedAt(LocalDateTime.of(2026, 2, 24, 10, 0))
+                    .build();
+            return Payment.from(state);
+        }
+
+        @Test
+        @DisplayName("전체 취소 성공 시 FULL_REFUND 환불 기록이 저장된다")
+        void shouldSaveFullRefundRecordOnFullCancel() {
+            Payment payment = createPaymentWithId(5L, 1L, ORDER_KEY, 50000L, "tno_123");
+            PspPaymentEvent event = createCompleteEvent(ORDER_KEY_STR, "tno_123", 50000L);
+            CancelPaymentCommand command = createFullCancelCommand(ORDER_KEY_STR);
+            PaymentCancelVendorResult vendorResult = createSuccessVendorResult();
+
+            when(findPaymentPort.findByOrderKey(ORDER_KEY)).thenReturn(Optional.of(payment));
+            when(findOrderPort.findById(1L)).thenReturn(Optional.of(createOrder(1L, BUYER_ID)));
+            when(findPspPaymentEventPort.findByOrderKey(ORDER_KEY_STR)).thenReturn(Optional.of(event));
+            when(paymentVendorPort.cancelPayment(any())).thenReturn(vendorResult);
+
+            cancelPaymentService.cancel(command);
+
+            verify(saveRefundPort).save(argThat(refund ->
+                    refund.getRefundType() == RefundType.FULL_REFUND
+                            && refund.getRefundAmount().equals(50000L)
+                            && "SYSTEM".equals(refund.getProcessedBy())
+            ));
+        }
+
+        @Test
+        @DisplayName("부분 취소 성공 시 PARTIAL_REFUND 환불 기록이 저장된다")
+        void shouldSavePartialRefundRecordOnPartialCancel() {
+            Payment payment = createPaymentWithId(5L, 1L, ORDER_KEY, 50000L, "tno_123");
+            PspPaymentEvent event = createCompleteEvent(ORDER_KEY_STR, "tno_123", 50000L);
+            CancelPaymentCommand command = createPartialCancelCommand(ORDER_KEY_STR, 20000L);
+            PaymentCancelVendorResult vendorResult = createSuccessVendorResult();
+
+            when(findPaymentPort.findByOrderKey(ORDER_KEY)).thenReturn(Optional.of(payment));
+            when(findOrderPort.findById(1L)).thenReturn(Optional.of(createOrder(1L, BUYER_ID)));
+            when(findPspPaymentEventPort.findByOrderKey(ORDER_KEY_STR)).thenReturn(Optional.of(event));
+            when(paymentVendorPort.cancelPayment(any())).thenReturn(vendorResult);
+
+            cancelPaymentService.cancel(command);
+
+            verify(saveRefundPort).save(argThat(refund ->
+                    refund.getRefundType() == RefundType.PARTIAL_REFUND
+                            && refund.getRefundAmount().equals(20000L)
+            ));
+        }
+
+        @Test
+        @DisplayName("환불 기록에 PG 응답 정보가 포함된다")
+        void shouldIncludePgResponseInRefundRecord() {
+            Payment payment = createPaymentWithId(5L, 1L, ORDER_KEY, 50000L, "tno_123");
+            PspPaymentEvent event = createCompleteEvent(ORDER_KEY_STR, "tno_123", 50000L);
+            CancelPaymentCommand command = createFullCancelCommand(ORDER_KEY_STR);
+            PaymentCancelVendorResult vendorResult = createSuccessVendorResult();
+
+            when(findPaymentPort.findByOrderKey(ORDER_KEY)).thenReturn(Optional.of(payment));
+            when(findOrderPort.findById(1L)).thenReturn(Optional.of(createOrder(1L, BUYER_ID)));
+            when(findPspPaymentEventPort.findByOrderKey(ORDER_KEY_STR)).thenReturn(Optional.of(event));
+            when(paymentVendorPort.cancelPayment(any())).thenReturn(vendorResult);
+
+            cancelPaymentService.cancel(command);
+
+            verify(saveRefundPort).save(argThat(refund ->
+                    refund.getPgRawResponse() != null
+                            && refund.getPgRefundKey() != null
+            ));
+        }
+
+        @Test
+        @DisplayName("환불 기록 저장 실패 시에도 결제 취소는 정상 완료된다")
+        void shouldCompleteCancelEvenWhenRefundRecordSaveFails() {
+            Payment payment = createPaymentWithId(5L, 1L, ORDER_KEY, 50000L, "tno_123");
+            PspPaymentEvent event = createCompleteEvent(ORDER_KEY_STR, "tno_123", 50000L);
+            CancelPaymentCommand command = createFullCancelCommand(ORDER_KEY_STR);
+            PaymentCancelVendorResult vendorResult = createSuccessVendorResult();
+
+            when(findPaymentPort.findByOrderKey(ORDER_KEY)).thenReturn(Optional.of(payment));
+            when(findOrderPort.findById(1L)).thenReturn(Optional.of(createOrder(1L, BUYER_ID)));
+            when(findPspPaymentEventPort.findByOrderKey(ORDER_KEY_STR)).thenReturn(Optional.of(event));
+            when(paymentVendorPort.cancelPayment(any())).thenReturn(vendorResult);
+            doThrow(new RuntimeException("환불 기록 저장 실패")).when(saveRefundPort).save(any(Refund.class));
 
             cancelPaymentService.cancel(command);
 

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/refund/GetAdminRefundsUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/refund/GetAdminRefundsUseCaseTest.java
@@ -1,0 +1,143 @@
+package com.personal.marketnote.commerce.service.refund;
+
+import com.personal.marketnote.commerce.domain.refund.Refund;
+import com.personal.marketnote.commerce.domain.refund.RefundSnapshotState;
+import com.personal.marketnote.commerce.domain.refund.RefundType;
+import com.personal.marketnote.commerce.port.in.result.refund.GetAdminRefundResult;
+import com.personal.marketnote.commerce.port.out.refund.FindRefundPort;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GetAdminRefundsUseCase 테스트")
+class GetAdminRefundsUseCaseTest {
+
+    @InjectMocks
+    private GetAdminRefundsService getAdminRefundsService;
+
+    @Mock
+    private FindRefundPort findRefundPort;
+
+    @Nested
+    @DisplayName("환불 목록 조회 성공")
+    class GetRefundsSuccessTest {
+
+        @Test
+        @DisplayName("주문 ID로 환불 목록을 정상적으로 조회한다")
+        void shouldReturnRefundsByOrderId() {
+            // given
+            Long orderId = 1L;
+            List<Refund> refunds = List.of(
+                    createRefund(100L, 1L, orderId, RefundType.FULL_REFUND, 50000L),
+                    createRefund(101L, 1L, orderId, RefundType.PARTIAL_REFUND, 20000L)
+            );
+            when(findRefundPort.findByOrderId(orderId)).thenReturn(refunds);
+
+            // when
+            List<GetAdminRefundResult> results = getAdminRefundsService.getRefundsByOrderId(orderId);
+
+            // then
+            assertThat(results).hasSize(2);
+            assertThat(results.get(0).id()).isEqualTo(100L);
+            assertThat(results.get(0).refundType()).isEqualTo(RefundType.FULL_REFUND);
+            assertThat(results.get(0).refundAmount()).isEqualTo(50000L);
+            assertThat(results.get(1).id()).isEqualTo(101L);
+            assertThat(results.get(1).refundType()).isEqualTo(RefundType.PARTIAL_REFUND);
+            verify(findRefundPort).findByOrderId(orderId);
+        }
+
+        @Test
+        @DisplayName("환불이 없는 주문 ID로 조회하면 빈 목록을 반환한다")
+        void shouldReturnEmptyListWhenNoRefundsExist() {
+            // given
+            Long orderId = 999L;
+            when(findRefundPort.findByOrderId(orderId)).thenReturn(List.of());
+
+            // when
+            List<GetAdminRefundResult> results = getAdminRefundsService.getRefundsByOrderId(orderId);
+
+            // then
+            assertThat(results).isEmpty();
+            verify(findRefundPort).findByOrderId(orderId);
+        }
+
+        @Test
+        @DisplayName("환불 결과에 PG 응답 정보가 포함된다")
+        void shouldIncludePgResponseInResult() {
+            // given
+            Long orderId = 1L;
+            Refund refund = createRefundWithPgInfo(100L, 1L, orderId);
+            when(findRefundPort.findByOrderId(orderId)).thenReturn(List.of(refund));
+
+            // when
+            List<GetAdminRefundResult> results = getAdminRefundsService.getRefundsByOrderId(orderId);
+
+            // then
+            assertThat(results).hasSize(1);
+            GetAdminRefundResult result = results.get(0);
+            assertThat(result.pgRefundKey()).isEqualTo("tno_123");
+            assertThat(result.pgRawResponse()).isEqualTo("{\"res_cd\":\"0000\"}");
+            assertThat(result.processedBy()).isEqualTo("SYSTEM");
+            assertThat(result.cancelReason()).isEqualTo("고객 요청");
+        }
+    }
+
+    @Nested
+    @DisplayName("Port 호출 검증")
+    class PortInvocationTest {
+
+        @Test
+        @DisplayName("findRefundPort.findByOrderId를 정확히 한 번 호출한다")
+        void shouldCallFindByOrderIdExactlyOnce() {
+            // given
+            Long orderId = 1L;
+            when(findRefundPort.findByOrderId(orderId)).thenReturn(List.of());
+
+            // when
+            getAdminRefundsService.getRefundsByOrderId(orderId);
+
+            // then
+            verify(findRefundPort).findByOrderId(orderId);
+        }
+    }
+
+    private Refund createRefund(Long id, Long paymentId, Long orderId, RefundType type, Long amount) {
+        return Refund.from(RefundSnapshotState.builder()
+                .id(id)
+                .paymentId(paymentId)
+                .orderId(orderId)
+                .refundType(type)
+                .refundAmount(amount)
+                .cancelReason("테스트")
+                .processedBy("SYSTEM")
+                .createdAt(LocalDateTime.of(2026, 2, 24, 10, 0))
+                .build());
+    }
+
+    private Refund createRefundWithPgInfo(Long id, Long paymentId, Long orderId) {
+        return Refund.from(RefundSnapshotState.builder()
+                .id(id)
+                .paymentId(paymentId)
+                .orderId(orderId)
+                .refundType(RefundType.FULL_REFUND)
+                .refundAmount(50000L)
+                .cancelReason("고객 요청")
+                .processedBy("SYSTEM")
+                .pgRefundKey("tno_123")
+                .pgRawResponse("{\"res_cd\":\"0000\"}")
+                .createdAt(LocalDateTime.of(2026, 2, 24, 10, 0))
+                .build());
+    }
+}

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/refund/Refund.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/refund/Refund.java
@@ -1,0 +1,112 @@
+package com.personal.marketnote.commerce.domain.refund;
+
+import com.personal.marketnote.common.utility.FormatValidator;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * 환불 도메인 모델.
+ * <p>
+ * 결제 취소 시 생성되는 환불 상세 정보를 관리한다.
+ * 환불 유형(전체/부분), 환불 금액, 취소 사유, 처리자, PG 응답 정보를 포함한다.
+ * </p>
+ *
+ * @author 성효빈
+ * @since 2026-03-02
+ */
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+@Getter
+public class Refund {
+    private Long id;
+    private Long paymentId;
+    private Long orderId;
+    private RefundType refundType;
+    private Long refundAmount;
+    private String cancelReason;
+    private String processedBy;
+    private String pgRefundKey;
+    private String pgRawResponse;
+    private LocalDateTime createdAt;
+
+    /**
+     * 새 환불을 생성한다.
+     *
+     * @param state 환불 생성 상태 객체
+     * @return 새 환불 도메인 객체
+     * @throws IllegalArgumentException 환불 금액이 0 이하이거나, 환불 유형 또는 결제 ID가 null인 경우
+     */
+    public static Refund from(RefundCreateState state) {
+        validate(state);
+        return Refund.builder()
+                .paymentId(state.getPaymentId())
+                .orderId(state.getOrderId())
+                .refundType(state.getRefundType())
+                .refundAmount(state.getRefundAmount())
+                .cancelReason(state.getCancelReason())
+                .processedBy(state.getProcessedBy())
+                .pgRefundKey(state.getPgRefundKey())
+                .pgRawResponse(state.getPgRawResponse())
+                .build();
+    }
+
+    /**
+     * 영속화된 상태로부터 환불 도메인 객체를 복원한다.
+     *
+     * @param state 환불 스냅샷 상태 객체
+     * @return 복원된 환불 도메인 객체
+     */
+    public static Refund from(RefundSnapshotState state) {
+        return Refund.builder()
+                .id(state.getId())
+                .paymentId(state.getPaymentId())
+                .orderId(state.getOrderId())
+                .refundType(state.getRefundType())
+                .refundAmount(state.getRefundAmount())
+                .cancelReason(state.getCancelReason())
+                .processedBy(state.getProcessedBy())
+                .pgRefundKey(state.getPgRefundKey())
+                .pgRawResponse(state.getPgRawResponse())
+                .createdAt(state.getCreatedAt())
+                .build();
+    }
+
+    /**
+     * 전체 환불인지 확인한다.
+     *
+     * @return 전체 환불이면 true
+     */
+    public boolean isFullRefund() {
+        return this.refundType == RefundType.FULL_REFUND;
+    }
+
+    /**
+     * 부분 환불인지 확인한다.
+     *
+     * @return 부분 환불이면 true
+     */
+    public boolean isPartialRefund() {
+        return this.refundType == RefundType.PARTIAL_REFUND;
+    }
+
+    private static void validate(RefundCreateState state) {
+        if (FormatValidator.hasNoValue(state.getPaymentId())) {
+            throw new IllegalArgumentException("결제 ID는 필수입니다");
+        }
+        if (FormatValidator.hasNoValue(state.getOrderId())) {
+            throw new IllegalArgumentException("주문 ID는 필수입니다");
+        }
+        if (FormatValidator.hasNoValue(state.getRefundType())) {
+            throw new IllegalArgumentException("환불 유형은 필수입니다");
+        }
+        if (FormatValidator.hasNoValue(state.getRefundAmount()) || state.getRefundAmount() <= 0) {
+            throw new IllegalArgumentException("환불 금액은 0보다 커야 합니다");
+        }
+    }
+}

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/refund/RefundCreateState.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/refund/RefundCreateState.java
@@ -1,0 +1,26 @@
+package com.personal.marketnote.commerce.domain.refund;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 환불 생성 시 필요한 상태 객체.
+ *
+ * @author 성효빈
+ * @since 2026-03-02
+ */
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class RefundCreateState {
+    private final Long paymentId;
+    private final Long orderId;
+    private final RefundType refundType;
+    private final Long refundAmount;
+    private final String cancelReason;
+    private final String processedBy;
+    private final String pgRefundKey;
+    private final String pgRawResponse;
+}

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/refund/RefundSnapshotState.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/refund/RefundSnapshotState.java
@@ -1,0 +1,30 @@
+package com.personal.marketnote.commerce.domain.refund;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+/**
+ * 환불 영속화 상태 복원 객체.
+ *
+ * @author 성효빈
+ * @since 2026-03-02
+ */
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class RefundSnapshotState {
+    private final Long id;
+    private final Long paymentId;
+    private final Long orderId;
+    private final RefundType refundType;
+    private final Long refundAmount;
+    private final String cancelReason;
+    private final String processedBy;
+    private final String pgRefundKey;
+    private final String pgRawResponse;
+    private final LocalDateTime createdAt;
+}

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/refund/RefundType.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/refund/RefundType.java
@@ -1,0 +1,19 @@
+package com.personal.marketnote.commerce.domain.refund;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 환불 유형을 정의하는 열거형.
+ *
+ * @author 성효빈
+ * @since 2026-03-02
+ */
+@RequiredArgsConstructor
+@Getter
+public enum RefundType {
+    FULL_REFUND("전체 환불"),
+    PARTIAL_REFUND("부분 환불");
+
+    private final String description;
+}

--- a/commerce-service/commerce-domain/src/test/java/com/personal/marketnote/commerce/domain/refund/RefundTest.java
+++ b/commerce-service/commerce-domain/src/test/java/com/personal/marketnote/commerce/domain/refund/RefundTest.java
@@ -1,0 +1,247 @@
+package com.personal.marketnote.commerce.domain.refund;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("Refund 도메인 테스트")
+class RefundTest {
+
+    @Nested
+    @DisplayName("생성 테스트")
+    class CreateTest {
+
+        @Test
+        @DisplayName("전체 환불을 정상적으로 생성한다")
+        void shouldCreateFullRefund() {
+            // given
+            RefundCreateState state = RefundCreateState.builder()
+                    .paymentId(1L)
+                    .orderId(10L)
+                    .refundType(RefundType.FULL_REFUND)
+                    .refundAmount(50000L)
+                    .cancelReason("고객 요청")
+                    .processedBy("SYSTEM")
+                    .pgRefundKey("tno_123")
+                    .pgRawResponse("{\"res_cd\":\"0000\"}")
+                    .build();
+
+            // when
+            Refund refund = Refund.from(state);
+
+            // then
+            assertThat(refund.getPaymentId()).isEqualTo(1L);
+            assertThat(refund.getOrderId()).isEqualTo(10L);
+            assertThat(refund.getRefundType()).isEqualTo(RefundType.FULL_REFUND);
+            assertThat(refund.getRefundAmount()).isEqualTo(50000L);
+            assertThat(refund.getCancelReason()).isEqualTo("고객 요청");
+            assertThat(refund.getProcessedBy()).isEqualTo("SYSTEM");
+            assertThat(refund.getPgRefundKey()).isEqualTo("tno_123");
+            assertThat(refund.getPgRawResponse()).isEqualTo("{\"res_cd\":\"0000\"}");
+        }
+
+        @Test
+        @DisplayName("부분 환불을 정상적으로 생성한다")
+        void shouldCreatePartialRefund() {
+            // given
+            RefundCreateState state = RefundCreateState.builder()
+                    .paymentId(1L)
+                    .orderId(10L)
+                    .refundType(RefundType.PARTIAL_REFUND)
+                    .refundAmount(20000L)
+                    .cancelReason("부분 취소")
+                    .processedBy("SYSTEM")
+                    .build();
+
+            // when
+            Refund refund = Refund.from(state);
+
+            // then
+            assertThat(refund.getRefundType()).isEqualTo(RefundType.PARTIAL_REFUND);
+            assertThat(refund.getRefundAmount()).isEqualTo(20000L);
+        }
+    }
+
+    @Nested
+    @DisplayName("생성 검증 실패 테스트")
+    class CreateValidationFailureTest {
+
+        @Test
+        @DisplayName("결제 ID가 null이면 IllegalArgumentException이 발생한다")
+        void shouldThrowWhenPaymentIdIsNull() {
+            // given
+            RefundCreateState state = RefundCreateState.builder()
+                    .paymentId(null)
+                    .orderId(10L)
+                    .refundType(RefundType.FULL_REFUND)
+                    .refundAmount(50000L)
+                    .build();
+
+            // when & then
+            assertThatThrownBy(() -> Refund.from(state))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("결제 ID");
+        }
+
+        @Test
+        @DisplayName("주문 ID가 null이면 IllegalArgumentException이 발생한다")
+        void shouldThrowWhenOrderIdIsNull() {
+            // given
+            RefundCreateState state = RefundCreateState.builder()
+                    .paymentId(1L)
+                    .orderId(null)
+                    .refundType(RefundType.FULL_REFUND)
+                    .refundAmount(50000L)
+                    .build();
+
+            // when & then
+            assertThatThrownBy(() -> Refund.from(state))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("주문 ID");
+        }
+
+        @Test
+        @DisplayName("환불 유형이 null이면 IllegalArgumentException이 발생한다")
+        void shouldThrowWhenRefundTypeIsNull() {
+            // given
+            RefundCreateState state = RefundCreateState.builder()
+                    .paymentId(1L)
+                    .orderId(10L)
+                    .refundType(null)
+                    .refundAmount(50000L)
+                    .build();
+
+            // when & then
+            assertThatThrownBy(() -> Refund.from(state))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("환불 유형");
+        }
+
+        @Test
+        @DisplayName("환불 금액이 null이면 IllegalArgumentException이 발생한다")
+        void shouldThrowWhenRefundAmountIsNull() {
+            // given
+            RefundCreateState state = RefundCreateState.builder()
+                    .paymentId(1L)
+                    .orderId(10L)
+                    .refundType(RefundType.FULL_REFUND)
+                    .refundAmount(null)
+                    .build();
+
+            // when & then
+            assertThatThrownBy(() -> Refund.from(state))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("환불 금액");
+        }
+
+        @Test
+        @DisplayName("환불 금액이 0이면 IllegalArgumentException이 발생한다")
+        void shouldThrowWhenRefundAmountIsZero() {
+            // given
+            RefundCreateState state = RefundCreateState.builder()
+                    .paymentId(1L)
+                    .orderId(10L)
+                    .refundType(RefundType.FULL_REFUND)
+                    .refundAmount(0L)
+                    .build();
+
+            // when & then
+            assertThatThrownBy(() -> Refund.from(state))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("환불 금액");
+        }
+
+        @Test
+        @DisplayName("환불 금액이 음수이면 IllegalArgumentException이 발생한다")
+        void shouldThrowWhenRefundAmountIsNegative() {
+            // given
+            RefundCreateState state = RefundCreateState.builder()
+                    .paymentId(1L)
+                    .orderId(10L)
+                    .refundType(RefundType.FULL_REFUND)
+                    .refundAmount(-1000L)
+                    .build();
+
+            // when & then
+            assertThatThrownBy(() -> Refund.from(state))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("환불 금액");
+        }
+    }
+
+    @Nested
+    @DisplayName("스냅샷 복원 테스트")
+    class SnapshotRestoreTest {
+
+        @Test
+        @DisplayName("스냅샷 상태로부터 환불을 정상적으로 복원한다")
+        void shouldRestoreFromSnapshotState() {
+            // given
+            LocalDateTime createdAt = LocalDateTime.of(2026, 2, 24, 10, 0);
+            RefundSnapshotState state = RefundSnapshotState.builder()
+                    .id(100L)
+                    .paymentId(1L)
+                    .orderId(10L)
+                    .refundType(RefundType.FULL_REFUND)
+                    .refundAmount(50000L)
+                    .cancelReason("고객 요청")
+                    .processedBy("SYSTEM")
+                    .pgRefundKey("tno_123")
+                    .pgRawResponse("{\"res_cd\":\"0000\"}")
+                    .createdAt(createdAt)
+                    .build();
+
+            // when
+            Refund refund = Refund.from(state);
+
+            // then
+            assertThat(refund.getId()).isEqualTo(100L);
+            assertThat(refund.getPaymentId()).isEqualTo(1L);
+            assertThat(refund.getCreatedAt()).isEqualTo(createdAt);
+        }
+    }
+
+    @Nested
+    @DisplayName("술어 메서드 테스트")
+    class PredicateTest {
+
+        @Test
+        @DisplayName("전체 환불이면 isFullRefund가 true를 반환한다")
+        void shouldReturnTrueForFullRefund() {
+            // given
+            Refund refund = createRefund(RefundType.FULL_REFUND, 50000L);
+
+            // then
+            assertThat(refund.isFullRefund()).isTrue();
+            assertThat(refund.isPartialRefund()).isFalse();
+        }
+
+        @Test
+        @DisplayName("부분 환불이면 isPartialRefund가 true를 반환한다")
+        void shouldReturnTrueForPartialRefund() {
+            // given
+            Refund refund = createRefund(RefundType.PARTIAL_REFUND, 20000L);
+
+            // then
+            assertThat(refund.isPartialRefund()).isTrue();
+            assertThat(refund.isFullRefund()).isFalse();
+        }
+    }
+
+    private Refund createRefund(RefundType refundType, Long amount) {
+        RefundCreateState state = RefundCreateState.builder()
+                .paymentId(1L)
+                .orderId(10L)
+                .refundType(refundType)
+                .refundAmount(amount)
+                .cancelReason("테스트")
+                .processedBy("SYSTEM")
+                .build();
+        return Refund.from(state);
+    }
+}


### PR DESCRIPTION
## partially addresses #216
## resolves #923

## Task
- [x] Refund 도메인 모델 추가 (RefundType, RefundCreateState, RefundSnapshotState, Refund)
- [x] 도메인 검증 로직 추가 (paymentId, orderId, refundType, refundAmount)
- [x] SaveRefundPort, FindRefundPort 아웃바운드 포트 추가
- [x] GetAdminRefundsUseCase / GetAdminRefundsService 구현
- [x] CancelPaymentService에 환불 상세 기록 저장 로직 추가
- [x] RefundJpaEntity, RefundJpaRepository, RefundPersistenceAdapter 구현
- [x] AdminRefundController (GET /api/v1/admin/refunds) 관리자 API 추가
- [x] Flyway 마이그레이션 V894 (refund 테이블 생성)
- [x] RefundTest 도메인 단위 테스트 (11 cases)
- [x] GetAdminRefundsUseCaseTest 유스케이스 테스트 (4 cases)
- [x] CancelPaymentUseCaseTest 환불 기록 검증 테스트 (4 cases)