### PR TITLE
[#128][#1329] feat: 장바구니 상품 추가 시 이미 존재하는 상품 수량 추가 기능 추가

### DIFF
--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/service/cart/AddCartProductService.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/service/cart/AddCartProductService.java
@@ -7,9 +7,13 @@ import com.personal.marketnote.product.mapper.CartProductCommandToStateMapper;
 import com.personal.marketnote.product.port.in.command.AddCartProductCommand;
 import com.personal.marketnote.product.port.in.usecase.cart.AddCartProductUseCase;
 import com.personal.marketnote.product.port.in.usecase.pricepolicy.GetPricePolicyUseCase;
+import com.personal.marketnote.product.port.out.cart.FindCartProductPort;
 import com.personal.marketnote.product.port.out.cart.SaveCartProductPort;
+import com.personal.marketnote.product.port.out.cart.UpdateCartProductPort;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
 
 import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
 
@@ -18,11 +22,24 @@ import static org.springframework.transaction.annotation.Isolation.READ_COMMITTE
 @Transactional(isolation = READ_COMMITTED)
 public class AddCartProductService implements AddCartProductUseCase {
     private final GetPricePolicyUseCase getPricePolicyUseCase;
+    private final FindCartProductPort findCartProductPort;
+    private final UpdateCartProductPort updateCartProductPort;
     private final SaveCartProductPort saveCartProductPort;
 
     @Override
     public void addCartProduct(AddCartProductCommand command) {
         PricePolicy pricePolicy = getPricePolicyUseCase.getPricePolicy(command.pricePolicyId());
+
+        Optional<CartProduct> existingCartProduct
+                = findCartProductPort.findCartProductByUserIdAndPricePolicyId(command.userId(), command.pricePolicyId());
+
+        if (existingCartProduct.isPresent()) {
+            CartProduct cartProduct = existingCartProduct.get();
+            cartProduct.addQuantity(command.quantity());
+            updateCartProductPort.update(cartProduct, command.pricePolicyId());
+            return;
+        }
+
         saveCartProductPort.save(
                 CartProduct.from(CartProductCommandToStateMapper.mapToState(command, pricePolicy))
         );

--- a/product-service/product-domain/src/main/java/com/personal/marketnote/product/domain/cart/CartProduct.java
+++ b/product-service/product-domain/src/main/java/com/personal/marketnote/product/domain/cart/CartProduct.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.product.domain.cart;
 
 import com.personal.marketnote.common.domain.BaseDomain;
+import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.product.domain.pricepolicy.PricePolicy;
 import lombok.*;
 
@@ -43,6 +44,17 @@ public class CartProduct extends BaseDomain {
 
     public Long getPricePolicyId() {
         return pricePolicy.getId();
+    }
+
+    public void addQuantity(Short additionalQuantity) {
+        if (FormatValidator.hasNoValue(additionalQuantity) || additionalQuantity <= 0) {
+            throw new InvalidCartProductQuantityException("추가 수량은 1 이상이어야 합니다.");
+        }
+        int sum = this.quantity + additionalQuantity;
+        if (sum > Short.MAX_VALUE) {
+            throw new InvalidCartProductQuantityException("수량 한도를 초과했습니다.");
+        }
+        this.quantity = (short) sum;
     }
 
     public void updateQuantity(Short newQuantity) {

--- a/product-service/product-domain/src/main/java/com/personal/marketnote/product/domain/cart/InvalidCartProductQuantityException.java
+++ b/product-service/product-domain/src/main/java/com/personal/marketnote/product/domain/cart/InvalidCartProductQuantityException.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.product.domain.cart;
+
+public class InvalidCartProductQuantityException extends IllegalArgumentException {
+    private static final String MESSAGE = "ERR_CART_01::장바구니 수량이 유효하지 않습니다. %s";
+
+    public InvalidCartProductQuantityException(String detail) {
+        super(String.format(MESSAGE, detail));
+    }
+}


### PR DESCRIPTION
## partially addresses #128
## resolves #1329

## Task
- [x] CartProduct 도메인에 addQuantity(Short) 수량 누적 행위 메서드 추가 (입력 검증 + 오버플로 방지)
- [x] InvalidCartProductQuantityException 도메인 예외 클래스 생성
- [x] AddCartProductService에 FindCartProductPort, UpdateCartProductPort 의존성 추가
- [x] AddCartProductService에 기존 상품 존재 시 수량 누적 / 미존재 시 신규 저장 분기 로직 구현