### PR TITLE
[#1][#1246] fix: 상품 서비스 애플리케이션 컨텍스트 스모크 테스트 @SpringBootConfiguration 충돌 픽스

### DIFF
--- a/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/CommerceApplicationContextTest.java
+++ b/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/CommerceApplicationContextTest.java
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.redisson.api.RedissonClient;
-import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.batch.BatchAutoConfiguration;
@@ -27,7 +27,7 @@ import org.springframework.test.context.TestPropertySource;
 })
 class CommerceApplicationContextTest {
 
-    @SpringBootConfiguration
+    @Configuration
     @EnableAutoConfiguration(exclude = {
             OAuth2ResourceServerAutoConfiguration.class,
             KafkaAutoConfiguration.class,

--- a/community-service/community-adapters/src/test/java/com/personal/marketnote/community/CommunityApplicationContextTest.java
+++ b/community-service/community-adapters/src/test/java/com/personal/marketnote/community/CommunityApplicationContextTest.java
@@ -2,7 +2,7 @@ package com.personal.marketnote.community;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.batch.BatchAutoConfiguration;
@@ -24,7 +24,7 @@ import org.springframework.test.context.TestPropertySource;
 })
 class CommunityApplicationContextTest {
 
-    @SpringBootConfiguration
+    @Configuration
     @EnableAutoConfiguration(exclude = {
             OAuth2ResourceServerAutoConfiguration.class,
             KafkaAutoConfiguration.class,

--- a/file-service/file-adapters/src/test/java/com/personal/marketnote/file/FileApplicationContextTest.java
+++ b/file-service/file-adapters/src/test/java/com/personal/marketnote/file/FileApplicationContextTest.java
@@ -3,7 +3,7 @@ package com.personal.marketnote.file;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
-import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.batch.BatchAutoConfiguration;
@@ -27,7 +27,7 @@ import software.amazon.awssdk.services.s3.S3Client;
 })
 class FileApplicationContextTest {
 
-    @SpringBootConfiguration
+    @Configuration
     @EnableAutoConfiguration(exclude = {
             OAuth2ResourceServerAutoConfiguration.class,
             KafkaAutoConfiguration.class,

--- a/fulfillment-service/fulfillment-adapters/src/test/java/com/personal/marketnote/fulfillment/FulfillmentApplicationContextTest.java
+++ b/fulfillment-service/fulfillment-adapters/src/test/java/com/personal/marketnote/fulfillment/FulfillmentApplicationContextTest.java
@@ -2,7 +2,7 @@ package com.personal.marketnote.fulfillment;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.batch.BatchAutoConfiguration;
@@ -24,7 +24,7 @@ import org.springframework.test.context.TestPropertySource;
 })
 class FulfillmentApplicationContextTest {
 
-    @SpringBootConfiguration
+    @Configuration
     @EnableAutoConfiguration(exclude = {
             OAuth2ResourceServerAutoConfiguration.class,
             KafkaAutoConfiguration.class,

--- a/product-service/product-adapters/src/test/java/com/personal/marketnote/product/ProductApplicationContextTest.java
+++ b/product-service/product-adapters/src/test/java/com/personal/marketnote/product/ProductApplicationContextTest.java
@@ -2,7 +2,7 @@ package com.personal.marketnote.product;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.batch.BatchAutoConfiguration;
@@ -24,7 +24,7 @@ import org.springframework.test.context.TestPropertySource;
 })
 class ProductApplicationContextTest {
 
-    @SpringBootConfiguration
+    @Configuration
     @EnableAutoConfiguration(exclude = {
             OAuth2ResourceServerAutoConfiguration.class,
             KafkaAutoConfiguration.class,

--- a/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/RewardApplicationContextTest.java
+++ b/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/RewardApplicationContextTest.java
@@ -2,7 +2,7 @@ package com.personal.marketnote.reward;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.batch.BatchAutoConfiguration;
@@ -24,7 +24,7 @@ import org.springframework.test.context.TestPropertySource;
 })
 class RewardApplicationContextTest {
 
-    @SpringBootConfiguration
+    @Configuration
     @EnableAutoConfiguration(exclude = {
             OAuth2ResourceServerAutoConfiguration.class,
             KafkaAutoConfiguration.class,

--- a/user-service/user-adapters/src/test/java/com/personal/marketnote/user/UserApplicationContextTest.java
+++ b/user-service/user-adapters/src/test/java/com/personal/marketnote/user/UserApplicationContextTest.java
@@ -2,7 +2,7 @@ package com.personal.marketnote.user;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.batch.BatchAutoConfiguration;
@@ -24,7 +24,7 @@ import org.springframework.test.context.TestPropertySource;
 })
 class UserApplicationContextTest {
 
-    @SpringBootConfiguration
+    @Configuration
     @EnableAutoConfiguration(exclude = {
             OAuth2ResourceServerAutoConfiguration.class,
             KafkaAutoConfiguration.class,


### PR DESCRIPTION
## partially addresses #1
## resolves #1246

## Task
## Reason
ApplicationContextTest.TestConfig에 @SpringBootConfiguration이 적용되어 있어, @DataJpaTest가 자동으로 @SpringBootConfiguration 클래스를 탐색할 때 메인 Application 클래스와 TestConfig 두 개가 발견됨으로써
Found multiple @SpringBootConfiguration annotated classes 에러 발생

## Action
- [x] 7개 서비스 ApplicationContextTest.TestConfig의 @SpringBootConfiguration → @configuration 교체