### PR TITLE
[#216][#928] feat: 회계 장부 조회/리포트 생성 기능 추가

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/ledger/controller/LedgerController.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/ledger/controller/LedgerController.java
@@ -1,0 +1,115 @@
+package com.personal.marketnote.commerce.adapter.in.web.ledger.controller;
+
+import com.personal.marketnote.commerce.adapter.in.web.ledger.controller.apidocs.GetAccountBalancesApiDocs;
+import com.personal.marketnote.commerce.adapter.in.web.ledger.controller.apidocs.GetLedgerTransactionsApiDocs;
+import com.personal.marketnote.commerce.adapter.in.web.ledger.response.GetAccountBalanceResponse;
+import com.personal.marketnote.commerce.adapter.in.web.ledger.response.GetLedgerTransactionResponse;
+import com.personal.marketnote.commerce.domain.ledger.LedgerTransactionType;
+import com.personal.marketnote.commerce.port.in.command.ledger.GetLedgerTransactionsQuery;
+import com.personal.marketnote.commerce.port.in.result.ledger.GetAccountBalanceResult;
+import com.personal.marketnote.commerce.port.in.result.ledger.GetLedgerTransactionResult;
+import com.personal.marketnote.commerce.port.in.usecase.ledger.GetAccountBalanceUseCase;
+import com.personal.marketnote.commerce.port.in.usecase.ledger.GetLedgerTransactionsUseCase;
+import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static com.personal.marketnote.common.domain.exception.ExceptionCode.DEFAULT_SUCCESS_CODE;
+import static com.personal.marketnote.common.utility.ApiConstant.ADMIN_POINTCUT;
+
+/**
+ * 회계 장부 컨트롤러 (관리자 전용)
+ *
+ * @author 성효빈
+ * @since 2026-03-02
+ */
+@RestController
+@RequestMapping("/api/v1/admin/ledger")
+@Tag(name = "(관리자) 회계 장부 API", description = "관리자 회계 거래/잔액 조회 API")
+@RequiredArgsConstructor
+public class LedgerController {
+    private final GetLedgerTransactionsUseCase getLedgerTransactionsUseCase;
+    private final GetAccountBalanceUseCase getAccountBalanceUseCase;
+
+    /**
+     * 회계 거래 목록 조회
+     *
+     * @param startDate       조회 시작일시
+     * @param endDate         조회 종료일시
+     * @param transactionType 거래 유형 필터
+     * @return 거래 목록 (분개 포함)
+     * @author 성효빈
+     * @since 2026-03-02
+     */
+    @GetMapping("/transactions")
+    @PreAuthorize(ADMIN_POINTCUT)
+    @GetLedgerTransactionsApiDocs
+    public ResponseEntity<BaseResponse<List<GetLedgerTransactionResponse>>> getLedgerTransactions(
+            @RequestParam(value = "start-date", required = false) LocalDateTime startDate,
+            @RequestParam(value = "end-date", required = false) LocalDateTime endDate,
+            @RequestParam(value = "transaction-type", required = false) LedgerTransactionType transactionType
+    ) {
+        GetLedgerTransactionsQuery query = GetLedgerTransactionsQuery.builder()
+                .startDate(startDate)
+                .endDate(endDate)
+                .transactionType(transactionType)
+                .build();
+
+        List<GetLedgerTransactionResult> results = getLedgerTransactionsUseCase.getLedgerTransactions(query);
+        List<GetLedgerTransactionResponse> responses = results.stream()
+                .map(GetLedgerTransactionResponse::from)
+                .toList();
+
+        return new ResponseEntity<>(
+                BaseResponse.of(
+                        responses,
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "거래 목록 조회 성공"
+                ),
+                HttpStatus.OK
+        );
+    }
+
+    /**
+     * 계정과목별 잔액 조회
+     *
+     * @param asOf 기준 시점 (미지정 시 현재 시점)
+     * @return 계정별 잔액 목록
+     * @author 성효빈
+     * @since 2026-03-02
+     */
+    @GetMapping("/balances")
+    @PreAuthorize(ADMIN_POINTCUT)
+    @GetAccountBalancesApiDocs
+    public ResponseEntity<BaseResponse<List<GetAccountBalanceResponse>>> getAccountBalances(
+            @RequestParam(value = "as-of", required = false) LocalDateTime asOf
+    ) {
+        LocalDateTime effectiveAsOf = (asOf != null) ? asOf : LocalDateTime.now();
+
+        List<GetAccountBalanceResult> results = getAccountBalanceUseCase.getAccountBalances(effectiveAsOf);
+        List<GetAccountBalanceResponse> responses = results.stream()
+                .map(GetAccountBalanceResponse::from)
+                .toList();
+
+        return new ResponseEntity<>(
+                BaseResponse.of(
+                        responses,
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "계정별 잔액 조회 성공"
+                ),
+                HttpStatus.OK
+        );
+    }
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/ledger/controller/apidocs/GetAccountBalancesApiDocs.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/ledger/controller/apidocs/GetAccountBalancesApiDocs.java
@@ -1,0 +1,65 @@
+package com.personal.marketnote.commerce.adapter.in.web.ledger.controller.apidocs;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Operation(
+        summary = "계정과목별 잔액 조회",
+        description = """
+                특정 시점 기준으로 계정과목별 DEBIT/CREDIT 누적 합계와 잔액을 조회합니다.
+
+                잔액 계산 규칙:
+                - 자산(ASSET), 비용(EXPENSE): DEBIT 합계 - CREDIT 합계
+                - 부채(LIABILITY), 자본(EQUITY), 수익(REVENUE): CREDIT 합계 - DEBIT 합계
+
+                - asOf: 기준 시점 (ISO 8601, 선택 — 미지정 시 현재 시점)
+                """,
+        parameters = {
+                @Parameter(name = "as-of", description = "기준 시점 (ISO 8601)", example = "2026-02-28T23:59:59")
+        },
+        security = @SecurityRequirement(name = "bearer")
+)
+@ApiResponse(
+        responseCode = "200",
+        description = "잔액 조회 성공",
+        content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                {
+                  "data": [
+                    {
+                      "accountId": 1,
+                      "accountName": "매출채권_PG",
+                      "accountType": "ASSET",
+                      "accountTypeDescription": "자산",
+                      "debitTotal": 100000,
+                      "creditTotal": 50000,
+                      "balance": 50000
+                    },
+                    {
+                      "accountId": 2,
+                      "accountName": "미지급금_판매자",
+                      "accountType": "LIABILITY",
+                      "accountTypeDescription": "부채",
+                      "debitTotal": 30000,
+                      "creditTotal": 80000,
+                      "balance": 50000
+                    }
+                  ],
+                  "status": 200,
+                  "code": "SUC01",
+                  "message": "계정별 잔액 조회 성공"
+                }
+                """))
+)
+public @interface GetAccountBalancesApiDocs {
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/ledger/controller/apidocs/GetLedgerTransactionsApiDocs.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/ledger/controller/apidocs/GetLedgerTransactionsApiDocs.java
@@ -1,0 +1,69 @@
+package com.personal.marketnote.commerce.adapter.in.web.ledger.controller.apidocs;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Operation(
+        summary = "회계 거래 목록 조회",
+        description = """
+                기간별, 거래 유형별로 회계 거래(분개 포함) 목록을 조회합니다.
+
+                - startDate, endDate: 조회 기간 (ISO 8601, 선택)
+                - transactionType: 거래 유형 필터 (선택)
+                  - PAYMENT_APPROVAL, PAYMENT_CANCELLATION, PAYMENT_PARTIAL_REFUND
+                  - PG_SETTLEMENT, SELLER_SETTLEMENT, SETTLEMENT_CANCELLATION
+                """,
+        parameters = {
+                @Parameter(name = "start-date", description = "조회 시작일시 (ISO 8601)", example = "2026-02-01T00:00:00"),
+                @Parameter(name = "end-date", description = "조회 종료일시 (ISO 8601)", example = "2026-02-28T23:59:59"),
+                @Parameter(name = "transaction-type", description = "거래 유형 필터", example = "PG_SETTLEMENT")
+        },
+        security = @SecurityRequirement(name = "bearer")
+)
+@ApiResponse(
+        responseCode = "200",
+        description = "거래 목록 조회 성공",
+        content = @Content(mediaType = "application/json", examples = @ExampleObject(value = """
+                {
+                  "data": [
+                    {
+                      "id": 1,
+                      "transactionType": "PG_SETTLEMENT",
+                      "transactionTypeDescription": "PG 정산 입금",
+                      "targetType": "SETTLEMENT",
+                      "targetId": 100,
+                      "description": "PG 정산 입금 - 정산 ID: 100",
+                      "idempotencyKey": "PG_SETTLEMENT:100",
+                      "createdAt": "2026-03-02T10:00:00",
+                      "entries": [
+                        {
+                          "id": 1,
+                          "accountId": 1,
+                          "transactionId": 1,
+                          "amount": 9700,
+                          "transactionType": "DEBIT",
+                          "transactionTypeDescription": "차변",
+                          "createdAt": "2026-03-02T10:00:00"
+                        }
+                      ]
+                    }
+                  ],
+                  "status": 200,
+                  "code": "SUC01",
+                  "message": "거래 목록 조회 성공"
+                }
+                """))
+)
+public @interface GetLedgerTransactionsApiDocs {
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/ledger/response/GetAccountBalanceResponse.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/ledger/response/GetAccountBalanceResponse.java
@@ -1,0 +1,26 @@
+package com.personal.marketnote.commerce.adapter.in.web.ledger.response;
+
+import com.personal.marketnote.commerce.domain.ledger.AccountType;
+import com.personal.marketnote.commerce.port.in.result.ledger.GetAccountBalanceResult;
+
+public record GetAccountBalanceResponse(
+        Long accountId,
+        String accountName,
+        AccountType accountType,
+        String accountTypeDescription,
+        Long debitTotal,
+        Long creditTotal,
+        Long balance
+) {
+    public static GetAccountBalanceResponse from(GetAccountBalanceResult result) {
+        return new GetAccountBalanceResponse(
+                result.accountId(),
+                result.accountName(),
+                result.accountType(),
+                result.accountType().getDescription(),
+                result.debitTotal(),
+                result.creditTotal(),
+                result.balance()
+        );
+    }
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/ledger/response/GetLedgerEntryResponse.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/ledger/response/GetLedgerEntryResponse.java
@@ -1,0 +1,28 @@
+package com.personal.marketnote.commerce.adapter.in.web.ledger.response;
+
+import com.personal.marketnote.commerce.domain.ledger.TransactionType;
+import com.personal.marketnote.commerce.port.in.result.ledger.GetLedgerEntryResult;
+
+import java.time.LocalDateTime;
+
+public record GetLedgerEntryResponse(
+        Long id,
+        Long accountId,
+        Long transactionId,
+        Long amount,
+        TransactionType transactionType,
+        String transactionTypeDescription,
+        LocalDateTime createdAt
+) {
+    public static GetLedgerEntryResponse from(GetLedgerEntryResult result) {
+        return new GetLedgerEntryResponse(
+                result.id(),
+                result.accountId(),
+                result.transactionId(),
+                result.amount(),
+                result.transactionType(),
+                result.transactionType().getDescription(),
+                result.createdAt()
+        );
+    }
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/ledger/response/GetLedgerTransactionResponse.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/ledger/response/GetLedgerTransactionResponse.java
@@ -1,0 +1,37 @@
+package com.personal.marketnote.commerce.adapter.in.web.ledger.response;
+
+import com.personal.marketnote.commerce.domain.ledger.LedgerTransactionType;
+import com.personal.marketnote.commerce.port.in.result.ledger.GetLedgerTransactionResult;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record GetLedgerTransactionResponse(
+        Long id,
+        LedgerTransactionType transactionType,
+        String transactionTypeDescription,
+        String targetType,
+        Long targetId,
+        String description,
+        String idempotencyKey,
+        LocalDateTime createdAt,
+        List<GetLedgerEntryResponse> entries
+) {
+    public static GetLedgerTransactionResponse from(GetLedgerTransactionResult result) {
+        List<GetLedgerEntryResponse> entryResponses = result.entries().stream()
+                .map(GetLedgerEntryResponse::from)
+                .toList();
+
+        return new GetLedgerTransactionResponse(
+                result.id(),
+                result.transactionType(),
+                result.transactionType().getDescription(),
+                result.targetType(),
+                result.targetId(),
+                result.description(),
+                result.idempotencyKey(),
+                result.createdAt(),
+                entryResponses
+        );
+    }
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/ledger/LedgerQueryPersistenceAdapter.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/ledger/LedgerQueryPersistenceAdapter.java
@@ -1,0 +1,90 @@
+package com.personal.marketnote.commerce.adapter.out.persistence.ledger;
+
+import com.personal.marketnote.commerce.adapter.out.persistence.ledger.mapper.LedgerEntryEntityToDomainMapper;
+import com.personal.marketnote.commerce.adapter.out.persistence.ledger.mapper.LedgerTransactionEntityToDomainMapper;
+import com.personal.marketnote.commerce.adapter.out.persistence.ledger.repository.LedgerEntryJpaRepository;
+import com.personal.marketnote.commerce.adapter.out.persistence.ledger.repository.LedgerTransactionJpaRepository;
+import com.personal.marketnote.commerce.domain.ledger.LedgerEntry;
+import com.personal.marketnote.commerce.domain.ledger.LedgerTransaction;
+import com.personal.marketnote.commerce.domain.ledger.LedgerTransactionType;
+import com.personal.marketnote.commerce.domain.ledger.TransactionType;
+import com.personal.marketnote.commerce.port.out.ledger.FindLedgerEntryPort;
+import com.personal.marketnote.commerce.port.out.ledger.FindLedgerTransactionPort;
+import com.personal.marketnote.commerce.port.out.ledger.dto.AccountBalanceDto;
+import com.personal.marketnote.common.adapter.out.PersistenceAdapter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 회계 장부 조회 퍼시스턴스 어댑터
+ *
+ * @author 성효빈
+ * @since 2026-03-02
+ */
+@PersistenceAdapter
+@RequiredArgsConstructor
+public class LedgerQueryPersistenceAdapter implements FindLedgerTransactionPort, FindLedgerEntryPort {
+    private final LedgerTransactionJpaRepository ledgerTransactionJpaRepository;
+    private final LedgerEntryJpaRepository ledgerEntryJpaRepository;
+
+    @Override
+    public List<LedgerTransaction> findByFilters(
+            LocalDateTime startDate,
+            LocalDateTime endDate,
+            LedgerTransactionType transactionType
+    ) {
+        return ledgerTransactionJpaRepository.findByFilters(startDate, endDate, transactionType)
+                .stream()
+                .map(LedgerTransactionEntityToDomainMapper::toDomain)
+                .toList();
+    }
+
+    @Override
+    public List<LedgerEntry> findByTransactionId(Long transactionId) {
+        return ledgerEntryJpaRepository.findByTransactionIdOrderByIdAsc(transactionId)
+                .stream()
+                .map(LedgerEntryEntityToDomainMapper::toDomain)
+                .toList();
+    }
+
+    @Override
+    public List<AccountBalanceDto> findAccountBalanceSummary(LocalDateTime asOf) {
+        List<Object[]> rows = ledgerEntryJpaRepository.findAccountBalanceSummary(asOf);
+
+        Map<Long, Long> debitMap = new HashMap<>();
+        Map<Long, Long> creditMap = new HashMap<>();
+
+        for (Object[] row : rows) {
+            Long accountId = (Long) row[0];
+            TransactionType transactionType = (TransactionType) row[1];
+            Long totalAmount = (Long) row[2];
+
+            if (transactionType.isDebit()) {
+                debitMap.put(accountId, totalAmount);
+            } else {
+                creditMap.put(accountId, totalAmount);
+            }
+        }
+
+        List<Long> accountIds = new ArrayList<>(debitMap.keySet());
+        for (Long accountId : creditMap.keySet()) {
+            if (!debitMap.containsKey(accountId)) {
+                accountIds.add(accountId);
+            }
+        }
+        accountIds.sort(Long::compareTo);
+
+        return accountIds.stream()
+                .map(accountId -> new AccountBalanceDto(
+                        accountId,
+                        debitMap.getOrDefault(accountId, 0L),
+                        creditMap.getOrDefault(accountId, 0L)
+                ))
+                .toList();
+    }
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/ledger/mapper/LedgerEntryEntityToDomainMapper.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/ledger/mapper/LedgerEntryEntityToDomainMapper.java
@@ -1,0 +1,22 @@
+package com.personal.marketnote.commerce.adapter.out.persistence.ledger.mapper;
+
+import com.personal.marketnote.commerce.adapter.out.persistence.ledger.entity.LedgerEntryJpaEntity;
+import com.personal.marketnote.commerce.domain.ledger.LedgerEntry;
+import com.personal.marketnote.commerce.domain.ledger.LedgerEntrySnapshotState;
+
+public class LedgerEntryEntityToDomainMapper {
+
+    private LedgerEntryEntityToDomainMapper() {
+    }
+
+    public static LedgerEntry toDomain(LedgerEntryJpaEntity entity) {
+        return LedgerEntry.from(LedgerEntrySnapshotState.builder()
+                .id(entity.getId())
+                .accountId(entity.getAccountId())
+                .transactionId(entity.getTransactionId())
+                .amount(entity.getAmount())
+                .transactionType(entity.getTransactionType())
+                .createdAt(entity.getCreatedAt())
+                .build());
+    }
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/ledger/repository/LedgerEntryJpaRepository.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/ledger/repository/LedgerEntryJpaRepository.java
@@ -2,6 +2,21 @@ package com.personal.marketnote.commerce.adapter.out.persistence.ledger.reposito
 
 import com.personal.marketnote.commerce.adapter.out.persistence.ledger.entity.LedgerEntryJpaEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 public interface LedgerEntryJpaRepository extends JpaRepository<LedgerEntryJpaEntity, Long> {
+    List<LedgerEntryJpaEntity> findByTransactionIdOrderByIdAsc(Long transactionId);
+
+    @Query("""
+            SELECT e.accountId, e.transactionType, SUM(e.amount)
+            FROM LedgerEntryJpaEntity e
+            WHERE e.createdAt <= :asOf
+            GROUP BY e.accountId, e.transactionType
+            ORDER BY e.accountId ASC
+            """)
+    List<Object[]> findAccountBalanceSummary(@Param("asOf") LocalDateTime asOf);
 }

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/ledger/repository/LedgerTransactionJpaRepository.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/ledger/repository/LedgerTransactionJpaRepository.java
@@ -1,8 +1,27 @@
 package com.personal.marketnote.commerce.adapter.out.persistence.ledger.repository;
 
 import com.personal.marketnote.commerce.adapter.out.persistence.ledger.entity.LedgerTransactionJpaEntity;
+import com.personal.marketnote.commerce.domain.ledger.LedgerTransactionType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 public interface LedgerTransactionJpaRepository extends JpaRepository<LedgerTransactionJpaEntity, Long> {
     boolean existsByIdempotencyKey(String idempotencyKey);
+
+    @Query("""
+            SELECT t FROM LedgerTransactionJpaEntity t
+            WHERE (:startDate IS NULL OR t.createdAt >= :startDate)
+            AND (:endDate IS NULL OR t.createdAt <= :endDate)
+            AND (:transactionType IS NULL OR t.transactionType = :transactionType)
+            ORDER BY t.createdAt DESC
+            """)
+    List<LedgerTransactionJpaEntity> findByFilters(
+            @Param("startDate") LocalDateTime startDate,
+            @Param("endDate") LocalDateTime endDate,
+            @Param("transactionType") LedgerTransactionType transactionType
+    );
 }

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/command/ledger/GetLedgerTransactionsQuery.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/command/ledger/GetLedgerTransactionsQuery.java
@@ -1,0 +1,14 @@
+package com.personal.marketnote.commerce.port.in.command.ledger;
+
+import com.personal.marketnote.commerce.domain.ledger.LedgerTransactionType;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record GetLedgerTransactionsQuery(
+        LocalDateTime startDate,
+        LocalDateTime endDate,
+        LedgerTransactionType transactionType
+) {
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/result/ledger/GetAccountBalanceResult.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/result/ledger/GetAccountBalanceResult.java
@@ -1,0 +1,26 @@
+package com.personal.marketnote.commerce.port.in.result.ledger;
+
+import com.personal.marketnote.commerce.domain.ledger.AccountBalance;
+import com.personal.marketnote.commerce.domain.ledger.AccountType;
+import lombok.Builder;
+
+@Builder
+public record GetAccountBalanceResult(
+        Long accountId,
+        String accountName,
+        AccountType accountType,
+        Long debitTotal,
+        Long creditTotal,
+        Long balance
+) {
+    public static GetAccountBalanceResult from(AccountBalance accountBalance) {
+        return GetAccountBalanceResult.builder()
+                .accountId(accountBalance.getAccountId())
+                .accountName(accountBalance.getAccountName())
+                .accountType(accountBalance.getAccountType())
+                .debitTotal(accountBalance.getDebitTotal())
+                .creditTotal(accountBalance.getCreditTotal())
+                .balance(accountBalance.getBalance())
+                .build();
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/result/ledger/GetLedgerEntryResult.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/result/ledger/GetLedgerEntryResult.java
@@ -1,0 +1,28 @@
+package com.personal.marketnote.commerce.port.in.result.ledger;
+
+import com.personal.marketnote.commerce.domain.ledger.LedgerEntry;
+import com.personal.marketnote.commerce.domain.ledger.TransactionType;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record GetLedgerEntryResult(
+        Long id,
+        Long accountId,
+        Long transactionId,
+        Long amount,
+        TransactionType transactionType,
+        LocalDateTime createdAt
+) {
+    public static GetLedgerEntryResult from(LedgerEntry entry) {
+        return GetLedgerEntryResult.builder()
+                .id(entry.getId())
+                .accountId(entry.getAccountId())
+                .transactionId(entry.getTransactionId())
+                .amount(entry.getAmount())
+                .transactionType(entry.getTransactionType())
+                .createdAt(entry.getCreatedAt())
+                .build();
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/result/ledger/GetLedgerTransactionResult.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/result/ledger/GetLedgerTransactionResult.java
@@ -1,0 +1,33 @@
+package com.personal.marketnote.commerce.port.in.result.ledger;
+
+import com.personal.marketnote.commerce.domain.ledger.LedgerTransaction;
+import com.personal.marketnote.commerce.domain.ledger.LedgerTransactionType;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Builder
+public record GetLedgerTransactionResult(
+        Long id,
+        LedgerTransactionType transactionType,
+        String targetType,
+        Long targetId,
+        String description,
+        String idempotencyKey,
+        LocalDateTime createdAt,
+        List<GetLedgerEntryResult> entries
+) {
+    public static GetLedgerTransactionResult from(LedgerTransaction transaction, List<GetLedgerEntryResult> entries) {
+        return GetLedgerTransactionResult.builder()
+                .id(transaction.getId())
+                .transactionType(transaction.getTransactionType())
+                .targetType(transaction.getTargetType())
+                .targetId(transaction.getTargetId())
+                .description(transaction.getDescription())
+                .idempotencyKey(transaction.getIdempotencyKey())
+                .createdAt(transaction.getCreatedAt())
+                .entries(entries)
+                .build();
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/ledger/GetAccountBalanceUseCase.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/ledger/GetAccountBalanceUseCase.java
@@ -1,0 +1,16 @@
+package com.personal.marketnote.commerce.port.in.usecase.ledger;
+
+import com.personal.marketnote.commerce.port.in.result.ledger.GetAccountBalanceResult;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * 계정과목별 잔액 조회 UseCase
+ *
+ * @author 성효빈
+ * @since 2026-03-02
+ */
+public interface GetAccountBalanceUseCase {
+    List<GetAccountBalanceResult> getAccountBalances(LocalDateTime asOf);
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/ledger/GetLedgerTransactionsUseCase.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/ledger/GetLedgerTransactionsUseCase.java
@@ -1,0 +1,16 @@
+package com.personal.marketnote.commerce.port.in.usecase.ledger;
+
+import com.personal.marketnote.commerce.port.in.command.ledger.GetLedgerTransactionsQuery;
+import com.personal.marketnote.commerce.port.in.result.ledger.GetLedgerTransactionResult;
+
+import java.util.List;
+
+/**
+ * 회계 거래 목록 조회 UseCase
+ *
+ * @author 성효빈
+ * @since 2026-03-02
+ */
+public interface GetLedgerTransactionsUseCase {
+    List<GetLedgerTransactionResult> getLedgerTransactions(GetLedgerTransactionsQuery query);
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/ledger/FindLedgerEntryPort.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/ledger/FindLedgerEntryPort.java
@@ -1,0 +1,13 @@
+package com.personal.marketnote.commerce.port.out.ledger;
+
+import com.personal.marketnote.commerce.domain.ledger.LedgerEntry;
+import com.personal.marketnote.commerce.port.out.ledger.dto.AccountBalanceDto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface FindLedgerEntryPort {
+    List<LedgerEntry> findByTransactionId(Long transactionId);
+
+    List<AccountBalanceDto> findAccountBalanceSummary(LocalDateTime asOf);
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/ledger/FindLedgerTransactionPort.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/ledger/FindLedgerTransactionPort.java
@@ -1,0 +1,11 @@
+package com.personal.marketnote.commerce.port.out.ledger;
+
+import com.personal.marketnote.commerce.domain.ledger.LedgerTransaction;
+import com.personal.marketnote.commerce.domain.ledger.LedgerTransactionType;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface FindLedgerTransactionPort {
+    List<LedgerTransaction> findByFilters(LocalDateTime startDate, LocalDateTime endDate, LedgerTransactionType transactionType);
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/ledger/dto/AccountBalanceDto.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/ledger/dto/AccountBalanceDto.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.commerce.port.out.ledger.dto;
+
+public record AccountBalanceDto(
+        Long accountId,
+        Long debitTotal,
+        Long creditTotal
+) {
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/ledger/GetAccountBalanceService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/ledger/GetAccountBalanceService.java
@@ -1,0 +1,49 @@
+package com.personal.marketnote.commerce.service.ledger;
+
+import com.personal.marketnote.commerce.domain.ledger.Account;
+import com.personal.marketnote.commerce.domain.ledger.AccountBalance;
+import com.personal.marketnote.commerce.exception.AccountNotFoundException;
+import com.personal.marketnote.commerce.port.in.result.ledger.GetAccountBalanceResult;
+import com.personal.marketnote.commerce.port.in.usecase.ledger.GetAccountBalanceUseCase;
+import com.personal.marketnote.commerce.port.out.ledger.FindAccountPort;
+import com.personal.marketnote.commerce.port.out.ledger.FindLedgerEntryPort;
+import com.personal.marketnote.commerce.port.out.ledger.dto.AccountBalanceDto;
+import com.personal.marketnote.common.application.UseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+/**
+ * 계정과목별 잔액 조회 서비스
+ *
+ * @author 성효빈
+ * @since 2026-03-02
+ */
+@UseCase
+@RequiredArgsConstructor
+@Transactional(isolation = READ_COMMITTED, readOnly = true)
+public class GetAccountBalanceService implements GetAccountBalanceUseCase {
+    private final FindLedgerEntryPort findLedgerEntryPort;
+    private final FindAccountPort findAccountPort;
+
+    @Override
+    public List<GetAccountBalanceResult> getAccountBalances(LocalDateTime asOf) {
+        List<AccountBalanceDto> balanceDtos = findLedgerEntryPort.findAccountBalanceSummary(asOf);
+
+        return balanceDtos.stream()
+                .map(this::toAccountBalanceResult)
+                .toList();
+    }
+
+    private GetAccountBalanceResult toAccountBalanceResult(AccountBalanceDto dto) {
+        Account account = findAccountPort.findById(dto.accountId())
+                .orElseThrow(() -> new AccountNotFoundException(dto.accountId()));
+
+        AccountBalance accountBalance = AccountBalance.of(account, dto.debitTotal(), dto.creditTotal());
+        return GetAccountBalanceResult.from(accountBalance);
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/ledger/GetLedgerTransactionsService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/ledger/GetLedgerTransactionsService.java
@@ -1,0 +1,52 @@
+package com.personal.marketnote.commerce.service.ledger;
+
+import com.personal.marketnote.commerce.domain.ledger.LedgerEntry;
+import com.personal.marketnote.commerce.domain.ledger.LedgerTransaction;
+import com.personal.marketnote.commerce.port.in.command.ledger.GetLedgerTransactionsQuery;
+import com.personal.marketnote.commerce.port.in.result.ledger.GetLedgerEntryResult;
+import com.personal.marketnote.commerce.port.in.result.ledger.GetLedgerTransactionResult;
+import com.personal.marketnote.commerce.port.in.usecase.ledger.GetLedgerTransactionsUseCase;
+import com.personal.marketnote.commerce.port.out.ledger.FindLedgerEntryPort;
+import com.personal.marketnote.commerce.port.out.ledger.FindLedgerTransactionPort;
+import com.personal.marketnote.common.application.UseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+/**
+ * 회계 거래 목록 조회 서비스
+ *
+ * @author 성효빈
+ * @since 2026-03-02
+ */
+@UseCase
+@RequiredArgsConstructor
+@Transactional(isolation = READ_COMMITTED, readOnly = true)
+public class GetLedgerTransactionsService implements GetLedgerTransactionsUseCase {
+    private final FindLedgerTransactionPort findLedgerTransactionPort;
+    private final FindLedgerEntryPort findLedgerEntryPort;
+
+    @Override
+    public List<GetLedgerTransactionResult> getLedgerTransactions(GetLedgerTransactionsQuery query) {
+        List<LedgerTransaction> transactions = findLedgerTransactionPort.findByFilters(
+                query.startDate(),
+                query.endDate(),
+                query.transactionType()
+        );
+
+        return transactions.stream()
+                .map(this::toResultWithEntries)
+                .toList();
+    }
+
+    private GetLedgerTransactionResult toResultWithEntries(LedgerTransaction transaction) {
+        List<LedgerEntry> entries = findLedgerEntryPort.findByTransactionId(transaction.getId());
+        List<GetLedgerEntryResult> entryResults = entries.stream()
+                .map(GetLedgerEntryResult::from)
+                .toList();
+        return GetLedgerTransactionResult.from(transaction, entryResults);
+    }
+}

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/ledger/AccountBalance.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/ledger/AccountBalance.java
@@ -1,0 +1,47 @@
+package com.personal.marketnote.commerce.domain.ledger;
+
+import lombok.*;
+
+/**
+ * 계정별 잔액 도메인 모델
+ *
+ * <p>계정별 DEBIT/CREDIT 누적 합계와 잔액을 계산한다.
+ * 잔액 계산 규칙:
+ * - 자산(ASSET), 비용(EXPENSE): DEBIT 합계 - CREDIT 합계
+ * - 부채(LIABILITY), 자본(EQUITY), 수익(REVENUE): CREDIT 합계 - DEBIT 합계
+ *
+ * @author 성효빈
+ * @since 2026-03-02
+ */
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+@Getter
+public class AccountBalance {
+    private Long accountId;
+    private String accountName;
+    private AccountType accountType;
+    private Long debitTotal;
+    private Long creditTotal;
+    private Long balance;
+
+    public static AccountBalance of(Account account, Long debitTotal, Long creditTotal) {
+        Long calculatedBalance = calculateBalance(account.getAccountType(), debitTotal, creditTotal);
+
+        return AccountBalance.builder()
+                .accountId(account.getId())
+                .accountName(account.getName())
+                .accountType(account.getAccountType())
+                .debitTotal(debitTotal)
+                .creditTotal(creditTotal)
+                .balance(calculatedBalance)
+                .build();
+    }
+
+    private static Long calculateBalance(AccountType accountType, Long debitTotal, Long creditTotal) {
+        if (accountType.isAsset() || accountType.isExpense()) {
+            return Math.subtractExact(debitTotal, creditTotal);
+        }
+        return Math.subtractExact(creditTotal, debitTotal);
+    }
+}


### PR DESCRIPTION
## partially addresses #216
## resolves #928

## Task
- [x] AccountBalance 도메인 모델 정의 (계정별 DEBIT/CREDIT 누적, 잔액 스냅샷)
- [x] GetLedgerTransactionsUseCase 인터페이스 및 서비스 구현 (기간별, 거래유형별 필터)
- [x] GetAccountBalanceUseCase 인터페이스 및 서비스 구현
- [x] FindLedgerTransactionPort, FindLedgerEntryPort 조회 Port 정의
- [x] LedgerEntry 기반 잔액 집계 쿼리 구현 (JPQL GROUP BY)
- [x] LedgerQueryPersistenceAdapter 조회 어댑터 구현
- [x] LedgerEntryEntityToDomainMapper 신규 생성
- [x] GET /api/v1/admin/ledger/transactions 엔드포인트 추가
- [x] GET /api/v1/admin/ledger/balances 엔드포인트 추가