### PR TITLE
[#929][#1062] test: 회원가입 시 리워드 서비스 포인트 초기화 연동 기능 Kafka 이벤트 전환 자동화 테스트 추가

### DIFF
--- a/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/adapter/in/event/UserSignupCompletedRewardConsumerTest.java
+++ b/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/adapter/in/event/UserSignupCompletedRewardConsumerTest.java
@@ -1,0 +1,129 @@
+package com.personal.marketnote.reward.adapter.in.event;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.UserSignupCompletedEvent;
+import com.personal.marketnote.reward.exception.DuplicateUserPointException;
+import com.personal.marketnote.reward.port.in.command.point.RegisterUserPointCommand;
+import com.personal.marketnote.reward.port.in.usecase.point.RegisterUserPointUseCase;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.support.Acknowledgment;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class UserSignupCompletedRewardConsumerTest {
+    @InjectMocks
+    private UserSignupCompletedRewardConsumer userSignupCompletedRewardConsumer;
+
+    @Mock
+    private RegisterUserPointUseCase registerUserPointUseCase;
+
+    @Spy
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @Mock
+    private Acknowledgment acknowledgment;
+
+    private ConsumerRecord<String, EventEnvelope<?>> buildRecord(Long userId, String userKey) {
+        UserSignupCompletedEvent event = new UserSignupCompletedEvent(userId, userKey);
+        EventEnvelope<UserSignupCompletedEvent> envelope = new EventEnvelope<>(
+                "test-event-id", "user.user.signup-completed", "user-service",
+                LocalDateTime.of(2026, 3, 2, 10, 0), event
+        );
+        return new ConsumerRecord<>("user.user.signup-completed", 0, 0L, "key-1", envelope);
+    }
+
+    @Test
+    @DisplayName("정상 이벤트 수신 시 포인트 등록 UseCase를 호출하고 acknowledge한다")
+    void handleUserSignupCompletedEvent_success_registersPointAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, "user-key-123");
+
+        // when
+        userSignupCompletedRewardConsumer.handleUserSignupCompletedEvent(record, acknowledgment);
+
+        // then
+        ArgumentCaptor<RegisterUserPointCommand> captor = ArgumentCaptor.forClass(RegisterUserPointCommand.class);
+        verify(registerUserPointUseCase).register(captor.capture());
+
+        RegisterUserPointCommand command = captor.getValue();
+        assertThat(command.userId()).isEqualTo(1L);
+        assertThat(command.userKey()).isEqualTo("user-key-123");
+
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("userId가 null이면 포인트 등록을 호출하지 않고 acknowledge한다")
+    void handleUserSignupCompletedEvent_nullUserId_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(null, "user-key-123");
+
+        // when
+        userSignupCompletedRewardConsumer.handleUserSignupCompletedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(registerUserPointUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("userKey가 null이면 포인트 등록을 호출하지 않고 acknowledge한다")
+    void handleUserSignupCompletedEvent_nullUserKey_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, null);
+
+        // when
+        userSignupCompletedRewardConsumer.handleUserSignupCompletedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(registerUserPointUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("이미 포인트가 존재하면 예외를 무시하고 acknowledge한다")
+    void handleUserSignupCompletedEvent_duplicateUserPoint_acknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, "user-key-123");
+        doThrow(new DuplicateUserPointException(1L))
+                .when(registerUserPointUseCase).register(any(RegisterUserPointCommand.class));
+
+        // when
+        userSignupCompletedRewardConsumer.handleUserSignupCompletedEvent(record, acknowledgment);
+
+        // then
+        verify(registerUserPointUseCase).register(any(RegisterUserPointCommand.class));
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("예기치 않은 예외 발생 시 acknowledge하지 않고 예외를 전파한다")
+    void handleUserSignupCompletedEvent_unexpectedException_propagatesWithoutAcknowledge() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, "user-key-123");
+        doThrow(new RuntimeException("DB 연결 실패"))
+                .when(registerUserPointUseCase).register(any(RegisterUserPointCommand.class));
+
+        // expect
+        assertThatThrownBy(() ->
+                userSignupCompletedRewardConsumer.handleUserSignupCompletedEvent(record, acknowledgment)
+        ).isInstanceOf(RuntimeException.class);
+
+        verifyNoInteractions(acknowledgment);
+    }
+}

