### PR TITLE
[#929][#931] feat: Kafka 공통 모듈 구성 기능 추가

### DIFF
--- a/commerce-service/commerce-adapters/build.gradle.kts
+++ b/commerce-service/commerce-adapters/build.gradle.kts
@@ -53,6 +53,9 @@ dependencies {
     // Redisson
     implementation("org.redisson:redisson-spring-boot-starter:3.17.4")
 
+    // Spring Kafka
+    implementation("org.springframework.kafka:spring-kafka")
+
     //querydsl 설정
     implementation("jakarta.persistence:jakarta.persistence-api:3.1.0")
     annotationProcessor("jakarta.persistence:jakarta.persistence-api:3.1.0")
@@ -88,6 +91,7 @@ dependencies {
     testImplementation("org.springframework.security:spring-security-test") // Spring Security 테스트 지원
     testRuntimeOnly("org.junit.platform:junit-platform-launcher") // JUnit 테스트 런처
     testImplementation("org.awaitility:awaitility:4.2.0") // 비동기,스케줄링 테스트 지원
+    testImplementation("org.springframework.kafka:spring-kafka-test")
 
     // 🔹 추가 라이브러리
     // dotenv

--- a/commerce-service/commerce-adapters/src/main/resources/application.yml
+++ b/commerce-service/commerce-adapters/src/main/resources/application.yml
@@ -37,6 +37,11 @@ spring:
       port: 6379
       password: ${REDIS_PASSWORD:}
 
+  kafka:
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:172.0.0.0:9092,172.0.0.1:9092,172.0.0.2:9092}
+    consumer:
+      group-id: ${spring.application.name}
+
 client:
   origin: ${CLIENT_ORIGIN:http://localhost:3000}
   cookie-domain: ${COOKIE_DOMAIN:localhost}

--- a/commerce-service/commerce-adapters/src/test/resources/application-test.yml
+++ b/commerce-service/commerce-adapters/src/test/resources/application-test.yml
@@ -25,6 +25,7 @@ spring:
       - org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration
       - org.springframework.boot.autoconfigure.security.oauth2.resource.servlet.OAuth2ResourceServerAutoConfiguration
       - org.springframework.boot.autoconfigure.batch.BatchAutoConfiguration
+      - org.springframework.boot.autoconfigure.kafka.KafkaAutoConfiguration
 
 settlement:
   scheduler:

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -65,6 +65,9 @@ dependencies {
     // UUID v7
     implementation("com.github.f4b6a3:uuid-creator:5.3.0")
 
+    // kafka
+    implementation("org.springframework.kafka:spring-kafka")
+
     // test
     testImplementation("org.springframework.boot:spring-boot-starter-test")
 }

--- a/common/src/main/java/com/personal/marketnote/common/configuration/kafka/KafkaConsumerConfig.java
+++ b/common/src/main/java/com/personal/marketnote/common/configuration/kafka/KafkaConsumerConfig.java
@@ -1,0 +1,54 @@
+package com.personal.marketnote.common.configuration.kafka;
+
+import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.listener.CommonErrorHandler;
+import org.springframework.kafka.listener.ContainerProperties;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+@ConditionalOnProperty(prefix = "spring.kafka", name = "bootstrap-servers")
+public class KafkaConsumerConfig {
+
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapServers;
+
+    @Value("${spring.kafka.consumer.group-id:${spring.application.name:unknown}}")
+    private String groupId;
+
+    @Bean
+    public ConsumerFactory<String, Object> consumerFactory() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
+        props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false);
+        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        props.put(JsonDeserializer.TRUSTED_PACKAGES, "com.personal.marketnote.common.kafka.event");
+        props.put(JsonDeserializer.USE_TYPE_INFO_HEADERS, false);
+        props.put(JsonDeserializer.VALUE_DEFAULT_TYPE, EventEnvelope.class.getName());
+        return new DefaultKafkaConsumerFactory<>(props);
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, Object> kafkaListenerContainerFactory(
+            CommonErrorHandler commonErrorHandler) {
+        ConcurrentKafkaListenerContainerFactory<String, Object> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory());
+        factory.setCommonErrorHandler(commonErrorHandler);
+        factory.getContainerProperties().setAckMode(ContainerProperties.AckMode.RECORD);
+        return factory;
+    }
+}

--- a/common/src/main/java/com/personal/marketnote/common/configuration/kafka/KafkaErrorHandler.java
+++ b/common/src/main/java/com/personal/marketnote/common/configuration/kafka/KafkaErrorHandler.java
@@ -1,0 +1,46 @@
+package com.personal.marketnote.common.configuration.kafka;
+
+import com.personal.marketnote.common.kafka.KafkaTopicConstants;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.common.TopicPartition;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.listener.CommonErrorHandler;
+import org.springframework.kafka.listener.DeadLetterPublishingRecoverer;
+import org.springframework.kafka.listener.DefaultErrorHandler;
+import org.springframework.util.backoff.ExponentialBackOff;
+
+@Slf4j
+@Configuration
+@ConditionalOnProperty(prefix = "spring.kafka", name = "bootstrap-servers")
+public class KafkaErrorHandler {
+
+    private static final long RETRY_INITIAL_INTERVAL_MS = 1000L;
+    private static final double RETRY_MULTIPLIER = 2.0;
+    private static final long RETRY_MAX_ELAPSED_TIME_MS = 10000L;
+
+    @Bean
+    public DeadLetterPublishingRecoverer deadLetterPublishingRecoverer(KafkaTemplate<String, Object> kafkaTemplate) {
+        return new DeadLetterPublishingRecoverer(kafkaTemplate,
+                (record, ex) -> {
+                    log.error("메시지 처리 실패 → DLT 전송. topic={}, key={}, offset={}",
+                            record.topic(), record.key(), record.offset(), ex);
+                    return new TopicPartition(
+                            record.topic() + KafkaTopicConstants.DLT_SUFFIX,
+                            record.partition());
+                });
+    }
+
+    @Bean
+    public CommonErrorHandler commonErrorHandler(DeadLetterPublishingRecoverer deadLetterPublishingRecoverer) {
+        ExponentialBackOff backOff = new ExponentialBackOff(RETRY_INITIAL_INTERVAL_MS, RETRY_MULTIPLIER);
+        backOff.setMaxElapsedTime(RETRY_MAX_ELAPSED_TIME_MS);
+        DefaultErrorHandler errorHandler = new DefaultErrorHandler(deadLetterPublishingRecoverer, backOff);
+        errorHandler.setRetryListeners((record, ex, deliveryAttempt) ->
+                log.warn("메시지 재시도 중. topic={}, key={}, attempt={}",
+                        record.topic(), record.key(), deliveryAttempt, ex));
+        return errorHandler;
+    }
+}

--- a/common/src/main/java/com/personal/marketnote/common/configuration/kafka/KafkaProducerConfig.java
+++ b/common/src/main/java/com/personal/marketnote/common/configuration/kafka/KafkaProducerConfig.java
@@ -1,0 +1,40 @@
+package com.personal.marketnote.common.configuration.kafka;
+
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+@ConditionalOnProperty(prefix = "spring.kafka", name = "bootstrap-servers")
+public class KafkaProducerConfig {
+
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapServers;
+
+    @Bean
+    public ProducerFactory<String, Object> producerFactory() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+        props.put(ProducerConfig.ACKS_CONFIG, "all");
+        props.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, true);
+        props.put(JsonSerializer.ADD_TYPE_INFO_HEADERS, false);
+        return new DefaultKafkaProducerFactory<>(props);
+    }
+
+    @Bean
+    public KafkaTemplate<String, Object> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+}

