### PR TITLE
[#1][#984] refactor: -1 센티널 값 제거 및 null 기반 통일 리팩터링

### DIFF
--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/settlement/Settlement.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/settlement/Settlement.java
@@ -32,8 +32,8 @@ public class Settlement {
             throw new InvalidSettlementAmountException(
                     "판매자 지급액은 0보다 커야 합니다. sellerPayoutAmount=" + state.getSellerPayoutAmount());
         }
-        long pgFee = state.getPgFeeAmount() != null ? state.getPgFeeAmount() : 0L;
-        long platformFee = state.getPlatformFeeAmount() != null ? state.getPlatformFeeAmount() : 0L;
+        long pgFee = FormatValidator.hasValue(state.getPgFeeAmount()) ? state.getPgFeeAmount() : 0L;
+        long platformFee = FormatValidator.hasValue(state.getPlatformFeeAmount()) ? state.getPlatformFeeAmount() : 0L;
 
         if (pgFee < 0) {
             throw new InvalidSettlementAmountException(

--- a/common/src/main/java/com/personal/marketnote/common/utility/FormatValidator.java
+++ b/common/src/main/java/com/personal/marketnote/common/utility/FormatValidator.java
@@ -3,8 +3,6 @@ package com.personal.marketnote.common.utility;
 import java.util.Collection;
 import java.util.regex.Pattern;
 
-import static com.personal.marketnote.common.utility.NumberConstant.MINUS_ONE;
-
 public class FormatValidator {
     public static boolean isValid(CharSequence value, Pattern pattern) {
         return hasValue(value) && hasValue(pattern) && pattern.matcher(value).matches();
@@ -31,7 +29,7 @@ public class FormatValidator {
     }
 
     public static boolean hasValue(Number value) {
-        return value != null && !equals(value.toString(), MINUS_ONE);
+        return value != null;
     }
 
     public static boolean notEquals(Object value1, Object value2) {

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/product/controller/ProductController.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/product/controller/ProductController.java
@@ -30,7 +30,6 @@ import java.util.List;
 
 import static com.personal.marketnote.common.domain.exception.ExceptionCode.DEFAULT_SUCCESS_CODE;
 import static com.personal.marketnote.common.utility.ApiConstant.*;
-import static com.personal.marketnote.common.utility.NumberConstant.MINUS_ONE;
 
 /**
  * 상품 컨트롤러
@@ -153,7 +152,7 @@ public class ProductController {
     public ResponseEntity<BaseResponse<GetProductsResponse>> getProducts(
             @RequestParam(value = "categoryId", required = false) Long categoryId,
             @RequestParam(value = "pricePolicyIds", required = false) List<Long> pricePolicyIds,
-            @RequestParam(value = "cursor", required = false, defaultValue = MINUS_ONE) Long cursor,
+            @RequestParam(value = "cursor", required = false) Long cursor,
             @RequestParam(value = "pageSize", required = false, defaultValue = GET_PRODUCTS_DEFAULT_PAGE_SIZE) int pageSize,
             @RequestParam(required = false, defaultValue = "DESC") Sort.Direction sortDirection,
             @RequestParam(required = false, defaultValue = "ORDER_NUM") ProductSortProperty sortProperty,
@@ -203,7 +202,7 @@ public class ProductController {
     public ResponseEntity<BaseResponse<GetAdminProductsResponse>> getAdminProducts(
             @RequestParam(value = "categoryId", required = false) Long categoryId,
             @RequestParam(value = "pricePolicyIds", required = false) List<Long> pricePolicyIds,
-            @RequestParam(value = "cursor", required = false, defaultValue = MINUS_ONE) Long cursor,
+            @RequestParam(value = "cursor", required = false) Long cursor,
             @RequestParam(value = "pageSize", required = false, defaultValue = GET_PRODUCTS_DEFAULT_PAGE_SIZE) int pageSize,
             @RequestParam(required = false, defaultValue = "DESC") Sort.Direction sortDirection,
             @RequestParam(required = false, defaultValue = "ORDER_NUM") ProductSortProperty sortProperty,

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/out/result/GetInventoryResult.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/out/result/GetInventoryResult.java
@@ -1,9 +1,6 @@
 package com.personal.marketnote.product.port.out.result;
 
-import com.personal.marketnote.common.utility.FormatConverter;
 import com.personal.marketnote.common.utility.FormatValidator;
-
-import static com.personal.marketnote.common.utility.NumberConstant.MINUS_ONE;
 
 public record GetInventoryResult(
         Long pricePolicyId,
@@ -14,7 +11,7 @@ public record GetInventoryResult(
     }
 
     public static GetInventoryResult generateResultWithoutStock(Long pricePolicyId) {
-        return new GetInventoryResult(pricePolicyId, FormatConverter.parseToInteger(MINUS_ONE));
+        return new GetInventoryResult(pricePolicyId, null);
     }
 
     public boolean hasNoStock() {

--- a/product-service/product-application/src/test/java/com/personal/marketnote/product/service/category/RegisterCategoryUseCaseTest.java
+++ b/product-service/product-application/src/test/java/com/personal/marketnote/product/service/category/RegisterCategoryUseCaseTest.java
@@ -89,23 +89,6 @@ class RegisterCategoryUseCaseTest {
     }
 
     @Test
-    @DisplayName("카테고리 등록 시 상위 카테고리 ID가 -1이면 검증 없이 저장한다")
-    void registerCategory_parentMinusOne_skipsFind() {
-        RegisterCategoryCommand command = RegisterCategoryCommand.of(-1L, "카테고리");
-        Category saved = buildCategory(300L, -1L, "카테고리");
-
-        when(saveCategoryPort.save(any(Category.class))).thenReturn(saved);
-
-        RegisterCategoryResult result = registerCategoryService.registerCategory(command);
-
-        assertThat(result.id()).isEqualTo(300L);
-        assertThat(result.parentCategoryId()).isEqualTo(-1L);
-        assertThat(result.name()).isEqualTo("카테고리");
-
-        verifyNoInteractions(findCategoryPort);
-    }
-
-    @Test
     @DisplayName("카테고리 등록 시 상위 카테고리 조회에 실패하면 예외를 전파한다")
     void registerCategory_findParentFails_propagates() {
         RegisterCategoryCommand command = RegisterCategoryCommand.of(12L, "카테고리");

--- a/product-service/product-application/src/test/java/com/personal/marketnote/product/service/product/GetProductInventoryUseCaseTest.java
+++ b/product-service/product-application/src/test/java/com/personal/marketnote/product/service/product/GetProductInventoryUseCaseTest.java
@@ -51,7 +51,6 @@ class GetProductInventoryUseCaseTest {
         List<Long> pricePolicyIds = List.of(1L, 2L, 3L);
         Map<Long, Integer> cacheInventories = new HashMap<>();
         cacheInventories.put(1L, 3);
-        cacheInventories.put(2L, -1);
 
         when(findCacheStockPort.findByPricePolicyIds(pricePolicyIds)).thenReturn(cacheInventories);
         when(findStockPort.findByPricePolicyIds(List.of(2L, 3L)))


### PR DESCRIPTION
## partially addresses #1
## resolves #984

## Task
- [x] FormatValidator hasValue(Number)에서 -1 센티널 값 비교 제거 (null만 "값 없음" 판단)
- [x] ProductController Cursor defaultValue MINUS_ONE 제거 (null 기반 통일)
- [x] GetInventoryResult 재고 미확인 표현 -1에서 null로 변경
- [x] -1 관련 자동화 테스트 수정 (RegisterCategoryUseCaseTest, GetProductInventoryUseCaseTest)
- [x] Settlement 수수료 null 체크 FormatValidator.hasValue() 적용