### PR TITLE
[#929][#937] feat: 추천코드 등록 시 리워드 서비스 포인트 적립 연동 기능 Kafka 이벤트 전환

### DIFF
--- a/common/src/main/java/com/personal/marketnote/common/kafka/event/UserReferralCompletedEvent.java
+++ b/common/src/main/java/com/personal/marketnote/common/kafka/event/UserReferralCompletedEvent.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.common.kafka.event;
+
+public record UserReferralCompletedEvent(
+        Long requestUserId,
+        Long referredUserId
+) {
+}

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/event/UserReferralCompletedRewardConsumer.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/event/UserReferralCompletedRewardConsumer.java
@@ -1,0 +1,93 @@
+package com.personal.marketnote.reward.adapter.in.event;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.common.kafka.KafkaTopicConstants;
+import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.UserReferralCompletedEvent;
+import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.reward.domain.point.UserPointChangeType;
+import com.personal.marketnote.reward.domain.point.UserPointSourceType;
+import com.personal.marketnote.reward.port.in.command.point.ModifyUserPointCommand;
+import com.personal.marketnote.reward.port.in.usecase.point.ModifyUserPointUseCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+
+import static com.personal.marketnote.common.utility.AccrualPointAmountConstant.REFERRED_USER_POINT_AMOUNT;
+import static com.personal.marketnote.common.utility.AccrualPointAmountConstant.REFERRER_USER_POINT_AMOUNT;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class UserReferralCompletedRewardConsumer {
+    private final ModifyUserPointUseCase modifyUserPointUseCase;
+    private final ObjectMapper objectMapper;
+
+    @KafkaListener(
+            topics = KafkaTopicConstants.USER_REFERRAL_COMPLETED,
+            groupId = "reward-service"
+    )
+    public void handleUserReferralCompletedEvent(
+            ConsumerRecord<String, EventEnvelope<?>> record,
+            Acknowledgment acknowledgment
+    ) {
+        EventEnvelope<?> envelope = record.value();
+
+        try {
+            UserReferralCompletedEvent payload = envelope.getPayloadAs(
+                    UserReferralCompletedEvent.class, objectMapper
+            );
+
+            log.info("추천코드 등록 완료 이벤트 수신. eventId={}, requestUserId={}, referredUserId={}",
+                    envelope.eventId(), payload.requestUserId(), payload.referredUserId());
+
+            if (FormatValidator.hasNoValue(payload.requestUserId())
+                    || FormatValidator.hasNoValue(payload.referredUserId())) {
+                log.error("유효하지 않은 이벤트 페이로드. eventId={}, requestUserId={}, referredUserId={}",
+                        envelope.eventId(), payload.requestUserId(), payload.referredUserId());
+                acknowledgment.acknowledge();
+                return;
+            }
+
+            accrueReferrerPoint(payload.referredUserId(), payload.requestUserId());
+            accrueReferredPoint(payload.requestUserId(), payload.referredUserId());
+
+            log.info("Kafka 이벤트로 추천 포인트 적립 완료. requestUserId={}, referredUserId={}",
+                    payload.requestUserId(), payload.referredUserId());
+        } catch (Exception e) {
+            // 예외 전파 → DefaultErrorHandler가 재시도 + DLT로 처리 (acknowledge 하지 않음)
+            log.error("추천 포인트 적립 실패. eventId={}, key={}, error={}",
+                    envelope.eventId(), record.key(), e.getMessage(), e);
+            throw e;
+        }
+
+        acknowledgment.acknowledge();
+    }
+
+    private void accrueReferrerPoint(Long referredUserId, Long requestUserId) {
+        ModifyUserPointCommand referrerCommand = ModifyUserPointCommand.builder()
+                .userId(referredUserId)
+                .changeType(UserPointChangeType.ACCRUAL)
+                .amount((long) REFERRER_USER_POINT_AMOUNT)
+                .sourceType(UserPointSourceType.USER)
+                .sourceId(requestUserId)
+                .reason("추천인 코드 등록 적립")
+                .build();
+        modifyUserPointUseCase.modify(referrerCommand);
+    }
+
+    private void accrueReferredPoint(Long requestUserId, Long referredUserId) {
+        ModifyUserPointCommand referredCommand = ModifyUserPointCommand.builder()
+                .userId(requestUserId)
+                .changeType(UserPointChangeType.ACCRUAL)
+                .amount((long) REFERRED_USER_POINT_AMOUNT)
+                .sourceType(UserPointSourceType.USER)
+                .sourceId(referredUserId)
+                .reason("신규 회원 초대 적립")
+                .build();
+        modifyUserPointUseCase.modify(referredCommand);
+    }
+}

--- a/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/adapter/in/event/UserSignupCompletedRewardConsumerTest.java
+++ b/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/adapter/in/event/UserSignupCompletedRewardConsumerTest.java
@@ -1,0 +1,129 @@
+package com.personal.marketnote.reward.adapter.in.event;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.UserSignupCompletedEvent;
+import com.personal.marketnote.reward.exception.DuplicateUserPointException;
+import com.personal.marketnote.reward.port.in.command.point.RegisterUserPointCommand;
+import com.personal.marketnote.reward.port.in.usecase.point.RegisterUserPointUseCase;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.support.Acknowledgment;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class UserSignupCompletedRewardConsumerTest {
+    @InjectMocks
+    private UserSignupCompletedRewardConsumer userSignupCompletedRewardConsumer;
+
+    @Mock
+    private RegisterUserPointUseCase registerUserPointUseCase;
+
+    @Spy
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @Mock
+    private Acknowledgment acknowledgment;
+
+    private ConsumerRecord<String, EventEnvelope<?>> buildRecord(Long userId, String userKey) {
+        UserSignupCompletedEvent event = new UserSignupCompletedEvent(userId, userKey);
+        EventEnvelope<UserSignupCompletedEvent> envelope = new EventEnvelope<>(
+                "test-event-id", "user.user.signup-completed", "user-service",
+                LocalDateTime.of(2026, 3, 2, 10, 0), event
+        );
+        return new ConsumerRecord<>("user.user.signup-completed", 0, 0L, "key-1", envelope);
+    }
+
+    @Test
+    @DisplayName("정상 이벤트 수신 시 포인트 등록 UseCase를 호출하고 acknowledge한다")
+    void handleUserSignupCompletedEvent_success_registersPointAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, "user-key-123");
+
+        // when
+        userSignupCompletedRewardConsumer.handleUserSignupCompletedEvent(record, acknowledgment);
+
+        // then
+        ArgumentCaptor<RegisterUserPointCommand> captor = ArgumentCaptor.forClass(RegisterUserPointCommand.class);
+        verify(registerUserPointUseCase).register(captor.capture());
+
+        RegisterUserPointCommand command = captor.getValue();
+        assertThat(command.userId()).isEqualTo(1L);
+        assertThat(command.userKey()).isEqualTo("user-key-123");
+
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("userId가 null이면 포인트 등록을 호출하지 않고 acknowledge한다")
+    void handleUserSignupCompletedEvent_nullUserId_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(null, "user-key-123");
+
+        // when
+        userSignupCompletedRewardConsumer.handleUserSignupCompletedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(registerUserPointUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("userKey가 null이면 포인트 등록을 호출하지 않고 acknowledge한다")
+    void handleUserSignupCompletedEvent_nullUserKey_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, null);
+
+        // when
+        userSignupCompletedRewardConsumer.handleUserSignupCompletedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(registerUserPointUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("이미 포인트가 존재하면 예외를 무시하고 acknowledge한다")
+    void handleUserSignupCompletedEvent_duplicateUserPoint_acknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, "user-key-123");
+        doThrow(new DuplicateUserPointException(1L))
+                .when(registerUserPointUseCase).register(any(RegisterUserPointCommand.class));
+
+        // when
+        userSignupCompletedRewardConsumer.handleUserSignupCompletedEvent(record, acknowledgment);
+
+        // then
+        verify(registerUserPointUseCase).register(any(RegisterUserPointCommand.class));
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("예기치 않은 예외 발생 시 acknowledge하지 않고 예외를 전파한다")
+    void handleUserSignupCompletedEvent_unexpectedException_propagatesWithoutAcknowledge() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, "user-key-123");
+        doThrow(new RuntimeException("DB 연결 실패"))
+                .when(registerUserPointUseCase).register(any(RegisterUserPointCommand.class));
+
+        // expect
+        assertThatThrownBy(() ->
+                userSignupCompletedRewardConsumer.handleUserSignupCompletedEvent(record, acknowledgment)
+        ).isInstanceOf(RuntimeException.class);
+
+        verifyNoInteractions(acknowledgment);
+    }
+}

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/out/event/UserEventKafkaProducer.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/out/event/UserEventKafkaProducer.java
@@ -3,6 +3,7 @@ package com.personal.marketnote.user.adapter.out.event;
 import com.personal.marketnote.common.adapter.out.ServiceAdapter;
 import com.personal.marketnote.common.kafka.KafkaTopicConstants;
 import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.UserReferralCompletedEvent;
 import com.personal.marketnote.common.kafka.event.UserSignupCompletedEvent;
 import com.personal.marketnote.user.port.out.event.PublishUserEventPort;
 import lombok.RequiredArgsConstructor;
