### PR TITLE
[#929][#932] feat: 주문 결제 완료 시 재고 차감 연동 기능 Kafka 이벤트 전환

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/OrderPaymentCompletedInventoryConsumer.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/OrderPaymentCompletedInventoryConsumer.java
@@ -1,0 +1,62 @@
+package com.personal.marketnote.commerce.adapter.in.event;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.common.kafka.KafkaTopicConstants;
+import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.OrderPaymentCompletedEvent;
+import com.personal.marketnote.common.utility.FormatValidator;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OrderPaymentCompletedInventoryConsumer {
+    private final ObjectMapper objectMapper;
+
+    @KafkaListener(
+            topics = KafkaTopicConstants.ORDER_PAYMENT_COMPLETED,
+            groupId = "commerce-inventory"
+    )
+    public void handleOrderPaymentCompletedEvent(
+            ConsumerRecord<String, EventEnvelope<?>> record,
+            Acknowledgment acknowledgment
+    ) {
+        EventEnvelope<?> envelope = record.value();
+
+        try {
+            OrderPaymentCompletedEvent payload = envelope.getPayloadAs(
+                    OrderPaymentCompletedEvent.class, objectMapper
+            );
+
+            log.info("주문 결제 완료 이벤트 수신 (재고 차감). eventId={}, orderId={}, orderProducts={}건",
+                    envelope.eventId(), payload.orderId(),
+                    FormatValidator.hasValue(payload.orderProducts()) ? payload.orderProducts().size() : 0);
+
+            if (FormatValidator.hasNoValue(payload.orderId())) {
+                log.error("유효하지 않은 이벤트 페이로드. eventId={}, orderId=null",
+                        envelope.eventId());
+                acknowledgment.acknowledge();
+                return;
+            }
+
+            // FIXME: [#929] 듀얼 라이트 기간 — 동기 호출(ChangeOrderStatusService)에서 이미 재고 차감 수행.
+            //  재고 차감은 멱등하지 않으므로, HTTP 제거 후 아래 코드 활성화:
+            //  List<OrderProduct> orderProducts = convertToOrderProducts(payload.orderProducts());
+            //  reduceProductInventoryUseCase.reduce(orderProducts, "Kafka 결제 완료 재고 차감");
+
+            log.info("듀얼 라이트: 이벤트 수신 확인 완료. orderId={}, 재고 차감은 동기 호출에서 처리됨",
+                    payload.orderId());
+        } catch (Exception e) {
+            log.error("재고 차감 이벤트 처리 실패. eventId={}, key={}, error={}",
+                    envelope.eventId(), record.key(), e.getMessage(), e);
+            throw e;
+        }
+
+        acknowledgment.acknowledge();
+    }
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/event/OrderEventKafkaProducer.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/event/OrderEventKafkaProducer.java
@@ -1,0 +1,60 @@
+package com.personal.marketnote.commerce.adapter.out.event;
+
+import com.personal.marketnote.commerce.domain.order.OrderProduct;
+import com.personal.marketnote.commerce.port.out.event.PublishOrderEventPort;
+import com.personal.marketnote.common.adapter.out.ServiceAdapter;
+import com.personal.marketnote.common.kafka.KafkaTopicConstants;
+import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.OrderPaymentCompletedEvent;
+import com.personal.marketnote.common.kafka.event.OrderPaymentCompletedEvent.OrderProductItem;
+import com.personal.marketnote.common.utility.FormatValidator;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+
+import java.time.Clock;
+import java.util.List;
+
+@Slf4j
+@ServiceAdapter
+@RequiredArgsConstructor
+public class OrderEventKafkaProducer implements PublishOrderEventPort {
+    private static final String SOURCE = "commerce-service";
+
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+    private final Clock clock;
+
+    @Override
+    public void publishOrderPaymentCompletedEvent(Long orderId, Long buyerId, Long totalAmount,
+                                                  Long pointAmount, List<OrderProduct> orderProducts) {
+        List<OrderProductItem> items = orderProducts.stream()
+                .map(op -> new OrderProductItem(
+                        op.getPricePolicyId(),
+                        op.getSharerId(),
+                        op.getQuantity(),
+                        op.getUnitAmount()
+                ))
+                .toList();
+
+        OrderPaymentCompletedEvent payload = new OrderPaymentCompletedEvent(
+                orderId, buyerId, totalAmount, pointAmount, items
+        );
+        String topic = KafkaTopicConstants.ORDER_PAYMENT_COMPLETED;
+        EventEnvelope<OrderPaymentCompletedEvent> envelope = EventEnvelope.of(
+                topic, SOURCE, payload, clock
+        );
+
+        kafkaTemplate.send(topic, orderId.toString(), envelope)
+                .whenComplete((result, ex) -> {
+                    if (FormatValidator.hasValue(ex)) {
+                        log.error("Kafka 이벤트 발행 실패. topic={}, orderId={}",
+                                topic, orderId, ex);
+                        return;
+                    }
+
+                    log.info("Kafka 이벤트 발행 성공. topic={}, orderId={}, offset={}",
+                            topic, orderId,
+                            result.getRecordMetadata().offset());
+                });
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/event/PublishOrderEventPort.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/event/PublishOrderEventPort.java
@@ -1,0 +1,11 @@
+package com.personal.marketnote.commerce.port.out.event;
+
+import com.personal.marketnote.commerce.domain.order.OrderProduct;
+
+import java.util.List;
+
+public interface PublishOrderEventPort {
+
+    void publishOrderPaymentCompletedEvent(Long orderId, Long buyerId, Long totalAmount,
+                                           Long pointAmount, List<OrderProduct> orderProducts);
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/ChangeOrderStatusService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/ChangeOrderStatusService.java
@@ -13,6 +13,7 @@ import com.personal.marketnote.commerce.port.in.command.order.ChangeOrderStatusC
 import com.personal.marketnote.commerce.port.in.usecase.inventory.ReduceProductInventoryUseCase;
 import com.personal.marketnote.commerce.port.in.usecase.order.ChangeOrderStatusUseCase;
 import com.personal.marketnote.commerce.port.in.usecase.order.GetOrderUseCase;
+import com.personal.marketnote.commerce.port.out.event.PublishOrderEventPort;
 import com.personal.marketnote.commerce.port.out.order.DeleteOrderedCartProductsPort;
 import com.personal.marketnote.commerce.port.out.order.UpdateOrderPort;
 import com.personal.marketnote.commerce.port.out.product.FindProductByPricePolicyPort;
@@ -43,6 +44,7 @@ public class ChangeOrderStatusService implements ChangeOrderStatusUseCase {
     private final DeleteOrderedCartProductsPort deleteOrderedCartProductsPort;
     private final FindProductByPricePolicyPort findProductByPricePolicyPort;
     private final ModifyUserPointPort modifyUserPointPort;
+    private final PublishOrderEventPort publishOrderEventPort;
 
     @Override
     public void changeOrderStatus(ChangeOrderStatusCommand command) {
@@ -109,7 +111,9 @@ public class ChangeOrderStatusService implements ChangeOrderStatusUseCase {
     }
 
     private void updatePaymentSubsequentProcesses(Order order, OrderStatus status) {
-        // FIXME: [#929] Kafka 이벤트 Consumption으로 변경(주문 상태 PAID로 변경 / 결제 금액 업데이트 / 재고 감소 / 장바구니 상품 삭제)
+        // FIXME: [#929] Kafka 이벤트 전환 진행 중
+        //  [전환 완료 - 듀얼 라이트] 재고 차감 (#932)
+        //  [미전환] 장바구니 삭제 (#1018), 공유 포인트 적립 (#1019), 포인트 차감 (#1020), 상품 포인트 적립 (#1131)
 
         // 결제 완료 시 재고 차감
         reduceProductInventoryUseCase.reduce(order.getOrderProducts(), status.getDescription());
@@ -126,6 +130,9 @@ public class ChangeOrderStatusService implements ChangeOrderStatusUseCase {
         Long totalAccumulatedPoint = calculateTotalAccumulatedPoint(order.getOrderProducts(), pricePolicyIds);
 
         runAfterCommit(() -> {
+            // Kafka 이벤트 발행 (듀얼 라이트)
+            publishOrderPaymentCompletedEvent(order);
+
             // 결제 완료 시 장바구니 상품 삭제
             deleteOrderedCartProductsPort.delete(pricePolicyIds);
 
@@ -210,6 +217,21 @@ public class ChangeOrderStatusService implements ChangeOrderStatusUseCase {
         } catch (Exception e) {
             log.error("적립 예정 포인트 확정 실패 - orderId: {}, buyerId: {}, error: {}",
                     orderId, buyerId, e.getMessage(), e);
+        }
+    }
+
+    private void publishOrderPaymentCompletedEvent(Order order) {
+        try {
+            publishOrderEventPort.publishOrderPaymentCompletedEvent(
+                    order.getId(),
+                    order.getBuyerId(),
+                    order.getTotalAmount(),
+                    order.getPointAmount(),
+                    order.getOrderProducts()
+            );
+        } catch (Exception e) {
+            log.error("주문 결제 완료 이벤트 발행 실패 - orderId: {}, error: {}",
+                    order.getId(), e.getMessage(), e);
         }
     }
 

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/ChangeOrderStatusConfirmProcessUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/ChangeOrderStatusConfirmProcessUseCaseTest.java
@@ -7,6 +7,7 @@ import com.personal.marketnote.commerce.domain.order.OrderStatus;
 import com.personal.marketnote.commerce.port.in.command.order.ChangeOrderStatusCommand;
 import com.personal.marketnote.commerce.port.in.usecase.inventory.ReduceProductInventoryUseCase;
 import com.personal.marketnote.commerce.port.in.usecase.order.GetOrderUseCase;
+import com.personal.marketnote.commerce.port.out.event.PublishOrderEventPort;
 import com.personal.marketnote.commerce.port.out.order.DeleteOrderedCartProductsPort;
 import com.personal.marketnote.commerce.port.out.order.UpdateOrderPort;
 import com.personal.marketnote.commerce.port.out.product.FindProductByPricePolicyPort;
@@ -41,6 +42,8 @@ class ChangeOrderStatusConfirmProcessUseCaseTest {
     private FindProductByPricePolicyPort findProductByPricePolicyPort;
     @Mock
     private ModifyUserPointPort modifyUserPointPort;
+    @Mock
+    private PublishOrderEventPort publishOrderEventPort;
 
     @InjectMocks
     private ChangeOrderStatusService changeOrderStatusService;

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/ChangeOrderStatusPaidProcessUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/ChangeOrderStatusPaidProcessUseCaseTest.java
@@ -7,6 +7,7 @@ import com.personal.marketnote.commerce.domain.order.OrderStatus;
 import com.personal.marketnote.commerce.port.in.command.order.ChangeOrderStatusCommand;
 import com.personal.marketnote.commerce.port.in.usecase.inventory.ReduceProductInventoryUseCase;
 import com.personal.marketnote.commerce.port.in.usecase.order.GetOrderUseCase;
+import com.personal.marketnote.commerce.port.out.event.PublishOrderEventPort;
 import com.personal.marketnote.commerce.port.out.order.DeleteOrderedCartProductsPort;
 import com.personal.marketnote.commerce.port.out.order.UpdateOrderPort;
 import com.personal.marketnote.commerce.port.out.product.FindProductByPricePolicyPort;
@@ -44,6 +45,8 @@ class ChangeOrderStatusPaidProcessUseCaseTest {
     private FindProductByPricePolicyPort findProductByPricePolicyPort;
     @Mock
     private ModifyUserPointPort modifyUserPointPort;
+    @Mock
+    private PublishOrderEventPort publishOrderEventPort;
 
     @InjectMocks
     private ChangeOrderStatusService changeOrderStatusService;

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/ChangeOrderStatusRoleValidationUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/ChangeOrderStatusRoleValidationUseCaseTest.java
@@ -9,6 +9,7 @@ import com.personal.marketnote.commerce.exception.UnauthorizedOrderStatusChangeE
 import com.personal.marketnote.commerce.port.in.command.order.ChangeOrderStatusCommand;
 import com.personal.marketnote.commerce.port.in.usecase.inventory.ReduceProductInventoryUseCase;
 import com.personal.marketnote.commerce.port.in.usecase.order.GetOrderUseCase;
+import com.personal.marketnote.commerce.port.out.event.PublishOrderEventPort;
 import com.personal.marketnote.commerce.port.out.order.DeleteOrderedCartProductsPort;
 import com.personal.marketnote.commerce.port.out.order.UpdateOrderPort;
 import com.personal.marketnote.commerce.port.out.product.FindProductByPricePolicyPort;
@@ -44,6 +45,8 @@ class ChangeOrderStatusRoleValidationUseCaseTest {
     private FindProductByPricePolicyPort findProductByPricePolicyPort;
     @Mock
     private ModifyUserPointPort modifyUserPointPort;
+    @Mock
+    private PublishOrderEventPort publishOrderEventPort;
 
     @InjectMocks
     private ChangeOrderStatusService changeOrderStatusService;

--- a/common/src/main/java/com/personal/marketnote/common/kafka/event/OrderPaymentCompletedEvent.java
+++ b/common/src/main/java/com/personal/marketnote/common/kafka/event/OrderPaymentCompletedEvent.java
@@ -1,0 +1,20 @@
+package com.personal.marketnote.common.kafka.event;
+
+import java.util.List;
+
+public record OrderPaymentCompletedEvent(
+        Long orderId,
+        Long buyerId,
+        Long totalAmount,
+        Long pointAmount,
+        List<OrderProductItem> orderProducts
+) {
+
+    public record OrderProductItem(
+            Long pricePolicyId,
+            Long sharerId,
+            Integer quantity,
+            Long unitAmount
+    ) {
+    }
+}


### PR DESCRIPTION
## partially addresses #929
## resolves #932

## Task
- [x] OrderPaymentCompletedEvent 이벤트 레코드 정의 (common)
- [x] PublishOrderEventPort Out Port 인터페이스 정의 (application)
- [x] OrderEventKafkaProducer Producer 어댑터 구현 (adapters)
- [x] OrderPaymentCompletedInventoryConsumer Consumer 구현 (adapters, 듀얼 라이트 기간 이벤트 수신/검증/로그만 수행)
- [x] ChangeOrderStatusService에 PublishOrderEventPort 주입 및 이벤트 발행 추가 (runAfterCommit)
- [x] 기존 테스트 3개에 @mock PublishOrderEventPort 추가