### PR TITLE
[#929][#1218] feat: 부분 결제 취소 시 회계 역분개 멱등성 보강

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/PaymentCancelledLedgerConsumer.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/PaymentCancelledLedgerConsumer.java
@@ -48,7 +48,7 @@ public class PaymentCancelledLedgerConsumer {
             //      idempotencyKey = "PAYMENT_CANCELLATION:" + payload.orderId();
             //  } else {
             //      idempotencyKey = "PAYMENT_PARTIAL_REFUND:" + payload.orderId()
-            //              + ":" + payload.cancelAmount() + ":" + payload.alreadyRefunded();
+            //              + ":" + payload.cancelId();
             //  }
             //  recordLedgerEntryUseCase.recordPaymentCancellation(
             //          payload.orderId(), payload.cancelAmount(), idempotencyKey

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/event/PaymentEventKafkaProducer.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/event/PaymentEventKafkaProducer.java
@@ -73,6 +73,7 @@ public class PaymentEventKafkaProducer implements PublishPaymentEventPort {
     public void publishPaymentCancelledEvent(Long orderId, String orderKey, Long buyerId,
                                              Long cancelAmount, Long paymentAmount, Long pointAmount,
                                              boolean isFullCancel, Long alreadyRefunded,
+                                             String cancelId,
                                              List<OrderProduct> orderProducts,
                                              List<OrderProduct> cancelProducts,
                                              Long partialProductPendingDeduction) {
@@ -98,7 +99,7 @@ public class PaymentEventKafkaProducer implements PublishPaymentEventPort {
 
         PaymentCancelledEvent payload = new PaymentCancelledEvent(
                 orderId, orderKey, buyerId, cancelAmount, paymentAmount,
-                pointAmount, isFullCancel, alreadyRefunded, items, cancelItems,
+                pointAmount, isFullCancel, alreadyRefunded, cancelId, items, cancelItems,
                 partialProductPendingDeduction
         );
         String topic = KafkaTopicConstants.PAYMENT_CANCELLED;

--- a/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/event/PaymentCancelledInventoryConsumerTest.java
+++ b/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/event/PaymentCancelledInventoryConsumerTest.java
@@ -55,7 +55,7 @@ class PaymentCancelledInventoryConsumerTest {
                                                                   List<OrderProductItem> cancelProducts) {
         PaymentCancelledEvent event = new PaymentCancelledEvent(
                 orderId, "order-key-1", 100L, 50000L, 80000L, 1000L,
-                isFullCancel, 0L, orderProducts, cancelProducts, null
+                isFullCancel, 0L, null, orderProducts, cancelProducts, null
         );
         EventEnvelope<PaymentCancelledEvent> envelope = new EventEnvelope<>(
                 "test-event-id", "commerce.payment.cancelled", "commerce-service",

--- a/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/event/PaymentCancelledOrderStatusConsumerTest.java
+++ b/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/event/PaymentCancelledOrderStatusConsumerTest.java
@@ -45,7 +45,7 @@ class PaymentCancelledOrderStatusConsumerTest {
                                                                   boolean isFullCancel, Long cancelAmount) {
         PaymentCancelledEvent event = new PaymentCancelledEvent(
                 orderId, orderKey, 100L, cancelAmount, 50000L, 1000L,
-                isFullCancel, 0L, List.of(), null, null
+                isFullCancel, 0L, null, List.of(), null, null
         );
         EventEnvelope<PaymentCancelledEvent> envelope = new EventEnvelope<>(
                 "test-event-id", "commerce.payment.cancelled", "commerce-service",

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/event/PublishPaymentEventPort.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/event/PublishPaymentEventPort.java
@@ -13,6 +13,7 @@ public interface PublishPaymentEventPort {
     void publishPaymentCancelledEvent(Long orderId, String orderKey, Long buyerId,
                                       Long cancelAmount, Long paymentAmount, Long pointAmount,
                                       boolean isFullCancel, Long alreadyRefunded,
+                                      String cancelId,
                                       List<OrderProduct> orderProducts,
                                       List<OrderProduct> cancelProducts,
                                       Long partialProductPendingDeduction);

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/CancelPaymentService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/CancelPaymentService.java
@@ -131,7 +131,8 @@ public class CancelPaymentService implements CancelPaymentUseCase {
                     order, payment.getPaymentAmount(), cancelAmount));
         }
 
-        recordLedgerEntryForCancellation(payment, isFullCancel, cancelAmount, alreadyRefunded);
+        String cancelId = isFullCancel ? null : UUID.randomUUID().toString();
+        recordLedgerEntryForCancellation(payment, isFullCancel, cancelAmount, cancelId);
 
         Long orderId = order.getId();
         String orderKey = command.orderKey();
@@ -143,7 +144,7 @@ public class CancelPaymentService implements CancelPaymentUseCase {
         Long finalPartialProductPendingDeduction = partialProductPendingDeduction;
         runAfterCommit(() -> publishPaymentCancelledEvent(
                 orderId, orderKey, buyerId, cancelAmount, paymentAmount,
-                pointAmount, isFullCancel, alreadyRefunded, orderProducts, cancelTargetProducts,
+                pointAmount, isFullCancel, alreadyRefunded, cancelId, orderProducts, cancelTargetProducts,
                 finalPartialProductPendingDeduction));
     }
 
@@ -218,7 +219,7 @@ public class CancelPaymentService implements CancelPaymentUseCase {
     }
 
     private void recordLedgerEntryForCancellation(
-            Payment payment, boolean isFullCancel, Long cancelAmount, Long alreadyRefunded
+            Payment payment, boolean isFullCancel, Long cancelAmount, String cancelId
     ) {
         try {
             String idempotencyKey;
@@ -226,7 +227,7 @@ public class CancelPaymentService implements CancelPaymentUseCase {
                 idempotencyKey = "PAYMENT_CANCELLATION:" + payment.getOrderId();
             } else {
                 idempotencyKey = "PAYMENT_PARTIAL_REFUND:" + payment.getOrderId()
-                        + ":" + cancelAmount + ":" + alreadyRefunded;
+                        + ":" + cancelId;
             }
             recordLedgerEntryUseCase.recordPaymentCancellation(
                     payment.getOrderId(), cancelAmount, idempotencyKey
@@ -453,13 +454,14 @@ public class CancelPaymentService implements CancelPaymentUseCase {
     private void publishPaymentCancelledEvent(Long orderId, String orderKey, Long buyerId,
                                                 Long cancelAmount, Long paymentAmount, Long pointAmount,
                                                 boolean isFullCancel, Long alreadyRefunded,
+                                                String cancelId,
                                                 List<OrderProduct> orderProducts,
                                                 List<OrderProduct> cancelProducts,
                                                 Long partialProductPendingDeduction) {
         try {
             publishPaymentEventPort.publishPaymentCancelledEvent(
                     orderId, orderKey, buyerId, cancelAmount, paymentAmount,
-                    pointAmount, isFullCancel, alreadyRefunded, orderProducts, cancelProducts,
+                    pointAmount, isFullCancel, alreadyRefunded, cancelId, orderProducts, cancelProducts,
                     partialProductPendingDeduction);
         } catch (Exception e) {
             log.error("결제 취소 이벤트 발행 실패 - orderId: {}, orderKey: {}, error: {}",

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/payment/CancelPaymentUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/payment/CancelPaymentUseCaseTest.java
@@ -405,8 +405,8 @@ class CancelPaymentUseCaseTest {
         }
 
         @Test
-        @DisplayName("부분 취소 성공 시 부분 환불 역분개가 기록된다")
-        void shouldRecordReverseLedgerEntryOnPartialCancel() {
+        @DisplayName("부분 취소 성공 시 cancelId 기반 멱등성 키로 역분개가 기록된다")
+        void shouldRecordReverseLedgerEntryOnPartialCancelWithCancelId() {
             Payment payment = createSuccessPayment(1L, ORDER_KEY, 50000L, "tno_123");
             PspPaymentEvent event = createCompleteEvent(ORDER_KEY_STR, "tno_123", 50000L);
             CancelPaymentCommand command = createPartialCancelCommand(ORDER_KEY_STR, 20000L);
@@ -420,13 +420,25 @@ class CancelPaymentUseCaseTest {
             cancelPaymentService.cancel(command);
 
             verify(recordLedgerEntryUseCase).recordPaymentCancellation(
-                    eq(1L), eq(20000L), eq("PAYMENT_PARTIAL_REFUND:1:20000:0")
+                    eq(1L), eq(20000L), argThat(key -> {
+                        String prefix = "PAYMENT_PARTIAL_REFUND:1:";
+                        if (!key.startsWith(prefix)) {
+                            return false;
+                        }
+                        String cancelId = key.substring(prefix.length());
+                        try {
+                            UUID.fromString(cancelId);
+                            return true;
+                        } catch (IllegalArgumentException e) {
+                            return false;
+                        }
+                    })
             );
         }
 
         @Test
-        @DisplayName("이미 부분환불된 상태에서 추가 부분 취소 시 누적 환불액이 멱등성 키에 포함된다")
-        void shouldIncludeAccumulatedRefundInIdempotencyKey() {
+        @DisplayName("이미 부분환불된 상태에서 추가 부분 취소 시에도 cancelId 기반 멱등성 키가 사용된다")
+        void shouldUseCancelIdBasedKeyRegardlessOfPriorRefundHistory() {
             Payment payment = createSuccessPayment(1L, ORDER_KEY, 50000L, "tno_123");
             payment.markAsPartiallyRefunded(10000L);
             PspPaymentEvent event = createCompleteEvent(ORDER_KEY_STR, "tno_123", 50000L);
@@ -441,7 +453,11 @@ class CancelPaymentUseCaseTest {
             cancelPaymentService.cancel(command);
 
             verify(recordLedgerEntryUseCase).recordPaymentCancellation(
-                    eq(1L), eq(20000L), eq("PAYMENT_PARTIAL_REFUND:1:20000:10000")
+                    eq(1L), eq(20000L), argThat(key ->
+                            key.startsWith("PAYMENT_PARTIAL_REFUND:1:")
+                                    && !key.contains("10000")
+                                    && !key.contains("20000")
+                    )
             );
         }
 

--- a/common/src/main/java/com/personal/marketnote/common/kafka/event/PaymentCancelledEvent.java
+++ b/common/src/main/java/com/personal/marketnote/common/kafka/event/PaymentCancelledEvent.java
@@ -11,6 +11,7 @@ public record PaymentCancelledEvent(
         Long pointAmount,
         boolean isFullCancel,
         Long alreadyRefunded,
+        String cancelId,
         List<OrderProductItem> orderProducts,
         List<OrderProductItem> cancelProducts,
         Long partialProductPendingDeduction

--- a/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/adapter/in/event/PaymentCancelledPartialProductPointConsumerTest.java
+++ b/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/adapter/in/event/PaymentCancelledPartialProductPointConsumerTest.java
@@ -46,7 +46,7 @@ class PaymentCancelledPartialProductPointConsumerTest {
     ) {
         PaymentCancelledEvent event = new PaymentCancelledEvent(
                 orderId, "order-key-1", buyerId, 30000L, 80000L, 1000L,
-                isFullCancel, 0L, null, null, partialProductPendingDeduction
+                isFullCancel, 0L, null, null, null, partialProductPendingDeduction
         );
         EventEnvelope<PaymentCancelledEvent> envelope = new EventEnvelope<>(
                 "test-event-id", "commerce.payment.cancelled", "commerce-service",

--- a/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/adapter/in/event/PaymentCancelledPartialSharedPointConsumerTest.java
+++ b/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/adapter/in/event/PaymentCancelledPartialSharedPointConsumerTest.java
@@ -55,7 +55,7 @@ class PaymentCancelledPartialSharedPointConsumerTest {
                                                                   List<OrderProductItem> orderProducts) {
         PaymentCancelledEvent event = new PaymentCancelledEvent(
                 orderId, "order-key-1", 100L, cancelAmount, paymentAmount, 1000L,
-                isFullCancel, 0L, orderProducts, null, null
+                isFullCancel, 0L, null, orderProducts, null, null
         );
         EventEnvelope<PaymentCancelledEvent> envelope = new EventEnvelope<>(
                 "test-event-id", "commerce.payment.cancelled", "commerce-service",

--- a/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/adapter/in/event/PaymentCancelledPendingProductPointConsumerTest.java
+++ b/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/adapter/in/event/PaymentCancelledPendingProductPointConsumerTest.java
@@ -36,7 +36,7 @@ class PaymentCancelledPendingProductPointConsumerTest {
                                                                   boolean isFullCancel) {
         PaymentCancelledEvent event = new PaymentCancelledEvent(
                 orderId, "order-key-1", buyerId, 50000L, 80000L, 1000L,
-                isFullCancel, 0L, List.of(), null, null
+                isFullCancel, 0L, null, List.of(), null, null
         );
         EventEnvelope<PaymentCancelledEvent> envelope = new EventEnvelope<>(
                 "test-event-id", "commerce.payment.cancelled", "commerce-service",

--- a/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/adapter/in/event/PaymentCancelledPendingSharedPointConsumerTest.java
+++ b/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/adapter/in/event/PaymentCancelledPendingSharedPointConsumerTest.java
@@ -37,7 +37,7 @@ class PaymentCancelledPendingSharedPointConsumerTest {
                                                                   List<OrderProductItem> orderProducts) {
         PaymentCancelledEvent event = new PaymentCancelledEvent(
                 orderId, "order-key-1", 100L, 50000L, 80000L, 1000L,
-                isFullCancel, 0L, orderProducts, null, null
+                isFullCancel, 0L, null, orderProducts, null, null
         );
         EventEnvelope<PaymentCancelledEvent> envelope = new EventEnvelope<>(
                 "test-event-id", "commerce.payment.cancelled", "commerce-service",

--- a/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/adapter/in/event/PaymentCancelledPointRefundConsumerTest.java
+++ b/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/adapter/in/event/PaymentCancelledPointRefundConsumerTest.java
@@ -46,7 +46,7 @@ class PaymentCancelledPointRefundConsumerTest {
                                                                   Long pointAmount, boolean isFullCancel) {
         PaymentCancelledEvent event = new PaymentCancelledEvent(
                 orderId, "order-key-1", buyerId, 50000L, 80000L, pointAmount,
-                isFullCancel, 0L, List.of(), null, null
+                isFullCancel, 0L, null, List.of(), null, null
         );
         EventEnvelope<PaymentCancelledEvent> envelope = new EventEnvelope<>(
                 "test-event-id", "commerce.payment.cancelled", "commerce-service",


### PR DESCRIPTION
## partially addresses #929
## resolves #1218

## Task
- [x] PaymentCancelledEvent에 cancelId(UUID) 필드 추가
- [x] CancelPaymentService에서 부분 취소 시 cancelId 생성 및 idempotencyKey 변경: PAYMENT_PARTIAL_REFUND:{orderId}:{cancelId}
- [x] PublishPaymentEventPort, PaymentEventKafkaProducer에 cancelId 파라미터 전달
- [x] PaymentCancelledLedgerConsumer FIXME 주석 업데이트
- [x] 기존 테스트 업데이트 (cancelId 기반 멱등성 키 검증)