### PR TITLE
[#929][#1212] fix: 주문 결제 완료 시 리워드 서비스 주문 포인트 차감 멱등성 기능 reason 불일치 수정

### DIFF
--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/event/OrderPaymentCompletedOrderPointConsumer.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/event/OrderPaymentCompletedOrderPointConsumer.java
@@ -21,7 +21,7 @@ import org.springframework.stereotype.Component;
 @Component
 @RequiredArgsConstructor
 public class OrderPaymentCompletedOrderPointConsumer {
-    private static final String ORDER_POINT_DEDUCTION_REASON = "주문 포인트 차감";
+    private static final String ORDER_POINT_DEDUCTION_REASON = "주문 포인트 사용";
 
     private final ModifyUserPointUseCase modifyUserPointUseCase;
     private final ObjectMapper objectMapper;

--- a/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/adapter/in/event/OrderPaymentCompletedOrderPointConsumerTest.java
+++ b/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/adapter/in/event/OrderPaymentCompletedOrderPointConsumerTest.java
@@ -74,7 +74,7 @@ class OrderPaymentCompletedOrderPointConsumerTest {
         assertThat(command.amount()).isEqualTo(5000L);
         assertThat(command.sourceType()).isEqualTo(UserPointSourceType.ORDER);
         assertThat(command.sourceId()).isEqualTo(1L);
-        assertThat(command.reason()).isEqualTo("주문 포인트 차감");
+        assertThat(command.reason()).isEqualTo("주문 포인트 사용");
 
         verify(acknowledgment).acknowledge();
     }
@@ -154,7 +154,7 @@ class OrderPaymentCompletedOrderPointConsumerTest {
     void handleOrderPaymentCompletedEvent_duplicateEvent_idempotentAndAcknowledges() {
         // given
         ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, 100L, 5000L);
-        doThrow(new DuplicateUserPointHistoryException(100L, UserPointSourceType.ORDER, 1L, "주문 포인트 차감"))
+        doThrow(new DuplicateUserPointHistoryException(100L, UserPointSourceType.ORDER, 1L, "주문 포인트 사용"))
                 .when(modifyUserPointUseCase).modify(any(ModifyUserPointCommand.class));
 
         // when


### PR DESCRIPTION
## partially addresses #929
## resolves #1212

## Task
## Reason
Consumer의 reason 값("주문 포인트 차감")이 RewardServiceClient의 reason 값("주문 포인트 사용")과 불일치하여, 듀얼 라이트 기간에 DB UNIQUE 제약(user_id, source_type, source_id, reason)이 중복을 차단하지 못하고 이중 차감이 발생할 수 있는 버그

## Action
- [x] OrderPaymentCompletedOrderPointConsumer reason 값을 "주문 포인트 사용"으로 변경
- [x] OrderPaymentCompletedOrderPointConsumerTest reason 검증 값 동기화