### PR TITLE
[#128][#1339] fix: 상품 목록 조회 시 Redis 캐시 역직렬화 실패로 두 번째 호출부터 500 에러 발생 버그 픽스

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/configuration/CacheConfig.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/configuration/CacheConfig.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.PropertyAccessor;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
 import com.fasterxml.jackson.datatype.hibernate5.jakarta.Hibernate5JakartaModule;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
@@ -45,7 +46,13 @@ public class CacheConfig {
     private ObjectMapper objectMapper() {
         ObjectMapper mapper = new ObjectMapper();
 
-        mapper.enableDefaultTyping(ObjectMapper.DefaultTyping.NON_FINAL, JsonTypeInfo.As.PROPERTY);
+        mapper.activateDefaultTyping(
+                BasicPolymorphicTypeValidator.builder()
+                        .allowIfBaseType(Object.class)
+                        .build(),
+                ObjectMapper.DefaultTyping.NON_FINAL,
+                JsonTypeInfo.As.PROPERTY
+        );
         mapper.setVisibility(PropertyAccessor.GETTER, JsonAutoDetect.Visibility.NONE);
         mapper.setVisibility(PropertyAccessor.IS_GETTER, JsonAutoDetect.Visibility.NONE);
         mapper.setVisibility(PropertyAccessor.SETTER, JsonAutoDetect.Visibility.NONE);

--- a/community-service/community-adapters/src/main/java/com/personal/marketnote/community/configuration/CacheConfig.java
+++ b/community-service/community-adapters/src/main/java/com/personal/marketnote/community/configuration/CacheConfig.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.PropertyAccessor;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
 import com.fasterxml.jackson.datatype.hibernate5.jakarta.Hibernate5JakartaModule;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
@@ -43,7 +44,13 @@ public class CacheConfig {
     private ObjectMapper objectMapper() {
         ObjectMapper mapper = new ObjectMapper();
 
-        mapper.enableDefaultTyping(ObjectMapper.DefaultTyping.NON_FINAL, JsonTypeInfo.As.PROPERTY);
+        mapper.activateDefaultTyping(
+                BasicPolymorphicTypeValidator.builder()
+                        .allowIfBaseType(Object.class)
+                        .build(),
+                ObjectMapper.DefaultTyping.NON_FINAL,
+                JsonTypeInfo.As.PROPERTY
+        );
         mapper.setVisibility(PropertyAccessor.GETTER, JsonAutoDetect.Visibility.NONE);
         mapper.setVisibility(PropertyAccessor.IS_GETTER, JsonAutoDetect.Visibility.NONE);
         mapper.setVisibility(PropertyAccessor.SETTER, JsonAutoDetect.Visibility.NONE);

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/pricepolicy/PricePolicyPersistenceAdapter.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/pricepolicy/PricePolicyPersistenceAdapter.java
@@ -197,13 +197,13 @@ public class PricePolicyPersistenceAdapter implements SavePricePolicyPort, FindP
                 null
         );
 
-        return loadPricePoliciesWithAssociations(entities).stream()
+        return new ArrayList<>(loadPricePoliciesWithAssociations(entities).stream()
                 .map(policyEntity -> PricePolicyJpaEntityToDomainMapper.mapToDomain(
                         policyEntity, productOptionPricePolicyJpaRepository.findOptionIdsByPricePolicyId(policyEntity.getId())
                 ))
                 .filter(Optional::isPresent)
                 .map(Optional::get)
-                .toList();
+                .toList());
     }
 
     @Override
@@ -249,13 +249,13 @@ public class PricePolicyPersistenceAdapter implements SavePricePolicyPort, FindP
                 categoryId
         );
 
-        return loadPricePoliciesWithAssociations(entities).stream()
+        return new ArrayList<>(loadPricePoliciesWithAssociations(entities).stream()
                 .map(policyEntity -> PricePolicyJpaEntityToDomainMapper.mapToDomain(
                         policyEntity, productOptionPricePolicyJpaRepository.findOptionIdsByPricePolicyId(policyEntity.getId())
                 ))
                 .filter(Optional::isPresent)
                 .map(Optional::get)
-                .toList();
+                .toList());
     }
 
     @Override

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/product/ProductPersistenceAdapter.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/product/ProductPersistenceAdapter.java
@@ -127,9 +127,9 @@ public class ProductPersistenceAdapter implements SaveProductPort, FindProductPo
 
         List<ProductJpaEntity> hydratedEntities = loadProductsWithAssociations(entities);
 
-        return hydratedEntities.stream()
+        return new ArrayList<>(hydratedEntities.stream()
                 .map(entity -> ProductJpaEntityToDomainMapper.mapToDomain(entity).orElse(null))
-                .toList();
+                .toList());
     }
 
     private boolean isAsc(Pageable pageable) {

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/configuration/CacheConfig.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/configuration/CacheConfig.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.PropertyAccessor;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
 import com.fasterxml.jackson.datatype.hibernate5.jakarta.Hibernate5JakartaModule;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
@@ -45,7 +46,13 @@ public class CacheConfig {
     private ObjectMapper objectMapper() {
         ObjectMapper mapper = new ObjectMapper();
 
-        mapper.enableDefaultTyping(ObjectMapper.DefaultTyping.NON_FINAL, JsonTypeInfo.As.PROPERTY);
+        mapper.activateDefaultTyping(
+                BasicPolymorphicTypeValidator.builder()
+                        .allowIfBaseType(Object.class)
+                        .build(),
+                ObjectMapper.DefaultTyping.NON_FINAL,
+                JsonTypeInfo.As.PROPERTY
+        );
         mapper.setVisibility(PropertyAccessor.GETTER, JsonAutoDetect.Visibility.NONE);
         mapper.setVisibility(PropertyAccessor.IS_GETTER, JsonAutoDetect.Visibility.NONE);
         mapper.setVisibility(PropertyAccessor.SETTER, JsonAutoDetect.Visibility.NONE);

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/configuration/CacheConfig.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/configuration/CacheConfig.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.PropertyAccessor;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
 import com.fasterxml.jackson.datatype.hibernate5.jakarta.Hibernate5JakartaModule;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
@@ -43,7 +44,13 @@ public class CacheConfig {
     private ObjectMapper objectMapper() {
         ObjectMapper mapper = new ObjectMapper();
 
-        mapper.enableDefaultTyping(ObjectMapper.DefaultTyping.NON_FINAL, JsonTypeInfo.As.PROPERTY);
+        mapper.activateDefaultTyping(
+                BasicPolymorphicTypeValidator.builder()
+                        .allowIfBaseType(Object.class)
+                        .build(),
+                ObjectMapper.DefaultTyping.NON_FINAL,
+                JsonTypeInfo.As.PROPERTY
+        );
         mapper.setVisibility(PropertyAccessor.GETTER, JsonAutoDetect.Visibility.NONE);
         mapper.setVisibility(PropertyAccessor.IS_GETTER, JsonAutoDetect.Visibility.NONE);
         mapper.setVisibility(PropertyAccessor.SETTER, JsonAutoDetect.Visibility.NONE);

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/configuration/CacheConfig.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/configuration/CacheConfig.java
@@ -2,6 +2,7 @@ package com.personal.marketnote.user.configuration;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
 import com.fasterxml.jackson.datatype.hibernate5.jakarta.Hibernate5JakartaModule;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
@@ -41,7 +42,13 @@ public class CacheConfig {
 
     private ObjectMapper objectMapper() {
         ObjectMapper mapper = new ObjectMapper();
-        mapper.enableDefaultTyping(ObjectMapper.DefaultTyping.NON_FINAL, JsonTypeInfo.As.PROPERTY);
+        mapper.activateDefaultTyping(
+                BasicPolymorphicTypeValidator.builder()
+                        .allowIfBaseType(Object.class)
+                        .build(),
+                ObjectMapper.DefaultTyping.NON_FINAL,
+                JsonTypeInfo.As.PROPERTY
+        );
         mapper.registerModule(new Jdk8Module());
         mapper.registerModule(new Hibernate5JakartaModule());
         mapper.registerModule(new JavaTimeModule());


### PR DESCRIPTION
## partially addresses #128
## resolves #1339

## Task
## Reason
- `stream().toList()`가 반환하는 `ImmutableCollections$ListN`은 package-private 클래스
- Jackson `GenericJackson2JsonRedisSerializer`가 최상위 레벨 타입 래퍼를 추가하지 못해 역직렬화 실패
- 첫 호출은 캐시 미스로 정상, 두 번째 호출부터 캐시 히트 시 500 에러

## Action
- [x] `@Cacheable` 메서드 3개의 리스트 반환을 `new ArrayList<>(.toList())`로 변환
- [x] 5개 서비스 CacheConfig의 deprecated `enableDefaultTyping` → `activateDefaultTyping` + `BasicPolymorphicTypeValidator` 교체