### PR TITLE
[#929][#1044] feat: Kafka 메트릭 수집 및 운영 대시보드 구성

### DIFF
--- a/common/src/main/java/com/personal/marketnote/common/configuration/kafka/KafkaProducerConfig.java
+++ b/common/src/main/java/com/personal/marketnote/common/configuration/kafka/KafkaProducerConfig.java
@@ -1,18 +1,22 @@
 package com.personal.marketnote.common.configuration.kafka;
 
+import com.personal.marketnote.common.utility.FormatValidator;
+import io.micrometer.core.instrument.MeterRegistry;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.core.DefaultKafkaProducerFactory;
 import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.MicrometerProducerListener;
 import org.springframework.kafka.core.ProducerFactory;
 import org.springframework.kafka.support.serializer.JsonSerializer;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -27,6 +31,7 @@ public class KafkaProducerConfig {
     private String bootstrapServers;
 
     private final KafkaSaslProperties kafkaSaslProperties;
+    private final ObjectProvider<MeterRegistry> meterRegistryProvider;
 
     @Bean
     public ProducerFactory<String, Object> producerFactory() {
@@ -38,7 +43,13 @@ public class KafkaProducerConfig {
         props.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, true);
         props.put(JsonSerializer.ADD_TYPE_INFO_HEADERS, false);
         kafkaSaslProperties.applyTo(props);
-        return new DefaultKafkaProducerFactory<>(props);
+
+        DefaultKafkaProducerFactory<String, Object> factory = new DefaultKafkaProducerFactory<>(props);
+        MeterRegistry meterRegistry = meterRegistryProvider.getIfAvailable();
+        if (FormatValidator.hasValue(meterRegistry)) {
+            factory.addListener(new MicrometerProducerListener<>(meterRegistry));
+        }
+        return factory;
     }
 
     @Bean

--- a/monitoring/grafana/dashboards/kafka-overview.json
+++ b/monitoring/grafana/dashboards/kafka-overview.json
@@ -1,0 +1,781 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": ["consumer-lag"],
+      "targetBlank": true,
+      "title": "Consumer Lag Monitor",
+      "type": "dashboards"
+    }
+  ],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "title": "Cluster Health",
+      "type": "row"
+    },
+    {
+      "title": "Active Controllers",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 1 },
+      "datasource": "Prometheus",
+      "targets": [
+        {
+          "expr": "sum(kafka_controller_kafkacontroller_activecontrollercount)",
+          "legendFormat": "Active Controllers"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "green", "value": 1 },
+              { "color": "red", "value": 2 }
+            ]
+          },
+          "unit": "short"
+        }
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "colorMode": "background",
+        "graphMode": "none",
+        "textMode": "value"
+      }
+    },
+    {
+      "title": "Online Brokers",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 1 },
+      "datasource": "Prometheus",
+      "targets": [
+        {
+          "expr": "count(up{job=\"kafka-broker\"} == 1)",
+          "legendFormat": "Online Brokers"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "yellow", "value": 2 },
+              { "color": "green", "value": 3 }
+            ]
+          },
+          "unit": "short"
+        }
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "colorMode": "background",
+        "graphMode": "none",
+        "textMode": "value"
+      }
+    },
+    {
+      "title": "Under-replicated Partitions",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 1 },
+      "datasource": "Prometheus",
+      "targets": [
+        {
+          "expr": "sum(kafka_server_replicamanager_underreplicatedpartitions)",
+          "legendFormat": "Under-replicated"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 1 }
+            ]
+          },
+          "unit": "short"
+        }
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "colorMode": "background",
+        "graphMode": "none",
+        "textMode": "value"
+      }
+    },
+    {
+      "title": "Offline Partitions",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 1 },
+      "datasource": "Prometheus",
+      "targets": [
+        {
+          "expr": "sum(kafka_controller_kafkacontroller_offlinepartitionscount)",
+          "legendFormat": "Offline Partitions"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 1 }
+            ]
+          },
+          "unit": "short"
+        }
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "colorMode": "background",
+        "graphMode": "none",
+        "textMode": "value"
+      }
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 5 },
+      "title": "Producer Metrics",
+      "type": "row"
+    },
+    {
+      "title": "Producer 전송 성공률 (records/sec)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 6 },
+      "datasource": "Prometheus",
+      "targets": [
+        {
+          "expr": "sum by (job) (rate(kafka_producer_record_send_total{job=~\"$service\"}[1m]))",
+          "legendFormat": "{{ job }}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "gradientMode": "scheme",
+            "showPoints": "never"
+          },
+          "unit": "ops"
+        }
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "mean", "max"] }
+      }
+    },
+    {
+      "title": "Producer 에러율 (errors/sec)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 6 },
+      "datasource": "Prometheus",
+      "targets": [
+        {
+          "expr": "sum by (job) (rate(kafka_producer_record_error_total{job=~\"$service\"}[1m]))",
+          "legendFormat": "{{ job }}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "gradientMode": "scheme",
+            "showPoints": "never"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 0.01 }
+            ]
+          },
+          "unit": "ops"
+        }
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "mean", "max"] }
+      }
+    },
+    {
+      "title": "Producer 평균 요청 지연 (ms)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 14 },
+      "datasource": "Prometheus",
+      "targets": [
+        {
+          "expr": "kafka_producer_request_latency_avg{job=~\"$service\"}",
+          "legendFormat": "{{ job }}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "showPoints": "never"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 200 },
+              { "color": "red", "value": 500 }
+            ]
+          },
+          "unit": "ms"
+        }
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "mean", "max"] }
+      }
+    },
+    {
+      "title": "Producer 배치 크기 / 재시도",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 14 },
+      "datasource": "Prometheus",
+      "targets": [
+        {
+          "expr": "kafka_producer_batch_size_avg{job=~\"$service\"}",
+          "legendFormat": "batch-size: {{ job }}"
+        },
+        {
+          "expr": "sum by (job) (rate(kafka_producer_record_retry_total{job=~\"$service\"}[1m]))",
+          "legendFormat": "retries/s: {{ job }}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "showPoints": "never"
+          },
+          "unit": "short"
+        }
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "mean", "max"] }
+      }
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 22 },
+      "title": "Broker Metrics",
+      "type": "row"
+    },
+    {
+      "title": "브로커별 메시지 인입률 (msg/sec)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 23 },
+      "datasource": "Prometheus",
+      "targets": [
+        {
+          "expr": "kafka_server_brokertopicmetrics_messagesinpersec_total_oneminuterate{broker=~\"$broker\"}",
+          "legendFormat": "{{ broker }}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "gradientMode": "scheme",
+            "showPoints": "never"
+          },
+          "unit": "ops"
+        }
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "mean", "max"] }
+      }
+    },
+    {
+      "title": "브로커별 바이트 In/Out (bytes/sec)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 23 },
+      "datasource": "Prometheus",
+      "targets": [
+        {
+          "expr": "kafka_server_brokertopicmetrics_bytesinpersec_total_oneminuterate{broker=~\"$broker\"}",
+          "legendFormat": "in: {{ broker }}"
+        },
+        {
+          "expr": "kafka_server_brokertopicmetrics_bytesoutpersec_total_oneminuterate{broker=~\"$broker\"}",
+          "legendFormat": "out: {{ broker }}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "showPoints": "never"
+          },
+          "unit": "Bps"
+        }
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "mean", "max"] }
+      }
+    },
+    {
+      "title": "ISR Shrink / Expand",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 31 },
+      "datasource": "Prometheus",
+      "targets": [
+        {
+          "expr": "rate(kafka_server_replicamanager_isrshrinkspersec_count{broker=~\"$broker\"}[5m])",
+          "legendFormat": "shrink: {{ broker }}"
+        },
+        {
+          "expr": "rate(kafka_server_replicamanager_isrexpandspersec_count{broker=~\"$broker\"}[5m])",
+          "legendFormat": "expand: {{ broker }}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "showPoints": "never"
+          },
+          "unit": "ops"
+        }
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "mean"] }
+      }
+    },
+    {
+      "title": "브로커별 파티션 / 리더 수",
+      "type": "table",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 31 },
+      "datasource": "Prometheus",
+      "targets": [
+        {
+          "expr": "kafka_server_replicamanager_partitioncount{broker=~\"$broker\"}",
+          "legendFormat": "{{ broker }}",
+          "instant": true,
+          "refId": "Partitions"
+        },
+        {
+          "expr": "kafka_server_replicamanager_leadercount{broker=~\"$broker\"}",
+          "legendFormat": "{{ broker }}",
+          "instant": true,
+          "refId": "Leaders"
+        },
+        {
+          "expr": "kafka_server_replicamanager_underreplicatedpartitions{broker=~\"$broker\"}",
+          "legendFormat": "{{ broker }}",
+          "instant": true,
+          "refId": "UnderReplicated"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "UnderReplicated" },
+            "properties": [
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    { "color": "green", "value": null },
+                    { "color": "red", "value": 1 }
+                  ]
+                }
+              },
+              { "id": "custom.displayMode", "value": "color-background" }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "showHeader": true
+      },
+      "transformations": [
+        { "id": "merge", "options": {} }
+      ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 39 },
+      "title": "Consumer Metrics",
+      "type": "row"
+    },
+    {
+      "title": "Consumer Group별 처리량 (records/sec)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 40 },
+      "datasource": "Prometheus",
+      "targets": [
+        {
+          "expr": "sum by (kafka_consumer_group_id) (rate(kafka_consumer_fetch_manager_records_consumed_total{kafka_consumer_group_id=~\"$consumer_group\"}[1m]))",
+          "legendFormat": "{{ kafka_consumer_group_id }}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "gradientMode": "scheme",
+            "showPoints": "never"
+          },
+          "unit": "ops"
+        }
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "mean", "max"] }
+      }
+    },
+    {
+      "title": "Consumer Group별 Lag",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 40 },
+      "datasource": "Prometheus",
+      "targets": [
+        {
+          "expr": "sum by (kafka_consumer_group_id) (kafka_consumer_fetch_manager_records_lag{kafka_consumer_group_id=~\"$consumer_group\"})",
+          "legendFormat": "{{ kafka_consumer_group_id }}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "gradientMode": "scheme",
+            "showPoints": "never"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 100 },
+              { "color": "red", "value": 1000 }
+            ]
+          },
+          "unit": "short"
+        }
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max"] }
+      }
+    },
+    {
+      "title": "Consumer Fetch 지연 (ms)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 48 },
+      "datasource": "Prometheus",
+      "targets": [
+        {
+          "expr": "kafka_consumer_fetch_manager_fetch_latency_avg{kafka_consumer_group_id=~\"$consumer_group\"}",
+          "legendFormat": "{{ kafka_consumer_group_id }}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "showPoints": "never"
+          },
+          "unit": "ms"
+        }
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "mean", "max"] }
+      }
+    },
+    {
+      "title": "Consumer 리밸런싱 횟수",
+      "type": "stat",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 48 },
+      "datasource": "Prometheus",
+      "targets": [
+        {
+          "expr": "sum by (kafka_consumer_group_id) (kafka_consumer_coordinator_rebalance_total{kafka_consumer_group_id=~\"$consumer_group\"})",
+          "legendFormat": "{{ kafka_consumer_group_id }}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 5 },
+              { "color": "red", "value": 10 }
+            ]
+          },
+          "unit": "short"
+        }
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "colorMode": "background",
+        "graphMode": "area",
+        "textMode": "auto"
+      }
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 56 },
+      "title": "End-to-End Flow",
+      "type": "row"
+    },
+    {
+      "title": "토픽별 메시지 흐름 (Producer vs Consumer)",
+      "type": "timeseries",
+      "gridPos": { "h": 10, "w": 12, "x": 0, "y": 57 },
+      "datasource": "Prometheus",
+      "targets": [
+        {
+          "expr": "sum by (topic) (kafka_server_brokertopicmetrics_messagesinpersec_oneminuterate{topic=~\"$topic\"})",
+          "legendFormat": "in: {{ topic }}"
+        },
+        {
+          "expr": "sum by (topic) (rate(kafka_consumer_fetch_manager_records_consumed_total{topic=~\"$topic\"}[1m]))",
+          "legendFormat": "out: {{ topic }}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "showPoints": "never"
+          },
+          "unit": "ops"
+        }
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "mean"] }
+      }
+    },
+    {
+      "title": "브로커 JVM Heap 사용률",
+      "type": "timeseries",
+      "gridPos": { "h": 10, "w": 12, "x": 12, "y": 57 },
+      "datasource": "Prometheus",
+      "targets": [
+        {
+          "expr": "kafka_jvm_heap_memory_used{broker=~\"$broker\"} / kafka_jvm_heap_memory_max{broker=~\"$broker\"}",
+          "legendFormat": "{{ broker }}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "showPoints": "never"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.8 },
+              { "color": "red", "value": 0.9 }
+            ]
+          },
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1
+        }
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "mean", "max"] }
+      }
+    },
+    {
+      "title": "브로커 Produce 응답 시간 (P99, ms)",
+      "type": "timeseries",
+      "gridPos": { "h": 10, "w": 12, "x": 0, "y": 67 },
+      "datasource": "Prometheus",
+      "targets": [
+        {
+          "expr": "kafka_network_requestmetrics_totaltimems_produce_p99{broker=~\"$broker\"}",
+          "legendFormat": "P99: {{ broker }}"
+        },
+        {
+          "expr": "kafka_network_requestmetrics_totaltimems_produce_mean{broker=~\"$broker\"}",
+          "legendFormat": "Mean: {{ broker }}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "showPoints": "never"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 500 },
+              { "color": "red", "value": 1000 }
+            ]
+          },
+          "unit": "ms"
+        }
+      },
+      "options": {
+        "tooltip": { "mode": "multi", "sort": "desc" },
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "mean", "max"] }
+      }
+    },
+    {
+      "title": "알림 상태 타임라인",
+      "type": "state-timeline",
+      "gridPos": { "h": 10, "w": 12, "x": 12, "y": 67 },
+      "datasource": "Prometheus",
+      "targets": [
+        {
+          "expr": "ALERTS{alertname=~\"Kafka.*\", alertstate=\"firing\"}",
+          "legendFormat": "{{ alertname }}: {{ broker }}{{ kafka_consumer_group_id }}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 1 }
+            ]
+          },
+          "custom": {
+            "fillOpacity": 80,
+            "lineWidth": 0
+          }
+        }
+      },
+      "options": {
+        "showValue": "auto",
+        "alignValue": "center",
+        "mergeValues": true
+      }
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": ["kafka", "overview", "monitoring"],
+  "templating": {
+    "list": [
+      {
+        "allValue": ".*",
+        "current": { "selected": true, "text": "All", "value": "$__all" },
+        "datasource": "Prometheus",
+        "definition": "label_values(up{job=~\"shop-.*\"}, job)",
+        "includeAll": true,
+        "multi": true,
+        "name": "service",
+        "query": "label_values(up{job=~\"shop-.*\"}, job)",
+        "refresh": 2,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": { "selected": true, "text": "All", "value": "$__all" },
+        "datasource": "Prometheus",
+        "definition": "label_values(kafka_consumer_fetch_manager_records_lag, kafka_consumer_group_id)",
+        "includeAll": true,
+        "multi": true,
+        "name": "consumer_group",
+        "query": "label_values(kafka_consumer_fetch_manager_records_lag, kafka_consumer_group_id)",
+        "refresh": 2,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": { "selected": true, "text": "All", "value": "$__all" },
+        "datasource": "Prometheus",
+        "definition": "label_values(up{job=\"kafka-broker\"}, broker)",
+        "includeAll": true,
+        "multi": true,
+        "name": "broker",
+        "query": "label_values(up{job=\"kafka-broker\"}, broker)",
+        "refresh": 2,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": { "selected": true, "text": "All", "value": "$__all" },
+        "datasource": "Prometheus",
+        "definition": "label_values(kafka_server_brokertopicmetrics_messagesinpersec_oneminuterate, topic)",
+        "includeAll": true,
+        "multi": true,
+        "name": "topic",
+        "query": "label_values(kafka_server_brokertopicmetrics_messagesinpersec_oneminuterate, topic)",
+        "refresh": 2,
+        "type": "query"
+      }
+    ]
+  },
+  "time": { "from": "now-3h", "to": "now" },
+  "timepicker": {},
+  "timezone": "Asia/Seoul",
+  "title": "Kafka Overview Dashboard",
+  "uid": "kafka-overview",
+  "version": 1
+}

