### PR TITLE
[#216][#1161] fix: 결제 승인 실패 시 트랜잭션 롤백으로 인한 상태 변경 미반영 버그 픽스

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/payment/mapper/PaymentRequestToCommandMapper.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/payment/mapper/PaymentRequestToCommandMapper.java
@@ -36,9 +36,9 @@ public class PaymentRequestToCommandMapper {
     public static CancelPaymentCommand mapToCommand(String orderKey, CancelPaymentRequest request, Long buyerId) {
         List<CancelPaymentCommand.CancelProductItem> cancelProducts = FormatValidator.hasValue(request.getCancelProducts())
                 ? request.getCancelProducts().stream()
-                        .map(item -> new CancelPaymentCommand.CancelProductItem(
-                                item.getPricePolicyId(), item.getQuantity()))
-                        .toList()
+                .map(item -> new CancelPaymentCommand.CancelProductItem(
+                        item.getPricePolicyId(), item.getQuantity()))
+                .toList()
                 : null;
 
         return CancelPaymentCommand.builder()

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/CancelPaymentService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/CancelPaymentService.java
@@ -2,13 +2,13 @@ package com.personal.marketnote.commerce.service.payment;
 
 import com.personal.marketnote.commerce.domain.order.Order;
 import com.personal.marketnote.commerce.domain.order.OrderProduct;
+import com.personal.marketnote.commerce.domain.order.OrderProductSnapshotState;
 import com.personal.marketnote.commerce.domain.order.OrderStatus;
 import com.personal.marketnote.commerce.domain.payment.Payment;
 import com.personal.marketnote.commerce.domain.payment.PspPaymentEvent;
 import com.personal.marketnote.commerce.domain.refund.Refund;
 import com.personal.marketnote.commerce.domain.refund.RefundCreateState;
 import com.personal.marketnote.commerce.domain.refund.RefundType;
-import com.personal.marketnote.commerce.domain.order.OrderProductSnapshotState;
 import com.personal.marketnote.commerce.exception.*;
 import com.personal.marketnote.commerce.port.in.command.order.ChangeOrderStatusCommand;
 import com.personal.marketnote.commerce.port.in.command.payment.CancelPaymentCommand;

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/PaymentApprovalContext.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/PaymentApprovalContext.java
@@ -6,13 +6,13 @@ import com.personal.marketnote.commerce.domain.payment.PspPaymentEvent;
 /**
  * 결제 승인 트랜잭션 간 데이터 전달 컨텍스트
  *
- * @param payment 결제 정보
- * @param event PSP 결제 이벤트
- * @param orderId 주문 ID
- * @param orderKey 주문 키
+ * @param payment       결제 정보
+ * @param event         PSP 결제 이벤트
+ * @param orderId       주문 ID
+ * @param orderKey      주문 키
  * @param paymentAmount 결제 금액
- * @param pgShopKey PG 가맹점 키
- * @param method 결제 수단
+ * @param pgShopKey     PG 가맹점 키
+ * @param method        결제 수단
  */
 public record PaymentApprovalContext(
         Payment payment,

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/PaymentApprovalTransactionHelper.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/PaymentApprovalTransactionHelper.java
@@ -2,7 +2,9 @@ package com.personal.marketnote.commerce.service.payment;
 
 import com.personal.marketnote.commerce.domain.order.Order;
 import com.personal.marketnote.commerce.domain.order.OrderStatus;
-import com.personal.marketnote.commerce.domain.payment.*;
+import com.personal.marketnote.commerce.domain.payment.Payment;
+import com.personal.marketnote.commerce.domain.payment.PaymentApprovalInfo;
+import com.personal.marketnote.commerce.domain.payment.PspPaymentEvent;
 import com.personal.marketnote.commerce.exception.*;
 import com.personal.marketnote.commerce.port.in.command.order.ChangeOrderStatusCommand;
 import com.personal.marketnote.commerce.port.in.command.payment.ApprovePaymentCommand;
@@ -10,7 +12,10 @@ import com.personal.marketnote.commerce.port.in.result.payment.ApprovePaymentRes
 import com.personal.marketnote.commerce.port.in.usecase.ledger.RecordLedgerEntryUseCase;
 import com.personal.marketnote.commerce.port.in.usecase.order.ChangeOrderStatusUseCase;
 import com.personal.marketnote.commerce.port.out.order.FindOrderPort;
-import com.personal.marketnote.commerce.port.out.payment.*;
+import com.personal.marketnote.commerce.port.out.payment.FindPaymentPort;
+import com.personal.marketnote.commerce.port.out.payment.FindPspPaymentEventPort;
+import com.personal.marketnote.commerce.port.out.payment.UpdatePaymentPort;
+import com.personal.marketnote.commerce.port.out.payment.UpdatePspPaymentEventPort;
 import com.personal.marketnote.commerce.port.out.payment.vendor.PaymentApprovalVendorResult;
 import com.personal.marketnote.common.utility.FormatValidator;
 import lombok.RequiredArgsConstructor;

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/payment/CancelPaymentUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/payment/CancelPaymentUseCaseTest.java
@@ -1361,7 +1361,7 @@ class CancelPaymentUseCaseTest {
     }
 
     private Order createOrderWithMultipleProducts(Long orderId, Long buyerId,
-                                                   List<Long> pricePolicyIds, List<Integer> quantities) {
+                                                  List<Long> pricePolicyIds, List<Integer> quantities) {
         List<OrderProductSnapshotState> productStates = new ArrayList<>();
         for (int i = 0; i < pricePolicyIds.size(); i++) {
             productStates.add(OrderProductSnapshotState.builder()


### PR DESCRIPTION
## partially addresses #216
## resolves #1161

## Task
- [x] ApprovePaymentService 트랜잭션 분리: 검증+EXECUTING 커밋 / KCP 호출 / 결과 반영 커밋
- [x] PaymentApprovalTransactionHelper 도입 (REQUIRES_NEW 전파)
- [x] KCP 명시적 오류 → FAILED, KCP 타임아웃 → UNKNOWN 상태 반영 보장
- [x] #1087 (PaymentEventStatus FAILED/UNKNOWN 추가) 이슈와 함께 해결