### PR TITLE
[#929][#1183] test: 부분 결제 취소 시 리워드 서비스 링크 공유 적립 예정 포인트 반환 연동 기능 자동화 테스트 추가

### DIFF
--- a/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/adapter/in/event/PaymentCancelledPartialSharedPointConsumerTest.java
+++ b/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/adapter/in/event/PaymentCancelledPartialSharedPointConsumerTest.java
@@ -1,0 +1,253 @@
+package com.personal.marketnote.reward.adapter.in.event;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.PaymentCancelledEvent;
+import com.personal.marketnote.common.kafka.event.PaymentCancelledEvent.OrderProductItem;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("PaymentCancelledPartialSharedPointConsumer 테스트")
+class PaymentCancelledPartialSharedPointConsumerTest {
+    @InjectMocks
+    private PaymentCancelledPartialSharedPointConsumer consumer;
+
+    @Spy
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @Mock
+    private Acknowledgment acknowledgment;
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(consumer, "sharePointRate", 0.1f);
+    }
+
+    private ConsumerRecord<String, EventEnvelope<?>> buildRecord(Long orderId, boolean isFullCancel,
+                                                                  Long cancelAmount, Long paymentAmount,
+                                                                  List<OrderProductItem> orderProducts) {
+        PaymentCancelledEvent event = new PaymentCancelledEvent(
+                orderId, "order-key-1", 100L, cancelAmount, paymentAmount, 1000L,
+                isFullCancel, 0L, orderProducts, null, null
+        );
+        EventEnvelope<PaymentCancelledEvent> envelope = new EventEnvelope<>(
+                "test-event-id", "commerce.payment.cancelled", "commerce-service",
+                LocalDateTime.of(2026, 3, 7, 10, 0), event
+        );
+        return new ConsumerRecord<>("commerce.payment.cancelled", 0, 0L, String.valueOf(orderId), envelope);
+    }
+
+    @Test
+    @DisplayName("부분 취소 이벤트 수신 시 공유자가 있으면 비례 차감 포인트를 검증 후 acknowledge한다")
+    void handlePaymentCancelledEvent_partialCancelWithSharers_validatesAndAcknowledges() {
+        // given
+        List<OrderProductItem> orderProducts = List.of(
+                new OrderProductItem(1L, 200L, 2, 10000L),
+                new OrderProductItem(2L, 300L, 1, 20000L)
+        );
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, false, 30000L, 80000L, orderProducts);
+
+        // when
+        consumer.handlePaymentCancelledEvent(record, acknowledgment);
+
+        // then
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("전체 취소 이벤트이면 부분 공유 적립 예정 포인트 차감 없이 acknowledge한다")
+    void handlePaymentCancelledEvent_fullCancel_skipsAndAcknowledges() {
+        // given
+        List<OrderProductItem> orderProducts = List.of(
+                new OrderProductItem(1L, 200L, 2, 10000L)
+        );
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, true, 50000L, 80000L, orderProducts);
+
+        // when
+        consumer.handlePaymentCancelledEvent(record, acknowledgment);
+
+        // then
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("orderId가 null이면 부분 공유 적립 예정 포인트 차감 없이 acknowledge한다")
+    void handlePaymentCancelledEvent_nullOrderId_skipsAndAcknowledges() {
+        // given
+        List<OrderProductItem> orderProducts = List.of(
+                new OrderProductItem(1L, 200L, 2, 10000L)
+        );
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(null, false, 30000L, 80000L, orderProducts);
+
+        // when
+        consumer.handlePaymentCancelledEvent(record, acknowledgment);
+
+        // then
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("공유자가 없는 주문이면 부분 공유 적립 예정 포인트 차감 없이 acknowledge한다")
+    void handlePaymentCancelledEvent_noSharers_skipsAndAcknowledges() {
+        // given
+        List<OrderProductItem> orderProducts = List.of(
+                new OrderProductItem(1L, null, 2, 10000L),
+                new OrderProductItem(2L, null, 1, 20000L)
+        );
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, false, 30000L, 80000L, orderProducts);
+
+        // when
+        consumer.handlePaymentCancelledEvent(record, acknowledgment);
+
+        // then
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("orderProducts가 빈 목록이면 부분 공유 적립 예정 포인트 차감 없이 acknowledge한다")
+    void handlePaymentCancelledEvent_emptyOrderProducts_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, false, 30000L, 80000L, List.of());
+
+        // when
+        consumer.handlePaymentCancelledEvent(record, acknowledgment);
+
+        // then
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("envelope이 null이면 부분 공유 적립 예정 포인트 차감 없이 acknowledge한다")
+    void handlePaymentCancelledEvent_nullEnvelope_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = new ConsumerRecord<>(
+                "commerce.payment.cancelled", 0, 0L, "1", null
+        );
+
+        // when
+        consumer.handlePaymentCancelledEvent(record, acknowledgment);
+
+        // then
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("paymentAmount가 null이면 비례 차감 계산 불가로 acknowledge한다")
+    void handlePaymentCancelledEvent_nullPaymentAmount_skipsAndAcknowledges() {
+        // given
+        List<OrderProductItem> orderProducts = List.of(
+                new OrderProductItem(1L, 200L, 2, 10000L)
+        );
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, false, 30000L, null, orderProducts);
+
+        // when
+        consumer.handlePaymentCancelledEvent(record, acknowledgment);
+
+        // then
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("paymentAmount가 0이면 비례 차감 계산 불가로 acknowledge한다")
+    void handlePaymentCancelledEvent_zeroPaymentAmount_skipsAndAcknowledges() {
+        // given
+        List<OrderProductItem> orderProducts = List.of(
+                new OrderProductItem(1L, 200L, 2, 10000L)
+        );
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, false, 30000L, 0L, orderProducts);
+
+        // when
+        consumer.handlePaymentCancelledEvent(record, acknowledgment);
+
+        // then
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("cancelAmount가 null이면 비례 차감 계산 불가로 acknowledge한다")
+    void handlePaymentCancelledEvent_nullCancelAmount_skipsAndAcknowledges() {
+        // given
+        List<OrderProductItem> orderProducts = List.of(
+                new OrderProductItem(1L, 200L, 2, 10000L)
+        );
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, false, null, 80000L, orderProducts);
+
+        // when
+        consumer.handlePaymentCancelledEvent(record, acknowledgment);
+
+        // then
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("cancelAmount가 0이면 비례 차감 계산 불가로 acknowledge한다")
+    void handlePaymentCancelledEvent_zeroCancelAmount_skipsAndAcknowledges() {
+        // given
+        List<OrderProductItem> orderProducts = List.of(
+                new OrderProductItem(1L, 200L, 2, 10000L)
+        );
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, false, 0L, 80000L, orderProducts);
+
+        // when
+        consumer.handlePaymentCancelledEvent(record, acknowledgment);
+
+        // then
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("중복 공유자가 있으면 중복 제거 후 검증한다")
+    void handlePaymentCancelledEvent_duplicateSharers_deduplicatesAndAcknowledges() {
+        // given
+        List<OrderProductItem> orderProducts = List.of(
+                new OrderProductItem(1L, 200L, 2, 10000L),
+                new OrderProductItem(2L, 200L, 1, 20000L),
+                new OrderProductItem(3L, 300L, 1, 15000L)
+        );
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, false, 30000L, 80000L, orderProducts);
+
+        // when
+        consumer.handlePaymentCancelledEvent(record, acknowledgment);
+
+        // then
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("예상치 못한 예외 발생 시 DefaultErrorHandler로 위임되어 예외가 전파된다")
+    @SuppressWarnings("unchecked")
+    void handlePaymentCancelledEvent_unexpectedException_propagatesForRetry() {
+        // given
+        EventEnvelope<String> envelope = new EventEnvelope<>(
+                "test-event-id", "commerce.payment.cancelled", "commerce-service",
+                LocalDateTime.of(2026, 3, 7, 10, 0), "invalid-payload"
+        );
+        ConsumerRecord<String, EventEnvelope<?>> record = new ConsumerRecord<>(
+                "commerce.payment.cancelled", 0, 0L, "1",
+                (EventEnvelope<?>) (EventEnvelope) envelope
+        );
+
+        // when & then
+        assertThatThrownBy(() -> consumer.handlePaymentCancelledEvent(record, acknowledgment))
+                .isInstanceOf(Exception.class);
+
+        verify(acknowledgment, never()).acknowledge();
+    }
+}


