### PR TITLE
[#387][#1078] feat: 적립 예정 포인트 추가/차감 기능 추가

### DIFF
--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/point/PointController.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/point/PointController.java
@@ -6,6 +6,7 @@ import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.common.utility.Role;
 import com.personal.marketnote.reward.adapter.in.web.point.apidocs.*;
 import com.personal.marketnote.reward.adapter.in.web.point.mapper.PointRequestToCommandMapper;
+import com.personal.marketnote.reward.adapter.in.web.point.request.ModifyPendingPointRequest;
 import com.personal.marketnote.reward.adapter.in.web.point.request.ModifyUserPointRequest;
 import com.personal.marketnote.reward.adapter.in.web.point.response.GetMyPointReponse;
 import com.personal.marketnote.reward.adapter.in.web.point.response.GetUserPointByIdResponse;
@@ -16,10 +17,7 @@ import com.personal.marketnote.reward.port.in.command.point.RegisterUserPointCom
 import com.personal.marketnote.reward.port.in.result.point.GetUserPointHistoryResult;
 import com.personal.marketnote.reward.port.in.result.point.GetUserPointResult;
 import com.personal.marketnote.reward.port.in.result.point.UpdateUserPointResult;
-import com.personal.marketnote.reward.port.in.usecase.point.GetUserPointHistoryUseCase;
-import com.personal.marketnote.reward.port.in.usecase.point.GetUserPointUseCase;
-import com.personal.marketnote.reward.port.in.usecase.point.ModifyUserPointUseCase;
-import com.personal.marketnote.reward.port.in.usecase.point.RegisterUserPointUseCase;
+import com.personal.marketnote.reward.port.in.usecase.point.*;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -44,6 +42,7 @@ import static com.personal.marketnote.common.utility.ApiConstant.ADMIN_POINTCUT;
 public class PointController {
     private final RegisterUserPointUseCase registerUserPointUseCase;
     private final ModifyUserPointUseCase modifyUserPointUseCase;
+    private final ModifyPendingPointUseCase modifyPendingPointUseCase;
     private final GetUserPointUseCase getUserPointUseCase;
     private final GetUserPointHistoryUseCase getUserPointHistoryUseCase;
 
@@ -181,6 +180,30 @@ public class PointController {
         }
 
         throw new AccessDeniedException("권한이 없습니다.");
+    }
+
+    /**
+     * (관리자) 회원 적립 예정 포인트 추가/차감
+     */
+    @PatchMapping("/{userId}/points/pending")
+    @PreAuthorize(ADMIN_POINTCUT)
+    @ModifyPendingPointApiDocs
+    public ResponseEntity<BaseResponse<UpdateUserPointResponse>> modifyPendingPoint(
+            @PathVariable("userId") Long userId,
+            @RequestBody @Valid ModifyPendingPointRequest request
+    ) {
+        UpdateUserPointResult result = modifyPendingPointUseCase.modifyPending(
+                PointRequestToCommandMapper.mapToModifyPendingPointCommand(userId, request)
+        );
+
+        return ResponseEntity.ok(
+                BaseResponse.of(
+                        UpdateUserPointResponse.from(result),
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "적립 예정 포인트 수정 성공"
+                )
+        );
     }
 
     /**

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/point/apidocs/ModifyPendingPointApiDocs.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/point/apidocs/ModifyPendingPointApiDocs.java
@@ -1,0 +1,150 @@
+package com.personal.marketnote.reward.adapter.in.web.point.apidocs;
+
+import com.personal.marketnote.reward.adapter.in.web.point.request.ModifyPendingPointRequest;
+import com.personal.marketnote.reward.adapter.in.web.point.response.RegisterUserPointResponseSchema;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Operation(
+        summary = "(관리자) 회원 적립 예정 포인트 추가/차감",
+        description = """
+                작성일자: 2026-03-04
+                
+                작성자: 성효빈
+                
+                ---
+                
+                ## Description
+                
+                - 회원의 적립 예정 포인트를 추가하거나 차감합니다.
+                
+                - 포인트 차감 시에도 양수를 전송합니다.
+                
+                    - 예) 300 적립 예정 포인트를 추가하는 경우 -> changeType: "ACCRUAL", amount: 300 전송
+                
+                    - 예) 300 적립 예정 포인트를 차감하는 경우 -> changeType: "DEDUCTION", amount: 300 전송
+                
+                - 적립 예정 포인트는 0 미만이 될 수 없습니다.
+                
+                - 이력은 isReflected: false로 저장됩니다.
+                
+                ---
+                
+                ## Request
+                
+                | **키** | **타입** | **설명** | **필수 여부** | **예시** |
+                | --- | --- | --- | --- | --- |
+                | userId (path) | number | 회원 ID | Y | 100 |
+                | changeType | string | ACCRUAL: 추가, DEDUCTION: 차감 | Y | "ACCRUAL" |
+                | amount | number | 변경 포인트(양수, 1 이상) | Y | 500 |
+                | sourceType | string | 출처 유형 | Y | "ORDER" |
+                | sourceId | number | 출처 ID | Y | 123 |
+                | reason | string | 사유 | N | "주문 결제 적립 예정" |
+                
+                ---
+                
+                ## Response
+                
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | statusCode | number | HTTP 상태 코드 | 200 |
+                | code | string | 응답 코드 | "SUC01" |
+                | timestamp | string(datetime) | 응답 시간 | "2026-03-04T12:00:00.000" |
+                | content | object | 응답 본문 | { ... } |
+                | message | string | 처리 결과 | "적립 예정 포인트 수정 성공" |
+                """,
+        security = {@SecurityRequirement(name = "bearer")},
+        parameters = {
+                @Parameter(
+                        name = "userId",
+                        in = ParameterIn.PATH,
+                        required = true,
+                        description = "회원 ID",
+                        schema = @Schema(type = "number", example = "100")
+                )
+        },
+        requestBody = @RequestBody(
+                required = true,
+                content = @Content(
+                        schema = @Schema(implementation = ModifyPendingPointRequest.class),
+                        examples = @ExampleObject("""
+                                {
+                                  "changeType": "ACCRUAL",
+                                  "amount": 500,
+                                  "sourceType": "ORDER",
+                                  "sourceId": 123,
+                                  "reason": "주문 결제 적립 예정"
+                                }
+                                """)
+                )
+        ),
+        responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "적립 예정 포인트 수정 성공",
+                        content = @Content(
+                                schema = @Schema(implementation = RegisterUserPointResponseSchema.class),
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 200,
+                                          "code": "SUC01",
+                                          "timestamp": "2026-03-04T12:00:00.000",
+                                          "content": {
+                                            "userId": 100,
+                                            "amount": 1000,
+                                            "addExpectedAmount": 500,
+                                            "expireExpectedAmount": 0,
+                                            "createdAt": "2026-03-04T11:00:00",
+                                            "modifiedAt": "2026-03-04T12:00:00"
+                                          },
+                                          "message": "적립 예정 포인트 수정 성공"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "400",
+                        description = "적립 예정 포인트 부족",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 400,
+                                          "code": "BAD_REQUEST",
+                                          "timestamp": "2026-03-04T12:00:00.000",
+                                          "content": null,
+                                          "message": "적립 예정 포인트가 부족합니다. 현재: 200, 요청: 500"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "404",
+                        description = "회원 포인트 정보 없음",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 404,
+                                          "code": "NOT_FOUND",
+                                          "timestamp": "2026-03-04T12:00:00.000",
+                                          "content": null,
+                                          "message": "회원 포인트 정보를 찾을 수 없습니다. 전송된 회원 ID: 101"
+                                        }
+                                        """)
+                        )
+                )
+        }
+)
+public @interface ModifyPendingPointApiDocs {
+}

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/point/mapper/PointRequestToCommandMapper.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/point/mapper/PointRequestToCommandMapper.java
@@ -1,6 +1,8 @@
 package com.personal.marketnote.reward.adapter.in.web.point.mapper;
 
+import com.personal.marketnote.reward.adapter.in.web.point.request.ModifyPendingPointRequest;
 import com.personal.marketnote.reward.adapter.in.web.point.request.ModifyUserPointRequest;
+import com.personal.marketnote.reward.port.in.command.point.ModifyPendingPointCommand;
 import com.personal.marketnote.reward.port.in.command.point.ModifyUserPointCommand;
 
 public class PointRequestToCommandMapper {
@@ -9,6 +11,20 @@ public class PointRequestToCommandMapper {
             ModifyUserPointRequest request
     ) {
         return ModifyUserPointCommand.builder()
+                .userId(userId)
+                .changeType(request.getChangeType())
+                .amount(request.getAmount())
+                .sourceType(request.getSourceType())
+                .sourceId(request.getSourceId())
+                .reason(request.getReason())
+                .build();
+    }
+
+    public static ModifyPendingPointCommand mapToModifyPendingPointCommand(
+            Long userId,
+            ModifyPendingPointRequest request
+    ) {
+        return ModifyPendingPointCommand.builder()
                 .userId(userId)
                 .changeType(request.getChangeType())
                 .amount(request.getAmount())

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/point/request/ModifyPendingPointRequest.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/point/request/ModifyPendingPointRequest.java
@@ -1,0 +1,29 @@
+package com.personal.marketnote.reward.adapter.in.web.point.request;
+
+import com.personal.marketnote.reward.domain.point.UserPointChangeType;
+import com.personal.marketnote.reward.domain.point.UserPointSourceType;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class ModifyPendingPointRequest {
+    @NotNull
+    private UserPointChangeType changeType;
+
+    @NotNull
+    @Min(1)
+    private Long amount;
+
+    @NotNull
+    private UserPointSourceType sourceType;
+
+    @NotNull
+    private Long sourceId;
+
+    private String reason;
+}

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/point/UserPointPersistenceAdapter.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/point/UserPointPersistenceAdapter.java
@@ -45,8 +45,7 @@ public class UserPointPersistenceAdapter implements SaveUserPointPort, FindUserP
 
     @Override
     public UserPoint update(UserPoint userPoint) throws UserPointNotFoundException {
-        UserPointJpaEntity userPointJpaEntity
-                = findEntityByUserId(userPoint.getUserId());
+        UserPointJpaEntity userPointJpaEntity = findEntityByUserId(userPoint.getUserId());
         userPointJpaEntity.updateFrom(userPoint);
 
         return userPoint;

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/mapper/RewardCommandToStateMapper.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/mapper/RewardCommandToStateMapper.java
@@ -11,6 +11,7 @@ import com.personal.marketnote.reward.domain.point.UserPointSourceType;
 import com.personal.marketnote.reward.port.in.command.attendance.RegisterAttendanceCommand;
 import com.personal.marketnote.reward.port.in.command.attendance.RegisterAttendancePolicyCommand;
 import com.personal.marketnote.reward.port.in.command.offerwall.RegisterOfferwallRewardCommand;
+import com.personal.marketnote.reward.port.in.command.point.ModifyPendingPointCommand;
 import com.personal.marketnote.reward.port.in.command.point.ModifyUserPointCommand;
 import com.personal.marketnote.reward.port.in.command.point.RegisterUserPointCommand;
 
@@ -75,6 +76,24 @@ public class RewardCommandToStateMapper {
                         ? -Math.abs(command.amount())
                         : Math.abs(command.amount()))
                 .isReflected(Boolean.TRUE)
+                .sourceType(command.sourceType())
+                .sourceId(command.sourceId())
+                .reason(command.reason())
+                .accumulatedAt(accumulatedAt)
+                .build();
+    }
+
+    public static UserPointHistoryCreateState mapToPendingPointHistoryCreateState(
+            ModifyPendingPointCommand command,
+            Long userId,
+            LocalDateTime accumulatedAt
+    ) {
+        return UserPointHistoryCreateState.builder()
+                .userId(userId)
+                .amount(command.changeType().equals(UserPointChangeType.DEDUCTION)
+                        ? -Math.abs(command.amount())
+                        : Math.abs(command.amount()))
+                .isReflected(Boolean.FALSE)
                 .sourceType(command.sourceType())
                 .sourceId(command.sourceId())
                 .reason(command.reason())

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/command/point/ModifyPendingPointCommand.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/command/point/ModifyPendingPointCommand.java
@@ -1,0 +1,19 @@
+package com.personal.marketnote.reward.port.in.command.point;
+
+import com.personal.marketnote.reward.domain.point.UserPointChangeType;
+import com.personal.marketnote.reward.domain.point.UserPointSourceType;
+import lombok.Builder;
+
+@Builder
+public record ModifyPendingPointCommand(
+        Long userId,
+        UserPointChangeType changeType,
+        Long amount,
+        UserPointSourceType sourceType,
+        Long sourceId,
+        String reason
+) {
+    public boolean isAccrual() {
+        return changeType.isAccrual();
+    }
+}

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/usecase/point/ModifyPendingPointUseCase.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/usecase/point/ModifyPendingPointUseCase.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.reward.port.in.usecase.point;
+
+import com.personal.marketnote.reward.port.in.command.point.ModifyPendingPointCommand;
+import com.personal.marketnote.reward.port.in.result.point.UpdateUserPointResult;
+
+public interface ModifyPendingPointUseCase {
+    UpdateUserPointResult modifyPending(ModifyPendingPointCommand command);
+}

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/service/point/ModifyPendingPointService.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/service/point/ModifyPendingPointService.java
@@ -1,0 +1,51 @@
+package com.personal.marketnote.reward.service.point;
+
+import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.reward.domain.point.UserPoint;
+import com.personal.marketnote.reward.domain.point.UserPointHistory;
+import com.personal.marketnote.reward.mapper.RewardCommandToStateMapper;
+import com.personal.marketnote.reward.port.in.command.point.ModifyPendingPointCommand;
+import com.personal.marketnote.reward.port.in.result.point.UpdateUserPointResult;
+import com.personal.marketnote.reward.port.in.usecase.point.GetUserPointUseCase;
+import com.personal.marketnote.reward.port.in.usecase.point.ModifyPendingPointUseCase;
+import com.personal.marketnote.reward.port.out.point.SaveUserPointHistoryPort;
+import com.personal.marketnote.reward.port.out.point.UpdateUserPointPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional(isolation = READ_COMMITTED)
+public class ModifyPendingPointService implements ModifyPendingPointUseCase {
+    private final GetUserPointUseCase getUserPointUseCase;
+    private final UpdateUserPointPort updateUserPointPort;
+    private final SaveUserPointHistoryPort saveUserPointHistoryPort;
+
+    @Override
+    public UpdateUserPointResult modifyPending(ModifyPendingPointCommand command) {
+        UserPoint userPoint = getUserPointUseCase.getUserPoint(command.userId());
+        addOrDeductExpectedPoint(userPoint, command);
+        UserPoint updatedPoint = updateUserPointPort.update(userPoint);
+
+        saveUserPointHistoryPort.save(
+                UserPointHistory.from(
+                        RewardCommandToStateMapper.mapToPendingPointHistoryCreateState(
+                                command, updatedPoint.getUserId(), updatedPoint.getModifiedAt()
+                        )
+                )
+        );
+
+        return UpdateUserPointResult.from(updatedPoint);
+    }
+
+    private void addOrDeductExpectedPoint(UserPoint userPoint, ModifyPendingPointCommand command) {
+        if (command.isAccrual()) {
+            userPoint.addPendingAmount(command.amount());
+            return;
+        }
+
+        userPoint.deductPendingAmount(command.amount());
+    }
+}

--- a/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/exception/InsufficientPendingPointAmountException.java
+++ b/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/exception/InsufficientPendingPointAmountException.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.reward.domain.exception;
+
+public class InsufficientPendingPointAmountException extends IllegalArgumentException {
+    private static final String MESSAGE = "적립 예정 포인트가 부족합니다. 현재: %d, 요청: %d";
+
+    public InsufficientPendingPointAmountException(long current, long requested) {
+        super(String.format(MESSAGE, current, requested));
+    }
+}

--- a/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/point/UserPoint.java
+++ b/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/point/UserPoint.java
@@ -1,5 +1,7 @@
 package com.personal.marketnote.reward.domain.point;
 
+import com.personal.marketnote.reward.domain.exception.InsufficientPendingPointAmountException;
+import com.personal.marketnote.reward.domain.exception.InvalidPointAmountException;
 import lombok.*;
 
 import java.time.LocalDateTime;
@@ -52,6 +54,31 @@ public class UserPoint {
 
     public void changeAmount(boolean isAccrual, Long amount) {
         this.amount = PointAmount.generateChangedAmount(isAccrual, this.amount, amount);
+    }
+
+    public void addPendingAmount(Long amount) {
+        validatePendingAmount(amount);
+        this.addExpectedAmount = Math.addExact(this.addExpectedAmount, amount);
+    }
+
+    public void deductPendingAmount(Long amount) {
+        validatePendingAmount(amount);
+        if (!hasSufficientPendingAmount(amount)) {
+            throw new InsufficientPendingPointAmountException(this.addExpectedAmount, amount);
+        }
+        this.addExpectedAmount = Math.subtractExact(this.addExpectedAmount, amount);
+    }
+
+    public boolean hasSufficientPendingAmount(Long amount) {
+        return this.addExpectedAmount >= amount;
+    }
+
+    private void validatePendingAmount(Long amount) {
+        if (amount <= 0) {
+            throw new InvalidPointAmountException(
+                    String.format("적립 예정 포인트 금액은 0보다 커야 합니다. 요청 금액: %d", amount)
+            );
+        }
     }
 
     public Long getAmountValue() {

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/service/user/UpdateUserService.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/service/user/UpdateUserService.java
@@ -41,35 +41,35 @@ public class UpdateUserService implements UpdateUserUseCase {
             return;
         }
 
-        String password = updateUserInfoCommand.password();
-        if (updateUserInfoCommand.hasPassword()) {
-            user.updatePassword(password, passwordEncoder);
-            return;
-        }
-
-        String email = updateUserInfoCommand.email();
-        if (updateUserInfoCommand.hasEmail()) {
-            user.validateDifferentEmail(email);
-            validateDuplicateEmail(email);
-            user.updateEmail(email);
-
-            return;
-        }
-
-        String nickname = updateUserInfoCommand.nickname();
         if (updateUserInfoCommand.hasNickname()) {
-            user.validateDifferentNickname(nickname);
-            validateDuplicateNickname(nickname);
-            user.updateNickname(nickname);
+            String newNickname = updateUserInfoCommand.nickname();
+            user.validateDifferentNickname(newNickname);
+            validateDuplicateNickname(newNickname);
+            user.updateNickname(newNickname);
 
             return;
         }
 
-        String phoneNumber = updateUserInfoCommand.phoneNumber();
+        if (updateUserInfoCommand.hasPassword()) {
+            String newPassword = updateUserInfoCommand.password();
+            user.updatePassword(newPassword, passwordEncoder);
+            return;
+        }
+
+        if (updateUserInfoCommand.hasEmail()) {
+            String newEmail = updateUserInfoCommand.email();
+            user.validateDifferentEmail(newEmail);
+            validateDuplicateEmail(newEmail);
+            user.updateEmail(newEmail);
+
+            return;
+        }
+
         if (updateUserInfoCommand.hasPhoneNumber()) {
-            user.validateDifferentPhoneNumber(phoneNumber);
-            validateDuplicatePhoneNumber(phoneNumber);
-            user.updatePhoneNumber(phoneNumber);
+            String newPhoneNumber = updateUserInfoCommand.phoneNumber();
+            user.validateDifferentPhoneNumber(newPhoneNumber);
+            validateDuplicatePhoneNumber(newPhoneNumber);
+            user.updatePhoneNumber(newPhoneNumber);
 
             return;
         }


### PR DESCRIPTION
## partially addresses #387
## resolves #1078

## Task
- [x] UserPoint 도메인에 addPendingAmount/deductPendingAmount 상태 전이 메서드 추가
- [x] InsufficientPendingPointAmountException 도메인 예외 추가
- [x] ModifyPendingPointUseCase + ModifyPendingPointCommand 추가
- [x] ModifyPendingPointService 서비스 구현 (isReflected=false 이력)
- [x] PATCH /api/v1/users/{userId}/points/pending 관리자 전용 엔드포인트 추가
- [x] ModifyPendingPointRequest DTO + 매퍼 + ApiDocs 추가