### PR TITLE
[#929][#681] feat: 상품 등록 시 커머스 서비스 재고 등록 요청 Kafka 이벤트 전환

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/ProductEventKafkaListener.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/ProductEventKafkaListener.java
@@ -1,0 +1,62 @@
+package com.personal.marketnote.commerce.adapter.in.event;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.commerce.exception.InventoryAlreadyExistsException;
+import com.personal.marketnote.commerce.port.in.command.inventory.RegisterInventoryCommand;
+import com.personal.marketnote.commerce.port.in.usecase.inventory.RegisterInventoryUseCase;
+import com.personal.marketnote.common.kafka.KafkaTopicConstants;
+import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.ProductRegisteredEvent;
+import com.personal.marketnote.common.utility.FormatValidator;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ProductEventKafkaListener {
+    private final RegisterInventoryUseCase registerInventoryUseCase;
+    private final ObjectMapper objectMapper;
+
+    @KafkaListener(
+            topics = KafkaTopicConstants.PRODUCT_REGISTERED,
+            groupId = "commerce-service"
+    )
+    public void handleProductRegisteredEvent(
+            ConsumerRecord<String, EventEnvelope<?>> record,
+            Acknowledgment acknowledgment
+    ) {
+        EventEnvelope<?> envelope = record.value();
+
+        try {
+            ProductRegisteredEvent payload = envelope.getPayloadAs(ProductRegisteredEvent.class, objectMapper);
+
+            log.info("상품 등록 이벤트 수신. eventId={}, productId={}, pricePolicyId={}",
+                    envelope.eventId(), payload.productId(), payload.pricePolicyId());
+
+            if (FormatValidator.hasNoValue(payload.productId()) || FormatValidator.hasNoValue(payload.pricePolicyId())) {
+                log.error("유효하지 않은 이벤트 페이로드. eventId={}, productId={}, pricePolicyId={}",
+                        envelope.eventId(), payload.productId(), payload.pricePolicyId());
+                acknowledgment.acknowledge();
+                return;
+            }
+
+            RegisterInventoryCommand command = RegisterInventoryCommand.of(
+                    payload.productId(), payload.pricePolicyId()
+            );
+            registerInventoryUseCase.registerInventory(command);
+
+            log.info("Kafka 이벤트로 재고 등록 완료. productId={}, pricePolicyId={}",
+                    payload.productId(), payload.pricePolicyId());
+        } catch (InventoryAlreadyExistsException e) {
+            log.info("재고가 이미 존재합니다 (듀얼 라이트 중복). eventId={}, key={}",
+                    envelope.eventId(), record.key());
+        }
+
+        acknowledgment.acknowledge();
+    }
+}

--- a/common/src/main/java/com/personal/marketnote/common/kafka/event/ProductRegisteredEvent.java
+++ b/common/src/main/java/com/personal/marketnote/common/kafka/event/ProductRegisteredEvent.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.common.kafka.event;
+
+public record ProductRegisteredEvent(
+        Long productId,
+        Long pricePolicyId,
+        Long sellerId
+) {
+}

--- a/community-service/community-adapters/src/main/resources/application.yml
+++ b/community-service/community-adapters/src/main/resources/application.yml
@@ -38,7 +38,7 @@ spring:
       password: ${REDIS_PASSWORD:password}
 
   kafka:
-    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:172.26.45.222:9092,172.26.21.200:9092,172.26.2.195:9092}
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:172.0.0.0:9092,172.0.0.1:9092,172.0.0.2:9092}
     consumer:
       group-id: ${spring.application.name}
 

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/event/ProductEventKafkaProducer.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/event/ProductEventKafkaProducer.java
@@ -1,0 +1,46 @@
+package com.personal.marketnote.product.adapter.out.event;
+
+import com.personal.marketnote.common.adapter.out.ServiceAdapter;
+import com.personal.marketnote.common.kafka.KafkaTopicConstants;
+import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.ProductRegisteredEvent;
+import com.personal.marketnote.product.port.out.event.PublishProductEventPort;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+
+import java.time.Clock;
+
+@Slf4j
+@ServiceAdapter
+@RequiredArgsConstructor
+public class ProductEventKafkaProducer implements PublishProductEventPort {
+    private static final String SOURCE = "product-service";
+
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+    private final Clock clock;
+
+    @Override
+    public void publishProductRegisteredEvent(Long productId, Long pricePolicyId, Long sellerId) {
+        ProductRegisteredEvent payload = new ProductRegisteredEvent(productId, pricePolicyId, sellerId);
+        EventEnvelope<ProductRegisteredEvent> envelope = EventEnvelope.of(
+                KafkaTopicConstants.PRODUCT_REGISTERED,
+                SOURCE,
+                payload,
+                clock
+        );
+
+        // TODO: Kafka 단독 전환 시 발행 실패 처리 보강 필요 (Outbox 패턴 또는 동기 전환)
+        kafkaTemplate.send(KafkaTopicConstants.PRODUCT_REGISTERED, productId.toString(), envelope)
+                .whenComplete((result, ex) -> {
+                    if (ex != null) {
+                        log.error("Kafka 이벤트 발행 실패. topic={}, productId={}, pricePolicyId={}, sellerId={}",
+                                KafkaTopicConstants.PRODUCT_REGISTERED, productId, pricePolicyId, sellerId, ex);
+                    } else {
+                        log.info("Kafka 이벤트 발행 성공. topic={}, productId={}, pricePolicyId={}, sellerId={}, offset={}",
+                                KafkaTopicConstants.PRODUCT_REGISTERED, productId, pricePolicyId, sellerId,
+                                result.getRecordMetadata().offset());
+                    }
+                });
+    }
+}

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/configuration/CommonConfig.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/configuration/CommonConfig.java
@@ -4,8 +4,12 @@ import com.personal.marketnote.common.application.aop.LoggingAspect;
 import com.personal.marketnote.common.configuration.security.OpaqueTokenIntrospectorConfig;
 import com.personal.marketnote.common.configuration.security.OpaqueTokenIntrospectorProvider;
 import com.personal.marketnote.common.domain.exception.GlobalExceptionHandler;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+
