### PR TITLE
[#216][#1115] test: 결제 취소 시 공유 적립 예정 포인트 회수 기능 자동화 테스트 추가

### DIFF
--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/payment/CancelPaymentUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/payment/CancelPaymentUseCaseTest.java
@@ -28,6 +28,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -778,6 +779,92 @@ class CancelPaymentUseCaseTest {
         }
     }
 
+    @Nested
+    @DisplayName("공유 적립 예정 포인트 회수 검증")
+    class SharedPurchasePointRevokeTest {
+
+        @Test
+        @DisplayName("전체 취소 시 공유자가 있으면 공유 적립 예정 포인트 회수가 호출된다")
+        void shouldRevokeSharedPendingPointsOnFullCancelWithSharers() {
+            Payment payment = createSuccessPayment(1L, ORDER_KEY, 50000L, "tno_123");
+            PspPaymentEvent event = createCompleteEvent(ORDER_KEY_STR, "tno_123", 50000L);
+            CancelPaymentCommand command = createFullCancelCommand(ORDER_KEY_STR);
+            PaymentCancelVendorResult vendorResult = createSuccessVendorResult();
+            Order order = createOrderWithSharers(1L, BUYER_ID, 0L, List.of(200L, 300L));
+
+            when(findPaymentPort.findByOrderKey(ORDER_KEY)).thenReturn(Optional.of(payment));
+            when(findOrderPort.findById(1L)).thenReturn(Optional.of(order));
+            when(findPspPaymentEventPort.findByOrderKey(ORDER_KEY_STR)).thenReturn(Optional.of(event));
+            when(paymentVendorPort.cancelPayment(any())).thenReturn(vendorResult);
+
+            cancelPaymentService.cancel(command);
+
+            verify(modifyUserPointPort).revokePendingSharedPurchasePoints(
+                    eq(List.of(200L, 300L)), eq(1L)
+            );
+        }
+
+        @Test
+        @DisplayName("전체 취소 시 공유자가 없으면 공유 적립 예정 포인트 회수가 호출되지 않는다")
+        void shouldNotRevokeSharedPendingPointsWhenNoSharers() {
+            Payment payment = createSuccessPayment(1L, ORDER_KEY, 50000L, "tno_123");
+            PspPaymentEvent event = createCompleteEvent(ORDER_KEY_STR, "tno_123", 50000L);
+            CancelPaymentCommand command = createFullCancelCommand(ORDER_KEY_STR);
+            PaymentCancelVendorResult vendorResult = createSuccessVendorResult();
+
+            when(findPaymentPort.findByOrderKey(ORDER_KEY)).thenReturn(Optional.of(payment));
+            when(findOrderPort.findById(1L)).thenReturn(Optional.of(createOrder(1L, BUYER_ID)));
+            when(findPspPaymentEventPort.findByOrderKey(ORDER_KEY_STR)).thenReturn(Optional.of(event));
+            when(paymentVendorPort.cancelPayment(any())).thenReturn(vendorResult);
+
+            cancelPaymentService.cancel(command);
+
+            verify(modifyUserPointPort, never()).revokePendingSharedPurchasePoints(anyList(), anyLong());
+        }
+
+        @Test
+        @DisplayName("부분 취소 시 공유 적립 예정 포인트 회수가 호출되지 않는다")
+        void shouldNotRevokeSharedPendingPointsOnPartialCancel() {
+            Payment payment = createSuccessPayment(1L, ORDER_KEY, 50000L, "tno_123");
+            PspPaymentEvent event = createCompleteEvent(ORDER_KEY_STR, "tno_123", 50000L);
+            CancelPaymentCommand command = createPartialCancelCommand(ORDER_KEY_STR, 20000L);
+            PaymentCancelVendorResult vendorResult = createSuccessVendorResult();
+            Order order = createOrderWithSharers(1L, BUYER_ID, 0L, List.of(200L));
+
+            when(findPaymentPort.findByOrderKey(ORDER_KEY)).thenReturn(Optional.of(payment));
+            when(findOrderPort.findById(1L)).thenReturn(Optional.of(order));
+            when(findPspPaymentEventPort.findByOrderKey(ORDER_KEY_STR)).thenReturn(Optional.of(event));
+            when(paymentVendorPort.cancelPayment(any())).thenReturn(vendorResult);
+
+            cancelPaymentService.cancel(command);
+
+            verify(modifyUserPointPort, never()).revokePendingSharedPurchasePoints(anyList(), anyLong());
+        }
+
+        @Test
+        @DisplayName("공유 적립 예정 포인트 회수 실패 시에도 결제 취소는 정상 완료된다")
+        void shouldCompleteCancelEvenWhenSharedPointRevokeFails() {
+            Payment payment = createSuccessPayment(1L, ORDER_KEY, 50000L, "tno_123");
+            PspPaymentEvent event = createCompleteEvent(ORDER_KEY_STR, "tno_123", 50000L);
+            CancelPaymentCommand command = createFullCancelCommand(ORDER_KEY_STR);
+            PaymentCancelVendorResult vendorResult = createSuccessVendorResult();
+            Order order = createOrderWithSharers(1L, BUYER_ID, 0L, List.of(200L));
+
+            when(findPaymentPort.findByOrderKey(ORDER_KEY)).thenReturn(Optional.of(payment));
+            when(findOrderPort.findById(1L)).thenReturn(Optional.of(order));
+            when(findPspPaymentEventPort.findByOrderKey(ORDER_KEY_STR)).thenReturn(Optional.of(event));
+            when(paymentVendorPort.cancelPayment(any())).thenReturn(vendorResult);
+            doThrow(new RuntimeException("공유 포인트 회수 실패")).when(modifyUserPointPort)
+                    .revokePendingSharedPurchasePoints(anyList(), anyLong());
+
+            cancelPaymentService.cancel(command);
+
+            verify(updatePaymentPort).update(any());
+            verify(updatePspPaymentEventPort).update(any());
+            verify(changeOrderStatusUseCase).changeOrderStatus(any());
+        }
+    }
+
     private Payment createSuccessPayment(Long orderId, UUID orderKey, Long amount, String pgPaymentKey) {
         PaymentCreateState state = PaymentCreateState.builder()
                 .orderId(orderId)
@@ -825,6 +912,29 @@ class CancelPaymentUseCaseTest {
                 .totalAmount(50000L)
                 .pointAmount(pointAmount)
                 .orderProductStates(List.of(productState))
+                .build();
+        return Order.from(state);
+    }
+
+    private Order createOrderWithSharers(Long orderId, Long buyerId, Long pointAmount, List<Long> sharerIds) {
+        List<OrderProductSnapshotState> productStates = new ArrayList<>();
+        for (int i = 0; i < sharerIds.size(); i++) {
+            productStates.add(OrderProductSnapshotState.builder()
+                    .pricePolicyId(100L + i)
+                    .quantity(1)
+                    .sellerId(10L)
+                    .unitAmount(25000L)
+                    .sharerId(sharerIds.get(i))
+                    .build());
+        }
+        OrderSnapshotState state = OrderSnapshotState.builder()
+                .id(orderId)
+                .buyerId(buyerId)
+                .orderKey(ORDER_KEY)
+                .orderStatus(OrderStatus.PAID)
+                .totalAmount(50000L)
+                .pointAmount(pointAmount)
+                .orderProductStates(productStates)
                 .build();
         return Order.from(state);
     }


### PR DESCRIPTION
## partially addresses #216
## resolves #1115

## Test Case
- [x] 전체 취소 시 공유자가 있으면 공유 적립 예정 포인트 회수가 호출된다
- [x] 전체 취소 시 공유자가 없으면 공유 적립 예정 포인트 회수가 호출되지 않는다
- [x] 부분 취소 시 공유 적립 예정 포인트 회수가 호출되지 않는다
- [x] 공유 적립 예정 포인트 회수 실패 시에도 결제 취소는 정상 완료된다