### PR TITLE
[#929][#1066] feat: Kafka 이벤트 발행 Outbox 패턴 도입

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/event/OrderEventKafkaProducer.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/event/OrderEventKafkaProducer.java
@@ -1,5 +1,6 @@
 package com.personal.marketnote.commerce.adapter.out.event;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.personal.marketnote.commerce.domain.order.OrderProduct;
 import com.personal.marketnote.commerce.port.out.event.PublishOrderEventPort;
 import com.personal.marketnote.common.adapter.out.ServiceAdapter;
@@ -8,10 +9,10 @@ import com.personal.marketnote.common.kafka.event.EventEnvelope;
 import com.personal.marketnote.common.kafka.event.OrderPaymentCompletedEvent;
 import com.personal.marketnote.common.kafka.event.OrderPaymentCompletedEvent.OrderProductItem;
 import com.personal.marketnote.common.kafka.event.OrderPurchaseConfirmedEvent;
-import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.common.outbox.OutboxEvent;
+import com.personal.marketnote.common.outbox.SaveOutboxEventPort;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.kafka.core.KafkaTemplate;
 
 import java.time.Clock;
 import java.util.List;
@@ -22,7 +23,8 @@ import java.util.List;
 public class OrderEventKafkaProducer implements PublishOrderEventPort {
     private static final String SOURCE = "commerce-service";
 
-    private final KafkaTemplate<String, Object> kafkaTemplate;
+    private final SaveOutboxEventPort saveOutboxEventPort;
+    private final ObjectMapper objectMapper;
     private final Clock clock;
 
     @Override
@@ -46,18 +48,7 @@ public class OrderEventKafkaProducer implements PublishOrderEventPort {
                 topic, SOURCE, payload, clock
         );
 
-        kafkaTemplate.send(topic, orderId.toString(), envelope)
-                .whenComplete((result, ex) -> {
-                    if (FormatValidator.hasValue(ex)) {
-                        log.error("Kafka 이벤트 발행 실패. topic={}, orderId={}",
-                                topic, orderId, ex);
-                        return;
-                    }
-
-                    log.info("Kafka 이벤트 발행 성공. topic={}, orderId={}, offset={}",
-                            topic, orderId,
-                            result.getRecordMetadata().offset());
-                });
+        saveToOutbox(envelope, topic, orderId.toString());
     }
 
     @Override
@@ -68,17 +59,22 @@ public class OrderEventKafkaProducer implements PublishOrderEventPort {
                 topic, SOURCE, payload, clock
         );
 
-        kafkaTemplate.send(topic, orderId.toString(), envelope)
-                .whenComplete((result, ex) -> {
-                    if (FormatValidator.hasValue(ex)) {
-                        log.error("Kafka 이벤트 발행 실패. topic={}, orderId={}, buyerId={}",
-                                topic, orderId, buyerId, ex);
-                        return;
-                    }
+        saveToOutbox(envelope, topic, orderId.toString());
+    }
 
-                    log.info("Kafka 이벤트 발행 성공. topic={}, orderId={}, buyerId={}, offset={}",
-                            topic, orderId, buyerId,
-                            result.getRecordMetadata().offset());
-                });
+    private <T> void saveToOutbox(EventEnvelope<T> envelope, String topic, String partitionKey) {
+        try {
+            String payloadJson = objectMapper.writeValueAsString(envelope);
+            OutboxEvent outboxEvent = OutboxEvent.of(
+                    envelope.eventId(), topic, partitionKey,
+                    envelope.eventType(), SOURCE, payloadJson, clock
+            );
+            saveOutboxEventPort.save(outboxEvent);
+            log.info("Outbox 이벤트 저장. topic={}, partitionKey={}, eventId={}",
+                    topic, partitionKey, envelope.eventId());
+        } catch (Exception e) {
+            log.error("Outbox 이벤트 저장 실패. topic={}, partitionKey={}, error={}",
+                    topic, partitionKey, e.getMessage(), e);
+        }
     }
 }

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/event/PaymentEventKafkaProducer.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/event/PaymentEventKafkaProducer.java
@@ -1,5 +1,6 @@
 package com.personal.marketnote.commerce.adapter.out.event;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.personal.marketnote.commerce.domain.order.OrderProduct;
 import com.personal.marketnote.commerce.port.out.event.PublishPaymentEventPort;
 import com.personal.marketnote.common.adapter.out.ServiceAdapter;
@@ -8,10 +9,11 @@ import com.personal.marketnote.common.kafka.event.EventEnvelope;
 import com.personal.marketnote.common.kafka.event.PaymentApprovedEvent;
 import com.personal.marketnote.common.kafka.event.PaymentCancelledEvent;
 import com.personal.marketnote.common.kafka.event.PaymentFailedEvent;
+import com.personal.marketnote.common.outbox.OutboxEvent;
+import com.personal.marketnote.common.outbox.SaveOutboxEventPort;
 import com.personal.marketnote.common.utility.FormatValidator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.kafka.core.KafkaTemplate;
 
 import java.time.Clock;
 import java.util.List;
@@ -22,7 +24,8 @@ import java.util.List;
 public class PaymentEventKafkaProducer implements PublishPaymentEventPort {
     private static final String SOURCE = "commerce-service";
 
-    private final KafkaTemplate<String, Object> kafkaTemplate;
+    private final SaveOutboxEventPort saveOutboxEventPort;
+    private final ObjectMapper objectMapper;
     private final Clock clock;
 
     @Override
@@ -33,18 +36,7 @@ public class PaymentEventKafkaProducer implements PublishPaymentEventPort {
                 topic, SOURCE, payload, clock
         );
 
-        kafkaTemplate.send(topic, orderId.toString(), envelope)
-                .whenComplete((result, ex) -> {
-                    if (FormatValidator.hasValue(ex)) {
-                        log.error("Kafka 이벤트 발행 실패. topic={}, orderId={}, orderKey={}",
-                                topic, orderId, orderKey, ex);
-                        return;
-                    }
-
-                    log.info("Kafka 이벤트 발행 성공. topic={}, orderId={}, orderKey={}, offset={}",
-                            topic, orderId, orderKey,
-                            result.getRecordMetadata().offset());
-                });
+        saveToOutbox(envelope, topic, orderId.toString());
     }
 
     @Override
@@ -55,18 +47,7 @@ public class PaymentEventKafkaProducer implements PublishPaymentEventPort {
                 topic, SOURCE, payload, clock
         );
 
-        kafkaTemplate.send(topic, orderId.toString(), envelope)
-                .whenComplete((result, ex) -> {
-                    if (FormatValidator.hasValue(ex)) {
-                        log.error("Kafka 이벤트 발행 실패. topic={}, orderId={}, orderKey={}",
-                                topic, orderId, orderKey, ex);
-                        return;
-                    }
-
-                    log.info("Kafka 이벤트 발행 성공. topic={}, orderId={}, orderKey={}, offset={}",
-                            topic, orderId, orderKey,
-                            result.getRecordMetadata().offset());
-                });
+        saveToOutbox(envelope, topic, orderId.toString());
     }
 
     @Override
@@ -107,17 +88,22 @@ public class PaymentEventKafkaProducer implements PublishPaymentEventPort {
                 topic, SOURCE, payload, clock
         );
 
-        kafkaTemplate.send(topic, orderId.toString(), envelope)
-                .whenComplete((result, ex) -> {
-                    if (FormatValidator.hasValue(ex)) {
-                        log.error("Kafka 이벤트 발행 실패. topic={}, orderId={}, orderKey={}",
-                                topic, orderId, orderKey, ex);
-                        return;
-                    }
+        saveToOutbox(envelope, topic, orderId.toString());
+    }
 
-                    log.info("Kafka 이벤트 발행 성공. topic={}, orderId={}, orderKey={}, offset={}",
-                            topic, orderId, orderKey,
-                            result.getRecordMetadata().offset());
-                });
+    private <T> void saveToOutbox(EventEnvelope<T> envelope, String topic, String partitionKey) {
+        try {
+            String payloadJson = objectMapper.writeValueAsString(envelope);
+            OutboxEvent outboxEvent = OutboxEvent.of(
+                    envelope.eventId(), topic, partitionKey,
+                    envelope.eventType(), SOURCE, payloadJson, clock
+            );
+            saveOutboxEventPort.save(outboxEvent);
+            log.info("Outbox 이벤트 저장. topic={}, partitionKey={}, eventId={}",
+                    topic, partitionKey, envelope.eventId());
+        } catch (Exception e) {
+            log.error("Outbox 이벤트 저장 실패. topic={}, partitionKey={}, error={}",
+                    topic, partitionKey, e.getMessage(), e);
+        }
     }
 }

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/event/SettlementEventKafkaProducer.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/event/SettlementEventKafkaProducer.java
@@ -1,14 +1,15 @@
 package com.personal.marketnote.commerce.adapter.out.event;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.personal.marketnote.commerce.port.out.event.PublishSettlementEventPort;
 import com.personal.marketnote.common.adapter.out.ServiceAdapter;
 import com.personal.marketnote.common.kafka.KafkaTopicConstants;
 import com.personal.marketnote.common.kafka.event.EventEnvelope;
 import com.personal.marketnote.common.kafka.event.SettlementExecutedEvent;
-import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.common.outbox.OutboxEvent;
+import com.personal.marketnote.common.outbox.SaveOutboxEventPort;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.kafka.core.KafkaTemplate;
 
 import java.time.Clock;
 
@@ -18,7 +19,8 @@ import java.time.Clock;
 public class SettlementEventKafkaProducer implements PublishSettlementEventPort {
     private static final String SOURCE = "commerce-service";
 
-    private final KafkaTemplate<String, Object> kafkaTemplate;
+    private final SaveOutboxEventPort saveOutboxEventPort;
+    private final ObjectMapper objectMapper;
     private final Clock clock;
 
     @Override
@@ -34,17 +36,18 @@ public class SettlementEventKafkaProducer implements PublishSettlementEventPort 
                 topic, SOURCE, payload, clock
         );
 
-        kafkaTemplate.send(topic, settlementId.toString(), envelope)
-                .whenComplete((result, ex) -> {
-                    if (FormatValidator.hasValue(ex)) {
-                        log.error("Kafka 이벤트 발행 실패. topic={}, settlementId={}, sellerId={}",
-                                topic, settlementId, sellerId, ex);
-                        return;
-                    }
-
-                    log.info("Kafka 이벤트 발행 성공. topic={}, settlementId={}, sellerId={}, offset={}",
-                            topic, settlementId, sellerId,
-                            result.getRecordMetadata().offset());
-                });
+        try {
+            String payloadJson = objectMapper.writeValueAsString(envelope);
+            OutboxEvent outboxEvent = OutboxEvent.of(
+                    envelope.eventId(), topic, settlementId.toString(),
+                    envelope.eventType(), SOURCE, payloadJson, clock
+            );
+            saveOutboxEventPort.save(outboxEvent);
+            log.info("Outbox 이벤트 저장. topic={}, settlementId={}, eventId={}",
+                    topic, settlementId, envelope.eventId());
+        } catch (Exception e) {
+            log.error("Outbox 이벤트 저장 실패. topic={}, settlementId={}, error={}",
+                    topic, settlementId, e.getMessage(), e);
+        }
     }
 }

