### PR TITLE
[#128][#1304] feat: 상품 태그 순서 변경 기능 추가

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/inventory/InventoryPersistenceAdapter.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/inventory/InventoryPersistenceAdapter.java
@@ -7,11 +7,7 @@ import com.personal.marketnote.commerce.adapter.out.persistence.inventory.entity
 import com.personal.marketnote.commerce.adapter.out.persistence.inventory.repository.InventoryDeductionHistoryJpaRepository;
 import com.personal.marketnote.commerce.adapter.out.persistence.inventory.repository.InventoryJpaRepository;
 import com.personal.marketnote.commerce.adapter.out.persistence.inventory.repository.InventoryRestorationHistoryJpaRepository;
-import com.personal.marketnote.commerce.domain.inventory.Inventory;
-import com.personal.marketnote.commerce.domain.inventory.InventoryDeductionHistories;
-import com.personal.marketnote.commerce.domain.inventory.InventoryDeductionHistory;
-import com.personal.marketnote.commerce.domain.inventory.InventoryRestorationHistories;
-import com.personal.marketnote.commerce.domain.inventory.InventoryRestorationHistory;
+import com.personal.marketnote.commerce.domain.inventory.*;
 import com.personal.marketnote.commerce.exception.DuplicateInventoryDeductionException;
 import com.personal.marketnote.commerce.exception.DuplicateInventoryRestorationException;
 import com.personal.marketnote.commerce.exception.InventoryNotFoundException;

--- a/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/event/PaymentCancelledInventoryConsumerTest.java
+++ b/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/event/PaymentCancelledInventoryConsumerTest.java
@@ -51,8 +51,8 @@ class PaymentCancelledInventoryConsumerTest {
     }
 
     private ConsumerRecord<String, EventEnvelope<?>> buildRecord(Long orderId, boolean isFullCancel,
-                                                                  List<OrderProductItem> orderProducts,
-                                                                  List<OrderProductItem> cancelProducts) {
+                                                                 List<OrderProductItem> orderProducts,
+                                                                 List<OrderProductItem> cancelProducts) {
         PaymentCancelledEvent event = new PaymentCancelledEvent(
                 orderId, "order-key-1", 100L, 50000L, 80000L, 1000L,
                 isFullCancel, 0L, null, orderProducts, cancelProducts, null

--- a/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/event/PaymentCancelledOrderStatusConsumerTest.java
+++ b/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/event/PaymentCancelledOrderStatusConsumerTest.java
@@ -42,7 +42,7 @@ class PaymentCancelledOrderStatusConsumerTest {
     private Acknowledgment acknowledgment;
 
     private ConsumerRecord<String, EventEnvelope<?>> buildRecord(Long orderId, String orderKey,
-                                                                  boolean isFullCancel, Long cancelAmount) {
+                                                                 boolean isFullCancel, Long cancelAmount) {
         PaymentCancelledEvent event = new PaymentCancelledEvent(
                 orderId, orderKey, 100L, cancelAmount, 50000L, 1000L,
                 isFullCancel, 0L, null, List.of(), null, null

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/CancelPaymentService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/CancelPaymentService.java
@@ -448,12 +448,12 @@ public class CancelPaymentService implements CancelPaymentUseCase {
     }
 
     private void publishPaymentCancelledEvent(Long orderId, String orderKey, Long buyerId,
-                                                Long cancelAmount, Long paymentAmount, Long pointAmount,
-                                                boolean isFullCancel, Long alreadyRefunded,
-                                                String cancelId,
-                                                List<OrderProduct> orderProducts,
-                                                List<OrderProduct> cancelProducts,
-                                                Long partialProductPendingDeduction) {
+                                              Long cancelAmount, Long paymentAmount, Long pointAmount,
+                                              boolean isFullCancel, Long alreadyRefunded,
+                                              String cancelId,
+                                              List<OrderProduct> orderProducts,
+                                              List<OrderProduct> cancelProducts,
+                                              Long partialProductPendingDeduction) {
         try {
             publishPaymentEventPort.publishPaymentCancelledEvent(
                     orderId, orderKey, buyerId, cancelAmount, paymentAmount,

--- a/common/src/main/java/com/personal/marketnote/common/adapter/in/web/kafka/controller/AdminDltController.java
+++ b/common/src/main/java/com/personal/marketnote/common/adapter/in/web/kafka/controller/AdminDltController.java
@@ -22,8 +22,8 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.security.oauth2.core.OAuth2AuthenticatedPrincipal;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.core.OAuth2AuthenticatedPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 

--- a/common/src/main/java/com/personal/marketnote/common/adapter/out/persistence/audit/BaseOrderedGeneralEntity.java
+++ b/common/src/main/java/com/personal/marketnote/common/adapter/out/persistence/audit/BaseOrderedGeneralEntity.java
@@ -14,4 +14,8 @@ public abstract class BaseOrderedGeneralEntity extends BaseGeneralEntity {
     public void setIdToOrderNum() {
         orderNum = getId();
     }
+
+    protected void updateOrderNum(Long orderNum) {
+        this.orderNum = orderNum;
+    }
 }

--- a/common/src/main/java/com/personal/marketnote/common/configuration/kafka/KafkaConsumerConfig.java
+++ b/common/src/main/java/com/personal/marketnote/common/configuration/kafka/KafkaConsumerConfig.java
@@ -1,8 +1,9 @@
 package com.personal.marketnote.common.configuration.kafka;
 
-import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.utility.FormatValidator;
 import io.micrometer.core.instrument.MeterRegistry;
+import lombok.RequiredArgsConstructor;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.springframework.beans.factory.ObjectProvider;
@@ -17,8 +18,6 @@ import org.springframework.kafka.core.MicrometerConsumerListener;
 import org.springframework.kafka.listener.CommonErrorHandler;
 import org.springframework.kafka.listener.ContainerProperties;
 import org.springframework.kafka.support.serializer.JsonDeserializer;
-
-import lombok.RequiredArgsConstructor;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/common/src/main/java/com/personal/marketnote/common/configuration/kafka/KafkaProducerConfig.java
+++ b/common/src/main/java/com/personal/marketnote/common/configuration/kafka/KafkaProducerConfig.java
@@ -2,6 +2,7 @@ package com.personal.marketnote.common.configuration.kafka;
 
 import com.personal.marketnote.common.utility.FormatValidator;
 import io.micrometer.core.instrument.MeterRegistry;
+import lombok.RequiredArgsConstructor;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.springframework.beans.factory.ObjectProvider;
@@ -15,8 +16,6 @@ import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.core.MicrometerProducerListener;
 import org.springframework.kafka.core.ProducerFactory;
 import org.springframework.kafka.support.serializer.JsonSerializer;
-
-import lombok.RequiredArgsConstructor;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/common/src/main/java/com/personal/marketnote/common/outbox/OutboxEvent.java
+++ b/common/src/main/java/com/personal/marketnote/common/outbox/OutboxEvent.java
@@ -1,10 +1,6 @@
 package com.personal.marketnote.common.outbox;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.time.Clock;
 import java.time.LocalDateTime;

--- a/common/src/main/java/com/personal/marketnote/common/outbox/entity/OutboxEventJpaEntity.java
+++ b/common/src/main/java/com/personal/marketnote/common/outbox/entity/OutboxEventJpaEntity.java
@@ -1,15 +1,7 @@
 package com.personal.marketnote.common.outbox.entity;
 
 import com.personal.marketnote.common.outbox.OutboxEventStatus;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Index;
-import jakarta.persistence.Table;
-import jakarta.persistence.UniqueConstraint;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/common/src/test/java/com/personal/marketnote/common/configuration/kafka/DltQueryServiceTest.java
+++ b/common/src/test/java/com/personal/marketnote/common/configuration/kafka/DltQueryServiceTest.java
@@ -24,7 +24,8 @@ import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("DltQueryService 테스트")

--- a/common/src/test/java/com/personal/marketnote/common/outbox/adapter/OutboxEventPublisherTest.java
+++ b/common/src/test/java/com/personal/marketnote/common/outbox/adapter/OutboxEventPublisherTest.java
@@ -1,5 +1,6 @@
 package com.personal.marketnote.common.outbox.adapter;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.personal.marketnote.common.outbox.OutboxEventStatus;
 import com.personal.marketnote.common.outbox.entity.OutboxEventJpaEntity;
@@ -12,8 +13,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.support.SendResult;
-
-import com.fasterxml.jackson.core.JsonProcessingException;
 
 import java.time.Clock;
 import java.time.Instant;
@@ -152,7 +151,8 @@ class OutboxEventPublisherTest {
                 .thenReturn(List.of(entity));
 
         when(objectMapper.readValue("invalid-json", Object.class))
-                .thenThrow(new JsonProcessingException("parse error") {});
+                .thenThrow(new JsonProcessingException("parse error") {
+                });
 
         // when
         outboxEventPublisher.publishPendingEvents();

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/product/controller/ProductController.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/product/controller/ProductController.java
@@ -7,6 +7,7 @@ import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.product.adapter.in.web.product.controller.apidocs.*;
 import com.personal.marketnote.product.adapter.in.web.product.mapper.ProductRequestToCommandMapper;
 import com.personal.marketnote.product.adapter.in.web.product.request.RegisterProductRequest;
+import com.personal.marketnote.product.adapter.in.web.product.request.ReorderProductTagsRequest;
 import com.personal.marketnote.product.adapter.in.web.product.request.UpdateProductRequest;
 import com.personal.marketnote.product.adapter.in.web.product.response.*;
 import com.personal.marketnote.product.domain.product.ProductSearchTarget;
@@ -53,6 +54,7 @@ public class ProductController {
     private final GetAdminProductDetailUseCase getAdminProductDetailUseCase;
     private final UpdateProductUseCase updateProductUseCase;
     private final DeleteProductUseCase deleteProductUseCase;
+    private final ReorderProductTagsUseCase reorderProductTagsUseCase;
     private final DeleteProductImageUseCase deleteProductImageUseCase;
 
     /**
@@ -354,6 +356,40 @@ public class ProductController {
                         HttpStatus.OK,
                         DEFAULT_SUCCESS_CODE,
                         "상품 정보 수정 성공"
+                )
+        );
+    }
+
+    /**
+     * (판매자/관리자) 상품 태그 순서 변경
+     *
+     * @param id        상품 ID
+     * @param request   상품 태그 순서 변경 요청
+     * @param principal 인증된 사용자
+     * @Author 성효빈
+     * @Date 2026-03-17
+     * @Description 상품 태그의 순서를 변경합니다.
+     */
+    @PatchMapping("/{id}/tags/order")
+    @PreAuthorize(ADMIN_OR_SELLER_POINTCUT)
+    @ReorderProductTagsApiDocs
+    public ResponseEntity<BaseResponse<Void>> reorderProductTags(
+            @PathVariable("id") Long id,
+            @Valid @RequestBody ReorderProductTagsRequest request,
+            @AuthenticationPrincipal OAuth2AuthenticatedPrincipal principal
+    ) {
+        reorderProductTagsUseCase.reorderProductTags(
+                ElementExtractor.extractUserId(principal),
+                AuthorityValidator.hasAdminRole(principal),
+                ProductRequestToCommandMapper.mapToCommand(id, request)
+        );
+
+        return ResponseEntity.ok(
+                BaseResponse.of(
+                        null,
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "상품 태그 순서 변경 성공"
                 )
         );
     }

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/product/controller/apidocs/ReorderProductTagsApiDocs.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/product/controller/apidocs/ReorderProductTagsApiDocs.java
@@ -1,0 +1,116 @@
+package com.personal.marketnote.product.adapter.in.web.product.controller.apidocs;
+
+import com.personal.marketnote.product.adapter.in.web.product.request.ReorderProductTagsRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Operation(
+        summary = "(판매자/관리자) 상품 태그 순서 변경",
+        description = """
+                작성일자: 2026-03-17
+                
+                작성자: 성효빈
+                
+                ---
+                
+                ## Description
+                
+                - 상품 태그의 순서(orderNum)를 변경합니다.
+                
+                - 판매자(소유자) 또는 관리자만 가능합니다.
+                
+                ---
+                
+                ## Request
+                
+                | **키** | **타입** | **설명** | **필수 여부** | **예시** |
+                | --- | --- | --- | --- | --- |
+                | tagOrders | array | 태그 순서 목록 | Y | [{"tagId": 1, "orderNum": 2}, {"tagId": 2, "orderNum": 1}] |
+                | tagOrders[].tagId | number | 태그 ID | Y | 1 |
+                | tagOrders[].orderNum | number | 순서 번호 (1 이상) | Y | 2 |
+                ---
+                
+                ## Response
+                
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | statusCode | number | 상태 코드 | 200: 성공 / 400: 클라이언트 요청 오류 / 401: 인증 실패 / 403: 인가 실패 / 404: 리소스 조회 실패 / 500: 그 외 |
+                | code | string | 응답 코드 | "SUC01" / "BAD_REQUEST" / "UNAUTHORIZED" / "FORBIDDEN" / "NOT_FOUND" / "INTERNAL_SERVER_ERROR" |
+                | timestamp | string(datetime) | 응답 일시 | "2026-03-17T12:00:00.000" |
+                | content | object | 응답 본문 | null |
+                | message | string | 처리 결과 | "상품 태그 순서 변경 성공" |
+                """,
+        security = {@SecurityRequirement(name = "bearer")},
+        requestBody = @RequestBody(
+                required = true,
+                content = @Content(
+                        schema = @Schema(implementation = ReorderProductTagsRequest.class),
+                        examples = @ExampleObject("""
+                                {
+                                  "tagOrders": [
+                                    {"tagId": 1, "orderNum": 2},
+                                    {"tagId": 2, "orderNum": 1}
+                                  ]
+                                }
+                                """)
+                )
+        ),
+        responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "상품 태그 순서 변경 성공",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 200,
+                                          "code": "SUC01",
+                                          "timestamp": "2026-03-17T12:00:00.000",
+                                          "content": null,
+                                          "message": "상품 태그 순서 변경 성공"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "401",
+                        description = "토큰 인증 실패",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 401,
+                                          "code": "UNAUTHORIZED",
+                                          "timestamp": "2026-03-17T12:00:00.000",
+                                          "content": null,
+                                          "message": "Invalid token"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "403",
+                        description = "토큰 인가 실패",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 403,
+                                          "code": "FORBIDDEN",
+                                          "timestamp": "2026-03-17T12:00:00.000",
+                                          "content": null,
+                                          "message": "Access Denied"
+                                        }
+                                        """)
+                        )
+                )
+        })
+public @interface ReorderProductTagsApiDocs {
+}

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/product/mapper/ProductRequestToCommandMapper.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/product/mapper/ProductRequestToCommandMapper.java
@@ -4,10 +4,7 @@ import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.product.adapter.in.web.cart.request.GetMyOrderingProductsRequest;
 import com.personal.marketnote.product.adapter.in.web.category.request.RegisterProductCategoriesRequest;
 import com.personal.marketnote.product.adapter.in.web.option.request.UpdateProductOptionsRequest;
-import com.personal.marketnote.product.adapter.in.web.product.request.RegisterProductFulfillmentVendorGoodsRequest;
-import com.personal.marketnote.product.adapter.in.web.product.request.RegisterProductRequest;
-import com.personal.marketnote.product.adapter.in.web.product.request.UpdateProductFulfillmentVendorGoodsRequest;
-import com.personal.marketnote.product.adapter.in.web.product.request.UpdateProductRequest;
+import com.personal.marketnote.product.adapter.in.web.product.request.*;
 import com.personal.marketnote.product.port.in.command.*;
 
 import java.util.List;
@@ -151,6 +148,16 @@ public class ProductRequestToCommandMapper {
                 .isFindAllOptions(request.isFindAllOptions())
                 .tags(request.tags())
                 .fulfillmentVendorGoods(mapToCommand(request.fulfillmentVendorGoods()))
+                .build();
+    }
+
+    public static ReorderProductTagsCommand mapToCommand(Long productId, ReorderProductTagsRequest request) {
+        List<ReorderProductTagsCommand.TagOrderItem> tagOrders = request.tagOrders().stream()
+                .map(item -> new ReorderProductTagsCommand.TagOrderItem(item.tagId(), item.orderNum()))
+                .toList();
+        return ReorderProductTagsCommand.builder()
+                .productId(productId)
+                .tagOrders(tagOrders)
                 .build();
     }
 

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/product/request/ReorderProductTagsRequest.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/product/request/ReorderProductTagsRequest.java
@@ -1,0 +1,24 @@
+package com.personal.marketnote.product.adapter.in.web.product.request;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.util.List;
+
+public record ReorderProductTagsRequest(
+        @NotNull(message = "태그 순서 목록은 필수값입니다.")
+        @Size(min = 1, message = "태그 순서 목록은 최소 1개 이상이어야 합니다.")
+        List<@Valid TagOrderItem> tagOrders
+) {
+    public record TagOrderItem(
+            @NotNull(message = "태그 ID는 필수값입니다.")
+            Long tagId,
+
+            @NotNull(message = "순서 번호는 필수값입니다.")
+            @Min(value = 1, message = "순서 번호는 1 이상이어야 합니다.")
+            Long orderNum
+    ) {
+    }
+}

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/product/ProductTagPersistenceAdapter.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/product/ProductTagPersistenceAdapter.java
@@ -1,0 +1,33 @@
+package com.personal.marketnote.product.adapter.out.persistence.product;
+
+import com.personal.marketnote.common.adapter.out.PersistenceAdapter;
+import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.product.adapter.out.persistence.product.entity.ProductTagJpaEntity;
+import com.personal.marketnote.product.adapter.out.persistence.product.repository.ProductTagJpaRepository;
+import com.personal.marketnote.product.port.out.product.UpdateProductTagPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+@PersistenceAdapter
+@RequiredArgsConstructor
+public class ProductTagPersistenceAdapter implements UpdateProductTagPort {
+    private final ProductTagJpaRepository productTagJpaRepository;
+
+    @Override
+    @CacheEvict(value = "product:detail", key = "#productId")
+    public void updateOrderNums(Long productId, Map<Long, Long> tagIdToOrderNumMap) {
+        List<ProductTagJpaEntity> tagEntities = productTagJpaRepository
+                .findAllByProductJpaEntityIdAndIdIn(productId, new ArrayList<>(tagIdToOrderNumMap.keySet()));
+
+        for (ProductTagJpaEntity tagEntity : tagEntities) {
+            Long newOrderNum = tagIdToOrderNumMap.get(tagEntity.getId());
+            if (FormatValidator.hasValue(newOrderNum)) {
+                tagEntity.changeOrderNum(newOrderNum);
+            }
+        }
+    }
+}

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/product/entity/ProductTagJpaEntity.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/product/entity/ProductTagJpaEntity.java
@@ -24,4 +24,8 @@ public class ProductTagJpaEntity extends BaseOrderedGeneralEntity {
     public static ProductTagJpaEntity from(ProductJpaEntity productJpaEntity, ProductTag productTag) {
         return new ProductTagJpaEntity(productJpaEntity, productTag.getName());
     }
+
+    public void changeOrderNum(Long orderNum) {
+        updateOrderNum(orderNum);
+    }
 }

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/product/repository/ProductTagJpaRepository.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/product/repository/ProductTagJpaRepository.java
@@ -1,0 +1,10 @@
+package com.personal.marketnote.product.adapter.out.persistence.product.repository;
+
+import com.personal.marketnote.product.adapter.out.persistence.product.entity.ProductTagJpaEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ProductTagJpaRepository extends JpaRepository<ProductTagJpaEntity, Long> {
+    List<ProductTagJpaEntity> findAllByProductJpaEntityIdAndIdIn(Long productId, List<Long> tagIds);
+}

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/exception/DuplicateProductTagOrderException.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/exception/DuplicateProductTagOrderException.java
@@ -1,0 +1,23 @@
+package com.personal.marketnote.product.exception;
+
+import lombok.Getter;
+
+@Getter
+public class DuplicateProductTagOrderException extends IllegalArgumentException {
+    private static final String DUPLICATE_TAG_ID_MESSAGE =
+            "ERR_PRODUCT_TAG_02::중복된 태그 ID가 존재합니다. tagId=%d";
+    private static final String DUPLICATE_ORDER_NUM_MESSAGE =
+            "ERR_PRODUCT_TAG_03::중복된 순서 번호가 존재합니다. orderNum=%d";
+
+    public static DuplicateProductTagOrderException duplicateTagId(Long tagId) {
+        return new DuplicateProductTagOrderException(String.format(DUPLICATE_TAG_ID_MESSAGE, tagId));
+    }
+
+    public static DuplicateProductTagOrderException duplicateOrderNum(Long orderNum) {
+        return new DuplicateProductTagOrderException(String.format(DUPLICATE_ORDER_NUM_MESSAGE, orderNum));
+    }
+
+    private DuplicateProductTagOrderException(String message) {
+        super(message);
+    }
+}

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/exception/ProductTagNotFoundException.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/exception/ProductTagNotFoundException.java
@@ -1,0 +1,13 @@
+package com.personal.marketnote.product.exception;
+
+import lombok.Getter;
+
+@Getter
+public class ProductTagNotFoundException extends RuntimeException {
+    private static final String PRODUCT_TAG_NOT_FOUND_EXCEPTION_MESSAGE =
+            "ERR_PRODUCT_TAG_01::상품 태그를 찾을 수 없습니다. tagId=%d, productId=%d";
+
+    public ProductTagNotFoundException(Long tagId, Long productId) {
+        super(String.format(PRODUCT_TAG_NOT_FOUND_EXCEPTION_MESSAGE, tagId, productId));
+    }
+}

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/command/ReorderProductTagsCommand.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/command/ReorderProductTagsCommand.java
@@ -1,0 +1,15 @@
+package com.personal.marketnote.product.port.in.command;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record ReorderProductTagsCommand(
+        Long productId,
+        List<TagOrderItem> tagOrders
+) {
+    @Builder
+    public record TagOrderItem(Long tagId, Long orderNum) {
+    }
+}

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/usecase/product/ReorderProductTagsUseCase.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/usecase/product/ReorderProductTagsUseCase.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.product.port.in.usecase.product;
+
+import com.personal.marketnote.product.port.in.command.ReorderProductTagsCommand;
+
+public interface ReorderProductTagsUseCase {
+    void reorderProductTags(Long userId, boolean isAdmin, ReorderProductTagsCommand command);
+}

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/out/product/UpdateProductTagPort.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/out/product/UpdateProductTagPort.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.product.port.out.product;
+
+import java.util.Map;
+
+public interface UpdateProductTagPort {
+    void updateOrderNums(Long productId, Map<Long, Long> tagIdToOrderNumMap);
+}

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/service/product/ReorderProductTagsService.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/service/product/ReorderProductTagsService.java
@@ -1,0 +1,90 @@
+package com.personal.marketnote.product.service.product;
+
+import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.product.domain.product.Product;
+import com.personal.marketnote.product.domain.product.ProductTag;
+import com.personal.marketnote.product.exception.DuplicateProductTagOrderException;
+import com.personal.marketnote.product.exception.NotProductOwnerException;
+import com.personal.marketnote.product.exception.ProductTagNotFoundException;
+import com.personal.marketnote.product.port.in.command.ReorderProductTagsCommand;
+import com.personal.marketnote.product.port.in.usecase.product.GetProductUseCase;
+import com.personal.marketnote.product.port.in.usecase.product.ReorderProductTagsUseCase;
+import com.personal.marketnote.product.port.out.product.FindProductPort;
+import com.personal.marketnote.product.port.out.product.UpdateProductTagPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static com.personal.marketnote.common.domain.exception.ExceptionCode.FIRST_ERROR_CODE;
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional(isolation = READ_COMMITTED)
+public class ReorderProductTagsService implements ReorderProductTagsUseCase {
+    private final GetProductUseCase getProductUseCase;
+    private final FindProductPort findProductPort;
+    private final UpdateProductTagPort updateProductTagPort;
+
+    @Override
+    public void reorderProductTags(Long userId, boolean isAdmin, ReorderProductTagsCommand command) {
+        Long productId = command.productId();
+
+        validateOwnership(userId, isAdmin, productId);
+
+        Product product = getProductUseCase.getProduct(productId);
+
+        validateNoDuplicates(command);
+        validateTagsBelongToProduct(product, command);
+
+        Map<Long, Long> tagIdToOrderNumMap = buildTagIdToOrderNumMap(command);
+        updateProductTagPort.updateOrderNums(productId, tagIdToOrderNumMap);
+    }
+
+    private void validateOwnership(Long userId, boolean isAdmin, Long productId) {
+        if (isAdmin) {
+            return;
+        }
+        if (!findProductPort.existsByIdAndSellerId(productId, userId)) {
+            throw new NotProductOwnerException(FIRST_ERROR_CODE, productId);
+        }
+    }
+
+    private void validateNoDuplicates(ReorderProductTagsCommand command) {
+        Set<Long> tagIds = new HashSet<>();
+        Set<Long> orderNums = new HashSet<>();
+        for (ReorderProductTagsCommand.TagOrderItem item : command.tagOrders()) {
+            if (!tagIds.add(item.tagId())) {
+                throw DuplicateProductTagOrderException.duplicateTagId(item.tagId());
+            }
+            if (!orderNums.add(item.orderNum())) {
+                throw DuplicateProductTagOrderException.duplicateOrderNum(item.orderNum());
+            }
+        }
+    }
+
+    private void validateTagsBelongToProduct(Product product, ReorderProductTagsCommand command) {
+        Set<Long> existingTagIds = product.getProductTags().stream()
+                .map(ProductTag::getId)
+                .collect(Collectors.toSet());
+
+        for (ReorderProductTagsCommand.TagOrderItem item : command.tagOrders()) {
+            if (!existingTagIds.contains(item.tagId())) {
+                throw new ProductTagNotFoundException(item.tagId(), product.getId());
+            }
+        }
+    }
+
+    private Map<Long, Long> buildTagIdToOrderNumMap(ReorderProductTagsCommand command) {
+        Map<Long, Long> map = new LinkedHashMap<>();
+        for (ReorderProductTagsCommand.TagOrderItem item : command.tagOrders()) {
+            map.put(item.tagId(), item.orderNum());
+        }
+        return map;
+    }
+}

--- a/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/adapter/in/event/PaymentCancelledPartialSharedPointConsumerTest.java
+++ b/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/adapter/in/event/PaymentCancelledPartialSharedPointConsumerTest.java
@@ -51,8 +51,8 @@ class PaymentCancelledPartialSharedPointConsumerTest {
     }
 
     private ConsumerRecord<String, EventEnvelope<?>> buildRecord(Long orderId, boolean isFullCancel,
-                                                                  Long cancelAmount, Long paymentAmount,
-                                                                  List<OrderProductItem> orderProducts) {
+                                                                 Long cancelAmount, Long paymentAmount,
+                                                                 List<OrderProductItem> orderProducts) {
         PaymentCancelledEvent event = new PaymentCancelledEvent(
                 orderId, "order-key-1", 100L, cancelAmount, paymentAmount, 1000L,
                 isFullCancel, 0L, null, orderProducts, null, null

--- a/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/adapter/in/event/PaymentCancelledPendingProductPointConsumerTest.java
+++ b/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/adapter/in/event/PaymentCancelledPendingProductPointConsumerTest.java
@@ -8,8 +8,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
-import org.mockito.Spy;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.kafka.support.Acknowledgment;
 
@@ -33,7 +33,7 @@ class PaymentCancelledPendingProductPointConsumerTest {
     private Acknowledgment acknowledgment;
 
     private ConsumerRecord<String, EventEnvelope<?>> buildRecord(Long orderId, Long buyerId,
-                                                                  boolean isFullCancel) {
+                                                                 boolean isFullCancel) {
         PaymentCancelledEvent event = new PaymentCancelledEvent(
                 orderId, "order-key-1", buyerId, 50000L, 80000L, 1000L,
                 isFullCancel, 0L, null, List.of(), null, null

--- a/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/adapter/in/event/PaymentCancelledPendingSharedPointConsumerTest.java
+++ b/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/adapter/in/event/PaymentCancelledPendingSharedPointConsumerTest.java
@@ -34,7 +34,7 @@ class PaymentCancelledPendingSharedPointConsumerTest {
     private Acknowledgment acknowledgment;
 
     private ConsumerRecord<String, EventEnvelope<?>> buildRecord(Long orderId, boolean isFullCancel,
-                                                                  List<OrderProductItem> orderProducts) {
+                                                                 List<OrderProductItem> orderProducts) {
         PaymentCancelledEvent event = new PaymentCancelledEvent(
                 orderId, "order-key-1", 100L, 50000L, 80000L, 1000L,
                 isFullCancel, 0L, null, orderProducts, null, null

--- a/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/adapter/in/event/PaymentCancelledPointRefundConsumerTest.java
+++ b/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/adapter/in/event/PaymentCancelledPointRefundConsumerTest.java
@@ -43,7 +43,7 @@ class PaymentCancelledPointRefundConsumerTest {
     private Acknowledgment acknowledgment;
 
     private ConsumerRecord<String, EventEnvelope<?>> buildRecord(Long orderId, Long buyerId,
-                                                                  Long pointAmount, boolean isFullCancel) {
+                                                                 Long pointAmount, boolean isFullCancel) {
         PaymentCancelledEvent event = new PaymentCancelledEvent(
                 orderId, "order-key-1", buyerId, 50000L, 80000L, pointAmount,
                 isFullCancel, 0L, null, List.of(), null, null


### PR DESCRIPTION
## partially addresses #128
## resolves #1304

## Task
- [x] PATCH /api/v1/products/{id}/tags/order 엔드포인트 추가
- [x] 관리자/판매자 인가 + 서비스 레이어 소유권 검증
- [x] 중복 tagId/orderNum 검증, 태그 소속 검증
- [x] @CacheEvict 캐시 무효화 적용
- [x] BaseOrderedGeneralEntity에 protected updateOrderNum 메서드 추가
- [x] 코드 포맷 정리 (커머스/공통/모니터링/리워드)