### PR TITLE
[#128][#1351] test: 상품 등록 시 할인가 0원일 때 Division by zero 에러 발생 버그 픽스 기능 자동화 테스트 추가

### DIFF
--- a/common/src/test/java/com/personal/marketnote/common/domain/exception/GlobalExceptionHandlerTest.java
+++ b/common/src/test/java/com/personal/marketnote/common/domain/exception/GlobalExceptionHandlerTest.java
@@ -205,6 +205,33 @@ class GlobalExceptionHandlerTest {
     }
 
     @Nested
+    @DisplayName("ArithmeticException 핸들러 정보 노출 방지")
+    class ArithmeticExceptionInfoLeakPreventionTest {
+
+        @Test
+        @DisplayName("ArithmeticException 핸들러는 500 INTERNAL_SERVER_ERROR를 반환한다")
+        void shouldReturn500ForArithmeticException() {
+            ArithmeticException exception = new ArithmeticException("/ by zero");
+
+            ResponseEntity<ErrorResponse> response = handler.handleArithmeticException(exception);
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+
+        @Test
+        @DisplayName("ArithmeticException 핸들러는 내부 정보를 노출하지 않고 고정 메시지를 반환한다")
+        void shouldNotExposeInternalInfoInArithmeticExceptionResponse() {
+            ArithmeticException exception = new ArithmeticException("/ by zero");
+
+            ResponseEntity<ErrorResponse> response = handler.handleArithmeticException(exception);
+
+            assertThat(response.getBody()).isNotNull();
+            assertThat(response.getBody().getMessage()).doesNotContain("/ by zero");
+            assertThat(response.getBody().getMessage()).isEqualTo("서버 내부 오류가 발생했습니다.");
+        }
+    }
+
+    @Nested
     @DisplayName("스레드 안전성")
     class ThreadSafetyTest {
 

--- a/product-service/product-application/src/test/java/com/personal/marketnote/product/service/pricepolicy/RegisterPricePolicyUseCaseTest.java
+++ b/product-service/product-application/src/test/java/com/personal/marketnote/product/service/pricepolicy/RegisterPricePolicyUseCaseTest.java
@@ -228,6 +228,70 @@ class RegisterPricePolicyUseCaseTest {
         verify(publishProductEventPort).publishPricePolicyCreatedEvent(productId, 400L);
     }
 
+    @Test
+    @DisplayName("할인가가 0원이고 적립 포인트가 0원이면 적립률이 0%로 설정되어 정상 등록된다")
+    void registerPricePolicy_zeroDiscountPriceAndZeroPoint_setsZeroAccumulationRate() {
+        Long userId = 10L;
+        Long productId = 100L;
+        RegisterPricePolicyCommand command = RegisterPricePolicyCommand.of(productId, 10000L, 0L, 0L, List.of());
+        Product product = buildProduct(productId, userId);
+
+        when(findProductPort.existsByIdAndSellerId(productId, userId)).thenReturn(true);
+        when(getProductUseCase.getProduct(productId)).thenReturn(product);
+        when(savePricePolicyPort.save(any(PricePolicy.class))).thenReturn(500L);
+
+        registerPricePolicyService.registerPricePolicy(userId, false, command);
+
+        ArgumentCaptor<PricePolicy> captor = ArgumentCaptor.forClass(PricePolicy.class);
+        verify(savePricePolicyPort).save(captor.capture());
+        PricePolicy saved = captor.getValue();
+
+        assertThat(saved.getAccumulationRate()).isEqualByComparingTo(BigDecimal.ZERO);
+    }
+
+    @Test
+    @DisplayName("할인가가 0원이고 적립 포인트가 0보다 크면 적립률이 0%로 설정되어 정상 등록된다")
+    void registerPricePolicy_zeroDiscountPriceWithPoint_setsZeroAccumulationRate() {
+        Long userId = 11L;
+        Long productId = 110L;
+        RegisterPricePolicyCommand command = RegisterPricePolicyCommand.of(productId, 10000L, 0L, 500L, List.of());
+        Product product = buildProduct(productId, userId);
+
+        when(findProductPort.existsByIdAndSellerId(productId, userId)).thenReturn(true);
+        when(getProductUseCase.getProduct(productId)).thenReturn(product);
+        when(savePricePolicyPort.save(any(PricePolicy.class))).thenReturn(600L);
+
+        registerPricePolicyService.registerPricePolicy(userId, false, command);
+
+        ArgumentCaptor<PricePolicy> captor = ArgumentCaptor.forClass(PricePolicy.class);
+        verify(savePricePolicyPort).save(captor.capture());
+        PricePolicy saved = captor.getValue();
+
+        assertThat(saved.getAccumulationRate()).isEqualByComparingTo(BigDecimal.ZERO);
+    }
+
+    @Test
+    @DisplayName("정가와 할인가 모두 0원이면 할인률과 적립률이 0%로 설정되어 정상 등록된다")
+    void registerPricePolicy_zeroPriceAndZeroDiscountPrice_setsZeroRates() {
+        Long userId = 12L;
+        Long productId = 120L;
+        RegisterPricePolicyCommand command = RegisterPricePolicyCommand.of(productId, 0L, 0L, 0L, List.of());
+        Product product = buildProduct(productId, userId);
+
+        when(findProductPort.existsByIdAndSellerId(productId, userId)).thenReturn(true);
+        when(getProductUseCase.getProduct(productId)).thenReturn(product);
+        when(savePricePolicyPort.save(any(PricePolicy.class))).thenReturn(700L);
+
+        registerPricePolicyService.registerPricePolicy(userId, false, command);
+
+        ArgumentCaptor<PricePolicy> captor = ArgumentCaptor.forClass(PricePolicy.class);
+        verify(savePricePolicyPort).save(captor.capture());
+        PricePolicy saved = captor.getValue();
+
+        assertThat(saved.getDiscountRate()).isEqualByComparingTo(BigDecimal.ZERO);
+        assertThat(saved.getAccumulationRate()).isEqualByComparingTo(BigDecimal.ZERO);
+    }
+
     private RegisterPricePolicyCommand buildCommand(Long productId, List<Long> optionIds) {
         return RegisterPricePolicyCommand.of(
                 productId,


### PR DESCRIPTION
## partially addresses #128
## resolves #1351

## Task
- [x] 할인가가 0원이고 적립 포인트가 0원이면 적립률이 0%로 설정되어 정상 등록된다
- [x] 할인가가 0원이고 적립 포인트가 0보다 크면 적립률이 0%로 설정되어 정상 등록된다
- [x] 정가와 할인가 모두 0원이면 할인률과 적립률이 0%로 설정되어 정상 등록된다
- [x] ArithmeticException 핸들러는 500 INTERNAL_SERVER_ERROR를 반환한다
- [x] ArithmeticException 핸들러는 내부 정보를 노출하지 않고 고정 메시지를 반환한다