### PR TITLE
[#929][#1213] feat: 주문 결제 완료 시 리워드 서비스 상품 구매 포인트 적립 멱등성 기능 추가

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/event/OrderEventKafkaProducer.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/event/OrderEventKafkaProducer.java
@@ -27,7 +27,8 @@ public class OrderEventKafkaProducer implements PublishOrderEventPort {
 
     @Override
     public void publishOrderPaymentCompletedEvent(Long orderId, Long buyerId, Long totalAmount,
-                                                  Long pointAmount, List<OrderProduct> orderProducts) {
+                                                  Long pointAmount, List<OrderProduct> orderProducts,
+                                                  Long totalAccumulatedPoint) {
         List<OrderProductItem> items = orderProducts.stream()
                 .map(op -> new OrderProductItem(
                         op.getPricePolicyId(),
@@ -38,7 +39,7 @@ public class OrderEventKafkaProducer implements PublishOrderEventPort {
                 .toList();
 
         OrderPaymentCompletedEvent payload = new OrderPaymentCompletedEvent(
-                orderId, buyerId, totalAmount, pointAmount, items
+                orderId, buyerId, totalAmount, pointAmount, items, totalAccumulatedPoint
         );
         String topic = KafkaTopicConstants.ORDER_PAYMENT_COMPLETED;
         EventEnvelope<OrderPaymentCompletedEvent> envelope = EventEnvelope.of(

--- a/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/event/OrderPaymentCompletedInventoryConsumerTest.java
+++ b/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/event/OrderPaymentCompletedInventoryConsumerTest.java
@@ -41,7 +41,7 @@ class OrderPaymentCompletedInventoryConsumerTest {
                                                                  Long totalAmount, Long pointAmount,
                                                                  List<OrderProductItem> orderProducts) {
         OrderPaymentCompletedEvent event = new OrderPaymentCompletedEvent(
-                orderId, buyerId, totalAmount, pointAmount, orderProducts
+                orderId, buyerId, totalAmount, pointAmount, orderProducts, null
         );
         EventEnvelope<OrderPaymentCompletedEvent> envelope = new EventEnvelope<>(
                 "test-event-id", "commerce.order.payment-completed", "commerce-service",

--- a/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/out/event/OrderEventKafkaProducerTest.java
+++ b/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/out/event/OrderEventKafkaProducerTest.java
@@ -78,7 +78,7 @@ class OrderEventKafkaProducerTest {
 
         // when
         orderEventKafkaProducer.publishOrderPaymentCompletedEvent(
-                1L, 50L, 80000L, 5000L, orderProducts
+                1L, 50L, 80000L, 5000L, orderProducts, 1500L
         );
 
         // then
@@ -102,7 +102,7 @@ class OrderEventKafkaProducerTest {
 
         // when
         orderEventKafkaProducer.publishOrderPaymentCompletedEvent(
-                10L, 50L, 80000L, 5000L, orderProducts
+                10L, 50L, 80000L, 5000L, orderProducts, 1500L
         );
 
         // then
@@ -137,5 +137,7 @@ class OrderEventKafkaProducerTest {
         assertThat(secondItem.sharerId()).isNull();
         assertThat(secondItem.quantity()).isEqualTo(1);
         assertThat(secondItem.unitAmount()).isEqualTo(20000L);
+
+        assertThat(payload.totalAccumulatedPoint()).isEqualTo(1500L);
     }
 }

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/event/PublishOrderEventPort.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/event/PublishOrderEventPort.java
@@ -7,7 +7,8 @@ import java.util.List;
 public interface PublishOrderEventPort {
 
     void publishOrderPaymentCompletedEvent(Long orderId, Long buyerId, Long totalAmount,
-                                           Long pointAmount, List<OrderProduct> orderProducts);
+                                           Long pointAmount, List<OrderProduct> orderProducts,
+                                           Long totalAccumulatedPoint);
 
     void publishOrderPurchaseConfirmedEvent(Long orderId, Long buyerId, List<Long> sharerIds);
 }

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/ChangeOrderStatusService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/ChangeOrderStatusService.java
@@ -131,7 +131,7 @@ public class ChangeOrderStatusService implements ChangeOrderStatusUseCase {
 
         runAfterCommit(() -> {
             // Kafka 이벤트 발행 (듀얼 라이트)
-            publishOrderPaymentCompletedEvent(order);
+            publishOrderPaymentCompletedEvent(order, totalAccumulatedPoint);
 
             // 결제 완료 시 장바구니 상품 삭제
             deleteOrderedCartProductsPort.delete(pricePolicyIds);
@@ -233,14 +233,15 @@ public class ChangeOrderStatusService implements ChangeOrderStatusUseCase {
         }
     }
 
-    private void publishOrderPaymentCompletedEvent(Order order) {
+    private void publishOrderPaymentCompletedEvent(Order order, Long totalAccumulatedPoint) {
         try {
             publishOrderEventPort.publishOrderPaymentCompletedEvent(
                     order.getId(),
                     order.getBuyerId(),
                     order.getTotalAmount(),
                     order.getPointAmount(),
-                    order.getOrderProducts()
+                    order.getOrderProducts(),
+                    totalAccumulatedPoint
             );
         } catch (Exception e) {
             log.error("주문 결제 완료 이벤트 발행 실패 - orderId: {}, error: {}",

--- a/common/src/main/java/com/personal/marketnote/common/kafka/event/OrderPaymentCompletedEvent.java
+++ b/common/src/main/java/com/personal/marketnote/common/kafka/event/OrderPaymentCompletedEvent.java
@@ -7,7 +7,8 @@ public record OrderPaymentCompletedEvent(
         Long buyerId,
         Long totalAmount,
         Long pointAmount,
-        List<OrderProductItem> orderProducts
+        List<OrderProductItem> orderProducts,
+        Long totalAccumulatedPoint
 ) {
 
     public record OrderProductItem(

--- a/product-service/product-adapters/src/test/java/com/personal/marketnote/product/adapter/in/event/OrderPaymentCompletedCartConsumerTest.java
+++ b/product-service/product-adapters/src/test/java/com/personal/marketnote/product/adapter/in/event/OrderPaymentCompletedCartConsumerTest.java
@@ -32,7 +32,7 @@ class OrderPaymentCompletedCartConsumerTest {
                                                                  Long totalAmount, Long pointAmount,
                                                                  List<OrderProductItem> orderProducts) {
         OrderPaymentCompletedEvent event = new OrderPaymentCompletedEvent(
-                orderId, buyerId, totalAmount, pointAmount, orderProducts
+                orderId, buyerId, totalAmount, pointAmount, orderProducts, null
         );
         EventEnvelope<OrderPaymentCompletedEvent> envelope = new EventEnvelope<>(
                 "test-event-id", "commerce.order.payment-completed", "commerce-service",

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/event/OrderPaymentCompletedProductPointConsumer.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/event/OrderPaymentCompletedProductPointConsumer.java
@@ -5,6 +5,11 @@ import com.personal.marketnote.common.kafka.KafkaTopicConstants;
 import com.personal.marketnote.common.kafka.event.EventEnvelope;
 import com.personal.marketnote.common.kafka.event.OrderPaymentCompletedEvent;
 import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.reward.domain.point.UserPointChangeType;
+import com.personal.marketnote.reward.domain.point.UserPointSourceType;
+import com.personal.marketnote.reward.exception.DuplicateUserPointHistoryException;
+import com.personal.marketnote.reward.port.in.command.point.ModifyPendingPointCommand;
+import com.personal.marketnote.reward.port.in.usecase.point.ModifyPendingPointUseCase;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -16,6 +21,9 @@ import org.springframework.stereotype.Component;
 @Component
 @RequiredArgsConstructor
 public class OrderPaymentCompletedProductPointConsumer {
+    private static final String PRODUCT_PURCHASE_REASON = "상품 구매 적립";
+
+    private final ModifyPendingPointUseCase modifyPendingPointUseCase;
     private final ObjectMapper objectMapper;
 
     @KafkaListener(
@@ -33,8 +41,8 @@ public class OrderPaymentCompletedProductPointConsumer {
                     OrderPaymentCompletedEvent.class, objectMapper
             );
 
-            log.info("주문 결제 완료 이벤트 수신 (상품 구매 포인트 적립). eventId={}, orderId={}, buyerId={}, totalAmount={}",
-                    envelope.eventId(), payload.orderId(), payload.buyerId(), payload.totalAmount());
+            log.info("주문 결제 완료 이벤트 수신 (상품 구매 포인트 적립). eventId={}, orderId={}, buyerId={}, totalAccumulatedPoint={}",
+                    envelope.eventId(), payload.orderId(), payload.buyerId(), payload.totalAccumulatedPoint());
 
             if (FormatValidator.hasNoValue(payload.orderId()) || FormatValidator.hasNoValue(payload.buyerId())) {
                 log.error("유효하지 않은 이벤트 페이로드. eventId={}, orderId={}, buyerId={}",
@@ -49,21 +57,17 @@ public class OrderPaymentCompletedProductPointConsumer {
                 return;
             }
 
-            // FIXME: [#929][#1131] HTTP 제거 후 ModifyPendingPointUseCase 활성화
-            //  현재 듀얼 라이트 기간: ChangeOrderStatusService.addPendingProductAccumulationPoints()가 HTTP로 처리 중
-            //  멱등성 보강 (#1213) 완료 후 아래 주석 해제:
-            //  ModifyPendingPointCommand command = ModifyPendingPointCommand.builder()
-            //          .userId(payload.buyerId())
-            //          .changeType(UserPointChangeType.ACCRUAL)
-            //          .amount(accumulatedPointAmount)  // 상품별 적립 포인트 합산 필요
-            //          .sourceType(UserPointSourceType.ORDER)
-            //          .sourceId(payload.orderId())
-            //          .reason("상품 구매 적립 예정 포인트")
-            //          .build();
-            //  modifyPendingPointUseCase.modifyPending(command);
+            if (FormatValidator.hasNoValue(payload.totalAccumulatedPoint()) || payload.totalAccumulatedPoint() <= 0) {
+                log.info("상품 적립 포인트가 없는 주문 (적립 생략). orderId={}, totalAccumulatedPoint={}",
+                        payload.orderId(), payload.totalAccumulatedPoint());
+                acknowledgment.acknowledge();
+                return;
+            }
 
-            log.info("상품 구매 포인트 적립 이벤트 검증 완료 (듀얼 라이트). orderId={}, buyerId={}, totalAmount={}",
-                    payload.orderId(), payload.buyerId(), payload.totalAmount());
+            modifyPendingPointIdempotent(envelope.eventId(), payload.buyerId(), payload.totalAccumulatedPoint(), payload.orderId());
+
+            log.info("상품 구매 포인트 적립 완료. orderId={}, buyerId={}, totalAccumulatedPoint={}",
+                    payload.orderId(), payload.buyerId(), payload.totalAccumulatedPoint());
         } catch (Exception e) {
             log.error("상품 구매 포인트 적립 이벤트 처리 실패. eventId={}, key={}, error={}",
                     envelope.eventId(), record.key(), e.getMessage(), e);
@@ -71,5 +75,22 @@ public class OrderPaymentCompletedProductPointConsumer {
         }
 
         acknowledgment.acknowledge();
+    }
+
+    private void modifyPendingPointIdempotent(String eventId, Long buyerId, Long totalAccumulatedPoint, Long orderId) {
+        try {
+            ModifyPendingPointCommand command = ModifyPendingPointCommand.builder()
+                    .userId(buyerId)
+                    .changeType(UserPointChangeType.ACCRUAL)
+                    .amount(totalAccumulatedPoint)
+                    .sourceType(UserPointSourceType.ORDER)
+                    .sourceId(orderId)
+                    .reason(PRODUCT_PURCHASE_REASON)
+                    .build();
+            modifyPendingPointUseCase.modifyPending(command);
+        } catch (DuplicateUserPointHistoryException e) {
+            log.info("이미 처리된 상품 구매 포인트 적립 이벤트 (멱등 처리). eventId={}, buyerId={}, message={}",
+                    eventId, buyerId, e.getMessage());
+        }
     }
 }

--- a/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/adapter/in/event/OrderPaymentCompletedOrderPointConsumerTest.java
+++ b/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/adapter/in/event/OrderPaymentCompletedOrderPointConsumerTest.java
@@ -46,7 +46,7 @@ class OrderPaymentCompletedOrderPointConsumerTest {
             Long orderId, Long buyerId, Long pointAmount
     ) {
         OrderPaymentCompletedEvent event = new OrderPaymentCompletedEvent(
-                orderId, buyerId, 50000L, pointAmount, List.of()
+                orderId, buyerId, 50000L, pointAmount, List.of(), null
         );
         EventEnvelope<OrderPaymentCompletedEvent> envelope = new EventEnvelope<>(
                 "test-event-id", "commerce.order.payment-completed", "commerce-service",

--- a/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/adapter/in/event/OrderPaymentCompletedSharedPointConsumerTest.java
+++ b/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/adapter/in/event/OrderPaymentCompletedSharedPointConsumerTest.java
@@ -54,7 +54,7 @@ class OrderPaymentCompletedSharedPointConsumerTest {
             Long orderId, Long buyerId, Long totalAmount, List<OrderProductItem> orderProducts
     ) {
         OrderPaymentCompletedEvent event = new OrderPaymentCompletedEvent(
-                orderId, buyerId, totalAmount, 0L, orderProducts
+                orderId, buyerId, totalAmount, 0L, orderProducts, null
         );
         EventEnvelope<OrderPaymentCompletedEvent> envelope = new EventEnvelope<>(
                 "test-event-id", "commerce.order.payment-completed", "commerce-service",


### PR DESCRIPTION
## partially addresses #929
## resolves #1213

## Task
- [x] OrderPaymentCompletedEvent에 totalAccumulatedPoint 필드 추가
- [x] PublishOrderEventPort 시그니처에 totalAccumulatedPoint 파라미터 추가
- [x] OrderEventKafkaProducer에서 이벤트 생성 시 totalAccumulatedPoint 전달
- [x] ChangeOrderStatusService에서 이벤트 발행 시 totalAccumulatedPoint 전달
- [x] OrderPaymentCompletedProductPointConsumer 멱등 래퍼 추가 및 비즈니스 로직 활성화
- [x] 기존 Consumer 테스트 이벤트 생성자 시그니처 변경 반영