+import java.time.Clock;
+import java.time.ZoneId;
 
 @Configuration
 @Import({
@@ -15,4 +19,9 @@ import org.springframework.context.annotation.Import;
         OpaqueTokenIntrospectorProvider.class
 })
 public class CommonConfig {
+
+    @Bean
+    public Clock productClock() {
+        return Clock.system(ZoneId.of("Asia/Seoul"));
+    }
 }

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/out/event/PublishProductEventPort.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/out/event/PublishProductEventPort.java
@@ -1,0 +1,6 @@
+package com.personal.marketnote.product.port.out.event;
+
+public interface PublishProductEventPort {
+
+    void publishProductRegisteredEvent(Long productId, Long pricePolicyId, Long sellerId);
+}

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/service/product/RegisterProductService.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/service/product/RegisterProductService.java
@@ -10,6 +10,7 @@ import com.personal.marketnote.product.port.in.result.pricepolicy.RegisterPriceP
 import com.personal.marketnote.product.port.in.result.product.RegisterProductResult;
 import com.personal.marketnote.product.port.in.usecase.pricepolicy.RegisterPricePolicyUseCase;
 import com.personal.marketnote.product.port.in.usecase.product.RegisterProductUseCase;
+import com.personal.marketnote.product.port.out.event.PublishProductEventPort;
 import com.personal.marketnote.product.port.out.fulfillment.RegisterFulfillmentVendorGoodsPort;
 import com.personal.marketnote.product.port.out.inventory.RegisterInventoryPort;
 import com.personal.marketnote.product.port.out.product.SaveProductPort;
