### PR TITLE
[#929][#1018] feat: 주문 결제 완료 시 상품 서비스 장바구니 삭제 연동 기능 Kafka 이벤트 전환

### DIFF
--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/ChangeOrderStatusService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/ChangeOrderStatusService.java
@@ -112,8 +112,8 @@ public class ChangeOrderStatusService implements ChangeOrderStatusUseCase {
 
     private void updatePaymentSubsequentProcesses(Order order, OrderStatus status) {
         // FIXME: [#929] Kafka 이벤트 전환 진행 중
-        //  [전환 완료 - 듀얼 라이트] 재고 차감 (#932)
-        //  [미전환] 장바구니 삭제 (#1018), 공유 포인트 적립 (#1019), 포인트 차감 (#1020), 상품 포인트 적립 (#1131)
+        //  [전환 완료 - 듀얼 라이트] 재고 차감 (#932), 장바구니 삭제 (#1018)
+        //  [미전환] 공유 포인트 적립 (#1019), 포인트 차감 (#1020), 상품 포인트 적립 (#1131)
 
         // 결제 완료 시 재고 차감
         reduceProductInventoryUseCase.reduce(order.getOrderProducts(), status.getDescription());

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/event/OrderPaymentCompletedCartConsumer.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/event/OrderPaymentCompletedCartConsumer.java
@@ -1,0 +1,72 @@
+package com.personal.marketnote.product.adapter.in.event;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.common.kafka.KafkaTopicConstants;
+import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.OrderPaymentCompletedEvent;
+import com.personal.marketnote.common.utility.FormatValidator;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OrderPaymentCompletedCartConsumer {
+    private final ObjectMapper objectMapper;
+
+    @KafkaListener(
+            topics = KafkaTopicConstants.ORDER_PAYMENT_COMPLETED,
+            groupId = "product-cart"
+    )
+    public void handleOrderPaymentCompletedEvent(
+            ConsumerRecord<String, EventEnvelope<?>> record,
+            Acknowledgment acknowledgment
+    ) {
+        EventEnvelope<?> envelope = record.value();
+
+        try {
+            OrderPaymentCompletedEvent payload = envelope.getPayloadAs(
+                    OrderPaymentCompletedEvent.class, objectMapper
+            );
+
+            log.info("주문 결제 완료 이벤트 수신 (장바구니 삭제). eventId={}, orderId={}, buyerId={}, orderProducts={}건",
+                    envelope.eventId(), payload.orderId(), payload.buyerId(),
+                    FormatValidator.hasValue(payload.orderProducts()) ? payload.orderProducts().size() : 0);
+
+            if (FormatValidator.hasNoValue(payload.buyerId())) {
+                log.error("유효하지 않은 이벤트 페이로드: buyerId 누락. eventId={}", envelope.eventId());
+                acknowledgment.acknowledge();
+                return;
+            }
+
+            if (FormatValidator.hasNoValue(payload.orderProducts()) || payload.orderProducts().isEmpty()) {
+                log.error("유효하지 않은 이벤트 페이로드: orderProducts 누락. eventId={}", envelope.eventId());
+                acknowledgment.acknowledge();
+                return;
+            }
+
+            List<Long> pricePolicyIds = payload.orderProducts().stream()
+                    .map(OrderPaymentCompletedEvent.OrderProductItem::pricePolicyId)
+                    .toList();
+
+            // FIXME: [#929] 듀얼 라이트 기간 — 동기 호출(ChangeOrderStatusService → CartServiceClient)에서 이미 장바구니 삭제 수행.
+            //  장바구니 삭제는 멱등 연산이나, HTTP 제거 후 아래 코드 활성화:
+            //  deleteCartProductUseCase.deleteCartProducts(DeleteCartProductCommand.of(payload.buyerId(), pricePolicyIds));
+
+            log.info("듀얼 라이트: 이벤트 수신 확인 완료. orderId={}, buyerId={}, pricePolicyIds={}, 장바구니 삭제는 동기 호출에서 처리됨",
+                    payload.orderId(), payload.buyerId(), pricePolicyIds);
+        } catch (Exception e) {
+            log.error("장바구니 삭제 이벤트 처리 실패. eventId={}, key={}, error={}",
+                    envelope.eventId(), record.key(), e.getMessage(), e);
+            throw e;
+        }
+
+        acknowledgment.acknowledge();
+    }
+}


### PR DESCRIPTION
## partially addresses #929
## resolves #1018

## Task
- [x] OrderPaymentCompletedCartConsumer 추가 (product-service, groupId: product-cart)
- [x] 듀얼 라이트 기간: 이벤트 수신/검증/로그만 수행 (HTTP 제거 후 DeleteCartProductUseCase 활성화)
- [x] ChangeOrderStatusService FIXME 주석 업데이트 (#1018 전환 완료 표시)