### PR TITLE
[#929][#1215] test: 부분 결제 취소 시 리워드 서비스 적립 예정 포인트 차감 멱등성 기능 자동화 테스트 추가

### DIFF
--- a/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/adapter/in/event/PaymentCancelledPartialProductPointConsumerTest.java
+++ b/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/adapter/in/event/PaymentCancelledPartialProductPointConsumerTest.java
@@ -1,0 +1,236 @@
+package com.personal.marketnote.reward.adapter.in.event;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.PaymentCancelledEvent;
+import com.personal.marketnote.reward.domain.point.UserPointChangeType;
+import com.personal.marketnote.reward.domain.point.UserPointSourceType;
+import com.personal.marketnote.reward.exception.DuplicateUserPointHistoryException;
+import com.personal.marketnote.reward.port.in.command.point.ModifyPendingPointCommand;
+import com.personal.marketnote.reward.port.in.usecase.point.ModifyPendingPointUseCase;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.support.Acknowledgment;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("PaymentCancelledPartialProductPointConsumer 테스트")
+class PaymentCancelledPartialProductPointConsumerTest {
+    @InjectMocks
+    private PaymentCancelledPartialProductPointConsumer consumer;
+
+    @Mock
+    private ModifyPendingPointUseCase modifyPendingPointUseCase;
+
+    @Spy
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @Mock
+    private Acknowledgment acknowledgment;
+
+    private ConsumerRecord<String, EventEnvelope<?>> buildRecord(
+            Long orderId, Long buyerId, Long partialProductPendingDeduction, boolean isFullCancel
+    ) {
+        PaymentCancelledEvent event = new PaymentCancelledEvent(
+                orderId, "order-key-1", buyerId, 30000L, 80000L, 1000L,
+                isFullCancel, 0L, null, null, partialProductPendingDeduction
+        );
+        EventEnvelope<PaymentCancelledEvent> envelope = new EventEnvelope<>(
+                "test-event-id", "commerce.payment.cancelled", "commerce-service",
+                LocalDateTime.of(2026, 3, 8, 10, 0), event
+        );
+        return new ConsumerRecord<>("commerce.payment.cancelled", 0, 0L, String.valueOf(orderId), envelope);
+    }
+
+    @Test
+    @DisplayName("부분 취소 이벤트 수신 시 상품 적립 예정 포인트를 차감하고 acknowledge한다")
+    void handlePaymentCancelledEvent_partialCancel_deductsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, 100L, 1500L, false);
+
+        // when
+        consumer.handlePaymentCancelledEvent(record, acknowledgment);
+
+        // then
+        ArgumentCaptor<ModifyPendingPointCommand> captor = ArgumentCaptor.forClass(ModifyPendingPointCommand.class);
+        verify(modifyPendingPointUseCase).modifyPending(captor.capture());
+
+        ModifyPendingPointCommand command = captor.getValue();
+        assertThat(command.userId()).isEqualTo(100L);
+        assertThat(command.changeType()).isEqualTo(UserPointChangeType.DEDUCTION);
+        assertThat(command.amount()).isEqualTo(1500L);
+        assertThat(command.sourceType()).isEqualTo(UserPointSourceType.ORDER);
+        assertThat(command.sourceId()).isEqualTo(1L);
+        assertThat(command.reason()).isEqualTo("부분 결제 취소 상품 적립 예정 포인트 차감");
+
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("전체 취소 이벤트이면 부분 상품 적립 예정 포인트 차감 없이 acknowledge한다")
+    void handlePaymentCancelledEvent_fullCancel_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, 100L, 1500L, true);
+
+        // when
+        consumer.handlePaymentCancelledEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(modifyPendingPointUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("orderId가 null이면 차감 없이 acknowledge한다")
+    void handlePaymentCancelledEvent_nullOrderId_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(null, 100L, 1500L, false);
+
+        // when
+        consumer.handlePaymentCancelledEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(modifyPendingPointUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("buyerId가 null이면 차감 없이 acknowledge한다")
+    void handlePaymentCancelledEvent_nullBuyerId_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, null, 1500L, false);
+
+        // when
+        consumer.handlePaymentCancelledEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(modifyPendingPointUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("partialProductPendingDeduction이 null이면 차감 없이 acknowledge한다")
+    void handlePaymentCancelledEvent_nullDeduction_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, 100L, null, false);
+
+        // when
+        consumer.handlePaymentCancelledEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(modifyPendingPointUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("partialProductPendingDeduction이 0이면 차감 없이 acknowledge한다")
+    void handlePaymentCancelledEvent_zeroDeduction_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, 100L, 0L, false);
+
+        // when
+        consumer.handlePaymentCancelledEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(modifyPendingPointUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("partialProductPendingDeduction이 음수이면 차감 없이 acknowledge한다")
+    void handlePaymentCancelledEvent_negativeDeduction_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, 100L, -500L, false);
+
+        // when
+        consumer.handlePaymentCancelledEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(modifyPendingPointUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("envelope이 null이면 차감 없이 acknowledge한다")
+    void handlePaymentCancelledEvent_nullEnvelope_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = new ConsumerRecord<>(
+                "commerce.payment.cancelled", 0, 0L, "1", null
+        );
+
+        // when
+        consumer.handlePaymentCancelledEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(modifyPendingPointUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("중복 이벤트 수신 시 DuplicateUserPointHistoryException이 발생하면 멱등 처리하고 acknowledge한다")
+    void handlePaymentCancelledEvent_duplicateEvent_idempotentAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, 100L, 1500L, false);
+        doThrow(new DuplicateUserPointHistoryException(100L, UserPointSourceType.ORDER, 1L, "부분 결제 취소 상품 적립 예정 포인트 차감"))
+                .when(modifyPendingPointUseCase).modifyPending(any(ModifyPendingPointCommand.class));
+
+        // when
+        consumer.handlePaymentCancelledEvent(record, acknowledgment);
+
+        // then
+        verify(modifyPendingPointUseCase).modifyPending(any(ModifyPendingPointCommand.class));
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("예상치 못한 예외 발생 시 acknowledge하지 않고 예외를 전파한다")
+    void handlePaymentCancelledEvent_unexpectedException_propagatesWithoutAcknowledge() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, 100L, 1500L, false);
+        doThrow(new RuntimeException("DB 연결 실패"))
+                .when(modifyPendingPointUseCase).modifyPending(any(ModifyPendingPointCommand.class));
+
+        // when & then
+        assertThatThrownBy(() -> consumer.handlePaymentCancelledEvent(record, acknowledgment))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("DB 연결 실패");
+
+        verify(modifyPendingPointUseCase).modifyPending(any(ModifyPendingPointCommand.class));
+        verify(acknowledgment, never()).acknowledge();
+    }
+
+    @Test
+    @DisplayName("예상치 못한 예외(잘못된 페이로드) 발생 시 DefaultErrorHandler로 위임되어 예외가 전파된다")
+    @SuppressWarnings("unchecked")
+    void handlePaymentCancelledEvent_invalidPayload_propagatesForRetry() {
+        // given
+        EventEnvelope<String> envelope = new EventEnvelope<>(
+                "test-event-id", "commerce.payment.cancelled", "commerce-service",
+                LocalDateTime.of(2026, 3, 8, 10, 0), "invalid-payload"
+        );
+        ConsumerRecord<String, EventEnvelope<?>> record = new ConsumerRecord<>(
+                "commerce.payment.cancelled", 0, 0L, "1",
+                (EventEnvelope<?>) (EventEnvelope) envelope
+        );
+
+        // when & then
+        assertThatThrownBy(() -> consumer.handlePaymentCancelledEvent(record, acknowledgment))
+                .isInstanceOf(Exception.class);
+
+        verifyNoInteractions(modifyPendingPointUseCase);
+        verify(acknowledgment, never()).acknowledge();
+    }
+}

