### PR TITLE
[#929][#1105] test: 결제 취소 시 리워드 서비스 포인트 환불 연동 기능 자동화 테스트 추가

### DIFF
--- a/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/adapter/in/event/PaymentCancelledPointRefundConsumerTest.java
+++ b/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/adapter/in/event/PaymentCancelledPointRefundConsumerTest.java
@@ -1,0 +1,174 @@
+package com.personal.marketnote.reward.adapter.in.event;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.PaymentCancelledEvent;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.support.Acknowledgment;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("PaymentCancelledPointRefundConsumer 테스트")
+class PaymentCancelledPointRefundConsumerTest {
+    @InjectMocks
+    private PaymentCancelledPointRefundConsumer consumer;
+
+    @Spy
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @Mock
+    private Acknowledgment acknowledgment;
+
+    private ConsumerRecord<String, EventEnvelope<?>> buildRecord(Long orderId, Long buyerId,
+                                                                  Long pointAmount, boolean isFullCancel) {
+        PaymentCancelledEvent event = new PaymentCancelledEvent(
+                orderId, "order-key-1", buyerId, 50000L, 80000L, pointAmount,
+                isFullCancel, 0L, List.of(), null
+        );
+        EventEnvelope<PaymentCancelledEvent> envelope = new EventEnvelope<>(
+                "test-event-id", "commerce.payment.cancelled", "commerce-service",
+                LocalDateTime.of(2026, 3, 6, 10, 0), event
+        );
+        return new ConsumerRecord<>("commerce.payment.cancelled", 0, 0L, String.valueOf(orderId), envelope);
+    }
+
+    @Test
+    @DisplayName("전체 취소 이벤트 수신 시 포인트 환불 검증 후 acknowledge한다")
+    void handlePaymentCancelledEvent_fullCancel_validatesAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, 100L, 1000L, true);
+
+        // when
+        consumer.handlePaymentCancelledEvent(record, acknowledgment);
+
+        // then
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("부분 취소 이벤트이면 포인트 환불 없이 acknowledge한다")
+    void handlePaymentCancelledEvent_partialCancel_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, 100L, 1000L, false);
+
+        // when
+        consumer.handlePaymentCancelledEvent(record, acknowledgment);
+
+        // then
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("orderId가 null이면 포인트 환불 없이 acknowledge한다")
+    void handlePaymentCancelledEvent_nullOrderId_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(null, 100L, 1000L, true);
+
+        // when
+        consumer.handlePaymentCancelledEvent(record, acknowledgment);
+
+        // then
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("buyerId가 null이면 포인트 환불 없이 acknowledge한다")
+    void handlePaymentCancelledEvent_nullBuyerId_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, null, 1000L, true);
+
+        // when
+        consumer.handlePaymentCancelledEvent(record, acknowledgment);
+
+        // then
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("pointAmount가 null이면 포인트 환불 없이 acknowledge한다")
+    void handlePaymentCancelledEvent_nullPointAmount_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, 100L, null, true);
+
+        // when
+        consumer.handlePaymentCancelledEvent(record, acknowledgment);
+
+        // then
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("pointAmount가 0이면 포인트 환불 없이 acknowledge한다")
+    void handlePaymentCancelledEvent_zeroPointAmount_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, 100L, 0L, true);
+
+        // when
+        consumer.handlePaymentCancelledEvent(record, acknowledgment);
+
+        // then
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("pointAmount가 음수이면 포인트 환불 없이 acknowledge한다")
+    void handlePaymentCancelledEvent_negativePointAmount_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, 100L, -500L, true);
+
+        // when
+        consumer.handlePaymentCancelledEvent(record, acknowledgment);
+
+        // then
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("envelope이 null이면 포인트 환불 없이 acknowledge한다")
+    void handlePaymentCancelledEvent_nullEnvelope_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = new ConsumerRecord<>(
+                "commerce.payment.cancelled", 0, 0L, "1", null
+        );
+
+        // when
+        consumer.handlePaymentCancelledEvent(record, acknowledgment);
+
+        // then
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("예상치 못한 예외 발생 시 DefaultErrorHandler로 위임되어 예외가 전파된다")
+    @SuppressWarnings("unchecked")
+    void handlePaymentCancelledEvent_unexpectedException_propagatesForRetry() {
+        // given
+        EventEnvelope<String> envelope = new EventEnvelope<>(
+                "test-event-id", "commerce.payment.cancelled", "commerce-service",
+                LocalDateTime.of(2026, 3, 6, 10, 0), "invalid-payload"
+        );
+        ConsumerRecord<String, EventEnvelope<?>> record = new ConsumerRecord<>(
+                "commerce.payment.cancelled", 0, 0L, "1",
+                (EventEnvelope<?>) (EventEnvelope) envelope
+        );
+
+        // when & then
+        assertThatThrownBy(() -> consumer.handlePaymentCancelledEvent(record, acknowledgment))
+                .isInstanceOf(Exception.class);
+
+        verify(acknowledgment, never()).acknowledge();
+    }
+}


### PR DESCRIPTION
## partially addresses #929
## resolves #1105

## Test Case
- [x] 전체 취소 이벤트 수신 시 포인트 환불 검증 후 acknowledge한다
- [x] 부분 취소 이벤트이면 포인트 환불 없이 acknowledge한다
- [x] orderId가 null이면 포인트 환불 없이 acknowledge한다
- [x] buyerId가 null이면 포인트 환불 없이 acknowledge한다
- [x] pointAmount가 null이면 포인트 환불 없이 acknowledge한다
- [x] pointAmount가 0이면 포인트 환불 없이 acknowledge한다
- [x] pointAmount가 음수이면 포인트 환불 없이 acknowledge한다
- [x] envelope이 null이면 포인트 환불 없이 acknowledge한다
- [x] 예상치 못한 예외 발생 시 DefaultErrorHandler로 위임되어 예외가 전파된다