### PR TITLE
[#128][#1363] feat: 상품 목록 조회 시 캐시 적립률 높은순 정렬 기능 추가

### DIFF
--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/product/controller/apidocs/GetProductsApiDocs.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/product/controller/apidocs/GetProductsApiDocs.java
@@ -51,7 +51,7 @@ import java.lang.annotation.*;
                 | cursor | number | 이전 페이지의 nextCursor 값, 전송하지 않는 경우 첫 데이터부터 조회 | N | 1 |
                 | page-size | number | 페이지 크기 | N | 4 |
                 | sortDirection | string | 정렬 방향(ASC, DESC) | N | DESC |
-                | sortProperty | string | 정렬 속성(ORDER_NUM, POPULARITY, DISCOUNT_PRICE, ACCUMULATED_POINT) | N | ORDER_NUM |
+                | sortProperty | string | 정렬 속성(ORDER_NUM, POPULARITY, DISCOUNT_PRICE, ACCUMULATED_POINT, ACCUMULATED_POINT_RATE) | N | ORDER_NUM |
                 | searchTarget | string | 검색 대상(NAME, BRAND_NAME) | N | NAME |
                 | searchKeyword | string | 검색 키워드 | N | "노트왕" |
                 
@@ -197,7 +197,7 @@ import java.lang.annotation.*;
                         schema = @Schema(
                                 type = "string",
                                 example = "ORDER_NUM",
-                                allowableValues = {"ORDER_NUM", "POPULARITY", "DISCOUNT_PRICE", "ACCUMULATED_POINT"},
+                                allowableValues = {"ORDER_NUM", "POPULARITY", "DISCOUNT_PRICE", "ACCUMULATED_POINT", "ACCUMULATED_POINT_RATE"},
                                 defaultValue = "ORDER_NUM"
                         )
                 ),

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/product/repository/ProductJpaRepository.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/product/repository/ProductJpaRepository.java
@@ -113,6 +113,19 @@ public interface ProductJpaRepository extends JpaRepository<ProductJpaEntity, Lo
                                 )
                                AND pp.id > :cursor)
                         ))
+                     OR (:sortProperty = 'accumulatedPointRate' AND (
+                              COALESCE(pp.accumulationRate, 0) > (
+                                  SELECT COALESCE(pp6.accumulationRate, 0)
+                                  FROM PricePolicyJpaEntity pp6
+                                  WHERE pp6.id = :cursor
+                              )
+                           OR (COALESCE(pp.accumulationRate, 0) = (
+                                    SELECT COALESCE(pp6.accumulationRate, 0)
+                                    FROM PricePolicyJpaEntity pp6
+                                    WHERE pp6.id = :cursor
+                                )
+                               AND pp.id > :cursor)
+                        ))
                  )
               )
             ORDER BY
@@ -120,6 +133,7 @@ public interface ProductJpaRepository extends JpaRepository<ProductJpaEntity, Lo
                 CASE WHEN :sortProperty = 'popularity' THEN p.sales END ASC,
                 CASE WHEN :sortProperty = 'discountPrice' THEN COALESCE(pp.discountPrice, 0) END ASC,
                 CASE WHEN :sortProperty = 'accumulatedPoint' THEN COALESCE(pp.accumulatedPoint, 0) END ASC,
+                CASE WHEN :sortProperty = 'accumulatedPointRate' THEN COALESCE(pp.accumulationRate, 0) END ASC,
                 p.id ASC
             """)
     List<ProductJpaEntity> findAllActiveByCursorAsc(
@@ -216,6 +230,19 @@ public interface ProductJpaRepository extends JpaRepository<ProductJpaEntity, Lo
                                 )
                                AND pp.id < :cursor)
                         ))
+                     OR (:sortProperty = 'accumulatedPointRate' AND (
+                              COALESCE(pp.accumulationRate, 0) < (
+                                  SELECT COALESCE(pp6.accumulationRate, 0)
+                                  FROM PricePolicyJpaEntity pp6
+                                  WHERE pp6.id = :cursor
+                              )
+                           OR (COALESCE(pp.accumulationRate, 0) = (
+                                    SELECT COALESCE(pp6.accumulationRate, 0)
+                                    FROM PricePolicyJpaEntity pp6
+                                    WHERE pp6.id = :cursor
+                                )
+                               AND pp.id < :cursor)
+                        ))
                  )
               )
             ORDER BY
@@ -223,6 +250,7 @@ public interface ProductJpaRepository extends JpaRepository<ProductJpaEntity, Lo
                 CASE WHEN :sortProperty = 'popularity' THEN p.sales END DESC,
                 CASE WHEN :sortProperty = 'discountPrice' THEN COALESCE(pp.discountPrice, 0) END DESC,
                 CASE WHEN :sortProperty = 'accumulatedPoint' THEN COALESCE(pp.accumulatedPoint, 0) END DESC,
+                CASE WHEN :sortProperty = 'accumulatedPointRate' THEN COALESCE(pp.accumulationRate, 0) END DESC,
                 p.id DESC
             """)
     List<ProductJpaEntity> findAllActiveByCursorDesc(
@@ -326,6 +354,19 @@ public interface ProductJpaRepository extends JpaRepository<ProductJpaEntity, Lo
                                 )
                                AND pp.id > :cursor)
                         ))