--- a/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/adapter/in/event/PaymentCancelledPartialSharedPointConsumerTest.java
+++ b/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/adapter/in/event/PaymentCancelledPartialSharedPointConsumerTest.java
@@ -4,11 +4,17 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.personal.marketnote.common.kafka.event.EventEnvelope;
 import com.personal.marketnote.common.kafka.event.PaymentCancelledEvent;
 import com.personal.marketnote.common.kafka.event.PaymentCancelledEvent.OrderProductItem;
+import com.personal.marketnote.reward.domain.point.UserPointChangeType;
+import com.personal.marketnote.reward.domain.point.UserPointSourceType;
+import com.personal.marketnote.reward.exception.DuplicateUserPointHistoryException;
+import com.personal.marketnote.reward.port.in.command.point.ModifyPendingPointCommand;
+import com.personal.marketnote.reward.port.in.usecase.point.ModifyPendingPointUseCase;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
@@ -19,15 +25,19 @@ import org.springframework.test.util.ReflectionTestUtils;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("PaymentCancelledPartialSharedPointConsumer 테스트")
 class PaymentCancelledPartialSharedPointConsumerTest {
     @InjectMocks
     private PaymentCancelledPartialSharedPointConsumer consumer;
+
+    @Mock
+    private ModifyPendingPointUseCase modifyPendingPointUseCase;
 
     @Spy
     private ObjectMapper objectMapper = new ObjectMapper();
@@ -55,8 +65,8 @@ class PaymentCancelledPartialSharedPointConsumerTest {
     }
 
     @Test
-    @DisplayName("부분 취소 이벤트 수신 시 공유자가 있으면 비례 차감 포인트를 검증 후 acknowledge한다")
-    void handlePaymentCancelledEvent_partialCancelWithSharers_validatesAndAcknowledges() {
+    @DisplayName("부분 취소 이벤트 수신 시 공유자가 있으면 비례 차감 포인트를 차감하고 acknowledge한다")
+    void handlePaymentCancelledEvent_partialCancelWithSharers_deductsAndAcknowledges() {
         // given
         List<OrderProductItem> orderProducts = List.of(
                 new OrderProductItem(1L, 200L, 2, 10000L),
@@ -68,6 +78,26 @@ class PaymentCancelledPartialSharedPointConsumerTest {
         consumer.handlePaymentCancelledEvent(record, acknowledgment);
 
         // then
+        ArgumentCaptor<ModifyPendingPointCommand> captor = ArgumentCaptor.forClass(ModifyPendingPointCommand.class);
+        verify(modifyPendingPointUseCase, times(2)).modifyPending(captor.capture());
+
+        List<ModifyPendingPointCommand> commands = captor.getAllValues();
+        long expectedOriginalSharePoint = Math.round(80000L * 0.1f);
+        long expectedProportionalPoint = (30000L * expectedOriginalSharePoint + 80000L / 2) / 80000L;
+
+        ModifyPendingPointCommand firstCommand = commands.get(0);
+        assertThat(firstCommand.userId()).isEqualTo(200L);
+        assertThat(firstCommand.changeType()).isEqualTo(UserPointChangeType.DEDUCTION);
+        assertThat(firstCommand.amount()).isEqualTo(expectedProportionalPoint);
+        assertThat(firstCommand.sourceType()).isEqualTo(UserPointSourceType.ORDER);
+        assertThat(firstCommand.sourceId()).isEqualTo(1L);
+        assertThat(firstCommand.reason()).isEqualTo("부분 결제 취소 공유 적립 예정 포인트 차감");
+
+        ModifyPendingPointCommand secondCommand = commands.get(1);
+        assertThat(secondCommand.userId()).isEqualTo(300L);
+        assertThat(secondCommand.changeType()).isEqualTo(UserPointChangeType.DEDUCTION);
+        assertThat(secondCommand.amount()).isEqualTo(expectedProportionalPoint);
+
         verify(acknowledgment).acknowledge();
     }
 
@@ -84,6 +114,7 @@ class PaymentCancelledPartialSharedPointConsumerTest {
         consumer.handlePaymentCancelledEvent(record, acknowledgment);
 
         // then
+        verifyNoInteractions(modifyPendingPointUseCase);
         verify(acknowledgment).acknowledge();
     }
 
@@ -100,6 +131,7 @@ class PaymentCancelledPartialSharedPointConsumerTest {
         consumer.handlePaymentCancelledEvent(record, acknowledgment);
 
         // then
+        verifyNoInteractions(modifyPendingPointUseCase);
         verify(acknowledgment).acknowledge();
     }
 
@@ -117,6 +149,7 @@ class PaymentCancelledPartialSharedPointConsumerTest {
         consumer.handlePaymentCancelledEvent(record, acknowledgment);
 
         // then
+        verifyNoInteractions(modifyPendingPointUseCase);
         verify(acknowledgment).acknowledge();
     }
 
@@ -130,6 +163,7 @@ class PaymentCancelledPartialSharedPointConsumerTest {
         consumer.handlePaymentCancelledEvent(record, acknowledgment);
 
         // then
+        verifyNoInteractions(modifyPendingPointUseCase);
         verify(acknowledgment).acknowledge();
     }
 
@@ -145,6 +179,7 @@ class PaymentCancelledPartialSharedPointConsumerTest {
         consumer.handlePaymentCancelledEvent(record, acknowledgment);
 
         // then
+        verifyNoInteractions(modifyPendingPointUseCase);
         verify(acknowledgment).acknowledge();
     }
 
@@ -161,6 +196,7 @@ class PaymentCancelledPartialSharedPointConsumerTest {
         consumer.handlePaymentCancelledEvent(record, acknowledgment);
 
         // then
+        verifyNoInteractions(modifyPendingPointUseCase);
         verify(acknowledgment).acknowledge();
     }
 
@@ -177,6 +213,7 @@ class PaymentCancelledPartialSharedPointConsumerTest {
         consumer.handlePaymentCancelledEvent(record, acknowledgment);
 
         // then
+        verifyNoInteractions(modifyPendingPointUseCase);
         verify(acknowledgment).acknowledge();
     }
 
@@ -193,6 +230,7 @@ class PaymentCancelledPartialSharedPointConsumerTest {
         consumer.handlePaymentCancelledEvent(record, acknowledgment);
 
         // then
+        verifyNoInteractions(modifyPendingPointUseCase);
         verify(acknowledgment).acknowledge();
     }
 
@@ -209,11 +247,29 @@ class PaymentCancelledPartialSharedPointConsumerTest {
         consumer.handlePaymentCancelledEvent(record, acknowledgment);
 
         // then
+        verifyNoInteractions(modifyPendingPointUseCase);
         verify(acknowledgment).acknowledge();
     }
 
     @Test
-    @DisplayName("중복 공유자가 있으면 중복 제거 후 검증한다")
+    @DisplayName("cancelAmount가 paymentAmount보다 크면 차감 없이 acknowledge한다")
+    void handlePaymentCancelledEvent_cancelExceedsPayment_skipsAndAcknowledges() {
+        // given
+        List<OrderProductItem> orderProducts = List.of(
+                new OrderProductItem(1L, 200L, 2, 10000L)
+        );
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, false, 100000L, 80000L, orderProducts);
+
+        // when
+        consumer.handlePaymentCancelledEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(modifyPendingPointUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("중복 공유자가 있으면 중복 제거 후 차감하고 acknowledge한다")
     void handlePaymentCancelledEvent_duplicateSharers_deduplicatesAndAcknowledges() {
         // given
         List<OrderProductItem> orderProducts = List.of(
@@ -227,13 +283,95 @@ class PaymentCancelledPartialSharedPointConsumerTest {
         consumer.handlePaymentCancelledEvent(record, acknowledgment);
 
         // then
+        verify(modifyPendingPointUseCase, times(2)).modifyPending(any(ModifyPendingPointCommand.class));
         verify(acknowledgment).acknowledge();
     }
 
     @Test
-    @DisplayName("예상치 못한 예외 발생 시 DefaultErrorHandler로 위임되어 예외가 전파된다")
+    @DisplayName("중복 이벤트 수신 시 DuplicateUserPointHistoryException이 발생하면 멱등 처리하고 acknowledge한다")
+    void handlePaymentCancelledEvent_duplicateEvent_idempotentAndAcknowledges() {
+        // given
+        List<OrderProductItem> orderProducts = List.of(
+                new OrderProductItem(1L, 200L, 2, 10000L)
+        );
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, false, 30000L, 80000L, orderProducts);
+        doThrow(new DuplicateUserPointHistoryException(200L, UserPointSourceType.ORDER, 1L, "부분 결제 취소 공유 적립 예정 포인트 차감"))
+                .when(modifyPendingPointUseCase).modifyPending(any(ModifyPendingPointCommand.class));
+
+        // when
+        consumer.handlePaymentCancelledEvent(record, acknowledgment);
+
+        // then
+        verify(modifyPendingPointUseCase).modifyPending(any(ModifyPendingPointCommand.class));
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("공유자 2명 중 첫 번째만 중복이면 두 번째는 정상 차감하고 acknowledge한다")
+    void handlePaymentCancelledEvent_partialDuplicate_continuesAndAcknowledges() {
+        // given
+        List<OrderProductItem> orderProducts = List.of(
+                new OrderProductItem(1L, 200L, 2, 10000L),
+                new OrderProductItem(2L, 300L, 1, 20000L)
+        );
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, false, 30000L, 80000L, orderProducts);
+        when(modifyPendingPointUseCase.modifyPending(any(ModifyPendingPointCommand.class)))
+                .thenThrow(new DuplicateUserPointHistoryException(200L, UserPointSourceType.ORDER, 1L, "부분 결제 취소 공유 적립 예정 포인트 차감"))
+                .thenReturn(null);
+
+        // when
+        consumer.handlePaymentCancelledEvent(record, acknowledgment);
+
+        // then
+        verify(modifyPendingPointUseCase, times(2)).modifyPending(any(ModifyPendingPointCommand.class));
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("공유자 전원 중복이면 모두 멱등 처리하고 acknowledge한다")
+    void handlePaymentCancelledEvent_allDuplicate_idempotentAndAcknowledges() {
+        // given
+        List<OrderProductItem> orderProducts = List.of(
+                new OrderProductItem(1L, 200L, 2, 10000L),
+                new OrderProductItem(2L, 300L, 1, 20000L)
+        );
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, false, 30000L, 80000L, orderProducts);
+        when(modifyPendingPointUseCase.modifyPending(any(ModifyPendingPointCommand.class)))
+                .thenThrow(new DuplicateUserPointHistoryException(200L, UserPointSourceType.ORDER, 1L, "부분 결제 취소 공유 적립 예정 포인트 차감"))
+                .thenThrow(new DuplicateUserPointHistoryException(300L, UserPointSourceType.ORDER, 1L, "부분 결제 취소 공유 적립 예정 포인트 차감"));
+
+        // when
+        consumer.handlePaymentCancelledEvent(record, acknowledgment);
+
+        // then
+        verify(modifyPendingPointUseCase, times(2)).modifyPending(any(ModifyPendingPointCommand.class));
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("예상치 못한 예외 발생 시 acknowledge하지 않고 예외를 전파한다")
+    void handlePaymentCancelledEvent_unexpectedException_propagatesWithoutAcknowledge() {
+        // given
+        List<OrderProductItem> orderProducts = List.of(
+                new OrderProductItem(1L, 200L, 2, 10000L)
+        );
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, false, 30000L, 80000L, orderProducts);
+        doThrow(new RuntimeException("DB 연결 실패"))
+                .when(modifyPendingPointUseCase).modifyPending(any(ModifyPendingPointCommand.class));
+
+        // when & then
+        assertThatThrownBy(() -> consumer.handlePaymentCancelledEvent(record, acknowledgment))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("DB 연결 실패");
+
+        verify(modifyPendingPointUseCase).modifyPending(any(ModifyPendingPointCommand.class));
+        verify(acknowledgment, never()).acknowledge();
+    }
+
+    @Test
+    @DisplayName("예상치 못한 예외(잘못된 페이로드) 발생 시 DefaultErrorHandler로 위임되어 예외가 전파된다")
     @SuppressWarnings("unchecked")
-    void handlePaymentCancelledEvent_unexpectedException_propagatesForRetry() {
+    void handlePaymentCancelledEvent_invalidPayload_propagatesForRetry() {
         // given
         EventEnvelope<String> envelope = new EventEnvelope<>(
                 "test-event-id", "commerce.payment.cancelled", "commerce-service",
@@ -248,6 +386,7 @@ class PaymentCancelledPartialSharedPointConsumerTest {
         assertThatThrownBy(() -> consumer.handlePaymentCancelledEvent(record, acknowledgment))
                 .isInstanceOf(Exception.class);
 
+        verifyNoInteractions(modifyPendingPointUseCase);
         verify(acknowledgment, never()).acknowledge();
     }
 }


### PR DESCRIPTION
## partially addresses #929
## resolves #1215

## Task
- [x] 부분 취소 이벤트 수신 시 상품 적립 예정 포인트를 차감하고 acknowledge한다
- [x] 전체 취소 이벤트이면 부분 상품 적립 예정 포인트 차감 없이 acknowledge한다
- [x] orderId가 null이면 차감 없이 acknowledge한다
- [x] buyerId가 null이면 차감 없이 acknowledge한다
- [x] partialProductPendingDeduction이 null이면 차감 없이 acknowledge한다
- [x] partialProductPendingDeduction이 0이면 차감 없이 acknowledge한다
- [x] partialProductPendingDeduction이 음수이면 차감 없이 acknowledge한다
- [x] envelope이 null이면 차감 없이 acknowledge한다
- [x] 중복 이벤트 수신 시 DuplicateUserPointHistoryException이 발생하면 멱등 처리하고 acknowledge한다
- [x] 예상치 못한 예외 발생 시 acknowledge하지 않고 예외를 전파한다
- [x] 예상치 못한 예외(잘못된 페이로드) 발생 시 DefaultErrorHandler로 위임되어 예외가 전파된다
- [x] 부분 취소 이벤트 수신 시 공유자가 있으면 비례 차감 포인트를 차감하고 acknowledge한다
- [x] 전체 취소 이벤트이면 부분 공유 적립 예정 포인트 차감 없이 acknowledge한다
- [x] orderId가 null이면 부분 공유 적립 예정 포인트 차감 없이 acknowledge한다
- [x] 공유자가 없는 주문이면 부분 공유 적립 예정 포인트 차감 없이 acknowledge한다
- [x] orderProducts가 빈 목록이면 부분 공유 적립 예정 포인트 차감 없이 acknowledge한다
- [x] envelope이 null이면 부분 공유 적립 예정 포인트 차감 없이 acknowledge한다
- [x] paymentAmount가 null이면 비례 차감 계산 불가로 acknowledge한다
- [x] paymentAmount가 0이면 비례 차감 계산 불가로 acknowledge한다
- [x] cancelAmount가 null이면 비례 차감 계산 불가로 acknowledge한다
- [x] cancelAmount가 0이면 비례 차감 계산 불가로 acknowledge한다
- [x] cancelAmount가 paymentAmount보다 크면 차감 없이 acknowledge한다
- [x] 중복 공유자가 있으면 중복 제거 후 차감하고 acknowledge한다
- [x] 중복 이벤트 수신 시 DuplicateUserPointHistoryException이 발생하면 멱등 처리하고 acknowledge한다
- [x] 공유자 2명 중 첫 번째만 중복이면 두 번째는 정상 차감하고 acknowledge한다
- [x] 공유자 전원 중복이면 모두 멱등 처리하고 acknowledge한다
- [x] 예상치 못한 예외 발생 시 acknowledge하지 않고 예외를 전파한다
- [x] 예상치 못한 예외(잘못된 페이로드) 발생 시 DefaultErrorHandler로 위임되어 예외가 전파된다