### PR TITLE
[#43][#1384] feat: 배송 요청사항 목록 조회 기능 추가

### DIFF
--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/shippingaddress/controller/DeliveryRequestTypeController.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/shippingaddress/controller/DeliveryRequestTypeController.java
@@ -1,0 +1,60 @@
+package com.personal.marketnote.user.adapter.in.web.shippingaddress.controller;
+
+import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
+import com.personal.marketnote.user.adapter.in.web.shippingaddress.controller.apidocs.GetDeliveryRequestTypesApiDocs;
+import com.personal.marketnote.user.adapter.in.web.shippingaddress.response.GetDeliveryRequestTypesResponse;
+import com.personal.marketnote.user.port.in.result.shippingaddress.GetDeliveryRequestTypesResult;
+import com.personal.marketnote.user.port.in.usecase.shippingaddress.GetDeliveryRequestTypesUseCase;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+import static com.personal.marketnote.common.domain.exception.ExceptionCode.DEFAULT_SUCCESS_CODE;
+
+/**
+ * 배송 요청사항 컨트롤러
+ *
+ * @Author 성효빈
+ * @Date 2026-03-19
+ * @Description 배송 요청사항 관련 API를 제공합니다.
+ */
+@RestController
+@RequestMapping("/api/v1/delivery-request-types")
+@Tag(
+        name = "배송 요청사항 API",
+        description = "배송 요청사항 관련 API"
+)
+@RequiredArgsConstructor
+public class DeliveryRequestTypeController {
+    private final GetDeliveryRequestTypesUseCase getDeliveryRequestTypesUseCase;
+
+    /**
+     * 배송 요청사항 목록 조회
+     *
+     * @return 배송 요청사항 목록 {@link GetDeliveryRequestTypesResponse}
+     */
+    @GetMapping
+    @GetDeliveryRequestTypesApiDocs
+    public ResponseEntity<BaseResponse<List<GetDeliveryRequestTypesResponse>>> getDeliveryRequestTypes() {
+        List<GetDeliveryRequestTypesResult> results = getDeliveryRequestTypesUseCase.getDeliveryRequestTypes();
+
+        List<GetDeliveryRequestTypesResponse> response = results.stream()
+                .map(GetDeliveryRequestTypesResponse::from)
+                .toList();
+
+        return ResponseEntity.ok(
+                BaseResponse.of(
+                        response,
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "배송 요청사항 목록 조회 성공"
+                )
+        );
+    }
+}

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/shippingaddress/controller/apidocs/GetDeliveryRequestTypesApiDocs.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/shippingaddress/controller/apidocs/GetDeliveryRequestTypesApiDocs.java
@@ -1,0 +1,82 @@
+package com.personal.marketnote.user.adapter.in.web.shippingaddress.controller.apidocs;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Operation(
+        summary = "배송 요청사항 목록 조회",
+        description = """
+                작성일자: 2026-03-19
+
+                작성자: 성효빈
+
+                ---
+
+                ## Description
+                - 배송 요청사항 타입 목록을 조회합니다.
+
+                - 배송지 등록/수정 화면에서 배송 요청사항 선택지를 표시하기 위해 사용합니다.
+
+                ---
+
+                ## Request
+
+                파라미터 없음
+
+                ---
+
+                ## Response
+
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | statusCode | number | 상태 코드 | 200: 성공 |
+                | code | string | 응답 코드 | "SUC01" |
+                | timestamp | string(datetime) | 응답 일시 | "2026-03-19T12:00:00.000" |
+                | content | array | 응답 본문 | [ ... ] |
+                | message | string | 처리 결과 | "배송 요청사항 목록 조회 성공" |
+
+                ---
+
+                ### Response > content[]
+
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | type | string | 배송 요청사항 타입 | "LEAVE_AT_DOOR" |
+                | description | string | 배송 요청사항 설명 | "문 앞에 놓아주세요" |
+                """,
+        security = {@SecurityRequirement(name = "bearer")},
+        responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "배송 요청사항 목록 조회 성공",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 200,
+                                          "code": "SUC01",
+                                          "timestamp": "2026-03-19T12:00:00.000000",
+                                          "content": [
+                                            { "type": "NONE", "description": "선택 안 함" },
+                                            { "type": "LEAVE_AT_DOOR", "description": "문 앞에 놓아주세요" },
+                                            { "type": "RECEIVE_OR_LEAVE_AT_DOOR", "description": "직접 받고 부재시 문 앞에 놓아 주세요" },
+                                            { "type": "LEAVE_AT_SECURITY", "description": "경비실에 맡겨주세요" },
+                                            { "type": "LEAVE_AT_DELIVERY_BOX", "description": "택배함에 넣어주세요" },
+                                            { "type": "CUSTOM", "description": "직접 입력" }
+                                          ],
+                                          "message": "배송 요청사항 목록 조회 성공"
+                                        }
+                                        """)
+                        )
+                )
+        }
+)
+public @interface GetDeliveryRequestTypesApiDocs {
+}

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/shippingaddress/controller/apidocs/RegisterShippingAddressApiDocs.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/shippingaddress/controller/apidocs/RegisterShippingAddressApiDocs.java
@@ -53,7 +53,7 @@ import java.lang.annotation.*;
                 | addressAlias | string | 주소 별명 (OTHER 타입 필수) | N | "친구집" |
                 | recipientName | string | 받는 분 | Y | "박구글" |
                 | recipientPhoneNumber | string | 휴대폰 번호 | Y | "01000000000" |
-                | deliveryRequestType | string(enum) | 배송 요청사항 타입 (NONE, LEAVE_AT_SECURITY, CALL_BEFORE_DELIVERY, LEAVE_AT_DOOR, LEAVE_AT_DELIVERY_BOX, CUSTOM) | N | "LEAVE_AT_DOOR" |
+                | deliveryRequestType | string(enum) | 배송 요청사항 타입 (NONE, LEAVE_AT_DOOR, RECEIVE_OR_LEAVE_AT_DOOR, LEAVE_AT_SECURITY, LEAVE_AT_DELIVERY_BOX, CUSTOM) | N | "LEAVE_AT_DOOR" |
                 | deliveryRequestMessage | string | 직접입력 메시지 (CUSTOM 시 필수, 최대 30자) | N | "공동현관 비밀번호 *1234" |
                 | isDefault | boolean | 기본 배송지 여부 | N | false |
                 

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/shippingaddress/controller/apidocs/UpdateShippingAddressApiDocs.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/shippingaddress/controller/apidocs/UpdateShippingAddressApiDocs.java
@@ -49,7 +49,7 @@ import java.lang.annotation.*;
                 | addressAlias | string | 주소 별명 (OTHER 타입 필수) | N | "친구집" |
                 | recipientName | string | 받는 분 | Y | "박구글" |
                 | recipientPhoneNumber | string | 휴대폰 번호 | Y | "01000000000" |
-                | deliveryRequestType | string(enum) | 배송 요청사항 타입 (NONE, LEAVE_AT_SECURITY, CALL_BEFORE_DELIVERY, LEAVE_AT_DOOR, LEAVE_AT_DELIVERY_BOX, CUSTOM) | N | "LEAVE_AT_DOOR" |
+                | deliveryRequestType | string(enum) | 배송 요청사항 타입 (NONE, LEAVE_AT_DOOR, RECEIVE_OR_LEAVE_AT_DOOR, LEAVE_AT_SECURITY, LEAVE_AT_DELIVERY_BOX, CUSTOM) | N | "LEAVE_AT_DOOR" |
                 | deliveryRequestMessage | string | 직접입력 메시지 (CUSTOM 시 필수, 최대 30자) | N | "공동현관 비밀번호 *1234" |
                 
                 ---

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/shippingaddress/response/GetDeliveryRequestTypesResponse.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/shippingaddress/response/GetDeliveryRequestTypesResponse.java
@@ -1,0 +1,15 @@
+package com.personal.marketnote.user.adapter.in.web.shippingaddress.response;
+
+import com.personal.marketnote.user.port.in.result.shippingaddress.GetDeliveryRequestTypesResult;
+
+public record GetDeliveryRequestTypesResponse(
+        String type,
+        String description
+) {
+    public static GetDeliveryRequestTypesResponse from(GetDeliveryRequestTypesResult result) {
+        return new GetDeliveryRequestTypesResponse(
+                result.type().name(),
+                result.description()
+        );
+    }
+}

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/port/in/result/shippingaddress/GetDeliveryRequestTypesResult.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/port/in/result/shippingaddress/GetDeliveryRequestTypesResult.java
@@ -1,0 +1,15 @@
+package com.personal.marketnote.user.port.in.result.shippingaddress;
+
+import com.personal.marketnote.user.domain.shippingaddress.DeliveryRequestType;
+
+public record GetDeliveryRequestTypesResult(
+        DeliveryRequestType type,
+        String description
+) {
+    public static GetDeliveryRequestTypesResult from(DeliveryRequestType deliveryRequestType) {
+        return new GetDeliveryRequestTypesResult(
+                deliveryRequestType,
+                deliveryRequestType.getDescription()
+        );
+    }
+}

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/port/in/usecase/shippingaddress/GetDeliveryRequestTypesUseCase.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/port/in/usecase/shippingaddress/GetDeliveryRequestTypesUseCase.java
@@ -1,0 +1,22 @@
+package com.personal.marketnote.user.port.in.usecase.shippingaddress;
+
+import com.personal.marketnote.user.port.in.result.shippingaddress.GetDeliveryRequestTypesResult;
+
+import java.util.List;
+
+/**
+ * 배송 요청사항 목록 조회 유스케이스
+ *
+ * @Author 성효빈
+ * @Date 2026-03-19
+ * @Description 배송 요청사항 타입 목록 조회 기능을 제공합니다.
+ */
+public interface GetDeliveryRequestTypesUseCase {
+    /**
+     * @return 배송 요청사항 타입 목록 {@link GetDeliveryRequestTypesResult}
+     * @Date 2026-03-19
+     * @Author 성효빈
+     * @Description 배송 요청사항 타입 목록을 조회합니다.
+     */
+    List<GetDeliveryRequestTypesResult> getDeliveryRequestTypes();
+}

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/service/shippingaddress/GetDeliveryRequestTypesService.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/service/shippingaddress/GetDeliveryRequestTypesService.java
@@ -1,0 +1,20 @@
+package com.personal.marketnote.user.service.shippingaddress;
+
+import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.user.domain.shippingaddress.DeliveryRequestType;
+import com.personal.marketnote.user.port.in.result.shippingaddress.GetDeliveryRequestTypesResult;
+import com.personal.marketnote.user.port.in.usecase.shippingaddress.GetDeliveryRequestTypesUseCase;
+
+import java.util.Arrays;
+import java.util.List;
+
+@UseCase
+public class GetDeliveryRequestTypesService implements GetDeliveryRequestTypesUseCase {
+
+    @Override
+    public List<GetDeliveryRequestTypesResult> getDeliveryRequestTypes() {
+        return Arrays.stream(DeliveryRequestType.values())
+                .map(GetDeliveryRequestTypesResult::from)
+                .toList();
+    }
+}

--- a/user-service/user-application/src/test/java/com/personal/marketnote/user/service/shippingaddress/GetMyShippingAddressesUseCaseTest.java
+++ b/user-service/user-application/src/test/java/com/personal/marketnote/user/service/shippingaddress/GetMyShippingAddressesUseCaseTest.java
@@ -73,7 +73,7 @@ class GetMyShippingAddressesUseCaseTest {
                 .addressAlias(null)
                 .recipientName("홍길동")
                 .recipientPhoneNumber("010-3333-3333")
-                .deliveryRequestType(DeliveryRequestType.CALL_BEFORE_DELIVERY)
+                .deliveryRequestType(DeliveryRequestType.LEAVE_AT_SECURITY)
                 .deliveryRequestMessage(null)
                 .isDefault(true)
                 .build());

--- a/user-service/user-application/src/test/java/com/personal/marketnote/user/service/shippingaddress/RegisterShippingAddressUseCaseTest.java
+++ b/user-service/user-application/src/test/java/com/personal/marketnote/user/service/shippingaddress/RegisterShippingAddressUseCaseTest.java
@@ -91,7 +91,7 @@ class RegisterShippingAddressUseCaseTest {
                 .addressAlias("친구 집")
                 .recipientName("김철수")
                 .recipientPhoneNumber("010-9876-5432")
-                .deliveryRequestType(DeliveryRequestType.CALL_BEFORE_DELIVERY)
+                .deliveryRequestType(DeliveryRequestType.LEAVE_AT_SECURITY)
                 .isDefault(true)
                 .build();
 

--- a/user-service/user-application/src/test/java/com/personal/marketnote/user/service/shippingaddress/SetDefaultShippingAddressUseCaseTest.java
+++ b/user-service/user-application/src/test/java/com/personal/marketnote/user/service/shippingaddress/SetDefaultShippingAddressUseCaseTest.java
@@ -179,7 +179,7 @@ class SetDefaultShippingAddressUseCaseTest {
                 .addressAlias("친구 집")
                 .recipientName("이영희")
                 .recipientPhoneNumber("010-5555-6666")
-                .deliveryRequestType(DeliveryRequestType.CALL_BEFORE_DELIVERY)
+                .deliveryRequestType(DeliveryRequestType.LEAVE_AT_SECURITY)
                 .isDefault(true)
                 .build());
 

--- a/user-service/user-application/src/test/java/com/personal/marketnote/user/service/shippingaddress/UpdateShippingAddressUseCaseTest.java
+++ b/user-service/user-application/src/test/java/com/personal/marketnote/user/service/shippingaddress/UpdateShippingAddressUseCaseTest.java
@@ -131,7 +131,7 @@ class UpdateShippingAddressUseCaseTest {
                 .addressAlias(null)
                 .recipientName("이영희")
                 .recipientPhoneNumber("010-5555-6666")
-                .deliveryRequestType(DeliveryRequestType.CALL_BEFORE_DELIVERY)
+                .deliveryRequestType(DeliveryRequestType.LEAVE_AT_SECURITY)
                 .deliveryRequestMessage(null)
                 .isDefault(false)
                 .build());

--- a/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/shippingaddress/DeliveryRequestType.java
+++ b/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/shippingaddress/DeliveryRequestType.java
@@ -7,11 +7,11 @@ import lombok.RequiredArgsConstructor;
 @Getter
 public enum DeliveryRequestType {
     NONE("선택 안 함"),
-    LEAVE_AT_SECURITY("부재 시 경비실에 맡겨주세요"),
-    CALL_BEFORE_DELIVERY("배송 전에 꼭 연락주세요"),
-    LEAVE_AT_DOOR("집 앞에 놔주세요"),
-    LEAVE_AT_DELIVERY_BOX("택배함에 놔주세요"),
-    CUSTOM("직접입력");
+    LEAVE_AT_DOOR("문 앞에 놓아주세요"),
+    RECEIVE_OR_LEAVE_AT_DOOR("직접 받고 부재시 문 앞에 놓아 주세요"),
+    LEAVE_AT_SECURITY("경비실에 맡겨주세요"),
+    LEAVE_AT_DELIVERY_BOX("택배함에 넣어주세요"),
+    CUSTOM("직접 입력");
 
     private final String description;
 


### PR DESCRIPTION
## partially addresses #43
## resolves #1384

## Task
- [x] DeliveryRequestType enum 디자인 기준 맞춤 수정
- [x] GET /api/v1/delivery-request-types API 추가
- [x] 기존 ApiDocs enum 목록 문자열 갱신
- [x] 기존 테스트 CALL_BEFORE_DELIVERY 참조 교체