### PR TITLE
[#929][#1058] test: 주문 결제 완료 시 리워드 서비스 주문 포인트 차감 연동 기능 Kafka 이벤트 전환 자동화 테스트 추가

### DIFF
--- a/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/adapter/in/event/OrderPaymentCompletedOrderPointConsumerTest.java
+++ b/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/adapter/in/event/OrderPaymentCompletedOrderPointConsumerTest.java
@@ -1,0 +1,184 @@
+package com.personal.marketnote.reward.adapter.in.event;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.OrderPaymentCompletedEvent;
+import com.personal.marketnote.reward.domain.point.UserPointChangeType;
+import com.personal.marketnote.reward.domain.point.UserPointSourceType;
+import com.personal.marketnote.reward.exception.DuplicateUserPointHistoryException;
+import com.personal.marketnote.reward.port.in.command.point.ModifyUserPointCommand;
+import com.personal.marketnote.reward.port.in.usecase.point.ModifyUserPointUseCase;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.support.Acknowledgment;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("OrderPaymentCompletedOrderPointConsumer 테스트")
+class OrderPaymentCompletedOrderPointConsumerTest {
+    @InjectMocks
+    private OrderPaymentCompletedOrderPointConsumer consumer;
+
+    @Mock
+    private ModifyUserPointUseCase modifyUserPointUseCase;
+
+    @Spy
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @Mock
+    private Acknowledgment acknowledgment;
+
+    private ConsumerRecord<String, EventEnvelope<?>> buildRecord(
+            Long orderId, Long buyerId, Long pointAmount
+    ) {
+        OrderPaymentCompletedEvent event = new OrderPaymentCompletedEvent(
+                orderId, buyerId, 50000L, pointAmount, List.of()
+        );
+        EventEnvelope<OrderPaymentCompletedEvent> envelope = new EventEnvelope<>(
+                "test-event-id", "commerce.order.payment-completed", "commerce-service",
+                LocalDateTime.of(2026, 3, 8, 10, 0), event
+        );
+        return new ConsumerRecord<>("commerce.order.payment-completed", 0, 0L, String.valueOf(orderId), envelope);
+    }
+
+    @Test
+    @DisplayName("포인트 사용 주문 결제 완료 이벤트 수신 시 포인트를 차감하고 acknowledge한다")
+    void handleOrderPaymentCompletedEvent_withPointAmount_deductsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, 100L, 5000L);
+
+        // when
+        consumer.handleOrderPaymentCompletedEvent(record, acknowledgment);
+
+        // then
+        ArgumentCaptor<ModifyUserPointCommand> captor = ArgumentCaptor.forClass(ModifyUserPointCommand.class);
+        verify(modifyUserPointUseCase).modify(captor.capture());
+
+        ModifyUserPointCommand command = captor.getValue();
+        assertThat(command.userId()).isEqualTo(100L);
+        assertThat(command.changeType()).isEqualTo(UserPointChangeType.DEDUCTION);
+        assertThat(command.amount()).isEqualTo(5000L);
+        assertThat(command.sourceType()).isEqualTo(UserPointSourceType.ORDER);
+        assertThat(command.sourceId()).isEqualTo(1L);
+        assertThat(command.reason()).isEqualTo("주문 포인트 차감");
+
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("orderId가 null이면 차감 없이 acknowledge한다")
+    void handleOrderPaymentCompletedEvent_nullOrderId_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(null, 100L, 5000L);
+
+        // when
+        consumer.handleOrderPaymentCompletedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(modifyUserPointUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("buyerId가 null이면 차감 없이 acknowledge한다")
+    void handleOrderPaymentCompletedEvent_nullBuyerId_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, null, 5000L);
+
+        // when
+        consumer.handleOrderPaymentCompletedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(modifyUserPointUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("pointAmount가 null이면 차감 없이 acknowledge한다")
+    void handleOrderPaymentCompletedEvent_nullPointAmount_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, 100L, null);
+
+        // when
+        consumer.handleOrderPaymentCompletedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(modifyUserPointUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("pointAmount가 0이면 차감 없이 acknowledge한다")
+    void handleOrderPaymentCompletedEvent_zeroPointAmount_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, 100L, 0L);
+
+        // when
+        consumer.handleOrderPaymentCompletedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(modifyUserPointUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("pointAmount가 음수이면 차감 없이 acknowledge한다")
+    void handleOrderPaymentCompletedEvent_negativePointAmount_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, 100L, -500L);
+
+        // when
+        consumer.handleOrderPaymentCompletedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(modifyUserPointUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("중복 이벤트 수신 시 DuplicateUserPointHistoryException이 발생하면 멱등 처리하고 acknowledge한다")
+    void handleOrderPaymentCompletedEvent_duplicateEvent_idempotentAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, 100L, 5000L);
+        doThrow(new DuplicateUserPointHistoryException(100L, UserPointSourceType.ORDER, 1L, "주문 포인트 차감"))
+                .when(modifyUserPointUseCase).modify(any(ModifyUserPointCommand.class));
+
+        // when
+        consumer.handleOrderPaymentCompletedEvent(record, acknowledgment);
+
+        // then
+        verify(modifyUserPointUseCase).modify(any(ModifyUserPointCommand.class));
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("예상치 못한 예외 발생 시 acknowledge하지 않고 예외를 전파한다")
+    void handleOrderPaymentCompletedEvent_unexpectedException_propagatesWithoutAcknowledge() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, 100L, 5000L);
+        doThrow(new RuntimeException("DB 연결 실패"))
+                .when(modifyUserPointUseCase).modify(any(ModifyUserPointCommand.class));
+
+        // when & then
+        assertThatThrownBy(() -> consumer.handleOrderPaymentCompletedEvent(record, acknowledgment))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("DB 연결 실패");
+
+        verify(modifyUserPointUseCase).modify(any(ModifyUserPointCommand.class));
+        verify(acknowledgment, never()).acknowledge();
+    }
+}


### PR DESCRIPTION
## partially addresses #929
## resolves #1058

## Test Case
- [x] 포인트 사용 주문 결제 완료 이벤트 수신 시 포인트를 차감하고 acknowledge한다
- [x] orderId가 null이면 차감 없이 acknowledge한다
- [x] buyerId가 null이면 차감 없이 acknowledge한다
- [x] pointAmount가 null이면 차감 없이 acknowledge한다
- [x] pointAmount가 0이면 차감 없이 acknowledge한다
- [x] pointAmount가 음수이면 차감 없이 acknowledge한다
- [x] 중복 이벤트 수신 시 DuplicateUserPointHistoryException이 발생하면 멱등 처리하고 acknowledge한다
- [x] 예상치 못한 예외 발생 시 acknowledge하지 않고 예외를 전파한다