### PR TITLE
[#929][#1193] test: Dead Letter Queue 및 재시도 정책 기능 자동화 테스트 추가

### DIFF
--- a/common/src/test/java/com/personal/marketnote/common/configuration/kafka/DeadLetterAlertConsumerTest.java
+++ b/common/src/test/java/com/personal/marketnote/common/configuration/kafka/DeadLetterAlertConsumerTest.java
@@ -1,0 +1,102 @@
+package com.personal.marketnote.common.configuration.kafka;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.support.Acknowledgment;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("DeadLetterAlertConsumer 테스트")
+class DeadLetterAlertConsumerTest {
+    @InjectMocks
+    private DeadLetterAlertConsumer consumer;
+
+    @Mock
+    private DltSlackNotifier dltSlackNotifier;
+
+    @Mock
+    private Acknowledgment acknowledgment;
+
+    private ConsumerRecord<String, Object> buildDltRecord(
+            String originalTopic,
+            String errorFqcn,
+            String errorMessage
+    ) {
+        ConsumerRecord<String, Object> record = new ConsumerRecord<>(
+                originalTopic + ".dlt", 0, 0L, "key-123", "value"
+        );
+        record.headers()
+                .add("kafka_dlt-original-topic", originalTopic.getBytes(StandardCharsets.UTF_8))
+                .add("kafka_dlt-exception-fqcn", errorFqcn.getBytes(StandardCharsets.UTF_8))
+                .add("kafka_dlt-exception-message", errorMessage.getBytes(StandardCharsets.UTF_8));
+        return record;
+    }
+
+    @Test
+    @DisplayName("DLT 메시지 수신 시 원본 토픽 정보를 추출하여 Slack 알림을 전송하고 acknowledge한다")
+    void handleDeadLetterMessage_extractsHeadersAndNotifiesSlackAndAcknowledges() {
+        // given
+        String originalTopic = "commerce.order.payment-completed";
+        ConsumerRecord<String, Object> record = buildDltRecord(
+                originalTopic, "java.lang.RuntimeException", "DB 연결 오류"
+        );
+
+        // when
+        consumer.handleDeadLetterMessage(record, acknowledgment);
+
+        // then
+        verify(dltSlackNotifier).notify(
+                eq(originalTopic),
+                eq(record),
+                eq("java.lang.RuntimeException"),
+                eq("DB 연결 오류")
+        );
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("DLT 메시지 처리 중 예외가 발생해도 acknowledge한다")
+    void handleDeadLetterMessage_exceptionDuringProcessing_stillAcknowledges() {
+        // given
+        ConsumerRecord<String, Object> record = buildDltRecord("some.topic", "Error", "msg");
+        doThrow(new RuntimeException("Slack API 오류"))
+                .when(dltSlackNotifier).notify(anyString(), any(), anyString(), anyString());
+
+        // when
+        consumer.handleDeadLetterMessage(record, acknowledgment);
+
+        // then
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("DLT 헤더가 없는 메시지도 UNKNOWN으로 처리하고 acknowledge한다")
+    void handleDeadLetterMessage_noHeaders_handlesGracefullyAndAcknowledges() {
+        // given
+        ConsumerRecord<String, Object> record = new ConsumerRecord<>(
+                "some.topic.dlt", 0, 0L, "key-123", "value"
+        );
+
+        // when
+        consumer.handleDeadLetterMessage(record, acknowledgment);
+
+        // then
+        verify(dltSlackNotifier).notify(
+                eq("UNKNOWN"),
+                eq(record),
+                eq("UNKNOWN"),
+                eq("UNKNOWN")
+        );
+        verify(acknowledgment).acknowledge();
+    }
+}

--- a/common/src/test/java/com/personal/marketnote/common/configuration/kafka/DltReprocessServiceTest.java
+++ b/common/src/test/java/com/personal/marketnote/common/configuration/kafka/DltReprocessServiceTest.java
@@ -1,0 +1,175 @@
+package com.personal.marketnote.common.configuration.kafka;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.TopicPartition;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+
+import org.springframework.kafka.support.SendResult;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("DltReprocessService 테스트")
+class DltReprocessServiceTest {
+    @InjectMocks
+    private DltReprocessService dltReprocessService;
+
+    @Mock
+    private ConsumerFactory<String, Object> consumerFactory;
+
+    @Mock
+    private KafkaTemplate<String, Object> kafkaTemplate;
+
+    @Mock
+    private Consumer<String, Object> consumer;
+
+    @Test
+    @DisplayName("DLT 토픽에서 메시지를 읽어 원본 토픽으로 재전송한다")
+    void reprocess_pollsFromDltAndSendsToOriginalTopic() {
+        // given
+        String originalTopic = "commerce.order.payment-completed";
+        String dltTopic = originalTopic + ".dlt";
+
+        when(consumerFactory.createConsumer(anyString(), eq(""))).thenReturn(consumer);
+
+        PartitionInfo partitionInfo = new PartitionInfo(dltTopic, 0, null, null, null);
+        when(consumer.partitionsFor(dltTopic)).thenReturn(List.of(partitionInfo));
+
+        TopicPartition topicPartition = new TopicPartition(dltTopic, 0);
+        ConsumerRecord<String, Object> record1 = new ConsumerRecord<>(dltTopic, 0, 0L, "key-1", "value-1");
+        ConsumerRecord<String, Object> record2 = new ConsumerRecord<>(dltTopic, 0, 1L, "key-2", "value-2");
+        ConsumerRecords<String, Object> records = new ConsumerRecords<>(
+                Map.of(topicPartition, List.of(record1, record2))
+        );
+        ConsumerRecords<String, Object> emptyRecords = new ConsumerRecords<>(Collections.emptyMap());
+
+        when(consumer.poll(any(Duration.class)))
+                .thenReturn(records)
+                .thenReturn(emptyRecords);
+
+        CompletableFuture<SendResult<String, Object>> future = CompletableFuture.completedFuture(null);
+        when(kafkaTemplate.send(anyString(), anyString(), any())).thenReturn(future);
+
+        // when
+        DltReprocessResult result = dltReprocessService.reprocess(originalTopic);
+
+        // then
+        assertThat(result.reprocessedCount()).isEqualTo(2);
+        assertThat(result.failedCount()).isEqualTo(0);
+        verify(kafkaTemplate).send(originalTopic, "key-1", "value-1");
+        verify(kafkaTemplate).send(originalTopic, "key-2", "value-2");
+        verify(consumer).close();
+    }
+
+    @Test
+    @DisplayName("DLT 토픽에 메시지가 없으면 reprocessedCount 0, failedCount 0을 반환한다")
+    void reprocess_emptyDlt_returnsZero() {
+        // given
+        String originalTopic = "commerce.payment.approved";
+        String dltTopic = originalTopic + ".dlt";
+
+        when(consumerFactory.createConsumer(anyString(), eq(""))).thenReturn(consumer);
+
+        PartitionInfo partitionInfo = new PartitionInfo(dltTopic, 0, null, null, null);
+        when(consumer.partitionsFor(dltTopic)).thenReturn(List.of(partitionInfo));
+
+        ConsumerRecords<String, Object> emptyRecords = new ConsumerRecords<>(Collections.emptyMap());
+        when(consumer.poll(any(Duration.class))).thenReturn(emptyRecords);
+
+        // when
+        DltReprocessResult result = dltReprocessService.reprocess(originalTopic);
+
+        // then
+        assertThat(result.reprocessedCount()).isEqualTo(0);
+        assertThat(result.failedCount()).isEqualTo(0);
+        verify(kafkaTemplate, never()).send(anyString(), anyString(), any());
+        verify(consumer).close();
+    }
+
+    @Test
+    @DisplayName("DLT 토픽 파티션이 없으면 reprocessedCount 0, failedCount 0을 반환한다")
+    void reprocess_noPartitions_returnsZero() {
+        // given
+        String originalTopic = "commerce.settlement.executed";
+        String dltTopic = originalTopic + ".dlt";
+
+        when(consumerFactory.createConsumer(anyString(), eq(""))).thenReturn(consumer);
+        when(consumer.partitionsFor(dltTopic)).thenReturn(Collections.emptyList());
+
+        // when
+        DltReprocessResult result = dltReprocessService.reprocess(originalTopic);
+
+        // then
+        assertThat(result.reprocessedCount()).isEqualTo(0);
+        assertThat(result.failedCount()).isEqualTo(0);
+        verify(kafkaTemplate, never()).send(anyString(), anyString(), any());
+        verify(consumer).close();
+    }
+
+    @Test
+    @DisplayName("허용되지 않은 토픽명으로 재처리 시 InvalidDltTopicException이 발생한다")
+    void reprocess_invalidTopic_throwsInvalidDltTopicException() {
+        // given
+        String invalidTopic = "unknown.topic";
+
+        // when & then
+        assertThatThrownBy(() -> dltReprocessService.reprocess(invalidTopic))
+                .isInstanceOf(InvalidDltTopicException.class)
+                .hasMessageContaining(invalidTopic);
+    }
+
+    @Test
+    @DisplayName("메시지 재전송 실패 시 failedCount가 증가한다")
+    void reprocess_sendFailure_incrementsFailedCount() {
+        // given
+        String originalTopic = "commerce.payment.cancelled";
+        String dltTopic = originalTopic + ".dlt";
+
+        when(consumerFactory.createConsumer(anyString(), eq(""))).thenReturn(consumer);
+
+        PartitionInfo partitionInfo = new PartitionInfo(dltTopic, 0, null, null, null);
+        when(consumer.partitionsFor(dltTopic)).thenReturn(List.of(partitionInfo));
+
+        TopicPartition topicPartition = new TopicPartition(dltTopic, 0);
+        ConsumerRecord<String, Object> record = new ConsumerRecord<>(dltTopic, 0, 0L, "key-1", "value-1");
+        ConsumerRecords<String, Object> records = new ConsumerRecords<>(
+                Map.of(topicPartition, List.of(record))
+        );
+        ConsumerRecords<String, Object> emptyRecords = new ConsumerRecords<>(Collections.emptyMap());
+
+        when(consumer.poll(any(Duration.class)))
+                .thenReturn(records)
+                .thenReturn(emptyRecords);
+
+        CompletableFuture<SendResult<String, Object>> failedFuture = new CompletableFuture<>();
+        failedFuture.completeExceptionally(new RuntimeException("전송 실패"));
+        when(kafkaTemplate.send(anyString(), anyString(), any())).thenReturn(failedFuture);
+
+        // when
+        DltReprocessResult result = dltReprocessService.reprocess(originalTopic);
+
+        // then
+        assertThat(result.reprocessedCount()).isEqualTo(0);
+        assertThat(result.failedCount()).isEqualTo(1);
+        verify(consumer).close();
+    }
+}

--- a/common/src/test/java/com/personal/marketnote/common/configuration/kafka/DltSlackNotifierTest.java
+++ b/common/src/test/java/com/personal/marketnote/common/configuration/kafka/DltSlackNotifierTest.java
@@ -1,0 +1,59 @@
+package com.personal.marketnote.common.configuration.kafka;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("DltSlackNotifier 테스트")
+class DltSlackNotifierTest {
+    @InjectMocks
+    private DltSlackNotifier dltSlackNotifier;
+
+    @Mock
+    private KafkaSlackProperties kafkaSlackProperties;
+
+    @Spy
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    @DisplayName("webhook URL이 null이면 Slack 호출을 건너뛴다")
+    void notify_nullWebhookUrl_skipsSlackCall() {
+        // given
+        when(kafkaSlackProperties.getWebhookUrl()).thenReturn(null);
+        ConsumerRecord<String, Object> record = new ConsumerRecord<>(
+                "some.topic.dlt", 0, 0L, "key-123", "value"
+        );
+
+        // when — 예외 없이 정상 반환
+        dltSlackNotifier.notify("some.topic", record, "Error", "msg");
+
+        // then
+        verify(kafkaSlackProperties).getWebhookUrl();
+    }
+
+    @Test
+    @DisplayName("webhook URL이 빈 문자열이면 Slack 호출을 건너뛴다")
+    void notify_emptyWebhookUrl_skipsSlackCall() {
+        // given
+        when(kafkaSlackProperties.getWebhookUrl()).thenReturn("");
+        ConsumerRecord<String, Object> record = new ConsumerRecord<>(
+                "some.topic.dlt", 0, 0L, "key-123", "value"
+        );
+
+        // when — 예외 없이 정상 반환
+        dltSlackNotifier.notify("some.topic", record, "Error", "msg");
+
+        // then
+        verify(kafkaSlackProperties).getWebhookUrl();
+    }
+}


### PR DESCRIPTION
## partially addresses #929
## resolves #1193

## Task
- [x] DeadLetterAlertConsumer 테스트 (DLT 메시지 Slack 알림 + acknowledge)
- [x] DltSlackNotifier 테스트 (webhook URL null/빈 문자열 처리)
- [x] DltReprocessService 테스트 (재전송, 빈 DLT, 파티션 없음, 토픽 검증, 전송 실패)