### PR TITLE
[#929][#1040] test: DLQ 모니터링 및 수동 재처리 시스템 구축 기능 자동화 테스트 추가

### DIFF
--- a/common/src/test/java/com/personal/marketnote/common/configuration/kafka/DltAuditLoggerTest.java
+++ b/common/src/test/java/com/personal/marketnote/common/configuration/kafka/DltAuditLoggerTest.java
@@ -1,0 +1,57 @@
+package com.personal.marketnote.common.configuration.kafka;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+@DisplayName("DltAuditLogger 테스트")
+class DltAuditLoggerTest {
+
+    private final DltAuditLogger dltAuditLogger = new DltAuditLogger();
+
+    @Test
+    @DisplayName("재처리 시작 감사 로그를 기록한다")
+    void logReprocessStart_logsWithoutException() {
+        // when & then
+        assertThatCode(() -> dltAuditLogger.logReprocessStart(
+                "commerce.order.payment-completed", "admin@personal.com"
+        )).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("재처리 완료 감사 로그를 기록한다")
+    void logReprocessComplete_logsWithoutException() {
+        // when & then
+        assertThatCode(() -> dltAuditLogger.logReprocessComplete(
+                "commerce.order.payment-completed", "admin@personal.com", 5, 1
+        )).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("재처리 에러 감사 로그를 기록한다")
+    void logReprocessError_logsWithoutException() {
+        // when & then
+        assertThatCode(() -> dltAuditLogger.logReprocessError(
+                "commerce.order.payment-completed", "admin@personal.com",
+                new RuntimeException("Kafka 연결 실패")
+        )).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("DLT 메시지 조회 감사 로그를 기록한다")
+    void logQuery_logsWithoutException() {
+        // when & then
+        assertThatCode(() -> dltAuditLogger.logQuery(
+                "commerce.order.payment-completed", 100, "admin@personal.com"
+        )).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("DLT 토픽 요약 조회 감사 로그를 기록한다")
+    void logSummaryQuery_logsWithoutException() {
+        // when & then
+        assertThatCode(() -> dltAuditLogger.logSummaryQuery("admin@personal.com"))
+                .doesNotThrowAnyException();
+    }
+}

--- a/common/src/test/java/com/personal/marketnote/common/configuration/kafka/DltHeaderExtractorTest.java
+++ b/common/src/test/java/com/personal/marketnote/common/configuration/kafka/DltHeaderExtractorTest.java
@@ -1,0 +1,80 @@
+package com.personal.marketnote.common.configuration.kafka;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("DltHeaderExtractor 테스트")
+class DltHeaderExtractorTest {
+
+    @Test
+    @DisplayName("DLT 헤더에서 원본 토픽을 추출한다")
+    void extractOriginalTopic_returnsHeaderValue() {
+        // given
+        ConsumerRecord<String, Object> record = new ConsumerRecord<>("topic.dlt", 0, 0L, "key", "value");
+        record.headers().add("kafka_dlt-original-topic", "commerce.order.payment-completed".getBytes(StandardCharsets.UTF_8));
+
+        // when
+        String result = DltHeaderExtractor.extractOriginalTopic(record);
+
+        // then
+        assertThat(result).isEqualTo("commerce.order.payment-completed");
+    }
+
+    @Test
+    @DisplayName("DLT 헤더에서 예외 FQCN을 추출한다")
+    void extractExceptionFqcn_returnsHeaderValue() {
+        // given
+        ConsumerRecord<String, Object> record = new ConsumerRecord<>("topic.dlt", 0, 0L, "key", "value");
+        record.headers().add("kafka_dlt-exception-fqcn", "java.lang.RuntimeException".getBytes(StandardCharsets.UTF_8));
+
+        // when
+        String result = DltHeaderExtractor.extractExceptionFqcn(record);
+
+        // then
+        assertThat(result).isEqualTo("java.lang.RuntimeException");
+    }
+
+    @Test
+    @DisplayName("DLT 헤더에서 예외 메시지를 추출한다")
+    void extractExceptionMessage_returnsHeaderValue() {
+        // given
+        ConsumerRecord<String, Object> record = new ConsumerRecord<>("topic.dlt", 0, 0L, "key", "value");
+        record.headers().add("kafka_dlt-exception-message", "DB 연결 오류".getBytes(StandardCharsets.UTF_8));
+
+        // when
+        String result = DltHeaderExtractor.extractExceptionMessage(record);
+
+        // then
+        assertThat(result).isEqualTo("DB 연결 오류");
+    }
+
+    @Test
+    @DisplayName("DLT 헤더가 없으면 UNKNOWN을 반환한다")
+    void extractOriginalTopic_noHeader_returnsUnknown() {
+        // given
+        ConsumerRecord<String, Object> record = new ConsumerRecord<>("topic.dlt", 0, 0L, "key", "value");
+
+        // when
+        String result = DltHeaderExtractor.extractOriginalTopic(record);
+
+        // then
+        assertThat(result).isEqualTo("UNKNOWN");
+    }
+
+    @Test
+    @DisplayName("모든 DLT 헤더가 없으면 모두 UNKNOWN을 반환한다")
+    void extractAll_noHeaders_allReturnUnknown() {
+        // given
+        ConsumerRecord<String, Object> record = new ConsumerRecord<>("topic.dlt", 0, 0L, "key", "value");
+
+        // when & then
+        assertThat(DltHeaderExtractor.extractOriginalTopic(record)).isEqualTo("UNKNOWN");
+        assertThat(DltHeaderExtractor.extractExceptionFqcn(record)).isEqualTo("UNKNOWN");
+        assertThat(DltHeaderExtractor.extractExceptionMessage(record)).isEqualTo("UNKNOWN");
+    }
+}

--- a/common/src/test/java/com/personal/marketnote/common/configuration/kafka/DltMetricsCollectorTest.java
+++ b/common/src/test/java/com/personal/marketnote/common/configuration/kafka/DltMetricsCollectorTest.java
@@ -1,0 +1,107 @@
+package com.personal.marketnote.common.configuration.kafka;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("DltMetricsCollector 테스트")
+class DltMetricsCollectorTest {
+
+    @Test
+    @DisplayName("DLT 메시지 카운터를 증가시킨다")
+    void incrementDltMessageCount_incrementsCounter() {
+        // given
+        MeterRegistry meterRegistry = new SimpleMeterRegistry();
+        DltMetricsCollector collector = new DltMetricsCollector(meterRegistry);
+
+        // when
+        collector.incrementDltMessageCount("commerce.order.payment-completed");
+        collector.incrementDltMessageCount("commerce.order.payment-completed");
+
+        // then
+        Counter counter = meterRegistry.find("kafka.dlt.messages.total")
+                .tag("original_topic", "commerce.order.payment-completed")
+                .counter();
+        assertThat(counter).isNotNull();
+        assertThat(counter.count()).isEqualTo(2.0);
+    }
+
+    @Test
+    @DisplayName("서로 다른 토픽의 DLT 카운터를 독립적으로 관리한다")
+    void incrementDltMessageCount_differentTopics_independentCounters() {
+        // given
+        MeterRegistry meterRegistry = new SimpleMeterRegistry();
+        DltMetricsCollector collector = new DltMetricsCollector(meterRegistry);
+
+        // when
+        collector.incrementDltMessageCount("commerce.order.payment-completed");
+        collector.incrementDltMessageCount("commerce.payment.approved");
+        collector.incrementDltMessageCount("commerce.payment.approved");
+
+        // then
+        Counter orderCounter = meterRegistry.find("kafka.dlt.messages.total")
+                .tag("original_topic", "commerce.order.payment-completed")
+                .counter();
+        Counter paymentCounter = meterRegistry.find("kafka.dlt.messages.total")
+                .tag("original_topic", "commerce.payment.approved")
+                .counter();
+
+        assertThat(orderCounter).isNotNull();
+        assertThat(orderCounter.count()).isEqualTo(1.0);
+        assertThat(paymentCounter).isNotNull();
+        assertThat(paymentCounter.count()).isEqualTo(2.0);
+    }
+
+    @Test
+    @DisplayName("재처리 성공 카운터를 증가시킨다")
+    void incrementDltReprocessCount_success_incrementsCounter() {
+        // given
+        MeterRegistry meterRegistry = new SimpleMeterRegistry();
+        DltMetricsCollector collector = new DltMetricsCollector(meterRegistry);
+
+        // when
+        collector.incrementDltReprocessCount("commerce.order.payment-completed", "success");
+
+        // then
+        Counter counter = meterRegistry.find("kafka.dlt.reprocess.total")
+                .tag("original_topic", "commerce.order.payment-completed")
+                .tag("outcome", "success")
+                .counter();
+        assertThat(counter).isNotNull();
+        assertThat(counter.count()).isEqualTo(1.0);
+    }
+
+    @Test
+    @DisplayName("재처리 실패 카운터를 증가시킨다")
+    void incrementDltReprocessCount_failure_incrementsCounter() {
+        // given
+        MeterRegistry meterRegistry = new SimpleMeterRegistry();
+        DltMetricsCollector collector = new DltMetricsCollector(meterRegistry);
+
+        // when
+        collector.incrementDltReprocessCount("commerce.payment.cancelled", "failure");
+
+        // then
+        Counter counter = meterRegistry.find("kafka.dlt.reprocess.total")
+                .tag("original_topic", "commerce.payment.cancelled")
+                .tag("outcome", "failure")
+                .counter();
+        assertThat(counter).isNotNull();
+        assertThat(counter.count()).isEqualTo(1.0);
+    }
+
+    @Test
+    @DisplayName("MeterRegistry가 null이면 카운터를 증가시키지 않는다")
+    void incrementDltMessageCount_nullMeterRegistry_noOp() {
+        // given
+        DltMetricsCollector collector = new DltMetricsCollector(null);
+
+        // when & then (예외 발생하지 않음)
+        collector.incrementDltMessageCount("commerce.order.payment-completed");
+        collector.incrementDltReprocessCount("commerce.order.payment-completed", "success");
+    }
+}

--- a/common/src/test/java/com/personal/marketnote/common/configuration/kafka/DltQueryServiceTest.java
+++ b/common/src/test/java/com/personal/marketnote/common/configuration/kafka/DltQueryServiceTest.java
@@ -1,0 +1,202 @@
+package com.personal.marketnote.common.configuration.kafka;
+
+import com.personal.marketnote.common.adapter.in.web.kafka.response.DltMessageResponse;
+import com.personal.marketnote.common.adapter.in.web.kafka.response.DltTopicSummaryResponse;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.TopicPartition;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.core.ConsumerFactory;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("DltQueryService 테스트")
+class DltQueryServiceTest {
+
+    @InjectMocks
+    private DltQueryService dltQueryService;
+
+    @Mock
+    private ConsumerFactory<String, Object> consumerFactory;
+
+    @Mock
+    private Consumer<String, Object> consumer;
+
+    @Test
+    @DisplayName("DLT 토픽에서 메시지를 조회한다")
+    void queryDltMessages_returnsMessages() {
+        // given
+        String originalTopic = "commerce.order.payment-completed";
+        String dltTopic = originalTopic + ".dlt";
+
+        when(consumerFactory.createConsumer(anyString(), eq(""))).thenReturn(consumer);
+
+        PartitionInfo partitionInfo = new PartitionInfo(dltTopic, 0, null, null, null);
+        when(consumer.partitionsFor(dltTopic)).thenReturn(List.of(partitionInfo));
+
+        TopicPartition topicPartition = new TopicPartition(dltTopic, 0);
+        ConsumerRecord<String, Object> record = buildDltRecord(dltTopic, "key-1", originalTopic,
+                "java.lang.RuntimeException", "DB 연결 오류");
+        ConsumerRecords<String, Object> records = new ConsumerRecords<>(
+                Map.of(topicPartition, List.of(record))
+        );
+        ConsumerRecords<String, Object> emptyRecords = new ConsumerRecords<>(Collections.emptyMap());
+
+        when(consumer.poll(any(Duration.class)))
+                .thenReturn(records)
+                .thenReturn(emptyRecords);
+
+        // when
+        List<DltMessageResponse> result = dltQueryService.queryDltMessages(originalTopic, 100);
+
+        // then
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).dltTopic()).isEqualTo(dltTopic);
+        assertThat(result.get(0).key()).isEqualTo("key-1");
+        assertThat(result.get(0).originalTopic()).isEqualTo(originalTopic);
+        assertThat(result.get(0).errorFqcn()).isEqualTo("RuntimeException");
+        assertThat(result.get(0).errorMessage()).isEqualTo("DB 연결 오류");
+        verify(consumer).close();
+    }
+
+    @Test
+    @DisplayName("DLT 토픽에 메시지가 없으면 빈 리스트를 반환한다")
+    void queryDltMessages_emptyDlt_returnsEmptyList() {
+        // given
+        String originalTopic = "commerce.payment.approved";
+        String dltTopic = originalTopic + ".dlt";
+
+        when(consumerFactory.createConsumer(anyString(), eq(""))).thenReturn(consumer);
+
+        PartitionInfo partitionInfo = new PartitionInfo(dltTopic, 0, null, null, null);
+        when(consumer.partitionsFor(dltTopic)).thenReturn(List.of(partitionInfo));
+
+        ConsumerRecords<String, Object> emptyRecords = new ConsumerRecords<>(Collections.emptyMap());
+        when(consumer.poll(any(Duration.class))).thenReturn(emptyRecords);
+
+        // when
+        List<DltMessageResponse> result = dltQueryService.queryDltMessages(originalTopic, 100);
+
+        // then
+        assertThat(result).isEmpty();
+        verify(consumer).close();
+    }
+
+    @Test
+    @DisplayName("DLT 토픽 파티션이 없으면 빈 리스트를 반환한다")
+    void queryDltMessages_noPartitions_returnsEmptyList() {
+        // given
+        String originalTopic = "commerce.settlement.executed";
+        String dltTopic = originalTopic + ".dlt";
+
+        when(consumerFactory.createConsumer(anyString(), eq(""))).thenReturn(consumer);
+        when(consumer.partitionsFor(dltTopic)).thenReturn(Collections.emptyList());
+
+        // when
+        List<DltMessageResponse> result = dltQueryService.queryDltMessages(originalTopic, 100);
+
+        // then
+        assertThat(result).isEmpty();
+        verify(consumer).close();
+    }
+
+    @Test
+    @DisplayName("허용되지 않은 토픽명으로 조회 시 InvalidDltTopicException이 발생한다")
+    void queryDltMessages_invalidTopic_throwsException() {
+        // given
+        String invalidTopic = "unknown.topic";
+
+        // when & then
+        assertThatThrownBy(() -> dltQueryService.queryDltMessages(invalidTopic, 100))
+                .isInstanceOf(InvalidDltTopicException.class)
+                .hasMessageContaining(invalidTopic);
+    }
+
+    @Test
+    @DisplayName("limit 이하의 메시지만 조회한다")
+    void queryDltMessages_respectsLimit() {
+        // given
+        String originalTopic = "commerce.order.payment-completed";
+        String dltTopic = originalTopic + ".dlt";
+
+        when(consumerFactory.createConsumer(anyString(), eq(""))).thenReturn(consumer);
+
+        PartitionInfo partitionInfo = new PartitionInfo(dltTopic, 0, null, null, null);
+        when(consumer.partitionsFor(dltTopic)).thenReturn(List.of(partitionInfo));
+
+        TopicPartition topicPartition = new TopicPartition(dltTopic, 0);
+        ConsumerRecord<String, Object> record1 = buildDltRecord(dltTopic, "key-1", originalTopic, "Error", "msg1");
+        ConsumerRecord<String, Object> record2 = buildDltRecord(dltTopic, "key-2", originalTopic, "Error", "msg2");
+        ConsumerRecord<String, Object> record3 = buildDltRecord(dltTopic, "key-3", originalTopic, "Error", "msg3");
+        ConsumerRecords<String, Object> records = new ConsumerRecords<>(
+                Map.of(topicPartition, List.of(record1, record2, record3))
+        );
+
+        when(consumer.poll(any(Duration.class))).thenReturn(records);
+
+        // when
+        List<DltMessageResponse> result = dltQueryService.queryDltMessages(originalTopic, 2);
+
+        // then
+        assertThat(result).hasSize(2);
+        verify(consumer).close();
+    }
+
+    @Test
+    @DisplayName("전체 DLT 토픽 요약을 조회한다")
+    void queryAllDltTopicSummaries_returnsSummaries() {
+        // given
+        when(consumerFactory.createConsumer(anyString(), eq(""))).thenReturn(consumer);
+
+        TopicPartition partition = new TopicPartition("commerce.order.payment-completed.dlt", 0);
+        PartitionInfo partitionInfo = new PartitionInfo("commerce.order.payment-completed.dlt", 0, null, null, null);
+
+        // 모든 DLT 토픽에 대해 partitionsFor 호출 시 반환
+        when(consumer.partitionsFor(anyString()))
+                .thenReturn(List.of(partitionInfo));
+
+        when(consumer.beginningOffsets(anyCollection()))
+                .thenReturn(Map.of(partition, 0L));
+        when(consumer.endOffsets(anyCollection()))
+                .thenReturn(Map.of(partition, 5L));
+
+        // when
+        List<DltTopicSummaryResponse> result = dltQueryService.queryAllDltTopicSummaries();
+
+        // then
+        assertThat(result).isNotEmpty();
+        assertThat(result).allSatisfy(summary -> {
+            assertThat(summary.dltTopic()).endsWith(".dlt");
+            assertThat(summary.originalTopic()).doesNotEndWith(".dlt");
+        });
+        verify(consumer).close();
+    }
+
+    private ConsumerRecord<String, Object> buildDltRecord(
+            String dltTopic, String key, String originalTopic, String errorFqcn, String errorMessage
+    ) {
+        ConsumerRecord<String, Object> record = new ConsumerRecord<>(dltTopic, 0, 0L, key, "value");
+        record.headers()
+                .add("kafka_dlt-original-topic", originalTopic.getBytes(StandardCharsets.UTF_8))
+                .add("kafka_dlt-exception-fqcn", errorFqcn.getBytes(StandardCharsets.UTF_8))
+                .add("kafka_dlt-exception-message", errorMessage.getBytes(StandardCharsets.UTF_8));
+        return record;
+    }
+}


### PR DESCRIPTION
## partially addresses #929
## resolves #1040

## Test Case
- [x] DltHeaderExtractor 단위 테스트 (5건)
- [x] DltMetricsCollector 단위 테스트 (5건)
- [x] DltAuditLogger 단위 테스트 (5건)
- [x] DltQueryService 단위 테스트 (6건)