### PR TITLE
[#929][#1021] feat: 리뷰 등록 시 커머스 서비스 주문상품 리뷰 상태 업데이트 연동 기능 Kafka 이벤트 전환

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/ReviewRegisteredCommerceConsumer.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/ReviewRegisteredCommerceConsumer.java
@@ -1,0 +1,62 @@
+package com.personal.marketnote.commerce.adapter.in.event;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.commerce.port.in.command.order.UpdateOrderProductReviewStatusCommand;
+import com.personal.marketnote.commerce.port.in.usecase.order.UpdateOrderProductUseCase;
+import com.personal.marketnote.common.kafka.KafkaTopicConstants;
+import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.ReviewRegisteredEvent;
+import com.personal.marketnote.common.utility.FormatValidator;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ReviewRegisteredCommerceConsumer {
+    private final UpdateOrderProductUseCase updateOrderProductUseCase;
+    private final ObjectMapper objectMapper;
+
+    @KafkaListener(
+            topics = KafkaTopicConstants.REVIEW_REGISTERED,
+            groupId = "commerce-service"
+    )
+    public void handleReviewRegisteredEvent(
+            ConsumerRecord<String, EventEnvelope<?>> record,
+            Acknowledgment acknowledgment
+    ) {
+        EventEnvelope<?> envelope = record.value();
+
+        try {
+            ReviewRegisteredEvent payload = envelope.getPayloadAs(ReviewRegisteredEvent.class, objectMapper);
+
+            log.info("리뷰 등록 이벤트 수신. eventId={}, orderId={}, pricePolicyId={}",
+                    envelope.eventId(), payload.orderId(), payload.pricePolicyId());
+
+            if (FormatValidator.hasNoValue(payload.orderId()) || FormatValidator.hasNoValue(payload.pricePolicyId())) {
+                log.error("유효하지 않은 이벤트 페이로드. eventId={}, orderId={}, pricePolicyId={}",
+                        envelope.eventId(), payload.orderId(), payload.pricePolicyId());
+                acknowledgment.acknowledge();
+                return;
+            }
+
+            UpdateOrderProductReviewStatusCommand command = UpdateOrderProductReviewStatusCommand.of(
+                    payload.orderId(), payload.pricePolicyId(), true
+            );
+            updateOrderProductUseCase.updateReviewStatus(command);
+
+            log.info("Kafka 이벤트로 주문상품 리뷰 상태 업데이트 완료. orderId={}, pricePolicyId={}",
+                    payload.orderId(), payload.pricePolicyId());
+        } catch (Exception e) {
+            log.error("주문상품 리뷰 상태 업데이트 실패. eventId={}, key={}, error={}",
+                    envelope.eventId(), record.key(), e.getMessage(), e);
+            throw e;
+        }
+
+        acknowledgment.acknowledge();
+    }
+}

--- a/common/src/main/java/com/personal/marketnote/common/kafka/event/ReviewRegisteredEvent.java
+++ b/common/src/main/java/com/personal/marketnote/common/kafka/event/ReviewRegisteredEvent.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.common.kafka.event;
+
+public record ReviewRegisteredEvent(
+        Long orderId,
+        Long pricePolicyId
+) {
+}

--- a/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/out/event/CommunityEventKafkaProducer.java
+++ b/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/out/event/CommunityEventKafkaProducer.java
@@ -1,0 +1,46 @@
+package com.personal.marketnote.community.adapter.out.event;
+
+import com.personal.marketnote.common.adapter.out.ServiceAdapter;
+import com.personal.marketnote.common.kafka.KafkaTopicConstants;
+import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.ReviewRegisteredEvent;
+import com.personal.marketnote.community.port.out.event.PublishReviewEventPort;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+
+import java.time.Clock;
+
+@Slf4j
+@ServiceAdapter
+@RequiredArgsConstructor
+public class CommunityEventKafkaProducer implements PublishReviewEventPort {
+    private static final String SOURCE = "community-service";
+
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+    private final Clock clock;
+
+    @Override
+    public void publishReviewRegisteredEvent(Long orderId, Long pricePolicyId) {
+        ReviewRegisteredEvent payload = new ReviewRegisteredEvent(orderId, pricePolicyId);
+        EventEnvelope<ReviewRegisteredEvent> envelope = EventEnvelope.of(
+                KafkaTopicConstants.REVIEW_REGISTERED,
+                SOURCE,
+                payload,
+                clock
+        );
+
+        // TODO: Kafka 단독 전환 시 발행 실패 처리 보강 필요 (Outbox 패턴 또는 동기 전환)
+        kafkaTemplate.send(KafkaTopicConstants.REVIEW_REGISTERED, orderId.toString(), envelope)
+                .whenComplete((result, ex) -> {
+                    if (ex != null) {
+                        log.error("Kafka 이벤트 발행 실패. topic={}, orderId={}, pricePolicyId={}",
+                                KafkaTopicConstants.REVIEW_REGISTERED, orderId, pricePolicyId, ex);
+                    } else {
+                        log.info("Kafka 이벤트 발행 성공. topic={}, orderId={}, offset={}",
+                                KafkaTopicConstants.REVIEW_REGISTERED, orderId,
+                                result.getRecordMetadata().offset());
+                    }
+                });
+    }
+}

--- a/community-service/community-application/src/main/java/com/personal/marketnote/community/port/out/event/PublishReviewEventPort.java
+++ b/community-service/community-application/src/main/java/com/personal/marketnote/community/port/out/event/PublishReviewEventPort.java
@@ -1,0 +1,6 @@
+package com.personal.marketnote.community.port.out.event;
+
+public interface PublishReviewEventPort {
+
+    void publishReviewRegisteredEvent(Long orderId, Long pricePolicyId);
+}

--- a/community-service/community-application/src/main/java/com/personal/marketnote/community/service/review/RegisterReviewService.java
+++ b/community-service/community-application/src/main/java/com/personal/marketnote/community/service/review/RegisterReviewService.java
@@ -11,6 +11,7 @@ import com.personal.marketnote.community.port.in.command.review.RegisterReviewCo
 import com.personal.marketnote.community.port.in.result.review.RegisterReviewResult;
 import com.personal.marketnote.community.port.in.usecase.review.GetReviewUseCase;
 import com.personal.marketnote.community.port.in.usecase.review.RegisterReviewUseCase;
+import com.personal.marketnote.community.port.out.event.PublishReviewEventPort;
 import com.personal.marketnote.community.port.out.order.UpdateOrderProductReviewStatusPort;
 import com.personal.marketnote.community.port.out.review.SaveReviewPort;
 import com.personal.marketnote.community.port.out.review.UpdateReviewPort;
@@ -28,6 +29,7 @@ public class RegisterReviewService implements RegisterReviewUseCase {
     private final GetReviewUseCase getReviewUseCase;
     private final SaveReviewPort saveReviewPort;
     private final UpdateReviewPort updateReviewPort;
+    private final PublishReviewEventPort publishReviewEventPort;
     private final UpdateOrderProductReviewStatusPort updateOrderProductReviewStatusPort;
 
     @Override
@@ -61,15 +63,18 @@ public class RegisterReviewService implements RegisterReviewUseCase {
         }
 
         // 주문 상품의 리뷰 작성 여부를 true로 업데이트
-        // FIXME: Kafka 이벤트 Production으로 변경
         if (TransactionSynchronizationManager.isActualTransactionActive()) {
             TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
                 @Override
                 public void afterCommit() {
+                    publishReviewEventPort.publishReviewRegisteredEvent(orderId, pricePolicyId);
+                    // TODO: Kafka 검증 완료 후 HTTP 호출 제거
                     updateOrderProductReviewStatusPort.update(orderId, pricePolicyId, true);
                 }
             });
         } else {
+            publishReviewEventPort.publishReviewRegisteredEvent(orderId, pricePolicyId);
+            // TODO: Kafka 검증 완료 후 HTTP 호출 제거
             updateOrderProductReviewStatusPort.update(orderId, pricePolicyId, true);
         }
 


### PR DESCRIPTION
## partially addresses #929
## resolves #1021

## Task
- ReviewRegisteredEvent 이벤트 페이로드 정의 (common)
- PublishReviewEventPort Out Port 인터페이스 추가 (community-application)
- CommunityEventKafkaProducer Kafka Producer 구현 (community-adapters)
- RegisterReviewService 듀얼 라이트 적용 (Kafka + 기존 HTTP 동시 발행)
- ReviewRegisteredCommerceConsumer Kafka Consumer 구현 (commerce-adapters)