### PR TITLE
[#43][#1332] feat: 닉네임 길이 및 허용 문자 정책 변경

### DIFF
--- a/common/src/main/java/com/personal/marketnote/common/utility/RegularExpressionConstant.java
+++ b/common/src/main/java/com/personal/marketnote/common/utility/RegularExpressionConstant.java
@@ -1,7 +1,7 @@
 package com.personal.marketnote.common.utility;
 
 public class RegularExpressionConstant {
-    public static final String NICKNAME_PATTERN = "^[가-힣]{1,6}$";
+    public static final String NICKNAME_PATTERN = "^[가-힣a-zA-Z0-9]{2,10}$";
     public static final String EMAIL_PATTERN = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$";
     public static final String PASSWORD_PATTERN = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{8,}$";
     public static final String FULL_NAME_PATTERN = "^[가-힣]{2,10}$";

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/user/request/SignUpRequest.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/user/request/SignUpRequest.java
@@ -40,7 +40,7 @@ public class SignUpRequest {
             description = "닉네임",
             requiredMode = Schema.RequiredMode.NOT_REQUIRED
     )
-    @Pattern(regexp = NICKNAME_PATTERN, message = "닉네임은 한글만 가능하며, 6글자 이하여야 합니다.")
+    @Pattern(regexp = NICKNAME_PATTERN, message = "닉네임은 한글, 영어 대소문자, 숫자만 가능하며, 2~10글자여야 합니다.")
     private String nickname;
 
     @Schema(

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/user/request/UpdateUserInfoRequest.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/user/request/UpdateUserInfoRequest.java
@@ -30,7 +30,7 @@ public class UpdateUserInfoRequest {
             description = "닉네임",
             requiredMode = Schema.RequiredMode.NOT_REQUIRED
     )
-    @Pattern(regexp = NICKNAME_PATTERN, message = "닉네임은 한글만 가능하며, 6글자 이하여야 합니다.")
+    @Pattern(regexp = NICKNAME_PATTERN, message = "닉네임은 한글, 영어 대소문자, 숫자만 가능하며, 2~10글자여야 합니다.")
     private String nickname;
 
     @Schema(


### PR DESCRIPTION
## partially addresses #43
## resolves #1332

## Task
- [x] `RegularExpressionConstant.NICKNAME_PATTERN` 정규식 변경: `^[가-힣]{1,6}$` → `^[가-힣a-zA-Z0-9]{2,10}$`
- [x] `SignUpRequest.nickname` 검증 메시지 변경
- [x] `UpdateUserInfoRequest.nickname` 검증 메시지 변경