### PR TITLE
[#128][#1305] feat: 상품 목록 조회 시 상품 태그 orderNum 기준 오름차순 2개 제한 조회 기능 추가

### DIFF
--- a/monitoring/alertmanager/alertmanager.yml
+++ b/monitoring/alertmanager/alertmanager.yml
@@ -3,7 +3,7 @@ global:
 
 route:
   receiver: 'slack-notifications'
-  group_by: ['alertname', 'kafka_consumer_group_id']
+  group_by: [ 'alertname', 'kafka_consumer_group_id', 'broker' ]
   group_wait: 30s
   group_interval: 5m
   repeat_interval: 1h
@@ -36,6 +36,7 @@ receivers:
           {{ range .Alerts }}
           *Alert:* {{ .Annotations.summary }}
           *Description:* {{ .Annotations.description }}
+          *Broker:* {{ .Labels.broker }}
           *Consumer Group:* {{ .Labels.kafka_consumer_group_id }}
           *Topic:* {{ .Labels.topic }}
           {{ end }}

--- a/monitoring/docker-compose.yml
+++ b/monitoring/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     networks:
       - monitoring
     healthcheck:
-      test: ["CMD", "wget", "--spider", "-q", "http://localhost:9090/-/ready"]
+      test: [ "CMD", "wget", "--spider", "-q", "http://localhost:9090/-/ready" ]
       interval: 10s
       timeout: 5s
       retries: 3

--- a/monitoring/grafana/dashboards/kafka-consumer-lag.json
+++ b/monitoring/grafana/dashboards/kafka-consumer-lag.json
@@ -16,12 +16,30 @@
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
   "id": null,
-  "links": [],
+  "links": [
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [
+        "overview"
+      ],
+      "targetBlank": true,
+      "title": "Kafka Overview Dashboard",
+      "type": "dashboards"
+    }
+  ],
   "panels": [
     {
       "title": "Consumer Group별 총 Lag",
       "type": "stat",
-      "gridPos": { "h": 5, "w": 24, "x": 0, "y": 0 },
+      "gridPos": {
+        "h": 5,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
       "datasource": "Prometheus",
       "targets": [
         {
@@ -34,9 +52,18 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null },
-              { "color": "yellow", "value": 100 },
-              { "color": "red", "value": 1000 }
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 100
+              },
+              {
+                "color": "red",
+                "value": 1000
+              }
             ]
           },
           "mappings": [],
@@ -45,7 +72,9 @@
       },
       "options": {
         "reduceOptions": {
-          "calcs": ["lastNotNull"]
+          "calcs": [
+            "lastNotNull"
+          ]
         },
         "colorMode": "background",
         "graphMode": "area",
@@ -56,7 +85,12 @@
     {
       "title": "Consumer Group별 Lag 추이",
       "type": "timeseries",
-      "gridPos": { "h": 10, "w": 12, "x": 0, "y": 5 },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 0,
+        "y": 5
+      },
       "datasource": "Prometheus",
       "targets": [
         {
@@ -77,23 +111,47 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null },
-              { "color": "yellow", "value": 100 },
-              { "color": "red", "value": 1000 }
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 100
+              },
+              {
+                "color": "red",
+                "value": 1000
+              }
             ]
           },
           "unit": "short"
         }
       },
       "options": {
-        "tooltip": { "mode": "multi", "sort": "desc" },
-        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max"] }
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        }
       }
     },
     {
       "title": "토픽별 Lag 상세",
       "type": "timeseries",
-      "gridPos": { "h": 10, "w": 12, "x": 12, "y": 5 },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 12,
+        "y": 5
+      },
       "datasource": "Prometheus",
       "targets": [
         {
@@ -114,14 +172,29 @@
         }
       },
       "options": {
-        "tooltip": { "mode": "multi", "sort": "desc" },
-        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max"] }
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        }
       }
     },
     {
       "title": "초당 메시지 소비량 (처리량)",
       "type": "timeseries",
-      "gridPos": { "h": 10, "w": 12, "x": 0, "y": 15 },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 0,
+        "y": 15
+      },
       "datasource": "Prometheus",
       "targets": [
         {
@@ -143,14 +216,30 @@
         }
       },
       "options": {
-        "tooltip": { "mode": "multi", "sort": "desc" },
-        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "mean", "max"] }
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "mean",
+            "max"
+          ]
+        }
       }
     },
     {
       "title": "Consumer Group 상태 요약",
       "type": "table",
-      "gridPos": { "h": 10, "w": 12, "x": 12, "y": 15 },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 12,
+        "y": 15
+      },
       "datasource": "Prometheus",
       "targets": [
         {
@@ -172,27 +261,47 @@
         },
         "overrides": [
           {
-            "matcher": { "id": "byName", "options": "Lag" },
+            "matcher": {
+              "id": "byName",
+              "options": "Lag"
+            },
             "properties": [
               {
                 "id": "thresholds",
                 "value": {
                   "mode": "absolute",
                   "steps": [
-                    { "color": "green", "value": null },
-                    { "color": "yellow", "value": 100 },
-                    { "color": "red", "value": 1000 }
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "yellow",
+                      "value": 100
+                    },
+                    {
+                      "color": "red",
+                      "value": 1000
+                    }
                   ]
                 }
               },
-              { "id": "custom.displayMode", "value": "color-background" }
+              {
+                "id": "custom.displayMode",
+                "value": "color-background"
+              }
             ]
           }
         ]
       },
       "options": {
         "showHeader": true,
-        "sortBy": [{ "displayName": "Lag", "desc": true }]
+        "sortBy": [
+          {
+            "displayName": "Lag",
+            "desc": true
+          }
+        ]
       },
       "transformations": [
         {
@@ -204,7 +313,12 @@
     {
       "title": "서비스별 총 Lag",
       "type": "piechart",
-      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 25 },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 25
+      },
       "datasource": "Prometheus",
       "targets": [
         {
@@ -213,15 +327,28 @@
         }
       ],
       "options": {
-        "legend": { "displayMode": "table", "placement": "right", "calcs": ["lastNotNull"] },
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
         "pieType": "donut",
-        "tooltip": { "mode": "single" }
+        "tooltip": {
+          "mode": "single"
+        }
       }
     },
     {
       "title": "Lag 임계값 알림 상태",
       "type": "state-timeline",
-      "gridPos": { "h": 8, "w": 16, "x": 8, "y": 25 },
+      "gridPos": {
+        "h": 8,
+        "w": 16,
+        "x": 8,
+        "y": 25
+      },
       "datasource": "Prometheus",
       "targets": [
         {
@@ -234,9 +361,18 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null },
-              { "color": "yellow", "value": 100 },
-              { "color": "red", "value": 1000 }
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 100
+              },
+              {
+                "color": "red",
+                "value": 1000
+              }
             ]
           },
           "custom": {
@@ -254,12 +390,20 @@
   ],
   "refresh": "30s",
   "schemaVersion": 39,
