### PR TITLE
[#929][#1047] feat: Kafka Consumer 이벤트 페이로드 입력 검증 통일

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/OrderPaymentCompletedInventoryConsumer.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/OrderPaymentCompletedInventoryConsumer.java
@@ -7,6 +7,7 @@ import com.personal.marketnote.commerce.exception.DuplicateInventoryDeductionExc
 import com.personal.marketnote.commerce.port.in.usecase.inventory.ReduceProductInventoryUseCase;
 import com.personal.marketnote.common.kafka.KafkaTopicConstants;
 import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.EventPayloadValidator;
 import com.personal.marketnote.common.kafka.event.OrderPaymentCompletedEvent;
 import com.personal.marketnote.common.kafka.event.OrderPaymentCompletedEvent.OrderProductItem;
 import com.personal.marketnote.common.utility.FormatValidator;
@@ -36,6 +37,16 @@ public class OrderPaymentCompletedInventoryConsumer {
     ) {
         EventEnvelope<?> envelope = record.value();
 
+        if (EventPayloadValidator.hasInvalidEnvelope(envelope, record)) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        if (EventPayloadValidator.hasEventTypeMismatch(envelope, KafkaTopicConstants.ORDER_PAYMENT_COMPLETED)) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
         try {
             OrderPaymentCompletedEvent payload = envelope.getPayloadAs(
                     OrderPaymentCompletedEvent.class, objectMapper
@@ -45,9 +56,8 @@ public class OrderPaymentCompletedInventoryConsumer {
                     envelope.eventId(), payload.orderId(),
                     FormatValidator.hasValue(payload.orderProducts()) ? payload.orderProducts().size() : 0);
 
-            if (FormatValidator.hasNoValue(payload.orderId())) {
-                log.error("유효하지 않은 이벤트 페이로드. eventId={}, orderId=null",
-                        envelope.eventId());
+            if (EventPayloadValidator.hasInvalidIds(envelope.eventId(),
+                    EventPayloadValidator.id("orderId", payload.orderId()))) {
                 acknowledgment.acknowledge();
                 return;
             }

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/PaymentApprovedLedgerConsumer.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/PaymentApprovedLedgerConsumer.java
@@ -3,8 +3,8 @@ package com.personal.marketnote.commerce.adapter.in.event;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.personal.marketnote.common.kafka.KafkaTopicConstants;
 import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.EventPayloadValidator;
 import com.personal.marketnote.common.kafka.event.PaymentApprovedEvent;
-import com.personal.marketnote.common.utility.FormatValidator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -28,15 +28,24 @@ public class PaymentApprovedLedgerConsumer {
     ) {
         EventEnvelope<?> envelope = record.value();
 
+        if (EventPayloadValidator.hasInvalidEnvelope(envelope, record)) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        if (EventPayloadValidator.hasEventTypeMismatch(envelope, KafkaTopicConstants.PAYMENT_APPROVED)) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
         try {
             PaymentApprovedEvent payload = envelope.getPayloadAs(PaymentApprovedEvent.class, objectMapper);
 
             log.info("결제 승인 이벤트 수신 (회계 분개). eventId={}, orderId={}, orderKey={}, paymentAmount={}",
                     envelope.eventId(), payload.orderId(), payload.orderKey(), payload.paymentAmount());
 
-            if (FormatValidator.hasNoValue(payload.orderId())) {
-                log.error("유효하지 않은 이벤트 페이로드. eventId={}, orderId=null",
-                        envelope.eventId());
+            if (EventPayloadValidator.hasInvalidIds(envelope.eventId(),
+                    EventPayloadValidator.id("orderId", payload.orderId()))) {
                 acknowledgment.acknowledge();
                 return;
             }

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/PaymentApprovedOrderStatusConsumer.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/PaymentApprovedOrderStatusConsumer.java
@@ -7,8 +7,8 @@ import com.personal.marketnote.commerce.port.in.command.order.ChangeOrderStatusC
 import com.personal.marketnote.commerce.port.in.usecase.order.ChangeOrderStatusUseCase;
 import com.personal.marketnote.common.kafka.KafkaTopicConstants;
 import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.EventPayloadValidator;
 import com.personal.marketnote.common.kafka.event.PaymentApprovedEvent;
-import com.personal.marketnote.common.utility.FormatValidator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -33,15 +33,24 @@ public class PaymentApprovedOrderStatusConsumer {
     ) {
         EventEnvelope<?> envelope = record.value();
 
+        if (EventPayloadValidator.hasInvalidEnvelope(envelope, record)) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        if (EventPayloadValidator.hasEventTypeMismatch(envelope, KafkaTopicConstants.PAYMENT_APPROVED)) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
         try {
             PaymentApprovedEvent payload = envelope.getPayloadAs(PaymentApprovedEvent.class, objectMapper);
 
             log.info("결제 승인 이벤트 수신. eventId={}, orderId={}, orderKey={}",
                     envelope.eventId(), payload.orderId(), payload.orderKey());
 
-            if (FormatValidator.hasNoValue(payload.orderId())) {
-                log.error("유효하지 않은 이벤트 페이로드. eventId={}, orderId=null",
-                        envelope.eventId());
+            if (EventPayloadValidator.hasInvalidIds(envelope.eventId(),
+                    EventPayloadValidator.id("orderId", payload.orderId()))) {
                 acknowledgment.acknowledge();
                 return;
             }

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/PaymentCancelledInventoryConsumer.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/PaymentCancelledInventoryConsumer.java
@@ -7,6 +7,7 @@ import com.personal.marketnote.commerce.exception.DuplicateInventoryRestorationE
 import com.personal.marketnote.commerce.port.in.usecase.inventory.RestoreProductInventoryUseCase;
 import com.personal.marketnote.common.kafka.KafkaTopicConstants;
 import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.EventPayloadValidator;
 import com.personal.marketnote.common.kafka.event.PaymentCancelledEvent;
 import com.personal.marketnote.common.kafka.event.PaymentCancelledEvent.OrderProductItem;
 import com.personal.marketnote.common.utility.FormatValidator;
@@ -36,15 +37,24 @@ public class PaymentCancelledInventoryConsumer {
     ) {
         EventEnvelope<?> envelope = record.value();
 
+        if (EventPayloadValidator.hasInvalidEnvelope(envelope, record)) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        if (EventPayloadValidator.hasEventTypeMismatch(envelope, KafkaTopicConstants.PAYMENT_CANCELLED)) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
         try {
             PaymentCancelledEvent payload = envelope.getPayloadAs(PaymentCancelledEvent.class, objectMapper);
 
             log.info("결제 취소 이벤트 수신 (재고 복구). eventId={}, orderId={}, isFullCancel={}",
                     envelope.eventId(), payload.orderId(), payload.isFullCancel());
 
-            if (FormatValidator.hasNoValue(payload.orderId())) {
-                log.error("유효하지 않은 이벤트 페이로드. eventId={}, orderId=null",
-                        envelope.eventId());
+            if (EventPayloadValidator.hasInvalidIds(envelope.eventId(),
+                    EventPayloadValidator.id("orderId", payload.orderId()))) {
                 acknowledgment.acknowledge();
                 return;
             }

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/PaymentCancelledLedgerConsumer.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/PaymentCancelledLedgerConsumer.java
@@ -3,8 +3,8 @@ package com.personal.marketnote.commerce.adapter.in.event;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.personal.marketnote.common.kafka.KafkaTopicConstants;
 import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.EventPayloadValidator;
 import com.personal.marketnote.common.kafka.event.PaymentCancelledEvent;
-import com.personal.marketnote.common.utility.FormatValidator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -28,15 +28,24 @@ public class PaymentCancelledLedgerConsumer {
     ) {
         EventEnvelope<?> envelope = record.value();
 
+        if (EventPayloadValidator.hasInvalidEnvelope(envelope, record)) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        if (EventPayloadValidator.hasEventTypeMismatch(envelope, KafkaTopicConstants.PAYMENT_CANCELLED)) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
         try {
             PaymentCancelledEvent payload = envelope.getPayloadAs(PaymentCancelledEvent.class, objectMapper);
 
             log.info("결제 취소 이벤트 수신 (회계 역분개). eventId={}, orderId={}, isFullCancel={}, cancelAmount={}",
                     envelope.eventId(), payload.orderId(), payload.isFullCancel(), payload.cancelAmount());
 
-            if (FormatValidator.hasNoValue(payload.orderId())) {
-                log.error("유효하지 않은 이벤트 페이로드. eventId={}, orderId=null",
-                        envelope.eventId());
+            if (EventPayloadValidator.hasInvalidIds(envelope.eventId(),
+                    EventPayloadValidator.id("orderId", payload.orderId()))) {
                 acknowledgment.acknowledge();
                 return;
             }

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/PaymentCancelledOrderStatusConsumer.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/PaymentCancelledOrderStatusConsumer.java
@@ -7,8 +7,8 @@ import com.personal.marketnote.commerce.port.in.command.order.ChangeOrderStatusC
 import com.personal.marketnote.commerce.port.in.usecase.order.ChangeOrderStatusUseCase;
 import com.personal.marketnote.common.kafka.KafkaTopicConstants;
 import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.EventPayloadValidator;
 import com.personal.marketnote.common.kafka.event.PaymentCancelledEvent;
-import com.personal.marketnote.common.utility.FormatValidator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -33,15 +33,24 @@ public class PaymentCancelledOrderStatusConsumer {
     ) {
         EventEnvelope<?> envelope = record.value();
 
+        if (EventPayloadValidator.hasInvalidEnvelope(envelope, record)) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        if (EventPayloadValidator.hasEventTypeMismatch(envelope, KafkaTopicConstants.PAYMENT_CANCELLED)) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
         try {
             PaymentCancelledEvent payload = envelope.getPayloadAs(PaymentCancelledEvent.class, objectMapper);
 
             log.info("결제 취소 이벤트 수신 (주문 상태 변경). eventId={}, orderId={}, isFullCancel={}",
                     envelope.eventId(), payload.orderId(), payload.isFullCancel());
 
-            if (FormatValidator.hasNoValue(payload.orderId())) {
-                log.error("유효하지 않은 이벤트 페이로드. eventId={}, orderId=null",
-                        envelope.eventId());
+            if (EventPayloadValidator.hasInvalidIds(envelope.eventId(),
+                    EventPayloadValidator.id("orderId", payload.orderId()))) {
                 acknowledgment.acknowledge();
                 return;
             }

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/PaymentFailedOrderStatusConsumer.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/PaymentFailedOrderStatusConsumer.java
@@ -7,8 +7,8 @@ import com.personal.marketnote.commerce.port.in.command.order.ChangeOrderStatusC
 import com.personal.marketnote.commerce.port.in.usecase.order.ChangeOrderStatusUseCase;
 import com.personal.marketnote.common.kafka.KafkaTopicConstants;
 import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.EventPayloadValidator;
 import com.personal.marketnote.common.kafka.event.PaymentFailedEvent;
-import com.personal.marketnote.common.utility.FormatValidator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -33,15 +33,24 @@ public class PaymentFailedOrderStatusConsumer {
     ) {
         EventEnvelope<?> envelope = record.value();
 
+        if (EventPayloadValidator.hasInvalidEnvelope(envelope, record)) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        if (EventPayloadValidator.hasEventTypeMismatch(envelope, KafkaTopicConstants.PAYMENT_FAILED)) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
         try {
             PaymentFailedEvent payload = envelope.getPayloadAs(PaymentFailedEvent.class, objectMapper);
 
             log.info("결제 실패 이벤트 수신. eventId={}, orderId={}, orderKey={}, resultCode={}",
                     envelope.eventId(), payload.orderId(), payload.orderKey(), payload.resultCode());
 
-            if (FormatValidator.hasNoValue(payload.orderId())) {
-                log.error("유효하지 않은 이벤트 페이로드. eventId={}, orderId=null",
-                        envelope.eventId());
+            if (EventPayloadValidator.hasInvalidIds(envelope.eventId(),
+                    EventPayloadValidator.id("orderId", payload.orderId()))) {
                 acknowledgment.acknowledge();
                 return;
             }

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/PricePolicyEventKafkaListener.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/PricePolicyEventKafkaListener.java
@@ -6,8 +6,8 @@ import com.personal.marketnote.commerce.port.in.command.inventory.RegisterInvent
 import com.personal.marketnote.commerce.port.in.usecase.inventory.RegisterInventoryUseCase;
 import com.personal.marketnote.common.kafka.KafkaTopicConstants;
 import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.EventPayloadValidator;
 import com.personal.marketnote.common.kafka.event.PricePolicyCreatedEvent;
-import com.personal.marketnote.common.utility.FormatValidator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -32,15 +32,25 @@ public class PricePolicyEventKafkaListener {
     ) {
         EventEnvelope<?> envelope = record.value();
 
+        if (EventPayloadValidator.hasInvalidEnvelope(envelope, record)) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        if (EventPayloadValidator.hasEventTypeMismatch(envelope, KafkaTopicConstants.PRICE_POLICY_CREATED)) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
         try {
             PricePolicyCreatedEvent payload = envelope.getPayloadAs(PricePolicyCreatedEvent.class, objectMapper);
 
             log.info("가격 정책 등록 이벤트 수신. eventId={}, productId={}, pricePolicyId={}",
                     envelope.eventId(), payload.productId(), payload.pricePolicyId());
 
-            if (FormatValidator.hasNoValue(payload.productId()) || FormatValidator.hasNoValue(payload.pricePolicyId())) {
-                log.error("유효하지 않은 이벤트 페이로드. eventId={}, productId={}, pricePolicyId={}",
-                        envelope.eventId(), payload.productId(), payload.pricePolicyId());
+            if (EventPayloadValidator.hasInvalidIds(envelope.eventId(),
+                    EventPayloadValidator.id("productId", payload.productId()),
+                    EventPayloadValidator.id("pricePolicyId", payload.pricePolicyId()))) {
                 acknowledgment.acknowledge();
                 return;
             }

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/ProductEventKafkaListener.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/ProductEventKafkaListener.java
@@ -6,8 +6,8 @@ import com.personal.marketnote.commerce.port.in.command.inventory.RegisterInvent
 import com.personal.marketnote.commerce.port.in.usecase.inventory.RegisterInventoryUseCase;
 import com.personal.marketnote.common.kafka.KafkaTopicConstants;
 import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.EventPayloadValidator;
 import com.personal.marketnote.common.kafka.event.ProductRegisteredEvent;
-import com.personal.marketnote.common.utility.FormatValidator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -32,15 +32,25 @@ public class ProductEventKafkaListener {
     ) {
         EventEnvelope<?> envelope = record.value();
 
+        if (EventPayloadValidator.hasInvalidEnvelope(envelope, record)) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        if (EventPayloadValidator.hasEventTypeMismatch(envelope, KafkaTopicConstants.PRODUCT_REGISTERED)) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
         try {
             ProductRegisteredEvent payload = envelope.getPayloadAs(ProductRegisteredEvent.class, objectMapper);
 
             log.info("상품 등록 이벤트 수신. eventId={}, productId={}, pricePolicyId={}",
                     envelope.eventId(), payload.productId(), payload.pricePolicyId());
 
-            if (FormatValidator.hasNoValue(payload.productId()) || FormatValidator.hasNoValue(payload.pricePolicyId())) {
-                log.error("유효하지 않은 이벤트 페이로드. eventId={}, productId={}, pricePolicyId={}",
-                        envelope.eventId(), payload.productId(), payload.pricePolicyId());
+            if (EventPayloadValidator.hasInvalidIds(envelope.eventId(),
+                    EventPayloadValidator.id("productId", payload.productId()),
+                    EventPayloadValidator.id("pricePolicyId", payload.pricePolicyId()))) {
                 acknowledgment.acknowledge();
                 return;
             }

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/ReviewRegisteredCommerceConsumer.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/ReviewRegisteredCommerceConsumer.java
@@ -5,8 +5,8 @@ import com.personal.marketnote.commerce.port.in.command.order.UpdateOrderProduct
 import com.personal.marketnote.commerce.port.in.usecase.order.UpdateOrderProductUseCase;
 import com.personal.marketnote.common.kafka.KafkaTopicConstants;
 import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.EventPayloadValidator;
 import com.personal.marketnote.common.kafka.event.ReviewRegisteredEvent;
-import com.personal.marketnote.common.utility.FormatValidator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -31,15 +31,25 @@ public class ReviewRegisteredCommerceConsumer {
     ) {
         EventEnvelope<?> envelope = record.value();
 
+        if (EventPayloadValidator.hasInvalidEnvelope(envelope, record)) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        if (EventPayloadValidator.hasEventTypeMismatch(envelope, KafkaTopicConstants.REVIEW_REGISTERED)) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
         try {
             ReviewRegisteredEvent payload = envelope.getPayloadAs(ReviewRegisteredEvent.class, objectMapper);
 
             log.info("리뷰 등록 이벤트 수신. eventId={}, orderId={}, pricePolicyId={}",
                     envelope.eventId(), payload.orderId(), payload.pricePolicyId());
 
-            if (FormatValidator.hasNoValue(payload.orderId()) || FormatValidator.hasNoValue(payload.pricePolicyId())) {
-                log.error("유효하지 않은 이벤트 페이로드. eventId={}, orderId={}, pricePolicyId={}",
-                        envelope.eventId(), payload.orderId(), payload.pricePolicyId());
+            if (EventPayloadValidator.hasInvalidIds(envelope.eventId(),
+                    EventPayloadValidator.id("orderId", payload.orderId()),
+                    EventPayloadValidator.id("pricePolicyId", payload.pricePolicyId()))) {
                 acknowledgment.acknowledge();
                 return;
             }

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/SettlementExecutedLedgerConsumer.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/SettlementExecutedLedgerConsumer.java
@@ -3,8 +3,8 @@ package com.personal.marketnote.commerce.adapter.in.event;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.personal.marketnote.common.kafka.KafkaTopicConstants;
 import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.EventPayloadValidator;
 import com.personal.marketnote.common.kafka.event.SettlementExecutedEvent;
-import com.personal.marketnote.common.utility.FormatValidator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -28,15 +28,24 @@ public class SettlementExecutedLedgerConsumer {
     ) {
         EventEnvelope<?> envelope = record.value();
 
+        if (EventPayloadValidator.hasInvalidEnvelope(envelope, record)) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        if (EventPayloadValidator.hasEventTypeMismatch(envelope, KafkaTopicConstants.SETTLEMENT_EXECUTED)) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
         try {
             SettlementExecutedEvent payload = envelope.getPayloadAs(SettlementExecutedEvent.class, objectMapper);
 
             log.info("정산 실행 이벤트 수신 (회계 분개). eventId={}, settlementId={}, sellerId={}",
                     envelope.eventId(), payload.settlementId(), payload.sellerId());
 
-            if (FormatValidator.hasNoValue(payload.settlementId())) {
-                log.error("유효하지 않은 이벤트 페이로드. eventId={}, settlementId=null",
-                        envelope.eventId());
+            if (EventPayloadValidator.hasInvalidIds(envelope.eventId(),
+                    EventPayloadValidator.id("settlementId", payload.settlementId()))) {
                 acknowledgment.acknowledge();
                 return;
             }

--- a/common/src/main/java/com/personal/marketnote/common/kafka/event/EventPayloadValidator.java
+++ b/common/src/main/java/com/personal/marketnote/common/kafka/event/EventPayloadValidator.java
@@ -1,0 +1,48 @@
+package com.personal.marketnote.common.kafka.event;
+
+import com.personal.marketnote.common.utility.FormatValidator;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+
+@Slf4j
+public final class EventPayloadValidator {
+
+    private EventPayloadValidator() {
+    }
+
+    public static boolean hasInvalidEnvelope(EventEnvelope<?> envelope, ConsumerRecord<?, ?> record) {
+        if (FormatValidator.hasNoValue(envelope)) {
+            log.warn("이벤트 envelope이 null. topic={}, partition={}, offset={}",
+                    record.topic(), record.partition(), record.offset());
+            return true;
+        }
+        return false;
+    }
+
+    public static boolean hasEventTypeMismatch(EventEnvelope<?> envelope, String expectedEventType) {
+        if (FormatValidator.hasNoValue(envelope.eventType()) || !envelope.eventType().equals(expectedEventType)) {
+            log.warn("이벤트 타입 불일치. eventId={}, expected={}, actual={}",
+                    envelope.eventId(), expectedEventType, envelope.eventType());
+            return true;
+        }
+        return false;
+    }
+
+    public static boolean hasInvalidIds(String eventId, IdField... fields) {
+        for (IdField field : fields) {
+            if (FormatValidator.hasNoValue(field.value()) || field.value() <= 0) {
+                log.error("유효하지 않은 이벤트 페이로드. eventId={}, {}={}",
+                        eventId, field.name(), field.value());
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public record IdField(String name, Long value) {
+    }
+
+    public static IdField id(String name, Long value) {
+        return new IdField(name, value);
+    }
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/event/OrderPaymentCompletedOutboundConsumer.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/event/OrderPaymentCompletedOutboundConsumer.java
@@ -3,6 +3,7 @@ package com.personal.marketnote.fulfillment.adapter.in.event;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.personal.marketnote.common.kafka.KafkaTopicConstants;
 import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.EventPayloadValidator;
 import com.personal.marketnote.common.kafka.event.OrderPaymentCompletedEvent;
 import com.personal.marketnote.common.utility.FormatValidator;
 import lombok.RequiredArgsConstructor;
@@ -28,6 +29,16 @@ public class OrderPaymentCompletedOutboundConsumer {
     ) {
         EventEnvelope<?> envelope = record.value();
 
+        if (EventPayloadValidator.hasInvalidEnvelope(envelope, record)) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        if (EventPayloadValidator.hasEventTypeMismatch(envelope, KafkaTopicConstants.ORDER_PAYMENT_COMPLETED)) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
         try {
             OrderPaymentCompletedEvent payload = envelope.getPayloadAs(
                     OrderPaymentCompletedEvent.class, objectMapper
@@ -37,9 +48,8 @@ public class OrderPaymentCompletedOutboundConsumer {
                     envelope.eventId(), payload.orderId(),
                     FormatValidator.hasValue(payload.orderProducts()) ? payload.orderProducts().size() : 0);
 
-            if (FormatValidator.hasNoValue(payload.orderId())) {
-                log.error("유효하지 않은 이벤트 페이로드. eventId={}, orderId=null",
-                        envelope.eventId());
+            if (EventPayloadValidator.hasInvalidIds(envelope.eventId(),
+                    EventPayloadValidator.id("orderId", payload.orderId()))) {
                 acknowledgment.acknowledge();
                 return;
             }

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/event/ProductRegisteredFulfillmentConsumer.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/event/ProductRegisteredFulfillmentConsumer.java
@@ -3,6 +3,7 @@ package com.personal.marketnote.fulfillment.adapter.in.event;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.personal.marketnote.common.kafka.KafkaTopicConstants;
 import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.EventPayloadValidator;
 import com.personal.marketnote.common.kafka.event.ProductRegisteredEvent;
 import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.fulfillment.configuration.FasstoAuthProperties;
@@ -44,15 +45,31 @@ public class ProductRegisteredFulfillmentConsumer {
     ) {
         EventEnvelope<?> envelope = record.value();
 
+        if (EventPayloadValidator.hasInvalidEnvelope(envelope, record)) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        if (EventPayloadValidator.hasEventTypeMismatch(envelope, KafkaTopicConstants.PRODUCT_REGISTERED)) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
         try {
             ProductRegisteredEvent payload = envelope.getPayloadAs(ProductRegisteredEvent.class, objectMapper);
 
             log.info("상품 등록 이벤트 수신 (풀필먼트). eventId={}, productId={}",
                     envelope.eventId(), payload.productId());
 
-            if (FormatValidator.hasNoValue(payload.productId()) || FormatValidator.hasNoValue(payload.productName())) {
-                log.error("유효하지 않은 이벤트 페이로드. eventId={}, productId={}, productName={}",
-                        envelope.eventId(), payload.productId(), payload.productName());
+            if (EventPayloadValidator.hasInvalidIds(envelope.eventId(),
+                    EventPayloadValidator.id("productId", payload.productId()))) {
+                acknowledgment.acknowledge();
+                return;
+            }
+
+            if (FormatValidator.hasNoValue(payload.productName())) {
+                log.error("유효하지 않은 이벤트 페이로드. eventId={}, productName={}",
+                        envelope.eventId(), payload.productName());
                 acknowledgment.acknowledge();
                 return;
             }

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/event/ProductUpdatedFulfillmentConsumer.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/event/ProductUpdatedFulfillmentConsumer.java
@@ -3,6 +3,7 @@ package com.personal.marketnote.fulfillment.adapter.in.event;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.personal.marketnote.common.kafka.KafkaTopicConstants;
 import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.EventPayloadValidator;
 import com.personal.marketnote.common.kafka.event.ProductUpdatedEvent;
 import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.fulfillment.configuration.FasstoAuthProperties;
@@ -40,15 +41,31 @@ public class ProductUpdatedFulfillmentConsumer {
     ) {
         EventEnvelope<?> envelope = record.value();
 
+        if (EventPayloadValidator.hasInvalidEnvelope(envelope, record)) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        if (EventPayloadValidator.hasEventTypeMismatch(envelope, KafkaTopicConstants.PRODUCT_UPDATED)) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
         try {
             ProductUpdatedEvent payload = envelope.getPayloadAs(ProductUpdatedEvent.class, objectMapper);
 
             log.info("상품 수정 이벤트 수신 (풀필먼트). eventId={}, productId={}",
                     envelope.eventId(), payload.productId());
 
-            if (FormatValidator.hasNoValue(payload.productId()) || FormatValidator.hasNoValue(payload.productName())) {
-                log.error("유효하지 않은 이벤트 페이로드. eventId={}, productId={}, productName={}",
-                        envelope.eventId(), payload.productId(), payload.productName());
+            if (EventPayloadValidator.hasInvalidIds(envelope.eventId(),
+                    EventPayloadValidator.id("productId", payload.productId()))) {
+                acknowledgment.acknowledge();
+                return;
+            }
+
+            if (FormatValidator.hasNoValue(payload.productName())) {
+                log.error("유효하지 않은 이벤트 페이로드. eventId={}, productName={}",
+                        envelope.eventId(), payload.productName());
                 acknowledgment.acknowledge();
                 return;
             }

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/event/OrderPaymentCompletedCartConsumer.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/event/OrderPaymentCompletedCartConsumer.java
@@ -3,6 +3,7 @@ package com.personal.marketnote.product.adapter.in.event;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.personal.marketnote.common.kafka.KafkaTopicConstants;
 import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.EventPayloadValidator;
 import com.personal.marketnote.common.kafka.event.OrderPaymentCompletedEvent;
 import com.personal.marketnote.common.utility.FormatValidator;
 import lombok.RequiredArgsConstructor;
@@ -30,6 +31,16 @@ public class OrderPaymentCompletedCartConsumer {
     ) {
         EventEnvelope<?> envelope = record.value();
 
+        if (EventPayloadValidator.hasInvalidEnvelope(envelope, record)) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        if (EventPayloadValidator.hasEventTypeMismatch(envelope, KafkaTopicConstants.ORDER_PAYMENT_COMPLETED)) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
         try {
             OrderPaymentCompletedEvent payload = envelope.getPayloadAs(
                     OrderPaymentCompletedEvent.class, objectMapper
@@ -39,8 +50,8 @@ public class OrderPaymentCompletedCartConsumer {
                     envelope.eventId(), payload.orderId(), payload.buyerId(),
                     FormatValidator.hasValue(payload.orderProducts()) ? payload.orderProducts().size() : 0);
 
-            if (FormatValidator.hasNoValue(payload.buyerId())) {
-                log.error("유효하지 않은 이벤트 페이로드: buyerId 누락. eventId={}", envelope.eventId());
+            if (EventPayloadValidator.hasInvalidIds(envelope.eventId(),
+                    EventPayloadValidator.id("buyerId", payload.buyerId()))) {
                 acknowledgment.acknowledge();
                 return;
             }

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/event/OrderPaymentCompletedOrderPointConsumer.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/event/OrderPaymentCompletedOrderPointConsumer.java
@@ -3,6 +3,7 @@ package com.personal.marketnote.reward.adapter.in.event;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.personal.marketnote.common.kafka.KafkaTopicConstants;
 import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.EventPayloadValidator;
 import com.personal.marketnote.common.kafka.event.OrderPaymentCompletedEvent;
 import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.reward.domain.point.UserPointChangeType;
@@ -36,6 +37,16 @@ public class OrderPaymentCompletedOrderPointConsumer {
     ) {
         EventEnvelope<?> envelope = record.value();
 
+        if (EventPayloadValidator.hasInvalidEnvelope(envelope, record)) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        if (EventPayloadValidator.hasEventTypeMismatch(envelope, KafkaTopicConstants.ORDER_PAYMENT_COMPLETED)) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
         try {
             OrderPaymentCompletedEvent payload = envelope.getPayloadAs(
                     OrderPaymentCompletedEvent.class, objectMapper
@@ -44,9 +55,9 @@ public class OrderPaymentCompletedOrderPointConsumer {
             log.info("주문 결제 완료 이벤트 수신 (주문 포인트 차감). eventId={}, orderId={}, buyerId={}, pointAmount={}",
                     envelope.eventId(), payload.orderId(), payload.buyerId(), payload.pointAmount());
 
-            if (FormatValidator.hasNoValue(payload.orderId()) || FormatValidator.hasNoValue(payload.buyerId())) {
-                log.error("유효하지 않은 이벤트 페이로드. eventId={}, orderId={}, buyerId={}",
-                        envelope.eventId(), payload.orderId(), payload.buyerId());
+            if (EventPayloadValidator.hasInvalidIds(envelope.eventId(),
+                    EventPayloadValidator.id("orderId", payload.orderId()),
+                    EventPayloadValidator.id("buyerId", payload.buyerId()))) {
                 acknowledgment.acknowledge();
                 return;
             }

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/event/OrderPaymentCompletedProductPointConsumer.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/event/OrderPaymentCompletedProductPointConsumer.java
@@ -3,6 +3,7 @@ package com.personal.marketnote.reward.adapter.in.event;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.personal.marketnote.common.kafka.KafkaTopicConstants;
 import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.EventPayloadValidator;
 import com.personal.marketnote.common.kafka.event.OrderPaymentCompletedEvent;
 import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.reward.domain.point.UserPointChangeType;
@@ -36,6 +37,16 @@ public class OrderPaymentCompletedProductPointConsumer {
     ) {
         EventEnvelope<?> envelope = record.value();
 
+        if (EventPayloadValidator.hasInvalidEnvelope(envelope, record)) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        if (EventPayloadValidator.hasEventTypeMismatch(envelope, KafkaTopicConstants.ORDER_PAYMENT_COMPLETED)) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
         try {
             OrderPaymentCompletedEvent payload = envelope.getPayloadAs(
                     OrderPaymentCompletedEvent.class, objectMapper
@@ -44,9 +55,9 @@ public class OrderPaymentCompletedProductPointConsumer {
             log.info("주문 결제 완료 이벤트 수신 (상품 구매 포인트 적립). eventId={}, orderId={}, buyerId={}, totalAccumulatedPoint={}",
                     envelope.eventId(), payload.orderId(), payload.buyerId(), payload.totalAccumulatedPoint());
 
-            if (FormatValidator.hasNoValue(payload.orderId()) || FormatValidator.hasNoValue(payload.buyerId())) {
-                log.error("유효하지 않은 이벤트 페이로드. eventId={}, orderId={}, buyerId={}",
-                        envelope.eventId(), payload.orderId(), payload.buyerId());
+            if (EventPayloadValidator.hasInvalidIds(envelope.eventId(),
+                    EventPayloadValidator.id("orderId", payload.orderId()),
+                    EventPayloadValidator.id("buyerId", payload.buyerId()))) {
                 acknowledgment.acknowledge();
                 return;
             }

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/event/OrderPaymentCompletedSharedPointConsumer.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/event/OrderPaymentCompletedSharedPointConsumer.java
@@ -3,6 +3,7 @@ package com.personal.marketnote.reward.adapter.in.event;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.personal.marketnote.common.kafka.KafkaTopicConstants;
 import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.EventPayloadValidator;
 import com.personal.marketnote.common.kafka.event.OrderPaymentCompletedEvent;
 import com.personal.marketnote.common.kafka.event.OrderPaymentCompletedEvent.OrderProductItem;
 import com.personal.marketnote.common.utility.FormatValidator;
@@ -44,6 +45,16 @@ public class OrderPaymentCompletedSharedPointConsumer {
     ) {
         EventEnvelope<?> envelope = record.value();
 
+        if (EventPayloadValidator.hasInvalidEnvelope(envelope, record)) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        if (EventPayloadValidator.hasEventTypeMismatch(envelope, KafkaTopicConstants.ORDER_PAYMENT_COMPLETED)) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
         try {
             OrderPaymentCompletedEvent payload = envelope.getPayloadAs(
                     OrderPaymentCompletedEvent.class, objectMapper
@@ -52,9 +63,9 @@ public class OrderPaymentCompletedSharedPointConsumer {
             log.info("주문 결제 완료 이벤트 수신 (공유 포인트 적립). eventId={}, orderId={}, buyerId={}",
                     envelope.eventId(), payload.orderId(), payload.buyerId());
 
-            if (FormatValidator.hasNoValue(payload.orderId()) || FormatValidator.hasNoValue(payload.buyerId())) {
-                log.error("유효하지 않은 이벤트 페이로드. eventId={}, orderId={}, buyerId={}",
-                        envelope.eventId(), payload.orderId(), payload.buyerId());
+            if (EventPayloadValidator.hasInvalidIds(envelope.eventId(),
+                    EventPayloadValidator.id("orderId", payload.orderId()),
+                    EventPayloadValidator.id("buyerId", payload.buyerId()))) {
                 acknowledgment.acknowledge();
                 return;
             }

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/event/OrderPurchaseConfirmedProductPointConsumer.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/event/OrderPurchaseConfirmedProductPointConsumer.java
@@ -3,8 +3,8 @@ package com.personal.marketnote.reward.adapter.in.event;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.personal.marketnote.common.kafka.KafkaTopicConstants;
 import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.EventPayloadValidator;
 import com.personal.marketnote.common.kafka.event.OrderPurchaseConfirmedEvent;
-import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.reward.domain.point.UserPointSourceType;
 import com.personal.marketnote.reward.port.in.command.point.ConfirmPendingPointCommand;
 import com.personal.marketnote.reward.port.in.usecase.point.ConfirmPendingPointUseCase;
@@ -34,9 +34,12 @@ public class OrderPurchaseConfirmedProductPointConsumer {
     ) {
         EventEnvelope<?> envelope = record.value();
 
-        if (FormatValidator.hasNoValue(envelope)) {
-            log.error("이벤트 envelope이 null. topic={}, partition={}, offset={}",
-                    record.topic(), record.partition(), record.offset());
+        if (EventPayloadValidator.hasInvalidEnvelope(envelope, record)) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        if (EventPayloadValidator.hasEventTypeMismatch(envelope, KafkaTopicConstants.ORDER_PURCHASE_CONFIRMED)) {
             acknowledgment.acknowledge();
             return;
         }
@@ -49,9 +52,9 @@ public class OrderPurchaseConfirmedProductPointConsumer {
             log.info("구매 확정 이벤트 수신 (상품 적립 예정 포인트 확정). eventId={}, orderId={}, buyerId={}",
                     envelope.eventId(), payload.orderId(), payload.buyerId());
 
-            if (FormatValidator.hasNoValue(payload.orderId()) || FormatValidator.hasNoValue(payload.buyerId())) {
-                log.error("유효하지 않은 이벤트 페이로드. eventId={}, orderId={}, buyerId={}",
-                        envelope.eventId(), payload.orderId(), payload.buyerId());
+            if (EventPayloadValidator.hasInvalidIds(envelope.eventId(),
+                    EventPayloadValidator.id("orderId", payload.orderId()),
+                    EventPayloadValidator.id("buyerId", payload.buyerId()))) {
                 acknowledgment.acknowledge();
                 return;
             }

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/event/OrderPurchaseConfirmedSharedPointConsumer.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/event/OrderPurchaseConfirmedSharedPointConsumer.java
@@ -3,6 +3,7 @@ package com.personal.marketnote.reward.adapter.in.event;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.personal.marketnote.common.kafka.KafkaTopicConstants;
 import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.EventPayloadValidator;
 import com.personal.marketnote.common.kafka.event.OrderPurchaseConfirmedEvent;
 import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.reward.domain.point.UserPointSourceType;
@@ -36,9 +37,12 @@ public class OrderPurchaseConfirmedSharedPointConsumer {
     ) {
         EventEnvelope<?> envelope = record.value();
 
-        if (FormatValidator.hasNoValue(envelope)) {
-            log.error("이벤트 envelope이 null. topic={}, partition={}, offset={}",
-                    record.topic(), record.partition(), record.offset());
+        if (EventPayloadValidator.hasInvalidEnvelope(envelope, record)) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        if (EventPayloadValidator.hasEventTypeMismatch(envelope, KafkaTopicConstants.ORDER_PURCHASE_CONFIRMED)) {
             acknowledgment.acknowledge();
             return;
         }
@@ -51,9 +55,8 @@ public class OrderPurchaseConfirmedSharedPointConsumer {
             log.info("구매 확정 이벤트 수신 (공유 적립 예정 포인트 확정). eventId={}, orderId={}, sharerIds={}",
                     envelope.eventId(), payload.orderId(), payload.sharerIds());
 
-            if (FormatValidator.hasNoValue(payload.orderId())) {
-                log.error("유효하지 않은 이벤트 페이로드. eventId={}, orderId=null",
-                        envelope.eventId());
+            if (EventPayloadValidator.hasInvalidIds(envelope.eventId(),
+                    EventPayloadValidator.id("orderId", payload.orderId()))) {
                 acknowledgment.acknowledge();
                 return;
             }

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/event/PaymentCancelledPartialProductPointConsumer.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/event/PaymentCancelledPartialProductPointConsumer.java
@@ -3,6 +3,7 @@ package com.personal.marketnote.reward.adapter.in.event;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.personal.marketnote.common.kafka.KafkaTopicConstants;
 import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.EventPayloadValidator;
 import com.personal.marketnote.common.kafka.event.PaymentCancelledEvent;
 import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.reward.domain.point.UserPointChangeType;
@@ -36,9 +37,12 @@ public class PaymentCancelledPartialProductPointConsumer {
     ) {
         EventEnvelope<?> envelope = record.value();
 
-        if (FormatValidator.hasNoValue(envelope)) {
-            log.error("이벤트 envelope이 null. topic={}, partition={}, offset={}",
-                    record.topic(), record.partition(), record.offset());
+        if (EventPayloadValidator.hasInvalidEnvelope(envelope, record)) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        if (EventPayloadValidator.hasEventTypeMismatch(envelope, KafkaTopicConstants.PAYMENT_CANCELLED)) {
             acknowledgment.acknowledge();
             return;
         }
@@ -51,9 +55,8 @@ public class PaymentCancelledPartialProductPointConsumer {
             log.info("결제 취소 이벤트 수신 (부분 상품 적립 예정 포인트 차감). eventId={}, orderId={}, buyerId={}, isFullCancel={}",
                     envelope.eventId(), payload.orderId(), payload.buyerId(), payload.isFullCancel());
 
-            if (FormatValidator.hasNoValue(payload.orderId())) {
-                log.error("유효하지 않은 이벤트 페이로드. eventId={}, orderId=null",
-                        envelope.eventId());
+            if (EventPayloadValidator.hasInvalidIds(envelope.eventId(),
+                    EventPayloadValidator.id("orderId", payload.orderId()))) {
                 acknowledgment.acknowledge();
                 return;
             }
@@ -64,9 +67,8 @@ public class PaymentCancelledPartialProductPointConsumer {
                 return;
             }
 
-            if (FormatValidator.hasNoValue(payload.buyerId())) {
-                log.error("유효하지 않은 이벤트 페이로드. eventId={}, orderId={}, buyerId=null",
-                        envelope.eventId(), payload.orderId());
+            if (EventPayloadValidator.hasInvalidIds(envelope.eventId(),
+                    EventPayloadValidator.id("buyerId", payload.buyerId()))) {
                 acknowledgment.acknowledge();
                 return;
             }

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/event/PaymentCancelledPartialSharedPointConsumer.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/event/PaymentCancelledPartialSharedPointConsumer.java
@@ -3,6 +3,7 @@ package com.personal.marketnote.reward.adapter.in.event;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.personal.marketnote.common.kafka.KafkaTopicConstants;
 import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.EventPayloadValidator;
 import com.personal.marketnote.common.kafka.event.PaymentCancelledEvent;
 import com.personal.marketnote.common.kafka.event.PaymentCancelledEvent.OrderProductItem;
 import com.personal.marketnote.common.utility.FormatValidator;
@@ -44,9 +45,12 @@ public class PaymentCancelledPartialSharedPointConsumer {
     ) {
         EventEnvelope<?> envelope = record.value();
 
-        if (FormatValidator.hasNoValue(envelope)) {
-            log.error("이벤트 envelope이 null. topic={}, partition={}, offset={}",
-                    record.topic(), record.partition(), record.offset());
+        if (EventPayloadValidator.hasInvalidEnvelope(envelope, record)) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        if (EventPayloadValidator.hasEventTypeMismatch(envelope, KafkaTopicConstants.PAYMENT_CANCELLED)) {
             acknowledgment.acknowledge();
             return;
         }
@@ -59,9 +63,8 @@ public class PaymentCancelledPartialSharedPointConsumer {
             log.info("결제 취소 이벤트 수신 (부분 공유 적립 예정 포인트 차감). eventId={}, orderId={}, isFullCancel={}",
                     envelope.eventId(), payload.orderId(), payload.isFullCancel());
 
-            if (FormatValidator.hasNoValue(payload.orderId())) {
-                log.error("유효하지 않은 이벤트 페이로드. eventId={}, orderId=null",
-                        envelope.eventId());
+            if (EventPayloadValidator.hasInvalidIds(envelope.eventId(),
+                    EventPayloadValidator.id("orderId", payload.orderId()))) {
                 acknowledgment.acknowledge();
                 return;
             }

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/event/PaymentCancelledPendingProductPointConsumer.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/event/PaymentCancelledPendingProductPointConsumer.java
@@ -3,8 +3,8 @@ package com.personal.marketnote.reward.adapter.in.event;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.personal.marketnote.common.kafka.KafkaTopicConstants;
 import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.EventPayloadValidator;
 import com.personal.marketnote.common.kafka.event.PaymentCancelledEvent;
-import com.personal.marketnote.common.utility.FormatValidator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -28,9 +28,12 @@ public class PaymentCancelledPendingProductPointConsumer {
     ) {
         EventEnvelope<?> envelope = record.value();
 
-        if (FormatValidator.hasNoValue(envelope)) {
-            log.error("이벤트 envelope이 null. topic={}, partition={}, offset={}",
-                    record.topic(), record.partition(), record.offset());
+        if (EventPayloadValidator.hasInvalidEnvelope(envelope, record)) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        if (EventPayloadValidator.hasEventTypeMismatch(envelope, KafkaTopicConstants.PAYMENT_CANCELLED)) {
             acknowledgment.acknowledge();
             return;
         }
@@ -43,9 +46,8 @@ public class PaymentCancelledPendingProductPointConsumer {
             log.info("결제 취소 이벤트 수신 (상품 적립 예정 포인트 회수). eventId={}, orderId={}, buyerId={}, isFullCancel={}",
                     envelope.eventId(), payload.orderId(), payload.buyerId(), payload.isFullCancel());
 
-            if (FormatValidator.hasNoValue(payload.orderId())) {
-                log.error("유효하지 않은 이벤트 페이로드. eventId={}, orderId=null",
-                        envelope.eventId());
+            if (EventPayloadValidator.hasInvalidIds(envelope.eventId(),
+                    EventPayloadValidator.id("orderId", payload.orderId()))) {
                 acknowledgment.acknowledge();
                 return;
             }
@@ -56,9 +58,8 @@ public class PaymentCancelledPendingProductPointConsumer {
                 return;
             }
 
-            if (FormatValidator.hasNoValue(payload.buyerId())) {
-                log.error("유효하지 않은 이벤트 페이로드. eventId={}, orderId={}, buyerId=null",
-                        envelope.eventId(), payload.orderId());
+            if (EventPayloadValidator.hasInvalidIds(envelope.eventId(),
+                    EventPayloadValidator.id("buyerId", payload.buyerId()))) {
                 acknowledgment.acknowledge();
                 return;
             }

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/event/PaymentCancelledPendingSharedPointConsumer.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/event/PaymentCancelledPendingSharedPointConsumer.java
@@ -3,6 +3,7 @@ package com.personal.marketnote.reward.adapter.in.event;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.personal.marketnote.common.kafka.KafkaTopicConstants;
 import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.EventPayloadValidator;
 import com.personal.marketnote.common.kafka.event.PaymentCancelledEvent;
 import com.personal.marketnote.common.kafka.event.PaymentCancelledEvent.OrderProductItem;
 import com.personal.marketnote.common.utility.FormatValidator;
@@ -32,9 +33,12 @@ public class PaymentCancelledPendingSharedPointConsumer {
     ) {
         EventEnvelope<?> envelope = record.value();
 
-        if (FormatValidator.hasNoValue(envelope)) {
-            log.error("이벤트 envelope이 null. topic={}, partition={}, offset={}",
-                    record.topic(), record.partition(), record.offset());
+        if (EventPayloadValidator.hasInvalidEnvelope(envelope, record)) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        if (EventPayloadValidator.hasEventTypeMismatch(envelope, KafkaTopicConstants.PAYMENT_CANCELLED)) {
             acknowledgment.acknowledge();
             return;
         }
@@ -47,9 +51,8 @@ public class PaymentCancelledPendingSharedPointConsumer {
             log.info("결제 취소 이벤트 수신 (공유 적립 예정 포인트 회수). eventId={}, orderId={}, isFullCancel={}",
                     envelope.eventId(), payload.orderId(), payload.isFullCancel());
 
-            if (FormatValidator.hasNoValue(payload.orderId())) {
-                log.error("유효하지 않은 이벤트 페이로드. eventId={}, orderId=null",
-                        envelope.eventId());
+            if (EventPayloadValidator.hasInvalidIds(envelope.eventId(),
+                    EventPayloadValidator.id("orderId", payload.orderId()))) {
                 acknowledgment.acknowledge();
                 return;
             }

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/event/PaymentCancelledPointRefundConsumer.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/event/PaymentCancelledPointRefundConsumer.java
@@ -3,6 +3,7 @@ package com.personal.marketnote.reward.adapter.in.event;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.personal.marketnote.common.kafka.KafkaTopicConstants;
 import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.EventPayloadValidator;
 import com.personal.marketnote.common.kafka.event.PaymentCancelledEvent;
 import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.reward.domain.point.UserPointChangeType;
@@ -36,9 +37,12 @@ public class PaymentCancelledPointRefundConsumer {
     ) {
         EventEnvelope<?> envelope = record.value();
 
-        if (FormatValidator.hasNoValue(envelope)) {
-            log.error("이벤트 envelope이 null. topic={}, partition={}, offset={}",
-                    record.topic(), record.partition(), record.offset());
+        if (EventPayloadValidator.hasInvalidEnvelope(envelope, record)) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        if (EventPayloadValidator.hasEventTypeMismatch(envelope, KafkaTopicConstants.PAYMENT_CANCELLED)) {
             acknowledgment.acknowledge();
             return;
         }
@@ -51,9 +55,8 @@ public class PaymentCancelledPointRefundConsumer {
             log.info("결제 취소 이벤트 수신 (포인트 환불). eventId={}, orderId={}, buyerId={}, pointAmount={}, isFullCancel={}",
                     envelope.eventId(), payload.orderId(), payload.buyerId(), payload.pointAmount(), payload.isFullCancel());
 
-            if (FormatValidator.hasNoValue(payload.orderId())) {
-                log.error("유효하지 않은 이벤트 페이로드. eventId={}, orderId=null",
-                        envelope.eventId());
+            if (EventPayloadValidator.hasInvalidIds(envelope.eventId(),
+                    EventPayloadValidator.id("orderId", payload.orderId()))) {
                 acknowledgment.acknowledge();
                 return;
             }
@@ -64,9 +67,8 @@ public class PaymentCancelledPointRefundConsumer {
                 return;
             }
 
-            if (FormatValidator.hasNoValue(payload.buyerId())) {
-                log.error("유효하지 않은 이벤트 페이로드. eventId={}, orderId={}, buyerId=null",
-                        envelope.eventId(), payload.orderId());
+            if (EventPayloadValidator.hasInvalidIds(envelope.eventId(),
+                    EventPayloadValidator.id("buyerId", payload.buyerId()))) {
                 acknowledgment.acknowledge();
                 return;
             }

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/event/UserReferralCompletedRewardConsumer.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/event/UserReferralCompletedRewardConsumer.java
@@ -3,8 +3,8 @@ package com.personal.marketnote.reward.adapter.in.event;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.personal.marketnote.common.kafka.KafkaTopicConstants;
 import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.EventPayloadValidator;
 import com.personal.marketnote.common.kafka.event.UserReferralCompletedEvent;
-import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.reward.domain.point.UserPointChangeType;
 import com.personal.marketnote.reward.domain.point.UserPointSourceType;
 import com.personal.marketnote.reward.exception.DuplicateUserPointHistoryException;
@@ -37,6 +37,16 @@ public class UserReferralCompletedRewardConsumer {
     ) {
         EventEnvelope<?> envelope = record.value();
 
+        if (EventPayloadValidator.hasInvalidEnvelope(envelope, record)) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        if (EventPayloadValidator.hasEventTypeMismatch(envelope, KafkaTopicConstants.USER_REFERRAL_COMPLETED)) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
         try {
             UserReferralCompletedEvent payload = envelope.getPayloadAs(
                     UserReferralCompletedEvent.class, objectMapper
@@ -45,10 +55,9 @@ public class UserReferralCompletedRewardConsumer {
             log.info("추천코드 등록 완료 이벤트 수신. eventId={}, requestUserId={}, referredUserId={}",
                     envelope.eventId(), payload.requestUserId(), payload.referredUserId());
 
-            if (FormatValidator.hasNoValue(payload.requestUserId())
-                    || FormatValidator.hasNoValue(payload.referredUserId())) {
-                log.error("유효하지 않은 이벤트 페이로드. eventId={}, requestUserId={}, referredUserId={}",
-                        envelope.eventId(), payload.requestUserId(), payload.referredUserId());
+            if (EventPayloadValidator.hasInvalidIds(envelope.eventId(),
+                    EventPayloadValidator.id("requestUserId", payload.requestUserId()),
+                    EventPayloadValidator.id("referredUserId", payload.referredUserId()))) {
                 acknowledgment.acknowledge();
                 return;
             }

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/event/UserSignupCompletedRewardConsumer.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/event/UserSignupCompletedRewardConsumer.java
@@ -3,6 +3,7 @@ package com.personal.marketnote.reward.adapter.in.event;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.personal.marketnote.common.kafka.KafkaTopicConstants;
 import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.EventPayloadValidator;
 import com.personal.marketnote.common.kafka.event.UserSignupCompletedEvent;
 import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.reward.exception.DuplicateUserPointException;
@@ -32,15 +33,31 @@ public class UserSignupCompletedRewardConsumer {
     ) {
         EventEnvelope<?> envelope = record.value();
 
+        if (EventPayloadValidator.hasInvalidEnvelope(envelope, record)) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        if (EventPayloadValidator.hasEventTypeMismatch(envelope, KafkaTopicConstants.USER_SIGNUP_COMPLETED)) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
         try {
             UserSignupCompletedEvent payload = envelope.getPayloadAs(UserSignupCompletedEvent.class, objectMapper);
 
             log.info("회원가입 완료 이벤트 수신. eventId={}, userId={}, userKey={}",
                     envelope.eventId(), payload.userId(), payload.userKey());
 
-            if (FormatValidator.hasNoValue(payload.userId()) || FormatValidator.hasNoValue(payload.userKey())) {
-                log.error("유효하지 않은 이벤트 페이로드. eventId={}, userId={}, userKey={}",
-                        envelope.eventId(), payload.userId(), payload.userKey());
+            if (EventPayloadValidator.hasInvalidIds(envelope.eventId(),
+                    EventPayloadValidator.id("userId", payload.userId()))) {
+                acknowledgment.acknowledge();
+                return;
+            }
+
+            if (FormatValidator.hasNoValue(payload.userKey())) {
+                log.error("유효하지 않은 이벤트 페이로드. eventId={}, userKey=null",
+                        envelope.eventId());
                 acknowledgment.acknowledge();
                 return;
             }


### PR DESCRIPTION
## partially addresses #929
## resolves #1047

## Task
- [x] EventPayloadValidator 공통 검증 유틸리티 신설 (common 모듈)
    - [x] hasInvalidEnvelope: envelope null 검증
    - [x] hasEventTypeMismatch: eventType 토픽 일치 검증
    - [x] hasInvalidIds: 숫자 ID null/0/음수 거부
- [x] 26개 Consumer에 3단계 검증 일괄 적용
    - [x] Commerce: 11개 (결제승인/실패/취소, 주문결제완료, 정산, 리뷰, 상품/가격정책)
    - [x] Reward: 12개 (포인트적립/차감/환불/확정, 회원가입/추천코드)
    - [x] Fulfillment: 3개 (상품등록/수정, 출고요청)
    - [x] Product: 1개 (장바구니삭제)
- [x] 기존 FormatValidator.hasNoValue(id) → EventPayloadValidator.hasInvalidIds() 교체
- [x] 사용하지 않는 FormatValidator import 정리