### PR TITLE
[#929][#1211] feat: 주문 결제 완료 시 리워드 서비스 공유 포인트 적립 멱등성 기능 추가

### DIFF
--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/reward/ModifyUserPointPort.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/reward/ModifyUserPointPort.java
@@ -14,7 +14,7 @@ public interface ModifyUserPointPort {
      * @param sharerIds   공유자 ID 목록
      * @param totalAmount 총 결제 금액
      * @param orderId     주문 ID (sourceId)
-     * @Date 2026-03-07
+     * @Date 2026-01-18
      * @Author 성효빈
      * @Description 공유 구매 포인트를 적립 예정 포인트로 추가합니다.
      */
@@ -53,7 +53,7 @@ public interface ModifyUserPointPort {
      * @param userId  회원 ID
      * @param amount  적립 예정 포인트
      * @param orderId 주문 ID (sourceId)
-     * @Date 2026-03-07
+     * @Date 2026-01-18
      * @Author 성효빈
      * @Description 주문 결제 완료 시 상품 적립 포인트를 적립 예정 포인트로 추가합니다.
      */

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/event/OrderPaymentCompletedSharedPointConsumer.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/event/OrderPaymentCompletedSharedPointConsumer.java
@@ -6,9 +6,15 @@ import com.personal.marketnote.common.kafka.event.EventEnvelope;
 import com.personal.marketnote.common.kafka.event.OrderPaymentCompletedEvent;
 import com.personal.marketnote.common.kafka.event.OrderPaymentCompletedEvent.OrderProductItem;
 import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.reward.domain.point.UserPointChangeType;
+import com.personal.marketnote.reward.domain.point.UserPointSourceType;
+import com.personal.marketnote.reward.exception.DuplicateUserPointHistoryException;
+import com.personal.marketnote.reward.port.in.command.point.ModifyPendingPointCommand;
+import com.personal.marketnote.reward.port.in.usecase.point.ModifyPendingPointUseCase;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.stereotype.Component;
@@ -20,7 +26,13 @@ import java.util.Objects;
 @Component
 @RequiredArgsConstructor
 public class OrderPaymentCompletedSharedPointConsumer {
+    private static final String SHARE_PURCHASE_REASON = "링크 공유 회원 상품 구매";
+
+    private final ModifyPendingPointUseCase modifyPendingPointUseCase;
     private final ObjectMapper objectMapper;
+
+    @Value("${reward.share-point-rate:0.1}")
+    private float sharePointRate;
 
     @KafkaListener(
             topics = KafkaTopicConstants.ORDER_PAYMENT_COMPLETED,
@@ -47,6 +59,13 @@ public class OrderPaymentCompletedSharedPointConsumer {
                 return;
             }
 
+            if (FormatValidator.hasNoValue(payload.totalAmount()) || payload.totalAmount() <= 0) {
+                log.info("결제 금액이 없는 주문 (공유 포인트 적립 생략). orderId={}, totalAmount={}",
+                        payload.orderId(), payload.totalAmount());
+                acknowledgment.acknowledge();
+                return;
+            }
+
             List<Long> sharerIds = extractSharerIds(payload.orderProducts());
             if (sharerIds.isEmpty()) {
                 log.info("공유자가 없는 주문 (공유 포인트 적립 생략). orderId={}", payload.orderId());
@@ -54,23 +73,20 @@ public class OrderPaymentCompletedSharedPointConsumer {
                 return;
             }
 
-            // FIXME: [#929][#1019] HTTP 제거 후 ModifyPendingPointUseCase 활성화
-            //  현재 듀얼 라이트 기간: ChangeOrderStatusService.addPendingSharedPurchasePoints()가 HTTP로 처리 중
-            //  멱등성 보강 (#1211) 완료 후 아래 주석 해제:
-            //  for (Long sharerId : sharerIds) {
-            //      ModifyPendingPointCommand command = ModifyPendingPointCommand.builder()
-            //              .userId(sharerId)
-            //              .changeType(UserPointChangeType.ACCRUAL)
-            //              .amount(payload.totalAmount())
-            //              .sourceType(UserPointSourceType.ORDER)
-            //              .sourceId(payload.orderId())
-            //              .reason("공유 구매 적립 예정 포인트")
-            //              .build();
-            //      modifyPendingPointUseCase.modifyPending(command);
-            //  }
+            long sharePointAmount = Math.round(payload.totalAmount() * sharePointRate);
+            if (sharePointAmount <= 0) {
+                log.info("공유 포인트 적립 금액이 0 이하 (적립 생략). orderId={}, totalAmount={}, sharePointRate={}",
+                        payload.orderId(), payload.totalAmount(), sharePointRate);
+                acknowledgment.acknowledge();
+                return;
+            }
 
-            log.info("공유 포인트 적립 이벤트 검증 완료 (듀얼 라이트). orderId={}, sharerIds={}, totalAmount={}",
-                    payload.orderId(), sharerIds, payload.totalAmount());
+            for (Long sharerId : sharerIds) {
+                modifyPendingPointIdempotent(envelope.eventId(), sharerId, sharePointAmount, payload.orderId());
+            }
+
+            log.info("공유 포인트 적립 완료. orderId={}, sharerIds={}, sharePointAmount={}",
+                    payload.orderId(), sharerIds, sharePointAmount);
         } catch (Exception e) {
             log.error("공유 포인트 적립 이벤트 처리 실패. eventId={}, key={}, error={}",
                     envelope.eventId(), record.key(), e.getMessage(), e);
@@ -78,6 +94,23 @@ public class OrderPaymentCompletedSharedPointConsumer {
         }
 
         acknowledgment.acknowledge();
+    }
+
+    private void modifyPendingPointIdempotent(String eventId, Long sharerId, long sharePointAmount, Long orderId) {
+        try {
+            ModifyPendingPointCommand command = ModifyPendingPointCommand.builder()
+                    .userId(sharerId)
+                    .changeType(UserPointChangeType.ACCRUAL)
+                    .amount(sharePointAmount)
+                    .sourceType(UserPointSourceType.ORDER)
+                    .sourceId(orderId)
+                    .reason(SHARE_PURCHASE_REASON)
+                    .build();
+            modifyPendingPointUseCase.modifyPending(command);
+        } catch (DuplicateUserPointHistoryException e) {
+            log.info("이미 처리된 공유 포인트 적립 이벤트 (멱등 처리). eventId={}, sharerId={}, message={}",
+                    eventId, sharerId, e.getMessage());
+        }
     }
 
     private List<Long> extractSharerIds(List<OrderProductItem> orderProducts) {


### PR DESCRIPTION
## partially addresses #929
## resolves #1211

## Task
- [x] OrderPaymentCompletedSharedPointConsumer FIXME 주석 제거 및 공유 포인트 적립 로직 활성화
- [x] ModifyPendingPointUseCase 의존성 주입 및 sharePointRate 설정 추가
- [x] 각 공유자별 modifyPendingPointIdempotent() 멱등 래퍼 구현 (DuplicateUserPointHistoryException catch)
- [x] totalAmount null/0 이하 검증 추가 (NPE 방지)
- [x] 포인트 금액 계산: Math.round(totalAmount * sharePointRate)
- [x] ModifyUserPointPort Javadoc 날짜 수정