### PR TITLE
[#929][#1194] test: Kafka Consumer 이벤트 페이로드 입력 검증 통일 기능 자동화 테스트 추가

### DIFF
--- a/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/event/OrderPaymentCompletedInventoryConsumerTest.java
+++ b/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/event/OrderPaymentCompletedInventoryConsumerTest.java
@@ -166,6 +166,80 @@ class OrderPaymentCompletedInventoryConsumerTest {
     }
 
     @Test
+    @DisplayName("envelope이 null이면 UseCase를 호출하지 않고 acknowledge한다")
+    void handleOrderPaymentCompletedEvent_nullEnvelope_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = new ConsumerRecord<>(
+                "commerce.order.payment-completed", 0, 0L, "1", null
+        );
+        Acknowledgment acknowledgment = mock(Acknowledgment.class);
+
+        // when
+        consumer.handleOrderPaymentCompletedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(reduceProductInventoryUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("eventType이 불일치하면 UseCase를 호출하지 않고 acknowledge한다")
+    void handleOrderPaymentCompletedEvent_eventTypeMismatch_skipsAndAcknowledges() {
+        // given
+        List<OrderProductItem> items = createOrderProductItems();
+        OrderPaymentCompletedEvent event = new OrderPaymentCompletedEvent(
+                1L, 50L, 80000L, 5000L, items, null
+        );
+        EventEnvelope<OrderPaymentCompletedEvent> envelope = new EventEnvelope<>(
+                "test-event-id", "wrong.event.type", "commerce-service",
+                LocalDateTime.of(2026, 3, 5, 10, 0), event
+        );
+        ConsumerRecord<String, EventEnvelope<?>> record = new ConsumerRecord<>(
+                "commerce.order.payment-completed", 0, 0L, "1", envelope
+        );
+        Acknowledgment acknowledgment = mock(Acknowledgment.class);
+
+        // when
+        consumer.handleOrderPaymentCompletedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(reduceProductInventoryUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("orderId가 0이면 UseCase를 호출하지 않고 acknowledge한다")
+    void handleOrderPaymentCompletedEvent_zeroOrderId_skipsAndAcknowledges() {
+        // given
+        List<OrderProductItem> items = createOrderProductItems();
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(0L, 50L, 80000L, 5000L, items);
+        Acknowledgment acknowledgment = mock(Acknowledgment.class);
+
+        // when
+        consumer.handleOrderPaymentCompletedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(reduceProductInventoryUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("orderId가 음수이면 UseCase를 호출하지 않고 acknowledge한다")
+    void handleOrderPaymentCompletedEvent_negativeOrderId_skipsAndAcknowledges() {
+        // given
+        List<OrderProductItem> items = createOrderProductItems();
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(-1L, 50L, 80000L, 5000L, items);
+        Acknowledgment acknowledgment = mock(Acknowledgment.class);
+
+        // when
+        consumer.handleOrderPaymentCompletedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(reduceProductInventoryUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
     @DisplayName("예상치 못한 예외 발생 시 DefaultErrorHandler로 위임되어 예외가 전파된다")
     void handleOrderPaymentCompletedEvent_unexpectedException_propagatesForRetry() {
         // given

--- a/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/event/PaymentApprovedOrderStatusConsumerTest.java
+++ b/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/event/PaymentApprovedOrderStatusConsumerTest.java
@@ -100,6 +100,71 @@ class PaymentApprovedOrderStatusConsumerTest {
     }
 
     @Test
+    @DisplayName("envelope이 null이면 UseCase를 호출하지 않고 acknowledge한다")
+    void handlePaymentApprovedEvent_nullEnvelope_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = new ConsumerRecord<>(
+                "commerce.payment.approved", 0, 0L, "1", null
+        );
+
+        // when
+        consumer.handlePaymentApprovedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(changeOrderStatusUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("eventType이 불일치하면 UseCase를 호출하지 않고 acknowledge한다")
+    void handlePaymentApprovedEvent_eventTypeMismatch_skipsAndAcknowledges() {
+        // given
+        PaymentApprovedEvent event = new PaymentApprovedEvent(1L, "order-key-1", 50000L);
+        EventEnvelope<PaymentApprovedEvent> envelope = new EventEnvelope<>(
+                "test-event-id", "wrong.event.type", "commerce-service",
+                LocalDateTime.of(2026, 3, 5, 10, 0), event
+        );
+        ConsumerRecord<String, EventEnvelope<?>> record = new ConsumerRecord<>(
+                "commerce.payment.approved", 0, 0L, "1", envelope
+        );
+
+        // when
+        consumer.handlePaymentApprovedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(changeOrderStatusUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("orderId가 0이면 UseCase를 호출하지 않고 acknowledge한다")
+    void handlePaymentApprovedEvent_zeroOrderId_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(0L, "order-key-1", 50000L);
+
+        // when
+        consumer.handlePaymentApprovedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(changeOrderStatusUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("orderId가 음수이면 UseCase를 호출하지 않고 acknowledge한다")
+    void handlePaymentApprovedEvent_negativeOrderId_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(-1L, "order-key-1", 50000L);
+
+        // when
+        consumer.handlePaymentApprovedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(changeOrderStatusUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
     @DisplayName("예상치 못한 예외 발생 시 DefaultErrorHandler로 위임되어 예외가 전파된다")
     void handlePaymentApprovedEvent_unexpectedException_propagatesForRetry() {
         // given

--- a/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/event/PaymentCancelledInventoryConsumerTest.java
+++ b/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/event/PaymentCancelledInventoryConsumerTest.java
@@ -195,6 +195,76 @@ class PaymentCancelledInventoryConsumerTest {
     }
 
     @Test
+    @DisplayName("envelope이 null이면 UseCase를 호출하지 않고 acknowledge한다")
+    void handlePaymentCancelledEvent_nullEnvelope_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = new ConsumerRecord<>(
+                "commerce.payment.cancelled", 0, 0L, "1", null
+        );
+
+        // when
+        consumer.handlePaymentCancelledEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(restoreProductInventoryUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("eventType이 불일치하면 UseCase를 호출하지 않고 acknowledge한다")
+    void handlePaymentCancelledEvent_eventTypeMismatch_skipsAndAcknowledges() {
+        // given
+        PaymentCancelledEvent event = new PaymentCancelledEvent(
+                1L, "order-key-1", 100L, 50000L, 80000L, 1000L,
+                true, 0L, null, List.of(), null, null
+        );
+        EventEnvelope<PaymentCancelledEvent> envelope = new EventEnvelope<>(
+                "test-event-id", "wrong.event.type", "commerce-service",
+                LocalDateTime.of(2026, 3, 6, 10, 0), event
+        );
+        ConsumerRecord<String, EventEnvelope<?>> record = new ConsumerRecord<>(
+                "commerce.payment.cancelled", 0, 0L, "1", envelope
+        );
+
+        // when
+        consumer.handlePaymentCancelledEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(restoreProductInventoryUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("orderId가 0이면 UseCase를 호출하지 않고 acknowledge한다")
+    void handlePaymentCancelledEvent_zeroOrderId_skipsAndAcknowledges() {
+        // given
+        List<OrderProductItem> orderProducts = createOrderProductItems();
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(0L, true, orderProducts, null);
+
+        // when
+        consumer.handlePaymentCancelledEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(restoreProductInventoryUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("orderId가 음수이면 UseCase를 호출하지 않고 acknowledge한다")
+    void handlePaymentCancelledEvent_negativeOrderId_skipsAndAcknowledges() {
+        // given
+        List<OrderProductItem> orderProducts = createOrderProductItems();
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(-1L, true, orderProducts, null);
+
+        // when
+        consumer.handlePaymentCancelledEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(restoreProductInventoryUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
     @DisplayName("예상치 못한 예외 발생 시 DefaultErrorHandler로 위임되어 예외가 전파된다")
     @SuppressWarnings("unchecked")
     void handlePaymentCancelledEvent_unexpectedException_propagatesForRetry() {

--- a/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/event/PaymentCancelledOrderStatusConsumerTest.java
+++ b/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/event/PaymentCancelledOrderStatusConsumerTest.java
@@ -119,6 +119,74 @@ class PaymentCancelledOrderStatusConsumerTest {
     }
 
     @Test
+    @DisplayName("envelope이 null이면 UseCase를 호출하지 않고 acknowledge한다")
+    void handlePaymentCancelledEvent_nullEnvelope_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = new ConsumerRecord<>(
+                "commerce.payment.cancelled", 0, 0L, "1", null
+        );
+
+        // when
+        consumer.handlePaymentCancelledEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(changeOrderStatusUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("eventType이 불일치하면 UseCase를 호출하지 않고 acknowledge한다")
+    void handlePaymentCancelledEvent_eventTypeMismatch_skipsAndAcknowledges() {
+        // given
+        PaymentCancelledEvent event = new PaymentCancelledEvent(
+                1L, "order-key-1", 100L, 50000L, 50000L, 1000L,
+                true, 0L, null, List.of(), null, null
+        );
+        EventEnvelope<PaymentCancelledEvent> envelope = new EventEnvelope<>(
+                "test-event-id", "wrong.event.type", "commerce-service",
+                LocalDateTime.of(2026, 3, 6, 10, 0), event
+        );
+        ConsumerRecord<String, EventEnvelope<?>> record = new ConsumerRecord<>(
+                "commerce.payment.cancelled", 0, 0L, "1", envelope
+        );
+
+        // when
+        consumer.handlePaymentCancelledEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(changeOrderStatusUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("orderId가 0이면 UseCase를 호출하지 않고 acknowledge한다")
+    void handlePaymentCancelledEvent_zeroOrderId_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(0L, "order-key-1", true, 50000L);
+
+        // when
+        consumer.handlePaymentCancelledEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(changeOrderStatusUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("orderId가 음수이면 UseCase를 호출하지 않고 acknowledge한다")
+    void handlePaymentCancelledEvent_negativeOrderId_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(-1L, "order-key-1", true, 50000L);
+
+        // when
+        consumer.handlePaymentCancelledEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(changeOrderStatusUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
     @DisplayName("예상치 못한 예외 발생 시 DefaultErrorHandler로 위임되어 예외가 전파된다")
     void handlePaymentCancelledEvent_unexpectedException_propagatesForRetry() {
         // given

--- a/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/event/PaymentFailedOrderStatusConsumerTest.java
+++ b/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/event/PaymentFailedOrderStatusConsumerTest.java
@@ -101,6 +101,71 @@ class PaymentFailedOrderStatusConsumerTest {
     }
 
     @Test
+    @DisplayName("envelope이 null이면 UseCase를 호출하지 않고 acknowledge한다")
+    void handlePaymentFailedEvent_nullEnvelope_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = new ConsumerRecord<>(
+                "commerce.payment.failed", 0, 0L, "1", null
+        );
+
+        // when
+        consumer.handlePaymentFailedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(changeOrderStatusUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("eventType이 불일치하면 UseCase를 호출하지 않고 acknowledge한다")
+    void handlePaymentFailedEvent_eventTypeMismatch_skipsAndAcknowledges() {
+        // given
+        PaymentFailedEvent event = new PaymentFailedEvent(1L, "order-key-1", "CARD_ERROR", "카드 잔액 부족");
+        EventEnvelope<PaymentFailedEvent> envelope = new EventEnvelope<>(
+                "test-event-id", "wrong.event.type", "commerce-service",
+                LocalDateTime.of(2026, 3, 5, 10, 0), event
+        );
+        ConsumerRecord<String, EventEnvelope<?>> record = new ConsumerRecord<>(
+                "commerce.payment.failed", 0, 0L, "1", envelope
+        );
+
+        // when
+        consumer.handlePaymentFailedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(changeOrderStatusUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("orderId가 0이면 UseCase를 호출하지 않고 acknowledge한다")
+    void handlePaymentFailedEvent_zeroOrderId_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(0L, "order-key-1", "CARD_ERROR", "카드 잔액 부족");
+
+        // when
+        consumer.handlePaymentFailedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(changeOrderStatusUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("orderId가 음수이면 UseCase를 호출하지 않고 acknowledge한다")
+    void handlePaymentFailedEvent_negativeOrderId_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(-1L, "order-key-1", "CARD_ERROR", "카드 잔액 부족");
+
+        // when
+        consumer.handlePaymentFailedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(changeOrderStatusUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
     @DisplayName("예상치 못한 예외 발생 시 DefaultErrorHandler로 위임되어 예외가 전파된다")
     void handlePaymentFailedEvent_unexpectedException_propagatesForRetry() {
         // given

--- a/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/event/PricePolicyEventKafkaListenerTest.java
+++ b/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/event/PricePolicyEventKafkaListenerTest.java
@@ -96,6 +96,99 @@ class PricePolicyEventKafkaListenerTest {
     }
 
     @Test
+    @DisplayName("envelope이 null이면 UseCase를 호출하지 않고 acknowledge한다")
+    void handlePricePolicyCreatedEvent_nullEnvelope_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = new ConsumerRecord<>(
+                "product.price-policy.created", 0, 0L, "key-1", null
+        );
+
+        // when
+        pricePolicyEventKafkaListener.handlePricePolicyCreatedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(registerInventoryUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("eventType이 불일치하면 UseCase를 호출하지 않고 acknowledge한다")
+    void handlePricePolicyCreatedEvent_eventTypeMismatch_skipsAndAcknowledges() {
+        // given
+        PricePolicyCreatedEvent event = new PricePolicyCreatedEvent(1L, 2L);
+        EventEnvelope<PricePolicyCreatedEvent> envelope = new EventEnvelope<>(
+                "test-event-id", "wrong.event.type", "product-service",
+                LocalDateTime.of(2026, 2, 27, 10, 0), event
+        );
+        ConsumerRecord<String, EventEnvelope<?>> record = new ConsumerRecord<>(
+                "product.price-policy.created", 0, 0L, "key-1", envelope
+        );
+
+        // when
+        pricePolicyEventKafkaListener.handlePricePolicyCreatedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(registerInventoryUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("productId가 0이면 UseCase를 호출하지 않고 acknowledge한다")
+    void handlePricePolicyCreatedEvent_zeroProductId_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(0L, 2L);
+
+        // when
+        pricePolicyEventKafkaListener.handlePricePolicyCreatedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(registerInventoryUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("productId가 음수이면 UseCase를 호출하지 않고 acknowledge한다")
+    void handlePricePolicyCreatedEvent_negativeProductId_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(-1L, 2L);
+
+        // when
+        pricePolicyEventKafkaListener.handlePricePolicyCreatedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(registerInventoryUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("pricePolicyId가 0이면 UseCase를 호출하지 않고 acknowledge한다")
+    void handlePricePolicyCreatedEvent_zeroPricePolicyId_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, 0L);
+
+        // when
+        pricePolicyEventKafkaListener.handlePricePolicyCreatedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(registerInventoryUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("pricePolicyId가 음수이면 UseCase를 호출하지 않고 acknowledge한다")
+    void handlePricePolicyCreatedEvent_negativePricePolicyId_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, -1L);
+
+        // when
+        pricePolicyEventKafkaListener.handlePricePolicyCreatedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(registerInventoryUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
     @DisplayName("이미 재고가 존재하면 예외를 무시하고 acknowledge한다")
     void handlePricePolicyCreatedEvent_inventoryAlreadyExists_acknowledges() {
         // given

--- a/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/event/ProductEventKafkaListenerTest.java
+++ b/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/event/ProductEventKafkaListenerTest.java
@@ -99,6 +99,101 @@ class ProductEventKafkaListenerTest {
     }
 
     @Test
+    @DisplayName("envelope이 null이면 UseCase를 호출하지 않고 acknowledge한다")
+    void handleProductRegisteredEvent_nullEnvelope_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = new ConsumerRecord<>(
+                "product.product.registered", 0, 0L, "key-1", null
+        );
+
+        // when
+        productEventKafkaListener.handleProductRegisteredEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(registerInventoryUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("eventType이 불일치하면 UseCase를 호출하지 않고 acknowledge한다")
+    void handleProductRegisteredEvent_eventTypeMismatch_skipsAndAcknowledges() {
+        // given
+        ProductRegisteredEvent event = new ProductRegisteredEvent(
+                1L, 2L, 3L, "테스트 상품", "1"
+        );
+        EventEnvelope<ProductRegisteredEvent> envelope = new EventEnvelope<>(
+                "test-event-id", "wrong.event.type", "product-service",
+                LocalDateTime.of(2026, 2, 27, 10, 0), event
+        );
+        ConsumerRecord<String, EventEnvelope<?>> record = new ConsumerRecord<>(
+                "product.product.registered", 0, 0L, "key-1", envelope
+        );
+
+        // when
+        productEventKafkaListener.handleProductRegisteredEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(registerInventoryUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("productId가 0이면 UseCase를 호출하지 않고 acknowledge한다")
+    void handleProductRegisteredEvent_zeroProductId_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(0L, 2L, 3L);
+
+        // when
+        productEventKafkaListener.handleProductRegisteredEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(registerInventoryUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("productId가 음수이면 UseCase를 호출하지 않고 acknowledge한다")
+    void handleProductRegisteredEvent_negativeProductId_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(-1L, 2L, 3L);
+
+        // when
+        productEventKafkaListener.handleProductRegisteredEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(registerInventoryUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("pricePolicyId가 0이면 UseCase를 호출하지 않고 acknowledge한다")
+    void handleProductRegisteredEvent_zeroPricePolicyId_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, 0L, 3L);
+
+        // when
+        productEventKafkaListener.handleProductRegisteredEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(registerInventoryUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("pricePolicyId가 음수이면 UseCase를 호출하지 않고 acknowledge한다")
+    void handleProductRegisteredEvent_negativePricePolicyId_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, -1L, 3L);
+
+        // when
+        productEventKafkaListener.handleProductRegisteredEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(registerInventoryUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
     @DisplayName("이미 재고가 존재하면 예외를 무시하고 acknowledge한다")
     void handleProductRegisteredEvent_inventoryAlreadyExists_acknowledges() {
         // given

--- a/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/event/ReviewRegisteredCommerceConsumerTest.java
+++ b/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/event/ReviewRegisteredCommerceConsumerTest.java
@@ -97,6 +97,99 @@ class ReviewRegisteredCommerceConsumerTest {
     }
 
     @Test
+    @DisplayName("envelope이 null이면 UseCase를 호출하지 않고 acknowledge한다")
+    void handleReviewRegisteredEvent_nullEnvelope_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = new ConsumerRecord<>(
+                "community.review.registered", 0, 0L, "key-1", null
+        );
+
+        // when
+        reviewRegisteredCommerceConsumer.handleReviewRegisteredEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(updateOrderProductUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("eventType이 불일치하면 UseCase를 호출하지 않고 acknowledge한다")
+    void handleReviewRegisteredEvent_eventTypeMismatch_skipsAndAcknowledges() {
+        // given
+        ReviewRegisteredEvent event = new ReviewRegisteredEvent(1L, 2L);
+        EventEnvelope<ReviewRegisteredEvent> envelope = new EventEnvelope<>(
+                "test-event-id", "wrong.event.type", "community-service",
+                LocalDateTime.of(2026, 3, 2, 10, 0), event
+        );
+        ConsumerRecord<String, EventEnvelope<?>> record = new ConsumerRecord<>(
+                "community.review.registered", 0, 0L, "key-1", envelope
+        );
+
+        // when
+        reviewRegisteredCommerceConsumer.handleReviewRegisteredEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(updateOrderProductUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("orderId가 0이면 UseCase를 호출하지 않고 acknowledge한다")
+    void handleReviewRegisteredEvent_zeroOrderId_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(0L, 2L);
+
+        // when
+        reviewRegisteredCommerceConsumer.handleReviewRegisteredEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(updateOrderProductUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("orderId가 음수이면 UseCase를 호출하지 않고 acknowledge한다")
+    void handleReviewRegisteredEvent_negativeOrderId_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(-1L, 2L);
+
+        // when
+        reviewRegisteredCommerceConsumer.handleReviewRegisteredEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(updateOrderProductUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("pricePolicyId가 0이면 UseCase를 호출하지 않고 acknowledge한다")
+    void handleReviewRegisteredEvent_zeroPricePolicyId_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, 0L);
+
+        // when
+        reviewRegisteredCommerceConsumer.handleReviewRegisteredEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(updateOrderProductUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("pricePolicyId가 음수이면 UseCase를 호출하지 않고 acknowledge한다")
+    void handleReviewRegisteredEvent_negativePricePolicyId_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, -1L);
+
+        // when
+        reviewRegisteredCommerceConsumer.handleReviewRegisteredEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(updateOrderProductUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
     @DisplayName("예상치 못한 예외 발생 시 DefaultErrorHandler로 위임되어 예외가 전파된다")
     void handleReviewRegisteredEvent_unexpectedException_propagatesForRetry() {
         // given

--- a/common/src/test/java/com/personal/marketnote/common/kafka/event/EventPayloadValidatorTest.java
+++ b/common/src/test/java/com/personal/marketnote/common/kafka/event/EventPayloadValidatorTest.java
@@ -1,0 +1,196 @@
+package com.personal.marketnote.common.kafka.event;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("EventPayloadValidator 테스트")
+class EventPayloadValidatorTest {
+    private static final String TOPIC = "commerce.payment.approved";
+    private static final String EVENT_ID = "test-event-id";
+
+    private EventEnvelope<?> buildEnvelope(String eventType) {
+        return new EventEnvelope<>(EVENT_ID, eventType, "test-source",
+                LocalDateTime.of(2026, 3, 9, 10, 0), "test-payload");
+    }
+
+    private ConsumerRecord<String, EventEnvelope<?>> buildRecord(EventEnvelope<?> envelope) {
+        return new ConsumerRecord<>(TOPIC, 0, 0L, "key", envelope);
+    }
+
+    @Nested
+    @DisplayName("hasInvalidEnvelope")
+    class HasInvalidEnvelope {
+
+        @Test
+        @DisplayName("envelope이 null이면 true를 반환한다")
+        void nullEnvelope_returnsTrue() {
+            // given
+            ConsumerRecord<String, EventEnvelope<?>> record = new ConsumerRecord<>(
+                    TOPIC, 0, 0L, "key", null
+            );
+
+            // when
+            boolean result = EventPayloadValidator.hasInvalidEnvelope(null, record);
+
+            // then
+            assertThat(result).isTrue();
+        }
+
+        @Test
+        @DisplayName("envelope이 유효하면 false를 반환한다")
+        void validEnvelope_returnsFalse() {
+            // given
+            EventEnvelope<?> envelope = buildEnvelope(TOPIC);
+            ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(envelope);
+
+            // when
+            boolean result = EventPayloadValidator.hasInvalidEnvelope(envelope, record);
+
+            // then
+            assertThat(result).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("hasEventTypeMismatch")
+    class HasEventTypeMismatch {
+
+        @Test
+        @DisplayName("eventType이 일치하면 false를 반환한다")
+        void matchingEventType_returnsFalse() {
+            // given
+            EventEnvelope<?> envelope = buildEnvelope(TOPIC);
+
+            // when
+            boolean result = EventPayloadValidator.hasEventTypeMismatch(envelope, TOPIC);
+
+            // then
+            assertThat(result).isFalse();
+        }
+
+        @Test
+        @DisplayName("eventType이 불일치하면 true를 반환한다")
+        void mismatchingEventType_returnsTrue() {
+            // given
+            EventEnvelope<?> envelope = buildEnvelope("commerce.payment.failed");
+
+            // when
+            boolean result = EventPayloadValidator.hasEventTypeMismatch(envelope, TOPIC);
+
+            // then
+            assertThat(result).isTrue();
+        }
+
+        @Test
+        @DisplayName("eventType이 null이면 true를 반환한다")
+        void nullEventType_returnsTrue() {
+            // given
+            EventEnvelope<?> envelope = buildEnvelope(null);
+
+            // when
+            boolean result = EventPayloadValidator.hasEventTypeMismatch(envelope, TOPIC);
+
+            // then
+            assertThat(result).isTrue();
+        }
+
+        @Test
+        @DisplayName("eventType이 빈 문자열이면 true를 반환한다")
+        void emptyEventType_returnsTrue() {
+            // given
+            EventEnvelope<?> envelope = buildEnvelope("");
+
+            // when
+            boolean result = EventPayloadValidator.hasEventTypeMismatch(envelope, TOPIC);
+
+            // then
+            assertThat(result).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("hasInvalidIds")
+    class HasInvalidIds {
+
+        @Test
+        @DisplayName("모든 ID가 양수이면 false를 반환한다")
+        void allPositiveIds_returnsFalse() {
+            // when
+            boolean result = EventPayloadValidator.hasInvalidIds(EVENT_ID,
+                    EventPayloadValidator.id("orderId", 1L),
+                    EventPayloadValidator.id("buyerId", 100L));
+
+            // then
+            assertThat(result).isFalse();
+        }
+
+        @Test
+        @DisplayName("ID가 null이면 true를 반환한다")
+        void nullId_returnsTrue() {
+            // when
+            boolean result = EventPayloadValidator.hasInvalidIds(EVENT_ID,
+                    EventPayloadValidator.id("orderId", null));
+
+            // then
+            assertThat(result).isTrue();
+        }
+
+        @ParameterizedTest
+        @ValueSource(longs = {0L, -1L, -100L})
+        @DisplayName("ID가 0 이하이면 true를 반환한다")
+        void nonPositiveId_returnsTrue(Long value) {
+            // when
+            boolean result = EventPayloadValidator.hasInvalidIds(EVENT_ID,
+                    EventPayloadValidator.id("orderId", value));
+
+            // then
+            assertThat(result).isTrue();
+        }
+
+        @Test
+        @DisplayName("복수 ID 중 하나라도 유효하지 않으면 true를 반환한다")
+        void oneInvalidAmongMultiple_returnsTrue() {
+            // when
+            boolean result = EventPayloadValidator.hasInvalidIds(EVENT_ID,
+                    EventPayloadValidator.id("orderId", 1L),
+                    EventPayloadValidator.id("buyerId", null));
+
+            // then
+            assertThat(result).isTrue();
+        }
+
+        @Test
+        @DisplayName("필드가 없으면 false를 반환한다")
+        void noFields_returnsFalse() {
+            // when
+            boolean result = EventPayloadValidator.hasInvalidIds(EVENT_ID);
+
+            // then
+            assertThat(result).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("id 팩토리 메서드")
+    class IdFactoryMethod {
+
+        @Test
+        @DisplayName("name과 value가 올바르게 설정된다")
+        void createsIdFieldWithCorrectValues() {
+            // when
+            EventPayloadValidator.IdField field = EventPayloadValidator.id("orderId", 42L);
+
+            // then
+            assertThat(field.name()).isEqualTo("orderId");
+            assertThat(field.value()).isEqualTo(42L);
+        }
+    }
+}

--- a/fulfillment-service/fulfillment-adapters/src/test/java/com/personal/marketnote/fulfillment/adapter/in/event/ProductRegisteredFulfillmentConsumerTest.java
+++ b/fulfillment-service/fulfillment-adapters/src/test/java/com/personal/marketnote/fulfillment/adapter/in/event/ProductRegisteredFulfillmentConsumerTest.java
@@ -211,6 +211,71 @@ class ProductRegisteredFulfillmentConsumerTest {
     }
 
     @Test
+    @DisplayName("envelope이 null이면 UseCase를 호출하지 않고 acknowledge한다")
+    void handleEvent_nullEnvelope_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = new ConsumerRecord<>(
+                "product.product.registered", 0, 0L, "1", null
+        );
+
+        // when
+        consumer.handleProductRegisteredEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(requestFasstoAuthUseCase, registerFasstoGoodsUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("eventType이 불일치하면 UseCase를 호출하지 않고 acknowledge한다")
+    void handleEvent_eventTypeMismatch_skipsAndAcknowledges() {
+        // given
+        ProductRegisteredEvent event = new ProductRegisteredEvent(1L, 100L, 1L, "테스트", "1");
+        EventEnvelope<ProductRegisteredEvent> envelope = new EventEnvelope<>(
+                "test-event-id", "wrong.event.type", "product-service",
+                LocalDateTime.of(2026, 2, 27, 10, 0), event
+        );
+        ConsumerRecord<String, EventEnvelope<?>> record = new ConsumerRecord<>(
+                "product.product.registered", 0, 0L, "key-1", envelope
+        );
+
+        // when
+        consumer.handleProductRegisteredEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(requestFasstoAuthUseCase, registerFasstoGoodsUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("productId가 0이면 상품 등록을 호출하지 않고 acknowledge한다")
+    void handleEvent_zeroProductId_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(0L, "테스트", "1");
+
+        // when
+        consumer.handleProductRegisteredEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(requestFasstoAuthUseCase, registerFasstoGoodsUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("productId가 음수이면 상품 등록을 호출하지 않고 acknowledge한다")
+    void handleEvent_negativeProductId_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(-1L, "테스트", "1");
+
+        // when
+        consumer.handleProductRegisteredEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(requestFasstoAuthUseCase, registerFasstoGoodsUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
     @DisplayName("예상치 못한 예외 발생 시 DefaultErrorHandler로 위임되어 예외가 전파된다")
     void handleEvent_unexpectedException_propagatesForRetry() {
         // given

--- a/fulfillment-service/fulfillment-adapters/src/test/java/com/personal/marketnote/fulfillment/adapter/in/event/ProductUpdatedFulfillmentConsumerTest.java
+++ b/fulfillment-service/fulfillment-adapters/src/test/java/com/personal/marketnote/fulfillment/adapter/in/event/ProductUpdatedFulfillmentConsumerTest.java
@@ -206,6 +206,77 @@ class ProductUpdatedFulfillmentConsumerTest {
     }
 
     @Test
+    @DisplayName("envelope이 null이면 UseCase를 호출하지 않고 acknowledge한다")
+    void handleEvent_nullEnvelope_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = new ConsumerRecord<>(
+                "product.product.updated", 0, 0L, "1", null
+        );
+
+        // when
+        consumer.handleProductUpdatedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(requestFasstoAuthUseCase, updateFasstoGoodsUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("eventType이 불일치하면 UseCase를 호출하지 않고 acknowledge한다")
+    void handleEvent_eventTypeMismatch_skipsAndAcknowledges() {
+        // given
+        ProductUpdatedEvent event = new ProductUpdatedEvent(
+                1L, "테스트", "1", "01",
+                null, null, null, null, null, null, null, null, null,
+                null, null, null, null, null, null, null, null, null,
+                null, null, null, null, null, null, null, null, null,
+                null, null, null, null
+        );
+        EventEnvelope<ProductUpdatedEvent> envelope = new EventEnvelope<>(
+                "test-event-id", "wrong.event.type", "product-service",
+                LocalDateTime.of(2026, 2, 27, 10, 0), event
+        );
+        ConsumerRecord<String, EventEnvelope<?>> record = new ConsumerRecord<>(
+                "product.product.updated", 0, 0L, "key-1", envelope
+        );
+
+        // when
+        consumer.handleProductUpdatedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(requestFasstoAuthUseCase, updateFasstoGoodsUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("productId가 0이면 상품 수정을 호출하지 않고 acknowledge한다")
+    void handleEvent_zeroProductId_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(0L, "테스트", "1", "01");
+
+        // when
+        consumer.handleProductUpdatedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(requestFasstoAuthUseCase, updateFasstoGoodsUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("productId가 음수이면 상품 수정을 호출하지 않고 acknowledge한다")
+    void handleEvent_negativeProductId_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(-1L, "테스트", "1", "01");
+
+        // when
+        consumer.handleProductUpdatedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(requestFasstoAuthUseCase, updateFasstoGoodsUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
     @DisplayName("예상치 못한 예외 발생 시 DefaultErrorHandler로 위임되어 예외가 전파된다")
     void handleEvent_unexpectedException_propagatesForRetry() {
         // given

--- a/product-service/product-adapters/src/test/java/com/personal/marketnote/product/adapter/in/event/OrderPaymentCompletedCartConsumerTest.java
+++ b/product-service/product-adapters/src/test/java/com/personal/marketnote/product/adapter/in/event/OrderPaymentCompletedCartConsumerTest.java
@@ -108,6 +108,76 @@ class OrderPaymentCompletedCartConsumerTest {
     }
 
     @Test
+    @DisplayName("envelope이 null이면 처리를 건너뛰고 acknowledge한다")
+    void handleOrderPaymentCompletedEvent_nullEnvelope_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = new ConsumerRecord<>(
+                "commerce.order.payment-completed", 0, 0L, "1", null
+        );
+        Acknowledgment acknowledgment = mock(Acknowledgment.class);
+
+        // when
+        consumer.handleOrderPaymentCompletedEvent(record, acknowledgment);
+
+        // then
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("eventType이 불일치하면 처리를 건너뛰고 acknowledge한다")
+    void handleOrderPaymentCompletedEvent_eventTypeMismatch_skipsAndAcknowledges() {
+        // given
+        List<OrderProductItem> items = createOrderProductItems();
+        OrderPaymentCompletedEvent event = new OrderPaymentCompletedEvent(
+                1L, 50L, 80000L, 5000L, items, null
+        );
+        EventEnvelope<OrderPaymentCompletedEvent> envelope = new EventEnvelope<>(
+                "test-event-id", "wrong.event.type", "commerce-service",
+                LocalDateTime.of(2026, 3, 5, 10, 0), event
+        );
+        ConsumerRecord<String, EventEnvelope<?>> record = new ConsumerRecord<>(
+                "commerce.order.payment-completed", 0, 0L, "1", envelope
+        );
+        Acknowledgment acknowledgment = mock(Acknowledgment.class);
+
+        // when
+        consumer.handleOrderPaymentCompletedEvent(record, acknowledgment);
+
+        // then
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("buyerId가 0이면 처리를 건너뛰고 acknowledge한다")
+    void handleOrderPaymentCompletedEvent_zeroBuyerId_skipsAndAcknowledges() {
+        // given
+        List<OrderProductItem> items = createOrderProductItems();
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, 0L, 80000L, 5000L, items);
+        Acknowledgment acknowledgment = mock(Acknowledgment.class);
+
+        // when
+        consumer.handleOrderPaymentCompletedEvent(record, acknowledgment);
+
+        // then
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("buyerId가 음수이면 처리를 건너뛰고 acknowledge한다")
+    void handleOrderPaymentCompletedEvent_negativeBuyerId_skipsAndAcknowledges() {
+        // given
+        List<OrderProductItem> items = createOrderProductItems();
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, -1L, 80000L, 5000L, items);
+        Acknowledgment acknowledgment = mock(Acknowledgment.class);
+
+        // when
+        consumer.handleOrderPaymentCompletedEvent(record, acknowledgment);
+
+        // then
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
     @DisplayName("예상치 못한 예외 발생 시 DefaultErrorHandler로 위임되어 예외가 전파된다")
     void handleOrderPaymentCompletedEvent_unexpectedException_propagatesForRetry() {
         // given

--- a/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/adapter/in/event/OrderPaymentCompletedOrderPointConsumerTest.java
+++ b/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/adapter/in/event/OrderPaymentCompletedOrderPointConsumerTest.java
@@ -166,6 +166,101 @@ class OrderPaymentCompletedOrderPointConsumerTest {
     }
 
     @Test
+    @DisplayName("envelope이 null이면 UseCase를 호출하지 않고 acknowledge한다")
+    void handleOrderPaymentCompletedEvent_nullEnvelope_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = new ConsumerRecord<>(
+                "commerce.order.payment-completed", 0, 0L, "1", null
+        );
+
+        // when
+        consumer.handleOrderPaymentCompletedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(modifyUserPointUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("eventType이 불일치하면 UseCase를 호출하지 않고 acknowledge한다")
+    void handleOrderPaymentCompletedEvent_eventTypeMismatch_skipsAndAcknowledges() {
+        // given
+        OrderPaymentCompletedEvent event = new OrderPaymentCompletedEvent(
+                1L, 100L, 50000L, 5000L, List.of(), null
+        );
+        EventEnvelope<OrderPaymentCompletedEvent> envelope = new EventEnvelope<>(
+                "test-event-id", "wrong.event.type", "commerce-service",
+                LocalDateTime.of(2026, 3, 8, 10, 0), event
+        );
+        ConsumerRecord<String, EventEnvelope<?>> record = new ConsumerRecord<>(
+                "commerce.order.payment-completed", 0, 0L, "1", envelope
+        );
+
+        // when
+        consumer.handleOrderPaymentCompletedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(modifyUserPointUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("orderId가 0이면 UseCase를 호출하지 않고 acknowledge한다")
+    void handleOrderPaymentCompletedEvent_zeroOrderId_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(0L, 100L, 5000L);
+
+        // when
+        consumer.handleOrderPaymentCompletedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(modifyUserPointUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("orderId가 음수이면 UseCase를 호출하지 않고 acknowledge한다")
+    void handleOrderPaymentCompletedEvent_negativeOrderId_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(-1L, 100L, 5000L);
+
+        // when
+        consumer.handleOrderPaymentCompletedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(modifyUserPointUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("buyerId가 0이면 UseCase를 호출하지 않고 acknowledge한다")
+    void handleOrderPaymentCompletedEvent_zeroBuyerId_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, 0L, 5000L);
+
+        // when
+        consumer.handleOrderPaymentCompletedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(modifyUserPointUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("buyerId가 음수이면 UseCase를 호출하지 않고 acknowledge한다")
+    void handleOrderPaymentCompletedEvent_negativeBuyerId_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, -1L, 5000L);
+
+        // when
+        consumer.handleOrderPaymentCompletedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(modifyUserPointUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
     @DisplayName("예상치 못한 예외 발생 시 acknowledge하지 않고 예외를 전파한다")
     void handleOrderPaymentCompletedEvent_unexpectedException_propagatesWithoutAcknowledge() {
         // given

--- a/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/adapter/in/event/OrderPaymentCompletedProductPointConsumerTest.java
+++ b/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/adapter/in/event/OrderPaymentCompletedProductPointConsumerTest.java
@@ -178,6 +178,101 @@ class OrderPaymentCompletedProductPointConsumerTest {
     }
 
     @Test
+    @DisplayName("envelope이 null이면 UseCase를 호출하지 않고 acknowledge한다")
+    void handleOrderPaymentCompletedEvent_nullEnvelope_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = new ConsumerRecord<>(
+                "commerce.order.payment-completed", 0, 0L, "1", null
+        );
+
+        // when
+        consumer.handleOrderPaymentCompletedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(modifyPendingPointUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("eventType이 불일치하면 UseCase를 호출하지 않고 acknowledge한다")
+    void handleOrderPaymentCompletedEvent_eventTypeMismatch_skipsAndAcknowledges() {
+        // given
+        OrderPaymentCompletedEvent event = new OrderPaymentCompletedEvent(
+                1L, 100L, 50000L, 0L, List.of(), 1500L
+        );
+        EventEnvelope<OrderPaymentCompletedEvent> envelope = new EventEnvelope<>(
+                "test-event-id", "wrong.event.type", "commerce-service",
+                LocalDateTime.of(2026, 3, 8, 10, 0), event
+        );
+        ConsumerRecord<String, EventEnvelope<?>> record = new ConsumerRecord<>(
+                "commerce.order.payment-completed", 0, 0L, "1", envelope
+        );
+
+        // when
+        consumer.handleOrderPaymentCompletedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(modifyPendingPointUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("orderId가 0이면 UseCase를 호출하지 않고 acknowledge한다")
+    void handleOrderPaymentCompletedEvent_zeroOrderId_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(0L, 100L, 50000L, 1500L);
+
+        // when
+        consumer.handleOrderPaymentCompletedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(modifyPendingPointUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("orderId가 음수이면 UseCase를 호출하지 않고 acknowledge한다")
+    void handleOrderPaymentCompletedEvent_negativeOrderId_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(-1L, 100L, 50000L, 1500L);
+
+        // when
+        consumer.handleOrderPaymentCompletedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(modifyPendingPointUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("buyerId가 0이면 UseCase를 호출하지 않고 acknowledge한다")
+    void handleOrderPaymentCompletedEvent_zeroBuyerId_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, 0L, 50000L, 1500L);
+
+        // when
+        consumer.handleOrderPaymentCompletedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(modifyPendingPointUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("buyerId가 음수이면 UseCase를 호출하지 않고 acknowledge한다")
+    void handleOrderPaymentCompletedEvent_negativeBuyerId_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, -1L, 50000L, 1500L);
+
+        // when
+        consumer.handleOrderPaymentCompletedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(modifyPendingPointUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
     @DisplayName("중복 이벤트 수신 시 DuplicateUserPointHistoryException이 발생하면 멱등 처리하고 acknowledge한다")
     void handleOrderPaymentCompletedEvent_duplicateEvent_idempotentAndAcknowledges() {
         // given

--- a/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/adapter/in/event/OrderPaymentCompletedSharedPointConsumerTest.java
+++ b/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/adapter/in/event/OrderPaymentCompletedSharedPointConsumerTest.java
@@ -175,6 +175,116 @@ class OrderPaymentCompletedSharedPointConsumerTest {
     }
 
     @Test
+    @DisplayName("envelope이 null이면 UseCase를 호출하지 않고 acknowledge한다")
+    void handleOrderPaymentCompletedEvent_nullEnvelope_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = new ConsumerRecord<>(
+                "commerce.order.payment-completed", 0, 0L, "1", null
+        );
+
+        // when
+        consumer.handleOrderPaymentCompletedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(modifyPendingPointUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("eventType이 불일치하면 UseCase를 호출하지 않고 acknowledge한다")
+    void handleOrderPaymentCompletedEvent_eventTypeMismatch_skipsAndAcknowledges() {
+        // given
+        List<OrderProductItem> orderProducts = List.of(
+                new OrderProductItem(1L, 200L, 2, 10000L)
+        );
+        OrderPaymentCompletedEvent event = new OrderPaymentCompletedEvent(
+                1L, 100L, 50000L, 0L, orderProducts, null
+        );
+        EventEnvelope<OrderPaymentCompletedEvent> envelope = new EventEnvelope<>(
+                "test-event-id", "wrong.event.type", "commerce-service",
+                LocalDateTime.of(2026, 3, 8, 10, 0), event
+        );
+        ConsumerRecord<String, EventEnvelope<?>> record = new ConsumerRecord<>(
+                "commerce.order.payment-completed", 0, 0L, "1", envelope
+        );
+
+        // when
+        consumer.handleOrderPaymentCompletedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(modifyPendingPointUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("orderId가 0이면 UseCase를 호출하지 않고 acknowledge한다")
+    void handleOrderPaymentCompletedEvent_zeroOrderId_skipsAndAcknowledges() {
+        // given
+        List<OrderProductItem> orderProducts = List.of(
+                new OrderProductItem(1L, 200L, 2, 10000L)
+        );
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(0L, 100L, 50000L, orderProducts);
+
+        // when
+        consumer.handleOrderPaymentCompletedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(modifyPendingPointUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("orderId가 음수이면 UseCase를 호출하지 않고 acknowledge한다")
+    void handleOrderPaymentCompletedEvent_negativeOrderId_skipsAndAcknowledges() {
+        // given
+        List<OrderProductItem> orderProducts = List.of(
+                new OrderProductItem(1L, 200L, 2, 10000L)
+        );
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(-1L, 100L, 50000L, orderProducts);
+
+        // when
+        consumer.handleOrderPaymentCompletedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(modifyPendingPointUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("buyerId가 0이면 UseCase를 호출하지 않고 acknowledge한다")
+    void handleOrderPaymentCompletedEvent_zeroBuyerId_skipsAndAcknowledges() {
+        // given
+        List<OrderProductItem> orderProducts = List.of(
+                new OrderProductItem(1L, 200L, 2, 10000L)
+        );
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, 0L, 50000L, orderProducts);
+
+        // when
+        consumer.handleOrderPaymentCompletedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(modifyPendingPointUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("buyerId가 음수이면 UseCase를 호출하지 않고 acknowledge한다")
+    void handleOrderPaymentCompletedEvent_negativeBuyerId_skipsAndAcknowledges() {
+        // given
+        List<OrderProductItem> orderProducts = List.of(
+                new OrderProductItem(1L, 200L, 2, 10000L)
+        );
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, -1L, 50000L, orderProducts);
+
+        // when
+        consumer.handleOrderPaymentCompletedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(modifyPendingPointUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
     @DisplayName("중복 이벤트 수신 시 DuplicateUserPointHistoryException이 발생하면 멱등 처리하고 acknowledge한다")
     void handleOrderPaymentCompletedEvent_duplicateEvent_idempotentAndAcknowledges() {
         // given

--- a/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/adapter/in/event/OrderPurchaseConfirmedProductPointConsumerTest.java
+++ b/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/adapter/in/event/OrderPurchaseConfirmedProductPointConsumerTest.java
@@ -100,6 +100,83 @@ class OrderPurchaseConfirmedProductPointConsumerTest {
     }
 
     @Test
+    @DisplayName("eventType이 불일치하면 UseCase를 호출하지 않고 acknowledge한다")
+    void handleOrderPurchaseConfirmedEvent_eventTypeMismatch_skipsAndAcknowledges() {
+        // given
+        OrderPurchaseConfirmedEvent event = new OrderPurchaseConfirmedEvent(1L, 100L, List.of());
+        EventEnvelope<OrderPurchaseConfirmedEvent> envelope = new EventEnvelope<>(
+                "test-event-id", "wrong.event.type", "commerce-service",
+                LocalDateTime.of(2026, 3, 8, 10, 0), event
+        );
+        ConsumerRecord<String, EventEnvelope<?>> record = new ConsumerRecord<>(
+                "commerce.order.purchase-confirmed", 0, 0L, "1", envelope
+        );
+
+        // when
+        consumer.handleOrderPurchaseConfirmedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(confirmPendingPointUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("orderId가 0이면 UseCase를 호출하지 않고 acknowledge한다")
+    void handleOrderPurchaseConfirmedEvent_zeroOrderId_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(0L, 100L, List.of());
+
+        // when
+        consumer.handleOrderPurchaseConfirmedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(confirmPendingPointUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("orderId가 음수이면 UseCase를 호출하지 않고 acknowledge한다")
+    void handleOrderPurchaseConfirmedEvent_negativeOrderId_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(-1L, 100L, List.of());
+
+        // when
+        consumer.handleOrderPurchaseConfirmedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(confirmPendingPointUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("buyerId가 0이면 UseCase를 호출하지 않고 acknowledge한다")
+    void handleOrderPurchaseConfirmedEvent_zeroBuyerId_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, 0L, List.of());
+
+        // when
+        consumer.handleOrderPurchaseConfirmedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(confirmPendingPointUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("buyerId가 음수이면 UseCase를 호출하지 않고 acknowledge한다")
+    void handleOrderPurchaseConfirmedEvent_negativeBuyerId_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, -1L, List.of());
+
+        // when
+        consumer.handleOrderPurchaseConfirmedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(confirmPendingPointUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
     @DisplayName("envelope이 null이면 확정 없이 acknowledge한다")
     void handleOrderPurchaseConfirmedEvent_nullEnvelope_skipsAndAcknowledges() {
         // given

--- a/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/adapter/in/event/OrderPurchaseConfirmedSharedPointConsumerTest.java
+++ b/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/adapter/in/event/OrderPurchaseConfirmedSharedPointConsumerTest.java
@@ -120,6 +120,57 @@ class OrderPurchaseConfirmedSharedPointConsumerTest {
     }
 
     @Test
+    @DisplayName("eventType이 불일치하면 UseCase를 호출하지 않고 acknowledge한다")
+    void handleOrderPurchaseConfirmedEvent_eventTypeMismatch_skipsAndAcknowledges() {
+        // given
+        OrderPurchaseConfirmedEvent event = new OrderPurchaseConfirmedEvent(1L, 100L, List.of(200L, 300L));
+        EventEnvelope<OrderPurchaseConfirmedEvent> envelope = new EventEnvelope<>(
+                "test-event-id", "wrong.event.type", "commerce-service",
+                LocalDateTime.of(2026, 3, 8, 10, 0), event
+        );
+        ConsumerRecord<String, EventEnvelope<?>> record = new ConsumerRecord<>(
+                "commerce.order.purchase-confirmed", 0, 0L, "1", envelope
+        );
+
+        // when
+        consumer.handleOrderPurchaseConfirmedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(confirmPendingPointUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("orderId가 0이면 UseCase를 호출하지 않고 acknowledge한다")
+    void handleOrderPurchaseConfirmedEvent_zeroOrderId_skipsAndAcknowledges() {
+        // given
+        List<Long> sharerIds = List.of(200L, 300L);
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(0L, 100L, sharerIds);
+
+        // when
+        consumer.handleOrderPurchaseConfirmedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(confirmPendingPointUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("orderId가 음수이면 UseCase를 호출하지 않고 acknowledge한다")
+    void handleOrderPurchaseConfirmedEvent_negativeOrderId_skipsAndAcknowledges() {
+        // given
+        List<Long> sharerIds = List.of(200L, 300L);
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(-1L, 100L, sharerIds);
+
+        // when
+        consumer.handleOrderPurchaseConfirmedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(confirmPendingPointUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
     @DisplayName("envelope이 null이면 공유 적립 예정 포인트 확정 없이 acknowledge한다")
     void handleOrderPurchaseConfirmedEvent_nullEnvelope_skipsAndAcknowledges() {
         // given

--- a/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/adapter/in/event/PaymentCancelledPartialProductPointConsumerTest.java
+++ b/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/adapter/in/event/PaymentCancelledPartialProductPointConsumerTest.java
@@ -164,6 +164,86 @@ class PaymentCancelledPartialProductPointConsumerTest {
     }
 
     @Test
+    @DisplayName("eventType이 불일치하면 UseCase를 호출하지 않고 acknowledge한다")
+    void handlePaymentCancelledEvent_eventTypeMismatch_skipsAndAcknowledges() {
+        // given
+        PaymentCancelledEvent event = new PaymentCancelledEvent(
+                1L, "order-key-1", 100L, 30000L, 80000L, 1000L,
+                false, 0L, null, null, null, 1500L
+        );
+        EventEnvelope<PaymentCancelledEvent> envelope = new EventEnvelope<>(
+                "test-event-id", "wrong.event.type", "commerce-service",
+                LocalDateTime.of(2026, 3, 8, 10, 0), event
+        );
+        ConsumerRecord<String, EventEnvelope<?>> record = new ConsumerRecord<>(
+                "commerce.payment.cancelled", 0, 0L, "1", envelope
+        );
+
+        // when
+        consumer.handlePaymentCancelledEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(modifyPendingPointUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("orderId가 0이면 UseCase를 호출하지 않고 acknowledge한다")
+    void handlePaymentCancelledEvent_zeroOrderId_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(0L, 100L, 1500L, false);
+
+        // when
+        consumer.handlePaymentCancelledEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(modifyPendingPointUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("orderId가 음수이면 UseCase를 호출하지 않고 acknowledge한다")
+    void handlePaymentCancelledEvent_negativeOrderId_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(-1L, 100L, 1500L, false);
+
+        // when
+        consumer.handlePaymentCancelledEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(modifyPendingPointUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("buyerId가 0이면 UseCase를 호출하지 않고 acknowledge한다")
+    void handlePaymentCancelledEvent_zeroBuyerId_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, 0L, 1500L, false);
+
+        // when
+        consumer.handlePaymentCancelledEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(modifyPendingPointUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("buyerId가 음수이면 UseCase를 호출하지 않고 acknowledge한다")
+    void handlePaymentCancelledEvent_negativeBuyerId_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, -1L, 1500L, false);
+
+        // when
+        consumer.handlePaymentCancelledEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(modifyPendingPointUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
     @DisplayName("envelope이 null이면 차감 없이 acknowledge한다")
     void handlePaymentCancelledEvent_nullEnvelope_skipsAndAcknowledges() {
         // given

--- a/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/adapter/in/event/PaymentCancelledPartialSharedPointConsumerTest.java
+++ b/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/adapter/in/event/PaymentCancelledPartialSharedPointConsumerTest.java
@@ -168,6 +168,67 @@ class PaymentCancelledPartialSharedPointConsumerTest {
     }
 
     @Test
+    @DisplayName("eventType이 불일치하면 UseCase를 호출하지 않고 acknowledge한다")
+    void handlePaymentCancelledEvent_eventTypeMismatch_skipsAndAcknowledges() {
+        // given
+        List<OrderProductItem> orderProducts = List.of(
+                new OrderProductItem(1L, 200L, 2, 10000L)
+        );
+        PaymentCancelledEvent event = new PaymentCancelledEvent(
+                1L, "order-key-1", 100L, 30000L, 80000L, 1000L,
+                false, 0L, null, orderProducts, null, null
+        );
+        EventEnvelope<PaymentCancelledEvent> envelope = new EventEnvelope<>(
+                "test-event-id", "wrong.event.type", "commerce-service",
+                LocalDateTime.of(2026, 3, 7, 10, 0), event
+        );
+        ConsumerRecord<String, EventEnvelope<?>> record = new ConsumerRecord<>(
+                "commerce.payment.cancelled", 0, 0L, "1", envelope
+        );
+
+        // when
+        consumer.handlePaymentCancelledEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(modifyPendingPointUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("orderId가 0이면 UseCase를 호출하지 않고 acknowledge한다")
+    void handlePaymentCancelledEvent_zeroOrderId_skipsAndAcknowledges() {
+        // given
+        List<OrderProductItem> orderProducts = List.of(
+                new OrderProductItem(1L, 200L, 2, 10000L)
+        );
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(0L, false, 30000L, 80000L, orderProducts);
+
+        // when
+        consumer.handlePaymentCancelledEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(modifyPendingPointUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("orderId가 음수이면 UseCase를 호출하지 않고 acknowledge한다")
+    void handlePaymentCancelledEvent_negativeOrderId_skipsAndAcknowledges() {
+        // given
+        List<OrderProductItem> orderProducts = List.of(
+                new OrderProductItem(1L, 200L, 2, 10000L)
+        );
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(-1L, false, 30000L, 80000L, orderProducts);
+
+        // when
+        consumer.handlePaymentCancelledEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(modifyPendingPointUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
     @DisplayName("envelope이 null이면 부분 공유 적립 예정 포인트 차감 없이 acknowledge한다")
     void handlePaymentCancelledEvent_nullEnvelope_skipsAndAcknowledges() {
         // given

--- a/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/adapter/in/event/PaymentCancelledPendingProductPointConsumerTest.java
+++ b/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/adapter/in/event/PaymentCancelledPendingProductPointConsumerTest.java
@@ -98,6 +98,81 @@ class PaymentCancelledPendingProductPointConsumerTest {
     }
 
     @Test
+    @DisplayName("eventType이 불일치하면 acknowledge한다")
+    void handlePaymentCancelledEvent_eventTypeMismatch_skipsAndAcknowledges() {
+        // given
+        PaymentCancelledEvent event = new PaymentCancelledEvent(
+                1L, "order-key-1", 100L, 50000L, 80000L, 1000L,
+                true, 0L, null, List.of(), null, null
+        );
+        EventEnvelope<PaymentCancelledEvent> envelope = new EventEnvelope<>(
+                "test-event-id", "wrong.event.type", "commerce-service",
+                LocalDateTime.of(2026, 3, 6, 10, 0), event
+        );
+        ConsumerRecord<String, EventEnvelope<?>> record = new ConsumerRecord<>(
+                "commerce.payment.cancelled", 0, 0L, "1", envelope
+        );
+
+        // when
+        consumer.handlePaymentCancelledEvent(record, acknowledgment);
+
+        // then
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("orderId가 0이면 acknowledge한다")
+    void handlePaymentCancelledEvent_zeroOrderId_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(0L, 100L, true);
+
+        // when
+        consumer.handlePaymentCancelledEvent(record, acknowledgment);
+
+        // then
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("orderId가 음수이면 acknowledge한다")
+    void handlePaymentCancelledEvent_negativeOrderId_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(-1L, 100L, true);
+
+        // when
+        consumer.handlePaymentCancelledEvent(record, acknowledgment);
+
+        // then
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("buyerId가 0이면 acknowledge한다")
+    void handlePaymentCancelledEvent_zeroBuyerId_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, 0L, true);
+
+        // when
+        consumer.handlePaymentCancelledEvent(record, acknowledgment);
+
+        // then
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("buyerId가 음수이면 acknowledge한다")
+    void handlePaymentCancelledEvent_negativeBuyerId_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, -1L, true);
+
+        // when
+        consumer.handlePaymentCancelledEvent(record, acknowledgment);
+
+        // then
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
     @DisplayName("envelope이 null이면 상품 적립 예정 포인트 회수 없이 acknowledge한다")
     void handlePaymentCancelledEvent_nullEnvelope_skipsAndAcknowledges() {
         // given

--- a/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/adapter/in/event/PaymentCancelledPendingSharedPointConsumerTest.java
+++ b/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/adapter/in/event/PaymentCancelledPendingSharedPointConsumerTest.java
@@ -126,6 +126,64 @@ class PaymentCancelledPendingSharedPointConsumerTest {
     }
 
     @Test
+    @DisplayName("eventType이 불일치하면 acknowledge한다")
+    void handlePaymentCancelledEvent_eventTypeMismatch_skipsAndAcknowledges() {
+        // given
+        List<OrderProductItem> orderProducts = List.of(
+                new OrderProductItem(1L, 200L, 2, 10000L)
+        );
+        PaymentCancelledEvent event = new PaymentCancelledEvent(
+                1L, "order-key-1", 100L, 50000L, 80000L, 1000L,
+                true, 0L, null, orderProducts, null, null
+        );
+        EventEnvelope<PaymentCancelledEvent> envelope = new EventEnvelope<>(
+                "test-event-id", "wrong.event.type", "commerce-service",
+                LocalDateTime.of(2026, 3, 6, 10, 0), event
+        );
+        ConsumerRecord<String, EventEnvelope<?>> record = new ConsumerRecord<>(
+                "commerce.payment.cancelled", 0, 0L, "1", envelope
+        );
+
+        // when
+        consumer.handlePaymentCancelledEvent(record, acknowledgment);
+
+        // then
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("orderId가 0이면 acknowledge한다")
+    void handlePaymentCancelledEvent_zeroOrderId_skipsAndAcknowledges() {
+        // given
+        List<OrderProductItem> orderProducts = List.of(
+                new OrderProductItem(1L, 200L, 2, 10000L)
+        );
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(0L, true, orderProducts);
+
+        // when
+        consumer.handlePaymentCancelledEvent(record, acknowledgment);
+
+        // then
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("orderId가 음수이면 acknowledge한다")
+    void handlePaymentCancelledEvent_negativeOrderId_skipsAndAcknowledges() {
+        // given
+        List<OrderProductItem> orderProducts = List.of(
+                new OrderProductItem(1L, 200L, 2, 10000L)
+        );
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(-1L, true, orderProducts);
+
+        // when
+        consumer.handlePaymentCancelledEvent(record, acknowledgment);
+
+        // then
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
     @DisplayName("envelope이 null이면 공유 적립 예정 포인트 회수 없이 acknowledge한다")
     void handlePaymentCancelledEvent_nullEnvelope_skipsAndAcknowledges() {
         // given

--- a/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/adapter/in/event/PaymentCancelledPointRefundConsumerTest.java
+++ b/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/adapter/in/event/PaymentCancelledPointRefundConsumerTest.java
@@ -163,6 +163,86 @@ class PaymentCancelledPointRefundConsumerTest {
     }
 
     @Test
+    @DisplayName("eventType이 불일치하면 UseCase를 호출하지 않고 acknowledge한다")
+    void handlePaymentCancelledEvent_eventTypeMismatch_skipsAndAcknowledges() {
+        // given
+        PaymentCancelledEvent event = new PaymentCancelledEvent(
+                1L, "order-key-1", 100L, 50000L, 80000L, 1000L,
+                true, 0L, null, List.of(), null, null
+        );
+        EventEnvelope<PaymentCancelledEvent> envelope = new EventEnvelope<>(
+                "test-event-id", "wrong.event.type", "commerce-service",
+                LocalDateTime.of(2026, 3, 6, 10, 0), event
+        );
+        ConsumerRecord<String, EventEnvelope<?>> record = new ConsumerRecord<>(
+                "commerce.payment.cancelled", 0, 0L, "1", envelope
+        );
+
+        // when
+        consumer.handlePaymentCancelledEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(modifyUserPointUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("orderId가 0이면 UseCase를 호출하지 않고 acknowledge한다")
+    void handlePaymentCancelledEvent_zeroOrderId_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(0L, 100L, 1000L, true);
+
+        // when
+        consumer.handlePaymentCancelledEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(modifyUserPointUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("orderId가 음수이면 UseCase를 호출하지 않고 acknowledge한다")
+    void handlePaymentCancelledEvent_negativeOrderId_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(-1L, 100L, 1000L, true);
+
+        // when
+        consumer.handlePaymentCancelledEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(modifyUserPointUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("buyerId가 0이면 UseCase를 호출하지 않고 acknowledge한다")
+    void handlePaymentCancelledEvent_zeroBuyerId_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, 0L, 1000L, true);
+
+        // when
+        consumer.handlePaymentCancelledEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(modifyUserPointUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("buyerId가 음수이면 UseCase를 호출하지 않고 acknowledge한다")
+    void handlePaymentCancelledEvent_negativeBuyerId_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, -1L, 1000L, true);
+
+        // when
+        consumer.handlePaymentCancelledEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(modifyUserPointUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
     @DisplayName("envelope이 null이면 포인트 환불 없이 acknowledge한다")
     void handlePaymentCancelledEvent_nullEnvelope_skipsAndAcknowledges() {
         // given

--- a/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/adapter/in/event/UserReferralCompletedRewardConsumerTest.java
+++ b/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/adapter/in/event/UserReferralCompletedRewardConsumerTest.java
@@ -117,6 +117,99 @@ class UserReferralCompletedRewardConsumerTest {
     }
 
     @Test
+    @DisplayName("envelope이 null이면 UseCase를 호출하지 않고 acknowledge한다")
+    void handleUserReferralCompletedEvent_nullEnvelope_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = new ConsumerRecord<>(
+                "user.user.referral-completed", 0, 0L, "1", null
+        );
+
+        // when
+        userReferralCompletedRewardConsumer.handleUserReferralCompletedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(modifyUserPointUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("eventType이 불일치하면 UseCase를 호출하지 않고 acknowledge한다")
+    void handleUserReferralCompletedEvent_eventTypeMismatch_skipsAndAcknowledges() {
+        // given
+        UserReferralCompletedEvent event = new UserReferralCompletedEvent(1L, 2L);
+        EventEnvelope<UserReferralCompletedEvent> envelope = new EventEnvelope<>(
+                "test-event-id", "wrong.event.type", "user-service",
+                LocalDateTime.of(2026, 3, 2, 10, 0), event
+        );
+        ConsumerRecord<String, EventEnvelope<?>> record = new ConsumerRecord<>(
+                "user.user.referral-completed", 0, 0L, "key-1", envelope
+        );
+
+        // when
+        userReferralCompletedRewardConsumer.handleUserReferralCompletedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(modifyUserPointUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("requestUserId가 0이면 UseCase를 호출하지 않고 acknowledge한다")
+    void handleUserReferralCompletedEvent_zeroRequestUserId_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(0L, 2L);
+
+        // when
+        userReferralCompletedRewardConsumer.handleUserReferralCompletedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(modifyUserPointUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("requestUserId가 음수이면 UseCase를 호출하지 않고 acknowledge한다")
+    void handleUserReferralCompletedEvent_negativeRequestUserId_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(-1L, 2L);
+
+        // when
+        userReferralCompletedRewardConsumer.handleUserReferralCompletedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(modifyUserPointUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("referredUserId가 0이면 UseCase를 호출하지 않고 acknowledge한다")
+    void handleUserReferralCompletedEvent_zeroReferredUserId_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, 0L);
+
+        // when
+        userReferralCompletedRewardConsumer.handleUserReferralCompletedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(modifyUserPointUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("referredUserId가 음수이면 UseCase를 호출하지 않고 acknowledge한다")
+    void handleUserReferralCompletedEvent_negativeReferredUserId_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, -1L);
+
+        // when
+        userReferralCompletedRewardConsumer.handleUserReferralCompletedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(modifyUserPointUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
     @DisplayName("추천인 포인트 적립 중 예외 발생 시 acknowledge하지 않고 예외를 전파한다")
     void handleUserReferralCompletedEvent_referrerAccrualFails_propagatesWithoutAcknowledge() {
         // given

--- a/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/adapter/in/event/UserSignupCompletedRewardConsumerTest.java
+++ b/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/adapter/in/event/UserSignupCompletedRewardConsumerTest.java
@@ -96,6 +96,71 @@ class UserSignupCompletedRewardConsumerTest {
     }
 
     @Test
+    @DisplayName("envelope이 null이면 UseCase를 호출하지 않고 acknowledge한다")
+    void handleUserSignupCompletedEvent_nullEnvelope_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = new ConsumerRecord<>(
+                "user.user.signup-completed", 0, 0L, "1", null
+        );
+
+        // when
+        userSignupCompletedRewardConsumer.handleUserSignupCompletedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(registerUserPointUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("eventType이 불일치하면 UseCase를 호출하지 않고 acknowledge한다")
+    void handleUserSignupCompletedEvent_eventTypeMismatch_skipsAndAcknowledges() {
+        // given
+        UserSignupCompletedEvent event = new UserSignupCompletedEvent(1L, "user-key-123");
+        EventEnvelope<UserSignupCompletedEvent> envelope = new EventEnvelope<>(
+                "test-event-id", "wrong.event.type", "user-service",
+                LocalDateTime.of(2026, 3, 2, 10, 0), event
+        );
+        ConsumerRecord<String, EventEnvelope<?>> record = new ConsumerRecord<>(
+                "user.user.signup-completed", 0, 0L, "key-1", envelope
+        );
+
+        // when
+        userSignupCompletedRewardConsumer.handleUserSignupCompletedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(registerUserPointUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("userId가 0이면 UseCase를 호출하지 않고 acknowledge한다")
+    void handleUserSignupCompletedEvent_zeroUserId_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(0L, "user-key-123");
+
+        // when
+        userSignupCompletedRewardConsumer.handleUserSignupCompletedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(registerUserPointUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("userId가 음수이면 UseCase를 호출하지 않고 acknowledge한다")
+    void handleUserSignupCompletedEvent_negativeUserId_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(-1L, "user-key-123");
+
+        // when
+        userSignupCompletedRewardConsumer.handleUserSignupCompletedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(registerUserPointUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
     @DisplayName("이미 포인트가 존재하면 예외를 무시하고 acknowledge한다")
     void handleUserSignupCompletedEvent_duplicateUserPoint_acknowledges() {
         // given


### PR DESCRIPTION
## partially addresses #929
## resolves #1194

## Test Case
- [x] EventPayloadValidator 단위 테스트 (hasInvalidEnvelope, hasEventTypeMismatch, hasInvalidIds)
- [x] 23개 Consumer 테스트에 검증 테스트 케이스 추가
    - [x] envelope null → UseCase 미호출, acknowledge
    - [x] eventType 불일치 → UseCase 미호출, acknowledge
    - [x] ID 0 → UseCase 미호출, acknowledge
    - [x] ID 음수 → UseCase 미호출, acknowledge