### PR TITLE
[#929][#1223] test: 추천코드 등록 시 리워드 서비스 포인트 적립 멱등성 기능 자동화 테스트 추가

### DIFF
--- a/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/adapter/in/event/UserReferralCompletedRewardConsumerTest.java
+++ b/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/adapter/in/event/UserReferralCompletedRewardConsumerTest.java
@@ -5,6 +5,7 @@ import com.personal.marketnote.common.kafka.event.EventEnvelope;
 import com.personal.marketnote.common.kafka.event.UserReferralCompletedEvent;
 import com.personal.marketnote.reward.domain.point.UserPointChangeType;
 import com.personal.marketnote.reward.domain.point.UserPointSourceType;
+import com.personal.marketnote.reward.exception.DuplicateUserPointHistoryException;
 import com.personal.marketnote.reward.port.in.command.point.ModifyUserPointCommand;
 import com.personal.marketnote.reward.port.in.usecase.point.ModifyUserPointUseCase;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -150,5 +151,56 @@ class UserReferralCompletedRewardConsumerTest {
 
         verify(modifyUserPointUseCase, times(2)).modify(any(ModifyUserPointCommand.class));
         verifyNoInteractions(acknowledgment);
+    }
+
+    @Test
+    @DisplayName("추천인 포인트 적립 중 DuplicateUserPointHistoryException 발생 시 멱등 처리하고 피추천인 적립은 정상 진행한다")
+    void handleUserReferralCompletedEvent_referrerDuplicate_idempotentAndContinuesReferred() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, 2L);
+        when(modifyUserPointUseCase.modify(any(ModifyUserPointCommand.class)))
+                .thenThrow(new DuplicateUserPointHistoryException(2L, UserPointSourceType.USER, 1L, "추천인 코드 등록 적립"))
+                .thenReturn(null);
+
+        // when
+        userReferralCompletedRewardConsumer.handleUserReferralCompletedEvent(record, acknowledgment);
+
+        // then
+        verify(modifyUserPointUseCase, times(2)).modify(any(ModifyUserPointCommand.class));
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("피추천인 포인트 적립 중 DuplicateUserPointHistoryException 발생 시 멱등 처리하고 acknowledge한다")
+    void handleUserReferralCompletedEvent_referredDuplicate_idempotentAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, 2L);
+        when(modifyUserPointUseCase.modify(any(ModifyUserPointCommand.class)))
+                .thenReturn(null)
+                .thenThrow(new DuplicateUserPointHistoryException(1L, UserPointSourceType.USER, 2L, "신규 회원 초대 적립"));
+
+        // when
+        userReferralCompletedRewardConsumer.handleUserReferralCompletedEvent(record, acknowledgment);
+
+        // then
+        verify(modifyUserPointUseCase, times(2)).modify(any(ModifyUserPointCommand.class));
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("추천인과 피추천인 모두 중복이면 멱등 처리하고 acknowledge한다")
+    void handleUserReferralCompletedEvent_bothDuplicate_idempotentAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, 2L);
+        when(modifyUserPointUseCase.modify(any(ModifyUserPointCommand.class)))
+                .thenThrow(new DuplicateUserPointHistoryException(2L, UserPointSourceType.USER, 1L, "추천인 코드 등록 적립"))
+                .thenThrow(new DuplicateUserPointHistoryException(1L, UserPointSourceType.USER, 2L, "신규 회원 초대 적립"));
+
+        // when
+        userReferralCompletedRewardConsumer.handleUserReferralCompletedEvent(record, acknowledgment);
+
+        // then
+        verify(modifyUserPointUseCase, times(2)).modify(any(ModifyUserPointCommand.class));
+        verify(acknowledgment).acknowledge();
     }
 }

--- a/reward-service/reward-application/src/test/java/com/personal/marketnote/reward/service/point/ModifyUserPointUseCaseTest.java
+++ b/reward-service/reward-application/src/test/java/com/personal/marketnote/reward/service/point/ModifyUserPointUseCaseTest.java
@@ -2,6 +2,7 @@ package com.personal.marketnote.reward.service.point;
 
 import com.personal.marketnote.common.exception.UserNotFoundException;
 import com.personal.marketnote.reward.domain.point.*;
+import com.personal.marketnote.reward.exception.DuplicateUserPointHistoryException;
 import com.personal.marketnote.reward.port.in.command.point.ModifyUserPointCommand;
 import com.personal.marketnote.reward.port.in.result.point.UpdateUserPointResult;
 import com.personal.marketnote.reward.port.in.usecase.point.GetUserPointUseCase;
@@ -256,6 +257,30 @@ class ModifyUserPointUseCaseTest {
 
             verify(updateUserPointPort, never()).update(any());
             verify(saveUserPointHistoryPort, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("포인트 이력 저장 시 중복이면 DuplicateUserPointHistoryException이 발생한다")
+        void shouldThrowWhenDuplicatePointHistory() {
+            // given
+            UserPoint userPoint = createUserPoint(1000L);
+            ModifyUserPointCommand command = createAccrualCommandWithUserId(500L);
+
+            when(getUserPointUseCase.getUserPoint(USER_ID)).thenReturn(userPoint);
+            when(updateUserPointPort.update(any(UserPoint.class)))
+                    .thenAnswer(invocation -> invocation.getArgument(0));
+            when(saveUserPointHistoryPort.save(any(UserPointHistory.class)))
+                    .thenThrow(new DuplicateUserPointHistoryException(
+                            USER_ID, UserPointSourceType.ORDER, 100L, "상품 구매 적립"));
+
+            // expect
+            assertThatThrownBy(() -> modifyUserPointService.modify(command))
+                    .isInstanceOf(DuplicateUserPointHistoryException.class)
+                    .hasMessageContaining("이미 처리된 포인트 변경입니다");
+
+            verify(getUserPointUseCase).getUserPoint(USER_ID);
+            verify(updateUserPointPort).update(any(UserPoint.class));
+            verify(saveUserPointHistoryPort).save(any(UserPointHistory.class));
         }
     }
 }


### PR DESCRIPTION
## partially addresses #929
## resolves #1223

## Task
- [x] 포인트 이력 저장 시 중복이면 DuplicateUserPointHistoryException이 발생한다
- [x] 추천인 포인트 적립 중 DuplicateUserPointHistoryException 발생 시 멱등 처리하고 피추천인 적립은 정상 진행한다
- [x] 피추천인 포인트 적립 중 DuplicateUserPointHistoryException 발생 시 멱등 처리하고 acknowledge한다
- [x] 추천인과 피추천인 모두 중복이면 멱등 처리하고 acknowledge한다