### PR TITLE
[#929][#1053] test: 가격 정책 등록 시 커머스 서비스 재고 등록 연동 Kafka 이벤트 자동화 테스트 추가

### DIFF
--- a/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/event/PricePolicyEventKafkaListenerTest.java
+++ b/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/event/PricePolicyEventKafkaListenerTest.java
@@ -1,0 +1,130 @@
+package com.personal.marketnote.commerce.adapter.in.event;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.commerce.exception.InventoryAlreadyExistsException;
+import com.personal.marketnote.commerce.port.in.command.inventory.RegisterInventoryCommand;
+import com.personal.marketnote.commerce.port.in.usecase.inventory.RegisterInventoryUseCase;
+import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.PricePolicyCreatedEvent;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.support.Acknowledgment;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class PricePolicyEventKafkaListenerTest {
+    @InjectMocks
+    private PricePolicyEventKafkaListener pricePolicyEventKafkaListener;
+
+    @Mock
+    private RegisterInventoryUseCase registerInventoryUseCase;
+
+    @Spy
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @Mock
+    private Acknowledgment acknowledgment;
+
+    private ConsumerRecord<String, EventEnvelope<?>> buildRecord(Long productId, Long pricePolicyId) {
+        PricePolicyCreatedEvent event = new PricePolicyCreatedEvent(productId, pricePolicyId);
+        EventEnvelope<PricePolicyCreatedEvent> envelope = new EventEnvelope<>(
+                "test-event-id", "product.price-policy.created", "product-service",
+                LocalDateTime.of(2026, 2, 27, 10, 0), event
+        );
+        return new ConsumerRecord<>("product.price-policy.created", 0, 0L, "key-1", envelope);
+    }
+
+    @Test
+    @DisplayName("정상 이벤트 수신 시 재고 등록 UseCase를 호출하고 acknowledge한다")
+    void handlePricePolicyCreatedEvent_success_registersInventoryAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, 2L);
+
+        // when
+        pricePolicyEventKafkaListener.handlePricePolicyCreatedEvent(record, acknowledgment);
+
+        // then
+        ArgumentCaptor<RegisterInventoryCommand> captor = ArgumentCaptor.forClass(RegisterInventoryCommand.class);
+        verify(registerInventoryUseCase).registerInventory(captor.capture());
+
+        RegisterInventoryCommand command = captor.getValue();
+        assertThat(command.productId()).isEqualTo(1L);
+        assertThat(command.pricePolicyId()).isEqualTo(2L);
+
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("productId가 null이면 재고 등록을 호출하지 않고 acknowledge한다")
+    void handlePricePolicyCreatedEvent_nullProductId_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(null, 2L);
+
+        // when
+        pricePolicyEventKafkaListener.handlePricePolicyCreatedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(registerInventoryUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("pricePolicyId가 null이면 재고 등록을 호출하지 않고 acknowledge한다")
+    void handlePricePolicyCreatedEvent_nullPricePolicyId_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, null);
+
+        // when
+        pricePolicyEventKafkaListener.handlePricePolicyCreatedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(registerInventoryUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("이미 재고가 존재하면 예외를 무시하고 acknowledge한다")
+    void handlePricePolicyCreatedEvent_inventoryAlreadyExists_acknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, 2L);
+        doThrow(new InventoryAlreadyExistsException(2L))
+                .when(registerInventoryUseCase).registerInventory(any(RegisterInventoryCommand.class));
+
+        // when
+        pricePolicyEventKafkaListener.handlePricePolicyCreatedEvent(record, acknowledgment);
+
+        // then
+        verify(registerInventoryUseCase).registerInventory(any(RegisterInventoryCommand.class));
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("예상치 못한 예외 발생 시 DefaultErrorHandler로 위임되어 예외가 전파된다")
+    void handlePricePolicyCreatedEvent_unexpectedException_propagatesForRetry() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, 2L);
+        doThrow(new RuntimeException("네트워크 오류"))
+                .when(registerInventoryUseCase).registerInventory(any(RegisterInventoryCommand.class));
+
+        // when & then
+        assertThatThrownBy(() -> pricePolicyEventKafkaListener.handlePricePolicyCreatedEvent(record, acknowledgment))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("네트워크 오류");
+
+        verify(registerInventoryUseCase).registerInventory(any(RegisterInventoryCommand.class));
+        verify(acknowledgment, never()).acknowledge();
+    }
+}

