### PR TITLE
[#929][#1022] feat: Dead Letter Queue 및 재시도 정책 기능 추가

### DIFF
--- a/common/src/main/java/com/personal/marketnote/common/adapter/in/web/kafka/controller/AdminDltController.java
+++ b/common/src/main/java/com/personal/marketnote/common/adapter/in/web/kafka/controller/AdminDltController.java
@@ -1,0 +1,50 @@
+package com.personal.marketnote.common.adapter.in.web.kafka.controller;
+
+import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
+import com.personal.marketnote.common.adapter.in.web.kafka.request.ReprocessDltRequest;
+import com.personal.marketnote.common.adapter.in.web.kafka.response.ReprocessDltResponse;
+import com.personal.marketnote.common.configuration.kafka.DltReprocessResult;
+import com.personal.marketnote.common.configuration.kafka.DltReprocessService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import static com.personal.marketnote.common.domain.exception.ExceptionCode.DEFAULT_SUCCESS_CODE;
+import static com.personal.marketnote.common.utility.ApiConstant.ADMIN_POINTCUT;
+
+@RestController
+@Tag(name = "관리자 DLT API", description = "Dead Letter Topic 관리 및 재처리")
+@RequiredArgsConstructor
+@ConditionalOnProperty(prefix = "spring.kafka", name = "bootstrap-servers")
+public class AdminDltController {
+    private final DltReprocessService dltReprocessService;
+
+    @PostMapping("/api/v1/admin/kafka/dlt/reprocess")
+    @PreAuthorize(ADMIN_POINTCUT)
+    @SecurityRequirement(name = "bearer")
+    @Operation(summary = "DLT 메시지 수동 재처리", description = "지정된 원본 토픽의 DLT 메시지를 원본 토픽으로 재전송합니다.")
+    public ResponseEntity<BaseResponse<ReprocessDltResponse>> reprocessDlt(
+            @Valid @RequestBody ReprocessDltRequest request
+    ) {
+        DltReprocessResult result = dltReprocessService.reprocess(request.originalTopic());
+
+        return new ResponseEntity<>(
+                BaseResponse.of(
+                        ReprocessDltResponse.from(request.originalTopic(), result),
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "DLT 메시지 재처리 완료"
+                ),
+                HttpStatus.OK
+        );
+    }
+}

--- a/common/src/main/java/com/personal/marketnote/common/adapter/in/web/kafka/request/ReprocessDltRequest.java
+++ b/common/src/main/java/com/personal/marketnote/common/adapter/in/web/kafka/request/ReprocessDltRequest.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.common.adapter.in.web.kafka.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record ReprocessDltRequest(
+        @NotBlank(message = "원본 토픽명은 필수입니다")
+        String originalTopic
+) {
+}

--- a/common/src/main/java/com/personal/marketnote/common/adapter/in/web/kafka/response/ReprocessDltResponse.java
+++ b/common/src/main/java/com/personal/marketnote/common/adapter/in/web/kafka/response/ReprocessDltResponse.java
@@ -1,0 +1,20 @@
+package com.personal.marketnote.common.adapter.in.web.kafka.response;
+
+import com.personal.marketnote.common.configuration.kafka.DltReprocessResult;
+import com.personal.marketnote.common.kafka.KafkaTopicConstants;
+
+public record ReprocessDltResponse(
+        String originalTopic,
+        String dltTopic,
+        int reprocessedCount,
+        int failedCount
+) {
+    public static ReprocessDltResponse from(String originalTopic, DltReprocessResult result) {
+        return new ReprocessDltResponse(
+                originalTopic,
+                originalTopic + KafkaTopicConstants.DLT_SUFFIX,
+                result.reprocessedCount(),
+                result.failedCount()
+        );
+    }
+}

--- a/common/src/main/java/com/personal/marketnote/common/configuration/kafka/DeadLetterAlertConsumer.java
+++ b/common/src/main/java/com/personal/marketnote/common/configuration/kafka/DeadLetterAlertConsumer.java
@@ -1,0 +1,53 @@
+package com.personal.marketnote.common.configuration.kafka;
+
+import com.personal.marketnote.common.utility.FormatValidator;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.header.Header;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(prefix = "spring.kafka", name = "bootstrap-servers")
+public class DeadLetterAlertConsumer {
+    private static final String HEADER_ORIGINAL_TOPIC = "kafka_dlt-original-topic";
+    private static final String HEADER_EXCEPTION_FQCN = "kafka_dlt-exception-fqcn";
+    private static final String HEADER_EXCEPTION_MESSAGE = "kafka_dlt-exception-message";
+
+    private final DltSlackNotifier dltSlackNotifier;
+
+    @KafkaListener(topicPattern = ".*\\.dlt", groupId = "dlt-alert")
+    public void handleDeadLetterMessage(
+            ConsumerRecord<String, Object> record,
+            Acknowledgment acknowledgment
+    ) {
+        try {
+            String originalTopic = extractHeader(record, HEADER_ORIGINAL_TOPIC);
+            String errorFqcn = extractHeader(record, HEADER_EXCEPTION_FQCN);
+            String errorMessage = extractHeader(record, HEADER_EXCEPTION_MESSAGE);
+
+            log.error("DLT 메시지 도착. originalTopic={}, partition={}, offset={}, key={}, error={}: {}",
+                    originalTopic, record.partition(), record.offset(), record.key(), errorFqcn, errorMessage);
+
+            dltSlackNotifier.notify(originalTopic, record, errorFqcn, errorMessage);
+        } catch (Exception e) {
+            log.error("DLT 알림 처리 실패. topic={}, key={}", record.topic(), record.key(), e);
+        }
+        acknowledgment.acknowledge();
+    }
+
+    private String extractHeader(ConsumerRecord<String, Object> record, String headerKey) {
+        Header header = record.headers().lastHeader(headerKey);
+        if (FormatValidator.hasNoValue(header)) {
+            return "UNKNOWN";
+        }
+        return new String(header.value(), StandardCharsets.UTF_8);
+    }
+}

--- a/common/src/main/java/com/personal/marketnote/common/configuration/kafka/DltReprocessResult.java
+++ b/common/src/main/java/com/personal/marketnote/common/configuration/kafka/DltReprocessResult.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.common.configuration.kafka;
+
+public record DltReprocessResult(
+        int reprocessedCount,
+        int failedCount
+) {
+}

--- a/common/src/main/java/com/personal/marketnote/common/configuration/kafka/DltReprocessService.java
+++ b/common/src/main/java/com/personal/marketnote/common/configuration/kafka/DltReprocessService.java
@@ -1,0 +1,99 @@
+package com.personal.marketnote.common.configuration.kafka;
+
+import com.personal.marketnote.common.kafka.KafkaTopicConstants;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.TopicPartition;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(prefix = "spring.kafka", name = "bootstrap-servers")
+public class DltReprocessService {
+    private static final Duration POLL_TIMEOUT = Duration.ofSeconds(5);
+    private static final int MAX_POLL_ITERATIONS = 100;
+    private static final long SEND_TIMEOUT_SECONDS = 10L;
+
+    private static final Set<String> ALLOWED_TOPICS = Set.of(
+            KafkaTopicConstants.ORDER_PAYMENT_COMPLETED,
+            KafkaTopicConstants.PAYMENT_APPROVED,
+            KafkaTopicConstants.PAYMENT_FAILED,
+            KafkaTopicConstants.PAYMENT_CANCELLED,
+            KafkaTopicConstants.SETTLEMENT_EXECUTED,
+            KafkaTopicConstants.ORDER_PURCHASE_CONFIRMED,
+            KafkaTopicConstants.PRODUCT_REGISTERED,
+            KafkaTopicConstants.PRICE_POLICY_CREATED,
+            KafkaTopicConstants.PRODUCT_UPDATED,
+            KafkaTopicConstants.USER_SIGNUP_COMPLETED,
+            KafkaTopicConstants.USER_REFERRAL_COMPLETED,
+            KafkaTopicConstants.REVIEW_REGISTERED
+    );
+
+    private final ConsumerFactory<String, Object> consumerFactory;
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+
+    public DltReprocessResult reprocess(String originalTopic) {
+        if (!ALLOWED_TOPICS.contains(originalTopic)) {
+            throw new InvalidDltTopicException(originalTopic);
+        }
+
+        String dltTopic = originalTopic + KafkaTopicConstants.DLT_SUFFIX;
+        String groupId = "dlt-reprocessor-" + UUID.randomUUID();
+
+        try (Consumer<String, Object> consumer = consumerFactory.createConsumer(groupId, "")) {
+            List<PartitionInfo> partitionInfos = consumer.partitionsFor(dltTopic);
+            if (partitionInfos == null || partitionInfos.isEmpty()) {
+                log.info("DLT 토픽 파티션 없음. dltTopic={}", dltTopic);
+                return new DltReprocessResult(0, 0);
+            }
+
+            List<TopicPartition> partitions = partitionInfos.stream()
+                    .map(pi -> new TopicPartition(dltTopic, pi.partition()))
+                    .toList();
+
+            consumer.assign(partitions);
+            consumer.seekToBeginning(partitions);
+
+            int reprocessedCount = 0;
+            int failedCount = 0;
+            int pollIteration = 0;
+
+            ConsumerRecords<String, Object> records = consumer.poll(POLL_TIMEOUT);
+            while (!records.isEmpty() && pollIteration < MAX_POLL_ITERATIONS) {
+                for (ConsumerRecord<String, Object> record : records) {
+                    try {
+                        kafkaTemplate.send(originalTopic, record.key(), record.value())
+                                .get(SEND_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+                        reprocessedCount++;
+                        log.info("DLT 메시지 재처리 성공. originalTopic={}, key={}, offset={}",
+                                originalTopic, record.key(), record.offset());
+                    } catch (Exception e) {
+                        failedCount++;
+                        log.error("DLT 메시지 재처리 실패. originalTopic={}, key={}, offset={}",
+                                originalTopic, record.key(), record.offset(), e);
+                    }
+                }
+                pollIteration++;
+                records = consumer.poll(POLL_TIMEOUT);
+            }
+
+            log.info("DLT 재처리 완료. dltTopic={}, reprocessed={}, failed={}",
+                    dltTopic, reprocessedCount, failedCount);
+            return new DltReprocessResult(reprocessedCount, failedCount);
+        }
+    }
+}

--- a/common/src/main/java/com/personal/marketnote/common/configuration/kafka/DltSlackNotifier.java
+++ b/common/src/main/java/com/personal/marketnote/common/configuration/kafka/DltSlackNotifier.java
@@ -1,0 +1,67 @@
+package com.personal.marketnote.common.configuration.kafka;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.common.utility.FormatValidator;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(prefix = "spring.kafka", name = "bootstrap-servers")
+public class DltSlackNotifier {
+    private static final HttpClient HTTP_CLIENT = HttpClient.newBuilder()
+            .connectTimeout(Duration.ofSeconds(5))
+            .build();
+
+    private final KafkaSlackProperties kafkaSlackProperties;
+    private final ObjectMapper objectMapper;
+
+    public void notify(
+            String originalTopic,
+            ConsumerRecord<String, Object> record,
+            String errorFqcn,
+            String errorMessage
+    ) {
+        String webhookUrl = kafkaSlackProperties.getWebhookUrl();
+        if (FormatValidator.hasNoValue(webhookUrl)) {
+            return;
+        }
+
+        String text = "[DLT Alert] Kafka 메시지 처리 실패\n\n" +
+                "• 원본 토픽: " + originalTopic + "\n" +
+                "• DLT 토픽: " + record.topic() + "\n" +
+                "• 파티션: " + record.partition() + "\n" +
+                "• 오프셋: " + record.offset() + "\n" +
+                "• 이벤트 키: " + record.key() + "\n" +
+                "• 에러 유형: " + errorFqcn + "\n" +
+                "• 에러 메시지: " + errorMessage;
+
+        try {
+            Map<String, String> payload = Map.of("text", text);
+            String jsonBody = objectMapper.writeValueAsString(payload);
+
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(webhookUrl))
+                    .header("Content-Type", "application/json")
+                    .POST(HttpRequest.BodyPublishers.ofString(jsonBody))
+                    .timeout(Duration.ofSeconds(10))
+                    .build();
+
+            HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.discarding());
+            log.info("Slack DLT 알림 전송 성공. originalTopic={}", originalTopic);
+        } catch (Exception e) {
+            log.error("Slack webhook 호출 실패. originalTopic={}", originalTopic, e);
+        }
+    }
+}

