### PR TITLE
[#216][#1220] fix: 커머스 서비스 Clock 빈 조건부 로드 의존으로 인한 애플리케이션 시작 실패 버그 픽스

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/configuration/CommonConfig.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/configuration/CommonConfig.java
@@ -4,8 +4,12 @@ import com.personal.marketnote.common.application.aop.LoggingAspect;
 import com.personal.marketnote.common.configuration.security.OpaqueTokenIntrospectorConfig;
 import com.personal.marketnote.common.configuration.security.OpaqueTokenIntrospectorProvider;
 import com.personal.marketnote.common.domain.exception.GlobalExceptionHandler;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+
+import java.time.Clock;
+import java.time.ZoneId;
 
 @Configuration
 @Import({
@@ -15,4 +19,8 @@ import org.springframework.context.annotation.Import;
         OpaqueTokenIntrospectorProvider.class
 })
 public class CommonConfig {
+    @Bean
+    public Clock commerceClock() {
+        return Clock.system(ZoneId.of("Asia/Seoul"));
+    }
 }

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/configuration/SchedulingConfig.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/configuration/SchedulingConfig.java
@@ -6,9 +6,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 
-import java.time.Clock;
-import java.time.ZoneId;
-
 @Configuration
 @EnableScheduling
 @ConditionalOnProperty(name = "settlement.scheduler.enabled", havingValue = "true", matchIfMissing = false)
@@ -21,10 +18,5 @@ public class SchedulingConfig {
         scheduler.setWaitForTasksToCompleteOnShutdown(true);
         scheduler.setAwaitTerminationSeconds(30);
         return scheduler;
-    }
-
-    @Bean
-    public Clock commerceClock() {
-        return Clock.system(ZoneId.of("Asia/Seoul"));
     }
 }


### PR DESCRIPTION
## partially addresses #216
## resolves #1220

## Task
- [x] `Clock` 빈(`commerceClock`)을 `SchedulingConfig`에서 `CommonConfig`로 이동하여 조건 없이 항상 로드되도록 분리
- [x] `SchedulingConfig`에서 미사용 import(`Clock`, `ZoneId`) 제거