### PR TITLE
[#929][#1064] test: 리뷰 등록 시 커머스 서비스 주문상품 리뷰 상태 업데이트 연동 기능 Kafka 이벤트 전환 자동화 테스트 추가

### DIFF
--- a/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/event/ReviewRegisteredCommerceConsumerTest.java
+++ b/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/event/ReviewRegisteredCommerceConsumerTest.java
@@ -1,0 +1,115 @@
+package com.personal.marketnote.commerce.adapter.in.event;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.commerce.port.in.command.order.UpdateOrderProductReviewStatusCommand;
+import com.personal.marketnote.commerce.port.in.usecase.order.UpdateOrderProductUseCase;
+import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.ReviewRegisteredEvent;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.support.Acknowledgment;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ReviewRegisteredCommerceConsumerTest {
+    @InjectMocks
+    private ReviewRegisteredCommerceConsumer reviewRegisteredCommerceConsumer;
+
+    @Mock
+    private UpdateOrderProductUseCase updateOrderProductUseCase;
+
+    @Spy
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @Mock
+    private Acknowledgment acknowledgment;
+
+    private ConsumerRecord<String, EventEnvelope<?>> buildRecord(Long orderId, Long pricePolicyId) {
+        ReviewRegisteredEvent event = new ReviewRegisteredEvent(orderId, pricePolicyId);
+        EventEnvelope<ReviewRegisteredEvent> envelope = new EventEnvelope<>(
+                "test-event-id", "community.review.registered", "community-service",
+                LocalDateTime.of(2026, 3, 2, 10, 0), event
+        );
+        return new ConsumerRecord<>("community.review.registered", 0, 0L, "key-1", envelope);
+    }
+
+    @Test
+    @DisplayName("정상 이벤트 수신 시 주문상품 리뷰 상태 업데이트 UseCase를 호출하고 acknowledge한다")
+    void handleReviewRegisteredEvent_success_updatesReviewStatusAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, 2L);
+
+        // when
+        reviewRegisteredCommerceConsumer.handleReviewRegisteredEvent(record, acknowledgment);
+
+        // then
+        ArgumentCaptor<UpdateOrderProductReviewStatusCommand> captor =
+                ArgumentCaptor.forClass(UpdateOrderProductReviewStatusCommand.class);
+        verify(updateOrderProductUseCase).updateReviewStatus(captor.capture());
+
+        UpdateOrderProductReviewStatusCommand command = captor.getValue();
+        assertThat(command.orderId()).isEqualTo(1L);
+        assertThat(command.pricePolicyId()).isEqualTo(2L);
+        assertThat(command.isReviewed()).isTrue();
+
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("orderId가 null이면 UseCase를 호출하지 않고 acknowledge한다")
+    void handleReviewRegisteredEvent_nullOrderId_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(null, 2L);
+
+        // when
+        reviewRegisteredCommerceConsumer.handleReviewRegisteredEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(updateOrderProductUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("pricePolicyId가 null이면 UseCase를 호출하지 않고 acknowledge한다")
+    void handleReviewRegisteredEvent_nullPricePolicyId_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, null);
+
+        // when
+        reviewRegisteredCommerceConsumer.handleReviewRegisteredEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(updateOrderProductUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("예상치 못한 예외 발생 시 DefaultErrorHandler로 위임되어 예외가 전파된다")
+    void handleReviewRegisteredEvent_unexpectedException_propagatesForRetry() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, 2L);
+        doThrow(new RuntimeException("네트워크 오류"))
+                .when(updateOrderProductUseCase).updateReviewStatus(any(UpdateOrderProductReviewStatusCommand.class));
+
+        // when & then
+        assertThatThrownBy(() -> reviewRegisteredCommerceConsumer.handleReviewRegisteredEvent(record, acknowledgment))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("네트워크 오류");
+
+        verify(updateOrderProductUseCase).updateReviewStatus(any(UpdateOrderProductReviewStatusCommand.class));
+        verify(acknowledgment, never()).acknowledge();
+    }
+}

