### PR TITLE
[#929][#936] feat: 회원가입 시 리워드 서비스 포인트 초기화 연동 기능 Kafka 이벤트 전환

### DIFF
--- a/common/src/main/java/com/personal/marketnote/common/kafka/event/UserSignupCompletedEvent.java
+++ b/common/src/main/java/com/personal/marketnote/common/kafka/event/UserSignupCompletedEvent.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.common.kafka.event;
+
+public record UserSignupCompletedEvent(
+        Long userId,
+        String userKey
+) {
+}

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/event/UserSignupCompletedRewardConsumer.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/event/UserSignupCompletedRewardConsumer.java
@@ -1,0 +1,62 @@
+package com.personal.marketnote.reward.adapter.in.event;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.common.kafka.KafkaTopicConstants;
+import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.UserSignupCompletedEvent;
+import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.reward.exception.DuplicateUserPointException;
+import com.personal.marketnote.reward.port.in.command.point.RegisterUserPointCommand;
+import com.personal.marketnote.reward.port.in.usecase.point.RegisterUserPointUseCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class UserSignupCompletedRewardConsumer {
+    private final RegisterUserPointUseCase registerUserPointUseCase;
+    private final ObjectMapper objectMapper;
+
+    @KafkaListener(
+            topics = KafkaTopicConstants.USER_SIGNUP_COMPLETED,
+            groupId = "reward-service"
+    )
+    public void handleUserSignupCompletedEvent(
+            ConsumerRecord<String, EventEnvelope<?>> record,
+            Acknowledgment acknowledgment
+    ) {
+        EventEnvelope<?> envelope = record.value();
+
+        try {
+            UserSignupCompletedEvent payload = envelope.getPayloadAs(UserSignupCompletedEvent.class, objectMapper);
+
+            log.info("회원가입 완료 이벤트 수신. eventId={}, userId={}, userKey={}",
+                    envelope.eventId(), payload.userId(), payload.userKey());
+
+            if (FormatValidator.hasNoValue(payload.userId()) || FormatValidator.hasNoValue(payload.userKey())) {
+                log.error("유효하지 않은 이벤트 페이로드. eventId={}, userId={}, userKey={}",
+                        envelope.eventId(), payload.userId(), payload.userKey());
+                acknowledgment.acknowledge();
+                return;
+            }
+
+            RegisterUserPointCommand command = RegisterUserPointCommand.of(
+                    payload.userId(), payload.userKey()
+            );
+            registerUserPointUseCase.register(command);
+
+            log.info("Kafka 이벤트로 포인트 초기화 완료. userId={}", payload.userId());
+        } catch (DuplicateUserPointException e) {
+            log.info("포인트가 이미 존재합니다 (듀얼 라이트 중복). eventId={}, key={}",
+                    envelope.eventId(), record.key());
+        }
+        // 그 외 예외는 DefaultErrorHandler가 재시도 + DLT로 처리
+
+        acknowledgment.acknowledge();
+    }
+}

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/out/event/UserEventKafkaProducer.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/out/event/UserEventKafkaProducer.java
@@ -1,0 +1,46 @@
+package com.personal.marketnote.user.adapter.out.event;
+
+import com.personal.marketnote.common.adapter.out.ServiceAdapter;
+import com.personal.marketnote.common.kafka.KafkaTopicConstants;
+import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.UserSignupCompletedEvent;
+import com.personal.marketnote.user.port.out.event.PublishUserEventPort;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+
+import java.time.Clock;
+
+@Slf4j
+@ServiceAdapter
+@RequiredArgsConstructor
+public class UserEventKafkaProducer implements PublishUserEventPort {
+    private static final String SOURCE = "user-service";
+
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+    private final Clock clock;
+
+    @Override
+    public void publishUserSignupCompletedEvent(Long userId, String userKey) {
+        UserSignupCompletedEvent payload = new UserSignupCompletedEvent(userId, userKey);
+        EventEnvelope<UserSignupCompletedEvent> envelope = EventEnvelope.of(
+                KafkaTopicConstants.USER_SIGNUP_COMPLETED,
+                SOURCE,
+                payload,
+                clock
+        );
+
+        // TODO: Kafka 단독 전환 시 발행 실패 처리 보강 필요 (Outbox 패턴 또는 동기 전환)
+        kafkaTemplate.send(KafkaTopicConstants.USER_SIGNUP_COMPLETED, userId.toString(), envelope)
+                .whenComplete((result, ex) -> {
+                    if (ex != null) {
+                        log.error("Kafka 이벤트 발행 실패. topic={}, userId={}, userKey={}",
+                                KafkaTopicConstants.USER_SIGNUP_COMPLETED, userId, userKey, ex);
+                    } else {
+                        log.info("Kafka 이벤트 발행 성공. topic={}, userId={}, offset={}",
+                                KafkaTopicConstants.USER_SIGNUP_COMPLETED, userId,
+                                result.getRecordMetadata().offset());
+                    }
+                });
+    }
+}

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/port/out/event/PublishUserEventPort.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/port/out/event/PublishUserEventPort.java
@@ -1,0 +1,6 @@
+package com.personal.marketnote.user.port.out.event;
+
+public interface PublishUserEventPort {
+
+    void publishUserSignupCompletedEvent(Long userId, String userKey);
+}

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/service/user/SignUpService.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/service/user/SignUpService.java
@@ -15,6 +15,7 @@ import com.personal.marketnote.user.port.in.result.SignUpResult;
 import com.personal.marketnote.user.port.in.usecase.user.GetUserUseCase;
 import com.personal.marketnote.user.port.in.usecase.user.SignUpUseCase;
 import com.personal.marketnote.user.port.out.authentication.VerifyCodePort;
+import com.personal.marketnote.user.port.out.event.PublishUserEventPort;
 import com.personal.marketnote.user.port.out.reward.ModifyUserPointPort;
 import com.personal.marketnote.user.port.out.user.*;
 import com.personal.marketnote.user.security.token.vendor.AuthVendor;
@@ -44,6 +45,7 @@ public class SignUpService implements SignUpUseCase {
     private final VerifyCodePort verifyCodePort;
     private final SaveLoginHistoryPort saveLoginHistoryPort;
     private final ModifyUserPointPort modifyUserPointPort;
+    private final PublishUserEventPort publishUserEventPort;
 
     @Override
     public SignUpResult signUp(SignUpCommand signUpCommand, AuthVendor authVendor, String oidcId, String ipAddress) {
@@ -149,12 +151,14 @@ public class SignUpService implements SignUpUseCase {
             TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
                 @Override
                 public void afterCommit() {
-                    modifyUserPointPort.registerUserPoint(userId, userKey);
+                    publishUserEventPort.publishUserSignupCompletedEvent(userId, userKey);
+                    modifyUserPointPort.registerUserPoint(userId, userKey); // TODO: Kafka 검증 완료 후 HTTP 호출 제거
                 }
             });
             return;
         }
 
-        modifyUserPointPort.registerUserPoint(userId, userKey);
+        publishUserEventPort.publishUserSignupCompletedEvent(userId, userKey);
+        modifyUserPointPort.registerUserPoint(userId, userKey); // TODO: Kafka 검증 완료 후 HTTP 호출 제거
     }
 }

