### PR TITLE
[#929][#1055] test: 주문 결제 완료 시 재고 차감 연동 기능 Kafka 이벤트 전환 자동화 테스트 추가

### DIFF
--- a/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/event/OrderPaymentCompletedInventoryConsumerTest.java
+++ b/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/event/OrderPaymentCompletedInventoryConsumerTest.java
@@ -1,0 +1,103 @@
+package com.personal.marketnote.commerce.adapter.in.event;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.OrderPaymentCompletedEvent;
+import com.personal.marketnote.common.kafka.event.OrderPaymentCompletedEvent.OrderProductItem;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.support.Acknowledgment;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("OrderPaymentCompletedInventoryConsumer 테스트")
+class OrderPaymentCompletedInventoryConsumerTest {
+    @InjectMocks
+    private OrderPaymentCompletedInventoryConsumer consumer;
+
+    @Spy
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    private ConsumerRecord<String, EventEnvelope<?>> buildRecord(Long orderId, Long buyerId,
+                                                                 Long totalAmount, Long pointAmount,
+                                                                 List<OrderProductItem> orderProducts) {
+        OrderPaymentCompletedEvent event = new OrderPaymentCompletedEvent(
+                orderId, buyerId, totalAmount, pointAmount, orderProducts
+        );
+        EventEnvelope<OrderPaymentCompletedEvent> envelope = new EventEnvelope<>(
+                "test-event-id", "commerce.order.payment-completed", "commerce-service",
+                LocalDateTime.of(2026, 3, 5, 10, 0), event
+        );
+        return new ConsumerRecord<>("commerce.order.payment-completed", 0, 0L,
+                String.valueOf(orderId), envelope);
+    }
+
+    private List<OrderProductItem> createOrderProductItems() {
+        return List.of(
+                new OrderProductItem(100L, 200L, 2, 30000L),
+                new OrderProductItem(101L, null, 1, 20000L)
+        );
+    }
+
+    @Test
+    @DisplayName("주문 결제 완료 이벤트 수신 시 이벤트를 검증하고 acknowledge한다")
+    void handleOrderPaymentCompletedEvent_success_validatesAndAcknowledges() {
+        // given
+        List<OrderProductItem> items = createOrderProductItems();
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, 50L, 80000L, 5000L, items);
+        Acknowledgment acknowledgment = mock(Acknowledgment.class);
+
+        // when
+        consumer.handleOrderPaymentCompletedEvent(record, acknowledgment);
+
+        // then
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("orderId가 null이면 acknowledge하고 종료한다")
+    void handleOrderPaymentCompletedEvent_nullOrderId_skipsAndAcknowledges() {
+        // given
+        List<OrderProductItem> items = createOrderProductItems();
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(null, 50L, 80000L, 5000L, items);
+        Acknowledgment acknowledgment = mock(Acknowledgment.class);
+
+        // when
+        consumer.handleOrderPaymentCompletedEvent(record, acknowledgment);
+
+        // then
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("예상치 못한 예외 발생 시 DefaultErrorHandler로 위임되어 예외가 전파된다")
+    void handleOrderPaymentCompletedEvent_unexpectedException_propagatesForRetry() {
+        // given
+        EventEnvelope<String> envelope = new EventEnvelope<>(
+                "test-event-id", "commerce.order.payment-completed", "commerce-service",
+                LocalDateTime.of(2026, 3, 5, 10, 0), "invalid-payload"
+        );
+        @SuppressWarnings("unchecked")
+        ConsumerRecord<String, EventEnvelope<?>> record = new ConsumerRecord<>(
+                "commerce.order.payment-completed", 0, 0L, "1",
+                (EventEnvelope<?>) (EventEnvelope) envelope
+        );
+        Acknowledgment acknowledgment = mock(Acknowledgment.class);
+
+        // when & then
+        assertThatThrownBy(() -> consumer.handleOrderPaymentCompletedEvent(record, acknowledgment))
+                .isInstanceOf(Exception.class);
+
+        verify(acknowledgment, never()).acknowledge();
+    }
+}

--- a/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/out/event/OrderEventKafkaProducerTest.java
+++ b/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/out/event/OrderEventKafkaProducerTest.java
@@ -1,0 +1,141 @@
+package com.personal.marketnote.commerce.adapter.out.event;
+
+import com.personal.marketnote.commerce.domain.order.OrderProduct;
+import com.personal.marketnote.commerce.domain.order.OrderProductSnapshotState;
+import com.personal.marketnote.commerce.domain.order.OrderStatus;
+import com.personal.marketnote.common.kafka.KafkaTopicConstants;
+import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.OrderPaymentCompletedEvent;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.core.KafkaTemplate;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("OrderEventKafkaProducer 테스트")
+class OrderEventKafkaProducerTest {
+    @InjectMocks
+    private OrderEventKafkaProducer orderEventKafkaProducer;
+
+    @Mock
+    private KafkaTemplate<String, Object> kafkaTemplate;
+
+    @Mock
+    private Clock clock;
+
+    private void setUpClock(String instant) {
+        Clock fixedClock = Clock.fixed(Instant.parse(instant), ZoneId.of("Asia/Seoul"));
+        when(clock.instant()).thenReturn(fixedClock.instant());
+        when(clock.getZone()).thenReturn(fixedClock.getZone());
+    }
+
+    private List<OrderProduct> createOrderProducts() {
+        OrderProduct product1 = OrderProduct.from(OrderProductSnapshotState.builder()
+                .orderId(1L)
+                .sellerId(10L)
+                .pricePolicyId(100L)
+                .sharerId(200L)
+                .quantity(2)
+                .unitAmount(30000L)
+                .orderStatus(OrderStatus.PAID)
+                .build());
+        OrderProduct product2 = OrderProduct.from(OrderProductSnapshotState.builder()
+                .orderId(1L)
+                .sellerId(10L)
+                .pricePolicyId(101L)
+                .quantity(1)
+                .unitAmount(20000L)
+                .orderStatus(OrderStatus.PAID)
+                .build());
+        return List.of(product1, product2);
+    }
+
+    @Test
+    @DisplayName("주문 결제 완료 이벤트 발행 시 올바른 토픽과 파티션 키로 전송된다")
+    void publishOrderPaymentCompletedEvent_sendsToCorrectTopicWithOrderIdKey() {
+        // given
+        setUpClock("2026-03-05T10:00:00Z");
+        when(kafkaTemplate.send(any(String.class), any(String.class), any()))
+                .thenReturn(new CompletableFuture<>());
+
+        List<OrderProduct> orderProducts = createOrderProducts();
+
+        // when
+        orderEventKafkaProducer.publishOrderPaymentCompletedEvent(
+                1L, 50L, 80000L, 5000L, orderProducts
+        );
+
+        // then
+        verify(kafkaTemplate).send(
+                eq(KafkaTopicConstants.ORDER_PAYMENT_COMPLETED),
+                eq("1"),
+                any(EventEnvelope.class)
+        );
+    }
+
+    @Test
+    @DisplayName("주문 결제 완료 이벤트 발행 시 EventEnvelope에 올바른 페이로드가 포함된다")
+    @SuppressWarnings("unchecked")
+    void publishOrderPaymentCompletedEvent_envelopeContainsCorrectPayload() {
+        // given
+        setUpClock("2026-03-05T10:00:00Z");
+        when(kafkaTemplate.send(any(String.class), any(String.class), any()))
+                .thenReturn(new CompletableFuture<>());
+
+        List<OrderProduct> orderProducts = createOrderProducts();
+
+        // when
+        orderEventKafkaProducer.publishOrderPaymentCompletedEvent(
+                10L, 50L, 80000L, 5000L, orderProducts
+        );
+
+        // then
+        ArgumentCaptor<EventEnvelope> envelopeCaptor = ArgumentCaptor.forClass(EventEnvelope.class);
+        verify(kafkaTemplate).send(
+                eq(KafkaTopicConstants.ORDER_PAYMENT_COMPLETED),
+                eq("10"),
+                envelopeCaptor.capture()
+        );
+
+        EventEnvelope<?> capturedEnvelope = envelopeCaptor.getValue();
+        assertThat(capturedEnvelope.eventType()).isEqualTo(KafkaTopicConstants.ORDER_PAYMENT_COMPLETED);
+        assertThat(capturedEnvelope.source()).isEqualTo("commerce-service");
+        assertThat(capturedEnvelope.eventId()).isNotNull();
+        assertThat(capturedEnvelope.timestamp()).isNotNull();
+
+        OrderPaymentCompletedEvent payload = (OrderPaymentCompletedEvent) capturedEnvelope.payload();
+        assertThat(payload.orderId()).isEqualTo(10L);
+        assertThat(payload.buyerId()).isEqualTo(50L);
+        assertThat(payload.totalAmount()).isEqualTo(80000L);
+        assertThat(payload.pointAmount()).isEqualTo(5000L);
+        assertThat(payload.orderProducts()).hasSize(2);
+
+        OrderPaymentCompletedEvent.OrderProductItem firstItem = payload.orderProducts().get(0);
+        assertThat(firstItem.pricePolicyId()).isEqualTo(100L);
+        assertThat(firstItem.sharerId()).isEqualTo(200L);
+        assertThat(firstItem.quantity()).isEqualTo(2);
+        assertThat(firstItem.unitAmount()).isEqualTo(30000L);
+
+        OrderPaymentCompletedEvent.OrderProductItem secondItem = payload.orderProducts().get(1);
+        assertThat(secondItem.pricePolicyId()).isEqualTo(101L);
+        assertThat(secondItem.sharerId()).isNull();
+        assertThat(secondItem.quantity()).isEqualTo(1);
+        assertThat(secondItem.unitAmount()).isEqualTo(20000L);
+    }
+}


### PR DESCRIPTION
## partially addresses #929
## resolves #1055

## Task
- [x] 주문 결제 완료 이벤트 발행 시 올바른 토픽과 파티션 키로 전송된다
- [x] 주문 결제 완료 이벤트 발행 시 EventEnvelope에 올바른 페이로드가 포함된다
- [x] 주문 결제 완료 이벤트 수신 시 이벤트를 검증하고 acknowledge한다
- [x] orderId가 null이면 acknowledge하고 종료한다
- [x] 예상치 못한 예외 발생 시 DefaultErrorHandler로 위임되어 예외가 전파된다