### PR TITLE
[#216][#1084] feat: 결제 취소 시 공유 적립 예정 포인트 회수 기능 추가

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/web/reward/RewardServiceClient.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/web/reward/RewardServiceClient.java
@@ -161,6 +161,30 @@ public class RewardServiceClient implements ModifyUserPointPort {
     }
 
     @Override
+    public void revokePendingSharedPurchasePoints(List<Long> sharerIds, Long orderId) {
+        if (FormatValidator.hasNoValue(sharerIds) || FormatValidator.hasNoValue(orderId)) {
+            return;
+        }
+
+        sharerIds.stream()
+                .filter(Objects::nonNull)
+                .distinct()
+                .forEach(sharerId -> revokeSharerPendingPoint(sharerId, orderId));
+    }
+
+    private void revokeSharerPendingPoint(Long sharerId, Long orderId) {
+        URI uri = buildPendingPointCancelUri(sharerId);
+        HttpHeaders headers = buildHeaders();
+
+        CancelPendingPointRequest request = new CancelPendingPointRequest(
+                SOURCE_TYPE_ORDER, orderId, PENDING_POINT_CANCEL_REASON
+        );
+        HttpEntity<CancelPendingPointRequest> httpEntity = new HttpEntity<>(request, headers);
+
+        sendRequestWithRetry(uri, httpEntity, HttpMethod.POST, sharerId, "공유 적립 예정 포인트 취소");
+    }
+
+    @Override
     public void addPendingSharedPurchasePoints(List<Long> sharerIds, Long totalAmount, Long orderId) {
         if (FormatValidator.hasNoValue(sharerIds) || FormatValidator.hasNoValue(totalAmount)) {
             return;

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/reward/ModifyUserPointPort.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/reward/ModifyUserPointPort.java
@@ -76,4 +76,13 @@ public interface ModifyUserPointPort {
      * @Description 결제 취소 시 적립 예정 포인트를 회수(취소)합니다.
      */
     void revokePendingPoints(Long userId, Long orderId);
+
+    /**
+     * @param sharerIds 공유자 ID 목록
+     * @param orderId   주문 ID (sourceId)
+     * @Date 2026-03-07
+     * @Author 성효빈
+     * @Description 결제 취소 시 공유자들의 적립 예정 포인트를 회수(취소)합니다.
+     */
+    void revokePendingSharedPurchasePoints(List<Long> sharerIds, Long orderId);
 }

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/CancelPaymentService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/CancelPaymentService.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.commerce.service.payment;
 
 import com.personal.marketnote.commerce.domain.order.Order;
+import com.personal.marketnote.commerce.domain.order.OrderProduct;
 import com.personal.marketnote.commerce.domain.order.OrderStatus;
 import com.personal.marketnote.commerce.domain.payment.Payment;
 import com.personal.marketnote.commerce.domain.payment.PspPaymentEvent;
@@ -26,6 +27,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 
 import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
@@ -99,6 +102,7 @@ public class CancelPaymentService implements CancelPaymentUseCase {
             restoreInventory(order);
             refundPoints(order);
             revokePendingProductAccumulationPoints(order);
+            revokePendingSharedPurchasePoints(order);
         }
 
         recordLedgerEntryForCancellation(payment, isFullCancel, cancelAmount, alreadyRefunded);
@@ -223,6 +227,28 @@ public class CancelPaymentService implements CancelPaymentUseCase {
             log.error("상품 적립 예정 포인트 회수 실패 - orderId: {}, buyerId: {}, error: {}",
                     order.getId(), order.getBuyerId(), e.getMessage(), e);
         }
+    }
+
+    private void revokePendingSharedPurchasePoints(Order order) {
+        List<Long> sharerIds = extractSharerIds(order);
+        if (sharerIds.isEmpty()) {
+            return;
+        }
+
+        try {
+            modifyUserPointPort.revokePendingSharedPurchasePoints(sharerIds, order.getId());
+        } catch (Exception e) {
+            log.error("공유 적립 예정 포인트 회수 실패 - orderId: {}, sharerIds: {}, error: {}",
+                    order.getId(), sharerIds, e.getMessage(), e);
+        }
+    }
+
+    private List<Long> extractSharerIds(Order order) {
+        return order.getOrderProducts().stream()
+                .map(OrderProduct::getSharerId)
+                .filter(Objects::nonNull)
+                .distinct()
+                .toList();
     }
 
     private void refundPoints(Order order) {


### PR DESCRIPTION
## partially addresses #216
## resolves #1084

## Task
- [x] ModifyUserPointPort에 revokePendingSharedPurchasePoints 메서드 추가
- [x] RewardServiceClient에 공유자별 cancel API 순회 호출 구현 (기존 buildPendingPointCancelUri, sendRequestWithRetry 재사용)
- [x] CancelPaymentService isFullCancel 블록에서 공유 적립 예정 포인트 회수 호출 추가 (fire-and-forget try-catch)
- [x] 공유자가 없으면 조기 반환, distinct()로 중복 공유자 제거