### PR TITLE
[#216][#1085] feat: 부분 결제 취소 시 재고 복구 기능 추가

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/payment/mapper/PaymentRequestToCommandMapper.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/payment/mapper/PaymentRequestToCommandMapper.java
@@ -6,6 +6,9 @@ import com.personal.marketnote.commerce.adapter.in.web.payment.request.ReadyPaym
 import com.personal.marketnote.commerce.port.in.command.payment.ApprovePaymentCommand;
 import com.personal.marketnote.commerce.port.in.command.payment.CancelPaymentCommand;
 import com.personal.marketnote.commerce.port.in.command.payment.ReadyPaymentCommand;
+import com.personal.marketnote.common.utility.FormatValidator;
+
+import java.util.List;
 
 public class PaymentRequestToCommandMapper {
     private PaymentRequestToCommandMapper() {
@@ -31,12 +34,20 @@ public class PaymentRequestToCommandMapper {
     }
 
     public static CancelPaymentCommand mapToCommand(String orderKey, CancelPaymentRequest request, Long buyerId) {
+        List<CancelPaymentCommand.CancelProductItem> cancelProducts = FormatValidator.hasValue(request.getCancelProducts())
+                ? request.getCancelProducts().stream()
+                        .map(item -> new CancelPaymentCommand.CancelProductItem(
+                                item.getPricePolicyId(), item.getQuantity()))
+                        .toList()
+                : null;
+
         return CancelPaymentCommand.builder()
                 .buyerId(buyerId)
                 .orderKey(orderKey)
                 .cancelType(request.getCancelType())
                 .cancelAmount(request.getCancelAmount())
                 .cancelReason(request.getCancelReason())
+                .cancelProducts(cancelProducts)
                 .build();
     }
 }

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/payment/request/CancelPaymentRequest.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/payment/request/CancelPaymentRequest.java
@@ -2,8 +2,12 @@ package com.personal.marketnote.commerce.adapter.in.web.payment.request;
 
 import com.personal.marketnote.commerce.port.in.command.payment.CancelPaymentCommand;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
+
+import java.util.List;
 
 @Getter
 public class CancelPaymentRequest {
@@ -16,4 +20,22 @@ public class CancelPaymentRequest {
 
     @Schema(name = "cancelReason", description = "취소 사유", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private String cancelReason;
+
+    @Schema(name = "cancelProducts", description = "취소 대상 상품 목록 (부분취소 시 재고 복구용, 선택)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @Valid
+    private List<CancelProductItemRequest> cancelProducts;
+
+    @Getter
+    public static class CancelProductItemRequest {
+        @Schema(description = "가격 정책 ID", requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotNull(message = "가격 정책 ID는 필수입니다")
+        @Min(1)
+        private Long pricePolicyId;
+
+        @Schema(description = "취소 수량", requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotNull(message = "취소 수량은 필수입니다")
+        @Min(1)
+        private Integer quantity;
+    }
 }
+

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/exception/InvalidCancelProductException.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/exception/InvalidCancelProductException.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.commerce.exception;
+
+public class InvalidCancelProductException extends IllegalArgumentException {
+    public InvalidCancelProductException(String message) {
+        super(message);
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/command/payment/CancelPaymentCommand.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/command/payment/CancelPaymentCommand.java
@@ -1,6 +1,9 @@
 package com.personal.marketnote.commerce.port.in.command.payment;
 
+import com.personal.marketnote.common.utility.FormatValidator;
 import lombok.Builder;
+
+import java.util.List;
 
 @Builder
 public record CancelPaymentCommand(
@@ -8,13 +11,24 @@ public record CancelPaymentCommand(
         String orderKey,
         CancelType cancelType,
         Long cancelAmount,
-        String cancelReason
+        String cancelReason,
+        List<CancelProductItem> cancelProducts
 ) {
     public enum CancelType {
         FULL, PARTIAL
     }
 
+    public record CancelProductItem(
+            Long pricePolicyId,
+            Integer quantity
+    ) {
+    }
+
     public boolean isFullCancel() {
         return cancelType == CancelType.FULL;
+    }
+
+    public boolean hasCancelProducts() {
+        return FormatValidator.hasValue(cancelProducts) && !cancelProducts.isEmpty();
     }
 }

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/CancelPaymentService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/CancelPaymentService.java
@@ -8,6 +8,7 @@ import com.personal.marketnote.commerce.domain.payment.PspPaymentEvent;
 import com.personal.marketnote.commerce.domain.refund.Refund;
 import com.personal.marketnote.commerce.domain.refund.RefundCreateState;
 import com.personal.marketnote.commerce.domain.refund.RefundType;
+import com.personal.marketnote.commerce.domain.order.OrderProductSnapshotState;
 import com.personal.marketnote.commerce.exception.*;
 import com.personal.marketnote.commerce.port.in.command.order.ChangeOrderStatusCommand;
 import com.personal.marketnote.commerce.port.in.command.payment.CancelPaymentCommand;
@@ -35,6 +36,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
 
@@ -82,6 +84,10 @@ public class CancelPaymentService implements CancelPaymentUseCase {
         Long cancelAmount = computeCancelAmount(isFullCancel, command.cancelAmount(), refundableAmount);
         Long remainAmount = refundableAmount - cancelAmount;
 
+        if (!isFullCancel && command.hasCancelProducts()) {
+            validateCancelProducts(order, command.cancelProducts());
+        }
+
         PaymentCancelVendorResult vendorResult = requestPaymentCancellationToPsp(
                 transactionNumber, modType, cancelAmount, remainAmount, command.cancelReason()
         );
@@ -110,6 +116,7 @@ public class CancelPaymentService implements CancelPaymentUseCase {
             revokePendingProductAccumulationPoints(order);
             revokePendingSharedPurchasePoints(order);
         } else {
+            restorePartialCancelInventory(order, command);
             Long buyerId = order.getBuyerId();
             Long orderId = order.getId();
             List<OrderProduct> orderProducts = order.getOrderProducts();
@@ -232,6 +239,57 @@ public class CancelPaymentService implements CancelPaymentUseCase {
         } catch (Exception e) {
             log.error("재고 복구 실패 - orderId: {}, error: {}",
                     order.getId(), e.getMessage(), e);
+        }
+    }
+
+    private void restorePartialCancelInventory(Order order, CancelPaymentCommand command) {
+        if (!command.hasCancelProducts()) {
+            return;
+        }
+
+        try {
+            List<OrderProduct> cancelTargetProducts = command.cancelProducts().stream()
+                    .map(item -> OrderProduct.from(
+                            OrderProductSnapshotState.builder()
+                                    .pricePolicyId(item.pricePolicyId())
+                                    .quantity(item.quantity())
+                                    .build()
+                    ))
+                    .toList();
+            restoreProductInventoryUseCase.restore(cancelTargetProducts, "주문 부분 취소에 의한 재고 복구");
+        } catch (Exception e) {
+            log.error("부분 취소 재고 복구 실패 - orderId: {}, error: {}",
+                    order.getId(), e.getMessage(), e);
+        }
+    }
+
+    private void validateCancelProducts(Order order, List<CancelPaymentCommand.CancelProductItem> cancelProducts) {
+        long distinctCount = cancelProducts.stream()
+                .map(CancelPaymentCommand.CancelProductItem::pricePolicyId)
+                .distinct()
+                .count();
+        if (distinctCount != cancelProducts.size()) {
+            throw new InvalidCancelProductException("중복된 상품이 포함되어 있습니다.");
+        }
+
+        Map<Long, Integer> orderQuantityByPricePolicyId = order.getOrderProducts().stream()
+                .collect(Collectors.toMap(OrderProduct::getPricePolicyId, OrderProduct::getQuantity, Integer::sum));
+
+        for (CancelPaymentCommand.CancelProductItem item : cancelProducts) {
+            if (FormatValidator.hasNoValue(item.quantity()) || item.quantity() <= 0) {
+                throw new InvalidCancelProductException(
+                        "취소 수량은 1 이상이어야 합니다. pricePolicyId=" + item.pricePolicyId());
+            }
+            Integer orderQuantity = orderQuantityByPricePolicyId.get(item.pricePolicyId());
+            if (FormatValidator.hasNoValue(orderQuantity)) {
+                throw new InvalidCancelProductException(
+                        "주문에 존재하지 않는 상품입니다. pricePolicyId=" + item.pricePolicyId());
+            }
+            if (item.quantity() > orderQuantity) {
+                throw new InvalidCancelProductException(
+                        "취소 수량이 주문 수량을 초과합니다. pricePolicyId=" + item.pricePolicyId()
+                                + ", 주문수량=" + orderQuantity + ", 취소수량=" + item.quantity());
+            }
         }
     }
 


### PR DESCRIPTION
## partially addresses #216
## resolves #1085

## Task
- [x] CancelPaymentCommand에 cancelProducts 필드 및 CancelProductItem inner record 추가
- [x] CancelPaymentRequest에 cancelProducts 필드 및 CancelProductItemRequest inner class 추가
- [x] PaymentRequestToCommandMapper에 cancelProducts 매핑 로직 추가
- [x] CancelPaymentService에 restorePartialCancelInventory() 메서드 추가
- [x] CancelPaymentService에 validateCancelProducts() 검증 메서드 추가 (pricePolicyId 중복, 주문 미존재 상품, 수량 초과, 수량 0이하)
- [x] InvalidCancelProductException 커스텀 예외 추가