### PR TITLE
[#300][#1145] fix: Clock 빈 누락으로 인한 커뮤니티 서비스 기동 실패 버그 픽스

### DIFF
--- a/community-service/community-adapters/src/main/java/com/personal/marketnote/community/configuration/CommonConfig.java
+++ b/community-service/community-adapters/src/main/java/com/personal/marketnote/community/configuration/CommonConfig.java
@@ -4,8 +4,12 @@ import com.personal.marketnote.common.application.aop.LoggingAspect;
 import com.personal.marketnote.common.configuration.security.OpaqueTokenIntrospectorConfig;
 import com.personal.marketnote.common.configuration.security.OpaqueTokenIntrospectorProvider;
 import com.personal.marketnote.common.domain.exception.GlobalExceptionHandler;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+
+import java.time.Clock;
+import java.time.ZoneId;
 
 @Configuration
 @Import({
@@ -15,4 +19,9 @@ import org.springframework.context.annotation.Import;
         OpaqueTokenIntrospectorProvider.class
 })
 public class CommonConfig {
+
+    @Bean
+    public Clock communityClock() {
+        return Clock.system(ZoneId.of("Asia/Seoul"));
+    }
 }


### PR DESCRIPTION
## partially addresses #300
## resolves #1145

## Task
- [x] community-service CommonConfig에 communityClock() 빈 추가