### PR TITLE
[#128][#1356] fix: 상품 등록 기능 가격정책 적립률/할인률 컬럼 정밀도 부족으로 인한 Data Integrity 오류 픽스

### DIFF
--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/pricepolicy/entity/PricePolicyJpaEntity.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/pricepolicy/entity/PricePolicyJpaEntity.java
@@ -34,13 +34,13 @@ public class PricePolicyJpaEntity extends BaseOrderedGeneralEntity {
     @Column(name = "discount_price", nullable = false)
     private Long discountPrice;
 
-    @Column(name = "discount_rate", nullable = false, precision = 3, scale = 1)
+    @Column(name = "discount_rate", nullable = false, precision = 4, scale = 1)
     private BigDecimal discountRate;
 
     @Column(name = "accumulated_point", nullable = false)
     private Long accumulatedPoint;
 
-    @Column(name = "accumulation_rate", nullable = false, precision = 3, scale = 1)
+    @Column(name = "accumulation_rate", nullable = false, precision = 4, scale = 1)
     private BigDecimal accumulationRate;
 
     @Column(name = "popularity", nullable = false, insertable = false, columnDefinition = "BIGINT DEFAULT 0")

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/exception/InvalidPricePolicyAccumulatedPointException.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/exception/InvalidPricePolicyAccumulatedPointException.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.product.exception;
+
+public class InvalidPricePolicyAccumulatedPointException extends IllegalArgumentException {
+    private static final String MESSAGE = "ERR_PRICE_POLICY_02::적립금이 현재 판매가를 초과할 수 없습니다.";
+
+    public InvalidPricePolicyAccumulatedPointException() {
+        super(MESSAGE);
+    }
+}

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/service/pricepolicy/RegisterPricePolicyService.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/service/pricepolicy/RegisterPricePolicyService.java
@@ -4,6 +4,7 @@ import com.personal.marketnote.common.application.UseCase;
 import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.product.domain.pricepolicy.PricePolicy;
 import com.personal.marketnote.product.domain.product.Product;
+import com.personal.marketnote.product.exception.InvalidPricePolicyAccumulatedPointException;
 import com.personal.marketnote.product.exception.InvalidPricePolicyPriceException;
 import com.personal.marketnote.product.exception.NotProductOwnerException;
 import com.personal.marketnote.product.mapper.ProductCommandToStateMapper;
@@ -47,6 +48,7 @@ public class RegisterPricePolicyService implements RegisterPricePolicyUseCase {
         }
 
         validateDiscountPriceNotExceedPrice(command);
+        validateAccumulatedPointNotExceedDiscountPrice(command);
 
         Product product = getProductUseCase.getProduct(productId);
 
@@ -70,6 +72,15 @@ public class RegisterPricePolicyService implements RegisterPricePolicyUseCase {
     private void validateDiscountPriceNotExceedPrice(RegisterPricePolicyCommand command) {
         if (command.discountPrice().compareTo(command.price()) > 0) {
             throw new InvalidPricePolicyPriceException();
+        }
+    }
+
+    private void validateAccumulatedPointNotExceedDiscountPrice(RegisterPricePolicyCommand command) {
+        if (command.discountPrice().compareTo(0L) <= 0) {
+            return;
+        }
+        if (command.accumulatedPoint().compareTo(command.discountPrice()) > 0) {
+            throw new InvalidPricePolicyAccumulatedPointException();
         }
     }
 


### PR DESCRIPTION
## partially addresses #128
## resolves #1356

## Task
- [x] `PricePolicyJpaEntity` discount_rate, accumulation_rate precision 3→4 변경 (최대 999.9)
- [x] 적립금 > 할인가 입력 검증 추가 (`InvalidPricePolicyAccumulatedPointException`)
- [x] 운영 DB `ALTER TABLE price_policy ALTER COLUMN discount_rate TYPE numeric(4,1), ALTER COLUMN accumulation_rate TYPE numeric(4,1)` 마이그레이션 필요