-  "tags": ["kafka", "consumer-lag", "monitoring"],
+  "tags": [
+    "kafka",
+    "consumer-lag",
+    "monitoring"
+  ],
   "templating": {
     "list": [
       {
         "allValue": ".*",
-        "current": { "selected": true, "text": "All", "value": "$__all" },
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
         "datasource": "Prometheus",
         "definition": "label_values(kafka_consumer_fetch_manager_records_lag, kafka_consumer_group_id)",
         "includeAll": true,
@@ -271,7 +415,10 @@
       }
     ]
   },
-  "time": { "from": "now-3h", "to": "now" },
+  "time": {
+    "from": "now-3h",
+    "to": "now"
+  },
   "timepicker": {},
   "timezone": "Asia/Seoul",
   "title": "Kafka Consumer Lag Monitor",

--- a/monitoring/grafana/dashboards/kafka-overview.json
+++ b/monitoring/grafana/dashboards/kafka-overview.json
@@ -22,7 +22,9 @@
       "icon": "external link",
       "includeVars": true,
       "keepTime": true,
-      "tags": ["consumer-lag"],
+      "tags": [
+        "consumer-lag"
+      ],
       "targetBlank": true,
       "title": "Consumer Lag Monitor",
       "type": "dashboards"
@@ -31,14 +33,24 @@
   "panels": [
     {
       "collapsed": false,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
       "title": "Cluster Health",
       "type": "row"
     },
     {
       "title": "Active Controllers",
       "type": "stat",
-      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 1 },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 1
+      },
       "datasource": "Prometheus",
       "targets": [
         {
@@ -51,16 +63,29 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "red", "value": null },
-              { "color": "green", "value": 1 },
-              { "color": "red", "value": 2 }
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 2
+              }
             ]
           },
           "unit": "short"
         }
       },
       "options": {
-        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
         "colorMode": "background",
         "graphMode": "none",
         "textMode": "value"
@@ -69,7 +94,12 @@
     {
       "title": "Online Brokers",
       "type": "stat",
-      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 1 },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 1
+      },
       "datasource": "Prometheus",
       "targets": [
         {
@@ -82,16 +112,29 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "red", "value": null },
-              { "color": "yellow", "value": 2 },
-              { "color": "green", "value": 3 }
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 2
+              },
+              {
+                "color": "green",
+                "value": 3
+              }
             ]
           },
           "unit": "short"
         }
       },
       "options": {
-        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
         "colorMode": "background",
         "graphMode": "none",
         "textMode": "value"
@@ -100,7 +143,12 @@
     {
       "title": "Under-replicated Partitions",
       "type": "stat",
-      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 1 },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 1
+      },
       "datasource": "Prometheus",
       "targets": [
         {
@@ -113,15 +161,25 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null },
-              { "color": "red", "value": 1 }
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
             ]
           },
           "unit": "short"
         }
       },
       "options": {
-        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
         "colorMode": "background",
         "graphMode": "none",
         "textMode": "value"
@@ -130,7 +188,12 @@
     {
       "title": "Offline Partitions",
       "type": "stat",
-      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 1 },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 1
+      },
       "datasource": "Prometheus",
       "targets": [
         {
@@ -143,15 +206,25 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null },
-              { "color": "red", "value": 1 }
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
             ]
           },
           "unit": "short"
         }
       },
       "options": {
-        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
         "colorMode": "background",
         "graphMode": "none",
         "textMode": "value"
@@ -159,14 +232,24 @@
     },
     {
       "collapsed": false,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 5 },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 5
