### PR TITLE
[#929][#1039] feat: Consumer Lag 모니터링 시스템 구축

### DIFF
--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -68,6 +68,9 @@ dependencies {
     // kafka
     implementation("org.springframework.kafka:spring-kafka")
 
+    // micrometer (Kafka Consumer 메트릭 수집)
+    implementation("io.micrometer:micrometer-core")
+
     // test
     testImplementation("org.springframework.boot:spring-boot-starter-test")
 }

--- a/common/src/main/java/com/personal/marketnote/common/configuration/kafka/KafkaConsumerConfig.java
+++ b/common/src/main/java/com/personal/marketnote/common/configuration/kafka/KafkaConsumerConfig.java
@@ -1,8 +1,11 @@
 package com.personal.marketnote.common.configuration.kafka;
 
+import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import io.micrometer.core.instrument.MeterRegistry;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
@@ -10,6 +13,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
 import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.core.MicrometerConsumerListener;
 import org.springframework.kafka.listener.CommonErrorHandler;
 import org.springframework.kafka.listener.ContainerProperties;
 import org.springframework.kafka.support.serializer.JsonDeserializer;
@@ -40,6 +44,7 @@ public class KafkaConsumerConfig {
     private int maxPollIntervalMs;
 
     private final KafkaSaslProperties kafkaSaslProperties;
+    private final ObjectProvider<MeterRegistry> meterRegistryProvider;
 
     @Bean
     public ConsumerFactory<String, Object> consumerFactory() {
@@ -57,7 +62,13 @@ public class KafkaConsumerConfig {
         props.put(JsonDeserializer.USE_TYPE_INFO_HEADERS, false);
         props.put(JsonDeserializer.VALUE_DEFAULT_TYPE, EventEnvelope.class.getName());
         kafkaSaslProperties.applyTo(props);
-        return new DefaultKafkaConsumerFactory<>(props);
+
+        DefaultKafkaConsumerFactory<String, Object> factory = new DefaultKafkaConsumerFactory<>(props);
+        MeterRegistry meterRegistry = meterRegistryProvider.getIfAvailable();
+        if (FormatValidator.hasValue(meterRegistry)) {
+            factory.addListener(new MicrometerConsumerListener<>(meterRegistry));
+        }
+        return factory;
     }
 
     @Bean

--- a/common/src/main/java/com/personal/marketnote/common/configuration/security/OpaqueTokenIntrospectorConfig.java
+++ b/common/src/main/java/com/personal/marketnote/common/configuration/security/OpaqueTokenIntrospectorConfig.java
@@ -58,7 +58,7 @@ public class OpaqueTokenIntrospectorConfig {
                         .requestMatchers(HttpMethod.POST, "/api/v1/authentication/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/v1/authentication/**").permitAll()
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
-                        .requestMatchers("/actuator/health").permitAll()
+                        .requestMatchers("/actuator/health", "/actuator/prometheus").permitAll()
                         .requestMatchers("/actuator/**").hasRole("ADMIN")
                         .requestMatchers(HttpMethod.POST, "/api/v1/users/sign-up").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/v1/users/sign-in").permitAll()

--- a/monitoring/.env.example
+++ b/monitoring/.env.example
@@ -1,0 +1,4 @@
+SLACK_WEBHOOK_URL=https://hooks.slack.com/services/YOUR/WEBHOOK/URL
+GRAFANA_ADMIN_USER=admin
+GRAFANA_ADMIN_PASSWORD=CHANGE_ME_TO_STRONG_PASSWORD
+GRAFANA_ROOT_URL=https://monitoring.your-domain.com

--- a/monitoring/alertmanager/Dockerfile
+++ b/monitoring/alertmanager/Dockerfile
@@ -1,0 +1,7 @@
+FROM quay.io/prometheus/alertmanager:v0.28.1
+RUN apk add --no-cache gettext
+COPY alertmanager.yml /etc/alertmanager/alertmanager.template.yml
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+EXPOSE 9093
+ENTRYPOINT ["/entrypoint.sh"]

--- a/monitoring/alertmanager/alertmanager.yml
+++ b/monitoring/alertmanager/alertmanager.yml
@@ -1,0 +1,42 @@
+global:
+  resolve_timeout: 5m
+
+route:
+  receiver: 'slack-notifications'
+  group_by: ['alertname', 'kafka_consumer_group_id']
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 1h
+  routes:
+    - receiver: 'slack-critical'
+      match:
+        severity: critical
+      repeat_interval: 15m
+
+receivers:
+  - name: 'slack-notifications'
+    slack_configs:
+      - api_url: '${SLACK_WEBHOOK_URL}'
+        channel: '#kafka-monitoring'
+        title: '[{{ .Status | toUpper }}] {{ .CommonLabels.alertname }}'
+        text: >-
+          {{ range .Alerts }}
+          *Alert:* {{ .Annotations.summary }}
+          *Description:* {{ .Annotations.description }}
+          *Severity:* {{ .Labels.severity }}
+          {{ end }}
+        send_resolved: true
+
+  - name: 'slack-critical'
+    slack_configs:
+      - api_url: '${SLACK_WEBHOOK_URL}'
+        channel: '#kafka-monitoring'
+        title: ':rotating_light: [CRITICAL] {{ .CommonLabels.alertname }}'
+        text: >-
+          {{ range .Alerts }}
+          *Alert:* {{ .Annotations.summary }}
+          *Description:* {{ .Annotations.description }}
+          *Consumer Group:* {{ .Labels.kafka_consumer_group_id }}
+          *Topic:* {{ .Labels.topic }}
+          {{ end }}
+        send_resolved: true

--- a/monitoring/alertmanager/entrypoint.sh
+++ b/monitoring/alertmanager/entrypoint.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+envsubst '${SLACK_WEBHOOK_URL}' < /etc/alertmanager/alertmanager.template.yml > /etc/alertmanager/alertmanager.yml
+exec /bin/alertmanager --config.file=/etc/alertmanager/alertmanager.yml "$@"

--- a/monitoring/docker-compose.yml
+++ b/monitoring/docker-compose.yml
@@ -1,0 +1,64 @@
+services:
+  prometheus:
+    build:
+      context: ./prometheus
+      dockerfile: Dockerfile
+    container_name: shop-prometheus
+    ports:
+      - "127.0.0.1:9090:9090"
+    volumes:
+      - prometheus_data:/prometheus
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.path=/prometheus'
+      - '--storage.tsdb.retention.time=15d'
+      - '--storage.tsdb.retention.size=5GB'
+    networks:
+      - monitoring
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:9090/-/ready"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+    restart: unless-stopped
+
+  alertmanager:
+    build:
+      context: ./alertmanager
+      dockerfile: Dockerfile
+    container_name: shop-alertmanager
+    ports:
+      - "127.0.0.1:9093:9093"
+    environment:
+      - SLACK_WEBHOOK_URL=${SLACK_WEBHOOK_URL:?SLACK_WEBHOOK_URL is required}
+    networks:
+      - monitoring
+    restart: unless-stopped
+
+  grafana:
+    build:
+      context: ./grafana
+      dockerfile: Dockerfile
+    container_name: shop-grafana
+    ports:
+      - "127.0.0.1:3000:3000"
+    environment:
+      - GF_SECURITY_ADMIN_USER=${GRAFANA_ADMIN_USER:-admin}
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:?GRAFANA_ADMIN_PASSWORD is required}
+      - GF_SERVER_ROOT_URL=${GRAFANA_ROOT_URL:-http://localhost:3000}
+    volumes:
+      - grafana_data:/var/lib/grafana
+    depends_on:
+      prometheus:
+        condition: service_healthy
+    networks:
+      - monitoring
+    restart: unless-stopped
+
+volumes:
+  prometheus_data:
+  grafana_data:
+
+networks:
+  monitoring:
+    driver: bridge

--- a/monitoring/grafana/Dockerfile
+++ b/monitoring/grafana/Dockerfile
@@ -1,0 +1,4 @@
+FROM grafana/grafana:11.6.0
+COPY provisioning /etc/grafana/provisioning
+COPY dashboards /var/lib/grafana/dashboards
+EXPOSE 3000

--- a/monitoring/grafana/dashboards/kafka-consumer-lag.json
+++ b/monitoring/grafana/dashboards/kafka-consumer-lag.json
@@ -1,0 +1,280 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "title": "Consumer Group별 총 Lag",
+      "type": "stat",
+      "gridPos": { "h": 5, "w": 24, "x": 0, "y": 0 },
+      "datasource": "Prometheus",
+      "targets": [
+        {
+          "expr": "sum by (kafka_consumer_group_id) (kafka_consumer_fetch_manager_records_lag{kafka_consumer_group_id=~\"$consumer_group\"})",
+          "legendFormat": "{{ kafka_consumer_group_id }}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 100 },
+              { "color": "red", "value": 1000 }
+            ]
+          },
+          "mappings": [],
+          "unit": "short"
+        }
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": ["lastNotNull"]
+        },
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "textMode": "auto"
+      }
+    },
+    {
+      "title": "Consumer Group별 Lag 추이",
+      "type": "timeseries",
+      "gridPos": { "h": 10, "w": 12, "x": 0, "y": 5 },
+      "datasource": "Prometheus",
+      "targets": [
+        {
+          "expr": "sum by (kafka_consumer_group_id) (kafka_consumer_fetch_manager_records_lag{kafka_consumer_group_id=~\"$consumer_group\"})",
+          "legendFormat": "{{ kafka_consumer_group_id }}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "gradientMode": "scheme",
+            "pointSize": 5,
+            "showPoints": "never"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 100 },
+              { "color": "red", "value": 1000 }
+            ]
+          },
+          "unit": "short"
+        }
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max"] }
+      }
+    },
+    {
+      "title": "토픽별 Lag 상세",
+      "type": "timeseries",
+      "gridPos": { "h": 10, "w": 12, "x": 12, "y": 5 },
+      "datasource": "Prometheus",
+      "targets": [
+        {
+          "expr": "sum by (kafka_consumer_group_id, topic) (kafka_consumer_fetch_manager_records_lag{kafka_consumer_group_id=~\"$consumer_group\"})",
+          "legendFormat": "{{ kafka_consumer_group_id }} / {{ topic }}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 5,
+            "pointSize": 5,
+            "showPoints": "never"
+          },
+          "unit": "short"
+        }
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max"] }
+      }
+    },
+    {
+      "title": "초당 메시지 소비량 (처리량)",
+      "type": "timeseries",
+      "gridPos": { "h": 10, "w": 12, "x": 0, "y": 15 },
+      "datasource": "Prometheus",
+      "targets": [
+        {
+          "expr": "sum by (kafka_consumer_group_id) (rate(kafka_consumer_fetch_manager_records_consumed_total{kafka_consumer_group_id=~\"$consumer_group\"}[1m]))",
+          "legendFormat": "{{ kafka_consumer_group_id }}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 15,
+            "gradientMode": "scheme",
+            "pointSize": 5,
+            "showPoints": "never"
+          },
+          "unit": "ops"
+        }
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "mean", "max"] }
+      }
+    },
+    {
+      "title": "Consumer Group 상태 요약",
+      "type": "table",
+      "gridPos": { "h": 10, "w": 12, "x": 12, "y": 15 },
+      "datasource": "Prometheus",
+      "targets": [
+        {
+          "expr": "sum by (kafka_consumer_group_id) (kafka_consumer_fetch_manager_records_lag{kafka_consumer_group_id=~\"$consumer_group\"})",
+          "legendFormat": "{{ kafka_consumer_group_id }}",
+          "instant": true,
+          "refId": "Lag"
+        },
+        {
+          "expr": "sum by (kafka_consumer_group_id) (rate(kafka_consumer_fetch_manager_records_consumed_total{kafka_consumer_group_id=~\"$consumer_group\"}[5m]))",
+          "legendFormat": "{{ kafka_consumer_group_id }}",
+          "instant": true,
+          "refId": "Throughput"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "Lag" },
+            "properties": [
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    { "color": "green", "value": null },
+                    { "color": "yellow", "value": 100 },
+                    { "color": "red", "value": 1000 }
+                  ]
+                }
+              },
+              { "id": "custom.displayMode", "value": "color-background" }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "showHeader": true,
+        "sortBy": [{ "displayName": "Lag", "desc": true }]
+      },
+      "transformations": [
+        {
+          "id": "merge",
+          "options": {}
+        }
+      ]
+    },
+    {
+      "title": "서비스별 총 Lag",
+      "type": "piechart",
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 25 },
+      "datasource": "Prometheus",
+      "targets": [
+        {
+          "expr": "sum by (job) (kafka_consumer_fetch_manager_records_lag{kafka_consumer_group_id=~\"$consumer_group\"})",
+          "legendFormat": "{{ job }}"
+        }
+      ],
+      "options": {
+        "legend": { "displayMode": "table", "placement": "right", "calcs": ["lastNotNull"] },
+        "pieType": "donut",
+        "tooltip": { "mode": "single" }
+      }
+    },
+    {
+      "title": "Lag 임계값 알림 상태",
+      "type": "state-timeline",
+      "gridPos": { "h": 8, "w": 16, "x": 8, "y": 25 },
+      "datasource": "Prometheus",
+      "targets": [
+        {
+          "expr": "sum by (kafka_consumer_group_id) (kafka_consumer_fetch_manager_records_lag{kafka_consumer_group_id=~\"$consumer_group\"})",
+          "legendFormat": "{{ kafka_consumer_group_id }}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 100 },
+              { "color": "red", "value": 1000 }
+            ]
+          },
+          "custom": {
+            "fillOpacity": 80,
+            "lineWidth": 0
+          }
+        }
+      },
+      "options": {
+        "showValue": "auto",
+        "alignValue": "center",
+        "mergeValues": true
+      }
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": ["kafka", "consumer-lag", "monitoring"],
+  "templating": {
+    "list": [
+      {
+        "allValue": ".*",
+        "current": { "selected": true, "text": "All", "value": "$__all" },
+        "datasource": "Prometheus",
+        "definition": "label_values(kafka_consumer_fetch_manager_records_lag, kafka_consumer_group_id)",
+        "includeAll": true,
+        "multi": true,
+        "name": "consumer_group",
+        "query": "label_values(kafka_consumer_fetch_manager_records_lag, kafka_consumer_group_id)",
+        "refresh": 2,
+        "type": "query"
+      }
+    ]
+  },
+  "time": { "from": "now-3h", "to": "now" },
+  "timepicker": {},
+  "timezone": "Asia/Seoul",
+  "title": "Kafka Consumer Lag Monitor",
+  "uid": "kafka-consumer-lag",
+  "version": 1
+}

