### PR TITLE
[#128][#1307] feat: 판매자 배송비 정책 도메인 모델 및 엔티티 추가

### DIFF
--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/mapper/ShippingPolicyJpaEntityToDomainMapper.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/mapper/ShippingPolicyJpaEntityToDomainMapper.java
@@ -1,0 +1,29 @@
+package com.personal.marketnote.product.adapter.out.mapper;
+
+import com.personal.marketnote.product.adapter.out.persistence.shipping.entity.ShippingPolicyJpaEntity;
+import com.personal.marketnote.product.domain.shipping.ShippingPolicy;
+import com.personal.marketnote.product.domain.shipping.ShippingPolicySnapshotState;
+
+import java.util.Optional;
+
+public class ShippingPolicyJpaEntityToDomainMapper {
+
+    private ShippingPolicyJpaEntityToDomainMapper() {
+    }
+
+    public static Optional<ShippingPolicy> mapToDomain(ShippingPolicyJpaEntity entity) {
+        return Optional.ofNullable(entity)
+                .map(e -> ShippingPolicy.from(
+                        ShippingPolicySnapshotState.builder()
+                                .id(e.getId())
+                                .sellerId(e.getSellerId())
+                                .deliveryCompany(e.getDeliveryCompany())
+                                .shippingFee(e.getShippingFee())
+                                .freeShippingThreshold(e.getFreeShippingThreshold())
+                                .status(e.getStatus())
+                                .createdAt(e.getCreatedAt())
+                                .modifiedAt(e.getModifiedAt())
+                                .build()
+                ));
+    }
+}

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/shipping/entity/ShippingPolicyJpaEntity.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/shipping/entity/ShippingPolicyJpaEntity.java
@@ -1,0 +1,53 @@
+package com.personal.marketnote.product.adapter.out.persistence.shipping.entity;
+
+import com.personal.marketnote.common.adapter.out.persistence.audit.BaseGeneralEntity;
+import com.personal.marketnote.product.domain.shipping.ShippingPolicy;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.DynamicInsert;
+
+@Entity
+@Table(name = "shipping_policy", indexes = {
+        @Index(name = "idx_shipping_policy_seller_id", columnList = "seller_id", unique = true)
+})
+@DynamicInsert
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+@Getter
+public class ShippingPolicyJpaEntity extends BaseGeneralEntity {
+
+    @Column(name = "seller_id", nullable = false)
+    private Long sellerId;
+
+    @Column(name = "delivery_company", nullable = false, length = 50)
+    private String deliveryCompany;
+
+    @Column(name = "shipping_fee", nullable = false)
+    private Long shippingFee;
+
+    @Column(name = "free_shipping_threshold", nullable = false)
+    private Long freeShippingThreshold;
+
+    public static ShippingPolicyJpaEntity from(ShippingPolicy policy) {
+        return ShippingPolicyJpaEntity.builder()
+                .sellerId(policy.getSellerId())
+                .deliveryCompany(policy.getDeliveryCompany())
+                .shippingFee(policy.getShippingFee())
+                .freeShippingThreshold(policy.getFreeShippingThreshold())
+                .build();
+    }
+
+    public void updateFrom(ShippingPolicy policy) {
+        this.deliveryCompany = policy.getDeliveryCompany();
+        this.shippingFee = policy.getShippingFee();
+        this.freeShippingThreshold = policy.getFreeShippingThreshold();
+    }
+}

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/shipping/repository/ShippingPolicyJpaRepository.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/shipping/repository/ShippingPolicyJpaRepository.java
@@ -1,0 +1,15 @@
+package com.personal.marketnote.product.adapter.out.persistence.shipping.repository;
+
+import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.product.adapter.out.persistence.shipping.entity.ShippingPolicyJpaEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ShippingPolicyJpaRepository extends JpaRepository<ShippingPolicyJpaEntity, Long> {
+
+    Optional<ShippingPolicyJpaEntity> findBySellerIdAndStatus(Long sellerId, EntityStatus status);
+
+    List<ShippingPolicyJpaEntity> findAllBySellerIdInAndStatus(List<Long> sellerIds, EntityStatus status);
+}

--- a/product-service/product-domain/src/main/java/com/personal/marketnote/product/domain/shipping/InvalidFreeShippingThresholdException.java
+++ b/product-service/product-domain/src/main/java/com/personal/marketnote/product/domain/shipping/InvalidFreeShippingThresholdException.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.product.domain.shipping;
+
+public class InvalidFreeShippingThresholdException extends IllegalArgumentException {
+    private static final String MESSAGE = "ERR_SHIPPING_POLICY_02::무료배송 기준금액이 유효하지 않습니다. %s";
+
+    public InvalidFreeShippingThresholdException(String detail) {
+        super(String.format(MESSAGE, detail));
+    }
+}

--- a/product-service/product-domain/src/main/java/com/personal/marketnote/product/domain/shipping/InvalidShippingFeeException.java
+++ b/product-service/product-domain/src/main/java/com/personal/marketnote/product/domain/shipping/InvalidShippingFeeException.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.product.domain.shipping;
+
+public class InvalidShippingFeeException extends IllegalArgumentException {
+    private static final String MESSAGE = "ERR_SHIPPING_POLICY_01::배송비가 유효하지 않습니다. %s";
+
+    public InvalidShippingFeeException(String detail) {
+        super(String.format(MESSAGE, detail));
+    }
+}

--- a/product-service/product-domain/src/main/java/com/personal/marketnote/product/domain/shipping/ShippingPolicy.java
+++ b/product-service/product-domain/src/main/java/com/personal/marketnote/product/domain/shipping/ShippingPolicy.java
@@ -1,0 +1,89 @@
+package com.personal.marketnote.product.domain.shipping;
+
+import com.personal.marketnote.common.domain.BaseDomain;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+@Getter
+public class ShippingPolicy extends BaseDomain {
+    private Long id;
+    private Long sellerId;
+    private String deliveryCompany;
+    private Long shippingFee;
+    private Long freeShippingThreshold;
+    private LocalDateTime createdAt;
+    private LocalDateTime modifiedAt;
+
+    public static ShippingPolicy from(ShippingPolicyCreateState state) {
+        validateShippingFee(state.getShippingFee());
+        validateFreeShippingThreshold(state.getFreeShippingThreshold());
+
+        ShippingPolicy policy = ShippingPolicy.builder()
+                .sellerId(state.getSellerId())
+                .deliveryCompany(state.getDeliveryCompany())
+                .shippingFee(state.getShippingFee())
+                .freeShippingThreshold(state.getFreeShippingThreshold())
+                .build();
+        policy.activate();
+        return policy;
+    }
+
+    public static ShippingPolicy from(ShippingPolicySnapshotState state) {
+        ShippingPolicy policy = ShippingPolicy.builder()
+                .id(state.getId())
+                .sellerId(state.getSellerId())
+                .deliveryCompany(state.getDeliveryCompany())
+                .shippingFee(state.getShippingFee())
+                .freeShippingThreshold(state.getFreeShippingThreshold())
+                .createdAt(state.getCreatedAt())
+                .modifiedAt(state.getModifiedAt())
+                .build();
+        policy.status = state.getStatus();
+        return policy;
+    }
+
+    public void update(String deliveryCompany, Long shippingFee, Long freeShippingThreshold) {
+        validateShippingFee(shippingFee);
+        validateFreeShippingThreshold(freeShippingThreshold);
+
+        this.deliveryCompany = deliveryCompany;
+        this.shippingFee = shippingFee;
+        this.freeShippingThreshold = freeShippingThreshold;
+    }
+
+    @Override
+    public void deactivate() {
+        super.deactivate();
+    }
+
+    public boolean isFreeShipping(long orderAmount) {
+        return orderAmount >= freeShippingThreshold;
+    }
+
+    public long calculateShippingFee(long orderAmount) {
+        if (isFreeShipping(orderAmount)) {
+            return 0L;
+        }
+        return shippingFee;
+    }
+
+    private static void validateShippingFee(Long shippingFee) {
+        if (shippingFee < 0) {
+            throw new InvalidShippingFeeException("배송비는 0 이상이어야 합니다. 입력값=" + shippingFee);
+        }
+    }
+
+    private static void validateFreeShippingThreshold(Long freeShippingThreshold) {
+        if (freeShippingThreshold < 0) {
+            throw new InvalidFreeShippingThresholdException("무료배송 기준금액은 0 이상이어야 합니다. 입력값=" + freeShippingThreshold);
+        }
+    }
+}

--- a/product-service/product-domain/src/main/java/com/personal/marketnote/product/domain/shipping/ShippingPolicyCreateState.java
+++ b/product-service/product-domain/src/main/java/com/personal/marketnote/product/domain/shipping/ShippingPolicyCreateState.java
@@ -1,0 +1,18 @@
+package com.personal.marketnote.product.domain.shipping;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+@Getter
+public class ShippingPolicyCreateState {
+    private Long sellerId;
+    private String deliveryCompany;
+    private Long shippingFee;
+    private Long freeShippingThreshold;
+}

--- a/product-service/product-domain/src/main/java/com/personal/marketnote/product/domain/shipping/ShippingPolicySnapshotState.java
+++ b/product-service/product-domain/src/main/java/com/personal/marketnote/product/domain/shipping/ShippingPolicySnapshotState.java
@@ -1,0 +1,25 @@
+package com.personal.marketnote.product.domain.shipping;
+
+import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+@Getter
+public class ShippingPolicySnapshotState {
+    private Long id;
+    private Long sellerId;
+    private String deliveryCompany;
+    private Long shippingFee;
+    private Long freeShippingThreshold;
+    private EntityStatus status;
+    private LocalDateTime createdAt;
+    private LocalDateTime modifiedAt;
+}


### PR DESCRIPTION
## partially addresses #128
## resolves #1307

## Task
- [x] ShippingPolicy 도메인 모델 추가 (BaseDomain 상속, 팩토리 메서드, 배송비 계산 로직)
- [x] ShippingPolicyCreateState / ShippingPolicySnapshotState 추가
- [x] InvalidShippingFeeException / InvalidFreeShippingThresholdException 도메인 예외 추가
- [x] ShippingPolicyJpaEntity 추가 (BaseGeneralEntity 상속, seller_id UNIQUE 인덱스)
- [x] ShippingPolicyJpaRepository 추가
- [x] ShippingPolicyJpaEntityToDomainMapper 추가