### PR TITLE
[#128][#1348] fix: 가격정책 등록 API 입력 검증 누락 픽스

### DIFF
--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/pricepolicy/request/RegisterPricePolicyRequest.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/pricepolicy/request/RegisterPricePolicyRequest.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.product.adapter.in.web.pricepolicy.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 
@@ -9,15 +10,18 @@ import java.util.List;
 @Getter
 public class RegisterPricePolicyRequest {
     @Schema(description = "정가", requiredMode = Schema.RequiredMode.REQUIRED, example = "45000")
-    @NotNull
+    @NotNull(message = "정가는 필수값입니다.")
+    @Min(value = 0, message = "정가는 0 이상이어야 합니다.")
     private Long price;
 
     @Schema(description = "현재 판매가", requiredMode = Schema.RequiredMode.REQUIRED, example = "37000")
-    @NotNull
+    @NotNull(message = "현재 판매가는 필수값입니다.")
+    @Min(value = 0, message = "현재 판매가는 0 이상이어야 합니다.")
     private Long discountPrice;
 
     @Schema(description = "적립 포인트", example = "1200")
-    @NotNull
+    @NotNull(message = "적립 포인트는 필수값입니다.")
+    @Min(value = 0, message = "적립 포인트는 0 이상이어야 합니다.")
     private Long accumulatedPoint;
 
     @Schema(description = "가격정책이 적용될 옵션 ID 목록(조합). 단일 카테고리일 경우 생략", example = "[3, 7]")

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/exception/InvalidPricePolicyPriceException.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/exception/InvalidPricePolicyPriceException.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.product.exception;
+
+public class InvalidPricePolicyPriceException extends IllegalArgumentException {
+    private static final String MESSAGE = "ERR_PRICE_POLICY_01::현재 판매가가 정가를 초과할 수 없습니다.";
+
+    public InvalidPricePolicyPriceException() {
+        super(MESSAGE);
+    }
+}

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/service/pricepolicy/RegisterPricePolicyService.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/service/pricepolicy/RegisterPricePolicyService.java
@@ -4,6 +4,7 @@ import com.personal.marketnote.common.application.UseCase;
 import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.product.domain.pricepolicy.PricePolicy;
 import com.personal.marketnote.product.domain.product.Product;
+import com.personal.marketnote.product.exception.InvalidPricePolicyPriceException;
 import com.personal.marketnote.product.exception.NotProductOwnerException;
 import com.personal.marketnote.product.mapper.ProductCommandToStateMapper;
 import com.personal.marketnote.product.port.in.command.RegisterPricePolicyCommand;
@@ -45,6 +46,8 @@ public class RegisterPricePolicyService implements RegisterPricePolicyUseCase {
             throw new NotProductOwnerException(FIRST_ERROR_CODE, productId);
         }
 
+        validateDiscountPriceNotExceedPrice(command);
+
         Product product = getProductUseCase.getProduct(productId);
 
         PricePolicy pricePolicy = PricePolicy.from(ProductCommandToStateMapper.mapToState(product, command));
@@ -62,6 +65,12 @@ public class RegisterPricePolicyService implements RegisterPricePolicyUseCase {
         registerInventoryHttpAfterCommit(productId, id);
 
         return RegisterPricePolicyResult.of(id);
+    }
+
+    private void validateDiscountPriceNotExceedPrice(RegisterPricePolicyCommand command) {
+        if (command.discountPrice().compareTo(command.price()) > 0) {
+            throw new InvalidPricePolicyPriceException();
+        }
     }
 
     private void registerInventoryHttpAfterCommit(Long productId, Long pricePolicyId) {


### PR DESCRIPTION
## partially addresses #128
## resolves #1348

## Task
- [x] RegisterPricePolicyRequest.price에 @Min(value = 0) 추가
- [x] RegisterPricePolicyRequest.discountPrice에 @Min(value = 0) 추가
- [x] RegisterPricePolicyRequest.accumulatedPoint에 @Min(value = 0) 추가
- [x] InvalidPricePolicyPriceException 커스텀 예외 생성
- [x] RegisterPricePolicyService에서 discountPrice <= price 비즈니스 검증 추가