### PR TITLE
[#929][#1026] feat: Kafka 브로커 SASL 인증 도입

### DIFF
--- a/commerce-service/commerce-adapters/src/main/resources/application.yml
+++ b/commerce-service/commerce-adapters/src/main/resources/application.yml
@@ -39,6 +39,12 @@ spring:
 
   kafka:
     bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+    sasl:
+      enabled: ${KAFKA_SASL_ENABLED:false}
+      mechanism: ${KAFKA_SASL_MECHANISM:SCRAM-SHA-256}
+      protocol: ${KAFKA_SASL_PROTOCOL:SASL_PLAINTEXT}
+      username: ${KAFKA_SASL_USERNAME:}
+      password: ${KAFKA_SASL_PASSWORD:}
     consumer:
       group-id: ${spring.application.name}
 

--- a/common/src/main/java/com/personal/marketnote/common/configuration/kafka/KafkaConsumerConfig.java
+++ b/common/src/main/java/com/personal/marketnote/common/configuration/kafka/KafkaConsumerConfig.java
@@ -14,11 +14,14 @@ import org.springframework.kafka.listener.CommonErrorHandler;
 import org.springframework.kafka.listener.ContainerProperties;
 import org.springframework.kafka.support.serializer.JsonDeserializer;
 
+import lombok.RequiredArgsConstructor;
+
 import java.util.HashMap;
 import java.util.Map;
 
 @Configuration
 @ConditionalOnProperty(prefix = "spring.kafka", name = "bootstrap-servers")
+@RequiredArgsConstructor
 public class KafkaConsumerConfig {
 
     @Value("${spring.kafka.bootstrap-servers}")
@@ -36,6 +39,8 @@ public class KafkaConsumerConfig {
     @Value("${spring.kafka.consumer.max-poll-interval-ms:300000}")
     private int maxPollIntervalMs;
 
+    private final KafkaSaslProperties kafkaSaslProperties;
+
     @Bean
     public ConsumerFactory<String, Object> consumerFactory() {
         Map<String, Object> props = new HashMap<>();
@@ -51,6 +56,7 @@ public class KafkaConsumerConfig {
         props.put(JsonDeserializer.TRUSTED_PACKAGES, "com.personal.marketnote.common.kafka.event");
         props.put(JsonDeserializer.USE_TYPE_INFO_HEADERS, false);
         props.put(JsonDeserializer.VALUE_DEFAULT_TYPE, EventEnvelope.class.getName());
+        kafkaSaslProperties.applyTo(props);
         return new DefaultKafkaConsumerFactory<>(props);
     }
 

--- a/common/src/main/java/com/personal/marketnote/common/configuration/kafka/KafkaProducerConfig.java
+++ b/common/src/main/java/com/personal/marketnote/common/configuration/kafka/KafkaProducerConfig.java
@@ -11,15 +11,22 @@ import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.core.ProducerFactory;
 import org.springframework.kafka.support.serializer.JsonSerializer;
 
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+
 import java.util.HashMap;
 import java.util.Map;
 
 @Configuration
 @ConditionalOnProperty(prefix = "spring.kafka", name = "bootstrap-servers")
+@EnableConfigurationProperties(KafkaSaslProperties.class)
+@RequiredArgsConstructor
 public class KafkaProducerConfig {
 
     @Value("${spring.kafka.bootstrap-servers}")
     private String bootstrapServers;
+
+    private final KafkaSaslProperties kafkaSaslProperties;
 
     @Bean
     public ProducerFactory<String, Object> producerFactory() {
@@ -30,6 +37,7 @@ public class KafkaProducerConfig {
         props.put(ProducerConfig.ACKS_CONFIG, "all");
         props.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, true);
         props.put(JsonSerializer.ADD_TYPE_INFO_HEADERS, false);
+        kafkaSaslProperties.applyTo(props);
         return new DefaultKafkaProducerFactory<>(props);
     }
 

--- a/common/src/main/java/com/personal/marketnote/common/configuration/kafka/KafkaSaslProperties.java
+++ b/common/src/main/java/com/personal/marketnote/common/configuration/kafka/KafkaSaslProperties.java
@@ -1,0 +1,70 @@
+package com.personal.marketnote.common.configuration.kafka;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.common.config.SaslConfigs;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.Map;
+import java.util.Set;
+
+@Getter
+@Setter
+@ToString(exclude = "password")
+@ConfigurationProperties(prefix = "spring.kafka.sasl")
+public class KafkaSaslProperties {
+
+    private static final Set<String> SUPPORTED_MECHANISMS = Set.of(
+            "SCRAM-SHA-256", "SCRAM-SHA-512", "PLAIN"
+    );
+
+    private boolean enabled = false;
+    private String mechanism = "SCRAM-SHA-256";
+    private String protocol = "SASL_PLAINTEXT";
+    private String username;
+    private String password;
+
+    public void applyTo(Map<String, Object> props) {
+        if (!enabled) {
+            return;
+        }
+        validateCredentials();
+        props.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, protocol);
+        props.put(SaslConfigs.SASL_MECHANISM, mechanism);
+        props.put(SaslConfigs.SASL_JAAS_CONFIG, buildJaasConfig());
+    }
+
+    private void validateCredentials() {
+        if (username == null || username.isBlank()) {
+            throw new IllegalStateException(
+                    "Kafka SASL 인증이 활성화되었으나 username이 설정되지 않았습니다. KAFKA_SASL_USERNAME 환경변수를 확인하세요.");
+        }
+        if (password == null || password.isBlank()) {
+            throw new IllegalStateException(
+                    "Kafka SASL 인증이 활성화되었으나 password가 설정되지 않았습니다. KAFKA_SASL_PASSWORD 환경변수를 확인하세요.");
+        }
+    }
+
+    private String buildJaasConfig() {
+        String loginModule = resolveLoginModule();
+        String sanitizedUsername = username.replace("\\", "\\\\").replace("\"", "\\\"");
+        String sanitizedPassword = password.replace("\\", "\\\\").replace("\"", "\\\"");
+        return loginModule + " required "
+                + "username=\"" + sanitizedUsername + "\" "
+                + "password=\"" + sanitizedPassword + "\";";
+    }
+
+    private String resolveLoginModule() {
+        if (mechanism.startsWith("SCRAM-SHA")) {
+            return "org.apache.kafka.common.security.scram.ScramLoginModule";
+        }
+        if ("PLAIN".equals(mechanism)) {
+            return "org.apache.kafka.common.security.plain.PlainLoginModule";
+        }
+        throw new IllegalStateException(
+                "지원하지 않는 SASL mechanism입니다: " + mechanism
+                        + ". 지원 목록: " + SUPPORTED_MECHANISMS);
+    }
+}

--- a/common/src/main/java/com/personal/marketnote/common/configuration/security/SecurityPropertiesValidator.java
+++ b/common/src/main/java/com/personal/marketnote/common/configuration/security/SecurityPropertiesValidator.java
@@ -33,6 +33,15 @@ public class SecurityPropertiesValidator {
     @Value("${spring.data.redis.password:#{null}}")
     private String redisPassword;
 
+    @Value("${spring.kafka.sasl.enabled:false}")
+    private boolean kafkaSaslEnabled;
+
+    @Value("${spring.kafka.sasl.username:}")
+    private String kafkaSaslUsername;
+
+    @Value("${spring.kafka.sasl.password:}")
+    private String kafkaSaslPassword;
+
     @PostConstruct
     public void validateSecurityProperties() {
         List<String> violations = new ArrayList<>();
@@ -40,6 +49,11 @@ public class SecurityPropertiesValidator {
         validateRequired(violations, "spring.jwt.secret (JWT_SECRET_KEY)", jwtSecret);
         validateRequired(violations, "spring.jwt.admin-access-token (JWT_ADMIN_ACCESS_TOKEN)", adminAccessToken);
         validateRequired(violations, "spring.datasource.password (DB_PASSWORD)", dbPassword);
+
+        if (kafkaSaslEnabled) {
+            validateRequired(violations, "spring.kafka.sasl.username (KAFKA_SASL_USERNAME)", kafkaSaslUsername);
+            validateRequired(violations, "spring.kafka.sasl.password (KAFKA_SASL_PASSWORD)", kafkaSaslPassword);
+        }
 
         if (!violations.isEmpty()) {
             String message = String.join("\n  - ", violations);

--- a/community-service/community-adapters/src/main/resources/application.yml
+++ b/community-service/community-adapters/src/main/resources/application.yml
@@ -39,6 +39,12 @@ spring:
 
   kafka:
     bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+    sasl:
+      enabled: ${KAFKA_SASL_ENABLED:false}
+      mechanism: ${KAFKA_SASL_MECHANISM:SCRAM-SHA-256}
+      protocol: ${KAFKA_SASL_PROTOCOL:SASL_PLAINTEXT}
+      username: ${KAFKA_SASL_USERNAME:}
+      password: ${KAFKA_SASL_PASSWORD:}
     consumer:
       group-id: ${spring.application.name}
 

--- a/file-service/file-adapters/src/main/resources/application.yml
+++ b/file-service/file-adapters/src/main/resources/application.yml
@@ -38,6 +38,12 @@ spring:
 
   kafka:
     bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+    sasl:
+      enabled: ${KAFKA_SASL_ENABLED:false}
+      mechanism: ${KAFKA_SASL_MECHANISM:SCRAM-SHA-256}
+      protocol: ${KAFKA_SASL_PROTOCOL:SASL_PLAINTEXT}
+      username: ${KAFKA_SASL_USERNAME:}
+      password: ${KAFKA_SASL_PASSWORD:}
     consumer:
       group-id: ${spring.application.name}
 

--- a/fulfillment-service/fulfillment-adapters/src/main/resources/application.yml
+++ b/fulfillment-service/fulfillment-adapters/src/main/resources/application.yml
@@ -33,6 +33,12 @@ spring:
 
   kafka:
     bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+    sasl:
+      enabled: ${KAFKA_SASL_ENABLED:false}
+      mechanism: ${KAFKA_SASL_MECHANISM:SCRAM-SHA-256}
+      protocol: ${KAFKA_SASL_PROTOCOL:SASL_PLAINTEXT}
+      username: ${KAFKA_SASL_USERNAME:}
+      password: ${KAFKA_SASL_PASSWORD:}
     consumer:
       group-id: ${spring.application.name}
 

--- a/product-service/product-adapters/src/main/resources/application.yml
+++ b/product-service/product-adapters/src/main/resources/application.yml
@@ -39,6 +39,12 @@ spring:
 
   kafka:
     bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+    sasl:
+      enabled: ${KAFKA_SASL_ENABLED:false}
+      mechanism: ${KAFKA_SASL_MECHANISM:SCRAM-SHA-256}
+      protocol: ${KAFKA_SASL_PROTOCOL:SASL_PLAINTEXT}
+      username: ${KAFKA_SASL_USERNAME:}
+      password: ${KAFKA_SASL_PASSWORD:}
     consumer:
       group-id: ${spring.application.name}
 

--- a/reward-service/reward-adapters/src/main/resources/application.yml
+++ b/reward-service/reward-adapters/src/main/resources/application.yml
@@ -39,6 +39,12 @@ spring:
 
   kafka:
     bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+    sasl:
+      enabled: ${KAFKA_SASL_ENABLED:false}
+      mechanism: ${KAFKA_SASL_MECHANISM:SCRAM-SHA-256}
+      protocol: ${KAFKA_SASL_PROTOCOL:SASL_PLAINTEXT}
+      username: ${KAFKA_SASL_USERNAME:}
+      password: ${KAFKA_SASL_PASSWORD:}
     consumer:
       group-id: ${spring.application.name}
 

--- a/user-service/user-adapters/src/main/resources/application.yml
+++ b/user-service/user-adapters/src/main/resources/application.yml
@@ -35,6 +35,12 @@ spring:
 
   kafka:
     bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+    sasl:
+      enabled: ${KAFKA_SASL_ENABLED:false}
+      mechanism: ${KAFKA_SASL_MECHANISM:SCRAM-SHA-256}
+      protocol: ${KAFKA_SASL_PROTOCOL:SASL_PLAINTEXT}
+      username: ${KAFKA_SASL_USERNAME:}
+      password: ${KAFKA_SASL_PASSWORD:}
     consumer:
       group-id: ${spring.application.name}
 


### PR DESCRIPTION
## partially addresses #929
## resolves #1026

## Task
- [x] KafkaSaslProperties 추가 (SCRAM-SHA-256/512, PLAIN 지원)
- [x] KafkaProducerConfig, KafkaConsumerConfig에 SASL 조건부 적용
- [x] SecurityPropertiesValidator에 Kafka 자격증명 검증 추가
- [x] 7개 서비스 application.yml에 SASL 환경변수 바인딩 추가
    - [x] KAFKA_SASL_ENABLED (기본: false)
    - [x] KAFKA_SASL_USERNAME
    - [x] KAFKA_SASL_PASSWORD
    - [x] KAFKA_SASL_MECHANISM (기본: SCRAM-SHA-256)
    - [x] KAFKA_SASL_PROTOCOL (기본: SASL_PLAINTEXT)