--- a/monitoring/grafana/provisioning/dashboards/dashboard.yml
+++ b/monitoring/grafana/provisioning/dashboards/dashboard.yml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+providers:
+  - name: 'default'
+    orgId: 1
+    folder: 'Kafka'
+    type: file
+    disableDeletion: false
+    editable: true
+    options:
+      path: /var/lib/grafana/dashboards
+      foldersFromFilesStructure: false

--- a/monitoring/grafana/provisioning/datasources/prometheus.yml
+++ b/monitoring/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false

--- a/monitoring/prometheus/Dockerfile
+++ b/monitoring/prometheus/Dockerfile
@@ -1,4 +1,5 @@
 ARG BASE_IMAGE=quay.io/prometheus/prometheus:v3.7.1
 FROM ${BASE_IMAGE}
 COPY prometheus.yml /etc/prometheus/prometheus.yml
+COPY alert-rules.yml /etc/prometheus/alert-rules.yml
 EXPOSE 9090

--- a/monitoring/prometheus/alert-rules.yml
+++ b/monitoring/prometheus/alert-rules.yml
@@ -1,0 +1,29 @@
+groups:
+  - name: kafka-consumer-lag
+    rules:
+      - alert: KafkaConsumerLagWarning
+        expr: sum by (kafka_consumer_group_id) (kafka_consumer_fetch_manager_records_lag) > 100
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Consumer Lag WARNING: {{ $labels.kafka_consumer_group_id }}"
+          description: "Consumer Group {{ $labels.kafka_consumer_group_id }}의 총 Lag이 {{ $value }}건입니다. 임계값: 100건"
+
+      - alert: KafkaConsumerLagCritical
+        expr: sum by (kafka_consumer_group_id) (kafka_consumer_fetch_manager_records_lag) > 1000
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Consumer Lag CRITICAL: {{ $labels.kafka_consumer_group_id }}"
+          description: "Consumer Group {{ $labels.kafka_consumer_group_id }}의 총 Lag이 {{ $value }}건입니다. 임계값: 1000건. 즉시 확인이 필요합니다."
+
+      - alert: KafkaConsumerNoActivity
+        expr: sum by (kafka_consumer_group_id) (rate(kafka_consumer_fetch_manager_records_consumed_total[5m])) == 0
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Consumer 비활성: {{ $labels.kafka_consumer_group_id }}"
+          description: "Consumer Group {{ $labels.kafka_consumer_group_id }}가 10분간 메시지를 소비하지 않고 있습니다. Consumer 장애 여부를 확인하세요."

