### PR TITLE
[#216][#1083] feat: 결제 취소 시 상품 구매 적립 예정 포인트 회수 기능 추가

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/web/reward/RewardServiceClient.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/web/reward/RewardServiceClient.java
@@ -32,6 +32,7 @@ public class RewardServiceClient implements ModifyUserPointPort {
     private static final String ORDER_POINT_REFUND_REASON = "주문 취소 포인트 환불";
     private static final String PRODUCT_ACCUMULATION_REASON = "상품 구매 적립";
     private static final String PENDING_POINT_CONFIRM_REASON = "구매 확정 포인트 적립";
+    private static final String PENDING_POINT_CANCEL_REASON = "결제 취소 적립 예정 포인트 회수";
 
     @Value("${reward-service.base-url}")
     private String rewardServiceBaseUrl;
@@ -143,6 +144,23 @@ public class RewardServiceClient implements ModifyUserPointPort {
     }
 
     @Override
+    public void revokePendingPoints(Long userId, Long orderId) {
+        if (FormatValidator.hasNoValue(userId) || FormatValidator.hasNoValue(orderId)) {
+            return;
+        }
+
+        URI uri = buildPendingPointCancelUri(userId);
+        HttpHeaders headers = buildHeaders();
+
+        CancelPendingPointRequest request = new CancelPendingPointRequest(
+                SOURCE_TYPE_ORDER, orderId, PENDING_POINT_CANCEL_REASON
+        );
+        HttpEntity<CancelPendingPointRequest> httpEntity = new HttpEntity<>(request, headers);
+
+        sendRequestWithRetry(uri, httpEntity, HttpMethod.POST, userId, "적립 예정 포인트 취소");
+    }
+
+    @Override
     public void addPendingSharedPurchasePoints(List<Long> sharerIds, Long totalAmount, Long orderId) {
         if (FormatValidator.hasNoValue(sharerIds) || FormatValidator.hasNoValue(totalAmount)) {
             return;
@@ -166,6 +184,14 @@ public class RewardServiceClient implements ModifyUserPointPort {
         HttpEntity<ModifyUserPointRequest> httpEntity = new HttpEntity<>(request, headers);
 
         sendRequestWithRetry(uri, httpEntity, HttpMethod.PATCH, sharerId, "포인트 변경");
+    }
+
+    private URI buildPendingPointCancelUri(Long userId) {
+        return UriComponentsBuilder
+                .fromUriString(rewardServiceBaseUrl)
+                .path("/api/v1/users/{userId}/points/pending/cancel")
+                .buildAndExpand(userId)
+                .toUri();
     }
 
     private URI buildPendingPointConfirmUri(Long userId) {
@@ -241,6 +267,13 @@ public class RewardServiceClient implements ModifyUserPointPort {
 
         log.error("{} 최종 실패 (비정상 응답) - userId: {}", operationName, userId);
         throw new RewardServiceRequestFailedException(new IOException(operationName + " 최종 실패"));
+    }
+
+    private record CancelPendingPointRequest(
+            String sourceType,
+            Long sourceId,
+            String reason
+    ) {
     }
 
     private record ConfirmPendingPointRequest(

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/reward/ModifyUserPointPort.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/reward/ModifyUserPointPort.java
@@ -67,4 +67,13 @@ public interface ModifyUserPointPort {
      * @Description 구매 확정 시 적립 예정 포인트를 실제 포인트로 확정합니다.
      */
     void confirmPendingPoints(Long userId, Long orderId);
+
+    /**
+     * @param userId  회원 ID
+     * @param orderId 주문 ID (sourceId)
+     * @Date 2026-03-07
+     * @Author 성효빈
+     * @Description 결제 취소 시 적립 예정 포인트를 회수(취소)합니다.
+     */
+    void revokePendingPoints(Long userId, Long orderId);
 }

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/CancelPaymentService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/CancelPaymentService.java
@@ -98,6 +98,7 @@ public class CancelPaymentService implements CancelPaymentUseCase {
             );
             restoreInventory(order);
             refundPoints(order);
+            revokePendingProductAccumulationPoints(order);
         }
 
         recordLedgerEntryForCancellation(payment, isFullCancel, cancelAmount, alreadyRefunded);
@@ -212,6 +213,15 @@ public class CancelPaymentService implements CancelPaymentUseCase {
         } catch (Exception e) {
             log.error("재고 복구 실패 - orderId: {}, error: {}",
                     order.getId(), e.getMessage(), e);
+        }
+    }
+
+    private void revokePendingProductAccumulationPoints(Order order) {
+        try {
+            modifyUserPointPort.revokePendingPoints(order.getBuyerId(), order.getId());
+        } catch (Exception e) {
+            log.error("상품 적립 예정 포인트 회수 실패 - orderId: {}, buyerId: {}, error: {}",
+                    order.getId(), order.getBuyerId(), e.getMessage(), e);
         }
     }
 

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/ChangeOrderStatusConfirmProcessUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/ChangeOrderStatusConfirmProcessUseCaseTest.java
@@ -1,0 +1,216 @@
+package com.personal.marketnote.commerce.service.order;
+
+import com.personal.marketnote.commerce.domain.order.Order;
+import com.personal.marketnote.commerce.domain.order.OrderProductSnapshotState;
+import com.personal.marketnote.commerce.domain.order.OrderSnapshotState;
+import com.personal.marketnote.commerce.domain.order.OrderStatus;
+import com.personal.marketnote.commerce.port.in.command.order.ChangeOrderStatusCommand;
+import com.personal.marketnote.commerce.port.in.usecase.inventory.ReduceProductInventoryUseCase;
+import com.personal.marketnote.commerce.port.in.usecase.order.GetOrderUseCase;
+import com.personal.marketnote.commerce.port.out.order.DeleteOrderedCartProductsPort;
+import com.personal.marketnote.commerce.port.out.order.UpdateOrderPort;
+import com.personal.marketnote.commerce.port.out.product.FindProductByPricePolicyPort;
+import com.personal.marketnote.commerce.port.out.reward.ModifyUserPointPort;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ChangeOrderStatusConfirmProcessUseCaseTest {
+    @Mock
+    private ReduceProductInventoryUseCase reduceProductInventoryUseCase;
+    @Mock
+    private GetOrderUseCase getOrderUseCase;
+    @Mock
+    private UpdateOrderPort updateOrderPort;
+    @Mock
+    private DeleteOrderedCartProductsPort deleteOrderedCartProductsPort;
+    @Mock
+    private FindProductByPricePolicyPort findProductByPricePolicyPort;
+    @Mock
+    private ModifyUserPointPort modifyUserPointPort;
+
+    @InjectMocks
+    private ChangeOrderStatusService changeOrderStatusService;
+
+    @Nested
+    @DisplayName("CONFIRMED 상태 변경 시 적립 예정 포인트 확정")
+    class ConfirmPendingPointTest {
+
+        @Test
+        @DisplayName("구매 확정 시 적립 예정 포인트 확정을 호출한다")
+        void shouldCallConfirmPendingPointsWhenConfirmed() {
+            // given
+            Long orderId = 1L;
+            Long buyerId = 100L;
+
+            Order order = createOrder(orderId, buyerId, OrderStatus.DELIVERED);
+            when(getOrderUseCase.getOrder(orderId)).thenReturn(order);
+
+            ChangeOrderStatusCommand command = ChangeOrderStatusCommand.builder()
+                    .id(orderId)
+                    .orderStatus(OrderStatus.CONFIRMED)
+                    .role("BUYER")
+                    .buyerId(buyerId)
+                    .build();
+
+            // when
+            changeOrderStatusService.changeOrderStatus(command);
+
+            // then
+            verify(modifyUserPointPort).confirmPendingPoints(buyerId, orderId);
+        }
+
+        @Test
+        @DisplayName("구매 확정 시 적립 예정 포인트 확정 실패해도 예외가 전파되지 않는다")
+        void shouldNotPropagateExceptionWhenConfirmPendingPointsFails() {
+            // given
+            Long orderId = 1L;
+            Long buyerId = 100L;
+
+            Order order = createOrder(orderId, buyerId, OrderStatus.DELIVERED);
+            when(getOrderUseCase.getOrder(orderId)).thenReturn(order);
+            doThrow(new RuntimeException("리워드 서비스 요청 실패"))
+                    .when(modifyUserPointPort).confirmPendingPoints(buyerId, orderId);
+
+            ChangeOrderStatusCommand command = ChangeOrderStatusCommand.builder()
+                    .id(orderId)
+                    .orderStatus(OrderStatus.CONFIRMED)
+                    .role("BUYER")
+                    .buyerId(buyerId)
+                    .build();
+
+            // when & then
+            assertThatCode(() -> changeOrderStatusService.changeOrderStatus(command))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("부분 구매 확정 시 적립 예정 포인트 확정을 호출하지 않는다")
+        void shouldNotCallConfirmPendingPointsWhenPartiallyConfirmed() {
+            // given
+            Long orderId = 1L;
+            Long buyerId = 100L;
+
+            Order order = createOrderWithMultipleProducts(orderId, buyerId);
+            when(getOrderUseCase.getOrder(orderId)).thenReturn(order);
+
+            ChangeOrderStatusCommand command = ChangeOrderStatusCommand.builder()
+                    .id(orderId)
+                    .pricePolicyIds(List.of(10L))
+                    .orderStatus(OrderStatus.CONFIRMED)
+                    .role("BUYER")
+                    .buyerId(buyerId)
+                    .build();
+
+            // when
+            changeOrderStatusService.changeOrderStatus(command);
+
+            // then
+            verify(modifyUserPointPort, never()).confirmPendingPoints(anyLong(), anyLong());
+        }
+
+        @Test
+        @DisplayName("결제 완료 시 적립 예정 포인트 확정을 호출하지 않는다")
+        void shouldNotCallConfirmPendingPointsWhenPaid() {
+            // given
+            Long orderId = 1L;
+            Long buyerId = 100L;
+            Long pricePolicyId = 10L;
+
+            Order order = createOrder(orderId, buyerId, OrderStatus.PAYMENT_PENDING);
+            when(getOrderUseCase.getOrder(orderId)).thenReturn(order);
+            when(findProductByPricePolicyPort.findByPricePolicyIds(List.of(pricePolicyId)))
+                    .thenReturn(Map.of());
+
+            ChangeOrderStatusCommand command = ChangeOrderStatusCommand.builder()
+                    .id(orderId)
+                    .orderStatus(OrderStatus.PAID)
+                    .build();
+
+            // when
+            changeOrderStatusService.changeOrderStatus(command);
+
+            // then
+            verify(modifyUserPointPort, never()).confirmPendingPoints(anyLong(), anyLong());
+        }
+    }
+
+    // ==================================================================================
+    // 헬퍼 메서드
+    // ==================================================================================
+
+    private Order createOrder(Long orderId, Long buyerId, OrderStatus status) {
+        List<OrderProductSnapshotState> productStates = List.of(
+                OrderProductSnapshotState.builder()
+                        .orderId(orderId)
+                        .sellerId(10L)
+                        .pricePolicyId(10L)
+                        .quantity(1)
+                        .unitAmount(50000L)
+                        .orderStatus(status)
+                        .build()
+        );
+
+        return Order.from(OrderSnapshotState.builder()
+                .id(orderId)
+                .buyerId(buyerId)
+                .orderKey(UUID.randomUUID())
+                .orderNumber("ORD-" + orderId)
+                .orderStatus(status)
+                .totalAmount(50000L)
+                .couponAmount(0L)
+                .pointAmount(0L)
+                .orderProductStates(productStates)
+                .createdAt(LocalDateTime.now())
+                .modifiedAt(LocalDateTime.now())
+                .build());
+    }
+
+    private Order createOrderWithMultipleProducts(Long orderId, Long buyerId) {
+        List<OrderProductSnapshotState> productStates = List.of(
+                OrderProductSnapshotState.builder()
+                        .orderId(orderId)
+                        .sellerId(10L)
+                        .pricePolicyId(10L)
+                        .quantity(1)
+                        .unitAmount(30000L)
+                        .orderStatus(OrderStatus.DELIVERED)
+                        .build(),
+                OrderProductSnapshotState.builder()
+                        .orderId(orderId)
+                        .sellerId(10L)
+                        .pricePolicyId(20L)
+                        .quantity(1)
+                        .unitAmount(20000L)
+                        .orderStatus(OrderStatus.DELIVERED)
+                        .build()
+        );
+
+        return Order.from(OrderSnapshotState.builder()
+                .id(orderId)
+                .buyerId(buyerId)
+                .orderKey(UUID.randomUUID())
+                .orderNumber("ORD-" + orderId)
+                .orderStatus(OrderStatus.DELIVERED)
+                .totalAmount(50000L)
+                .couponAmount(0L)
+                .pointAmount(0L)
+                .orderProductStates(productStates)
+                .createdAt(LocalDateTime.now())
+                .modifiedAt(LocalDateTime.now())
+                .build());
+    }
+}

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/point/PointController.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/point/PointController.java
@@ -6,6 +6,7 @@ import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.common.utility.Role;
 import com.personal.marketnote.reward.adapter.in.web.point.apidocs.*;
 import com.personal.marketnote.reward.adapter.in.web.point.mapper.PointRequestToCommandMapper;
+import com.personal.marketnote.reward.adapter.in.web.point.request.CancelPendingPointRequest;
 import com.personal.marketnote.reward.adapter.in.web.point.request.ConfirmPendingPointRequest;
 import com.personal.marketnote.reward.adapter.in.web.point.request.ModifyPendingPointRequest;
 import com.personal.marketnote.reward.adapter.in.web.point.request.ModifyUserPointRequest;
@@ -45,6 +46,7 @@ public class PointController {
     private final ModifyUserPointUseCase modifyUserPointUseCase;
     private final ModifyPendingPointUseCase modifyPendingPointUseCase;
     private final ConfirmPendingPointUseCase confirmPendingPointUseCase;
+    private final CancelPendingPointUseCase cancelPendingPointUseCase;
     private final GetUserPointUseCase getUserPointUseCase;
     private final GetUserPointHistoryUseCase getUserPointHistoryUseCase;
 
@@ -235,6 +237,37 @@ public class PointController {
                         HttpStatus.OK,
                         DEFAULT_SUCCESS_CODE,
                         "적립 예정 포인트 확정 성공"
+                )
+        );
+    }
+
+    /**
+     * (관리자) 적립 예정 포인트 취소
+     *
+     * @param userId  회원 ID
+     * @param request 적립 예정 포인트 취소 요청 {@link CancelPendingPointRequest}
+     * @return 적립 예정 포인트 취소 응답 {@link UpdateUserPointResponse}
+     * @Author 성효빈
+     * @Date 2026-03-07
+     * @Description 적립 예정 포인트를 취소(회수)합니다. 취소 대상이 없으면 현재 포인트를 반환합니다.
+     */
+    @PostMapping("/{userId}/points/pending/cancel")
+    @PreAuthorize(ADMIN_POINTCUT)
+    @CancelPendingPointApiDocs
+    public ResponseEntity<BaseResponse<UpdateUserPointResponse>> cancelPendingPoint(
+            @PathVariable("userId") Long userId,
+            @RequestBody @Valid CancelPendingPointRequest request
+    ) {
+        UpdateUserPointResult result = cancelPendingPointUseCase.cancelPending(
+                PointRequestToCommandMapper.mapToCancelPendingPointCommand(userId, request)
+        );
+
+        return ResponseEntity.ok(
+                BaseResponse.of(
+                        UpdateUserPointResponse.from(result),
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "적립 예정 포인트 취소 성공"
                 )
         );
     }

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/point/apidocs/CancelPendingPointApiDocs.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/point/apidocs/CancelPendingPointApiDocs.java
@@ -1,0 +1,129 @@
+package com.personal.marketnote.reward.adapter.in.web.point.apidocs;
+
+import com.personal.marketnote.reward.adapter.in.web.point.request.CancelPendingPointRequest;
+import com.personal.marketnote.reward.adapter.in.web.point.response.RegisterUserPointResponseSchema;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Operation(
+        summary = "(관리자) 적립 예정 포인트 취소",
+        description = """
+                작성일자: 2026-03-07
+
+                작성자: 성효빈
+
+                ---
+
+                ## Description
+
+                - 적립 예정 포인트를 취소(회수)합니다.
+
+                - sourceType과 sourceId로 취소 대상 적립 예정 포인트 이력을 식별합니다.
+
+                - 취소 시 적립 예정 포인트에서 차감되고, 실제 포인트는 변경되지 않습니다.
+
+                - 기존 pending 이력은 isReflected: true로 업데이트됩니다.
+
+                - 취소 대상 이력이 없으면 현재 포인트를 그대로 반환합니다 (멱등성 보장).
+
+                ---
+
+                ## Request
+
+                | **키** | **타입** | **설명** | **필수 여부** | **예시** |
+                | --- | --- | --- | --- | --- |
+                | userId (path) | number | 회원 ID | Y | 100 |
+                | sourceType | string | 출처 유형 | Y | "ORDER" |
+                | sourceId | number | 출처 ID (주문 ID) | Y | 123 |
+                | reason | string | 사유 | N | "결제 취소 적립 예정 포인트 회수" |
+
+                ---
+
+                ## Response
+
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | statusCode | number | HTTP 상태 코드 | 200 |
+                | code | string | 응답 코드 | "SUC01" |
+                | timestamp | string(datetime) | 응답 시간 | "2026-03-07T12:00:00.000" |
+                | content | object | 응답 본문 | { ... } |
+                | message | string | 처리 결과 | "적립 예정 포인트 취소 성공" |
+                """,
+        security = {@SecurityRequirement(name = "bearer")},
+        parameters = {
+                @Parameter(
+                        name = "userId",
+                        in = ParameterIn.PATH,
+                        required = true,
+                        description = "회원 ID",
+                        schema = @Schema(type = "number", example = "100")
+                )
+        },
+        requestBody = @RequestBody(
+                required = true,
+                content = @Content(
+                        schema = @Schema(implementation = CancelPendingPointRequest.class),
+                        examples = @ExampleObject("""
+                                {
+                                  "sourceType": "ORDER",
+                                  "sourceId": 123,
+                                  "reason": "결제 취소 적립 예정 포인트 회수"
+                                }
+                                """)
+                )
+        ),
+        responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "적립 예정 포인트 취소 성공",
+                        content = @Content(
+                                schema = @Schema(implementation = RegisterUserPointResponseSchema.class),
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 200,
+                                          "code": "SUC01",
+                                          "timestamp": "2026-03-07T12:00:00.000",
+                                          "content": {
+                                            "userId": 100,
+                                            "amount": 1000,
+                                            "addExpectedAmount": 0,
+                                            "expireExpectedAmount": 0,
+                                            "createdAt": "2026-03-07T11:00:00",
+                                            "modifiedAt": "2026-03-07T12:00:00"
+                                          },
+                                          "message": "적립 예정 포인트 취소 성공"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "400",
+                        description = "적립 예정 포인트 부족",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 400,
+                                          "code": "BAD_REQUEST",
+                                          "timestamp": "2026-03-07T12:00:00.000",
+                                          "content": null,
+                                          "message": "적립 예정 포인트가 부족합니다. 현재: 200, 요청: 500"
+                                        }
+                                        """)
+                        )
+                )
+        }
+)
+public @interface CancelPendingPointApiDocs {
+}

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/point/mapper/PointRequestToCommandMapper.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/point/mapper/PointRequestToCommandMapper.java
@@ -1,8 +1,10 @@
 package com.personal.marketnote.reward.adapter.in.web.point.mapper;
 
+import com.personal.marketnote.reward.adapter.in.web.point.request.CancelPendingPointRequest;
 import com.personal.marketnote.reward.adapter.in.web.point.request.ConfirmPendingPointRequest;
 import com.personal.marketnote.reward.adapter.in.web.point.request.ModifyPendingPointRequest;
 import com.personal.marketnote.reward.adapter.in.web.point.request.ModifyUserPointRequest;
+import com.personal.marketnote.reward.port.in.command.point.CancelPendingPointCommand;
 import com.personal.marketnote.reward.port.in.command.point.ConfirmPendingPointCommand;
 import com.personal.marketnote.reward.port.in.command.point.ModifyPendingPointCommand;
 import com.personal.marketnote.reward.port.in.command.point.ModifyUserPointCommand;
@@ -41,6 +43,18 @@ public class PointRequestToCommandMapper {
             ConfirmPendingPointRequest request
     ) {
         return ConfirmPendingPointCommand.builder()
+                .userId(userId)
+                .sourceType(request.getSourceType())
+                .sourceId(request.getSourceId())
+                .reason(request.getReason())
+                .build();
+    }
+
+    public static CancelPendingPointCommand mapToCancelPendingPointCommand(
+            Long userId,
+            CancelPendingPointRequest request
+    ) {
+        return CancelPendingPointCommand.builder()
                 .userId(userId)
                 .sourceType(request.getSourceType())
                 .sourceId(request.getSourceId())

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/point/request/CancelPendingPointRequest.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/point/request/CancelPendingPointRequest.java
@@ -1,0 +1,24 @@
+package com.personal.marketnote.reward.adapter.in.web.point.request;
+
+import com.personal.marketnote.reward.domain.point.UserPointSourceType;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class CancelPendingPointRequest {
+    @NotNull
+    private UserPointSourceType sourceType;
+
+    @NotNull
+    @Min(1)
+    private Long sourceId;
+
+    @Size(max = 500)
+    private String reason;
+}

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/command/point/CancelPendingPointCommand.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/command/point/CancelPendingPointCommand.java
@@ -1,0 +1,13 @@
+package com.personal.marketnote.reward.port.in.command.point;
+
+import com.personal.marketnote.reward.domain.point.UserPointSourceType;
+import lombok.Builder;
+
+@Builder
+public record CancelPendingPointCommand(
+        Long userId,
+        UserPointSourceType sourceType,
+        Long sourceId,
+        String reason
+) {
+}

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/usecase/point/CancelPendingPointUseCase.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/usecase/point/CancelPendingPointUseCase.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.reward.port.in.usecase.point;
+
+import com.personal.marketnote.reward.port.in.command.point.CancelPendingPointCommand;
+import com.personal.marketnote.reward.port.in.result.point.UpdateUserPointResult;
+
+public interface CancelPendingPointUseCase {
+    UpdateUserPointResult cancelPending(CancelPendingPointCommand command);
+}

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/service/point/CancelPendingPointService.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/service/point/CancelPendingPointService.java
@@ -1,0 +1,69 @@
+package com.personal.marketnote.reward.service.point;
+
+import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.reward.domain.exception.PendingPointReflectionMismatchException;
+import com.personal.marketnote.reward.domain.point.UserPoint;
+import com.personal.marketnote.reward.domain.point.UserPointHistory;
+import com.personal.marketnote.reward.port.in.command.point.CancelPendingPointCommand;
+import com.personal.marketnote.reward.port.in.result.point.UpdateUserPointResult;
+import com.personal.marketnote.reward.port.in.usecase.point.CancelPendingPointUseCase;
+import com.personal.marketnote.reward.port.in.usecase.point.GetUserPointUseCase;
+import com.personal.marketnote.reward.port.out.point.FindUserPointHistoryPort;
+import com.personal.marketnote.reward.port.out.point.UpdateUserPointHistoryPort;
+import com.personal.marketnote.reward.port.out.point.UpdateUserPointPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional(isolation = READ_COMMITTED)
+public class CancelPendingPointService implements CancelPendingPointUseCase {
+    private final GetUserPointUseCase getUserPointUseCase;
+    private final FindUserPointHistoryPort findUserPointHistoryPort;
+    private final UpdateUserPointPort updateUserPointPort;
+    private final UpdateUserPointHistoryPort updateUserPointHistoryPort;
+
+    @Override
+    public UpdateUserPointResult cancelPending(CancelPendingPointCommand command) {
+        List<UserPointHistory> pendingHistories = findUserPointHistoryPort.findUnreflectedByUserIdAndSource(
+                command.userId(), command.sourceType(), command.sourceId()
+        );
+
+        // 이미 취소 처리된 경우 현재 포인트를 그대로 반환 (멱등성 보장 - 결제 취소 재시도 대응)
+        if (pendingHistories.isEmpty()) {
+            UserPoint userPoint = getUserPointUseCase.getUserPoint(command.userId());
+            return UpdateUserPointResult.from(userPoint);
+        }
+
+        Long totalAmount = calculateTotalPendingAmount(pendingHistories);
+
+        UserPoint userPoint = getUserPointUseCase.getUserPoint(command.userId());
+        userPoint.deductPendingAmount(totalAmount);
+        UserPoint updatedPoint = updateUserPointPort.update(userPoint);
+
+        int updatedCount = updateUserPointHistoryPort.markAsReflected(
+                command.userId(), command.sourceType(), command.sourceId()
+        );
+        validateReflectionCount(pendingHistories.size(), updatedCount);
+
+        return UpdateUserPointResult.from(updatedPoint);
+    }
+
+    private Long calculateTotalPendingAmount(List<UserPointHistory> pendingHistories) {
+        long total = 0L;
+        for (UserPointHistory history : pendingHistories) {
+            total = Math.addExact(total, history.getAmount());
+        }
+        return total;
+    }
+
+    private void validateReflectionCount(int expectedCount, int actualCount) {
+        if (expectedCount != actualCount) {
+            throw new PendingPointReflectionMismatchException(expectedCount, actualCount);
+        }
+    }
+}


### PR DESCRIPTION
## partially addresses #216
## resolves #1083

## Task
- CancelPendingPointUseCase / CancelPendingPointService 구현
- POST /{userId}/points/pending/cancel 엔드포인트 추가 (reward-service)
- ModifyUserPointPort.revokePendingPoints 메서드 추가 (commerce-service)
- RewardServiceClient.revokePendingPoints 구현
- CancelPaymentService에서 전액 취소 시 적립 예정 포인트 회수 호출