### PR TITLE
[#929][#1048][#1051][#1052] test: Kafka 공통 모듈 및 상품 등록 이벤트 전환 자동화 테스트 추가

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/configuration/CommerceSwaggerConfig.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/configuration/CommerceSwaggerConfig.java
@@ -107,6 +107,9 @@ public class CommerceSwaggerConfig {
                         .description("""
                                 마켓노트 서비스 커머스 API 서버입니다.
                                 
+                                ### 개발
+                                성효빈
+                                
                                 ### 서비스 목록
                                 - [회원 서비스](https://users.marketnote.store/swagger-ui/index.html)
                                 

--- a/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/event/ProductEventKafkaListenerTest.java
+++ b/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/event/ProductEventKafkaListenerTest.java
@@ -1,0 +1,117 @@
+package com.personal.marketnote.commerce.adapter.in.event;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.commerce.exception.InventoryAlreadyExistsException;
+import com.personal.marketnote.commerce.port.in.command.inventory.RegisterInventoryCommand;
+import com.personal.marketnote.commerce.port.in.usecase.inventory.RegisterInventoryUseCase;
+import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.ProductRegisteredEvent;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.support.Acknowledgment;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ProductEventKafkaListenerTest {
+    @InjectMocks
+    private ProductEventKafkaListener productEventKafkaListener;
+
+    @Mock
+    private RegisterInventoryUseCase registerInventoryUseCase;
+
+    @Spy
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @Mock
+    private Acknowledgment acknowledgment;
+
+    private ConsumerRecord<String, EventEnvelope<?>> buildRecord(
+            Long productId, Long pricePolicyId, Long sellerId
+    ) {
+        ProductRegisteredEvent event = new ProductRegisteredEvent(
+                productId, pricePolicyId, sellerId, "테스트 상품", "1"
+        );
+        EventEnvelope<ProductRegisteredEvent> envelope = new EventEnvelope<>(
+                "test-event-id", "product.product.registered", "product-service",
+                LocalDateTime.of(2026, 2, 27, 10, 0), event
+        );
+        return new ConsumerRecord<>("product.product.registered", 0, 0L, "key-1", envelope);
+    }
+
+    @Test
+    @DisplayName("정상 이벤트 수신 시 재고 등록 UseCase를 호출하고 acknowledge한다")
+    void handleProductRegisteredEvent_success_registersInventoryAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, 2L, 3L);
+
+        // when
+        productEventKafkaListener.handleProductRegisteredEvent(record, acknowledgment);
+
+        // then
+        ArgumentCaptor<RegisterInventoryCommand> captor = ArgumentCaptor.forClass(RegisterInventoryCommand.class);
+        verify(registerInventoryUseCase).registerInventory(captor.capture());
+
+        RegisterInventoryCommand command = captor.getValue();
+        assertThat(command.productId()).isEqualTo(1L);
+        assertThat(command.pricePolicyId()).isEqualTo(2L);
+
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("productId가 null이면 재고 등록을 호출하지 않고 acknowledge한다")
+    void handleProductRegisteredEvent_nullProductId_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(null, 2L, 3L);
+
+        // when
+        productEventKafkaListener.handleProductRegisteredEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(registerInventoryUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("pricePolicyId가 null이면 재고 등록을 호출하지 않고 acknowledge한다")
+    void handleProductRegisteredEvent_nullPricePolicyId_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, null, 3L);
+
+        // when
+        productEventKafkaListener.handleProductRegisteredEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(registerInventoryUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("이미 재고가 존재하면 예외를 무시하고 acknowledge한다")
+    void handleProductRegisteredEvent_inventoryAlreadyExists_acknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, 2L, 3L);
+        doThrow(new InventoryAlreadyExistsException(2L))
+                .when(registerInventoryUseCase).registerInventory(any(RegisterInventoryCommand.class));
+
+        // when
+        productEventKafkaListener.handleProductRegisteredEvent(record, acknowledgment);
+
+        // then
+        verify(registerInventoryUseCase).registerInventory(any(RegisterInventoryCommand.class));
+        verify(acknowledgment).acknowledge();
+    }
+
+}

--- a/common/src/main/java/com/personal/marketnote/common/kafka/event/ProductRegisteredEvent.java
+++ b/common/src/main/java/com/personal/marketnote/common/kafka/event/ProductRegisteredEvent.java
@@ -3,6 +3,8 @@ package com.personal.marketnote.common.kafka.event;
 public record ProductRegisteredEvent(
         Long productId,
         Long pricePolicyId,
-        Long sellerId
+        Long sellerId,
+        String productName,
+        String godType
 ) {
 }

--- a/common/src/test/java/com/personal/marketnote/common/kafka/event/EventEnvelopeTest.java
+++ b/common/src/test/java/com/personal/marketnote/common/kafka/event/EventEnvelopeTest.java
@@ -1,0 +1,130 @@
+package com.personal.marketnote.common.kafka.event;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class EventEnvelopeTest {
+    private static final Clock FIXED_CLOCK = Clock.fixed(
+            Instant.parse("2026-02-27T10:00:00Z"), ZoneId.of("Asia/Seoul")
+    );
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    @Test
+    @DisplayName("of 메서드로 생성 시 UUID v7 형식의 eventId가 생성된다")
+    void of_generatesTimeOrderedUuidEventId() {
+        // when
+        EventEnvelope<String> envelope = EventEnvelope.of("test.topic", "test-source", "payload", FIXED_CLOCK);
+
+        // then
+        assertThat(envelope.eventId()).isNotNull();
+        assertThat(envelope.eventId()).matches("^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$");
+    }
+
+    @Test
+    @DisplayName("of 메서드로 생성 시 eventType과 source가 올바르게 설정된다")
+    void of_setsEventTypeAndSource() {
+        // when
+        EventEnvelope<String> envelope = EventEnvelope.of("product.product.registered", "product-service", "payload", FIXED_CLOCK);
+
+        // then
+        assertThat(envelope.eventType()).isEqualTo("product.product.registered");
+        assertThat(envelope.source()).isEqualTo("product-service");
+    }
+
+    @Test
+    @DisplayName("of 메서드로 생성 시 Clock 기반 timestamp가 설정된다")
+    void of_setsTimestampFromClock() {
+        // when
+        EventEnvelope<String> envelope = EventEnvelope.of("test.topic", "test-source", "payload", FIXED_CLOCK);
+
+        // then
+        LocalDateTime expectedTimestamp = LocalDateTime.now(FIXED_CLOCK);
+        assertThat(envelope.timestamp()).isEqualTo(expectedTimestamp);
+    }
+
+    @Test
+    @DisplayName("of 메서드로 생성 시 payload가 올바르게 설정된다")
+    void of_setsPayload() {
+        // given
+        ProductRegisteredEvent event = new ProductRegisteredEvent(1L, 2L, 3L, "상품명", "1");
+
+        // when
+        EventEnvelope<ProductRegisteredEvent> envelope = EventEnvelope.of(
+                "product.product.registered", "product-service", event, FIXED_CLOCK
+        );
+
+        // then
+        assertThat(envelope.payload()).isEqualTo(event);
+        assertThat(envelope.payload().productId()).isEqualTo(1L);
+        assertThat(envelope.payload().pricePolicyId()).isEqualTo(2L);
+        assertThat(envelope.payload().sellerId()).isEqualTo(3L);
+        assertThat(envelope.payload().productName()).isEqualTo("상품명");
+        assertThat(envelope.payload().godType()).isEqualTo("1");
+    }
+
+    @Test
+    @DisplayName("getPayloadAs 호출 시 이미 올바른 타입이면 캐스트하여 반환한다")
+    void getPayloadAs_alreadyCorrectType_returnsCast() {
+        // given
+        ProductRegisteredEvent event = new ProductRegisteredEvent(10L, 20L, 30L, "테스트", "2");
+        EventEnvelope<ProductRegisteredEvent> envelope = EventEnvelope.of(
+                "product.product.registered", "product-service", event, FIXED_CLOCK
+        );
+
+        // when
+        ProductRegisteredEvent result = envelope.getPayloadAs(ProductRegisteredEvent.class, OBJECT_MAPPER);
+
+        // then
+        assertThat(result).isSameAs(event);
+    }
+
+    @Test
+    @DisplayName("getPayloadAs 호출 시 LinkedHashMap 타입이면 ObjectMapper로 변환한다")
+    void getPayloadAs_linkedHashMap_convertsViaObjectMapper() {
+        // given — Kafka 역직렬화 시 payload가 LinkedHashMap으로 들어오는 케이스
+        Map<String, Object> rawPayload = new LinkedHashMap<>();
+        rawPayload.put("productId", 100L);
+        rawPayload.put("pricePolicyId", 200L);
+        rawPayload.put("sellerId", 300L);
+        rawPayload.put("productName", "맵 변환 상품");
+        rawPayload.put("godType", "1");
+
+        EventEnvelope<Map<String, Object>> envelope = new EventEnvelope<>(
+                "test-event-id", "product.product.registered", "product-service",
+                LocalDateTime.now(FIXED_CLOCK), rawPayload
+        );
+
+        // when
+        @SuppressWarnings("unchecked")
+        ProductRegisteredEvent result = ((EventEnvelope<?>) envelope)
+                .getPayloadAs(ProductRegisteredEvent.class, OBJECT_MAPPER);
+
+        // then
+        assertThat(result.productId()).isEqualTo(100L);
+        assertThat(result.pricePolicyId()).isEqualTo(200L);
+        assertThat(result.sellerId()).isEqualTo(300L);
+        assertThat(result.productName()).isEqualTo("맵 변환 상품");
+        assertThat(result.godType()).isEqualTo("1");
+    }
+
+    @Test
+    @DisplayName("서로 다른 of 호출은 서로 다른 eventId를 생성한다")
+    void of_generatesUniqueEventIds() {
+        // when
+        EventEnvelope<String> first = EventEnvelope.of("topic", "source", "a", FIXED_CLOCK);
+        EventEnvelope<String> second = EventEnvelope.of("topic", "source", "b", FIXED_CLOCK);
+
+        // then
+        assertThat(first.eventId()).isNotEqualTo(second.eventId());
+    }
+}

--- a/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/in/configuration/CommunitySwaggerConfig.java
+++ b/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/in/configuration/CommunitySwaggerConfig.java
@@ -105,6 +105,9 @@ public class CommunitySwaggerConfig {
                         .description("""
                                 마켓노트 서비스 커뮤니티 API 서버입니다.
                                 
+                                ### 개발
+                                성효빈
+                                
                                 ### 서비스 목록
                                 - [회원 서비스](https://users.marketnote.store/swagger-ui/index.html)
                                 

--- a/file-service/file-adapters/src/main/java/com/personal/marketnote/file/adapter/in/configuration/FileSwaggerConfig.java
+++ b/file-service/file-adapters/src/main/java/com/personal/marketnote/file/adapter/in/configuration/FileSwaggerConfig.java
@@ -104,6 +104,9 @@ public class FileSwaggerConfig {
                         .description("""
                                 마켓노트 서비스 파일 API 서버입니다.
                                 
+                                ### 개발
+                                성효빈
+                                
                                 ### 서비스 목록
                                 - [회원 서비스](https://users.marketnote.store/swagger-ui/index.html)
                                 

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter.in.configuration/FulfillmentSwaggerConfig.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter.in.configuration/FulfillmentSwaggerConfig.java
@@ -109,6 +109,9 @@ public class FulfillmentSwaggerConfig {
                         .description("""
                                 마켓노트 서비스 풀필먼트 API 서버입니다.
                                 
+                                ### 개발
+                                성효빈
+                                
                                 ### 서비스 목록
                                 - [회원 서비스](https://users.marketnote.store/swagger-ui/index.html)
                                 

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/event/ProductRegisteredFulfillmentConsumer.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/event/ProductRegisteredFulfillmentConsumer.java
@@ -1,0 +1,97 @@
+package com.personal.marketnote.fulfillment.adapter.in.event;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.common.kafka.KafkaTopicConstants;
+import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.ProductRegisteredEvent;
+import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.fulfillment.configuration.FasstoAuthProperties;
+import com.personal.marketnote.fulfillment.domain.FasstoAccessToken;
+import com.personal.marketnote.fulfillment.exception.RegisterFasstoGoodsFailedException;
+import com.personal.marketnote.fulfillment.port.in.command.vendor.RegisterFasstoGoodsCommand;
+import com.personal.marketnote.fulfillment.port.in.command.vendor.RegisterFasstoGoodsItemCommand;
+import com.personal.marketnote.fulfillment.port.in.usecase.vendor.RegisterFasstoGoodsUseCase;
+import com.personal.marketnote.fulfillment.port.in.usecase.vendor.RequestFasstoAuthUseCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ProductRegisteredFulfillmentConsumer {
+    private static final String DEFAULT_GOD_TYPE = "1";
+    private static final String DEFAULT_GIFT_DIV = "01";
+
+    private final RegisterFasstoGoodsUseCase registerFasstoGoodsUseCase;
+    private final RequestFasstoAuthUseCase requestFasstoAuthUseCase;
+    private final FasstoAuthProperties fasstoAuthProperties;
+    private final ObjectMapper objectMapper;
+
+    @KafkaListener(
+            topics = KafkaTopicConstants.PRODUCT_REGISTERED,
+            groupId = "fulfillment-service"
+    )
+    public void handleProductRegisteredEvent(
+            ConsumerRecord<String, EventEnvelope<?>> record,
+            Acknowledgment acknowledgment
+    ) {
+        EventEnvelope<?> envelope = record.value();
+
+        try {
+            ProductRegisteredEvent payload = envelope.getPayloadAs(ProductRegisteredEvent.class, objectMapper);
+
+            log.info("상품 등록 이벤트 수신 (풀필먼트). eventId={}, productId={}",
+                    envelope.eventId(), payload.productId());
+
+            if (FormatValidator.hasNoValue(payload.productId()) || FormatValidator.hasNoValue(payload.productName())) {
+                log.error("유효하지 않은 이벤트 페이로드. eventId={}, productId={}, productName={}",
+                        envelope.eventId(), payload.productId(), payload.productName());
+                acknowledgment.acknowledge();
+                return;
+            }
+
+            FasstoAccessToken accessToken = requestFasstoAuthUseCase.requestAccessToken();
+            if (FormatValidator.hasNoValue(accessToken) || FormatValidator.hasNoValue(accessToken.getValue())) {
+                log.error("Fassto 액세스 토큰 발급 실패. eventId={}, productId={}",
+                        envelope.eventId(), payload.productId());
+                acknowledgment.acknowledge();
+                return;
+            }
+
+            String godType = FormatValidator.hasValue(payload.godType()) ? payload.godType() : DEFAULT_GOD_TYPE;
+
+            RegisterFasstoGoodsItemCommand itemCommand = RegisterFasstoGoodsItemCommand.of(
+                    String.valueOf(payload.productId()),
+                    payload.productName(),
+                    godType,
+                    DEFAULT_GIFT_DIV,
+                    null, null, null, null, null, null, null, null, null,
+                    null, null, null, null, null, null, null, null, null,
+                    null, null, null, null, null, null, null, null, null,
+                    null, null, null, null
+            );
+
+            RegisterFasstoGoodsCommand command = RegisterFasstoGoodsCommand.of(
+                    fasstoAuthProperties.getCustomerCode(),
+                    accessToken.getValue(),
+                    List.of(itemCommand)
+            );
+
+            registerFasstoGoodsUseCase.registerGoods(command);
+
+            log.info("Kafka 이벤트로 풀필먼트 상품 등록 완료. productId={}", payload.productId());
+        } catch (RegisterFasstoGoodsFailedException e) {
+            log.warn("풀필먼트 상품 등록 실패 (듀얼 라이트 기간 HTTP 호출로 처리됨). eventId={}, key={}, message={}",
+                    envelope.eventId(), record.key(), e.getMessage());
+        }
+        // 그 외 예외는 DefaultErrorHandler가 재시도 + DLT로 처리
+
+        acknowledgment.acknowledge();
+    }
+}

--- a/fulfillment-service/fulfillment-adapters/src/test/java/com/personal/marketnote/fulfillment/adapter/in/event/ProductRegisteredFulfillmentConsumerTest.java
+++ b/fulfillment-service/fulfillment-adapters/src/test/java/com/personal/marketnote/fulfillment/adapter/in/event/ProductRegisteredFulfillmentConsumerTest.java
@@ -1,0 +1,212 @@
+package com.personal.marketnote.fulfillment.adapter.in.event;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.ProductRegisteredEvent;
+import com.personal.marketnote.fulfillment.configuration.FasstoAuthProperties;
+import com.personal.marketnote.fulfillment.domain.FasstoAccessToken;
+import com.personal.marketnote.fulfillment.exception.RegisterFasstoGoodsFailedException;
+import com.personal.marketnote.fulfillment.port.in.command.vendor.RegisterFasstoGoodsCommand;
+import com.personal.marketnote.fulfillment.port.in.usecase.vendor.RegisterFasstoGoodsUseCase;
+import com.personal.marketnote.fulfillment.port.in.usecase.vendor.RequestFasstoAuthUseCase;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.support.Acknowledgment;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ProductRegisteredFulfillmentConsumerTest {
+    @InjectMocks
+    private ProductRegisteredFulfillmentConsumer consumer;
+
+    @Mock
+    private RegisterFasstoGoodsUseCase registerFasstoGoodsUseCase;
+
+    @Mock
+    private RequestFasstoAuthUseCase requestFasstoAuthUseCase;
+
+    @Mock
+    private FasstoAuthProperties fasstoAuthProperties;
+
+    @Spy
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @Mock
+    private Acknowledgment acknowledgment;
+
+    private ConsumerRecord<String, EventEnvelope<?>> buildRecord(
+            Long productId, String productName, String godType
+    ) {
+        ProductRegisteredEvent event = new ProductRegisteredEvent(
+                productId, 100L, 1L, productName, godType
+        );
+        EventEnvelope<ProductRegisteredEvent> envelope = new EventEnvelope<>(
+                "test-event-id", "product.product.registered", "product-service",
+                LocalDateTime.of(2026, 2, 27, 10, 0), event
+        );
+        return new ConsumerRecord<>("product.product.registered", 0, 0L, "key-1", envelope);
+    }
+
+    private FasstoAccessToken buildValidAccessToken() {
+        return FasstoAccessToken.of("valid-token", "20261231235959");
+    }
+
+    @Test
+    @DisplayName("정상 이벤트 수신 시 Fassto 상품 등록 UseCase를 호출하고 acknowledge한다")
+    void handleEvent_success_registersFasstoGoodsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(10L, "테스트 상품", "1");
+        when(requestFasstoAuthUseCase.requestAccessToken()).thenReturn(buildValidAccessToken());
+        when(fasstoAuthProperties.getCustomerCode()).thenReturn("CUST001");
+
+        // when
+        consumer.handleProductRegisteredEvent(record, acknowledgment);
+
+        // then
+        ArgumentCaptor<RegisterFasstoGoodsCommand> captor = ArgumentCaptor.forClass(RegisterFasstoGoodsCommand.class);
+        verify(registerFasstoGoodsUseCase).registerGoods(captor.capture());
+
+        RegisterFasstoGoodsCommand command = captor.getValue();
+        assertThat(command.customerCode()).isEqualTo("CUST001");
+        assertThat(command.accessToken()).isEqualTo("valid-token");
+        assertThat(command.goods()).hasSize(1);
+        assertThat(command.goods().get(0).cstGodCd()).isEqualTo("10");
+        assertThat(command.goods().get(0).godNm()).isEqualTo("테스트 상품");
+        assertThat(command.goods().get(0).godType()).isEqualTo("1");
+        assertThat(command.goods().get(0).giftDiv()).isEqualTo("01");
+
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("이벤트의 godType이 있으면 해당 값으로 상품을 등록한다")
+    void handleEvent_withCustomGodType_usesProvidedGodType() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(20L, "커스텀 상품", "2");
+        when(requestFasstoAuthUseCase.requestAccessToken()).thenReturn(buildValidAccessToken());
+        when(fasstoAuthProperties.getCustomerCode()).thenReturn("CUST001");
+
+        // when
+        consumer.handleProductRegisteredEvent(record, acknowledgment);
+
+        // then
+        ArgumentCaptor<RegisterFasstoGoodsCommand> captor = ArgumentCaptor.forClass(RegisterFasstoGoodsCommand.class);
+        verify(registerFasstoGoodsUseCase).registerGoods(captor.capture());
+
+        assertThat(captor.getValue().goods().get(0).godType()).isEqualTo("2");
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("이벤트의 godType이 null이면 기본값 '1'로 등록한다")
+    void handleEvent_nullGodType_usesDefault() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(30L, "기본 타입 상품", null);
+        when(requestFasstoAuthUseCase.requestAccessToken()).thenReturn(buildValidAccessToken());
+        when(fasstoAuthProperties.getCustomerCode()).thenReturn("CUST001");
+
+        // when
+        consumer.handleProductRegisteredEvent(record, acknowledgment);
+
+        // then
+        ArgumentCaptor<RegisterFasstoGoodsCommand> captor = ArgumentCaptor.forClass(RegisterFasstoGoodsCommand.class);
+        verify(registerFasstoGoodsUseCase).registerGoods(captor.capture());
+
+        assertThat(captor.getValue().goods().get(0).godType()).isEqualTo("1");
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("productId가 null이면 상품 등록을 호출하지 않고 acknowledge한다")
+    void handleEvent_nullProductId_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(null, "테스트", "1");
+
+        // when
+        consumer.handleProductRegisteredEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(requestFasstoAuthUseCase, registerFasstoGoodsUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("productName이 null이면 상품 등록을 호출하지 않고 acknowledge한다")
+    void handleEvent_nullProductName_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, null, "1");
+
+        // when
+        consumer.handleProductRegisteredEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(requestFasstoAuthUseCase, registerFasstoGoodsUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("Fassto 액세스 토큰이 null이면 상품 등록을 호출하지 않고 acknowledge한다")
+    void handleEvent_nullAccessToken_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, "테스트", "1");
+        when(requestFasstoAuthUseCase.requestAccessToken()).thenReturn(null);
+
+        // when
+        consumer.handleProductRegisteredEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(registerFasstoGoodsUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("RegisterFasstoGoodsFailedException 발생 시 warn 로그 후 acknowledge한다")
+    void handleEvent_registerFasstoGoodsFailed_warnsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, "테스트", "1");
+        when(requestFasstoAuthUseCase.requestAccessToken()).thenReturn(buildValidAccessToken());
+        when(fasstoAuthProperties.getCustomerCode()).thenReturn("CUST001");
+        doThrow(new RegisterFasstoGoodsFailedException(new IOException("Fassto API 오류")))
+                .when(registerFasstoGoodsUseCase).registerGoods(any(RegisterFasstoGoodsCommand.class));
+
+        // when
+        consumer.handleProductRegisteredEvent(record, acknowledgment);
+
+        // then
+        verify(registerFasstoGoodsUseCase).registerGoods(any(RegisterFasstoGoodsCommand.class));
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("예상치 못한 예외 발생 시 DefaultErrorHandler로 위임되어 예외가 전파된다")
+    void handleEvent_unexpectedException_propagatesForRetry() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, "테스트", "1");
+        when(requestFasstoAuthUseCase.requestAccessToken()).thenReturn(buildValidAccessToken());
+        when(fasstoAuthProperties.getCustomerCode()).thenReturn("CUST001");
+        doThrow(new RuntimeException("네트워크 오류"))
+                .when(registerFasstoGoodsUseCase).registerGoods(any(RegisterFasstoGoodsCommand.class));
+
+        // when & then
+        assertThatThrownBy(() -> consumer.handleProductRegisteredEvent(record, acknowledgment))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("네트워크 오류");
+
+        verify(registerFasstoGoodsUseCase).registerGoods(any(RegisterFasstoGoodsCommand.class));
+        verify(acknowledgment, never()).acknowledge();
+    }
+}

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/configuration/ProductSwaggerConfig.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/configuration/ProductSwaggerConfig.java
@@ -106,6 +106,9 @@ public class ProductSwaggerConfig {
                         .description("""
                                 마켓노트 서비스 상품 API 서버입니다.
                                 
+                                ### 개발
+                                성효빈
+                                
                                 ### 서비스 목록
                                 - [회원 서비스](https://users.marketnote.store/swagger-ui/index.html)
                                 

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/event/ProductEventKafkaProducer.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/event/ProductEventKafkaProducer.java
@@ -21,8 +21,8 @@ public class ProductEventKafkaProducer implements PublishProductEventPort {
     private final Clock clock;
 
     @Override
-    public void publishProductRegisteredEvent(Long productId, Long pricePolicyId, Long sellerId) {
-        ProductRegisteredEvent payload = new ProductRegisteredEvent(productId, pricePolicyId, sellerId);
+    public void publishProductRegisteredEvent(Long productId, Long pricePolicyId, Long sellerId, String productName, String godType) {
+        ProductRegisteredEvent payload = new ProductRegisteredEvent(productId, pricePolicyId, sellerId, productName, godType);
         EventEnvelope<ProductRegisteredEvent> envelope = EventEnvelope.of(
                 KafkaTopicConstants.PRODUCT_REGISTERED,
                 SOURCE,

--- a/product-service/product-adapters/src/test/java/com/personal/marketnote/product/adapter/out/event/ProductEventKafkaProducerTest.java
+++ b/product-service/product-adapters/src/test/java/com/personal/marketnote/product/adapter/out/event/ProductEventKafkaProducerTest.java
@@ -1,0 +1,95 @@
+package com.personal.marketnote.product.adapter.out.event;
+
+import com.personal.marketnote.common.kafka.KafkaTopicConstants;
+import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.ProductRegisteredEvent;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.core.KafkaTemplate;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.concurrent.CompletableFuture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ProductEventKafkaProducerTest {
+    @InjectMocks
+    private ProductEventKafkaProducer productEventKafkaProducer;
+
+    @Mock
+    private KafkaTemplate<String, Object> kafkaTemplate;
+
+    @Mock
+    private Clock clock;
+
+    private void setUpClock(String instant) {
+        Clock fixedClock = Clock.fixed(Instant.parse(instant), ZoneId.of("Asia/Seoul"));
+        when(clock.instant()).thenReturn(fixedClock.instant());
+        when(clock.getZone()).thenReturn(fixedClock.getZone());
+    }
+
+    @Test
+    @DisplayName("상품 등록 이벤트 발행 시 올바른 토픽과 파티션 키로 전송된다")
+    void publishProductRegisteredEvent_sendsToCorrectTopicWithProductIdKey() {
+        // given
+        setUpClock("2026-02-27T10:00:00Z");
+        when(kafkaTemplate.send(any(String.class), any(String.class), any()))
+                .thenReturn(new CompletableFuture<>());
+
+        // when
+        productEventKafkaProducer.publishProductRegisteredEvent(1L, 2L, 3L, "테스트 상품", "1");
+
+        // then
+        verify(kafkaTemplate).send(
+                eq(KafkaTopicConstants.PRODUCT_REGISTERED),
+                eq("1"),
+                any(EventEnvelope.class)
+        );
+    }
+
+    @Test
+    @DisplayName("상품 등록 이벤트 발행 시 EventEnvelope에 올바른 페이로드가 포함된다")
+    @SuppressWarnings("unchecked")
+    void publishProductRegisteredEvent_envelopeContainsCorrectPayload() {
+        // given
+        setUpClock("2026-02-27T10:00:00Z");
+        when(kafkaTemplate.send(any(String.class), any(String.class), any()))
+                .thenReturn(new CompletableFuture<>());
+
+        // when
+        productEventKafkaProducer.publishProductRegisteredEvent(10L, 20L, 30L, "상품명", "2");
+
+        // then
+        ArgumentCaptor<EventEnvelope> envelopeCaptor = ArgumentCaptor.forClass(EventEnvelope.class);
+        verify(kafkaTemplate).send(
+                eq(KafkaTopicConstants.PRODUCT_REGISTERED),
+                eq("10"),
+                envelopeCaptor.capture()
+        );
+
+        EventEnvelope<?> capturedEnvelope = envelopeCaptor.getValue();
+        assertThat(capturedEnvelope.eventType()).isEqualTo(KafkaTopicConstants.PRODUCT_REGISTERED);
+        assertThat(capturedEnvelope.source()).isEqualTo("product-service");
+        assertThat(capturedEnvelope.eventId()).isNotNull();
+        assertThat(capturedEnvelope.timestamp()).isNotNull();
+
+        ProductRegisteredEvent payload = (ProductRegisteredEvent) capturedEnvelope.payload();
+        assertThat(payload.productId()).isEqualTo(10L);
+        assertThat(payload.pricePolicyId()).isEqualTo(20L);
+        assertThat(payload.sellerId()).isEqualTo(30L);
+        assertThat(payload.productName()).isEqualTo("상품명");
+        assertThat(payload.godType()).isEqualTo("2");
+    }
+}

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/out/event/PublishProductEventPort.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/out/event/PublishProductEventPort.java
@@ -2,5 +2,5 @@ package com.personal.marketnote.product.port.out.event;
 
 public interface PublishProductEventPort {
 
-    void publishProductRegisteredEvent(Long productId, Long pricePolicyId, Long sellerId);
+    void publishProductRegisteredEvent(Long productId, Long pricePolicyId, Long sellerId, String productName, String godType);
 }

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/service/product/RegisterProductService.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/service/product/RegisterProductService.java
@@ -1,9 +1,11 @@
 package com.personal.marketnote.product.service.product;
 
 import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.product.domain.product.Product;
 import com.personal.marketnote.product.mapper.FulfillmentVendorGoodsCommandMapper;
 import com.personal.marketnote.product.mapper.ProductCommandToStateMapper;
+import com.personal.marketnote.product.port.in.command.FulfillmentVendorGoodsOptionCommand;
 import com.personal.marketnote.product.port.in.command.RegisterPricePolicyCommand;
 import com.personal.marketnote.product.port.in.command.RegisterProductCommand;
 import com.personal.marketnote.product.port.in.result.pricepolicy.RegisterPricePolicyResult;
@@ -25,6 +27,8 @@ import static org.springframework.transaction.annotation.Isolation.READ_COMMITTE
 @RequiredArgsConstructor
 @Transactional(isolation = READ_COMMITTED)
 public class RegisterProductService implements RegisterProductUseCase {
+    private static final String DEFAULT_GOD_TYPE = "1";
+
     private final RegisterPricePolicyUseCase registerPricePolicyUseCase;
     private final SaveProductPort saveProductPort;
     private final PublishProductEventPort publishProductEventPort;
@@ -69,14 +73,19 @@ public class RegisterProductService implements RegisterProductUseCase {
             Long pricePolicyId
     ) {
         // Kafka 이벤트 발행 (비동기)
+        FulfillmentVendorGoodsOptionCommand fulfillmentOptions = command.fulfillmentVendorGoods();
+        String godType = FormatValidator.hasValue(fulfillmentOptions) && FormatValidator.hasValue(fulfillmentOptions.godType())
+                ? fulfillmentOptions.godType()
+                : DEFAULT_GOD_TYPE;
+
         publishProductEventPort.publishProductRegisteredEvent(
-                savedProduct.getId(), pricePolicyId, command.sellerId()
+                savedProduct.getId(), pricePolicyId, command.sellerId(), savedProduct.getName(), godType
         );
 
         // TODO: Kafka 검증 완료 후 HTTP 호출 제거
         registerInventoryPort.registerInventory(savedProduct.getId(), pricePolicyId);
 
-        // FIXME: Kafka 이벤트 Production으로 변경 (#935)
+        // TODO: Kafka 검증 완료 후 HTTP 호출 제거 (#934)
         registerFulfillmentVendorGoodsPort.registerFulfillmentVendorGoods(
                 FulfillmentVendorGoodsCommandMapper.mapToRegisterCommand(savedProduct, command.fulfillmentVendorGoods())
         );

--- a/product-service/product-application/src/test/java/com/personal/marketnote/product/service/product/RegisterProductUseCaseTest.java
+++ b/product-service/product-application/src/test/java/com/personal/marketnote/product/service/product/RegisterProductUseCaseTest.java
@@ -90,7 +90,7 @@ class RegisterProductUseCaseTest {
         assertThat(pricePolicyCommand.accumulatedPoint()).isEqualTo(command.accumulatedPoint());
         assertThat(pricePolicyCommand.optionIds()).isNull();
 
-        verify(publishProductEventPort).publishProductRegisteredEvent(10L, 100L, command.sellerId());
+        verify(publishProductEventPort).publishProductRegisteredEvent(10L, 100L, command.sellerId(), "테스트 상품", "1");
         verify(registerInventoryPort).registerInventory(10L, 100L);
 
         ArgumentCaptor<RegisterFulfillmentVendorGoodsCommand> fulfillmentCaptor =
@@ -127,7 +127,7 @@ class RegisterProductUseCaseTest {
 
         registerProductService.registerProduct(command);
 
-        verify(publishProductEventPort).publishProductRegisteredEvent(11L, 101L, command.sellerId());
+        verify(publishProductEventPort).publishProductRegisteredEvent(11L, 101L, command.sellerId(), "테스트 상품", "2");
 
         ArgumentCaptor<RegisterFulfillmentVendorGoodsCommand> fulfillmentCaptor =
                 ArgumentCaptor.forClass(RegisterFulfillmentVendorGoodsCommand.class);
@@ -174,7 +174,7 @@ class RegisterProductUseCaseTest {
         assertThatThrownBy(() -> registerProductService.registerProduct(command))
                 .isInstanceOf(IllegalStateException.class);
 
-        verify(publishProductEventPort).publishProductRegisteredEvent(30L, 200L, command.sellerId());
+        verify(publishProductEventPort).publishProductRegisteredEvent(30L, 200L, command.sellerId(), "테스트 상품", "1");
         verify(registerFulfillmentVendorGoodsPort, never()).registerFulfillmentVendorGoods(any());
     }
 
@@ -196,7 +196,7 @@ class RegisterProductUseCaseTest {
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("godType");
 
-        verify(publishProductEventPort).publishProductRegisteredEvent(40L, 300L, command.sellerId());
+        verify(publishProductEventPort).publishProductRegisteredEvent(40L, 300L, command.sellerId(), "테스트 상품", "1");
         verify(registerInventoryPort).registerInventory(40L, 300L);
         verify(registerFulfillmentVendorGoodsPort, never()).registerFulfillmentVendorGoods(any());
     }
@@ -216,7 +216,7 @@ class RegisterProductUseCaseTest {
                 .isInstanceOf(ProductInfoNoValueException.class)
                 .hasMessageContaining("상품 ID가 존재하지 않습니다.");
 
-        verify(publishProductEventPort).publishProductRegisteredEvent(null, 400L, command.sellerId());
+        verify(publishProductEventPort).publishProductRegisteredEvent(null, 400L, command.sellerId(), "테스트 상품", "1");
         verify(registerInventoryPort).registerInventory(null, 400L);
         verify(registerFulfillmentVendorGoodsPort, never()).registerFulfillmentVendorGoods(any());
     }

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/configuration/RewardSwaggerConfig.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/configuration/RewardSwaggerConfig.java
@@ -104,6 +104,9 @@ public class RewardSwaggerConfig {
                         .description("""
                                 마켓노트 서비스 리워드 API 서버입니다.
                                 
+                                ### 개발
+                                성효빈
+                                
                                 ### 서비스 목록
                                 - [회원 서비스](https://users.marketnote.store/swagger-ui/index.html)
                                 

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/configuration/UserSwaggerConfig.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/configuration/UserSwaggerConfig.java
@@ -113,6 +113,9 @@ public class UserSwaggerConfig {
                         .description("""
                                 마켓노트 서비스 회원 API 서버입니다.
                                 
+                                ### 개발
+                                성효빈
+                                
                                 ### 서비스 목록
                                 - [회원 서비스](https://users.marketnote.store/swagger-ui/index.html)
                                 


### PR DESCRIPTION
## partially addresses #929
## resolves #1048
## resolves #1051
## resolves #1052

- EventEnvelopeTest: of() UUID/타입/시간/페이로드 검증, getPayloadAs() 타입캐스트/맵변환 검증 (7건)
- ProductEventKafkaProducerTest: 이벤트 발행 토픽/파티션 키/페이로드 내용 검증 (2건)
- ProductEventKafkaListenerTest: 정상 재고 등록, null 검증, 멱등 중복 처리 검증 (4건)
- ProductRegisteredFulfillmentConsumerTest: 정상 등록, godType 기본값/커스텀, null 검증, Fassto 실패, 예외 전파 검증 (8건)

## Test Case

### EventEnvelopeTest (#1048)
- [x] of 메서드로 생성 시 UUID v7 형식의 eventId가 생성된다
- [x] of 메서드로 생성 시 eventType과 source가 올바르게 설정된다
- [x] of 메서드로 생성 시 Clock 기반 timestamp가 설정된다
- [x] of 메서드로 생성 시 payload가 올바르게 설정된다
- [x] getPayloadAs 호출 시 이미 올바른 타입이면 캐스트하여 반환한다
- [x] getPayloadAs 호출 시 LinkedHashMap 타입이면 ObjectMapper로 변환한다
- [x] 서로 다른 of 호출은 서로 다른 eventId를 생성한다

### ProductEventKafkaProducerTest / ProductEventKafkaListenerTest (#1051)
- [x] 상품 등록 이벤트 발행 시 올바른 토픽과 파티션 키로 전송된다
- [x] 상품 등록 이벤트 발행 시 EventEnvelope에 올바른 페이로드가 포함된다
- [x] 정상 이벤트 수신 시 재고 등록 UseCase를 호출하고 acknowledge한다
- [x] productId가 null이면 재고 등록을 호출하지 않고 acknowledge한다
- [x] pricePolicyId가 null이면 재고 등록을 호출하지 않고 acknowledge한다
- [x] 이미 재고가 존재하면 예외를 무시하고 acknowledge한다

### ProductRegisteredFulfillmentConsumerTest (#1052)
- [x] 정상 이벤트 수신 시 Fassto 상품 등록 UseCase를 호출하고 acknowledge한다
- [x] 이벤트의 godType이 있으면 해당 값으로 상품을 등록한다
- [x] 이벤트의 godType이 null이면 기본값 '1'로 등록한다
- [x] productId가 null이면 상품 등록을 호출하지 않고 acknowledge한다
- [x] productName이 null이면 상품 등록을 호출하지 않고 acknowledge한다
- [x] Fassto 액세스 토큰이 null이면 상품 등록을 호출하지 않고 acknowledge한다
- [x] RegisterFasstoGoodsFailedException 발생 시 warn 로그 후 acknowledge한다
- [x] 예상치 못한 예외 발생 시 DefaultErrorHandler로 위임되어 예외가 전파된다