### PR TITLE
[#929][#1217] feat: 구매 확정 시 리워드 서비스 적립 예정 포인트 확정 멱등성 기능 추가

### DIFF
--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/event/OrderPurchaseConfirmedProductPointConsumer.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/event/OrderPurchaseConfirmedProductPointConsumer.java
@@ -5,6 +5,9 @@ import com.personal.marketnote.common.kafka.KafkaTopicConstants;
 import com.personal.marketnote.common.kafka.event.EventEnvelope;
 import com.personal.marketnote.common.kafka.event.OrderPurchaseConfirmedEvent;
 import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.reward.domain.point.UserPointSourceType;
+import com.personal.marketnote.reward.port.in.command.point.ConfirmPendingPointCommand;
+import com.personal.marketnote.reward.port.in.usecase.point.ConfirmPendingPointUseCase;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -16,6 +19,9 @@ import org.springframework.stereotype.Component;
 @Component
 @RequiredArgsConstructor
 public class OrderPurchaseConfirmedProductPointConsumer {
+    private static final String CONFIRM_REASON = "구매 확정 포인트 적립";
+
+    private final ConfirmPendingPointUseCase confirmPendingPointUseCase;
     private final ObjectMapper objectMapper;
 
     @KafkaListener(
@@ -27,6 +33,13 @@ public class OrderPurchaseConfirmedProductPointConsumer {
             Acknowledgment acknowledgment
     ) {
         EventEnvelope<?> envelope = record.value();
+
+        if (FormatValidator.hasNoValue(envelope)) {
+            log.error("이벤트 envelope이 null. topic={}, partition={}, offset={}",
+                    record.topic(), record.partition(), record.offset());
+            acknowledgment.acknowledge();
+            return;
+        }
 
         try {
             OrderPurchaseConfirmedEvent payload = envelope.getPayloadAs(
@@ -43,18 +56,9 @@ public class OrderPurchaseConfirmedProductPointConsumer {
                 return;
             }
 
-            // FIXME: [#929][#1135] HTTP 제거 후 ConfirmPendingPointUseCase 활성화
-            //  현재 듀얼 라이트 기간: ChangeOrderStatusService.confirmPendingPoints()가 HTTP로 처리 중
-            //  멱등성 보강 (#1217) 완료 후 아래 주석 해제:
-            //  ConfirmPendingPointCommand command = ConfirmPendingPointCommand.builder()
-            //          .userId(payload.buyerId())
-            //          .sourceType(UserPointSourceType.ORDER)
-            //          .sourceId(payload.orderId())
-            //          .reason("구매 확정 포인트 적립")
-            //          .build();
-            //  confirmPendingPointUseCase.confirmPending(command);
+            confirmPending(payload.buyerId(), payload.orderId());
 
-            log.info("상품 적립 예정 포인트 확정 이벤트 검증 완료 (듀얼 라이트). orderId={}, buyerId={}",
+            log.info("상품 적립 예정 포인트 확정 완료. orderId={}, buyerId={}",
                     payload.orderId(), payload.buyerId());
         } catch (Exception e) {
             log.error("상품 적립 예정 포인트 확정 이벤트 처리 실패. eventId={}, key={}, error={}",
@@ -63,5 +67,15 @@ public class OrderPurchaseConfirmedProductPointConsumer {
         }
 
         acknowledgment.acknowledge();
+    }
+
+    private void confirmPending(Long buyerId, Long orderId) {
+        ConfirmPendingPointCommand command = ConfirmPendingPointCommand.builder()
+                .userId(buyerId)
+                .sourceType(UserPointSourceType.ORDER)
+                .sourceId(orderId)
+                .reason(CONFIRM_REASON)
+                .build();
+        confirmPendingPointUseCase.confirmPending(command);
     }
 }

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/event/OrderPurchaseConfirmedSharedPointConsumer.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/event/OrderPurchaseConfirmedSharedPointConsumer.java
@@ -5,6 +5,9 @@ import com.personal.marketnote.common.kafka.KafkaTopicConstants;
 import com.personal.marketnote.common.kafka.event.EventEnvelope;
 import com.personal.marketnote.common.kafka.event.OrderPurchaseConfirmedEvent;
 import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.reward.domain.point.UserPointSourceType;
+import com.personal.marketnote.reward.port.in.command.point.ConfirmPendingPointCommand;
+import com.personal.marketnote.reward.port.in.usecase.point.ConfirmPendingPointUseCase;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -18,6 +21,9 @@ import java.util.List;
 @Component
 @RequiredArgsConstructor
 public class OrderPurchaseConfirmedSharedPointConsumer {
+    private static final String CONFIRM_REASON = "구매 확정 공유 포인트 적립";
+
+    private final ConfirmPendingPointUseCase confirmPendingPointUseCase;
     private final ObjectMapper objectMapper;
 
     @KafkaListener(
@@ -31,7 +37,8 @@ public class OrderPurchaseConfirmedSharedPointConsumer {
         EventEnvelope<?> envelope = record.value();
 
         if (FormatValidator.hasNoValue(envelope)) {
-            log.warn("envelope이 null입니다. key={}", record.key());
+            log.error("이벤트 envelope이 null. topic={}, partition={}, offset={}",
+                    record.topic(), record.partition(), record.offset());
             acknowledgment.acknowledge();
             return;
         }
@@ -58,20 +65,11 @@ public class OrderPurchaseConfirmedSharedPointConsumer {
                 return;
             }
 
-            // FIXME: [#929][#1132] HTTP 제거 후 ConfirmPendingPointUseCase 활성화
-            //  현재 듀얼 라이트 기간: ChangeOrderStatusService.confirmPendingPoints()가 HTTP로 처리 중
-            //  멱등성 보강 (#1217) 완료 후 아래 주석 해제:
-            //  for (Long sharerId : sharerIds) {
-            //      ConfirmPendingPointCommand command = ConfirmPendingPointCommand.builder()
-            //              .userId(sharerId)
-            //              .sourceType(UserPointSourceType.ORDER)
-            //              .sourceId(payload.orderId())
-            //              .reason("구매 확정 공유 포인트 적립")
-            //              .build();
-            //      confirmPendingPointUseCase.confirmPending(command);
-            //  }
+            for (Long sharerId : sharerIds) {
+                confirmPending(sharerId, payload.orderId());
+            }
 
-            log.info("공유 적립 예정 포인트 확정 이벤트 검증 완료 (듀얼 라이트). orderId={}, sharerIds={}",
+            log.info("공유 적립 예정 포인트 확정 완료. orderId={}, sharerIds={}",
                     payload.orderId(), sharerIds);
         } catch (Exception e) {
             log.error("공유 적립 예정 포인트 확정 이벤트 처리 실패. eventId={}, key={}, error={}",
@@ -80,5 +78,15 @@ public class OrderPurchaseConfirmedSharedPointConsumer {
         }
 
         acknowledgment.acknowledge();
+    }
+
+    private void confirmPending(Long sharerId, Long orderId) {
+        ConfirmPendingPointCommand command = ConfirmPendingPointCommand.builder()
+                .userId(sharerId)
+                .sourceType(UserPointSourceType.ORDER)
+                .sourceId(orderId)
+                .reason(CONFIRM_REASON)
+                .build();
+        confirmPendingPointUseCase.confirmPending(command);
     }
 }

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/service/point/ConfirmPendingPointService.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/service/point/ConfirmPendingPointService.java
@@ -1,7 +1,6 @@
 package com.personal.marketnote.reward.service.point;
 
 import com.personal.marketnote.common.application.UseCase;
-import com.personal.marketnote.reward.domain.exception.PendingPointHistoryNotFoundException;
 import com.personal.marketnote.reward.domain.exception.PendingPointReflectionMismatchException;
 import com.personal.marketnote.reward.domain.point.UserPoint;
 import com.personal.marketnote.reward.domain.point.UserPointHistory;
@@ -15,12 +14,14 @@ import com.personal.marketnote.reward.port.out.point.SaveUserPointHistoryPort;
 import com.personal.marketnote.reward.port.out.point.UpdateUserPointHistoryPort;
 import com.personal.marketnote.reward.port.out.point.UpdateUserPointPort;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
 import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
 
+@Slf4j
 @UseCase
 @RequiredArgsConstructor
 @Transactional(isolation = READ_COMMITTED)
@@ -33,7 +34,17 @@ public class ConfirmPendingPointService implements ConfirmPendingPointUseCase {
 
     @Override
     public UpdateUserPointResult confirmPending(ConfirmPendingPointCommand command) {
-        List<UserPointHistory> pendingHistories = findPendingHistories(command);
+        List<UserPointHistory> pendingHistories = findUserPointHistoryPort.findUnreflectedByUserIdAndSource(
+                command.userId(), command.sourceType(), command.sourceId()
+        );
+
+        if (pendingHistories.isEmpty()) {
+            log.info("이미 확정 처리된 적립 예정 포인트 (멱등 처리). userId={}, sourceType={}, sourceId={}",
+                    command.userId(), command.sourceType(), command.sourceId());
+            UserPoint userPoint = getUserPointUseCase.getUserPoint(command.userId());
+            return UpdateUserPointResult.from(userPoint);
+        }
+
         Long totalAmount = calculateTotalPendingAmount(pendingHistories);
 
         UserPoint userPoint = getUserPointUseCase.getUserPoint(command.userId());
@@ -48,20 +59,6 @@ public class ConfirmPendingPointService implements ConfirmPendingPointUseCase {
         saveConfirmedHistory(command, totalAmount, updatedPoint);
 
         return UpdateUserPointResult.from(updatedPoint);
-    }
-
-    private List<UserPointHistory> findPendingHistories(ConfirmPendingPointCommand command) {
-        List<UserPointHistory> histories = findUserPointHistoryPort.findUnreflectedByUserIdAndSource(
-                command.userId(), command.sourceType(), command.sourceId()
-        );
-
-        if (histories.isEmpty()) {
-            throw new PendingPointHistoryNotFoundException(
-                    command.userId(), command.sourceType().name(), command.sourceId()
-            );
-        }
-
-        return histories;
     }
 
     private Long calculateTotalPendingAmount(List<UserPointHistory> pendingHistories) {


### PR DESCRIPTION
## partially addresses #929
## resolves #1217

## Task
- [x] ConfirmPendingPointService에서 미반영 이력이 없을 때 예외 대신 현재 포인트를 반환하도록 멱등성 추가 (CancelPendingPointService 패턴 적용)
- [x] OrderPurchaseConfirmedProductPointConsumer에서 FIXME 주석 해제 및 ConfirmPendingPointUseCase 호출 활성화
- [x] OrderPurchaseConfirmedSharedPointConsumer에서 FIXME 주석 해제 및 ConfirmPendingPointUseCase 호출 활성화
- [x] OrderPurchaseConfirmedProductPointConsumer에 envelope null 검증 추가
- [x] OrderPurchaseConfirmedSharedPointConsumer envelope null 로그 레벨 통일 (warn → error)