### PR TITLE
[#128][#1340] fix: 상품 등록 시 할인가 0원일 때 Division by zero 에러 발생 버그 픽스

### DIFF
--- a/common/src/main/java/com/personal/marketnote/common/domain/exception/GlobalExceptionHandler.java
+++ b/common/src/main/java/com/personal/marketnote/common/domain/exception/GlobalExceptionHandler.java
@@ -81,6 +81,13 @@ public class GlobalExceptionHandler {
         return buildErrorResponse(httpStatus, httpStatus.name(), "서버 내부 오류가 발생했습니다.");
     }
 
+    @ExceptionHandler(ArithmeticException.class)
+    ResponseEntity<ErrorResponse> handleArithmeticException(ArithmeticException e) {
+        HttpStatus httpStatus = HttpStatus.INTERNAL_SERVER_ERROR;
+        log.error(LOG_ERROR_MESSAGE, e.getMessage(), e);
+        return buildErrorResponse(httpStatus, httpStatus.name(), "서버 내부 오류가 발생했습니다.");
+    }
+
     @ExceptionHandler(EntityNotFoundException.class)
     ResponseEntity<ErrorResponse> handleEntityNotFoundException(EntityNotFoundException e) {
         HttpStatus httpStatus = HttpStatus.NOT_FOUND;

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/mapper/ProductCommandToStateMapper.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/mapper/ProductCommandToStateMapper.java
@@ -11,9 +11,14 @@ import com.personal.marketnote.product.port.in.command.RegisterPricePolicyComman
 import com.personal.marketnote.product.port.in.command.RegisterProductCommand;
 import com.personal.marketnote.product.port.in.command.RegisterProductOptionsCommand;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.stream.Collectors;
 
 public class ProductCommandToStateMapper {
+
+    private static final BigDecimal HUNDRED = new BigDecimal("100");
+
     public static ProductCreateState mapToState(RegisterProductCommand command) {
         return ProductCreateState.builder()
                 .sellerId(command.sellerId())
@@ -55,21 +60,13 @@ public class ProductCommandToStateMapper {
     public static PricePolicyCreateState mapToState(
             Product product, RegisterPricePolicyCommand command
     ) {
-        java.math.BigDecimal price = java.math.BigDecimal.valueOf(command.price());
-        java.math.BigDecimal discountPrice = java.math.BigDecimal.valueOf(command.discountPrice());
-        java.math.BigDecimal hundred = new java.math.BigDecimal("100");
+        BigDecimal price = BigDecimal.valueOf(command.price());
+        BigDecimal discountPrice = BigDecimal.valueOf(command.discountPrice());
 
-        // discountRate = (price - discountPrice) / price * 100
-        java.math.BigDecimal discountRate = price.subtract(discountPrice)
-                .divide(price, 3, java.math.RoundingMode.HALF_UP)
-                .multiply(hundred)
-                .setScale(1, java.math.RoundingMode.HALF_UP);
-
-        // accumulationRate = accumulatedPoint / discountPrice * 100
-        java.math.BigDecimal accumulationRate = java.math.BigDecimal.valueOf(command.accumulatedPoint())
-                .divide(discountPrice, 3, java.math.RoundingMode.HALF_UP)
-                .multiply(hundred)
-                .setScale(1, java.math.RoundingMode.HALF_UP);
+        BigDecimal discountRate = calculateDiscountRate(price, discountPrice);
+        BigDecimal accumulationRate = calculateAccumulationRate(
+                BigDecimal.valueOf(command.accumulatedPoint()), discountPrice
+        );
 
         return
                 PricePolicyCreateState.builder()
@@ -82,5 +79,25 @@ public class ProductCommandToStateMapper {
                         .status(EntityStatus.ACTIVE)
                         .optionIds(command.optionIds())
                         .build();
+    }
+
+    private static BigDecimal calculateDiscountRate(BigDecimal price, BigDecimal discountPrice) {
+        if (price.signum() == 0) {
+            return BigDecimal.ZERO;
+        }
+        return price.subtract(discountPrice)
+                .divide(price, 3, RoundingMode.HALF_UP)
+                .multiply(HUNDRED)
+                .setScale(1, RoundingMode.HALF_UP);
+    }
+
+    private static BigDecimal calculateAccumulationRate(BigDecimal accumulatedPoint, BigDecimal discountPrice) {
+        if (discountPrice.signum() == 0) {
+            return BigDecimal.ZERO;
+        }
+        return accumulatedPoint
+                .divide(discountPrice, 3, RoundingMode.HALF_UP)
+                .multiply(HUNDRED)
+                .setScale(1, RoundingMode.HALF_UP);
     }
 }


### PR DESCRIPTION
## partially addresses #128
## resolves #1340

## Reason
ProductCommandToStateMapper.mapToState()에서 accumulationRate = accumulatedPoint / discountPrice * 100 계산 시, discountPrice=0에 대한 방어 로직이 없어 ArithmeticException 발생. 동일 메서드의 discountRate = (price - discountPrice) / price 계산에서 price=0인 경우도 동일 버그 존재. GlobalExceptionHandler에 ArithmeticException 핸들러 미등록으로 내부 스택트레이스 노출 가능

## Action
- [x] ProductCommandToStateMapper.mapToState()에 discountPrice=0 방어 로직 추가 (accumulationRate = BigDecimal.ZERO)
- [x] ProductCommandToStateMapper.mapToState()에 price=0 방어 로직 추가 (discountRate = BigDecimal.ZERO)
- [x] calculateDiscountRate/calculateAccumulationRate 메서드 추출 및 import 정리
- [x] GlobalExceptionHandler에 ArithmeticException 핸들러 추가 (500, 고정 메시지)