--- a/monitoring/kafka-jmx-exporter/kafka-jmx-config.yml
+++ b/monitoring/kafka-jmx-exporter/kafka-jmx-config.yml
@@ -1,0 +1,151 @@
+---
+# Prometheus JMX Exporter Configuration for Kafka Broker
+# Agent: -javaagent:/opt/kafka/libs/jmx_prometheus_javaagent-1.3.0.jar=7071:/opt/kafka/config/jmx-exporter-config.yml
+
+lowercaseOutputName: true
+lowercaseOutputLabelNames: true
+
+rules:
+  # ===== Broker Health =====
+
+  # Under-replicated partitions (0 = healthy)
+  - pattern: kafka.server<type=ReplicaManager, name=UnderReplicatedPartitions><>Value
+    name: kafka_server_replicamanager_underreplicatedpartitions
+    type: GAUGE
+
+  # Partition count per broker
+  - pattern: kafka.server<type=ReplicaManager, name=PartitionCount><>Value
+    name: kafka_server_replicamanager_partitioncount
+    type: GAUGE
+
+  # Leader count per broker
+  - pattern: kafka.server<type=ReplicaManager, name=LeaderCount><>Value
+    name: kafka_server_replicamanager_leadercount
+    type: GAUGE
+
+  # ISR shrink/expand rate
+  - pattern: kafka.server<type=ReplicaManager, name=IsrShrinksPerSec><>Count
+    name: kafka_server_replicamanager_isrshrinkspersec_count
+    type: COUNTER
+
+  - pattern: kafka.server<type=ReplicaManager, name=IsrExpandsPerSec><>Count
+    name: kafka_server_replicamanager_isrexpandspersec_count
+    type: COUNTER
+
+  # ===== Controller =====
+
+  # Active controller count (exactly 1 = healthy)
+  - pattern: kafka.controller<type=KafkaController, name=ActiveControllerCount><>Value
+    name: kafka_controller_kafkacontroller_activecontrollercount
+    type: GAUGE
+
+  # Offline partitions (0 = healthy)
+  - pattern: kafka.controller<type=KafkaController, name=OfflinePartitionsCount><>Value
+    name: kafka_controller_kafkacontroller_offlinepartitionscount
+    type: GAUGE
+
+  # ===== Topic Metrics =====
+
+  # Messages in per second (by topic)
+  - pattern: kafka.server<type=BrokerTopicMetrics, name=MessagesInPerSec, topic=(.+)><>OneMinuteRate
+    name: kafka_server_brokertopicmetrics_messagesinpersec_oneminuterate
+    type: GAUGE
+    labels:
+      topic: "$1"
+
+  # Total messages in per second (all topics)
+  - pattern: kafka.server<type=BrokerTopicMetrics, name=MessagesInPerSec><>OneMinuteRate
+    name: kafka_server_brokertopicmetrics_messagesinpersec_total_oneminuterate
+    type: GAUGE
+
+  # Bytes in per second (by topic)
+  - pattern: kafka.server<type=BrokerTopicMetrics, name=BytesInPerSec, topic=(.+)><>OneMinuteRate
+    name: kafka_server_brokertopicmetrics_bytesinpersec_oneminuterate
+    type: GAUGE
+    labels:
+      topic: "$1"
+
+  # Bytes out per second (by topic)
+  - pattern: kafka.server<type=BrokerTopicMetrics, name=BytesOutPerSec, topic=(.+)><>OneMinuteRate
+    name: kafka_server_brokertopicmetrics_bytesoutpersec_oneminuterate
+    type: GAUGE
+    labels:
+      topic: "$1"
+
+  # Total bytes in/out per second (all topics)
+  - pattern: kafka.server<type=BrokerTopicMetrics, name=BytesInPerSec><>OneMinuteRate
+    name: kafka_server_brokertopicmetrics_bytesinpersec_total_oneminuterate
+    type: GAUGE
+
+  - pattern: kafka.server<type=BrokerTopicMetrics, name=BytesOutPerSec><>OneMinuteRate
+    name: kafka_server_brokertopicmetrics_bytesoutpersec_total_oneminuterate
+    type: GAUGE
+
+  # ===== Request Metrics =====
+
+  # Produce request rate
+  - pattern: kafka.network<type=RequestMetrics, name=RequestsPerSec, request=Produce, version=(.+)><>OneMinuteRate
+    name: kafka_network_requestmetrics_requestspersec_produce_oneminuterate
+    type: GAUGE
+
+  # Produce total time (ms)
+  - pattern: kafka.network<type=RequestMetrics, name=TotalTimeMs, request=Produce><>Mean
+    name: kafka_network_requestmetrics_totaltimems_produce_mean
+    type: GAUGE
+
+  - pattern: kafka.network<type=RequestMetrics, name=TotalTimeMs, request=Produce><>99thPercentile
+    name: kafka_network_requestmetrics_totaltimems_produce_p99
+    type: GAUGE
+
+  # Fetch request rate
+  - pattern: kafka.network<type=RequestMetrics, name=RequestsPerSec, request=FetchConsumer, version=(.+)><>OneMinuteRate
+    name: kafka_network_requestmetrics_requestspersec_fetchconsumer_oneminuterate
+    type: GAUGE
+
+  # Fetch total time (ms)
+  - pattern: kafka.network<type=RequestMetrics, name=TotalTimeMs, request=FetchConsumer><>Mean
+    name: kafka_network_requestmetrics_totaltimems_fetchconsumer_mean
+    type: GAUGE
+
+  # ===== Log Metrics =====
+
+  # Log flush rate and time
+  - pattern: kafka.log<type=LogFlushStats, name=LogFlushRateAndTimeMs><>Count
+    name: kafka_log_logflushstats_logflushratems_count
+    type: COUNTER
+
+  - pattern: kafka.log<type=LogFlushStats, name=LogFlushRateAndTimeMs><>Mean
+    name: kafka_log_logflushstats_logflushratems_mean
+    type: GAUGE
+
+  # Log size per topic
+  - pattern: kafka.log<type=Log, name=Size, topic=(.+), partition=(.+)><>Value
+    name: kafka_log_log_size
+    type: GAUGE
+    labels:
+      topic: "$1"
+      partition: "$2"
+
+  # ===== JVM Metrics =====
+
+  # JVM memory
+  - pattern: java.lang<type=Memory><HeapMemoryUsage>used
+    name: kafka_jvm_heap_memory_used
+    type: GAUGE
+
+  - pattern: java.lang<type=Memory><HeapMemoryUsage>max
+    name: kafka_jvm_heap_memory_max
+    type: GAUGE
+
+  # JVM GC
+  - pattern: java.lang<type=GarbageCollector, name=(.+)><>CollectionCount
+    name: kafka_jvm_gc_collection_count
+    type: COUNTER
+    labels:
+      gc: "$1"
+
+  - pattern: java.lang<type=GarbageCollector, name=(.+)><>CollectionTime
+    name: kafka_jvm_gc_collection_time_ms
+    type: COUNTER
+    labels:
+      gc: "$1"

