### PR TITLE
[#128][#1357] fix: 상품 목록 조회 기능 가격정책 캐시 역직렬화 시 productId 누락으로 인한 500 오류 픽스

### DIFF
--- a/product-service/product-domain/src/main/java/com/personal/marketnote/product/domain/pricepolicy/PricePolicy.java
+++ b/product-service/product-domain/src/main/java/com/personal/marketnote/product/domain/pricepolicy/PricePolicy.java
@@ -21,6 +21,7 @@ import java.util.List;
 @Getter
 public class PricePolicy extends BaseDomain {
     private Long id;
+    private Long productId;
 
     @JsonIgnore
     private Product product;
@@ -38,6 +39,7 @@ public class PricePolicy extends BaseDomain {
     @JsonCreator
     private static PricePolicy jsonCreator(
             @JsonProperty("id") Long id,
+            @JsonProperty("productId") Long productId,
             @JsonProperty("price") Long price,
             @JsonProperty("discountPrice") Long discountPrice,
             @JsonProperty("discountRate") BigDecimal discountRate,
@@ -51,6 +53,7 @@ public class PricePolicy extends BaseDomain {
         return from(
                 PricePolicySnapshotState.builder()
                         .id(id)
+                        .productId(productId)
                         .price(price)
                         .discountPrice(discountPrice)
                         .discountRate(discountRate)
@@ -65,8 +68,12 @@ public class PricePolicy extends BaseDomain {
     }
 
     public static PricePolicy from(PricePolicyCreateState state) {
+        Product product = state.getProduct();
+        Long productId = FormatValidator.hasValue(product) ? product.getId() : null;
+
         return PricePolicy.builder()
-                .product(state.getProduct())
+                .productId(productId)
+                .product(product)
                 .price(state.getPrice())
                 .discountPrice(state.getDiscountPrice())
                 .discountRate(state.getDiscountRate())
@@ -79,9 +86,16 @@ public class PricePolicy extends BaseDomain {
     }
 
     public static PricePolicy from(PricePolicySnapshotState state) {
+        Product product = state.getProduct();
+        Long productId = state.getProductId();
+        if (FormatValidator.hasNoValue(productId) && FormatValidator.hasValue(product)) {
+            productId = product.getId();
+        }
+
         PricePolicy pricePolicy = PricePolicy.builder()
                 .id(state.getId())
-                .product(state.getProduct())
+                .productId(productId)
+                .product(product)
                 .price(state.getPrice())
                 .discountPrice(state.getDiscountPrice())
                 .discountRate(state.getDiscountRate())
@@ -103,10 +117,13 @@ public class PricePolicy extends BaseDomain {
 
     public void addProduct(Product product) {
         this.product = product;
+        if (FormatValidator.hasValue(product) && FormatValidator.hasNoValue(productId)) {
+            this.productId = product.getId();
+        }
     }
 
-    public Long getProductId() {
-        return product.getId();
+    public boolean hasProduct() {
+        return FormatValidator.hasValue(productId);
     }
 
     public void setOptionIds() {

--- a/product-service/product-domain/src/main/java/com/personal/marketnote/product/domain/pricepolicy/PricePolicySnapshotState.java
+++ b/product-service/product-domain/src/main/java/com/personal/marketnote/product/domain/pricepolicy/PricePolicySnapshotState.java
@@ -16,6 +16,7 @@ import java.util.List;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class PricePolicySnapshotState {
     private final Long id;
+    private final Long productId;
     private final Product product;
     private final Long price;
     private final Long discountPrice;


### PR DESCRIPTION
## partially addresses #128
## resolves #1357

## Task
- [x] `PricePolicy`에 `productId` 독립 필드 추가 + `@JsonCreator`에 `productId` 파라미터 포함하여 캐시 역직렬화 시 복원 보장
- [x] `PricePolicySnapshotState`에 `productId` 필드 추가
- [x] `from(PricePolicyCreateState)` — product에서 productId 추출하여 설정
- [x] `from(PricePolicySnapshotState)` — productId 우선, 없으면 product에서 추출
- [x] `addProduct()` — product 설정 시 productId도 동기화
- [x] `hasProduct()` — productId 기반 술어 메서드 추가 (Tell, Don't Ask)