--- a/user-service/user-adapters/src/test/java/com/personal/marketnote/user/adapter/out/event/UserEventKafkaProducerTest.java
+++ b/user-service/user-adapters/src/test/java/com/personal/marketnote/user/adapter/out/event/UserEventKafkaProducerTest.java
@@ -1,0 +1,92 @@
+package com.personal.marketnote.user.adapter.out.event;
+
+import com.personal.marketnote.common.kafka.KafkaTopicConstants;
+import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.UserSignupCompletedEvent;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.core.KafkaTemplate;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.concurrent.CompletableFuture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class UserEventKafkaProducerTest {
+    @InjectMocks
+    private UserEventKafkaProducer userEventKafkaProducer;
+
+    @Mock
+    private KafkaTemplate<String, Object> kafkaTemplate;
+
+    @Mock
+    private Clock clock;
+
+    private void setUpClock(String instant) {
+        Clock fixedClock = Clock.fixed(Instant.parse(instant), ZoneId.of("Asia/Seoul"));
+        when(clock.instant()).thenReturn(fixedClock.instant());
+        when(clock.getZone()).thenReturn(fixedClock.getZone());
+    }
+
+    @Test
+    @DisplayName("회원가입 완료 이벤트 발행 시 올바른 토픽과 파티션 키로 전송된다")
+    void publishUserSignupCompletedEvent_sendsToCorrectTopicWithUserIdKey() {
+        // given
+        setUpClock("2026-03-02T10:00:00Z");
+        when(kafkaTemplate.send(any(String.class), any(String.class), any()))
+                .thenReturn(new CompletableFuture<>());
+
+        // when
+        userEventKafkaProducer.publishUserSignupCompletedEvent(1L, "user-key-123");
+
+        // then
+        verify(kafkaTemplate).send(
+                eq(KafkaTopicConstants.USER_SIGNUP_COMPLETED),
+                eq("1"),
+                any(EventEnvelope.class)
+        );
+    }
+
+    @Test
+    @DisplayName("회원가입 완료 이벤트 발행 시 EventEnvelope에 올바른 페이로드가 포함된다")
+    @SuppressWarnings("unchecked")
+    void publishUserSignupCompletedEvent_envelopeContainsCorrectPayload() {
+        // given
+        setUpClock("2026-03-02T10:00:00Z");
+        when(kafkaTemplate.send(any(String.class), any(String.class), any()))
+                .thenReturn(new CompletableFuture<>());
+
+        // when
+        userEventKafkaProducer.publishUserSignupCompletedEvent(10L, "user-key-456");
+
+        // then
+        ArgumentCaptor<EventEnvelope> envelopeCaptor = ArgumentCaptor.forClass(EventEnvelope.class);
+        verify(kafkaTemplate).send(
+                eq(KafkaTopicConstants.USER_SIGNUP_COMPLETED),
+                eq("10"),
+                envelopeCaptor.capture()
+        );
+
+        EventEnvelope<?> capturedEnvelope = envelopeCaptor.getValue();
+        assertThat(capturedEnvelope.eventType()).isEqualTo(KafkaTopicConstants.USER_SIGNUP_COMPLETED);
+        assertThat(capturedEnvelope.source()).isEqualTo("user-service");
+        assertThat(capturedEnvelope.eventId()).isNotNull();
+        assertThat(capturedEnvelope.timestamp()).isNotNull();
+
+        UserSignupCompletedEvent payload = (UserSignupCompletedEvent) capturedEnvelope.payload();
+        assertThat(payload.userId()).isEqualTo(10L);
+        assertThat(payload.userKey()).isEqualTo("user-key-456");
+    }
+}


### PR DESCRIPTION
## partially addresses #929
## resolves #1062

## Test Case
- [x] UserEventKafkaProducer 토픽/파티션 키 전송 검증
- [x] UserEventKafkaProducer EventEnvelope 페이로드 검증
- [x] UserSignupCompletedRewardConsumer 정상 이벤트 수신 시 포인트 등록 검증
- [x] UserSignupCompletedRewardConsumer userId null 검증
- [x] UserSignupCompletedRewardConsumer userKey null 검증
- [x] UserSignupCompletedRewardConsumer 중복 포인트 멱등성 검증
- [x] UserSignupCompletedRewardConsumer 예기치 않은 예외 전파 검증