### PR TITLE
[#43][#1401] feat: 닉네임 중복 여부 조회 기능 추가

### DIFF
--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/user/controller/UserController.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/user/controller/UserController.java
@@ -13,15 +13,20 @@ import com.personal.marketnote.user.adapter.in.web.user.response.*;
 import com.personal.marketnote.user.port.in.result.SignInResult;
 import com.personal.marketnote.user.port.in.result.SignUpResult;
 import com.personal.marketnote.user.port.in.result.WithdrawResult;
+import com.personal.marketnote.user.port.in.result.CheckNicknameResult;
 import com.personal.marketnote.user.port.in.usecase.user.*;
 import com.personal.marketnote.user.security.token.vendor.AuthVendor;
 import com.personal.marketnote.user.utility.jwt.JwtUtil;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
+import com.personal.marketnote.common.utility.RegularExpressionConstant;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -55,12 +60,14 @@ import static com.personal.marketnote.common.security.token.utility.TokenConstan
 @RequestMapping("/api/v1/users")
 @Tag(name = "회원 API", description = "회원 관련 API")
 @RequiredArgsConstructor
+@Validated
 @Slf4j
 public class UserController {
     private final SignUpUseCase signUpUseCase;
     private final SignInUseCase signInUseCase;
     private final GetUserUseCase getUserUseCase;
     private final UpdateUserUseCase updateUserUseCase;
+    private final CheckNicknameUseCase checkNicknameUseCase;
     private final RegisterReferredUserCodeUseCase registerReferredUserCodeUseCase;
     private final SignOutUseCase signOutUseCase;
     private final WithdrawUseCase withdrawUseCase;
@@ -280,6 +287,38 @@ public class UserController {
         }
 
         return AuthVendor.NATIVE;
+    }
+
+    /**
+     * 닉네임 중복 여부 조회
+     *
+     * @param nickname 닉네임
+     * @return 닉네임 중복 여부 응답 {@link CheckNicknameResponse}
+     * @Author 성효빈
+     * @Date 2026-03-19
+     * @Description 닉네임 중복 여부를 조회합니다.
+     */
+    @GetMapping("/nickname/check")
+    @CheckNicknameApiDocs
+    public ResponseEntity<BaseResponse<CheckNicknameResponse>> checkNickname(
+            @RequestParam
+            @Pattern(regexp = RegularExpressionConstant.NICKNAME_PATTERN,
+                    message = "닉네임은 한글, 영어 대소문자, 숫자만 가능하며, 2~10글자여야 합니다.")
+            @NotBlank(message = "닉네임은 필수입니다")
+            String nickname
+    ) {
+        CheckNicknameResult checkNicknameResult = checkNicknameUseCase.checkNickname(nickname);
+        CheckNicknameResponse checkNicknameResponse = CheckNicknameResponse.from(checkNicknameResult);
+
+        return new ResponseEntity<>(
+                BaseResponse.of(
+                        checkNicknameResponse,
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "닉네임 중복 여부 조회 성공"
+                ),
+                HttpStatus.OK
+        );
     }
 
     /**

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/user/controller/apidocs/CheckNicknameApiDocs.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/user/controller/apidocs/CheckNicknameApiDocs.java
@@ -1,0 +1,107 @@
+package com.personal.marketnote.user.adapter.in.web.user.controller.apidocs;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Operation(
+        summary = "닉네임 중복 여부 조회",
+        description = """
+                작성일자: 2026-03-19
+
+                작성자: 성효빈
+
+                ---
+
+                ## Description
+
+                닉네임 중복 여부를 조회합니다.
+
+                ---
+
+                ## Request
+
+                | **키** | **타입** | **설명** | **필수 여부** | **예시** |
+                | --- | --- | --- | --- | --- |
+                | nickname | string | 닉네임 | 필수 | "향긋한스윗피" |
+
+                ---
+
+                ## Response
+
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | statusCode | number | 상태 코드 | 200: 성공 / 400: 클라이언트 요청 오류 / 401: 인증 실패 |
+                | code | string | 응답 코드 | "SUC01" / "UNAUTHORIZED" |
+                | timestamp | string(datetime) | 응답 일시 | "2026-03-19T12:00:00.000" |
+                | content | object | 응답 본문 | { ... } |
+                | message | string | 처리 결과 | "닉네임 중복 여부 조회 성공" |
+
+                ---
+
+                ### Response > content
+
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | isDuplicated | boolean | 닉네임 중복 여부 | true / false |
+                """,
+        security = {@SecurityRequirement(name = "bearer")},
+        responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "닉네임 중복 여부 조회 성공",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 200,
+                                          "code": "SUC01",
+                                          "timestamp": "2026-03-19T12:00:00.000000",
+                                          "content": {
+                                            "isDuplicated": false
+                                          },
+                                          "message": "닉네임 중복 여부 조회 성공"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "400",
+                        description = "닉네임 형식 오류",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 400,
+                                          "code": "BAD_REQUEST",
+                                          "timestamp": "2026-03-19T12:00:00.000000",
+                                          "content": null,
+                                          "message": "닉네임은 한글, 영어 대소문자, 숫자만 가능하며, 2~10글자여야 합니다."
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "401",
+                        description = "토큰 인증 실패",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 401,
+                                          "code": "UNAUTHORIZED",
+                                          "timestamp": "2026-03-19T12:00:00.000000",
+                                          "content": null,
+                                          "message": "Invalid token"
+                                        }
+                                        """)
+                        )
+                )
+        }
+)
+public @interface CheckNicknameApiDocs {
+}

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/user/response/CheckNicknameResponse.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/user/response/CheckNicknameResponse.java
@@ -1,0 +1,11 @@
+package com.personal.marketnote.user.adapter.in.web.user.response;
+
+import com.personal.marketnote.user.port.in.result.CheckNicknameResult;
+
+public record CheckNicknameResponse(
+        boolean isDuplicated
+) {
+    public static CheckNicknameResponse from(CheckNicknameResult result) {
+        return new CheckNicknameResponse(result.isDuplicated());
+    }
+}

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/port/in/result/CheckNicknameResult.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/port/in/result/CheckNicknameResult.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.user.port.in.result;
+
+public record CheckNicknameResult(
+        boolean isDuplicated
+) {
+    public static CheckNicknameResult of(boolean isDuplicated) {
+        return new CheckNicknameResult(isDuplicated);
+    }
+}

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/port/in/usecase/user/CheckNicknameUseCase.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/port/in/usecase/user/CheckNicknameUseCase.java
@@ -1,0 +1,21 @@
+package com.personal.marketnote.user.port.in.usecase.user;
+
+import com.personal.marketnote.user.port.in.result.CheckNicknameResult;
+
+/**
+ * 닉네임 중복 여부 조회 유스케이스
+ *
+ * @Author 성효빈
+ * @Date 2026-03-19
+ * @Description 닉네임 중복 여부를 조회합니다.
+ */
+public interface CheckNicknameUseCase {
+    /**
+     * @param nickname 닉네임
+     * @return 닉네임 중복 여부 {@link CheckNicknameResult}
+     * @Date 2026-03-19
+     * @Author 성효빈
+     * @Description 닉네임 중복 여부를 조회합니다.
+     */
+    CheckNicknameResult checkNickname(String nickname);
+}

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/service/user/CheckNicknameService.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/service/user/CheckNicknameService.java
@@ -1,0 +1,23 @@
+package com.personal.marketnote.user.service.user;
+
+import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.user.port.in.result.CheckNicknameResult;
+import com.personal.marketnote.user.port.in.usecase.user.CheckNicknameUseCase;
+import com.personal.marketnote.user.port.out.user.FindUserPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@RequiredArgsConstructor
+@UseCase
+@Transactional(isolation = READ_COMMITTED, readOnly = true)
+public class CheckNicknameService implements CheckNicknameUseCase {
+    private final FindUserPort findUserPort;
+
+    @Override
+    public CheckNicknameResult checkNickname(String nickname) {
+        boolean isDuplicated = findUserPort.existsByNickname(nickname);
+        return CheckNicknameResult.of(isDuplicated);
+    }
+}


### PR DESCRIPTION
## partially addresses #43
## resolves #1401

## Task
- [x] `CheckNicknameUseCase` 인터페이스 정의
- [x] `CheckNicknameResult` record 정의
- [x] `CheckNicknameService` 구현 (`FindUserPort.existsByNickname()` 활용)
- [x] `GET /api/v1/users/nickname/check` 엔드포인트 추가
- [x] 요청 파라미터 검증 (`@Pattern` + `@NotBlank`)
- [x] `CheckNicknameResponse` 응답 DTO 정의
- [x] `CheckNicknameApiDocs` API 문서 합성 애노테이션 추가