+                     OR (:sortProperty = 'accumulatedPointRate' AND (
+                              COALESCE(pp.accumulationRate, 0) > (
+                                  SELECT COALESCE(pp6.accumulationRate, 0)
+                                  FROM PricePolicyJpaEntity pp6
+                                  WHERE pp6.id = :cursor
+                              )
+                           OR (COALESCE(pp.accumulationRate, 0) = (
+                                    SELECT COALESCE(pp6.accumulationRate, 0)
+                                    FROM PricePolicyJpaEntity pp6
+                                    WHERE pp6.id = :cursor
+                                )
+                               AND pp.id > :cursor)
+                        ))
                  )
               )
             ORDER BY
@@ -333,6 +374,7 @@ public interface ProductJpaRepository extends JpaRepository<ProductJpaEntity, Lo
                 CASE WHEN :sortProperty = 'popularity' THEN p.sales END ASC,
                 CASE WHEN :sortProperty = 'discountPrice' THEN COALESCE(pp.discountPrice, 0) END ASC,
                 CASE WHEN :sortProperty = 'accumulatedPoint' THEN COALESCE(pp.accumulatedPoint, 0) END ASC,
+                CASE WHEN :sortProperty = 'accumulatedPointRate' THEN COALESCE(pp.accumulationRate, 0) END ASC,
                 p.id ASC
             """)
     List<ProductJpaEntity> findAllActiveByCategoryIdCursorAsc(
@@ -437,6 +479,19 @@ public interface ProductJpaRepository extends JpaRepository<ProductJpaEntity, Lo
                                 )
                                AND pp.id < :cursor)
                         ))
+                     OR (:sortProperty = 'accumulatedPointRate' AND (
+                              COALESCE(pp.accumulationRate, 0) < (
+                                  SELECT COALESCE(pp6.accumulationRate, 0)
+                                  FROM PricePolicyJpaEntity pp6
+                                  WHERE pp6.id = :cursor
+                              )
+                           OR (COALESCE(pp.accumulationRate, 0) = (
+                                    SELECT COALESCE(pp6.accumulationRate, 0)
+                                    FROM PricePolicyJpaEntity pp6
+                                    WHERE pp6.id = :cursor
+                                )
+                               AND pp.id < :cursor)
+                        ))
                  )
               )
             ORDER BY
@@ -444,6 +499,7 @@ public interface ProductJpaRepository extends JpaRepository<ProductJpaEntity, Lo
                 CASE WHEN :sortProperty = 'popularity' THEN p.sales END DESC,
                 CASE WHEN :sortProperty = 'discountPrice' THEN COALESCE(pp.discountPrice, 0) END DESC,
                 CASE WHEN :sortProperty = 'accumulatedPoint' THEN COALESCE(pp.accumulatedPoint, 0) END DESC,
+                CASE WHEN :sortProperty = 'accumulatedPointRate' THEN COALESCE(pp.accumulationRate, 0) END DESC,
                 p.id DESC
             """)
     List<ProductJpaEntity> findAllActiveByCategoryIdCursorDesc(

--- a/product-service/product-domain/src/main/java/com/personal/marketnote/product/domain/product/ProductSortProperty.java
+++ b/product-service/product-domain/src/main/java/com/personal/marketnote/product/domain/product/ProductSortProperty.java
@@ -8,6 +8,7 @@ public enum ProductSortProperty {
     ORDER_NUM("정렬 순서"),
     POPULARITY("인기도"),
     ACCUMULATED_POINT("적립금"),
+    ACCUMULATED_POINT_RATE("적립률"),
     DISCOUNT_PRICE("할인 가격");
 
     private final String description;


### PR DESCRIPTION
## partially addresses #128
## resolves #1363

## Task
- [x] `ProductSortProperty` enum에 `ACCUMULATED_POINT_RATE`(캐시 적립률) 정렬 기준 추가
- [x] 적립률 계산 로직 구현: `적립률(%) = (적립 캐시 / 상품 판매가) x 100`
- [x] 적립률 기준 내림차순 정렬 쿼리 구현 (동일 적립률 시 최신 등록순)