### PR TITLE
[#387][#1079] feat: 적립 예정 포인트 확정 기능 추가

### DIFF
--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/point/PointController.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/point/PointController.java
@@ -6,6 +6,7 @@ import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.common.utility.Role;
 import com.personal.marketnote.reward.adapter.in.web.point.apidocs.*;
 import com.personal.marketnote.reward.adapter.in.web.point.mapper.PointRequestToCommandMapper;
+import com.personal.marketnote.reward.adapter.in.web.point.request.ConfirmPendingPointRequest;
 import com.personal.marketnote.reward.adapter.in.web.point.request.ModifyPendingPointRequest;
 import com.personal.marketnote.reward.adapter.in.web.point.request.ModifyUserPointRequest;
 import com.personal.marketnote.reward.adapter.in.web.point.response.GetMyPointReponse;
@@ -43,6 +44,7 @@ public class PointController {
     private final RegisterUserPointUseCase registerUserPointUseCase;
     private final ModifyUserPointUseCase modifyUserPointUseCase;
     private final ModifyPendingPointUseCase modifyPendingPointUseCase;
+    private final ConfirmPendingPointUseCase confirmPendingPointUseCase;
     private final GetUserPointUseCase getUserPointUseCase;
     private final GetUserPointHistoryUseCase getUserPointHistoryUseCase;
 
@@ -202,6 +204,37 @@ public class PointController {
                         HttpStatus.OK,
                         DEFAULT_SUCCESS_CODE,
                         "적립 예정 포인트 수정 성공"
+                )
+        );
+    }
+
+    /**
+     * (관리자) 적립 예정 포인트 확정
+     *
+     * @param userId  회원 ID
+     * @param request 적립 예정 포인트 확정 요청 {@link ConfirmPendingPointRequest}
+     * @return 적립 예정 포인트 확정 응답 {@link UpdateUserPointResponse}
+     * @Author 성효빈
+     * @Date 2026-03-07
+     * @Description 적립 예정 포인트를 실제 포인트로 확정(전환)합니다.
+     */
+    @PostMapping("/{userId}/points/pending/confirm")
+    @PreAuthorize(ADMIN_POINTCUT)
+    @ConfirmPendingPointApiDocs
+    public ResponseEntity<BaseResponse<UpdateUserPointResponse>> confirmPendingPoint(
+            @PathVariable("userId") Long userId,
+            @RequestBody @Valid ConfirmPendingPointRequest request
+    ) {
+        UpdateUserPointResult result = confirmPendingPointUseCase.confirmPending(
+                PointRequestToCommandMapper.mapToConfirmPendingPointCommand(userId, request)
+        );
+
+        return ResponseEntity.ok(
+                BaseResponse.of(
+                        UpdateUserPointResponse.from(result),
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "적립 예정 포인트 확정 성공"
                 )
         );
     }

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/point/apidocs/ConfirmPendingPointApiDocs.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/point/apidocs/ConfirmPendingPointApiDocs.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.reward.adapter.in.web.point.apidocs;
 
