### PR TITLE
[#929][#1195] test: Kafka 이벤트 발행 Outbox 패턴 도입 기능 자동화 테스트 추가

### DIFF
--- a/common/src/test/java/com/personal/marketnote/common/outbox/OutboxEventStatusTest.java
+++ b/common/src/test/java/com/personal/marketnote/common/outbox/OutboxEventStatusTest.java
@@ -1,0 +1,49 @@
+package com.personal.marketnote.common.outbox;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("OutboxEventStatus Enum 테스트")
+class OutboxEventStatusTest {
+
+    @Test
+    @DisplayName("PENDING 상태의 isPending은 true를 반환한다")
+    void pending_isPendingReturnsTrue() {
+        assertThat(OutboxEventStatus.PENDING.isPending()).isTrue();
+    }
+
+    @Test
+    @DisplayName("PUBLISHED 상태의 isPublished는 true를 반환한다")
+    void published_isPublishedReturnsTrue() {
+        assertThat(OutboxEventStatus.PUBLISHED.isPublished()).isTrue();
+    }
+
+    @Test
+    @DisplayName("FAILED 상태의 isFailed는 true를 반환한다")
+    void failed_isFailedReturnsTrue() {
+        assertThat(OutboxEventStatus.FAILED.isFailed()).isTrue();
+    }
+
+    @Test
+    @DisplayName("PENDING 상태의 isPublished와 isFailed는 false를 반환한다")
+    void pending_otherPredicatesReturnFalse() {
+        assertThat(OutboxEventStatus.PENDING.isPublished()).isFalse();
+        assertThat(OutboxEventStatus.PENDING.isFailed()).isFalse();
+    }
+
+    @Test
+    @DisplayName("PUBLISHED 상태의 isPending과 isFailed는 false를 반환한다")
+    void published_otherPredicatesReturnFalse() {
+        assertThat(OutboxEventStatus.PUBLISHED.isPending()).isFalse();
+        assertThat(OutboxEventStatus.PUBLISHED.isFailed()).isFalse();
+    }
+
+    @Test
+    @DisplayName("FAILED 상태의 isPending과 isPublished는 false를 반환한다")
+    void failed_otherPredicatesReturnFalse() {
+        assertThat(OutboxEventStatus.FAILED.isPending()).isFalse();
+        assertThat(OutboxEventStatus.FAILED.isPublished()).isFalse();
+    }
+}

--- a/common/src/test/java/com/personal/marketnote/common/outbox/OutboxEventTest.java
+++ b/common/src/test/java/com/personal/marketnote/common/outbox/OutboxEventTest.java
@@ -1,0 +1,149 @@
+package com.personal.marketnote.common.outbox;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("OutboxEvent 도메인 테스트")
+class OutboxEventTest {
+    private static final Clock FIXED_CLOCK = Clock.fixed(
+            Instant.parse("2026-03-15T10:00:00Z"), ZoneId.of("Asia/Seoul")
+    );
+
+    @Test
+    @DisplayName("of 메서드로 생성 시 PENDING 상태와 retryCount 0으로 초기화된다")
+    void of_initializesPendingStatusAndZeroRetryCount() {
+        // when
+        OutboxEvent event = OutboxEvent.of(
+                "event-id-1", "commerce.payment.approved", "order-123",
+                "PaymentApproved", "commerce-service", "{\"orderId\":123}", FIXED_CLOCK
+        );
+
+        // then
+        assertThat(event.getStatus()).isEqualTo(OutboxEventStatus.PENDING);
+        assertThat(event.getRetryCount()).isZero();
+        assertThat(event.getMaxRetries()).isEqualTo(5);
+        assertThat(event.getPublishedAt()).isNull();
+    }
+
+    @Test
+    @DisplayName("of 메서드로 생성 시 Clock 기반 createdAt이 설정된다")
+    void of_setsCreatedAtFromClock() {
+        // when
+        OutboxEvent event = OutboxEvent.of(
+                "event-id-1", "commerce.payment.approved", "order-123",
+                "PaymentApproved", "commerce-service", "{}", FIXED_CLOCK
+        );
+
+        // then
+        LocalDateTime expectedCreatedAt = LocalDateTime.now(FIXED_CLOCK);
+        assertThat(event.getCreatedAt()).isEqualTo(expectedCreatedAt);
+    }
+
+    @Test
+    @DisplayName("of 메서드로 생성 시 전달된 필드가 올바르게 설정된다")
+    void of_setsAllFields() {
+        // given
+        String eventId = "event-id-1";
+        String topic = "commerce.payment.approved";
+        String partitionKey = "order-123";
+        String eventType = "PaymentApproved";
+        String source = "commerce-service";
+        String payload = "{\"orderId\":123}";
+
+        // when
+        OutboxEvent event = OutboxEvent.of(eventId, topic, partitionKey, eventType, source, payload, FIXED_CLOCK);
+
+        // then
+        assertThat(event.getEventId()).isEqualTo(eventId);
+        assertThat(event.getTopic()).isEqualTo(topic);
+        assertThat(event.getPartitionKey()).isEqualTo(partitionKey);
+        assertThat(event.getEventType()).isEqualTo(eventType);
+        assertThat(event.getSource()).isEqualTo(source);
+        assertThat(event.getPayload()).isEqualTo(payload);
+    }
+
+    @Test
+    @DisplayName("markPublished 호출 시 PUBLISHED 상태로 전환되고 publishedAt이 설정된다")
+    void markPublished_changesStatusToPublishedAndSetsPublishedAt() {
+        // given
+        OutboxEvent event = OutboxEvent.of(
+                "event-id-1", "topic", "key", "type", "source", "{}", FIXED_CLOCK
+        );
+
+        // when
+        event.markPublished(FIXED_CLOCK);
+
+        // then
+        assertThat(event.getStatus()).isEqualTo(OutboxEventStatus.PUBLISHED);
+        assertThat(event.getPublishedAt()).isEqualTo(LocalDateTime.now(FIXED_CLOCK));
+    }
+
+    @Test
+    @DisplayName("incrementRetry 호출 시 retryCount가 1 증가한다")
+    void incrementRetry_incrementsRetryCount() {
+        // given
+        OutboxEvent event = OutboxEvent.of(
+                "event-id-1", "topic", "key", "type", "source", "{}", FIXED_CLOCK
+        );
+
+        // when
+        event.incrementRetry();
+
+        // then
+        assertThat(event.getRetryCount()).isEqualTo(1);
+        assertThat(event.getStatus()).isEqualTo(OutboxEventStatus.PENDING);
+    }
+
+    @Test
+    @DisplayName("incrementRetry 호출 시 maxRetries에 도달하면 FAILED 상태로 전환된다")
+    void incrementRetry_changesStatusToFailedWhenMaxRetriesReached() {
+        // given
+        OutboxEvent event = OutboxEvent.of(
+                "event-id-1", "topic", "key", "type", "source", "{}", FIXED_CLOCK
+        );
+
+        // when
+        for (int i = 0; i < 5; i++) {
+            event.incrementRetry();
+        }
+
+        // then
+        assertThat(event.getRetryCount()).isEqualTo(5);
+        assertThat(event.getStatus()).isEqualTo(OutboxEventStatus.FAILED);
+    }
+
+    @Test
+    @DisplayName("isExhausted는 retryCount가 maxRetries 이상이면 true를 반환한다")
+    void isExhausted_returnsTrueWhenRetryCountReachesMaxRetries() {
+        // given
+        OutboxEvent event = OutboxEvent.of(
+                "event-id-1", "topic", "key", "type", "source", "{}", FIXED_CLOCK
+        );
+        for (int i = 0; i < 5; i++) {
+            event.incrementRetry();
+        }
+
+        // when & then
+        assertThat(event.isExhausted()).isTrue();
+    }
+
+    @Test
+    @DisplayName("isExhausted는 retryCount가 maxRetries 미만이면 false를 반환한다")
+    void isExhausted_returnsFalseWhenRetryCountBelowMaxRetries() {
+        // given
+        OutboxEvent event = OutboxEvent.of(
+                "event-id-1", "topic", "key", "type", "source", "{}", FIXED_CLOCK
+        );
+        event.incrementRetry();
+
+        // when & then
+        assertThat(event.isExhausted()).isFalse();
+    }
+}

--- a/common/src/test/java/com/personal/marketnote/common/outbox/adapter/OutboxEventCleanerTest.java
+++ b/common/src/test/java/com/personal/marketnote/common/outbox/adapter/OutboxEventCleanerTest.java
@@ -1,0 +1,56 @@
+package com.personal.marketnote.common.outbox.adapter;
+
+import com.personal.marketnote.common.outbox.OutboxEventStatus;
+import com.personal.marketnote.common.outbox.OutboxProperties;
+import com.personal.marketnote.common.outbox.repository.OutboxEventJpaRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("OutboxEventCleaner 테스트")
+class OutboxEventCleanerTest {
+    private static final Clock FIXED_CLOCK = Clock.fixed(
+            Instant.parse("2026-03-15T10:00:00Z"), ZoneId.of("Asia/Seoul")
+    );
+
+    @InjectMocks
+    private OutboxEventCleaner outboxEventCleaner;
+
+    @Mock
+    private OutboxEventJpaRepository outboxEventJpaRepository;
+
+    @Mock
+    private OutboxProperties outboxProperties;
+
+    @Mock
+    private Clock clock;
+
+    @Test
+    @DisplayName("보존기간이 지난 PUBLISHED 이벤트를 삭제한다")
+    void cleanupPublishedEvents_deletesPublishedEventsOlderThanRetentionDays() {
+        // given
+        when(clock.instant()).thenReturn(FIXED_CLOCK.instant());
+        when(clock.getZone()).thenReturn(FIXED_CLOCK.getZone());
+        when(outboxProperties.getRetentionDays()).thenReturn(7);
+
+        LocalDateTime expectedCutoff = LocalDateTime.now(FIXED_CLOCK).minusDays(7);
+
+        // when
+        outboxEventCleaner.cleanupPublishedEvents();
+
+        // then
+        verify(outboxEventJpaRepository).deleteByStatusAndPublishedAtBefore(OutboxEventStatus.PUBLISHED, expectedCutoff);
+    }
+}

--- a/common/src/test/java/com/personal/marketnote/common/outbox/adapter/OutboxEventPersistenceAdapterTest.java
+++ b/common/src/test/java/com/personal/marketnote/common/outbox/adapter/OutboxEventPersistenceAdapterTest.java
@@ -1,0 +1,61 @@
+package com.personal.marketnote.common.outbox.adapter;
+
+import com.personal.marketnote.common.outbox.OutboxEvent;
+import com.personal.marketnote.common.outbox.OutboxEventStatus;
+import com.personal.marketnote.common.outbox.entity.OutboxEventJpaEntity;
+import com.personal.marketnote.common.outbox.repository.OutboxEventJpaRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("OutboxEventPersistenceAdapter 테스트")
+class OutboxEventPersistenceAdapterTest {
+    private static final Clock FIXED_CLOCK = Clock.fixed(
+            Instant.parse("2026-03-15T10:00:00Z"), ZoneId.of("Asia/Seoul")
+    );
+
+    @InjectMocks
+    private OutboxEventPersistenceAdapter outboxEventPersistenceAdapter;
+
+    @Mock
+    private OutboxEventJpaRepository outboxEventJpaRepository;
+
+    @Test
+    @DisplayName("save 호출 시 OutboxEvent를 JPA 엔티티로 변환하여 저장한다")
+    void save_convertsOutboxEventToJpaEntityAndPersists() {
+        // given
+        OutboxEvent event = OutboxEvent.of(
+                "event-id-1", "commerce.payment.approved", "order-123",
+                "PaymentApproved", "commerce-service", "{\"orderId\":123}", FIXED_CLOCK
+        );
+
+        // when
+        outboxEventPersistenceAdapter.save(event);
+
+        // then
+        ArgumentCaptor<OutboxEventJpaEntity> captor = ArgumentCaptor.forClass(OutboxEventJpaEntity.class);
+        verify(outboxEventJpaRepository).save(captor.capture());
+
+        OutboxEventJpaEntity savedEntity = captor.getValue();
+        assertThat(savedEntity.getEventId()).isEqualTo("event-id-1");
+        assertThat(savedEntity.getTopic()).isEqualTo("commerce.payment.approved");
+        assertThat(savedEntity.getPartitionKey()).isEqualTo("order-123");
+        assertThat(savedEntity.getEventType()).isEqualTo("PaymentApproved");
+        assertThat(savedEntity.getSource()).isEqualTo("commerce-service");
+        assertThat(savedEntity.getPayload()).isEqualTo("{\"orderId\":123}");
+        assertThat(savedEntity.getStatus()).isEqualTo(OutboxEventStatus.PENDING);
+        assertThat(savedEntity.getRetryCount()).isZero();
+    }
+}

--- a/common/src/test/java/com/personal/marketnote/common/outbox/adapter/OutboxEventPublisherTest.java
+++ b/common/src/test/java/com/personal/marketnote/common/outbox/adapter/OutboxEventPublisherTest.java
@@ -1,0 +1,209 @@
+package com.personal.marketnote.common.outbox.adapter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.common.outbox.OutboxEventStatus;
+import com.personal.marketnote.common.outbox.entity.OutboxEventJpaEntity;
+import com.personal.marketnote.common.outbox.repository.OutboxEventJpaRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("OutboxEventPublisher 테스트")
+class OutboxEventPublisherTest {
+    private static final Clock FIXED_CLOCK = Clock.fixed(
+            Instant.parse("2026-03-15T10:00:00Z"), ZoneId.of("Asia/Seoul")
+    );
+
+    @InjectMocks
+    private OutboxEventPublisher outboxEventPublisher;
+
+    @Mock
+    private OutboxEventJpaRepository outboxEventJpaRepository;
+
+    @Mock
+    private KafkaTemplate<String, Object> kafkaTemplate;
+
+    @Mock
+    private ObjectMapper objectMapper;
+
+    @Mock
+    private Clock clock;
+
+    @Test
+    @DisplayName("PENDING 이벤트를 Kafka로 발행하고 PUBLISHED 상태로 변경한다")
+    void publishPendingEvents_publishesToKafkaAndMarksPublished() throws Exception {
+        // given
+        OutboxEventJpaEntity entity = createPendingEntity("event-1", "commerce.payment.approved", "order-123", "{\"orderId\":123}");
+
+        when(outboxEventJpaRepository.findTop100ByStatusOrderByCreatedAtAsc(OutboxEventStatus.PENDING))
+                .thenReturn(List.of(entity));
+
+        Object deserializedPayload = new Object();
+        when(objectMapper.readValue("{\"orderId\":123}", Object.class)).thenReturn(deserializedPayload);
+
+        CompletableFuture<SendResult<String, Object>> future = CompletableFuture.completedFuture(null);
+        when(kafkaTemplate.send("commerce.payment.approved", "order-123", deserializedPayload)).thenReturn(future);
+
+        when(clock.instant()).thenReturn(FIXED_CLOCK.instant());
+        when(clock.getZone()).thenReturn(FIXED_CLOCK.getZone());
+
+        // when
+        outboxEventPublisher.publishPendingEvents();
+
+        // then
+        assertThat(entity.getStatus()).isEqualTo(OutboxEventStatus.PUBLISHED);
+        assertThat(entity.getPublishedAt()).isNotNull();
+        verify(outboxEventJpaRepository).save(entity);
+    }
+
+    @Test
+    @DisplayName("PENDING 이벤트가 없으면 Kafka 발행을 수행하지 않는다")
+    void publishPendingEvents_noPendingEvents_doesNotPublish() {
+        // given
+        when(outboxEventJpaRepository.findTop100ByStatusOrderByCreatedAtAsc(OutboxEventStatus.PENDING))
+                .thenReturn(Collections.emptyList());
+
+        // when
+        outboxEventPublisher.publishPendingEvents();
+
+        // then
+        verifyNoInteractions(kafkaTemplate);
+        verify(outboxEventJpaRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("Kafka 발행 실패 시 retryCount를 증가시킨다")
+    void publishPendingEvents_kafkaSendFails_incrementsRetryCount() throws Exception {
+        // given
+        OutboxEventJpaEntity entity = createPendingEntity("event-1", "commerce.payment.approved", "order-123", "{}");
+
+        when(outboxEventJpaRepository.findTop100ByStatusOrderByCreatedAtAsc(OutboxEventStatus.PENDING))
+                .thenReturn(List.of(entity));
+
+        when(objectMapper.readValue("{}", Object.class)).thenReturn(new Object());
+
+        CompletableFuture<SendResult<String, Object>> failedFuture = new CompletableFuture<>();
+        failedFuture.completeExceptionally(new RuntimeException("Kafka 전송 실패"));
+        when(kafkaTemplate.send(eq("commerce.payment.approved"), eq("order-123"), any())).thenReturn(failedFuture);
+
+        // when
+        outboxEventPublisher.publishPendingEvents();
+
+        // then
+        assertThat(entity.getRetryCount()).isEqualTo(1);
+        assertThat(entity.getStatus()).isEqualTo(OutboxEventStatus.PENDING);
+        verify(outboxEventJpaRepository).save(entity);
+    }
+
+    @Test
+    @DisplayName("최대 재시도 초과 시 FAILED 상태로 변경한다")
+    void publishPendingEvents_maxRetriesExceeded_marksAsFailed() throws Exception {
+        // given
+        OutboxEventJpaEntity entity = createPendingEntity("event-1", "commerce.payment.approved", "order-123", "{}");
+        for (int i = 0; i < 4; i++) {
+            entity.incrementRetry();
+        }
+
+        when(outboxEventJpaRepository.findTop100ByStatusOrderByCreatedAtAsc(OutboxEventStatus.PENDING))
+                .thenReturn(List.of(entity));
+
+        when(objectMapper.readValue("{}", Object.class)).thenReturn(new Object());
+
+        CompletableFuture<SendResult<String, Object>> failedFuture = new CompletableFuture<>();
+        failedFuture.completeExceptionally(new RuntimeException("Kafka 전송 실패"));
+        when(kafkaTemplate.send(eq("commerce.payment.approved"), eq("order-123"), any())).thenReturn(failedFuture);
+
+        // when
+        outboxEventPublisher.publishPendingEvents();
+
+        // then
+        assertThat(entity.getRetryCount()).isEqualTo(5);
+        assertThat(entity.getStatus()).isEqualTo(OutboxEventStatus.FAILED);
+        verify(outboxEventJpaRepository).save(entity);
+    }
+
+    @Test
+    @DisplayName("payload JSON 역직렬화 실패 시 retryCount를 증가시킨다")
+    void publishPendingEvents_invalidPayload_incrementsRetryCount() throws Exception {
+        // given
+        OutboxEventJpaEntity entity = createPendingEntity("event-1", "commerce.payment.approved", "order-123", "invalid-json");
+
+        when(outboxEventJpaRepository.findTop100ByStatusOrderByCreatedAtAsc(OutboxEventStatus.PENDING))
+                .thenReturn(List.of(entity));
+
+        when(objectMapper.readValue("invalid-json", Object.class))
+                .thenThrow(new JsonProcessingException("parse error") {});
+
+        // when
+        outboxEventPublisher.publishPendingEvents();
+
+        // then
+        assertThat(entity.getRetryCount()).isEqualTo(1);
+        assertThat(entity.getStatus()).isEqualTo(OutboxEventStatus.PENDING);
+        verify(outboxEventJpaRepository).save(entity);
+        verifyNoInteractions(kafkaTemplate);
+    }
+
+    @Test
+    @DisplayName("다건 이벤트 처리 시 하나가 실패해도 나머지는 정상 발행된다")
+    void publishPendingEvents_multipleEvents_processesIndependently() throws Exception {
+        // given
+        OutboxEventJpaEntity successEntity = createPendingEntity("event-1", "commerce.payment.approved", "order-1", "{\"orderId\":1}");
+        OutboxEventJpaEntity failEntity = createPendingEntity("event-2", "commerce.payment.cancelled", "order-2", "{\"orderId\":2}");
+
+        when(outboxEventJpaRepository.findTop100ByStatusOrderByCreatedAtAsc(OutboxEventStatus.PENDING))
+                .thenReturn(List.of(successEntity, failEntity));
+
+        Object successPayload = new Object();
+        when(objectMapper.readValue("{\"orderId\":1}", Object.class)).thenReturn(successPayload);
+        Object failPayload = new Object();
+        when(objectMapper.readValue("{\"orderId\":2}", Object.class)).thenReturn(failPayload);
+
+        CompletableFuture<SendResult<String, Object>> successFuture = CompletableFuture.completedFuture(null);
+        when(kafkaTemplate.send("commerce.payment.approved", "order-1", successPayload)).thenReturn(successFuture);
+
+        CompletableFuture<SendResult<String, Object>> failedFuture = new CompletableFuture<>();
+        failedFuture.completeExceptionally(new RuntimeException("Kafka 전송 실패"));
+        when(kafkaTemplate.send("commerce.payment.cancelled", "order-2", failPayload)).thenReturn(failedFuture);
+
+        when(clock.instant()).thenReturn(FIXED_CLOCK.instant());
+        when(clock.getZone()).thenReturn(FIXED_CLOCK.getZone());
+
+        // when
+        outboxEventPublisher.publishPendingEvents();
+
+        // then
+        assertThat(successEntity.getStatus()).isEqualTo(OutboxEventStatus.PUBLISHED);
+        assertThat(successEntity.getPublishedAt()).isNotNull();
+        assertThat(failEntity.getRetryCount()).isEqualTo(1);
+        assertThat(failEntity.getStatus()).isEqualTo(OutboxEventStatus.PENDING);
+        verify(outboxEventJpaRepository, times(2)).save(any());
+    }
+
+    private OutboxEventJpaEntity createPendingEntity(String eventId, String topic, String partitionKey, String payload) {
+        com.personal.marketnote.common.outbox.OutboxEvent domainEvent = com.personal.marketnote.common.outbox.OutboxEvent.of(
+                eventId, topic, partitionKey, "TestEvent", "test-service", payload, FIXED_CLOCK
+        );
+        return OutboxEventJpaEntity.from(domainEvent);
+    }
+}


### PR DESCRIPTION
## partially addresses #929
## resolves #1195

## Test Case
- [x] OutboxEvent 도메인 생성/상태전이/재시도 소진 테스트 추가
- [x] OutboxEventStatus Enum 술어 메서드 테스트 추가
- [x] OutboxEventPersistenceAdapter JPA 엔티티 변환 저장 테스트 추가
- [x] OutboxEventPublisher Kafka 발행 성공/실패/재시도 초과/JSON 역직렬화 실패/다건 처리 테스트 추가
- [x] OutboxEventCleaner 보존기간 경과 이벤트 삭제 테스트 추가