### PR TITLE
[#929][#1214] feat: 결제 취소 시 리워드 서비스 포인트 환불 멱등성 기능 추가

### DIFF
--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/event/PaymentCancelledPointRefundConsumer.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/event/PaymentCancelledPointRefundConsumer.java
@@ -5,6 +5,11 @@ import com.personal.marketnote.common.kafka.KafkaTopicConstants;
 import com.personal.marketnote.common.kafka.event.EventEnvelope;
 import com.personal.marketnote.common.kafka.event.PaymentCancelledEvent;
 import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.reward.domain.point.UserPointChangeType;
+import com.personal.marketnote.reward.domain.point.UserPointSourceType;
+import com.personal.marketnote.reward.exception.DuplicateUserPointHistoryException;
+import com.personal.marketnote.reward.port.in.command.point.ModifyUserPointCommand;
+import com.personal.marketnote.reward.port.in.usecase.point.ModifyUserPointUseCase;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -16,6 +21,9 @@ import org.springframework.stereotype.Component;
 @Component
 @RequiredArgsConstructor
 public class PaymentCancelledPointRefundConsumer {
+    private static final String POINT_REFUND_REASON = "주문 취소 포인트 환불";
+
+    private final ModifyUserPointUseCase modifyUserPointUseCase;
     private final ObjectMapper objectMapper;
 
     @KafkaListener(
@@ -69,20 +77,9 @@ public class PaymentCancelledPointRefundConsumer {
                 return;
             }
 
-            // FIXME: [#929][#1102] HTTP 제거 후 ModifyUserPointUseCase 활성화
-            //  현재 듀얼 라이트 기간: CancelPaymentService.refundPoints()에서 HTTP로 처리 중
-            //  멱등성 보강 (#1214) 완료 후 아래 주석 해제:
-            //  ModifyUserPointCommand command = ModifyUserPointCommand.builder()
-            //          .userId(payload.buyerId())
-            //          .changeType(UserPointChangeType.ACCRUAL)
-            //          .amount(payload.pointAmount())
-            //          .sourceType(UserPointSourceType.ORDER)
-            //          .sourceId(payload.orderId())
-            //          .reason("주문 취소 포인트 환불")
-            //          .build();
-            //  modifyUserPointUseCase.modify(command);
+            modifyUserPointIdempotent(envelope.eventId(), payload.buyerId(), payload.pointAmount(), payload.orderId());
 
-            log.info("포인트 환불 이벤트 검증 완료 (듀얼 라이트). orderId={}, buyerId={}, pointAmount={}",
+            log.info("포인트 환불 완료. orderId={}, buyerId={}, pointAmount={}",
                     payload.orderId(), payload.buyerId(), payload.pointAmount());
         } catch (Exception e) {
             log.error("포인트 환불 이벤트 처리 실패. eventId={}, key={}, error={}",
@@ -91,5 +88,22 @@ public class PaymentCancelledPointRefundConsumer {
         }
 
         acknowledgment.acknowledge();
+    }
+
+    private void modifyUserPointIdempotent(String eventId, Long buyerId, Long pointAmount, Long orderId) {
+        try {
+            ModifyUserPointCommand command = ModifyUserPointCommand.builder()
+                    .userId(buyerId)
+                    .changeType(UserPointChangeType.ACCRUAL)
+                    .amount(pointAmount)
+                    .sourceType(UserPointSourceType.ORDER)
+                    .sourceId(orderId)
+                    .reason(POINT_REFUND_REASON)
+                    .build();
+            modifyUserPointUseCase.modify(command);
+        } catch (DuplicateUserPointHistoryException e) {
+            log.info("이미 처리된 포인트 환불 이벤트 (멱등 처리). eventId={}, buyerId={}, message={}",
+                    eventId, buyerId, e.getMessage());
+        }
     }
 }


### PR DESCRIPTION
## partially addresses #929
## resolves #1214

## Task
- [x] ModifyUserPointUseCase 의존성 추가 및 듀얼 라이트 주석 제거
- [x] modifyUserPointIdempotent() 멱등 래퍼 메서드 추가
- [x] DuplicateUserPointHistoryException catch 시 INFO 로그 + 정상 acknowledge
- [x] reason 상수 "주문 취소 포인트 환불"로 멱등성 키 구성