--- a/common/src/main/java/com/personal/marketnote/common/configuration/kafka/InvalidDltTopicException.java
+++ b/common/src/main/java/com/personal/marketnote/common/configuration/kafka/InvalidDltTopicException.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.common.configuration.kafka;
+
+public class InvalidDltTopicException extends IllegalArgumentException {
+    public InvalidDltTopicException(String topic) {
+        super("허용되지 않은 DLT 토픽입니다. topic=" + topic);
+    }
+}

--- a/common/src/main/java/com/personal/marketnote/common/configuration/kafka/KafkaErrorHandler.java
+++ b/common/src/main/java/com/personal/marketnote/common/configuration/kafka/KafkaErrorHandler.java
@@ -4,22 +4,24 @@ import com.personal.marketnote.common.kafka.KafkaTopicConstants;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.common.TopicPartition;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.listener.CommonErrorHandler;
 import org.springframework.kafka.listener.DeadLetterPublishingRecoverer;
 import org.springframework.kafka.listener.DefaultErrorHandler;
-import org.springframework.util.backoff.ExponentialBackOff;
+import org.springframework.util.backoff.FixedBackOff;
 
 @Slf4j
 @Configuration
 @ConditionalOnProperty(prefix = "spring.kafka", name = "bootstrap-servers")