--- a/product-service/product-adapters/src/test/java/com/personal/marketnote/product/adapter/out/event/ProductEventKafkaProducerTest.java
+++ b/product-service/product-adapters/src/test/java/com/personal/marketnote/product/adapter/out/event/ProductEventKafkaProducerTest.java
@@ -2,6 +2,7 @@ package com.personal.marketnote.product.adapter.out.event;
 
 import com.personal.marketnote.common.kafka.KafkaTopicConstants;
 import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.PricePolicyCreatedEvent;
 import com.personal.marketnote.common.kafka.event.ProductRegisteredEvent;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -91,5 +92,55 @@ class ProductEventKafkaProducerTest {
         assertThat(payload.sellerId()).isEqualTo(30L);
         assertThat(payload.productName()).isEqualTo("상품명");
         assertThat(payload.godType()).isEqualTo("2");
+    }
+
+    @Test
+    @DisplayName("가격 정책 생성 이벤트 발행 시 올바른 토픽과 파티션 키로 전송된다")
+    void publishPricePolicyCreatedEvent_sendsToCorrectTopicWithProductIdKey() {
+        // given
+        setUpClock("2026-02-27T10:00:00Z");
+        when(kafkaTemplate.send(any(String.class), any(String.class), any()))
+                .thenReturn(new CompletableFuture<>());
+
+        // when
+        productEventKafkaProducer.publishPricePolicyCreatedEvent(1L, 2L);
+
+        // then
+        verify(kafkaTemplate).send(
+                eq(KafkaTopicConstants.PRICE_POLICY_CREATED),
+                eq("1"),
+                any(EventEnvelope.class)
+        );
+    }
+
+    @Test
+    @DisplayName("가격 정책 생성 이벤트 발행 시 EventEnvelope에 올바른 페이로드가 포함된다")
+    @SuppressWarnings("unchecked")
+    void publishPricePolicyCreatedEvent_envelopeContainsCorrectPayload() {
+        // given
+        setUpClock("2026-02-27T10:00:00Z");
+        when(kafkaTemplate.send(any(String.class), any(String.class), any()))
+                .thenReturn(new CompletableFuture<>());
+
+        // when
+        productEventKafkaProducer.publishPricePolicyCreatedEvent(10L, 20L);
+
+        // then
+        ArgumentCaptor<EventEnvelope> envelopeCaptor = ArgumentCaptor.forClass(EventEnvelope.class);
+        verify(kafkaTemplate).send(
+                eq(KafkaTopicConstants.PRICE_POLICY_CREATED),
+                eq("10"),
+                envelopeCaptor.capture()
+        );
+
+        EventEnvelope<?> capturedEnvelope = envelopeCaptor.getValue();
+        assertThat(capturedEnvelope.eventType()).isEqualTo(KafkaTopicConstants.PRICE_POLICY_CREATED);
+        assertThat(capturedEnvelope.source()).isEqualTo("product-service");
+        assertThat(capturedEnvelope.eventId()).isNotNull();
+        assertThat(capturedEnvelope.timestamp()).isNotNull();
+
+        PricePolicyCreatedEvent payload = (PricePolicyCreatedEvent) capturedEnvelope.payload();
+        assertThat(payload.productId()).isEqualTo(10L);
+        assertThat(payload.pricePolicyId()).isEqualTo(20L);
     }
 }


### PR DESCRIPTION
## partially addresses #929
## resolves #1053

## Test Case
- [x] 가격 정책 생성 이벤트 발행 시 올바른 토픽과 파티션 키로 전송된다
- [x] 가격 정책 생성 이벤트 발행 시 EventEnvelope에 올바른 페이로드가 포함된다
- [x] 정상 이벤트 수신 시 재고 등록 UseCase를 호출하고 acknowledge한다
- [x] productId가 null이면 재고 등록을 호출하지 않고 acknowledge한다
- [x] pricePolicyId가 null이면 재고 등록을 호출하지 않고 acknowledge한다
- [x] 이미 재고가 존재하면 예외를 무시하고 acknowledge한다
- [x] 예상치 못한 예외 발생 시 DefaultErrorHandler로 위임되어 예외가 전파된다