### PR TITLE
[#216][#924] feat: 정산 실패 재시도/복구 기능 추가

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/settlement/controller/SettlementController.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/settlement/controller/SettlementController.java
@@ -1,9 +1,6 @@
 package com.personal.marketnote.commerce.adapter.in.web.settlement.controller;
 
-import com.personal.marketnote.commerce.adapter.in.web.settlement.controller.apidocs.ExecuteSettlementApiDocs;
-import com.personal.marketnote.commerce.adapter.in.web.settlement.controller.apidocs.GetSettlementApiDocs;
-import com.personal.marketnote.commerce.adapter.in.web.settlement.controller.apidocs.GetSettlementDetailApiDocs;
-import com.personal.marketnote.commerce.adapter.in.web.settlement.controller.apidocs.GetSettlementsApiDocs;
+import com.personal.marketnote.commerce.adapter.in.web.settlement.controller.apidocs.*;
 import com.personal.marketnote.commerce.adapter.in.web.settlement.mapper.SettlementRequestToCommandMapper;
 import com.personal.marketnote.commerce.adapter.in.web.settlement.request.ExecuteSettlementRequest;
 import com.personal.marketnote.commerce.adapter.in.web.settlement.response.GetSettlementDetailResponse;
@@ -13,8 +10,10 @@ import com.personal.marketnote.commerce.port.in.result.settlement.GetSettlementD
 import com.personal.marketnote.commerce.port.in.result.settlement.GetSettlementResult;
 import com.personal.marketnote.commerce.port.in.result.settlement.GetSettlementsResult;
 import com.personal.marketnote.commerce.port.in.usecase.settlement.ExecuteSettlementUseCase;
+import com.personal.marketnote.commerce.port.in.usecase.settlement.GetFailedSettlementsUseCase;
 import com.personal.marketnote.commerce.port.in.usecase.settlement.GetSettlementDetailUseCase;
 import com.personal.marketnote.commerce.port.in.usecase.settlement.GetSettlementUseCase;
+import com.personal.marketnote.commerce.port.in.usecase.settlement.RetryFailedSettlementUseCase;
 import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -47,6 +46,8 @@ import static com.personal.marketnote.common.utility.ApiConstant.ADMIN_POINTCUT;
 @Validated
 public class SettlementController {
     private final ExecuteSettlementUseCase executeSettlementUseCase;
+    private final RetryFailedSettlementUseCase retryFailedSettlementUseCase;
+    private final GetFailedSettlementsUseCase getFailedSettlementsUseCase;
     private final GetSettlementUseCase getSettlementUseCase;
     private final GetSettlementDetailUseCase getSettlementDetailUseCase;
 
@@ -74,6 +75,57 @@ public class SettlementController {
                         HttpStatus.OK,
                         DEFAULT_SUCCESS_CODE,
                         "정산 실행 성공"
+                ),
+                HttpStatus.OK
+        );
+    }
+
+    /**
+     * 실패한 정산을 재시도한다.
+     *
+     * @param id 정산 ID
+     * @return 재시도 결과 응답
+     * @author 성효빈
+     * @since 2026-03-02
+     */
+    @PostMapping("/{id}/retry")
+    @PreAuthorize(ADMIN_POINTCUT)
+    @RetryFailedSettlementApiDocs
+    public ResponseEntity<BaseResponse<Void>> retrySettlement(
+            @PathVariable("id") Long id
+    ) {
+        retryFailedSettlementUseCase.retrySettlement(id);
+
+        return new ResponseEntity<>(
+                BaseResponse.of(
+                        null,
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "정산 재시도 성공"
+                ),
+                HttpStatus.OK
+        );
+    }
+
+    /**
+     * 실패한 정산 목록을 조회한다.
+     *
+     * @return 실패한 정산 목록 응답
+     * @author 성효빈
+     * @since 2026-03-02
+     */
+    @GetMapping("/failed")
+    @PreAuthorize(ADMIN_POINTCUT)
+    @GetFailedSettlementsApiDocs
+    public ResponseEntity<BaseResponse<GetSettlementsResponse>> getFailedSettlements() {
+        GetSettlementsResult result = getFailedSettlementsUseCase.getFailedSettlements();
+
+        return new ResponseEntity<>(
+                BaseResponse.of(
+                        GetSettlementsResponse.from(result),
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "실패한 정산 목록 조회 성공"
                 ),
                 HttpStatus.OK
         );

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/settlement/controller/apidocs/GetFailedSettlementsApiDocs.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/settlement/controller/apidocs/GetFailedSettlementsApiDocs.java
@@ -1,0 +1,70 @@
+package com.personal.marketnote.commerce.adapter.in.web.settlement.controller.apidocs;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.*;
+
+/**
+ * 실패한 정산 목록 조회 API 문서.
+ *
+ * @author 성효빈
+ * @since 2026-03-02
+ */
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Operation(
+        summary = "(관리자) 실패한 정산 목록 조회",
+        description = """
+                작성일자: 2026-03-02
+
+                작성자: 성효빈
+
+                ---
+
+                ## Description
+
+                - FAILED 상태의 정산 목록을 조회합니다.
+
+                - 재시도가 필요한 정산을 식별하기 위해 사용합니다.
+                """,
+        security = {@SecurityRequirement(name = "bearer")},
+        responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "실패한 정산 목록 조회 성공",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 200,
+                                          "code": "SUC01",
+                                          "timestamp": "2026-03-02T12:00:00.000",
+                                          "content": {
+                                            "settlements": [
+                                              {
+                                                "id": 1,
+                                                "sellerId": 10,
+                                                "year": 2026,
+                                                "month": 2,
+                                                "totalAllocatedAmount": 100000,
+                                                "pgFeeAmount": 3000,
+                                                "platformFeeAmount": 5000,
+                                                "sellerPayoutAmount": 92000,
+                                                "status": "FAILED",
+                                                "createdAt": "2026-03-02T10:00:00.000",
+                                                "modifiedAt": "2026-03-02T10:00:01.000"
+                                              }
+                                            ]
+                                          },
+                                          "message": "실패한 정산 목록 조회 성공"
+                                        }
+                                        """)
+                        )
+                )
+        })
+public @interface GetFailedSettlementsApiDocs {
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/settlement/controller/apidocs/RetryFailedSettlementApiDocs.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/settlement/controller/apidocs/RetryFailedSettlementApiDocs.java
@@ -1,0 +1,74 @@
+package com.personal.marketnote.commerce.adapter.in.web.settlement.controller.apidocs;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.*;
+
+/**
+ * 실패한 정산 재시도 API 문서.
+ *
+ * @author 성효빈
+ * @since 2026-03-02
+ */
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Operation(
+        summary = "(관리자) 실패한 정산 재시도",
+        description = """
+                작성일자: 2026-03-02
+
+                작성자: 성효빈
+
+                ---
+
+                ## Description
+
+                - FAILED 상태의 정산을 재시도합니다.
+
+                - 분개(Ledger) 기록을 다시 실행하고 정산을 완료 처리합니다.
+
+                - PaymentAllocation은 최초 정산 시 이미 할당되어 있으므로 재할당하지 않습니다.
+
+                ---
+
+                ## Path Variable
+
+                | **키** | **타입** | **설명** | **필수 여부** | **예시** |
+                | --- | --- | --- | --- | --- |
+                | id | number | 정산 ID | Y | 1 |
+                """,
+        security = {@SecurityRequirement(name = "bearer")},
+        parameters = @Parameter(name = "id", description = "정산 ID", required = true, example = "1"),
+        responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "정산 재시도 성공",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 200,
+                                          "code": "SUC01",
+                                          "timestamp": "2026-03-02T12:00:00.000",
+                                          "content": null,
+                                          "message": "정산 재시도 성공"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "404",
+                        description = "정산을 찾을 수 없음"
+                ),
+                @ApiResponse(
+                        responseCode = "500",
+                        description = "FAILED 상태가 아닌 정산에 대한 재시도 시도"
+                )
+        })
+public @interface RetryFailedSettlementApiDocs {
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/settlement/SettlementPersistenceAdapter.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/settlement/SettlementPersistenceAdapter.java
@@ -4,6 +4,7 @@ import com.personal.marketnote.commerce.adapter.out.persistence.settlement.entit
 import com.personal.marketnote.commerce.adapter.out.persistence.settlement.mapper.SettlementEntityToDomainMapper;
 import com.personal.marketnote.commerce.adapter.out.persistence.settlement.repository.SettlementJpaRepository;
 import com.personal.marketnote.commerce.domain.settlement.Settlement;
+import com.personal.marketnote.commerce.domain.settlement.SettlementStatus;
 import com.personal.marketnote.commerce.port.out.settlement.FindSettlementPort;
 import com.personal.marketnote.commerce.port.out.settlement.SaveSettlementPort;
 import com.personal.marketnote.commerce.port.out.settlement.UpdateSettlementPort;
@@ -52,6 +53,13 @@ public class SettlementPersistenceAdapter implements SaveSettlementPort, FindSet
     @Override
     public List<Settlement> findAllBySellerIdAndYear(Long sellerId, Integer year) {
         return settlementJpaRepository.findAllBySellerIdAndYear(sellerId, year).stream()
+                .map(SettlementEntityToDomainMapper::toDomain)
+                .toList();
+    }
+
+    @Override
+    public List<Settlement> findAllByStatus(SettlementStatus status) {
+        return settlementJpaRepository.findAllByStatus(status).stream()
                 .map(SettlementEntityToDomainMapper::toDomain)
                 .toList();
     }

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/settlement/repository/SettlementJpaRepository.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/settlement/repository/SettlementJpaRepository.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.commerce.adapter.out.persistence.settlement.repository;
 
 import com.personal.marketnote.commerce.adapter.out.persistence.settlement.entity.SettlementJpaEntity;
+import com.personal.marketnote.commerce.domain.settlement.SettlementStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -15,4 +16,6 @@ public interface SettlementJpaRepository extends JpaRepository<SettlementJpaEnti
     boolean existsBySellerIdAndYearAndMonth(Long sellerId, Integer year, Integer month);
 
     List<SettlementJpaEntity> findAllBySellerIdAndYear(Long sellerId, Integer year);
+
+    List<SettlementJpaEntity> findAllByStatus(SettlementStatus status);
 }

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/settlement/GetFailedSettlementsUseCase.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/settlement/GetFailedSettlementsUseCase.java
@@ -1,0 +1,19 @@
+package com.personal.marketnote.commerce.port.in.usecase.settlement;
+
+import com.personal.marketnote.commerce.port.in.result.settlement.GetSettlementsResult;
+
+/**
+ * 실패한 정산 목록을 조회하는 유스케이스.
+ *
+ * @author 성효빈
+ * @since 2026-03-02
+ */
+public interface GetFailedSettlementsUseCase {
+
+    /**
+     * 실패 상태인 정산 목록을 조회한다.
+     *
+     * @return 실패한 정산 목록
+     */
+    GetSettlementsResult getFailedSettlements();
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/settlement/RetryFailedSettlementUseCase.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/settlement/RetryFailedSettlementUseCase.java
@@ -1,0 +1,19 @@
+package com.personal.marketnote.commerce.port.in.usecase.settlement;
+
+/**
+ * 실패한 정산을 재시도하는 유스케이스.
+ *
+ * @author 성효빈
+ * @since 2026-03-02
+ */
+public interface RetryFailedSettlementUseCase {
+
+    /**
+     * 실패한 정산을 재시도한다.
+     *
+     * @param settlementId 재시도할 정산 ID
+     * @throws com.personal.marketnote.commerce.exception.SettlementNotFoundException 정산이 존재하지 않는 경우
+     * @throws com.personal.marketnote.commerce.domain.settlement.InvalidSettlementStatusTransitionException 정산이 FAILED 상태가 아닌 경우
+     */
+    void retrySettlement(Long settlementId);
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/settlement/FindSettlementPort.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/settlement/FindSettlementPort.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.commerce.port.out.settlement;
 
 import com.personal.marketnote.commerce.domain.settlement.Settlement;
+import com.personal.marketnote.commerce.domain.settlement.SettlementStatus;
 
 import java.util.List;
 import java.util.Optional;
@@ -23,4 +24,14 @@ public interface FindSettlementPort {
      * @Description 판매자 ID와 연도로 정산 목록을 조회합니다.
      */
     List<Settlement> findAllBySellerIdAndYear(Long sellerId, Integer year);
+
+    /**
+     * 특정 상태의 정산 목록을 조회한다.
+     *
+     * @param status 조회할 정산 상태
+     * @return 해당 상태의 정산 목록
+     * @author 성효빈
+     * @since 2026-03-02
+     */
+    List<Settlement> findAllByStatus(SettlementStatus status);
 }

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/settlement/ExecuteSettlementService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/settlement/ExecuteSettlementService.java
@@ -1,15 +1,11 @@
 package com.personal.marketnote.commerce.service.settlement;
 
 import com.personal.marketnote.commerce.domain.settlement.PaymentAllocation;
-import com.personal.marketnote.commerce.domain.settlement.Settlement;
-import com.personal.marketnote.commerce.domain.settlement.SettlementCreateState;
 import com.personal.marketnote.commerce.exception.InvalidFeeRateException;
 import com.personal.marketnote.commerce.exception.NoUnsettledAllocationException;
-import com.personal.marketnote.commerce.exception.SettlementAlreadyExistsException;
 import com.personal.marketnote.commerce.port.in.command.settlement.ExecuteSettlementCommand;
-import com.personal.marketnote.commerce.port.in.usecase.ledger.RecordLedgerEntryUseCase;
 import com.personal.marketnote.commerce.port.in.usecase.settlement.ExecuteSettlementUseCase;
-import com.personal.marketnote.commerce.port.out.settlement.*;
+import com.personal.marketnote.commerce.port.out.settlement.FindPaymentAllocationPort;
 import com.personal.marketnote.common.application.UseCase;
 import com.personal.marketnote.common.utility.FormatValidator;
 import lombok.RequiredArgsConstructor;
@@ -22,6 +18,17 @@ import java.util.stream.Collectors;
 
 import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
 
+/**
+ * 정산 실행 서비스.
+ * <p>
+ * 판매자별 독립 트랜잭션으로 정산을 처리한다.
+ * 한 판매자의 정산 실패가 다른 판매자에게 영향을 주지 않으며,
+ * 실패한 정산은 FAILED 상태로 저장되어 재시도가 가능하다.
+ * </p>
+ *
+ * @author 성효빈
+ * @since 2026-02-16
+ */
 @UseCase
 @RequiredArgsConstructor
 @Slf4j
@@ -29,11 +36,7 @@ public class ExecuteSettlementService implements ExecuteSettlementUseCase {
     private static final int BASIS_POINT_DENOMINATOR = 10000;
 
     private final FindPaymentAllocationPort findPaymentAllocationPort;
-    private final FindSettlementPort findSettlementPort;
-    private final SaveSettlementPort saveSettlementPort;
-    private final UpdateSettlementPort updateSettlementPort;
-    private final UpdatePaymentAllocationPort updatePaymentAllocationPort;
-    private final RecordLedgerEntryUseCase recordLedgerEntryUseCase;
+    private final ProcessSellerSettlementService processSellerSettlementService;
 
     @Override
     @Transactional(isolation = READ_COMMITTED)
@@ -50,11 +53,22 @@ public class ExecuteSettlementService implements ExecuteSettlementUseCase {
         Map<Long, List<PaymentAllocation>> allocationsBySeller = unsettledAllocations.stream()
                 .collect(Collectors.groupingBy(PaymentAllocation::getSellerId));
 
+        int failedCount = 0;
         for (Map.Entry<Long, List<PaymentAllocation>> entry : allocationsBySeller.entrySet()) {
             Long sellerId = entry.getKey();
             List<PaymentAllocation> sellerAllocations = entry.getValue();
 
-            processSellerSettlement(command, sellerId, sellerAllocations);
+            try {
+                processSellerSettlementService.process(command, sellerId, sellerAllocations);
+            } catch (Exception e) {
+                failedCount++;
+                log.error("판매자 정산 실패 - sellerId: {}, year: {}, month: {}, error: {}",
+                        sellerId, command.year(), command.month(), e.getMessage(), e);
+            }
+        }
+
+        if (failedCount > 0) {
+            log.warn("정산 실행 완료 - 총 {}건 중 {}건 실패", allocationsBySeller.size(), failedCount);
         }
     }
 
@@ -69,52 +83,5 @@ public class ExecuteSettlementService implements ExecuteSettlementUseCase {
             throw new InvalidFeeRateException("수수료율 합계가 100%를 초과합니다. pgFeeRate=" + command.pgFeeRate()
                     + ", platformFeeRate=" + command.platformFeeRate());
         }
-    }
-
-    private void processSellerSettlement(ExecuteSettlementCommand command, Long sellerId,
-                                         List<PaymentAllocation> sellerAllocations) {
-        Integer year = command.year();
-        Integer month = command.month();
-
-        if (findSettlementPort.existsBySellerIdAndYearAndMonth(sellerId, year, month)) {
-            throw new SettlementAlreadyExistsException(sellerId, year, month);
-        }
-
-        long totalAllocatedAmount = sellerAllocations.stream()
-                .mapToLong(PaymentAllocation::getAllocatedAmount)
-                .sum();
-
-        long pgFeeAmount = Math.multiplyExact(totalAllocatedAmount, command.pgFeeRate()) / BASIS_POINT_DENOMINATOR;
-        long platformFeeAmount = Math.multiplyExact(totalAllocatedAmount, command.platformFeeRate()) / BASIS_POINT_DENOMINATOR;
-        long sellerPayoutAmount = totalAllocatedAmount - pgFeeAmount - platformFeeAmount;
-
-        Settlement settlement = Settlement.from(SettlementCreateState.builder()
-                .sellerId(sellerId)
-                .year(year)
-                .month(month)
-                .totalAllocatedAmount(totalAllocatedAmount)
-                .pgFeeAmount(pgFeeAmount)
-                .platformFeeAmount(platformFeeAmount)
-                .sellerPayoutAmount(sellerPayoutAmount)
-                .build());
-
-        Settlement savedSettlement = saveSettlementPort.save(settlement);
-        Long settlementId = savedSettlement.getId();
-
-        List<Long> allocationIds = sellerAllocations.stream()
-                .map(PaymentAllocation::getId)
-                .toList();
-        updatePaymentAllocationPort.assignSettlement(allocationIds, settlementId);
-
-        recordLedgerEntryUseCase.recordPgSettlement(settlementId, totalAllocatedAmount, pgFeeAmount);
-
-        long sellerSettlementDebit = sellerPayoutAmount + platformFeeAmount;
-        recordLedgerEntryUseCase.recordSellerSettlement(settlementId, sellerSettlementDebit, sellerPayoutAmount, platformFeeAmount);
-
-        savedSettlement.complete();
-        updateSettlementPort.update(savedSettlement);
-
-        log.info("정산 완료 - settlementId: {}, sellerId: {}, year: {}, month: {}, total: {}, pgFee: {}, platformFee: {}, sellerPayout: {}",
-                settlementId, sellerId, year, month, totalAllocatedAmount, pgFeeAmount, platformFeeAmount, sellerPayoutAmount);
     }
 }

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/settlement/GetFailedSettlementsService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/settlement/GetFailedSettlementsService.java
@@ -1,0 +1,33 @@
+package com.personal.marketnote.commerce.service.settlement;
+
+import com.personal.marketnote.commerce.domain.settlement.Settlement;
+import com.personal.marketnote.commerce.domain.settlement.SettlementStatus;
+import com.personal.marketnote.commerce.port.in.result.settlement.GetSettlementsResult;
+import com.personal.marketnote.commerce.port.in.usecase.settlement.GetFailedSettlementsUseCase;
+import com.personal.marketnote.commerce.port.out.settlement.FindSettlementPort;
+import com.personal.marketnote.common.application.UseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+/**
+ * 실패한 정산 목록을 조회하는 서비스.
+ *
+ * @author 성효빈
+ * @since 2026-03-02
+ */
+@UseCase
+@RequiredArgsConstructor
+public class GetFailedSettlementsService implements GetFailedSettlementsUseCase {
+    private final FindSettlementPort findSettlementPort;
+
+    @Override
+    @Transactional(isolation = READ_COMMITTED, readOnly = true)
+    public GetSettlementsResult getFailedSettlements() {
+        List<Settlement> failedSettlements = findSettlementPort.findAllByStatus(SettlementStatus.FAILED);
+        return GetSettlementsResult.from(failedSettlements);
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/settlement/ProcessSellerSettlementService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/settlement/ProcessSellerSettlementService.java
@@ -1,0 +1,103 @@
+package com.personal.marketnote.commerce.service.settlement;
+
+import com.personal.marketnote.commerce.domain.settlement.PaymentAllocation;
+import com.personal.marketnote.commerce.domain.settlement.Settlement;
+import com.personal.marketnote.commerce.domain.settlement.SettlementCreateState;
+import com.personal.marketnote.commerce.exception.SettlementAlreadyExistsException;
+import com.personal.marketnote.commerce.port.in.command.settlement.ExecuteSettlementCommand;
+import com.personal.marketnote.commerce.port.in.usecase.ledger.RecordLedgerEntryUseCase;
+import com.personal.marketnote.commerce.port.out.settlement.*;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+/**
+ * 판매자별 정산 처리를 담당하는 서비스.
+ * <p>
+ * {@code REQUIRES_NEW} 전파 수준으로 판매자별 독립 트랜잭션을 보장한다.
+ * 한 판매자의 정산 실패가 다른 판매자의 정산에 영향을 주지 않는다.
+ * UseCase 인터페이스를 구현하지 않는 내부 위임 서비스이므로 {@code @Service}를 사용한다.
+ * </p>
+ *
+ * @author 성효빈
+ * @since 2026-03-02
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ProcessSellerSettlementService {
+    private static final int BASIS_POINT_DENOMINATOR = 10000;
+
+    private final FindSettlementPort findSettlementPort;
+    private final SaveSettlementPort saveSettlementPort;
+    private final UpdateSettlementPort updateSettlementPort;
+    private final UpdatePaymentAllocationPort updatePaymentAllocationPort;
+    private final RecordLedgerEntryUseCase recordLedgerEntryUseCase;
+
+    /**
+     * 개별 판매자의 정산을 독립 트랜잭션으로 처리한다.
+     * <p>
+     * 정산 생성, 배분 할당, 분개 기록, 상태 완료를 하나의 독립 트랜잭션으로 수행한다.
+     * 실패 시 해당 판매자의 정산만 FAILED 상태로 저장된다.
+     * </p>
+     *
+     * @param command            정산 실행 커맨드
+     * @param sellerId           판매자 ID
+     * @param sellerAllocations  판매자의 결제 배분 목록
+     * @author 성효빈
+     * @since 2026-03-02
+     */
+    @Transactional(isolation = READ_COMMITTED, propagation = Propagation.REQUIRES_NEW)
+    public void process(ExecuteSettlementCommand command, Long sellerId,
+                        List<PaymentAllocation> sellerAllocations) {
+        Integer year = command.year();
+        Integer month = command.month();
+
+        if (findSettlementPort.existsBySellerIdAndYearAndMonth(sellerId, year, month)) {
+            throw new SettlementAlreadyExistsException(sellerId, year, month);
+        }
+
+        long totalAllocatedAmount = sellerAllocations.stream()
+                .mapToLong(PaymentAllocation::getAllocatedAmount)
+                .sum();
+
+        long pgFeeAmount = Math.multiplyExact(totalAllocatedAmount, command.pgFeeRate()) / BASIS_POINT_DENOMINATOR;
+        long platformFeeAmount = Math.multiplyExact(totalAllocatedAmount, command.platformFeeRate()) / BASIS_POINT_DENOMINATOR;
+        long sellerPayoutAmount = totalAllocatedAmount - pgFeeAmount - platformFeeAmount;
+
+        Settlement settlement = Settlement.from(SettlementCreateState.builder()
+                .sellerId(sellerId)
+                .year(year)
+                .month(month)
+                .totalAllocatedAmount(totalAllocatedAmount)
+                .pgFeeAmount(pgFeeAmount)
+                .platformFeeAmount(platformFeeAmount)
+                .sellerPayoutAmount(sellerPayoutAmount)
+                .build());
+
+        Settlement savedSettlement = saveSettlementPort.save(settlement);
+        Long settlementId = savedSettlement.getId();
+
+        List<Long> allocationIds = sellerAllocations.stream()
+                .map(PaymentAllocation::getId)
+                .toList();
+        updatePaymentAllocationPort.assignSettlement(allocationIds, settlementId);
+
+        recordLedgerEntryUseCase.recordPgSettlement(settlementId, totalAllocatedAmount, pgFeeAmount);
+
+        long sellerSettlementDebit = sellerPayoutAmount + platformFeeAmount;
+        recordLedgerEntryUseCase.recordSellerSettlement(settlementId, sellerSettlementDebit, sellerPayoutAmount, platformFeeAmount);
+
+        savedSettlement.complete();
+        updateSettlementPort.update(savedSettlement);
+
+        log.info("정산 완료 - settlementId: {}, sellerId: {}, year: {}, month: {}, total: {}, pgFee: {}, platformFee: {}, sellerPayout: {}",
+                settlementId, sellerId, year, month, totalAllocatedAmount, pgFeeAmount, platformFeeAmount, sellerPayoutAmount);
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/settlement/RetryFailedSettlementService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/settlement/RetryFailedSettlementService.java
@@ -1,0 +1,67 @@
+package com.personal.marketnote.commerce.service.settlement;
+
+import com.personal.marketnote.commerce.domain.settlement.Settlement;
+import com.personal.marketnote.commerce.exception.SettlementNotFoundException;
+import com.personal.marketnote.commerce.port.in.usecase.ledger.RecordLedgerEntryUseCase;
+import com.personal.marketnote.commerce.port.in.usecase.settlement.RetryFailedSettlementUseCase;
+import com.personal.marketnote.commerce.port.out.settlement.FindSettlementPort;
+import com.personal.marketnote.commerce.port.out.settlement.UpdateSettlementPort;
+import com.personal.marketnote.common.application.UseCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+/**
+ * 실패한 정산을 재시도하는 서비스.
+ * <p>
+ * FAILED 상태의 정산을 PENDING으로 리셋한 후 분개 기록과 상태 완료 처리를 재실행한다.
+ * PaymentAllocation은 최초 정산 실행 시 이미 할당되어 있으므로 재할당하지 않는다.
+ * 분개 기록 중 실패하면 정산을 다시 FAILED 상태로 되돌린다.
+ * </p>
+ *
+ * @author 성효빈
+ * @since 2026-03-02
+ */
+@UseCase
+@RequiredArgsConstructor
+@Slf4j
+public class RetryFailedSettlementService implements RetryFailedSettlementUseCase {
+    private final FindSettlementPort findSettlementPort;
+    private final UpdateSettlementPort updateSettlementPort;
+    private final RecordLedgerEntryUseCase recordLedgerEntryUseCase;
+
+    @Override
+    @Transactional(isolation = READ_COMMITTED)
+    public void retrySettlement(Long settlementId) {
+        Settlement settlement = findSettlementPort.findById(settlementId)
+                .orElseThrow(() -> new SettlementNotFoundException(settlementId));
+
+        settlement.resetToPending();
+
+        try {
+            Long totalAllocatedAmount = settlement.getTotalAllocatedAmount();
+            Long pgFeeAmount = settlement.getPgFeeAmount();
+            Long platformFeeAmount = settlement.getPlatformFeeAmount();
+            Long sellerPayoutAmount = settlement.getSellerPayoutAmount();
+
+            recordLedgerEntryUseCase.recordPgSettlement(settlementId, totalAllocatedAmount, pgFeeAmount);
+
+            long sellerSettlementDebit = sellerPayoutAmount + platformFeeAmount;
+            recordLedgerEntryUseCase.recordSellerSettlement(settlementId, sellerSettlementDebit, sellerPayoutAmount, platformFeeAmount);
+
+            settlement.complete();
+        } catch (Exception e) {
+            settlement.fail();
+            updateSettlementPort.update(settlement);
+            log.error("정산 재시도 실패 - settlementId: {}, error: {}", settlementId, e.getMessage(), e);
+            throw e;
+        }
+
+        updateSettlementPort.update(settlement);
+
+        log.info("정산 재시도 완료 - settlementId: {}, sellerId: {}, year: {}, month: {}",
+                settlementId, settlement.getSellerId(), settlement.getYear(), settlement.getMonth());
+    }
+}

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/settlement/ExecuteSettlementUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/settlement/ExecuteSettlementUseCaseTest.java
@@ -2,16 +2,12 @@ package com.personal.marketnote.commerce.service.settlement;
 
 import com.personal.marketnote.commerce.domain.settlement.*;
 import com.personal.marketnote.commerce.exception.NoUnsettledAllocationException;
-import com.personal.marketnote.commerce.exception.SettlementAlreadyExistsException;
 import com.personal.marketnote.commerce.port.in.command.settlement.ExecuteSettlementCommand;
-import com.personal.marketnote.commerce.port.in.usecase.ledger.RecordLedgerEntryUseCase;
-import com.personal.marketnote.commerce.port.out.settlement.*;
+import com.personal.marketnote.commerce.port.out.settlement.FindPaymentAllocationPort;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -19,7 +15,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.time.LocalDateTime;
 import java.util.List;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
@@ -35,25 +30,7 @@ class ExecuteSettlementUseCaseTest {
     private FindPaymentAllocationPort findPaymentAllocationPort;
 
     @Mock
-    private FindSettlementPort findSettlementPort;
-
-    @Mock
-    private SaveSettlementPort saveSettlementPort;
-
-    @Mock
-    private UpdateSettlementPort updateSettlementPort;
-
-    @Mock
-    private UpdatePaymentAllocationPort updatePaymentAllocationPort;
-
-    @Mock
-    private RecordLedgerEntryUseCase recordLedgerEntryUseCase;
-
-    @Captor
-    private ArgumentCaptor<Settlement> settlementCaptor;
-
-    @Captor
-    private ArgumentCaptor<List<Long>> allocationIdsCaptor;
+    private ProcessSellerSettlementService processSellerSettlementService;
 
     private PaymentAllocation createAllocation(Long id, Long sellerId, Long allocatedAmount) {
         return PaymentAllocation.from(PaymentAllocationSnapshotState.builder()
@@ -68,49 +45,19 @@ class ExecuteSettlementUseCaseTest {
                 .build());
     }
 
-    private Settlement createSavedSettlement(Long id, Long sellerId, Integer year, Integer month,
-                                             Long totalAllocatedAmount, Long pgFeeAmount,
-                                             Long platformFeeAmount, Long sellerPayoutAmount) {
-        return Settlement.from(SettlementSnapshotState.builder()
-                .id(id)
-                .sellerId(sellerId)
-                .year(year)
-                .month(month)
-                .totalAllocatedAmount(totalAllocatedAmount)
-                .pgFeeAmount(pgFeeAmount)
-                .platformFeeAmount(platformFeeAmount)
-                .sellerPayoutAmount(sellerPayoutAmount)
-                .status(SettlementStatus.PENDING)
-                .version(0L)
-                .createdAt(LocalDateTime.now())
-                .modifiedAt(LocalDateTime.now())
-                .build());
-    }
-
     @Nested
     @DisplayName("정상 정산 실행")
     class SuccessfulSettlement {
 
         @Test
-        @DisplayName("단일 판매자 정산을 정상 처리한다")
-        void shouldExecuteSettlementForSingleSeller() {
+        @DisplayName("단일 판매자 정산 시 ProcessSellerSettlementService를 호출한다")
+        void shouldDelegateToProcessService() {
             // given
             PaymentAllocation allocation1 = createAllocation(1L, 10L, 5000L);
             PaymentAllocation allocation2 = createAllocation(2L, 10L, 3000L);
 
             when(findPaymentAllocationPort.findUnsettledAllocations(2026, 2))
                     .thenReturn(List.of(allocation1, allocation2));
-            when(findSettlementPort.existsBySellerIdAndYearAndMonth(10L, 2026, 2))
-                    .thenReturn(false);
-            when(saveSettlementPort.save(any(Settlement.class)))
-                    .thenAnswer(invocation -> {
-                        Settlement s = invocation.getArgument(0);
-                        return createSavedSettlement(1L, s.getSellerId(), s.getYear(), s.getMonth(),
-                                s.getTotalAllocatedAmount(), s.getPgFeeAmount(),
-                                s.getPlatformFeeAmount(), s.getSellerPayoutAmount());
-                    });
-            when(updateSettlementPort.update(any(Settlement.class)))
-                    .thenAnswer(invocation -> invocation.getArgument(0));
 
             ExecuteSettlementCommand command = ExecuteSettlementCommand.builder()
                     .year(2026).month(2).pgFeeRate(300).platformFeeRate(500).build();
@@ -119,43 +66,18 @@ class ExecuteSettlementUseCaseTest {
             executeSettlementService.executeSettlement(command);
 
             // then
-            verify(saveSettlementPort).save(settlementCaptor.capture());
-            Settlement savedSettlement = settlementCaptor.getValue();
-            assertThat(savedSettlement.getSellerId()).isEqualTo(10L);
-            assertThat(savedSettlement.getTotalAllocatedAmount()).isEqualTo(8000L);
-            assertThat(savedSettlement.getPgFeeAmount()).isEqualTo(240L);      // 8000 * 300 / 10000
-            assertThat(savedSettlement.getPlatformFeeAmount()).isEqualTo(400L); // 8000 * 500 / 10000
-            assertThat(savedSettlement.getSellerPayoutAmount()).isEqualTo(7360L); // 8000 - 240 - 400
-
-            verify(updatePaymentAllocationPort).assignSettlement(allocationIdsCaptor.capture(), eq(1L));
-            assertThat(allocationIdsCaptor.getValue()).containsExactlyInAnyOrder(1L, 2L);
-
-            verify(recordLedgerEntryUseCase).recordPgSettlement(1L, 8000L, 240L);
-            verify(recordLedgerEntryUseCase).recordSellerSettlement(1L, 7760L, 7360L, 400L); // 7760 = 7360 + 400
-            verify(updateSettlementPort).update(argThat(Settlement::isCompleted));
+            verify(processSellerSettlementService).process(eq(command), eq(10L), anyList());
         }
 
         @Test
-        @DisplayName("다중 판매자 정산 시 각각 독립 Settlement를 생성한다")
-        void shouldExecuteSettlementForMultipleSellers() {
+        @DisplayName("다중 판매자 정산 시 각 판매자별로 ProcessSellerSettlementService를 호출한다")
+        void shouldProcessEachSellerIndependently() {
             // given
             PaymentAllocation seller10Alloc = createAllocation(1L, 10L, 10000L);
             PaymentAllocation seller20Alloc = createAllocation(2L, 20L, 20000L);
 
             when(findPaymentAllocationPort.findUnsettledAllocations(2026, 2))
                     .thenReturn(List.of(seller10Alloc, seller20Alloc));
-            when(findSettlementPort.existsBySellerIdAndYearAndMonth(anyLong(), eq(2026), eq(2)))
-                    .thenReturn(false);
-            when(saveSettlementPort.save(any(Settlement.class)))
-                    .thenAnswer(invocation -> {
-                        Settlement s = invocation.getArgument(0);
-                        Long id = s.getSellerId().equals(10L) ? 1L : 2L;
-                        return createSavedSettlement(id, s.getSellerId(), s.getYear(), s.getMonth(),
-                                s.getTotalAllocatedAmount(), s.getPgFeeAmount(),
-                                s.getPlatformFeeAmount(), s.getSellerPayoutAmount());
-                    });
-            when(updateSettlementPort.update(any(Settlement.class)))
-                    .thenAnswer(invocation -> invocation.getArgument(0));
 
             ExecuteSettlementCommand command = ExecuteSettlementCommand.builder()
                     .year(2026).month(2).pgFeeRate(300).platformFeeRate(500).build();
@@ -164,72 +86,27 @@ class ExecuteSettlementUseCaseTest {
             executeSettlementService.executeSettlement(command);
 
             // then
-            verify(saveSettlementPort, times(2)).save(any(Settlement.class));
-            verify(recordLedgerEntryUseCase, times(2)).recordPgSettlement(anyLong(), anyLong(), anyLong());
-            verify(recordLedgerEntryUseCase, times(2)).recordSellerSettlement(anyLong(), anyLong(), anyLong(), anyLong());
-            verify(updateSettlementPort, times(2)).update(argThat(Settlement::isCompleted));
-        }
-
-        @Test
-        @DisplayName("PG 수수료가 0인 경우 정상 처리한다")
-        void shouldHandleZeroPgFee() {
-            // given
-            PaymentAllocation allocation = createAllocation(1L, 10L, 10000L);
-
-            when(findPaymentAllocationPort.findUnsettledAllocations(2026, 2))
-                    .thenReturn(List.of(allocation));
-            when(findSettlementPort.existsBySellerIdAndYearAndMonth(10L, 2026, 2))
-                    .thenReturn(false);
-            when(saveSettlementPort.save(any(Settlement.class)))
-                    .thenAnswer(invocation -> {
-                        Settlement s = invocation.getArgument(0);
-                        return createSavedSettlement(1L, s.getSellerId(), s.getYear(), s.getMonth(),
-                                s.getTotalAllocatedAmount(), s.getPgFeeAmount(),
-                                s.getPlatformFeeAmount(), s.getSellerPayoutAmount());
-                    });
-            when(updateSettlementPort.update(any(Settlement.class)))
-                    .thenAnswer(invocation -> invocation.getArgument(0));
-
-            ExecuteSettlementCommand command = ExecuteSettlementCommand.builder()
-                    .year(2026).month(2).pgFeeRate(0).platformFeeRate(500).build();
-
-            // when
-            executeSettlementService.executeSettlement(command);
-
-            // then
-            verify(saveSettlementPort).save(settlementCaptor.capture());
-            Settlement saved = settlementCaptor.getValue();
-            assertThat(saved.getPgFeeAmount()).isEqualTo(0L);
-            assertThat(saved.getPlatformFeeAmount()).isEqualTo(500L);
-            assertThat(saved.getSellerPayoutAmount()).isEqualTo(9500L);
-
-            verify(recordLedgerEntryUseCase).recordPgSettlement(1L, 10000L, 0L);
+            verify(processSellerSettlementService, times(2)).process(eq(command), anyLong(), anyList());
         }
     }
 
     @Nested
-    @DisplayName("수수료 계산 정합성")
-    class FeeCalculation {
+    @DisplayName("부분 실패 처리")
+    class PartialFailureHandling {
 
         @Test
-        @DisplayName("수수료 역산 정합성: totalAllocated = pgFee + platformFee + sellerPayout")
-        void shouldMaintainFeeIntegrity() {
+        @DisplayName("한 판매자 정산 실패 시 나머지 판매자 정산은 계속 진행된다")
+        void shouldContinueProcessingWhenOneSellerFails() {
             // given
-            PaymentAllocation allocation = createAllocation(1L, 10L, 10001L);
+            PaymentAllocation seller10Alloc = createAllocation(1L, 10L, 10000L);
+            PaymentAllocation seller20Alloc = createAllocation(2L, 20L, 20000L);
 
             when(findPaymentAllocationPort.findUnsettledAllocations(2026, 2))
-                    .thenReturn(List.of(allocation));
-            when(findSettlementPort.existsBySellerIdAndYearAndMonth(10L, 2026, 2))
-                    .thenReturn(false);
-            when(saveSettlementPort.save(any(Settlement.class)))
-                    .thenAnswer(invocation -> {
-                        Settlement s = invocation.getArgument(0);
-                        return createSavedSettlement(1L, s.getSellerId(), s.getYear(), s.getMonth(),
-                                s.getTotalAllocatedAmount(), s.getPgFeeAmount(),
-                                s.getPlatformFeeAmount(), s.getSellerPayoutAmount());
-                    });
-            when(updateSettlementPort.update(any(Settlement.class)))
-                    .thenAnswer(invocation -> invocation.getArgument(0));
+                    .thenReturn(List.of(seller10Alloc, seller20Alloc));
+
+            doThrow(new RuntimeException("분개 기록 실패"))
+                    .doNothing()
+                    .when(processSellerSettlementService).process(any(), anyLong(), anyList());
 
             ExecuteSettlementCommand command = ExecuteSettlementCommand.builder()
                     .year(2026).month(2).pgFeeRate(300).platformFeeRate(500).build();
@@ -238,60 +115,29 @@ class ExecuteSettlementUseCaseTest {
             executeSettlementService.executeSettlement(command);
 
             // then
-            verify(saveSettlementPort).save(settlementCaptor.capture());
-            Settlement saved = settlementCaptor.getValue();
-
-            long pgFee = saved.getPgFeeAmount();
-            long platformFee = saved.getPlatformFeeAmount();
-            long sellerPayout = saved.getSellerPayoutAmount();
-            long total = saved.getTotalAllocatedAmount();
-
-            // 역산 정합성: pgFee + platformFee + sellerPayout == totalAllocatedAmount
-            assertThat(pgFee + platformFee + sellerPayout).isEqualTo(total);
-
-            // basis point 내림: 10001 * 300 / 10000 = 300 (not 300.03)
-            assertThat(pgFee).isEqualTo(300L);
-            // 10001 * 500 / 10000 = 500
-            assertThat(platformFee).isEqualTo(500L);
-            // 10001 - 300 - 500 = 9201
-            assertThat(sellerPayout).isEqualTo(9201L);
+            verify(processSellerSettlementService, times(2)).process(eq(command), anyLong(), anyList());
         }
 
         @Test
-        @DisplayName("수수료율 합계가 100%일 때 판매자 지급액이 0이 되지 않고 정합성 유지")
-        void shouldHandleHighFeeRates() {
+        @DisplayName("모든 판매자 정산이 실패해도 예외를 던지지 않는다")
+        void shouldNotThrowWhenAllSellersFail() {
             // given
-            PaymentAllocation allocation = createAllocation(1L, 10L, 10000L);
+            PaymentAllocation seller10Alloc = createAllocation(1L, 10L, 10000L);
 
             when(findPaymentAllocationPort.findUnsettledAllocations(2026, 2))
-                    .thenReturn(List.of(allocation));
-            when(findSettlementPort.existsBySellerIdAndYearAndMonth(10L, 2026, 2))
-                    .thenReturn(false);
-            when(saveSettlementPort.save(any(Settlement.class)))
-                    .thenAnswer(invocation -> {
-                        Settlement s = invocation.getArgument(0);
-                        return createSavedSettlement(1L, s.getSellerId(), s.getYear(), s.getMonth(),
-                                s.getTotalAllocatedAmount(), s.getPgFeeAmount(),
-                                s.getPlatformFeeAmount(), s.getSellerPayoutAmount());
-                    });
-            when(updateSettlementPort.update(any(Settlement.class)))
-                    .thenAnswer(invocation -> invocation.getArgument(0));
+                    .thenReturn(List.of(seller10Alloc));
 
-            // pgFeeRate=3000 (30%) + platformFeeRate=2000 (20%) = 50%
+            doThrow(new RuntimeException("분개 기록 실패"))
+                    .when(processSellerSettlementService).process(any(), anyLong(), anyList());
+
             ExecuteSettlementCommand command = ExecuteSettlementCommand.builder()
-                    .year(2026).month(2).pgFeeRate(3000).platformFeeRate(2000).build();
+                    .year(2026).month(2).pgFeeRate(300).platformFeeRate(500).build();
 
-            // when
+            // when - 예외 없이 완료
             executeSettlementService.executeSettlement(command);
 
             // then
-            verify(saveSettlementPort).save(settlementCaptor.capture());
-            Settlement saved = settlementCaptor.getValue();
-            assertThat(saved.getPgFeeAmount()).isEqualTo(3000L);
-            assertThat(saved.getPlatformFeeAmount()).isEqualTo(2000L);
-            assertThat(saved.getSellerPayoutAmount()).isEqualTo(5000L);
-            assertThat(saved.getPgFeeAmount() + saved.getPlatformFeeAmount() + saved.getSellerPayoutAmount())
-                    .isEqualTo(saved.getTotalAllocatedAmount());
+            verify(processSellerSettlementService).process(eq(command), eq(10L), anyList());
         }
     }
 
@@ -313,31 +159,7 @@ class ExecuteSettlementUseCaseTest {
             assertThatThrownBy(() -> executeSettlementService.executeSettlement(command))
                     .isInstanceOf(NoUnsettledAllocationException.class);
 
-            verify(saveSettlementPort, never()).save(any());
-        }
-
-        @Test
-        @DisplayName("이미 해당 기간 정산이 존재하면 SettlementAlreadyExistsException을 던진다")
-        void shouldThrowWhenSettlementAlreadyExists() {
-            // given
-            PaymentAllocation allocation = createAllocation(1L, 10L, 10000L);
-
-            when(findPaymentAllocationPort.findUnsettledAllocations(2026, 2))
-                    .thenReturn(List.of(allocation));
-            when(findSettlementPort.existsBySellerIdAndYearAndMonth(10L, 2026, 2))
-                    .thenReturn(true);
-
-            ExecuteSettlementCommand command = ExecuteSettlementCommand.builder()
-                    .year(2026).month(2).pgFeeRate(300).platformFeeRate(500).build();
-
-            // when & then
-            assertThatThrownBy(() -> executeSettlementService.executeSettlement(command))
-                    .isInstanceOf(SettlementAlreadyExistsException.class)
-                    .hasMessageContaining("10")
-                    .hasMessageContaining("2026")
-                    .hasMessageContaining("2");
-
-            verify(saveSettlementPort, never()).save(any());
+            verifyNoInteractions(processSellerSettlementService);
         }
 
         @Test
@@ -364,43 +186,6 @@ class ExecuteSettlementUseCaseTest {
             assertThatThrownBy(() -> executeSettlementService.executeSettlement(command))
                     .isInstanceOf(IllegalArgumentException.class)
                     .hasMessageContaining("100%");
-        }
-    }
-
-    @Nested
-    @DisplayName("PaymentAllocation 정산 할당")
-    class AllocationAssignment {
-
-        @Test
-        @DisplayName("정산 완료 후 PaymentAllocation에 settlementId를 할당한다")
-        void shouldAssignSettlementIdToAllocations() {
-            // given
-            PaymentAllocation alloc1 = createAllocation(1L, 10L, 3000L);
-            PaymentAllocation alloc2 = createAllocation(2L, 10L, 7000L);
-
-            when(findPaymentAllocationPort.findUnsettledAllocations(2026, 2))
-                    .thenReturn(List.of(alloc1, alloc2));
-            when(findSettlementPort.existsBySellerIdAndYearAndMonth(10L, 2026, 2))
-                    .thenReturn(false);
-            when(saveSettlementPort.save(any(Settlement.class)))
-                    .thenAnswer(invocation -> {
-                        Settlement s = invocation.getArgument(0);
-                        return createSavedSettlement(99L, s.getSellerId(), s.getYear(), s.getMonth(),
-                                s.getTotalAllocatedAmount(), s.getPgFeeAmount(),
-                                s.getPlatformFeeAmount(), s.getSellerPayoutAmount());
-                    });
-            when(updateSettlementPort.update(any(Settlement.class)))
-                    .thenAnswer(invocation -> invocation.getArgument(0));
-
-            ExecuteSettlementCommand command = ExecuteSettlementCommand.builder()
-                    .year(2026).month(2).pgFeeRate(300).platformFeeRate(500).build();
-
-            // when
-            executeSettlementService.executeSettlement(command);
-
-            // then
-            verify(updatePaymentAllocationPort).assignSettlement(allocationIdsCaptor.capture(), eq(99L));
-            assertThat(allocationIdsCaptor.getValue()).containsExactlyInAnyOrder(1L, 2L);
         }
     }
 }

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/settlement/GetFailedSettlementsUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/settlement/GetFailedSettlementsUseCaseTest.java
@@ -1,0 +1,71 @@
+package com.personal.marketnote.commerce.service.settlement;
+
+import com.personal.marketnote.commerce.domain.settlement.Settlement;
+import com.personal.marketnote.commerce.domain.settlement.SettlementSnapshotState;
+import com.personal.marketnote.commerce.domain.settlement.SettlementStatus;
+import com.personal.marketnote.commerce.port.in.result.settlement.GetSettlementsResult;
+import com.personal.marketnote.commerce.port.out.settlement.FindSettlementPort;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GetFailedSettlementsUseCase 테스트")
+class GetFailedSettlementsUseCaseTest {
+
+    @InjectMocks
+    private GetFailedSettlementsService getFailedSettlementsService;
+
+    @Mock
+    private FindSettlementPort findSettlementPort;
+
+    @Test
+    @DisplayName("실패한 정산이 있으면 목록을 반환한다")
+    void shouldReturnFailedSettlements() {
+        // given
+        Settlement failed1 = Settlement.from(SettlementSnapshotState.builder()
+                .id(1L).sellerId(10L).year(2026).month(2)
+                .totalAllocatedAmount(100000L).pgFeeAmount(3000L)
+                .platformFeeAmount(5000L).sellerPayoutAmount(92000L)
+                .status(SettlementStatus.FAILED).version(0L)
+                .createdAt(LocalDateTime.of(2026, 2, 24, 10, 0))
+                .modifiedAt(LocalDateTime.of(2026, 2, 24, 10, 0))
+                .build());
+
+        when(findSettlementPort.findAllByStatus(SettlementStatus.FAILED))
+                .thenReturn(List.of(failed1));
+
+        // when
+        GetSettlementsResult result = getFailedSettlementsService.getFailedSettlements();
+
+        // then
+        assertThat(result.settlements()).hasSize(1);
+        assertThat(result.settlements().get(0).id()).isEqualTo(1L);
+        assertThat(result.settlements().get(0).status()).isEqualTo(SettlementStatus.FAILED);
+        verify(findSettlementPort).findAllByStatus(SettlementStatus.FAILED);
+    }
+
+    @Test
+    @DisplayName("실패한 정산이 없으면 빈 목록을 반환한다")
+    void shouldReturnEmptyListWhenNoFailedSettlements() {
+        // given
+        when(findSettlementPort.findAllByStatus(SettlementStatus.FAILED))
+                .thenReturn(List.of());
+
+        // when
+        GetSettlementsResult result = getFailedSettlementsService.getFailedSettlements();
+
+        // then
+        assertThat(result.settlements()).isEmpty();
+    }
+}

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/settlement/ProcessSellerSettlementServiceTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/settlement/ProcessSellerSettlementServiceTest.java
@@ -1,0 +1,223 @@
+package com.personal.marketnote.commerce.service.settlement;
+
+import com.personal.marketnote.commerce.domain.settlement.*;
+import com.personal.marketnote.commerce.exception.SettlementAlreadyExistsException;
+import com.personal.marketnote.commerce.port.in.command.settlement.ExecuteSettlementCommand;
+import com.personal.marketnote.commerce.port.in.usecase.ledger.RecordLedgerEntryUseCase;
+import com.personal.marketnote.commerce.port.out.settlement.*;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ProcessSellerSettlementService 테스트")
+class ProcessSellerSettlementServiceTest {
+
+    @InjectMocks
+    private ProcessSellerSettlementService processSellerSettlementService;
+
+    @Mock
+    private FindSettlementPort findSettlementPort;
+
+    @Mock
+    private SaveSettlementPort saveSettlementPort;
+
+    @Mock
+    private UpdateSettlementPort updateSettlementPort;
+
+    @Mock
+    private UpdatePaymentAllocationPort updatePaymentAllocationPort;
+
+    @Mock
+    private RecordLedgerEntryUseCase recordLedgerEntryUseCase;
+
+    @Captor
+    private ArgumentCaptor<Settlement> settlementCaptor;
+
+    @Captor
+    private ArgumentCaptor<List<Long>> allocationIdsCaptor;
+
+    private PaymentAllocation createAllocation(Long id, Long sellerId, Long allocatedAmount) {
+        return PaymentAllocation.from(PaymentAllocationSnapshotState.builder()
+                .id(id)
+                .orderId(100L)
+                .sellerId(sellerId)
+                .allocatedAmount(allocatedAmount)
+                .transactionType(PaymentAllocationTransactionType.ORDER_REGISTRATION)
+                .targetType(PaymentAllocationTargetType.ORDER)
+                .idempotencyKey("TEST:" + id)
+                .createdAt(LocalDateTime.of(2026, 2, 15, 10, 0))
+                .build());
+    }
+
+    private Settlement createSavedSettlement(Long id, Long sellerId, Integer year, Integer month,
+                                             Long totalAllocatedAmount, Long pgFeeAmount,
+                                             Long platformFeeAmount, Long sellerPayoutAmount) {
+        return Settlement.from(SettlementSnapshotState.builder()
+                .id(id)
+                .sellerId(sellerId)
+                .year(year)
+                .month(month)
+                .totalAllocatedAmount(totalAllocatedAmount)
+                .pgFeeAmount(pgFeeAmount)
+                .platformFeeAmount(platformFeeAmount)
+                .sellerPayoutAmount(sellerPayoutAmount)
+                .status(SettlementStatus.PENDING)
+                .version(0L)
+                .createdAt(LocalDateTime.now())
+                .modifiedAt(LocalDateTime.now())
+                .build());
+    }
+
+    @Nested
+    @DisplayName("정상 처리")
+    class SuccessfulProcess {
+
+        @Test
+        @DisplayName("판매자 정산을 정상 처리한다")
+        void shouldProcessSellerSettlement() {
+            // given
+            PaymentAllocation allocation1 = createAllocation(1L, 10L, 5000L);
+            PaymentAllocation allocation2 = createAllocation(2L, 10L, 3000L);
+
+            when(findSettlementPort.existsBySellerIdAndYearAndMonth(10L, 2026, 2))
+                    .thenReturn(false);
+            when(saveSettlementPort.save(any(Settlement.class)))
+                    .thenAnswer(invocation -> {
+                        Settlement s = invocation.getArgument(0);
+                        return createSavedSettlement(1L, s.getSellerId(), s.getYear(), s.getMonth(),
+                                s.getTotalAllocatedAmount(), s.getPgFeeAmount(),
+                                s.getPlatformFeeAmount(), s.getSellerPayoutAmount());
+                    });
+            when(updateSettlementPort.update(any(Settlement.class)))
+                    .thenAnswer(invocation -> invocation.getArgument(0));
+
+            ExecuteSettlementCommand command = ExecuteSettlementCommand.builder()
+                    .year(2026).month(2).pgFeeRate(300).platformFeeRate(500).build();
+
+            // when
+            processSellerSettlementService.process(command, 10L, List.of(allocation1, allocation2));
+
+            // then
+            verify(saveSettlementPort).save(settlementCaptor.capture());
+            Settlement savedSettlement = settlementCaptor.getValue();
+            assertThat(savedSettlement.getSellerId()).isEqualTo(10L);
+            assertThat(savedSettlement.getTotalAllocatedAmount()).isEqualTo(8000L);
+            assertThat(savedSettlement.getPgFeeAmount()).isEqualTo(240L);
+            assertThat(savedSettlement.getPlatformFeeAmount()).isEqualTo(400L);
+            assertThat(savedSettlement.getSellerPayoutAmount()).isEqualTo(7360L);
+
+            verify(updatePaymentAllocationPort).assignSettlement(allocationIdsCaptor.capture(), eq(1L));
+            assertThat(allocationIdsCaptor.getValue()).containsExactlyInAnyOrder(1L, 2L);
+
+            verify(recordLedgerEntryUseCase).recordPgSettlement(1L, 8000L, 240L);
+            verify(recordLedgerEntryUseCase).recordSellerSettlement(1L, 7760L, 7360L, 400L);
+            verify(updateSettlementPort).update(argThat(Settlement::isCompleted));
+        }
+
+        @Test
+        @DisplayName("PG 수수료가 0인 경우 정상 처리한다")
+        void shouldHandleZeroPgFee() {
+            // given
+            PaymentAllocation allocation = createAllocation(1L, 10L, 10000L);
+
+            when(findSettlementPort.existsBySellerIdAndYearAndMonth(10L, 2026, 2))
+                    .thenReturn(false);
+            when(saveSettlementPort.save(any(Settlement.class)))
+                    .thenAnswer(invocation -> {
+                        Settlement s = invocation.getArgument(0);
+                        return createSavedSettlement(1L, s.getSellerId(), s.getYear(), s.getMonth(),
+                                s.getTotalAllocatedAmount(), s.getPgFeeAmount(),
+                                s.getPlatformFeeAmount(), s.getSellerPayoutAmount());
+                    });
+            when(updateSettlementPort.update(any(Settlement.class)))
+                    .thenAnswer(invocation -> invocation.getArgument(0));
+
+            ExecuteSettlementCommand command = ExecuteSettlementCommand.builder()
+                    .year(2026).month(2).pgFeeRate(0).platformFeeRate(500).build();
+
+            // when
+            processSellerSettlementService.process(command, 10L, List.of(allocation));
+
+            // then
+            verify(saveSettlementPort).save(settlementCaptor.capture());
+            Settlement saved = settlementCaptor.getValue();
+            assertThat(saved.getPgFeeAmount()).isEqualTo(0L);
+            assertThat(saved.getSellerPayoutAmount()).isEqualTo(9500L);
+        }
+
+        @Test
+        @DisplayName("수수료 역산 정합성이 유지된다")
+        void shouldMaintainFeeIntegrity() {
+            // given
+            PaymentAllocation allocation = createAllocation(1L, 10L, 10001L);
+
+            when(findSettlementPort.existsBySellerIdAndYearAndMonth(10L, 2026, 2))
+                    .thenReturn(false);
+            when(saveSettlementPort.save(any(Settlement.class)))
+                    .thenAnswer(invocation -> {
+                        Settlement s = invocation.getArgument(0);
+                        return createSavedSettlement(1L, s.getSellerId(), s.getYear(), s.getMonth(),
+                                s.getTotalAllocatedAmount(), s.getPgFeeAmount(),
+                                s.getPlatformFeeAmount(), s.getSellerPayoutAmount());
+                    });
+            when(updateSettlementPort.update(any(Settlement.class)))
+                    .thenAnswer(invocation -> invocation.getArgument(0));
+
+            ExecuteSettlementCommand command = ExecuteSettlementCommand.builder()
+                    .year(2026).month(2).pgFeeRate(300).platformFeeRate(500).build();
+
+            // when
+            processSellerSettlementService.process(command, 10L, List.of(allocation));
+
+            // then
+            verify(saveSettlementPort).save(settlementCaptor.capture());
+            Settlement saved = settlementCaptor.getValue();
+
+            long pgFee = saved.getPgFeeAmount();
+            long platformFee = saved.getPlatformFeeAmount();
+            long sellerPayout = saved.getSellerPayoutAmount();
+            long total = saved.getTotalAllocatedAmount();
+
+            assertThat(pgFee + platformFee + sellerPayout).isEqualTo(total);
+        }
+    }
+
+    @Nested
+    @DisplayName("예외 처리")
+    class ExceptionHandling {
+
+        @Test
+        @DisplayName("이미 해당 기간 정산이 존재하면 SettlementAlreadyExistsException을 던진다")
+        void shouldThrowWhenSettlementAlreadyExists() {
+            // given
+            PaymentAllocation allocation = createAllocation(1L, 10L, 10000L);
+
+            when(findSettlementPort.existsBySellerIdAndYearAndMonth(10L, 2026, 2))
+                    .thenReturn(true);
+
+            ExecuteSettlementCommand command = ExecuteSettlementCommand.builder()
+                    .year(2026).month(2).pgFeeRate(300).platformFeeRate(500).build();
+
+            // when & then
+            assertThatThrownBy(() -> processSellerSettlementService.process(command, 10L, List.of(allocation)))
+                    .isInstanceOf(SettlementAlreadyExistsException.class);
+
+            verify(saveSettlementPort, never()).save(any());
+        }
+    }
+}

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/settlement/RetryFailedSettlementUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/settlement/RetryFailedSettlementUseCaseTest.java
@@ -1,0 +1,203 @@
+package com.personal.marketnote.commerce.service.settlement;
+
+import com.personal.marketnote.commerce.domain.settlement.*;
+import com.personal.marketnote.commerce.exception.SettlementNotFoundException;
+import com.personal.marketnote.commerce.port.in.usecase.ledger.RecordLedgerEntryUseCase;
+import com.personal.marketnote.commerce.port.out.settlement.FindSettlementPort;
+import com.personal.marketnote.commerce.port.out.settlement.UpdateSettlementPort;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("RetryFailedSettlementUseCase 테스트")
+class RetryFailedSettlementUseCaseTest {
+
+    @InjectMocks
+    private RetryFailedSettlementService retryFailedSettlementService;
+
+    @Mock
+    private FindSettlementPort findSettlementPort;
+
+    @Mock
+    private UpdateSettlementPort updateSettlementPort;
+
+    @Mock
+    private RecordLedgerEntryUseCase recordLedgerEntryUseCase;
+
+    private Settlement createFailedSettlement(Long id, Long sellerId, Long totalAllocatedAmount,
+                                              Long pgFeeAmount, Long platformFeeAmount, Long sellerPayoutAmount) {
+        Settlement settlement = Settlement.from(SettlementSnapshotState.builder()
+                .id(id)
+                .sellerId(sellerId)
+                .year(2026)
+                .month(2)
+                .totalAllocatedAmount(totalAllocatedAmount)
+                .pgFeeAmount(pgFeeAmount)
+                .platformFeeAmount(platformFeeAmount)
+                .sellerPayoutAmount(sellerPayoutAmount)
+                .status(SettlementStatus.FAILED)
+                .version(0L)
+                .createdAt(LocalDateTime.now())
+                .modifiedAt(LocalDateTime.now())
+                .build());
+        return settlement;
+    }
+
+    @Nested
+    @DisplayName("재시도 성공")
+    class RetrySuccess {
+
+        @Test
+        @DisplayName("실패한 정산을 재시도하면 분개를 기록하고 COMPLETED 상태로 전이한다")
+        void shouldRetryFailedSettlementSuccessfully() {
+            // given
+            Settlement failedSettlement = createFailedSettlement(1L, 10L, 100000L, 3000L, 5000L, 92000L);
+
+            when(findSettlementPort.findById(1L)).thenReturn(Optional.of(failedSettlement));
+            when(updateSettlementPort.update(any(Settlement.class)))
+                    .thenAnswer(invocation -> invocation.getArgument(0));
+
+            // when
+            retryFailedSettlementService.retrySettlement(1L);
+
+            // then
+            verify(recordLedgerEntryUseCase).recordPgSettlement(1L, 100000L, 3000L);
+            verify(recordLedgerEntryUseCase).recordSellerSettlement(1L, 97000L, 92000L, 5000L);
+            verify(updateSettlementPort).update(argThat(Settlement::isCompleted));
+        }
+
+        @Test
+        @DisplayName("PG 수수료가 0인 실패 정산을 재시도한다")
+        void shouldRetryWithZeroPgFee() {
+            // given
+            Settlement failedSettlement = createFailedSettlement(2L, 20L, 50000L, 0L, 2500L, 47500L);
+
+            when(findSettlementPort.findById(2L)).thenReturn(Optional.of(failedSettlement));
+            when(updateSettlementPort.update(any(Settlement.class)))
+                    .thenAnswer(invocation -> invocation.getArgument(0));
+
+            // when
+            retryFailedSettlementService.retrySettlement(2L);
+
+            // then
+            verify(recordLedgerEntryUseCase).recordPgSettlement(2L, 50000L, 0L);
+            verify(recordLedgerEntryUseCase).recordSellerSettlement(2L, 50000L, 47500L, 2500L);
+            verify(updateSettlementPort).update(argThat(Settlement::isCompleted));
+        }
+    }
+
+    @Nested
+    @DisplayName("재시도 실패")
+    class RetryFailure {
+
+        @Test
+        @DisplayName("존재하지 않는 정산 ID로 재시도하면 SettlementNotFoundException을 던진다")
+        void shouldThrowWhenSettlementNotFound() {
+            // given
+            when(findSettlementPort.findById(999L)).thenReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> retryFailedSettlementService.retrySettlement(999L))
+                    .isInstanceOf(SettlementNotFoundException.class);
+
+            verifyNoInteractions(recordLedgerEntryUseCase);
+            verifyNoInteractions(updateSettlementPort);
+        }
+
+        @Test
+        @DisplayName("PENDING 상태의 정산에 대해 재시도하면 InvalidSettlementStatusTransitionException을 던진다")
+        void shouldThrowWhenSettlementIsPending() {
+            // given
+            Settlement pendingSettlement = Settlement.from(SettlementSnapshotState.builder()
+                    .id(1L)
+                    .sellerId(10L)
+                    .year(2026)
+                    .month(2)
+                    .totalAllocatedAmount(100000L)
+                    .pgFeeAmount(3000L)
+                    .platformFeeAmount(5000L)
+                    .sellerPayoutAmount(92000L)
+                    .status(SettlementStatus.PENDING)
+                    .version(0L)
+                    .createdAt(LocalDateTime.now())
+                    .modifiedAt(LocalDateTime.now())
+                    .build());
+
+            when(findSettlementPort.findById(1L)).thenReturn(Optional.of(pendingSettlement));
+
+            // when & then
+            assertThatThrownBy(() -> retryFailedSettlementService.retrySettlement(1L))
+                    .isInstanceOf(InvalidSettlementStatusTransitionException.class);
+
+            verifyNoInteractions(recordLedgerEntryUseCase);
+            verifyNoInteractions(updateSettlementPort);
+        }
+
+        @Test
+        @DisplayName("COMPLETED 상태의 정산에 대해 재시도하면 InvalidSettlementStatusTransitionException을 던진다")
+        void shouldThrowWhenSettlementIsCompleted() {
+            // given
+            Settlement completedSettlement = Settlement.from(SettlementSnapshotState.builder()
+                    .id(1L)
+                    .sellerId(10L)
+                    .year(2026)
+                    .month(2)
+                    .totalAllocatedAmount(100000L)
+                    .pgFeeAmount(3000L)
+                    .platformFeeAmount(5000L)
+                    .sellerPayoutAmount(92000L)
+                    .status(SettlementStatus.COMPLETED)
+                    .version(1L)
+                    .createdAt(LocalDateTime.now())
+                    .modifiedAt(LocalDateTime.now())
+                    .build());
+
+            when(findSettlementPort.findById(1L)).thenReturn(Optional.of(completedSettlement));
+
+            // when & then
+            assertThatThrownBy(() -> retryFailedSettlementService.retrySettlement(1L))
+                    .isInstanceOf(InvalidSettlementStatusTransitionException.class);
+
+            verifyNoInteractions(recordLedgerEntryUseCase);
+            verifyNoInteractions(updateSettlementPort);
+        }
+    }
+
+    @Nested
+    @DisplayName("분개 기록 검증")
+    class LedgerVerification {
+
+        @Test
+        @DisplayName("재시도 시 분개 금액이 기존 정산 금액과 일치한다")
+        void shouldRecordLedgerWithCorrectAmounts() {
+            // given
+            Settlement failedSettlement = createFailedSettlement(5L, 30L, 200000L, 6000L, 10000L, 184000L);
+
+            when(findSettlementPort.findById(5L)).thenReturn(Optional.of(failedSettlement));
+            when(updateSettlementPort.update(any(Settlement.class)))
+                    .thenAnswer(invocation -> invocation.getArgument(0));
+
+            // when
+            retryFailedSettlementService.retrySettlement(5L);
+
+            // then
+            // PG 정산: settlementId, totalAllocatedAmount, pgFeeAmount
+            verify(recordLedgerEntryUseCase).recordPgSettlement(5L, 200000L, 6000L);
+
+            // 판매자 정산: settlementId, debit(sellerPayout+platformFee), sellerPayout, platformFee
+            verify(recordLedgerEntryUseCase).recordSellerSettlement(5L, 194000L, 184000L, 10000L);
+        }
+    }
+}

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/settlement/InvalidSettlementStatusTransitionException.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/settlement/InvalidSettlementStatusTransitionException.java
@@ -2,6 +2,6 @@ package com.personal.marketnote.commerce.domain.settlement;
 
 public class InvalidSettlementStatusTransitionException extends IllegalStateException {
     public InvalidSettlementStatusTransitionException(SettlementStatus currentStatus) {
-        super("PENDING 상태에서만 처리할 수 있습니다. 현재 상태: " + currentStatus);
+        super("현재 상태에서는 전이할 수 없습니다. 현재 상태: " + currentStatus);
     }
 }

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/settlement/Settlement.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/settlement/Settlement.java
@@ -89,6 +89,34 @@ public class Settlement {
         return status == SettlementStatus.COMPLETED;
     }
 
+    /**
+     * 실패 상태인지 확인한다.
+     *
+     * @return 실패 상태이면 true
+     * @author 성효빈
+     * @since 2026-03-02
+     */
+    public boolean isFailed() {
+        return status == SettlementStatus.FAILED;
+    }
+
+    /**
+     * 실패한 정산을 대기 상태로 재설정한다.
+     * <p>
+     * FAILED → PENDING 상태 전이만 허용한다.
+     * </p>
+     *
+     * @throws InvalidSettlementStatusTransitionException 현재 상태가 FAILED가 아닌 경우
+     * @author 성효빈
+     * @since 2026-03-02
+     */
+    public void resetToPending() {
+        if (!isFailed()) {
+            throw new InvalidSettlementStatusTransitionException(status);
+        }
+        this.status = SettlementStatus.PENDING;
+    }
+
     public void complete() {
         if (!isPending()) {
             throw new InvalidSettlementStatusTransitionException(status);

--- a/commerce-service/commerce-domain/src/test/java/com/personal/marketnote/commerce/domain/settlement/SettlementTest.java
+++ b/commerce-service/commerce-domain/src/test/java/com/personal/marketnote/commerce/domain/settlement/SettlementTest.java
@@ -234,7 +234,7 @@ class SettlementTest {
             // when & then
             assertThatThrownBy(settlement::complete)
                     .isInstanceOf(IllegalStateException.class)
-                    .hasMessageContaining("PENDING");
+                    .hasMessageContaining("현재 상태");
         }
 
         @Test
@@ -253,7 +253,101 @@ class SettlementTest {
             // when & then
             assertThatThrownBy(settlement::fail)
                     .isInstanceOf(IllegalStateException.class)
-                    .hasMessageContaining("PENDING");
+                    .hasMessageContaining("현재 상태");
         }
+
+        @Test
+        @DisplayName("FAILED 상태에서 resetToPending() 호출 시 PENDING 상태로 전이된다")
+        void shouldResetToPendingFromFailed() {
+            // given
+            Settlement settlement = createPendingSettlement();
+            settlement.fail();
+            assertThat(settlement.isFailed()).isTrue();
+
+            // when
+            settlement.resetToPending();
+
+            // then
+            assertThat(settlement.isPending()).isTrue();
+            assertThat(settlement.isFailed()).isFalse();
+        }
+
+        @Test
+        @DisplayName("PENDING 상태에서 resetToPending() 호출 시 IllegalStateException을 던진다")
+        void shouldThrowWhenResetToPendingFromPending() {
+            // given
+            Settlement settlement = createPendingSettlement();
+
+            // when & then
+            assertThatThrownBy(settlement::resetToPending)
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("현재 상태");
+        }
+
+        @Test
+        @DisplayName("COMPLETED 상태에서 resetToPending() 호출 시 IllegalStateException을 던진다")
+        void shouldThrowWhenResetToPendingFromCompleted() {
+            // given
+            Settlement settlement = createPendingSettlement();
+            settlement.complete();
+
+            // when & then
+            assertThatThrownBy(settlement::resetToPending)
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("현재 상태");
+        }
+
+        @Test
+        @DisplayName("FAILED 상태에서 resetToPending 후 complete() 호출 시 COMPLETED 상태로 전이된다")
+        void shouldCompleteAfterResetFromFailed() {
+            // given
+            Settlement settlement = createPendingSettlement();
+            settlement.fail();
+            settlement.resetToPending();
+
+            // when
+            settlement.complete();
+
+            // then
+            assertThat(settlement.isCompleted()).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("술어 메서드")
+    class PredicateTest {
+
+        @Test
+        @DisplayName("isFailed()는 FAILED 상태에서 true를 반환한다")
+        void shouldReturnTrueWhenFailed() {
+            // given
+            Settlement settlement = createPendingSettlement();
+            settlement.fail();
+
+            // then
+            assertThat(settlement.isFailed()).isTrue();
+            assertThat(settlement.isPending()).isFalse();
+            assertThat(settlement.isCompleted()).isFalse();
+        }
+
+        @Test
+        @DisplayName("isFailed()는 PENDING 상태에서 false를 반환한다")
+        void shouldReturnFalseWhenPending() {
+            // given
+            Settlement settlement = createPendingSettlement();
+
+            // then
+            assertThat(settlement.isFailed()).isFalse();
+        }
+    }
+
+    private Settlement createPendingSettlement() {
+        return Settlement.from(
+                SettlementCreateState.builder()
+                        .sellerId(10L).year(2026).month(2)
+                        .totalAllocatedAmount(100000L).pgFeeAmount(3000L)
+                        .platformFeeAmount(5000L).sellerPayoutAmount(92000L)
+                        .build()
+        );
     }
 }


### PR DESCRIPTION
## partially addresses #216
## resolves #924

## Task
- [x] Settlement 도메인에 isFailed(), resetToPending() 상태 전이 메서드 추가
- [x] RetryFailedSettlementUseCase/Service: FAILED 정산 재시도 (분개 재기록 + 상태 완료)
- [x] GetFailedSettlementsUseCase/Service: FAILED 상태 정산 목록 조회
- [x] ProcessSellerSettlementService: 판매자별 독립 트랜잭션(REQUIRES_NEW) 분리
- [x] ExecuteSettlementService 리팩토링: 판매자별 실패 격리 처리
- [x] FindSettlementPort에 findAllByStatus() 추가
- [x] SettlementController에 재시도/실패목록 API 엔드포인트 추가
- [x] RetryFailedSettlementUseCaseTest (6건), ProcessSellerSettlementServiceTest (5건), GetFailedSettlementsUseCaseTest (2건), ExecuteSettlementUseCaseTest (6건) 자동화 테스트 추가