+      },
       "title": "Producer Metrics",
       "type": "row"
     },
     {
       "title": "Producer 전송 성공률 (records/sec)",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 6 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 6
+      },
       "datasource": "Prometheus",
       "targets": [
         {
@@ -187,14 +270,30 @@
         }
       },
       "options": {
-        "tooltip": { "mode": "multi", "sort": "desc" },
-        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "mean", "max"] }
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "mean",
+            "max"
+          ]
+        }
       }
     },
     {
       "title": "Producer 에러율 (errors/sec)",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 6 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 6
+      },
       "datasource": "Prometheus",
       "targets": [
         {
@@ -214,22 +313,44 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null },
-              { "color": "red", "value": 0.01 }
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 0.01
+              }
             ]
           },
           "unit": "ops"
         }
       },
       "options": {
-        "tooltip": { "mode": "multi", "sort": "desc" },
-        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "mean", "max"] }
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "mean",
+            "max"
+          ]
+        }
       }
     },
     {
       "title": "Producer 평균 요청 지연 (ms)",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 14 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 14
+      },
       "datasource": "Prometheus",
       "targets": [
         {
@@ -248,23 +369,48 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null },
-              { "color": "yellow", "value": 200 },
-              { "color": "red", "value": 500 }
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 200
+              },
+              {
+                "color": "red",
+                "value": 500
+              }
             ]
           },
           "unit": "ms"
         }
       },
       "options": {
-        "tooltip": { "mode": "multi", "sort": "desc" },
-        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "mean", "max"] }
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "mean",
+            "max"
+          ]
+        }
       }
     },
     {
       "title": "Producer 배치 크기 / 재시도",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 14 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 14
+      },
       "datasource": "Prometheus",
       "targets": [
         {
@@ -288,20 +434,41 @@
         }
       },
       "options": {
-        "tooltip": { "mode": "multi", "sort": "desc" },
-        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "mean", "max"] }
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "mean",
+            "max"
+          ]
+        }
       }
     },
     {
       "collapsed": false,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 22 },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 22