@@ -39,6 +40,30 @@ public class UserEventKafkaProducer implements PublishUserEventPort {
                     } else {
                         log.info("Kafka 이벤트 발행 성공. topic={}, userId={}, offset={}",
                                 KafkaTopicConstants.USER_SIGNUP_COMPLETED, userId,
+                                result.getRecordMetadata().offset());
+                    }
+                });
+    }
+
+    @Override
+    public void publishUserReferralCompletedEvent(Long requestUserId, Long referredUserId) {
+        UserReferralCompletedEvent payload = new UserReferralCompletedEvent(requestUserId, referredUserId);
+        EventEnvelope<UserReferralCompletedEvent> envelope = EventEnvelope.of(
+                KafkaTopicConstants.USER_REFERRAL_COMPLETED,
+                SOURCE,
+                payload,
+                clock
+        );
+
+        // TODO: Kafka 단독 전환 시 발행 실패 처리 보강 필요 (Outbox 패턴 또는 동기 전환)
+        kafkaTemplate.send(KafkaTopicConstants.USER_REFERRAL_COMPLETED, requestUserId.toString(), envelope)
+                .whenComplete((result, ex) -> {
+                    if (ex != null) {
+                        log.error("Kafka 이벤트 발행 실패. topic={}, requestUserId={}, referredUserId={}",
+                                KafkaTopicConstants.USER_REFERRAL_COMPLETED, requestUserId, referredUserId, ex);
+                    } else {
+                        log.info("Kafka 이벤트 발행 성공. topic={}, requestUserId={}, offset={}",
+                                KafkaTopicConstants.USER_REFERRAL_COMPLETED, requestUserId,
                                 result.getRecordMetadata().offset());
                     }
                 });

--- a/user-service/user-adapters/src/test/java/com/personal/marketnote/user/adapter/out/event/UserEventKafkaProducerTest.java
+++ b/user-service/user-adapters/src/test/java/com/personal/marketnote/user/adapter/out/event/UserEventKafkaProducerTest.java
@@ -1,0 +1,92 @@
+package com.personal.marketnote.user.adapter.out.event;
+
+import com.personal.marketnote.common.kafka.KafkaTopicConstants;
+import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.UserSignupCompletedEvent;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.core.KafkaTemplate;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.concurrent.CompletableFuture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class UserEventKafkaProducerTest {
+    @InjectMocks
+    private UserEventKafkaProducer userEventKafkaProducer;
+
+    @Mock
+    private KafkaTemplate<String, Object> kafkaTemplate;
+
+    @Mock
+    private Clock clock;
+
+    private void setUpClock(String instant) {
+        Clock fixedClock = Clock.fixed(Instant.parse(instant), ZoneId.of("Asia/Seoul"));
+        when(clock.instant()).thenReturn(fixedClock.instant());
+        when(clock.getZone()).thenReturn(fixedClock.getZone());
+    }
+
+    @Test
+    @DisplayName("회원가입 완료 이벤트 발행 시 올바른 토픽과 파티션 키로 전송된다")
+    void publishUserSignupCompletedEvent_sendsToCorrectTopicWithUserIdKey() {
+        // given
+        setUpClock("2026-03-02T10:00:00Z");
+        when(kafkaTemplate.send(any(String.class), any(String.class), any()))
+                .thenReturn(new CompletableFuture<>());
+
+        // when
+        userEventKafkaProducer.publishUserSignupCompletedEvent(1L, "user-key-123");
+
+        // then
+        verify(kafkaTemplate).send(
+                eq(KafkaTopicConstants.USER_SIGNUP_COMPLETED),
+                eq("1"),
+                any(EventEnvelope.class)
+        );
+    }
+
+    @Test
+    @DisplayName("회원가입 완료 이벤트 발행 시 EventEnvelope에 올바른 페이로드가 포함된다")
+    @SuppressWarnings("unchecked")
+    void publishUserSignupCompletedEvent_envelopeContainsCorrectPayload() {
+        // given
+        setUpClock("2026-03-02T10:00:00Z");
+        when(kafkaTemplate.send(any(String.class), any(String.class), any()))
+                .thenReturn(new CompletableFuture<>());
+
+        // when
+        userEventKafkaProducer.publishUserSignupCompletedEvent(10L, "user-key-456");
+
+        // then
+        ArgumentCaptor<EventEnvelope> envelopeCaptor = ArgumentCaptor.forClass(EventEnvelope.class);
+        verify(kafkaTemplate).send(
+                eq(KafkaTopicConstants.USER_SIGNUP_COMPLETED),
+                eq("10"),
+                envelopeCaptor.capture()
+        );
+
+        EventEnvelope<?> capturedEnvelope = envelopeCaptor.getValue();
+        assertThat(capturedEnvelope.eventType()).isEqualTo(KafkaTopicConstants.USER_SIGNUP_COMPLETED);
+        assertThat(capturedEnvelope.source()).isEqualTo("user-service");
+        assertThat(capturedEnvelope.eventId()).isNotNull();
+        assertThat(capturedEnvelope.timestamp()).isNotNull();
+
+        UserSignupCompletedEvent payload = (UserSignupCompletedEvent) capturedEnvelope.payload();
+        assertThat(payload.userId()).isEqualTo(10L);
+        assertThat(payload.userKey()).isEqualTo("user-key-456");
+    }
+}

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/port/out/event/PublishUserEventPort.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/port/out/event/PublishUserEventPort.java
@@ -3,4 +3,6 @@ package com.personal.marketnote.user.port.out.event;
 public interface PublishUserEventPort {
 
     void publishUserSignupCompletedEvent(Long userId, String userKey);
+
+    void publishUserReferralCompletedEvent(Long requestUserId, Long referredUserId);
 }

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/service/user/RegisterReferredUserCodeService.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/service/user/RegisterReferredUserCodeService.java
@@ -5,6 +5,7 @@ import com.personal.marketnote.common.exception.UserNotFoundException;
 import com.personal.marketnote.user.domain.user.User;
 import com.personal.marketnote.user.port.in.usecase.user.GetUserUseCase;
 import com.personal.marketnote.user.port.in.usecase.user.RegisterReferredUserCodeUseCase;
+import com.personal.marketnote.user.port.out.event.PublishUserEventPort;
 import com.personal.marketnote.user.port.out.reward.ModifyUserPointPort;
 import com.personal.marketnote.user.port.out.user.UpdateUserPort;
 import lombok.RequiredArgsConstructor;
@@ -21,6 +22,7 @@ import static org.springframework.transaction.annotation.Isolation.READ_COMMITTE
 public class RegisterReferredUserCodeService implements RegisterReferredUserCodeUseCase {
     private final GetUserUseCase getUserUseCase;
     private final UpdateUserPort updateUserPort;
+    private final PublishUserEventPort publishUserEventPort;
     private final ModifyUserPointPort modifyUserPointPort;
 
     @Override
@@ -39,9 +41,12 @@ public class RegisterReferredUserCodeService implements RegisterReferredUserCode
         User referredUser = getUserUseCase.getUser(referredUserCode);
 
         // 추천한 회원/추천 받은 회원 포인트 적립 요청
-        // FIXME: Kafka 이벤트 Production으로 변경
         try {
-            runAfterCommit(() -> modifyUserPointPort.accrueReferralPoints(requestUser.getId(), referredUser.getId()));
+            runAfterCommit(() -> {
+                publishUserEventPort.publishUserReferralCompletedEvent(requestUser.getId(), referredUser.getId());
+                modifyUserPointPort.accrueReferralPoints(requestUser.getId(), referredUser.getId());
+                // TODO: Kafka 검증 완료 후 HTTP 호출 제거
+            });
         } catch (Exception e) {
             requestUser.removeReferredUserCode();
             updateUserPort.update(requestUser);

--- a/user-service/user-application/src/test/java/com/personal/marketnote/user/service/user/RegisterReferredUserCodeUseCaseTest.java
+++ b/user-service/user-application/src/test/java/com/personal/marketnote/user/service/user/RegisterReferredUserCodeUseCaseTest.java
@@ -6,6 +6,7 @@ import com.personal.marketnote.common.exception.UserNotFoundException;
 import com.personal.marketnote.user.domain.user.User;
 import com.personal.marketnote.user.exception.ReferredUserCodeAlreadyExistsException;
 import com.personal.marketnote.user.port.in.usecase.user.GetUserUseCase;
+import com.personal.marketnote.user.port.out.event.PublishUserEventPort;
 import com.personal.marketnote.user.port.out.reward.ModifyUserPointPort;
 import com.personal.marketnote.user.port.out.user.UpdateUserPort;
 import org.junit.jupiter.api.DisplayName;
@@ -30,6 +31,8 @@ class RegisterReferredUserCodeUseCaseTest {
     @Mock
     private UpdateUserPort updateUserPort;
     @Mock
+    private PublishUserEventPort publishUserEventPort;
+    @Mock
     private ModifyUserPointPort modifyUserPointPort;
 
     @InjectMocks
@@ -53,7 +56,7 @@ class RegisterReferredUserCodeUseCaseTest {
 
         verify(getUserUseCase).existsUser(referredUserCode);
         verifyNoMoreInteractions(getUserUseCase);
-        verifyNoInteractions(updateUserPort, modifyUserPointPort);
+        verifyNoInteractions(updateUserPort, publishUserEventPort, modifyUserPointPort);
     }
 
     @Test
@@ -82,11 +85,12 @@ class RegisterReferredUserCodeUseCaseTest {
         verify(requestUser).registerReferredUserCode(referredUserCode);
         verify(updateUserPort).update(requestUser);
         verify(getUserUseCase).getUser(referredUserCode);
-        verify(referredUser).getId();
-        verify(requestUser).getId();
+        verify(referredUser, times(2)).getId();
+        verify(requestUser, times(2)).getId();
+        verify(publishUserEventPort).publishUserReferralCompletedEvent(requestUserId, referredUserId);
         verify(modifyUserPointPort).accrueReferralPoints(requestUserId, referredUserId);
         verify(requestUser, never()).removeReferredUserCode();
-        verifyNoMoreInteractions(getUserUseCase, updateUserPort, modifyUserPointPort, referredUser);
+        verifyNoMoreInteractions(getUserUseCase, updateUserPort, publishUserEventPort, modifyUserPointPort, referredUser);
     }
 
     @Test
@@ -112,7 +116,7 @@ class RegisterReferredUserCodeUseCaseTest {
         verify(getUserUseCase).getUser(requestUserId);
         verify(requestUser).registerReferredUserCode(referredUserCode);
         verify(getUserUseCase, never()).getUser(referredUserCode);
-        verifyNoInteractions(updateUserPort, modifyUserPointPort);
+        verifyNoInteractions(updateUserPort, publishUserEventPort, modifyUserPointPort);
         verifyNoMoreInteractions(getUserUseCase);
     }
 
@@ -146,11 +150,12 @@ class RegisterReferredUserCodeUseCaseTest {
         verify(requestUser).registerReferredUserCode(referredUserCode);
         verify(updateUserPort, times(2)).update(requestUser);
         verify(getUserUseCase).getUser(referredUserCode);
-        verify(referredUser).getId();
-        verify(requestUser).getId();
+        verify(referredUser, times(2)).getId();
+        verify(requestUser, times(2)).getId();
+        verify(publishUserEventPort).publishUserReferralCompletedEvent(requestUserId, referredUserId);
         verify(modifyUserPointPort).accrueReferralPoints(requestUserId, referredUserId);
         verify(requestUser).removeReferredUserCode();
-        verifyNoMoreInteractions(getUserUseCase, updateUserPort, modifyUserPointPort, referredUser);
+        verifyNoMoreInteractions(getUserUseCase, updateUserPort, publishUserEventPort, modifyUserPointPort, referredUser);
     }
 
     @Test
@@ -171,7 +176,7 @@ class RegisterReferredUserCodeUseCaseTest {
         verify(getUserUseCase).existsUser(referredUserCode);
         verify(getUserUseCase).getUser(requestUserId);
         verify(getUserUseCase, never()).getUser(referredUserCode);
-        verifyNoInteractions(updateUserPort, modifyUserPointPort);
+        verifyNoInteractions(updateUserPort, publishUserEventPort, modifyUserPointPort);
         verifyNoMoreInteractions(getUserUseCase);
     }
 
@@ -199,7 +204,7 @@ class RegisterReferredUserCodeUseCaseTest {
         verify(requestUser).registerReferredUserCode(referredUserCode);
         verify(updateUserPort).update(requestUser);
         verify(getUserUseCase).getUser(referredUserCode);
-        verifyNoInteractions(modifyUserPointPort);
+        verifyNoInteractions(publishUserEventPort, modifyUserPointPort);
         verify(requestUser, never()).removeReferredUserCode();
         verifyNoMoreInteractions(getUserUseCase, updateUserPort);
     }


### PR DESCRIPTION
## partially addresses #929
## resolves #937

## Task
- [x] UserReferralCompletedEvent 이벤트 record 추가
- [x] PublishUserEventPort에 publishUserReferralCompletedEvent() 메서드 추가
- [x] UserEventKafkaProducer에 추천코드 등록 이벤트 발행 구현
- [x] RegisterReferredUserCodeService 듀얼 라이트 적용 (Kafka + HTTP)
- [x] UserReferralCompletedRewardConsumer 추가 (추천인 2,000원 + 피추천인 3,000원 적립)
- [x] RegisterReferredUserCodeUseCaseTest PublishUserEventPort Mock 추가