### PR TITLE
[#929][#1023] feat: 결제 취소 시 회계 역분개 연동 기능 Kafka 이벤트 전환

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/PaymentCancelledLedgerConsumer.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/PaymentCancelledLedgerConsumer.java
@@ -1,0 +1,67 @@
+package com.personal.marketnote.commerce.adapter.in.event;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.common.kafka.KafkaTopicConstants;
+import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.PaymentCancelledEvent;
+import com.personal.marketnote.common.utility.FormatValidator;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PaymentCancelledLedgerConsumer {
+    private final ObjectMapper objectMapper;
+
+    @KafkaListener(
+            topics = KafkaTopicConstants.PAYMENT_CANCELLED,
+            groupId = "commerce-ledger"
+    )
+    public void handlePaymentCancelledEvent(
+            ConsumerRecord<String, EventEnvelope<?>> record,
+            Acknowledgment acknowledgment
+    ) {
+        EventEnvelope<?> envelope = record.value();
+
+        try {
+            PaymentCancelledEvent payload = envelope.getPayloadAs(PaymentCancelledEvent.class, objectMapper);
+
+            log.info("결제 취소 이벤트 수신 (회계 역분개). eventId={}, orderId={}, isFullCancel={}, cancelAmount={}",
+                    envelope.eventId(), payload.orderId(), payload.isFullCancel(), payload.cancelAmount());
+
+            if (FormatValidator.hasNoValue(payload.orderId())) {
+                log.error("유효하지 않은 이벤트 페이로드. eventId={}, orderId=null",
+                        envelope.eventId());
+                acknowledgment.acknowledge();
+                return;
+            }
+
+            // FIXME: [#929][#1023] HTTP 제거 후 RecordLedgerEntryUseCase.recordPaymentCancellation() 활성화
+            //  현재 듀얼 라이트 기간: CancelPaymentService.recordLedgerEntryForCancellation()에서 동기로 역분개 처리 중
+            //  String idempotencyKey;
+            //  if (payload.isFullCancel()) {
+            //      idempotencyKey = "PAYMENT_CANCELLATION:" + payload.orderId();
+            //  } else {
+            //      idempotencyKey = "PAYMENT_PARTIAL_REFUND:" + payload.orderId()
+            //              + ":" + payload.cancelAmount() + ":" + payload.alreadyRefunded();
+            //  }
+            //  recordLedgerEntryUseCase.recordPaymentCancellation(
+            //          payload.orderId(), payload.cancelAmount(), idempotencyKey
+            //  );
+
+            log.info("결제 취소 역분개 이벤트 검증 완료 (듀얼 라이트). orderId={}, isFullCancel={}, cancelAmount={}",
+                    payload.orderId(), payload.isFullCancel(), payload.cancelAmount());
+        } catch (Exception e) {
+            log.error("결제 취소 역분개 이벤트 처리 실패. eventId={}, key={}, error={}",
+                    envelope.eventId(), record.key(), e.getMessage(), e);
+            throw e;
+        }
+
+        acknowledgment.acknowledge();
+    }
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/event/PaymentEventKafkaProducer.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/event/PaymentEventKafkaProducer.java
@@ -1,10 +1,12 @@
 package com.personal.marketnote.commerce.adapter.out.event;
 
+import com.personal.marketnote.commerce.domain.order.OrderProduct;
 import com.personal.marketnote.commerce.port.out.event.PublishPaymentEventPort;
 import com.personal.marketnote.common.adapter.out.ServiceAdapter;
 import com.personal.marketnote.common.kafka.KafkaTopicConstants;
 import com.personal.marketnote.common.kafka.event.EventEnvelope;
 import com.personal.marketnote.common.kafka.event.PaymentApprovedEvent;
+import com.personal.marketnote.common.kafka.event.PaymentCancelledEvent;
 import com.personal.marketnote.common.kafka.event.PaymentFailedEvent;
 import com.personal.marketnote.common.utility.FormatValidator;
 import lombok.RequiredArgsConstructor;
@@ -12,6 +14,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.core.KafkaTemplate;
 
 import java.time.Clock;
+import java.util.List;
 
 @Slf4j
 @ServiceAdapter
@@ -49,6 +52,43 @@ public class PaymentEventKafkaProducer implements PublishPaymentEventPort {
         PaymentFailedEvent payload = new PaymentFailedEvent(orderId, orderKey, resultCode, resultMessage);
         String topic = KafkaTopicConstants.PAYMENT_FAILED;
         EventEnvelope<PaymentFailedEvent> envelope = EventEnvelope.of(
+                topic, SOURCE, payload, clock
+        );
+
+        kafkaTemplate.send(topic, orderId.toString(), envelope)
+                .whenComplete((result, ex) -> {
+                    if (FormatValidator.hasValue(ex)) {
+                        log.error("Kafka 이벤트 발행 실패. topic={}, orderId={}, orderKey={}",
+                                topic, orderId, orderKey, ex);
+                        return;
+                    }
+
+                    log.info("Kafka 이벤트 발행 성공. topic={}, orderId={}, orderKey={}, offset={}",
+                            topic, orderId, orderKey,
+                            result.getRecordMetadata().offset());
+                });
+    }
+
+    @Override
+    public void publishPaymentCancelledEvent(Long orderId, String orderKey, Long buyerId,
+                                             Long cancelAmount, Long paymentAmount, Long pointAmount,
+                                             boolean isFullCancel, Long alreadyRefunded,
+                                             List<OrderProduct> orderProducts) {
+        List<PaymentCancelledEvent.OrderProductItem> items = orderProducts.stream()
+                .map(op -> new PaymentCancelledEvent.OrderProductItem(
+                        op.getPricePolicyId(),
+                        op.getSharerId(),
+                        op.getQuantity(),
+                        op.getUnitAmount()
+                ))
+                .toList();
+
+        PaymentCancelledEvent payload = new PaymentCancelledEvent(
+                orderId, orderKey, buyerId, cancelAmount, paymentAmount,
+                pointAmount, isFullCancel, alreadyRefunded, items
+        );
+        String topic = KafkaTopicConstants.PAYMENT_CANCELLED;
+        EventEnvelope<PaymentCancelledEvent> envelope = EventEnvelope.of(
                 topic, SOURCE, payload, clock
         );
 

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/event/PublishPaymentEventPort.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/event/PublishPaymentEventPort.java
@@ -1,8 +1,17 @@
 package com.personal.marketnote.commerce.port.out.event;
 
+import com.personal.marketnote.commerce.domain.order.OrderProduct;
+
+import java.util.List;
+
 public interface PublishPaymentEventPort {
 
     void publishPaymentApprovedEvent(Long orderId, String orderKey, Long paymentAmount);
 
     void publishPaymentFailedEvent(Long orderId, String orderKey, String resultCode, String resultMessage);
+
+    void publishPaymentCancelledEvent(Long orderId, String orderKey, Long buyerId,
+                                      Long cancelAmount, Long paymentAmount, Long pointAmount,
+                                      boolean isFullCancel, Long alreadyRefunded,
+                                      List<OrderProduct> orderProducts);
 }

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/CancelPaymentService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/CancelPaymentService.java
@@ -16,6 +16,7 @@ import com.personal.marketnote.commerce.port.in.usecase.inventory.RestoreProduct
 import com.personal.marketnote.commerce.port.in.usecase.ledger.RecordLedgerEntryUseCase;
 import com.personal.marketnote.commerce.port.in.usecase.order.ChangeOrderStatusUseCase;
 import com.personal.marketnote.commerce.port.in.usecase.payment.CancelPaymentUseCase;
+import com.personal.marketnote.commerce.port.out.event.PublishPaymentEventPort;
 import com.personal.marketnote.commerce.port.out.order.FindOrderPort;
 import com.personal.marketnote.commerce.port.out.payment.*;
 import com.personal.marketnote.commerce.port.out.payment.vendor.PaymentCancelVendorCommand;
@@ -60,6 +61,7 @@ public class CancelPaymentService implements CancelPaymentUseCase {
     private final ModifyUserPointPort modifyUserPointPort;
     private final SaveRefundPort saveRefundPort;
     private final FindProductByPricePolicyPort findProductByPricePolicyPort;
+    private final PublishPaymentEventPort publishPaymentEventPort;
 
     @Override
     public void cancel(CancelPaymentCommand command) {
@@ -128,6 +130,16 @@ public class CancelPaymentService implements CancelPaymentUseCase {
         }
 
         recordLedgerEntryForCancellation(payment, isFullCancel, cancelAmount, alreadyRefunded);
+
+        Long orderId = order.getId();
+        String orderKey = command.orderKey();
+        Long buyerId = order.getBuyerId();
+        Long paymentAmount = payment.getPaymentAmount();
+        Long pointAmount = order.getPointAmount();
+        List<OrderProduct> orderProducts = order.getOrderProducts();
+        runAfterCommit(() -> publishPaymentCancelledEvent(
+                orderId, orderKey, buyerId, cancelAmount, paymentAmount,
+                pointAmount, isFullCancel, alreadyRefunded, orderProducts));
     }
 
     private Long computeCancelAmount(boolean isFullCancel, Long partialCancelAmount, Long refundableAmount) {
@@ -401,6 +413,20 @@ public class CancelPaymentService implements CancelPaymentUseCase {
         }
 
         action.run();
+    }
+
+    private void publishPaymentCancelledEvent(Long orderId, String orderKey, Long buyerId,
+                                                Long cancelAmount, Long paymentAmount, Long pointAmount,
+                                                boolean isFullCancel, Long alreadyRefunded,
+                                                List<OrderProduct> orderProducts) {
+        try {
+            publishPaymentEventPort.publishPaymentCancelledEvent(
+                    orderId, orderKey, buyerId, cancelAmount, paymentAmount,
+                    pointAmount, isFullCancel, alreadyRefunded, orderProducts);
+        } catch (Exception e) {
+            log.error("결제 취소 이벤트 발행 실패 - orderId: {}, orderKey: {}, error: {}",
+                    orderId, orderKey, e.getMessage(), e);
+        }
     }
 
     private void refundPoints(Order order) {

--- a/common/src/main/java/com/personal/marketnote/common/kafka/event/PaymentCancelledEvent.java
+++ b/common/src/main/java/com/personal/marketnote/common/kafka/event/PaymentCancelledEvent.java
@@ -1,0 +1,24 @@
+package com.personal.marketnote.common.kafka.event;
+
+import java.util.List;
+
+public record PaymentCancelledEvent(
+        Long orderId,
+        String orderKey,
+        Long buyerId,
+        Long cancelAmount,
+        Long paymentAmount,
+        Long pointAmount,
+        boolean isFullCancel,
+        Long alreadyRefunded,
+        List<OrderProductItem> orderProducts
+) {
+
+    public record OrderProductItem(
+            Long pricePolicyId,
+            Long sharerId,
+            Integer quantity,
+            Long unitAmount
+    ) {
+    }
+}


### PR DESCRIPTION
## partially addresses #929
## resolves #1023

## Task
- [x] PaymentCancelledEvent 정의 (common)
- [x] PublishPaymentEventPort.publishPaymentCancelledEvent() 메서드 추가
- [x] PaymentEventKafkaProducer에 cancelled 이벤트 발행 구현
- [x] CancelPaymentService에 runAfterCommit 이벤트 발행 추가
- [x] PaymentCancelledLedgerConsumer 추가 (groupId: commerce-ledger, 듀얼 라이트)