### PR TITLE
[#1326][#1311] feat: 상품 상세 조회 응답에 배송비 정보 추가

### DIFF
--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/result/product/GetProductInfoResult.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/result/product/GetProductInfoResult.java
@@ -1,9 +1,12 @@
 package com.personal.marketnote.product.port.in.result.product;
 
+import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.product.domain.pricepolicy.PricePolicy;
 import com.personal.marketnote.product.domain.product.Product;
 import com.personal.marketnote.product.domain.product.ProductTag;
+import com.personal.marketnote.product.domain.shipping.ShippingPolicy;
 import com.personal.marketnote.product.port.in.result.pricepolicy.GetProductPricePolicyResult;
+import com.personal.marketnote.product.port.in.result.shipping.GetShippingPolicyResult;
 import lombok.Builder;
 
 import java.util.List;
@@ -23,9 +26,12 @@ public record GetProductInfoResult(
         List<ProductTag> productTags,
         Integer stock,
         Long orderNum,
-        String status
+        String status,
+        GetShippingPolicyResult shippingPolicy
 ) {
-    public static GetProductInfoResult from(Product product, PricePolicy pricePolicy, Integer stock) {
+    public static GetProductInfoResult from(
+            Product product, PricePolicy pricePolicy, Integer stock, ShippingPolicy shippingPolicy
+    ) {
         return GetProductInfoResult.builder()
                 .id(product.getId())
                 .sellerId(product.getSellerId())
@@ -41,6 +47,9 @@ public record GetProductInfoResult(
                 .stock(stock)
                 .orderNum(product.getOrderNum())
                 .status(product.getStatus().name())
+                .shippingPolicy(
+                        FormatValidator.hasValue(shippingPolicy) ? GetShippingPolicyResult.from(shippingPolicy) : null
+                )
                 .build();
     }
 }

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/service/product/GetProductService.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/service/product/GetProductService.java
@@ -21,10 +21,12 @@ import com.personal.marketnote.product.port.in.usecase.product.GetProductInvento
 import com.personal.marketnote.product.port.in.usecase.product.GetProductUseCase;
 import com.personal.marketnote.product.port.out.file.FindProductImagesPort;
 import com.personal.marketnote.product.port.out.pricepolicy.FindPricePoliciesPort;
+import com.personal.marketnote.product.domain.shipping.ShippingPolicy;
 import com.personal.marketnote.product.port.out.product.FindProductPort;
 import com.personal.marketnote.product.port.out.productoption.FindProductOptionCategoryPort;
 import com.personal.marketnote.product.port.out.result.ProductReviewAggregateResult;
 import com.personal.marketnote.product.port.out.review.FindProductReviewAggregatesPort;
+import com.personal.marketnote.product.port.out.shipping.FindShippingPolicyPort;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.domain.PageRequest;
@@ -54,6 +56,7 @@ public class GetProductService implements GetProductUseCase {
     private final FindPricePoliciesPort findPricePoliciesPort;
     private final FindProductImagesPort findProductImagesPort;
     private final FindProductReviewAggregatesPort findProductReviewAggregatesPort;
+    private final FindShippingPolicyPort findShippingPolicyPort;
 
     @Qualifier("productImageExecutor")
     private final Executor productImageExecutor;
@@ -134,8 +137,12 @@ public class GetProductService implements GetProductUseCase {
         // 상품 재고 수량 조회
         Map<Long, Integer> inventories = getProductInventoryUseCase.getProductStocks(List.of(pricePolicyId));
 
+        // 판매자 배송비 정책 조회
+        ShippingPolicy shippingPolicy = findShippingPolicyPort.findActiveBySellerId(product.getSellerId())
+                .orElse(null);
+
         GetProductInfoResult productInfo
-                = GetProductInfoResult.from(product, selectedPricePolicy, inventories.get(pricePolicyId));
+                = GetProductInfoResult.from(product, selectedPricePolicy, inventories.get(pricePolicyId), shippingPolicy);
 
         List<SelectableProductOptionCategoryItemResult> selectableCategories
                 = categories.stream()


### PR DESCRIPTION
## partially addresses #1326
## resolves #1311

## Task
- [x] GetProductInfoResult에 GetShippingPolicyResult shippingPolicy 필드 추가
- [x] GetProductService에 FindShippingPolicyPort 주입, buildProductInfo()에서 판매자 배송비 정책 조회
- [x] 배송비 정책 미등록 판매자는 shippingPolicy null 응답