+      },
       "title": "Broker Metrics",
       "type": "row"
     },
     {
       "title": "브로커별 메시지 인입률 (msg/sec)",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 23 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 23
+      },
       "datasource": "Prometheus",
       "targets": [
         {
@@ -322,14 +489,30 @@
         }
       },
       "options": {
-        "tooltip": { "mode": "multi", "sort": "desc" },
-        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "mean", "max"] }
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "mean",
+            "max"
+          ]
+        }
       }
     },
     {
       "title": "브로커별 바이트 In/Out (bytes/sec)",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 23 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 23
+      },
       "datasource": "Prometheus",
       "targets": [
         {
@@ -353,14 +536,30 @@
         }
       },
       "options": {
-        "tooltip": { "mode": "multi", "sort": "desc" },
-        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "mean", "max"] }
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "mean",
+            "max"
+          ]
+        }
       }
     },
     {
       "title": "ISR Shrink / Expand",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 31 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 31
+      },
       "datasource": "Prometheus",
       "targets": [
         {
@@ -384,14 +583,29 @@
         }
       },
       "options": {
-        "tooltip": { "mode": "multi", "sort": "desc" },
-        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "mean"] }
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "mean"
+          ]
+        }
       }
     },
     {
       "title": "브로커별 파티션 / 리더 수",
       "type": "table",
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 31 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 31
+      },
       "datasource": "Prometheus",
       "targets": [
         {
@@ -419,19 +633,31 @@
         },
         "overrides": [
           {
-            "matcher": { "id": "byName", "options": "UnderReplicated" },
+            "matcher": {
+              "id": "byName",
+              "options": "UnderReplicated"
+            },
             "properties": [
               {
                 "id": "thresholds",
                 "value": {
                   "mode": "absolute",
                   "steps": [
-                    { "color": "green", "value": null },
-                    { "color": "red", "value": 1 }
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "red",
+                      "value": 1
+                    }
                   ]
                 }
               },
-              { "id": "custom.displayMode", "value": "color-background" }
+              {
+                "id": "custom.displayMode",
+                "value": "color-background"
+              }
             ]
           }
         ]
@@ -440,19 +666,32 @@
         "showHeader": true
       },
       "transformations": [
-        { "id": "merge", "options": {} }
+        {
+          "id": "merge",
+          "options": {}
+        }
       ]
     },
     {
       "collapsed": false,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 39 },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 39
