### PR TITLE
[#128][#1354] test: 가격정책 등록 API 입력 검증 누락 픽스 기능 자동화 테스트 추가

### DIFF
--- a/product-service/product-adapters/src/test/java/com/personal/marketnote/product/adapter/in/web/pricepolicy/request/RegisterPricePolicyRequestValidationTest.java
+++ b/product-service/product-adapters/src/test/java/com/personal/marketnote/product/adapter/in/web/pricepolicy/request/RegisterPricePolicyRequestValidationTest.java
@@ -1,0 +1,105 @@
+package com.personal.marketnote.product.adapter.in.web.pricepolicy.request;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RegisterPricePolicyRequestValidationTest {
+    private static ValidatorFactory factory;
+    private static Validator validator;
+
+    @BeforeAll
+    static void setUp() {
+        factory = Validation.buildDefaultValidatorFactory();
+        validator = factory.getValidator();
+    }
+
+    @AfterAll
+    static void tearDown() {
+        factory.close();
+    }
+
+    @Test
+    @DisplayName("정가가 음수이면 검증에 실패한다")
+    void shouldFailWhenPriceIsNegative() {
+        RegisterPricePolicyRequest request = buildRequest(-1L, 0L, 0L);
+
+        Set<ConstraintViolation<RegisterPricePolicyRequest>> violations = validator.validate(request);
+
+        assertThat(violations).isNotEmpty();
+        assertThat(violations)
+                .anyMatch(v -> v.getPropertyPath().toString().equals("price"));
+    }
+
+    @Test
+    @DisplayName("현재 판매가가 음수이면 검증에 실패한다")
+    void shouldFailWhenDiscountPriceIsNegative() {
+        RegisterPricePolicyRequest request = buildRequest(10000L, -1L, 0L);
+
+        Set<ConstraintViolation<RegisterPricePolicyRequest>> violations = validator.validate(request);
+
+        assertThat(violations).isNotEmpty();
+        assertThat(violations)
+                .anyMatch(v -> v.getPropertyPath().toString().equals("discountPrice"));
+    }
+
+    @Test
+    @DisplayName("적립 포인트가 음수이면 검증에 실패한다")
+    void shouldFailWhenAccumulatedPointIsNegative() {
+        RegisterPricePolicyRequest request = buildRequest(10000L, 8000L, -1L);
+
+        Set<ConstraintViolation<RegisterPricePolicyRequest>> violations = validator.validate(request);
+
+        assertThat(violations).isNotEmpty();
+        assertThat(violations)
+                .anyMatch(v -> v.getPropertyPath().toString().equals("accumulatedPoint"));
+    }
+
+    @Test
+    @DisplayName("정가, 현재 판매가, 적립 포인트가 모두 0이면 검증에 성공한다")
+    void shouldPassWhenAllValuesAreZero() {
+        RegisterPricePolicyRequest request = buildRequest(0L, 0L, 0L);
+
+        Set<ConstraintViolation<RegisterPricePolicyRequest>> violations = validator.validate(request);
+
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    @DisplayName("정가, 현재 판매가, 적립 포인트가 양수이면 검증에 성공한다")
+    void shouldPassWhenAllValuesArePositive() {
+        RegisterPricePolicyRequest request = buildRequest(10000L, 8000L, 200L);
+
+        Set<ConstraintViolation<RegisterPricePolicyRequest>> violations = validator.validate(request);
+
+        assertThat(violations).isEmpty();
+    }
+
+    private RegisterPricePolicyRequest buildRequest(Long price, Long discountPrice, Long accumulatedPoint) {
+        RegisterPricePolicyRequest request = new RegisterPricePolicyRequest();
+        setField(request, "price", price);
+        setField(request, "discountPrice", discountPrice);
+        setField(request, "accumulatedPoint", accumulatedPoint);
+        return request;
+    }
+
+    private void setField(Object target, String fieldName, Object value) {
+        try {
+            Field field = target.getClass().getDeclaredField(fieldName);
+            field.setAccessible(true);
+            field.set(target, value);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/product-service/product-application/src/test/java/com/personal/marketnote/product/service/pricepolicy/RegisterPricePolicyUseCaseTest.java
+++ b/product-service/product-application/src/test/java/com/personal/marketnote/product/service/pricepolicy/RegisterPricePolicyUseCaseTest.java
@@ -4,6 +4,7 @@ import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus
 import com.personal.marketnote.product.domain.pricepolicy.PricePolicy;
 import com.personal.marketnote.product.domain.product.Product;
 import com.personal.marketnote.product.domain.product.ProductSnapshotState;
+import com.personal.marketnote.product.exception.InvalidPricePolicyPriceException;
 import com.personal.marketnote.product.exception.NotProductOwnerException;
 import com.personal.marketnote.product.port.in.command.RegisterPricePolicyCommand;
 import com.personal.marketnote.product.port.in.result.pricepolicy.RegisterPricePolicyResult;
@@ -290,6 +291,22 @@ class RegisterPricePolicyUseCaseTest {
 
         assertThat(saved.getDiscountRate()).isEqualByComparingTo(BigDecimal.ZERO);
         assertThat(saved.getAccumulationRate()).isEqualByComparingTo(BigDecimal.ZERO);
+    }
+
+    @Test
+    @DisplayName("현재 판매가가 정가를 초과하면 InvalidPricePolicyPriceException 예외를 던진다")
+    void registerPricePolicy_discountPriceExceedsPrice_throws() {
+        Long userId = 13L;
+        Long productId = 130L;
+        RegisterPricePolicyCommand command = RegisterPricePolicyCommand.of(productId, 10000L, 15000L, 200L, List.of());
+
+        when(findProductPort.existsByIdAndSellerId(productId, userId)).thenReturn(true);
+
+        assertThatThrownBy(() -> registerPricePolicyService.registerPricePolicy(userId, false, command))
+                .isInstanceOf(InvalidPricePolicyPriceException.class)
+                .hasMessageContaining("현재 판매가가 정가를 초과할 수 없습니다");
+
+        verifyNoInteractions(getProductUseCase, savePricePolicyPort, updateOptionPricePolicyPort, publishProductEventPort, registerInventoryPort);
     }
 
     private RegisterPricePolicyCommand buildCommand(Long productId, List<Long> optionIds) {


### PR DESCRIPTION
## partially addresses #128
## resolves #1354

## Test Case
- [x] 정가가 음수이면 검증에 실패한다
- [x] 현재 판매가가 음수이면 검증에 실패한다
- [x] 적립 포인트가 음수이면 검증에 실패한다
- [x] 정가, 현재 판매가, 적립 포인트가 모두 0이면 검증에 성공한다
- [x] 정가, 현재 판매가, 적립 포인트가 양수이면 검증에 성공한다
- [x] 현재 판매가가 정가를 초과하면 InvalidPricePolicyPriceException 예외를 던진다