### PR TITLE
[#929][#1208] feat: 추천코드 등록 시 리워드 서비스 포인트 적립 멱등성 기능 추가

### DIFF
--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/event/UserReferralCompletedRewardConsumer.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/event/UserReferralCompletedRewardConsumer.java
@@ -7,6 +7,7 @@ import com.personal.marketnote.common.kafka.event.UserReferralCompletedEvent;
 import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.reward.domain.point.UserPointChangeType;
 import com.personal.marketnote.reward.domain.point.UserPointSourceType;
+import com.personal.marketnote.reward.exception.DuplicateUserPointHistoryException;
 import com.personal.marketnote.reward.port.in.command.point.ModifyUserPointCommand;
 import com.personal.marketnote.reward.port.in.usecase.point.ModifyUserPointUseCase;
 import lombok.RequiredArgsConstructor;
@@ -52,8 +53,8 @@ public class UserReferralCompletedRewardConsumer {
                 return;
             }
 
-            accrueReferrerPoint(payload.referredUserId(), payload.requestUserId());
-            accrueReferredPoint(payload.requestUserId(), payload.referredUserId());
+            accrueReferrerPointIdempotent(envelope.eventId(), payload.referredUserId(), payload.requestUserId());
+            accrueReferredPointIdempotent(envelope.eventId(), payload.requestUserId(), payload.referredUserId());
 
             log.info("Kafka 이벤트로 추천 포인트 적립 완료. requestUserId={}, referredUserId={}",
                     payload.requestUserId(), payload.referredUserId());
@@ -65,6 +66,24 @@ public class UserReferralCompletedRewardConsumer {
         }
 
         acknowledgment.acknowledge();
+    }
+
+    private void accrueReferrerPointIdempotent(String eventId, Long referredUserId, Long requestUserId) {
+        try {
+            accrueReferrerPoint(referredUserId, requestUserId);
+        } catch (DuplicateUserPointHistoryException e) {
+            log.info("이미 처리된 추천인 포인트 적립 이벤트 (멱등 처리). eventId={}, message={}",
+                    eventId, e.getMessage());
+        }
+    }
+
+    private void accrueReferredPointIdempotent(String eventId, Long requestUserId, Long referredUserId) {
+        try {
+            accrueReferredPoint(requestUserId, referredUserId);
+        } catch (DuplicateUserPointHistoryException e) {
+            log.info("이미 처리된 피추천인 포인트 적립 이벤트 (멱등 처리). eventId={}, message={}",
+                    eventId, e.getMessage());
+        }
     }
 
     private void accrueReferrerPoint(Long referredUserId, Long requestUserId) {

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/point/UserPointHistoryPersistenceAdapter.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/point/UserPointHistoryPersistenceAdapter.java
@@ -6,10 +6,12 @@ import com.personal.marketnote.reward.adapter.out.persistence.point.repository.U
 import com.personal.marketnote.reward.domain.point.UserPointHistory;
 import com.personal.marketnote.reward.domain.point.UserPointHistoryFilter;
 import com.personal.marketnote.reward.domain.point.UserPointSourceType;
+import com.personal.marketnote.reward.exception.DuplicateUserPointHistoryException;
 import com.personal.marketnote.reward.port.out.point.FindUserPointHistoryPort;
 import com.personal.marketnote.reward.port.out.point.SaveUserPointHistoryPort;
 import com.personal.marketnote.reward.port.out.point.UpdateUserPointHistoryPort;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 
 import java.util.List;
 import java.util.Objects;
@@ -21,10 +23,17 @@ public class UserPointHistoryPersistenceAdapter implements SaveUserPointHistoryP
 
     @Override
     public UserPointHistory save(UserPointHistory history) {
-        UserPointHistoryJpaEntity saved = repository.save(
-                Objects.requireNonNull(UserPointHistoryJpaEntity.from(history))
-        );
-        return saved.toDomain();
+        try {
+            UserPointHistoryJpaEntity saved = repository.saveAndFlush(
+                    Objects.requireNonNull(UserPointHistoryJpaEntity.from(history))
+            );
+            return saved.toDomain();
+        } catch (DataIntegrityViolationException e) {
+            throw new DuplicateUserPointHistoryException(
+                    history.getUserId(), history.getSourceType(),
+                    history.getSourceId(), history.getReason()
+            );
+        }
     }
 
     @Override

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/point/entity/UserPointHistoryJpaEntity.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/point/entity/UserPointHistoryJpaEntity.java
@@ -11,7 +11,13 @@ import org.hibernate.annotations.CreationTimestamp;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "user_point_history")
+@Table(
+        name = "user_point_history",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_user_point_history_source",
+                columnNames = {"user_id", "source_type", "source_id", "reason"}
+        )
+)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder(access = AccessLevel.PRIVATE)

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/exception/DuplicateUserPointHistoryException.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/exception/DuplicateUserPointHistoryException.java
@@ -1,0 +1,12 @@
+package com.personal.marketnote.reward.exception;
+
+import com.personal.marketnote.reward.domain.point.UserPointSourceType;
+
+public class DuplicateUserPointHistoryException extends RuntimeException {
+    public DuplicateUserPointHistoryException(Long userId, UserPointSourceType sourceType, Long sourceId, String reason) {
+        super("이미 처리된 포인트 변경입니다. userId=" + userId
+                + ", sourceType=" + sourceType
+                + ", sourceId=" + sourceId
+                + ", reason=" + reason);
+    }
+}


### PR DESCRIPTION
## partially addresses #929
## resolves #1208

## Task
- [x] DuplicateUserPointHistoryException 도메인 예외 생성
- [x] UserPointHistoryJpaEntity에 (user_id, source_type, source_id, reason) UNIQUE 제약 추가
- [x] UserPointHistoryPersistenceAdapter.save()에서 DataIntegrityViolationException → DuplicateUserPointHistoryException 변환 (saveAndFlush 적용)
- [x] UserReferralCompletedRewardConsumer에서 추천인/피추천인 개별 DuplicateUserPointHistoryException catch → 멱등 처리