### PR TITLE
[#43][#1146] fix: Clock 빈 누락으로 인한 회원 서비스 기동 실패 사전 방지

### DIFF
--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/configuration/CommonConfig.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/configuration/CommonConfig.java
@@ -2,10 +2,19 @@ package com.personal.marketnote.user.configuration;
 
 import com.personal.marketnote.common.application.aop.LoggingAspect;
 import com.personal.marketnote.common.domain.exception.GlobalExceptionHandler;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+
+import java.time.Clock;
+import java.time.ZoneId;
 
 @Configuration
 @Import({LoggingAspect.class, GlobalExceptionHandler.class})
 public class CommonConfig {
+
+    @Bean
+    public Clock userClock() {
+        return Clock.system(ZoneId.of("Asia/Seoul"));
+    }
 }


### PR DESCRIPTION
## partially addresses #43
## resolves #1146

## Task
- [x] user-service CommonConfig에 userClock() 빈 추가