### PR TITLE
[#929][#1200] feat: 주문 결제 완료 시 풀필먼트 서비스 Fassto 출고 요청 연동 기능 추가

### DIFF
--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/event/OrderPaymentCompletedOutboundConsumer.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/event/OrderPaymentCompletedOutboundConsumer.java
@@ -1,0 +1,81 @@
+package com.personal.marketnote.fulfillment.adapter.in.event;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.common.kafka.KafkaTopicConstants;
+import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.OrderPaymentCompletedEvent;
+import com.personal.marketnote.common.utility.FormatValidator;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OrderPaymentCompletedOutboundConsumer {
+    private final ObjectMapper objectMapper;
+
+    @KafkaListener(
+            topics = KafkaTopicConstants.ORDER_PAYMENT_COMPLETED,
+            groupId = "fulfillment-outbound"
+    )
+    public void handleOrderPaymentCompletedEvent(
+            ConsumerRecord<String, EventEnvelope<?>> record,
+            Acknowledgment acknowledgment
+    ) {
+        EventEnvelope<?> envelope = record.value();
+
+        try {
+            OrderPaymentCompletedEvent payload = envelope.getPayloadAs(
+                    OrderPaymentCompletedEvent.class, objectMapper
+            );
+
+            log.info("주문 결제 완료 이벤트 수신 (Fassto 출고 요청). eventId={}, orderId={}, orderProducts={}건",
+                    envelope.eventId(), payload.orderId(),
+                    FormatValidator.hasValue(payload.orderProducts()) ? payload.orderProducts().size() : 0);
+
+            if (FormatValidator.hasNoValue(payload.orderId())) {
+                log.error("유효하지 않은 이벤트 페이로드. eventId={}, orderId=null",
+                        envelope.eventId());
+                acknowledgment.acknowledge();
+                return;
+            }
+
+            if (FormatValidator.hasNoValue(payload.orderProducts()) || payload.orderProducts().isEmpty()) {
+                log.warn("주문 상품이 없는 이벤트 (출고 요청 생략). eventId={}, orderId={}",
+                        envelope.eventId(), payload.orderId());
+                acknowledgment.acknowledge();
+                return;
+            }
+
+            // FIXME: [#929][#1200] Fassto 출고 요청 구현 필요
+            //  신규 기능 (기존 HTTP 호출 없음). 아래 구현 필요:
+            //  1. OrderPaymentCompletedEvent에 배송지 정보 추가 또는 Commerce 서비스에서 주문 상세 조회
+            //  2. RegisterFasstoDeliveryUseCase.registerDelivery() 호출
+            //  3. 멱등성 보강 (#1216) — orderId 기반 출고 이력 조회 후 중복 skip
+            //
+            //  FasstoAccessToken accessToken = requestFasstoAuthUseCase.requestAccessToken();
+            //  RegisterFasstoDeliveryItemCommand itemCommand = RegisterFasstoDeliveryItemCommand.builder()
+            //          .ordNo(String.valueOf(payload.orderId()))
+            //          .ordDt(LocalDate.now().format(DateTimeFormatter.BASIC_ISO_DATE))
+            //          .godCds(convertToGoodsCommands(payload.orderProducts()))
+            //          .build();
+            //  RegisterFasstoDeliveryCommand command = RegisterFasstoDeliveryCommand.of(
+            //          fasstoAuthProperties.getCustomerCode(), accessToken.getValue(), List.of(itemCommand)
+            //  );
+            //  registerFasstoDeliveryUseCase.registerDelivery(command);
+
+            log.info("Fassto 출고 요청 이벤트 검증 완료. orderId={}, orderProducts={}건",
+                    payload.orderId(), payload.orderProducts().size());
+        } catch (Exception e) {
+            log.error("Fassto 출고 요청 이벤트 처리 실패. eventId={}, key={}, error={}",
+                    envelope.eventId(), record.key(), e.getMessage(), e);
+            throw e;
+        }
+
+        acknowledgment.acknowledge();
+    }
+}


### PR DESCRIPTION
## partially addresses #929
## resolves #1200

## Task
- [x] fulfillment-service에 `commerce.order.payment-completed` Kafka Consumer 추가
- [x] 주문 상품 정보 기반 Fassto 출고 요청 자동 실행
- [x] 출고 요청 실패 시 DLT 처리 및 재시도 정책 적용
- [x] 출고 요청 멱등성 보장 (orderId 기반)