-import com.personal.marketnote.reward.adapter.in.web.point.request.ModifyPendingPointRequest;
+import com.personal.marketnote.reward.adapter.in.web.point.request.ConfirmPendingPointRequest;
 import com.personal.marketnote.reward.adapter.in.web.point.response.RegisterUserPointResponseSchema;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -18,7 +18,7 @@ import java.lang.annotation.*;
 @Retention(RetentionPolicy.RUNTIME)
 @Inherited
 @Operation(
-        summary = "(관리자) 회원 적립 예정 포인트 추가/차감",
+        summary = "(관리자) 적립 예정 포인트 확정",
         description = """
                 작성일자: 2026-03-07
                 
@@ -28,17 +28,13 @@ import java.lang.annotation.*;
                 
                 ## Description
                 
-                - 회원의 적립 예정 포인트를 추가하거나 차감합니다.
+                - 적립 예정 포인트를 실제 포인트로 확정(전환)합니다.
                 
-                - 포인트 차감 시에도 양수를 전송합니다.
+                - sourceType과 sourceId로 확정 대상 적립 예정 포인트 이력을 식별합니다.
                 
-                    - 예) 300 적립 예정 포인트를 추가하는 경우 -> changeType: "ACCRUAL", amount: 300 전송
+                - 확정 시 적립 예정 포인트에서 차감되고, 동일 금액이 실제 포인트에 적립됩니다.
                 
-                    - 예) 300 적립 예정 포인트를 차감하는 경우 -> changeType: "DEDUCTION", amount: 300 전송
-                
-                - 적립 예정 포인트는 0 미만이 될 수 없습니다.
-                
-                - 이력은 isReflected: false로 저장됩니다.
+                - 기존 pending 이력은 isReflected: true로 업데이트되고, 확정 이력이 새로 생성됩니다.
                 
                 ---
                 
@@ -47,11 +43,9 @@ import java.lang.annotation.*;
                 | **키** | **타입** | **설명** | **필수 여부** | **예시** |
                 | --- | --- | --- | --- | --- |
                 | userId (path) | number | 회원 ID | Y | 100 |
-                | changeType | string | ACCRUAL: 추가, DEDUCTION: 차감 | Y | "ACCRUAL" |
-                | amount | number | 변경 포인트(양수, 1 이상) | Y | 500 |
                 | sourceType | string | 출처 유형 | Y | "ORDER" |
-                | sourceId | number | 출처 ID | Y | 123 |
-                | reason | string | 사유 | N | "주문 결제 적립 예정" |
+                | sourceId | number | 출처 ID (주문 ID) | Y | 123 |
+                | reason | string | 사유 | N | "구매 확정 포인트 적립" |
                 
                 ---
                 
@@ -63,7 +57,7 @@ import java.lang.annotation.*;
                 | code | string | 응답 코드 | "SUC01" |
                 | timestamp | string(datetime) | 응답 시간 | "2026-03-07T12:00:00.000" |
                 | content | object | 응답 본문 | { ... } |
-                | message | string | 처리 결과 | "적립 예정 포인트 수정 성공" |
+                | message | string | 처리 결과 | "적립 예정 포인트 확정 성공" |
                 """,
         security = {@SecurityRequirement(name = "bearer")},
         parameters = {
@@ -78,14 +72,12 @@ import java.lang.annotation.*;
         requestBody = @RequestBody(
                 required = true,
                 content = @Content(
-                        schema = @Schema(implementation = ModifyPendingPointRequest.class),
+                        schema = @Schema(implementation = ConfirmPendingPointRequest.class),
                         examples = @ExampleObject("""
                                 {
-                                  "changeType": "ACCRUAL",
-                                  "amount": 500,
                                   "sourceType": "ORDER",
                                   "sourceId": 123,
-                                  "reason": "주문 결제 적립 예정"
+                                  "reason": "구매 확정 포인트 적립"
                                 }
                                 """)
                 )
@@ -93,7 +85,7 @@ import java.lang.annotation.*;
         responses = {
                 @ApiResponse(
                         responseCode = "200",
-                        description = "적립 예정 포인트 수정 성공",
+                        description = "적립 예정 포인트 확정 성공",
                         content = @Content(
                                 schema = @Schema(implementation = RegisterUserPointResponseSchema.class),
                                 examples = @ExampleObject("""
@@ -103,13 +95,13 @@ import java.lang.annotation.*;
                                           "timestamp": "2026-03-07T12:00:00.000",
                                           "content": {
                                             "userId": 100,
-                                            "amount": 1000,
-                                            "addExpectedAmount": 500,
+                                            "amount": 1500,
+                                            "addExpectedAmount": 0,
                                             "expireExpectedAmount": 0,
                                             "createdAt": "2026-03-07T11:00:00",
                                             "modifiedAt": "2026-03-07T12:00:00"
                                           },
-                                          "message": "적립 예정 포인트 수정 성공"
+                                          "message": "적립 예정 포인트 확정 성공"
                                         }
                                         """)
                         )
@@ -131,7 +123,7 @@ import java.lang.annotation.*;
                 ),
                 @ApiResponse(
                         responseCode = "404",
-                        description = "회원 포인트 정보 없음",
+                        description = "확정 대상 적립 예정 포인트 이력 없음",
                         content = @Content(
                                 examples = @ExampleObject("""
                                         {
@@ -139,12 +131,12 @@ import java.lang.annotation.*;
                                           "code": "NOT_FOUND",
                                           "timestamp": "2026-03-07T12:00:00.000",
                                           "content": null,
-                                          "message": "회원 포인트 정보를 찾을 수 없습니다. 전송된 회원 ID: 101"
+                                          "message": "확정 대상 적립 예정 포인트 이력을 찾을 수 없습니다. userId=100, sourceType=ORDER, sourceId=123"
                                         }
                                         """)
                         )
                 )
         }
 )
-public @interface ModifyPendingPointApiDocs {
+public @interface ConfirmPendingPointApiDocs {
 }

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/point/mapper/PointRequestToCommandMapper.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/point/mapper/PointRequestToCommandMapper.java
@@ -1,7 +1,9 @@
 package com.personal.marketnote.reward.adapter.in.web.point.mapper;
 
+import com.personal.marketnote.reward.adapter.in.web.point.request.ConfirmPendingPointRequest;
 import com.personal.marketnote.reward.adapter.in.web.point.request.ModifyPendingPointRequest;
 import com.personal.marketnote.reward.adapter.in.web.point.request.ModifyUserPointRequest;
+import com.personal.marketnote.reward.port.in.command.point.ConfirmPendingPointCommand;
 import com.personal.marketnote.reward.port.in.command.point.ModifyPendingPointCommand;
 import com.personal.marketnote.reward.port.in.command.point.ModifyUserPointCommand;
 
@@ -28,6 +30,18 @@ public class PointRequestToCommandMapper {
                 .userId(userId)
                 .changeType(request.getChangeType())
                 .amount(request.getAmount())
+                .sourceType(request.getSourceType())
+                .sourceId(request.getSourceId())
+                .reason(request.getReason())
+                .build();
+    }
+
+    public static ConfirmPendingPointCommand mapToConfirmPendingPointCommand(
+            Long userId,
+            ConfirmPendingPointRequest request
+    ) {
+        return ConfirmPendingPointCommand.builder()
+                .userId(userId)
                 .sourceType(request.getSourceType())
                 .sourceId(request.getSourceId())
                 .reason(request.getReason())

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/point/request/ConfirmPendingPointRequest.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/point/request/ConfirmPendingPointRequest.java
@@ -1,0 +1,24 @@
+package com.personal.marketnote.reward.adapter.in.web.point.request;
+
+import com.personal.marketnote.reward.domain.point.UserPointSourceType;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class ConfirmPendingPointRequest {
+    @NotNull
+    private UserPointSourceType sourceType;
+
+    @NotNull
+    @Min(1)
+    private Long sourceId;
+
+    @Size(max = 500)
+    private String reason;
+}

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/point/UserPointHistoryPersistenceAdapter.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/point/UserPointHistoryPersistenceAdapter.java
@@ -5,8 +5,10 @@ import com.personal.marketnote.reward.adapter.out.persistence.point.entity.UserP
 import com.personal.marketnote.reward.adapter.out.persistence.point.repository.UserPointHistoryJpaRepository;
 import com.personal.marketnote.reward.domain.point.UserPointHistory;
 import com.personal.marketnote.reward.domain.point.UserPointHistoryFilter;
+import com.personal.marketnote.reward.domain.point.UserPointSourceType;
 import com.personal.marketnote.reward.port.out.point.FindUserPointHistoryPort;
 import com.personal.marketnote.reward.port.out.point.SaveUserPointHistoryPort;
+import com.personal.marketnote.reward.port.out.point.UpdateUserPointHistoryPort;
 import lombok.RequiredArgsConstructor;
 
 import java.util.List;
@@ -14,7 +16,7 @@ import java.util.Objects;
 
 @PersistenceAdapter
 @RequiredArgsConstructor
-public class UserPointHistoryPersistenceAdapter implements SaveUserPointHistoryPort, FindUserPointHistoryPort {
+public class UserPointHistoryPersistenceAdapter implements SaveUserPointHistoryPort, FindUserPointHistoryPort, UpdateUserPointHistoryPort {
     private final UserPointHistoryJpaRepository repository;
 
     @Override
@@ -32,6 +34,22 @@ public class UserPointHistoryPersistenceAdapter implements SaveUserPointHistoryP
         return histories.stream()
                 .map(UserPointHistoryJpaEntity::toDomain)
                 .toList();
+    }
+
+    @Override
+    public List<UserPointHistory> findUnreflectedByUserIdAndSource(
+            Long userId, UserPointSourceType sourceType, Long sourceId
+    ) {
+        return repository.findByUserIdAndIsReflectedAndSourceTypeAndSourceId(
+                        userId, Boolean.FALSE, sourceType, sourceId
+                ).stream()
+                .map(UserPointHistoryJpaEntity::toDomain)
+                .toList();
+    }
+
+    @Override
+    public int markAsReflected(Long userId, UserPointSourceType sourceType, Long sourceId) {
+        return repository.markAsReflected(userId, sourceType, sourceId);
     }
 
     private List<UserPointHistoryJpaEntity> getHistories(Long userId, UserPointHistoryFilter filter) {

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/point/repository/UserPointHistoryJpaRepository.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/point/repository/UserPointHistoryJpaRepository.java
@@ -1,7 +1,11 @@
 package com.personal.marketnote.reward.adapter.out.persistence.point.repository;
 
 import com.personal.marketnote.reward.adapter.out.persistence.point.entity.UserPointHistoryJpaEntity;
+import com.personal.marketnote.reward.domain.point.UserPointSourceType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -11,4 +15,23 @@ public interface UserPointHistoryJpaRepository extends JpaRepository<UserPointHi
     List<UserPointHistoryJpaEntity> findByUserIdAndAmountGreaterThanOrderByAccumulatedAtDesc(Long userId, Long amount);
 
     List<UserPointHistoryJpaEntity> findByUserIdAndAmountLessThanOrderByAccumulatedAtDesc(Long userId, Long amount);
+
+    List<UserPointHistoryJpaEntity> findByUserIdAndIsReflectedAndSourceTypeAndSourceId(
+            Long userId, Boolean isReflected, UserPointSourceType sourceType, Long sourceId
+    );
+
+    @Modifying(clearAutomatically = true)
+    @Query("""
+            UPDATE UserPointHistoryJpaEntity h
+            SET h.isReflected = true
+            WHERE h.userId = :userId
+              AND h.sourceType = :sourceType
+              AND h.sourceId = :sourceId
+              AND h.isReflected = false
+            """)
+    int markAsReflected(
+            @Param("userId") Long userId,
+            @Param("sourceType") UserPointSourceType sourceType,
+            @Param("sourceId") Long sourceId
+    );
 }

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/mapper/RewardCommandToStateMapper.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/mapper/RewardCommandToStateMapper.java
@@ -11,6 +11,7 @@ import com.personal.marketnote.reward.domain.point.UserPointSourceType;
 import com.personal.marketnote.reward.port.in.command.attendance.RegisterAttendanceCommand;
 import com.personal.marketnote.reward.port.in.command.attendance.RegisterAttendancePolicyCommand;
 import com.personal.marketnote.reward.port.in.command.offerwall.RegisterOfferwallRewardCommand;
+import com.personal.marketnote.reward.port.in.command.point.ConfirmPendingPointCommand;
 import com.personal.marketnote.reward.port.in.command.point.ModifyPendingPointCommand;
 import com.personal.marketnote.reward.port.in.command.point.ModifyUserPointCommand;
 import com.personal.marketnote.reward.port.in.command.point.RegisterUserPointCommand;
@@ -94,6 +95,23 @@ public class RewardCommandToStateMapper {
                         ? -Math.abs(command.amount())
                         : Math.abs(command.amount()))
                 .isReflected(Boolean.FALSE)
+                .sourceType(command.sourceType())
+                .sourceId(command.sourceId())
+                .reason(command.reason())
+                .accumulatedAt(accumulatedAt)
+                .build();
+    }
+
+    public static UserPointHistoryCreateState mapToConfirmedPointHistoryCreateState(
+            ConfirmPendingPointCommand command,
+            Long totalAmount,
+            Long userId,
+            LocalDateTime accumulatedAt
+    ) {
+        return UserPointHistoryCreateState.builder()
+                .userId(userId)
+                .amount(Math.abs(totalAmount))
+                .isReflected(Boolean.TRUE)
                 .sourceType(command.sourceType())
                 .sourceId(command.sourceId())
                 .reason(command.reason())

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/command/point/ConfirmPendingPointCommand.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/command/point/ConfirmPendingPointCommand.java
@@ -1,0 +1,13 @@
+package com.personal.marketnote.reward.port.in.command.point;
+
+import com.personal.marketnote.reward.domain.point.UserPointSourceType;
+import lombok.Builder;
+
+@Builder
+public record ConfirmPendingPointCommand(
+        Long userId,
+        UserPointSourceType sourceType,
+        Long sourceId,
+        String reason
+) {
+}

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/usecase/point/ConfirmPendingPointUseCase.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/usecase/point/ConfirmPendingPointUseCase.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.reward.port.in.usecase.point;
+
+import com.personal.marketnote.reward.port.in.command.point.ConfirmPendingPointCommand;
+import com.personal.marketnote.reward.port.in.result.point.UpdateUserPointResult;
+
+public interface ConfirmPendingPointUseCase {
+    UpdateUserPointResult confirmPending(ConfirmPendingPointCommand command);
+}

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/out/point/FindUserPointHistoryPort.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/out/point/FindUserPointHistoryPort.java
@@ -2,6 +2,7 @@ package com.personal.marketnote.reward.port.out.point;
 
 import com.personal.marketnote.reward.domain.point.UserPointHistory;
 import com.personal.marketnote.reward.domain.point.UserPointHistoryFilter;
+import com.personal.marketnote.reward.domain.point.UserPointSourceType;
 
 import java.util.List;
 
@@ -22,5 +23,16 @@ public interface FindUserPointHistoryPort {
      * @Description 회원 식별자와 필터 조건으로 포인트 이력을 조회합니다.
      */
     List<UserPointHistory> findByUserId(Long userId, UserPointHistoryFilter filter);
+
+    /**
+     * @param userId     회원 식별자
+     * @param sourceType 포인트 출처 유형
+     * @param sourceId   포인트 출처 식별자
+     * @return 미반영 적립 예정 포인트 이력 목록 {@link UserPointHistory}
+     * @Date 2026-03-07
+     * @Author 성효빈
+     * @Description 미반영(isReflected = false) 적립 예정 포인트 이력을 출처 기준으로 조회합니다.
+     */
+    List<UserPointHistory> findUnreflectedByUserIdAndSource(Long userId, UserPointSourceType sourceType, Long sourceId);
 }
 

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/out/point/UpdateUserPointHistoryPort.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/out/point/UpdateUserPointHistoryPort.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.reward.port.out.point;
+
+import com.personal.marketnote.reward.domain.point.UserPointSourceType;
+
+public interface UpdateUserPointHistoryPort {
+    int markAsReflected(Long userId, UserPointSourceType sourceType, Long sourceId);
+}

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/service/point/ConfirmPendingPointService.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/service/point/ConfirmPendingPointService.java
@@ -1,0 +1,94 @@
+package com.personal.marketnote.reward.service.point;
+
+import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.reward.domain.exception.PendingPointHistoryNotFoundException;
+import com.personal.marketnote.reward.domain.exception.PendingPointReflectionMismatchException;
+import com.personal.marketnote.reward.domain.point.UserPoint;
+import com.personal.marketnote.reward.domain.point.UserPointHistory;
+import com.personal.marketnote.reward.mapper.RewardCommandToStateMapper;
+import com.personal.marketnote.reward.port.in.command.point.ConfirmPendingPointCommand;
+import com.personal.marketnote.reward.port.in.result.point.UpdateUserPointResult;
+import com.personal.marketnote.reward.port.in.usecase.point.ConfirmPendingPointUseCase;
+import com.personal.marketnote.reward.port.in.usecase.point.GetUserPointUseCase;
+import com.personal.marketnote.reward.port.out.point.FindUserPointHistoryPort;
+import com.personal.marketnote.reward.port.out.point.SaveUserPointHistoryPort;
+import com.personal.marketnote.reward.port.out.point.UpdateUserPointHistoryPort;
+import com.personal.marketnote.reward.port.out.point.UpdateUserPointPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional(isolation = READ_COMMITTED)
+public class ConfirmPendingPointService implements ConfirmPendingPointUseCase {
+    private final GetUserPointUseCase getUserPointUseCase;
+    private final FindUserPointHistoryPort findUserPointHistoryPort;
+    private final UpdateUserPointPort updateUserPointPort;
+    private final UpdateUserPointHistoryPort updateUserPointHistoryPort;
+    private final SaveUserPointHistoryPort saveUserPointHistoryPort;
+
+    @Override
+    public UpdateUserPointResult confirmPending(ConfirmPendingPointCommand command) {
+        List<UserPointHistory> pendingHistories = findPendingHistories(command);
+        Long totalAmount = calculateTotalPendingAmount(pendingHistories);
+
+        UserPoint userPoint = getUserPointUseCase.getUserPoint(command.userId());
+        userPoint.confirmPendingAmount(totalAmount);
+        UserPoint updatedPoint = updateUserPointPort.update(userPoint);
+
+        int updatedCount = updateUserPointHistoryPort.markAsReflected(
+                command.userId(), command.sourceType(), command.sourceId()
+        );
+        validateReflectionCount(pendingHistories.size(), updatedCount);
+
+        saveConfirmedHistory(command, totalAmount, updatedPoint);
+
+        return UpdateUserPointResult.from(updatedPoint);
+    }
+
+    private List<UserPointHistory> findPendingHistories(ConfirmPendingPointCommand command) {
+        List<UserPointHistory> histories = findUserPointHistoryPort.findUnreflectedByUserIdAndSource(
+                command.userId(), command.sourceType(), command.sourceId()
+        );
+
+        if (histories.isEmpty()) {
+            throw new PendingPointHistoryNotFoundException(
+                    command.userId(), command.sourceType().name(), command.sourceId()
+            );
+        }
+
+        return histories;
+    }
+
+    private Long calculateTotalPendingAmount(List<UserPointHistory> pendingHistories) {
+        long total = 0L;
+        for (UserPointHistory history : pendingHistories) {
+            total = Math.addExact(total, history.getAmount());
+        }
+        return total;
+    }
+
+    private void validateReflectionCount(int expectedCount, int actualCount) {
+        if (expectedCount != actualCount) {
+            throw new PendingPointReflectionMismatchException(expectedCount, actualCount);
+        }
+    }
+
+    private void saveConfirmedHistory(
+            ConfirmPendingPointCommand command,
+            Long totalAmount,
+            UserPoint updatedPoint
+    ) {
+        saveUserPointHistoryPort.save(
+                UserPointHistory.from(
+                        RewardCommandToStateMapper.mapToConfirmedPointHistoryCreateState(
+                                command, totalAmount, updatedPoint.getUserId(), updatedPoint.getModifiedAt()
+                        )
+                )
+        );
+    }
+}

--- a/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/exception/PendingPointHistoryNotFoundException.java
+++ b/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/exception/PendingPointHistoryNotFoundException.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.reward.domain.exception;
+
+public class PendingPointHistoryNotFoundException extends RuntimeException {
+    private static final String MESSAGE = "확정 대상 적립 예정 포인트 이력을 찾을 수 없습니다. userId=%d, sourceType=%s, sourceId=%d";
+
+    public PendingPointHistoryNotFoundException(Long userId, String sourceType, Long sourceId) {
+        super(String.format(MESSAGE, userId, sourceType, sourceId));
+    }
+}

--- a/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/exception/PendingPointReflectionMismatchException.java
+++ b/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/exception/PendingPointReflectionMismatchException.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.reward.domain.exception;
+
+public class PendingPointReflectionMismatchException extends RuntimeException {
+    private static final String MESSAGE = "적립 예정 포인트 이력 반영 건수가 일치하지 않습니다. 조회: %d건, 반영: %d건";
+
+    public PendingPointReflectionMismatchException(int expected, int actual) {
+        super(String.format(MESSAGE, expected, actual));
+    }
+}

--- a/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/point/UserPoint.java
+++ b/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/point/UserPoint.java
@@ -81,6 +81,11 @@ public class UserPoint {
         }
     }
 
+    public void confirmPendingAmount(Long amount) {
+        deductPendingAmount(amount);
+        changeAmount(true, amount);
+    }
+
     public Long getAmountValue() {
         return amount.getValue();
     }


### PR DESCRIPTION
## partially addresses #387
## resolves #1079

## Task
- [x] ConfirmPendingPointUseCase + ConfirmPendingPointService 구현
- [x] POST /api/v1/users/{userId}/points/pending/confirm 관리자 전용 API
- [x] UserPoint.confirmPendingAmount() 상태 전이 메서드 추가
- [x] FindUserPointHistoryPort.findUnreflectedByUserIdAndSource() 미반영 이력 조회
- [x] UpdateUserPointHistoryPort.markAsReflected() 기존 pending 이력 반영 처리
- [x] PendingPointHistoryNotFoundException, PendingPointReflectionMismatchException 도메인 예외