### PR TITLE
[#128][#1327] feat: 상품 태그 등록/수정 시 orderNum 자동 할당 기능 추가

### DIFF
--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/product/ProductPersistenceAdapter.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/product/ProductPersistenceAdapter.java
@@ -4,6 +4,7 @@ import com.personal.marketnote.common.adapter.out.PersistenceAdapter;
 import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.product.adapter.out.mapper.ProductJpaEntityToDomainMapper;
 import com.personal.marketnote.product.adapter.out.persistence.product.entity.ProductJpaEntity;
+import com.personal.marketnote.product.adapter.out.persistence.product.entity.ProductTagJpaEntity;
 import com.personal.marketnote.product.adapter.out.persistence.product.repository.ProductJpaRepository;
 import com.personal.marketnote.product.domain.product.Product;
 import com.personal.marketnote.product.domain.product.ProductSearchTarget;
@@ -31,6 +32,7 @@ public class ProductPersistenceAdapter implements SaveProductPort, FindProductPo
     public Product save(Product product) {
         ProductJpaEntity savedEntity = productJpaRepository.save(ProductJpaEntity.from(product));
         savedEntity.setIdToOrderNum();
+        savedEntity.getProductTagJpaEntities().forEach(ProductTagJpaEntity::setIdToOrderNum);
 
         return ProductJpaEntityToDomainMapper.mapToDomain(savedEntity).get();
     }
@@ -217,6 +219,8 @@ public class ProductPersistenceAdapter implements SaveProductPort, FindProductPo
     public void update(Product product) throws ProductNotFoundException {
         ProductJpaEntity entity = findEntityById(product.getId());
         entity.updateFrom(product);
+        productJpaRepository.flush();
+        entity.getProductTagJpaEntities().forEach(ProductTagJpaEntity::setIdToOrderNum);
     }
 
     private ProductJpaEntity findEntityById(Long id) throws ProductNotFoundException {


### PR DESCRIPTION
## partially addresses #128
## resolves #1327

## Task
- ProductPersistenceAdapter.save()에서 cascade 저장된 태그에 setIdToOrderNum() 호출 추가
- ProductPersistenceAdapter.update()에서 flush() 후 태그에 setIdToOrderNum() 호출 추가