### PR TITLE
[#929][#1101] feat: 결제 취소 시 재고 복구 연동 기능 Kafka 이벤트 전환

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/PaymentCancelledInventoryConsumer.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/PaymentCancelledInventoryConsumer.java
@@ -1,0 +1,96 @@
+package com.personal.marketnote.commerce.adapter.in.event;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.common.kafka.KafkaTopicConstants;
+import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.PaymentCancelledEvent;
+import com.personal.marketnote.common.kafka.event.PaymentCancelledEvent.OrderProductItem;
+import com.personal.marketnote.common.utility.FormatValidator;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PaymentCancelledInventoryConsumer {
+    private final ObjectMapper objectMapper;
+
+    @KafkaListener(
+            topics = KafkaTopicConstants.PAYMENT_CANCELLED,
+            groupId = "commerce-inventory"
+    )
+    public void handlePaymentCancelledEvent(
+            ConsumerRecord<String, EventEnvelope<?>> record,
+            Acknowledgment acknowledgment
+    ) {
+        EventEnvelope<?> envelope = record.value();
+
+        try {
+            PaymentCancelledEvent payload = envelope.getPayloadAs(PaymentCancelledEvent.class, objectMapper);
+
+            log.info("결제 취소 이벤트 수신 (재고 복구). eventId={}, orderId={}, isFullCancel={}",
+                    envelope.eventId(), payload.orderId(), payload.isFullCancel());
+
+            if (FormatValidator.hasNoValue(payload.orderId())) {
+                log.error("유효하지 않은 이벤트 페이로드. eventId={}, orderId=null",
+                        envelope.eventId());
+                acknowledgment.acknowledge();
+                return;
+            }
+
+            if (payload.isFullCancel()) {
+                handleFullCancelInventoryRestore(envelope, payload);
+            } else {
+                handlePartialCancelInventoryRestore(envelope, payload);
+            }
+        } catch (Exception e) {
+            log.error("재고 복구 이벤트 처리 실패. eventId={}, key={}, error={}",
+                    envelope.eventId(), record.key(), e.getMessage(), e);
+            throw e;
+        }
+
+        acknowledgment.acknowledge();
+    }
+
+    private void handleFullCancelInventoryRestore(EventEnvelope<?> envelope, PaymentCancelledEvent payload) {
+        if (FormatValidator.hasNoValue(payload.orderProducts()) || payload.orderProducts().isEmpty()) {
+            log.warn("전체 취소인데 주문 상품이 없는 이벤트. eventId={}, orderId={}",
+                    envelope.eventId(), payload.orderId());
+            return;
+        }
+
+        // FIXME: [#929][#1101] HTTP 제거 후 RestoreProductInventoryUseCase.restore() 활성화
+        //  현재 듀얼 라이트 기간: CancelPaymentService.restoreInventory()에서 동기로 재고 복구 처리 중
+        //  멱등성 보강(#1210) 완료 후 활성화
+        //  List<OrderProduct> orderProducts = convertToOrderProducts(payload.orderProducts());
+        //  restoreProductInventoryUseCase.restore(orderProducts, "Kafka 전액 취소 재고 복구");
+
+        log.info("전체 취소 재고 복구 이벤트 검증 완료 (듀얼 라이트). orderId={}, orderProducts={}건",
+                payload.orderId(), payload.orderProducts().size());
+    }
+
+    private void handlePartialCancelInventoryRestore(EventEnvelope<?> envelope, PaymentCancelledEvent payload) {
+        List<OrderProductItem> cancelProducts = payload.cancelProducts();
+
+        if (FormatValidator.hasNoValue(cancelProducts) || cancelProducts.isEmpty()) {
+            log.warn("부분 취소인데 cancelProducts가 없는 이벤트. eventId={}, orderId={}",
+                    envelope.eventId(), payload.orderId());
+            return;
+        }
+
+        // FIXME: [#929][#1101] HTTP 제거 후 RestoreProductInventoryUseCase.restore() 활성화
+        //  현재 듀얼 라이트 기간: CancelPaymentService.restorePartialCancelInventory()에서 동기로 부분 재고 복구 처리 중
+        //  멱등성 보강(#1210) 완료 후 활성화
+        //  List<OrderProduct> cancelOrderProducts = convertToOrderProducts(cancelProducts);
+        //  restoreProductInventoryUseCase.restore(cancelOrderProducts, "Kafka 부분 취소 재고 복구");
+
+        log.info("부분 취소 재고 복구 이벤트 검증 완료 (듀얼 라이트). orderId={}, cancelProducts={}건",
+                payload.orderId(), cancelProducts.size());
+    }
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/event/PaymentEventKafkaProducer.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/event/PaymentEventKafkaProducer.java
@@ -73,7 +73,8 @@ public class PaymentEventKafkaProducer implements PublishPaymentEventPort {
     public void publishPaymentCancelledEvent(Long orderId, String orderKey, Long buyerId,
                                              Long cancelAmount, Long paymentAmount, Long pointAmount,
                                              boolean isFullCancel, Long alreadyRefunded,
-                                             List<OrderProduct> orderProducts) {
+                                             List<OrderProduct> orderProducts,
+                                             List<OrderProduct> cancelProducts) {
         List<PaymentCancelledEvent.OrderProductItem> items = orderProducts.stream()
                 .map(op -> new PaymentCancelledEvent.OrderProductItem(
                         op.getPricePolicyId(),
@@ -83,9 +84,20 @@ public class PaymentEventKafkaProducer implements PublishPaymentEventPort {
                 ))
                 .toList();
 
+        List<PaymentCancelledEvent.OrderProductItem> cancelItems = FormatValidator.hasValue(cancelProducts)
+                ? cancelProducts.stream()
+                .map(op -> new PaymentCancelledEvent.OrderProductItem(
+                        op.getPricePolicyId(),
+                        op.getSharerId(),
+                        op.getQuantity(),
+                        op.getUnitAmount()
+                ))
+                .toList()
+                : null;
+
         PaymentCancelledEvent payload = new PaymentCancelledEvent(
                 orderId, orderKey, buyerId, cancelAmount, paymentAmount,
-                pointAmount, isFullCancel, alreadyRefunded, items
+                pointAmount, isFullCancel, alreadyRefunded, items, cancelItems
         );
         String topic = KafkaTopicConstants.PAYMENT_CANCELLED;
         EventEnvelope<PaymentCancelledEvent> envelope = EventEnvelope.of(

--- a/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/CommerceApplicationContextTest.java
+++ b/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/CommerceApplicationContextTest.java
@@ -4,7 +4,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.redisson.api.RedissonClient;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.batch.BatchAutoConfiguration;
@@ -13,6 +12,7 @@ import org.springframework.boot.autoconfigure.security.oauth2.resource.servlet.O
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.FilterType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;

--- a/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/event/PaymentCancelledOrderStatusConsumerTest.java
+++ b/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/event/PaymentCancelledOrderStatusConsumerTest.java
@@ -45,7 +45,7 @@ class PaymentCancelledOrderStatusConsumerTest {
                                                                   boolean isFullCancel, Long cancelAmount) {
         PaymentCancelledEvent event = new PaymentCancelledEvent(
                 orderId, orderKey, 100L, cancelAmount, 50000L, 1000L,
-                isFullCancel, 0L, List.of()
+                isFullCancel, 0L, List.of(), null
         );
         EventEnvelope<PaymentCancelledEvent> envelope = new EventEnvelope<>(
                 "test-event-id", "commerce.payment.cancelled", "commerce-service",

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/inventory/ReduceProductInventoryUseCase.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/inventory/ReduceProductInventoryUseCase.java
@@ -19,7 +19,7 @@ public interface ReduceProductInventoryUseCase {
      * @Date 2026-01-06
      * @Author 성효빈
      * @Description 주문 상품의 재고를 차감합니다. 분산 락/낙관적 락 이중 동시성 제어 로직이 적용되어 있습니다.
-     *              동일 orderId+pricePolicyId 조합의 이중 차감은 DB UNIQUE 제약으로 방지됩니다.
+     * 동일 orderId+pricePolicyId 조합의 이중 차감은 DB UNIQUE 제약으로 방지됩니다.
      */
     void reduce(List<OrderProduct> orderProducts, Long orderId, String reason);
 }

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/event/PublishPaymentEventPort.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/event/PublishPaymentEventPort.java
@@ -13,5 +13,6 @@ public interface PublishPaymentEventPort {
     void publishPaymentCancelledEvent(Long orderId, String orderKey, Long buyerId,
                                       Long cancelAmount, Long paymentAmount, Long pointAmount,
                                       boolean isFullCancel, Long alreadyRefunded,
-                                      List<OrderProduct> orderProducts);
+                                      List<OrderProduct> orderProducts,
+                                      List<OrderProduct> cancelProducts);
 }

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/CancelPaymentService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/CancelPaymentService.java
@@ -137,9 +137,10 @@ public class CancelPaymentService implements CancelPaymentUseCase {
         Long paymentAmount = payment.getPaymentAmount();
         Long pointAmount = order.getPointAmount();
         List<OrderProduct> orderProducts = order.getOrderProducts();
+        List<OrderProduct> cancelTargetProducts = resolveCancelProducts(isFullCancel, command);
         runAfterCommit(() -> publishPaymentCancelledEvent(
                 orderId, orderKey, buyerId, cancelAmount, paymentAmount,
-                pointAmount, isFullCancel, alreadyRefunded, orderProducts));
+                pointAmount, isFullCancel, alreadyRefunded, orderProducts, cancelTargetProducts));
     }
 
     private Long computeCancelAmount(boolean isFullCancel, Long partialCancelAmount, Long refundableAmount) {
@@ -415,14 +416,30 @@ public class CancelPaymentService implements CancelPaymentUseCase {
         action.run();
     }
 
+    private List<OrderProduct> resolveCancelProducts(boolean isFullCancel, CancelPaymentCommand command) {
+        if (isFullCancel || !command.hasCancelProducts()) {
+            return null;
+        }
+
+        return command.cancelProducts().stream()
+                .map(item -> OrderProduct.from(
+                        OrderProductSnapshotState.builder()
+                                .pricePolicyId(item.pricePolicyId())
+                                .quantity(item.quantity())
+                                .build()
+                ))
+                .toList();
+    }
+
     private void publishPaymentCancelledEvent(Long orderId, String orderKey, Long buyerId,
                                                 Long cancelAmount, Long paymentAmount, Long pointAmount,
                                                 boolean isFullCancel, Long alreadyRefunded,
-                                                List<OrderProduct> orderProducts) {
+                                                List<OrderProduct> orderProducts,
+                                                List<OrderProduct> cancelProducts) {
         try {
             publishPaymentEventPort.publishPaymentCancelledEvent(
                     orderId, orderKey, buyerId, cancelAmount, paymentAmount,
-                    pointAmount, isFullCancel, alreadyRefunded, orderProducts);
+                    pointAmount, isFullCancel, alreadyRefunded, orderProducts, cancelProducts);
         } catch (Exception e) {
             log.error("결제 취소 이벤트 발행 실패 - orderId: {}, orderKey: {}, error: {}",
                     orderId, orderKey, e.getMessage(), e);

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/settlement/ProcessSellerSettlementService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/settlement/ProcessSellerSettlementService.java
@@ -111,8 +111,8 @@ public class ProcessSellerSettlementService {
     }
 
     private void publishSettlementExecutedEvent(Long settlementId, Long sellerId,
-                                                 Long totalAllocatedAmount, Long pgFeeAmount,
-                                                 Long platformFeeAmount, Long sellerPayoutAmount) {
+                                                Long totalAllocatedAmount, Long pgFeeAmount,
+                                                Long platformFeeAmount, Long sellerPayoutAmount) {
         try {
             publishSettlementEventPort.publishSettlementExecutedEvent(
                     settlementId, sellerId, totalAllocatedAmount,

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/ChangeOrderStatusPaidProcessUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/ChangeOrderStatusPaidProcessUseCaseTest.java
@@ -27,7 +27,8 @@ import java.util.Map;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThatCode;
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)

--- a/common/src/main/java/com/personal/marketnote/common/kafka/event/PaymentCancelledEvent.java
+++ b/common/src/main/java/com/personal/marketnote/common/kafka/event/PaymentCancelledEvent.java
@@ -11,7 +11,8 @@ public record PaymentCancelledEvent(
         Long pointAmount,
         boolean isFullCancel,
         Long alreadyRefunded,
-        List<OrderProductItem> orderProducts
+        List<OrderProductItem> orderProducts,
+        List<OrderProductItem> cancelProducts
 ) {
 
     public record OrderProductItem(

--- a/community-service/community-adapters/src/test/java/com/personal/marketnote/community/CommunityApplicationContextTest.java
+++ b/community-service/community-adapters/src/test/java/com/personal/marketnote/community/CommunityApplicationContextTest.java
@@ -2,7 +2,6 @@ package com.personal.marketnote.community;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.batch.BatchAutoConfiguration;
@@ -10,6 +9,7 @@ import org.springframework.boot.autoconfigure.kafka.KafkaAutoConfiguration;
 import org.springframework.boot.autoconfigure.security.oauth2.resource.servlet.OAuth2ResourceServerAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.FilterType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;

--- a/file-service/file-adapters/src/test/java/com/personal/marketnote/file/FileApplicationContextTest.java
+++ b/file-service/file-adapters/src/test/java/com/personal/marketnote/file/FileApplicationContextTest.java
@@ -3,7 +3,6 @@ package com.personal.marketnote.file;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.batch.BatchAutoConfiguration;
@@ -12,6 +11,7 @@ import org.springframework.boot.autoconfigure.security.oauth2.resource.servlet.O
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.FilterType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;

--- a/fulfillment-service/fulfillment-adapters/src/test/java/com/personal/marketnote/fulfillment/FulfillmentApplicationContextTest.java
+++ b/fulfillment-service/fulfillment-adapters/src/test/java/com/personal/marketnote/fulfillment/FulfillmentApplicationContextTest.java
@@ -2,7 +2,6 @@ package com.personal.marketnote.fulfillment;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.batch.BatchAutoConfiguration;
@@ -10,6 +9,7 @@ import org.springframework.boot.autoconfigure.kafka.KafkaAutoConfiguration;
 import org.springframework.boot.autoconfigure.security.oauth2.resource.servlet.OAuth2ResourceServerAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.FilterType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;

--- a/product-service/product-adapters/src/test/java/com/personal/marketnote/product/ProductApplicationContextTest.java
+++ b/product-service/product-adapters/src/test/java/com/personal/marketnote/product/ProductApplicationContextTest.java
@@ -2,7 +2,6 @@ package com.personal.marketnote.product;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.batch.BatchAutoConfiguration;
@@ -10,6 +9,7 @@ import org.springframework.boot.autoconfigure.kafka.KafkaAutoConfiguration;
 import org.springframework.boot.autoconfigure.security.oauth2.resource.servlet.OAuth2ResourceServerAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.FilterType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;

--- a/product-service/product-adapters/src/test/java/com/personal/marketnote/product/adapter/in/event/OrderPaymentCompletedCartConsumerTest.java
+++ b/product-service/product-adapters/src/test/java/com/personal/marketnote/product/adapter/in/event/OrderPaymentCompletedCartConsumerTest.java
@@ -29,8 +29,8 @@ class OrderPaymentCompletedCartConsumerTest {
     private ObjectMapper objectMapper = new ObjectMapper();
 
     private ConsumerRecord<String, EventEnvelope<?>> buildRecord(Long orderId, Long buyerId,
-                                                                  Long totalAmount, Long pointAmount,
-                                                                  List<OrderProductItem> orderProducts) {
+                                                                 Long totalAmount, Long pointAmount,
+                                                                 List<OrderProductItem> orderProducts) {
         OrderPaymentCompletedEvent event = new OrderPaymentCompletedEvent(
                 orderId, buyerId, totalAmount, pointAmount, orderProducts
         );

--- a/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/RewardApplicationContextTest.java
+++ b/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/RewardApplicationContextTest.java
@@ -2,7 +2,6 @@ package com.personal.marketnote.reward;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.batch.BatchAutoConfiguration;
@@ -10,6 +9,7 @@ import org.springframework.boot.autoconfigure.kafka.KafkaAutoConfiguration;
 import org.springframework.boot.autoconfigure.security.oauth2.resource.servlet.OAuth2ResourceServerAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.FilterType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;

--- a/user-service/user-adapters/src/test/java/com/personal/marketnote/user/UserApplicationContextTest.java
+++ b/user-service/user-adapters/src/test/java/com/personal/marketnote/user/UserApplicationContextTest.java
@@ -2,7 +2,6 @@ package com.personal.marketnote.user;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.batch.BatchAutoConfiguration;
@@ -10,6 +9,7 @@ import org.springframework.boot.autoconfigure.kafka.KafkaAutoConfiguration;
 import org.springframework.boot.autoconfigure.security.oauth2.resource.servlet.OAuth2ResourceServerAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.FilterType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;


### PR DESCRIPTION
## partially addresses #929
## resolves #1101

## Task
- [x] PaymentCancelledEvent에 cancelProducts 필드 추가 (부분 취소 대상 상품)
- [x] PublishPaymentEventPort/PaymentEventKafkaProducer에 cancelProducts 매핑 추가
- [x] CancelPaymentService에 resolveCancelProducts() 메서드 추가
- [x] PaymentCancelledInventoryConsumer 생성 (groupId: commerce-inventory, 듀얼 라이트 로그만)
- [x] 전체 취소: orderProducts 기반 재고 복구 (FIXME, 멱등성 #1210 완료 후 활성화)
- [x] 부분 취소: cancelProducts 기반 재고 복구 (FIXME, 멱등성 #1210 완료 후 활성화)