### PR TITLE
[#194][#1316] feat: 상품 상세 정보 상단 대표 이미지 업로드 시 최대 8개 제한 기능 추가

### DIFF
--- a/common/src/main/java/com/personal/marketnote/common/domain/file/FileSort.java
+++ b/common/src/main/java/com/personal/marketnote/common/domain/file/FileSort.java
@@ -9,18 +9,19 @@ import java.util.Arrays;
 @RequiredArgsConstructor
 @Getter
 public enum FileSort {
-    PRODUCT_CATALOG_IMAGE("상품 카탈로그 이미지"),
-    PRODUCT_REPRESENTATIVE_IMAGE("상품 대표 이미지"),
-    PRODUCT_CONTENT_IMAGE("상품 본문 이미지"),
-    CANCEL_REASON_IMAGE("취소 사유 이미지"),
-    EXCHANGE_REASON_IMAGE("교환 사유 이미지"),
-    REFUND_REASON_IMAGE("환불 사유 이미지"),
-    POST_IMAGE("게시글 이미지"),
-    REVIEW_IMAGE("리뷰 이미지"),
-    ICON("아이콘"),
-    ETC("기타");
+    PRODUCT_CATALOG_IMAGE("상품 카탈로그 이미지", 1),
+    PRODUCT_REPRESENTATIVE_IMAGE("상품 대표 이미지", 8),
+    PRODUCT_CONTENT_IMAGE("상품 본문 이미지", 5),
+    CANCEL_REASON_IMAGE("취소 사유 이미지", Integer.MAX_VALUE),
+    EXCHANGE_REASON_IMAGE("교환 사유 이미지", Integer.MAX_VALUE),
+    REFUND_REASON_IMAGE("환불 사유 이미지", Integer.MAX_VALUE),
+    POST_IMAGE("게시글 이미지", Integer.MAX_VALUE),
+    REVIEW_IMAGE("리뷰 이미지", Integer.MAX_VALUE),
+    ICON("아이콘", Integer.MAX_VALUE),
+    ETC("기타", Integer.MAX_VALUE);
 
     private final String description;
+    private final int maxCount;
 
     public static FileSort from(String targetValue) throws IllegalArgumentException {
         return Arrays.stream(FileSort.values())

--- a/file-service/file-adapters/src/main/java/com/personal/marketnote/file/adapter/out/persistence/file/FilePersistenceAdapter.java
+++ b/file-service/file-adapters/src/main/java/com/personal/marketnote/file/adapter/out/persistence/file/FilePersistenceAdapter.java
@@ -17,6 +17,7 @@ import com.personal.marketnote.file.port.out.file.SaveFilesPort;
 import com.personal.marketnote.file.port.out.file.UpdateFilePort;
 import com.personal.marketnote.file.port.out.file.UpdateFilesPort;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -75,15 +76,9 @@ public class FilePersistenceAdapter implements SaveFilesPort, FindFilePort, Upda
     }
 
     private List<FileJpaEntity> getEntities(OwnerType ownerType, Long ownerId, FileSort sort) {
-        String sortName = sort.name();
-        if (sort.isCatalogImage()) {
-            return fileJpaRepository.findTop1ByOwnerTypeAndOwnerIdAndSortOrderByOrderNumDesc(
-                    ownerType, ownerId, sortName
-            );
-        }
-
-        return fileJpaRepository.findTop5ByOwnerTypeAndOwnerIdAndSortOrderByOrderNumDesc(
-                ownerType, ownerId, sortName
+        return fileJpaRepository.findByOwnerTypeAndOwnerIdAndSort(
+                ownerType, ownerId, sort.name(),
+                PageRequest.of(0, sort.getMaxCount())
         );
     }
 

--- a/file-service/file-adapters/src/main/java/com/personal/marketnote/file/adapter/out/persistence/file/repository/FileJpaRepository.java
+++ b/file-service/file-adapters/src/main/java/com/personal/marketnote/file/adapter/out/persistence/file/repository/FileJpaRepository.java
@@ -2,6 +2,7 @@ package com.personal.marketnote.file.adapter.out.persistence.file.repository;
 
 import com.personal.marketnote.common.domain.file.OwnerType;
 import com.personal.marketnote.file.adapter.out.persistence.file.entity.FileJpaEntity;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -31,25 +32,11 @@ public interface FileJpaRepository extends JpaRepository<FileJpaEntity, Long> {
               AND f.status = 'ACTIVE'
             ORDER BY f.orderNum DESC
             """)
-    List<FileJpaEntity> findTop1ByOwnerTypeAndOwnerIdAndSortOrderByOrderNumDesc(
+    List<FileJpaEntity> findByOwnerTypeAndOwnerIdAndSort(
             @Param("ownerType") OwnerType ownerType,
             @Param("ownerId") Long ownerId,
-            @Param("sort") String sort
-    );
-
-    @Query("""
-            SELECT f
-            FROM FileJpaEntity f
-            WHERE f.ownerType = :ownerType
-              AND f.ownerId = :ownerId
-              AND f.sort = :sort
-              AND f.status = 'ACTIVE'
-            ORDER BY f.orderNum DESC
-            """)
-    List<FileJpaEntity> findTop5ByOwnerTypeAndOwnerIdAndSortOrderByOrderNumDesc(
-            @Param("ownerType") OwnerType ownerType,
-            @Param("ownerId") Long ownerId,
-            @Param("sort") String sort
+            @Param("sort") String sort,
+            Pageable pageable
     );
 
     @Query("""

--- a/file-service/file-application/src/main/java/com/personal/marketnote/file/exception/InvalidFileCountLimitException.java
+++ b/file-service/file-application/src/main/java/com/personal/marketnote/file/exception/InvalidFileCountLimitException.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.file.exception;
+
+public class InvalidFileCountLimitException extends IllegalArgumentException {
+    private static final String MESSAGE = "파일 업로드 최대 개수를 초과했습니다. 최대: %d, 요청: %d";
+
+    public InvalidFileCountLimitException(int maxCount, int requestedCount) {
+        super(String.format(MESSAGE, maxCount, requestedCount));
+    }
+}

--- a/file-service/file-application/src/main/java/com/personal/marketnote/file/service/file/UpdateFilesService.java
+++ b/file-service/file-application/src/main/java/com/personal/marketnote/file/service/file/UpdateFilesService.java
@@ -6,6 +6,7 @@ import com.personal.marketnote.common.domain.file.OwnerType;
 import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.file.domain.file.FileDomain;
 import com.personal.marketnote.file.domain.file.ResizedFile;
+import com.personal.marketnote.file.exception.InvalidFileCountLimitException;
 import com.personal.marketnote.file.mapper.FileCommandToDomainMapper;
 import com.personal.marketnote.file.port.in.command.UpdateFileCommand;
 import com.personal.marketnote.file.port.in.command.UpdateFilesCommand;
@@ -48,6 +49,13 @@ public class UpdateFilesService implements UpdateFileUseCase {
         String ownerType = updateFilesCommand.ownerType();
         Long ownerId = updateFilesCommand.ownerId();
         String sort = updateFilesCommand.fileInfo().getFirst().sort();
+
+        FileSort fileSort = FileSort.from(sort);
+        int maxCount = fileSort.getMaxCount();
+        int requestedCount = updateFilesCommand.fileInfo().size();
+        if (requestedCount > maxCount) {
+            throw new InvalidFileCountLimitException(maxCount, requestedCount);
+        }
 
         // 기존 파일 목록이 존재하는 경우 비활성화
         List<FileDomain> currentFiles = getFileUseCase.getFiles(OwnerType.from(ownerType), ownerId, sort);

--- a/product-service/product-adapters/src/test/java/com/personal/marketnote/product/configuration/CacheConfigObjectMapperTest.java
+++ b/product-service/product-adapters/src/test/java/com/personal/marketnote/product/configuration/CacheConfigObjectMapperTest.java
@@ -31,10 +31,10 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 
 /**
  * CacheConfig ObjectMapper 직렬화/역직렬화 왕복 테스트
- *
+ * <p>
  * GenericJackson2JsonRedisSerializer는 역직렬화 시 Object.class로 읽으므로,
  * mapper.readValue(json, Object.class)로 테스트해야 실제 Redis 캐시 동작을 재현한다.
- *
+ * <p>
  * 근본 원인: stream().toList()가 반환하는 ImmutableCollections$ListN은 package-private 클래스로,
  * Jackson NON_FINAL defaultTyping에서 최상위 레벨 직렬화 시 타입 래퍼가 누락된다.
  * ArrayList는 공개 클래스이므로 ["java.util.ArrayList", [...]] 형태로 정상 직렬화된다.


### PR DESCRIPTION
## partially addresses #194
## resolves #1316

## Task
- [x] FileSort enum에 maxCount 필드 추가 (CATALOG=1, REPRESENTATIVE=8, CONTENT=5)
- [x] InvalidFileCountLimitException 커스텀 예외 추가
- [x] UpdateFilesService에 업로드 개수 검증 추가 (S3 업로드 전 early validation)
- [x] FileJpaRepository findTop1/findTop5 → Pageable 기반 단일 메서드로 통합
- [x] FilePersistenceAdapter getEntities() 간소화