### PR TITLE
[#216][#1090] feat: 부분 결제 취소 시 링크 공유 적립 예정 포인트 반환 기능 추가

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/web/reward/RewardServiceClient.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/web/reward/RewardServiceClient.java
@@ -34,6 +34,7 @@ public class RewardServiceClient implements ModifyUserPointPort {
     private static final String PENDING_POINT_CONFIRM_REASON = "구매 확정 포인트 적립";
     private static final String PENDING_POINT_CANCEL_REASON = "결제 취소 적립 예정 포인트 회수";
     private static final String PARTIAL_CANCEL_PRODUCT_ACCUMULATION_REASON = "부분 결제 취소 상품 적립 포인트 차감";
+    private static final String PARTIAL_CANCEL_SHARED_PURCHASE_REASON = "부분 결제 취소 링크 공유 적립 포인트 차감";
 
     @Value("${reward-service.base-url}")
     private String rewardServiceBaseUrl;
@@ -176,6 +177,43 @@ public class RewardServiceClient implements ModifyUserPointPort {
         HttpEntity<ModifyUserPointRequest> httpEntity = new HttpEntity<>(request, headers);
 
         sendRequestWithRetry(uri, httpEntity, HttpMethod.PATCH, userId, "부분 취소 적립 예정 포인트 차감");
+    }
+
+    @Override
+    public void reducePartialPendingSharedPurchasePoints(List<Long> sharerIds, Long paymentAmount, Long cancelAmount, Long orderId) {
+        if (FormatValidator.hasNoValue(sharerIds)
+                || FormatValidator.hasNoValue(paymentAmount) || paymentAmount <= 0
+                || FormatValidator.hasNoValue(cancelAmount) || cancelAmount <= 0) {
+            return;
+        }
+
+        long originalSharePoint = Math.round(paymentAmount * sharePointRate);
+        if (originalSharePoint <= 0) {
+            return;
+        }
+
+        long numerator = Math.multiplyExact(cancelAmount, originalSharePoint);
+        long proportionalPoint = (numerator + paymentAmount / 2) / paymentAmount;
+        if (proportionalPoint <= 0) {
+            return;
+        }
+
+        sharerIds.stream()
+                .filter(Objects::nonNull)
+                .distinct()
+                .forEach(sharerId -> reduceSharerPartialPendingPoint(sharerId, proportionalPoint, orderId));
+    }
+
+    private void reduceSharerPartialPendingPoint(Long sharerId, Long amount, Long orderId) {
+        URI uri = buildPendingPointUri(sharerId);
+        HttpHeaders headers = buildHeaders();
+
+        ModifyUserPointRequest request = ModifyUserPointRequest.pendingDeduction(
+                amount, orderId, PARTIAL_CANCEL_SHARED_PURCHASE_REASON
+        );
+        HttpEntity<ModifyUserPointRequest> httpEntity = new HttpEntity<>(request, headers);
+
+        sendRequestWithRetry(uri, httpEntity, HttpMethod.PATCH, sharerId, "부분 취소 공유 적립 예정 포인트 차감");
     }
 
     @Override

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/reward/ModifyUserPointPort.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/reward/ModifyUserPointPort.java
@@ -95,4 +95,15 @@ public interface ModifyUserPointPort {
      * @Description 부분 결제 취소 시 취소 금액에 비례한 적립 예정 포인트를 차감합니다.
      */
     void reducePartialPendingPoints(Long userId, Long amount, Long orderId);
+
+    /**
+     * @param sharerIds     공유자 ID 목록
+     * @param paymentAmount 원 결제 금액
+     * @param cancelAmount  부분 취소 금액
+     * @param orderId       주문 ID (sourceId)
+     * @Date 2026-03-07
+     * @Author 성효빈
+     * @Description 부분 결제 취소 시 공유자들의 적립 예정 포인트를 취소 금액에 비례하여 차감합니다.
+     */
+    void reducePartialPendingSharedPurchasePoints(List<Long> sharerIds, Long paymentAmount, Long cancelAmount, Long orderId);
 }

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/CancelPaymentService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/CancelPaymentService.java
@@ -116,6 +116,8 @@ public class CancelPaymentService implements CancelPaymentUseCase {
             Long paymentAmount = payment.getPaymentAmount();
             runAfterCommit(() -> reducePartialPendingProductAccumulationPoints(
                     buyerId, orderId, orderProducts, paymentAmount, cancelAmount));
+            runAfterCommit(() -> reducePartialPendingSharedPurchasePoints(
+                    order, paymentAmount, cancelAmount));
         }
 
         recordLedgerEntryForCancellation(payment, isFullCancel, cancelAmount, alreadyRefunded);
@@ -262,6 +264,21 @@ public class CancelPaymentService implements CancelPaymentUseCase {
                 .filter(Objects::nonNull)
                 .distinct()
                 .toList();
+    }
+
+    private void reducePartialPendingSharedPurchasePoints(Order order, Long paymentAmount, Long cancelAmount) {
+        List<Long> sharerIds = extractSharerIds(order);
+        if (sharerIds.isEmpty()) {
+            return;
+        }
+
+        try {
+            modifyUserPointPort.reducePartialPendingSharedPurchasePoints(
+                    sharerIds, paymentAmount, cancelAmount, order.getId());
+        } catch (Exception e) {
+            log.error("부분 취소 공유 적립 예정 포인트 차감 실패 - orderId: {}, sharerIds: {}, error: {}",
+                    order.getId(), sharerIds, e.getMessage(), e);
+        }
     }
 
     private void reducePartialPendingProductAccumulationPoints(


### PR DESCRIPTION
## partially addresses #216
## resolves #1090

## Task
- [x] ModifyUserPointPort에 reducePartialPendingSharedPurchasePoints 메서드 추가
- [x] RewardServiceClient에 공유자별 비례 포인트 차감 구현
- [x] CancelPaymentService 부분 취소 분기에 runAfterCommit 호출 추가