+      },
       "title": "Consumer Metrics",
       "type": "row"
     },
     {
       "title": "Consumer Group별 처리량 (records/sec)",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 40 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 40
+      },
       "datasource": "Prometheus",
       "targets": [
         {
@@ -473,14 +712,30 @@
         }
       },
       "options": {
-        "tooltip": { "mode": "multi", "sort": "desc" },
-        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "mean", "max"] }
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "mean",
+            "max"
+          ]
+        }
       }
     },
     {
       "title": "Consumer Group별 Lag",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 40 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 40
+      },
       "datasource": "Prometheus",
       "targets": [
         {
@@ -500,23 +755,47 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null },
-              { "color": "yellow", "value": 100 },
-              { "color": "red", "value": 1000 }
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 100
+              },
+              {
+                "color": "red",
+                "value": 1000
+              }
             ]
           },
           "unit": "short"
         }
       },
       "options": {
-        "tooltip": { "mode": "multi", "sort": "desc" },
-        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max"] }
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ]
+        }
       }
     },
     {
       "title": "Consumer Fetch 지연 (ms)",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 48 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 48
+      },
       "datasource": "Prometheus",
       "targets": [
         {
@@ -536,14 +815,30 @@
         }
       },
       "options": {
-        "tooltip": { "mode": "multi", "sort": "desc" },
-        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "mean", "max"] }
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "mean",
+            "max"
+          ]
+        }
       }
     },
     {
       "title": "Consumer 리밸런싱 횟수",
       "type": "stat",
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 48 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 48
+      },
       "datasource": "Prometheus",
       "targets": [
         {
@@ -556,16 +851,29 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null },
-              { "color": "yellow", "value": 5 },
-              { "color": "red", "value": 10 }
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 5
+              },
+              {
+                "color": "red",
+                "value": 10
+              }
             ]
           },
           "unit": "short"
         }
       },
       "options": {
-        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
         "colorMode": "background",
         "graphMode": "area",
         "textMode": "auto"
@@ -573,14 +881,24 @@
     },
     {
       "collapsed": false,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 56 },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 56
+      },
       "title": "End-to-End Flow",
       "type": "row"
     },
     {
       "title": "토픽별 메시지 흐름 (Producer vs Consumer)",
       "type": "timeseries",
-      "gridPos": { "h": 10, "w": 12, "x": 0, "y": 57 },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 0,
+        "y": 57
+      },
       "datasource": "Prometheus",
       "targets": [
         {
@@ -604,14 +922,29 @@
         }
       },
       "options": {
-        "tooltip": { "mode": "multi", "sort": "desc" },
-        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "mean"] }
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "mean"
+          ]
+        }
       }
     },
     {
       "title": "브로커 JVM Heap 사용률",
       "type": "timeseries",
-      "gridPos": { "h": 10, "w": 12, "x": 12, "y": 57 },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 12,
+        "y": 57
+      },
       "datasource": "Prometheus",
       "targets": [
         {
@@ -630,9 +963,18 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null },
-              { "color": "yellow", "value": 0.8 },
-              { "color": "red", "value": 0.9 }
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.8
+              },
+              {
+                "color": "red",
+                "value": 0.9
+              }
             ]
           },
           "unit": "percentunit",
@@ -641,14 +983,30 @@
         }
       },
       "options": {
-        "tooltip": { "mode": "multi", "sort": "desc" },
-        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "mean", "max"] }
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "mean",
+            "max"
+          ]
+        }
       }
     },
     {
       "title": "브로커 Produce 응답 시간 (P99, ms)",
       "type": "timeseries",
-      "gridPos": { "h": 10, "w": 12, "x": 0, "y": 67 },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 0,
+        "y": 67
+      },
       "datasource": "Prometheus",
       "targets": [
         {
@@ -671,23 +1029,48 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null },
-              { "color": "yellow", "value": 500 },
-              { "color": "red", "value": 1000 }
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 500
+              },
+              {
+                "color": "red",
+                "value": 1000
+              }
             ]
           },
           "unit": "ms"
         }
       },
       "options": {
-        "tooltip": { "mode": "multi", "sort": "desc" },
-        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "mean", "max"] }
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "mean",
+            "max"
+          ]
+        }
       }
     },
     {
       "title": "알림 상태 타임라인",
       "type": "state-timeline",
-      "gridPos": { "h": 10, "w": 12, "x": 12, "y": 67 },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 12,
+        "y": 67
+      },
       "datasource": "Prometheus",
       "targets": [
         {
@@ -700,8 +1083,14 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "green", "value": null },
-              { "color": "red", "value": 1 }
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
             ]
           },
           "custom": {
@@ -715,16 +1104,179 @@
         "alignValue": "center",
         "mergeValues": true
       }
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 80
+      },
+      "title": "Dead Letter Topic (DLT)",
+      "type": "row"
+    },
+    {
+      "title": "DLT 토픽별 총 메시지 수",
+      "type": "stat",
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 81
+      },
+      "datasource": "Prometheus",
+      "targets": [
+        {
+          "expr": "sum by (original_topic) (kafka_dlt_messages_total)",
+          "legendFormat": "{{ original_topic }}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 5
+              }
+            ]
+          },
+          "unit": "short"
+        }
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "colorMode": "background",
+        "graphMode": "none",
+        "textMode": "auto"
+      }
+    },
+    {
+      "title": "DLT 메시지 도착률 (5분)",
+      "type": "timeseries",
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 81
+      },
+      "datasource": "Prometheus",
+      "targets": [
+        {
+          "expr": "rate(kafka_dlt_messages_total[5m])",
+          "legendFormat": "{{ original_topic }}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "smooth",
+            "fillOpacity": 20,
+            "lineWidth": 2,
+            "pointSize": 5
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 0.1
+              }
+            ]
+          }
+        }
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      }
+    },
+    {
+      "title": "DLT 재처리 결과 (1시간)",
+      "type": "bargauge",
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 87
+      },
+      "datasource": "Prometheus",
+      "targets": [
+        {
+          "expr": "sum by (original_topic, outcome) (increase(kafka_dlt_reprocess_total[1h]))",
+          "legendFormat": "{{ original_topic }} ({{ outcome }})"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        }
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "displayMode": "gradient",
+        "orientation": "horizontal"
+      }
     }
   ],
   "refresh": "30s",
   "schemaVersion": 39,
