### PR TITLE
[#128][#1310] feat: 판매자 배송비 정책 조회 기능 추가

### DIFF
--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/shipping/controller/ShippingPolicyController.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/shipping/controller/ShippingPolicyController.java
@@ -2,16 +2,20 @@ package com.personal.marketnote.product.adapter.in.web.shipping.controller;
 
 import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
 import com.personal.marketnote.common.utility.ElementExtractor;
+import com.personal.marketnote.product.adapter.in.web.shipping.controller.apidocs.GetShippingPolicyApiDocs;
 import com.personal.marketnote.product.adapter.in.web.shipping.controller.apidocs.RegisterShippingPolicyApiDocs;
 import com.personal.marketnote.product.adapter.in.web.shipping.controller.apidocs.UpdateShippingPolicyApiDocs;
 import com.personal.marketnote.product.adapter.in.web.shipping.request.RegisterShippingPolicyRequest;
 import com.personal.marketnote.product.adapter.in.web.shipping.request.UpdateShippingPolicyRequest;
+import com.personal.marketnote.product.adapter.in.web.shipping.response.GetShippingPolicyResponse;
 import com.personal.marketnote.product.adapter.in.web.shipping.response.RegisterShippingPolicyResponse;
 import com.personal.marketnote.product.adapter.in.web.shipping.response.UpdateShippingPolicyResponse;
 import com.personal.marketnote.product.port.in.command.RegisterShippingPolicyCommand;
 import com.personal.marketnote.product.port.in.command.UpdateShippingPolicyCommand;
+import com.personal.marketnote.product.port.in.result.shipping.GetShippingPolicyResult;
 import com.personal.marketnote.product.port.in.result.shipping.RegisterShippingPolicyResult;
 import com.personal.marketnote.product.port.in.result.shipping.UpdateShippingPolicyResult;
+import com.personal.marketnote.product.port.in.usecase.shipping.GetShippingPolicyUseCase;
 import com.personal.marketnote.product.port.in.usecase.shipping.RegisterShippingPolicyUseCase;
 import com.personal.marketnote.product.port.in.usecase.shipping.UpdateShippingPolicyUseCase;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -23,6 +27,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.core.OAuth2AuthenticatedPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -46,8 +51,39 @@ import static com.personal.marketnote.common.utility.ApiConstant.ADMIN_OR_SELLER
 @Slf4j
 public class ShippingPolicyController {
 
+    private final GetShippingPolicyUseCase getShippingPolicyUseCase;
     private final RegisterShippingPolicyUseCase registerShippingPolicyUseCase;
     private final UpdateShippingPolicyUseCase updateShippingPolicyUseCase;
+
+    /**
+     * (판매자/관리자) 배송비 정책 조회
+     *
+     * @param principal 인증된 사용자 정보
+     * @return 배송비 정책 조회 응답 {@link GetShippingPolicyResponse}
+     * @Author 성효빈
+     * @Date 2026-03-19
+     * @Description 판매자의 배송비 정책을 조회합니다.
+     */
+    @GetMapping
+    @PreAuthorize(ADMIN_OR_SELLER_POINTCUT)
+    @GetShippingPolicyApiDocs
+    public ResponseEntity<BaseResponse<GetShippingPolicyResponse>> getShippingPolicy(
+            @AuthenticationPrincipal OAuth2AuthenticatedPrincipal principal
+    ) {
+        Long sellerId = ElementExtractor.extractUserId(principal);
+
+        GetShippingPolicyResult result = getShippingPolicyUseCase.getShippingPolicy(sellerId);
+
+        return new ResponseEntity<>(
+                BaseResponse.of(
+                        GetShippingPolicyResponse.from(result),
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "판매자 배송비 정책 조회 성공"
+                ),
+                HttpStatus.OK
+        );
+    }
 
     /**
      * (판매자/관리자) 배송비 정책 등록

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/shipping/controller/apidocs/GetShippingPolicyApiDocs.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/shipping/controller/apidocs/GetShippingPolicyApiDocs.java
@@ -1,0 +1,127 @@
+package com.personal.marketnote.product.adapter.in.web.shipping.controller.apidocs;
+
+import com.personal.marketnote.common.adapter.in.api.schema.StringResponseSchema;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Operation(
+        summary = "(판매자/관리자) 배송비 정책 조회",
+        description = """
+                작성일자: 2026-03-19
+
+                작성자: 성효빈
+
+                ---
+
+                ## Description
+
+                - 판매자의 배송비 정책을 조회합니다.
+
+                - 판매자 본인 또는 관리자만 가능합니다.
+
+                ---
+
+                ## Response
+
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | statusCode | number | 상태 코드 | 200: 성공 / 401: 인증 실패 / 403: 인가 실패 / 404: 정책 미존재 / 500: 그 외 |
+                | code | string | 응답 코드 | "SUC01" / "UNAUTHORIZED" / "FORBIDDEN" / "NOT_FOUND" / "INTERNAL_SERVER_ERROR" |
+                | timestamp | string(datetime) | 응답 일시 | "2026-03-19T10:00:00.000" |
+                | content | object | 응답 본문 | { ... } |
+                | message | string | 처리 결과 | "판매자 배송비 정책 조회 성공" |
+
+                ### Response > content
+
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | id | number | 배송비 정책 ID | 1 |
+                | deliveryCompany | string | 배송업체 | "한진택배" |
+                | shippingFee | number | 배송비 | 3000 |
+                | freeShippingThreshold | number | 무료배송 기준금액 | 20000 |
+                """,
+        security = {@SecurityRequirement(name = "bearer")},
+        responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "조회 성공",
+                        content = @Content(
+                                schema = @Schema(implementation = StringResponseSchema.class),
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 200,
+                                          "code": "SUC01",
+                                          "timestamp": "2026-03-19T10:00:00.000",
+                                          "content": {
+                                            "id": 1,
+                                            "deliveryCompany": "한진택배",
+                                            "shippingFee": 3000,
+                                            "freeShippingThreshold": 20000
+                                          },
+                                          "message": "판매자 배송비 정책 조회 성공"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "401",
+                        description = "토큰 인증 실패",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 401,
+                                          "code": "UNAUTHORIZED",
+                                          "timestamp": "2026-03-19T10:00:00.000",
+                                          "content": null,
+                                          "message": "Invalid token"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "403",
+                        description = "토큰 인가 실패",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 403,
+                                          "code": "FORBIDDEN",
+                                          "timestamp": "2026-03-19T10:00:00.000",
+                                          "content": null,
+                                          "message": "Access Denied"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "404",
+                        description = "배송비 정책 미존재",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 404,
+                                          "code": "NOT_FOUND",
+                                          "timestamp": "2026-03-19T10:00:00.000",
+                                          "content": null,
+                                          "message": "해당 판매자의 배송비 정책을 찾을 수 없습니다. sellerId=10"
+                                        }
+                                        """)
+                        )
+                )
+        }
+)
+public @interface GetShippingPolicyApiDocs {
+}

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/shipping/response/GetShippingPolicyResponse.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/shipping/response/GetShippingPolicyResponse.java
@@ -1,0 +1,20 @@
+package com.personal.marketnote.product.adapter.in.web.shipping.response;
+
+import com.personal.marketnote.product.port.in.result.shipping.GetShippingPolicyResult;
+
+public record GetShippingPolicyResponse(
+        Long id,
+        String deliveryCompany,
+        Long shippingFee,
+        Long freeShippingThreshold
+) {
+
+    public static GetShippingPolicyResponse from(GetShippingPolicyResult result) {
+        return new GetShippingPolicyResponse(
+                result.id(),
+                result.deliveryCompany(),
+                result.shippingFee(),
+                result.freeShippingThreshold()
+        );
+    }
+}

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/result/shipping/GetShippingPolicyResult.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/result/shipping/GetShippingPolicyResult.java
@@ -1,0 +1,20 @@
+package com.personal.marketnote.product.port.in.result.shipping;
+
+import com.personal.marketnote.product.domain.shipping.ShippingPolicy;
+
+public record GetShippingPolicyResult(
+        Long id,
+        String deliveryCompany,
+        Long shippingFee,
+        Long freeShippingThreshold
+) {
+
+    public static GetShippingPolicyResult from(ShippingPolicy shippingPolicy) {
+        return new GetShippingPolicyResult(
+                shippingPolicy.getId(),
+                shippingPolicy.getDeliveryCompany(),
+                shippingPolicy.getShippingFee(),
+                shippingPolicy.getFreeShippingThreshold()
+        );
+    }
+}

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/usecase/shipping/GetShippingPolicyUseCase.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/usecase/shipping/GetShippingPolicyUseCase.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.product.port.in.usecase.shipping;
+
+import com.personal.marketnote.product.port.in.result.shipping.GetShippingPolicyResult;
+
+public interface GetShippingPolicyUseCase {
+
+    GetShippingPolicyResult getShippingPolicy(Long sellerId);
+}

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/service/shipping/GetShippingPolicyService.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/service/shipping/GetShippingPolicyService.java
@@ -1,0 +1,31 @@
+package com.personal.marketnote.product.service.shipping;
+
+import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.product.domain.shipping.ShippingPolicy;
+import com.personal.marketnote.product.exception.ShippingPolicyNotFoundException;
+import com.personal.marketnote.product.port.in.result.shipping.GetShippingPolicyResult;
+import com.personal.marketnote.product.port.in.usecase.shipping.GetShippingPolicyUseCase;
+import com.personal.marketnote.product.port.out.shipping.FindShippingPolicyPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@UseCase
+@RequiredArgsConstructor
+public class GetShippingPolicyService implements GetShippingPolicyUseCase {
+
+    private final FindShippingPolicyPort findShippingPolicyPort;
+
+    @Override
+    @Transactional(isolation = READ_COMMITTED, readOnly = true)
+    public GetShippingPolicyResult getShippingPolicy(Long sellerId) {
+        ShippingPolicy shippingPolicy = findShippingPolicy(sellerId);
+        return GetShippingPolicyResult.from(shippingPolicy);
+    }
+
+    private ShippingPolicy findShippingPolicy(Long sellerId) {
+        return findShippingPolicyPort.findActiveBySellerId(sellerId)
+                .orElseThrow(() -> new ShippingPolicyNotFoundException(sellerId));
+    }
+}


### PR DESCRIPTION
## partially addresses #128
## resolves #1310

## Task
- [x] GetShippingPolicyUseCase 인터페이스 추가
- [x] GetShippingPolicyResult 결과 record 추가
- [x] GetShippingPolicyService 조회 서비스 구현 (@Transactional readOnly)
- [x] GetShippingPolicyResponse 응답 DTO 추가
- [x] GetShippingPolicyApiDocs Swagger 합성 애노테이션 추가
- [x] ShippingPolicyController에 GET /api/v1/shipping-policies 엔드포인트 추가