### PR TITLE
[#929][#1180] test: 결제 취소 시 리워드 서비스 상품 구매 적립 예정 포인트 회수 연동 기능 자동화 테스트 추가

### DIFF
--- a/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/adapter/in/event/PaymentCancelledPendingProductPointConsumerTest.java
+++ b/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/adapter/in/event/PaymentCancelledPendingProductPointConsumerTest.java
@@ -1,0 +1,135 @@
+package com.personal.marketnote.reward.adapter.in.event;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.PaymentCancelledEvent;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Spy;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.support.Acknowledgment;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("PaymentCancelledPendingProductPointConsumer 테스트")
+class PaymentCancelledPendingProductPointConsumerTest {
+    @InjectMocks
+    private PaymentCancelledPendingProductPointConsumer consumer;
+
+    @Spy
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @Mock
+    private Acknowledgment acknowledgment;
+
+    private ConsumerRecord<String, EventEnvelope<?>> buildRecord(Long orderId, Long buyerId,
+                                                                  boolean isFullCancel) {
+        PaymentCancelledEvent event = new PaymentCancelledEvent(
+                orderId, "order-key-1", buyerId, 50000L, 80000L, 1000L,
+                isFullCancel, 0L, List.of(), null
+        );
+        EventEnvelope<PaymentCancelledEvent> envelope = new EventEnvelope<>(
+                "test-event-id", "commerce.payment.cancelled", "commerce-service",
+                LocalDateTime.of(2026, 3, 6, 10, 0), event
+        );
+        return new ConsumerRecord<>("commerce.payment.cancelled", 0, 0L, String.valueOf(orderId), envelope);
+    }
+
+    @Test
+    @DisplayName("전체 취소 이벤트 수신 시 상품 적립 예정 포인트 회수 검증 후 acknowledge한다")
+    void handlePaymentCancelledEvent_fullCancel_validatesAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, 100L, true);
+
+        // when
+        consumer.handlePaymentCancelledEvent(record, acknowledgment);
+
+        // then
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("부분 취소 이벤트이면 상품 적립 예정 포인트 회수 없이 acknowledge한다")
+    void handlePaymentCancelledEvent_partialCancel_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, 100L, false);
+
+        // when
+        consumer.handlePaymentCancelledEvent(record, acknowledgment);
+
+        // then
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("orderId가 null이면 상품 적립 예정 포인트 회수 없이 acknowledge한다")
+    void handlePaymentCancelledEvent_nullOrderId_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(null, 100L, true);
+
+        // when
+        consumer.handlePaymentCancelledEvent(record, acknowledgment);
+
+        // then
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("buyerId가 null이면 상품 적립 예정 포인트 회수 없이 acknowledge한다")
+    void handlePaymentCancelledEvent_nullBuyerId_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, null, true);
+
+        // when
+        consumer.handlePaymentCancelledEvent(record, acknowledgment);
+
+        // then
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("envelope이 null이면 상품 적립 예정 포인트 회수 없이 acknowledge한다")
+    void handlePaymentCancelledEvent_nullEnvelope_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = new ConsumerRecord<>(
+                "commerce.payment.cancelled", 0, 0L, "1", null
+        );
+
+        // when
+        consumer.handlePaymentCancelledEvent(record, acknowledgment);
+
+        // then
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("예상치 못한 예외 발생 시 DefaultErrorHandler로 위임되어 예외가 전파된다")
+    @SuppressWarnings("unchecked")
+    void handlePaymentCancelledEvent_unexpectedException_propagatesForRetry() {
+        // given
+        EventEnvelope<String> envelope = new EventEnvelope<>(
+                "test-event-id", "commerce.payment.cancelled", "commerce-service",
+                LocalDateTime.of(2026, 3, 6, 10, 0), "invalid-payload"
+        );
+        ConsumerRecord<String, EventEnvelope<?>> record = new ConsumerRecord<>(
+                "commerce.payment.cancelled", 0, 0L, "1",
+                (EventEnvelope<?>) (EventEnvelope) envelope
+        );
+
+        // when & then
+        assertThatThrownBy(() -> consumer.handlePaymentCancelledEvent(record, acknowledgment))
+                .isInstanceOf(Exception.class);
+
+        verify(acknowledgment, never()).acknowledge();
+    }
+}


### PR DESCRIPTION
## partially addresses #929
## resolves #1180

## Test Case
- [x] 전체 취소 이벤트 수신 시 상품 적립 예정 포인트 회수 검증 후 acknowledge한다
- [x] 부분 취소 이벤트이면 상품 적립 예정 포인트 회수 없이 acknowledge한다
- [x] orderId가 null이면 상품 적립 예정 포인트 회수 없이 acknowledge한다
- [x] buyerId가 null이면 상품 적립 예정 포인트 회수 없이 acknowledge한다
- [x] envelope이 null이면 상품 적립 예정 포인트 회수 없이 acknowledge한다
- [x] 예상치 못한 예외 발생 시 DefaultErrorHandler로 위임되어 예외가 전파된다