### PR TITLE
[#929][#1175] feat: 주문 결제 실패 시 주문 상태 변경 Kafka 이벤트 전환

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/PaymentFailedOrderStatusConsumer.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/PaymentFailedOrderStatusConsumer.java
@@ -1,0 +1,68 @@
+package com.personal.marketnote.commerce.adapter.in.event;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.commerce.domain.order.OrderStatus;
+import com.personal.marketnote.commerce.exception.OrderStatusAlreadyChangedException;
+import com.personal.marketnote.commerce.port.in.command.order.ChangeOrderStatusCommand;
+import com.personal.marketnote.commerce.port.in.usecase.order.ChangeOrderStatusUseCase;
+import com.personal.marketnote.common.kafka.KafkaTopicConstants;
+import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.PaymentFailedEvent;
+import com.personal.marketnote.common.utility.FormatValidator;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PaymentFailedOrderStatusConsumer {
+    private final ChangeOrderStatusUseCase changeOrderStatusUseCase;
+    private final ObjectMapper objectMapper;
+
+    @KafkaListener(
+            topics = KafkaTopicConstants.PAYMENT_FAILED,
+            groupId = "commerce-order-status"
+    )
+    public void handlePaymentFailedEvent(
+            ConsumerRecord<String, EventEnvelope<?>> record,
+            Acknowledgment acknowledgment
+    ) {
+        EventEnvelope<?> envelope = record.value();
+
+        try {
+            PaymentFailedEvent payload = envelope.getPayloadAs(PaymentFailedEvent.class, objectMapper);
+
+            log.info("결제 실패 이벤트 수신. eventId={}, orderId={}, orderKey={}, resultCode={}",
+                    envelope.eventId(), payload.orderId(), payload.orderKey(), payload.resultCode());
+
+            if (FormatValidator.hasNoValue(payload.orderId())) {
+                log.error("유효하지 않은 이벤트 페이로드. eventId={}, orderId=null",
+                        envelope.eventId());
+                acknowledgment.acknowledge();
+                return;
+            }
+
+            ChangeOrderStatusCommand command = ChangeOrderStatusCommand.builder()
+                    .id(payload.orderId())
+                    .orderStatus(OrderStatus.FAILED)
+                    .build();
+            changeOrderStatusUseCase.changeOrderStatus(command);
+
+            log.info("Kafka 이벤트로 주문 상태 FAILED 변경 완료. orderId={}, orderKey={}",
+                    payload.orderId(), payload.orderKey());
+        } catch (OrderStatusAlreadyChangedException e) {
+            log.warn("듀얼 라이트: 이미 주문 상태가 변경됨. eventId={}, key={}, message={}",
+                    envelope.eventId(), record.key(), e.getMessage());
+        } catch (Exception e) {
+            log.error("주문 상태 FAILED 변경 실패. eventId={}, key={}, error={}",
+                    envelope.eventId(), record.key(), e.getMessage(), e);
+            throw e;
+        }
+
+        acknowledgment.acknowledge();
+    }
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/event/PaymentEventKafkaProducer.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/event/PaymentEventKafkaProducer.java
@@ -5,6 +5,7 @@ import com.personal.marketnote.common.adapter.out.ServiceAdapter;
 import com.personal.marketnote.common.kafka.KafkaTopicConstants;
 import com.personal.marketnote.common.kafka.event.EventEnvelope;
 import com.personal.marketnote.common.kafka.event.PaymentApprovedEvent;
+import com.personal.marketnote.common.kafka.event.PaymentFailedEvent;
 import com.personal.marketnote.common.utility.FormatValidator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -26,6 +27,28 @@ public class PaymentEventKafkaProducer implements PublishPaymentEventPort {
         PaymentApprovedEvent payload = new PaymentApprovedEvent(orderId, orderKey, paymentAmount);
         String topic = KafkaTopicConstants.PAYMENT_APPROVED;
         EventEnvelope<PaymentApprovedEvent> envelope = EventEnvelope.of(
+                topic, SOURCE, payload, clock
+        );
+
+        kafkaTemplate.send(topic, orderId.toString(), envelope)
+                .whenComplete((result, ex) -> {
+                    if (FormatValidator.hasValue(ex)) {
+                        log.error("Kafka 이벤트 발행 실패. topic={}, orderId={}, orderKey={}",
+                                topic, orderId, orderKey, ex);
+                        return;
+                    }
+
+                    log.info("Kafka 이벤트 발행 성공. topic={}, orderId={}, orderKey={}, offset={}",
+                            topic, orderId, orderKey,
+                            result.getRecordMetadata().offset());
+                });
+    }
+
+    @Override
+    public void publishPaymentFailedEvent(Long orderId, String orderKey, String resultCode, String resultMessage) {
+        PaymentFailedEvent payload = new PaymentFailedEvent(orderId, orderKey, resultCode, resultMessage);
+        String topic = KafkaTopicConstants.PAYMENT_FAILED;
+        EventEnvelope<PaymentFailedEvent> envelope = EventEnvelope.of(
                 topic, SOURCE, payload, clock
         );
 

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/event/PublishPaymentEventPort.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/event/PublishPaymentEventPort.java
@@ -3,4 +3,6 @@ package com.personal.marketnote.commerce.port.out.event;
 public interface PublishPaymentEventPort {
 
     void publishPaymentApprovedEvent(Long orderId, String orderKey, Long paymentAmount);
+
+    void publishPaymentFailedEvent(Long orderId, String orderKey, String resultCode, String resultMessage);
 }

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/PaymentApprovalTransactionHelper.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/PaymentApprovalTransactionHelper.java
@@ -139,6 +139,8 @@ public class PaymentApprovalTransactionHelper {
                         .orderStatus(OrderStatus.FAILED)
                         .build()
         );
+
+        publishPaymentFailedEvent(payment, resultCode, resultMessage);
     }
 
     /**
@@ -192,6 +194,19 @@ public class PaymentApprovalTransactionHelper {
             );
         } catch (Exception e) {
             log.error("결제 승인 이벤트 발행 실패 - orderId: {}, error: {}", payment.getOrderId(), e.getMessage(), e);
+        }
+    }
+
+    private void publishPaymentFailedEvent(Payment payment, String resultCode, String resultMessage) {
+        try {
+            publishPaymentEventPort.publishPaymentFailedEvent(
+                    payment.getOrderId(),
+                    payment.getOrderKey().toString(),
+                    resultCode,
+                    resultMessage
+            );
+        } catch (Exception e) {
+            log.error("결제 실패 이벤트 발행 실패 - orderId: {}, error: {}", payment.getOrderId(), e.getMessage(), e);
         }
     }
 

--- a/common/src/main/java/com/personal/marketnote/common/kafka/KafkaTopicConstants.java
+++ b/common/src/main/java/com/personal/marketnote/common/kafka/KafkaTopicConstants.java
@@ -8,6 +8,7 @@ public final class KafkaTopicConstants {
     // Commerce 이벤트
     public static final String ORDER_PAYMENT_COMPLETED = "commerce.order.payment-completed";
     public static final String PAYMENT_APPROVED = "commerce.payment.approved";
+    public static final String PAYMENT_FAILED = "commerce.payment.failed";
     public static final String PAYMENT_CANCELLED = "commerce.payment.cancelled";
     public static final String SETTLEMENT_EXECUTED = "commerce.settlement.executed";
 

--- a/common/src/main/java/com/personal/marketnote/common/kafka/event/PaymentFailedEvent.java
+++ b/common/src/main/java/com/personal/marketnote/common/kafka/event/PaymentFailedEvent.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.common.kafka.event;
+
+public record PaymentFailedEvent(
+        Long orderId,
+        String orderKey,
+        String resultCode,
+        String resultMessage
+) {
+}


### PR DESCRIPTION
## partially addresses #929
## resolves #1175

## Task
- [x] PaymentFailedEvent record 생성 (common 모듈)
- [x] KafkaTopicConstants에 PAYMENT_FAILED 상수 추가
- [x] PublishPaymentEventPort에 publishPaymentFailedEvent() 메서드 추가
- [x] PaymentEventKafkaProducer에 publishPaymentFailedEvent() 구현
- [x] PaymentApprovalTransactionHelper.commitFailure()에 이벤트 발행 추가 (듀얼 라이트)
- [x] PaymentFailedOrderStatusConsumer 생성 (commerce.payment.failed 토픽 구독)
- [x] 듀얼 라이트 기간 OrderStatusAlreadyChangedException 멱등 처리