### PR TITLE
[#929][#1216] feat: 주문 결제 완료 시 풀필먼트 서비스 Fassto 출고 요청 멱등성 기능 추가

### DIFF
--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/event/OrderPaymentCompletedOutboundConsumer.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/event/OrderPaymentCompletedOutboundConsumer.java
@@ -52,10 +52,7 @@ public class OrderPaymentCompletedOutboundConsumer {
             }
 
             // FIXME: [#929][#1200] Fassto 출고 요청 구현 필요
-            //  신규 기능 (기존 HTTP 호출 없음). 아래 구현 필요:
-            //  1. OrderPaymentCompletedEvent에 배송지 정보 추가 또는 Commerce 서비스에서 주문 상세 조회
-            //  2. RegisterFasstoDeliveryUseCase.registerDelivery() 호출
-            //  3. 멱등성 보강 (#1216) — orderId 기반 출고 이력 조회 후 중복 skip
+            //  신규 기능 (기존 HTTP 호출 없음). 배송지 정보 추가 후 아래 코드 활성화:
             //
             //  FasstoAccessToken accessToken = requestFasstoAuthUseCase.requestAccessToken();
             //  RegisterFasstoDeliveryItemCommand itemCommand = RegisterFasstoDeliveryItemCommand.builder()
@@ -66,7 +63,11 @@ public class OrderPaymentCompletedOutboundConsumer {
             //  RegisterFasstoDeliveryCommand command = RegisterFasstoDeliveryCommand.of(
             //          fasstoAuthProperties.getCustomerCode(), accessToken.getValue(), List.of(itemCommand)
             //  );
-            //  registerFasstoDeliveryUseCase.registerDelivery(command);
+            //  registerFasstoDeliveryUseCase.registerDeliveryIdempotent(command);
+            //
+            //  [#1216] 멱등성 보강 완료: registerDeliveryIdempotent() 사용
+            //  — orderId 기반 출고 이력 DB 저장 (UNIQUE 제약) → 중복 시 FasstoDeliveryAlreadyRegisteredException
+            //  — Consumer에서 FasstoDeliveryAlreadyRegisteredException catch → warn + acknowledge
 
             log.info("Fassto 출고 요청 이벤트 검증 완료. orderId={}, orderProducts={}건",
                     payload.orderId(), payload.orderProducts().size());

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/persistence/delivery/FasstoDeliveryRegistrationPersistenceAdapter.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/persistence/delivery/FasstoDeliveryRegistrationPersistenceAdapter.java
@@ -1,0 +1,25 @@
+package com.personal.marketnote.fulfillment.adapter.out.persistence.delivery;
+
+import com.personal.marketnote.common.adapter.out.PersistenceAdapter;
+import com.personal.marketnote.fulfillment.adapter.out.persistence.delivery.entity.FasstoDeliveryRegistrationJpaEntity;
+import com.personal.marketnote.fulfillment.adapter.out.persistence.delivery.repository.FasstoDeliveryRegistrationJpaRepository;
+import com.personal.marketnote.fulfillment.domain.delivery.FasstoDeliveryRegistration;
+import com.personal.marketnote.fulfillment.exception.FasstoDeliveryAlreadyRegisteredException;
+import com.personal.marketnote.fulfillment.port.out.delivery.SaveFasstoDeliveryRegistrationPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+
+@PersistenceAdapter
+@RequiredArgsConstructor
+public class FasstoDeliveryRegistrationPersistenceAdapter implements SaveFasstoDeliveryRegistrationPort {
+    private final FasstoDeliveryRegistrationJpaRepository repository;
+
+    @Override
+    public void save(FasstoDeliveryRegistration registration) {
+        try {
+            repository.saveAndFlush(FasstoDeliveryRegistrationJpaEntity.from(registration));
+        } catch (DataIntegrityViolationException e) {
+            throw new FasstoDeliveryAlreadyRegisteredException(registration.getOrderId());
+        }
+    }
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/persistence/delivery/entity/FasstoDeliveryRegistrationJpaEntity.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/persistence/delivery/entity/FasstoDeliveryRegistrationJpaEntity.java
@@ -1,0 +1,48 @@
+package com.personal.marketnote.fulfillment.adapter.out.persistence.delivery.entity;
+
+import com.personal.marketnote.fulfillment.domain.delivery.FasstoDeliveryRegistration;
+import com.personal.marketnote.fulfillment.domain.delivery.FasstoDeliveryRegistrationSnapshotState;
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "fassto_delivery_registration")
+@EntityListeners(value = AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+@Getter
+public class FasstoDeliveryRegistrationJpaEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "order_id", nullable = false, unique = true)
+    private Long orderId;
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    public static FasstoDeliveryRegistrationJpaEntity from(FasstoDeliveryRegistration registration) {
+        return FasstoDeliveryRegistrationJpaEntity.builder()
+                .id(registration.getId())
+                .orderId(registration.getOrderId())
+                .createdAt(registration.getCreatedAt())
+                .build();
+    }
+
+    public FasstoDeliveryRegistration toDomain() {
+        return FasstoDeliveryRegistration.from(
+                FasstoDeliveryRegistrationSnapshotState.builder()
+                        .id(id)
+                        .orderId(orderId)
+                        .createdAt(createdAt)
+                        .build()
+        );
+    }
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/persistence/delivery/repository/FasstoDeliveryRegistrationJpaRepository.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/persistence/delivery/repository/FasstoDeliveryRegistrationJpaRepository.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.fulfillment.adapter.out.persistence.delivery.repository;
+
+import com.personal.marketnote.fulfillment.adapter.out.persistence.delivery.entity.FasstoDeliveryRegistrationJpaEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FasstoDeliveryRegistrationJpaRepository extends JpaRepository<FasstoDeliveryRegistrationJpaEntity, Long> {
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/FasstoDeliveryAlreadyRegisteredException.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/FasstoDeliveryAlreadyRegisteredException.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.fulfillment.exception;
+
+public class FasstoDeliveryAlreadyRegisteredException extends RuntimeException {
+    public FasstoDeliveryAlreadyRegisteredException(Long orderId) {
+        super("이미 Fassto에 출고 요청된 주문입니다. orderId=" + orderId);
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/usecase/vendor/RegisterFasstoDeliveryUseCase.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/usecase/vendor/RegisterFasstoDeliveryUseCase.java
@@ -19,4 +19,15 @@ public interface RegisterFasstoDeliveryUseCase {
      * @Description 파스토 출고(택배) 등록을 요청합니다.
      */
     RegisterFasstoDeliveryResult registerDelivery(RegisterFasstoDeliveryCommand command);
+
+    /**
+     * @param command 출고 등록 커맨드
+     * @return 출고 등록 결과 {@link RegisterFasstoDeliveryResult}
+     * @Author 성효빈
+     * @Date 2026-03-15
+     * @Description 파스토 출고(택배) 등록을 멱등하게 요청합니다.
+     * orderId 기반 출고 이력을 먼저 저장하여 중복 출고 요청을 방지합니다.
+     * Kafka Consumer에서 사용합니다.
+     */
+    RegisterFasstoDeliveryResult registerDeliveryIdempotent(RegisterFasstoDeliveryCommand command);
 }

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/delivery/SaveFasstoDeliveryRegistrationPort.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/delivery/SaveFasstoDeliveryRegistrationPort.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.fulfillment.port.out.delivery;
+
+import com.personal.marketnote.fulfillment.domain.delivery.FasstoDeliveryRegistration;
+
+public interface SaveFasstoDeliveryRegistrationPort {
+    void save(FasstoDeliveryRegistration registration);
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/vendor/RegisterFasstoDeliveryService.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/vendor/RegisterFasstoDeliveryService.java
@@ -1,10 +1,13 @@
 package com.personal.marketnote.fulfillment.service.vendor;
 
 import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.fulfillment.domain.delivery.FasstoDeliveryRegistration;
+import com.personal.marketnote.fulfillment.domain.delivery.FasstoDeliveryRegistrationCreateState;
 import com.personal.marketnote.fulfillment.mapper.FasstoDeliveryCommandToRequestMapper;
 import com.personal.marketnote.fulfillment.port.in.command.vendor.RegisterFasstoDeliveryCommand;
 import com.personal.marketnote.fulfillment.port.in.result.vendor.RegisterFasstoDeliveryResult;
 import com.personal.marketnote.fulfillment.port.in.usecase.vendor.RegisterFasstoDeliveryUseCase;
+import com.personal.marketnote.fulfillment.port.out.delivery.SaveFasstoDeliveryRegistrationPort;
 import com.personal.marketnote.fulfillment.port.out.vendor.RegisterFasstoDeliveryPort;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,9 +19,27 @@ import static org.springframework.transaction.annotation.Isolation.READ_COMMITTE
 @Transactional(isolation = READ_COMMITTED, readOnly = true)
 public class RegisterFasstoDeliveryService implements RegisterFasstoDeliveryUseCase {
     private final RegisterFasstoDeliveryPort registerFasstoDeliveryPort;
+    private final SaveFasstoDeliveryRegistrationPort saveFasstoDeliveryRegistrationPort;
 
     @Override
     public RegisterFasstoDeliveryResult registerDelivery(RegisterFasstoDeliveryCommand command) {
+        return registerFasstoDeliveryPort.registerDelivery(
+                FasstoDeliveryCommandToRequestMapper.mapToRegisterRequest(command)
+        );
+    }
+
+    @Override
+    @Transactional(isolation = READ_COMMITTED)
+    public RegisterFasstoDeliveryResult registerDeliveryIdempotent(RegisterFasstoDeliveryCommand command) {
+        Long orderId = Long.parseLong(command.deliveryRequests().getFirst().ordNo());
+
+        FasstoDeliveryRegistration registration = FasstoDeliveryRegistration.from(
+                FasstoDeliveryRegistrationCreateState.builder()
+                        .orderId(orderId)
+                        .build()
+        );
+        saveFasstoDeliveryRegistrationPort.save(registration);
+
         return registerFasstoDeliveryPort.registerDelivery(
                 FasstoDeliveryCommandToRequestMapper.mapToRegisterRequest(command)
         );

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/delivery/FasstoDeliveryRegistration.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/delivery/FasstoDeliveryRegistration.java
@@ -1,0 +1,33 @@
+package com.personal.marketnote.fulfillment.domain.delivery;
+
+import com.personal.marketnote.common.utility.FormatValidator;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+@Getter
+public class FasstoDeliveryRegistration {
+    private Long id;
+    private Long orderId;
+    private LocalDateTime createdAt;
+
+    public static FasstoDeliveryRegistration from(FasstoDeliveryRegistrationCreateState state) {
+        if (FormatValidator.hasNoValue(state.getOrderId())) {
+            throw new IllegalArgumentException("orderId는 필수입니다.");
+        }
+        return FasstoDeliveryRegistration.builder()
+                .orderId(state.getOrderId())
+                .build();
+    }
+
+    public static FasstoDeliveryRegistration from(FasstoDeliveryRegistrationSnapshotState state) {
+        return FasstoDeliveryRegistration.builder()
+                .id(state.getId())
+                .orderId(state.getOrderId())
+                .createdAt(state.getCreatedAt())
+                .build();
+    }
+}

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/delivery/FasstoDeliveryRegistrationCreateState.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/delivery/FasstoDeliveryRegistrationCreateState.java
@@ -1,0 +1,10 @@
+package com.personal.marketnote.fulfillment.domain.delivery;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class FasstoDeliveryRegistrationCreateState {
+    private final Long orderId;
+}

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/delivery/FasstoDeliveryRegistrationSnapshotState.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/delivery/FasstoDeliveryRegistrationSnapshotState.java
@@ -1,0 +1,14 @@
+package com.personal.marketnote.fulfillment.domain.delivery;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class FasstoDeliveryRegistrationSnapshotState {
+    private final Long id;
+    private final Long orderId;
+    private final LocalDateTime createdAt;
+}


### PR DESCRIPTION
## partially addresses #929
## resolves #1216

## Task
- [x] FasstoDeliveryRegistration 도메인 모델 추가 (orderId 기반 출고 이력)
- [x] SaveFasstoDeliveryRegistrationPort Out Port 정의
- [x] FasstoDeliveryAlreadyRegisteredException 도메인 예외 추가
- [x] RegisterFasstoDeliveryUseCase에 registerDeliveryIdempotent() 메서드 추가
- [x] RegisterFasstoDeliveryService에 멱등성 구현 (이력 선제 저장 → API 호출)
- [x] FasstoDeliveryRegistrationJpaEntity (order_id UNIQUE 제약) 추가
- [x] FasstoDeliveryRegistrationPersistenceAdapter (DataIntegrityViolationException → 도메인 예외 변환)
- [x] OrderPaymentCompletedOutboundConsumer FIXME 업데이트 (registerDeliveryIdempotent 참조)