### PR TITLE
[#216][#1229] test: 커머스 서비스 애플리케이션 컨텍스트 스모크 테스트 추가

### DIFF
--- a/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/CommerceApplicationContextTest.java
+++ b/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/CommerceApplicationContextTest.java
@@ -1,0 +1,65 @@
+package com.personal.marketnote.commerce;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.redisson.api.RedissonClient;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.batch.BatchAutoConfiguration;
+import org.springframework.boot.autoconfigure.kafka.KafkaAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.oauth2.resource.servlet.OAuth2ResourceServerAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+
+@SpringBootTest(classes = CommerceApplicationContextTest.TestConfig.class)
+@ActiveProfiles("test")
+@TestPropertySource(properties = {
+        "spring.autoconfigure.exclude="
+                + "org.springframework.boot.autoconfigure.security.oauth2.resource.servlet.OAuth2ResourceServerAutoConfiguration,"
+                + "org.springframework.boot.autoconfigure.batch.BatchAutoConfiguration,"
+                + "org.springframework.boot.autoconfigure.kafka.KafkaAutoConfiguration"
+})
+class CommerceApplicationContextTest {
+
+    @SpringBootConfiguration
+    @EnableAutoConfiguration(exclude = {
+            OAuth2ResourceServerAutoConfiguration.class,
+            KafkaAutoConfiguration.class,
+            BatchAutoConfiguration.class
+    })
+    @ComponentScan(
+            basePackages = "com.personal.marketnote",
+            excludeFilters = {
+                    @ComponentScan.Filter(
+                            type = FilterType.ANNOTATION,
+                            classes = SpringBootApplication.class
+                    ),
+                    @ComponentScan.Filter(
+                            type = FilterType.REGEX,
+                            pattern = {
+                                    "com\\.personal\\.shop\\.common\\.security\\..*",
+                                    "com\\.personal\\.shop\\.common\\.configuration\\.security\\..*",
+                                    "com\\.personal\\.shop\\.commerce\\.configuration\\.RedissonConfig"
+                            }
+                    )
+            }
+    )
+    static class TestConfig {
+
+        @Bean
+        public RedissonClient redissonClient() {
+            return Mockito.mock(RedissonClient.class);
+        }
+    }
+
+    @Test
+    @DisplayName("애플리케이션 컨텍스트가 정상적으로 로드된다")
+    void contextLoads() {
+    }
+}


### PR DESCRIPTION
## partially addresses #216
## resolves #1229

## Task
- [x] @SpringBootTest 기반 컨텍스트 로드 테스트 추가
- [x] common 보안 모듈 컴포넌트 스캔 제외
- [x] RedissonConfig 제외 + mock RedissonClient 제공
- [x] OAuth2/Kafka/Batch auto-config 제외