--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -74,3 +74,24 @@ scrape_configs:
           - 'file.marketnote.store:443'
         labels:
           service: 'file-service'
+
+  - job_name: 'kafka-broker'
+    metrics_path: '/metrics'
+    scheme: http
+    scrape_interval: 30s
+    static_configs:
+      - targets:
+          - '172.26.45.222:7071'
+        labels:
+          broker: 'broker-1'
+          node_id: '1'
+      - targets:
+          - '172.26.21.200:7071'
+        labels:
+          broker: 'broker-2'
+          node_id: '2'
+      - targets:
+          - '172.26.2.195:7071'
+        labels:
+          broker: 'broker-3'
+          node_id: '3'


### PR DESCRIPTION
## partially addresses #929
## resolves #1044

## Task
- [x] KafkaProducerConfig에 MicrometerProducerListener 등록
- [x] Kafka Broker JMX Exporter 설정 파일 추가
- [x] Prometheus scrape_config에 kafka-broker 추가
- [x] Producer/Broker 알림 규칙 추가 (에러율, 지연, ISR, Under-replicated, 브로커 다운)
- [x] Grafana kafka-overview.json 통합 대시보드 구성 (5개 Row, 20개 패널)
- [x] Alertmanager broker 라벨 group_by 추가
- [x] Consumer Lag 대시보드에 Overview 대시보드 링크 추가