--- a/commerce-service/commerce-adapters/src/main/resources/application.yml
+++ b/commerce-service/commerce-adapters/src/main/resources/application.yml
@@ -89,6 +89,14 @@ kcp:
     read-timeout-max-attempts: ${KCP_RETRY_READ_TIMEOUT_MAX_ATTEMPTS:2}
   ret-url: ${KCP_RET_URL:https://marketnote-dev.vercel.app/payments/kcp/callback}
 
+outbox:
+  enabled: ${OUTBOX_ENABLED:true}
+  polling-interval-ms: ${OUTBOX_POLLING_INTERVAL_MS:3000}
+  batch-size: ${OUTBOX_BATCH_SIZE:100}
+  max-retries: ${OUTBOX_MAX_RETRIES:5}
+  retention-days: ${OUTBOX_RETENTION_DAYS:7}
+  cleanup-cron: ${OUTBOX_CLEANUP_CRON:0 0 3 * * ?}
+
 settlement:
   scheduler:
     enabled: ${SETTLEMENT_SCHEDULER_ENABLED:false}

--- a/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/out/event/OrderEventKafkaProducerTest.java
+++ b/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/out/event/OrderEventKafkaProducerTest.java
@@ -1,11 +1,14 @@
 package com.personal.marketnote.commerce.adapter.out.event;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.personal.marketnote.commerce.domain.order.OrderProduct;
 import com.personal.marketnote.commerce.domain.order.OrderProductSnapshotState;
 import com.personal.marketnote.commerce.domain.order.OrderStatus;
 import com.personal.marketnote.common.kafka.KafkaTopicConstants;
 import com.personal.marketnote.common.kafka.event.EventEnvelope;
 import com.personal.marketnote.common.kafka.event.OrderPaymentCompletedEvent;
+import com.personal.marketnote.common.outbox.OutboxEvent;
+import com.personal.marketnote.common.outbox.SaveOutboxEventPort;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -13,17 +16,14 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.kafka.core.KafkaTemplate;
 
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -34,7 +34,10 @@ class OrderEventKafkaProducerTest {
     private OrderEventKafkaProducer orderEventKafkaProducer;
 
     @Mock
-    private KafkaTemplate<String, Object> kafkaTemplate;
+    private SaveOutboxEventPort saveOutboxEventPort;
+
+    @Mock
+    private ObjectMapper objectMapper;
 
     @Mock
     private Clock clock;
@@ -67,12 +70,11 @@ class OrderEventKafkaProducerTest {
     }
 
     @Test
-    @DisplayName("주문 결제 완료 이벤트 발행 시 올바른 토픽과 파티션 키로 전송된다")
-    void publishOrderPaymentCompletedEvent_sendsToCorrectTopicWithOrderIdKey() {
+    @DisplayName("주문 결제 완료 이벤트 발행 시 올바른 토픽과 파티션 키로 Outbox에 저장된다")
+    void publishOrderPaymentCompletedEvent_savesToOutboxWithCorrectTopicAndPartitionKey() throws Exception {
         // given
         setUpClock("2026-03-05T10:00:00Z");
-        when(kafkaTemplate.send(any(String.class), any(String.class), any()))
-                .thenReturn(new CompletableFuture<>());
+        when(objectMapper.writeValueAsString(any())).thenReturn("{}");
 
         List<OrderProduct> orderProducts = createOrderProducts();
 
@@ -82,21 +84,23 @@ class OrderEventKafkaProducerTest {
         );
 
         // then
-        verify(kafkaTemplate).send(
-                eq(KafkaTopicConstants.ORDER_PAYMENT_COMPLETED),
-                eq("1"),
-                any(EventEnvelope.class)
-        );
+        ArgumentCaptor<OutboxEvent> outboxCaptor = ArgumentCaptor.forClass(OutboxEvent.class);
+        verify(saveOutboxEventPort).save(outboxCaptor.capture());
+
+        OutboxEvent captured = outboxCaptor.getValue();
+        assertThat(captured.getTopic()).isEqualTo(KafkaTopicConstants.ORDER_PAYMENT_COMPLETED);
+        assertThat(captured.getPartitionKey()).isEqualTo("1");
+        assertThat(captured.getSource()).isEqualTo("commerce-service");
+        assertThat(captured.getEventId()).isNotNull();
     }
 
     @Test
     @DisplayName("주문 결제 완료 이벤트 발행 시 EventEnvelope에 올바른 페이로드가 포함된다")
     @SuppressWarnings("unchecked")
-    void publishOrderPaymentCompletedEvent_envelopeContainsCorrectPayload() {
+    void publishOrderPaymentCompletedEvent_envelopeContainsCorrectPayload() throws Exception {
         // given
         setUpClock("2026-03-05T10:00:00Z");
-        when(kafkaTemplate.send(any(String.class), any(String.class), any()))
-                .thenReturn(new CompletableFuture<>());
+        when(objectMapper.writeValueAsString(any())).thenReturn("{}");
 
         List<OrderProduct> orderProducts = createOrderProducts();
 
@@ -107,11 +111,7 @@ class OrderEventKafkaProducerTest {
 
         // then
         ArgumentCaptor<EventEnvelope> envelopeCaptor = ArgumentCaptor.forClass(EventEnvelope.class);
-        verify(kafkaTemplate).send(
-                eq(KafkaTopicConstants.ORDER_PAYMENT_COMPLETED),
-                eq("10"),
-                envelopeCaptor.capture()
-        );
+        verify(objectMapper).writeValueAsString(envelopeCaptor.capture());
 
         EventEnvelope<?> capturedEnvelope = envelopeCaptor.getValue();
         assertThat(capturedEnvelope.eventType()).isEqualTo(KafkaTopicConstants.ORDER_PAYMENT_COMPLETED);

--- a/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/out/event/PaymentEventKafkaProducerTest.java
+++ b/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/out/event/PaymentEventKafkaProducerTest.java
@@ -1,8 +1,11 @@
 package com.personal.marketnote.commerce.adapter.out.event;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.personal.marketnote.common.kafka.KafkaTopicConstants;
 import com.personal.marketnote.common.kafka.event.EventEnvelope;
 import com.personal.marketnote.common.kafka.event.PaymentApprovedEvent;
+import com.personal.marketnote.common.outbox.OutboxEvent;
+import com.personal.marketnote.common.outbox.SaveOutboxEventPort;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -10,16 +13,13 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.kafka.core.KafkaTemplate;
 
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
-import java.util.concurrent.CompletableFuture;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -30,7 +30,10 @@ class PaymentEventKafkaProducerTest {
     private PaymentEventKafkaProducer paymentEventKafkaProducer;
 
     @Mock
-    private KafkaTemplate<String, Object> kafkaTemplate;
+    private SaveOutboxEventPort saveOutboxEventPort;
+
+    @Mock
+    private ObjectMapper objectMapper;
 
     @Mock
     private Clock clock;
@@ -42,43 +45,40 @@ class PaymentEventKafkaProducerTest {
     }
 
     @Test
-    @DisplayName("결제 승인 이벤트 발행 시 올바른 토픽과 파티션 키로 전송된다")
-    void publishPaymentApprovedEvent_sendsToCorrectTopicWithOrderIdKey() {
+    @DisplayName("결제 승인 이벤트 발행 시 올바른 토픽과 파티션 키로 Outbox에 저장된다")
+    void publishPaymentApprovedEvent_savesToOutboxWithCorrectTopicAndPartitionKey() throws Exception {
         // given
         setUpClock("2026-03-05T10:00:00Z");
-        when(kafkaTemplate.send(any(String.class), any(String.class), any()))
-                .thenReturn(new CompletableFuture<>());
+        when(objectMapper.writeValueAsString(any())).thenReturn("{}");
 
         // when
         paymentEventKafkaProducer.publishPaymentApprovedEvent(1L, "order-key-1", 50000L);
 
         // then
-        verify(kafkaTemplate).send(
-                eq(KafkaTopicConstants.PAYMENT_APPROVED),
-                eq("1"),
-                any(EventEnvelope.class)
-        );
+        ArgumentCaptor<OutboxEvent> outboxCaptor = ArgumentCaptor.forClass(OutboxEvent.class);
+        verify(saveOutboxEventPort).save(outboxCaptor.capture());
+
+        OutboxEvent captured = outboxCaptor.getValue();
+        assertThat(captured.getTopic()).isEqualTo(KafkaTopicConstants.PAYMENT_APPROVED);
+        assertThat(captured.getPartitionKey()).isEqualTo("1");
+        assertThat(captured.getSource()).isEqualTo("commerce-service");
+        assertThat(captured.getEventId()).isNotNull();
     }
 
     @Test
     @DisplayName("결제 승인 이벤트 발행 시 EventEnvelope에 올바른 페이로드가 포함된다")
     @SuppressWarnings("unchecked")
-    void publishPaymentApprovedEvent_envelopeContainsCorrectPayload() {
+    void publishPaymentApprovedEvent_envelopeContainsCorrectPayload() throws Exception {
         // given
         setUpClock("2026-03-05T10:00:00Z");
-        when(kafkaTemplate.send(any(String.class), any(String.class), any()))
-                .thenReturn(new CompletableFuture<>());
+        when(objectMapper.writeValueAsString(any())).thenReturn("{}");
 
         // when
         paymentEventKafkaProducer.publishPaymentApprovedEvent(10L, "order-key-10", 75000L);
 
         // then
         ArgumentCaptor<EventEnvelope> envelopeCaptor = ArgumentCaptor.forClass(EventEnvelope.class);
-        verify(kafkaTemplate).send(
-                eq(KafkaTopicConstants.PAYMENT_APPROVED),
-                eq("10"),
-                envelopeCaptor.capture()
-        );
+        verify(objectMapper).writeValueAsString(envelopeCaptor.capture());
 
         EventEnvelope<?> capturedEnvelope = envelopeCaptor.getValue();
         assertThat(capturedEnvelope.eventType()).isEqualTo(KafkaTopicConstants.PAYMENT_APPROVED);

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/ChangeOrderStatusService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/ChangeOrderStatusService.java
@@ -129,10 +129,10 @@ public class ChangeOrderStatusService implements ChangeOrderStatusUseCase {
         Long totalAmount = order.getTotalAmount();
         Long totalAccumulatedPoint = calculateTotalAccumulatedPoint(order.getOrderProducts(), pricePolicyIds);
 
-        runAfterCommit(() -> {
-            // Kafka 이벤트 발행 (듀얼 라이트)
-            publishOrderPaymentCompletedEvent(order, totalAccumulatedPoint);
+        // Outbox 이벤트 저장 (트랜잭션 내)
+        publishOrderPaymentCompletedEvent(order, totalAccumulatedPoint);
 
+        runAfterCommit(() -> {
             // 결제 완료 시 장바구니 상품 삭제
             deleteOrderedCartProductsPort.delete(pricePolicyIds);
 
@@ -209,10 +209,10 @@ public class ChangeOrderStatusService implements ChangeOrderStatusUseCase {
         Long buyerId = order.getBuyerId();
         List<Long> sharerIds = extractSharerIds(order.getOrderProducts());
 
-        runAfterCommit(() -> {
-            confirmPendingPoints(buyerId, orderId);
-            publishOrderPurchaseConfirmedEvent(orderId, buyerId, sharerIds);
-        });
+        // Outbox 이벤트 저장 (트랜잭션 내)
+        publishOrderPurchaseConfirmedEvent(orderId, buyerId, sharerIds);
+
+        runAfterCommit(() -> confirmPendingPoints(buyerId, orderId));
     }
 
     private void publishOrderPurchaseConfirmedEvent(Long orderId, Long buyerId, List<Long> sharerIds) {

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/CancelPaymentService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/CancelPaymentService.java
@@ -134,18 +134,14 @@ public class CancelPaymentService implements CancelPaymentUseCase {
         String cancelId = isFullCancel ? null : UUID.randomUUID().toString();
         recordLedgerEntryForCancellation(payment, isFullCancel, cancelAmount, cancelId);
 
-        Long orderId = order.getId();
-        String orderKey = command.orderKey();
-        Long buyerId = order.getBuyerId();
-        Long paymentAmount = payment.getPaymentAmount();
-        Long pointAmount = order.getPointAmount();
-        List<OrderProduct> orderProducts = order.getOrderProducts();
         List<OrderProduct> cancelTargetProducts = resolveCancelProducts(isFullCancel, command);
-        Long finalPartialProductPendingDeduction = partialProductPendingDeduction;
-        runAfterCommit(() -> publishPaymentCancelledEvent(
-                orderId, orderKey, buyerId, cancelAmount, paymentAmount,
-                pointAmount, isFullCancel, alreadyRefunded, cancelId, orderProducts, cancelTargetProducts,
-                finalPartialProductPendingDeduction));
+
+        // Outbox 이벤트 저장 (트랜잭션 내)
+        publishPaymentCancelledEvent(
+                order.getId(), command.orderKey(), order.getBuyerId(), cancelAmount,
+                payment.getPaymentAmount(), order.getPointAmount(), isFullCancel, alreadyRefunded,
+                cancelId, order.getOrderProducts(), cancelTargetProducts,
+                partialProductPendingDeduction);
     }
 
     private Long computeCancelAmount(boolean isFullCancel, Long partialCancelAmount, Long refundableAmount) {

--- a/common/src/main/java/com/personal/marketnote/common/outbox/OutboxConfiguration.java
+++ b/common/src/main/java/com/personal/marketnote/common/outbox/OutboxConfiguration.java
@@ -1,0 +1,13 @@
+package com.personal.marketnote.common.outbox;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@ConditionalOnProperty(prefix = "outbox", name = "enabled", havingValue = "true")
+@EnableConfigurationProperties(OutboxProperties.class)
+@EnableScheduling
+public class OutboxConfiguration {
+}

--- a/common/src/main/java/com/personal/marketnote/common/outbox/OutboxEvent.java
+++ b/common/src/main/java/com/personal/marketnote/common/outbox/OutboxEvent.java
@@ -1,0 +1,64 @@
+package com.personal.marketnote.common.outbox;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+@Getter
+public class OutboxEvent {
+    private static final int DEFAULT_MAX_RETRIES = 5;
+
+    private Long id;
+    private String eventId;
+    private String topic;
+    private String partitionKey;
+    private String eventType;
+    private String source;
+    private String payload;
+    private OutboxEventStatus status;
+    private int retryCount;
+    private int maxRetries;
+    private LocalDateTime createdAt;
+    private LocalDateTime publishedAt;
+
+    public static OutboxEvent of(String eventId, String topic, String partitionKey,
+                                 String eventType, String source, String payload,
+                                 Clock clock) {
+        return OutboxEvent.builder()
+                .eventId(eventId)
+                .topic(topic)
+                .partitionKey(partitionKey)
+                .eventType(eventType)
+                .source(source)
+                .payload(payload)
+                .status(OutboxEventStatus.PENDING)
+                .retryCount(0)
+                .maxRetries(DEFAULT_MAX_RETRIES)
+                .createdAt(LocalDateTime.now(clock))
+                .build();
+    }
+
+    public void markPublished(Clock clock) {
+        this.status = OutboxEventStatus.PUBLISHED;
+        this.publishedAt = LocalDateTime.now(clock);
+    }
+
+    public void incrementRetry() {
+        this.retryCount++;
+        if (this.retryCount >= this.maxRetries) {
+            this.status = OutboxEventStatus.FAILED;
+        }
+    }
+
+    public boolean isExhausted() {
+        return this.retryCount >= this.maxRetries;
+    }
+}

--- a/common/src/main/java/com/personal/marketnote/common/outbox/OutboxEventStatus.java
+++ b/common/src/main/java/com/personal/marketnote/common/outbox/OutboxEventStatus.java
@@ -1,0 +1,19 @@
+package com.personal.marketnote.common.outbox;
+
+public enum OutboxEventStatus {
+    PENDING,
+    PUBLISHED,
+    FAILED;
+
+    public boolean isPending() {
+        return this == PENDING;
+    }
+
+    public boolean isPublished() {
+        return this == PUBLISHED;
+    }
+
+    public boolean isFailed() {
+        return this == FAILED;
+    }
+}

--- a/common/src/main/java/com/personal/marketnote/common/outbox/OutboxProperties.java
+++ b/common/src/main/java/com/personal/marketnote/common/outbox/OutboxProperties.java
@@ -1,0 +1,17 @@
+package com.personal.marketnote.common.outbox;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "outbox")
+@Getter
+@Setter
+public class OutboxProperties {
+    private boolean enabled = false;
+    private long pollingIntervalMs = 3000;
+    private int batchSize = 100;
+    private int maxRetries = 5;
+    private int retentionDays = 7;
+    private String cleanupCron = "0 0 3 * * ?";
+}

--- a/common/src/main/java/com/personal/marketnote/common/outbox/OutboxRepositoryConfiguration.java
+++ b/common/src/main/java/com/personal/marketnote/common/outbox/OutboxRepositoryConfiguration.java
@@ -1,0 +1,11 @@
+package com.personal.marketnote.common.outbox;
+
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+
+@Configuration
+@EnableJpaRepositories(basePackages = "com.personal.marketnote")
+@EntityScan(basePackages = "com.personal.marketnote")
+public class OutboxRepositoryConfiguration {
+}

--- a/common/src/main/java/com/personal/marketnote/common/outbox/SaveOutboxEventPort.java
+++ b/common/src/main/java/com/personal/marketnote/common/outbox/SaveOutboxEventPort.java
@@ -1,0 +1,5 @@
+package com.personal.marketnote.common.outbox;
+
+public interface SaveOutboxEventPort {
+    void save(OutboxEvent event);
+}

--- a/common/src/main/java/com/personal/marketnote/common/outbox/adapter/OutboxEventCleaner.java
+++ b/common/src/main/java/com/personal/marketnote/common/outbox/adapter/OutboxEventCleaner.java
@@ -1,0 +1,34 @@
+package com.personal.marketnote.common.outbox.adapter;
+
+import com.personal.marketnote.common.outbox.OutboxEventStatus;
+import com.personal.marketnote.common.outbox.OutboxProperties;
+import com.personal.marketnote.common.outbox.repository.OutboxEventJpaRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@Component
+@ConditionalOnProperty(prefix = "outbox", name = "enabled", havingValue = "true")
+@RequiredArgsConstructor
+@Slf4j
+public class OutboxEventCleaner {
+    private final OutboxEventJpaRepository outboxEventJpaRepository;
+    private final OutboxProperties outboxProperties;
+    private final Clock clock;
+
+    @Scheduled(cron = "${outbox.cleanup-cron:0 0 3 * * ?}")
+    @Transactional(isolation = READ_COMMITTED)
+    public void cleanupPublishedEvents() {
+        LocalDateTime cutoff = LocalDateTime.now(clock).minusDays(outboxProperties.getRetentionDays());
+        outboxEventJpaRepository.deleteByStatusAndPublishedAtBefore(OutboxEventStatus.PUBLISHED, cutoff);
+        log.info("Outbox 발행 완료 이벤트 정리 완료 - cutoff: {}", cutoff);
+    }
+}

--- a/common/src/main/java/com/personal/marketnote/common/outbox/adapter/OutboxEventPersistenceAdapter.java
+++ b/common/src/main/java/com/personal/marketnote/common/outbox/adapter/OutboxEventPersistenceAdapter.java
@@ -1,0 +1,19 @@
+package com.personal.marketnote.common.outbox.adapter;
+
+import com.personal.marketnote.common.adapter.out.PersistenceAdapter;
+import com.personal.marketnote.common.outbox.OutboxEvent;
+import com.personal.marketnote.common.outbox.SaveOutboxEventPort;
+import com.personal.marketnote.common.outbox.entity.OutboxEventJpaEntity;
+import com.personal.marketnote.common.outbox.repository.OutboxEventJpaRepository;
+import lombok.RequiredArgsConstructor;
+
+@PersistenceAdapter
+@RequiredArgsConstructor
+public class OutboxEventPersistenceAdapter implements SaveOutboxEventPort {
+    private final OutboxEventJpaRepository outboxEventJpaRepository;
+
+    @Override
+    public void save(OutboxEvent event) {
+        outboxEventJpaRepository.save(OutboxEventJpaEntity.from(event));
+    }
+}

--- a/common/src/main/java/com/personal/marketnote/common/outbox/adapter/OutboxEventPublisher.java
+++ b/common/src/main/java/com/personal/marketnote/common/outbox/adapter/OutboxEventPublisher.java
@@ -1,0 +1,62 @@
+package com.personal.marketnote.common.outbox.adapter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.common.outbox.OutboxEventStatus;
+import com.personal.marketnote.common.outbox.entity.OutboxEventJpaEntity;
+import com.personal.marketnote.common.outbox.repository.OutboxEventJpaRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Component
+@ConditionalOnProperty(prefix = "outbox", name = "enabled", havingValue = "true")
+@RequiredArgsConstructor
+@Slf4j
+public class OutboxEventPublisher {
+    private final OutboxEventJpaRepository outboxEventJpaRepository;
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+    private final ObjectMapper objectMapper;
+    private final Clock clock;
+
+    @Scheduled(fixedDelayString = "${outbox.polling-interval-ms:3000}")
+    public void publishPendingEvents() {
+        List<OutboxEventJpaEntity> pendingEvents =
+                outboxEventJpaRepository.findTop100ByStatusOrderByCreatedAtAsc(OutboxEventStatus.PENDING);
+
+        for (OutboxEventJpaEntity event : pendingEvents) {
+            publishEvent(event);
+        }
+    }
+
+    private void publishEvent(OutboxEventJpaEntity event) {
+        try {
+            Object payload = objectMapper.readValue(event.getPayload(), Object.class);
+            kafkaTemplate.send(event.getTopic(), event.getPartitionKey(), payload).get();
+
+            event.markPublished(LocalDateTime.now(clock));
+            outboxEventJpaRepository.save(event);
+
+            log.info("Outbox 이벤트 발행 성공. topic={}, partitionKey={}, eventId={}",
+                    event.getTopic(), event.getPartitionKey(), event.getEventId());
+        } catch (Exception e) {
+            event.incrementRetry();
+            outboxEventJpaRepository.save(event);
+
+            if (event.getStatus().isFailed()) {
+                log.error("Outbox 이벤트 최대 재시도 초과. topic={}, eventId={}, retryCount={}",
+                        event.getTopic(), event.getEventId(), event.getRetryCount(), e);
+                return;
+            }
+
+            log.warn("Outbox 이벤트 발행 실패 (재시도 예정). topic={}, eventId={}, retryCount={}, error={}",
+                    event.getTopic(), event.getEventId(), event.getRetryCount(), e.getMessage());
+        }
+    }
+}

--- a/common/src/main/java/com/personal/marketnote/common/outbox/entity/OutboxEventJpaEntity.java
+++ b/common/src/main/java/com/personal/marketnote/common/outbox/entity/OutboxEventJpaEntity.java
@@ -1,0 +1,117 @@
+package com.personal.marketnote.common.outbox.entity;
+
+import com.personal.marketnote.common.outbox.OutboxEventStatus;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+
+@Entity
+@Table(
+        name = "outbox_event",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_outbox_event_id",
+                columnNames = {"event_id"}
+        ),
+        indexes = @Index(
+                name = "idx_outbox_status_created",
+                columnList = "status, created_at"
+        )
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class OutboxEventJpaEntity {
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @Column(name = "event_id", nullable = false, length = 36)
+    private String eventId;
+
+    @Column(name = "topic", nullable = false, length = 100)
+    private String topic;
+
+    @Column(name = "partition_key", nullable = false, length = 100)
+    private String partitionKey;
+
+    @Column(name = "event_type", nullable = false, length = 100)
+    private String eventType;
+
+    @Column(name = "source", nullable = false, length = 50)
+    private String source;
+
+    @Column(name = "payload", nullable = false, columnDefinition = "TEXT")
+    private String payload;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private OutboxEventStatus status;
+
+    @Column(name = "retry_count", nullable = false)
+    private int retryCount;
+
+    @Column(name = "max_retries", nullable = false)
+    private int maxRetries;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "published_at")
+    private LocalDateTime publishedAt;
+
+    private OutboxEventJpaEntity(String eventId, String topic, String partitionKey,
+                                 String eventType, String source, String payload,
+                                 OutboxEventStatus status, int retryCount, int maxRetries,
+                                 LocalDateTime createdAt) {
+        this.eventId = eventId;
+        this.topic = topic;
+        this.partitionKey = partitionKey;
+        this.eventType = eventType;
+        this.source = source;
+        this.payload = payload;
+        this.status = status;
+        this.retryCount = retryCount;
+        this.maxRetries = maxRetries;
+        this.createdAt = createdAt;
+    }
+
+    public static OutboxEventJpaEntity from(com.personal.marketnote.common.outbox.OutboxEvent event) {
+        return new OutboxEventJpaEntity(
+                event.getEventId(),
+                event.getTopic(),
+                event.getPartitionKey(),
+                event.getEventType(),
+                event.getSource(),
+                event.getPayload(),
+                event.getStatus(),
+                event.getRetryCount(),
+                event.getMaxRetries(),
+                event.getCreatedAt()
+        );
+    }
+
+    public void markPublished(LocalDateTime publishedAt) {
+        this.status = OutboxEventStatus.PUBLISHED;
+        this.publishedAt = publishedAt;
+    }
+
+    public void incrementRetry() {
+        this.retryCount++;
+        if (this.retryCount >= this.maxRetries) {
+            this.status = OutboxEventStatus.FAILED;
+        }
+    }
+}

--- a/common/src/main/java/com/personal/marketnote/common/outbox/repository/OutboxEventJpaRepository.java
+++ b/common/src/main/java/com/personal/marketnote/common/outbox/repository/OutboxEventJpaRepository.java
@@ -1,0 +1,15 @@
+package com.personal.marketnote.common.outbox.repository;
+
+import com.personal.marketnote.common.outbox.OutboxEventStatus;
+import com.personal.marketnote.common.outbox.entity.OutboxEventJpaEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface OutboxEventJpaRepository extends JpaRepository<OutboxEventJpaEntity, Long> {
+
+    List<OutboxEventJpaEntity> findTop100ByStatusOrderByCreatedAtAsc(OutboxEventStatus status);
+
+    void deleteByStatusAndPublishedAtBefore(OutboxEventStatus status, LocalDateTime before);
+}

--- a/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/out/event/CommunityEventKafkaProducer.java
+++ b/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/out/event/CommunityEventKafkaProducer.java
@@ -1,13 +1,15 @@
 package com.personal.marketnote.community.adapter.out.event;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.personal.marketnote.common.adapter.out.ServiceAdapter;
 import com.personal.marketnote.common.kafka.KafkaTopicConstants;
 import com.personal.marketnote.common.kafka.event.EventEnvelope;
 import com.personal.marketnote.common.kafka.event.ReviewRegisteredEvent;
+import com.personal.marketnote.common.outbox.OutboxEvent;
+import com.personal.marketnote.common.outbox.SaveOutboxEventPort;
 import com.personal.marketnote.community.port.out.event.PublishReviewEventPort;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.kafka.core.KafkaTemplate;
 
 import java.time.Clock;
 
@@ -17,30 +19,28 @@ import java.time.Clock;
 public class CommunityEventKafkaProducer implements PublishReviewEventPort {
     private static final String SOURCE = "community-service";
 
-    private final KafkaTemplate<String, Object> kafkaTemplate;
+    private final SaveOutboxEventPort saveOutboxEventPort;
+    private final ObjectMapper objectMapper;
     private final Clock clock;
 
     @Override
     public void publishReviewRegisteredEvent(Long orderId, Long pricePolicyId) {
         ReviewRegisteredEvent payload = new ReviewRegisteredEvent(orderId, pricePolicyId);
-        EventEnvelope<ReviewRegisteredEvent> envelope = EventEnvelope.of(
-                KafkaTopicConstants.REVIEW_REGISTERED,
-                SOURCE,
-                payload,
-                clock
-        );
+        String topic = KafkaTopicConstants.REVIEW_REGISTERED;
+        EventEnvelope<ReviewRegisteredEvent> envelope = EventEnvelope.of(topic, SOURCE, payload, clock);
 
-        // TODO: Kafka 단독 전환 시 발행 실패 처리 보강 필요 (Outbox 패턴 또는 동기 전환)
-        kafkaTemplate.send(KafkaTopicConstants.REVIEW_REGISTERED, orderId.toString(), envelope)
-                .whenComplete((result, ex) -> {
-                    if (ex != null) {
-                        log.error("Kafka 이벤트 발행 실패. topic={}, orderId={}, pricePolicyId={}",
-                                KafkaTopicConstants.REVIEW_REGISTERED, orderId, pricePolicyId, ex);
-                    } else {
-                        log.info("Kafka 이벤트 발행 성공. topic={}, orderId={}, offset={}",
-                                KafkaTopicConstants.REVIEW_REGISTERED, orderId,
-                                result.getRecordMetadata().offset());
-                    }
-                });
+        try {
+            String payloadJson = objectMapper.writeValueAsString(envelope);
+            OutboxEvent outboxEvent = OutboxEvent.of(
+                    envelope.eventId(), topic, orderId.toString(),
+                    envelope.eventType(), SOURCE, payloadJson, clock
+            );
+            saveOutboxEventPort.save(outboxEvent);
+            log.info("Outbox 이벤트 저장. topic={}, orderId={}, eventId={}",
+                    topic, orderId, envelope.eventId());
+        } catch (Exception e) {
+            log.error("Outbox 이벤트 저장 실패. topic={}, orderId={}, error={}",
+                    topic, orderId, e.getMessage(), e);
+        }
     }
 }

--- a/community-service/community-adapters/src/main/resources/application.yml
+++ b/community-service/community-adapters/src/main/resources/application.yml
@@ -67,6 +67,14 @@ logging:
   level:
     org.springframework.security: ERROR
 
+outbox:
+  enabled: ${OUTBOX_ENABLED:true}
+  polling-interval-ms: ${OUTBOX_POLLING_INTERVAL_MS:3000}
+  batch-size: ${OUTBOX_BATCH_SIZE:100}
+  max-retries: ${OUTBOX_MAX_RETRIES:5}
+  retention-days: ${OUTBOX_RETENTION_DAYS:7}
+  cleanup-cron: ${OUTBOX_CLEANUP_CRON:0 0 3 * * ?}
+
 product-service:
   base-url: ${PRODUCT_SERVICE_SERVER_ORIGIN:http://localhost:8081}
 

--- a/community-service/community-adapters/src/test/java/com/personal/marketnote/community/adapter/out/event/CommunityEventKafkaProducerTest.java
+++ b/community-service/community-adapters/src/test/java/com/personal/marketnote/community/adapter/out/event/CommunityEventKafkaProducerTest.java
@@ -1,8 +1,11 @@
 package com.personal.marketnote.community.adapter.out.event;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.personal.marketnote.common.kafka.KafkaTopicConstants;
 import com.personal.marketnote.common.kafka.event.EventEnvelope;
 import com.personal.marketnote.common.kafka.event.ReviewRegisteredEvent;
+import com.personal.marketnote.common.outbox.OutboxEvent;
+import com.personal.marketnote.common.outbox.SaveOutboxEventPort;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -10,16 +13,13 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.kafka.core.KafkaTemplate;
 
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
-import java.util.concurrent.CompletableFuture;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -29,7 +29,10 @@ class CommunityEventKafkaProducerTest {
     private CommunityEventKafkaProducer communityEventKafkaProducer;
 
     @Mock
-    private KafkaTemplate<String, Object> kafkaTemplate;
+    private SaveOutboxEventPort saveOutboxEventPort;
+
+    @Mock
+    private ObjectMapper objectMapper;
 
     @Mock
     private Clock clock;
@@ -41,43 +44,40 @@ class CommunityEventKafkaProducerTest {
     }
 
     @Test
-    @DisplayName("리뷰 등록 이벤트 발행 시 올바른 토픽과 파티션 키(orderId)로 전송된다")
-    void publishReviewRegisteredEvent_sendsToCorrectTopicWithOrderIdKey() {
+    @DisplayName("리뷰 등록 이벤트 발행 시 올바른 토픽과 파티션 키(orderId)로 Outbox에 저장된다")
+    void publishReviewRegisteredEvent_savesToOutboxWithCorrectTopicAndPartitionKey() throws Exception {
         // given
         setUpClock("2026-03-02T10:00:00Z");
-        when(kafkaTemplate.send(any(String.class), any(String.class), any()))
-                .thenReturn(new CompletableFuture<>());
+        when(objectMapper.writeValueAsString(any())).thenReturn("{}");
 
         // when
         communityEventKafkaProducer.publishReviewRegisteredEvent(1L, 2L);
 
         // then
-        verify(kafkaTemplate).send(
-                eq(KafkaTopicConstants.REVIEW_REGISTERED),
-                eq("1"),
-                any(EventEnvelope.class)
-        );
+        ArgumentCaptor<OutboxEvent> outboxCaptor = ArgumentCaptor.forClass(OutboxEvent.class);
+        verify(saveOutboxEventPort).save(outboxCaptor.capture());
+
+        OutboxEvent captured = outboxCaptor.getValue();
+        assertThat(captured.getTopic()).isEqualTo(KafkaTopicConstants.REVIEW_REGISTERED);
+        assertThat(captured.getPartitionKey()).isEqualTo("1");
+        assertThat(captured.getSource()).isEqualTo("community-service");
+        assertThat(captured.getEventId()).isNotNull();
     }
 
     @Test
     @DisplayName("리뷰 등록 이벤트 발행 시 EventEnvelope에 올바른 페이로드(orderId, pricePolicyId)가 포함된다")
     @SuppressWarnings("unchecked")
-    void publishReviewRegisteredEvent_envelopeContainsCorrectPayload() {
+    void publishReviewRegisteredEvent_envelopeContainsCorrectPayload() throws Exception {
         // given
         setUpClock("2026-03-02T10:00:00Z");
-        when(kafkaTemplate.send(any(String.class), any(String.class), any()))
-                .thenReturn(new CompletableFuture<>());
+        when(objectMapper.writeValueAsString(any())).thenReturn("{}");
 
         // when
         communityEventKafkaProducer.publishReviewRegisteredEvent(10L, 20L);
 
         // then
         ArgumentCaptor<EventEnvelope> envelopeCaptor = ArgumentCaptor.forClass(EventEnvelope.class);
-        verify(kafkaTemplate).send(
-                eq(KafkaTopicConstants.REVIEW_REGISTERED),
-                eq("10"),
-                envelopeCaptor.capture()
-        );
+        verify(objectMapper).writeValueAsString(envelopeCaptor.capture());
 
         EventEnvelope<?> capturedEnvelope = envelopeCaptor.getValue();
         assertThat(capturedEnvelope.eventType()).isEqualTo(KafkaTopicConstants.REVIEW_REGISTERED);

--- a/community-service/community-application/src/main/java/com/personal/marketnote/community/service/review/RegisterReviewService.java
+++ b/community-service/community-application/src/main/java/com/personal/marketnote/community/service/review/RegisterReviewService.java
@@ -62,18 +62,19 @@ public class RegisterReviewService implements RegisterReviewUseCase {
             );
         }
 
-        // 주문 상품의 리뷰 작성 여부를 true로 업데이트
+        // Outbox 이벤트 저장 (트랜잭션 내)
+        publishReviewEventPort.publishReviewRegisteredEvent(orderId, pricePolicyId);
+
+        // 주문 상품의 리뷰 작성 여부를 true로 업데이트 (커밋 후 HTTP 호출)
         if (TransactionSynchronizationManager.isActualTransactionActive()) {
             TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
                 @Override
                 public void afterCommit() {
-                    publishReviewEventPort.publishReviewRegisteredEvent(orderId, pricePolicyId);
                     // TODO: Kafka 검증 완료 후 HTTP 호출 제거
                     updateOrderProductReviewStatusPort.update(orderId, pricePolicyId, true);
                 }
             });
         } else {
-            publishReviewEventPort.publishReviewRegisteredEvent(orderId, pricePolicyId);
             // TODO: Kafka 검증 완료 후 HTTP 호출 제거
             updateOrderProductReviewStatusPort.update(orderId, pricePolicyId, true);
         }

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/event/ProductEventKafkaProducer.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/event/ProductEventKafkaProducer.java
@@ -1,15 +1,17 @@
 package com.personal.marketnote.product.adapter.out.event;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.personal.marketnote.common.adapter.out.ServiceAdapter;
 import com.personal.marketnote.common.kafka.KafkaTopicConstants;
 import com.personal.marketnote.common.kafka.event.EventEnvelope;
 import com.personal.marketnote.common.kafka.event.PricePolicyCreatedEvent;
 import com.personal.marketnote.common.kafka.event.ProductRegisteredEvent;
 import com.personal.marketnote.common.kafka.event.ProductUpdatedEvent;
+import com.personal.marketnote.common.outbox.OutboxEvent;
+import com.personal.marketnote.common.outbox.SaveOutboxEventPort;
 import com.personal.marketnote.product.port.out.event.PublishProductEventPort;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.kafka.core.KafkaTemplate;
 
 import java.time.Clock;
 
@@ -19,75 +21,49 @@ import java.time.Clock;
 public class ProductEventKafkaProducer implements PublishProductEventPort {
     private static final String SOURCE = "product-service";
 
-    private final KafkaTemplate<String, Object> kafkaTemplate;
+    private final SaveOutboxEventPort saveOutboxEventPort;
+    private final ObjectMapper objectMapper;
     private final Clock clock;
 
     @Override
     public void publishProductRegisteredEvent(Long productId, Long pricePolicyId, Long sellerId, String productName, String godType) {
         ProductRegisteredEvent payload = new ProductRegisteredEvent(productId, pricePolicyId, sellerId, productName, godType);
-        EventEnvelope<ProductRegisteredEvent> envelope = EventEnvelope.of(
-                KafkaTopicConstants.PRODUCT_REGISTERED,
-                SOURCE,
-                payload,
-                clock
-        );
+        String topic = KafkaTopicConstants.PRODUCT_REGISTERED;
+        EventEnvelope<ProductRegisteredEvent> envelope = EventEnvelope.of(topic, SOURCE, payload, clock);
 
-        // TODO: Kafka 단독 전환 시 발행 실패 처리 보강 필요 (Outbox 패턴 또는 동기 전환)
-        kafkaTemplate.send(KafkaTopicConstants.PRODUCT_REGISTERED, productId.toString(), envelope)
-                .whenComplete((result, ex) -> {
-                    if (ex != null) {
-                        log.error("Kafka 이벤트 발행 실패. topic={}, productId={}, pricePolicyId={}, sellerId={}",
-                                KafkaTopicConstants.PRODUCT_REGISTERED, productId, pricePolicyId, sellerId, ex);
-                    } else {
-                        log.info("Kafka 이벤트 발행 성공. topic={}, productId={}, pricePolicyId={}, sellerId={}, offset={}",
-                                KafkaTopicConstants.PRODUCT_REGISTERED, productId, pricePolicyId, sellerId,
-                                result.getRecordMetadata().offset());
-                    }
-                });
+        saveToOutbox(envelope, topic, productId.toString());
     }
 
     @Override
     public void publishPricePolicyCreatedEvent(Long productId, Long pricePolicyId) {
         PricePolicyCreatedEvent payload = new PricePolicyCreatedEvent(productId, pricePolicyId);
-        EventEnvelope<PricePolicyCreatedEvent> envelope = EventEnvelope.of(
-                KafkaTopicConstants.PRICE_POLICY_CREATED,
-                SOURCE,
-                payload,
-                clock
-        );
+        String topic = KafkaTopicConstants.PRICE_POLICY_CREATED;
+        EventEnvelope<PricePolicyCreatedEvent> envelope = EventEnvelope.of(topic, SOURCE, payload, clock);
 
-        kafkaTemplate.send(KafkaTopicConstants.PRICE_POLICY_CREATED, productId.toString(), envelope)
-                .whenComplete((result, ex) -> {
-                    if (ex != null) {
-                        log.error("Kafka 이벤트 발행 실패. topic={}, productId={}, pricePolicyId={}",
-                                KafkaTopicConstants.PRICE_POLICY_CREATED, productId, pricePolicyId, ex);
-                    } else {
-                        log.info("Kafka 이벤트 발행 성공. topic={}, productId={}, pricePolicyId={}, offset={}",
-                                KafkaTopicConstants.PRICE_POLICY_CREATED, productId, pricePolicyId,
-                                result.getRecordMetadata().offset());
-                    }
-                });
+        saveToOutbox(envelope, topic, productId.toString());
     }
 
     @Override
     public void publishProductUpdatedEvent(ProductUpdatedEvent payload) {
-        EventEnvelope<ProductUpdatedEvent> envelope = EventEnvelope.of(
-                KafkaTopicConstants.PRODUCT_UPDATED,
-                SOURCE,
-                payload,
-                clock
-        );
+        String topic = KafkaTopicConstants.PRODUCT_UPDATED;
+        EventEnvelope<ProductUpdatedEvent> envelope = EventEnvelope.of(topic, SOURCE, payload, clock);
 
-        kafkaTemplate.send(KafkaTopicConstants.PRODUCT_UPDATED, payload.productId().toString(), envelope)
-                .whenComplete((result, ex) -> {
-                    if (ex != null) {
-                        log.error("Kafka 이벤트 발행 실패. topic={}, productId={}",
-                                KafkaTopicConstants.PRODUCT_UPDATED, payload.productId(), ex);
-                    } else {
-                        log.info("Kafka 이벤트 발행 성공. topic={}, productId={}, offset={}",
-                                KafkaTopicConstants.PRODUCT_UPDATED, payload.productId(),
-                                result.getRecordMetadata().offset());
-                    }
-                });
+        saveToOutbox(envelope, topic, payload.productId().toString());
+    }
+
+    private <T> void saveToOutbox(EventEnvelope<T> envelope, String topic, String partitionKey) {
+        try {
+            String payloadJson = objectMapper.writeValueAsString(envelope);
+            OutboxEvent outboxEvent = OutboxEvent.of(
+                    envelope.eventId(), topic, partitionKey,
+                    envelope.eventType(), SOURCE, payloadJson, clock
+            );
+            saveOutboxEventPort.save(outboxEvent);
+            log.info("Outbox 이벤트 저장. topic={}, partitionKey={}, eventId={}",
+                    topic, partitionKey, envelope.eventId());
+        } catch (Exception e) {
+            log.error("Outbox 이벤트 저장 실패. topic={}, partitionKey={}, error={}",
+                    topic, partitionKey, e.getMessage(), e);
+        }
     }
 }

--- a/product-service/product-adapters/src/main/resources/application.yml
+++ b/product-service/product-adapters/src/main/resources/application.yml
@@ -67,6 +67,14 @@ logging:
   level:
     org.springframework.security: ERROR
 
+outbox:
+  enabled: ${OUTBOX_ENABLED:true}
+  polling-interval-ms: ${OUTBOX_POLLING_INTERVAL_MS:3000}
+  batch-size: ${OUTBOX_BATCH_SIZE:100}
+  max-retries: ${OUTBOX_MAX_RETRIES:5}
+  retention-days: ${OUTBOX_RETENTION_DAYS:7}
+  cleanup-cron: ${OUTBOX_CLEANUP_CRON:0 0 3 * * ?}
+
 file-service:
   base-url: ${FILE_SERVICE_SERVER_ORIGIN:http://localhost:9000}
 

--- a/product-service/product-adapters/src/test/java/com/personal/marketnote/product/adapter/out/event/ProductEventKafkaProducerTest.java
+++ b/product-service/product-adapters/src/test/java/com/personal/marketnote/product/adapter/out/event/ProductEventKafkaProducerTest.java
@@ -1,9 +1,12 @@
 package com.personal.marketnote.product.adapter.out.event;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.personal.marketnote.common.kafka.KafkaTopicConstants;
 import com.personal.marketnote.common.kafka.event.EventEnvelope;
 import com.personal.marketnote.common.kafka.event.PricePolicyCreatedEvent;
 import com.personal.marketnote.common.kafka.event.ProductRegisteredEvent;
+import com.personal.marketnote.common.outbox.OutboxEvent;
+import com.personal.marketnote.common.outbox.SaveOutboxEventPort;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -11,16 +14,13 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.kafka.core.KafkaTemplate;
 
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
-import java.util.concurrent.CompletableFuture;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -30,7 +30,10 @@ class ProductEventKafkaProducerTest {
     private ProductEventKafkaProducer productEventKafkaProducer;
 
     @Mock
-    private KafkaTemplate<String, Object> kafkaTemplate;
+    private SaveOutboxEventPort saveOutboxEventPort;
+
+    @Mock
+    private ObjectMapper objectMapper;
 
     @Mock
     private Clock clock;
@@ -42,43 +45,40 @@ class ProductEventKafkaProducerTest {
     }
 
     @Test
-    @DisplayName("상품 등록 이벤트 발행 시 올바른 토픽과 파티션 키로 전송된다")
-    void publishProductRegisteredEvent_sendsToCorrectTopicWithProductIdKey() {
+    @DisplayName("상품 등록 이벤트 발행 시 올바른 토픽과 파티션 키로 Outbox에 저장된다")
+    void publishProductRegisteredEvent_savesToOutboxWithCorrectTopicAndPartitionKey() throws Exception {
         // given
         setUpClock("2026-02-27T10:00:00Z");
-        when(kafkaTemplate.send(any(String.class), any(String.class), any()))
-                .thenReturn(new CompletableFuture<>());
+        when(objectMapper.writeValueAsString(any())).thenReturn("{}");
 
         // when
         productEventKafkaProducer.publishProductRegisteredEvent(1L, 2L, 3L, "테스트 상품", "1");
 
         // then
-        verify(kafkaTemplate).send(
-                eq(KafkaTopicConstants.PRODUCT_REGISTERED),
-                eq("1"),
-                any(EventEnvelope.class)
-        );
+        ArgumentCaptor<OutboxEvent> outboxCaptor = ArgumentCaptor.forClass(OutboxEvent.class);
+        verify(saveOutboxEventPort).save(outboxCaptor.capture());
+
+        OutboxEvent captured = outboxCaptor.getValue();
+        assertThat(captured.getTopic()).isEqualTo(KafkaTopicConstants.PRODUCT_REGISTERED);
+        assertThat(captured.getPartitionKey()).isEqualTo("1");
+        assertThat(captured.getSource()).isEqualTo("product-service");
+        assertThat(captured.getEventId()).isNotNull();
     }
 
     @Test
     @DisplayName("상품 등록 이벤트 발행 시 EventEnvelope에 올바른 페이로드가 포함된다")
     @SuppressWarnings("unchecked")
-    void publishProductRegisteredEvent_envelopeContainsCorrectPayload() {
+    void publishProductRegisteredEvent_envelopeContainsCorrectPayload() throws Exception {
         // given
         setUpClock("2026-02-27T10:00:00Z");
-        when(kafkaTemplate.send(any(String.class), any(String.class), any()))
-                .thenReturn(new CompletableFuture<>());
+        when(objectMapper.writeValueAsString(any())).thenReturn("{}");
 
         // when
         productEventKafkaProducer.publishProductRegisteredEvent(10L, 20L, 30L, "상품명", "2");
 
         // then
         ArgumentCaptor<EventEnvelope> envelopeCaptor = ArgumentCaptor.forClass(EventEnvelope.class);
-        verify(kafkaTemplate).send(
-                eq(KafkaTopicConstants.PRODUCT_REGISTERED),
-                eq("10"),
-                envelopeCaptor.capture()
-        );
+        verify(objectMapper).writeValueAsString(envelopeCaptor.capture());
 
         EventEnvelope<?> capturedEnvelope = envelopeCaptor.getValue();
         assertThat(capturedEnvelope.eventType()).isEqualTo(KafkaTopicConstants.PRODUCT_REGISTERED);
@@ -95,43 +95,39 @@ class ProductEventKafkaProducerTest {
     }
 
     @Test
-    @DisplayName("가격 정책 생성 이벤트 발행 시 올바른 토픽과 파티션 키로 전송된다")
-    void publishPricePolicyCreatedEvent_sendsToCorrectTopicWithProductIdKey() {
+    @DisplayName("가격 정책 생성 이벤트 발행 시 올바른 토픽과 파티션 키로 Outbox에 저장된다")
+    void publishPricePolicyCreatedEvent_savesToOutboxWithCorrectTopicAndPartitionKey() throws Exception {
         // given
         setUpClock("2026-02-27T10:00:00Z");
-        when(kafkaTemplate.send(any(String.class), any(String.class), any()))
-                .thenReturn(new CompletableFuture<>());
+        when(objectMapper.writeValueAsString(any())).thenReturn("{}");
 
         // when
         productEventKafkaProducer.publishPricePolicyCreatedEvent(1L, 2L);
 
         // then
-        verify(kafkaTemplate).send(
-                eq(KafkaTopicConstants.PRICE_POLICY_CREATED),
-                eq("1"),
-                any(EventEnvelope.class)
-        );
+        ArgumentCaptor<OutboxEvent> outboxCaptor = ArgumentCaptor.forClass(OutboxEvent.class);
+        verify(saveOutboxEventPort).save(outboxCaptor.capture());
+
+        OutboxEvent captured = outboxCaptor.getValue();
+        assertThat(captured.getTopic()).isEqualTo(KafkaTopicConstants.PRICE_POLICY_CREATED);
+        assertThat(captured.getPartitionKey()).isEqualTo("1");
+        assertThat(captured.getSource()).isEqualTo("product-service");
     }
 
     @Test
     @DisplayName("가격 정책 생성 이벤트 발행 시 EventEnvelope에 올바른 페이로드가 포함된다")
     @SuppressWarnings("unchecked")
-    void publishPricePolicyCreatedEvent_envelopeContainsCorrectPayload() {
+    void publishPricePolicyCreatedEvent_envelopeContainsCorrectPayload() throws Exception {
         // given
         setUpClock("2026-02-27T10:00:00Z");
-        when(kafkaTemplate.send(any(String.class), any(String.class), any()))
-                .thenReturn(new CompletableFuture<>());
+        when(objectMapper.writeValueAsString(any())).thenReturn("{}");
 
         // when
         productEventKafkaProducer.publishPricePolicyCreatedEvent(10L, 20L);
 
         // then
         ArgumentCaptor<EventEnvelope> envelopeCaptor = ArgumentCaptor.forClass(EventEnvelope.class);
-        verify(kafkaTemplate).send(
-                eq(KafkaTopicConstants.PRICE_POLICY_CREATED),
-                eq("10"),
-                envelopeCaptor.capture()
-        );
+        verify(objectMapper).writeValueAsString(envelopeCaptor.capture());
 
         EventEnvelope<?> capturedEnvelope = envelopeCaptor.getValue();
         assertThat(capturedEnvelope.eventType()).isEqualTo(KafkaTopicConstants.PRICE_POLICY_CREATED);

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/service/pricepolicy/RegisterPricePolicyService.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/service/pricepolicy/RegisterPricePolicyService.java
@@ -55,18 +55,20 @@ public class RegisterPricePolicyService implements RegisterPricePolicyUseCase {
             updateOptionPricePolicyPort.assignPricePolicyToOptions(productId, id, optionIds);
         }
 
-        registerInventoryAfterCommit(productId, id);
+        // Outbox 이벤트 저장 (트랜잭션 내)
+        publishProductEventPort.publishPricePolicyCreatedEvent(productId, id);
+
+        // 트랜잭션 커밋 후 HTTP 호출
+        registerInventoryHttpAfterCommit(productId, id);
 
         return RegisterPricePolicyResult.of(id);
     }
 
-    private void registerInventoryAfterCommit(Long productId, Long pricePolicyId) {
+    private void registerInventoryHttpAfterCommit(Long productId, Long pricePolicyId) {
         if (TransactionSynchronizationManager.isActualTransactionActive()) {
             TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
                 @Override
                 public void afterCommit() {
-                    publishProductEventPort.publishPricePolicyCreatedEvent(productId, pricePolicyId);
-
                     // TODO: Kafka 검증 완료 후 HTTP 호출 제거 (#1017)
                     registerInventoryPort.registerInventory(productId, pricePolicyId);
                 }
@@ -74,8 +76,6 @@ public class RegisterPricePolicyService implements RegisterPricePolicyUseCase {
 
             return;
         }
-
-        publishProductEventPort.publishPricePolicyCreatedEvent(productId, pricePolicyId);
 
         // TODO: Kafka 검증 완료 후 HTTP 호출 제거 (#1017)
         registerInventoryPort.registerInventory(productId, pricePolicyId);

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/service/product/RegisterProductService.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/service/product/RegisterProductService.java
@@ -48,40 +48,38 @@ public class RegisterProductService implements RegisterProductUseCase {
                 sellerId, false, RegisterPricePolicyCommand.from(productId, command)
         );
 
-        // 트랜잭션이 있는 경우 트랜잭션 커밋 후 외부 시스템 요청
-        if (TransactionSynchronizationManager.isActualTransactionActive()) {
-            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
-                @Override
-                public void afterCommit() {
-                    registerExternalSystems(savedProduct, command, registerPricePolicyResult.id());
-                }
-            });
-
-            return RegisterProductResult.from(savedProduct);
-
-        }
-
-        // 트랜잭션이 없는 경우 직접 호출
-        registerExternalSystems(savedProduct, command, registerPricePolicyResult.id());
-
-        return RegisterProductResult.from(savedProduct);
-    }
-
-    private void registerExternalSystems(
-            Product savedProduct,
-            RegisterProductCommand command,
-            Long pricePolicyId
-    ) {
-        // Kafka 이벤트 발행 (비동기)
+        // Outbox 이벤트 저장 (트랜잭션 내)
         FulfillmentVendorGoodsOptionCommand fulfillmentOptions = command.fulfillmentVendorGoods();
         String godType = FormatValidator.hasValue(fulfillmentOptions) && FormatValidator.hasValue(fulfillmentOptions.godType())
                 ? fulfillmentOptions.godType()
                 : DEFAULT_GOD_TYPE;
 
         publishProductEventPort.publishProductRegisteredEvent(
-                savedProduct.getId(), pricePolicyId, command.sellerId(), savedProduct.getName(), godType
+                savedProduct.getId(), registerPricePolicyResult.id(), command.sellerId(), savedProduct.getName(), godType
         );
 
+        // 트랜잭션 커밋 후 외부 시스템 HTTP 호출
+        if (TransactionSynchronizationManager.isActualTransactionActive()) {
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCommit() {
+                    registerExternalSystemsHttp(savedProduct, command, registerPricePolicyResult.id());
+                }
+            });
+
+            return RegisterProductResult.from(savedProduct);
+        }
+
+        registerExternalSystemsHttp(savedProduct, command, registerPricePolicyResult.id());
+
+        return RegisterProductResult.from(savedProduct);
+    }
+
+    private void registerExternalSystemsHttp(
+            Product savedProduct,
+            RegisterProductCommand command,
+            Long pricePolicyId
+    ) {
         // TODO: Kafka 검증 완료 후 HTTP 호출 제거
         registerInventoryPort.registerInventory(savedProduct.getId(), pricePolicyId);
 

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/service/product/UpdateProductService.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/service/product/UpdateProductService.java
@@ -53,10 +53,12 @@ public class UpdateProductService implements UpdateProductUseCase {
                     FulfillmentVendorGoodsCommandMapper.mapToUpdateCommand(product, command.fulfillmentVendorGoods());
             ProductUpdatedEvent productUpdatedEvent =
                     ProductUpdatedEventMapper.mapToEvent(product, command.fulfillmentVendorGoods());
-            runAfterCommit(() -> {
-                updateFulfillmentVendorGoodsPort.updateFulfillmentVendorGoods(updateCommand);
-                publishProductEventPort.publishProductUpdatedEvent(productUpdatedEvent);
-            });
+
+            // Outbox 이벤트 저장 (트랜잭션 내)
+            publishProductEventPort.publishProductUpdatedEvent(productUpdatedEvent);
+
+            // 트랜잭션 커밋 후 HTTP 호출
+            runAfterCommit(() -> updateFulfillmentVendorGoodsPort.updateFulfillmentVendorGoods(updateCommand));
         }
     }
 

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/out/event/UserEventKafkaProducer.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/out/event/UserEventKafkaProducer.java
@@ -1,14 +1,16 @@
 package com.personal.marketnote.user.adapter.out.event;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.personal.marketnote.common.adapter.out.ServiceAdapter;
 import com.personal.marketnote.common.kafka.KafkaTopicConstants;
 import com.personal.marketnote.common.kafka.event.EventEnvelope;
 import com.personal.marketnote.common.kafka.event.UserReferralCompletedEvent;
 import com.personal.marketnote.common.kafka.event.UserSignupCompletedEvent;
+import com.personal.marketnote.common.outbox.OutboxEvent;
+import com.personal.marketnote.common.outbox.SaveOutboxEventPort;
 import com.personal.marketnote.user.port.out.event.PublishUserEventPort;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.kafka.core.KafkaTemplate;
 
 import java.time.Clock;
 
@@ -18,54 +20,41 @@ import java.time.Clock;
 public class UserEventKafkaProducer implements PublishUserEventPort {
     private static final String SOURCE = "user-service";
 
-    private final KafkaTemplate<String, Object> kafkaTemplate;
+    private final SaveOutboxEventPort saveOutboxEventPort;
+    private final ObjectMapper objectMapper;
     private final Clock clock;
 
     @Override
     public void publishUserSignupCompletedEvent(Long userId, String userKey) {
         UserSignupCompletedEvent payload = new UserSignupCompletedEvent(userId, userKey);
-        EventEnvelope<UserSignupCompletedEvent> envelope = EventEnvelope.of(
-                KafkaTopicConstants.USER_SIGNUP_COMPLETED,
-                SOURCE,
-                payload,
-                clock
-        );
+        String topic = KafkaTopicConstants.USER_SIGNUP_COMPLETED;
+        EventEnvelope<UserSignupCompletedEvent> envelope = EventEnvelope.of(topic, SOURCE, payload, clock);
 
-        // TODO: Kafka 단독 전환 시 발행 실패 처리 보강 필요 (Outbox 패턴 또는 동기 전환)
-        kafkaTemplate.send(KafkaTopicConstants.USER_SIGNUP_COMPLETED, userId.toString(), envelope)
-                .whenComplete((result, ex) -> {
-                    if (ex != null) {
-                        log.error("Kafka 이벤트 발행 실패. topic={}, userId={}, userKey={}",
-                                KafkaTopicConstants.USER_SIGNUP_COMPLETED, userId, userKey, ex);
-                    } else {
-                        log.info("Kafka 이벤트 발행 성공. topic={}, userId={}, offset={}",
-                                KafkaTopicConstants.USER_SIGNUP_COMPLETED, userId,
-                                result.getRecordMetadata().offset());
-                    }
-                });
+        saveToOutbox(envelope, topic, userId.toString());
     }
 
     @Override
     public void publishUserReferralCompletedEvent(Long requestUserId, Long referredUserId) {
         UserReferralCompletedEvent payload = new UserReferralCompletedEvent(requestUserId, referredUserId);
-        EventEnvelope<UserReferralCompletedEvent> envelope = EventEnvelope.of(
-                KafkaTopicConstants.USER_REFERRAL_COMPLETED,
-                SOURCE,
-                payload,
-                clock
-        );
+        String topic = KafkaTopicConstants.USER_REFERRAL_COMPLETED;
+        EventEnvelope<UserReferralCompletedEvent> envelope = EventEnvelope.of(topic, SOURCE, payload, clock);
 
-        // TODO: Kafka 단독 전환 시 발행 실패 처리 보강 필요 (Outbox 패턴 또는 동기 전환)
-        kafkaTemplate.send(KafkaTopicConstants.USER_REFERRAL_COMPLETED, requestUserId.toString(), envelope)
-                .whenComplete((result, ex) -> {
-                    if (ex != null) {
-                        log.error("Kafka 이벤트 발행 실패. topic={}, requestUserId={}, referredUserId={}",
-                                KafkaTopicConstants.USER_REFERRAL_COMPLETED, requestUserId, referredUserId, ex);
-                    } else {
-                        log.info("Kafka 이벤트 발행 성공. topic={}, requestUserId={}, offset={}",
-                                KafkaTopicConstants.USER_REFERRAL_COMPLETED, requestUserId,
-                                result.getRecordMetadata().offset());
-                    }
-                });
+        saveToOutbox(envelope, topic, requestUserId.toString());
+    }
+
+    private <T> void saveToOutbox(EventEnvelope<T> envelope, String topic, String partitionKey) {
+        try {
+            String payloadJson = objectMapper.writeValueAsString(envelope);
+            OutboxEvent outboxEvent = OutboxEvent.of(
+                    envelope.eventId(), topic, partitionKey,
+                    envelope.eventType(), SOURCE, payloadJson, clock
+            );
+            saveOutboxEventPort.save(outboxEvent);
+            log.info("Outbox 이벤트 저장. topic={}, partitionKey={}, eventId={}",
+                    topic, partitionKey, envelope.eventId());
+        } catch (Exception e) {
+            log.error("Outbox 이벤트 저장 실패. topic={}, partitionKey={}, error={}",
+                    topic, partitionKey, e.getMessage(), e);
+        }
     }
 }

--- a/user-service/user-adapters/src/main/resources/application.yml
+++ b/user-service/user-adapters/src/main/resources/application.yml
@@ -87,6 +87,14 @@ logging:
   level:
     org.springframework.security: ERROR
 
+outbox:
+  enabled: ${OUTBOX_ENABLED:true}
+  polling-interval-ms: ${OUTBOX_POLLING_INTERVAL_MS:3000}
+  batch-size: ${OUTBOX_BATCH_SIZE:100}
+  max-retries: ${OUTBOX_MAX_RETRIES:5}
+  retention-days: ${OUTBOX_RETENTION_DAYS:7}
+  cleanup-cron: ${OUTBOX_CLEANUP_CRON:0 0 3 * * ?}
+
 reward-service:
   base-url: ${REWARD_SERVICE_SERVER_ORIGIN:http://localhost:8084}
   referral-point:

--- a/user-service/user-adapters/src/test/java/com/personal/marketnote/user/adapter/out/event/UserEventKafkaProducerReferralTest.java
+++ b/user-service/user-adapters/src/test/java/com/personal/marketnote/user/adapter/out/event/UserEventKafkaProducerReferralTest.java
@@ -1,8 +1,11 @@
 package com.personal.marketnote.user.adapter.out.event;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.personal.marketnote.common.kafka.KafkaTopicConstants;
 import com.personal.marketnote.common.kafka.event.EventEnvelope;
 import com.personal.marketnote.common.kafka.event.UserReferralCompletedEvent;
+import com.personal.marketnote.common.outbox.OutboxEvent;
+import com.personal.marketnote.common.outbox.SaveOutboxEventPort;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -10,16 +13,13 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.kafka.core.KafkaTemplate;
 
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
-import java.util.concurrent.CompletableFuture;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -29,7 +29,10 @@ class UserEventKafkaProducerReferralTest {
     private UserEventKafkaProducer userEventKafkaProducer;
 
     @Mock
-    private KafkaTemplate<String, Object> kafkaTemplate;
+    private SaveOutboxEventPort saveOutboxEventPort;
+
+    @Mock
+    private ObjectMapper objectMapper;
 
     @Mock
     private Clock clock;
@@ -41,43 +44,40 @@ class UserEventKafkaProducerReferralTest {
     }
 
     @Test
-    @DisplayName("추천코드 등록 완료 이벤트 발행 시 올바른 토픽과 파티션 키로 전송된다")
-    void publishUserReferralCompletedEvent_sendsToCorrectTopicWithRequestUserIdKey() {
+    @DisplayName("추천코드 등록 완료 이벤트 발행 시 올바른 토픽과 파티션 키로 Outbox에 저장된다")
+    void publishUserReferralCompletedEvent_savesToOutboxWithCorrectTopicAndPartitionKey() throws Exception {
         // given
         setUpClock("2026-03-02T10:00:00Z");
-        when(kafkaTemplate.send(any(String.class), any(String.class), any()))
-                .thenReturn(new CompletableFuture<>());
+        when(objectMapper.writeValueAsString(any())).thenReturn("{}");
 
         // when
         userEventKafkaProducer.publishUserReferralCompletedEvent(1L, 2L);
 
         // then
-        verify(kafkaTemplate).send(
-                eq(KafkaTopicConstants.USER_REFERRAL_COMPLETED),
-                eq("1"),
-                any(EventEnvelope.class)
-        );
+        ArgumentCaptor<OutboxEvent> outboxCaptor = ArgumentCaptor.forClass(OutboxEvent.class);
+        verify(saveOutboxEventPort).save(outboxCaptor.capture());
+
+        OutboxEvent captured = outboxCaptor.getValue();
+        assertThat(captured.getTopic()).isEqualTo(KafkaTopicConstants.USER_REFERRAL_COMPLETED);
+        assertThat(captured.getPartitionKey()).isEqualTo("1");
+        assertThat(captured.getSource()).isEqualTo("user-service");
+        assertThat(captured.getEventId()).isNotNull();
     }
 
     @Test
     @DisplayName("추천코드 등록 완료 이벤트 발행 시 EventEnvelope에 올바른 페이로드가 포함된다")
     @SuppressWarnings("unchecked")
-    void publishUserReferralCompletedEvent_envelopeContainsCorrectPayload() {
+    void publishUserReferralCompletedEvent_envelopeContainsCorrectPayload() throws Exception {
         // given
         setUpClock("2026-03-02T10:00:00Z");
-        when(kafkaTemplate.send(any(String.class), any(String.class), any()))
-                .thenReturn(new CompletableFuture<>());
+        when(objectMapper.writeValueAsString(any())).thenReturn("{}");
 
         // when
         userEventKafkaProducer.publishUserReferralCompletedEvent(10L, 20L);
 
         // then
         ArgumentCaptor<EventEnvelope> envelopeCaptor = ArgumentCaptor.forClass(EventEnvelope.class);
-        verify(kafkaTemplate).send(
-                eq(KafkaTopicConstants.USER_REFERRAL_COMPLETED),
-                eq("10"),
-                envelopeCaptor.capture()
-        );
+        verify(objectMapper).writeValueAsString(envelopeCaptor.capture());
 
         EventEnvelope<?> capturedEnvelope = envelopeCaptor.getValue();
         assertThat(capturedEnvelope.eventType()).isEqualTo(KafkaTopicConstants.USER_REFERRAL_COMPLETED);

--- a/user-service/user-adapters/src/test/java/com/personal/marketnote/user/adapter/out/event/UserEventKafkaProducerTest.java
+++ b/user-service/user-adapters/src/test/java/com/personal/marketnote/user/adapter/out/event/UserEventKafkaProducerTest.java
@@ -1,8 +1,11 @@
 package com.personal.marketnote.user.adapter.out.event;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.personal.marketnote.common.kafka.KafkaTopicConstants;
 import com.personal.marketnote.common.kafka.event.EventEnvelope;
 import com.personal.marketnote.common.kafka.event.UserSignupCompletedEvent;
+import com.personal.marketnote.common.outbox.OutboxEvent;
+import com.personal.marketnote.common.outbox.SaveOutboxEventPort;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -10,16 +13,13 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.kafka.core.KafkaTemplate;
 
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
-import java.util.concurrent.CompletableFuture;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -29,7 +29,10 @@ class UserEventKafkaProducerTest {
     private UserEventKafkaProducer userEventKafkaProducer;
 
     @Mock
-    private KafkaTemplate<String, Object> kafkaTemplate;
+    private SaveOutboxEventPort saveOutboxEventPort;
+
+    @Mock
+    private ObjectMapper objectMapper;
 
     @Mock
     private Clock clock;
@@ -41,43 +44,40 @@ class UserEventKafkaProducerTest {
     }
 
     @Test
-    @DisplayName("회원가입 완료 이벤트 발행 시 올바른 토픽과 파티션 키로 전송된다")
-    void publishUserSignupCompletedEvent_sendsToCorrectTopicWithUserIdKey() {
+    @DisplayName("회원가입 완료 이벤트 발행 시 올바른 토픽과 파티션 키로 Outbox에 저장된다")
+    void publishUserSignupCompletedEvent_savesToOutboxWithCorrectTopicAndPartitionKey() throws Exception {
         // given
         setUpClock("2026-03-02T10:00:00Z");
-        when(kafkaTemplate.send(any(String.class), any(String.class), any()))
-                .thenReturn(new CompletableFuture<>());
+        when(objectMapper.writeValueAsString(any())).thenReturn("{}");
 
         // when
         userEventKafkaProducer.publishUserSignupCompletedEvent(1L, "user-key-123");
 
         // then
-        verify(kafkaTemplate).send(
-                eq(KafkaTopicConstants.USER_SIGNUP_COMPLETED),
-                eq("1"),
-                any(EventEnvelope.class)
-        );
+        ArgumentCaptor<OutboxEvent> outboxCaptor = ArgumentCaptor.forClass(OutboxEvent.class);
+        verify(saveOutboxEventPort).save(outboxCaptor.capture());
+
+        OutboxEvent captured = outboxCaptor.getValue();
+        assertThat(captured.getTopic()).isEqualTo(KafkaTopicConstants.USER_SIGNUP_COMPLETED);
+        assertThat(captured.getPartitionKey()).isEqualTo("1");
+        assertThat(captured.getSource()).isEqualTo("user-service");
+        assertThat(captured.getEventId()).isNotNull();
     }
 
     @Test
     @DisplayName("회원가입 완료 이벤트 발행 시 EventEnvelope에 올바른 페이로드가 포함된다")
     @SuppressWarnings("unchecked")
-    void publishUserSignupCompletedEvent_envelopeContainsCorrectPayload() {
+    void publishUserSignupCompletedEvent_envelopeContainsCorrectPayload() throws Exception {
         // given
         setUpClock("2026-03-02T10:00:00Z");
-        when(kafkaTemplate.send(any(String.class), any(String.class), any()))
-                .thenReturn(new CompletableFuture<>());
+        when(objectMapper.writeValueAsString(any())).thenReturn("{}");
 
         // when
         userEventKafkaProducer.publishUserSignupCompletedEvent(10L, "user-key-456");
 
         // then
         ArgumentCaptor<EventEnvelope> envelopeCaptor = ArgumentCaptor.forClass(EventEnvelope.class);
-        verify(kafkaTemplate).send(
-                eq(KafkaTopicConstants.USER_SIGNUP_COMPLETED),
-                eq("10"),
-                envelopeCaptor.capture()
-        );
+        verify(objectMapper).writeValueAsString(envelopeCaptor.capture());
 
         EventEnvelope<?> capturedEnvelope = envelopeCaptor.getValue();
         assertThat(capturedEnvelope.eventType()).isEqualTo(KafkaTopicConstants.USER_SIGNUP_COMPLETED);

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/service/user/RegisterReferredUserCodeService.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/service/user/RegisterReferredUserCodeService.java
@@ -40,18 +40,22 @@ public class RegisterReferredUserCodeService implements RegisterReferredUserCode
 
         User referredUser = getUserUseCase.getUser(referredUserCode);
 
-        // 추천한 회원/추천 받은 회원 포인트 적립 요청
+        // Outbox 이벤트 저장 (트랜잭션 내)
         try {
-            runAfterCommit(() -> {
-                publishUserEventPort.publishUserReferralCompletedEvent(requestUser.getId(), referredUser.getId());
-                modifyUserPointPort.accrueReferralPoints(requestUser.getId(), referredUser.getId());
-                // TODO: Kafka 검증 완료 후 HTTP 호출 제거
-            });
+            publishUserEventPort.publishUserReferralCompletedEvent(requestUser.getId(), referredUser.getId());
         } catch (Exception e) {
             requestUser.removeReferredUserCode();
             updateUserPort.update(requestUser);
             throw e;
         }
+
+        // 추천한 회원/추천 받은 회원 포인트 적립 요청 (커밋 후 HTTP 호출)
+        Long requestId = requestUser.getId();
+        Long referredId = referredUser.getId();
+        runAfterCommit(() -> {
+            modifyUserPointPort.accrueReferralPoints(requestId, referredId);
+            // TODO: Kafka 검증 완료 후 HTTP 호출 제거
+        });
     }
 
     private void runAfterCommit(Runnable action) {

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/service/user/SignUpService.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/service/user/SignUpService.java
@@ -78,9 +78,13 @@ public class SignUpService implements SignUpUseCase {
                 )
         );
 
-        registerUserPointAfterCommit(
+        // Outbox 이벤트 저장 (트랜잭션 내)
+        publishUserEventPort.publishUserSignupCompletedEvent(
                 signedUpUser.getId(), signedUpUser.getUserKey().toString()
         );
+
+        // 트랜잭션 커밋 후 HTTP 호출
+        registerUserPointHttpAfterCommit(signedUpUser.getId(), signedUpUser.getUserKey().toString());
 
         saveLoginHistoryPort.saveLoginHistory(
                 LoginHistory.of(signedUpUser, authVendor, ipAddress)
@@ -146,19 +150,17 @@ public class SignUpService implements SignUpUseCase {
         throw new UserNotActiveException(SIXTH_ERROR_CODE, email);
     }
 
-    private void registerUserPointAfterCommit(Long userId, String userKey) {
+    private void registerUserPointHttpAfterCommit(Long userId, String userKey) {
         if (TransactionSynchronizationManager.isActualTransactionActive()) {
             TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
                 @Override
                 public void afterCommit() {
-                    publishUserEventPort.publishUserSignupCompletedEvent(userId, userKey);
                     modifyUserPointPort.registerUserPoint(userId, userKey); // TODO: Kafka 검증 완료 후 HTTP 호출 제거
                 }
             });
             return;
         }
 
-        publishUserEventPort.publishUserSignupCompletedEvent(userId, userKey);
         modifyUserPointPort.registerUserPoint(userId, userKey); // TODO: Kafka 검증 완료 후 HTTP 호출 제거
     }
 }

--- a/user-service/user-application/src/test/java/com/personal/marketnote/user/service/user/RegisterReferredUserCodeUseCaseTest.java
+++ b/user-service/user-application/src/test/java/com/personal/marketnote/user/service/user/RegisterReferredUserCodeUseCaseTest.java
@@ -121,8 +121,8 @@ class RegisterReferredUserCodeUseCaseTest {
     }
 
     @Test
-    @DisplayName("포인트 적립 요청이 실패하면 추천인 코드 등록 변경사항을 롤백한다")
-    void registerReferredUserCode_rewardAccrualFails_rollsBack() {
+    @DisplayName("포인트 적립 HTTP 요청이 실패해도 Outbox 이벤트는 롤백되지 않는다")
+    void registerReferredUserCode_rewardAccrualFails_outboxNotRolledBack() {
         // given
         Long requestUserId = 1L;
         String referredUserCode = "ref-123";
@@ -148,13 +148,13 @@ class RegisterReferredUserCodeUseCaseTest {
         verify(getUserUseCase).existsUser(referredUserCode);
         verify(getUserUseCase).getUser(requestUserId);
         verify(requestUser).registerReferredUserCode(referredUserCode);
-        verify(updateUserPort, times(2)).update(requestUser);
+        verify(updateUserPort).update(requestUser);
         verify(getUserUseCase).getUser(referredUserCode);
         verify(referredUser, times(2)).getId();
         verify(requestUser, times(2)).getId();
         verify(publishUserEventPort).publishUserReferralCompletedEvent(requestUserId, referredUserId);
         verify(modifyUserPointPort).accrueReferralPoints(requestUserId, referredUserId);
-        verify(requestUser).removeReferredUserCode();
+        verify(requestUser, never()).removeReferredUserCode();
         verifyNoMoreInteractions(getUserUseCase, updateUserPort, publishUserEventPort, modifyUserPointPort, referredUser);
     }
 


### PR DESCRIPTION
## partially addresses #929
## resolves #1066

## Task
- [x] Outbox 인프라 구축 (OutboxEvent, OutboxEventJpaEntity, OutboxEventJpaRepository, OutboxEventPersistenceAdapter, SaveOutboxEventPort)
- [x] Outbox 스케줄러 구현 (OutboxEventPublisher 폴링 발행, OutboxEventCleaner 보존기간 경과 삭제)
- [x] Outbox 설정 (OutboxProperties, OutboxConfiguration, OutboxRepositoryConfiguration)
- [x] 6개 Kafka Producer KafkaTemplate → SaveOutboxEventPort 전환 (commerce 3, product 1, user 1, community 1)
- [x] 8개 Service afterCommit 이벤트 발행 → 트랜잭션 내 Outbox 저장으로 전환
- [x] 4개 Producer 서비스 application.yml Outbox 설정 추가
- [x] 기존 Producer/Service 테스트 KafkaTemplate → SaveOutboxEventPort 목 전환