### PR TITLE
[#128][#1354] test: 가격정책 등록 API 입력 검증 누락 픽스 기능 자동화 테스트 추가

### DIFF
--- a/product-service/product-adapters/src/test/java/com/personal/marketnote/product/configuration/CacheConfigObjectMapperTest.java
+++ b/product-service/product-adapters/src/test/java/com/personal/marketnote/product/configuration/CacheConfigObjectMapperTest.java
@@ -31,10 +31,10 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 
 /**
  * CacheConfig ObjectMapper 직렬화/역직렬화 왕복 테스트
- * <p>
+ *
  * GenericJackson2JsonRedisSerializer는 역직렬화 시 Object.class로 읽으므로,
  * mapper.readValue(json, Object.class)로 테스트해야 실제 Redis 캐시 동작을 재현한다.
- * <p>
+ *
  * 근본 원인: stream().toList()가 반환하는 ImmutableCollections$ListN은 package-private 클래스로,
  * Jackson NON_FINAL defaultTyping에서 최상위 레벨 직렬화 시 타입 래퍼가 누락된다.
  * ArrayList는 공개 클래스이므로 ["java.util.ArrayList", [...]] 형태로 정상 직렬화된다.

--- a/product-service/product-application/src/test/java/com/personal/marketnote/product/service/pricepolicy/RegisterPricePolicyUseCaseTest.java
+++ b/product-service/product-application/src/test/java/com/personal/marketnote/product/service/pricepolicy/RegisterPricePolicyUseCaseTest.java
@@ -4,6 +4,7 @@ import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus
 import com.personal.marketnote.product.domain.pricepolicy.PricePolicy;
 import com.personal.marketnote.product.domain.product.Product;
 import com.personal.marketnote.product.domain.product.ProductSnapshotState;
+import com.personal.marketnote.product.exception.InvalidPricePolicyAccumulatedPointException;
 import com.personal.marketnote.product.exception.InvalidPricePolicyPriceException;
 import com.personal.marketnote.product.exception.NotProductOwnerException;
 import com.personal.marketnote.product.port.in.command.RegisterPricePolicyCommand;
@@ -291,6 +292,43 @@ class RegisterPricePolicyUseCaseTest {
 
         assertThat(saved.getDiscountRate()).isEqualByComparingTo(BigDecimal.ZERO);
         assertThat(saved.getAccumulationRate()).isEqualByComparingTo(BigDecimal.ZERO);
+    }
+
+    @Test
+    @DisplayName("적립금이 할인가와 같으면 적립률 100%로 정상 등록된다")
+    void registerPricePolicy_accumulatedPointEqualsDiscountPrice_registers100PercentRate() {
+        Long userId = 14L;
+        Long productId = 140L;
+        RegisterPricePolicyCommand command = RegisterPricePolicyCommand.of(productId, 10000L, 10000L, 10000L, List.of());
+        Product product = buildProduct(productId, userId);
+
+        when(findProductPort.existsByIdAndSellerId(productId, userId)).thenReturn(true);
+        when(getProductUseCase.getProduct(productId)).thenReturn(product);
+        when(savePricePolicyPort.save(any(PricePolicy.class))).thenReturn(800L);
+
+        registerPricePolicyService.registerPricePolicy(userId, false, command);
+
+        ArgumentCaptor<PricePolicy> captor = ArgumentCaptor.forClass(PricePolicy.class);
+        verify(savePricePolicyPort).save(captor.capture());
+        PricePolicy saved = captor.getValue();
+
+        assertThat(saved.getAccumulationRate()).isEqualByComparingTo(new BigDecimal("100.0"));
+    }
+
+    @Test
+    @DisplayName("적립금이 할인가를 초과하면 InvalidPricePolicyAccumulatedPointException 예외를 던진다")
+    void registerPricePolicy_accumulatedPointExceedsDiscountPrice_throws() {
+        Long userId = 15L;
+        Long productId = 150L;
+        RegisterPricePolicyCommand command = RegisterPricePolicyCommand.of(productId, 10000L, 1000L, 2000L, List.of());
+
+        when(findProductPort.existsByIdAndSellerId(productId, userId)).thenReturn(true);
+
+        assertThatThrownBy(() -> registerPricePolicyService.registerPricePolicy(userId, false, command))
+                .isInstanceOf(InvalidPricePolicyAccumulatedPointException.class)
+                .hasMessageContaining("적립금이 현재 판매가를 초과할 수 없습니다");
+
+        verifyNoInteractions(getProductUseCase, savePricePolicyPort, updateOptionPricePolicyPort, publishProductEventPort, registerInventoryPort);
     }
 
     @Test


### PR DESCRIPTION
## partially addresses #128
## resolves #1354

## Test Case
- [x] 적립금이 할인가와 같으면 적립률 100%로 정상 등록된다
- [x] 적립금이 할인가를 초과하면 InvalidPricePolicyAccumulatedPointException 예외를 던진다