--- a/community-service/community-adapters/src/test/java/com/personal/marketnote/community/adapter/out/event/CommunityEventKafkaProducerTest.java
+++ b/community-service/community-adapters/src/test/java/com/personal/marketnote/community/adapter/out/event/CommunityEventKafkaProducerTest.java
@@ -1,0 +1,92 @@
+package com.personal.marketnote.community.adapter.out.event;
+
+import com.personal.marketnote.common.kafka.KafkaTopicConstants;
+import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.ReviewRegisteredEvent;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.core.KafkaTemplate;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.concurrent.CompletableFuture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CommunityEventKafkaProducerTest {
+    @InjectMocks
+    private CommunityEventKafkaProducer communityEventKafkaProducer;
+
+    @Mock
+    private KafkaTemplate<String, Object> kafkaTemplate;
+
+    @Mock
+    private Clock clock;
+
+    private void setUpClock(String instant) {
+        Clock fixedClock = Clock.fixed(Instant.parse(instant), ZoneId.of("Asia/Seoul"));
+        when(clock.instant()).thenReturn(fixedClock.instant());
+        when(clock.getZone()).thenReturn(fixedClock.getZone());
+    }
+
+    @Test
+    @DisplayName("리뷰 등록 이벤트 발행 시 올바른 토픽과 파티션 키(orderId)로 전송된다")
+    void publishReviewRegisteredEvent_sendsToCorrectTopicWithOrderIdKey() {
+        // given
+        setUpClock("2026-03-02T10:00:00Z");
+        when(kafkaTemplate.send(any(String.class), any(String.class), any()))
+                .thenReturn(new CompletableFuture<>());
+
+        // when
+        communityEventKafkaProducer.publishReviewRegisteredEvent(1L, 2L);
+
+        // then
+        verify(kafkaTemplate).send(
+                eq(KafkaTopicConstants.REVIEW_REGISTERED),
+                eq("1"),
+                any(EventEnvelope.class)
+        );
+    }
+
+    @Test
+    @DisplayName("리뷰 등록 이벤트 발행 시 EventEnvelope에 올바른 페이로드(orderId, pricePolicyId)가 포함된다")
+    @SuppressWarnings("unchecked")
+    void publishReviewRegisteredEvent_envelopeContainsCorrectPayload() {
+        // given
+        setUpClock("2026-03-02T10:00:00Z");
+        when(kafkaTemplate.send(any(String.class), any(String.class), any()))
+                .thenReturn(new CompletableFuture<>());
+
+        // when
+        communityEventKafkaProducer.publishReviewRegisteredEvent(10L, 20L);
+
+        // then
+        ArgumentCaptor<EventEnvelope> envelopeCaptor = ArgumentCaptor.forClass(EventEnvelope.class);
+        verify(kafkaTemplate).send(
+                eq(KafkaTopicConstants.REVIEW_REGISTERED),
+                eq("10"),
+                envelopeCaptor.capture()
+        );
+
+        EventEnvelope<?> capturedEnvelope = envelopeCaptor.getValue();
+        assertThat(capturedEnvelope.eventType()).isEqualTo(KafkaTopicConstants.REVIEW_REGISTERED);
+        assertThat(capturedEnvelope.source()).isEqualTo("community-service");
+        assertThat(capturedEnvelope.eventId()).isNotNull();
+        assertThat(capturedEnvelope.timestamp()).isNotNull();
+
+        ReviewRegisteredEvent payload = (ReviewRegisteredEvent) capturedEnvelope.payload();
+        assertThat(payload.orderId()).isEqualTo(10L);
+        assertThat(payload.pricePolicyId()).isEqualTo(20L);
+    }
+}


### PR DESCRIPTION
## partially addresses #929
## resolves #1064

## Test Case
- [x] CommunityEventKafkaProducerTest Producer 단위 테스트 2개 추가
- [x] ReviewRegisteredCommerceConsumerTest Consumer 단위 테스트 4개 추가