### PR TITLE
[#929][#1209] feat: Fassto 상품 등록 멱등성 기능 추가

### DIFF
--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/event/ProductRegisteredFulfillmentConsumer.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/event/ProductRegisteredFulfillmentConsumer.java
@@ -7,6 +7,7 @@ import com.personal.marketnote.common.kafka.event.ProductRegisteredEvent;
 import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.fulfillment.configuration.FasstoAuthProperties;
 import com.personal.marketnote.fulfillment.domain.FasstoAccessToken;
+import com.personal.marketnote.fulfillment.exception.FasstoGoodsAlreadyRegisteredException;
 import com.personal.marketnote.fulfillment.exception.RegisterFasstoGoodsFailedException;
 import com.personal.marketnote.fulfillment.port.in.command.vendor.RegisterFasstoGoodsCommand;
 import com.personal.marketnote.fulfillment.port.in.command.vendor.RegisterFasstoGoodsItemCommand;
@@ -83,9 +84,12 @@ public class ProductRegisteredFulfillmentConsumer {
                     List.of(itemCommand)
             );
 
-            registerFasstoGoodsUseCase.registerGoods(command);
+            registerFasstoGoodsUseCase.registerGoodsIdempotent(command);
 
             log.info("Kafka 이벤트로 풀필먼트 상품 등록 완료. productId={}", payload.productId());
+        } catch (FasstoGoodsAlreadyRegisteredException e) {
+            log.warn("이미 Fassto에 등록된 상품입니다 (멱등 처리). eventId={}, key={}, message={}",
+                    envelope.eventId(), record.key(), e.getMessage());
         } catch (RegisterFasstoGoodsFailedException e) {
             log.warn("풀필먼트 상품 등록 실패 (듀얼 라이트 기간 HTTP 호출로 처리됨). eventId={}, key={}, message={}",
                     envelope.eventId(), record.key(), e.getMessage());

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/persistence/goods/FasstoGoodsRegistrationPersistenceAdapter.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/persistence/goods/FasstoGoodsRegistrationPersistenceAdapter.java
@@ -1,0 +1,32 @@
+package com.personal.marketnote.fulfillment.adapter.out.persistence.goods;
+
+import com.personal.marketnote.common.adapter.out.PersistenceAdapter;
+import com.personal.marketnote.fulfillment.adapter.out.persistence.goods.entity.FasstoGoodsRegistrationJpaEntity;
+import com.personal.marketnote.fulfillment.adapter.out.persistence.goods.repository.FasstoGoodsRegistrationJpaRepository;
+import com.personal.marketnote.fulfillment.domain.goods.FasstoGoodsRegistration;
+import com.personal.marketnote.fulfillment.exception.FasstoGoodsAlreadyRegisteredException;
+import com.personal.marketnote.fulfillment.port.out.goods.FindFasstoGoodsRegistrationPort;
+import com.personal.marketnote.fulfillment.port.out.goods.SaveFasstoGoodsRegistrationPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+
+@PersistenceAdapter
+@RequiredArgsConstructor
+public class FasstoGoodsRegistrationPersistenceAdapter
+        implements FindFasstoGoodsRegistrationPort, SaveFasstoGoodsRegistrationPort {
+    private final FasstoGoodsRegistrationJpaRepository repository;
+
+    @Override
+    public boolean existsByProductId(Long productId) {
+        return repository.existsByProductId(productId);
+    }
+
+    @Override
+    public void save(FasstoGoodsRegistration registration) {
+        try {
+            repository.saveAndFlush(FasstoGoodsRegistrationJpaEntity.from(registration));
+        } catch (DataIntegrityViolationException e) {
+            throw new FasstoGoodsAlreadyRegisteredException(registration.getProductId());
+        }
+    }
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/persistence/goods/entity/FasstoGoodsRegistrationJpaEntity.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/persistence/goods/entity/FasstoGoodsRegistrationJpaEntity.java
@@ -1,0 +1,48 @@
+package com.personal.marketnote.fulfillment.adapter.out.persistence.goods.entity;
+
+import com.personal.marketnote.fulfillment.domain.goods.FasstoGoodsRegistration;
+import com.personal.marketnote.fulfillment.domain.goods.FasstoGoodsRegistrationSnapshotState;
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "fassto_goods_registration")
+@EntityListeners(value = AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+@Getter
+public class FasstoGoodsRegistrationJpaEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "product_id", nullable = false, unique = true)
+    private Long productId;
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    public static FasstoGoodsRegistrationJpaEntity from(FasstoGoodsRegistration registration) {
+        return FasstoGoodsRegistrationJpaEntity.builder()
+                .id(registration.getId())
+                .productId(registration.getProductId())
+                .createdAt(registration.getCreatedAt())
+                .build();
+    }
+
+    public FasstoGoodsRegistration toDomain() {
+        return FasstoGoodsRegistration.from(
+                FasstoGoodsRegistrationSnapshotState.builder()
+                        .id(id)
+                        .productId(productId)
+                        .createdAt(createdAt)
+                        .build()
+        );
+    }
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/persistence/goods/repository/FasstoGoodsRegistrationJpaRepository.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/persistence/goods/repository/FasstoGoodsRegistrationJpaRepository.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.fulfillment.adapter.out.persistence.goods.repository;
+
+import com.personal.marketnote.fulfillment.adapter.out.persistence.goods.entity.FasstoGoodsRegistrationJpaEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FasstoGoodsRegistrationJpaRepository extends JpaRepository<FasstoGoodsRegistrationJpaEntity, Long> {
+    boolean existsByProductId(Long productId);
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/FasstoGoodsAlreadyRegisteredException.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/FasstoGoodsAlreadyRegisteredException.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.fulfillment.exception;
+
+public class FasstoGoodsAlreadyRegisteredException extends RuntimeException {
+    public FasstoGoodsAlreadyRegisteredException(Long productId) {
+        super("이미 Fassto에 등록된 상품입니다. productId=" + productId);
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/usecase/vendor/RegisterFasstoGoodsUseCase.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/usecase/vendor/RegisterFasstoGoodsUseCase.java
@@ -19,4 +19,6 @@ public interface RegisterFasstoGoodsUseCase {
      * @Description 파스토 상품을 등록합니다.
      */
     RegisterFasstoGoodsResult registerGoods(RegisterFasstoGoodsCommand command);
+
+    RegisterFasstoGoodsResult registerGoodsIdempotent(RegisterFasstoGoodsCommand command);
 }

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/goods/FindFasstoGoodsRegistrationPort.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/goods/FindFasstoGoodsRegistrationPort.java
@@ -1,0 +1,5 @@
+package com.personal.marketnote.fulfillment.port.out.goods;
+
+public interface FindFasstoGoodsRegistrationPort {
+    boolean existsByProductId(Long productId);
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/goods/SaveFasstoGoodsRegistrationPort.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/goods/SaveFasstoGoodsRegistrationPort.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.fulfillment.port.out.goods;
+
+import com.personal.marketnote.fulfillment.domain.goods.FasstoGoodsRegistration;
+
+public interface SaveFasstoGoodsRegistrationPort {
+    void save(FasstoGoodsRegistration registration);
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/vendor/RegisterFasstoGoodsService.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/vendor/RegisterFasstoGoodsService.java
@@ -1,10 +1,13 @@
 package com.personal.marketnote.fulfillment.service.vendor;
 
 import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.fulfillment.domain.goods.FasstoGoodsRegistration;
+import com.personal.marketnote.fulfillment.domain.goods.FasstoGoodsRegistrationCreateState;
 import com.personal.marketnote.fulfillment.mapper.FasstoGoodsCommandToRequestMapper;
 import com.personal.marketnote.fulfillment.port.in.command.vendor.RegisterFasstoGoodsCommand;
 import com.personal.marketnote.fulfillment.port.in.result.vendor.RegisterFasstoGoodsResult;
 import com.personal.marketnote.fulfillment.port.in.usecase.vendor.RegisterFasstoGoodsUseCase;
+import com.personal.marketnote.fulfillment.port.out.goods.SaveFasstoGoodsRegistrationPort;
 import com.personal.marketnote.fulfillment.port.out.vendor.RegisterFasstoGoodsPort;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,9 +19,27 @@ import static org.springframework.transaction.annotation.Isolation.READ_COMMITTE
 @Transactional(isolation = READ_COMMITTED, readOnly = true)
 public class RegisterFasstoGoodsService implements RegisterFasstoGoodsUseCase {
     private final RegisterFasstoGoodsPort registerFasstoGoodsPort;
+    private final SaveFasstoGoodsRegistrationPort saveFasstoGoodsRegistrationPort;
 
     @Override
     public RegisterFasstoGoodsResult registerGoods(RegisterFasstoGoodsCommand command) {
+        return registerFasstoGoodsPort.registerGoods(
+                FasstoGoodsCommandToRequestMapper.mapToRegisterRequest(command)
+        );
+    }
+
+    @Override
+    @Transactional(isolation = READ_COMMITTED)
+    public RegisterFasstoGoodsResult registerGoodsIdempotent(RegisterFasstoGoodsCommand command) {
+        Long productId = Long.parseLong(command.goods().getFirst().cstGodCd());
+
+        FasstoGoodsRegistration registration = FasstoGoodsRegistration.from(
+                FasstoGoodsRegistrationCreateState.builder()
+                        .productId(productId)
+                        .build()
+        );
+        saveFasstoGoodsRegistrationPort.save(registration);
+
         return registerFasstoGoodsPort.registerGoods(
                 FasstoGoodsCommandToRequestMapper.mapToRegisterRequest(command)
         );

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/goods/FasstoGoodsRegistration.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/goods/FasstoGoodsRegistration.java
@@ -1,0 +1,33 @@
+package com.personal.marketnote.fulfillment.domain.goods;
+
+import com.personal.marketnote.common.utility.FormatValidator;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+@Getter
+public class FasstoGoodsRegistration {
+    private Long id;
+    private Long productId;
+    private LocalDateTime createdAt;
+
+    public static FasstoGoodsRegistration from(FasstoGoodsRegistrationCreateState state) {
+        if (FormatValidator.hasNoValue(state.getProductId())) {
+            throw new IllegalArgumentException("productId는 필수입니다.");
+        }
+        return FasstoGoodsRegistration.builder()
+                .productId(state.getProductId())
+                .build();
+    }
+
+    public static FasstoGoodsRegistration from(FasstoGoodsRegistrationSnapshotState state) {
+        return FasstoGoodsRegistration.builder()
+                .id(state.getId())
+                .productId(state.getProductId())
+                .createdAt(state.getCreatedAt())
+                .build();
+    }
+}

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/goods/FasstoGoodsRegistrationCreateState.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/goods/FasstoGoodsRegistrationCreateState.java
@@ -1,0 +1,10 @@
+package com.personal.marketnote.fulfillment.domain.goods;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class FasstoGoodsRegistrationCreateState {
+    private final Long productId;
+}

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/goods/FasstoGoodsRegistrationSnapshotState.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/goods/FasstoGoodsRegistrationSnapshotState.java
@@ -1,0 +1,14 @@
+package com.personal.marketnote.fulfillment.domain.goods;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class FasstoGoodsRegistrationSnapshotState {
+    private final Long id;
+    private final Long productId;
+    private final LocalDateTime createdAt;
+}


### PR DESCRIPTION
## partially addresses #929
## resolves #1209

## Task
- [x] FasstoGoodsRegistration 도메인 모델 + CreateState/SnapshotState 추가
- [x] FasstoGoodsAlreadyRegisteredException 도메인 예외 추가
- [x] FindFasstoGoodsRegistrationPort, SaveFasstoGoodsRegistrationPort 아웃 포트 추가
- [x] FasstoGoodsRegistrationJpaEntity + Repository + FasstoGoodsRegistrationPersistenceAdapter 구현
- [x] RegisterFasstoGoodsUseCase에 registerGoodsIdempotent() 메서드 추가
- [x] RegisterFasstoGoodsService.registerGoodsIdempotent() 구현 (등록 이력 선 저장 → 후 API 호출)
- [x] ProductRegisteredFulfillmentConsumer에서 registerGoodsIdempotent() 호출 + FasstoGoodsAlreadyRegisteredException catch → warn + ack