--- a/common/src/main/java/com/personal/marketnote/common/kafka/KafkaTopicConstants.java
+++ b/common/src/main/java/com/personal/marketnote/common/kafka/KafkaTopicConstants.java
@@ -1,0 +1,28 @@
+package com.personal.marketnote.common.kafka;
+
+public final class KafkaTopicConstants {
+
+    private KafkaTopicConstants() {
+    }
+
+    // Commerce 이벤트
+    public static final String ORDER_PAYMENT_COMPLETED = "commerce.order.payment-completed";
+    public static final String PAYMENT_APPROVED = "commerce.payment.approved";
+    public static final String PAYMENT_CANCELLED = "commerce.payment.cancelled";
+    public static final String SETTLEMENT_EXECUTED = "commerce.settlement.executed";
+
+    // Product 이벤트
+    public static final String PRODUCT_REGISTERED = "product.product.registered";
+    public static final String PRICE_POLICY_CREATED = "product.price-policy.created";
+    public static final String PRODUCT_UPDATED = "product.product.updated";
+
+    // User 이벤트
+    public static final String USER_SIGNUP_COMPLETED = "user.user.signup-completed";
+    public static final String USER_REFERRAL_COMPLETED = "user.user.referral-completed";
+
+    // Community 이벤트
+    public static final String REVIEW_REGISTERED = "community.review.registered";
+
+    // Dead Letter Topic 접미사
+    public static final String DLT_SUFFIX = ".dlt";
+}