-  "tags": ["kafka", "overview", "monitoring"],
+  "tags": [
+    "kafka",
+    "overview",
+    "monitoring"
+  ],
   "templating": {
     "list": [
       {
         "allValue": ".*",
-        "current": { "selected": true, "text": "All", "value": "$__all" },
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
         "datasource": "Prometheus",
         "definition": "label_values(up{job=~\"shop-.*\"}, job)",
         "includeAll": true,
@@ -736,7 +1288,11 @@
       },
       {
         "allValue": ".*",
-        "current": { "selected": true, "text": "All", "value": "$__all" },
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
         "datasource": "Prometheus",
         "definition": "label_values(kafka_consumer_fetch_manager_records_lag, kafka_consumer_group_id)",
         "includeAll": true,
@@ -748,7 +1304,11 @@
       },
       {
         "allValue": ".*",
-        "current": { "selected": true, "text": "All", "value": "$__all" },
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
         "datasource": "Prometheus",
         "definition": "label_values(up{job=\"kafka-broker\"}, broker)",
         "includeAll": true,
@@ -760,7 +1320,11 @@
       },
       {
         "allValue": ".*",
-        "current": { "selected": true, "text": "All", "value": "$__all" },
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
         "datasource": "Prometheus",
         "definition": "label_values(kafka_server_brokertopicmetrics_messagesinpersec_oneminuterate, topic)",
         "includeAll": true,
@@ -772,7 +1336,10 @@
       }
     ]
   },
-  "time": { "from": "now-3h", "to": "now" },
+  "time": {
+    "from": "now-3h",
+    "to": "now"
+  },
   "timepicker": {},
   "timezone": "Asia/Seoul",
   "title": "Kafka Overview Dashboard",

--- a/monitoring/prometheus/alert-rules.yml
+++ b/monitoring/prometheus/alert-rules.yml
@@ -27,3 +27,141 @@ groups:
         annotations:
           summary: "Consumer 비활성: {{ $labels.kafka_consumer_group_id }}"
           description: "Consumer Group {{ $labels.kafka_consumer_group_id }}가 10분간 메시지를 소비하지 않고 있습니다. Consumer 장애 여부를 확인하세요."
