### PR TITLE
[#128][#1308] feat: 판매자 배송비 정책 등록 기능 추가

### DIFF
--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/shipping/controller/ShippingPolicyController.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/shipping/controller/ShippingPolicyController.java
@@ -1,0 +1,82 @@
+package com.personal.marketnote.product.adapter.in.web.shipping.controller;
+
+import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
+import com.personal.marketnote.common.utility.ElementExtractor;
+import com.personal.marketnote.product.adapter.in.web.shipping.controller.apidocs.RegisterShippingPolicyApiDocs;
+import com.personal.marketnote.product.adapter.in.web.shipping.request.RegisterShippingPolicyRequest;
+import com.personal.marketnote.product.adapter.in.web.shipping.response.RegisterShippingPolicyResponse;
+import com.personal.marketnote.product.port.in.command.RegisterShippingPolicyCommand;
+import com.personal.marketnote.product.port.in.result.shipping.RegisterShippingPolicyResult;
+import com.personal.marketnote.product.port.in.usecase.shipping.RegisterShippingPolicyUseCase;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.core.OAuth2AuthenticatedPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static com.personal.marketnote.common.domain.exception.ExceptionCode.DEFAULT_SUCCESS_CODE;
+import static com.personal.marketnote.common.utility.ApiConstant.ADMIN_OR_SELLER_POINTCUT;
+
+/**
+ * 배송비 정책 컨트롤러
+ *
+ * @Author 성효빈
+ * @Date 2026-03-17
+ * @Description 판매자 배송비 정책 관련 API를 제공합니다.
+ */
+@RestController
+@RequestMapping("/api/v1/shipping-policies")
+@Tag(name = "배송비 정책 API", description = "판매자 배송비 정책 관련 API")
+@RequiredArgsConstructor
+@Slf4j
+public class ShippingPolicyController {
+
+    private final RegisterShippingPolicyUseCase registerShippingPolicyUseCase;
+
+    /**
+     * (판매자/관리자) 배송비 정책 등록
+     *
+     * @param request   배송비 정책 등록 요청
+     * @param principal 인증된 사용자 정보
+     * @return 배송비 정책 등록 응답 {@link RegisterShippingPolicyResponse}
+     * @Author 성효빈
+     * @Date 2026-03-17
+     * @Description 판매자의 배송비 정책을 등록합니다.
+     */
+    @PostMapping
+    @PreAuthorize(ADMIN_OR_SELLER_POINTCUT)
+    @RegisterShippingPolicyApiDocs
+    public ResponseEntity<BaseResponse<RegisterShippingPolicyResponse>> registerShippingPolicy(
+            @Valid @RequestBody RegisterShippingPolicyRequest request,
+            @AuthenticationPrincipal OAuth2AuthenticatedPrincipal principal
+    ) {
+        Long sellerId = ElementExtractor.extractUserId(principal);
+
+        RegisterShippingPolicyResult result = registerShippingPolicyUseCase.registerShippingPolicy(
+                sellerId,
+                new RegisterShippingPolicyCommand(
+                        request.deliveryCompany(),
+                        request.shippingFee(),
+                        request.freeShippingThreshold()
+                )
+        );
+
+        return new ResponseEntity<>(
+                BaseResponse.of(
+                        RegisterShippingPolicyResponse.from(result),
+                        HttpStatus.CREATED,
+                        DEFAULT_SUCCESS_CODE,
+                        "판매자 배송비 정책 등록 성공"
+                ),
+                HttpStatus.CREATED
+        );
+    }
+}

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/shipping/controller/apidocs/RegisterShippingPolicyApiDocs.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/shipping/controller/apidocs/RegisterShippingPolicyApiDocs.java
@@ -1,0 +1,129 @@
+package com.personal.marketnote.product.adapter.in.web.shipping.controller.apidocs;
+
+import com.personal.marketnote.common.adapter.in.api.schema.StringResponseSchema;
+import com.personal.marketnote.product.adapter.in.web.shipping.request.RegisterShippingPolicyRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Operation(
+        summary = "(판매자/관리자) 배송비 정책 등록",
+        description = """
+                작성일자: 2026-03-17
+
+                작성자: 성효빈
+
+                ---
+
+                ## Description
+
+                - 판매자의 배송비 정책을 등록합니다.
+
+                - 판매자 1명당 배송비 정책은 1개만 등록할 수 있습니다.
+
+                - 판매자 본인 또는 관리자만 가능합니다.
+
+                ---
+
+                ## Request
+
+                | **키** | **타입** | **설명** | **필수 여부** | **예시** |
+                | --- | --- | --- | --- | --- |
+                | deliveryCompany | string | 배송업체 | Y | "한진택배" |
+                | shippingFee | number | 배송비 | Y | 3000 |
+                | freeShippingThreshold | number | 무료배송 기준금액 | Y | 20000 |
+
+                ---
+
+                ## Response
+
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | statusCode | number | 상태 코드 | 201: 성공 / 400: 클라이언트 요청 오류 / 401: 인증 실패 / 403: 인가 실패 / 409: 충돌 / 500: 그 외 |
+                | code | string | 응답 코드 | "SUC01" / "BAD_REQUEST" / "UNAUTHORIZED" / "FORBIDDEN" / "CONFLICT" / "INTERNAL_SERVER_ERROR" |
+                | timestamp | string(datetime) | 응답 일시 | "2026-03-17T10:00:00.000" |
+                | content | object | 응답 본문 | { ... } |
+                | message | string | 처리 결과 | "판매자 배송비 정책 등록 성공" |
+
+                ### Response > content
+
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | id | number | 배송비 정책 ID | 1 |
+                """,
+        security = {@SecurityRequirement(name = "bearer")},
+        requestBody = @RequestBody(
+                required = true,
+                content = @Content(
+                        schema = @Schema(implementation = RegisterShippingPolicyRequest.class),
+                        examples = @ExampleObject("""
+                                {
+                                  "deliveryCompany": "한진택배",
+                                  "shippingFee": 3000,
+                                  "freeShippingThreshold": 20000
+                                }
+                                """)
+                )
+        ),
+        responses = {
+                @ApiResponse(
+                        responseCode = "201",
+                        description = "등록 성공",
+                        content = @Content(
+                                schema = @Schema(implementation = StringResponseSchema.class),
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 201,
+                                          "code": "SUC01",
+                                          "timestamp": "2026-03-17T10:00:00.000",
+                                          "content": {
+                                            "id": 1
+                                          },
+                                          "message": "판매자 배송비 정책 등록 성공"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "401",
+                        description = "토큰 인증 실패",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 401,
+                                          "code": "UNAUTHORIZED",
+                                          "timestamp": "2026-03-17T10:00:00.000",
+                                          "content": null,
+                                          "message": "Invalid token"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "403",
+                        description = "토큰 인가 실패",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 403,
+                                          "code": "FORBIDDEN",
+                                          "timestamp": "2026-03-17T10:00:00.000",
+                                          "content": null,
+                                          "message": "Access Denied"
+                                        }
+                                        """)
+                        )
+                )
+        }
+)
+public @interface RegisterShippingPolicyApiDocs {
+}

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/shipping/request/RegisterShippingPolicyRequest.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/shipping/request/RegisterShippingPolicyRequest.java
@@ -1,0 +1,25 @@
+package com.personal.marketnote.product.adapter.in.web.shipping.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record RegisterShippingPolicyRequest(
+        @NotBlank(message = "배송업체는 필수입니다")
+        @Size(max = 50)
+        @Schema(description = "배송업체", example = "한진택배")
+        String deliveryCompany,
+
+        @NotNull(message = "배송비는 필수입니다")
+        @Min(value = 0, message = "배송비는 0 이상이어야 합니다")
+        @Schema(description = "배송비", example = "3000")
+        Long shippingFee,
+
+        @NotNull(message = "무료배송 기준금액은 필수입니다")
+        @Min(value = 0, message = "무료배송 기준금액은 0 이상이어야 합니다")
+        @Schema(description = "무료배송 기준금액", example = "20000")
+        Long freeShippingThreshold
+) {
+}

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/shipping/response/RegisterShippingPolicyResponse.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/shipping/response/RegisterShippingPolicyResponse.java
@@ -1,0 +1,10 @@
+package com.personal.marketnote.product.adapter.in.web.shipping.response;
+
+import com.personal.marketnote.product.port.in.result.shipping.RegisterShippingPolicyResult;
+
+public record RegisterShippingPolicyResponse(Long id) {
+
+    public static RegisterShippingPolicyResponse from(RegisterShippingPolicyResult result) {
+        return new RegisterShippingPolicyResponse(result.id());
+    }
+}

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/shipping/ShippingPolicyPersistenceAdapter.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/shipping/ShippingPolicyPersistenceAdapter.java
@@ -1,0 +1,39 @@
+package com.personal.marketnote.product.adapter.out.persistence.shipping;
+
+import com.personal.marketnote.common.adapter.out.PersistenceAdapter;
+import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.product.adapter.out.mapper.ShippingPolicyJpaEntityToDomainMapper;
+import com.personal.marketnote.product.adapter.out.persistence.shipping.entity.ShippingPolicyJpaEntity;
+import com.personal.marketnote.product.adapter.out.persistence.shipping.repository.ShippingPolicyJpaRepository;
+import com.personal.marketnote.product.domain.shipping.ShippingPolicy;
+import com.personal.marketnote.product.exception.ShippingPolicyAlreadyExistsException;
+import com.personal.marketnote.product.port.out.shipping.FindShippingPolicyPort;
+import com.personal.marketnote.product.port.out.shipping.SaveShippingPolicyPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+
+import java.util.Optional;
+
+@PersistenceAdapter
+@RequiredArgsConstructor
+public class ShippingPolicyPersistenceAdapter implements SaveShippingPolicyPort, FindShippingPolicyPort {
+
+    private final ShippingPolicyJpaRepository shippingPolicyJpaRepository;
+
+    @Override
+    public Long save(ShippingPolicy shippingPolicy) {
+        try {
+            ShippingPolicyJpaEntity entity = ShippingPolicyJpaEntity.from(shippingPolicy);
+            ShippingPolicyJpaEntity saved = shippingPolicyJpaRepository.save(entity);
+            return saved.getId();
+        } catch (DataIntegrityViolationException dive) {
+            throw new ShippingPolicyAlreadyExistsException(shippingPolicy.getSellerId());
+        }
+    }
+
+    @Override
+    public Optional<ShippingPolicy> findActiveBySellerId(Long sellerId) {
+        return shippingPolicyJpaRepository.findBySellerIdAndStatus(sellerId, EntityStatus.ACTIVE)
+                .flatMap(ShippingPolicyJpaEntityToDomainMapper::mapToDomain);
+    }
+}

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/exception/ShippingPolicyAlreadyExistsException.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/exception/ShippingPolicyAlreadyExistsException.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.product.exception;
+
+public class ShippingPolicyAlreadyExistsException extends IllegalStateException {
+
+    public ShippingPolicyAlreadyExistsException(Long sellerId) {
+        super("해당 판매자의 배송비 정책이 이미 존재합니다. sellerId=" + sellerId);
+    }
+}

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/command/RegisterShippingPolicyCommand.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/command/RegisterShippingPolicyCommand.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.product.port.in.command;
+
+public record RegisterShippingPolicyCommand(
+        String deliveryCompany,
+        Long shippingFee,
+        Long freeShippingThreshold
+) {
+}

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/result/shipping/RegisterShippingPolicyResult.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/result/shipping/RegisterShippingPolicyResult.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.product.port.in.result.shipping;
+
+public record RegisterShippingPolicyResult(Long id) {
+
+    public static RegisterShippingPolicyResult of(Long id) {
+        return new RegisterShippingPolicyResult(id);
+    }
+}

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/usecase/shipping/RegisterShippingPolicyUseCase.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/usecase/shipping/RegisterShippingPolicyUseCase.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.product.port.in.usecase.shipping;
+
+import com.personal.marketnote.product.port.in.command.RegisterShippingPolicyCommand;
+import com.personal.marketnote.product.port.in.result.shipping.RegisterShippingPolicyResult;
+
+public interface RegisterShippingPolicyUseCase {
+
+    RegisterShippingPolicyResult registerShippingPolicy(Long sellerId, RegisterShippingPolicyCommand command);
+}

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/out/shipping/FindShippingPolicyPort.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/out/shipping/FindShippingPolicyPort.java
@@ -1,0 +1,10 @@
+package com.personal.marketnote.product.port.out.shipping;
+
+import com.personal.marketnote.product.domain.shipping.ShippingPolicy;
+
+import java.util.Optional;
+
+public interface FindShippingPolicyPort {
+
+    Optional<ShippingPolicy> findActiveBySellerId(Long sellerId);
+}

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/out/shipping/SaveShippingPolicyPort.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/out/shipping/SaveShippingPolicyPort.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.product.port.out.shipping;
+
+import com.personal.marketnote.product.domain.shipping.ShippingPolicy;
+
+public interface SaveShippingPolicyPort {
+
+    Long save(ShippingPolicy shippingPolicy);
+}

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/service/shipping/RegisterShippingPolicyService.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/service/shipping/RegisterShippingPolicyService.java
@@ -1,0 +1,46 @@
+package com.personal.marketnote.product.service.shipping;
+
+import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.product.domain.shipping.ShippingPolicy;
+import com.personal.marketnote.product.domain.shipping.ShippingPolicyCreateState;
+import com.personal.marketnote.product.exception.ShippingPolicyAlreadyExistsException;
+import com.personal.marketnote.product.port.in.command.RegisterShippingPolicyCommand;
+import com.personal.marketnote.product.port.in.result.shipping.RegisterShippingPolicyResult;
+import com.personal.marketnote.product.port.in.usecase.shipping.RegisterShippingPolicyUseCase;
+import com.personal.marketnote.product.port.out.shipping.FindShippingPolicyPort;
+import com.personal.marketnote.product.port.out.shipping.SaveShippingPolicyPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@UseCase
+@RequiredArgsConstructor
+public class RegisterShippingPolicyService implements RegisterShippingPolicyUseCase {
+
+    private final FindShippingPolicyPort findShippingPolicyPort;
+    private final SaveShippingPolicyPort saveShippingPolicyPort;
+
+    @Override
+    @Transactional(isolation = READ_COMMITTED)
+    public RegisterShippingPolicyResult registerShippingPolicy(Long sellerId, RegisterShippingPolicyCommand command) {
+        validateNoDuplicatePolicy(sellerId);
+
+        ShippingPolicy shippingPolicy = ShippingPolicy.from(ShippingPolicyCreateState.builder()
+                .sellerId(sellerId)
+                .deliveryCompany(command.deliveryCompany())
+                .shippingFee(command.shippingFee())
+                .freeShippingThreshold(command.freeShippingThreshold())
+                .build());
+
+        Long savedId = saveShippingPolicyPort.save(shippingPolicy);
+        return RegisterShippingPolicyResult.of(savedId);
+    }
+
+    private void validateNoDuplicatePolicy(Long sellerId) {
+        findShippingPolicyPort.findActiveBySellerId(sellerId)
+                .ifPresent(existing -> {
+                    throw new ShippingPolicyAlreadyExistsException(sellerId);
+                });
+    }
+}


### PR DESCRIPTION
## partially addresses #128
## resolves #1308

## Task
- [x] RegisterShippingPolicyCommand, RegisterShippingPolicyResult
- [x] RegisterShippingPolicyUseCase, RegisterShippingPolicyService
- [x] FindShippingPolicyPort, SaveShippingPolicyPort
- [x] ShippingPolicyAlreadyExistsException
- [x] ShippingPolicyPersistenceAdapter (DataIntegrityViolationException 방어)
- [x] RegisterShippingPolicyRequest (record), RegisterShippingPolicyResponse (record)
- [x] RegisterShippingPolicyApiDocs, ShippingPolicyController
- [x] POST /api/v1/shipping-policies