### PR TITLE
[#387][#1136] test: 회원 포인트 등록 기능 자동화 테스트 추가

### DIFF
--- a/product-service/product-application/src/test/java/com/personal/marketnote/product/service/product/UpdateProductUseCaseTest.java
+++ b/product-service/product-application/src/test/java/com/personal/marketnote/product/service/product/UpdateProductUseCaseTest.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.product.service.product;
 
 import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.kafka.event.ProductUpdatedEvent;
 import com.personal.marketnote.product.domain.product.Product;
 import com.personal.marketnote.product.domain.product.ProductSnapshotState;
 import com.personal.marketnote.product.domain.product.ProductTag;
@@ -8,7 +9,6 @@ import com.personal.marketnote.product.exception.NotProductOwnerException;
 import com.personal.marketnote.product.exception.ProductInfoNoValueException;
 import com.personal.marketnote.product.exception.ProductNotFoundException;
 import com.personal.marketnote.product.port.in.command.FulfillmentVendorGoodsOptionCommand;
-import com.personal.marketnote.common.kafka.event.ProductUpdatedEvent;
 import com.personal.marketnote.product.port.in.command.UpdateProductCommand;
 import com.personal.marketnote.product.port.in.usecase.product.GetProductUseCase;
 import com.personal.marketnote.product.port.out.event.PublishProductEventPort;

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/point/apidocs/CancelPendingPointApiDocs.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/point/apidocs/CancelPendingPointApiDocs.java
@@ -21,38 +21,38 @@ import java.lang.annotation.*;
         summary = "(관리자) 적립 예정 포인트 취소",
         description = """
                 작성일자: 2026-03-07
-
+                
                 작성자: 성효빈
-
+                
                 ---
-
+                
                 ## Description
-
+                
                 - 적립 예정 포인트를 취소(회수)합니다.
-
+                
                 - sourceType과 sourceId로 취소 대상 적립 예정 포인트 이력을 식별합니다.
-
+                
                 - 취소 시 적립 예정 포인트에서 차감되고, 실제 포인트는 변경되지 않습니다.
-
+                
                 - 기존 pending 이력은 isReflected: true로 업데이트됩니다.
-
+                
                 - 취소 대상 이력이 없으면 현재 포인트를 그대로 반환합니다 (멱등성 보장).
-
+                
                 ---
-
+                
                 ## Request
-
+                
                 | **키** | **타입** | **설명** | **필수 여부** | **예시** |
                 | --- | --- | --- | --- | --- |
                 | userId (path) | number | 회원 ID | Y | 100 |
                 | sourceType | string | 출처 유형 | Y | "ORDER" |
                 | sourceId | number | 출처 ID (주문 ID) | Y | 123 |
                 | reason | string | 사유 | N | "결제 취소 적립 예정 포인트 회수" |
-
+                
                 ---
-
+                
                 ## Response
-
+                
                 | **키** | **타입** | **설명** | **예시** |
                 | --- | --- | --- | --- |
                 | statusCode | number | HTTP 상태 코드 | 200 |

--- a/reward-service/reward-application/src/test/java/com/personal/marketnote/reward/service/point/RegisterUserPointUseCaseTest.java
+++ b/reward-service/reward-application/src/test/java/com/personal/marketnote/reward/service/point/RegisterUserPointUseCaseTest.java
@@ -1,0 +1,164 @@
+package com.personal.marketnote.reward.service.point;
+
+import com.personal.marketnote.reward.domain.point.UserPoint;
+import com.personal.marketnote.reward.domain.point.UserPointHistory;
+import com.personal.marketnote.reward.domain.point.UserPointSnapshotState;
+import com.personal.marketnote.reward.exception.DuplicateUserPointException;
+import com.personal.marketnote.reward.port.in.command.point.RegisterUserPointCommand;
+import com.personal.marketnote.reward.port.out.point.FindUserPointPort;
+import com.personal.marketnote.reward.port.out.point.SaveUserPointHistoryPort;
+import com.personal.marketnote.reward.port.out.point.SaveUserPointPort;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class RegisterUserPointUseCaseTest {
+
+    @InjectMocks
+    private RegisterUserPointService registerUserPointService;
+
+    @Mock
+    private SaveUserPointPort saveUserPointPort;
+
+    @Mock
+    private SaveUserPointHistoryPort saveUserPointHistoryPort;
+
+    @Mock
+    private FindUserPointPort findUserPointPort;
+
+    private static final Long USER_ID = 1L;
+    private static final String USER_KEY = "test-user-key";
+    private static final LocalDateTime NOW = LocalDateTime.of(2026, 3, 5, 10, 0);
+
+    private RegisterUserPointCommand createCommand() {
+        return RegisterUserPointCommand.of(USER_ID, USER_KEY);
+    }
+
+    private UserPoint createSavedUserPoint() {
+        return UserPoint.from(UserPointSnapshotState.builder()
+                .userId(USER_ID)
+                .userKey(USER_KEY)
+                .amount(0L)
+                .addExpectedAmount(0L)
+                .expireExpectedAmount(0L)
+                .createdAt(NOW)
+                .modifiedAt(NOW)
+                .build());
+    }
+
+    @Test
+    @DisplayName("신규 회원 포인트를 등록하면 포인트와 이력이 저장된다")
+    void shouldRegisterUserPointAndHistorySuccessfully() {
+        // given
+        RegisterUserPointCommand command = createCommand();
+        UserPoint savedUserPoint = createSavedUserPoint();
+
+        when(findUserPointPort.existsByUserId(USER_ID)).thenReturn(false);
+        when(saveUserPointPort.save(any(UserPoint.class))).thenReturn(savedUserPoint);
+        when(saveUserPointHistoryPort.save(any(UserPointHistory.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        // when
+        registerUserPointService.register(command);
+
+        // then
+        verify(findUserPointPort).existsByUserId(USER_ID);
+        verify(saveUserPointPort).save(any(UserPoint.class));
+        verify(saveUserPointHistoryPort).save(any(UserPointHistory.class));
+    }
+
+    @Test
+    @DisplayName("신규 회원 포인트 등록 시 초기 금액은 0이다")
+    void shouldRegisterWithZeroInitialAmount() {
+        // given
+        RegisterUserPointCommand command = createCommand();
+        UserPoint savedUserPoint = createSavedUserPoint();
+
+        when(findUserPointPort.existsByUserId(USER_ID)).thenReturn(false);
+        when(saveUserPointPort.save(any(UserPoint.class))).thenReturn(savedUserPoint);
+        when(saveUserPointHistoryPort.save(any(UserPointHistory.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        // when
+        registerUserPointService.register(command);
+
+        // then
+        ArgumentCaptor<UserPoint> pointCaptor = ArgumentCaptor.forClass(UserPoint.class);
+        verify(saveUserPointPort).save(pointCaptor.capture());
+        UserPoint capturedPoint = pointCaptor.getValue();
+
+        assertThat(capturedPoint.getUserId()).isEqualTo(USER_ID);
+        assertThat(capturedPoint.getAmountValue()).isZero();
+        assertThat(capturedPoint.getAddExpectedAmount()).isZero();
+        assertThat(capturedPoint.getExpireExpectedAmount()).isZero();
+    }
+
+    @Test
+    @DisplayName("신규 회원 포인트 등록 시 이력의 출처 유형은 USER이다")
+    void shouldSaveHistoryWithUserSourceType() {
+        // given
+        RegisterUserPointCommand command = createCommand();
+        UserPoint savedUserPoint = createSavedUserPoint();
+
+        when(findUserPointPort.existsByUserId(USER_ID)).thenReturn(false);
+        when(saveUserPointPort.save(any(UserPoint.class))).thenReturn(savedUserPoint);
+        when(saveUserPointHistoryPort.save(any(UserPointHistory.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        // when
+        registerUserPointService.register(command);
+
+        // then
+        ArgumentCaptor<UserPointHistory> historyCaptor = ArgumentCaptor.forClass(UserPointHistory.class);
+        verify(saveUserPointHistoryPort).save(historyCaptor.capture());
+        UserPointHistory capturedHistory = historyCaptor.getValue();
+
+        assertThat(capturedHistory.getUserId()).isEqualTo(USER_ID);
+        assertThat(capturedHistory.getAmount()).isZero();
+        assertThat(capturedHistory.getIsReflected()).isTrue();
+    }
+
+    @Test
+    @DisplayName("이미 포인트가 존재하는 회원이면 DuplicateUserPointException이 발생한다")
+    void shouldThrowWhenUserPointAlreadyExists() {
+        // given
+        RegisterUserPointCommand command = createCommand();
+
+        when(findUserPointPort.existsByUserId(USER_ID)).thenReturn(true);
+
+        // expect
+        assertThatThrownBy(() -> registerUserPointService.register(command))
+                .isInstanceOf(DuplicateUserPointException.class);
+
+        verify(saveUserPointPort, never()).save(any());
+        verify(saveUserPointHistoryPort, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("중복 검증 실패 시 포인트 저장과 이력 저장이 수행되지 않는다")
+    void shouldNotSaveAnythingWhenDuplicateValidationFails() {
+        // given
+        RegisterUserPointCommand command = createCommand();
+
+        when(findUserPointPort.existsByUserId(USER_ID)).thenReturn(true);
+
+        // expect
+        assertThatThrownBy(() -> registerUserPointService.register(command))
+                .isInstanceOf(DuplicateUserPointException.class);
+
+        verifyNoInteractions(saveUserPointPort);
+        verifyNoInteractions(saveUserPointHistoryPort);
+    }
+}


### PR DESCRIPTION
## partially addresses #387
## resolves #1136

## Test Case
- [x] 신규 회원 포인트를 등록하면 포인트와 이력이 저장된다
- [x] 신규 회원 포인트 등록 시 초기 금액은 0이다
- [x] 신규 회원 포인트 등록 시 이력의 출처 유형은 USER이다
- [x] 이미 포인트가 존재하는 회원이면 DuplicateUserPointException이 발생한다
- [x] 중복 검증 실패 시 포인트 저장과 이력 저장이 수행되지 않는다