### PR TITLE
[#929][#1176] feat: 결제 취소 시 리워드 서비스 상품 구매 적립 예정 포인트 회수 연동 기능 Kafka 이벤트 전환

### DIFF
--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/event/PaymentCancelledPendingProductPointConsumer.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/event/PaymentCancelledPendingProductPointConsumer.java
@@ -1,0 +1,87 @@
+package com.personal.marketnote.reward.adapter.in.event;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.common.kafka.KafkaTopicConstants;
+import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.PaymentCancelledEvent;
+import com.personal.marketnote.common.utility.FormatValidator;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PaymentCancelledPendingProductPointConsumer {
+    private final ObjectMapper objectMapper;
+
+    @KafkaListener(
+            topics = KafkaTopicConstants.PAYMENT_CANCELLED,
+            groupId = "reward-pending-product-point"
+    )
+    public void handlePaymentCancelledEvent(
+            ConsumerRecord<String, EventEnvelope<?>> record,
+            Acknowledgment acknowledgment
+    ) {
+        EventEnvelope<?> envelope = record.value();
+
+        if (FormatValidator.hasNoValue(envelope)) {
+            log.error("이벤트 envelope이 null. topic={}, partition={}, offset={}",
+                    record.topic(), record.partition(), record.offset());
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        try {
+            PaymentCancelledEvent payload = envelope.getPayloadAs(
+                    PaymentCancelledEvent.class, objectMapper
+            );
+
+            log.info("결제 취소 이벤트 수신 (상품 적립 예정 포인트 회수). eventId={}, orderId={}, buyerId={}, isFullCancel={}",
+                    envelope.eventId(), payload.orderId(), payload.buyerId(), payload.isFullCancel());
+
+            if (FormatValidator.hasNoValue(payload.orderId())) {
+                log.error("유효하지 않은 이벤트 페이로드. eventId={}, orderId=null",
+                        envelope.eventId());
+                acknowledgment.acknowledge();
+                return;
+            }
+
+            if (!payload.isFullCancel()) {
+                log.info("부분 취소 이벤트 -- 상품 적립 예정 포인트 회수 불필요. orderId={}", payload.orderId());
+                acknowledgment.acknowledge();
+                return;
+            }
+
+            if (FormatValidator.hasNoValue(payload.buyerId())) {
+                log.error("유효하지 않은 이벤트 페이로드. eventId={}, orderId={}, buyerId=null",
+                        envelope.eventId(), payload.orderId());
+                acknowledgment.acknowledge();
+                return;
+            }
+
+            // FIXME: [#929][#1176] HTTP 제거 후 CancelPendingPointUseCase 활성화
+            //  현재 듀얼 라이트 기간: CancelPaymentService.revokePendingProductAccumulationPoints()에서 HTTP로 처리 중
+            //  아래 주석 해제 시 활성화:
+            //  CancelPendingPointCommand command = CancelPendingPointCommand.builder()
+            //          .userId(payload.buyerId())
+            //          .sourceType(UserPointSourceType.ORDER)
+            //          .sourceId(payload.orderId())
+            //          .reason("결제 취소 적립 예정 포인트 회수")
+            //          .build();
+            //  cancelPendingPointUseCase.cancelPending(command);
+
+            log.info("상품 적립 예정 포인트 회수 이벤트 검증 완료 (듀얼 라이트). orderId={}, buyerId={}",
+                    payload.orderId(), payload.buyerId());
+        } catch (Exception e) {
+            log.error("상품 적립 예정 포인트 회수 이벤트 처리 실패. eventId={}, key={}, error={}",
+                    envelope.eventId(), record.key(), e.getMessage(), e);
+            throw e;
+        }
+
+        acknowledgment.acknowledge();
+    }
+}


### PR DESCRIPTION
## partially addresses #929
## resolves #1176

## Task
- [x] PaymentCancelledPendingProductPointConsumer 추가 (reward-service, groupId: reward-pending-product-point)
- [x] commerce.payment.cancelled 토픽 구독, isFullCancel==true일 때만 처리
- [x] 듀얼 라이트: 검증 로그만 수행 (HTTP 제거 후 CancelPendingPointUseCase 활성화)