### PR TITLE
[#929][#1045] fix: 풀필먼트 Consumer Fassto 토큰 발급 실패 시 이벤트 영구 유실 버그 픽스

### DIFF
--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/event/ProductRegisteredFulfillmentConsumer.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/event/ProductRegisteredFulfillmentConsumer.java
@@ -8,6 +8,7 @@ import com.personal.marketnote.common.kafka.event.ProductRegisteredEvent;
 import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.fulfillment.configuration.FasstoAuthProperties;
 import com.personal.marketnote.fulfillment.domain.FasstoAccessToken;
+import com.personal.marketnote.fulfillment.exception.FasstoAccessTokenIssuanceFailedException;
 import com.personal.marketnote.fulfillment.exception.FasstoGoodsAlreadyRegisteredException;
 import com.personal.marketnote.fulfillment.exception.RegisterFasstoGoodsFailedException;
 import com.personal.marketnote.fulfillment.port.in.command.vendor.RegisterFasstoGoodsCommand;
@@ -76,10 +77,7 @@ public class ProductRegisteredFulfillmentConsumer {
 
             FasstoAccessToken accessToken = requestFasstoAuthUseCase.requestAccessToken();
             if (FormatValidator.hasNoValue(accessToken) || FormatValidator.hasNoValue(accessToken.getValue())) {
-                log.error("Fassto 액세스 토큰 발급 실패. eventId={}, productId={}",
-                        envelope.eventId(), payload.productId());
-                acknowledgment.acknowledge();
-                return;
+                throw new FasstoAccessTokenIssuanceFailedException(envelope.eventId(), payload.productId());
             }
 
             String godType = FormatValidator.hasValue(payload.godType()) ? payload.godType() : DEFAULT_GOD_TYPE;

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/event/ProductUpdatedFulfillmentConsumer.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/event/ProductUpdatedFulfillmentConsumer.java
@@ -8,6 +8,7 @@ import com.personal.marketnote.common.kafka.event.ProductUpdatedEvent;
 import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.fulfillment.configuration.FasstoAuthProperties;
 import com.personal.marketnote.fulfillment.domain.FasstoAccessToken;
+import com.personal.marketnote.fulfillment.exception.FasstoAccessTokenIssuanceFailedException;
 import com.personal.marketnote.fulfillment.exception.UpdateFasstoGoodsFailedException;
 import com.personal.marketnote.fulfillment.port.in.command.vendor.UpdateFasstoGoodsCommand;
 import com.personal.marketnote.fulfillment.port.in.command.vendor.UpdateFasstoGoodsItemCommand;
@@ -72,10 +73,7 @@ public class ProductUpdatedFulfillmentConsumer {
 
             FasstoAccessToken accessToken = requestFasstoAuthUseCase.requestAccessToken();
             if (FormatValidator.hasNoValue(accessToken) || FormatValidator.hasNoValue(accessToken.getValue())) {
-                log.error("Fassto 액세스 토큰 발급 실패. eventId={}, productId={}",
-                        envelope.eventId(), payload.productId());
-                acknowledgment.acknowledge();
-                return;
+                throw new FasstoAccessTokenIssuanceFailedException(envelope.eventId(), payload.productId());
             }
 
             UpdateFasstoGoodsItemCommand itemCommand = UpdateFasstoGoodsItemCommand.of(

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/FasstoAccessTokenIssuanceFailedException.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/FasstoAccessTokenIssuanceFailedException.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.fulfillment.exception;
+
+public class FasstoAccessTokenIssuanceFailedException extends RuntimeException {
+    public FasstoAccessTokenIssuanceFailedException(String eventId, Long targetId) {
+        super("Fassto 액세스 토큰 발급 실패. eventId=" + eventId + ", targetId=" + targetId);
+    }
+}


### PR DESCRIPTION
## partially addresses #929
## resolves #1045

## Reason
토큰 발급 실패(null 반환) 시 acknowledge() + return으로 메시지를 즉시 확인 처리하여, DefaultErrorHandler의 재시도/DLT 파이프라인이 우회되고 이벤트가 영구 유실됨

## Action
- [x] FasstoAccessTokenIssuanceFailedException 커스텀 예외 생성
- [x] ProductRegisteredFulfillmentConsumer 토큰 발급 실패 시 예외 throw로 변경
- [x] ProductUpdatedFulfillmentConsumer 토큰 발급 실패 시 예외 throw로 변경