### PR TITLE
[#929][#1210] feat: 결제 취소 시 재고 복구 멱등성 기능 추가

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/PaymentCancelledInventoryConsumer.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/PaymentCancelledInventoryConsumer.java
@@ -1,6 +1,10 @@
 package com.personal.marketnote.commerce.adapter.in.event;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.commerce.domain.order.OrderProduct;
+import com.personal.marketnote.commerce.domain.order.OrderProductSnapshotState;
+import com.personal.marketnote.commerce.exception.DuplicateInventoryRestorationException;
+import com.personal.marketnote.commerce.port.in.usecase.inventory.RestoreProductInventoryUseCase;
 import com.personal.marketnote.common.kafka.KafkaTopicConstants;
 import com.personal.marketnote.common.kafka.event.EventEnvelope;
 import com.personal.marketnote.common.kafka.event.PaymentCancelledEvent;
@@ -20,6 +24,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class PaymentCancelledInventoryConsumer {
     private final ObjectMapper objectMapper;
+    private final RestoreProductInventoryUseCase restoreProductInventoryUseCase;
 
     @KafkaListener(
             topics = KafkaTopicConstants.PAYMENT_CANCELLED,
@@ -46,9 +51,14 @@ public class PaymentCancelledInventoryConsumer {
 
             if (payload.isFullCancel()) {
                 handleFullCancelInventoryRestore(envelope, payload);
-            } else {
+            }
+
+            if (!payload.isFullCancel()) {
                 handlePartialCancelInventoryRestore(envelope, payload);
             }
+        } catch (DuplicateInventoryRestorationException e) {
+            log.info("이미 처리된 재고 복구 이벤트 (멱등 처리). eventId={}, message={}",
+                    envelope.eventId(), e.getMessage());
         } catch (Exception e) {
             log.error("재고 복구 이벤트 처리 실패. eventId={}, key={}, error={}",
                     envelope.eventId(), record.key(), e.getMessage(), e);
@@ -65,13 +75,10 @@ public class PaymentCancelledInventoryConsumer {
             return;
         }
 
-        // FIXME: [#929][#1101] HTTP 제거 후 RestoreProductInventoryUseCase.restore() 활성화
-        //  현재 듀얼 라이트 기간: CancelPaymentService.restoreInventory()에서 동기로 재고 복구 처리 중
-        //  멱등성 보강(#1210) 완료 후 활성화
-        //  List<OrderProduct> orderProducts = convertToOrderProducts(payload.orderProducts());
-        //  restoreProductInventoryUseCase.restore(orderProducts, "Kafka 전액 취소 재고 복구");
+        List<OrderProduct> orderProducts = convertToOrderProducts(payload.orderProducts());
+        restoreProductInventoryUseCase.restore(orderProducts, payload.orderId(), "Kafka 전액 취소 재고 복구");
 
-        log.info("전체 취소 재고 복구 이벤트 검증 완료 (듀얼 라이트). orderId={}, orderProducts={}건",
+        log.info("전체 취소 재고 복구 완료. orderId={}, orderProducts={}건",
                 payload.orderId(), payload.orderProducts().size());
     }
 
@@ -84,13 +91,23 @@ public class PaymentCancelledInventoryConsumer {
             return;
         }
 
-        // FIXME: [#929][#1101] HTTP 제거 후 RestoreProductInventoryUseCase.restore() 활성화
-        //  현재 듀얼 라이트 기간: CancelPaymentService.restorePartialCancelInventory()에서 동기로 부분 재고 복구 처리 중
-        //  멱등성 보강(#1210) 완료 후 활성화
-        //  List<OrderProduct> cancelOrderProducts = convertToOrderProducts(cancelProducts);
-        //  restoreProductInventoryUseCase.restore(cancelOrderProducts, "Kafka 부분 취소 재고 복구");
+        List<OrderProduct> cancelOrderProducts = convertToOrderProducts(cancelProducts);
+        restoreProductInventoryUseCase.restore(cancelOrderProducts, payload.orderId(), "Kafka 부분 취소 재고 복구");
 
-        log.info("부분 취소 재고 복구 이벤트 검증 완료 (듀얼 라이트). orderId={}, cancelProducts={}건",
+        log.info("부분 취소 재고 복구 완료. orderId={}, cancelProducts={}건",
                 payload.orderId(), cancelProducts.size());
+    }
+
+    private List<OrderProduct> convertToOrderProducts(List<OrderProductItem> items) {
+        return items.stream()
+                .map(item -> OrderProduct.from(
+                        OrderProductSnapshotState.builder()
+                                .pricePolicyId(item.pricePolicyId())
+                                .quantity(item.quantity())
+                                .unitAmount(item.unitAmount())
+                                .sharerId(item.sharerId())
+                                .build()
+                ))
+                .toList();
     }
 }

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/inventory/InventoryPersistenceAdapter.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/inventory/InventoryPersistenceAdapter.java
@@ -3,17 +3,19 @@ package com.personal.marketnote.commerce.adapter.out.persistence.inventory;
 import com.personal.marketnote.commerce.adapter.out.mapper.InventoryJpaEntityToDomainMapper;
 import com.personal.marketnote.commerce.adapter.out.persistence.inventory.entity.InventoryDeductionHistoryJpaEntity;
 import com.personal.marketnote.commerce.adapter.out.persistence.inventory.entity.InventoryJpaEntity;
+import com.personal.marketnote.commerce.adapter.out.persistence.inventory.entity.InventoryRestorationHistoryJpaEntity;
 import com.personal.marketnote.commerce.adapter.out.persistence.inventory.repository.InventoryDeductionHistoryJpaRepository;
 import com.personal.marketnote.commerce.adapter.out.persistence.inventory.repository.InventoryJpaRepository;
+import com.personal.marketnote.commerce.adapter.out.persistence.inventory.repository.InventoryRestorationHistoryJpaRepository;
 import com.personal.marketnote.commerce.domain.inventory.Inventory;
 import com.personal.marketnote.commerce.domain.inventory.InventoryDeductionHistories;
 import com.personal.marketnote.commerce.domain.inventory.InventoryDeductionHistory;
+import com.personal.marketnote.commerce.domain.inventory.InventoryRestorationHistories;
+import com.personal.marketnote.commerce.domain.inventory.InventoryRestorationHistory;
 import com.personal.marketnote.commerce.exception.DuplicateInventoryDeductionException;
+import com.personal.marketnote.commerce.exception.DuplicateInventoryRestorationException;
 import com.personal.marketnote.commerce.exception.InventoryNotFoundException;
-import com.personal.marketnote.commerce.port.out.inventory.FindInventoryPort;
-import com.personal.marketnote.commerce.port.out.inventory.SaveInventoryDeductionHistoryPort;
-import com.personal.marketnote.commerce.port.out.inventory.SaveInventoryPort;
-import com.personal.marketnote.commerce.port.out.inventory.UpdateInventoryPort;
+import com.personal.marketnote.commerce.port.out.inventory.*;
 import com.personal.marketnote.common.adapter.out.PersistenceAdapter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -24,9 +26,10 @@ import java.util.stream.Collectors;
 
 @PersistenceAdapter
 @RequiredArgsConstructor
-public class InventoryPersistenceAdapter implements SaveInventoryPort, FindInventoryPort, UpdateInventoryPort, SaveInventoryDeductionHistoryPort {
+public class InventoryPersistenceAdapter implements SaveInventoryPort, FindInventoryPort, UpdateInventoryPort, SaveInventoryDeductionHistoryPort, SaveInventoryRestorationHistoryPort {
     private final InventoryJpaRepository inventoryJpaRepository;
     private final InventoryDeductionHistoryJpaRepository inventoryDeductionHistoryJpaRepository;
+    private final InventoryRestorationHistoryJpaRepository inventoryRestorationHistoryJpaRepository;
 
     @Override
     public void save(Inventory inventory) {
@@ -102,6 +105,25 @@ public class InventoryPersistenceAdapter implements SaveInventoryPort, FindInven
                     .map(InventoryDeductionHistory::getOrderId)
                     .orElse(null);
             throw new DuplicateInventoryDeductionException(orderId);
+        }
+    }
+
+    @Override
+    public void save(InventoryRestorationHistories inventoryRestorationHistories) {
+        try {
+            inventoryRestorationHistoryJpaRepository.saveAllAndFlush(
+                    inventoryRestorationHistories.getInventoryRestorationHistories()
+                            .stream()
+                            .map(InventoryRestorationHistoryJpaEntity::from)
+                            .toList()
+            );
+        } catch (DataIntegrityViolationException e) {
+            Long orderId = inventoryRestorationHistories.getInventoryRestorationHistories()
+                    .stream()
+                    .findFirst()
+                    .map(InventoryRestorationHistory::getOrderId)
+                    .orElse(null);
+            throw new DuplicateInventoryRestorationException(orderId);
         }
     }
 }

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/inventory/entity/InventoryRestorationHistoryJpaEntity.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/inventory/entity/InventoryRestorationHistoryJpaEntity.java
@@ -1,0 +1,70 @@
+package com.personal.marketnote.commerce.adapter.out.persistence.inventory.entity;
+
+import com.personal.marketnote.commerce.domain.inventory.InventoryRestorationHistory;
+import com.personal.marketnote.common.adapter.out.persistence.audit.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+
+@Entity
+@Table(
+        name = "inventory_restoration_history",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_inventory_restoration_order_policy",
+                columnNames = {"order_id", "price_policy_id"}
+        )
+)
+@DynamicInsert
+@DynamicUpdate
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class InventoryRestorationHistoryJpaEntity extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @Column(name = "product_id")
+    private Long productId;
+
+    @Column(name = "price_policy_id", nullable = false)
+    private Long pricePolicyId;
+
+    @Column(name = "order_id")
+    private Long orderId;
+
+    @Column(name = "stock", nullable = false)
+    private Integer stock;
+
+    @Column(name = "reason", length = 511)
+    private String reason;
+
+    private InventoryRestorationHistoryJpaEntity(
+            Long productId,
+            Long pricePolicyId,
+            Long orderId,
+            Integer stock,
+            String reason
+    ) {
+        this.productId = productId;
+        this.pricePolicyId = pricePolicyId;
+        this.orderId = orderId;
+        this.stock = stock;
+        this.reason = reason;
+    }
+
+    public static InventoryRestorationHistoryJpaEntity from(InventoryRestorationHistory inventoryRestorationHistory) {
+        return new InventoryRestorationHistoryJpaEntity(
+                inventoryRestorationHistory.getProductId(),
+                inventoryRestorationHistory.getPricePolicyId(),
+                inventoryRestorationHistory.getOrderId(),
+                inventoryRestorationHistory.getStockValue(),
+                inventoryRestorationHistory.getReason()
+        );
+    }
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/inventory/repository/InventoryRestorationHistoryJpaRepository.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/inventory/repository/InventoryRestorationHistoryJpaRepository.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.commerce.adapter.out.persistence.inventory.repository;
+
+import com.personal.marketnote.commerce.adapter.out.persistence.inventory.entity.InventoryRestorationHistoryJpaEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface InventoryRestorationHistoryJpaRepository extends JpaRepository<InventoryRestorationHistoryJpaEntity, Long> {
+}

--- a/commerce-service/commerce-adapters/src/main/resources/db/migration/V898__create_inventory_restoration_history.sql
+++ b/commerce-service/commerce-adapters/src/main/resources/db/migration/V898__create_inventory_restoration_history.sql
@@ -1,0 +1,14 @@
+CREATE TABLE inventory_restoration_history (
+    id BIGSERIAL PRIMARY KEY,
+    product_id BIGINT,
+    price_policy_id BIGINT NOT NULL,
+    order_id BIGINT,
+    stock INT NOT NULL,
+    reason VARCHAR(511),
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    modified_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX uk_inventory_restoration_order_policy
+    ON inventory_restoration_history (order_id, price_policy_id)
+    WHERE order_id IS NOT NULL;

--- a/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/event/PaymentCancelledInventoryConsumerTest.java
+++ b/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/event/PaymentCancelledInventoryConsumerTest.java
@@ -1,6 +1,8 @@
 package com.personal.marketnote.commerce.adapter.in.event;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.commerce.exception.DuplicateInventoryRestorationException;
+import com.personal.marketnote.commerce.port.in.usecase.inventory.RestoreProductInventoryUseCase;
 import com.personal.marketnote.common.kafka.event.EventEnvelope;
 import com.personal.marketnote.common.kafka.event.PaymentCancelledEvent;
 import com.personal.marketnote.common.kafka.event.PaymentCancelledEvent.OrderProductItem;
@@ -28,6 +30,9 @@ class PaymentCancelledInventoryConsumerTest {
 
     @Spy
     private ObjectMapper objectMapper = new ObjectMapper();
+
+    @Mock
+    private RestoreProductInventoryUseCase restoreProductInventoryUseCase;
 
     @Mock
     private Acknowledgment acknowledgment;
@@ -60,8 +65,8 @@ class PaymentCancelledInventoryConsumerTest {
     }
 
     @Test
-    @DisplayName("전체 취소 이벤트 수신 시 재고 복구 검증 후 acknowledge한다")
-    void handlePaymentCancelledEvent_fullCancel_validatesAndAcknowledges() {
+    @DisplayName("전체 취소 이벤트 수신 시 재고를 복구하고 acknowledge한다")
+    void handlePaymentCancelledEvent_fullCancel_restoresInventoryAndAcknowledges() {
         // given
         List<OrderProductItem> orderProducts = createOrderProductItems();
         ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, true, orderProducts, null);
@@ -70,16 +75,44 @@ class PaymentCancelledInventoryConsumerTest {
         consumer.handlePaymentCancelledEvent(record, acknowledgment);
 
         // then
+        verify(restoreProductInventoryUseCase).restore(argThat(products ->
+                products.size() == 2
+                        && products.get(0).getPricePolicyId().equals(100L)
+                        && products.get(0).getQuantity() == 2
+                        && products.get(1).getPricePolicyId().equals(101L)
+                        && products.get(1).getQuantity() == 1
+        ), eq(1L), eq("Kafka 전액 취소 재고 복구"));
         verify(acknowledgment).acknowledge();
     }
 
     @Test
-    @DisplayName("부분 취소 이벤트 수신 시 cancelProducts 검증 후 acknowledge한다")
-    void handlePaymentCancelledEvent_partialCancel_validatesAndAcknowledges() {
+    @DisplayName("부분 취소 이벤트 수신 시 cancelProducts로 재고를 복구하고 acknowledge한다")
+    void handlePaymentCancelledEvent_partialCancel_restoresInventoryAndAcknowledges() {
         // given
         List<OrderProductItem> orderProducts = createOrderProductItems();
         List<OrderProductItem> cancelProducts = createCancelProductItems();
         ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, false, orderProducts, cancelProducts);
+
+        // when
+        consumer.handlePaymentCancelledEvent(record, acknowledgment);
+
+        // then
+        verify(restoreProductInventoryUseCase).restore(argThat(products ->
+                products.size() == 1
+                        && products.get(0).getPricePolicyId().equals(100L)
+                        && products.get(0).getQuantity() == 1
+        ), eq(1L), eq("Kafka 부분 취소 재고 복구"));
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("중복 재고 복구 시 DuplicateInventoryRestorationException을 catch하고 acknowledge한다")
+    void handlePaymentCancelledEvent_duplicateRestoration_catchesAndAcknowledges() {
+        // given
+        List<OrderProductItem> orderProducts = createOrderProductItems();
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, true, orderProducts, null);
+        doThrow(new DuplicateInventoryRestorationException(1L))
+                .when(restoreProductInventoryUseCase).restore(anyList(), anyLong(), anyString());
 
         // when
         consumer.handlePaymentCancelledEvent(record, acknowledgment);
@@ -99,6 +132,7 @@ class PaymentCancelledInventoryConsumerTest {
         consumer.handlePaymentCancelledEvent(record, acknowledgment);
 
         // then
+        verify(restoreProductInventoryUseCase, never()).restore(anyList(), anyLong(), anyString());
         verify(acknowledgment).acknowledge();
     }
 
@@ -112,6 +146,7 @@ class PaymentCancelledInventoryConsumerTest {
         consumer.handlePaymentCancelledEvent(record, acknowledgment);
 
         // then
+        verify(restoreProductInventoryUseCase, never()).restore(anyList(), anyLong(), anyString());
         verify(acknowledgment).acknowledge();
     }
 
@@ -125,6 +160,7 @@ class PaymentCancelledInventoryConsumerTest {
         consumer.handlePaymentCancelledEvent(record, acknowledgment);
 
         // then
+        verify(restoreProductInventoryUseCase, never()).restore(anyList(), anyLong(), anyString());
         verify(acknowledgment).acknowledge();
     }
 
@@ -139,6 +175,7 @@ class PaymentCancelledInventoryConsumerTest {
         consumer.handlePaymentCancelledEvent(record, acknowledgment);
 
         // then
+        verify(restoreProductInventoryUseCase, never()).restore(anyList(), anyLong(), anyString());
         verify(acknowledgment).acknowledge();
     }
 
@@ -153,6 +190,7 @@ class PaymentCancelledInventoryConsumerTest {
         consumer.handlePaymentCancelledEvent(record, acknowledgment);
 
         // then
+        verify(restoreProductInventoryUseCase, never()).restore(anyList(), anyLong(), anyString());
         verify(acknowledgment).acknowledge();
     }
 

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/exception/DuplicateInventoryRestorationException.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/exception/DuplicateInventoryRestorationException.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.commerce.exception;
+
+public class DuplicateInventoryRestorationException extends RuntimeException {
+    public DuplicateInventoryRestorationException(Long orderId) {
+        super("이미 처리된 재고 복구입니다. orderId=" + orderId);
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/inventory/RestoreProductInventoryUseCase.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/inventory/RestoreProductInventoryUseCase.java
@@ -7,10 +7,11 @@ import java.util.List;
 public interface RestoreProductInventoryUseCase {
     /**
      * @param orderProducts 주문 상품 목록
+     * @param orderId       주문 ID (멱등성 보장용)
      * @param reason        재고 복원 이유
      * @Date 2026-03-07
      * @Author 성효빈
      * @Description 주문 상품 재고를 복원합니다.
      */
-    void restore(List<OrderProduct> orderProducts, String reason);
+    void restore(List<OrderProduct> orderProducts, Long orderId, String reason);
 }

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/inventory/SaveInventoryRestorationHistoryPort.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/inventory/SaveInventoryRestorationHistoryPort.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.commerce.port.out.inventory;
+
+import com.personal.marketnote.commerce.domain.inventory.InventoryRestorationHistories;
+
+public interface SaveInventoryRestorationHistoryPort {
+    void save(InventoryRestorationHistories inventoryRestorationHistories);
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/inventory/RestoreProductInventoryService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/inventory/RestoreProductInventoryService.java
@@ -1,16 +1,15 @@
 package com.personal.marketnote.commerce.service.inventory;
 
 import com.personal.marketnote.commerce.domain.inventory.Inventory;
+import com.personal.marketnote.commerce.domain.inventory.InventoryRestorationHistories;
 import com.personal.marketnote.commerce.domain.order.OrderProduct;
 import com.personal.marketnote.commerce.port.in.usecase.inventory.RestoreProductInventoryUseCase;
-import com.personal.marketnote.commerce.port.out.inventory.FindInventoryPort;
-import com.personal.marketnote.commerce.port.out.inventory.InventoryLockPort;
-import com.personal.marketnote.commerce.port.out.inventory.SaveCacheStockPort;
-import com.personal.marketnote.commerce.port.out.inventory.UpdateInventoryPort;
+import com.personal.marketnote.commerce.port.out.inventory.*;
 import com.personal.marketnote.common.application.UseCase;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -24,11 +23,12 @@ import static org.springframework.transaction.annotation.Isolation.READ_COMMITTE
 public class RestoreProductInventoryService implements RestoreProductInventoryUseCase {
     private final FindInventoryPort findInventoryPort;
     private final UpdateInventoryPort updateInventoryPort;
+    private final SaveInventoryRestorationHistoryPort saveInventoryRestorationHistoryPort;
     private final SaveCacheStockPort saveCacheStockPort;
     private final InventoryLockPort inventoryLockPort;
 
     @Override
-    public void restore(List<OrderProduct> orderProducts, String reason) {
+    public void restore(List<OrderProduct> orderProducts, Long orderId, String reason) {
         Map<Long, Integer> stocksByPricePolicyId = orderProducts.stream()
                 .collect(
                         Collectors.groupingBy(
@@ -43,6 +43,15 @@ public class RestoreProductInventoryService implements RestoreProductInventoryUs
             ));
 
             updateInventoryPort.update(inventories);
+
+            Map<Long, Long> productIdsByPricePolicyId = new HashMap<>();
+            inventories.forEach(inventory ->
+                    productIdsByPricePolicyId.put(inventory.getPricePolicyId(), inventory.getProductId())
+            );
+            saveInventoryRestorationHistoryPort.save(
+                    InventoryRestorationHistories.from(stocksByPricePolicyId, productIdsByPricePolicyId, orderId, reason)
+            );
+
             saveCacheStockPort.save(inventories);
         });
     }

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/CancelPaymentService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/CancelPaymentService.java
@@ -251,7 +251,7 @@ public class CancelPaymentService implements CancelPaymentUseCase {
     private void restoreInventory(Order order) {
         try {
             restoreProductInventoryUseCase.restore(
-                    order.getOrderProducts(), "주문 전액 취소에 의한 재고 복구"
+                    order.getOrderProducts(), order.getId(), "주문 전액 취소에 의한 재고 복구"
             );
         } catch (Exception e) {
             log.error("재고 복구 실패 - orderId: {}, error: {}",
@@ -273,7 +273,7 @@ public class CancelPaymentService implements CancelPaymentUseCase {
                                     .build()
                     ))
                     .toList();
-            restoreProductInventoryUseCase.restore(cancelTargetProducts, "주문 부분 취소에 의한 재고 복구");
+            restoreProductInventoryUseCase.restore(cancelTargetProducts, order.getId(), "주문 부분 취소에 의한 재고 복구");
         } catch (Exception e) {
             log.error("부분 취소 재고 복구 실패 - orderId: {}, error: {}",
                     order.getId(), e.getMessage(), e);

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/inventory/RestoreProductInventoryUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/inventory/RestoreProductInventoryUseCaseTest.java
@@ -1,12 +1,11 @@
 package com.personal.marketnote.commerce.service.inventory;
 
 import com.personal.marketnote.commerce.domain.inventory.Inventory;
+import com.personal.marketnote.commerce.domain.inventory.InventoryRestorationHistories;
+import com.personal.marketnote.commerce.domain.inventory.InventoryRestorationHistory;
 import com.personal.marketnote.commerce.domain.order.OrderProduct;
 import com.personal.marketnote.commerce.domain.order.OrderProductSnapshotState;
-import com.personal.marketnote.commerce.port.out.inventory.FindInventoryPort;
-import com.personal.marketnote.commerce.port.out.inventory.InventoryLockPort;
-import com.personal.marketnote.commerce.port.out.inventory.SaveCacheStockPort;
-import com.personal.marketnote.commerce.port.out.inventory.UpdateInventoryPort;
+import com.personal.marketnote.commerce.port.out.inventory.*;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -32,6 +31,8 @@ class RestoreProductInventoryUseCaseTest {
     @Mock
     private UpdateInventoryPort updateInventoryPort;
     @Mock
+    private SaveInventoryRestorationHistoryPort saveInventoryRestorationHistoryPort;
+    @Mock
     private SaveCacheStockPort saveCacheStockPort;
     @Mock
     private InventoryLockPort inventoryLockPort;
@@ -52,7 +53,7 @@ class RestoreProductInventoryUseCaseTest {
             stubLockToExecuteTask();
             when(findInventoryPort.findByPricePolicyIds(any())).thenReturn(Set.of(inventory));
 
-            restoreProductInventoryService.restore(orderProducts, "주문 취소");
+            restoreProductInventoryService.restore(orderProducts, 1L, "주문 취소");
 
             assertThat(inventory.getStockValue()).isEqualTo(10);
         }
@@ -70,7 +71,7 @@ class RestoreProductInventoryUseCaseTest {
             stubLockToExecuteTask();
             when(findInventoryPort.findByPricePolicyIds(any())).thenReturn(Set.of(inventory1, inventory2));
 
-            restoreProductInventoryService.restore(orderProducts, "주문 취소");
+            restoreProductInventoryService.restore(orderProducts, 1L, "주문 취소");
 
             assertThat(inventory1.getStockValue()).isEqualTo(10);
             assertThat(inventory2.getStockValue()).isEqualTo(20);
@@ -88,7 +89,7 @@ class RestoreProductInventoryUseCaseTest {
             stubLockToExecuteTask();
             when(findInventoryPort.findByPricePolicyIds(any())).thenReturn(Set.of(inventory));
 
-            restoreProductInventoryService.restore(orderProducts, "주문 취소");
+            restoreProductInventoryService.restore(orderProducts, 1L, "주문 취소");
 
             assertThat(inventory.getStockValue()).isEqualTo(10);
         }
@@ -108,7 +109,7 @@ class RestoreProductInventoryUseCaseTest {
                     buildInventory(2L, 200L, 17)
             ));
 
-            restoreProductInventoryService.restore(orderProducts, "주문 취소");
+            restoreProductInventoryService.restore(orderProducts, 1L, "주문 취소");
 
             ArgumentCaptor<Set<Long>> lockKeysCaptor = ArgumentCaptor.forClass(Set.class);
             verify(inventoryLockPort).executeWithLock(lockKeysCaptor.capture(), any());
@@ -116,7 +117,7 @@ class RestoreProductInventoryUseCaseTest {
         }
 
         @Test
-        @DisplayName("재고 복구 시 재고 조회 → 업데이트 → 캐시 저장 순서로 호출한다")
+        @DisplayName("재고 복구 시 재고 조회 → 업데이트 → 이력 저장 → 캐시 저장 순서로 호출한다")
         @SuppressWarnings("unchecked")
         void restore_success_callsPortsInCorrectOrder() {
             List<OrderProduct> orderProducts = List.of(buildOrderProduct(100L, 3));
@@ -125,11 +126,13 @@ class RestoreProductInventoryUseCaseTest {
             stubLockToExecuteTask();
             when(findInventoryPort.findByPricePolicyIds(any())).thenReturn(Set.of(inventory));
 
-            restoreProductInventoryService.restore(orderProducts, "주문 취소");
+            restoreProductInventoryService.restore(orderProducts, 1L, "주문 취소");
 
-            InOrder inOrder = inOrder(findInventoryPort, updateInventoryPort, saveCacheStockPort);
+            InOrder inOrder = inOrder(findInventoryPort, updateInventoryPort,
+                    saveInventoryRestorationHistoryPort, saveCacheStockPort);
             inOrder.verify(findInventoryPort).findByPricePolicyIds(any());
             inOrder.verify(updateInventoryPort).update(any());
+            inOrder.verify(saveInventoryRestorationHistoryPort).save(any(InventoryRestorationHistories.class));
             inOrder.verify(saveCacheStockPort).save(any(Set.class));
             inOrder.verifyNoMoreInteractions();
         }
@@ -139,11 +142,12 @@ class RestoreProductInventoryUseCaseTest {
         void restore_lockNotExecuted_doesNotCallInternalPorts() {
             List<OrderProduct> orderProducts = List.of(buildOrderProduct(100L, 3));
 
-            restoreProductInventoryService.restore(orderProducts, "주문 취소");
+            restoreProductInventoryService.restore(orderProducts, 1L, "주문 취소");
 
             verify(inventoryLockPort).executeWithLock(any(), any());
             verifyNoInteractions(findInventoryPort);
             verifyNoInteractions(updateInventoryPort);
+            verifyNoInteractions(saveInventoryRestorationHistoryPort);
             verifyNoInteractions(saveCacheStockPort);
         }
 
@@ -156,13 +160,13 @@ class RestoreProductInventoryUseCaseTest {
             stubLockToExecuteTask();
             when(findInventoryPort.findByPricePolicyIds(any())).thenThrow(exception);
 
-            assertThatThrownBy(() -> restoreProductInventoryService.restore(orderProducts, "주문 취소"))
+            assertThatThrownBy(() -> restoreProductInventoryService.restore(orderProducts, 1L, "주문 취소"))
                     .isSameAs(exception);
         }
 
         @Test
-        @DisplayName("재고 업데이트 중 예외 발생 시 캐시 저장을 호출하지 않는다")
-        void restore_updatePortFails_doesNotSaveCache() {
+        @DisplayName("재고 업데이트 중 예외 발생 시 이력 저장과 캐시 저장을 호출하지 않는다")
+        void restore_updatePortFails_doesNotSaveHistoryAndCache() {
             List<OrderProduct> orderProducts = List.of(buildOrderProduct(100L, 3));
             Inventory inventory = buildInventory(1L, 100L, 7);
 
@@ -170,10 +174,186 @@ class RestoreProductInventoryUseCaseTest {
             when(findInventoryPort.findByPricePolicyIds(any())).thenReturn(Set.of(inventory));
             doThrow(new RuntimeException("update fail")).when(updateInventoryPort).update(any());
 
-            assertThatThrownBy(() -> restoreProductInventoryService.restore(orderProducts, "주문 취소"))
+            assertThatThrownBy(() -> restoreProductInventoryService.restore(orderProducts, 1L, "주문 취소"))
                     .isInstanceOf(RuntimeException.class);
 
+            verifyNoInteractions(saveInventoryRestorationHistoryPort);
             verifyNoInteractions(saveCacheStockPort);
+        }
+
+        // ==================================================================================
+        // 복구 이력 저장 검증
+        // ==================================================================================
+
+        @Test
+        @DisplayName("재고 복구 시 올바른 상품ID와 가격정책ID로 복구 이력을 저장한다")
+        void restore_success_savesHistoryWithCorrectProductIdAndPricePolicyId() {
+            List<OrderProduct> orderProducts = List.of(buildOrderProduct(100L, 3));
+            Inventory inventory = buildInventory(1L, 100L, 7);
+
+            stubLockToExecuteTask();
+            when(findInventoryPort.findByPricePolicyIds(any())).thenReturn(Set.of(inventory));
+
+            restoreProductInventoryService.restore(orderProducts, 1L, "주문 취소");
+
+            ArgumentCaptor<InventoryRestorationHistories> captor =
+                    ArgumentCaptor.forClass(InventoryRestorationHistories.class);
+            verify(saveInventoryRestorationHistoryPort).save(captor.capture());
+            List<InventoryRestorationHistory> histories =
+                    captor.getValue().getInventoryRestorationHistories();
+
+            assertThat(histories).hasSize(1);
+            assertThat(histories.get(0).getProductId()).isEqualTo(1L);
+            assertThat(histories.get(0).getPricePolicyId()).isEqualTo(100L);
+        }
+
+        @Test
+        @DisplayName("재고 복구 시 올바른 복구 수량으로 복구 이력을 저장한다")
+        void restore_success_savesHistoryWithCorrectRestorationQuantity() {
+            List<OrderProduct> orderProducts = List.of(buildOrderProduct(100L, 3));
+            Inventory inventory = buildInventory(1L, 100L, 7);
+
+            stubLockToExecuteTask();
+            when(findInventoryPort.findByPricePolicyIds(any())).thenReturn(Set.of(inventory));
+
+            restoreProductInventoryService.restore(orderProducts, 1L, "주문 취소");
+
+            ArgumentCaptor<InventoryRestorationHistories> captor =
+                    ArgumentCaptor.forClass(InventoryRestorationHistories.class);
+            verify(saveInventoryRestorationHistoryPort).save(captor.capture());
+            List<InventoryRestorationHistory> histories =
+                    captor.getValue().getInventoryRestorationHistories();
+
+            assertThat(histories).hasSize(1);
+            assertThat(histories.get(0).getStockValue()).isEqualTo(3);
+        }
+
+        @Test
+        @DisplayName("재고 복구 시 올바른 주문ID로 복구 이력을 저장한다")
+        void restore_success_savesHistoryWithCorrectOrderId() {
+            List<OrderProduct> orderProducts = List.of(buildOrderProduct(100L, 3));
+            Inventory inventory = buildInventory(1L, 100L, 7);
+
+            stubLockToExecuteTask();
+            when(findInventoryPort.findByPricePolicyIds(any())).thenReturn(Set.of(inventory));
+
+            restoreProductInventoryService.restore(orderProducts, 99L, "주문 취소");
+
+            ArgumentCaptor<InventoryRestorationHistories> captor =
+                    ArgumentCaptor.forClass(InventoryRestorationHistories.class);
+            verify(saveInventoryRestorationHistoryPort).save(captor.capture());
+            List<InventoryRestorationHistory> histories =
+                    captor.getValue().getInventoryRestorationHistories();
+
+            assertThat(histories).hasSize(1);
+            assertThat(histories.get(0).getOrderId()).isEqualTo(99L);
+        }
+
+        @Test
+        @DisplayName("재고 복구 시 올바른 사유로 복구 이력을 저장한다")
+        void restore_success_savesHistoryWithCorrectReason() {
+            List<OrderProduct> orderProducts = List.of(buildOrderProduct(100L, 3));
+            Inventory inventory = buildInventory(1L, 100L, 7);
+            String reason = "주문 전액 취소에 의한 재고 복구";
+
+            stubLockToExecuteTask();
+            when(findInventoryPort.findByPricePolicyIds(any())).thenReturn(Set.of(inventory));
+
+            restoreProductInventoryService.restore(orderProducts, 1L, reason);
+
+            ArgumentCaptor<InventoryRestorationHistories> captor =
+                    ArgumentCaptor.forClass(InventoryRestorationHistories.class);
+            verify(saveInventoryRestorationHistoryPort).save(captor.capture());
+            List<InventoryRestorationHistory> histories =
+                    captor.getValue().getInventoryRestorationHistories();
+
+            assertThat(histories).hasSize(1);
+            assertThat(histories.get(0).getReason()).isEqualTo(reason);
+        }
+
+        @Test
+        @DisplayName("복수 가격 정책 재고 복구 시 각 가격 정책별 복구 이력을 저장한다")
+        void restore_multipleProducts_savesHistoryForEachPolicy() {
+            List<OrderProduct> orderProducts = List.of(
+                    buildOrderProduct(100L, 2),
+                    buildOrderProduct(200L, 5)
+            );
+            Inventory inventory1 = buildInventory(1L, 100L, 8);
+            Inventory inventory2 = buildInventory(2L, 200L, 15);
+
+            stubLockToExecuteTask();
+            when(findInventoryPort.findByPricePolicyIds(any())).thenReturn(Set.of(inventory1, inventory2));
+
+            restoreProductInventoryService.restore(orderProducts, 1L, "주문 취소");
+
+            ArgumentCaptor<InventoryRestorationHistories> captor =
+                    ArgumentCaptor.forClass(InventoryRestorationHistories.class);
+            verify(saveInventoryRestorationHistoryPort).save(captor.capture());
+            List<InventoryRestorationHistory> histories =
+                    captor.getValue().getInventoryRestorationHistories();
+
+            assertThat(histories).hasSize(2);
+            assertThat(histories).extracting(InventoryRestorationHistory::getPricePolicyId)
+                    .containsExactlyInAnyOrder(100L, 200L);
+            assertThat(histories).extracting(InventoryRestorationHistory::getStockValue)
+                    .containsExactlyInAnyOrder(2, 5);
+        }
+
+        @Test
+        @DisplayName("동일 가격 정책의 복수 주문 상품 복구 시 합산된 수량으로 이력을 저장한다")
+        void restore_samePolicyMultipleProducts_savesHistoryWithSummedQuantity() {
+            List<OrderProduct> orderProducts = List.of(
+                    buildOrderProduct(100L, 2),
+                    buildOrderProduct(100L, 3)
+            );
+            Inventory inventory = buildInventory(1L, 100L, 5);
+
+            stubLockToExecuteTask();
+            when(findInventoryPort.findByPricePolicyIds(any())).thenReturn(Set.of(inventory));
+
+            restoreProductInventoryService.restore(orderProducts, 1L, "주문 취소");
+
+            ArgumentCaptor<InventoryRestorationHistories> captor =
+                    ArgumentCaptor.forClass(InventoryRestorationHistories.class);
+            verify(saveInventoryRestorationHistoryPort).save(captor.capture());
+            List<InventoryRestorationHistory> histories =
+                    captor.getValue().getInventoryRestorationHistories();
+
+            assertThat(histories).hasSize(1);
+            assertThat(histories.get(0).getStockValue()).isEqualTo(5);
+        }
+
+        @Test
+        @DisplayName("이력 저장 중 예외 발생 시 캐시 저장을 호출하지 않는다")
+        void restore_saveHistoryPortFails_doesNotSaveCache() {
+            List<OrderProduct> orderProducts = List.of(buildOrderProduct(100L, 3));
+            Inventory inventory = buildInventory(1L, 100L, 7);
+
+            stubLockToExecuteTask();
+            when(findInventoryPort.findByPricePolicyIds(any())).thenReturn(Set.of(inventory));
+            doThrow(new RuntimeException("history save fail"))
+                    .when(saveInventoryRestorationHistoryPort).save(any());
+
+            assertThatThrownBy(() -> restoreProductInventoryService.restore(orderProducts, 1L, "주문 취소"))
+                    .isInstanceOf(RuntimeException.class);
+
+            verify(updateInventoryPort).update(any());
+            verifyNoInteractions(saveCacheStockPort);
+        }
+
+        @Test
+        @DisplayName("이력 저장 중 예외 발생 시 예외를 전파한다")
+        void restore_saveHistoryPortFails_propagates() {
+            List<OrderProduct> orderProducts = List.of(buildOrderProduct(100L, 3));
+            Inventory inventory = buildInventory(1L, 100L, 7);
+            RuntimeException exception = new RuntimeException("history save fail");
+
+            stubLockToExecuteTask();
+            when(findInventoryPort.findByPricePolicyIds(any())).thenReturn(Set.of(inventory));
+            doThrow(exception).when(saveInventoryRestorationHistoryPort).save(any());
+
+            assertThatThrownBy(() -> restoreProductInventoryService.restore(orderProducts, 1L, "주문 취소"))
+                    .isSameAs(exception);
         }
     }
 

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/payment/CancelPaymentUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/payment/CancelPaymentUseCaseTest.java
@@ -487,7 +487,7 @@ class CancelPaymentUseCaseTest {
 
             cancelPaymentService.cancel(command);
 
-            verify(restoreProductInventoryUseCase).restore(anyList(), anyString());
+            verify(restoreProductInventoryUseCase).restore(anyList(), anyLong(), anyString());
         }
 
         @Test
@@ -505,7 +505,7 @@ class CancelPaymentUseCaseTest {
 
             cancelPaymentService.cancel(command);
 
-            verify(restoreProductInventoryUseCase, never()).restore(anyList(), anyString());
+            verify(restoreProductInventoryUseCase, never()).restore(anyList(), anyLong(), anyString());
         }
 
         @Test
@@ -523,7 +523,7 @@ class CancelPaymentUseCaseTest {
 
             cancelPaymentService.cancel(command);
 
-            verify(restoreProductInventoryUseCase, never()).restore(anyList(), anyString());
+            verify(restoreProductInventoryUseCase, never()).restore(anyList(), anyLong(), anyString());
         }
 
         @Test
@@ -548,7 +548,7 @@ class CancelPaymentUseCaseTest {
                     products.size() == 1
                             && products.get(0).getPricePolicyId().equals(100L)
                             && products.get(0).getQuantity().equals(1)
-            ), eq("주문 부분 취소에 의한 재고 복구"));
+            ), eq(1L), eq("주문 부분 취소에 의한 재고 복구"));
         }
 
         @Test
@@ -577,7 +577,7 @@ class CancelPaymentUseCaseTest {
                             && products.get(0).getQuantity().equals(1)
                             && products.get(1).getPricePolicyId().equals(200L)
                             && products.get(1).getQuantity().equals(2)
-            ), eq("주문 부분 취소에 의한 재고 복구"));
+            ), eq(1L), eq("주문 부분 취소에 의한 재고 복구"));
         }
 
         @Test
@@ -596,7 +596,7 @@ class CancelPaymentUseCaseTest {
             when(findPspPaymentEventPort.findByOrderKey(ORDER_KEY_STR)).thenReturn(Optional.of(event));
             when(paymentVendorPort.cancelPayment(any())).thenReturn(vendorResult);
             doThrow(new RuntimeException("재고 복구 실패")).when(restoreProductInventoryUseCase)
-                    .restore(anyList(), anyString());
+                    .restore(anyList(), anyLong(), anyString());
 
             cancelPaymentService.cancel(command);
 
@@ -629,7 +629,7 @@ class CancelPaymentUseCaseTest {
             cancelPaymentService.cancel(command);
 
             // 전액 취소는 기존 restoreInventory(order)가 호출되므로 전체 주문 상품 목록으로 복구
-            verify(restoreProductInventoryUseCase).restore(anyList(), eq("주문 전액 취소에 의한 재고 복구"));
+            verify(restoreProductInventoryUseCase).restore(anyList(), eq(1L), eq("주문 전액 취소에 의한 재고 복구"));
         }
 
         @Test
@@ -645,7 +645,7 @@ class CancelPaymentUseCaseTest {
             when(findPspPaymentEventPort.findByOrderKey(ORDER_KEY_STR)).thenReturn(Optional.of(event));
             when(paymentVendorPort.cancelPayment(any())).thenReturn(vendorResult);
             doThrow(new RuntimeException("재고 복구 실패")).when(restoreProductInventoryUseCase)
-                    .restore(anyList(), anyString());
+                    .restore(anyList(), anyLong(), anyString());
 
             cancelPaymentService.cancel(command);
 

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/inventory/InventoryRestorationHistories.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/inventory/InventoryRestorationHistories.java
@@ -1,0 +1,38 @@
+package com.personal.marketnote.commerce.domain.inventory;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+import java.util.Map;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class InventoryRestorationHistories {
+    private List<InventoryRestorationHistory> inventoryRestorationHistories;
+
+    public static InventoryRestorationHistories from(
+            Map<Long, Integer> stocksByPricePolicyId,
+            Map<Long, Long> productIdsByPricePolicyId,
+            Long orderId,
+            String reason
+    ) {
+        return new InventoryRestorationHistories(
+                stocksByPricePolicyId.entrySet()
+                        .stream()
+                        .map(entry -> InventoryRestorationHistory.from(
+                                InventoryRestorationHistoryCreateState.builder()
+                                        .productId(productIdsByPricePolicyId.get(entry.getKey()))
+                                        .pricePolicyId(entry.getKey())
+                                        .orderId(orderId)
+                                        .stock(entry.getValue())
+                                        .reason(reason)
+                                        .build()
+                        ))
+                        .toList()
+        );
+    }
+}

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/inventory/InventoryRestorationHistory.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/inventory/InventoryRestorationHistory.java
@@ -1,0 +1,45 @@
+package com.personal.marketnote.commerce.domain.inventory;
+
+import lombok.*;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+@Getter
+public class InventoryRestorationHistory {
+    private Long id;
+    private Long productId;
+    private Long pricePolicyId;
+    private Long orderId;
+    private Stock stock;
+    private String reason;
+
+    public static InventoryRestorationHistory from(InventoryRestorationHistoryCreateState state) {
+        return InventoryRestorationHistory.builder()
+                .productId(state.getProductId())
+                .pricePolicyId(state.getPricePolicyId())
+                .orderId(state.getOrderId())
+                .stock(Stock.of(
+                        String.valueOf(state.getStock())
+                ))
+                .reason(state.getReason())
+                .build();
+    }
+
+    public static InventoryRestorationHistory from(InventoryRestorationHistorySnapshotState state) {
+        return InventoryRestorationHistory.builder()
+                .id(state.getId())
+                .productId(state.getProductId())
+                .pricePolicyId(state.getPricePolicyId())
+                .orderId(state.getOrderId())
+                .stock(Stock.of(
+                        String.valueOf(state.getStock())
+                ))
+                .reason(state.getReason())
+                .build();
+    }
+
+    public Integer getStockValue() {
+        return stock.getValue();
+    }
+}

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/inventory/InventoryRestorationHistoryCreateState.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/inventory/InventoryRestorationHistoryCreateState.java
@@ -1,0 +1,17 @@
+package com.personal.marketnote.commerce.domain.inventory;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class InventoryRestorationHistoryCreateState {
+    private final Long productId;
+    private final Long pricePolicyId;
+    private final Long orderId;
+    private final Integer stock;
+    private final String reason;
+}

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/inventory/InventoryRestorationHistorySnapshotState.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/inventory/InventoryRestorationHistorySnapshotState.java
@@ -1,0 +1,18 @@
+package com.personal.marketnote.commerce.domain.inventory;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class InventoryRestorationHistorySnapshotState {
+    private final Long id;
+    private final Long productId;
+    private final Long pricePolicyId;
+    private final Long orderId;
+    private final Integer stock;
+    private final String reason;
+}


### PR DESCRIPTION
## partially addresses #929
## resolves #1210

## Task
- [x] 재고 복구 이력 도메인 모델 추가 (InventoryRestorationHistory, InventoryRestorationHistories)
- [x] 재고 복구 이력 저장 포트/어댑터 추가 (SaveInventoryRestorationHistoryPort, InventoryPersistenceAdapter)
- [x] inventory_restoration_history 테이블 생성 마이그레이션 (V898, order_id + price_policy_id UNIQUE)
- [x] RestoreProductInventoryUseCase에 orderId 파라미터 추가
- [x] RestoreProductInventoryService에 복구 이력 저장 로직 추가
- [x] CancelPaymentService에 orderId 전달 추가
- [x] PaymentCancelledInventoryConsumer FIXME 해제 및 UseCase 호출 활성화
- [x] DuplicateInventoryRestorationException 멱등성 catch 처리
- [x] RestoreProductInventoryUseCaseTest 이력 저장 검증 테스트 추가
- [x] PaymentCancelledInventoryConsumerTest UseCase 호출 및 멱등성 테스트 추가
- [x] CancelPaymentUseCaseTest orderId 파라미터 반영