### PR TITLE
[#929][#1178] feat: 부분 결제 취소 시 리워드 서비스 상품 구매 적립 예정 포인트 반환 연동 기능 Kafka 이벤트 전환

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/event/PaymentEventKafkaProducer.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/event/PaymentEventKafkaProducer.java
@@ -74,7 +74,8 @@ public class PaymentEventKafkaProducer implements PublishPaymentEventPort {
                                              Long cancelAmount, Long paymentAmount, Long pointAmount,
                                              boolean isFullCancel, Long alreadyRefunded,
                                              List<OrderProduct> orderProducts,
-                                             List<OrderProduct> cancelProducts) {
+                                             List<OrderProduct> cancelProducts,
+                                             Long partialProductPendingDeduction) {
         List<PaymentCancelledEvent.OrderProductItem> items = orderProducts.stream()
                 .map(op -> new PaymentCancelledEvent.OrderProductItem(
                         op.getPricePolicyId(),
@@ -97,7 +98,8 @@ public class PaymentEventKafkaProducer implements PublishPaymentEventPort {
 
         PaymentCancelledEvent payload = new PaymentCancelledEvent(
                 orderId, orderKey, buyerId, cancelAmount, paymentAmount,
-                pointAmount, isFullCancel, alreadyRefunded, items, cancelItems
+                pointAmount, isFullCancel, alreadyRefunded, items, cancelItems,
+                partialProductPendingDeduction
         );
         String topic = KafkaTopicConstants.PAYMENT_CANCELLED;
         EventEnvelope<PaymentCancelledEvent> envelope = EventEnvelope.of(

--- a/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/event/PaymentCancelledInventoryConsumerTest.java
+++ b/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/event/PaymentCancelledInventoryConsumerTest.java
@@ -50,7 +50,7 @@ class PaymentCancelledInventoryConsumerTest {
                                                                   List<OrderProductItem> cancelProducts) {
         PaymentCancelledEvent event = new PaymentCancelledEvent(
                 orderId, "order-key-1", 100L, 50000L, 80000L, 1000L,
-                isFullCancel, 0L, orderProducts, cancelProducts
+                isFullCancel, 0L, orderProducts, cancelProducts, null
         );
         EventEnvelope<PaymentCancelledEvent> envelope = new EventEnvelope<>(
                 "test-event-id", "commerce.payment.cancelled", "commerce-service",

--- a/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/event/PaymentCancelledOrderStatusConsumerTest.java
+++ b/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/event/PaymentCancelledOrderStatusConsumerTest.java
@@ -45,7 +45,7 @@ class PaymentCancelledOrderStatusConsumerTest {
                                                                   boolean isFullCancel, Long cancelAmount) {
         PaymentCancelledEvent event = new PaymentCancelledEvent(
                 orderId, orderKey, 100L, cancelAmount, 50000L, 1000L,
-                isFullCancel, 0L, List.of(), null
+                isFullCancel, 0L, List.of(), null, null
         );
         EventEnvelope<PaymentCancelledEvent> envelope = new EventEnvelope<>(
                 "test-event-id", "commerce.payment.cancelled", "commerce-service",

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/event/PublishPaymentEventPort.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/event/PublishPaymentEventPort.java
@@ -14,5 +14,6 @@ public interface PublishPaymentEventPort {
                                       Long cancelAmount, Long paymentAmount, Long pointAmount,
                                       boolean isFullCancel, Long alreadyRefunded,
                                       List<OrderProduct> orderProducts,
-                                      List<OrderProduct> cancelProducts);
+                                      List<OrderProduct> cancelProducts,
+                                      Long partialProductPendingDeduction);
 }

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/CancelPaymentService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/CancelPaymentService.java
@@ -106,6 +106,7 @@ public class CancelPaymentService implements CancelPaymentUseCase {
 
         saveRefundRecord(payment, isFullCancel, cancelAmount, command.cancelReason(), vendorResult);
 
+        Long partialProductPendingDeduction = null;
         if (isFullCancel) {
             changeOrderStatusUseCase.changeOrderStatus(
                     ChangeOrderStatusCommand.builder()
@@ -119,14 +120,15 @@ public class CancelPaymentService implements CancelPaymentUseCase {
             revokePendingSharedPurchasePoints(order);
         } else {
             restorePartialCancelInventory(order, command);
+            partialProductPendingDeduction = resolveProportionalDeductionPoint(
+                    order.getOrderProducts(), payment.getPaymentAmount(), cancelAmount);
             Long buyerId = order.getBuyerId();
             Long orderId = order.getId();
-            List<OrderProduct> orderProducts = order.getOrderProducts();
-            Long paymentAmount = payment.getPaymentAmount();
+            Long precomputedDeduction = partialProductPendingDeduction;
             runAfterCommit(() -> reducePartialPendingProductAccumulationPoints(
-                    buyerId, orderId, orderProducts, paymentAmount, cancelAmount));
+                    buyerId, orderId, precomputedDeduction));
             runAfterCommit(() -> reducePartialPendingSharedPurchasePoints(
-                    order, paymentAmount, cancelAmount));
+                    order, payment.getPaymentAmount(), cancelAmount));
         }
 
         recordLedgerEntryForCancellation(payment, isFullCancel, cancelAmount, alreadyRefunded);
@@ -138,9 +140,11 @@ public class CancelPaymentService implements CancelPaymentUseCase {
         Long pointAmount = order.getPointAmount();
         List<OrderProduct> orderProducts = order.getOrderProducts();
         List<OrderProduct> cancelTargetProducts = resolveCancelProducts(isFullCancel, command);
+        Long finalPartialProductPendingDeduction = partialProductPendingDeduction;
         runAfterCommit(() -> publishPaymentCancelledEvent(
                 orderId, orderKey, buyerId, cancelAmount, paymentAmount,
-                pointAmount, isFullCancel, alreadyRefunded, orderProducts, cancelTargetProducts));
+                pointAmount, isFullCancel, alreadyRefunded, orderProducts, cancelTargetProducts,
+                finalPartialProductPendingDeduction));
     }
 
     private Long computeCancelAmount(boolean isFullCancel, Long partialCancelAmount, Long refundableAmount) {
@@ -353,20 +357,14 @@ public class CancelPaymentService implements CancelPaymentUseCase {
     }
 
     private void reducePartialPendingProductAccumulationPoints(
-            Long buyerId, Long orderId, List<OrderProduct> orderProducts, Long paymentAmount, Long cancelAmount
+            Long buyerId, Long orderId, Long precomputedDeduction
     ) {
         try {
-            Long totalAccumulatedPoint = calculateTotalAccumulatedPoint(orderProducts);
-            if (FormatValidator.hasNoValue(totalAccumulatedPoint) || totalAccumulatedPoint <= 0) {
+            if (FormatValidator.hasNoValue(precomputedDeduction) || precomputedDeduction <= 0) {
                 return;
             }
 
-            Long proportionalPoint = calculateProportionalPoint(cancelAmount, paymentAmount, totalAccumulatedPoint);
-            if (proportionalPoint <= 0) {
-                return;
-            }
-
-            modifyUserPointPort.reducePartialPendingPoints(buyerId, proportionalPoint, orderId);
+            modifyUserPointPort.reducePartialPendingPoints(buyerId, precomputedDeduction, orderId);
         } catch (Exception e) {
             log.error("부분 취소 상품 적립 예정 포인트 차감 실패 - orderId: {}, buyerId: {}, error: {}",
                     orderId, buyerId, e.getMessage(), e);
@@ -431,15 +429,38 @@ public class CancelPaymentService implements CancelPaymentUseCase {
                 .toList();
     }
 
+    private Long resolveProportionalDeductionPoint(
+            List<OrderProduct> orderProducts, Long paymentAmount, Long cancelAmount
+    ) {
+        try {
+            Long totalAccumulatedPoint = calculateTotalAccumulatedPoint(orderProducts);
+            if (FormatValidator.hasNoValue(totalAccumulatedPoint) || totalAccumulatedPoint <= 0) {
+                return null;
+            }
+
+            Long proportionalPoint = calculateProportionalPoint(cancelAmount, paymentAmount, totalAccumulatedPoint);
+            if (proportionalPoint <= 0) {
+                return null;
+            }
+
+            return proportionalPoint;
+        } catch (Exception e) {
+            log.error("부분 취소 비례 포인트 사전 계산 실패 - error: {}", e.getMessage(), e);
+            return null;
+        }
+    }
+
     private void publishPaymentCancelledEvent(Long orderId, String orderKey, Long buyerId,
                                                 Long cancelAmount, Long paymentAmount, Long pointAmount,
                                                 boolean isFullCancel, Long alreadyRefunded,
                                                 List<OrderProduct> orderProducts,
-                                                List<OrderProduct> cancelProducts) {
+                                                List<OrderProduct> cancelProducts,
+                                                Long partialProductPendingDeduction) {
         try {
             publishPaymentEventPort.publishPaymentCancelledEvent(
                     orderId, orderKey, buyerId, cancelAmount, paymentAmount,
-                    pointAmount, isFullCancel, alreadyRefunded, orderProducts, cancelProducts);
+                    pointAmount, isFullCancel, alreadyRefunded, orderProducts, cancelProducts,
+                    partialProductPendingDeduction);
         } catch (Exception e) {
             log.error("결제 취소 이벤트 발행 실패 - orderId: {}, orderKey: {}, error: {}",
                     orderId, orderKey, e.getMessage(), e);

--- a/common/src/main/java/com/personal/marketnote/common/kafka/event/PaymentCancelledEvent.java
+++ b/common/src/main/java/com/personal/marketnote/common/kafka/event/PaymentCancelledEvent.java
@@ -12,7 +12,8 @@ public record PaymentCancelledEvent(
         boolean isFullCancel,
         Long alreadyRefunded,
         List<OrderProductItem> orderProducts,
-        List<OrderProductItem> cancelProducts
+        List<OrderProductItem> cancelProducts,
+        Long partialProductPendingDeduction
 ) {
 
     public record OrderProductItem(

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/event/PaymentCancelledPartialProductPointConsumer.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/event/PaymentCancelledPartialProductPointConsumer.java
@@ -1,0 +1,97 @@
+package com.personal.marketnote.reward.adapter.in.event;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.common.kafka.KafkaTopicConstants;
+import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.PaymentCancelledEvent;
+import com.personal.marketnote.common.utility.FormatValidator;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PaymentCancelledPartialProductPointConsumer {
+    private final ObjectMapper objectMapper;
+
+    @KafkaListener(
+            topics = KafkaTopicConstants.PAYMENT_CANCELLED,
+            groupId = "reward-partial-pending-product-point"
+    )
+    public void handlePaymentCancelledEvent(
+            ConsumerRecord<String, EventEnvelope<?>> record,
+            Acknowledgment acknowledgment
+    ) {
+        EventEnvelope<?> envelope = record.value();
+
+        if (FormatValidator.hasNoValue(envelope)) {
+            log.error("이벤트 envelope이 null. topic={}, partition={}, offset={}",
+                    record.topic(), record.partition(), record.offset());
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        try {
+            PaymentCancelledEvent payload = envelope.getPayloadAs(
+                    PaymentCancelledEvent.class, objectMapper
+            );
+
+            log.info("결제 취소 이벤트 수신 (부분 상품 적립 예정 포인트 차감). eventId={}, orderId={}, buyerId={}, isFullCancel={}",
+                    envelope.eventId(), payload.orderId(), payload.buyerId(), payload.isFullCancel());
+
+            if (FormatValidator.hasNoValue(payload.orderId())) {
+                log.error("유효하지 않은 이벤트 페이로드. eventId={}, orderId=null",
+                        envelope.eventId());
+                acknowledgment.acknowledge();
+                return;
+            }
+
+            if (payload.isFullCancel()) {
+                log.info("전체 취소 이벤트 -- 부분 상품 적립 예정 포인트 차감 불필요. orderId={}", payload.orderId());
+                acknowledgment.acknowledge();
+                return;
+            }
+
+            if (FormatValidator.hasNoValue(payload.buyerId())) {
+                log.error("유효하지 않은 이벤트 페이로드. eventId={}, orderId={}, buyerId=null",
+                        envelope.eventId(), payload.orderId());
+                acknowledgment.acknowledge();
+                return;
+            }
+
+            if (FormatValidator.hasNoValue(payload.partialProductPendingDeduction())
+                    || payload.partialProductPendingDeduction() <= 0) {
+                log.info("부분 상품 적립 예정 포인트 차감 금액 없음. orderId={}, deductionAmount={}",
+                        payload.orderId(), payload.partialProductPendingDeduction());
+                acknowledgment.acknowledge();
+                return;
+            }
+
+            // FIXME: [#929][#1178] HTTP 제거 후 ModifyPendingPointUseCase 활성화
+            //  현재 듀얼 라이트 기간: CancelPaymentService.reducePartialPendingProductAccumulationPoints()에서 HTTP로 처리 중
+            //  아래 주석 해제 시 활성화:
+            //  ModifyPendingPointCommand command = ModifyPendingPointCommand.builder()
+            //          .userId(payload.buyerId())
+            //          .changeType(UserPointChangeType.DEDUCTION)
+            //          .amount(payload.partialProductPendingDeduction())
+            //          .sourceType(UserPointSourceType.ORDER)
+            //          .sourceId(payload.orderId())
+            //          .reason("부분 결제 취소 상품 적립 예정 포인트 차감")
+            //          .build();
+            //  modifyPendingPointUseCase.modifyPending(command);
+
+            log.info("부분 상품 적립 예정 포인트 차감 이벤트 검증 완료 (듀얼 라이트). orderId={}, buyerId={}, deductionAmount={}",
+                    payload.orderId(), payload.buyerId(), payload.partialProductPendingDeduction());
+        } catch (Exception e) {
+            log.error("부분 상품 적립 예정 포인트 차감 이벤트 처리 실패. eventId={}, key={}, error={}",
+                    envelope.eventId(), record.key(), e.getMessage(), e);
+            throw e;
+        }
+
+        acknowledgment.acknowledge();
+    }
+}

--- a/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/adapter/in/event/PaymentCancelledPendingProductPointConsumerTest.java
+++ b/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/adapter/in/event/PaymentCancelledPendingProductPointConsumerTest.java
@@ -36,7 +36,7 @@ class PaymentCancelledPendingProductPointConsumerTest {
                                                                   boolean isFullCancel) {
         PaymentCancelledEvent event = new PaymentCancelledEvent(
                 orderId, "order-key-1", buyerId, 50000L, 80000L, 1000L,
-                isFullCancel, 0L, List.of(), null
+                isFullCancel, 0L, List.of(), null, null
         );
         EventEnvelope<PaymentCancelledEvent> envelope = new EventEnvelope<>(
                 "test-event-id", "commerce.payment.cancelled", "commerce-service",

--- a/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/adapter/in/event/PaymentCancelledPendingSharedPointConsumerTest.java
+++ b/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/adapter/in/event/PaymentCancelledPendingSharedPointConsumerTest.java
@@ -37,7 +37,7 @@ class PaymentCancelledPendingSharedPointConsumerTest {
                                                                   List<OrderProductItem> orderProducts) {
         PaymentCancelledEvent event = new PaymentCancelledEvent(
                 orderId, "order-key-1", 100L, 50000L, 80000L, 1000L,
-                isFullCancel, 0L, orderProducts, null
+                isFullCancel, 0L, orderProducts, null, null
         );
         EventEnvelope<PaymentCancelledEvent> envelope = new EventEnvelope<>(
                 "test-event-id", "commerce.payment.cancelled", "commerce-service",

--- a/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/adapter/in/event/PaymentCancelledPointRefundConsumerTest.java
+++ b/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/adapter/in/event/PaymentCancelledPointRefundConsumerTest.java
@@ -36,7 +36,7 @@ class PaymentCancelledPointRefundConsumerTest {
                                                                   Long pointAmount, boolean isFullCancel) {
         PaymentCancelledEvent event = new PaymentCancelledEvent(
                 orderId, "order-key-1", buyerId, 50000L, 80000L, pointAmount,
-                isFullCancel, 0L, List.of(), null
+                isFullCancel, 0L, List.of(), null, null
         );
         EventEnvelope<PaymentCancelledEvent> envelope = new EventEnvelope<>(
                 "test-event-id", "commerce.payment.cancelled", "commerce-service",


### PR DESCRIPTION
## partially addresses #929
## resolves #1178

## Task
- [x] PaymentCancelledEvent에 partialProductPendingDeduction 필드 추가
- [x] Producer(CancelPaymentService)에서 비례 포인트 사전 계산하여 이벤트에 포함
- [x] PaymentCancelledPartialProductPointConsumer 신규 Consumer (듀얼 라이트)
- [x] 중복 계산 로직 resolveProportionalDeductionPoint로 추출
- [x] reducePartialPendingProductAccumulationPoints 사전 계산 재사용
- [x] 기존 테스트 호환성 수정 (5개 파일)