### PR TITLE
[#128][#1368] test: 상품 목록 조회 기능 가격정책 캐시 역직렬화 시 productId 누락 픽스 자동화 테스트 추가

### DIFF
--- a/product-service/product-adapters/src/test/java/com/personal/marketnote/product/configuration/CacheConfigObjectMapperTest.java
+++ b/product-service/product-adapters/src/test/java/com/personal/marketnote/product/configuration/CacheConfigObjectMapperTest.java
@@ -31,10 +31,10 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 
 /**
  * CacheConfig ObjectMapper 직렬화/역직렬화 왕복 테스트
- *
+ * <p>
  * GenericJackson2JsonRedisSerializer는 역직렬화 시 Object.class로 읽으므로,
  * mapper.readValue(json, Object.class)로 테스트해야 실제 Redis 캐시 동작을 재현한다.
- *
+ * <p>
  * 근본 원인: stream().toList()가 반환하는 ImmutableCollections$ListN은 package-private 클래스로,
  * Jackson NON_FINAL defaultTyping에서 최상위 레벨 직렬화 시 타입 래퍼가 누락된다.
  * ArrayList는 공개 클래스이므로 ["java.util.ArrayList", [...]] 형태로 정상 직렬화된다.

--- a/product-service/product-application/src/test/java/com/personal/marketnote/product/service/product/GetProductUseCaseTest.java
+++ b/product-service/product-application/src/test/java/com/personal/marketnote/product/service/product/GetProductUseCaseTest.java
@@ -632,6 +632,38 @@ class GetProductUseCaseTest {
     }
 
     @Test
+    @DisplayName("캐시에서 복원된 가격 정책도 productId가 유지되어 정상 조회된다")
+    void getProducts_cachedPricePolicyWithProductId_worksCorrectly() {
+        stubProductImageExecutor();
+        Product product = buildProduct(10L, false);
+        PricePolicy cachedPolicy = buildPricePolicyWithProductIdOnly(100L, 10L);
+
+        when(findPricePoliciesPort.findPricePolicies(
+                any(), any(), any(), any(), any(), any()
+        )).thenReturn(List.of(cachedPolicy));
+        when(findProductPort.findById(10L)).thenReturn(Optional.of(product));
+        when(getProductInventoryUseCase.getProductStocks(List.of(100L)))
+                .thenReturn(Map.of(100L, 5));
+        when(findProductImagesPort.findImagesByProductIdAndSort(anyLong(), eq(FileSort.PRODUCT_CATALOG_IMAGE)))
+                .thenReturn(Optional.empty());
+        when(findProductReviewAggregatesPort.findByProductIds(List.of(10L)))
+                .thenReturn(Map.of());
+        when(findPricePoliciesPort.countActivePricePoliciesByCategoryId(
+                isNull(), eq(ProductSearchTarget.NAME), isNull()
+        )).thenReturn(1L);
+
+        GetProductsResult result = getProductService.getProducts(
+                null, null, null, 10,
+                Sort.Direction.DESC, ProductSortProperty.POPULARITY,
+                ProductSearchTarget.NAME, null
+        );
+
+        assertThat(result.products()).hasSize(1);
+        assertThat(result.products().getFirst().getId()).isEqualTo(10L);
+        assertThat(result.products().getFirst().getStock()).isEqualTo(5);
+    }
+
+    @Test
     @DisplayName("리뷰 집계 값이 없으면 평점과 리뷰 수를 0으로 반환한다")
     void getProducts_reviewAggregateNullValues_returnsZero() {
         stubProductImageExecutor();
@@ -720,6 +752,22 @@ class GetProductUseCaseTest {
                         .status(EntityStatus.ACTIVE)
                         .optionIds(optionIds)
                         .productOptions(productOptions)
+                        .build()
+        );
+    }
+
+    private PricePolicy buildPricePolicyWithProductIdOnly(Long id, Long productId) {
+        return PricePolicy.from(
+                PricePolicySnapshotState.builder()
+                        .id(id)
+                        .productId(productId)
+                        .product(null)
+                        .price(10000L)
+                        .discountPrice(9000L)
+                        .discountRate(BigDecimal.valueOf(10))
+                        .accumulatedPoint(100L)
+                        .accumulationRate(BigDecimal.valueOf(1))
+                        .status(EntityStatus.ACTIVE)
                         .build()
         );
     }


### PR DESCRIPTION
## partially addresses #128
## resolves #1368

## Test Case
- [x] 캐시에서 복원된 가격 정책도 productId가 유지되어 정상 조회된다