### PR TITLE
[#929][#1040] feat: DLQ 모니터링 및 수동 재처리 시스템 구축

### DIFF
--- a/common/src/main/java/com/personal/marketnote/common/adapter/in/web/kafka/controller/AdminDltController.java
+++ b/common/src/main/java/com/personal/marketnote/common/adapter/in/web/kafka/controller/AdminDltController.java
@@ -2,40 +2,57 @@ package com.personal.marketnote.common.adapter.in.web.kafka.controller;
 
 import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
 import com.personal.marketnote.common.adapter.in.web.kafka.request.ReprocessDltRequest;
+import com.personal.marketnote.common.adapter.in.web.kafka.response.DltMessageResponse;
+import com.personal.marketnote.common.adapter.in.web.kafka.response.DltTopicSummaryResponse;
 import com.personal.marketnote.common.adapter.in.web.kafka.response.ReprocessDltResponse;
+import com.personal.marketnote.common.configuration.kafka.DltAuditLogger;
+import com.personal.marketnote.common.configuration.kafka.DltQueryService;
 import com.personal.marketnote.common.configuration.kafka.DltReprocessResult;
 import com.personal.marketnote.common.configuration.kafka.DltReprocessService;
+import com.personal.marketnote.common.utility.FormatValidator;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.oauth2.core.OAuth2AuthenticatedPrincipal;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 import static com.personal.marketnote.common.domain.exception.ExceptionCode.DEFAULT_SUCCESS_CODE;
 import static com.personal.marketnote.common.utility.ApiConstant.ADMIN_POINTCUT;
 
+@Validated
 @RestController
 @Tag(name = "관리자 DLT API", description = "Dead Letter Topic 관리 및 재처리")
 @RequiredArgsConstructor
 @ConditionalOnProperty(prefix = "spring.kafka", name = "bootstrap-servers")
 public class AdminDltController {
+
     private final DltReprocessService dltReprocessService;
+    private final DltQueryService dltQueryService;
+    private final DltAuditLogger dltAuditLogger;
 
     @PostMapping("/api/v1/admin/kafka/dlt/reprocess")
     @PreAuthorize(ADMIN_POINTCUT)
     @SecurityRequirement(name = "bearer")
     @Operation(summary = "DLT 메시지 수동 재처리", description = "지정된 원본 토픽의 DLT 메시지를 원본 토픽으로 재전송합니다.")
     public ResponseEntity<BaseResponse<ReprocessDltResponse>> reprocessDlt(
-            @Valid @RequestBody ReprocessDltRequest request
+            @Valid @RequestBody ReprocessDltRequest request,
+            @AuthenticationPrincipal OAuth2AuthenticatedPrincipal principal
     ) {
-        DltReprocessResult result = dltReprocessService.reprocess(request.originalTopic());
+        String operatorInfo = resolveOperatorInfo(principal);
+        DltReprocessResult result = dltReprocessService.reprocess(request.originalTopic(), operatorInfo);
 
         return new ResponseEntity<>(
                 BaseResponse.of(
@@ -46,5 +63,56 @@ public class AdminDltController {
                 ),
                 HttpStatus.OK
         );
+    }
+
+    @GetMapping("/api/v1/admin/kafka/dlt")
+    @PreAuthorize(ADMIN_POINTCUT)
+    @SecurityRequirement(name = "bearer")
+    @Operation(summary = "DLT 메시지 조회", description = "지정된 원본 토픽의 DLT 메시지를 조회합니다.")
+    public ResponseEntity<BaseResponse<List<DltMessageResponse>>> queryDltMessages(
+            @RequestParam("original-topic") @NotBlank(message = "토픽명은 필수입니다") String topic,
+            @RequestParam(value = "limit", defaultValue = "100") @Min(1) @Max(500) int limit,
+            @AuthenticationPrincipal OAuth2AuthenticatedPrincipal principal
+    ) {
+        dltAuditLogger.logQuery(topic, limit, resolveOperatorInfo(principal));
+        List<DltMessageResponse> messages = dltQueryService.queryDltMessages(topic, limit);
+
+        return new ResponseEntity<>(
+                BaseResponse.of(
+                        messages,
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "DLT 메시지 조회 완료"
+                ),
+                HttpStatus.OK
+        );
+    }
+
+    @GetMapping("/api/v1/admin/kafka/dlt/summary")
+    @PreAuthorize(ADMIN_POINTCUT)
+    @SecurityRequirement(name = "bearer")
+    @Operation(summary = "전체 DLT 토픽 요약 조회", description = "전체 DLT 토픽의 메시지 건수를 조회합니다.")
+    public ResponseEntity<BaseResponse<List<DltTopicSummaryResponse>>> queryDltTopicSummaries(
+            @AuthenticationPrincipal OAuth2AuthenticatedPrincipal principal
+    ) {
+        dltAuditLogger.logSummaryQuery(resolveOperatorInfo(principal));
+        List<DltTopicSummaryResponse> summaries = dltQueryService.queryAllDltTopicSummaries();
+
+        return new ResponseEntity<>(
+                BaseResponse.of(
+                        summaries,
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "DLT 토픽 요약 조회 완료"
+                ),
+                HttpStatus.OK
+        );
+    }
+
+    private String resolveOperatorInfo(OAuth2AuthenticatedPrincipal principal) {
+        if (FormatValidator.hasNoValue(principal)) {
+            return "UNKNOWN";
+        }
+        return principal.getName();
     }
 }

--- a/common/src/main/java/com/personal/marketnote/common/adapter/in/web/kafka/response/DltMessageResponse.java
+++ b/common/src/main/java/com/personal/marketnote/common/adapter/in/web/kafka/response/DltMessageResponse.java
@@ -1,0 +1,37 @@
+package com.personal.marketnote.common.adapter.in.web.kafka.response;
+
+import com.personal.marketnote.common.configuration.kafka.DltHeaderExtractor;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+
+public record DltMessageResponse(
+        String dltTopic,
+        int partition,
+        long offset,
+        String key,
+        String originalTopic,
+        String errorFqcn,
+        String errorMessage,
+        long timestamp
+) {
+    private static final int MAX_ERROR_MESSAGE_LENGTH = 200;
+
+    public static DltMessageResponse from(ConsumerRecord<String, Object> record) {
+        String fqcn = DltHeaderExtractor.extractExceptionFqcn(record);
+        String simpleName = fqcn.contains(".") ? fqcn.substring(fqcn.lastIndexOf('.') + 1) : fqcn;
+        String message = DltHeaderExtractor.extractExceptionMessage(record);
+        String truncatedMessage = message.length() > MAX_ERROR_MESSAGE_LENGTH
+                ? message.substring(0, MAX_ERROR_MESSAGE_LENGTH) + "..."
+                : message;
+
+        return new DltMessageResponse(
+                record.topic(),
+                record.partition(),
+                record.offset(),
+                record.key(),
+                DltHeaderExtractor.extractOriginalTopic(record),
+                simpleName,
+                truncatedMessage,
+                record.timestamp()
+        );
+    }
+}

--- a/common/src/main/java/com/personal/marketnote/common/adapter/in/web/kafka/response/DltTopicSummaryResponse.java
+++ b/common/src/main/java/com/personal/marketnote/common/adapter/in/web/kafka/response/DltTopicSummaryResponse.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.common.adapter.in.web.kafka.response;
+
+public record DltTopicSummaryResponse(
+        String originalTopic,
+        String dltTopic,
+        long messageCount
+) {
+}

--- a/common/src/main/java/com/personal/marketnote/common/configuration/kafka/DeadLetterAlertConsumer.java
+++ b/common/src/main/java/com/personal/marketnote/common/configuration/kafka/DeadLetterAlertConsumer.java
@@ -1,27 +1,21 @@
 package com.personal.marketnote.common.configuration.kafka;
 
-import com.personal.marketnote.common.utility.FormatValidator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.apache.kafka.common.header.Header;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.stereotype.Component;
-
-import java.nio.charset.StandardCharsets;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
 @ConditionalOnProperty(prefix = "spring.kafka", name = "bootstrap-servers")
 public class DeadLetterAlertConsumer {
-    private static final String HEADER_ORIGINAL_TOPIC = "kafka_dlt-original-topic";
-    private static final String HEADER_EXCEPTION_FQCN = "kafka_dlt-exception-fqcn";
-    private static final String HEADER_EXCEPTION_MESSAGE = "kafka_dlt-exception-message";
 
     private final DltSlackNotifier dltSlackNotifier;
+    private final DltMetricsCollector dltMetricsCollector;
 
     @KafkaListener(topicPattern = ".*\\.dlt", groupId = "dlt-alert")
     public void handleDeadLetterMessage(
@@ -29,25 +23,18 @@ public class DeadLetterAlertConsumer {
             Acknowledgment acknowledgment
     ) {
         try {
-            String originalTopic = extractHeader(record, HEADER_ORIGINAL_TOPIC);
-            String errorFqcn = extractHeader(record, HEADER_EXCEPTION_FQCN);
-            String errorMessage = extractHeader(record, HEADER_EXCEPTION_MESSAGE);
+            String originalTopic = DltHeaderExtractor.extractOriginalTopic(record);
+            String errorFqcn = DltHeaderExtractor.extractExceptionFqcn(record);
+            String errorMessage = DltHeaderExtractor.extractExceptionMessage(record);
 
             log.error("DLT 메시지 도착. originalTopic={}, partition={}, offset={}, key={}, error={}: {}",
                     originalTopic, record.partition(), record.offset(), record.key(), errorFqcn, errorMessage);
 
             dltSlackNotifier.notify(originalTopic, record, errorFqcn, errorMessage);
+            dltMetricsCollector.incrementDltMessageCount(originalTopic);
         } catch (Exception e) {
             log.error("DLT 알림 처리 실패. topic={}, key={}", record.topic(), record.key(), e);
         }
         acknowledgment.acknowledge();
-    }
-
-    private String extractHeader(ConsumerRecord<String, Object> record, String headerKey) {
-        Header header = record.headers().lastHeader(headerKey);
-        if (FormatValidator.hasNoValue(header)) {
-            return "UNKNOWN";
-        }
-        return new String(header.value(), StandardCharsets.UTF_8);
     }
 }

--- a/common/src/main/java/com/personal/marketnote/common/configuration/kafka/DltAuditLogger.java
+++ b/common/src/main/java/com/personal/marketnote/common/configuration/kafka/DltAuditLogger.java
@@ -1,0 +1,35 @@
+package com.personal.marketnote.common.configuration.kafka;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@ConditionalOnProperty(prefix = "spring.kafka", name = "bootstrap-servers")
+public class DltAuditLogger {
+
+    public void logReprocessStart(String originalTopic, String operatorInfo) {
+        log.info("[DLT-AUDIT] action=REPROCESS_START, topic={}, operator={}",
+                originalTopic, operatorInfo);
+    }
+
+    public void logReprocessComplete(String originalTopic, String operatorInfo, int reprocessed, int failed) {
+        log.info("[DLT-AUDIT] action=REPROCESS_COMPLETE, topic={}, operator={}, reprocessed={}, failed={}",
+                originalTopic, operatorInfo, reprocessed, failed);
+    }
+
+    public void logReprocessError(String originalTopic, String operatorInfo, Exception ex) {
+        log.error("[DLT-AUDIT] action=REPROCESS_ERROR, topic={}, operator={}, error={}",
+                originalTopic, operatorInfo, ex.getMessage(), ex);
+    }
+
+    public void logQuery(String originalTopic, int limit, String operatorInfo) {
+        log.info("[DLT-AUDIT] action=QUERY, topic={}, limit={}, operator={}",
+                originalTopic, limit, operatorInfo);
+    }
+
+    public void logSummaryQuery(String operatorInfo) {
+        log.info("[DLT-AUDIT] action=SUMMARY_QUERY, operator={}", operatorInfo);
+    }
+}

--- a/common/src/main/java/com/personal/marketnote/common/configuration/kafka/DltHeaderExtractor.java
+++ b/common/src/main/java/com/personal/marketnote/common/configuration/kafka/DltHeaderExtractor.java
@@ -1,0 +1,42 @@
+package com.personal.marketnote.common.configuration.kafka;
+
+import com.personal.marketnote.common.utility.FormatValidator;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.header.Header;
+
+import java.nio.charset.StandardCharsets;
+
+public final class DltHeaderExtractor {
+
+    private static final String HEADER_ORIGINAL_TOPIC = "kafka_dlt-original-topic";
+    private static final String HEADER_EXCEPTION_FQCN = "kafka_dlt-exception-fqcn";
+    private static final String HEADER_EXCEPTION_MESSAGE = "kafka_dlt-exception-message";
+    private static final String UNKNOWN = "UNKNOWN";
+
+    private DltHeaderExtractor() {
+    }
+
+    public static String extractOriginalTopic(ConsumerRecord<?, ?> record) {
+        return extractHeader(record, HEADER_ORIGINAL_TOPIC);
+    }
+
+    public static String extractExceptionFqcn(ConsumerRecord<?, ?> record) {
+        return extractHeader(record, HEADER_EXCEPTION_FQCN);
+    }
+
+    public static String extractExceptionMessage(ConsumerRecord<?, ?> record) {
+        return extractHeader(record, HEADER_EXCEPTION_MESSAGE);
+    }
+
+    private static String extractHeader(ConsumerRecord<?, ?> record, String headerKey) {
+        Header header = record.headers().lastHeader(headerKey);
+        if (FormatValidator.hasNoValue(header)) {
+            return UNKNOWN;
+        }
+        byte[] value = header.value();
+        if (FormatValidator.hasNoValue(value)) {
+            return UNKNOWN;
+        }
+        return new String(value, StandardCharsets.UTF_8);
+    }
+}

--- a/common/src/main/java/com/personal/marketnote/common/configuration/kafka/DltMetricsCollector.java
+++ b/common/src/main/java/com/personal/marketnote/common/configuration/kafka/DltMetricsCollector.java
@@ -1,0 +1,41 @@
+package com.personal.marketnote.common.configuration.kafka;
+
+import com.personal.marketnote.common.utility.FormatValidator;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConditionalOnProperty(prefix = "spring.kafka", name = "bootstrap-servers")
+public class DltMetricsCollector {
+
+    private final MeterRegistry meterRegistry;
+
+    public DltMetricsCollector(MeterRegistry meterRegistry) {
+        this.meterRegistry = meterRegistry;
+    }
+
+    public void incrementDltMessageCount(String originalTopic) {
+        if (FormatValidator.hasNoValue(meterRegistry)) {
+            return;
+        }
+        Counter.builder("kafka.dlt.messages.total")
+                .tag("original_topic", originalTopic)
+                .description("DLT에 적재된 메시지 총 건수")
+                .register(meterRegistry)
+                .increment();
+    }
+
+    public void incrementDltReprocessCount(String originalTopic, String outcome) {
+        if (FormatValidator.hasNoValue(meterRegistry)) {
+            return;
+        }
+        Counter.builder("kafka.dlt.reprocess.total")
+                .tag("original_topic", originalTopic)
+                .tag("outcome", outcome)
+                .description("DLT 메시지 재처리 건수")
+                .register(meterRegistry)
+                .increment();
+    }
+}

--- a/common/src/main/java/com/personal/marketnote/common/configuration/kafka/DltQueryService.java
+++ b/common/src/main/java/com/personal/marketnote/common/configuration/kafka/DltQueryService.java
@@ -1,0 +1,115 @@
+package com.personal.marketnote.common.configuration.kafka;
+
+import com.personal.marketnote.common.adapter.in.web.kafka.response.DltMessageResponse;
+import com.personal.marketnote.common.adapter.in.web.kafka.response.DltTopicSummaryResponse;
+import com.personal.marketnote.common.kafka.DltTopicRegistry;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.TopicPartition;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(prefix = "spring.kafka", name = "bootstrap-servers")
+public class DltQueryService {
+
+    private static final Duration POLL_TIMEOUT = Duration.ofSeconds(2);
+    private static final int MAX_POLL_ITERATIONS = 50;
+
+    private final ConsumerFactory<String, Object> consumerFactory;
+
+    public List<DltMessageResponse> queryDltMessages(String originalTopic, int limit) {
+        if (!DltTopicRegistry.isAllowed(originalTopic)) {
+            throw new InvalidDltTopicException(originalTopic);
+        }
+
+        String dltTopic = DltTopicRegistry.toDltTopic(originalTopic);
+        String groupId = "dlt-query-" + UUID.randomUUID();
+
+        try (Consumer<String, Object> consumer = consumerFactory.createConsumer(groupId, "")) {
+            List<PartitionInfo> partitionInfos = consumer.partitionsFor(dltTopic);
+            if (partitionInfos == null || partitionInfos.isEmpty()) {
+                return List.of();
+            }
+
+            List<TopicPartition> partitions = partitionInfos.stream()
+                    .map(pi -> new TopicPartition(dltTopic, pi.partition()))
+                    .toList();
+
+            consumer.assign(partitions);
+            consumer.seekToBeginning(partitions);
+
+            List<DltMessageResponse> messages = new ArrayList<>();
+            int pollIteration = 0;
+
+            ConsumerRecords<String, Object> records = consumer.poll(POLL_TIMEOUT);
+            while (!records.isEmpty() && messages.size() < limit && pollIteration < MAX_POLL_ITERATIONS) {
+                for (ConsumerRecord<String, Object> record : records) {
+                    if (messages.size() >= limit) {
+                        break;
+                    }
+                    messages.add(DltMessageResponse.from(record));
+                }
+                pollIteration++;
+                if (messages.size() >= limit) {
+                    break;
+                }
+                records = consumer.poll(POLL_TIMEOUT);
+            }
+
+            return messages;
+        }
+    }
+
+    public List<DltTopicSummaryResponse> queryAllDltTopicSummaries() {
+        String groupId = "dlt-summary-" + UUID.randomUUID();
+
+        try (Consumer<String, Object> consumer = consumerFactory.createConsumer(groupId, "")) {
+            List<DltTopicSummaryResponse> summaries = new ArrayList<>();
+
+            for (String originalTopic : DltTopicRegistry.getAllOriginalTopics()) {
+                String dltTopic = DltTopicRegistry.toDltTopic(originalTopic);
+                long messageCount = calculateMessageCount(consumer, dltTopic);
+                summaries.add(new DltTopicSummaryResponse(originalTopic, dltTopic, messageCount));
+            }
+
+            return summaries;
+        }
+    }
+
+    private long calculateMessageCount(Consumer<String, Object> consumer, String dltTopic) {
+        List<PartitionInfo> partitionInfos = consumer.partitionsFor(dltTopic);
+        if (partitionInfos == null || partitionInfos.isEmpty()) {
+            return 0L;
+        }
+
+        List<TopicPartition> partitions = partitionInfos.stream()
+                .map(pi -> new TopicPartition(dltTopic, pi.partition()))
+                .toList();
+
+        Map<TopicPartition, Long> beginOffsets = consumer.beginningOffsets(partitions);
+        Map<TopicPartition, Long> endOffsets = consumer.endOffsets(partitions);
+
+        long totalCount = 0L;
+        for (TopicPartition partition : partitions) {
+            long begin = beginOffsets.getOrDefault(partition, 0L);
+            long end = endOffsets.getOrDefault(partition, 0L);
+            totalCount += Math.max(0L, end - begin);
+        }
+
+        return totalCount;
+    }
+}

--- a/common/src/main/java/com/personal/marketnote/common/configuration/kafka/DltReprocessAlreadyInProgressException.java
+++ b/common/src/main/java/com/personal/marketnote/common/configuration/kafka/DltReprocessAlreadyInProgressException.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.common.configuration.kafka;
+
+public class DltReprocessAlreadyInProgressException extends RuntimeException {
+    public DltReprocessAlreadyInProgressException(String originalTopic) {
+        super("해당 토픽의 DLT 재처리가 이미 진행 중입니다. originalTopic=" + originalTopic);
+    }
+}

--- a/common/src/main/java/com/personal/marketnote/common/configuration/kafka/DltReprocessFailedException.java
+++ b/common/src/main/java/com/personal/marketnote/common/configuration/kafka/DltReprocessFailedException.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.common.configuration.kafka;
+
+public class DltReprocessFailedException extends RuntimeException {
+    public DltReprocessFailedException(String originalTopic) {
+        super("DLT 메시지 재처리 중 오류가 발생했습니다. originalTopic=" + originalTopic);
+    }
+}

--- a/common/src/main/java/com/personal/marketnote/common/configuration/kafka/DltReprocessService.java
+++ b/common/src/main/java/com/personal/marketnote/common/configuration/kafka/DltReprocessService.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.common.configuration.kafka;
 
-import com.personal.marketnote.common.kafka.KafkaTopicConstants;
+import com.personal.marketnote.common.kafka.DltTopicRegistry;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.Consumer;
@@ -15,8 +15,8 @@ import org.springframework.stereotype.Component;
 
 import java.time.Duration;
 import java.util.List;
-import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
 @Slf4j
@@ -28,36 +28,40 @@ public class DltReprocessService {
     private static final int MAX_POLL_ITERATIONS = 100;
     private static final long SEND_TIMEOUT_SECONDS = 10L;
 
-    private static final Set<String> ALLOWED_TOPICS = Set.of(
-            KafkaTopicConstants.ORDER_PAYMENT_COMPLETED,
-            KafkaTopicConstants.PAYMENT_APPROVED,
-            KafkaTopicConstants.PAYMENT_FAILED,
-            KafkaTopicConstants.PAYMENT_CANCELLED,
-            KafkaTopicConstants.SETTLEMENT_EXECUTED,
-            KafkaTopicConstants.ORDER_PURCHASE_CONFIRMED,
-            KafkaTopicConstants.PRODUCT_REGISTERED,
-            KafkaTopicConstants.PRICE_POLICY_CREATED,
-            KafkaTopicConstants.PRODUCT_UPDATED,
-            KafkaTopicConstants.USER_SIGNUP_COMPLETED,
-            KafkaTopicConstants.USER_REFERRAL_COMPLETED,
-            KafkaTopicConstants.REVIEW_REGISTERED
-    );
+    private final ConcurrentHashMap<String, Boolean> reprocessingTopics = new ConcurrentHashMap<>();
 
     private final ConsumerFactory<String, Object> consumerFactory;
     private final KafkaTemplate<String, Object> kafkaTemplate;
+    private final DltAuditLogger dltAuditLogger;
+    private final DltMetricsCollector dltMetricsCollector;
 
-    public DltReprocessResult reprocess(String originalTopic) {
-        if (!ALLOWED_TOPICS.contains(originalTopic)) {
+    public DltReprocessResult reprocess(String originalTopic, String operatorInfo) {
+        if (!DltTopicRegistry.isAllowed(originalTopic)) {
             throw new InvalidDltTopicException(originalTopic);
         }
 
-        String dltTopic = originalTopic + KafkaTopicConstants.DLT_SUFFIX;
+        if (reprocessingTopics.putIfAbsent(originalTopic, Boolean.TRUE) != null) {
+            throw new DltReprocessAlreadyInProgressException(originalTopic);
+        }
+
+        try {
+            return doReprocess(originalTopic, operatorInfo);
+        } finally {
+            reprocessingTopics.remove(originalTopic);
+        }
+    }
+
+    private DltReprocessResult doReprocess(String originalTopic, String operatorInfo) {
+        String dltTopic = DltTopicRegistry.toDltTopic(originalTopic);
         String groupId = "dlt-reprocessor-" + UUID.randomUUID();
+
+        dltAuditLogger.logReprocessStart(originalTopic, operatorInfo);
 
         try (Consumer<String, Object> consumer = consumerFactory.createConsumer(groupId, "")) {
             List<PartitionInfo> partitionInfos = consumer.partitionsFor(dltTopic);
             if (partitionInfos == null || partitionInfos.isEmpty()) {
                 log.info("DLT 토픽 파티션 없음. dltTopic={}", dltTopic);
+                dltAuditLogger.logReprocessComplete(originalTopic, operatorInfo, 0, 0);
                 return new DltReprocessResult(0, 0);
             }
 
@@ -79,10 +83,12 @@ public class DltReprocessService {
                         kafkaTemplate.send(originalTopic, record.key(), record.value())
                                 .get(SEND_TIMEOUT_SECONDS, TimeUnit.SECONDS);
                         reprocessedCount++;
+                        dltMetricsCollector.incrementDltReprocessCount(originalTopic, "success");
                         log.info("DLT 메시지 재처리 성공. originalTopic={}, key={}, offset={}",
                                 originalTopic, record.key(), record.offset());
                     } catch (Exception e) {
                         failedCount++;
+                        dltMetricsCollector.incrementDltReprocessCount(originalTopic, "failure");
                         log.error("DLT 메시지 재처리 실패. originalTopic={}, key={}, offset={}",
                                 originalTopic, record.key(), record.offset(), e);
                     }
@@ -93,7 +99,13 @@ public class DltReprocessService {
 
             log.info("DLT 재처리 완료. dltTopic={}, reprocessed={}, failed={}",
                     dltTopic, reprocessedCount, failedCount);
+            dltAuditLogger.logReprocessComplete(originalTopic, operatorInfo, reprocessedCount, failedCount);
             return new DltReprocessResult(reprocessedCount, failedCount);
+        } catch (InvalidDltTopicException e) {
+            throw e;
+        } catch (Exception e) {
+            dltAuditLogger.logReprocessError(originalTopic, operatorInfo, e);
+            throw new DltReprocessFailedException(originalTopic);
         }
     }
 }

--- a/common/src/main/java/com/personal/marketnote/common/kafka/DltTopicRegistry.java
+++ b/common/src/main/java/com/personal/marketnote/common/kafka/DltTopicRegistry.java
@@ -1,0 +1,43 @@
+package com.personal.marketnote.common.kafka;
+
+import java.util.List;
+import java.util.Set;
+
+public final class DltTopicRegistry {
+
+    private static final Set<String> ALLOWED_TOPICS = Set.of(
+            KafkaTopicConstants.ORDER_PAYMENT_COMPLETED,
+            KafkaTopicConstants.PAYMENT_APPROVED,
+            KafkaTopicConstants.PAYMENT_FAILED,
+            KafkaTopicConstants.PAYMENT_CANCELLED,
+            KafkaTopicConstants.SETTLEMENT_EXECUTED,
+            KafkaTopicConstants.ORDER_PURCHASE_CONFIRMED,
+            KafkaTopicConstants.PRODUCT_REGISTERED,
+            KafkaTopicConstants.PRICE_POLICY_CREATED,
+            KafkaTopicConstants.PRODUCT_UPDATED,
+            KafkaTopicConstants.USER_SIGNUP_COMPLETED,
+            KafkaTopicConstants.USER_REFERRAL_COMPLETED,
+            KafkaTopicConstants.REVIEW_REGISTERED
+    );
+
+    private DltTopicRegistry() {
+    }
+
+    public static boolean isAllowed(String topic) {
+        return ALLOWED_TOPICS.contains(topic);
+    }
+
+    public static String toDltTopic(String originalTopic) {
+        return originalTopic + KafkaTopicConstants.DLT_SUFFIX;
+    }
+
+    public static List<String> getAllOriginalTopics() {
+        return List.copyOf(ALLOWED_TOPICS);
+    }
+
+    public static List<String> getAllDltTopics() {
+        return ALLOWED_TOPICS.stream()
+                .map(DltTopicRegistry::toDltTopic)
+                .toList();
+    }
+}

--- a/common/src/test/java/com/personal/marketnote/common/configuration/kafka/DeadLetterAlertConsumerTest.java
+++ b/common/src/test/java/com/personal/marketnote/common/configuration/kafka/DeadLetterAlertConsumerTest.java
@@ -25,6 +25,9 @@ class DeadLetterAlertConsumerTest {
     private DltSlackNotifier dltSlackNotifier;
 
     @Mock
+    private DltMetricsCollector dltMetricsCollector;
+
+    @Mock
     private Acknowledgment acknowledgment;
 
     private ConsumerRecord<String, Object> buildDltRecord(
@@ -43,8 +46,8 @@ class DeadLetterAlertConsumerTest {
     }
 
     @Test
-    @DisplayName("DLT 메시지 수신 시 원본 토픽 정보를 추출하여 Slack 알림을 전송하고 acknowledge한다")
-    void handleDeadLetterMessage_extractsHeadersAndNotifiesSlackAndAcknowledges() {
+    @DisplayName("DLT 메시지 수신 시 원본 토픽 정보를 추출하여 Slack 알림을 전송하고 메트릭을 증가시키고 acknowledge한다")
+    void handleDeadLetterMessage_extractsHeadersAndNotifiesSlackAndIncrementMetricsAndAcknowledges() {
         // given
         String originalTopic = "commerce.order.payment-completed";
         ConsumerRecord<String, Object> record = buildDltRecord(
@@ -61,6 +64,7 @@ class DeadLetterAlertConsumerTest {
                 eq("java.lang.RuntimeException"),
                 eq("DB 연결 오류")
         );
+        verify(dltMetricsCollector).incrementDltMessageCount(originalTopic);
         verify(acknowledgment).acknowledge();
     }
 
@@ -97,6 +101,7 @@ class DeadLetterAlertConsumerTest {
                 eq("UNKNOWN"),
                 eq("UNKNOWN")
         );
+        verify(dltMetricsCollector).incrementDltMessageCount("UNKNOWN");
         verify(acknowledgment).acknowledge();
     }
 }

--- a/common/src/test/java/com/personal/marketnote/common/configuration/kafka/DltReprocessServiceTest.java
+++ b/common/src/test/java/com/personal/marketnote/common/configuration/kafka/DltReprocessServiceTest.java
@@ -13,7 +13,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.core.KafkaTemplate;
-
 import org.springframework.kafka.support.SendResult;
 
 import java.time.Duration;
@@ -40,7 +39,15 @@ class DltReprocessServiceTest {
     private KafkaTemplate<String, Object> kafkaTemplate;
 
     @Mock
+    private DltAuditLogger dltAuditLogger;
+
+    @Mock
+    private DltMetricsCollector dltMetricsCollector;
+
+    @Mock
     private Consumer<String, Object> consumer;
+
+    private static final String OPERATOR = "admin@personal.com";
 
     @Test
     @DisplayName("DLT 토픽에서 메시지를 읽어 원본 토픽으로 재전송한다")
@@ -70,13 +77,16 @@ class DltReprocessServiceTest {
         when(kafkaTemplate.send(anyString(), anyString(), any())).thenReturn(future);
 
         // when
-        DltReprocessResult result = dltReprocessService.reprocess(originalTopic);
+        DltReprocessResult result = dltReprocessService.reprocess(originalTopic, OPERATOR);
 
         // then
         assertThat(result.reprocessedCount()).isEqualTo(2);
         assertThat(result.failedCount()).isEqualTo(0);
         verify(kafkaTemplate).send(originalTopic, "key-1", "value-1");
         verify(kafkaTemplate).send(originalTopic, "key-2", "value-2");
+        verify(dltAuditLogger).logReprocessStart(originalTopic, OPERATOR);
+        verify(dltAuditLogger).logReprocessComplete(originalTopic, OPERATOR, 2, 0);
+        verify(dltMetricsCollector, times(2)).incrementDltReprocessCount(originalTopic, "success");
         verify(consumer).close();
     }
 
@@ -96,12 +106,13 @@ class DltReprocessServiceTest {
         when(consumer.poll(any(Duration.class))).thenReturn(emptyRecords);
 
         // when
-        DltReprocessResult result = dltReprocessService.reprocess(originalTopic);
+        DltReprocessResult result = dltReprocessService.reprocess(originalTopic, OPERATOR);
 
         // then
         assertThat(result.reprocessedCount()).isEqualTo(0);
         assertThat(result.failedCount()).isEqualTo(0);
         verify(kafkaTemplate, never()).send(anyString(), anyString(), any());
+        verify(dltAuditLogger).logReprocessStart(originalTopic, OPERATOR);
         verify(consumer).close();
     }
 
@@ -116,12 +127,14 @@ class DltReprocessServiceTest {
         when(consumer.partitionsFor(dltTopic)).thenReturn(Collections.emptyList());
 
         // when
-        DltReprocessResult result = dltReprocessService.reprocess(originalTopic);
+        DltReprocessResult result = dltReprocessService.reprocess(originalTopic, OPERATOR);
 
         // then
         assertThat(result.reprocessedCount()).isEqualTo(0);
         assertThat(result.failedCount()).isEqualTo(0);
         verify(kafkaTemplate, never()).send(anyString(), anyString(), any());
+        verify(dltAuditLogger).logReprocessStart(originalTopic, OPERATOR);
+        verify(dltAuditLogger).logReprocessComplete(originalTopic, OPERATOR, 0, 0);
         verify(consumer).close();
     }
 
@@ -132,14 +145,14 @@ class DltReprocessServiceTest {
         String invalidTopic = "unknown.topic";
 
         // when & then
-        assertThatThrownBy(() -> dltReprocessService.reprocess(invalidTopic))
+        assertThatThrownBy(() -> dltReprocessService.reprocess(invalidTopic, OPERATOR))
                 .isInstanceOf(InvalidDltTopicException.class)
                 .hasMessageContaining(invalidTopic);
     }
 
     @Test
-    @DisplayName("메시지 재전송 실패 시 failedCount가 증가한다")
-    void reprocess_sendFailure_incrementsFailedCount() {
+    @DisplayName("메시지 재전송 실패 시 failedCount가 증가하고 실패 메트릭이 기록된다")
+    void reprocess_sendFailure_incrementsFailedCountAndMetrics() {
         // given
         String originalTopic = "commerce.payment.cancelled";
         String dltTopic = originalTopic + ".dlt";
@@ -165,11 +178,13 @@ class DltReprocessServiceTest {
         when(kafkaTemplate.send(anyString(), anyString(), any())).thenReturn(failedFuture);
 
         // when
-        DltReprocessResult result = dltReprocessService.reprocess(originalTopic);
+        DltReprocessResult result = dltReprocessService.reprocess(originalTopic, OPERATOR);
 
         // then
         assertThat(result.reprocessedCount()).isEqualTo(0);
         assertThat(result.failedCount()).isEqualTo(1);
+        verify(dltMetricsCollector).incrementDltReprocessCount(originalTopic, "failure");
+        verify(dltAuditLogger).logReprocessComplete(originalTopic, OPERATOR, 0, 1);
         verify(consumer).close();
     }
 }


### PR DESCRIPTION
## partially addresses #929
## resolves #1040

## Task
- [x] DLT Prometheus 메트릭 수집 (DltMetricsCollector)
- [x] DLT 메시지 조회 관리자 API (GET /api/v1/admin/kafka/dlt)
- [x] 전체 DLT 토픽 요약 조회 API (GET /api/v1/admin/kafka/dlt/summary)
- [x] DLT 재처리 감사 추적 (DltAuditLogger)
- [x] 재처리 동시 실행 방지 (ConcurrentHashMap)
- [x] DLT 헤더 추출 공통화 (DltHeaderExtractor)
- [x] 토픽 허용 목록 공통화 (DltTopicRegistry)
- [x] Prometheus DLT 알림 규칙 추가
- [x] Grafana DLT 대시보드 패널 추가
- [x] 보안 강화 (errorFqcn 간소화, errorMessage 제한, 예외 래핑)