--- a/common/src/main/java/com/personal/marketnote/common/kafka/event/EventEnvelope.java
+++ b/common/src/main/java/com/personal/marketnote/common/kafka/event/EventEnvelope.java
@@ -1,0 +1,34 @@
+package com.personal.marketnote.common.kafka.event;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.f4b6a3.uuid.UuidCreator;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+
+public record EventEnvelope<T>(
+        String eventId,
+        String eventType,
+        String source,
+        LocalDateTime timestamp,
+        T payload
+) {
+
+    public static <T> EventEnvelope<T> of(String eventType, String source, T payload, Clock clock) {
+        return new EventEnvelope<>(
+                UuidCreator.getTimeOrdered().toString(),
+                eventType,
+                source,
+                LocalDateTime.now(clock),
+                payload
+        );
+    }
+
+    @SuppressWarnings("unchecked")
+    public <R> R getPayloadAs(Class<R> type, ObjectMapper objectMapper) {
+        if (type.isInstance(payload)) {
+            return type.cast(payload);
+        }
+        return objectMapper.convertValue(payload, type);
+    }
+}

--- a/community-service/community-adapters/build.gradle.kts
+++ b/community-service/community-adapters/build.gradle.kts
@@ -50,6 +50,9 @@ dependencies {
     // Spring Data Redis
     implementation("org.springframework.boot:spring-boot-starter-data-redis")
 
+    // Spring Kafka
+    implementation("org.springframework.kafka:spring-kafka")
+
     //querydsl 설정
     implementation("jakarta.persistence:jakarta.persistence-api:3.1.0")
     annotationProcessor("jakarta.persistence:jakarta.persistence-api:3.1.0")
@@ -85,6 +88,7 @@ dependencies {
     testImplementation("org.springframework.security:spring-security-test") // Spring Security 테스트 지원
     testRuntimeOnly("org.junit.platform:junit-platform-launcher") // JUnit 테스트 런처
     testImplementation("org.awaitility:awaitility:4.2.0") // 비동기,스케줄링 테스트 지원
+    testImplementation("org.springframework.kafka:spring-kafka-test")
 
     // 🔹 추가 라이브러리
     // dotenv

--- a/community-service/community-adapters/src/main/resources/application.yml
+++ b/community-service/community-adapters/src/main/resources/application.yml
@@ -37,6 +37,11 @@ spring:
       port: 6379
       password: ${REDIS_PASSWORD:password}
 
+  kafka:
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:172.26.45.222:9092,172.26.21.200:9092,172.26.2.195:9092}
+    consumer:
+      group-id: ${spring.application.name}
+
 client:
   origin: ${CLIENT_ORIGIN:http://localhost:3000}
   cookie-domain: ${COOKIE_DOMAIN:localhost}

--- a/community-service/community-adapters/src/test/resources/application-test.yml
+++ b/community-service/community-adapters/src/test/resources/application-test.yml
@@ -25,3 +25,4 @@ spring:
       - org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration
       - org.springframework.boot.autoconfigure.security.oauth2.resource.servlet.OAuth2ResourceServerAutoConfiguration
       - org.springframework.boot.autoconfigure.batch.BatchAutoConfiguration
+      - org.springframework.boot.autoconfigure.kafka.KafkaAutoConfiguration

--- a/file-service/file-adapters/build.gradle.kts
+++ b/file-service/file-adapters/build.gradle.kts
@@ -50,6 +50,9 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-security") // Spring Security
     implementation("org.springframework.boot:spring-boot-starter-oauth2-resource-server") // OAuth 2.0 Resource server
 
+    // Spring Kafka
+    implementation("org.springframework.kafka:spring-kafka")
+
     //querydsl 설정
     implementation("jakarta.persistence:jakarta.persistence-api:3.1.0")
     annotationProcessor("jakarta.persistence:jakarta.persistence-api:3.1.0")
@@ -85,6 +88,7 @@ dependencies {
     testImplementation("org.springframework.security:spring-security-test") // Spring Security 테스트 지원
     testRuntimeOnly("org.junit.platform:junit-platform-launcher") // JUnit 테스트 런처
     testImplementation("org.awaitility:awaitility:4.2.0") // 비동기,스케줄링 테스트 지원
+    testImplementation("org.springframework.kafka:spring-kafka-test")
     // 🔹 추가 라이브러리
     // dotenv
     implementation("io.github.cdimascio:dotenv-java:$dotenvVersion")

--- a/file-service/file-adapters/src/main/resources/application.yml
+++ b/file-service/file-adapters/src/main/resources/application.yml
@@ -36,6 +36,11 @@ spring:
       schema-locations: classpath:org/springframework/batch/core/schema-postgresql.sql
       continue-on-error: true
 
+  kafka:
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:172.0.0.0:9092,172.0.0.1:9092,172.0.0.2:9092}
+    consumer:
+      group-id: ${spring.application.name}
+
 client:
   origin: ${CLIENT_ORIGIN:http://localhost:3000}
   cookie-domain: ${COOKIE_DOMAIN:localhost}

--- a/file-service/file-adapters/src/test/resources/application-test.yml
+++ b/file-service/file-adapters/src/test/resources/application-test.yml
@@ -25,3 +25,4 @@ spring:
       - org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration
       - org.springframework.boot.autoconfigure.security.oauth2.resource.servlet.OAuth2ResourceServerAutoConfiguration
       - org.springframework.boot.autoconfigure.batch.BatchAutoConfiguration
+      - org.springframework.boot.autoconfigure.kafka.KafkaAutoConfiguration

--- a/fulfillment-service/fulfillment-adapters/build.gradle.kts
+++ b/fulfillment-service/fulfillment-adapters/build.gradle.kts
@@ -47,6 +47,9 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-security") // Spring Security
     implementation("org.springframework.boot:spring-boot-starter-oauth2-resource-server") // OAuth 2.0 Resource server
 
+    // Spring Kafka
+    implementation("org.springframework.kafka:spring-kafka")
+
     //querydsl 설정
     implementation("jakarta.persistence:jakarta.persistence-api:3.1.0")
     annotationProcessor("jakarta.persistence:jakarta.persistence-api:3.1.0")
@@ -82,6 +85,7 @@ dependencies {
     testImplementation("org.springframework.security:spring-security-test") // Spring Security 테스트 지원
     testRuntimeOnly("org.junit.platform:junit-platform-launcher") // JUnit 테스트 런처
     testImplementation("org.awaitility:awaitility:4.2.0") // 비동기,스케줄링 테스트 지원
+    testImplementation("org.springframework.kafka:spring-kafka-test")
 
     // 🔹 추가 라이브러리
     // dotenv

--- a/fulfillment-service/fulfillment-adapters/src/main/resources/application.yml
+++ b/fulfillment-service/fulfillment-adapters/src/main/resources/application.yml
@@ -31,6 +31,11 @@ spring:
       schema-locations: classpath:org/springframework/batch/core/schema-postgresql.sql
       continue-on-error: true
 
+  kafka:
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:172.0.0.0:9092,172.0.0.1:9092,172.0.0.2:9092}
+    consumer:
+      group-id: ${spring.application.name}
+
 client:
   origin: ${CLIENT_ORIGIN:http://localhost:3000}
   cookie-domain: ${COOKIE_DOMAIN:localhost}

--- a/fulfillment-service/fulfillment-adapters/src/test/resources/application-test.yml
+++ b/fulfillment-service/fulfillment-adapters/src/test/resources/application-test.yml
@@ -25,3 +25,4 @@ spring:
       - org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration
       - org.springframework.boot.autoconfigure.security.oauth2.resource.servlet.OAuth2ResourceServerAutoConfiguration
       - org.springframework.boot.autoconfigure.batch.BatchAutoConfiguration
+      - org.springframework.boot.autoconfigure.kafka.KafkaAutoConfiguration

--- a/product-service/product-adapters/build.gradle.kts
+++ b/product-service/product-adapters/build.gradle.kts
@@ -53,6 +53,9 @@ dependencies {
     // Spring Data Redis
     implementation("org.springframework.boot:spring-boot-starter-data-redis")
 
+    // Spring Kafka
+    implementation("org.springframework.kafka:spring-kafka")
+
     //querydsl 설정
     implementation("jakarta.persistence:jakarta.persistence-api:3.1.0")
     annotationProcessor("jakarta.persistence:jakarta.persistence-api:3.1.0")
@@ -88,6 +91,7 @@ dependencies {
     testImplementation("org.springframework.security:spring-security-test") // Spring Security 테스트 지원
     testRuntimeOnly("org.junit.platform:junit-platform-launcher") // JUnit 테스트 런처
     testImplementation("org.awaitility:awaitility:4.2.0") // 비동기,스케줄링 테스트 지원
+    testImplementation("org.springframework.kafka:spring-kafka-test")
 
     // 🔹 추가 라이브러리
     // dotenv

--- a/product-service/product-adapters/src/main/resources/application.yml
+++ b/product-service/product-adapters/src/main/resources/application.yml
@@ -37,6 +37,11 @@ spring:
       port: 6379
       password: ${REDIS_PASSWORD:password}
 
+  kafka:
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:172.0.0.0:9092,172.0.0.1:9092,172.0.0.2:9092}
+    consumer:
+      group-id: ${spring.application.name}
+
 client:
   origin: ${CLIENT_ORIGIN:http://localhost:3000}
   cookie-domain: ${COOKIE_DOMAIN:localhost}

--- a/product-service/product-adapters/src/test/resources/application-test.yml
+++ b/product-service/product-adapters/src/test/resources/application-test.yml
@@ -25,3 +25,4 @@ spring:
       - org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration
       - org.springframework.boot.autoconfigure.security.oauth2.resource.servlet.OAuth2ResourceServerAutoConfiguration
       - org.springframework.boot.autoconfigure.batch.BatchAutoConfiguration
+      - org.springframework.boot.autoconfigure.kafka.KafkaAutoConfiguration

--- a/reward-service/reward-adapters/build.gradle.kts
+++ b/reward-service/reward-adapters/build.gradle.kts
@@ -50,6 +50,9 @@ dependencies {
     // Spring Data Redis
     implementation("org.springframework.boot:spring-boot-starter-data-redis")
 
+    // Spring Kafka
+    implementation("org.springframework.kafka:spring-kafka")
+
     //querydsl 설정
     implementation("jakarta.persistence:jakarta.persistence-api:3.1.0")
     annotationProcessor("jakarta.persistence:jakarta.persistence-api:3.1.0")
@@ -85,6 +88,7 @@ dependencies {
     testImplementation("org.springframework.security:spring-security-test") // Spring Security 테스트 지원
     testRuntimeOnly("org.junit.platform:junit-platform-launcher") // JUnit 테스트 런처
     testImplementation("org.awaitility:awaitility:4.2.0") // 비동기,스케줄링 테스트 지원
+    testImplementation("org.springframework.kafka:spring-kafka-test")
 
     // 🔹 추가 라이브러리
     // dotenv

--- a/reward-service/reward-adapters/src/main/resources/application.yml
+++ b/reward-service/reward-adapters/src/main/resources/application.yml
@@ -37,6 +37,11 @@ spring:
       port: 6379
       password: ${REDIS_PASSWORD:password}
 
+  kafka:
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:172.0.0.0:9092,172.0.0.1:9092,172.0.0.2:9092}
+    consumer:
+      group-id: ${spring.application.name}
+
 client:
   origin: ${CLIENT_ORIGIN:http://localhost:3000}
   cookie-domain: ${COOKIE_DOMAIN:localhost}

--- a/reward-service/reward-adapters/src/test/resources/application-test.yml
+++ b/reward-service/reward-adapters/src/test/resources/application-test.yml
@@ -25,3 +25,4 @@ spring:
       - org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration
       - org.springframework.boot.autoconfigure.security.oauth2.resource.servlet.OAuth2ResourceServerAutoConfiguration
       - org.springframework.boot.autoconfigure.batch.BatchAutoConfiguration
+      - org.springframework.boot.autoconfigure.kafka.KafkaAutoConfiguration

--- a/user-service/user-adapters/build.gradle.kts
+++ b/user-service/user-adapters/build.gradle.kts
@@ -56,6 +56,9 @@ dependencies {
     // session
     implementation("org.springframework.session:spring-session-data-redis")
 
+    // Spring Kafka
+    implementation("org.springframework.kafka:spring-kafka")
+
     //querydsl 설정
     implementation("jakarta.persistence:jakarta.persistence-api:3.1.0")
     annotationProcessor("jakarta.persistence:jakarta.persistence-api:3.1.0")
@@ -87,6 +90,7 @@ dependencies {
     testImplementation("org.springframework.security:spring-security-test") // Spring Security 테스트 지원
     testRuntimeOnly("org.junit.platform:junit-platform-launcher") // JUnit 테스트 런처
     testImplementation("org.awaitility:awaitility:4.2.0") // 비동기,스케줄링 테스트 지원
+    testImplementation("org.springframework.kafka:spring-kafka-test")
 
     // 🔹 추가 라이브러리
     // dotenv

--- a/user-service/user-adapters/src/main/resources/application.yml
+++ b/user-service/user-adapters/src/main/resources/application.yml
@@ -33,6 +33,11 @@ spring:
       port: 6379
       password: ${REDIS_PASSWORD:password}
 
+  kafka:
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:172.0.0.0:9092,172.0.0.1:9092,172.0.0.2:9092}
+    consumer:
+      group-id: ${spring.application.name}
+
   jwt:
     secret: ${JWT_SECRET_KEY:dev-secret-change-me}
     admin-access-token: ${JWT_ADMIN_ACCESS_TOKEN:abc}

--- a/user-service/user-adapters/src/test/resources/application-test.yml
+++ b/user-service/user-adapters/src/test/resources/application-test.yml
@@ -25,3 +25,4 @@ spring:
       - org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration
       - org.springframework.boot.autoconfigure.security.oauth2.resource.servlet.OAuth2ResourceServerAutoConfiguration
       - org.springframework.boot.autoconfigure.batch.BatchAutoConfiguration
+      - org.springframework.boot.autoconfigure.kafka.KafkaAutoConfiguration


### PR DESCRIPTION
## partially addresses #929
## resolves #931

## Task
- [x] KafkaProducerConfig (ProducerFactory, KafkaTemplate, acks=all, 멱등 프로듀서) 추가
- [x] KafkaConsumerConfig (ConsumerFactory, ContainerFactory, 수동 커밋, AckMode.RECORD) 추가
- [x] KafkaTopicConstants (토픽명 상수 10개 + DLT 접미사) 추가
- [x] EventEnvelope (이벤트 래퍼 record: eventId, eventType, source, timestamp, payload) 추가
- [x] KafkaErrorHandler (ExponentialBackOff 재시도 + DeadLetterPublishingRecoverer) 추가
- [x] 7개 서비스 build.gradle.kts에 spring-kafka, spring-kafka-test 의존성 추가
- [x] 7개 서비스 application.yml에 spring.kafka.bootstrap-servers, consumer.group-id 설정 추가
- [x] 7개 서비스 application-test.yml에 KafkaAutoConfiguration exclude 추가