### PR TITLE
[#929][#1024] feat: 정산 실행 시 회계 분개 연동 기능 Kafka 이벤트 전환

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/SettlementExecutedLedgerConsumer.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/SettlementExecutedLedgerConsumer.java
@@ -1,0 +1,65 @@
+package com.personal.marketnote.commerce.adapter.in.event;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.common.kafka.KafkaTopicConstants;
+import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.SettlementExecutedEvent;
+import com.personal.marketnote.common.utility.FormatValidator;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SettlementExecutedLedgerConsumer {
+    private final ObjectMapper objectMapper;
+
+    @KafkaListener(
+            topics = KafkaTopicConstants.SETTLEMENT_EXECUTED,
+            groupId = "commerce-ledger"
+    )
+    public void handleSettlementExecutedEvent(
+            ConsumerRecord<String, EventEnvelope<?>> record,
+            Acknowledgment acknowledgment
+    ) {
+        EventEnvelope<?> envelope = record.value();
+
+        try {
+            SettlementExecutedEvent payload = envelope.getPayloadAs(SettlementExecutedEvent.class, objectMapper);
+
+            log.info("정산 실행 이벤트 수신 (회계 분개). eventId={}, settlementId={}, sellerId={}",
+                    envelope.eventId(), payload.settlementId(), payload.sellerId());
+
+            if (FormatValidator.hasNoValue(payload.settlementId())) {
+                log.error("유효하지 않은 이벤트 페이로드. eventId={}, settlementId=null",
+                        envelope.eventId());
+                acknowledgment.acknowledge();
+                return;
+            }
+
+            // FIXME: [#929][#1024] HTTP 제거 후 RecordLedgerEntryUseCase 활성화
+            //  현재 듀얼 라이트 기간: ProcessSellerSettlementService.process()에서 동기로 분개 처리 중
+            //  recordLedgerEntryUseCase.recordPgSettlement(
+            //          payload.settlementId(), payload.totalAllocatedAmount(), payload.pgFeeAmount()
+            //  );
+            //  long sellerSettlementDebit = payload.sellerPayoutAmount() + payload.platformFeeAmount();
+            //  recordLedgerEntryUseCase.recordSellerSettlement(
+            //          payload.settlementId(), sellerSettlementDebit,
+            //          payload.sellerPayoutAmount(), payload.platformFeeAmount()
+            //  );
+
+            log.info("정산 실행 분개 이벤트 검증 완료 (듀얼 라이트). settlementId={}, sellerId={}, totalAllocated={}",
+                    payload.settlementId(), payload.sellerId(), payload.totalAllocatedAmount());
+        } catch (Exception e) {
+            log.error("정산 실행 분개 이벤트 처리 실패. eventId={}, key={}, error={}",
+                    envelope.eventId(), record.key(), e.getMessage(), e);
+            throw e;
+        }
+
+        acknowledgment.acknowledge();
+    }
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/event/SettlementEventKafkaProducer.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/event/SettlementEventKafkaProducer.java
@@ -1,0 +1,50 @@
+package com.personal.marketnote.commerce.adapter.out.event;
+
+import com.personal.marketnote.commerce.port.out.event.PublishSettlementEventPort;
+import com.personal.marketnote.common.adapter.out.ServiceAdapter;
+import com.personal.marketnote.common.kafka.KafkaTopicConstants;
+import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.SettlementExecutedEvent;
+import com.personal.marketnote.common.utility.FormatValidator;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+
+import java.time.Clock;
+
+@Slf4j
+@ServiceAdapter
+@RequiredArgsConstructor
+public class SettlementEventKafkaProducer implements PublishSettlementEventPort {
+    private static final String SOURCE = "commerce-service";
+
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+    private final Clock clock;
+
+    @Override
+    public void publishSettlementExecutedEvent(Long settlementId, Long sellerId,
+                                               Long totalAllocatedAmount, Long pgFeeAmount,
+                                               Long platformFeeAmount, Long sellerPayoutAmount) {
+        SettlementExecutedEvent payload = new SettlementExecutedEvent(
+                settlementId, sellerId, totalAllocatedAmount,
+                pgFeeAmount, platformFeeAmount, sellerPayoutAmount
+        );
+        String topic = KafkaTopicConstants.SETTLEMENT_EXECUTED;
+        EventEnvelope<SettlementExecutedEvent> envelope = EventEnvelope.of(
+                topic, SOURCE, payload, clock
+        );
+
+        kafkaTemplate.send(topic, settlementId.toString(), envelope)
+                .whenComplete((result, ex) -> {
+                    if (FormatValidator.hasValue(ex)) {
+                        log.error("Kafka 이벤트 발행 실패. topic={}, settlementId={}, sellerId={}",
+                                topic, settlementId, sellerId, ex);
+                        return;
+                    }
+
+                    log.info("Kafka 이벤트 발행 성공. topic={}, settlementId={}, sellerId={}, offset={}",
+                            topic, settlementId, sellerId,
+                            result.getRecordMetadata().offset());
+                });
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/event/PublishSettlementEventPort.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/event/PublishSettlementEventPort.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.commerce.port.out.event;
+
+public interface PublishSettlementEventPort {
+
+    void publishSettlementExecutedEvent(Long settlementId, Long sellerId,
+                                        Long totalAllocatedAmount, Long pgFeeAmount,
+                                        Long platformFeeAmount, Long sellerPayoutAmount);
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/settlement/ProcessSellerSettlementService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/settlement/ProcessSellerSettlementService.java
@@ -6,6 +6,7 @@ import com.personal.marketnote.commerce.domain.settlement.SettlementCreateState;
 import com.personal.marketnote.commerce.exception.SettlementAlreadyExistsException;
 import com.personal.marketnote.commerce.port.in.command.settlement.ExecuteSettlementCommand;
 import com.personal.marketnote.commerce.port.in.usecase.ledger.RecordLedgerEntryUseCase;
+import com.personal.marketnote.commerce.port.out.event.PublishSettlementEventPort;
 import com.personal.marketnote.commerce.port.out.settlement.FindSettlementPort;
 import com.personal.marketnote.commerce.port.out.settlement.SaveSettlementPort;
 import com.personal.marketnote.commerce.port.out.settlement.UpdatePaymentAllocationPort;
@@ -42,6 +43,7 @@ public class ProcessSellerSettlementService {
     private final UpdateSettlementPort updateSettlementPort;
     private final UpdatePaymentAllocationPort updatePaymentAllocationPort;
     private final RecordLedgerEntryUseCase recordLedgerEntryUseCase;
+    private final PublishSettlementEventPort publishSettlementEventPort;
 
     /**
      * 개별 판매자의 정산을 독립 트랜잭션으로 처리한다.
@@ -101,7 +103,23 @@ public class ProcessSellerSettlementService {
         savedSettlement.complete();
         updateSettlementPort.update(savedSettlement);
 
+        publishSettlementExecutedEvent(settlementId, sellerId, totalAllocatedAmount,
+                pgFeeAmount, platformFeeAmount, sellerPayoutAmount);
+
         log.info("정산 완료 - settlementId: {}, sellerId: {}, year: {}, month: {}, total: {}, pgFee: {}, platformFee: {}, sellerPayout: {}",
                 settlementId, sellerId, year, month, totalAllocatedAmount, pgFeeAmount, platformFeeAmount, sellerPayoutAmount);
+    }
+
+    private void publishSettlementExecutedEvent(Long settlementId, Long sellerId,
+                                                 Long totalAllocatedAmount, Long pgFeeAmount,
+                                                 Long platformFeeAmount, Long sellerPayoutAmount) {
+        try {
+            publishSettlementEventPort.publishSettlementExecutedEvent(
+                    settlementId, sellerId, totalAllocatedAmount,
+                    pgFeeAmount, platformFeeAmount, sellerPayoutAmount);
+        } catch (Exception e) {
+            log.error("정산 실행 이벤트 발행 실패 - settlementId: {}, sellerId: {}, error: {}",
+                    settlementId, sellerId, e.getMessage(), e);
+        }
     }
 }

--- a/common/src/main/java/com/personal/marketnote/common/kafka/event/SettlementExecutedEvent.java
+++ b/common/src/main/java/com/personal/marketnote/common/kafka/event/SettlementExecutedEvent.java
@@ -1,0 +1,11 @@
+package com.personal.marketnote.common.kafka.event;
+
+public record SettlementExecutedEvent(
+        Long settlementId,
+        Long sellerId,
+        Long totalAllocatedAmount,
+        Long pgFeeAmount,
+        Long platformFeeAmount,
+        Long sellerPayoutAmount
+) {
+}


### PR DESCRIPTION
## partially addresses #929
## resolves #1024

## Task
- [x] SettlementExecutedEvent 정의 (common)
- [x] PublishSettlementEventPort 추가
- [x] SettlementEventKafkaProducer 추가
- [x] ProcessSellerSettlementService에 이벤트 발행 추가
- [x] SettlementExecutedLedgerConsumer 추가 (groupId: commerce-ledger, 듀얼 라이트)