+
+  - name: kafka-producer
+    rules:
+      - alert: KafkaProducerErrorRateHigh
+        expr: >
+          sum by (job) (rate(kafka_producer_record_error_total[5m]))
+          / sum by (job) (rate(kafka_producer_record_send_total[5m])) > 0.01
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Producer 에러율 1% 초과: {{ $labels.job }}"
+          description: "서비스 {{ $labels.job }}의 Kafka Producer 에러율이 {{ $value | humanizePercentage }}입니다."
+
+      - alert: KafkaProducerErrorRateCritical
+        expr: >
+          sum by (job) (rate(kafka_producer_record_error_total[5m]))
+          / sum by (job) (rate(kafka_producer_record_send_total[5m])) > 0.05
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Producer 에러율 5% 초과 (CRITICAL): {{ $labels.job }}"
+          description: "서비스 {{ $labels.job }}의 Kafka Producer 에러율이 {{ $value | humanizePercentage }}입니다. 즉시 확인이 필요합니다."
+
+      - alert: KafkaProducerLatencyHigh
+        expr: kafka_producer_request_latency_avg > 500
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Producer 지연 시간 500ms 초과: {{ $labels.job }}"
+          description: "서비스 {{ $labels.job }}의 Kafka Producer 평균 요청 지연이 {{ $value }}ms입니다."
+
+      - alert: KafkaProducerNoActivity
+        expr: sum by (job) (rate(kafka_producer_record_send_total[5m])) == 0
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Producer 비활성: {{ $labels.job }}"
+          description: "서비스 {{ $labels.job }}에서 15분간 Kafka 메시지 전송이 없습니다."
+
+  - name: kafka-broker
+    rules:
+      - alert: KafkaBrokerDown
+        expr: up{job="kafka-broker"} == 0
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Kafka 브로커 다운: {{ $labels.broker }}"
+          description: "브로커 {{ $labels.broker }} ({{ $labels.instance }})이 1분 이상 응답하지 않습니다. 즉시 확인이 필요합니다."
+
+      - alert: KafkaActiveControllerZero
+        expr: sum(kafka_controller_kafkacontroller_activecontrollercount) == 0
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: "활성 컨트롤러 없음 - Kafka 클러스터 장애"
+          description: "Kafka 클러스터에 활성 컨트롤러가 없습니다. 전체 클러스터 장애 가능성이 있습니다."
+
+      - alert: KafkaOfflinePartitions
+        expr: kafka_controller_kafkacontroller_offlinepartitionscount > 0
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: "오프라인 파티션 감지: {{ $labels.broker }}"
+          description: "브로커 {{ $labels.broker }}에 오프라인 파티션 {{ $value }}개가 있습니다. 메시지 유실 가능성이 있습니다."
+
+      - alert: KafkaUnderReplicatedPartitions
+        expr: kafka_server_replicamanager_underreplicatedpartitions > 0
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Under-replicated 파티션 감지: {{ $labels.broker }}"
+          description: "브로커 {{ $labels.broker }}에 Under-replicated 파티션 {{ $value }}개가 있습니다. 데이터 안전성이 저하될 수 있습니다."
+
+      - alert: KafkaISRShrink
+        expr: rate(kafka_server_replicamanager_isrshrinkspersec_count[5m]) > 0
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "ISR Shrink 감지: {{ $labels.broker }}"
+          description: "브로커 {{ $labels.broker }}에서 ISR Shrink가 지속적으로 발생하고 있습니다. 네트워크 또는 디스크 I/O 문제를 확인하세요."
+
+      - alert: KafkaBrokerHighProduceLatency
+        expr: kafka_network_requestmetrics_totaltimems_produce_p99 > 1000
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "브로커 Produce 지연 P99 > 1s: {{ $labels.broker }}"
+          description: "브로커 {{ $labels.broker }}의 Produce 요청 P99 지연이 {{ $value }}ms입니다."
+
+      - alert: KafkaBrokerHeapUsageHigh
+        expr: kafka_jvm_heap_memory_used / kafka_jvm_heap_memory_max > 0.9
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "브로커 JVM Heap 사용률 90% 초과: {{ $labels.broker }}"
+          description: "브로커 {{ $labels.broker }}의 JVM Heap 사용률이 {{ $value | humanizePercentage }}입니다."
+
+  - name: kafka-dlt
+    rules:
+      - alert: KafkaDltMessageReceived
+        expr: increase(kafka_dlt_messages_total[5m]) > 0
+        for: 0m
+        labels:
+          severity: warning
+        annotations:
+          summary: "DLT 메시지 적재 감지: {{ $labels.original_topic }}"
+          description: "토픽 {{ $labels.original_topic }}에서 최근 5분간 DLT 메시지 {{ $value }}건이 적재되었습니다. 즉시 확인이 필요합니다."
+
+      - alert: KafkaDltMessageAccumulating
+        expr: increase(kafka_dlt_messages_total[1h]) > 10
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "DLT 메시지 누적 CRITICAL: {{ $labels.original_topic }}"
+          description: "토픽 {{ $labels.original_topic }}의 DLT 메시지가 {{ $value }}건 누적되었습니다. 수동 재처리 또는 원인 분석이 필요합니다."
+
+      - alert: KafkaDltReprocessFailureHigh
+        expr: >
+          sum by (original_topic) (increase(kafka_dlt_reprocess_total{outcome="failure"}[1h]))
+          / sum by (original_topic) (increase(kafka_dlt_reprocess_total[1h])) > 0.5
+        for: 0m
+        labels:
+          severity: warning
+        annotations:
+          summary: "DLT 재처리 실패율 50% 초과: {{ $labels.original_topic }}"
+          description: "토픽 {{ $labels.original_topic }}의 DLT 재처리 실패율이 {{ $value | humanizePercentage }}입니다."

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/result/product/ProductItemResult.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/result/product/ProductItemResult.java
@@ -11,6 +11,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.util.Comparator;
 import java.util.List;
 
 @Builder(access = AccessLevel.PRIVATE)
