### PR TITLE
[#216][#1080] feat: 주문 결제 완료 시 상품 구매 적립 포인트를 적립 예정 포인트로 적립하는 기능 추가

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/web/product/ProductServiceClient.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/web/product/ProductServiceClient.java
@@ -187,6 +187,7 @@ public class ProductServiceClient implements FindProductByPricePolicyPort {
                             productInfo.brandName(),
                             productInfo.pricePolicy().price(),
                             productInfo.pricePolicy().discountPrice(),
+                            productInfo.pricePolicy().accumulatedPoint(),
                             productInfo.selectedOptions()
                     )
             );

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/web/reward/RewardServiceClient.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/web/reward/RewardServiceClient.java
@@ -36,6 +36,7 @@ public class RewardServiceClient implements ModifyUserPointPort {
     private static final String SHARE_PURCHASE_REASON = "링크 공유 회원 상품 구매";
     private static final String ORDER_POINT_DEDUCTION_REASON = "주문 포인트 사용";
     private static final String ORDER_POINT_REFUND_REASON = "주문 취소 포인트 환불";
+    private static final String PRODUCT_ACCUMULATION_REASON = "상품 구매 적립";
     private static final CommerceServiceCommunicationTargetType TARGET_TYPE =
             CommerceServiceCommunicationTargetType.USER_POINT;
     private static final CommerceServiceCommunicationSenderType REQUEST_SENDER =
@@ -117,6 +118,21 @@ public class RewardServiceClient implements ModifyUserPointPort {
         HttpHeaders headers = buildHeaders();
 
         ModifyUserPointRequest request = ModifyUserPointRequest.refund(amount, orderId);
+        HttpEntity<ModifyUserPointRequest> httpEntity = new HttpEntity<>(request, headers);
+
+        sendDeductionRequest(uri, httpEntity, userId);
+    }
+
+    @Override
+    public void addPendingProductAccumulationPoints(Long userId, Long amount, Long orderId) {
+        if (FormatValidator.hasNoValue(amount) || amount <= 0) {
+            return;
+        }
+
+        URI uri = buildPendingPointUri(userId);
+        HttpHeaders headers = buildHeaders();
+
+        ModifyUserPointRequest request = ModifyUserPointRequest.pendingAccrual(amount, orderId, PRODUCT_ACCUMULATION_REASON);
         HttpEntity<ModifyUserPointRequest> httpEntity = new HttpEntity<>(request, headers);
 
         sendDeductionRequest(uri, httpEntity, userId);
@@ -282,6 +298,14 @@ public class RewardServiceClient implements ModifyUserPointPort {
         throw new RewardServiceRequestFailedException(new IOException());
     }
 
+    private URI buildPendingPointUri(Long userId) {
+        return UriComponentsBuilder
+                .fromUriString(rewardServiceBaseUrl)
+                .path("/api/v1/users/{userId}/points/pending")
+                .buildAndExpand(userId)
+                .toUri();
+    }
+
     private URI buildUserPointUri(Long userId) {
         return UriComponentsBuilder
                 .fromUriString(rewardServiceBaseUrl)
@@ -371,6 +395,16 @@ public class RewardServiceClient implements ModifyUserPointPort {
                     SOURCE_TYPE_ORDER,
                     orderId,
                     ORDER_POINT_REFUND_REASON
+            );
+        }
+
+        private static ModifyUserPointRequest pendingAccrual(long amount, Long orderId, String reason) {
+            return new ModifyUserPointRequest(
+                    CHANGE_TYPE_ACCRUAL,
+                    Math.abs(amount),
+                    SOURCE_TYPE_ORDER,
+                    orderId,
+                    reason
             );
         }
     }

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/product/result/ProductPricePolicyInfoResult.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/product/result/ProductPricePolicyInfoResult.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 public record ProductPricePolicyInfoResult(
         Long id,
         Long price,
-        Long discountPrice
+        Long discountPrice,
+        Long accumulatedPoint
 ) {
 }

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/result/product/ProductInfoResult.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/result/product/ProductInfoResult.java
@@ -12,6 +12,7 @@ public record ProductInfoResult(
         String brandName,
         Long price,
         Long discountPrice,
+        Long accumulatedPoint,
         List<ProductOptionInfoResult> selectedOptions
 ) {
     /**

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/reward/ModifyUserPointPort.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/reward/ModifyUserPointPort.java
@@ -47,4 +47,14 @@ public interface ModifyUserPointPort {
      * @Description 주문 취소 시 포인트를 환불합니다.
      */
     void refundOrderPoints(Long userId, Long amount, Long orderId);
+
+    /**
+     * @param userId  회원 ID
+     * @param amount  적립 예정 포인트
+     * @param orderId 주문 ID (sourceId)
+     * @Date 2026-03-07
+     * @Author 성효빈
+     * @Description 주문 결제 완료 시 상품 적립 포인트를 적립 예정 포인트로 추가합니다.
+     */
+    void addPendingProductAccumulationPoints(Long userId, Long amount, Long orderId);
 }

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/ChangeOrderStatusService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/ChangeOrderStatusService.java
@@ -15,6 +15,8 @@ import com.personal.marketnote.commerce.port.in.usecase.order.ChangeOrderStatusU
 import com.personal.marketnote.commerce.port.in.usecase.order.GetOrderUseCase;
 import com.personal.marketnote.commerce.port.out.order.DeleteOrderedCartProductsPort;
 import com.personal.marketnote.commerce.port.out.order.UpdateOrderPort;
+import com.personal.marketnote.commerce.port.out.product.FindProductByPricePolicyPort;
+import com.personal.marketnote.commerce.port.out.result.product.ProductInfoResult;
 import com.personal.marketnote.commerce.port.out.reward.ModifyUserPointPort;
 import com.personal.marketnote.common.application.UseCase;
 import com.personal.marketnote.common.utility.FormatValidator;
@@ -25,6 +27,7 @@ import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
@@ -38,6 +41,7 @@ public class ChangeOrderStatusService implements ChangeOrderStatusUseCase {
     private final GetOrderUseCase getOrderUseCase;
     private final UpdateOrderPort updateOrderPort;
     private final DeleteOrderedCartProductsPort deleteOrderedCartProductsPort;
+    private final FindProductByPricePolicyPort findProductByPricePolicyPort;
     private final ModifyUserPointPort modifyUserPointPort;
 
     @Override
@@ -101,7 +105,7 @@ public class ChangeOrderStatusService implements ChangeOrderStatusUseCase {
     }
 
     private void updatePaymentSubsequentProcesses(Order order, OrderStatus status) {
-        // FIXME: Kafka 이벤트 Consumption으로 변경(주문 상태 PAID로 변경 / 결제 금액 업데이트 / 재고 감소 / 장바구니 상품 삭제)
+        // FIXME: [#929] Kafka 이벤트 Consumption으로 변경(주문 상태 PAID로 변경 / 결제 금액 업데이트 / 재고 감소 / 장바구니 상품 삭제)
 
         // 결제 완료 시 재고 차감
         reduceProductInventoryUseCase.reduce(order.getOrderProducts(), status.getDescription());
@@ -114,13 +118,20 @@ public class ChangeOrderStatusService implements ChangeOrderStatusUseCase {
         Long orderId = order.getId();
         Long buyerId = order.getBuyerId();
         Long pointAmount = order.getPointAmount();
+        Long totalAmount = order.getTotalAmount();
+        Long totalAccumulatedPoint = calculateTotalAccumulatedPoint(order.getOrderProducts(), pricePolicyIds);
 
         runAfterCommit(() -> {
             // 결제 완료 시 장바구니 상품 삭제
             deleteOrderedCartProductsPort.delete(pricePolicyIds);
 
             // 링크 공유 회원 포인트 적립
-            modifyUserPointPort.accrueSharedPurchasePoints(sharerIds, order.getTotalAmount());
+            try {
+                modifyUserPointPort.accrueSharedPurchasePoints(sharerIds, totalAmount);
+            } catch (Exception e) {
+                log.error("공유 구매 포인트 적립 실패 - orderId: {}, buyerId: {}, error: {}",
+                        orderId, buyerId, e.getMessage(), e);
+            }
 
             // 포인트 사용 시 차감
             if (FormatValidator.hasValue(pointAmount) && pointAmount > 0) {
@@ -131,7 +142,47 @@ public class ChangeOrderStatusService implements ChangeOrderStatusUseCase {
                             orderId, buyerId, pointAmount, e.getMessage(), e);
                 }
             }
+
+            // 상품 적립 포인트를 적립 예정 포인트로 추가
+            addPendingProductAccumulationPoints(buyerId, totalAccumulatedPoint, orderId);
         });
+    }
+
+    private Long calculateTotalAccumulatedPoint(List<OrderProduct> orderProducts, List<Long> pricePolicyIds) {
+        Map<Long, ProductInfoResult> productInfoMap = findProductByPricePolicyPort.findByPricePolicyIds(pricePolicyIds);
+
+        long totalAccumulatedPoint = 0L;
+        for (OrderProduct orderProduct : orderProducts) {
+            ProductInfoResult productInfo = productInfoMap.get(orderProduct.getPricePolicyId());
+            if (FormatValidator.hasNoValue(productInfo)) {
+                log.warn("상품 정보 조회 누락 - pricePolicyId: {}", orderProduct.getPricePolicyId());
+                continue;
+            }
+            if (FormatValidator.hasNoValue(productInfo.accumulatedPoint())) {
+                continue;
+            }
+            totalAccumulatedPoint = Math.addExact(totalAccumulatedPoint,
+                    Math.multiplyExact(productInfo.accumulatedPoint(), orderProduct.getQuantity()));
+        }
+
+        return totalAccumulatedPoint;
+    }
+
+    private void addPendingProductAccumulationPoints(Long buyerId, Long totalAccumulatedPoint, Long orderId) {
+        if (FormatValidator.hasNoValue(totalAccumulatedPoint) || totalAccumulatedPoint <= 0) {
+            return;
+        }
+
+        try {
+            modifyUserPointPort.addPendingProductAccumulationPoints(
+                    buyerId,
+                    totalAccumulatedPoint,
+                    orderId
+            );
+        } catch (Exception e) {
+            log.error("상품 적립 예정 포인트 추가 실패 - orderId: {}, buyerId: {}, amount: {}, error: {}",
+                    orderId, buyerId, totalAccumulatedPoint, e.getMessage(), e);
+        }
     }
 
     private List<Long> extractSharerIds(List<OrderProduct> orderProducts) {

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/ChangeOrderStatusRoleValidationUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/ChangeOrderStatusRoleValidationUseCaseTest.java
@@ -11,6 +11,7 @@ import com.personal.marketnote.commerce.port.in.usecase.inventory.ReduceProductI
 import com.personal.marketnote.commerce.port.in.usecase.order.GetOrderUseCase;
 import com.personal.marketnote.commerce.port.out.order.DeleteOrderedCartProductsPort;
 import com.personal.marketnote.commerce.port.out.order.UpdateOrderPort;
+import com.personal.marketnote.commerce.port.out.product.FindProductByPricePolicyPort;
 import com.personal.marketnote.commerce.port.out.reward.ModifyUserPointPort;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -39,6 +40,8 @@ class ChangeOrderStatusRoleValidationUseCaseTest {
     private UpdateOrderPort updateOrderPort;
     @Mock
     private DeleteOrderedCartProductsPort deleteOrderedCartProductsPort;
+    @Mock
+    private FindProductByPricePolicyPort findProductByPricePolicyPort;
     @Mock
     private ModifyUserPointPort modifyUserPointPort;
 

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/GetAdminOrdersUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/GetAdminOrdersUseCaseTest.java
@@ -67,7 +67,7 @@ class GetAdminOrdersUseCaseTest {
     }
 
     private ProductInfoResult createProductInfo(Long id, String name, String brandName) {
-        return new ProductInfoResult(id, 10L, name, brandName, 50000L, null, List.of());
+        return new ProductInfoResult(id, 10L, name, brandName, 50000L, null, null, List.of());
     }
 
     @Test

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/GetBuyerOrderCountUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/GetBuyerOrderCountUseCaseTest.java
@@ -1018,6 +1018,6 @@ class GetBuyerOrderCountUseCaseTest {
     }
 
     private ProductInfoResult createProductInfo(Long id, String name) {
-        return new ProductInfoResult(id, null, name, "브랜드", null, null, List.of());
+        return new ProductInfoResult(id, null, name, "브랜드", null, null, null, List.of());
     }
 }

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/GetBuyerOrderHistoryUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/GetBuyerOrderHistoryUseCaseTest.java
@@ -1129,6 +1129,6 @@ class GetBuyerOrderHistoryUseCaseTest {
     }
 
     private ProductInfoResult createProductInfo(Long id, String name) {
-        return new ProductInfoResult(id, null, name, "브랜드", null, null, List.of());
+        return new ProductInfoResult(id, null, name, "브랜드", null, null, null, List.of());
     }
 }

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/GetBuyerOrderProductsUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/GetBuyerOrderProductsUseCaseTest.java
@@ -475,7 +475,7 @@ class GetBuyerOrderProductsUseCaseTest {
             when(findOrderPort.findByBuyerId(eq(buyerId), isNull(), isNull(), eq(List.of())))
                     .thenReturn(List.of(order));
             when(findProductByPricePolicyPort.findByPricePolicyIds(anyList()))
-                    .thenReturn(Map.of(100L, new ProductInfoResult(100L, null, "상품A", "나이키", null, null, List.of())));
+                    .thenReturn(Map.of(100L, new ProductInfoResult(100L, null, "상품A", "나이키", null, null, null, List.of())));
 
             GetBuyerOrderProductsResult result = getOrderService.getBuyerOrderProducts(query);
 
@@ -988,6 +988,6 @@ class GetBuyerOrderProductsUseCaseTest {
     }
 
     private ProductInfoResult createProductInfo(Long id, String name) {
-        return new ProductInfoResult(id, null, name, "브랜드", null, null, List.of());
+        return new ProductInfoResult(id, null, name, "브랜드", null, null, null, List.of());
     }
 }

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/GetOrderAndOrderProductsUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/GetOrderAndOrderProductsUseCaseTest.java
@@ -58,7 +58,7 @@ class GetOrderAndOrderProductsUseCaseTest {
             when(findOrderPort.findById(orderId)).thenReturn(Optional.of(order));
 
             ProductInfoResult productInfo = new ProductInfoResult(
-                    1L, null, "테스트 상품", "테스트 브랜드", null, null, List.of()
+                    1L, null, "테스트 상품", "테스트 브랜드", null, null, null, List.of()
             );
             when(findProductByPricePolicyPort.findByPricePolicyIds(List.of(pricePolicyId)))
                     .thenReturn(Map.of(pricePolicyId, productInfo));
@@ -86,9 +86,9 @@ class GetOrderAndOrderProductsUseCaseTest {
             when(findOrderPort.findById(orderId)).thenReturn(Optional.of(order));
 
             Map<Long, ProductInfoResult> productInfoMap = Map.of(
-                    pricePolicyId1, new ProductInfoResult(1L, null, "상품1", "브랜드1", null, null, List.of()),
-                    pricePolicyId2, new ProductInfoResult(2L, null, "상품2", "브랜드2", null, null, List.of()),
-                    pricePolicyId3, new ProductInfoResult(3L, null, "상품3", "브랜드3", null, null, List.of())
+                    pricePolicyId1, new ProductInfoResult(1L, null, "상품1", "브랜드1", null, null, null, List.of()),
+                    pricePolicyId2, new ProductInfoResult(2L, null, "상품2", "브랜드2", null, null, null, List.of()),
+                    pricePolicyId3, new ProductInfoResult(3L, null, "상품3", "브랜드3", null, null, null, List.of())
             );
             when(findProductByPricePolicyPort.findByPricePolicyIds(anyList()))
                     .thenReturn(productInfoMap);
@@ -134,7 +134,7 @@ class GetOrderAndOrderProductsUseCaseTest {
             when(findOrderPort.findById(orderId)).thenReturn(Optional.of(order));
 
             Map<Long, ProductInfoResult> productInfoMap = new HashMap<>();
-            productInfoMap.put(pricePolicyId1, new ProductInfoResult(1L, null, "상품1", "브랜드1", null, null, List.of()));
+            productInfoMap.put(pricePolicyId1, new ProductInfoResult(1L, null, "상품1", "브랜드1", null, null, null, List.of()));
             when(findProductByPricePolicyPort.findByPricePolicyIds(anyList()))
                     .thenReturn(productInfoMap);
 
@@ -173,7 +173,7 @@ class GetOrderAndOrderProductsUseCaseTest {
                     new ProductOptionInfoResult(2L, "사이즈: L", "ACTIVE")
             );
             ProductInfoResult productInfo = new ProductInfoResult(
-                    1L, null, "테스트 상품", "테스트 브랜드", null, null, options
+                    1L, null, "테스트 상품", "테스트 브랜드", null, null, null, options
             );
             when(findProductByPricePolicyPort.findByPricePolicyIds(List.of(pricePolicyId)))
                     .thenReturn(Map.of(pricePolicyId, productInfo));
@@ -607,7 +607,7 @@ class GetOrderAndOrderProductsUseCaseTest {
             when(findOrderPort.findById(orderId)).thenReturn(Optional.of(order));
 
             ProductInfoResult productInfo = new ProductInfoResult(
-                    productId, null, "테스트 상품", "테스트 브랜드", null, null, List.of()
+                    productId, null, "테스트 상품", "테스트 브랜드", null, null, null, List.of()
             );
             when(findProductByPricePolicyPort.findByPricePolicyIds(List.of(pricePolicyId)))
                     .thenReturn(Map.of(pricePolicyId, productInfo));
@@ -630,7 +630,7 @@ class GetOrderAndOrderProductsUseCaseTest {
             when(findOrderPort.findById(orderId)).thenReturn(Optional.of(order));
 
             ProductInfoResult productInfo = new ProductInfoResult(
-                    1L, null, productName, "테스트 브랜드", null, null, List.of()
+                    1L, null, productName, "테스트 브랜드", null, null, null, List.of()
             );
             when(findProductByPricePolicyPort.findByPricePolicyIds(List.of(pricePolicyId)))
                     .thenReturn(Map.of(pricePolicyId, productInfo));
@@ -653,7 +653,7 @@ class GetOrderAndOrderProductsUseCaseTest {
             when(findOrderPort.findById(orderId)).thenReturn(Optional.of(order));
 
             ProductInfoResult productInfo = new ProductInfoResult(
-                    1L, null, "테스트 상품", brandName, null, null, List.of()
+                    1L, null, "테스트 상품", brandName, null, null, null, List.of()
             );
             when(findProductByPricePolicyPort.findByPricePolicyIds(List.of(pricePolicyId)))
                     .thenReturn(Map.of(pricePolicyId, productInfo));
@@ -680,7 +680,7 @@ class GetOrderAndOrderProductsUseCaseTest {
                     new ProductOptionInfoResult(3L, "소재: 면", "ACTIVE")
             );
             ProductInfoResult productInfo = new ProductInfoResult(
-                    1L, null, "테스트 상품", "테스트 브랜드", null, null, options
+                    1L, null, "테스트 상품", "테스트 브랜드", null, null, null, options
             );
             when(findProductByPricePolicyPort.findByPricePolicyIds(List.of(pricePolicyId)))
                     .thenReturn(Map.of(pricePolicyId, productInfo));
@@ -949,7 +949,7 @@ class GetOrderAndOrderProductsUseCaseTest {
             when(findOrderPort.findById(orderId)).thenReturn(Optional.of(order));
 
             ProductInfoResult productInfo = new ProductInfoResult(
-                    1L, null, "테스트 상품", "테스트 브랜드", null, null, List.of()
+                    1L, null, "테스트 상품", "테스트 브랜드", null, null, null, List.of()
             );
             when(findProductByPricePolicyPort.findByPricePolicyIds(anyList()))
                     .thenReturn(Map.of(pricePolicyId, productInfo));

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/GetOrderWithBuyerVerificationUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/GetOrderWithBuyerVerificationUseCaseTest.java
@@ -80,7 +80,7 @@ class GetOrderWithBuyerVerificationUseCaseTest {
 
             when(findOrderPort.findById(orderId)).thenReturn(Optional.of(order));
 
-            ProductInfoResult productInfo = new ProductInfoResult(1L, null, "테스트 상품", "테스트 브랜드", null, null, List.of());
+            ProductInfoResult productInfo = new ProductInfoResult(1L, null, "테스트 상품", "테스트 브랜드", null, null, null, List.of());
             when(findProductByPricePolicyPort.findByPricePolicyIds(List.of(pricePolicyId)))
                     .thenReturn(Map.of(pricePolicyId, productInfo));
 

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/RegisterOrderUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/RegisterOrderUseCaseTest.java
@@ -966,7 +966,7 @@ class RegisterOrderUseCaseTest {
 
             when(findProductByPricePolicyPort.findByPricePolicyIds(anyList()))
                     .thenReturn(Map.of(pricePolicyId,
-                            new ProductInfoResult(1L, 10L, "상품", "브랜드", 50000L, 40000L, List.of())));
+                            new ProductInfoResult(1L, 10L, "상품", "브랜드", 50000L, 40000L, null, List.of())));
             mockInventoryAndSave(pricePolicyId, 100, 1L);
 
             assertThatCode(() -> registerOrderService.registerOrder(command))
@@ -981,7 +981,7 @@ class RegisterOrderUseCaseTest {
 
             when(findProductByPricePolicyPort.findByPricePolicyIds(anyList()))
                     .thenReturn(Map.of(pricePolicyId,
-                            new ProductInfoResult(1L, 10L, "상품", "브랜드", 50000L, null, List.of())));
+                            new ProductInfoResult(1L, 10L, "상품", "브랜드", 50000L, null, null, List.of())));
             mockInventoryAndSave(pricePolicyId, 100, 1L);
 
             assertThatCode(() -> registerOrderService.registerOrder(command))
@@ -1166,8 +1166,8 @@ class RegisterOrderUseCaseTest {
                     .build();
 
             java.util.HashMap<Long, ProductInfoResult> productInfoMap = new java.util.HashMap<>();
-            productInfoMap.put(pricePolicyId1, new ProductInfoResult(1L, 10L, "상품1", "브랜드1", 50000L, null, List.of()));
-            productInfoMap.put(pricePolicyId2, new ProductInfoResult(2L, 20L, "상품2", "브랜드2", 50000L, null, List.of()));
+            productInfoMap.put(pricePolicyId1, new ProductInfoResult(1L, 10L, "상품1", "브랜드1", 50000L, null, null, List.of()));
+            productInfoMap.put(pricePolicyId2, new ProductInfoResult(2L, 20L, "상품2", "브랜드2", 50000L, null, null, List.of()));
             when(findProductByPricePolicyPort.findByPricePolicyIds(anyList()))
                     .thenReturn(productInfoMap);
 
@@ -2299,7 +2299,7 @@ class RegisterOrderUseCaseTest {
 
     private void mockProductPrice(Long pricePolicyId, Long price) {
         ProductInfoResult productInfo = new ProductInfoResult(
-                1L, 10L, "테스트 상품", "테스트 브랜드", price, null, List.of()
+                1L, 10L, "테스트 상품", "테스트 브랜드", price, null, null, List.of()
         );
         when(findProductByPricePolicyPort.findByPricePolicyIds(anyList()))
                 .thenReturn(Map.of(pricePolicyId, productInfo));
@@ -2307,7 +2307,7 @@ class RegisterOrderUseCaseTest {
 
     private void mockProductPriceWithSellerId(Long pricePolicyId, Long price, Long sellerId) {
         ProductInfoResult productInfo = new ProductInfoResult(
-                1L, sellerId, "테스트 상품", "테스트 브랜드", price, null, List.of()
+                1L, sellerId, "테스트 상품", "테스트 브랜드", price, null, null, List.of()
         );
         when(findProductByPricePolicyPort.findByPricePolicyIds(anyList()))
                 .thenReturn(Map.of(pricePolicyId, productInfo));
@@ -2318,7 +2318,7 @@ class RegisterOrderUseCaseTest {
         pricePolicyIdToPriceAndSellerId.forEach((pricePolicyId, priceAndSellerId) ->
                 result.put(pricePolicyId, new ProductInfoResult(
                         pricePolicyId, priceAndSellerId.getValue(), "테스트 상품", "테스트 브랜드",
-                        priceAndSellerId.getKey(), null, List.of()
+                        priceAndSellerId.getKey(), null, null, List.of()
                 ))
         );
         when(findProductByPricePolicyPort.findByPricePolicyIds(anyList()))
@@ -2329,7 +2329,7 @@ class RegisterOrderUseCaseTest {
         java.util.HashMap<Long, ProductInfoResult> result = new java.util.HashMap<>();
         pricePolicyIdToPrice.forEach((pricePolicyId, price) ->
                 result.put(pricePolicyId, new ProductInfoResult(
-                        pricePolicyId, 10L, "테스트 상품", "테스트 브랜드", price, null, List.of()
+                        pricePolicyId, 10L, "테스트 상품", "테스트 브랜드", price, null, null, List.of()
                 ))
         );
         when(findProductByPricePolicyPort.findByPricePolicyIds(anyList()))


### PR DESCRIPTION
## partially addresses #216
## resolves #1080

## Task
- ProductPricePolicyInfoResult/ProductInfoResult에 accumulatedPoint 필드 추가
- ProductServiceClient.generateResult()에서 accumulatedPoint 매핑 추가
- ModifyUserPointPort에 addPendingProductAccumulationPoints() 메서드 추가
- RewardServiceClient에 적립 예정 포인트 API(PATCH /pending) 호출 구현
- ChangeOrderStatusService에 PAID 시 적립 예정 포인트 합산 및 호출 로직 추가
- accrueSharedPurchasePoints 실패 격리(try-catch) 추가
- 기존 테스트 ProductInfoResult 생성자 호출 수정(accumulatedPoint 파라미터 추가)