### PR TITLE
[#929][#1017] feat: 가격 정책 등록 시 커머스 서비스 재고 등록 연동 기능 Kafka 이벤트 전환

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/configuration/CommerceSwaggerConfig.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/configuration/CommerceSwaggerConfig.java
@@ -107,8 +107,7 @@ public class CommerceSwaggerConfig {
                         .description("""
                                 마켓노트 서비스 커머스 API 서버입니다.
                                 
-                                ### 개발
-                                성효빈
+                                **개발: 성효빈**
                                 
                                 ### 서비스 목록
                                 - [회원 서비스](https://users.marketnote.store/swagger-ui/index.html)

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/PricePolicyEventKafkaListener.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/PricePolicyEventKafkaListener.java
@@ -1,0 +1,63 @@
+package com.personal.marketnote.commerce.adapter.in.event;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.commerce.exception.InventoryAlreadyExistsException;
+import com.personal.marketnote.commerce.port.in.command.inventory.RegisterInventoryCommand;
+import com.personal.marketnote.commerce.port.in.usecase.inventory.RegisterInventoryUseCase;
+import com.personal.marketnote.common.kafka.KafkaTopicConstants;
+import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.PricePolicyCreatedEvent;
+import com.personal.marketnote.common.utility.FormatValidator;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PricePolicyEventKafkaListener {
+    private final RegisterInventoryUseCase registerInventoryUseCase;
+    private final ObjectMapper objectMapper;
+
+    @KafkaListener(
+            topics = KafkaTopicConstants.PRICE_POLICY_CREATED,
+            groupId = "commerce-service"
+    )
+    public void handlePricePolicyCreatedEvent(
+            ConsumerRecord<String, EventEnvelope<?>> record,
+            Acknowledgment acknowledgment
+    ) {
+        EventEnvelope<?> envelope = record.value();
+
+        try {
+            PricePolicyCreatedEvent payload = envelope.getPayloadAs(PricePolicyCreatedEvent.class, objectMapper);
+
+            log.info("가격 정책 등록 이벤트 수신. eventId={}, productId={}, pricePolicyId={}",
+                    envelope.eventId(), payload.productId(), payload.pricePolicyId());
+
+            if (FormatValidator.hasNoValue(payload.productId()) || FormatValidator.hasNoValue(payload.pricePolicyId())) {
+                log.error("유효하지 않은 이벤트 페이로드. eventId={}, productId={}, pricePolicyId={}",
+                        envelope.eventId(), payload.productId(), payload.pricePolicyId());
+                acknowledgment.acknowledge();
+                return;
+            }
+
+            RegisterInventoryCommand command = RegisterInventoryCommand.of(
+                    payload.productId(), payload.pricePolicyId()
+            );
+            registerInventoryUseCase.registerInventory(command);
+
+            log.info("Kafka 이벤트로 재고 등록 완료. productId={}, pricePolicyId={}",
+                    payload.productId(), payload.pricePolicyId());
+        } catch (InventoryAlreadyExistsException e) {
+            log.info("재고가 이미 존재합니다 (듀얼 라이트 중복). eventId={}, key={}",
+                    envelope.eventId(), record.key());
+        }
+        // 그 외 예외는 DefaultErrorHandler가 재시도 + DLT로 처리
+
+        acknowledgment.acknowledge();
+    }
+}

--- a/common/src/main/java/com/personal/marketnote/common/kafka/event/PricePolicyCreatedEvent.java
+++ b/common/src/main/java/com/personal/marketnote/common/kafka/event/PricePolicyCreatedEvent.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.common.kafka.event;
+
+public record PricePolicyCreatedEvent(
+        Long productId,
+        Long pricePolicyId
+) {
+}

--- a/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/in/configuration/CommunitySwaggerConfig.java
+++ b/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/in/configuration/CommunitySwaggerConfig.java
@@ -105,8 +105,7 @@ public class CommunitySwaggerConfig {
                         .description("""
                                 마켓노트 서비스 커뮤니티 API 서버입니다.
                                 
-                                ### 개발
-                                성효빈
+                                **개발: 성효빈**
                                 
                                 ### 서비스 목록
                                 - [회원 서비스](https://users.marketnote.store/swagger-ui/index.html)

--- a/file-service/file-adapters/src/main/java/com/personal/marketnote/file/adapter/in/configuration/FileSwaggerConfig.java
+++ b/file-service/file-adapters/src/main/java/com/personal/marketnote/file/adapter/in/configuration/FileSwaggerConfig.java
@@ -104,8 +104,7 @@ public class FileSwaggerConfig {
                         .description("""
                                 마켓노트 서비스 파일 API 서버입니다.
                                 
-                                ### 개발
-                                성효빈
+                                **개발: 성효빈**
                                 
                                 ### 서비스 목록
                                 - [회원 서비스](https://users.marketnote.store/swagger-ui/index.html)

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter.in.configuration/FulfillmentSwaggerConfig.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter.in.configuration/FulfillmentSwaggerConfig.java
@@ -109,8 +109,7 @@ public class FulfillmentSwaggerConfig {
                         .description("""
                                 마켓노트 서비스 풀필먼트 API 서버입니다.
                                 
-                                ### 개발
-                                성효빈
+                                **개발: 성효빈**
                                 
                                 ### 서비스 목록
                                 - [회원 서비스](https://users.marketnote.store/swagger-ui/index.html)

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/configuration/ProductSwaggerConfig.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/configuration/ProductSwaggerConfig.java
@@ -106,8 +106,7 @@ public class ProductSwaggerConfig {
                         .description("""
                                 마켓노트 서비스 상품 API 서버입니다.
                                 
-                                ### 개발
-                                성효빈
+                                **개발: 성효빈**
                                 
                                 ### 서비스 목록
                                 - [회원 서비스](https://users.marketnote.store/swagger-ui/index.html)

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/event/ProductEventKafkaProducer.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/event/ProductEventKafkaProducer.java
@@ -3,6 +3,7 @@ package com.personal.marketnote.product.adapter.out.event;
 import com.personal.marketnote.common.adapter.out.ServiceAdapter;
 import com.personal.marketnote.common.kafka.KafkaTopicConstants;
 import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.PricePolicyCreatedEvent;
 import com.personal.marketnote.common.kafka.event.ProductRegisteredEvent;
 import com.personal.marketnote.product.port.out.event.PublishProductEventPort;
 import lombok.RequiredArgsConstructor;
@@ -39,6 +40,29 @@ public class ProductEventKafkaProducer implements PublishProductEventPort {
                     } else {
                         log.info("Kafka 이벤트 발행 성공. topic={}, productId={}, pricePolicyId={}, sellerId={}, offset={}",
                                 KafkaTopicConstants.PRODUCT_REGISTERED, productId, pricePolicyId, sellerId,
+                                result.getRecordMetadata().offset());
+                    }
+                });
+    }
+
+    @Override
+    public void publishPricePolicyCreatedEvent(Long productId, Long pricePolicyId) {
+        PricePolicyCreatedEvent payload = new PricePolicyCreatedEvent(productId, pricePolicyId);
+        EventEnvelope<PricePolicyCreatedEvent> envelope = EventEnvelope.of(
+                KafkaTopicConstants.PRICE_POLICY_CREATED,
+                SOURCE,
+                payload,
+                clock
+        );
+
+        kafkaTemplate.send(KafkaTopicConstants.PRICE_POLICY_CREATED, productId.toString(), envelope)
+                .whenComplete((result, ex) -> {
+                    if (ex != null) {
+                        log.error("Kafka 이벤트 발행 실패. topic={}, productId={}, pricePolicyId={}",
+                                KafkaTopicConstants.PRICE_POLICY_CREATED, productId, pricePolicyId, ex);
+                    } else {
+                        log.info("Kafka 이벤트 발행 성공. topic={}, productId={}, pricePolicyId={}, offset={}",
+                                KafkaTopicConstants.PRICE_POLICY_CREATED, productId, pricePolicyId,
                                 result.getRecordMetadata().offset());
                     }
                 });

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/out/event/PublishProductEventPort.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/out/event/PublishProductEventPort.java
@@ -3,4 +3,6 @@ package com.personal.marketnote.product.port.out.event;
 public interface PublishProductEventPort {
 
     void publishProductRegisteredEvent(Long productId, Long pricePolicyId, Long sellerId, String productName, String godType);
+
+    void publishPricePolicyCreatedEvent(Long productId, Long pricePolicyId);
 }

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/service/pricepolicy/RegisterPricePolicyService.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/service/pricepolicy/RegisterPricePolicyService.java
@@ -10,6 +10,7 @@ import com.personal.marketnote.product.port.in.command.RegisterPricePolicyComman
 import com.personal.marketnote.product.port.in.result.pricepolicy.RegisterPricePolicyResult;
 import com.personal.marketnote.product.port.in.usecase.pricepolicy.RegisterPricePolicyUseCase;
 import com.personal.marketnote.product.port.in.usecase.product.GetProductUseCase;
+import com.personal.marketnote.product.port.out.event.PublishProductEventPort;
 import com.personal.marketnote.product.port.out.inventory.RegisterInventoryPort;
 import com.personal.marketnote.product.port.out.pricepolicy.SavePricePolicyPort;
 import com.personal.marketnote.product.port.out.product.FindProductPort;
@@ -32,6 +33,7 @@ public class RegisterPricePolicyService implements RegisterPricePolicyUseCase {
     private final FindProductPort findProductPort;
     private final SavePricePolicyPort savePricePolicyPort;
     private final UpdateOptionPricePolicyPort updateOptionPricePolicyPort;
+    private final PublishProductEventPort publishProductEventPort;
     private final RegisterInventoryPort registerInventoryPort;
 
     @Override
@@ -63,6 +65,9 @@ public class RegisterPricePolicyService implements RegisterPricePolicyUseCase {
             TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
                 @Override
                 public void afterCommit() {
+                    publishProductEventPort.publishPricePolicyCreatedEvent(productId, pricePolicyId);
+
+                    // TODO: Kafka 검증 완료 후 HTTP 호출 제거 (#1017)
                     registerInventoryPort.registerInventory(productId, pricePolicyId);
                 }
             });
@@ -70,6 +75,9 @@ public class RegisterPricePolicyService implements RegisterPricePolicyUseCase {
             return;
         }
 
+        publishProductEventPort.publishPricePolicyCreatedEvent(productId, pricePolicyId);
+
+        // TODO: Kafka 검증 완료 후 HTTP 호출 제거 (#1017)
         registerInventoryPort.registerInventory(productId, pricePolicyId);
     }
 }

--- a/product-service/product-application/src/test/java/com/personal/marketnote/product/service/pricepolicy/RegisterPricePolicyUseCaseTest.java
+++ b/product-service/product-application/src/test/java/com/personal/marketnote/product/service/pricepolicy/RegisterPricePolicyUseCaseTest.java
@@ -8,6 +8,7 @@ import com.personal.marketnote.product.exception.NotProductOwnerException;
 import com.personal.marketnote.product.port.in.command.RegisterPricePolicyCommand;
 import com.personal.marketnote.product.port.in.result.pricepolicy.RegisterPricePolicyResult;
 import com.personal.marketnote.product.port.in.usecase.product.GetProductUseCase;
+import com.personal.marketnote.product.port.out.event.PublishProductEventPort;
 import com.personal.marketnote.product.port.out.inventory.RegisterInventoryPort;
 import com.personal.marketnote.product.port.out.pricepolicy.SavePricePolicyPort;
 import com.personal.marketnote.product.port.out.product.FindProductPort;
@@ -40,6 +41,8 @@ class RegisterPricePolicyUseCaseTest {
     @Mock
     private UpdateOptionPricePolicyPort updateOptionPricePolicyPort;
     @Mock
+    private PublishProductEventPort publishProductEventPort;
+    @Mock
     private RegisterInventoryPort registerInventoryPort;
 
     @InjectMocks
@@ -62,6 +65,7 @@ class RegisterPricePolicyUseCaseTest {
                 getProductUseCase,
                 savePricePolicyPort,
                 updateOptionPricePolicyPort,
+                publishProductEventPort,
                 registerInventoryPort
         );
     }
@@ -100,6 +104,7 @@ class RegisterPricePolicyUseCaseTest {
                 .isEqualByComparingTo(calculateAccumulationRate(command.accumulatedPoint(), command.discountPrice()));
 
         verify(updateOptionPricePolicyPort).assignPricePolicyToOptions(productId, 100L, optionIds);
+        verify(publishProductEventPort).publishPricePolicyCreatedEvent(productId, 100L);
         verify(registerInventoryPort).registerInventory(productId, 100L);
     }
 
@@ -117,6 +122,7 @@ class RegisterPricePolicyUseCaseTest {
         RegisterPricePolicyResult result = registerPricePolicyService.registerPricePolicy(userId, true, command);
 
         assertThat(result.id()).isEqualTo(200L);
+        verify(publishProductEventPort).publishPricePolicyCreatedEvent(productId, 200L);
         verify(registerInventoryPort).registerInventory(productId, 200L);
         verify(updateOptionPricePolicyPort, never()).assignPricePolicyToOptions(anyLong(), anyLong(), anyList());
         verifyNoInteractions(findProductPort);
@@ -137,6 +143,7 @@ class RegisterPricePolicyUseCaseTest {
         registerPricePolicyService.registerPricePolicy(userId, false, command);
 
         verify(updateOptionPricePolicyPort, never()).assignPricePolicyToOptions(anyLong(), anyLong(), anyList());
+        verify(publishProductEventPort).publishPricePolicyCreatedEvent(productId, 250L);
         verify(registerInventoryPort).registerInventory(productId, 250L);
     }
 
@@ -155,7 +162,7 @@ class RegisterPricePolicyUseCaseTest {
                 .isSameAs(exception);
 
         verify(savePricePolicyPort, never()).save(any(PricePolicy.class));
-        verifyNoInteractions(updateOptionPricePolicyPort, registerInventoryPort);
+        verifyNoInteractions(updateOptionPricePolicyPort, publishProductEventPort, registerInventoryPort);
     }
 
     @Test
@@ -175,7 +182,7 @@ class RegisterPricePolicyUseCaseTest {
                 .isSameAs(exception);
 
         verify(updateOptionPricePolicyPort, never()).assignPricePolicyToOptions(anyLong(), anyLong(), anyList());
-        verifyNoInteractions(registerInventoryPort);
+        verifyNoInteractions(publishProductEventPort, registerInventoryPort);
     }
 
     @Test
@@ -218,6 +225,7 @@ class RegisterPricePolicyUseCaseTest {
                 .isSameAs(exception);
 
         verify(updateOptionPricePolicyPort).assignPricePolicyToOptions(productId, 400L, optionIds);
+        verify(publishProductEventPort).publishPricePolicyCreatedEvent(productId, 400L);
     }
 
     private RegisterPricePolicyCommand buildCommand(Long productId, List<Long> optionIds) {

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/configuration/RewardSwaggerConfig.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/configuration/RewardSwaggerConfig.java
@@ -104,8 +104,7 @@ public class RewardSwaggerConfig {
                         .description("""
                                 마켓노트 서비스 리워드 API 서버입니다.
                                 
-                                ### 개발
-                                성효빈
+                                **개발: 성효빈**
                                 
                                 ### 서비스 목록
                                 - [회원 서비스](https://users.marketnote.store/swagger-ui/index.html)

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/configuration/UserSwaggerConfig.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/configuration/UserSwaggerConfig.java
@@ -113,8 +113,7 @@ public class UserSwaggerConfig {
                         .description("""
                                 마켓노트 서비스 회원 API 서버입니다.
                                 
-                                ### 개발
-                                성효빈
+                                **개발: 성효빈**
                                 
                                 ### 서비스 목록
                                 - [회원 서비스](https://users.marketnote.store/swagger-ui/index.html)


### PR DESCRIPTION
## partially addresses #929
## resolves #1017

## Task
- [x] PricePolicyCreatedEvent 이벤트 정의
- [x] RegisterPricePolicyService에서 afterCommit → Kafka 이벤트 발행으로 교체
- [x] PricePolicyCreatedInventoryConsumer 구현 (commerce-adapters, 재고 등록)