### PR TITLE
[#929][#934] feat: 상품 등록 시 풀필먼트 서비스 상품 등록 연동 기능 Kafka 이벤트 전환

### DIFF
--- a/common/src/main/java/com/personal/marketnote/common/kafka/event/ProductRegisteredEvent.java
+++ b/common/src/main/java/com/personal/marketnote/common/kafka/event/ProductRegisteredEvent.java
@@ -3,6 +3,8 @@ package com.personal.marketnote.common.kafka.event;
 public record ProductRegisteredEvent(
         Long productId,
         Long pricePolicyId,
-        Long sellerId
+        Long sellerId,
+        String productName,
+        String godType
 ) {
 }

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/event/ProductRegisteredFulfillmentConsumer.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/event/ProductRegisteredFulfillmentConsumer.java
@@ -1,0 +1,97 @@
+package com.personal.marketnote.fulfillment.adapter.in.event;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.common.kafka.KafkaTopicConstants;
+import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.ProductRegisteredEvent;
+import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.fulfillment.configuration.FasstoAuthProperties;
+import com.personal.marketnote.fulfillment.domain.FasstoAccessToken;
+import com.personal.marketnote.fulfillment.exception.RegisterFasstoGoodsFailedException;
+import com.personal.marketnote.fulfillment.port.in.command.vendor.RegisterFasstoGoodsCommand;
+import com.personal.marketnote.fulfillment.port.in.command.vendor.RegisterFasstoGoodsItemCommand;
+import com.personal.marketnote.fulfillment.port.in.usecase.vendor.RegisterFasstoGoodsUseCase;
+import com.personal.marketnote.fulfillment.port.in.usecase.vendor.RequestFasstoAuthUseCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ProductRegisteredFulfillmentConsumer {
+    private static final String DEFAULT_GOD_TYPE = "1";
+    private static final String DEFAULT_GIFT_DIV = "01";
+
+    private final RegisterFasstoGoodsUseCase registerFasstoGoodsUseCase;
+    private final RequestFasstoAuthUseCase requestFasstoAuthUseCase;
+    private final FasstoAuthProperties fasstoAuthProperties;
+    private final ObjectMapper objectMapper;
+
+    @KafkaListener(
+            topics = KafkaTopicConstants.PRODUCT_REGISTERED,
+            groupId = "fulfillment-service"
+    )
+    public void handleProductRegisteredEvent(
+            ConsumerRecord<String, EventEnvelope<?>> record,
+            Acknowledgment acknowledgment
+    ) {
+        EventEnvelope<?> envelope = record.value();
+
+        try {
+            ProductRegisteredEvent payload = envelope.getPayloadAs(ProductRegisteredEvent.class, objectMapper);
+
+            log.info("상품 등록 이벤트 수신 (풀필먼트). eventId={}, productId={}",
+                    envelope.eventId(), payload.productId());
+
+            if (FormatValidator.hasNoValue(payload.productId()) || FormatValidator.hasNoValue(payload.productName())) {
+                log.error("유효하지 않은 이벤트 페이로드. eventId={}, productId={}, productName={}",
+                        envelope.eventId(), payload.productId(), payload.productName());
+                acknowledgment.acknowledge();
+                return;
+            }
+
+            FasstoAccessToken accessToken = requestFasstoAuthUseCase.requestAccessToken();
+            if (FormatValidator.hasNoValue(accessToken) || FormatValidator.hasNoValue(accessToken.getValue())) {
+                log.error("Fassto 액세스 토큰 발급 실패. eventId={}, productId={}",
+                        envelope.eventId(), payload.productId());
+                acknowledgment.acknowledge();
+                return;
+            }
+
+            String godType = FormatValidator.hasValue(payload.godType()) ? payload.godType() : DEFAULT_GOD_TYPE;
+
+            RegisterFasstoGoodsItemCommand itemCommand = RegisterFasstoGoodsItemCommand.of(
+                    String.valueOf(payload.productId()),
+                    payload.productName(),
+                    godType,
+                    DEFAULT_GIFT_DIV,
+                    null, null, null, null, null, null, null, null, null,
+                    null, null, null, null, null, null, null, null, null,
+                    null, null, null, null, null, null, null, null, null,
+                    null, null, null, null
+            );
+
+            RegisterFasstoGoodsCommand command = RegisterFasstoGoodsCommand.of(
+                    fasstoAuthProperties.getCustomerCode(),
+                    accessToken.getValue(),
+                    List.of(itemCommand)
+            );
+
+            registerFasstoGoodsUseCase.registerGoods(command);
+
+            log.info("Kafka 이벤트로 풀필먼트 상품 등록 완료. productId={}", payload.productId());
+        } catch (RegisterFasstoGoodsFailedException e) {
+            log.warn("풀필먼트 상품 등록 실패 (듀얼 라이트 기간 HTTP 호출로 처리됨). eventId={}, key={}, message={}",
+                    envelope.eventId(), record.key(), e.getMessage());
+        }
+        // 그 외 예외는 DefaultErrorHandler가 재시도 + DLT로 처리
+
+        acknowledgment.acknowledge();
+    }
+}

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/event/ProductEventKafkaProducer.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/event/ProductEventKafkaProducer.java
@@ -21,8 +21,8 @@ public class ProductEventKafkaProducer implements PublishProductEventPort {
     private final Clock clock;
 
     @Override
-    public void publishProductRegisteredEvent(Long productId, Long pricePolicyId, Long sellerId) {
-        ProductRegisteredEvent payload = new ProductRegisteredEvent(productId, pricePolicyId, sellerId);
+    public void publishProductRegisteredEvent(Long productId, Long pricePolicyId, Long sellerId, String productName, String godType) {
+        ProductRegisteredEvent payload = new ProductRegisteredEvent(productId, pricePolicyId, sellerId, productName, godType);
         EventEnvelope<ProductRegisteredEvent> envelope = EventEnvelope.of(
                 KafkaTopicConstants.PRODUCT_REGISTERED,
                 SOURCE,

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/out/event/PublishProductEventPort.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/out/event/PublishProductEventPort.java
@@ -2,5 +2,5 @@ package com.personal.marketnote.product.port.out.event;
 
 public interface PublishProductEventPort {
 
-    void publishProductRegisteredEvent(Long productId, Long pricePolicyId, Long sellerId);
+    void publishProductRegisteredEvent(Long productId, Long pricePolicyId, Long sellerId, String productName, String godType);
 }

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/service/product/RegisterProductService.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/service/product/RegisterProductService.java
@@ -1,9 +1,11 @@
 package com.personal.marketnote.product.service.product;
 
 import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.product.domain.product.Product;
 import com.personal.marketnote.product.mapper.FulfillmentVendorGoodsCommandMapper;
 import com.personal.marketnote.product.mapper.ProductCommandToStateMapper;
+import com.personal.marketnote.product.port.in.command.FulfillmentVendorGoodsOptionCommand;
 import com.personal.marketnote.product.port.in.command.RegisterPricePolicyCommand;
 import com.personal.marketnote.product.port.in.command.RegisterProductCommand;
 import com.personal.marketnote.product.port.in.result.pricepolicy.RegisterPricePolicyResult;
@@ -25,6 +27,8 @@ import static org.springframework.transaction.annotation.Isolation.READ_COMMITTE
 @RequiredArgsConstructor
 @Transactional(isolation = READ_COMMITTED)
 public class RegisterProductService implements RegisterProductUseCase {
+    private static final String DEFAULT_GOD_TYPE = "1";
+
     private final RegisterPricePolicyUseCase registerPricePolicyUseCase;
     private final SaveProductPort saveProductPort;
     private final PublishProductEventPort publishProductEventPort;
@@ -69,14 +73,19 @@ public class RegisterProductService implements RegisterProductUseCase {
             Long pricePolicyId
     ) {
         // Kafka 이벤트 발행 (비동기)
+        FulfillmentVendorGoodsOptionCommand fulfillmentOptions = command.fulfillmentVendorGoods();
+        String godType = FormatValidator.hasValue(fulfillmentOptions) && FormatValidator.hasValue(fulfillmentOptions.godType())
+                ? fulfillmentOptions.godType()
+                : DEFAULT_GOD_TYPE;
+
         publishProductEventPort.publishProductRegisteredEvent(
-                savedProduct.getId(), pricePolicyId, command.sellerId()
+                savedProduct.getId(), pricePolicyId, command.sellerId(), savedProduct.getName(), godType
         );
 
         // TODO: Kafka 검증 완료 후 HTTP 호출 제거
         registerInventoryPort.registerInventory(savedProduct.getId(), pricePolicyId);
 
-        // FIXME: Kafka 이벤트 Production으로 변경 (#935)
+        // TODO: Kafka 검증 완료 후 HTTP 호출 제거 (#934)
         registerFulfillmentVendorGoodsPort.registerFulfillmentVendorGoods(
                 FulfillmentVendorGoodsCommandMapper.mapToRegisterCommand(savedProduct, command.fulfillmentVendorGoods())
         );

--- a/product-service/product-application/src/test/java/com/personal/marketnote/product/service/product/RegisterProductUseCaseTest.java
+++ b/product-service/product-application/src/test/java/com/personal/marketnote/product/service/product/RegisterProductUseCaseTest.java
@@ -90,7 +90,7 @@ class RegisterProductUseCaseTest {
         assertThat(pricePolicyCommand.accumulatedPoint()).isEqualTo(command.accumulatedPoint());
         assertThat(pricePolicyCommand.optionIds()).isNull();
 
-        verify(publishProductEventPort).publishProductRegisteredEvent(10L, 100L, command.sellerId());
+        verify(publishProductEventPort).publishProductRegisteredEvent(10L, 100L, command.sellerId(), "테스트 상품", "1");
         verify(registerInventoryPort).registerInventory(10L, 100L);
 
         ArgumentCaptor<RegisterFulfillmentVendorGoodsCommand> fulfillmentCaptor =
@@ -127,7 +127,7 @@ class RegisterProductUseCaseTest {
 
         registerProductService.registerProduct(command);
 
-        verify(publishProductEventPort).publishProductRegisteredEvent(11L, 101L, command.sellerId());
+        verify(publishProductEventPort).publishProductRegisteredEvent(11L, 101L, command.sellerId(), "테스트 상품", "2");
 
         ArgumentCaptor<RegisterFulfillmentVendorGoodsCommand> fulfillmentCaptor =
                 ArgumentCaptor.forClass(RegisterFulfillmentVendorGoodsCommand.class);
@@ -174,7 +174,7 @@ class RegisterProductUseCaseTest {
         assertThatThrownBy(() -> registerProductService.registerProduct(command))
                 .isInstanceOf(IllegalStateException.class);
 
-        verify(publishProductEventPort).publishProductRegisteredEvent(30L, 200L, command.sellerId());
+        verify(publishProductEventPort).publishProductRegisteredEvent(30L, 200L, command.sellerId(), "테스트 상품", "1");
         verify(registerFulfillmentVendorGoodsPort, never()).registerFulfillmentVendorGoods(any());
     }
 
@@ -196,7 +196,7 @@ class RegisterProductUseCaseTest {
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("godType");
 
-        verify(publishProductEventPort).publishProductRegisteredEvent(40L, 300L, command.sellerId());
+        verify(publishProductEventPort).publishProductRegisteredEvent(40L, 300L, command.sellerId(), "테스트 상품", "1");
         verify(registerInventoryPort).registerInventory(40L, 300L);
         verify(registerFulfillmentVendorGoodsPort, never()).registerFulfillmentVendorGoods(any());
     }
@@ -216,7 +216,7 @@ class RegisterProductUseCaseTest {
                 .isInstanceOf(ProductInfoNoValueException.class)
                 .hasMessageContaining("상품 ID가 존재하지 않습니다.");
 
-        verify(publishProductEventPort).publishProductRegisteredEvent(null, 400L, command.sellerId());
+        verify(publishProductEventPort).publishProductRegisteredEvent(null, 400L, command.sellerId(), "테스트 상품", "1");
         verify(registerInventoryPort).registerInventory(null, 400L);
         verify(registerFulfillmentVendorGoodsPort, never()).registerFulfillmentVendorGoods(any());
     }


### PR DESCRIPTION
## partially addresses #929
## resolves #934

## Task
- ProductRegisteredEvent에 productName, godType 필드 추가
- ProductRegisteredFulfillmentConsumer 구현 (듀얼 라이트)
- RegisterProductService에서 godType 추출 및 이벤트 enrichment
- 기존 HTTP 호출 유지 (Kafka 검증 완료 후 제거 예정)