### PR TITLE
[#929][#1204] feat: 주문 결제 완료 시 재고 차감 멱등성 기능 추가

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/OrderPaymentCompletedInventoryConsumer.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/OrderPaymentCompletedInventoryConsumer.java
@@ -1,9 +1,14 @@
 package com.personal.marketnote.commerce.adapter.in.event;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.commerce.domain.order.OrderProduct;
+import com.personal.marketnote.commerce.domain.order.OrderProductSnapshotState;
+import com.personal.marketnote.commerce.exception.DuplicateInventoryDeductionException;
+import com.personal.marketnote.commerce.port.in.usecase.inventory.ReduceProductInventoryUseCase;
 import com.personal.marketnote.common.kafka.KafkaTopicConstants;
 import com.personal.marketnote.common.kafka.event.EventEnvelope;
 import com.personal.marketnote.common.kafka.event.OrderPaymentCompletedEvent;
+import com.personal.marketnote.common.kafka.event.OrderPaymentCompletedEvent.OrderProductItem;
 import com.personal.marketnote.common.utility.FormatValidator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -12,11 +17,14 @@ import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class OrderPaymentCompletedInventoryConsumer {
     private final ObjectMapper objectMapper;
+    private final ReduceProductInventoryUseCase reduceProductInventoryUseCase;
 
     @KafkaListener(
             topics = KafkaTopicConstants.ORDER_PAYMENT_COMPLETED,
@@ -44,13 +52,21 @@ public class OrderPaymentCompletedInventoryConsumer {
                 return;
             }
 
-            // FIXME: [#929] 듀얼 라이트 기간 — 동기 호출(ChangeOrderStatusService)에서 이미 재고 차감 수행.
-            //  재고 차감은 멱등하지 않으므로, HTTP 제거 후 아래 코드 활성화:
-            //  List<OrderProduct> orderProducts = convertToOrderProducts(payload.orderProducts());
-            //  reduceProductInventoryUseCase.reduce(orderProducts, "Kafka 결제 완료 재고 차감");
+            if (FormatValidator.hasNoValue(payload.orderProducts()) || payload.orderProducts().isEmpty()) {
+                log.warn("주문 상품이 없는 이벤트. eventId={}, orderId={}",
+                        envelope.eventId(), payload.orderId());
+                acknowledgment.acknowledge();
+                return;
+            }
 
-            log.info("듀얼 라이트: 이벤트 수신 확인 완료. orderId={}, 재고 차감은 동기 호출에서 처리됨",
-                    payload.orderId());
+            List<OrderProduct> orderProducts = convertToOrderProducts(payload.orderProducts());
+            reduceProductInventoryUseCase.reduce(orderProducts, payload.orderId(), "Kafka 결제 완료 재고 차감");
+
+            log.info("재고 차감 완료. orderId={}, 차감 상품={}건",
+                    payload.orderId(), orderProducts.size());
+        } catch (DuplicateInventoryDeductionException e) {
+            log.info("이미 처리된 재고 차감 이벤트 (멱등 처리). eventId={}, message={}",
+                    envelope.eventId(), e.getMessage());
         } catch (Exception e) {
             log.error("재고 차감 이벤트 처리 실패. eventId={}, key={}, error={}",
                     envelope.eventId(), record.key(), e.getMessage(), e);
@@ -58,5 +74,18 @@ public class OrderPaymentCompletedInventoryConsumer {
         }
 
         acknowledgment.acknowledge();
+    }
+
+    private List<OrderProduct> convertToOrderProducts(List<OrderProductItem> items) {
+        return items.stream()
+                .map(item -> OrderProduct.from(
+                        OrderProductSnapshotState.builder()
+                                .pricePolicyId(item.pricePolicyId())
+                                .quantity(item.quantity())
+                                .unitAmount(item.unitAmount())
+                                .sharerId(item.sharerId())
+                                .build()
+                ))
+                .toList();
     }
 }

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/inventory/InventoryPersistenceAdapter.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/inventory/InventoryPersistenceAdapter.java
@@ -7,6 +7,8 @@ import com.personal.marketnote.commerce.adapter.out.persistence.inventory.reposi
 import com.personal.marketnote.commerce.adapter.out.persistence.inventory.repository.InventoryJpaRepository;
 import com.personal.marketnote.commerce.domain.inventory.Inventory;
 import com.personal.marketnote.commerce.domain.inventory.InventoryDeductionHistories;
+import com.personal.marketnote.commerce.domain.inventory.InventoryDeductionHistory;
+import com.personal.marketnote.commerce.exception.DuplicateInventoryDeductionException;
 import com.personal.marketnote.commerce.exception.InventoryNotFoundException;
 import com.personal.marketnote.commerce.port.out.inventory.FindInventoryPort;
 import com.personal.marketnote.commerce.port.out.inventory.SaveInventoryDeductionHistoryPort;
@@ -14,6 +16,7 @@ import com.personal.marketnote.commerce.port.out.inventory.SaveInventoryPort;
 import com.personal.marketnote.commerce.port.out.inventory.UpdateInventoryPort;
 import com.personal.marketnote.common.adapter.out.PersistenceAdapter;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 
 import java.util.Optional;
 import java.util.Set;
@@ -85,11 +88,20 @@ public class InventoryPersistenceAdapter implements SaveInventoryPort, FindInven
 
     @Override
     public void save(InventoryDeductionHistories inventoryDeductionHistories) {
-        inventoryDeductionHistoryJpaRepository.saveAll(
-                inventoryDeductionHistories.getInventoryDeductionHistories()
-                        .stream()
-                        .map(InventoryDeductionHistoryJpaEntity::from)
-                        .toList()
-        );
+        try {
+            inventoryDeductionHistoryJpaRepository.saveAllAndFlush(
+                    inventoryDeductionHistories.getInventoryDeductionHistories()
+                            .stream()
+                            .map(InventoryDeductionHistoryJpaEntity::from)
+                            .toList()
+            );
+        } catch (DataIntegrityViolationException e) {
+            Long orderId = inventoryDeductionHistories.getInventoryDeductionHistories()
+                    .stream()
+                    .findFirst()
+                    .map(InventoryDeductionHistory::getOrderId)
+                    .orElse(null);
+            throw new DuplicateInventoryDeductionException(orderId);
+        }
     }
 }

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/inventory/entity/InventoryDeductionHistoryJpaEntity.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/inventory/entity/InventoryDeductionHistoryJpaEntity.java
@@ -12,7 +12,13 @@ import org.hibernate.annotations.DynamicUpdate;
 import static jakarta.persistence.GenerationType.IDENTITY;
 
 @Entity