--- a/user-service/user-application/src/test/java/com/personal/marketnote/user/service/user/SignUpUseCaseTest.java
+++ b/user-service/user-application/src/test/java/com/personal/marketnote/user/service/user/SignUpUseCaseTest.java
@@ -12,6 +12,7 @@ import com.personal.marketnote.user.port.in.command.SignUpCommand;
 import com.personal.marketnote.user.port.in.result.SignUpResult;
 import com.personal.marketnote.user.port.in.usecase.user.GetUserUseCase;
 import com.personal.marketnote.user.port.out.authentication.VerifyCodePort;
+import com.personal.marketnote.user.port.out.event.PublishUserEventPort;
 import com.personal.marketnote.user.port.out.reward.ModifyUserPointPort;
 import com.personal.marketnote.user.port.out.user.*;
 import com.personal.marketnote.user.security.token.vendor.AuthVendor;
@@ -51,6 +52,8 @@ class SignUpUseCaseTest {
     private SaveLoginHistoryPort saveLoginHistoryPort;
     @Mock
     private ModifyUserPointPort modifyUserPointPort;
+    @Mock
+    private PublishUserEventPort publishUserEventPort;
 
     @InjectMocks
     private SignUpService signUpService;
@@ -87,6 +90,7 @@ class SignUpUseCaseTest {
         assertThat(result.roleId()).isEqualTo("ROLE_BUYER");
 
         verify(saveUserPort).save(any(User.class));
+        verify(publishUserEventPort).publishUserSignupCompletedEvent(1L, userKey.toString());
         verify(modifyUserPointPort).registerUserPoint(1L, userKey.toString());
         verify(saveLoginHistoryPort).saveLoginHistory(any(LoginHistory.class));
         verify(updateUserPort, never()).update(any());
@@ -121,6 +125,7 @@ class SignUpUseCaseTest {
 
         verify(updateUserPort).update(existingUser);
         verify(saveLoginHistoryPort).saveLoginHistory(any(LoginHistory.class));
+        verify(publishUserEventPort, never()).publishUserSignupCompletedEvent(anyLong(), anyString());
         verify(modifyUserPointPort, never()).registerUserPoint(anyLong(), anyString());
         verify(saveUserPort, never()).save(any());
     }
@@ -135,7 +140,7 @@ class SignUpUseCaseTest {
         assertThatThrownBy(() -> signUpService.signUp(command, AuthVendor.NATIVE, null, "127.0.0.1"))
                 .isInstanceOf(PasswordNoValueException.class);
 
-        verifyNoInteractions(saveUserPort, updateUserPort, saveLoginHistoryPort, modifyUserPointPort, findTermsPort, verifyCodePort, getUserUseCase);
+        verifyNoInteractions(saveUserPort, updateUserPort, saveLoginHistoryPort, modifyUserPointPort, publishUserEventPort, findTermsPort, verifyCodePort, getUserUseCase);
     }
 
     @Test
@@ -153,7 +158,7 @@ class SignUpUseCaseTest {
                 .isInstanceOf(UserExistsException.class);
 
         verify(verifyCodePort, never()).verify(anyString(), anyString());
-        verifyNoInteractions(saveUserPort, updateUserPort, saveLoginHistoryPort, modifyUserPointPort, findTermsPort, getUserUseCase);
+        verifyNoInteractions(saveUserPort, updateUserPort, saveLoginHistoryPort, modifyUserPointPort, publishUserEventPort, findTermsPort, getUserUseCase);
     }
 
     @Test
@@ -171,7 +176,7 @@ class SignUpUseCaseTest {
                 .isInstanceOf(UserExistsException.class);
 
         verify(verifyCodePort, never()).verify(anyString(), anyString());
-        verifyNoInteractions(saveUserPort, updateUserPort, saveLoginHistoryPort, modifyUserPointPort, findTermsPort, getUserUseCase);
+        verifyNoInteractions(saveUserPort, updateUserPort, saveLoginHistoryPort, modifyUserPointPort, publishUserEventPort, findTermsPort, getUserUseCase);
     }
 
     @Test
@@ -191,7 +196,7 @@ class SignUpUseCaseTest {
                 .isInstanceOf(UserExistsException.class);
 
         verify(verifyCodePort, never()).verify(anyString(), anyString());
-        verifyNoInteractions(saveUserPort, updateUserPort, saveLoginHistoryPort, modifyUserPointPort, findTermsPort, getUserUseCase);
+        verifyNoInteractions(saveUserPort, updateUserPort, saveLoginHistoryPort, modifyUserPointPort, publishUserEventPort, findTermsPort, getUserUseCase);
     }
 
     @Test
@@ -210,6 +215,7 @@ class SignUpUseCaseTest {
                 .isInstanceOf(InvalidVerificationCodeException.class);
 
         verify(saveUserPort, never()).save(any());
+        verify(publishUserEventPort, never()).publishUserSignupCompletedEvent(anyLong(), anyString());
         verify(modifyUserPointPort, never()).registerUserPoint(anyLong(), anyString());
         verify(saveLoginHistoryPort, never()).saveLoginHistory(any());
     }
@@ -237,6 +243,7 @@ class SignUpUseCaseTest {
 
         verify(updateUserPort, never()).update(any());
         verify(saveUserPort, never()).save(any());
+        verify(publishUserEventPort, never()).publishUserSignupCompletedEvent(anyLong(), anyString());
         verify(modifyUserPointPort, never()).registerUserPoint(anyLong(), anyString());
     }
 


### PR DESCRIPTION
## partially addresses #929
## resolves #936

## Task
- [x] UserSignupCompletedEvent 이벤트 record 정의 (common)
- [x] PublishUserEventPort Out Port 인터페이스 정의 (user-application)
- [x] UserEventKafkaProducer Kafka Producer 구현 (user-adapters)
- [x] SignUpService 듀얼 라이트 적용 (Kafka + HTTP 동시 발행)
- [x] UserSignupCompletedRewardConsumer Kafka Consumer 구현 (reward-adapters)
- [x] SignUpUseCaseTest PublishUserEventPort Mock 추가