### PR TITLE
[#929][#1067] feat: Kafka Consumer 처리량 제한 설정 추가

### DIFF
--- a/common/src/main/java/com/personal/marketnote/common/configuration/kafka/KafkaConsumerConfig.java
+++ b/common/src/main/java/com/personal/marketnote/common/configuration/kafka/KafkaConsumerConfig.java
@@ -27,6 +27,15 @@ public class KafkaConsumerConfig {
     @Value("${spring.kafka.consumer.group-id:${spring.application.name:unknown}}")
     private String groupId;
 
+    @Value("${spring.kafka.consumer.max-poll-records:10}")
+    private int maxPollRecords;
+
+    @Value("${spring.kafka.consumer.fetch-max-bytes:1048576}")
+    private int fetchMaxBytes;
+
+    @Value("${spring.kafka.consumer.max-poll-interval-ms:300000}")
+    private int maxPollIntervalMs;
+
     @Bean
     public ConsumerFactory<String, Object> consumerFactory() {
         Map<String, Object> props = new HashMap<>();
@@ -36,6 +45,9 @@ public class KafkaConsumerConfig {
         props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
         props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false);
         props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        props.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, maxPollRecords);
+        props.put(ConsumerConfig.FETCH_MAX_BYTES_CONFIG, fetchMaxBytes);
+        props.put(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, maxPollIntervalMs);
         props.put(JsonDeserializer.TRUSTED_PACKAGES, "com.personal.marketnote.common.kafka.event");
         props.put(JsonDeserializer.USE_TYPE_INFO_HEADERS, false);
         props.put(JsonDeserializer.VALUE_DEFAULT_TYPE, EventEnvelope.class.getName());


### PR DESCRIPTION
## partially addresses #929
## resolves #1067

## Task
- [x] KafkaConsumerConfig에 MAX_POLL_RECORDS(10) 설정 추가
- [x] FETCH_MAX_BYTES(1MB) 설정 추가
- [x] MAX_POLL_INTERVAL_MS(300000) 적정값 설정