-@Table(name = "inventory_deduction_history")
+@Table(
+        name = "inventory_deduction_history",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_inventory_deduction_order_policy",
+                columnNames = {"order_id", "price_policy_id"}
+        )
+)
 @DynamicInsert
 @DynamicUpdate
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -29,6 +35,9 @@ public class InventoryDeductionHistoryJpaEntity extends BaseEntity {
     @Column(name = "price_policy_id", nullable = false)
     private Long pricePolicyId;
 
+    @Column(name = "order_id")
+    private Long orderId;
+
     @Column(name = "stock", nullable = false)
     private Integer stock;
 
@@ -38,11 +47,13 @@ public class InventoryDeductionHistoryJpaEntity extends BaseEntity {
     private InventoryDeductionHistoryJpaEntity(
             Long productId,
             Long pricePolicyId,
+            Long orderId,
             Integer stock,
             String reason
     ) {
         this.productId = productId;
         this.pricePolicyId = pricePolicyId;
+        this.orderId = orderId;
         this.stock = stock;
         this.reason = reason;
     }
@@ -51,6 +62,7 @@ public class InventoryDeductionHistoryJpaEntity extends BaseEntity {
         return new InventoryDeductionHistoryJpaEntity(
                 inventoryDeductionHistory.getProductId(),
                 inventoryDeductionHistory.getPricePolicyId(),
+                inventoryDeductionHistory.getOrderId(),
                 inventoryDeductionHistory.getStockValue(),
                 inventoryDeductionHistory.getReason()
         );

--- a/commerce-service/commerce-adapters/src/main/resources/db/migration/V897__add_order_id_to_inventory_deduction_history.sql
+++ b/commerce-service/commerce-adapters/src/main/resources/db/migration/V897__add_order_id_to_inventory_deduction_history.sql
@@ -1,0 +1,7 @@
+-- 재고 차감 이력에 orderId 컬럼 추가 (멱등성 보장)
+ALTER TABLE inventory_deduction_history ADD COLUMN order_id BIGINT;
+
+-- 기존 데이터는 NULL 유지, 신규 데이터만 UNIQUE 제약 적용 (partial index)
+CREATE UNIQUE INDEX uk_inventory_deduction_order_policy
+    ON inventory_deduction_history (order_id, price_policy_id)
+    WHERE order_id IS NOT NULL;

--- a/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/event/OrderPaymentCompletedInventoryConsumerTest.java
+++ b/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/event/OrderPaymentCompletedInventoryConsumerTest.java
@@ -1,6 +1,9 @@
 package com.personal.marketnote.commerce.adapter.in.event;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.commerce.domain.order.OrderProduct;
+import com.personal.marketnote.commerce.exception.DuplicateInventoryDeductionException;
+import com.personal.marketnote.commerce.port.in.usecase.inventory.ReduceProductInventoryUseCase;
 import com.personal.marketnote.common.kafka.event.EventEnvelope;
 import com.personal.marketnote.common.kafka.event.OrderPaymentCompletedEvent;
 import com.personal.marketnote.common.kafka.event.OrderPaymentCompletedEvent.OrderProductItem;
@@ -9,6 +12,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.kafka.support.Acknowledgment;
@@ -16,7 +20,9 @@ import org.springframework.kafka.support.Acknowledgment;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -24,6 +30,9 @@ import static org.mockito.Mockito.*;
 class OrderPaymentCompletedInventoryConsumerTest {
     @InjectMocks
     private OrderPaymentCompletedInventoryConsumer consumer;
+
+    @Mock
+    private ReduceProductInventoryUseCase reduceProductInventoryUseCase;
 
     @Spy
     private ObjectMapper objectMapper = new ObjectMapper();
@@ -50,8 +59,8 @@ class OrderPaymentCompletedInventoryConsumerTest {
     }
 
     @Test
-    @DisplayName("주문 결제 완료 이벤트 수신 시 이벤트를 검증하고 acknowledge한다")
-    void handleOrderPaymentCompletedEvent_success_validatesAndAcknowledges() {
+    @DisplayName("주문 결제 완료 이벤트 수신 시 재고를 차감하고 acknowledge한다")
+    void handleOrderPaymentCompletedEvent_success_reducesInventoryAndAcknowledges() {
         // given
         List<OrderProductItem> items = createOrderProductItems();
         ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, 50L, 80000L, 5000L, items);
@@ -61,16 +70,93 @@ class OrderPaymentCompletedInventoryConsumerTest {
         consumer.handleOrderPaymentCompletedEvent(record, acknowledgment);
 
         // then
+        verify(reduceProductInventoryUseCase).reduce(
+                anyList(), eq(1L), eq("Kafka 결제 완료 재고 차감")
+        );
         verify(acknowledgment).acknowledge();
     }
 
     @Test
-    @DisplayName("orderId가 null이면 acknowledge하고 종료한다")
+    @DisplayName("재고 차감 시 주문 상품 목록이 올바르게 변환된다")
+    void handleOrderPaymentCompletedEvent_success_convertsOrderProductsCorrectly() {
+        // given
+        List<OrderProductItem> items = createOrderProductItems();
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, 50L, 80000L, 5000L, items);
+        Acknowledgment acknowledgment = mock(Acknowledgment.class);
+
+        // when
+        consumer.handleOrderPaymentCompletedEvent(record, acknowledgment);
+
+        // then
+        @SuppressWarnings("unchecked")
+        org.mockito.ArgumentCaptor<List<OrderProduct>> captor =
+                org.mockito.ArgumentCaptor.forClass(List.class);
+        verify(reduceProductInventoryUseCase).reduce(captor.capture(), eq(1L), anyString());
+
+        List<OrderProduct> orderProducts = captor.getValue();
+        assertThat(orderProducts).hasSize(2);
+        assertThat(orderProducts.get(0).getPricePolicyId()).isEqualTo(100L);
+        assertThat(orderProducts.get(0).getQuantity()).isEqualTo(2);
+        assertThat(orderProducts.get(1).getPricePolicyId()).isEqualTo(101L);
+        assertThat(orderProducts.get(1).getQuantity()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("orderId가 null이면 재고 차감 없이 acknowledge한다")
     void handleOrderPaymentCompletedEvent_nullOrderId_skipsAndAcknowledges() {
         // given
         List<OrderProductItem> items = createOrderProductItems();
         ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(null, 50L, 80000L, 5000L, items);
         Acknowledgment acknowledgment = mock(Acknowledgment.class);
+
+        // when
+        consumer.handleOrderPaymentCompletedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(reduceProductInventoryUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("주문 상품이 없으면 재고 차감 없이 acknowledge한다")
+    void handleOrderPaymentCompletedEvent_emptyOrderProducts_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, 50L, 80000L, 5000L, List.of());
+        Acknowledgment acknowledgment = mock(Acknowledgment.class);
+
+        // when
+        consumer.handleOrderPaymentCompletedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(reduceProductInventoryUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("주문 상품이 null이면 재고 차감 없이 acknowledge한다")
+    void handleOrderPaymentCompletedEvent_nullOrderProducts_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, 50L, 80000L, 5000L, null);
+        Acknowledgment acknowledgment = mock(Acknowledgment.class);
+
+        // when
+        consumer.handleOrderPaymentCompletedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(reduceProductInventoryUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("중복 재고 차감 시 DuplicateInventoryDeductionException을 catch하고 acknowledge한다")
+    void handleOrderPaymentCompletedEvent_duplicateDeduction_acknowledgesAndLogs() {
+        // given
+        List<OrderProductItem> items = createOrderProductItems();
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, 50L, 80000L, 5000L, items);
+        Acknowledgment acknowledgment = mock(Acknowledgment.class);
+
+        doThrow(new DuplicateInventoryDeductionException(1L))
+                .when(reduceProductInventoryUseCase).reduce(anyList(), eq(1L), anyString());
 
         // when
         consumer.handleOrderPaymentCompletedEvent(record, acknowledgment);
@@ -100,4 +186,5 @@ class OrderPaymentCompletedInventoryConsumerTest {
 
         verify(acknowledgment, never()).acknowledge();
     }
+
 }

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/exception/DuplicateInventoryDeductionException.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/exception/DuplicateInventoryDeductionException.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.commerce.exception;
+
+public class DuplicateInventoryDeductionException extends RuntimeException {
+    public DuplicateInventoryDeductionException(Long orderId) {
+        super("이미 처리된 재고 차감입니다. orderId=" + orderId);
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/inventory/ReduceProductInventoryUseCase.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/inventory/ReduceProductInventoryUseCase.java
@@ -14,10 +14,12 @@ import java.util.List;
 public interface ReduceProductInventoryUseCase {
     /**
      * @param orderProducts 주문 상품 목록
+     * @param orderId       주문 ID (멱등성 키)
      * @param reason        재고 차감 이유
      * @Date 2026-01-06
      * @Author 성효빈
      * @Description 주문 상품의 재고를 차감합니다. 분산 락/낙관적 락 이중 동시성 제어 로직이 적용되어 있습니다.
+     *              동일 orderId+pricePolicyId 조합의 이중 차감은 DB UNIQUE 제약으로 방지됩니다.
      */
-    void reduce(List<OrderProduct> orderProducts, String reason);
+    void reduce(List<OrderProduct> orderProducts, Long orderId, String reason);
 }

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/inventory/ReduceProductInventoryService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/inventory/ReduceProductInventoryService.java
@@ -28,7 +28,7 @@ public class ReduceProductInventoryService implements ReduceProductInventoryUseC
     private final InventoryLockPort inventoryLockPort;
 
     @Override
-    public void reduce(List<OrderProduct> orderProducts, String reason) {
+    public void reduce(List<OrderProduct> orderProducts, Long orderId, String reason) {
         Map<Long, Integer> stocksByPricePolicyId = orderProducts.stream()
                 .collect(
                         Collectors.groupingBy(
@@ -49,7 +49,7 @@ public class ReduceProductInventoryService implements ReduceProductInventoryUseC
                     productIdsByPricePolicyId.put(inventory.getPricePolicyId(), inventory.getProductId())
             );
             saveInventoryDeductionHistoryPort.save(
-                    InventoryDeductionHistories.from(stocksByPricePolicyId, productIdsByPricePolicyId, reason)
+                    InventoryDeductionHistories.from(stocksByPricePolicyId, productIdsByPricePolicyId, orderId, reason)
             );
             saveCacheStockPort.save(inventories);
         });

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/ChangeOrderStatusService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/ChangeOrderStatusService.java
@@ -116,7 +116,7 @@ public class ChangeOrderStatusService implements ChangeOrderStatusUseCase {
         //  [미전환] 공유 포인트 적립 (#1019), 포인트 차감 (#1020), 상품 포인트 적립 (#1131)
 
         // 결제 완료 시 재고 차감
-        reduceProductInventoryUseCase.reduce(order.getOrderProducts(), status.getDescription());
+        reduceProductInventoryUseCase.reduce(order.getOrderProducts(), order.getId(), status.getDescription());
 
         List<Long> pricePolicyIds = order.getOrderProducts()
                 .stream()

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/inventory/ReduceProductInventoryUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/inventory/ReduceProductInventoryUseCaseTest.java
@@ -64,7 +64,7 @@ class ReduceProductInventoryUseCaseTest {
             stubLockToExecuteTask();
             when(findInventoryPort.findByPricePolicyIds(any())).thenReturn(Set.of(inventory));
 
-            reduceProductInventoryService.reduce(orderProducts, "결제 완료");
+            reduceProductInventoryService.reduce(orderProducts, 1L, "결제 완료");
 
             assertThat(inventory.getStockValue()).isEqualTo(7);
         }
@@ -82,7 +82,7 @@ class ReduceProductInventoryUseCaseTest {
             stubLockToExecuteTask();
             when(findInventoryPort.findByPricePolicyIds(any())).thenReturn(Set.of(inventory1, inventory2));
 
-            reduceProductInventoryService.reduce(orderProducts, "결제 완료");
+            reduceProductInventoryService.reduce(orderProducts, 1L, "결제 완료");
 
             assertThat(inventory1.getStockValue()).isEqualTo(8);
             assertThat(inventory2.getStockValue()).isEqualTo(15);
@@ -100,7 +100,7 @@ class ReduceProductInventoryUseCaseTest {
             stubLockToExecuteTask();
             when(findInventoryPort.findByPricePolicyIds(any())).thenReturn(Set.of(inventory));
 
-            reduceProductInventoryService.reduce(orderProducts, "결제 완료");
+            reduceProductInventoryService.reduce(orderProducts, 1L, "결제 완료");
 
             assertThat(inventory.getStockValue()).isEqualTo(5);
         }
@@ -119,7 +119,7 @@ class ReduceProductInventoryUseCaseTest {
             stubLockToExecuteTask();
             when(findInventoryPort.findByPricePolicyIds(any())).thenReturn(Set.of(inventory1, inventory2));
 
-            reduceProductInventoryService.reduce(orderProducts, "결제 완료");
+            reduceProductInventoryService.reduce(orderProducts, 1L, "결제 완료");
 
             assertThat(inventory1.getStockValue()).isEqualTo(15);
             assertThat(inventory2.getStockValue()).isEqualTo(11);
@@ -144,7 +144,7 @@ class ReduceProductInventoryUseCaseTest {
                     buildInventory(2L, 200L, 20)
             ));
 
-            reduceProductInventoryService.reduce(orderProducts, "결제 완료");
+            reduceProductInventoryService.reduce(orderProducts, 1L, "결제 완료");
 
             ArgumentCaptor<Set<Long>> lockKeysCaptor = ArgumentCaptor.forClass(Set.class);
             verify(inventoryLockPort).executeWithLock(lockKeysCaptor.capture(), any());
@@ -156,7 +156,7 @@ class ReduceProductInventoryUseCaseTest {
         void reduce_lockNotExecuted_doesNotCallInternalPorts() {
             List<OrderProduct> orderProducts = List.of(buildOrderProduct(100L, 3));
 
-            reduceProductInventoryService.reduce(orderProducts, "결제 완료");
+            reduceProductInventoryService.reduce(orderProducts, 1L, "결제 완료");
 
             verify(inventoryLockPort).executeWithLock(any(), any());
             verifyNoInteractions(findInventoryPort);
@@ -173,7 +173,7 @@ class ReduceProductInventoryUseCaseTest {
 
             doThrow(exception).when(inventoryLockPort).executeWithLock(any(), any());
 
-            assertThatThrownBy(() -> reduceProductInventoryService.reduce(orderProducts, "결제 완료"))
+            assertThatThrownBy(() -> reduceProductInventoryService.reduce(orderProducts, 1L, "결제 완료"))
                     .isSameAs(exception);
         }
 
@@ -185,7 +185,7 @@ class ReduceProductInventoryUseCaseTest {
             doThrow(new InventoryLockAcquisitionException(100L))
                     .when(inventoryLockPort).executeWithLock(any(), any());
 
-            assertThatThrownBy(() -> reduceProductInventoryService.reduce(orderProducts, "결제 완료"))
+            assertThatThrownBy(() -> reduceProductInventoryService.reduce(orderProducts, 1L, "결제 완료"))
                     .isInstanceOf(InventoryLockAcquisitionException.class);
 
             verifyNoInteractions(findInventoryPort);
@@ -203,7 +203,7 @@ class ReduceProductInventoryUseCaseTest {
 
             doThrow(exception).when(inventoryLockPort).executeWithLock(any(), any());
 
-            assertThatThrownBy(() -> reduceProductInventoryService.reduce(orderProducts, "결제 완료"))
+            assertThatThrownBy(() -> reduceProductInventoryService.reduce(orderProducts, 1L, "결제 완료"))
                     .isSameAs(exception);
         }
 
@@ -221,7 +221,7 @@ class ReduceProductInventoryUseCaseTest {
             stubLockToExecuteTask();
             when(findInventoryPort.findByPricePolicyIds(any())).thenReturn(Set.of(inventory));
 
-            reduceProductInventoryService.reduce(orderProducts, "결제 완료");
+            reduceProductInventoryService.reduce(orderProducts, 1L, "결제 완료");
 
             InOrder inOrder = inOrder(findInventoryPort, updateInventoryPort,
                     saveInventoryDeductionHistoryPort, saveCacheStockPort);
@@ -252,7 +252,7 @@ class ReduceProductInventoryUseCaseTest {
                     buildInventory(2L, 200L, 20)
             ));
 
-            reduceProductInventoryService.reduce(orderProducts, "결제 완료");
+            reduceProductInventoryService.reduce(orderProducts, 1L, "결제 완료");
 
             ArgumentCaptor<Set<Long>> captor = ArgumentCaptor.forClass(Set.class);
             verify(findInventoryPort).findByPricePolicyIds(captor.capture());
@@ -273,7 +273,7 @@ class ReduceProductInventoryUseCaseTest {
                     buildInventory(1L, 100L, 10)
             ));
 
-            reduceProductInventoryService.reduce(orderProducts, "결제 완료");
+            reduceProductInventoryService.reduce(orderProducts, 1L, "결제 완료");
 
             ArgumentCaptor<Set<Long>> captor = ArgumentCaptor.forClass(Set.class);
             verify(findInventoryPort).findByPricePolicyIds(captor.capture());
@@ -294,7 +294,7 @@ class ReduceProductInventoryUseCaseTest {
             stubLockToExecuteTask();
             when(findInventoryPort.findByPricePolicyIds(any())).thenReturn(Set.of(inventory));
 
-            reduceProductInventoryService.reduce(orderProducts, "결제 완료");
+            reduceProductInventoryService.reduce(orderProducts, 1L, "결제 완료");
 
             ArgumentCaptor<Set<Inventory>> captor = ArgumentCaptor.forClass(Set.class);
             verify(updateInventoryPort).update(captor.capture());
@@ -320,7 +320,7 @@ class ReduceProductInventoryUseCaseTest {
             stubLockToExecuteTask();
             when(findInventoryPort.findByPricePolicyIds(any())).thenReturn(Set.of(inventory1, inventory2));
 
-            reduceProductInventoryService.reduce(orderProducts, "결제 완료");
+            reduceProductInventoryService.reduce(orderProducts, 1L, "결제 완료");
 
             ArgumentCaptor<Set<Inventory>> captor = ArgumentCaptor.forClass(Set.class);
             verify(updateInventoryPort).update(captor.capture());
@@ -354,7 +354,7 @@ class ReduceProductInventoryUseCaseTest {
             stubLockToExecuteTask();
             when(findInventoryPort.findByPricePolicyIds(any())).thenReturn(Set.of(inventory));
 
-            reduceProductInventoryService.reduce(orderProducts, "결제 완료");
+            reduceProductInventoryService.reduce(orderProducts, 1L, "결제 완료");
 
             ArgumentCaptor<InventoryDeductionHistories> captor =
                     ArgumentCaptor.forClass(InventoryDeductionHistories.class);
@@ -376,7 +376,7 @@ class ReduceProductInventoryUseCaseTest {
             stubLockToExecuteTask();
             when(findInventoryPort.findByPricePolicyIds(any())).thenReturn(Set.of(inventory));
 
-            reduceProductInventoryService.reduce(orderProducts, "결제 완료");
+            reduceProductInventoryService.reduce(orderProducts, 1L, "결제 완료");
 
             ArgumentCaptor<InventoryDeductionHistories> captor =
                     ArgumentCaptor.forClass(InventoryDeductionHistories.class);
@@ -398,7 +398,7 @@ class ReduceProductInventoryUseCaseTest {
             stubLockToExecuteTask();
             when(findInventoryPort.findByPricePolicyIds(any())).thenReturn(Set.of(inventory));
 
-            reduceProductInventoryService.reduce(orderProducts, reason);
+            reduceProductInventoryService.reduce(orderProducts, 1L, reason);
 
             ArgumentCaptor<InventoryDeductionHistories> captor =
                     ArgumentCaptor.forClass(InventoryDeductionHistories.class);
@@ -408,6 +408,27 @@ class ReduceProductInventoryUseCaseTest {
 
             assertThat(histories).hasSize(1);
             assertThat(histories.get(0).getReason()).isEqualTo(reason);
+        }
+
+        @Test
+        @DisplayName("재고 차감 시 올바른 주문ID로 차감 이력을 저장한다")
+        void reduce_success_savesHistoryWithCorrectOrderId() {
+            List<OrderProduct> orderProducts = List.of(buildOrderProduct(100L, 3));
+            Inventory inventory = buildInventory(1L, 100L, 10);
+
+            stubLockToExecuteTask();
+            when(findInventoryPort.findByPricePolicyIds(any())).thenReturn(Set.of(inventory));
+
+            reduceProductInventoryService.reduce(orderProducts, 99L, "결제 완료");
+
+            ArgumentCaptor<InventoryDeductionHistories> captor =
+                    ArgumentCaptor.forClass(InventoryDeductionHistories.class);
+            verify(saveInventoryDeductionHistoryPort).save(captor.capture());
+            List<InventoryDeductionHistory> histories =
+                    captor.getValue().getInventoryDeductionHistories();
+
+            assertThat(histories).hasSize(1);
+            assertThat(histories.get(0).getOrderId()).isEqualTo(99L);
         }
 
         @Test
@@ -423,7 +444,7 @@ class ReduceProductInventoryUseCaseTest {
             stubLockToExecuteTask();
             when(findInventoryPort.findByPricePolicyIds(any())).thenReturn(Set.of(inventory1, inventory2));
 
-            reduceProductInventoryService.reduce(orderProducts, "결제 완료");
+            reduceProductInventoryService.reduce(orderProducts, 1L, "결제 완료");
 
             ArgumentCaptor<InventoryDeductionHistories> captor =
                     ArgumentCaptor.forClass(InventoryDeductionHistories.class);
@@ -450,7 +471,7 @@ class ReduceProductInventoryUseCaseTest {
             stubLockToExecuteTask();
             when(findInventoryPort.findByPricePolicyIds(any())).thenReturn(Set.of(inventory));
 
-            reduceProductInventoryService.reduce(orderProducts, "결제 완료");
+            reduceProductInventoryService.reduce(orderProducts, 1L, "결제 완료");
 
             ArgumentCaptor<InventoryDeductionHistories> captor =
                     ArgumentCaptor.forClass(InventoryDeductionHistories.class);
@@ -476,7 +497,7 @@ class ReduceProductInventoryUseCaseTest {
             stubLockToExecuteTask();
             when(findInventoryPort.findByPricePolicyIds(any())).thenReturn(Set.of(inventory));
 
-            reduceProductInventoryService.reduce(orderProducts, "결제 완료");
+            reduceProductInventoryService.reduce(orderProducts, 1L, "결제 완료");
 
             ArgumentCaptor<Set<Inventory>> captor = ArgumentCaptor.forClass(Set.class);
             verify(saveCacheStockPort).save(captor.capture());
@@ -502,7 +523,7 @@ class ReduceProductInventoryUseCaseTest {
             stubLockToExecuteTask();
             when(findInventoryPort.findByPricePolicyIds(any())).thenReturn(Set.of(inventory1, inventory2));
 
-            reduceProductInventoryService.reduce(orderProducts, "결제 완료");
+            reduceProductInventoryService.reduce(orderProducts, 1L, "결제 완료");
 
             ArgumentCaptor<Set<Inventory>> captor = ArgumentCaptor.forClass(Set.class);
             verify(saveCacheStockPort).save(captor.capture());
@@ -526,7 +547,7 @@ class ReduceProductInventoryUseCaseTest {
             stubLockToExecuteTask();
             when(findInventoryPort.findByPricePolicyIds(any())).thenThrow(exception);
 
-            assertThatThrownBy(() -> reduceProductInventoryService.reduce(orderProducts, "결제 완료"))
+            assertThatThrownBy(() -> reduceProductInventoryService.reduce(orderProducts, 1L, "결제 완료"))
                     .isSameAs(exception);
         }
 
@@ -538,7 +559,7 @@ class ReduceProductInventoryUseCaseTest {
             stubLockToExecuteTask();
             when(findInventoryPort.findByPricePolicyIds(any())).thenThrow(new RuntimeException("find fail"));
 
-            assertThatThrownBy(() -> reduceProductInventoryService.reduce(orderProducts, "결제 완료"))
+            assertThatThrownBy(() -> reduceProductInventoryService.reduce(orderProducts, 1L, "결제 완료"))
                     .isInstanceOf(RuntimeException.class);
 
             verifyNoInteractions(updateInventoryPort);
@@ -557,7 +578,7 @@ class ReduceProductInventoryUseCaseTest {
             when(findInventoryPort.findByPricePolicyIds(any())).thenReturn(Set.of(inventory));
             doThrow(exception).when(updateInventoryPort).update(any());
 
-            assertThatThrownBy(() -> reduceProductInventoryService.reduce(orderProducts, "결제 완료"))
+            assertThatThrownBy(() -> reduceProductInventoryService.reduce(orderProducts, 1L, "결제 완료"))
                     .isSameAs(exception);
         }
 
@@ -571,7 +592,7 @@ class ReduceProductInventoryUseCaseTest {
             when(findInventoryPort.findByPricePolicyIds(any())).thenReturn(Set.of(inventory));
             doThrow(new RuntimeException("update fail")).when(updateInventoryPort).update(any());
 
-            assertThatThrownBy(() -> reduceProductInventoryService.reduce(orderProducts, "결제 완료"))
+            assertThatThrownBy(() -> reduceProductInventoryService.reduce(orderProducts, 1L, "결제 완료"))
                     .isInstanceOf(RuntimeException.class);
 
             verifyNoInteractions(saveInventoryDeductionHistoryPort);
@@ -589,7 +610,7 @@ class ReduceProductInventoryUseCaseTest {
             when(findInventoryPort.findByPricePolicyIds(any())).thenReturn(Set.of(inventory));
             doThrow(exception).when(updateInventoryPort).update(any());
 
-            assertThatThrownBy(() -> reduceProductInventoryService.reduce(orderProducts, "결제 완료"))
+            assertThatThrownBy(() -> reduceProductInventoryService.reduce(orderProducts, 1L, "결제 완료"))
                     .isSameAs(exception);
         }
 
@@ -604,7 +625,7 @@ class ReduceProductInventoryUseCaseTest {
             when(findInventoryPort.findByPricePolicyIds(any())).thenReturn(Set.of(inventory));
             doThrow(exception).when(saveInventoryDeductionHistoryPort).save(any());
 
-            assertThatThrownBy(() -> reduceProductInventoryService.reduce(orderProducts, "결제 완료"))
+            assertThatThrownBy(() -> reduceProductInventoryService.reduce(orderProducts, 1L, "결제 완료"))
                     .isSameAs(exception);
         }
 
@@ -619,7 +640,7 @@ class ReduceProductInventoryUseCaseTest {
             doThrow(new RuntimeException("history save fail"))
                     .when(saveInventoryDeductionHistoryPort).save(any());
 
-            assertThatThrownBy(() -> reduceProductInventoryService.reduce(orderProducts, "결제 완료"))
+            assertThatThrownBy(() -> reduceProductInventoryService.reduce(orderProducts, 1L, "결제 완료"))
                     .isInstanceOf(RuntimeException.class);
 
             verify(updateInventoryPort).update(any());
@@ -638,7 +659,7 @@ class ReduceProductInventoryUseCaseTest {
             when(findInventoryPort.findByPricePolicyIds(any())).thenReturn(Set.of(inventory));
             doThrow(exception).when(saveCacheStockPort).save(any(Set.class));
 
-            assertThatThrownBy(() -> reduceProductInventoryService.reduce(orderProducts, "결제 완료"))
+            assertThatThrownBy(() -> reduceProductInventoryService.reduce(orderProducts, 1L, "결제 완료"))
                     .isSameAs(exception);
         }
 
@@ -654,7 +675,7 @@ class ReduceProductInventoryUseCaseTest {
             doThrow(new RuntimeException("cache save fail"))
                     .when(saveCacheStockPort).save(any(Set.class));
 
-            assertThatThrownBy(() -> reduceProductInventoryService.reduce(orderProducts, "결제 완료"))
+            assertThatThrownBy(() -> reduceProductInventoryService.reduce(orderProducts, 1L, "결제 완료"))
                     .isInstanceOf(RuntimeException.class);
 
             verify(findInventoryPort).findByPricePolicyIds(any());
@@ -675,7 +696,7 @@ class ReduceProductInventoryUseCaseTest {
             stubLockToExecuteTask();
             when(findInventoryPort.findByPricePolicyIds(any())).thenReturn(Set.of());
 
-            reduceProductInventoryService.reduce(orderProducts, "결제 완료");
+            reduceProductInventoryService.reduce(orderProducts, 1L, "결제 완료");
 
             ArgumentCaptor<Set<Long>> lockKeysCaptor = ArgumentCaptor.forClass(Set.class);
             verify(inventoryLockPort).executeWithLock(lockKeysCaptor.capture(), any());
@@ -691,7 +712,7 @@ class ReduceProductInventoryUseCaseTest {
             stubLockToExecuteTask();
             when(findInventoryPort.findByPricePolicyIds(any())).thenReturn(Set.of());
 
-            reduceProductInventoryService.reduce(orderProducts, "결제 완료");
+            reduceProductInventoryService.reduce(orderProducts, 1L, "결제 완료");
 
             ArgumentCaptor<Set<Inventory>> updateCaptor = ArgumentCaptor.forClass(Set.class);
             verify(updateInventoryPort).update(updateCaptor.capture());
@@ -716,7 +737,7 @@ class ReduceProductInventoryUseCaseTest {
             stubLockToExecuteTask();
             when(findInventoryPort.findByPricePolicyIds(any())).thenReturn(Set.of(inventory));
 
-            reduceProductInventoryService.reduce(orderProducts, "결제 완료");
+            reduceProductInventoryService.reduce(orderProducts, 1L, "결제 완료");
 
             assertThat(inventory.getStockValue()).isEqualTo(9);
         }
@@ -730,7 +751,7 @@ class ReduceProductInventoryUseCaseTest {
             stubLockToExecuteTask();
             when(findInventoryPort.findByPricePolicyIds(any())).thenReturn(Set.of(inventory));
 
-            reduceProductInventoryService.reduce(orderProducts, "결제 완료");
+            reduceProductInventoryService.reduce(orderProducts, 1L, "결제 완료");
 
             assertThat(inventory.getStockValue()).isEqualTo(0);
         }
@@ -744,7 +765,7 @@ class ReduceProductInventoryUseCaseTest {
             stubLockToExecuteTask();
             when(findInventoryPort.findByPricePolicyIds(any())).thenReturn(Set.of(inventory));
 
-            reduceProductInventoryService.reduce(orderProducts, "결제 완료");
+            reduceProductInventoryService.reduce(orderProducts, 1L, "결제 완료");
 
             assertThat(inventory.getStockValue()).isEqualTo(1);
         }
@@ -761,7 +782,7 @@ class ReduceProductInventoryUseCaseTest {
             stubLockToExecuteTask();
             when(findInventoryPort.findByPricePolicyIds(any())).thenReturn(Set.of(inventory));
 
-            reduceProductInventoryService.reduce(orderProducts, "결제 완료");
+            reduceProductInventoryService.reduce(orderProducts, 1L, "결제 완료");
 
             assertThat(inventory.getStockValue()).isEqualTo(8);
 
@@ -795,7 +816,7 @@ class ReduceProductInventoryUseCaseTest {
             stubLockToExecuteTask();
             when(findInventoryPort.findByPricePolicyIds(any())).thenReturn(Set.of(inventory));
 
-            reduceProductInventoryService.reduce(orderProducts, "결제 완료");
+            reduceProductInventoryService.reduce(orderProducts, 1L, "결제 완료");
 
             assertThat(inventory.getStockValue()).isEqualTo(40);
         }

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/ChangeOrderStatusPaidProcessUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/ChangeOrderStatusPaidProcessUseCaseTest.java
@@ -27,8 +27,7 @@ import java.util.Map;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThatCode;
-import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/inventory/InventoryDeductionHistories.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/inventory/InventoryDeductionHistories.java
@@ -17,6 +17,7 @@ public class InventoryDeductionHistories {
     public static InventoryDeductionHistories from(
             Map<Long, Integer> stocksByPricePolicyId,
             Map<Long, Long> productIdsByPricePolicyId,
+            Long orderId,
             String reason
     ) {
         return new InventoryDeductionHistories(
@@ -26,6 +27,7 @@ public class InventoryDeductionHistories {
                                 InventoryDeductionHistoryCreateState.builder()
                                         .productId(productIdsByPricePolicyId.get(entry.getKey()))
                                         .pricePolicyId(entry.getKey())
+                                        .orderId(orderId)
                                         .stock(entry.getValue())
                                         .reason(reason)
                                         .build()

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/inventory/InventoryDeductionHistory.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/inventory/InventoryDeductionHistory.java
@@ -10,6 +10,7 @@ public class InventoryDeductionHistory {
     private Long id;
     private Long productId;
     private Long pricePolicyId;
+    private Long orderId;
     private Stock stock;
     private String reason;
 
@@ -17,6 +18,7 @@ public class InventoryDeductionHistory {
         return InventoryDeductionHistory.builder()
                 .productId(state.getProductId())
                 .pricePolicyId(state.getPricePolicyId())
+                .orderId(state.getOrderId())
                 .stock(Stock.of(
                         String.valueOf(state.getStock())
                 ))
@@ -29,6 +31,7 @@ public class InventoryDeductionHistory {
                 .id(state.getId())
                 .productId(state.getProductId())
                 .pricePolicyId(state.getPricePolicyId())
+                .orderId(state.getOrderId())
                 .stock(Stock.of(
                         String.valueOf(state.getStock())
                 ))

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/inventory/InventoryDeductionHistoryCreateState.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/inventory/InventoryDeductionHistoryCreateState.java
@@ -11,6 +11,7 @@ import lombok.Getter;
 public class InventoryDeductionHistoryCreateState {
     private final Long productId;
     private final Long pricePolicyId;
+    private final Long orderId;
     private final Integer stock;
     private final String reason;
 }

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/inventory/InventoryDeductionHistorySnapshotState.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/inventory/InventoryDeductionHistorySnapshotState.java
@@ -12,6 +12,7 @@ public class InventoryDeductionHistorySnapshotState {
     private final Long id;
     private final Long productId;
     private final Long pricePolicyId;
+    private final Long orderId;
     private final Integer stock;
     private final String reason;
 }


### PR DESCRIPTION
## partially addresses #929
## resolves #1204

## Task
- [x] InventoryDeductionHistory 도메인에 orderId 필드 추가
- [x] InventoryDeductionHistoryJpaEntity에 orderId 컬럼 + UNIQUE(order_id, price_policy_id) 제약 추가
- [x] InventoryDeductionHistoryCreateState에 orderId 필드 추가
- [x] InventoryDeductionHistories.from()에 orderId 파라미터 추가
- [x] ReduceProductInventoryUseCase / ReduceProductInventoryService에 orderId 파라미터 추가
- [x] DuplicateInventoryDeductionException 커스텀 예외 생성
- [x] Adapter에서 DataIntegrityViolationException → DuplicateInventoryDeductionException 변환
- [x] OrderPaymentCompletedInventoryConsumer에서 DuplicateInventoryDeductionException catch → ack 처리
- [x] DB 마이그레이션 스크립트 작성 (partial index: WHERE order_id IS NOT NULL)