@@ -26,6 +27,7 @@ import static org.springframework.transaction.annotation.Isolation.READ_COMMITTE
 public class RegisterProductService implements RegisterProductUseCase {
     private final RegisterPricePolicyUseCase registerPricePolicyUseCase;
     private final SaveProductPort saveProductPort;
+    private final PublishProductEventPort publishProductEventPort;
     private final RegisterInventoryPort registerInventoryPort;
     private final RegisterFulfillmentVendorGoodsPort registerFulfillmentVendorGoodsPort;
 
@@ -66,10 +68,15 @@ public class RegisterProductService implements RegisterProductUseCase {
             RegisterProductCommand command,
             Long pricePolicyId
     ) {
-        // FIXME: Kafka 이벤트 Production으로 변경
+        // Kafka 이벤트 발행 (비동기)
+        publishProductEventPort.publishProductRegisteredEvent(
+                savedProduct.getId(), pricePolicyId, command.sellerId()
+        );
+
+        // TODO: Kafka 검증 완료 후 HTTP 호출 제거
         registerInventoryPort.registerInventory(savedProduct.getId(), pricePolicyId);
 
-        // FIXME: Kafka 이벤트 Production으로 변경
+        // FIXME: Kafka 이벤트 Production으로 변경 (#935)
         registerFulfillmentVendorGoodsPort.registerFulfillmentVendorGoods(
                 FulfillmentVendorGoodsCommandMapper.mapToRegisterCommand(savedProduct, command.fulfillmentVendorGoods())
         );

--- a/product-service/product-application/src/test/java/com/personal/marketnote/product/service/product/RegisterProductUseCaseTest.java
+++ b/product-service/product-application/src/test/java/com/personal/marketnote/product/service/product/RegisterProductUseCaseTest.java
@@ -11,6 +11,7 @@ import com.personal.marketnote.product.port.in.command.RegisterProductCommand;
 import com.personal.marketnote.product.port.in.result.pricepolicy.RegisterPricePolicyResult;
 import com.personal.marketnote.product.port.in.result.product.RegisterProductResult;
 import com.personal.marketnote.product.port.in.usecase.pricepolicy.RegisterPricePolicyUseCase;
+import com.personal.marketnote.product.port.out.event.PublishProductEventPort;
 import com.personal.marketnote.product.port.out.fulfillment.RegisterFulfillmentVendorGoodsCommand;
 import com.personal.marketnote.product.port.out.fulfillment.RegisterFulfillmentVendorGoodsPort;
 import com.personal.marketnote.product.port.out.inventory.RegisterInventoryPort;
@@ -37,6 +38,8 @@ class RegisterProductUseCaseTest {
     private RegisterPricePolicyUseCase registerPricePolicyUseCase;
     @Mock
     private SaveProductPort saveProductPort;
+    @Mock
+    private PublishProductEventPort publishProductEventPort;
     @Mock
     private RegisterInventoryPort registerInventoryPort;
     @Mock
@@ -87,6 +90,7 @@ class RegisterProductUseCaseTest {
         assertThat(pricePolicyCommand.accumulatedPoint()).isEqualTo(command.accumulatedPoint());
         assertThat(pricePolicyCommand.optionIds()).isNull();
 
+        verify(publishProductEventPort).publishProductRegisteredEvent(10L, 100L, command.sellerId());
         verify(registerInventoryPort).registerInventory(10L, 100L);
 
         ArgumentCaptor<RegisterFulfillmentVendorGoodsCommand> fulfillmentCaptor =
@@ -103,6 +107,7 @@ class RegisterProductUseCaseTest {
         verifyNoMoreInteractions(
                 registerPricePolicyUseCase,
                 saveProductPort,
+                publishProductEventPort,
                 registerInventoryPort,
                 registerFulfillmentVendorGoodsPort
         );
@@ -121,6 +126,8 @@ class RegisterProductUseCaseTest {
         )).thenReturn(RegisterPricePolicyResult.of(101L));
 
         registerProductService.registerProduct(command);
+
+        verify(publishProductEventPort).publishProductRegisteredEvent(11L, 101L, command.sellerId());
 
         ArgumentCaptor<RegisterFulfillmentVendorGoodsCommand> fulfillmentCaptor =
                 ArgumentCaptor.forClass(RegisterFulfillmentVendorGoodsCommand.class);
@@ -148,7 +155,7 @@ class RegisterProductUseCaseTest {
         verify(registerPricePolicyUseCase).registerPricePolicy(
                 eq(command.sellerId()), eq(false), any(RegisterPricePolicyCommand.class)
         );
-        verifyNoInteractions(registerInventoryPort, registerFulfillmentVendorGoodsPort);
+        verifyNoInteractions(publishProductEventPort, registerInventoryPort, registerFulfillmentVendorGoodsPort);
     }
 
     @Test
@@ -167,6 +174,7 @@ class RegisterProductUseCaseTest {
         assertThatThrownBy(() -> registerProductService.registerProduct(command))
                 .isInstanceOf(IllegalStateException.class);
 
+        verify(publishProductEventPort).publishProductRegisteredEvent(30L, 200L, command.sellerId());
         verify(registerFulfillmentVendorGoodsPort, never()).registerFulfillmentVendorGoods(any());
     }
 
@@ -188,6 +196,7 @@ class RegisterProductUseCaseTest {
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("godType");
 
+        verify(publishProductEventPort).publishProductRegisteredEvent(40L, 300L, command.sellerId());
         verify(registerInventoryPort).registerInventory(40L, 300L);
         verify(registerFulfillmentVendorGoodsPort, never()).registerFulfillmentVendorGoods(any());
     }
@@ -207,6 +216,7 @@ class RegisterProductUseCaseTest {
                 .isInstanceOf(ProductInfoNoValueException.class)
                 .hasMessageContaining("상품 ID가 존재하지 않습니다.");
 
+        verify(publishProductEventPort).publishProductRegisteredEvent(null, 400L, command.sellerId());
         verify(registerInventoryPort).registerInventory(null, 400L);
         verify(registerFulfillmentVendorGoodsPort, never()).registerFulfillmentVendorGoods(any());
     }


### PR DESCRIPTION
## partially addresses #929
## resolves #681

## Task
- ProductRegisteredEvent 이벤트 페이로드 정의 (common)
- PublishProductEventPort 아웃 포트 정의 (product-application)
- ProductEventKafkaProducer Kafka 발행 어댑터 구현 (product-adapters)
- RegisterProductService에 Kafka 발행 추가 (듀얼 라이트: Kafka + HTTP)
- ProductEventKafkaListener Kafka 수신 리스너 구현 (commerce-adapters)
- Consumer 페이로드 검증 및 멱등성 처리
- 기존 테스트 수정 (PublishProductEventPort Mock 추가)