### PR TITLE
[#216][#926] feat: 정산 일괄 실행 스케줄러 기능 추가

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/scheduler/SettlementScheduler.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/scheduler/SettlementScheduler.java
@@ -1,0 +1,48 @@
+package com.personal.marketnote.commerce.adapter.in.scheduler;
+
+import com.personal.marketnote.commerce.configuration.SettlementSchedulerProperties;
+import com.personal.marketnote.commerce.exception.NoUnsettledAllocationException;
+import com.personal.marketnote.commerce.port.in.command.settlement.ExecuteSettlementCommand;
+import com.personal.marketnote.commerce.port.in.usecase.settlement.ExecuteSettlementUseCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.Clock;
+import java.time.YearMonth;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SettlementScheduler {
+    private final ExecuteSettlementUseCase executeSettlementUseCase;
+    private final SettlementSchedulerProperties properties;
+    private final Clock commerceClock;
+
+    @Scheduled(cron = "${settlement.scheduler.cron}", zone = "Asia/Seoul")
+    public void executeMonthlySettlement() {
+        YearMonth previousMonth = YearMonth.now(commerceClock).minusMonths(1);
+        int year = previousMonth.getYear();
+        int month = previousMonth.getMonthValue();
+
+        log.info("월별 자동 정산 실행 시작 - year: {}, month: {}, pgFeeRate: {}, platformFeeRate: {}",
+                year, month, properties.getPgFeeRate(), properties.getPlatformFeeRate());
+
+        try {
+            ExecuteSettlementCommand command = ExecuteSettlementCommand.builder()
+                    .year(year)
+                    .month(month)
+                    .pgFeeRate(properties.getPgFeeRate())
+                    .platformFeeRate(properties.getPlatformFeeRate())
+                    .build();
+
+            executeSettlementUseCase.executeSettlement(command);
+            log.info("월별 자동 정산 실행 완료 - year: {}, month: {}", year, month);
+        } catch (NoUnsettledAllocationException e) {
+            log.info("전월 미정산 배분 없음, 정산 스킵 - year: {}, month: {}", year, month);
+        } catch (Exception e) {
+            log.error("월별 자동 정산 실행 실패 - year: {}, month: {}", year, month, e);
+        }
+    }
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/configuration/SchedulingConfig.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/configuration/SchedulingConfig.java
@@ -1,0 +1,30 @@
+package com.personal.marketnote.commerce.configuration;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+import java.time.Clock;
+import java.time.ZoneId;
+
+@Configuration
+@EnableScheduling
+@ConditionalOnProperty(name = "settlement.scheduler.enabled", havingValue = "true", matchIfMissing = false)
+public class SchedulingConfig {
+    @Bean
+    public ThreadPoolTaskScheduler taskScheduler() {
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        scheduler.setPoolSize(2);
+        scheduler.setThreadNamePrefix("commerce-scheduler-");
+        scheduler.setWaitForTasksToCompleteOnShutdown(true);
+        scheduler.setAwaitTerminationSeconds(30);
+        return scheduler;
+    }
+
+    @Bean
+    public Clock commerceClock() {
+        return Clock.system(ZoneId.of("Asia/Seoul"));
+    }
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/configuration/SettlementSchedulerProperties.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/configuration/SettlementSchedulerProperties.java
@@ -1,0 +1,17 @@
+package com.personal.marketnote.commerce.configuration;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationProperties(prefix = "settlement.scheduler")
+@Getter
+@Setter
+public class SettlementSchedulerProperties {
+    private boolean enabled;
+    private String cron = "0 0 2 1 * *";
+    private Integer pgFeeRate;
+    private Integer platformFeeRate;
+}

--- a/commerce-service/commerce-adapters/src/main/resources/application.yml
+++ b/commerce-service/commerce-adapters/src/main/resources/application.yml
@@ -73,6 +73,13 @@ kcp:
     payment-cancel-url: ${KCP_PAYMENT_CANCEL_URL:https://stg-spl.kcp.co.kr/gw/mod/v1/cancel}
   ret-url: ${KCP_RET_URL:https://marketnote-dev.vercel.app/payments/kcp/callback}
 
+settlement:
+  scheduler:
+    enabled: ${SETTLEMENT_SCHEDULER_ENABLED:false}
+    cron: ${SETTLEMENT_SCHEDULER_CRON:0 0 2 1 * *}
+    pg-fee-rate: ${SETTLEMENT_PG_FEE_RATE:300}
+    platform-fee-rate: ${SETTLEMENT_PLATFORM_FEE_RATE:500}
+
 management:
   endpoints:
     web:

--- a/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/scheduler/SettlementSchedulerTest.java
+++ b/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/scheduler/SettlementSchedulerTest.java
@@ -1,0 +1,151 @@
+package com.personal.marketnote.commerce.adapter.in.scheduler;
+
+import com.personal.marketnote.commerce.configuration.SettlementSchedulerProperties;
+import com.personal.marketnote.commerce.exception.NoUnsettledAllocationException;
+import com.personal.marketnote.commerce.port.in.command.settlement.ExecuteSettlementCommand;
+import com.personal.marketnote.commerce.port.in.usecase.settlement.ExecuteSettlementUseCase;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class SettlementSchedulerTest {
+    @InjectMocks
+    private SettlementScheduler settlementScheduler;
+
+    @Mock
+    private ExecuteSettlementUseCase executeSettlementUseCase;
+
+    @Mock
+    private SettlementSchedulerProperties properties;
+
+    @Mock(name = "commerceClock")
+    private Clock commerceClock;
+
+    private void setUpClock(String instant) {
+        Clock fixedClock = Clock.fixed(Instant.parse(instant), ZoneId.of("Asia/Seoul"));
+        when(commerceClock.instant()).thenReturn(fixedClock.instant());
+        when(commerceClock.getZone()).thenReturn(fixedClock.getZone());
+    }
+
+    private void setUpProperties(int pgFeeRate, int platformFeeRate) {
+        when(properties.getPgFeeRate()).thenReturn(pgFeeRate);
+        when(properties.getPlatformFeeRate()).thenReturn(platformFeeRate);
+    }
+
+    @Test
+    @DisplayName("월별 자동 정산 실행 시 전월의 연/월로 정산 커맨드가 생성된다")
+    void executeMonthlySettlement_createsCommandWithPreviousMonth() {
+        // given
+        setUpClock("2026-03-01T02:00:00Z");
+        setUpProperties(300, 500);
+
+        // when
+        settlementScheduler.executeMonthlySettlement();
+
+        // then
+        ArgumentCaptor<ExecuteSettlementCommand> captor = ArgumentCaptor.forClass(ExecuteSettlementCommand.class);
+        verify(executeSettlementUseCase).executeSettlement(captor.capture());
+
+        ExecuteSettlementCommand command = captor.getValue();
+        assertThat(command.year()).isEqualTo(2026);
+        assertThat(command.month()).isEqualTo(2);
+        assertThat(command.pgFeeRate()).isEqualTo(300);
+        assertThat(command.platformFeeRate()).isEqualTo(500);
+    }
+
+    @Test
+    @DisplayName("1월에 실행하면 전년 12월 정산 커맨드가 생성된다")
+    void executeMonthlySettlement_januaryCreatesDecemberOfPreviousYear() {
+        // given
+        setUpClock("2026-01-01T02:00:00Z");
+        setUpProperties(300, 500);
+
+        // when
+        settlementScheduler.executeMonthlySettlement();
+
+        // then
+        ArgumentCaptor<ExecuteSettlementCommand> captor = ArgumentCaptor.forClass(ExecuteSettlementCommand.class);
+        verify(executeSettlementUseCase).executeSettlement(captor.capture());
+
+        ExecuteSettlementCommand command = captor.getValue();
+        assertThat(command.year()).isEqualTo(2025);
+        assertThat(command.month()).isEqualTo(12);
+    }
+
+    @Test
+    @DisplayName("Properties에 설정된 수수료율이 커맨드에 정확히 전달된다")
+    void executeMonthlySettlement_feeRatesFromProperties() {
+        // given
+        setUpClock("2026-03-01T02:00:00Z");
+        setUpProperties(250, 700);
+
+        // when
+        settlementScheduler.executeMonthlySettlement();
+
+        // then
+        ArgumentCaptor<ExecuteSettlementCommand> captor = ArgumentCaptor.forClass(ExecuteSettlementCommand.class);
+        verify(executeSettlementUseCase).executeSettlement(captor.capture());
+
+        ExecuteSettlementCommand command = captor.getValue();
+        assertThat(command.pgFeeRate()).isEqualTo(250);
+        assertThat(command.platformFeeRate()).isEqualTo(700);
+    }
+
+    @Test
+    @DisplayName("미정산 배분이 없으면 예외가 전파되지 않는다")
+    void executeMonthlySettlement_noUnsettledAllocation_doesNotPropagate() {
+        // given
+        setUpClock("2026-03-01T02:00:00Z");
+        setUpProperties(300, 500);
+        doThrow(new NoUnsettledAllocationException())
+                .when(executeSettlementUseCase).executeSettlement(any(ExecuteSettlementCommand.class));
+
+        // when & then
+        settlementScheduler.executeMonthlySettlement();
+
+        verify(executeSettlementUseCase).executeSettlement(any(ExecuteSettlementCommand.class));
+    }
+
+    @Test
+    @DisplayName("예상치 못한 예외 발생 시에도 예외가 전파되지 않는다")
+    void executeMonthlySettlement_unexpectedException_doesNotPropagate() {
+        // given
+        setUpClock("2026-03-01T02:00:00Z");
+        setUpProperties(300, 500);
+        doThrow(new RuntimeException("DB 연결 실패"))
+                .when(executeSettlementUseCase).executeSettlement(any(ExecuteSettlementCommand.class));
+
+        // when & then
+        settlementScheduler.executeMonthlySettlement();
+
+        verify(executeSettlementUseCase).executeSettlement(any(ExecuteSettlementCommand.class));
+    }
+
+    @Test
+    @DisplayName("정산 실행이 성공하면 UseCase가 정확히 한 번 호출된다")
+    void executeMonthlySettlement_success_callsUseCaseOnce() {
+        // given
+        setUpClock("2026-06-01T02:00:00Z");
+        setUpProperties(300, 500);
+
+        // when
+        settlementScheduler.executeMonthlySettlement();
+
+        // then
+        verify(executeSettlementUseCase, times(1)).executeSettlement(any(ExecuteSettlementCommand.class));
+        verifyNoMoreInteractions(executeSettlementUseCase);
+    }
+}

--- a/commerce-service/commerce-adapters/src/test/resources/application-test.yml
+++ b/commerce-service/commerce-adapters/src/test/resources/application-test.yml
@@ -25,3 +25,9 @@ spring:
       - org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration
       - org.springframework.boot.autoconfigure.security.oauth2.resource.servlet.OAuth2ResourceServerAutoConfiguration
       - org.springframework.boot.autoconfigure.batch.BatchAutoConfiguration
+
+settlement:
+  scheduler:
+    enabled: false
+    pg-fee-rate: 300
+    platform-fee-rate: 500


### PR DESCRIPTION
## partially addresses #216
## resolves #926

## Task
- [x] Spring @scheduled 기반 월별 정산 스케줄러 구현 (SettlementScheduler)
- [x] @ConditionalOnProperty로 스케줄러 on/off 제어 (SchedulingConfig)
- [x] @ConfigurationProperties로 수수료율/cron 외부화 (SettlementSchedulerProperties)
- [x] 정산 대상 기간 자동 계산 (전월 연/월)
- [x] 스케줄러 실행 결과 로깅 (성공/스킵/실패)
- [x] 단위 테스트 6건 추가 (SettlementSchedulerTest)
