### PR TITLE
[#128][#1309] feat: 판매자 배송비 정책 수정 기능 추가

### DIFF
--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/shipping/controller/ShippingPolicyController.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/shipping/controller/ShippingPolicyController.java
@@ -3,11 +3,17 @@ package com.personal.marketnote.product.adapter.in.web.shipping.controller;
 import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
 import com.personal.marketnote.common.utility.ElementExtractor;
 import com.personal.marketnote.product.adapter.in.web.shipping.controller.apidocs.RegisterShippingPolicyApiDocs;
+import com.personal.marketnote.product.adapter.in.web.shipping.controller.apidocs.UpdateShippingPolicyApiDocs;
 import com.personal.marketnote.product.adapter.in.web.shipping.request.RegisterShippingPolicyRequest;
+import com.personal.marketnote.product.adapter.in.web.shipping.request.UpdateShippingPolicyRequest;
 import com.personal.marketnote.product.adapter.in.web.shipping.response.RegisterShippingPolicyResponse;
+import com.personal.marketnote.product.adapter.in.web.shipping.response.UpdateShippingPolicyResponse;
 import com.personal.marketnote.product.port.in.command.RegisterShippingPolicyCommand;
+import com.personal.marketnote.product.port.in.command.UpdateShippingPolicyCommand;
 import com.personal.marketnote.product.port.in.result.shipping.RegisterShippingPolicyResult;
+import com.personal.marketnote.product.port.in.result.shipping.UpdateShippingPolicyResult;
 import com.personal.marketnote.product.port.in.usecase.shipping.RegisterShippingPolicyUseCase;
+import com.personal.marketnote.product.port.in.usecase.shipping.UpdateShippingPolicyUseCase;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -18,6 +24,7 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.core.OAuth2AuthenticatedPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -40,6 +47,7 @@ import static com.personal.marketnote.common.utility.ApiConstant.ADMIN_OR_SELLER
 public class ShippingPolicyController {
 
     private final RegisterShippingPolicyUseCase registerShippingPolicyUseCase;
+    private final UpdateShippingPolicyUseCase updateShippingPolicyUseCase;
 
     /**
      * (판매자/관리자) 배송비 정책 등록
@@ -77,6 +85,45 @@ public class ShippingPolicyController {
                         "판매자 배송비 정책 등록 성공"
                 ),
                 HttpStatus.CREATED
+        );
+    }
+
+    /**
+     * (판매자/관리자) 배송비 정책 수정
+     *
+     * @param request   배송비 정책 수정 요청
+     * @param principal 인증된 사용자 정보
+     * @return 배송비 정책 수정 응답 {@link UpdateShippingPolicyResponse}
+     * @Author 성효빈
+     * @Date 2026-03-19
+     * @Description 판매자의 배송비 정책을 수정합니다.
+     */
+    @PutMapping
+    @PreAuthorize(ADMIN_OR_SELLER_POINTCUT)
+    @UpdateShippingPolicyApiDocs
+    public ResponseEntity<BaseResponse<UpdateShippingPolicyResponse>> updateShippingPolicy(
+            @Valid @RequestBody UpdateShippingPolicyRequest request,
+            @AuthenticationPrincipal OAuth2AuthenticatedPrincipal principal
+    ) {
+        Long sellerId = ElementExtractor.extractUserId(principal);
+
+        UpdateShippingPolicyResult result = updateShippingPolicyUseCase.updateShippingPolicy(
+                sellerId,
+                new UpdateShippingPolicyCommand(
+                        request.deliveryCompany(),
+                        request.shippingFee(),
+                        request.freeShippingThreshold()
+                )
+        );
+
+        return new ResponseEntity<>(
+                BaseResponse.of(
+                        UpdateShippingPolicyResponse.from(result),
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "판매자 배송비 정책 수정 성공"
+                ),
+                HttpStatus.OK
         );
     }
 }

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/shipping/controller/apidocs/UpdateShippingPolicyApiDocs.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/shipping/controller/apidocs/UpdateShippingPolicyApiDocs.java
@@ -1,0 +1,148 @@
+package com.personal.marketnote.product.adapter.in.web.shipping.controller.apidocs;
+
+import com.personal.marketnote.common.adapter.in.api.schema.StringResponseSchema;
+import com.personal.marketnote.product.adapter.in.web.shipping.request.UpdateShippingPolicyRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Operation(
+        summary = "(판매자/관리자) 배송비 정책 수정",
+        description = """
+                작성일자: 2026-03-19
+
+                작성자: 성효빈
+
+                ---
+
+                ## Description
+
+                - 판매자의 배송비 정책을 수정합니다.
+
+                - 판매자 본인 또는 관리자만 가능합니다.
+
+                ---
+
+                ## Request
+
+                | **키** | **타입** | **설명** | **필수 여부** | **예시** |
+                | --- | --- | --- | --- | --- |
+                | deliveryCompany | string | 배송업체 | Y | "CJ대한통운" |
+                | shippingFee | number | 배송비 | Y | 2500 |
+                | freeShippingThreshold | number | 무료배송 기준금액 | Y | 30000 |
+
+                ---
+
+                ## Response
+
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | statusCode | number | 상태 코드 | 200: 성공 / 400: 클라이언트 요청 오류 / 401: 인증 실패 / 403: 인가 실패 / 404: 정책 미존재 / 500: 그 외 |
+                | code | string | 응답 코드 | "SUC01" / "BAD_REQUEST" / "UNAUTHORIZED" / "FORBIDDEN" / "NOT_FOUND" / "INTERNAL_SERVER_ERROR" |
+                | timestamp | string(datetime) | 응답 일시 | "2026-03-19T10:00:00.000" |
+                | content | object | 응답 본문 | { ... } |
+                | message | string | 처리 결과 | "판매자 배송비 정책 수정 성공" |
+
+                ### Response > content
+
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | id | number | 배송비 정책 ID | 1 |
+                | deliveryCompany | string | 배송업체 | "CJ대한통운" |
+                | shippingFee | number | 배송비 | 2500 |
+                | freeShippingThreshold | number | 무료배송 기준금액 | 30000 |
+                """,
+        security = {@SecurityRequirement(name = "bearer")},
+        requestBody = @RequestBody(
+                required = true,
+                content = @Content(
+                        schema = @Schema(implementation = UpdateShippingPolicyRequest.class),
+                        examples = @ExampleObject("""
+                                {
+                                  "deliveryCompany": "CJ대한통운",
+                                  "shippingFee": 2500,
+                                  "freeShippingThreshold": 30000
+                                }
+                                """)
+                )
+        ),
+        responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "수정 성공",
+                        content = @Content(
+                                schema = @Schema(implementation = StringResponseSchema.class),
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 200,
+                                          "code": "SUC01",
+                                          "timestamp": "2026-03-19T10:00:00.000",
+                                          "content": {
+                                            "id": 1,
+                                            "deliveryCompany": "CJ대한통운",
+                                            "shippingFee": 2500,
+                                            "freeShippingThreshold": 30000
+                                          },
+                                          "message": "판매자 배송비 정책 수정 성공"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "401",
+                        description = "토큰 인증 실패",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 401,
+                                          "code": "UNAUTHORIZED",
+                                          "timestamp": "2026-03-19T10:00:00.000",
+                                          "content": null,
+                                          "message": "Invalid token"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "403",
+                        description = "토큰 인가 실패",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 403,
+                                          "code": "FORBIDDEN",
+                                          "timestamp": "2026-03-19T10:00:00.000",
+                                          "content": null,
+                                          "message": "Access Denied"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "404",
+                        description = "배송비 정책 미존재",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 404,
+                                          "code": "NOT_FOUND",
+                                          "timestamp": "2026-03-19T10:00:00.000",
+                                          "content": null,
+                                          "message": "해당 판매자의 배송비 정책을 찾을 수 없습니다. sellerId=10"
+                                        }
+                                        """)
+                        )
+                )
+        }
+)
+public @interface UpdateShippingPolicyApiDocs {
+}

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/shipping/request/UpdateShippingPolicyRequest.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/shipping/request/UpdateShippingPolicyRequest.java
@@ -1,0 +1,25 @@
+package com.personal.marketnote.product.adapter.in.web.shipping.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record UpdateShippingPolicyRequest(
+        @NotBlank(message = "배송업체는 필수입니다")
+        @Size(max = 50)
+        @Schema(description = "배송업체", example = "한진택배")
+        String deliveryCompany,
+
+        @NotNull(message = "배송비는 필수입니다")
+        @Min(value = 0, message = "배송비는 0 이상이어야 합니다")
+        @Schema(description = "배송비", example = "3000")
+        Long shippingFee,
+
+        @NotNull(message = "무료배송 기준금액은 필수입니다")
+        @Min(value = 0, message = "무료배송 기준금액은 0 이상이어야 합니다")
+        @Schema(description = "무료배송 기준금액", example = "20000")
+        Long freeShippingThreshold
+) {
+}

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/shipping/response/UpdateShippingPolicyResponse.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/shipping/response/UpdateShippingPolicyResponse.java
@@ -1,0 +1,20 @@
+package com.personal.marketnote.product.adapter.in.web.shipping.response;
+
+import com.personal.marketnote.product.port.in.result.shipping.UpdateShippingPolicyResult;
+
+public record UpdateShippingPolicyResponse(
+        Long id,
+        String deliveryCompany,
+        Long shippingFee,
+        Long freeShippingThreshold
+) {
+
+    public static UpdateShippingPolicyResponse from(UpdateShippingPolicyResult result) {
+        return new UpdateShippingPolicyResponse(
+                result.id(),
+                result.deliveryCompany(),
+                result.shippingFee(),
+                result.freeShippingThreshold()
+        );
+    }
+}

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/shipping/ShippingPolicyPersistenceAdapter.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/shipping/ShippingPolicyPersistenceAdapter.java
@@ -7,8 +7,10 @@ import com.personal.marketnote.product.adapter.out.persistence.shipping.entity.S
 import com.personal.marketnote.product.adapter.out.persistence.shipping.repository.ShippingPolicyJpaRepository;
 import com.personal.marketnote.product.domain.shipping.ShippingPolicy;
 import com.personal.marketnote.product.exception.ShippingPolicyAlreadyExistsException;
+import com.personal.marketnote.product.exception.ShippingPolicyNotFoundException;
 import com.personal.marketnote.product.port.out.shipping.FindShippingPolicyPort;
 import com.personal.marketnote.product.port.out.shipping.SaveShippingPolicyPort;
+import com.personal.marketnote.product.port.out.shipping.UpdateShippingPolicyPort;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
 
@@ -16,7 +18,7 @@ import java.util.Optional;
 
 @PersistenceAdapter
 @RequiredArgsConstructor
-public class ShippingPolicyPersistenceAdapter implements SaveShippingPolicyPort, FindShippingPolicyPort {
+public class ShippingPolicyPersistenceAdapter implements SaveShippingPolicyPort, FindShippingPolicyPort, UpdateShippingPolicyPort {
 
     private final ShippingPolicyJpaRepository shippingPolicyJpaRepository;
 
@@ -35,5 +37,14 @@ public class ShippingPolicyPersistenceAdapter implements SaveShippingPolicyPort,
     public Optional<ShippingPolicy> findActiveBySellerId(Long sellerId) {
         return shippingPolicyJpaRepository.findBySellerIdAndStatus(sellerId, EntityStatus.ACTIVE)
                 .flatMap(ShippingPolicyJpaEntityToDomainMapper::mapToDomain);
+    }
+
+    @Override
+    public void update(ShippingPolicy shippingPolicy) {
+        ShippingPolicyJpaEntity entity = shippingPolicyJpaRepository
+                .findById(shippingPolicy.getId())
+                .orElseThrow(() -> new ShippingPolicyNotFoundException(shippingPolicy.getSellerId()));
+
+        entity.updateFrom(shippingPolicy);
     }
 }

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/exception/ShippingPolicyNotFoundException.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/exception/ShippingPolicyNotFoundException.java
@@ -1,0 +1,10 @@
+package com.personal.marketnote.product.exception;
+
+import jakarta.persistence.EntityNotFoundException;
+
+public class ShippingPolicyNotFoundException extends EntityNotFoundException {
+
+    public ShippingPolicyNotFoundException(Long sellerId) {
+        super("해당 판매자의 배송비 정책을 찾을 수 없습니다. sellerId=" + sellerId);
+    }
+}

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/command/UpdateShippingPolicyCommand.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/command/UpdateShippingPolicyCommand.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.product.port.in.command;
+
+public record UpdateShippingPolicyCommand(
+        String deliveryCompany,
+        Long shippingFee,
+        Long freeShippingThreshold
+) {
+}

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/result/shipping/UpdateShippingPolicyResult.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/result/shipping/UpdateShippingPolicyResult.java
@@ -1,0 +1,20 @@
+package com.personal.marketnote.product.port.in.result.shipping;
+
+import com.personal.marketnote.product.domain.shipping.ShippingPolicy;
+
+public record UpdateShippingPolicyResult(
+        Long id,
+        String deliveryCompany,
+        Long shippingFee,
+        Long freeShippingThreshold
+) {
+
+    public static UpdateShippingPolicyResult from(ShippingPolicy shippingPolicy) {
+        return new UpdateShippingPolicyResult(
+                shippingPolicy.getId(),
+                shippingPolicy.getDeliveryCompany(),
+                shippingPolicy.getShippingFee(),
+                shippingPolicy.getFreeShippingThreshold()
+        );
+    }
+}

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/usecase/shipping/UpdateShippingPolicyUseCase.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/usecase/shipping/UpdateShippingPolicyUseCase.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.product.port.in.usecase.shipping;
+
+import com.personal.marketnote.product.port.in.command.UpdateShippingPolicyCommand;
+import com.personal.marketnote.product.port.in.result.shipping.UpdateShippingPolicyResult;
+
+public interface UpdateShippingPolicyUseCase {
+
+    UpdateShippingPolicyResult updateShippingPolicy(Long sellerId, UpdateShippingPolicyCommand command);
+}

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/out/shipping/UpdateShippingPolicyPort.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/out/shipping/UpdateShippingPolicyPort.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.product.port.out.shipping;
+
+import com.personal.marketnote.product.domain.shipping.ShippingPolicy;
+
+public interface UpdateShippingPolicyPort {
+
+    void update(ShippingPolicy shippingPolicy);
+}

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/service/shipping/UpdateShippingPolicyService.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/service/shipping/UpdateShippingPolicyService.java
@@ -1,0 +1,42 @@
+package com.personal.marketnote.product.service.shipping;
+
+import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.product.domain.shipping.ShippingPolicy;
+import com.personal.marketnote.product.exception.ShippingPolicyNotFoundException;
+import com.personal.marketnote.product.port.in.command.UpdateShippingPolicyCommand;
+import com.personal.marketnote.product.port.in.result.shipping.UpdateShippingPolicyResult;
+import com.personal.marketnote.product.port.in.usecase.shipping.UpdateShippingPolicyUseCase;
+import com.personal.marketnote.product.port.out.shipping.FindShippingPolicyPort;
+import com.personal.marketnote.product.port.out.shipping.UpdateShippingPolicyPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@UseCase
+@RequiredArgsConstructor
+public class UpdateShippingPolicyService implements UpdateShippingPolicyUseCase {
+
+    private final FindShippingPolicyPort findShippingPolicyPort;
+    private final UpdateShippingPolicyPort updateShippingPolicyPort;
+
+    @Override
+    @Transactional(isolation = READ_COMMITTED)
+    public UpdateShippingPolicyResult updateShippingPolicy(Long sellerId, UpdateShippingPolicyCommand command) {
+        ShippingPolicy shippingPolicy = findShippingPolicy(sellerId);
+
+        shippingPolicy.update(
+                command.deliveryCompany(),
+                command.shippingFee(),
+                command.freeShippingThreshold()
+        );
+
+        updateShippingPolicyPort.update(shippingPolicy);
+        return UpdateShippingPolicyResult.from(shippingPolicy);
+    }
+
+    private ShippingPolicy findShippingPolicy(Long sellerId) {
+        return findShippingPolicyPort.findActiveBySellerId(sellerId)
+                .orElseThrow(() -> new ShippingPolicyNotFoundException(sellerId));
+    }
+}


### PR DESCRIPTION
## partially addresses #128
## resolves #1309

## Task
- [x] UpdateShippingPolicyUseCase 인터페이스 추가
- [x] UpdateShippingPolicyCommand record 추가
- [x] UpdateShippingPolicyResult record 추가 (from 팩토리)
- [x] UpdateShippingPolicyService 구현 (@usecase, @transactional)
- [x] UpdateShippingPolicyPort Out Port 인터페이스 추가
- [x] ShippingPolicyNotFoundException 예외 추가 (EntityNotFoundException 상속)
- [x] ShippingPolicyPersistenceAdapter에 UpdateShippingPolicyPort 구현 추가 (PK 기반 조회)
- [x] UpdateShippingPolicyRequest DTO 추가 (Bean Validation)
- [x] UpdateShippingPolicyResponse DTO 추가
- [x] UpdateShippingPolicyApiDocs 합성 애노테이션 추가
- [x] ShippingPolicyController에 PUT /api/v1/shipping-policies 엔드포인트 추가