--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -2,10 +2,75 @@ global:
   scrape_interval: 30s
   evaluation_interval: 30s
 
+rule_files:
+  - 'alert-rules.yml'
+
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets:
+            - 'alertmanager:9093'
+
 scrape_configs:
-  - job_name: 'marketnote'
+  - job_name: 'shop-user'
     metrics_path: '/actuator/prometheus'
+    scheme: https
     static_configs:
       - targets:
           - 'users.marketnote.store:443'
+        labels:
+          service: 'user-service'
+
+  - job_name: 'shop-product'
+    metrics_path: '/actuator/prometheus'
     scheme: https
+    static_configs:
+      - targets:
+          - 'product.marketnote.store:443'
+        labels:
+          service: 'product-service'
+
+  - job_name: 'shop-commerce'
+    metrics_path: '/actuator/prometheus'
+    scheme: https
+    static_configs:
+      - targets:
+          - 'commerce.marketnote.store:443'
+        labels:
+          service: 'commerce-service'
+
+  - job_name: 'shop-community'
+    metrics_path: '/actuator/prometheus'
+    scheme: https
+    static_configs:
+      - targets:
+          - 'community.marketnote.store:443'
+        labels:
+          service: 'community-service'
+
+  - job_name: 'marketnote'
+    metrics_path: '/actuator/prometheus'
+    scheme: https
+    static_configs:
+      - targets:
+          - 'reward.marketnote.store:443'
+        labels:
+          service: 'reward-service'
+
+  - job_name: 'shop-fulfillment'
+    metrics_path: '/actuator/prometheus'
+    scheme: https
+    static_configs:
+      - targets:
+          - 'fulfillment.marketnote.store:443'
+        labels:
+          service: 'fulfillment-service'
+
+  - job_name: 'shop-file'
+    metrics_path: '/actuator/prometheus'
+    scheme: https
+    static_configs:
+      - targets:
+          - 'file.marketnote.store:443'
+        labels:
+          service: 'file-service'


### PR DESCRIPTION
## partially addresses #929
## resolves #1039

## Task
- [x] Micrometer Kafka Consumer 메트릭 수집 설정 (KafkaConsumerConfig에 MicrometerConsumerListener 적용)
- [x] Prometheus 스크래핑 설정에 전체 서비스 등록
- [x] Prometheus Alert Rules 생성 (Lag > 100 WARNING, > 1000 CRITICAL)
- [x] Alertmanager Slack Webhook 연동 설정
- [x] Grafana 대시보드 구성 (Lag 추이, 처리량, 상태 테이블)
- [x] 모니터링 스택 Docker Compose 통합
- [x] /actuator/prometheus permitAll 추가
- [x] 보안 강화: 포트 localhost 바인딩, lifecycle API 제거, 비밀번호 필수화