### PR TITLE
[#929][#1135] feat: 구매 확정 시 리워드 서비스 상품 적립 예정 포인트 확정 연동 기능 Kafka 이벤트 전환

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/event/OrderEventKafkaProducer.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/event/OrderEventKafkaProducer.java
@@ -7,6 +7,7 @@ import com.personal.marketnote.common.kafka.KafkaTopicConstants;
 import com.personal.marketnote.common.kafka.event.EventEnvelope;
 import com.personal.marketnote.common.kafka.event.OrderPaymentCompletedEvent;
 import com.personal.marketnote.common.kafka.event.OrderPaymentCompletedEvent.OrderProductItem;
+import com.personal.marketnote.common.kafka.event.OrderPurchaseConfirmedEvent;
 import com.personal.marketnote.common.utility.FormatValidator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -54,6 +55,28 @@ public class OrderEventKafkaProducer implements PublishOrderEventPort {
 
                     log.info("Kafka 이벤트 발행 성공. topic={}, orderId={}, offset={}",
                             topic, orderId,
+                            result.getRecordMetadata().offset());
+                });
+    }
+
+    @Override
+    public void publishOrderPurchaseConfirmedEvent(Long orderId, Long buyerId, List<Long> sharerIds) {
+        OrderPurchaseConfirmedEvent payload = new OrderPurchaseConfirmedEvent(orderId, buyerId, sharerIds);
+        String topic = KafkaTopicConstants.ORDER_PURCHASE_CONFIRMED;
+        EventEnvelope<OrderPurchaseConfirmedEvent> envelope = EventEnvelope.of(
+                topic, SOURCE, payload, clock
+        );
+
+        kafkaTemplate.send(topic, orderId.toString(), envelope)
+                .whenComplete((result, ex) -> {
+                    if (FormatValidator.hasValue(ex)) {
+                        log.error("Kafka 이벤트 발행 실패. topic={}, orderId={}, buyerId={}",
+                                topic, orderId, buyerId, ex);
+                        return;
+                    }
+
+                    log.info("Kafka 이벤트 발행 성공. topic={}, orderId={}, buyerId={}, offset={}",
+                            topic, orderId, buyerId,
                             result.getRecordMetadata().offset());
                 });
     }

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/event/PublishOrderEventPort.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/event/PublishOrderEventPort.java
@@ -8,4 +8,6 @@ public interface PublishOrderEventPort {
 
     void publishOrderPaymentCompletedEvent(Long orderId, Long buyerId, Long totalAmount,
                                            Long pointAmount, List<OrderProduct> orderProducts);
+
+    void publishOrderPurchaseConfirmedEvent(Long orderId, Long buyerId, List<Long> sharerIds);
 }

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/ChangeOrderStatusService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/ChangeOrderStatusService.java
@@ -207,8 +207,21 @@ public class ChangeOrderStatusService implements ChangeOrderStatusUseCase {
     private void updateConfirmSubsequentProcesses(Order order) {
         Long orderId = order.getId();
         Long buyerId = order.getBuyerId();
+        List<Long> sharerIds = extractSharerIds(order.getOrderProducts());
 
-        runAfterCommit(() -> confirmPendingPoints(buyerId, orderId));
+        runAfterCommit(() -> {
+            confirmPendingPoints(buyerId, orderId);
+            publishOrderPurchaseConfirmedEvent(orderId, buyerId, sharerIds);
+        });
+    }
+
+    private void publishOrderPurchaseConfirmedEvent(Long orderId, Long buyerId, List<Long> sharerIds) {
+        try {
+            publishOrderEventPort.publishOrderPurchaseConfirmedEvent(orderId, buyerId, sharerIds);
+        } catch (Exception e) {
+            log.error("구매 확정 이벤트 발행 실패 - orderId: {}, buyerId: {}, error: {}",
+                    orderId, buyerId, e.getMessage(), e);
+        }
     }
 
     private void confirmPendingPoints(Long buyerId, Long orderId) {

--- a/common/src/main/java/com/personal/marketnote/common/kafka/KafkaTopicConstants.java
+++ b/common/src/main/java/com/personal/marketnote/common/kafka/KafkaTopicConstants.java
@@ -11,6 +11,7 @@ public final class KafkaTopicConstants {
     public static final String PAYMENT_FAILED = "commerce.payment.failed";
     public static final String PAYMENT_CANCELLED = "commerce.payment.cancelled";
     public static final String SETTLEMENT_EXECUTED = "commerce.settlement.executed";
+    public static final String ORDER_PURCHASE_CONFIRMED = "commerce.order.purchase-confirmed";
 
     // Product 이벤트
     public static final String PRODUCT_REGISTERED = "product.product.registered";

--- a/common/src/main/java/com/personal/marketnote/common/kafka/event/OrderPurchaseConfirmedEvent.java
+++ b/common/src/main/java/com/personal/marketnote/common/kafka/event/OrderPurchaseConfirmedEvent.java
@@ -1,0 +1,10 @@
+package com.personal.marketnote.common.kafka.event;
+
+import java.util.List;
+
+public record OrderPurchaseConfirmedEvent(
+        Long orderId,
+        Long buyerId,
+        List<Long> sharerIds
+) {
+}

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/event/OrderPurchaseConfirmedProductPointConsumer.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/event/OrderPurchaseConfirmedProductPointConsumer.java
@@ -1,0 +1,67 @@
+package com.personal.marketnote.reward.adapter.in.event;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.common.kafka.KafkaTopicConstants;
+import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.OrderPurchaseConfirmedEvent;
+import com.personal.marketnote.common.utility.FormatValidator;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OrderPurchaseConfirmedProductPointConsumer {
+    private final ObjectMapper objectMapper;
+
+    @KafkaListener(
+            topics = KafkaTopicConstants.ORDER_PURCHASE_CONFIRMED,
+            groupId = "reward-pending-point"
+    )
+    public void handleOrderPurchaseConfirmedEvent(
+            ConsumerRecord<String, EventEnvelope<?>> record,
+            Acknowledgment acknowledgment
+    ) {
+        EventEnvelope<?> envelope = record.value();
+
+        try {
+            OrderPurchaseConfirmedEvent payload = envelope.getPayloadAs(
+                    OrderPurchaseConfirmedEvent.class, objectMapper
+            );
+
+            log.info("구매 확정 이벤트 수신 (상품 적립 예정 포인트 확정). eventId={}, orderId={}, buyerId={}",
+                    envelope.eventId(), payload.orderId(), payload.buyerId());
+
+            if (FormatValidator.hasNoValue(payload.orderId()) || FormatValidator.hasNoValue(payload.buyerId())) {
+                log.error("유효하지 않은 이벤트 페이로드. eventId={}, orderId={}, buyerId={}",
+                        envelope.eventId(), payload.orderId(), payload.buyerId());
+                acknowledgment.acknowledge();
+                return;
+            }
+
+            // FIXME: [#929][#1135] HTTP 제거 후 ConfirmPendingPointUseCase 활성화
+            //  현재 듀얼 라이트 기간: ChangeOrderStatusService.confirmPendingPoints()가 HTTP로 처리 중
+            //  멱등성 보강 (#1217) 완료 후 아래 주석 해제:
+            //  ConfirmPendingPointCommand command = ConfirmPendingPointCommand.builder()
+            //          .userId(payload.buyerId())
+            //          .sourceType(UserPointSourceType.ORDER)
+            //          .sourceId(payload.orderId())
+            //          .reason("구매 확정 포인트 적립")
+            //          .build();
+            //  confirmPendingPointUseCase.confirmPending(command);
+
+            log.info("상품 적립 예정 포인트 확정 이벤트 검증 완료 (듀얼 라이트). orderId={}, buyerId={}",
+                    payload.orderId(), payload.buyerId());
+        } catch (Exception e) {
+            log.error("상품 적립 예정 포인트 확정 이벤트 처리 실패. eventId={}, key={}, error={}",
+                    envelope.eventId(), record.key(), e.getMessage(), e);
+            throw e;
+        }
+
+        acknowledgment.acknowledge();
+    }
+}


### PR DESCRIPTION
## partially addresses #929
## resolves #1135

## Task
- [x] `OrderPurchaseConfirmedEvent` 이벤트 레코드 정의 (common)
- [x] `KafkaTopicConstants`에 `ORDER_PURCHASE_CONFIRMED` 토픽 상수 추가
- [x] `PublishOrderEventPort`에 `publishOrderPurchaseConfirmedEvent()` 메서드 추가
- [x] `OrderEventKafkaProducer`에 구매 확정 이벤트 발행 구현
- [x] `ChangeOrderStatusService`에서 구매 확정 시 Kafka 이벤트 발행 (듀얼 라이트)
- [x] `OrderPurchaseConfirmedProductPointConsumer` 리워드 서비스 Consumer 구현 (듀얼 라이트 검증/로그)