@@ -39,7 +40,7 @@ public class ProductItemResult {
                 .brandName(product.getBrandName())
                 .pricePolicy(GetProductPricePolicyResult.from(product.getDefaultPricePolicy()))
                 .sales(product.getSales())
-                .productTags(product.getProductTags())
+                .productTags(getTopOrderedTags(product.getProductTags()))
                 .status(product.getStatus().name())
                 .orderNum(product.getOrderNum())
                 .build();
@@ -56,7 +57,7 @@ public class ProductItemResult {
                 .brandName(product.getBrandName())
                 .pricePolicy(GetProductPricePolicyResult.from(pricePolicy))
                 .sales(product.getSales())
-                .productTags(product.getProductTags())
+                .productTags(getTopOrderedTags(product.getProductTags()))
                 .status(product.getStatus().name())
                 .orderNum(product.getOrderNum())
                 .build();
@@ -74,7 +75,7 @@ public class ProductItemResult {
                 .brandName(product.getBrandName())
                 .pricePolicy(GetProductPricePolicyResult.from(pricePolicy))
                 .sales(product.getSales())
-                .productTags(product.getProductTags())
+                .productTags(getTopOrderedTags(product.getProductTags()))
                 .selectedOptions(selectedOptions.stream()
                         .map(ProductOptionItemResult::from)
                         .toList())
@@ -131,5 +132,14 @@ public class ProductItemResult {
 
     public Long getPricePolicyId() {
         return pricePolicy.id();
+    }
+
+    private static final int MAX_DISPLAY_TAGS = 2;
+
+    private static List<ProductTag> getTopOrderedTags(List<ProductTag> productTags) {
+        return productTags.stream()
+                .sorted(Comparator.comparingLong(ProductTag::getOrderNum))
+                .limit(MAX_DISPLAY_TAGS)
+                .toList();
     }
 }


### PR DESCRIPTION
## partially addresses #128
## resolves #1305

## Task
- [x] ProductItemResult의 from(Product ...) 메서드 3개에서 상품 태그를 orderNum 기준 오름차순 정렬 후 상위 2개만 반환하도록 변경
- [x] 중복 제거를 위해 getTopOrderedTags() 헬퍼 메서드 추가
- [x] enrichment 메서드(이미지/재고/리뷰 보강)는 이미 필터된 태그를 pass-through하므로 변경 불필요