### PR TITLE
[#929][#1174] feat: 주문 결제 완료 시 주문 상태 변경 Kafka 이벤트 전환

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/PaymentApprovedOrderStatusConsumer.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/PaymentApprovedOrderStatusConsumer.java
@@ -1,0 +1,64 @@
+package com.personal.marketnote.commerce.adapter.in.event;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.commerce.domain.order.OrderStatus;
+import com.personal.marketnote.commerce.port.in.command.order.ChangeOrderStatusCommand;
+import com.personal.marketnote.commerce.port.in.usecase.order.ChangeOrderStatusUseCase;
+import com.personal.marketnote.common.kafka.KafkaTopicConstants;
+import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.PaymentApprovedEvent;
+import com.personal.marketnote.common.utility.FormatValidator;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PaymentApprovedOrderStatusConsumer {
+    private final ChangeOrderStatusUseCase changeOrderStatusUseCase;
+    private final ObjectMapper objectMapper;
+
+    @KafkaListener(
+            topics = KafkaTopicConstants.PAYMENT_APPROVED,
+            groupId = "commerce-order-status"
+    )
+    public void handlePaymentApprovedEvent(
+            ConsumerRecord<String, EventEnvelope<?>> record,
+            Acknowledgment acknowledgment
+    ) {
+        EventEnvelope<?> envelope = record.value();
+
+        try {
+            PaymentApprovedEvent payload = envelope.getPayloadAs(PaymentApprovedEvent.class, objectMapper);
+
+            log.info("결제 승인 이벤트 수신. eventId={}, orderId={}, orderKey={}",
+                    envelope.eventId(), payload.orderId(), payload.orderKey());
+
+            if (FormatValidator.hasNoValue(payload.orderId())) {
+                log.error("유효하지 않은 이벤트 페이로드. eventId={}, orderId=null",
+                        envelope.eventId());
+                acknowledgment.acknowledge();
+                return;
+            }
+
+            ChangeOrderStatusCommand command = ChangeOrderStatusCommand.builder()
+                    .id(payload.orderId())
+                    .orderStatus(OrderStatus.PAID)
+                    .build();
+            changeOrderStatusUseCase.changeOrderStatus(command);
+
+            log.info("Kafka 이벤트로 주문 상태 PAID 변경 완료. orderId={}, orderKey={}",
+                    payload.orderId(), payload.orderKey());
+        } catch (Exception e) {
+            log.error("주문 상태 PAID 변경 실패. eventId={}, key={}, error={}",
+                    envelope.eventId(), record.key(), e.getMessage(), e);
+            throw e;
+        }
+
+        acknowledgment.acknowledge();
+    }
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/event/PaymentEventKafkaProducer.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/event/PaymentEventKafkaProducer.java
@@ -1,0 +1,45 @@
+package com.personal.marketnote.commerce.adapter.out.event;
+
+import com.personal.marketnote.commerce.port.out.event.PublishPaymentEventPort;
+import com.personal.marketnote.common.adapter.out.ServiceAdapter;
+import com.personal.marketnote.common.kafka.KafkaTopicConstants;
+import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.PaymentApprovedEvent;
+import com.personal.marketnote.common.utility.FormatValidator;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+
+import java.time.Clock;
+
+@Slf4j
+@ServiceAdapter
+@RequiredArgsConstructor
+public class PaymentEventKafkaProducer implements PublishPaymentEventPort {
+    private static final String SOURCE = "commerce-service";
+
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+    private final Clock clock;
+
+    @Override
+    public void publishPaymentApprovedEvent(Long orderId, String orderKey, Long paymentAmount) {
+        PaymentApprovedEvent payload = new PaymentApprovedEvent(orderId, orderKey, paymentAmount);
+        String topic = KafkaTopicConstants.PAYMENT_APPROVED;
+        EventEnvelope<PaymentApprovedEvent> envelope = EventEnvelope.of(
+                topic, SOURCE, payload, clock
+        );
+
+        kafkaTemplate.send(topic, orderId.toString(), envelope)
+                .whenComplete((result, ex) -> {
+                    if (FormatValidator.hasValue(ex)) {
+                        log.error("Kafka 이벤트 발행 실패. topic={}, orderId={}, orderKey={}",
+                                topic, orderId, orderKey, ex);
+                        return;
+                    }
+
+                    log.info("Kafka 이벤트 발행 성공. topic={}, orderId={}, orderKey={}, offset={}",
+                            topic, orderId, orderKey,
+                            result.getRecordMetadata().offset());
+                });
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/event/PublishPaymentEventPort.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/event/PublishPaymentEventPort.java
@@ -1,0 +1,6 @@
+package com.personal.marketnote.commerce.port.out.event;
+
+public interface PublishPaymentEventPort {
+
+    void publishPaymentApprovedEvent(Long orderId, String orderKey, Long paymentAmount);
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/payment/vendor/PaymentApprovalVendorResult.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/payment/vendor/PaymentApprovalVendorResult.java
@@ -1,5 +1,6 @@
 package com.personal.marketnote.commerce.port.out.payment.vendor;
 
+import com.personal.marketnote.common.utility.FormatValidator;
 import lombok.Builder;
 
 @Builder
@@ -26,6 +27,6 @@ public record PaymentApprovalVendorResult(
         String rawResponse
 ) {
     public boolean isSuccess() {
-        return "0000".equals(resCd);
+        return FormatValidator.equals(resCd, "0000");
     }
 }

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/ApprovePaymentService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/ApprovePaymentService.java
@@ -36,19 +36,7 @@ public class ApprovePaymentService implements ApprovePaymentUseCase {
         // TX-1: 검증 + EXECUTING 커밋
         PaymentApprovalContext context = txHelper.prepareExecution(command);
 
-        // KCP 호출 (트랜잭션 외부 — 어댑터에서 재시도 수행)
-        PaymentApprovalVendorResult vendorResult;
-        try {
-            vendorResult = paymentVendorPort.approvePayment(buildVendorCommand(command, context));
-        } catch (PaymentVendorConnectionFailedException e) {
-            // TX-2: 연결 실패 → FAILED (요청이 KCP에 도달하지 않음)
-            txHelper.commitFailure(context, "CONN_FAIL", e.getMessage());
-            throw PaymentApprovalException.kcpApprovalRequestFailed(e);
-        } catch (Exception e) {
-            // TX-2: 기타 통신 오류 → UNKNOWN (요청이 KCP에 도달했을 수 있음)
-            txHelper.commitUnknown(context, "UNKNOWN", "KCP 통신 오류: " + e.getMessage());
-            throw PaymentApprovalException.kcpApprovalRequestFailed(e);
-        }
+        PaymentApprovalVendorResult vendorResult = requestPaymentApprovalToPsp(command, context);
 
         // TX-2: 성공 또는 실패 커밋
         if (vendorResult.isSuccess()) {
@@ -58,6 +46,23 @@ public class ApprovePaymentService implements ApprovePaymentUseCase {
 
         txHelper.commitFailure(context, vendorResult.resCd(), vendorResult.resMsg());
         throw PaymentApprovalException.kcpApprovalFailed(vendorResult.resCd(), vendorResult.resMsg());
+    }
+
+    private PaymentApprovalVendorResult requestPaymentApprovalToPsp(
+            ApprovePaymentCommand command, PaymentApprovalContext context
+    ) {
+        // KCP 호출 (트랜잭션 외부 — 어댑터에서 재시도 수행)
+        try {
+            return paymentVendorPort.approvePayment(buildVendorCommand(command, context));
+        } catch (PaymentVendorConnectionFailedException e) {
+            // TX-2: 연결 실패 → FAILED (요청이 KCP에 도달하지 않음)
+            txHelper.commitFailure(context, "CONN_FAIL", e.getMessage());
+            throw PaymentApprovalException.kcpApprovalRequestFailed(e);
+        } catch (Exception e) {
+            // TX-2: 기타 통신 오류 → UNKNOWN (요청이 KCP에 도달했을 수 있음)
+            txHelper.commitUnknown(context, "UNKNOWN", "KCP 통신 오류: " + e.getMessage());
+            throw PaymentApprovalException.kcpApprovalRequestFailed(e);
+        }
     }
 
     private PaymentApprovalVendorCommand buildVendorCommand(

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/PaymentApprovalTransactionHelper.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/PaymentApprovalTransactionHelper.java
@@ -11,6 +11,7 @@ import com.personal.marketnote.commerce.port.in.command.payment.ApprovePaymentCo
 import com.personal.marketnote.commerce.port.in.result.payment.ApprovePaymentResult;
 import com.personal.marketnote.commerce.port.in.usecase.ledger.RecordLedgerEntryUseCase;
 import com.personal.marketnote.commerce.port.in.usecase.order.ChangeOrderStatusUseCase;
+import com.personal.marketnote.commerce.port.out.event.PublishPaymentEventPort;
 import com.personal.marketnote.commerce.port.out.order.FindOrderPort;
 import com.personal.marketnote.commerce.port.out.payment.FindPaymentPort;
 import com.personal.marketnote.commerce.port.out.payment.FindPspPaymentEventPort;
@@ -45,6 +46,7 @@ public class PaymentApprovalTransactionHelper {
     private final UpdatePspPaymentEventPort updatePspPaymentEventPort;
     private final ChangeOrderStatusUseCase changeOrderStatusUseCase;
     private final RecordLedgerEntryUseCase recordLedgerEntryUseCase;
+    private final PublishPaymentEventPort publishPaymentEventPort;
 
     /**
      * TX-1: 검증 + EXECUTING 상태 커밋
@@ -103,6 +105,8 @@ public class PaymentApprovalTransactionHelper {
         );
 
         recordLedgerEntryForPaymentApproval(payment);
+
+        publishPaymentApprovedEvent(payment);
 
         return ApprovePaymentResult.builder()
                 .orderId(payment.getOrderId())
@@ -177,6 +181,18 @@ public class PaymentApprovalTransactionHelper {
             throw new UnauthorizedOrderAccessException();
         }
         return order;
+    }
+
+    private void publishPaymentApprovedEvent(Payment payment) {
+        try {
+            publishPaymentEventPort.publishPaymentApprovedEvent(
+                    payment.getOrderId(),
+                    payment.getOrderKey().toString(),
+                    payment.getPaymentAmount()
+            );
+        } catch (Exception e) {
+            log.error("결제 승인 이벤트 발행 실패 - orderId: {}, error: {}", payment.getOrderId(), e.getMessage(), e);
+        }
     }
 
     private void recordLedgerEntryForPaymentApproval(Payment payment) {

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/payment/Payment.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/payment/Payment.java
@@ -50,28 +50,28 @@ public class Payment {
 
     public void markAsSuccess(String pgPaymentKey) {
         this.pgPaymentKey = pgPaymentKey;
-        this.successYn = true;
+        successYn = true;
     }
 
     public void markAsFailed() {
-        this.successYn = false;
+        successYn = false;
     }
 
     public void markAsRefunded() {
-        this.refundedYn = true;
-        this.refundAmount = this.paymentAmount;
+        refundedYn = true;
+        refundAmount = paymentAmount;
     }
 
     public void markAsPartiallyRefunded(Long amount) {
-        long newRefundAmount = this.refundAmount + amount;
-        if (newRefundAmount > this.paymentAmount) {
+        long newRefundAmount = refundAmount + amount;
+        if (newRefundAmount > paymentAmount) {
             throw new InvalidRefundAmountException(
-                    "누적 환불 금액이 결제 금액을 초과합니다. paymentAmount=" + this.paymentAmount
-                            + ", 현재 환불액=" + this.refundAmount + ", 요청 환불액=" + amount);
+                    "누적 환불 금액이 결제 금액을 초과합니다. paymentAmount=" + paymentAmount
+                            + ", 현재 환불액=" + refundAmount + ", 요청 환불액=" + amount);
         }
-        this.refundAmount = newRefundAmount;
-        if (this.refundAmount.equals(this.paymentAmount)) {
-            this.refundedYn = true;
+        refundAmount = newRefundAmount;
+        if (FormatValidator.equals(refundAmount, paymentAmount)) {
+            refundedYn = true;
         }
     }
 }

--- a/common/src/main/java/com/personal/marketnote/common/kafka/event/EventEnvelope.java
+++ b/common/src/main/java/com/personal/marketnote/common/kafka/event/EventEnvelope.java
@@ -2,10 +2,13 @@ package com.personal.marketnote.common.kafka.event;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.f4b6a3.uuid.UuidCreator;
+import lombok.AccessLevel;
+import lombok.Builder;
 
 import java.time.Clock;
 import java.time.LocalDateTime;
 
+@Builder(access = AccessLevel.PRIVATE)
 public record EventEnvelope<T>(
         String eventId,
         String eventType,
@@ -15,13 +18,13 @@ public record EventEnvelope<T>(
 ) {
 
     public static <T> EventEnvelope<T> of(String eventType, String source, T payload, Clock clock) {
-        return new EventEnvelope<>(
-                UuidCreator.getTimeOrdered().toString(),
-                eventType,
-                source,
-                LocalDateTime.now(clock),
-                payload
-        );
+        return EventEnvelope.<T>builder()
+                .eventId(UuidCreator.getTimeOrdered().toString())
+                .eventType(eventType)
+                .source(source)
+                .timestamp(LocalDateTime.now(clock))
+                .payload(payload)
+                .build();
     }
 
     @SuppressWarnings("unchecked")

--- a/common/src/main/java/com/personal/marketnote/common/kafka/event/PaymentApprovedEvent.java
+++ b/common/src/main/java/com/personal/marketnote/common/kafka/event/PaymentApprovedEvent.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.common.kafka.event;
+
+public record PaymentApprovedEvent(
+        Long orderId,
+        String orderKey,
+        Long paymentAmount
+) {
+}


### PR DESCRIPTION
## partially addresses #929
## resolves #1174

## Task
- [x] PaymentApprovedEvent 이벤트 정의 (common)
- [x] PublishPaymentEventPort 인터페이스 추가 (commerce-application)
- [x] PaymentEventKafkaProducer 구현 (commerce-adapters)
- [x] PaymentApprovedOrderStatusConsumer 구현 (commerce-adapters)
- [x] PaymentApprovalTransactionHelper.commitSuccess()에 이벤트 발행 추가 (듀얼 라이트)
- [x] EventEnvelope에 @builder(access = PRIVATE) 추가
- [x] Payment 도메인 this. 접두사 제거 + FormatValidator.equals() 적용