+@EnableConfigurationProperties(KafkaSlackProperties.class)
 public class KafkaErrorHandler {
 
-    private static final long RETRY_INITIAL_INTERVAL_MS = 1000L;
-    private static final double RETRY_MULTIPLIER = 2.0;
-    private static final long RETRY_MAX_ELAPSED_TIME_MS = 10000L;
+    private static final long RETRY_INTERVAL_MS = 1000L;
+    // 최초 시도 1회 + 재시도 3회 = 총 4회 시도
+    private static final long RETRY_MAX_ATTEMPTS = 3L;
 
     @Bean
     public DeadLetterPublishingRecoverer deadLetterPublishingRecoverer(KafkaTemplate<String, Object> kafkaTemplate) {
@@ -35,8 +37,7 @@ public class KafkaErrorHandler {
 
     @Bean
     public CommonErrorHandler commonErrorHandler(DeadLetterPublishingRecoverer deadLetterPublishingRecoverer) {
-        ExponentialBackOff backOff = new ExponentialBackOff(RETRY_INITIAL_INTERVAL_MS, RETRY_MULTIPLIER);
-        backOff.setMaxElapsedTime(RETRY_MAX_ELAPSED_TIME_MS);
+        FixedBackOff backOff = new FixedBackOff(RETRY_INTERVAL_MS, RETRY_MAX_ATTEMPTS);
         DefaultErrorHandler errorHandler = new DefaultErrorHandler(deadLetterPublishingRecoverer, backOff);
         errorHandler.setRetryListeners((record, ex, deliveryAttempt) ->
                 log.warn("메시지 재시도 중. topic={}, key={}, attempt={}",

--- a/common/src/main/java/com/personal/marketnote/common/configuration/kafka/KafkaSlackProperties.java
+++ b/common/src/main/java/com/personal/marketnote/common/configuration/kafka/KafkaSlackProperties.java
@@ -1,0 +1,12 @@
+package com.personal.marketnote.common.configuration.kafka;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "kafka.slack")
+public class KafkaSlackProperties {
+    private String webhookUrl;
+}


### PR DESCRIPTION
## partially addresses #929
## resolves #1022

## Task
- [x] DefaultErrorHandler + FixedBackOff 재시도 정책 구현 (1초 간격, 3회)
- [x] DeadLetterPublishingRecoverer 구현 (실패 메시지 → *.dlt 토픽 전송)
- [x] DeadLetterAlertConsumer 구현 (DLT 메시지 도착 시 Slack 알림)
- [x] DLT 메시지 수동 재처리 API 추가