### PR TITLE
[#216][#1089] feat: 부분 결제 취소 시 상품 구매 적립 예정 포인트 반환 기능 추가

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/web/reward/RewardServiceClient.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/web/reward/RewardServiceClient.java
@@ -33,6 +33,7 @@ public class RewardServiceClient implements ModifyUserPointPort {
     private static final String PRODUCT_ACCUMULATION_REASON = "상품 구매 적립";
     private static final String PENDING_POINT_CONFIRM_REASON = "구매 확정 포인트 적립";
     private static final String PENDING_POINT_CANCEL_REASON = "결제 취소 적립 예정 포인트 회수";
+    private static final String PARTIAL_CANCEL_PRODUCT_ACCUMULATION_REASON = "부분 결제 취소 상품 적립 포인트 차감";
 
     @Value("${reward-service.base-url}")
     private String rewardServiceBaseUrl;
@@ -158,6 +159,23 @@ public class RewardServiceClient implements ModifyUserPointPort {
         HttpEntity<CancelPendingPointRequest> httpEntity = new HttpEntity<>(request, headers);
 
         sendRequestWithRetry(uri, httpEntity, HttpMethod.POST, userId, "적립 예정 포인트 취소");
+    }
+
+    @Override
+    public void reducePartialPendingPoints(Long userId, Long amount, Long orderId) {
+        if (FormatValidator.hasNoValue(amount) || amount <= 0) {
+            return;
+        }
+
+        URI uri = buildPendingPointUri(userId);
+        HttpHeaders headers = buildHeaders();
+
+        ModifyUserPointRequest request = ModifyUserPointRequest.pendingDeduction(
+                amount, orderId, PARTIAL_CANCEL_PRODUCT_ACCUMULATION_REASON
+        );
+        HttpEntity<ModifyUserPointRequest> httpEntity = new HttpEntity<>(request, headers);
+
+        sendRequestWithRetry(uri, httpEntity, HttpMethod.PATCH, userId, "부분 취소 적립 예정 포인트 차감");
     }
 
     @Override
@@ -337,6 +355,16 @@ public class RewardServiceClient implements ModifyUserPointPort {
         private static ModifyUserPointRequest pendingAccrual(long amount, Long orderId, String reason) {
             return new ModifyUserPointRequest(
                     CHANGE_TYPE_ACCRUAL,
+                    Math.abs(amount),
+                    SOURCE_TYPE_ORDER,
+                    orderId,
+                    reason
+            );
+        }
+
+        private static ModifyUserPointRequest pendingDeduction(long amount, Long orderId, String reason) {
+            return new ModifyUserPointRequest(
+                    CHANGE_TYPE_DEDUCTION,
                     Math.abs(amount),
                     SOURCE_TYPE_ORDER,
                     orderId,

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/reward/ModifyUserPointPort.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/reward/ModifyUserPointPort.java
@@ -85,4 +85,14 @@ public interface ModifyUserPointPort {
      * @Description 결제 취소 시 공유자들의 적립 예정 포인트를 회수(취소)합니다.
      */
     void revokePendingSharedPurchasePoints(List<Long> sharerIds, Long orderId);
+
+    /**
+     * @param userId  회원 ID
+     * @param amount  차감할 적립 예정 포인트
+     * @param orderId 주문 ID (sourceId)
+     * @Date 2026-03-07
+     * @Author 성효빈
+     * @Description 부분 결제 취소 시 취소 금액에 비례한 적립 예정 포인트를 차감합니다.
+     */
+    void reducePartialPendingPoints(Long userId, Long amount, Long orderId);
 }

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/CancelPaymentService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/CancelPaymentService.java
@@ -19,15 +19,20 @@ import com.personal.marketnote.commerce.port.out.order.FindOrderPort;
 import com.personal.marketnote.commerce.port.out.payment.*;
 import com.personal.marketnote.commerce.port.out.payment.vendor.PaymentCancelVendorCommand;
 import com.personal.marketnote.commerce.port.out.payment.vendor.PaymentCancelVendorResult;
+import com.personal.marketnote.commerce.port.out.product.FindProductByPricePolicyPort;
 import com.personal.marketnote.commerce.port.out.refund.SaveRefundPort;
+import com.personal.marketnote.commerce.port.out.result.product.ProductInfoResult;
 import com.personal.marketnote.commerce.port.out.reward.ModifyUserPointPort;
 import com.personal.marketnote.common.application.UseCase;
 import com.personal.marketnote.common.utility.FormatValidator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
 
@@ -52,6 +57,7 @@ public class CancelPaymentService implements CancelPaymentUseCase {
     private final RestoreProductInventoryUseCase restoreProductInventoryUseCase;
     private final ModifyUserPointPort modifyUserPointPort;
     private final SaveRefundPort saveRefundPort;
+    private final FindProductByPricePolicyPort findProductByPricePolicyPort;
 
     @Override
     public void cancel(CancelPaymentCommand command) {
@@ -103,6 +109,13 @@ public class CancelPaymentService implements CancelPaymentUseCase {
             refundPoints(order);
             revokePendingProductAccumulationPoints(order);
             revokePendingSharedPurchasePoints(order);
+        } else {
+            Long buyerId = order.getBuyerId();
+            Long orderId = order.getId();
+            List<OrderProduct> orderProducts = order.getOrderProducts();
+            Long paymentAmount = payment.getPaymentAmount();
+            runAfterCommit(() -> reducePartialPendingProductAccumulationPoints(
+                    buyerId, orderId, orderProducts, paymentAmount, cancelAmount));
         }
 
         recordLedgerEntryForCancellation(payment, isFullCancel, cancelAmount, alreadyRefunded);
@@ -249,6 +262,70 @@ public class CancelPaymentService implements CancelPaymentUseCase {
                 .filter(Objects::nonNull)
                 .distinct()
                 .toList();
+    }
+
+    private void reducePartialPendingProductAccumulationPoints(
+            Long buyerId, Long orderId, List<OrderProduct> orderProducts, Long paymentAmount, Long cancelAmount
+    ) {
+        try {
+            Long totalAccumulatedPoint = calculateTotalAccumulatedPoint(orderProducts);
+            if (FormatValidator.hasNoValue(totalAccumulatedPoint) || totalAccumulatedPoint <= 0) {
+                return;
+            }
+
+            Long proportionalPoint = calculateProportionalPoint(cancelAmount, paymentAmount, totalAccumulatedPoint);
+            if (proportionalPoint <= 0) {
+                return;
+            }
+
+            modifyUserPointPort.reducePartialPendingPoints(buyerId, proportionalPoint, orderId);
+        } catch (Exception e) {
+            log.error("부분 취소 상품 적립 예정 포인트 차감 실패 - orderId: {}, buyerId: {}, error: {}",
+                    orderId, buyerId, e.getMessage(), e);
+        }
+    }
+
+    private Long calculateTotalAccumulatedPoint(List<OrderProduct> orderProducts) {
+        List<Long> pricePolicyIds = orderProducts.stream()
+                .map(OrderProduct::getPricePolicyId)
+                .toList();
+        Map<Long, ProductInfoResult> productInfoMap = findProductByPricePolicyPort.findByPricePolicyIds(pricePolicyIds);
+
+        long total = 0L;
+        for (OrderProduct orderProduct : orderProducts) {
+            ProductInfoResult productInfo = productInfoMap.get(orderProduct.getPricePolicyId());
+            if (FormatValidator.hasNoValue(productInfo)) {
+                log.warn("상품 정보 조회 누락 - pricePolicyId: {}", orderProduct.getPricePolicyId());
+                continue;
+            }
+            if (FormatValidator.hasNoValue(productInfo.accumulatedPoint())) {
+                continue;
+            }
+            total = Math.addExact(total, Math.multiplyExact(productInfo.accumulatedPoint(), orderProduct.getQuantity()));
+        }
+        return total;
+    }
+
+    private Long calculateProportionalPoint(Long cancelAmount, Long paymentAmount, Long totalPoint) {
+        if (FormatValidator.hasNoValue(paymentAmount) || paymentAmount <= 0) {
+            return 0L;
+        }
+        long numerator = Math.multiplyExact(cancelAmount, totalPoint);
+        return (numerator + paymentAmount / 2) / paymentAmount;
+    }
+
+    private void runAfterCommit(Runnable action) {
+        if (TransactionSynchronizationManager.isActualTransactionActive()) {
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCommit() {
+                    action.run();
+                }
+            });
+            return;
+        }
+
+        action.run();
     }
 
     private void refundPoints(Order order) {


### PR DESCRIPTION
## partially addresses #216
## resolves #1089

## Task
- ModifyUserPointPort에 reducePartialPendingPoints 메서드 추가
- RewardServiceClient에 기존 DEDUCTION API 재사용한 구현 추가
- CancelPaymentService 부분 취소 분기에 비례 포인트 차감 로직 추가
- runAfterCommit 패턴으로 트랜잭션 커밋 후 외부 서비스 호출
- 정수 비례 계산으로 부동소수점 정밀도 손실 방지