### PR DESCRIPTION
## partially addresses #929
## resolves #1183

## Test Case
- [x] 부분 취소 이벤트 수신 시 공유자가 있으면 비례 차감 포인트를 검증 후 acknowledge한다
- [x] 전체 취소 이벤트이면 부분 공유 적립 예정 포인트 차감 없이 acknowledge한다
- [x] orderId가 null이면 부분 공유 적립 예정 포인트 차감 없이 acknowledge한다
- [x] 공유자가 없는 주문이면 부분 공유 적립 예정 포인트 차감 없이 acknowledge한다
- [x] orderProducts가 빈 목록이면 부분 공유 적립 예정 포인트 차감 없이 acknowledge한다
- [x] envelope이 null이면 부분 공유 적립 예정 포인트 차감 없이 acknowledge한다
- [x] paymentAmount가 null이면 비례 차감 계산 불가로 acknowledge한다
- [x] paymentAmount가 0이면 비례 차감 계산 불가로 acknowledge한다
- [x] cancelAmount가 null이면 비례 차감 계산 불가로 acknowledge한다
- [x] cancelAmount가 0이면 비례 차감 계산 불가로 acknowledge한다
- [x] 중복 공유자가 있으면 중복 제거 후 검증한다
- [x] 예상치 못한 예외 발생 시 DefaultErrorHandler로 위임되어 예외가 전파된다