### PR TITLE
[#216][#1087] feat: 결제 이벤트 FAILED/UNKNOWN 상태 추가 및 트랜잭션 분리

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/payment/controller/AdminPaymentEventController.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/payment/controller/AdminPaymentEventController.java
@@ -1,0 +1,79 @@
+package com.personal.marketnote.commerce.adapter.in.web.payment.controller;
+
+import com.personal.marketnote.commerce.adapter.in.web.payment.request.ResolveUnknownPaymentRequest;
+import com.personal.marketnote.commerce.adapter.in.web.payment.response.GetUnknownPaymentEventsResponse;
+import com.personal.marketnote.commerce.adapter.in.web.payment.response.ResolveUnknownPaymentResponse;
+import com.personal.marketnote.commerce.port.in.command.payment.ResolveUnknownPaymentCommand;
+import com.personal.marketnote.commerce.port.in.result.payment.GetUnknownPaymentEventsResult;
+import com.personal.marketnote.commerce.port.in.result.payment.ResolveUnknownPaymentResult;
+import com.personal.marketnote.commerce.port.in.usecase.payment.GetUnknownPaymentEventsUseCase;
+import com.personal.marketnote.commerce.port.in.usecase.payment.ResolveUnknownPaymentUseCase;
+import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+import static com.personal.marketnote.common.domain.exception.ExceptionCode.DEFAULT_SUCCESS_CODE;
+import static com.personal.marketnote.common.utility.ApiConstant.ADMIN_POINTCUT;
+
+@RestController
+@Tag(name = "관리자 결제 이벤트 API", description = "UNKNOWN 상태 결제 이벤트 관리")
+@RequiredArgsConstructor
+public class AdminPaymentEventController {
+    private final GetUnknownPaymentEventsUseCase getUnknownPaymentEventsUseCase;
+    private final ResolveUnknownPaymentUseCase resolveUnknownPaymentUseCase;
+
+    @GetMapping("/api/v1/admin/payments/events/unknown")
+    @PreAuthorize(ADMIN_POINTCUT)
+    @SecurityRequirement(name = "bearer")
+    @Operation(summary = "UNKNOWN 상태 결제 이벤트 조회", description = "KCP 통신 장애로 승인 여부를 알 수 없는 결제 이벤트 목록을 조회합니다.")
+    public ResponseEntity<BaseResponse<List<GetUnknownPaymentEventsResponse>>> getUnknownPaymentEvents() {
+        List<GetUnknownPaymentEventsResult> results = getUnknownPaymentEventsUseCase.getUnknownPaymentEvents();
+        List<GetUnknownPaymentEventsResponse> responses = results.stream()
+                .map(GetUnknownPaymentEventsResponse::from)
+                .toList();
+        return new ResponseEntity<>(
+                BaseResponse.of(responses, HttpStatus.OK, DEFAULT_SUCCESS_CODE, "UNKNOWN 결제 이벤트 조회 성공"),
+                HttpStatus.OK
+        );
+    }
+
+    @PostMapping("/api/v1/admin/payments/events/{orderKey}/resolve")
+    @PreAuthorize(ADMIN_POINTCUT)
+    @SecurityRequirement(name = "bearer")
+    @Operation(summary = "UNKNOWN 결제 이벤트 수동 해소", description = "관리자가 KCP 가맹점 사이트에서 확인한 결과를 바탕으로 UNKNOWN 이벤트를 COMPLETE 또는 FAILED로 해소합니다.")
+    public ResponseEntity<BaseResponse<ResolveUnknownPaymentResponse>> resolveUnknownPaymentEvent(
+            @PathVariable("orderKey") String orderKey,
+            @Valid @RequestBody ResolveUnknownPaymentRequest request
+    ) {
+        ResolveUnknownPaymentCommand command = ResolveUnknownPaymentCommand.builder()
+                .orderKey(orderKey)
+                .resolvedStatus(request.resolvedStatus())
+                .resultCode(request.resultCode())
+                .resultMessage(request.resultMessage())
+                .pgPaymentKey(request.pgPaymentKey())
+                .approvalNumber(request.approvalNumber())
+                .appTime(request.appTime())
+                .build();
+
+        ResolveUnknownPaymentResult result = resolveUnknownPaymentUseCase.resolve(command);
+
+        return new ResponseEntity<>(
+                BaseResponse.of(
+                        ResolveUnknownPaymentResponse.from(result),
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "UNKNOWN 결제 이벤트 해소 성공"
+                ),
+                HttpStatus.OK
+        );
+    }
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/payment/request/ResolveUnknownPaymentRequest.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/payment/request/ResolveUnknownPaymentRequest.java
@@ -1,0 +1,16 @@
+package com.personal.marketnote.commerce.adapter.in.web.payment.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record ResolveUnknownPaymentRequest(
+        @NotBlank(message = "해소 상태는 필수입니다 (COMPLETE 또는 FAILED)")
+        @Pattern(regexp = "^(COMPLETE|FAILED)$", message = "해소 상태는 COMPLETE 또는 FAILED만 허용됩니다")
+        String resolvedStatus,
+        String resultCode,
+        String resultMessage,
+        String pgPaymentKey,
+        String approvalNumber,
+        String appTime
+) {
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/payment/response/GetUnknownPaymentEventsResponse.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/payment/response/GetUnknownPaymentEventsResponse.java
@@ -1,0 +1,31 @@
+package com.personal.marketnote.commerce.adapter.in.web.payment.response;
+
+import com.personal.marketnote.commerce.port.in.result.payment.GetUnknownPaymentEventsResult;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record GetUnknownPaymentEventsResponse(
+        Long id,
+        Long orderId,
+        String orderKey,
+        Long amount,
+        String method,
+        String resultCode,
+        String resultMessage,
+        LocalDateTime createdAt
+) {
+    public static GetUnknownPaymentEventsResponse from(GetUnknownPaymentEventsResult result) {
+        return GetUnknownPaymentEventsResponse.builder()
+                .id(result.id())
+                .orderId(result.orderId())
+                .orderKey(result.orderKey())
+                .amount(result.amount())
+                .method(result.method())
+                .resultCode(result.resultCode())
+                .resultMessage(result.resultMessage())
+                .createdAt(result.createdAt())
+                .build();
+    }
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/payment/response/ResolveUnknownPaymentResponse.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/payment/response/ResolveUnknownPaymentResponse.java
@@ -1,0 +1,19 @@
+package com.personal.marketnote.commerce.adapter.in.web.payment.response;
+
+import com.personal.marketnote.commerce.port.in.result.payment.ResolveUnknownPaymentResult;
+import lombok.Builder;
+
+@Builder
+public record ResolveUnknownPaymentResponse(
+        String orderKey,
+        String resolvedStatus,
+        Long orderId
+) {
+    public static ResolveUnknownPaymentResponse from(ResolveUnknownPaymentResult result) {
+        return ResolveUnknownPaymentResponse.builder()
+                .orderKey(result.orderKey())
+                .resolvedStatus(result.resolvedStatus())
+                .orderId(result.orderId())
+                .build();
+    }
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/payment/PspPaymentEventPersistenceAdapter.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/payment/PspPaymentEventPersistenceAdapter.java
@@ -3,6 +3,7 @@ package com.personal.marketnote.commerce.adapter.out.persistence.payment;
 import com.personal.marketnote.commerce.adapter.out.persistence.payment.entity.PspPaymentEventJpaEntity;
 import com.personal.marketnote.commerce.adapter.out.persistence.payment.mapper.PspPaymentEventEntityToDomainMapper;
 import com.personal.marketnote.commerce.adapter.out.persistence.payment.repository.PspPaymentEventJpaRepository;
+import com.personal.marketnote.commerce.domain.payment.PaymentEventStatus;
 import com.personal.marketnote.commerce.domain.payment.PspPaymentEvent;
 import com.personal.marketnote.commerce.port.out.payment.FindPspPaymentEventPort;
 import com.personal.marketnote.commerce.port.out.payment.SavePspPaymentEventPort;
@@ -11,6 +12,7 @@ import com.personal.marketnote.common.adapter.out.PersistenceAdapter;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 
+import java.util.List;
 import java.util.Optional;
 
 @PersistenceAdapter
@@ -29,6 +31,13 @@ public class PspPaymentEventPersistenceAdapter implements SavePspPaymentEventPor
     public Optional<PspPaymentEvent> findByOrderKey(String orderKey) {
         return pspPaymentEventJpaRepository.findByOrderKey(orderKey)
                 .map(PspPaymentEventEntityToDomainMapper::toDomain);
+    }
+
+    @Override
+    public List<PspPaymentEvent> findAllByUnknownStatus() {
+        return pspPaymentEventJpaRepository.findAllByPoStatus(PaymentEventStatus.UNKNOWN).stream()
+                .map(PspPaymentEventEntityToDomainMapper::toDomain)
+                .toList();
     }
 
     @Override

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/payment/repository/PspPaymentEventJpaRepository.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/payment/repository/PspPaymentEventJpaRepository.java
@@ -1,10 +1,14 @@
 package com.personal.marketnote.commerce.adapter.out.persistence.payment.repository;
 
 import com.personal.marketnote.commerce.adapter.out.persistence.payment.entity.PspPaymentEventJpaEntity;
+import com.personal.marketnote.commerce.domain.payment.PaymentEventStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface PspPaymentEventJpaRepository extends JpaRepository<PspPaymentEventJpaEntity, Long> {
     Optional<PspPaymentEventJpaEntity> findByOrderKey(String orderKey);
+
+    List<PspPaymentEventJpaEntity> findAllByPoStatus(PaymentEventStatus poStatus);
 }

--- a/commerce-service/commerce-adapters/src/main/resources/db/migration/V896__update_psp_payment_event_active_index_add_unknown.sql
+++ b/commerce-service/commerce-adapters/src/main/resources/db/migration/V896__update_psp_payment_event_active_index_add_unknown.sql
@@ -1,0 +1,5 @@
+-- UNKNOWN 상태 이벤트도 동일 orderKey 중복 방지
+DROP INDEX IF EXISTS idx_psp_payment_event_order_key_active;
+CREATE UNIQUE INDEX idx_psp_payment_event_order_key_active
+    ON psp_payment_event (order_key)
+    WHERE po_status IN ('READY', 'EXECUTING', 'UNKNOWN');

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/exception/InvalidPaymentEventResolveStatusException.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/exception/InvalidPaymentEventResolveStatusException.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.commerce.exception;
+
+public class InvalidPaymentEventResolveStatusException extends IllegalArgumentException {
+    public InvalidPaymentEventResolveStatusException(String resolvedStatus) {
+        super("유효하지 않은 resolve 상태입니다. resolvedStatus=" + resolvedStatus + " (COMPLETE 또는 FAILED만 허용)");
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/command/payment/ResolveUnknownPaymentCommand.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/command/payment/ResolveUnknownPaymentCommand.java
@@ -1,0 +1,15 @@
+package com.personal.marketnote.commerce.port.in.command.payment;
+
+import lombok.Builder;
+
+@Builder
+public record ResolveUnknownPaymentCommand(
+        String orderKey,
+        String resolvedStatus,
+        String resultCode,
+        String resultMessage,
+        String pgPaymentKey,
+        String approvalNumber,
+        String appTime
+) {
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/result/payment/GetUnknownPaymentEventsResult.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/result/payment/GetUnknownPaymentEventsResult.java
@@ -1,0 +1,31 @@
+package com.personal.marketnote.commerce.port.in.result.payment;
+
+import com.personal.marketnote.commerce.domain.payment.PspPaymentEvent;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record GetUnknownPaymentEventsResult(
+        Long id,
+        Long orderId,
+        String orderKey,
+        Long amount,
+        String method,
+        String resultCode,
+        String resultMessage,
+        LocalDateTime createdAt
+) {
+    public static GetUnknownPaymentEventsResult from(PspPaymentEvent event) {
+        return GetUnknownPaymentEventsResult.builder()
+                .id(event.getId())
+                .orderId(event.getOrderId())
+                .orderKey(event.getOrderKey())
+                .amount(event.getAmount())
+                .method(event.getMethod())
+                .resultCode(event.getResultCode())
+                .resultMessage(event.getResultMessage())
+                .createdAt(event.getCreatedAt())
+                .build();
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/result/payment/ResolveUnknownPaymentResult.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/result/payment/ResolveUnknownPaymentResult.java
@@ -1,0 +1,11 @@
+package com.personal.marketnote.commerce.port.in.result.payment;
+
+import lombok.Builder;
+
+@Builder
+public record ResolveUnknownPaymentResult(
+        String orderKey,
+        String resolvedStatus,
+        Long orderId
+) {
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/payment/GetUnknownPaymentEventsUseCase.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/payment/GetUnknownPaymentEventsUseCase.java
@@ -1,0 +1,12 @@
+package com.personal.marketnote.commerce.port.in.usecase.payment;
+
+import com.personal.marketnote.commerce.port.in.result.payment.GetUnknownPaymentEventsResult;
+
+import java.util.List;
+
+/**
+ * UNKNOWN 상태 결제 이벤트 조회 유스케이스
+ */
+public interface GetUnknownPaymentEventsUseCase {
+    List<GetUnknownPaymentEventsResult> getUnknownPaymentEvents();
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/payment/ResolveUnknownPaymentUseCase.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/payment/ResolveUnknownPaymentUseCase.java
@@ -1,0 +1,11 @@
+package com.personal.marketnote.commerce.port.in.usecase.payment;
+
+import com.personal.marketnote.commerce.port.in.command.payment.ResolveUnknownPaymentCommand;
+import com.personal.marketnote.commerce.port.in.result.payment.ResolveUnknownPaymentResult;
+
+/**
+ * UNKNOWN 상태 결제 이벤트 수동 해소 유스케이스
+ */
+public interface ResolveUnknownPaymentUseCase {
+    ResolveUnknownPaymentResult resolve(ResolveUnknownPaymentCommand command);
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/payment/FindPspPaymentEventPort.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/payment/FindPspPaymentEventPort.java
@@ -2,6 +2,7 @@ package com.personal.marketnote.commerce.port.out.payment;
 
 import com.personal.marketnote.commerce.domain.payment.PspPaymentEvent;
 
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -20,4 +21,11 @@ public interface FindPspPaymentEventPort {
      * @Description 주문 키로 PSP 결제 이벤트를 조회합니다.
      */
     Optional<PspPaymentEvent> findByOrderKey(String orderKey);
+
+    /**
+     * UNKNOWN 상태의 PSP 결제 이벤트 전체를 조회합니다.
+     *
+     * @return UNKNOWN 상태의 PSP 결제 이벤트 목록
+     */
+    List<PspPaymentEvent> findAllByUnknownStatus();
 }

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/ApprovePaymentService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/ApprovePaymentService.java
@@ -1,187 +1,70 @@
 package com.personal.marketnote.commerce.service.payment;
 
-import com.personal.marketnote.commerce.domain.order.Order;
-import com.personal.marketnote.commerce.domain.order.OrderStatus;
-import com.personal.marketnote.commerce.domain.payment.Payment;
-import com.personal.marketnote.commerce.domain.payment.PaymentApprovalInfo;
-import com.personal.marketnote.commerce.domain.payment.PspPaymentEvent;
-import com.personal.marketnote.commerce.exception.*;
-import com.personal.marketnote.commerce.port.in.command.order.ChangeOrderStatusCommand;
+import com.personal.marketnote.commerce.exception.PaymentApprovalException;
 import com.personal.marketnote.commerce.port.in.command.payment.ApprovePaymentCommand;
 import com.personal.marketnote.commerce.port.in.result.payment.ApprovePaymentResult;
-import com.personal.marketnote.commerce.port.in.usecase.ledger.RecordLedgerEntryUseCase;
-import com.personal.marketnote.commerce.port.in.usecase.order.ChangeOrderStatusUseCase;
 import com.personal.marketnote.commerce.port.in.usecase.payment.ApprovePaymentUseCase;
-import com.personal.marketnote.commerce.port.out.order.FindOrderPort;
-import com.personal.marketnote.commerce.port.out.payment.*;
+import com.personal.marketnote.commerce.port.out.payment.PaymentVendorPort;
 import com.personal.marketnote.commerce.port.out.payment.vendor.PaymentApprovalVendorCommand;
 import com.personal.marketnote.commerce.port.out.payment.vendor.PaymentApprovalVendorResult;
 import com.personal.marketnote.common.application.UseCase;
-import com.personal.marketnote.common.utility.FormatValidator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.transaction.annotation.Transactional;
 
-import java.util.UUID;
-
-import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
-
+/**
+ * 결제 승인 서비스
+ *
+ * <p>트랜잭션을 3단계로 분리하여 오케스트레이션만 수행한다:
+ * <ol>
+ *   <li>TX-1: 검증 + EXECUTING 커밋 (prepareExecution)</li>
+ *   <li>KCP 호출 (트랜잭션 외부)</li>
+ *   <li>TX-2: 결과 반영 커밋 (commitSuccess / commitFailure / commitUnknown)</li>
+ * </ol>
+ *
+ * <p>이 구조로 handleFailure/commitUnknown 후 예외 throw 시에도 상태 변경이 롤백되지 않는다. (#1161 해결)
+ */
 @UseCase
 @RequiredArgsConstructor
-@Transactional(isolation = READ_COMMITTED)
 @Slf4j
 public class ApprovePaymentService implements ApprovePaymentUseCase {
-    private final FindOrderPort findOrderPort;
-    private final FindPaymentPort findPaymentPort;
-    private final UpdatePaymentPort updatePaymentPort;
-    private final FindPspPaymentEventPort findPspPaymentEventPort;
-    private final UpdatePspPaymentEventPort updatePspPaymentEventPort;
+    private final PaymentApprovalTransactionHelper txHelper;
     private final PaymentVendorPort paymentVendorPort;
-    private final ChangeOrderStatusUseCase changeOrderStatusUseCase;
-    private final RecordLedgerEntryUseCase recordLedgerEntryUseCase;
 
     @Override
     public ApprovePaymentResult approve(ApprovePaymentCommand command) {
-        UUID orderKey = UUID.fromString(command.orderKey());
-        Payment payment = findPaymentPort.findByOrderKey(orderKey)
-                .orElseThrow(() -> new PaymentNotFoundException(command.orderKey()));
+        // TX-1: 검증 + EXECUTING 커밋
+        PaymentApprovalContext context = txHelper.prepareExecution(command);
 
-        Order order = findVerifiedOrder(payment.getOrderId(), command.buyerId());
-        verifyPaymentAmount(order, payment);
-
-        PspPaymentEvent event = findPspPaymentEventPort.findByOrderKey(command.orderKey())
-                .orElseThrow(() -> new PaymentEventNotFoundException(command.orderKey()));
-        event.startExecution();
-        updatePspPaymentEventPort.update(event);
-
-        PaymentApprovalVendorResult vendorResult = requestPaymentApprovalToPsp(
-                command, payment, event, payment.getPaymentAmount()
-        );
-
-        if (vendorResult.isSuccess()) {
-            return handleSuccess(payment, event, vendorResult);
+        // KCP 호출 (트랜잭션 외부)
+        PaymentApprovalVendorResult vendorResult;
+        try {
+            vendorResult = paymentVendorPort.approvePayment(buildVendorCommand(command, context));
+        } catch (Exception e) {
+            // TX-2: UNKNOWN 커밋
+            txHelper.commitUnknown(context, "UNKNOWN", "KCP 통신 오류: " + e.getMessage());
+            throw PaymentApprovalException.kcpApprovalRequestFailed(e);
         }
 
-        handleFailure(payment, event, vendorResult.resMsg());
+        // TX-2: 성공 또는 실패 커밋
+        if (vendorResult.isSuccess()) {
+            Short installment = parseInstallment(vendorResult.quota());
+            return txHelper.commitSuccess(context, vendorResult, installment);
+        }
+
+        txHelper.commitFailure(context, vendorResult.resCd(), vendorResult.resMsg());
         throw PaymentApprovalException.kcpApprovalFailed(vendorResult.resCd(), vendorResult.resMsg());
     }
 
-    private void verifyPaymentAmount(Order order, Payment payment) {
-        Long couponAmount = FormatValidator.hasValue(order.getCouponAmount())
-                ? order.getCouponAmount()
-                : 0L;
-        Long pointAmount = FormatValidator.hasValue(order.getPointAmount())
-                ? order.getPointAmount()
-                : 0L;
-        Long expectedAmount = Math.subtractExact(
-                Math.subtractExact(order.getTotalAmount(), couponAmount),
-                pointAmount
-        );
-
-        if (FormatValidator.notEquals(expectedAmount, payment.getPaymentAmount())) {
-            log.error("결제 금액 불일치: orderId={}, 주문금액={}, 쿠폰={}, 포인트={}, 예상결제금액={}, 실제결제금액={}",
-                    order.getId(), order.getTotalAmount(), couponAmount, pointAmount,
-                    expectedAmount, payment.getPaymentAmount());
-            throw new PaymentAmountMismatchException(expectedAmount, payment.getPaymentAmount());
-        }
-    }
-
-    private PaymentApprovalVendorResult requestPaymentApprovalToPsp(
-            ApprovePaymentCommand command, Payment payment, PspPaymentEvent event, Long amount
+    private PaymentApprovalVendorCommand buildVendorCommand(
+            ApprovePaymentCommand command, PaymentApprovalContext context
     ) {
-        PaymentApprovalVendorCommand vendorCommand = PaymentApprovalVendorCommand.builder()
+        return PaymentApprovalVendorCommand.builder()
                 .encData(command.encData())
                 .encInfo(command.encInfo())
-                .ordrMony(String.valueOf(amount))
+                .ordrMony(String.valueOf(context.paymentAmount()))
                 .ordrNo(command.orderKey())
                 .payType(command.payType())
                 .build();
-
-        try {
-            return paymentVendorPort.approvePayment(vendorCommand);
-        } catch (Exception e) {
-            handleFailure(payment, event, "KCP 통신 오류: " + e.getMessage());
-            throw PaymentApprovalException.kcpApprovalRequestFailed(e);
-        }
-    }
-
-    private ApprovePaymentResult handleSuccess(
-            Payment payment, PspPaymentEvent event, PaymentApprovalVendorResult vendorResult
-    ) {
-        payment.markAsSuccess(vendorResult.tno());
-        updatePaymentPort.update(payment);
-
-        Short installment = parseInstallment(vendorResult.quota());
-        PaymentApprovalInfo approvalInfo = PaymentApprovalInfo.builder()
-                .pgPaymentKey(vendorResult.tno())
-                .method(vendorResult.payMethod())
-                .cardNumber(vendorResult.cardNo())
-                .approvalNumber(vendorResult.appNo())
-                .installment(installment)
-                .issueCompanyCode(vendorResult.cardCd())
-                .issueCompanyName(vendorResult.cardName())
-                .resultCode(vendorResult.resCd())
-                .resultMessage(vendorResult.resMsg())
-                .pgApprovalResult(vendorResult.rawResponse())
-                .appTime(vendorResult.appTime())
-                .build();
-        event.completeWithApproval(approvalInfo);
-        updatePspPaymentEventPort.update(event);
-
-        changeOrderStatusUseCase.changeOrderStatus(
-                ChangeOrderStatusCommand.builder()
-                        .id(payment.getOrderId())
-                        .orderStatus(OrderStatus.PAID)
-                        .build()
-        );
-
-        recordLedgerEntryForPaymentApproval(payment);
-
-        return ApprovePaymentResult.builder()
-                .orderId(payment.getOrderId())
-                .orderKey(payment.getOrderKey().toString())
-                .pgPaymentKey(vendorResult.tno())
-                .amount(payment.getPaymentAmount())
-                .resultCode(vendorResult.resCd())
-                .resultMessage(vendorResult.resMsg())
-                .payMethod(vendorResult.payMethod())
-                .build();
-    }
-
-    private void handleFailure(Payment payment, PspPaymentEvent event, String reason) {
-        payment.markAsFailed();
-        updatePaymentPort.update(payment);
-
-        event.failExecution("FAIL", reason);
-        updatePspPaymentEventPort.update(event);
-
-        changeOrderStatusUseCase.changeOrderStatus(
-                ChangeOrderStatusCommand.builder()
-                        .id(payment.getOrderId())
-                        .orderStatus(OrderStatus.FAILED)
-                        .build()
-        );
-    }
-
-    private void recordLedgerEntryForPaymentApproval(Payment payment) {
-        try {
-            recordLedgerEntryUseCase.recordPaymentApproval(
-                    payment.getOrderId(), payment.getPaymentAmount()
-            );
-        } catch (Exception e) {
-            log.error("결제 승인 분개 기록 실패 - orderId: {}, error: {}", payment.getOrderId(), e.getMessage(), e);
-        }
-    }
-
-    private Order findVerifiedOrder(Long orderId, Long buyerId) {
-        Order order = findOrderPort.findById(orderId)
-                .orElseThrow(() -> new OrderNotFoundException(orderId));
-        if (!order.isBuyer(buyerId)) {
-            log.warn("결제 승인 소유자 불일치 - orderId: {}, 주문소유자: {}, 요청자: {}",
-                    orderId, order.getBuyerId(), buyerId);
-            throw new UnauthorizedOrderAccessException();
-        }
-        return order;
     }
 
     private Short parseInstallment(String quota) {

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/GetUnknownPaymentEventsService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/GetUnknownPaymentEventsService.java
@@ -1,0 +1,26 @@
+package com.personal.marketnote.commerce.service.payment;
+
+import com.personal.marketnote.commerce.port.in.result.payment.GetUnknownPaymentEventsResult;
+import com.personal.marketnote.commerce.port.in.usecase.payment.GetUnknownPaymentEventsUseCase;
+import com.personal.marketnote.commerce.port.out.payment.FindPspPaymentEventPort;
+import com.personal.marketnote.common.application.UseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional(isolation = READ_COMMITTED, readOnly = true)
+public class GetUnknownPaymentEventsService implements GetUnknownPaymentEventsUseCase {
+    private final FindPspPaymentEventPort findPspPaymentEventPort;
+
+    @Override
+    public List<GetUnknownPaymentEventsResult> getUnknownPaymentEvents() {
+        return findPspPaymentEventPort.findAllByUnknownStatus().stream()
+                .map(GetUnknownPaymentEventsResult::from)
+                .toList();
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/PaymentApprovalContext.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/PaymentApprovalContext.java
@@ -1,0 +1,37 @@
+package com.personal.marketnote.commerce.service.payment;
+
+import com.personal.marketnote.commerce.domain.payment.Payment;
+import com.personal.marketnote.commerce.domain.payment.PspPaymentEvent;
+
+/**
+ * 결제 승인 트랜잭션 간 데이터 전달 컨텍스트
+ *
+ * @param payment 결제 정보
+ * @param event PSP 결제 이벤트
+ * @param orderId 주문 ID
+ * @param orderKey 주문 키
+ * @param paymentAmount 결제 금액
+ * @param pgShopKey PG 가맹점 키
+ * @param method 결제 수단
+ */
+public record PaymentApprovalContext(
+        Payment payment,
+        PspPaymentEvent event,
+        Long orderId,
+        String orderKey,
+        Long paymentAmount,
+        String pgShopKey,
+        String method
+) {
+    public static PaymentApprovalContext of(Payment payment, PspPaymentEvent event) {
+        return new PaymentApprovalContext(
+                payment,
+                event,
+                payment.getOrderId(),
+                payment.getOrderKey().toString(),
+                payment.getPaymentAmount(),
+                event.getPgShopKey(),
+                event.getMethod()
+        );
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/PaymentApprovalTransactionHelper.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/PaymentApprovalTransactionHelper.java
@@ -1,0 +1,186 @@
+package com.personal.marketnote.commerce.service.payment;
+
+import com.personal.marketnote.commerce.domain.order.Order;
+import com.personal.marketnote.commerce.domain.order.OrderStatus;
+import com.personal.marketnote.commerce.domain.payment.*;
+import com.personal.marketnote.commerce.exception.*;
+import com.personal.marketnote.commerce.port.in.command.order.ChangeOrderStatusCommand;
+import com.personal.marketnote.commerce.port.in.command.payment.ApprovePaymentCommand;
+import com.personal.marketnote.commerce.port.in.result.payment.ApprovePaymentResult;
+import com.personal.marketnote.commerce.port.in.usecase.ledger.RecordLedgerEntryUseCase;
+import com.personal.marketnote.commerce.port.in.usecase.order.ChangeOrderStatusUseCase;
+import com.personal.marketnote.commerce.port.out.order.FindOrderPort;
+import com.personal.marketnote.commerce.port.out.payment.*;
+import com.personal.marketnote.commerce.port.out.payment.vendor.PaymentApprovalVendorResult;
+import com.personal.marketnote.common.utility.FormatValidator;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+import static org.springframework.transaction.annotation.Propagation.REQUIRES_NEW;
+
+/**
+ * 결제 승인 트랜잭션 헬퍼
+ *
+ * <p>결제 승인 플로우의 각 단계를 독립 트랜잭션(REQUIRES_NEW)으로 분리하여
+ * 실패/UNKNOWN 상태 반영이 RuntimeException throw에 의해 롤백되지 않도록 보장한다.</p>
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class PaymentApprovalTransactionHelper {
+    private final FindOrderPort findOrderPort;
+    private final FindPaymentPort findPaymentPort;
+    private final UpdatePaymentPort updatePaymentPort;
+    private final FindPspPaymentEventPort findPspPaymentEventPort;
+    private final UpdatePspPaymentEventPort updatePspPaymentEventPort;
+    private final ChangeOrderStatusUseCase changeOrderStatusUseCase;
+    private final RecordLedgerEntryUseCase recordLedgerEntryUseCase;
+
+    /**
+     * TX-1: 검증 + EXECUTING 상태 커밋
+     */
+    @Transactional(propagation = REQUIRES_NEW, isolation = READ_COMMITTED)
+    public PaymentApprovalContext prepareExecution(ApprovePaymentCommand command) {
+        UUID orderKey = UUID.fromString(command.orderKey());
+        Payment payment = findPaymentPort.findByOrderKey(orderKey)
+                .orElseThrow(() -> new PaymentNotFoundException(command.orderKey()));
+
+        Order order = findVerifiedOrder(payment.getOrderId(), command.buyerId());
+        verifyPaymentAmount(order, payment);
+
+        PspPaymentEvent event = findPspPaymentEventPort.findByOrderKey(command.orderKey())
+                .orElseThrow(() -> new PaymentEventNotFoundException(command.orderKey()));
+        event.startExecution();
+        updatePspPaymentEventPort.update(event);
+
+        return PaymentApprovalContext.of(payment, event);
+    }
+
+    /**
+     * TX-2: 성공 상태 커밋 (COMPLETE + PAID + 분개)
+     */
+    @Transactional(propagation = REQUIRES_NEW, isolation = READ_COMMITTED)
+    public ApprovePaymentResult commitSuccess(
+            PaymentApprovalContext context, PaymentApprovalVendorResult vendorResult, Short installment
+    ) {
+        Payment payment = context.payment();
+        PspPaymentEvent event = context.event();
+
+        payment.markAsSuccess(vendorResult.tno());
+        updatePaymentPort.update(payment);
+
+        PaymentApprovalInfo approvalInfo = PaymentApprovalInfo.builder()
+                .pgPaymentKey(vendorResult.tno())
+                .method(vendorResult.payMethod())
+                .cardNumber(vendorResult.cardNo())
+                .approvalNumber(vendorResult.appNo())
+                .installment(installment)
+                .issueCompanyCode(vendorResult.cardCd())
+                .issueCompanyName(vendorResult.cardName())
+                .resultCode(vendorResult.resCd())
+                .resultMessage(vendorResult.resMsg())
+                .pgApprovalResult(vendorResult.rawResponse())
+                .appTime(vendorResult.appTime())
+                .build();
+        event.completeWithApproval(approvalInfo);
+        updatePspPaymentEventPort.update(event);
+
+        changeOrderStatusUseCase.changeOrderStatus(
+                ChangeOrderStatusCommand.builder()
+                        .id(payment.getOrderId())
+                        .orderStatus(OrderStatus.PAID)
+                        .build()
+        );
+
+        recordLedgerEntryForPaymentApproval(payment);
+
+        return ApprovePaymentResult.builder()
+                .orderId(payment.getOrderId())
+                .orderKey(payment.getOrderKey().toString())
+                .pgPaymentKey(vendorResult.tno())
+                .amount(payment.getPaymentAmount())
+                .resultCode(vendorResult.resCd())
+                .resultMessage(vendorResult.resMsg())
+                .payMethod(vendorResult.payMethod())
+                .build();
+    }
+
+    /**
+     * TX-2: 실패 상태 커밋 (FAILED + order FAILED)
+     */
+    @Transactional(propagation = REQUIRES_NEW, isolation = READ_COMMITTED)
+    public void commitFailure(PaymentApprovalContext context, String resultCode, String resultMessage) {
+        Payment payment = context.payment();
+        PspPaymentEvent event = context.event();
+
+        payment.markAsFailed();
+        updatePaymentPort.update(payment);
+
+        event.failExecution(resultCode, resultMessage);
+        updatePspPaymentEventPort.update(event);
+
+        changeOrderStatusUseCase.changeOrderStatus(
+                ChangeOrderStatusCommand.builder()
+                        .id(payment.getOrderId())
+                        .orderStatus(OrderStatus.FAILED)
+                        .build()
+        );
+    }
+
+    /**
+     * TX-2: UNKNOWN 상태 커밋 (이벤트만 UNKNOWN, payment/order 변경 없음)
+     */
+    @Transactional(propagation = REQUIRES_NEW, isolation = READ_COMMITTED)
+    public void commitUnknown(PaymentApprovalContext context, String resultCode, String resultMessage) {
+        PspPaymentEvent event = context.event();
+
+        event.markUnknown(resultCode, resultMessage);
+        updatePspPaymentEventPort.update(event);
+    }
+
+    private void verifyPaymentAmount(Order order, Payment payment) {
+        Long couponAmount = FormatValidator.hasValue(order.getCouponAmount())
+                ? order.getCouponAmount()
+                : 0L;
+        Long pointAmount = FormatValidator.hasValue(order.getPointAmount())
+                ? order.getPointAmount()
+                : 0L;
+        Long expectedAmount = Math.subtractExact(
+                Math.subtractExact(order.getTotalAmount(), couponAmount),
+                pointAmount
+        );
+
+        if (FormatValidator.notEquals(expectedAmount, payment.getPaymentAmount())) {
+            log.error("결제 금액 불일치: orderId={}, 주문금액={}, 쿠폰={}, 포인트={}, 예상결제금액={}, 실제결제금액={}",
+                    order.getId(), order.getTotalAmount(), couponAmount, pointAmount,
+                    expectedAmount, payment.getPaymentAmount());
+            throw new PaymentAmountMismatchException(expectedAmount, payment.getPaymentAmount());
+        }
+    }
+
+    private Order findVerifiedOrder(Long orderId, Long buyerId) {
+        Order order = findOrderPort.findById(orderId)
+                .orElseThrow(() -> new OrderNotFoundException(orderId));
+        if (!order.isBuyer(buyerId)) {
+            log.warn("결제 승인 소유자 불일치 - orderId: {}, 주문소유자: {}, 요청자: {}",
+                    orderId, order.getBuyerId(), buyerId);
+            throw new UnauthorizedOrderAccessException();
+        }
+        return order;
+    }
+
+    private void recordLedgerEntryForPaymentApproval(Payment payment) {
+        try {
+            recordLedgerEntryUseCase.recordPaymentApproval(
+                    payment.getOrderId(), payment.getPaymentAmount()
+            );
+        } catch (Exception e) {
+            log.error("결제 승인 분개 기록 실패 - orderId: {}, error: {}", payment.getOrderId(), e.getMessage(), e);
+        }
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/ReadyPaymentService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/ReadyPaymentService.java
@@ -84,7 +84,7 @@ public class ReadyPaymentService implements ReadyPaymentUseCase {
 
     private void verifyNoDuplicatePaymentReady(String orderKey) {
         findPspPaymentEventPort.findByOrderKey(orderKey)
-                .filter(PspPaymentEvent::isActiveEvent)
+                .filter(PspPaymentEvent::isUnresolved)
                 .ifPresent(event -> {
                     log.warn("중복 거래 등록 시도 - orderKey: {}, 기존 이벤트 상태: {}", orderKey, event.getPoStatus());
                     throw new DuplicatePaymentReadyException(orderKey);

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/ResolveUnknownPaymentService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/ResolveUnknownPaymentService.java
@@ -1,0 +1,128 @@
+package com.personal.marketnote.commerce.service.payment;
+
+import com.personal.marketnote.commerce.domain.order.OrderStatus;
+import com.personal.marketnote.commerce.domain.payment.Payment;
+import com.personal.marketnote.commerce.domain.payment.PaymentApprovalInfo;
+import com.personal.marketnote.commerce.domain.payment.PspPaymentEvent;
+import com.personal.marketnote.commerce.exception.InvalidPaymentEventResolveStatusException;
+import com.personal.marketnote.commerce.exception.PaymentEventNotFoundException;
+import com.personal.marketnote.commerce.exception.PaymentNotFoundException;
+import com.personal.marketnote.commerce.port.in.command.order.ChangeOrderStatusCommand;
+import com.personal.marketnote.commerce.port.in.command.payment.ResolveUnknownPaymentCommand;
+import com.personal.marketnote.commerce.port.in.result.payment.ResolveUnknownPaymentResult;
+import com.personal.marketnote.commerce.port.in.usecase.ledger.RecordLedgerEntryUseCase;
+import com.personal.marketnote.commerce.port.in.usecase.order.ChangeOrderStatusUseCase;
+import com.personal.marketnote.commerce.port.in.usecase.payment.ResolveUnknownPaymentUseCase;
+import com.personal.marketnote.commerce.port.out.payment.FindPaymentPort;
+import com.personal.marketnote.commerce.port.out.payment.FindPspPaymentEventPort;
+import com.personal.marketnote.commerce.port.out.payment.UpdatePaymentPort;
+import com.personal.marketnote.commerce.port.out.payment.UpdatePspPaymentEventPort;
+import com.personal.marketnote.common.application.UseCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional(isolation = READ_COMMITTED)
+@Slf4j
+public class ResolveUnknownPaymentService implements ResolveUnknownPaymentUseCase {
+    private static final String RESOLVE_STATUS_COMPLETE = "COMPLETE";
+    private static final String RESOLVE_STATUS_FAILED = "FAILED";
+
+    private final FindPspPaymentEventPort findPspPaymentEventPort;
+    private final UpdatePspPaymentEventPort updatePspPaymentEventPort;
+    private final FindPaymentPort findPaymentPort;
+    private final UpdatePaymentPort updatePaymentPort;
+    private final ChangeOrderStatusUseCase changeOrderStatusUseCase;
+    private final RecordLedgerEntryUseCase recordLedgerEntryUseCase;
+
+    @Override
+    public ResolveUnknownPaymentResult resolve(ResolveUnknownPaymentCommand command) {
+        PspPaymentEvent event = findPspPaymentEventPort.findByOrderKey(command.orderKey())
+                .orElseThrow(() -> new PaymentEventNotFoundException(command.orderKey()));
+
+        Payment payment = findPaymentPort.findByOrderKey(UUID.fromString(command.orderKey()))
+                .orElseThrow(() -> new PaymentNotFoundException(command.orderKey()));
+
+        return switch (command.resolvedStatus()) {
+            case RESOLVE_STATUS_COMPLETE -> resolveToComplete(event, payment, command);
+            case RESOLVE_STATUS_FAILED -> resolveToFailed(event, payment, command);
+            default -> throw new InvalidPaymentEventResolveStatusException(command.resolvedStatus());
+        };
+    }
+
+    private ResolveUnknownPaymentResult resolveToComplete(
+            PspPaymentEvent event, Payment payment, ResolveUnknownPaymentCommand command
+    ) {
+        PaymentApprovalInfo approvalInfo = PaymentApprovalInfo.builder()
+                .pgPaymentKey(command.pgPaymentKey())
+                .method(event.getMethod())
+                .approvalNumber(command.approvalNumber())
+                .resultCode(command.resultCode())
+                .resultMessage(command.resultMessage())
+                .appTime(command.appTime())
+                .build();
+        event.resolveToComplete(approvalInfo);
+        updatePspPaymentEventPort.update(event);
+
+        payment.markAsSuccess(command.pgPaymentKey());
+        updatePaymentPort.update(payment);
+
+        changeOrderStatusUseCase.changeOrderStatus(
+                ChangeOrderStatusCommand.builder()
+                        .id(payment.getOrderId())
+                        .orderStatus(OrderStatus.PAID)
+                        .build()
+        );
+
+        recordLedgerEntry(payment);
+
+        log.info("UNKNOWN → COMPLETE 해소 - orderKey: {}, orderId: {}", command.orderKey(), payment.getOrderId());
+
+        return ResolveUnknownPaymentResult.builder()
+                .orderKey(command.orderKey())
+                .resolvedStatus(RESOLVE_STATUS_COMPLETE)
+                .orderId(payment.getOrderId())
+                .build();
+    }
+
+    private ResolveUnknownPaymentResult resolveToFailed(
+            PspPaymentEvent event, Payment payment, ResolveUnknownPaymentCommand command
+    ) {
+        event.resolveToFailed(command.resultCode(), command.resultMessage());
+        updatePspPaymentEventPort.update(event);
+
+        payment.markAsFailed();
+        updatePaymentPort.update(payment);
+
+        changeOrderStatusUseCase.changeOrderStatus(
+                ChangeOrderStatusCommand.builder()
+                        .id(payment.getOrderId())
+                        .orderStatus(OrderStatus.FAILED)
+                        .build()
+        );
+
+        log.info("UNKNOWN → FAILED 해소 - orderKey: {}, orderId: {}", command.orderKey(), payment.getOrderId());
+
+        return ResolveUnknownPaymentResult.builder()
+                .orderKey(command.orderKey())
+                .resolvedStatus(RESOLVE_STATUS_FAILED)
+                .orderId(payment.getOrderId())
+                .build();
+    }
+
+    private void recordLedgerEntry(Payment payment) {
+        try {
+            recordLedgerEntryUseCase.recordPaymentApproval(
+                    payment.getOrderId(), payment.getPaymentAmount()
+            );
+        } catch (Exception e) {
+            log.error("UNKNOWN 해소 분개 기록 실패 - orderId: {}, error: {}", payment.getOrderId(), e.getMessage(), e);
+        }
+    }
+}

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/payment/PaymentEventStatus.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/payment/PaymentEventStatus.java
@@ -7,6 +7,8 @@ public enum PaymentEventStatus {
     READY("결제 대기"),
     EXECUTING("결제 진행 중"),
     COMPLETE("결제 완료"),
+    FAILED("결제 실패"),
+    UNKNOWN("결제 상태 미확인"),
     PARTIALLY_REFUNDED("부분 환불됨"),
     REFUNDED("환불 완료"),
     CANCELLED("취소됨");
@@ -27,6 +29,14 @@ public enum PaymentEventStatus {
 
     public boolean isPartiallyRefunded() {
         return this == PARTIALLY_REFUNDED;
+    }
+
+    public boolean isFailed() {
+        return this == FAILED;
+    }
+
+    public boolean isUnknown() {
+        return this == UNKNOWN;
     }
 
     public boolean isRefundable() {

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/payment/PspPaymentEvent.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/payment/PspPaymentEvent.java
@@ -137,7 +137,43 @@ public class PspPaymentEvent {
         if (!poStatus.isExecuting()) {
             throw new InvalidPaymentStatusTransitionException("EXECUTING 상태에서만 실행 실패 처리할 수 있습니다.", poStatus);
         }
-        poStatus = PaymentEventStatus.READY;
+        poStatus = PaymentEventStatus.FAILED;
+        this.resultCode = resultCode;
+        this.resultMessage = resultMessage;
+    }
+
+    public void markUnknown(String resultCode, String resultMessage) {
+        if (!poStatus.isExecuting()) {
+            throw new InvalidPaymentStatusTransitionException("EXECUTING 상태에서만 UNKNOWN으로 전이할 수 있습니다.", poStatus);
+        }
+        poStatus = PaymentEventStatus.UNKNOWN;
+        this.resultCode = resultCode;
+        this.resultMessage = resultMessage;
+    }
+
+    public void resolveToComplete(PaymentApprovalInfo info) {
+        if (!poStatus.isUnknown()) {
+            throw new InvalidPaymentStatusTransitionException("UNKNOWN 상태에서만 COMPLETE로 해소할 수 있습니다.", poStatus);
+        }
+        poStatus = PaymentEventStatus.COMPLETE;
+        pgPaymentKey = info.getPgPaymentKey();
+        method = info.getMethod();
+        cardNumber = info.getCardNumber();
+        approvalNumber = info.getApprovalNumber();
+        installment = info.getInstallment();
+        issueCompanyCode = info.getIssueCompanyCode();
+        issueCompanyName = info.getIssueCompanyName();
+        resultCode = info.getResultCode();
+        resultMessage = info.getResultMessage();
+        pgApprovalResult = info.getPgApprovalResult();
+        paidAt = parseAppTime(info.getAppTime());
+    }
+
+    public void resolveToFailed(String resultCode, String resultMessage) {
+        if (!poStatus.isUnknown()) {
+            throw new InvalidPaymentStatusTransitionException("UNKNOWN 상태에서만 FAILED로 해소할 수 있습니다.", poStatus);
+        }
+        poStatus = PaymentEventStatus.FAILED;
         this.resultCode = resultCode;
         this.resultMessage = resultMessage;
     }
@@ -148,6 +184,14 @@ public class PspPaymentEvent {
      */
     public boolean isActiveEvent() {
         return poStatus.isReady() || poStatus.isExecuting();
+    }
+
+    /**
+     * 미해결 상태인지 확인한다.
+     * READY, EXECUTING, UNKNOWN 상태면 true — 중복 결제 방지에 사용된다.
+     */
+    public boolean isUnresolved() {
+        return isActiveEvent() || poStatus.isUnknown();
     }
 
     public void cancel(String pgCancelApprovalResult) {


### PR DESCRIPTION
## partially addresses #216
## resolves #1087

## Task
- [x] PaymentEventStatus에 FAILED, UNKNOWN 상태 추가 및 술어 메서드(isFailed, isUnknown)
- [x] failExecution(): EXECUTING → READY에서 EXECUTING → FAILED로 변경
- [x] markUnknown(): KCP 통신 장애 시 EXECUTING → UNKNOWN 전이
- [x] resolveToComplete/resolveToFailed(): UNKNOWN 수동 해소 전이 메서드
- [x] isUnresolved(): READY/EXECUTING/UNKNOWN 통합 술어 (중복 방지)
- [x] ApprovePaymentService REQUIRES_NEW 트랜잭션 분리 (PaymentApprovalTransactionHelper)
- [x] UNKNOWN 상태 조회 관리자 API (GET /api/v1/admin/payments/events/unknown)
- [x] UNKNOWN 수동 해소 관리자 API (POST /api/v1/admin/payments/events/{orderKey}/resolve)
- [x] partial unique index에 UNKNOWN 포함 (V896 마이그레이션)
- [x] resolvedStatus 입력 검증 @pattern(COMPLETE|FAILED) 추가