### PR TITLE
[#216][#925] feat: 정산 취소/재실행 기능 추가

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/settlement/controller/SettlementController.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/settlement/controller/SettlementController.java
@@ -9,10 +9,12 @@ import com.personal.marketnote.commerce.adapter.in.web.settlement.response.GetSe
 import com.personal.marketnote.commerce.port.in.result.settlement.GetSettlementDetailResult;
 import com.personal.marketnote.commerce.port.in.result.settlement.GetSettlementResult;
 import com.personal.marketnote.commerce.port.in.result.settlement.GetSettlementsResult;
+import com.personal.marketnote.commerce.port.in.usecase.settlement.CancelSettlementUseCase;
 import com.personal.marketnote.commerce.port.in.usecase.settlement.ExecuteSettlementUseCase;
 import com.personal.marketnote.commerce.port.in.usecase.settlement.GetFailedSettlementsUseCase;
 import com.personal.marketnote.commerce.port.in.usecase.settlement.GetSettlementDetailUseCase;
 import com.personal.marketnote.commerce.port.in.usecase.settlement.GetSettlementUseCase;
+import com.personal.marketnote.commerce.port.in.usecase.settlement.ReExecuteSettlementUseCase;
 import com.personal.marketnote.commerce.port.in.usecase.settlement.RetryFailedSettlementUseCase;
 import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -47,6 +49,8 @@ import static com.personal.marketnote.common.utility.ApiConstant.ADMIN_POINTCUT;
 public class SettlementController {
     private final ExecuteSettlementUseCase executeSettlementUseCase;
     private final RetryFailedSettlementUseCase retryFailedSettlementUseCase;
+    private final CancelSettlementUseCase cancelSettlementUseCase;
+    private final ReExecuteSettlementUseCase reExecuteSettlementUseCase;
     private final GetFailedSettlementsUseCase getFailedSettlementsUseCase;
     private final GetSettlementUseCase getSettlementUseCase;
     private final GetSettlementDetailUseCase getSettlementDetailUseCase;
@@ -102,6 +106,60 @@ public class SettlementController {
                         HttpStatus.OK,
                         DEFAULT_SUCCESS_CODE,
                         "정산 재시도 성공"
+                ),
+                HttpStatus.OK
+        );
+    }
+
+    /**
+     * 완료된 정산을 취소한다.
+     *
+     * @param id 정산 ID
+     * @return 취소 결과 응답
+     * @author 성효빈
+     * @since 2026-03-02
+     */
+    @PostMapping("/{id}/cancel")
+    @PreAuthorize(ADMIN_POINTCUT)
+    @CancelSettlementApiDocs
+    public ResponseEntity<BaseResponse<Void>> cancelSettlement(
+            @PathVariable("id") Long id
+    ) {
+        cancelSettlementUseCase.cancelSettlement(id);
+
+        return new ResponseEntity<>(
+                BaseResponse.of(
+                        null,
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "정산 취소 성공"
+                ),
+                HttpStatus.OK
+        );
+    }
+
+    /**
+     * 취소된 정산을 재실행한다.
+     *
+     * @param id 정산 ID
+     * @return 재실행 결과 응답
+     * @author 성효빈
+     * @since 2026-03-02
+     */
+    @PostMapping("/{id}/re-execute")
+    @PreAuthorize(ADMIN_POINTCUT)
+    @ReExecuteSettlementApiDocs
+    public ResponseEntity<BaseResponse<Void>> reExecuteSettlement(
+            @PathVariable("id") Long id
+    ) {
+        reExecuteSettlementUseCase.reExecuteSettlement(id);
+
+        return new ResponseEntity<>(
+                BaseResponse.of(
+                        null,
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "정산 재실행 성공"
                 ),
                 HttpStatus.OK
         );

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/settlement/controller/apidocs/CancelSettlementApiDocs.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/settlement/controller/apidocs/CancelSettlementApiDocs.java
@@ -1,0 +1,74 @@
+package com.personal.marketnote.commerce.adapter.in.web.settlement.controller.apidocs;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.*;
+
+/**
+ * 정산 취소 API 문서.
+ *
+ * @author 성효빈
+ * @since 2026-03-02
+ */
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Operation(
+        summary = "(관리자) 정산 취소",
+        description = """
+                작성일자: 2026-03-02
+
+                작성자: 성효빈
+
+                ---
+
+                ## Description
+
+                - COMPLETED 상태의 정산을 취소합니다.
+
+                - 역분개(reverse journal entry)를 기록하고 CANCELLED 상태로 전이합니다.
+
+                - PaymentAllocation의 settlementId는 유지됩니다 (재실행 시 추적 가능).
+
+                ---
+
+                ## Path Variable
+
+                | **키** | **타입** | **설명** | **필수 여부** | **예시** |
+                | --- | --- | --- | --- | --- |
+                | id | number | 정산 ID | Y | 1 |
+                """,
+        security = {@SecurityRequirement(name = "bearer")},
+        parameters = @Parameter(name = "id", description = "정산 ID", required = true, example = "1"),
+        responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "정산 취소 성공",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 200,
+                                          "code": "SUC01",
+                                          "timestamp": "2026-03-02T12:00:00.000",
+                                          "content": null,
+                                          "message": "정산 취소 성공"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "404",
+                        description = "정산을 찾을 수 없음"
+                ),
+                @ApiResponse(
+                        responseCode = "500",
+                        description = "COMPLETED 상태가 아닌 정산에 대한 취소 시도"
+                )
+        })
+public @interface CancelSettlementApiDocs {
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/settlement/controller/apidocs/ReExecuteSettlementApiDocs.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/settlement/controller/apidocs/ReExecuteSettlementApiDocs.java
@@ -1,0 +1,76 @@
+package com.personal.marketnote.commerce.adapter.in.web.settlement.controller.apidocs;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.*;
+
+/**
+ * 정산 재실행 API 문서.
+ *
+ * @author 성효빈
+ * @since 2026-03-02
+ */
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Operation(
+        summary = "(관리자) 정산 재실행",
+        description = """
+                작성일자: 2026-03-02
+
+                작성자: 성효빈
+
+                ---
+
+                ## Description
+
+                - CANCELLED 상태의 정산을 재실행합니다.
+
+                - 분개를 재기록하고 COMPLETED 상태로 전이합니다.
+
+                - PaymentAllocation은 취소 시에도 연결 상태가 유지되므로 재할당하지 않습니다.
+
+                - 분개 기록 중 실패하면 정산을 FAILED 상태로 저장합니다.
+
+                ---
+
+                ## Path Variable
+
+                | **키** | **타입** | **설명** | **필수 여부** | **예시** |
+                | --- | --- | --- | --- | --- |
+                | id | number | 정산 ID | Y | 1 |
+                """,
+        security = {@SecurityRequirement(name = "bearer")},
+        parameters = @Parameter(name = "id", description = "정산 ID", required = true, example = "1"),
+        responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "정산 재실행 성공",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 200,
+                                          "code": "SUC01",
+                                          "timestamp": "2026-03-02T12:00:00.000",
+                                          "content": null,
+                                          "message": "정산 재실행 성공"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "404",
+                        description = "정산을 찾을 수 없음"
+                ),
+                @ApiResponse(
+                        responseCode = "500",
+                        description = "CANCELLED 상태가 아닌 정산에 대한 재실행 시도"
+                )
+        })
+public @interface ReExecuteSettlementApiDocs {
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/settlement/CancelSettlementUseCase.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/settlement/CancelSettlementUseCase.java
@@ -1,0 +1,26 @@
+package com.personal.marketnote.commerce.port.in.usecase.settlement;
+
+/**
+ * 완료된 정산을 취소하는 유스케이스.
+ * <p>
+ * COMPLETED 상태의 정산을 CANCELLED로 전이하고 역분개를 기록한다.
+ * </p>
+ *
+ * @author 성효빈
+ * @since 2026-03-02
+ */
+public interface CancelSettlementUseCase {
+
+    /**
+     * 완료된 정산을 취소한다.
+     * <p>
+     * 역분개(reverse journal entry)를 기록하고 CANCELLED 상태로 전이한다.
+     * PaymentAllocation의 settlementId는 유지한다.
+     * </p>
+     *
+     * @param settlementId 취소할 정산 ID
+     * @throws com.personal.marketnote.commerce.exception.SettlementNotFoundException 정산이 존재하지 않는 경우
+     * @throws com.personal.marketnote.commerce.domain.settlement.InvalidSettlementStatusTransitionException 정산이 COMPLETED 상태가 아닌 경우
+     */
+    void cancelSettlement(Long settlementId);
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/settlement/ReExecuteSettlementUseCase.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/settlement/ReExecuteSettlementUseCase.java
@@ -1,0 +1,26 @@
+package com.personal.marketnote.commerce.port.in.usecase.settlement;
+
+/**
+ * 취소된 정산을 재실행하는 유스케이스.
+ * <p>
+ * CANCELLED 상태의 정산을 PENDING으로 리셋한 후 분개를 재기록하고 COMPLETED로 전이한다.
+ * </p>
+ *
+ * @author 성효빈
+ * @since 2026-03-02
+ */
+public interface ReExecuteSettlementUseCase {
+
+    /**
+     * 취소된 정산을 재실행한다.
+     * <p>
+     * CANCELLED → PENDING → COMPLETED 상태 전이를 수행하며,
+     * 분개를 재기록한다. PaymentAllocation은 이미 연결되어 있으므로 재할당하지 않는다.
+     * </p>
+     *
+     * @param settlementId 재실행할 정산 ID
+     * @throws com.personal.marketnote.commerce.exception.SettlementNotFoundException 정산이 존재하지 않는 경우
+     * @throws com.personal.marketnote.commerce.domain.settlement.InvalidSettlementStatusTransitionException 정산이 CANCELLED 상태가 아닌 경우
+     */
+    void reExecuteSettlement(Long settlementId);
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/settlement/CancelSettlementService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/settlement/CancelSettlementService.java
@@ -1,0 +1,175 @@
+package com.personal.marketnote.commerce.service.settlement;
+
+import com.personal.marketnote.commerce.domain.ledger.Account;
+import com.personal.marketnote.commerce.domain.ledger.LedgerTransactionType;
+import com.personal.marketnote.commerce.domain.ledger.TransactionType;
+import com.personal.marketnote.commerce.domain.settlement.Settlement;
+import com.personal.marketnote.commerce.exception.AccountNotFoundException;
+import com.personal.marketnote.commerce.exception.SettlementNotFoundException;
+import com.personal.marketnote.commerce.port.in.command.ledger.RecordLedgerEntryCommand;
+import com.personal.marketnote.commerce.port.in.usecase.ledger.RecordLedgerEntryUseCase;
+import com.personal.marketnote.commerce.port.in.usecase.settlement.CancelSettlementUseCase;
+import com.personal.marketnote.commerce.port.out.ledger.FindAccountPort;
+import com.personal.marketnote.commerce.port.out.settlement.FindSettlementPort;
+import com.personal.marketnote.commerce.port.out.settlement.UpdateSettlementPort;
+import com.personal.marketnote.common.application.UseCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+/**
+ * 정산 취소 서비스.
+ * <p>
+ * COMPLETED 상태의 정산을 CANCELLED로 전이하고,
+ * 원래 분개의 역분개(reverse journal entry)를 기록한다.
+ * PaymentAllocation의 settlementId는 유지하여 재실행 시 추적 가능하도록 한다.
+ * </p>
+ *
+ * @author 성효빈
+ * @since 2026-03-02
+ */
+@UseCase
+@RequiredArgsConstructor
+@Slf4j
+public class CancelSettlementService implements CancelSettlementUseCase {
+    private static final String ACCOUNT_PG_RECEIVABLE = "매출채권_PG";
+    private static final String ACCOUNT_SELLER_PAYABLE = "미지급금_판매자";
+    private static final String ACCOUNT_CASH = "보통예금";
+    private static final String ACCOUNT_PG_FEE = "PG수수료비용";
+    private static final String ACCOUNT_PLATFORM_FEE_REVENUE = "플랫폼수수료수익";
+
+    private final FindSettlementPort findSettlementPort;
+    private final UpdateSettlementPort updateSettlementPort;
+    private final RecordLedgerEntryUseCase recordLedgerEntryUseCase;
+    private final FindAccountPort findAccountPort;
+
+    @Override
+    @Transactional(isolation = READ_COMMITTED)
+    public void cancelSettlement(Long settlementId) {
+        Settlement settlement = findSettlementPort.findById(settlementId)
+                .orElseThrow(() -> new SettlementNotFoundException(settlementId));
+
+        settlement.cancel();
+
+        recordPgSettlementCancellation(settlementId, settlement.getTotalAllocatedAmount(), settlement.getPgFeeAmount());
+        recordSellerSettlementCancellation(settlementId, settlement.getSellerPayoutAmount(), settlement.getPlatformFeeAmount());
+
+        updateSettlementPort.update(settlement);
+
+        log.info("정산 취소 완료 - settlementId: {}, sellerId: {}, year: {}, month: {}",
+                settlementId, settlement.getSellerId(), settlement.getYear(), settlement.getMonth());
+    }
+
+    /**
+     * PG 정산 역분개를 기록한다.
+     * <p>
+     * 원래 PG 정산 분개의 DEBIT/CREDIT을 반전한다.
+     * <pre>
+     * DEBIT  매출채권_PG      = totalAllocatedAmount
+     * CREDIT 보통예금         = totalAllocatedAmount - pgFeeAmount
+     * CREDIT PG수수료비용     = pgFeeAmount (if > 0)
+     * </pre>
+     * </p>
+     */
+    private void recordPgSettlementCancellation(Long settlementId, Long totalAllocatedAmount, Long pgFeeAmount) {
+        Account pgReceivable = findAccountPort.findByName(ACCOUNT_PG_RECEIVABLE)
+                .orElseThrow(() -> new AccountNotFoundException(ACCOUNT_PG_RECEIVABLE));
+        Account cashAccount = findAccountPort.findByName(ACCOUNT_CASH)
+                .orElseThrow(() -> new AccountNotFoundException(ACCOUNT_CASH));
+        Account pgFeeAccount = findAccountPort.findByName(ACCOUNT_PG_FEE)
+                .orElseThrow(() -> new AccountNotFoundException(ACCOUNT_PG_FEE));
+
+        List<RecordLedgerEntryCommand.EntryLine> entries = new ArrayList<>();
+
+        entries.add(RecordLedgerEntryCommand.EntryLine.builder()
+                .accountId(pgReceivable.getId())
+                .amount(totalAllocatedAmount)
+                .transactionType(TransactionType.DEBIT)
+                .build());
+
+        long cashAmount = totalAllocatedAmount - pgFeeAmount;
+        entries.add(RecordLedgerEntryCommand.EntryLine.builder()
+                .accountId(cashAccount.getId())
+                .amount(cashAmount)
+                .transactionType(TransactionType.CREDIT)
+                .build());
+
+        if (pgFeeAmount > 0) {
+            entries.add(RecordLedgerEntryCommand.EntryLine.builder()
+                    .accountId(pgFeeAccount.getId())
+                    .amount(pgFeeAmount)
+                    .transactionType(TransactionType.CREDIT)
+                    .build());
+        }
+
+        RecordLedgerEntryCommand command = RecordLedgerEntryCommand.builder()
+                .transactionType(LedgerTransactionType.SETTLEMENT_CANCELLATION)
+                .targetType("SETTLEMENT")
+                .targetId(settlementId)
+                .description("PG 정산 취소 역분개")
+                .idempotencyKey("PG_SETTLEMENT_CANCEL:" + settlementId)
+                .entries(entries)
+                .build();
+
+        recordLedgerEntryUseCase.record(command);
+    }
+
+    /**
+     * 판매자 정산 역분개를 기록한다.
+     * <p>
+     * 원래 판매자 정산 분개의 DEBIT/CREDIT을 반전한다.
+     * <pre>
+     * DEBIT  보통예금           = sellerPayoutAmount
+     * DEBIT  플랫폼수수료수익    = platformFeeAmount (if > 0)
+     * CREDIT 미지급금_판매자     = sellerPayoutAmount + platformFeeAmount
+     * </pre>
+     * </p>
+     */
+    private void recordSellerSettlementCancellation(Long settlementId, Long sellerPayoutAmount, Long platformFeeAmount) {
+        Account sellerPayable = findAccountPort.findByName(ACCOUNT_SELLER_PAYABLE)
+                .orElseThrow(() -> new AccountNotFoundException(ACCOUNT_SELLER_PAYABLE));
+        Account cashAccount = findAccountPort.findByName(ACCOUNT_CASH)
+                .orElseThrow(() -> new AccountNotFoundException(ACCOUNT_CASH));
+        Account platformFeeAccount = findAccountPort.findByName(ACCOUNT_PLATFORM_FEE_REVENUE)
+                .orElseThrow(() -> new AccountNotFoundException(ACCOUNT_PLATFORM_FEE_REVENUE));
+
+        List<RecordLedgerEntryCommand.EntryLine> entries = new ArrayList<>();
+
+        entries.add(RecordLedgerEntryCommand.EntryLine.builder()
+                .accountId(cashAccount.getId())
+                .amount(sellerPayoutAmount)
+                .transactionType(TransactionType.DEBIT)
+                .build());
+
+        if (platformFeeAmount > 0) {
+            entries.add(RecordLedgerEntryCommand.EntryLine.builder()
+                    .accountId(platformFeeAccount.getId())
+                    .amount(platformFeeAmount)
+                    .transactionType(TransactionType.DEBIT)
+                    .build());
+        }
+
+        long totalDebit = sellerPayoutAmount + platformFeeAmount;
+        entries.add(RecordLedgerEntryCommand.EntryLine.builder()
+                .accountId(sellerPayable.getId())
+                .amount(totalDebit)
+                .transactionType(TransactionType.CREDIT)
+                .build());
+
+        RecordLedgerEntryCommand command = RecordLedgerEntryCommand.builder()
+                .transactionType(LedgerTransactionType.SETTLEMENT_CANCELLATION)
+                .targetType("SETTLEMENT")
+                .targetId(settlementId)
+                .description("판매자 정산 취소 역분개")
+                .idempotencyKey("SELLER_SETTLEMENT_CANCEL:" + settlementId)
+                .entries(entries)
+                .build();
+
+        recordLedgerEntryUseCase.record(command);
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/settlement/ReExecuteSettlementService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/settlement/ReExecuteSettlementService.java
@@ -1,0 +1,190 @@
+package com.personal.marketnote.commerce.service.settlement;
+
+import com.personal.marketnote.commerce.domain.ledger.Account;
+import com.personal.marketnote.commerce.domain.ledger.LedgerTransactionType;
+import com.personal.marketnote.commerce.domain.ledger.TransactionType;
+import com.personal.marketnote.commerce.domain.settlement.Settlement;
+import com.personal.marketnote.commerce.exception.AccountNotFoundException;
+import com.personal.marketnote.commerce.exception.SettlementNotFoundException;
+import com.personal.marketnote.commerce.port.in.command.ledger.RecordLedgerEntryCommand;
+import com.personal.marketnote.commerce.port.in.usecase.ledger.RecordLedgerEntryUseCase;
+import com.personal.marketnote.commerce.port.in.usecase.settlement.ReExecuteSettlementUseCase;
+import com.personal.marketnote.commerce.port.out.ledger.FindAccountPort;
+import com.personal.marketnote.commerce.port.out.settlement.FindSettlementPort;
+import com.personal.marketnote.commerce.port.out.settlement.UpdateSettlementPort;
+import com.personal.marketnote.common.application.UseCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+/**
+ * 취소된 정산을 재실행하는 서비스.
+ * <p>
+ * CANCELLED 상태의 정산을 PENDING으로 리셋한 후 분개를 재기록하고 COMPLETED로 전이한다.
+ * PaymentAllocation은 취소 시에도 연결 상태를 유지하므로 재할당하지 않는다.
+ * 분개 기록 중 실패하면 정산을 FAILED 상태로 저장한다.
+ * </p>
+ *
+ * @author 성효빈
+ * @since 2026-03-02
+ */
+@UseCase
+@RequiredArgsConstructor
+@Slf4j
+public class ReExecuteSettlementService implements ReExecuteSettlementUseCase {
+    private static final String ACCOUNT_PG_RECEIVABLE = "매출채권_PG";
+    private static final String ACCOUNT_SELLER_PAYABLE = "미지급금_판매자";
+    private static final String ACCOUNT_CASH = "보통예금";
+    private static final String ACCOUNT_PG_FEE = "PG수수료비용";
+    private static final String ACCOUNT_PLATFORM_FEE_REVENUE = "플랫폼수수료수익";
+
+    private final FindSettlementPort findSettlementPort;
+    private final UpdateSettlementPort updateSettlementPort;
+    private final RecordLedgerEntryUseCase recordLedgerEntryUseCase;
+    private final FindAccountPort findAccountPort;
+
+    @Override
+    @Transactional(isolation = READ_COMMITTED)
+    public void reExecuteSettlement(Long settlementId) {
+        Settlement settlement = findSettlementPort.findById(settlementId)
+                .orElseThrow(() -> new SettlementNotFoundException(settlementId));
+
+        settlement.resetCancelledToPending();
+
+        try {
+            Long totalAllocatedAmount = settlement.getTotalAllocatedAmount();
+            Long pgFeeAmount = settlement.getPgFeeAmount();
+            Long platformFeeAmount = settlement.getPlatformFeeAmount();
+            Long sellerPayoutAmount = settlement.getSellerPayoutAmount();
+
+            recordPgSettlementReExecution(settlementId, totalAllocatedAmount, pgFeeAmount);
+
+            long sellerSettlementDebit = sellerPayoutAmount + platformFeeAmount;
+            recordSellerSettlementReExecution(settlementId, sellerSettlementDebit, sellerPayoutAmount, platformFeeAmount);
+
+            settlement.complete();
+        } catch (Exception e) {
+            settlement.fail();
+            updateSettlementPort.update(settlement);
+            log.error("정산 재실행 실패 - settlementId: {}, error: {}", settlementId, e.getMessage(), e);
+            throw e;
+        }
+
+        updateSettlementPort.update(settlement);
+
+        log.info("정산 재실행 완료 - settlementId: {}, sellerId: {}, year: {}, month: {}",
+                settlementId, settlement.getSellerId(), settlement.getYear(), settlement.getMonth());
+    }
+
+    /**
+     * PG 정산 분개를 재기록한다.
+     * <p>
+     * 원래 PG 정산과 동일한 분개를 재실행용 idempotencyKey로 기록한다.
+     * <pre>
+     * DEBIT  보통예금         = totalAllocatedAmount - pgFeeAmount
+     * DEBIT  PG수수료비용     = pgFeeAmount (if > 0)
+     * CREDIT 매출채권_PG      = totalAllocatedAmount
+     * </pre>
+     * </p>
+     */
+    private void recordPgSettlementReExecution(Long settlementId, Long totalAllocatedAmount, Long pgFeeAmount) {
+        Account cashAccount = findAccountPort.findByName(ACCOUNT_CASH)
+                .orElseThrow(() -> new AccountNotFoundException(ACCOUNT_CASH));
+        Account pgFeeAccount = findAccountPort.findByName(ACCOUNT_PG_FEE)
+                .orElseThrow(() -> new AccountNotFoundException(ACCOUNT_PG_FEE));
+        Account pgReceivable = findAccountPort.findByName(ACCOUNT_PG_RECEIVABLE)
+                .orElseThrow(() -> new AccountNotFoundException(ACCOUNT_PG_RECEIVABLE));
+
+        List<RecordLedgerEntryCommand.EntryLine> entries = new ArrayList<>();
+
+        long cashAmount = totalAllocatedAmount - pgFeeAmount;
+        entries.add(RecordLedgerEntryCommand.EntryLine.builder()
+                .accountId(cashAccount.getId())
+                .amount(cashAmount)
+                .transactionType(TransactionType.DEBIT)
+                .build());
+
+        if (pgFeeAmount > 0) {
+            entries.add(RecordLedgerEntryCommand.EntryLine.builder()
+                    .accountId(pgFeeAccount.getId())
+                    .amount(pgFeeAmount)
+                    .transactionType(TransactionType.DEBIT)
+                    .build());
+        }
+
+        entries.add(RecordLedgerEntryCommand.EntryLine.builder()
+                .accountId(pgReceivable.getId())
+                .amount(totalAllocatedAmount)
+                .transactionType(TransactionType.CREDIT)
+                .build());
+
+        RecordLedgerEntryCommand command = RecordLedgerEntryCommand.builder()
+                .transactionType(LedgerTransactionType.PG_SETTLEMENT)
+                .targetType("SETTLEMENT")
+                .targetId(settlementId)
+                .description("PG 정산 재실행 분개")
+                .idempotencyKey("PG_SETTLEMENT_REEXEC:" + settlementId)
+                .entries(entries)
+                .build();
+
+        recordLedgerEntryUseCase.record(command);
+    }
+
+    /**
+     * 판매자 정산 분개를 재기록한다.
+     * <p>
+     * 원래 판매자 정산과 동일한 분개를 재실행용 idempotencyKey로 기록한다.
+     * <pre>
+     * DEBIT  미지급금_판매자    = sellerPayoutAmount + platformFeeAmount
+     * CREDIT 보통예금          = sellerPayoutAmount
+     * CREDIT 플랫폼수수료수익   = platformFeeAmount (if > 0)
+     * </pre>
+     * </p>
+     */
+    private void recordSellerSettlementReExecution(Long settlementId, Long totalAmount, Long sellerPayoutAmount, Long platformFeeAmount) {
+        Account sellerPayable = findAccountPort.findByName(ACCOUNT_SELLER_PAYABLE)
+                .orElseThrow(() -> new AccountNotFoundException(ACCOUNT_SELLER_PAYABLE));
+        Account cashAccount = findAccountPort.findByName(ACCOUNT_CASH)
+                .orElseThrow(() -> new AccountNotFoundException(ACCOUNT_CASH));
+        Account platformFeeAccount = findAccountPort.findByName(ACCOUNT_PLATFORM_FEE_REVENUE)
+                .orElseThrow(() -> new AccountNotFoundException(ACCOUNT_PLATFORM_FEE_REVENUE));
+
+        List<RecordLedgerEntryCommand.EntryLine> entries = new ArrayList<>();
+
+        entries.add(RecordLedgerEntryCommand.EntryLine.builder()
+                .accountId(sellerPayable.getId())
+                .amount(totalAmount)
+                .transactionType(TransactionType.DEBIT)
+                .build());
+
+        entries.add(RecordLedgerEntryCommand.EntryLine.builder()
+                .accountId(cashAccount.getId())
+                .amount(sellerPayoutAmount)
+                .transactionType(TransactionType.CREDIT)
+                .build());
+
+        if (platformFeeAmount > 0) {
+            entries.add(RecordLedgerEntryCommand.EntryLine.builder()
+                    .accountId(platformFeeAccount.getId())
+                    .amount(platformFeeAmount)
+                    .transactionType(TransactionType.CREDIT)
+                    .build());
+        }
+
+        RecordLedgerEntryCommand command = RecordLedgerEntryCommand.builder()
+                .transactionType(LedgerTransactionType.SELLER_SETTLEMENT)
+                .targetType("SETTLEMENT")
+                .targetId(settlementId)
+                .description("판매자 정산 재실행 분개")
+                .idempotencyKey("SELLER_SETTLEMENT_REEXEC:" + settlementId)
+                .entries(entries)
+                .build();
+
+        recordLedgerEntryUseCase.record(command);
+    }
+}

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/settlement/CancelSettlementUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/settlement/CancelSettlementUseCaseTest.java
@@ -1,0 +1,313 @@
+package com.personal.marketnote.commerce.service.settlement;
+
+import com.personal.marketnote.commerce.domain.ledger.*;
+import com.personal.marketnote.commerce.domain.settlement.*;
+import com.personal.marketnote.commerce.exception.SettlementNotFoundException;
+import com.personal.marketnote.commerce.port.in.command.ledger.RecordLedgerEntryCommand;
+import com.personal.marketnote.commerce.port.in.usecase.ledger.RecordLedgerEntryUseCase;
+import com.personal.marketnote.commerce.port.out.ledger.FindAccountPort;
+import com.personal.marketnote.commerce.port.out.settlement.FindSettlementPort;
+import com.personal.marketnote.commerce.port.out.settlement.UpdateSettlementPort;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("CancelSettlementUseCase 테스트")
+class CancelSettlementUseCaseTest {
+
+    @InjectMocks
+    private CancelSettlementService cancelSettlementService;
+
+    @Mock
+    private FindSettlementPort findSettlementPort;
+
+    @Mock
+    private UpdateSettlementPort updateSettlementPort;
+
+    @Mock
+    private RecordLedgerEntryUseCase recordLedgerEntryUseCase;
+
+    @Mock
+    private FindAccountPort findAccountPort;
+
+    private static final Long PG_RECEIVABLE_ID = 1L;
+    private static final Long SELLER_PAYABLE_ID = 2L;
+    private static final Long CASH_ID = 3L;
+    private static final Long PG_FEE_ID = 4L;
+    private static final Long PLATFORM_FEE_ID = 5L;
+
+    @BeforeEach
+    void setUpAccounts() {
+        lenient().when(findAccountPort.findByName("매출채권_PG")).thenReturn(Optional.of(createAccount(PG_RECEIVABLE_ID, "매출채권_PG")));
+        lenient().when(findAccountPort.findByName("미지급금_판매자")).thenReturn(Optional.of(createAccount(SELLER_PAYABLE_ID, "미지급금_판매자")));
+        lenient().when(findAccountPort.findByName("보통예금")).thenReturn(Optional.of(createAccount(CASH_ID, "보통예금")));
+        lenient().when(findAccountPort.findByName("PG수수료비용")).thenReturn(Optional.of(createAccount(PG_FEE_ID, "PG수수료비용")));
+        lenient().when(findAccountPort.findByName("플랫폼수수료수익")).thenReturn(Optional.of(createAccount(PLATFORM_FEE_ID, "플랫폼수수료수익")));
+    }
+
+    private Account createAccount(Long id, String name) {
+        return Account.from(AccountSnapshotState.builder()
+                .id(id)
+                .name(name)
+                .accountType(AccountType.ASSET)
+                .status(com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus.ACTIVE)
+                .createdAt(LocalDateTime.now())
+                .modifiedAt(LocalDateTime.now())
+                .build());
+    }
+
+    private Settlement createCompletedSettlement(Long id, Long sellerId, Long totalAllocatedAmount,
+                                                  Long pgFeeAmount, Long platformFeeAmount, Long sellerPayoutAmount) {
+        return Settlement.from(SettlementSnapshotState.builder()
+                .id(id)
+                .sellerId(sellerId)
+                .year(2026)
+                .month(2)
+                .totalAllocatedAmount(totalAllocatedAmount)
+                .pgFeeAmount(pgFeeAmount)
+                .platformFeeAmount(platformFeeAmount)
+                .sellerPayoutAmount(sellerPayoutAmount)
+                .status(SettlementStatus.COMPLETED)
+                .version(1L)
+                .createdAt(LocalDateTime.now())
+                .modifiedAt(LocalDateTime.now())
+                .build());
+    }
+
+    @Nested
+    @DisplayName("취소 성공")
+    class CancelSuccess {
+
+        @Test
+        @DisplayName("완료된 정산을 취소하면 역분개를 기록하고 CANCELLED 상태로 전이한다")
+        void shouldCancelCompletedSettlementSuccessfully() {
+            // given
+            Settlement completedSettlement = createCompletedSettlement(1L, 10L, 100000L, 3000L, 5000L, 92000L);
+            when(findSettlementPort.findById(1L)).thenReturn(Optional.of(completedSettlement));
+
+            // when
+            cancelSettlementService.cancelSettlement(1L);
+
+            // then
+            verify(recordLedgerEntryUseCase, times(2)).record(any(RecordLedgerEntryCommand.class));
+            verify(updateSettlementPort).update(argThat(Settlement::isCancelled));
+        }
+
+        @Test
+        @DisplayName("PG 수수료가 0인 정산을 취소하면 PG수수료비용 항목 없이 역분개를 기록한다")
+        void shouldCancelWithZeroPgFee() {
+            // given
+            Settlement settlement = createCompletedSettlement(2L, 20L, 50000L, 0L, 2500L, 47500L);
+            when(findSettlementPort.findById(2L)).thenReturn(Optional.of(settlement));
+
+            // when
+            cancelSettlementService.cancelSettlement(2L);
+
+            // then
+            ArgumentCaptor<RecordLedgerEntryCommand> captor = ArgumentCaptor.forClass(RecordLedgerEntryCommand.class);
+            verify(recordLedgerEntryUseCase, times(2)).record(captor.capture());
+
+            RecordLedgerEntryCommand pgCommand = captor.getAllValues().get(0);
+            assertThat(pgCommand.entries()).hasSize(2);
+            assertThat(pgCommand.idempotencyKey()).isEqualTo("PG_SETTLEMENT_CANCEL:2");
+        }
+
+        @Test
+        @DisplayName("플랫폼 수수료가 0인 정산을 취소하면 플랫폼수수료수익 항목 없이 역분개를 기록한다")
+        void shouldCancelWithZeroPlatformFee() {
+            // given
+            Settlement settlement = createCompletedSettlement(3L, 30L, 80000L, 4000L, 0L, 76000L);
+            when(findSettlementPort.findById(3L)).thenReturn(Optional.of(settlement));
+
+            // when
+            cancelSettlementService.cancelSettlement(3L);
+
+            // then
+            ArgumentCaptor<RecordLedgerEntryCommand> captor = ArgumentCaptor.forClass(RecordLedgerEntryCommand.class);
+            verify(recordLedgerEntryUseCase, times(2)).record(captor.capture());
+
+            RecordLedgerEntryCommand sellerCommand = captor.getAllValues().get(1);
+            assertThat(sellerCommand.entries()).hasSize(2);
+            assertThat(sellerCommand.idempotencyKey()).isEqualTo("SELLER_SETTLEMENT_CANCEL:3");
+        }
+    }
+
+    @Nested
+    @DisplayName("취소 실패")
+    class CancelFailure {
+
+        @Test
+        @DisplayName("존재하지 않는 정산 ID로 취소하면 SettlementNotFoundException을 던진다")
+        void shouldThrowWhenSettlementNotFound() {
+            // given
+            when(findSettlementPort.findById(999L)).thenReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> cancelSettlementService.cancelSettlement(999L))
+                    .isInstanceOf(SettlementNotFoundException.class);
+
+            verifyNoInteractions(recordLedgerEntryUseCase);
+            verifyNoInteractions(updateSettlementPort);
+        }
+
+        @Test
+        @DisplayName("PENDING 상태의 정산을 취소하면 InvalidSettlementStatusTransitionException을 던진다")
+        void shouldThrowWhenSettlementIsPending() {
+            // given
+            Settlement pendingSettlement = Settlement.from(SettlementSnapshotState.builder()
+                    .id(1L).sellerId(10L).year(2026).month(2)
+                    .totalAllocatedAmount(100000L).pgFeeAmount(3000L)
+                    .platformFeeAmount(5000L).sellerPayoutAmount(92000L)
+                    .status(SettlementStatus.PENDING).version(0L)
+                    .createdAt(LocalDateTime.now()).modifiedAt(LocalDateTime.now())
+                    .build());
+            when(findSettlementPort.findById(1L)).thenReturn(Optional.of(pendingSettlement));
+
+            // when & then
+            assertThatThrownBy(() -> cancelSettlementService.cancelSettlement(1L))
+                    .isInstanceOf(InvalidSettlementStatusTransitionException.class);
+
+            verifyNoInteractions(recordLedgerEntryUseCase);
+            verifyNoInteractions(updateSettlementPort);
+        }
+
+        @Test
+        @DisplayName("FAILED 상태의 정산을 취소하면 InvalidSettlementStatusTransitionException을 던진다")
+        void shouldThrowWhenSettlementIsFailed() {
+            // given
+            Settlement failedSettlement = Settlement.from(SettlementSnapshotState.builder()
+                    .id(1L).sellerId(10L).year(2026).month(2)
+                    .totalAllocatedAmount(100000L).pgFeeAmount(3000L)
+                    .platformFeeAmount(5000L).sellerPayoutAmount(92000L)
+                    .status(SettlementStatus.FAILED).version(0L)
+                    .createdAt(LocalDateTime.now()).modifiedAt(LocalDateTime.now())
+                    .build());
+            when(findSettlementPort.findById(1L)).thenReturn(Optional.of(failedSettlement));
+
+            // when & then
+            assertThatThrownBy(() -> cancelSettlementService.cancelSettlement(1L))
+                    .isInstanceOf(InvalidSettlementStatusTransitionException.class);
+
+            verifyNoInteractions(recordLedgerEntryUseCase);
+            verifyNoInteractions(updateSettlementPort);
+        }
+
+        @Test
+        @DisplayName("CANCELLED 상태의 정산을 취소하면 InvalidSettlementStatusTransitionException을 던진다")
+        void shouldThrowWhenSettlementIsCancelled() {
+            // given
+            Settlement cancelledSettlement = Settlement.from(SettlementSnapshotState.builder()
+                    .id(1L).sellerId(10L).year(2026).month(2)
+                    .totalAllocatedAmount(100000L).pgFeeAmount(3000L)
+                    .platformFeeAmount(5000L).sellerPayoutAmount(92000L)
+                    .status(SettlementStatus.CANCELLED).version(2L)
+                    .createdAt(LocalDateTime.now()).modifiedAt(LocalDateTime.now())
+                    .build());
+            when(findSettlementPort.findById(1L)).thenReturn(Optional.of(cancelledSettlement));
+
+            // when & then
+            assertThatThrownBy(() -> cancelSettlementService.cancelSettlement(1L))
+                    .isInstanceOf(InvalidSettlementStatusTransitionException.class);
+
+            verifyNoInteractions(recordLedgerEntryUseCase);
+            verifyNoInteractions(updateSettlementPort);
+        }
+    }
+
+    @Nested
+    @DisplayName("역분개 검증")
+    class ReverseLedgerVerification {
+
+        @Test
+        @DisplayName("PG 정산 역분개의 DEBIT/CREDIT이 원래 분개와 반대이다")
+        void shouldRecordPgReversalWithCorrectAmounts() {
+            // given
+            Settlement settlement = createCompletedSettlement(5L, 30L, 200000L, 6000L, 10000L, 184000L);
+            when(findSettlementPort.findById(5L)).thenReturn(Optional.of(settlement));
+
+            // when
+            cancelSettlementService.cancelSettlement(5L);
+
+            // then
+            ArgumentCaptor<RecordLedgerEntryCommand> captor = ArgumentCaptor.forClass(RecordLedgerEntryCommand.class);
+            verify(recordLedgerEntryUseCase, times(2)).record(captor.capture());
+
+            RecordLedgerEntryCommand pgCommand = captor.getAllValues().get(0);
+            assertThat(pgCommand.transactionType()).isEqualTo(LedgerTransactionType.SETTLEMENT_CANCELLATION);
+            assertThat(pgCommand.idempotencyKey()).isEqualTo("PG_SETTLEMENT_CANCEL:5");
+            assertThat(pgCommand.entries()).hasSize(3);
+
+            // DEBIT 매출채권_PG = 200000
+            RecordLedgerEntryCommand.EntryLine debit = pgCommand.entries().get(0);
+            assertThat(debit.accountId()).isEqualTo(PG_RECEIVABLE_ID);
+            assertThat(debit.amount()).isEqualTo(200000L);
+            assertThat(debit.transactionType()).isEqualTo(TransactionType.DEBIT);
+
+            // CREDIT 보통예금 = 194000
+            RecordLedgerEntryCommand.EntryLine creditCash = pgCommand.entries().get(1);
+            assertThat(creditCash.accountId()).isEqualTo(CASH_ID);
+            assertThat(creditCash.amount()).isEqualTo(194000L);
+            assertThat(creditCash.transactionType()).isEqualTo(TransactionType.CREDIT);
+
+            // CREDIT PG수수료비용 = 6000
+            RecordLedgerEntryCommand.EntryLine creditPgFee = pgCommand.entries().get(2);
+            assertThat(creditPgFee.accountId()).isEqualTo(PG_FEE_ID);
+            assertThat(creditPgFee.amount()).isEqualTo(6000L);
+            assertThat(creditPgFee.transactionType()).isEqualTo(TransactionType.CREDIT);
+        }
+
+        @Test
+        @DisplayName("판매자 정산 역분개의 DEBIT/CREDIT이 원래 분개와 반대이다")
+        void shouldRecordSellerReversalWithCorrectAmounts() {
+            // given
+            Settlement settlement = createCompletedSettlement(5L, 30L, 200000L, 6000L, 10000L, 184000L);
+            when(findSettlementPort.findById(5L)).thenReturn(Optional.of(settlement));
+
+            // when
+            cancelSettlementService.cancelSettlement(5L);
+
+            // then
+            ArgumentCaptor<RecordLedgerEntryCommand> captor = ArgumentCaptor.forClass(RecordLedgerEntryCommand.class);
+            verify(recordLedgerEntryUseCase, times(2)).record(captor.capture());
+
+            RecordLedgerEntryCommand sellerCommand = captor.getAllValues().get(1);
+            assertThat(sellerCommand.transactionType()).isEqualTo(LedgerTransactionType.SETTLEMENT_CANCELLATION);
+            assertThat(sellerCommand.idempotencyKey()).isEqualTo("SELLER_SETTLEMENT_CANCEL:5");
+            assertThat(sellerCommand.entries()).hasSize(3);
+
+            // DEBIT 보통예금 = 184000
+            RecordLedgerEntryCommand.EntryLine debitCash = sellerCommand.entries().get(0);
+            assertThat(debitCash.accountId()).isEqualTo(CASH_ID);
+            assertThat(debitCash.amount()).isEqualTo(184000L);
+            assertThat(debitCash.transactionType()).isEqualTo(TransactionType.DEBIT);
+
+            // DEBIT 플랫폼수수료수익 = 10000
+            RecordLedgerEntryCommand.EntryLine debitPlatformFee = sellerCommand.entries().get(1);
+            assertThat(debitPlatformFee.accountId()).isEqualTo(PLATFORM_FEE_ID);
+            assertThat(debitPlatformFee.amount()).isEqualTo(10000L);
+            assertThat(debitPlatformFee.transactionType()).isEqualTo(TransactionType.DEBIT);
+
+            // CREDIT 미지급금_판매자 = 194000
+            RecordLedgerEntryCommand.EntryLine creditPayable = sellerCommand.entries().get(2);
+            assertThat(creditPayable.accountId()).isEqualTo(SELLER_PAYABLE_ID);
+            assertThat(creditPayable.amount()).isEqualTo(194000L);
+            assertThat(creditPayable.transactionType()).isEqualTo(TransactionType.CREDIT);
+        }
+    }
+}

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/settlement/ReExecuteSettlementUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/settlement/ReExecuteSettlementUseCaseTest.java
@@ -1,0 +1,316 @@
+package com.personal.marketnote.commerce.service.settlement;
+
+import com.personal.marketnote.commerce.domain.ledger.*;
+import com.personal.marketnote.commerce.domain.settlement.*;
+import com.personal.marketnote.commerce.exception.SettlementNotFoundException;
+import com.personal.marketnote.commerce.port.in.command.ledger.RecordLedgerEntryCommand;
+import com.personal.marketnote.commerce.port.in.usecase.ledger.RecordLedgerEntryUseCase;
+import com.personal.marketnote.commerce.port.out.ledger.FindAccountPort;
+import com.personal.marketnote.commerce.port.out.settlement.FindSettlementPort;
+import com.personal.marketnote.commerce.port.out.settlement.UpdateSettlementPort;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ReExecuteSettlementUseCase 테스트")
+class ReExecuteSettlementUseCaseTest {
+
+    @InjectMocks
+    private ReExecuteSettlementService reExecuteSettlementService;
+
+    @Mock
+    private FindSettlementPort findSettlementPort;
+
+    @Mock
+    private UpdateSettlementPort updateSettlementPort;
+
+    @Mock
+    private RecordLedgerEntryUseCase recordLedgerEntryUseCase;
+
+    @Mock
+    private FindAccountPort findAccountPort;
+
+    private static final Long PG_RECEIVABLE_ID = 1L;
+    private static final Long SELLER_PAYABLE_ID = 2L;
+    private static final Long CASH_ID = 3L;
+    private static final Long PG_FEE_ID = 4L;
+    private static final Long PLATFORM_FEE_ID = 5L;
+
+    @BeforeEach
+    void setUpAccounts() {
+        lenient().when(findAccountPort.findByName("매출채권_PG")).thenReturn(Optional.of(createAccount(PG_RECEIVABLE_ID, "매출채권_PG")));
+        lenient().when(findAccountPort.findByName("미지급금_판매자")).thenReturn(Optional.of(createAccount(SELLER_PAYABLE_ID, "미지급금_판매자")));
+        lenient().when(findAccountPort.findByName("보통예금")).thenReturn(Optional.of(createAccount(CASH_ID, "보통예금")));
+        lenient().when(findAccountPort.findByName("PG수수료비용")).thenReturn(Optional.of(createAccount(PG_FEE_ID, "PG수수료비용")));
+        lenient().when(findAccountPort.findByName("플랫폼수수료수익")).thenReturn(Optional.of(createAccount(PLATFORM_FEE_ID, "플랫폼수수료수익")));
+    }
+
+    private Account createAccount(Long id, String name) {
+        return Account.from(AccountSnapshotState.builder()
+                .id(id)
+                .name(name)
+                .accountType(AccountType.ASSET)
+                .status(com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus.ACTIVE)
+                .createdAt(LocalDateTime.now())
+                .modifiedAt(LocalDateTime.now())
+                .build());
+    }
+
+    private Settlement createCancelledSettlement(Long id, Long sellerId, Long totalAllocatedAmount,
+                                                  Long pgFeeAmount, Long platformFeeAmount, Long sellerPayoutAmount) {
+        return Settlement.from(SettlementSnapshotState.builder()
+                .id(id)
+                .sellerId(sellerId)
+                .year(2026)
+                .month(2)
+                .totalAllocatedAmount(totalAllocatedAmount)
+                .pgFeeAmount(pgFeeAmount)
+                .platformFeeAmount(platformFeeAmount)
+                .sellerPayoutAmount(sellerPayoutAmount)
+                .status(SettlementStatus.CANCELLED)
+                .version(2L)
+                .createdAt(LocalDateTime.now())
+                .modifiedAt(LocalDateTime.now())
+                .build());
+    }
+
+    @Nested
+    @DisplayName("재실행 성공")
+    class ReExecuteSuccess {
+
+        @Test
+        @DisplayName("취소된 정산을 재실행하면 분개를 기록하고 COMPLETED 상태로 전이한다")
+        void shouldReExecuteCancelledSettlementSuccessfully() {
+            // given
+            Settlement cancelledSettlement = createCancelledSettlement(1L, 10L, 100000L, 3000L, 5000L, 92000L);
+            when(findSettlementPort.findById(1L)).thenReturn(Optional.of(cancelledSettlement));
+
+            // when
+            reExecuteSettlementService.reExecuteSettlement(1L);
+
+            // then
+            verify(recordLedgerEntryUseCase, times(2)).record(any(RecordLedgerEntryCommand.class));
+            verify(updateSettlementPort).update(argThat(Settlement::isCompleted));
+        }
+
+        @Test
+        @DisplayName("PG 수수료가 0인 취소 정산을 재실행한다")
+        void shouldReExecuteWithZeroPgFee() {
+            // given
+            Settlement settlement = createCancelledSettlement(2L, 20L, 50000L, 0L, 2500L, 47500L);
+            when(findSettlementPort.findById(2L)).thenReturn(Optional.of(settlement));
+
+            // when
+            reExecuteSettlementService.reExecuteSettlement(2L);
+
+            // then
+            ArgumentCaptor<RecordLedgerEntryCommand> captor = ArgumentCaptor.forClass(RecordLedgerEntryCommand.class);
+            verify(recordLedgerEntryUseCase, times(2)).record(captor.capture());
+
+            RecordLedgerEntryCommand pgCommand = captor.getAllValues().get(0);
+            assertThat(pgCommand.entries()).hasSize(2);
+            assertThat(pgCommand.idempotencyKey()).isEqualTo("PG_SETTLEMENT_REEXEC:2");
+        }
+
+        @Test
+        @DisplayName("플랫폼 수수료가 0인 취소 정산을 재실행한다")
+        void shouldReExecuteWithZeroPlatformFee() {
+            // given
+            Settlement settlement = createCancelledSettlement(3L, 30L, 80000L, 4000L, 0L, 76000L);
+            when(findSettlementPort.findById(3L)).thenReturn(Optional.of(settlement));
+
+            // when
+            reExecuteSettlementService.reExecuteSettlement(3L);
+
+            // then
+            ArgumentCaptor<RecordLedgerEntryCommand> captor = ArgumentCaptor.forClass(RecordLedgerEntryCommand.class);
+            verify(recordLedgerEntryUseCase, times(2)).record(captor.capture());
+
+            RecordLedgerEntryCommand sellerCommand = captor.getAllValues().get(1);
+            assertThat(sellerCommand.entries()).hasSize(2);
+            assertThat(sellerCommand.idempotencyKey()).isEqualTo("SELLER_SETTLEMENT_REEXEC:3");
+        }
+    }
+
+    @Nested
+    @DisplayName("재실행 실패")
+    class ReExecuteFailure {
+
+        @Test
+        @DisplayName("존재하지 않는 정산 ID로 재실행하면 SettlementNotFoundException을 던진다")
+        void shouldThrowWhenSettlementNotFound() {
+            // given
+            when(findSettlementPort.findById(999L)).thenReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> reExecuteSettlementService.reExecuteSettlement(999L))
+                    .isInstanceOf(SettlementNotFoundException.class);
+
+            verifyNoInteractions(recordLedgerEntryUseCase);
+            verifyNoInteractions(updateSettlementPort);
+        }
+
+        @Test
+        @DisplayName("PENDING 상태의 정산을 재실행하면 InvalidSettlementStatusTransitionException을 던진다")
+        void shouldThrowWhenSettlementIsPending() {
+            // given
+            Settlement pendingSettlement = Settlement.from(SettlementSnapshotState.builder()
+                    .id(1L).sellerId(10L).year(2026).month(2)
+                    .totalAllocatedAmount(100000L).pgFeeAmount(3000L)
+                    .platformFeeAmount(5000L).sellerPayoutAmount(92000L)
+                    .status(SettlementStatus.PENDING).version(0L)
+                    .createdAt(LocalDateTime.now()).modifiedAt(LocalDateTime.now())
+                    .build());
+            when(findSettlementPort.findById(1L)).thenReturn(Optional.of(pendingSettlement));
+
+            // when & then
+            assertThatThrownBy(() -> reExecuteSettlementService.reExecuteSettlement(1L))
+                    .isInstanceOf(InvalidSettlementStatusTransitionException.class);
+
+            verifyNoInteractions(recordLedgerEntryUseCase);
+            verifyNoInteractions(updateSettlementPort);
+        }
+
+        @Test
+        @DisplayName("COMPLETED 상태의 정산을 재실행하면 InvalidSettlementStatusTransitionException을 던진다")
+        void shouldThrowWhenSettlementIsCompleted() {
+            // given
+            Settlement completedSettlement = Settlement.from(SettlementSnapshotState.builder()
+                    .id(1L).sellerId(10L).year(2026).month(2)
+                    .totalAllocatedAmount(100000L).pgFeeAmount(3000L)
+                    .platformFeeAmount(5000L).sellerPayoutAmount(92000L)
+                    .status(SettlementStatus.COMPLETED).version(1L)
+                    .createdAt(LocalDateTime.now()).modifiedAt(LocalDateTime.now())
+                    .build());
+            when(findSettlementPort.findById(1L)).thenReturn(Optional.of(completedSettlement));
+
+            // when & then
+            assertThatThrownBy(() -> reExecuteSettlementService.reExecuteSettlement(1L))
+                    .isInstanceOf(InvalidSettlementStatusTransitionException.class);
+
+            verifyNoInteractions(recordLedgerEntryUseCase);
+            verifyNoInteractions(updateSettlementPort);
+        }
+
+        @Test
+        @DisplayName("FAILED 상태의 정산을 재실행하면 InvalidSettlementStatusTransitionException을 던진다")
+        void shouldThrowWhenSettlementIsFailed() {
+            // given
+            Settlement failedSettlement = Settlement.from(SettlementSnapshotState.builder()
+                    .id(1L).sellerId(10L).year(2026).month(2)
+                    .totalAllocatedAmount(100000L).pgFeeAmount(3000L)
+                    .platformFeeAmount(5000L).sellerPayoutAmount(92000L)
+                    .status(SettlementStatus.FAILED).version(0L)
+                    .createdAt(LocalDateTime.now()).modifiedAt(LocalDateTime.now())
+                    .build());
+            when(findSettlementPort.findById(1L)).thenReturn(Optional.of(failedSettlement));
+
+            // when & then
+            assertThatThrownBy(() -> reExecuteSettlementService.reExecuteSettlement(1L))
+                    .isInstanceOf(InvalidSettlementStatusTransitionException.class);
+
+            verifyNoInteractions(recordLedgerEntryUseCase);
+            verifyNoInteractions(updateSettlementPort);
+        }
+    }
+
+    @Nested
+    @DisplayName("분개 실패 시 FAILED 상태 전이")
+    class LedgerFailure {
+
+        @Test
+        @DisplayName("분개 기록 중 예외 발생 시 FAILED 상태로 저장하고 예외를 재throw한다")
+        void shouldTransitionToFailedOnLedgerException() {
+            // given
+            Settlement cancelledSettlement = createCancelledSettlement(1L, 10L, 100000L, 3000L, 5000L, 92000L);
+            when(findSettlementPort.findById(1L)).thenReturn(Optional.of(cancelledSettlement));
+            doThrow(new RuntimeException("분개 기록 실패"))
+                    .when(recordLedgerEntryUseCase).record(any(RecordLedgerEntryCommand.class));
+
+            // when & then
+            assertThatThrownBy(() -> reExecuteSettlementService.reExecuteSettlement(1L))
+                    .isInstanceOf(RuntimeException.class)
+                    .hasMessageContaining("분개 기록 실패");
+
+            verify(updateSettlementPort).update(argThat(Settlement::isFailed));
+        }
+    }
+
+    @Nested
+    @DisplayName("분개 검증")
+    class LedgerVerification {
+
+        @Test
+        @DisplayName("재실행 분개의 DEBIT/CREDIT이 원래 정산과 동일하다")
+        void shouldRecordLedgerWithCorrectAmounts() {
+            // given
+            Settlement settlement = createCancelledSettlement(5L, 30L, 200000L, 6000L, 10000L, 184000L);
+            when(findSettlementPort.findById(5L)).thenReturn(Optional.of(settlement));
+
+            // when
+            reExecuteSettlementService.reExecuteSettlement(5L);
+
+            // then
+            ArgumentCaptor<RecordLedgerEntryCommand> captor = ArgumentCaptor.forClass(RecordLedgerEntryCommand.class);
+            verify(recordLedgerEntryUseCase, times(2)).record(captor.capture());
+
+            // PG 정산 분개
+            RecordLedgerEntryCommand pgCommand = captor.getAllValues().get(0);
+            assertThat(pgCommand.transactionType()).isEqualTo(LedgerTransactionType.PG_SETTLEMENT);
+            assertThat(pgCommand.idempotencyKey()).isEqualTo("PG_SETTLEMENT_REEXEC:5");
+            assertThat(pgCommand.entries()).hasSize(3);
+
+            // DEBIT 보통예금 = 194000
+            assertThat(pgCommand.entries().get(0).accountId()).isEqualTo(CASH_ID);
+            assertThat(pgCommand.entries().get(0).amount()).isEqualTo(194000L);
+            assertThat(pgCommand.entries().get(0).transactionType()).isEqualTo(TransactionType.DEBIT);
+
+            // DEBIT PG수수료비용 = 6000
+            assertThat(pgCommand.entries().get(1).accountId()).isEqualTo(PG_FEE_ID);
+            assertThat(pgCommand.entries().get(1).amount()).isEqualTo(6000L);
+            assertThat(pgCommand.entries().get(1).transactionType()).isEqualTo(TransactionType.DEBIT);
+
+            // CREDIT 매출채권_PG = 200000
+            assertThat(pgCommand.entries().get(2).accountId()).isEqualTo(PG_RECEIVABLE_ID);
+            assertThat(pgCommand.entries().get(2).amount()).isEqualTo(200000L);
+            assertThat(pgCommand.entries().get(2).transactionType()).isEqualTo(TransactionType.CREDIT);
+
+            // 판매자 정산 분개
+            RecordLedgerEntryCommand sellerCommand = captor.getAllValues().get(1);
+            assertThat(sellerCommand.transactionType()).isEqualTo(LedgerTransactionType.SELLER_SETTLEMENT);
+            assertThat(sellerCommand.idempotencyKey()).isEqualTo("SELLER_SETTLEMENT_REEXEC:5");
+            assertThat(sellerCommand.entries()).hasSize(3);
+
+            // DEBIT 미지급금_판매자 = 194000
+            assertThat(sellerCommand.entries().get(0).accountId()).isEqualTo(SELLER_PAYABLE_ID);
+            assertThat(sellerCommand.entries().get(0).amount()).isEqualTo(194000L);
+            assertThat(sellerCommand.entries().get(0).transactionType()).isEqualTo(TransactionType.DEBIT);
+
+            // CREDIT 보통예금 = 184000
+            assertThat(sellerCommand.entries().get(1).accountId()).isEqualTo(CASH_ID);
+            assertThat(sellerCommand.entries().get(1).amount()).isEqualTo(184000L);
+            assertThat(sellerCommand.entries().get(1).transactionType()).isEqualTo(TransactionType.CREDIT);
+
+            // CREDIT 플랫폼수수료수익 = 10000
+            assertThat(sellerCommand.entries().get(2).accountId()).isEqualTo(PLATFORM_FEE_ID);
+            assertThat(sellerCommand.entries().get(2).amount()).isEqualTo(10000L);
+            assertThat(sellerCommand.entries().get(2).transactionType()).isEqualTo(TransactionType.CREDIT);
+        }
+    }
+}

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/ledger/LedgerTransactionType.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/ledger/LedgerTransactionType.java
@@ -10,7 +10,8 @@ public enum LedgerTransactionType {
     PAYMENT_CANCELLATION("결제 전체 취소"),
     PAYMENT_PARTIAL_REFUND("결제 부분 환불"),
     PG_SETTLEMENT("PG 정산 입금"),
-    SELLER_SETTLEMENT("판매자 정산");
+    SELLER_SETTLEMENT("판매자 정산"),
+    SETTLEMENT_CANCELLATION("정산 취소 역분개");
 
     private final String description;
 }

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/settlement/Settlement.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/settlement/Settlement.java
@@ -130,4 +130,49 @@ public class Settlement {
         }
         this.status = SettlementStatus.FAILED;
     }
+
+    /**
+     * 취소 상태인지 확인한다.
+     *
+     * @return 취소 상태이면 true
+     * @author 성효빈
+     * @since 2026-03-02
+     */
+    public boolean isCancelled() {
+        return status == SettlementStatus.CANCELLED;
+    }
+
+    /**
+     * 완료된 정산을 취소한다.
+     * <p>
+     * COMPLETED → CANCELLED 상태 전이만 허용한다.
+     * </p>
+     *
+     * @throws InvalidSettlementStatusTransitionException 현재 상태가 COMPLETED가 아닌 경우
+     * @author 성효빈
+     * @since 2026-03-02
+     */
+    public void cancel() {
+        if (!isCompleted()) {
+            throw new InvalidSettlementStatusTransitionException(status);
+        }
+        this.status = SettlementStatus.CANCELLED;
+    }
+
+    /**
+     * 취소된 정산을 대기 상태로 재설정한다.
+     * <p>
+     * CANCELLED → PENDING 상태 전이만 허용한다.
+     * </p>
+     *
+     * @throws InvalidSettlementStatusTransitionException 현재 상태가 CANCELLED가 아닌 경우
+     * @author 성효빈
+     * @since 2026-03-02
+     */
+    public void resetCancelledToPending() {
+        if (!isCancelled()) {
+            throw new InvalidSettlementStatusTransitionException(status);
+        }
+        this.status = SettlementStatus.PENDING;
+    }
 }

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/settlement/SettlementStatus.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/settlement/SettlementStatus.java
@@ -8,7 +8,8 @@ import lombok.RequiredArgsConstructor;
 public enum SettlementStatus {
     PENDING("정산 대기"),
     COMPLETED("정산 완료"),
-    FAILED("정산 실패");
+    FAILED("정산 실패"),
+    CANCELLED("정산 취소");
 
     private final String description;
 }

--- a/commerce-service/commerce-domain/src/test/java/com/personal/marketnote/commerce/domain/settlement/SettlementTest.java
+++ b/commerce-service/commerce-domain/src/test/java/com/personal/marketnote/commerce/domain/settlement/SettlementTest.java
@@ -298,6 +298,118 @@ class SettlementTest {
         }
 
         @Test
+        @DisplayName("COMPLETED 상태에서 cancel() 호출 시 CANCELLED 상태로 전이된다")
+        void shouldTransitionToCancelled() {
+            // given
+            Settlement settlement = createPendingSettlement();
+            settlement.complete();
+
+            // when
+            settlement.cancel();
+
+            // then
+            assertThat(settlement.isCancelled()).isTrue();
+            assertThat(settlement.isCompleted()).isFalse();
+        }
+
+        @Test
+        @DisplayName("PENDING 상태에서 cancel() 호출 시 IllegalStateException을 던진다")
+        void shouldThrowWhenCancelFromPending() {
+            // given
+            Settlement settlement = createPendingSettlement();
+
+            // when & then
+            assertThatThrownBy(settlement::cancel)
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("현재 상태");
+        }
+
+        @Test
+        @DisplayName("FAILED 상태에서 cancel() 호출 시 IllegalStateException을 던진다")
+        void shouldThrowWhenCancelFromFailed() {
+            // given
+            Settlement settlement = createPendingSettlement();
+            settlement.fail();
+
+            // when & then
+            assertThatThrownBy(settlement::cancel)
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("현재 상태");
+        }
+
+        @Test
+        @DisplayName("CANCELLED 상태에서 cancel() 호출 시 IllegalStateException을 던진다")
+        void shouldThrowWhenCancelFromCancelled() {
+            // given
+            Settlement settlement = createPendingSettlement();
+            settlement.complete();
+            settlement.cancel();
+
+            // when & then
+            assertThatThrownBy(settlement::cancel)
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("현재 상태");
+        }
+
+        @Test
+        @DisplayName("CANCELLED 상태에서 resetCancelledToPending() 호출 시 PENDING 상태로 전이된다")
+        void shouldResetCancelledToPending() {
+            // given
+            Settlement settlement = createPendingSettlement();
+            settlement.complete();
+            settlement.cancel();
+            assertThat(settlement.isCancelled()).isTrue();
+
+            // when
+            settlement.resetCancelledToPending();
+
+            // then
+            assertThat(settlement.isPending()).isTrue();
+            assertThat(settlement.isCancelled()).isFalse();
+        }
+
+        @Test
+        @DisplayName("PENDING 상태에서 resetCancelledToPending() 호출 시 IllegalStateException을 던진다")
+        void shouldThrowWhenResetCancelledFromPending() {
+            // given
+            Settlement settlement = createPendingSettlement();
+
+            // when & then
+            assertThatThrownBy(settlement::resetCancelledToPending)
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("현재 상태");
+        }
+
+        @Test
+        @DisplayName("COMPLETED 상태에서 resetCancelledToPending() 호출 시 IllegalStateException을 던진다")
+        void shouldThrowWhenResetCancelledFromCompleted() {
+            // given
+            Settlement settlement = createPendingSettlement();
+            settlement.complete();
+
+            // when & then
+            assertThatThrownBy(settlement::resetCancelledToPending)
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("현재 상태");
+        }
+
+        @Test
+        @DisplayName("CANCELLED → PENDING → COMPLETED 전체 흐름이 성공한다")
+        void shouldCompleteCancelReExecuteFlow() {
+            // given
+            Settlement settlement = createPendingSettlement();
+            settlement.complete();
+            settlement.cancel();
+            settlement.resetCancelledToPending();
+
+            // when
+            settlement.complete();
+
+            // then
+            assertThat(settlement.isCompleted()).isTrue();
+        }
+
+        @Test
         @DisplayName("FAILED 상태에서 resetToPending 후 complete() 호출 시 COMPLETED 상태로 전이된다")
         void shouldCompleteAfterResetFromFailed() {
             // given
@@ -328,6 +440,21 @@ class SettlementTest {
             assertThat(settlement.isFailed()).isTrue();
             assertThat(settlement.isPending()).isFalse();
             assertThat(settlement.isCompleted()).isFalse();
+        }
+
+        @Test
+        @DisplayName("isCancelled()는 CANCELLED 상태에서 true를 반환한다")
+        void shouldReturnTrueWhenCancelled() {
+            // given
+            Settlement settlement = createPendingSettlement();
+            settlement.complete();
+            settlement.cancel();
+
+            // then
+            assertThat(settlement.isCancelled()).isTrue();
+            assertThat(settlement.isPending()).isFalse();
+            assertThat(settlement.isCompleted()).isFalse();
+            assertThat(settlement.isFailed()).isFalse();
         }
 
         @Test


### PR DESCRIPTION
## partially addresses #216
## resolves #925

## Task
- [x] SettlementStatus에 CANCELLED 상태 추가
- [x] Settlement 도메인에 cancel(), isCancelled(), resetCancelledToPending() 상태 전이 메서드 추가
- [x] LedgerTransactionType에 SETTLEMENT_CANCELLATION 역분개 유형 추가
- [x] CancelSettlementUseCase/Service: COMPLETED 정산 취소, 역분개 기록 (PG + 판매자)
- [x] ReExecuteSettlementUseCase/Service: CANCELLED 정산 재실행, 분개 재기록
- [x] SettlementController에 취소/재실행 API 엔드포인트 추가
- [x] Swagger 문서 합성 애노테이션 추가 (CancelSettlementApiDocs, ReExecuteSettlementApiDocs)
- [x] CancelSettlementUseCaseTest (9건), ReExecuteSettlementUseCaseTest (10건), SettlementTest 도메인 테스트 (10건 추가) 자동화 테스트 추가