### PR TITLE
[#216][#1088] feat: KCP 결제 승인 재시도 로직 추가

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/vendor/kcp/KcpPaymentVendorAdapter.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/vendor/kcp/KcpPaymentVendorAdapter.java
@@ -10,6 +10,7 @@ import com.personal.marketnote.commerce.domain.vendorcommunication.CommerceVendo
 import com.personal.marketnote.commerce.domain.vendorcommunication.CommerceVendorCommunicationTargetType;
 import com.personal.marketnote.commerce.domain.vendorcommunication.CommerceVendorCommunicationType;
 import com.personal.marketnote.commerce.domain.vendorcommunication.CommerceVendorName;
+import com.personal.marketnote.commerce.exception.PaymentVendorConnectionFailedException;
 import com.personal.marketnote.commerce.port.out.payment.PaymentVendorPort;
 import com.personal.marketnote.commerce.port.out.payment.vendor.*;
 import com.personal.marketnote.commerce.utility.VendorCommunicationRecorder;
@@ -17,8 +18,12 @@ import com.personal.marketnote.common.adapter.out.ServiceAdapter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+import java.net.ConnectException;
+import java.net.SocketTimeoutException;
+import java.net.UnknownHostException;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ThreadLocalRandom;
 
 @ServiceAdapter
 @RequiredArgsConstructor
@@ -96,35 +101,113 @@ public class KcpPaymentVendorAdapter implements PaymentVendorPort {
 
         recordRequest(CommerceVendorCommunicationTargetType.PAYMENT_APPROVAL, command.ordrNo(), request);
 
-        try {
-            KcpPaymentApprovalResponse response = kcpApiClient.approvePayment(request);
-            recordResponse(CommerceVendorCommunicationTargetType.PAYMENT_APPROVAL, command.ordrNo(), response);
+        return executeApprovalWithRetry(request, command.ordrNo());
+    }
 
-            return PaymentApprovalVendorResult.builder()
-                    .resCd(response.resCd())
-                    .resMsg(response.resMsg())
-                    .resEnMsg(response.resEnMsg())
-                    .tno(response.tno())
-                    .amount(response.amount())
-                    .payMethod(response.payMethod())
-                    .cardCd(response.cardCd())
-                    .cardName(response.cardName())
-                    .cardNo(response.cardNo())
-                    .appNo(response.appNo())
-                    .appTime(response.appTime())
-                    .noinf(response.noinf())
-                    .noinfType(response.noinfType())
-                    .quota(response.quota())
-                    .cardMny(response.cardMny())
-                    .couponMny(response.couponMny())
-                    .partcancYn(response.partcancYn())
-                    .cardBinType01(response.cardBinType01())
-                    .cardBinType02(response.cardBinType02())
-                    .rawResponse(kcpApiClient.toJsonNode(response).toString())
-                    .build();
-        } catch (KcpCommunicationException e) {
-            recordError(CommerceVendorCommunicationTargetType.PAYMENT_APPROVAL, command.ordrNo(), e);
-            throw e;
+    private PaymentApprovalVendorResult executeApprovalWithRetry(
+            KcpPaymentApprovalRequest request, String orderNo
+    ) {
+        KcpProperties.Retry retryConfig = kcpProperties.getRetry();
+        long sleepMillis = retryConfig.getInitialDelayMs();
+        int maxAttempts = retryConfig.getMaxAttempts();
+        int readTimeoutAttemptCount = 0;
+        Exception lastException = null;
+
+        for (int attempt = 1; attempt <= maxAttempts; attempt++) {
+            try {
+                KcpPaymentApprovalResponse response = kcpApiClient.approvePayment(request);
+                recordResponse(CommerceVendorCommunicationTargetType.PAYMENT_APPROVAL, orderNo, response);
+                return buildApprovalResult(response);
+            } catch (Exception e) {
+                lastException = e;
+                recordError(CommerceVendorCommunicationTargetType.PAYMENT_APPROVAL, orderNo, e);
+
+                if (isConnectionFailure(e)) {
+                    log.warn("KCP 결제승인 연결 실패 - orderNo: {}, attempt: {}/{}, error: {}",
+                            orderNo, attempt, maxAttempts, e.getMessage());
+                    if (attempt < maxAttempts) {
+                        sleep(sleepMillis);
+                        sleepMillis *= retryConfig.getBackoffMultiplier();
+                        continue;
+                    }
+                    throw new PaymentVendorConnectionFailedException(
+                            "KCP 연결 실패: " + e.getMessage(), e
+                    );
+                }
+
+                if (isReadTimeout(e)) {
+                    readTimeoutAttemptCount++;
+                    log.warn("KCP 결제승인 읽기 타임아웃 - orderNo: {}, attempt: {}/{}, readTimeoutCount: {}/{}",
+                            orderNo, attempt, maxAttempts, readTimeoutAttemptCount, retryConfig.getReadTimeoutMaxAttempts());
+                    if (readTimeoutAttemptCount < retryConfig.getReadTimeoutMaxAttempts() && attempt < maxAttempts) {
+                        sleep(sleepMillis);
+                        sleepMillis *= retryConfig.getBackoffMultiplier();
+                        continue;
+                    }
+                    throw new KcpCommunicationException(
+                            "KCP 결제승인 읽기 타임아웃 초과: " + e.getMessage(), e
+                    );
+                }
+
+                throw e;
+            }
+        }
+
+        throw new KcpCommunicationException("KCP 결제승인 재시도 소진", lastException);
+    }
+
+    private PaymentApprovalVendorResult buildApprovalResult(KcpPaymentApprovalResponse response) {
+        return PaymentApprovalVendorResult.builder()
+                .resCd(response.resCd())
+                .resMsg(response.resMsg())
+                .resEnMsg(response.resEnMsg())
+                .tno(response.tno())
+                .amount(response.amount())
+                .payMethod(response.payMethod())
+                .cardCd(response.cardCd())
+                .cardName(response.cardName())
+                .cardNo(response.cardNo())
+                .appNo(response.appNo())
+                .appTime(response.appTime())
+                .noinf(response.noinf())
+                .noinfType(response.noinfType())
+                .quota(response.quota())
+                .cardMny(response.cardMny())
+                .couponMny(response.couponMny())
+                .partcancYn(response.partcancYn())
+                .cardBinType01(response.cardBinType01())
+                .cardBinType02(response.cardBinType02())
+                .rawResponse(kcpApiClient.toJsonNode(response).toString())
+                .build();
+    }
+
+    private boolean isConnectionFailure(Throwable throwable) {
+        return hasCause(throwable, ConnectException.class)
+                || hasCause(throwable, UnknownHostException.class);
+    }
+
+    private boolean isReadTimeout(Throwable throwable) {
+        return hasCause(throwable, SocketTimeoutException.class);
+    }
+
+    private boolean hasCause(Throwable throwable, Class<? extends Throwable> causeType) {
+        Throwable current = throwable;
+        while (current != null) {
+            if (causeType.isInstance(current)) {
+                return true;
+            }
+            current = current.getCause();
+        }
+        return false;
+    }
+
+    private void sleep(long millis) {
+        try {
+            long jitteredSleepMillis = ThreadLocalRandom.current()
+                    .nextLong(Math.max(1L, millis) + 1);
+            Thread.sleep(jitteredSleepMillis);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
         }
     }
 

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/configuration/KcpProperties.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/configuration/KcpProperties.java
@@ -14,6 +14,7 @@ public class KcpProperties {
     private String certInfoPath;
     private String privateKeyPath;
     private Api api = new Api();
+    private Retry retry = new Retry();
     private String retUrl;
 
     @Getter
@@ -22,5 +23,14 @@ public class KcpProperties {
         private String tradeRegisterUrl;
         private String paymentApprovalUrl;
         private String paymentCancelUrl;
+    }
+
+    @Getter
+    @Setter
+    public static class Retry {
+        private int maxAttempts = 3;
+        private long initialDelayMs = 1000L;
+        private long backoffMultiplier = 2;
+        private int readTimeoutMaxAttempts = 2;
     }
 }

--- a/commerce-service/commerce-adapters/src/main/resources/application.yml
+++ b/commerce-service/commerce-adapters/src/main/resources/application.yml
@@ -76,6 +76,11 @@ kcp:
     trade-register-url: ${KCP_TRADE_REGISTER_URL:https://testsmpay.kcp.co.kr/trade/register.do}
     payment-approval-url: ${KCP_PAYMENT_APPROVAL_URL:https://stg-spl.kcp.co.kr/gw/enc/v1/payment}
     payment-cancel-url: ${KCP_PAYMENT_CANCEL_URL:https://stg-spl.kcp.co.kr/gw/mod/v1/cancel}
+  retry:
+    max-attempts: ${KCP_RETRY_MAX_ATTEMPTS:3}
+    initial-delay-ms: ${KCP_RETRY_INITIAL_DELAY_MS:1000}
+    backoff-multiplier: ${KCP_RETRY_BACKOFF_MULTIPLIER:2}
+    read-timeout-max-attempts: ${KCP_RETRY_READ_TIMEOUT_MAX_ATTEMPTS:2}
   ret-url: ${KCP_RET_URL:https://marketnote-dev.vercel.app/payments/kcp/callback}
 
 settlement:

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/exception/PaymentVendorConnectionFailedException.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/exception/PaymentVendorConnectionFailedException.java
@@ -1,0 +1,11 @@
+package com.personal.marketnote.commerce.exception;
+
+public class PaymentVendorConnectionFailedException extends RuntimeException {
+    public PaymentVendorConnectionFailedException(String message) {
+        super(message);
+    }
+
+    public PaymentVendorConnectionFailedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/ApprovePaymentService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/ApprovePaymentService.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.commerce.service.payment;
 
 import com.personal.marketnote.commerce.exception.PaymentApprovalException;
+import com.personal.marketnote.commerce.exception.PaymentVendorConnectionFailedException;
 import com.personal.marketnote.commerce.port.in.command.payment.ApprovePaymentCommand;
 import com.personal.marketnote.commerce.port.in.result.payment.ApprovePaymentResult;
 import com.personal.marketnote.commerce.port.in.usecase.payment.ApprovePaymentUseCase;
@@ -35,12 +36,16 @@ public class ApprovePaymentService implements ApprovePaymentUseCase {
         // TX-1: 검증 + EXECUTING 커밋
         PaymentApprovalContext context = txHelper.prepareExecution(command);
 
-        // KCP 호출 (트랜잭션 외부)
+        // KCP 호출 (트랜잭션 외부 — 어댑터에서 재시도 수행)
         PaymentApprovalVendorResult vendorResult;
         try {
             vendorResult = paymentVendorPort.approvePayment(buildVendorCommand(command, context));
+        } catch (PaymentVendorConnectionFailedException e) {
+            // TX-2: 연결 실패 → FAILED (요청이 KCP에 도달하지 않음)
+            txHelper.commitFailure(context, "CONN_FAIL", e.getMessage());
+            throw PaymentApprovalException.kcpApprovalRequestFailed(e);
         } catch (Exception e) {
-            // TX-2: UNKNOWN 커밋
+            // TX-2: 기타 통신 오류 → UNKNOWN (요청이 KCP에 도달했을 수 있음)
             txHelper.commitUnknown(context, "UNKNOWN", "KCP 통신 오류: " + e.getMessage());
             throw PaymentApprovalException.kcpApprovalRequestFailed(e);
         }


### PR DESCRIPTION
## partially addresses #216
## resolves #1088

## Task
- [x] executeApprovalWithRetry 재시도 루프 구현
- [x] isConnectionFailure/isReadTimeout 예외 분류 메서드
- [x] jitter sleep (ThreadLocalRandom)
- [x] KcpProperties.Retry 설정 클래스
- [x] application.yml 재시도 설정 추가
- [x] PaymentVendorConnectionFailedException 예외 클래스
- [x] ApprovePaymentService catch 블록 분기