### PR TITLE
[#929][#1219] feat: 결제 승인 시 주문 상태 변경 멱등성 기능 추가

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/PaymentApprovedOrderStatusConsumer.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/PaymentApprovedOrderStatusConsumer.java
@@ -2,6 +2,7 @@ package com.personal.marketnote.commerce.adapter.in.event;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.personal.marketnote.commerce.domain.order.OrderStatus;
+import com.personal.marketnote.commerce.exception.OrderStatusAlreadyChangedException;
 import com.personal.marketnote.commerce.port.in.command.order.ChangeOrderStatusCommand;
 import com.personal.marketnote.commerce.port.in.usecase.order.ChangeOrderStatusUseCase;
 import com.personal.marketnote.common.kafka.KafkaTopicConstants;
@@ -53,6 +54,9 @@ public class PaymentApprovedOrderStatusConsumer {
 
             log.info("Kafka 이벤트로 주문 상태 PAID 변경 완료. orderId={}, orderKey={}",
                     payload.orderId(), payload.orderKey());
+        } catch (OrderStatusAlreadyChangedException e) {
+            log.warn("듀얼 라이트: 이미 주문 상태가 변경됨. eventId={}, key={}, message={}",
+                    envelope.eventId(), record.key(), e.getMessage());
         } catch (Exception e) {
             log.error("주문 상태 PAID 변경 실패. eventId={}, key={}, error={}",
                     envelope.eventId(), record.key(), e.getMessage(), e);

--- a/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/event/PaymentApprovedOrderStatusConsumerTest.java
+++ b/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/event/PaymentApprovedOrderStatusConsumerTest.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.commerce.adapter.in.event;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.commerce.exception.OrderStatusAlreadyChangedException;
 import com.personal.marketnote.commerce.port.in.command.order.ChangeOrderStatusCommand;
 import com.personal.marketnote.commerce.port.in.usecase.order.ChangeOrderStatusUseCase;
 import com.personal.marketnote.common.kafka.event.EventEnvelope;
@@ -79,6 +80,22 @@ class PaymentApprovedOrderStatusConsumerTest {
 
         // then
         verifyNoInteractions(changeOrderStatusUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("듀얼 라이트 기간 중 이미 PAID 상태인 주문에 대해 OrderStatusAlreadyChangedException 발생 시 정상 acknowledge한다")
+    void handlePaymentApprovedEvent_alreadyChanged_acknowledgesGracefully() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, "order-key-1", 50000L);
+        doThrow(new OrderStatusAlreadyChangedException(PAID))
+                .when(changeOrderStatusUseCase).changeOrderStatus(any(ChangeOrderStatusCommand.class));
+
+        // when
+        consumer.handlePaymentApprovedEvent(record, acknowledgment);
+
+        // then
+        verify(changeOrderStatusUseCase).changeOrderStatus(any(ChangeOrderStatusCommand.class));
         verify(acknowledgment).acknowledge();
     }
 


### PR DESCRIPTION
## partially addresses #929
## resolves #1219

## Task
- [x] PaymentApprovedOrderStatusConsumer에 OrderStatusAlreadyChangedException catch 블록 추가
- [x] 듀얼 라이트 기간 중 이미 PAID 상태인 주문에 대해 warn 로그 + 정상 acknowledge 처리
- [x] PaymentApprovedOrderStatusConsumerTest에 멱등성 테스트 케이스 추가