### PR TITLE
[#1196][#1313] feat: 주문 등록 시 판매자별 배송비 계산 및 적용 기능 추가

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/web/product/ShippingPolicyServiceClient.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/web/product/ShippingPolicyServiceClient.java
@@ -1,0 +1,142 @@
+package com.personal.marketnote.commerce.adapter.out.web.product;
+
+import com.personal.marketnote.commerce.adapter.out.web.product.response.ShippingPoliciesBySellerIdsResponse;
+import com.personal.marketnote.commerce.adapter.out.web.product.response.ShippingPoliciesBySellerIdsResponse.ShippingPolicyBySellerResponse;
+import com.personal.marketnote.commerce.port.out.result.shipping.ShippingPolicyInfoResult;
+import com.personal.marketnote.commerce.port.out.shipping.FindShippingPolicyBySellerIdsPort;
+import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
+import com.personal.marketnote.common.adapter.out.ServiceAdapter;
+import com.personal.marketnote.common.utility.FormatValidator;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
+
+import static com.personal.marketnote.common.utility.ApiConstant.INTER_SERVER_DEFAULT_RETRIAL_PENDING_MILLI_SECOND;
+import static com.personal.marketnote.common.utility.ApiConstant.INTER_SERVER_MAX_REQUEST_COUNT;
+
+/**
+ * 상품 서비스의 배송비 정책 배치 조회 클라이언트
+ *
+ * @Author 성효빈
+ * @Date 2026-03-19
+ * @Description 커머스 서비스에서 상품 서비스의 배송비 정책을 조회합니다.
+ */
+@ServiceAdapter
+@RequiredArgsConstructor
+@Slf4j
+public class ShippingPolicyServiceClient implements FindShippingPolicyBySellerIdsPort {
+
+    private static final ParameterizedTypeReference<BaseResponse<ShippingPoliciesBySellerIdsResponse>> RESPONSE_TYPE =
+            new ParameterizedTypeReference<>() {
+            };
+
+    @Value("${product-service.base-url:http://localhost:8081}")
+    private String productServiceBaseUrl;
+
+    @Value("${spring.jwt.admin-access-token}")
+    private String adminAccessToken;
+
+    private final RestTemplate restTemplate;
+
+    @Override
+    public Map<Long, ShippingPolicyInfoResult> findBySellerIds(List<Long> sellerIds) {
+        if (FormatValidator.hasNoValue(sellerIds)) {
+            return Map.of();
+        }
+
+        URI uri = UriComponentsBuilder.fromUriString(productServiceBaseUrl)
+                .path("/api/v1/shipping-policies/sellers")
+                .queryParam("sellerIds", sellerIds.toArray())
+                .build()
+                .toUri();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(adminAccessToken);
+        HttpEntity<Void> request = new HttpEntity<>(headers);
+
+        return sendRequest(uri, request);
+    }
+
+    private Map<Long, ShippingPolicyInfoResult> sendRequest(URI uri, HttpEntity<Void> request) {
+        Exception lastError = new Exception();
+
+        for (int i = 0; i < INTER_SERVER_MAX_REQUEST_COUNT; i++) {
+            try {
+                ResponseEntity<BaseResponse<ShippingPoliciesBySellerIdsResponse>> response = restTemplate.exchange(
+                        uri,
+                        HttpMethod.GET,
+                        request,
+                        RESPONSE_TYPE
+                );
+
+                return parseResponse(response);
+            } catch (Exception e) {
+                log.warn("배송비 정책 조회 실패 (attempt {}/{}): {}", i + 1, INTER_SERVER_MAX_REQUEST_COUNT, e.getMessage());
+                lastError = e;
+
+                if (i < INTER_SERVER_MAX_REQUEST_COUNT - 1) {
+                    sleepWithJitter();
+                }
+            }
+        }
+
+        log.error("배송비 정책 조회 최종 실패 - URI: {}, error: {}", uri, lastError.getMessage(), lastError);
+        return Map.of();
+    }
+
+    private Map<Long, ShippingPolicyInfoResult> parseResponse(
+            ResponseEntity<BaseResponse<ShippingPoliciesBySellerIdsResponse>> response
+    ) {
+        BaseResponse<ShippingPoliciesBySellerIdsResponse> body = response.getBody();
+        if (FormatValidator.hasNoValue(body)) {
+            return Map.of();
+        }
+
+        ShippingPoliciesBySellerIdsResponse content = body.getContent();
+        if (FormatValidator.hasNoValue(content)) {
+            return Map.of();
+        }
+
+        List<ShippingPolicyBySellerResponse> policies = content.shippingPolicies();
+        if (FormatValidator.hasNoValue(policies)) {
+            return Map.of();
+        }
+
+        Map<Long, ShippingPolicyInfoResult> result = new HashMap<>();
+        for (ShippingPolicyBySellerResponse policy : policies) {
+            if (FormatValidator.hasNoValue(policy.sellerId())) {
+                continue;
+            }
+            result.put(policy.sellerId(), new ShippingPolicyInfoResult(
+                    policy.sellerId(),
+                    policy.shippingFee(),
+                    policy.freeShippingThreshold()
+            ));
+        }
+
+        return result;
+    }
+
+    private void sleepWithJitter() {
+        try {
+            long jitteredSleepMillis = ThreadLocalRandom.current()
+                    .nextLong(Math.max(1L, INTER_SERVER_DEFAULT_RETRIAL_PENDING_MILLI_SECOND) + 1);
+            Thread.sleep(jitteredSleepMillis);
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+        }
+    }
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/web/product/response/ShippingPoliciesBySellerIdsResponse.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/web/product/response/ShippingPoliciesBySellerIdsResponse.java
@@ -1,0 +1,15 @@
+package com.personal.marketnote.commerce.adapter.out.web.product.response;
+
+import java.util.List;
+
+public record ShippingPoliciesBySellerIdsResponse(
+        List<ShippingPolicyBySellerResponse> shippingPolicies
+) {
+
+    public record ShippingPolicyBySellerResponse(
+            Long sellerId,
+            Long shippingFee,
+            Long freeShippingThreshold
+    ) {
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/exception/ShippingFeeMismatchException.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/exception/ShippingFeeMismatchException.java
@@ -1,0 +1,19 @@
+package com.personal.marketnote.commerce.exception;
+
+import com.personal.marketnote.common.domain.exception.illegalargument.invalidvalue.InvalidValueException;
+
+/**
+ * 클라이언트 전송 배송비와 서버 계산 배송비가 불일치할 때 발생하는 예외
+ *
+ * @Author 성효빈
+ * @Date 2026-03-19
+ * @Description 주문 등록 시 클라이언트가 전송한 shippingFee가 판매자별 배송비 정책 기반 계산 결과와 일치하지 않으면 발생합니다.
+ */
+public class ShippingFeeMismatchException extends InvalidValueException {
+    private static final String MESSAGE =
+            "ERR_ORDER_SHIPPING_01::배송비가 서버 계산 결과와 일치하지 않습니다.";
+
+    public ShippingFeeMismatchException(Long requestedShippingFee, Long calculatedShippingFee) {
+        super(MESSAGE);
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/result/shipping/ShippingPolicyInfoResult.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/result/shipping/ShippingPolicyInfoResult.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.commerce.port.out.result.shipping;
+
+public record ShippingPolicyInfoResult(
+        Long sellerId,
+        Long shippingFee,
+        Long freeShippingThreshold
+) {
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/shipping/FindShippingPolicyBySellerIdsPort.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/shipping/FindShippingPolicyBySellerIdsPort.java
@@ -1,0 +1,25 @@
+package com.personal.marketnote.commerce.port.out.shipping;
+
+import com.personal.marketnote.commerce.port.out.result.shipping.ShippingPolicyInfoResult;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 판매자 ID 목록 기반 배송비 정책 조회 포트
+ *
+ * @Author 성효빈
+ * @Date 2026-03-19
+ * @Description 판매자 ID 목록으로 배송비 정책을 조회합니다.
+ */
+public interface FindShippingPolicyBySellerIdsPort {
+
+    /**
+     * @param sellerIds 판매자 ID 목록
+     * @return 판매자 ID별 배송비 정책 정보 맵 {@link Map}
+     * @Date 2026-03-19
+     * @Author 성효빈
+     * @Description 판매자 ID 목록으로 배송비 정책을 조회합니다.
+     */
+    Map<Long, ShippingPolicyInfoResult> findBySellerIds(List<Long> sellerIds);
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/RegisterOrderService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/RegisterOrderService.java
@@ -20,8 +20,10 @@ import com.personal.marketnote.commerce.port.out.order.SaveOrderPort;
 import com.personal.marketnote.commerce.port.out.payment.SavePaymentPort;
 import com.personal.marketnote.commerce.port.out.product.FindProductByPricePolicyPort;
 import com.personal.marketnote.commerce.port.out.result.product.ProductInfoResult;
+import com.personal.marketnote.commerce.port.out.result.shipping.ShippingPolicyInfoResult;
 import com.personal.marketnote.commerce.port.out.reward.ModifyUserPointPort;
 import com.personal.marketnote.commerce.port.out.settlement.SavePaymentAllocationPort;
+import com.personal.marketnote.commerce.port.out.shipping.FindShippingPolicyBySellerIdsPort;
 import com.personal.marketnote.common.application.UseCase;
 import com.personal.marketnote.common.utility.FormatValidator;
 import lombok.RequiredArgsConstructor;
@@ -42,6 +44,7 @@ import static org.springframework.transaction.annotation.Isolation.READ_COMMITTE
 public class RegisterOrderService implements RegisterOrderUseCase {
     private final GetInventoryUseCase getInventoryUseCase;
     private final FindProductByPricePolicyPort findProductByPricePolicyPort;
+    private final FindShippingPolicyBySellerIdsPort findShippingPolicyBySellerIdsPort;
     private final SaveOrderPort saveOrderPort;
     private final SavePaymentPort savePaymentPort;
     private final SavePaymentAllocationPort savePaymentAllocationPort;
@@ -53,6 +56,7 @@ public class RegisterOrderService implements RegisterOrderUseCase {
         validateDiscountAmounts(command);
         validatePointBalance(command);
         validateUnitAmountsAgainstActualPrices(command);
+        validateShippingFee(command);
 
         Map<Long, Long> productIdsByPricePolicyId = command.orderProducts().stream()
                 .collect(Collectors.toMap(
@@ -243,6 +247,63 @@ public class RegisterOrderService implements RegisterOrderUseCase {
                     command.buyerId(), pointAmount, availablePoints);
             throw new InsufficientPointException(pointAmount, availablePoints);
         }
+    }
+
+    private void validateShippingFee(RegisterOrderCommand command) {
+        long requestedShippingFee = resolveAmount(command.shippingFee());
+
+        List<Long> sellerIds = command.orderProducts().stream()
+                .map(OrderProductItemCommand::sellerId)
+                .distinct()
+                .toList();
+
+        if (sellerIds.isEmpty()) {
+            return;
+        }
+
+        Map<Long, ShippingPolicyInfoResult> shippingPolicies =
+                findShippingPolicyBySellerIdsPort.findBySellerIds(sellerIds);
+
+        if (shippingPolicies.isEmpty()) {
+            log.warn("[SHIPPING_VALIDATION_SKIPPED] product-service 응답 없음 - 배송비 검증 생략. sellerIds: {}", sellerIds);
+            return;
+        }
+
+        long calculatedShippingFee = calculateExpectedShippingFee(command.orderProducts(), shippingPolicies);
+
+        if (requestedShippingFee != calculatedShippingFee) {
+            log.warn("배송비 불일치 - 전송된 배송비: {}, 계산된 배송비: {}", requestedShippingFee, calculatedShippingFee);
+            throw new ShippingFeeMismatchException(requestedShippingFee, calculatedShippingFee);
+        }
+    }
+
+    private long calculateExpectedShippingFee(
+            List<OrderProductItemCommand> orderProducts,
+            Map<Long, ShippingPolicyInfoResult> shippingPolicies
+    ) {
+        Map<Long, Long> sellerAmounts = orderProducts.stream()
+                .collect(Collectors.groupingBy(
+                        OrderProductItemCommand::sellerId,
+                        Collectors.summingLong(item ->
+                                Math.multiplyExact(item.unitAmount(), (long) item.quantity()))
+                ));
+
+        long totalShippingFee = 0L;
+        for (Map.Entry<Long, Long> entry : sellerAmounts.entrySet()) {
+            Long sellerId = entry.getKey();
+            Long sellerAmount = entry.getValue();
+
+            ShippingPolicyInfoResult policy = shippingPolicies.get(sellerId);
+            if (FormatValidator.hasNoValue(policy)) {
+                continue;
+            }
+
+            if (sellerAmount < policy.freeShippingThreshold()) {
+                totalShippingFee = Math.addExact(totalShippingFee, policy.shippingFee());
+            }
+        }
+
+        return totalShippingFee;
     }
 
     private long resolveAmount(Long amount) {

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/RegisterOrderUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/RegisterOrderUseCaseTest.java
@@ -19,7 +19,9 @@ import com.personal.marketnote.commerce.port.out.product.FindProductByPricePolic
 import com.personal.marketnote.commerce.port.out.result.product.ProductInfoResult;
 import com.personal.marketnote.commerce.port.out.reward.ModifyUserPointPort;
 import com.personal.marketnote.commerce.port.out.settlement.SavePaymentAllocationPort;
+import com.personal.marketnote.commerce.port.out.shipping.FindShippingPolicyBySellerIdsPort;
 import com.personal.marketnote.common.domain.exception.illegalargument.invalidvalue.InsufficientQuantityException;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -49,10 +51,18 @@ class RegisterOrderUseCaseTest {
     @Mock
     private SavePaymentAllocationPort savePaymentAllocationPort;
     @Mock
+    private FindShippingPolicyBySellerIdsPort findShippingPolicyBySellerIdsPort;
+    @Mock
     private ModifyUserPointPort modifyUserPointPort;
 
     @InjectMocks
     private RegisterOrderService registerOrderService;
+
+    @BeforeEach
+    void setUp() {
+        lenient().when(findShippingPolicyBySellerIdsPort.findBySellerIds(anyList()))
+                .thenReturn(Map.of());
+    }
 
     // ==================================================================================
     // 성공 케이스

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/shipping/controller/ShippingPolicyController.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/shipping/controller/ShippingPolicyController.java
@@ -2,16 +2,19 @@ package com.personal.marketnote.product.adapter.in.web.shipping.controller;
 
 import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
 import com.personal.marketnote.common.utility.ElementExtractor;
+import com.personal.marketnote.product.adapter.in.web.shipping.controller.apidocs.GetShippingPoliciesBySellerIdsApiDocs;
 import com.personal.marketnote.product.adapter.in.web.shipping.controller.apidocs.GetShippingPolicyApiDocs;
 import com.personal.marketnote.product.adapter.in.web.shipping.controller.apidocs.RegisterShippingPolicyApiDocs;
 import com.personal.marketnote.product.adapter.in.web.shipping.controller.apidocs.UpdateShippingPolicyApiDocs;
 import com.personal.marketnote.product.adapter.in.web.shipping.request.RegisterShippingPolicyRequest;
 import com.personal.marketnote.product.adapter.in.web.shipping.request.UpdateShippingPolicyRequest;
+import com.personal.marketnote.product.adapter.in.web.shipping.response.GetShippingPoliciesBySellerIdsResponse;
 import com.personal.marketnote.product.adapter.in.web.shipping.response.GetShippingPolicyResponse;
 import com.personal.marketnote.product.adapter.in.web.shipping.response.RegisterShippingPolicyResponse;
 import com.personal.marketnote.product.adapter.in.web.shipping.response.UpdateShippingPolicyResponse;
 import com.personal.marketnote.product.port.in.command.RegisterShippingPolicyCommand;
 import com.personal.marketnote.product.port.in.command.UpdateShippingPolicyCommand;
+import com.personal.marketnote.product.port.in.result.shipping.GetShippingPolicyBySellerResult;
 import com.personal.marketnote.product.port.in.result.shipping.GetShippingPolicyResult;
 import com.personal.marketnote.product.port.in.result.shipping.RegisterShippingPolicyResult;
 import com.personal.marketnote.product.port.in.result.shipping.UpdateShippingPolicyResult;
@@ -20,6 +23,7 @@ import com.personal.marketnote.product.port.in.usecase.shipping.RegisterShipping
 import com.personal.marketnote.product.port.in.usecase.shipping.UpdateShippingPolicyUseCase;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Size;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -32,10 +36,14 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 import static com.personal.marketnote.common.domain.exception.ExceptionCode.DEFAULT_SUCCESS_CODE;
 import static com.personal.marketnote.common.utility.ApiConstant.ADMIN_OR_SELLER_POINTCUT;
+import static com.personal.marketnote.common.utility.ApiConstant.ADMIN_POINTCUT;
 
 /**
  * 배송비 정책 컨트롤러
@@ -80,6 +88,34 @@ public class ShippingPolicyController {
                         HttpStatus.OK,
                         DEFAULT_SUCCESS_CODE,
                         "판매자 배송비 정책 조회 성공"
+                ),
+                HttpStatus.OK
+        );
+    }
+
+    /**
+     * (관리자) 판매자별 배송비 정책 배치 조회
+     *
+     * @param sellerIds 판매자 ID 목록
+     * @return 배송비 정책 배치 조회 응답 {@link GetShippingPoliciesBySellerIdsResponse}
+     * @Author 성효빈
+     * @Date 2026-03-19
+     * @Description 판매자 ID 목록으로 배송비 정책을 배치 조회합니다. 서비스 간 내부 통신용 API입니다.
+     */
+    @GetMapping("/sellers")
+    @PreAuthorize(ADMIN_POINTCUT)
+    @GetShippingPoliciesBySellerIdsApiDocs
+    public ResponseEntity<BaseResponse<GetShippingPoliciesBySellerIdsResponse>> getShippingPoliciesBySellerIds(
+            @RequestParam @Size(max = 100, message = "판매자 ID는 최대 100개까지 조회 가능합니다") List<Long> sellerIds
+    ) {
+        List<GetShippingPolicyBySellerResult> results = getShippingPolicyUseCase.getShippingPolicies(sellerIds);
+
+        return new ResponseEntity<>(
+                BaseResponse.of(
+                        GetShippingPoliciesBySellerIdsResponse.from(results),
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "판매자별 배송비 정책 배치 조회 성공"
                 ),
                 HttpStatus.OK
         );

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/shipping/controller/apidocs/GetShippingPoliciesBySellerIdsApiDocs.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/shipping/controller/apidocs/GetShippingPoliciesBySellerIdsApiDocs.java
@@ -1,0 +1,136 @@
+package com.personal.marketnote.product.adapter.in.web.shipping.controller.apidocs;
+
+import com.personal.marketnote.common.adapter.in.api.schema.StringResponseSchema;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Operation(
+        summary = "(관리자) 판매자별 배송비 정책 배치 조회",
+        description = """
+                작성일자: 2026-03-19
+
+                작성자: 성효빈
+
+                ---
+
+                ## Description
+
+                - 판매자 ID 목록으로 배송비 정책을 배치 조회합니다.
+
+                - 서비스 간 내부 통신용 API입니다.
+
+                - 관리자 권한이 필요합니다.
+
+                ---
+
+                ## Response
+
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | statusCode | number | 상태 코드 | 200: 성공 / 401: 인증 실패 / 403: 인가 실패 / 500: 그 외 |
+                | code | string | 응답 코드 | "SUC01" / "UNAUTHORIZED" / "FORBIDDEN" / "INTERNAL_SERVER_ERROR" |
+                | timestamp | string(datetime) | 응답 일시 | "2026-03-19T10:00:00.000" |
+                | content | object | 응답 본문 | { ... } |
+                | message | string | 처리 결과 | "판매자별 배송비 정책 배치 조회 성공" |
+
+                ### Response > content
+
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | shippingPolicies | array | 배송비 정책 목록 | [ ... ] |
+
+                ### Response > content > shippingPolicies[]
+
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | sellerId | number | 판매자 ID | 10 |
+                | shippingFee | number | 배송비 | 3000 |
+                | freeShippingThreshold | number | 무료배송 기준금액 | 20000 |
+                """,
+        security = {@SecurityRequirement(name = "bearer")},
+        parameters = {
+                @Parameter(
+                        name = "sellerIds",
+                        description = "판매자 ID 목록",
+                        required = true,
+                        example = "10,20,30"
+                )
+        },
+        responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "조회 성공",
+                        content = @Content(
+                                schema = @Schema(implementation = StringResponseSchema.class),
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 200,
+                                          "code": "SUC01",
+                                          "timestamp": "2026-03-19T10:00:00.000",
+                                          "content": {
+                                            "shippingPolicies": [
+                                              {
+                                                "sellerId": 10,
+                                                "shippingFee": 3000,
+                                                "freeShippingThreshold": 20000
+                                              },
+                                              {
+                                                "sellerId": 20,
+                                                "shippingFee": 2500,
+                                                "freeShippingThreshold": 30000
+                                              }
+                                            ]
+                                          },
+                                          "message": "판매자별 배송비 정책 배치 조회 성공"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "401",
+                        description = "토큰 인증 실패",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 401,
+                                          "code": "UNAUTHORIZED",
+                                          "timestamp": "2026-03-19T10:00:00.000",
+                                          "content": null,
+                                          "message": "Invalid token"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "403",
+                        description = "토큰 인가 실패",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 403,
+                                          "code": "FORBIDDEN",
+                                          "timestamp": "2026-03-19T10:00:00.000",
+                                          "content": null,
+                                          "message": "Access Denied"
+                                        }
+                                        """)
+                        )
+                )
+        }
+)
+public @interface GetShippingPoliciesBySellerIdsApiDocs {
+}

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/shipping/response/GetShippingPoliciesBySellerIdsResponse.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/shipping/response/GetShippingPoliciesBySellerIdsResponse.java
@@ -1,0 +1,32 @@
+package com.personal.marketnote.product.adapter.in.web.shipping.response;
+
+import com.personal.marketnote.product.port.in.result.shipping.GetShippingPolicyBySellerResult;
+
+import java.util.List;
+
+public record GetShippingPoliciesBySellerIdsResponse(
+        List<ShippingPolicyBySellerResponse> shippingPolicies
+) {
+
+    public static GetShippingPoliciesBySellerIdsResponse from(List<GetShippingPolicyBySellerResult> results) {
+        List<ShippingPolicyBySellerResponse> responses = results.stream()
+                .map(ShippingPolicyBySellerResponse::from)
+                .toList();
+        return new GetShippingPoliciesBySellerIdsResponse(responses);
+    }
+
+    public record ShippingPolicyBySellerResponse(
+            Long sellerId,
+            Long shippingFee,
+            Long freeShippingThreshold
+    ) {
+
+        public static ShippingPolicyBySellerResponse from(GetShippingPolicyBySellerResult result) {
+            return new ShippingPolicyBySellerResponse(
+                    result.sellerId(),
+                    result.shippingFee(),
+                    result.freeShippingThreshold()
+            );
+        }
+    }
+}

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/shipping/ShippingPolicyPersistenceAdapter.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/shipping/ShippingPolicyPersistenceAdapter.java
@@ -14,6 +14,7 @@ import com.personal.marketnote.product.port.out.shipping.UpdateShippingPolicyPor
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
 
+import java.util.List;
 import java.util.Optional;
 
 @PersistenceAdapter
@@ -37,6 +38,16 @@ public class ShippingPolicyPersistenceAdapter implements SaveShippingPolicyPort,
     public Optional<ShippingPolicy> findActiveBySellerId(Long sellerId) {
         return shippingPolicyJpaRepository.findBySellerIdAndStatus(sellerId, EntityStatus.ACTIVE)
                 .flatMap(ShippingPolicyJpaEntityToDomainMapper::mapToDomain);
+    }
+
+    @Override
+    public List<ShippingPolicy> findActiveBySellerIds(List<Long> sellerIds) {
+        return shippingPolicyJpaRepository.findAllBySellerIdInAndStatus(sellerIds, EntityStatus.ACTIVE)
+                .stream()
+                .map(ShippingPolicyJpaEntityToDomainMapper::mapToDomain)
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .toList();
     }
 
     @Override

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/result/shipping/GetShippingPolicyBySellerResult.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/result/shipping/GetShippingPolicyBySellerResult.java
@@ -1,0 +1,18 @@
+package com.personal.marketnote.product.port.in.result.shipping;
+
+import com.personal.marketnote.product.domain.shipping.ShippingPolicy;
+
+public record GetShippingPolicyBySellerResult(
+        Long sellerId,
+        Long shippingFee,
+        Long freeShippingThreshold
+) {
+
+    public static GetShippingPolicyBySellerResult from(ShippingPolicy shippingPolicy) {
+        return new GetShippingPolicyBySellerResult(
+                shippingPolicy.getSellerId(),
+                shippingPolicy.getShippingFee(),
+                shippingPolicy.getFreeShippingThreshold()
+        );
+    }
+}

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/usecase/shipping/GetShippingPolicyUseCase.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/usecase/shipping/GetShippingPolicyUseCase.java
@@ -1,8 +1,13 @@
 package com.personal.marketnote.product.port.in.usecase.shipping;
 
+import com.personal.marketnote.product.port.in.result.shipping.GetShippingPolicyBySellerResult;
 import com.personal.marketnote.product.port.in.result.shipping.GetShippingPolicyResult;
+
+import java.util.List;
 
 public interface GetShippingPolicyUseCase {
 
     GetShippingPolicyResult getShippingPolicy(Long sellerId);
+
+    List<GetShippingPolicyBySellerResult> getShippingPolicies(List<Long> sellerIds);
 }

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/out/shipping/FindShippingPolicyPort.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/out/shipping/FindShippingPolicyPort.java
@@ -2,9 +2,12 @@ package com.personal.marketnote.product.port.out.shipping;
 
 import com.personal.marketnote.product.domain.shipping.ShippingPolicy;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface FindShippingPolicyPort {
 
     Optional<ShippingPolicy> findActiveBySellerId(Long sellerId);
+
+    List<ShippingPolicy> findActiveBySellerIds(List<Long> sellerIds);
 }

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/service/shipping/GetShippingPolicyService.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/service/shipping/GetShippingPolicyService.java
@@ -1,13 +1,17 @@
 package com.personal.marketnote.product.service.shipping;
 
 import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.product.domain.shipping.ShippingPolicy;
 import com.personal.marketnote.product.exception.ShippingPolicyNotFoundException;
+import com.personal.marketnote.product.port.in.result.shipping.GetShippingPolicyBySellerResult;
 import com.personal.marketnote.product.port.in.result.shipping.GetShippingPolicyResult;
 import com.personal.marketnote.product.port.in.usecase.shipping.GetShippingPolicyUseCase;
 import com.personal.marketnote.product.port.out.shipping.FindShippingPolicyPort;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
 
@@ -22,6 +26,19 @@ public class GetShippingPolicyService implements GetShippingPolicyUseCase {
     public GetShippingPolicyResult getShippingPolicy(Long sellerId) {
         ShippingPolicy shippingPolicy = findShippingPolicy(sellerId);
         return GetShippingPolicyResult.from(shippingPolicy);
+    }
+
+    @Override
+    @Transactional(isolation = READ_COMMITTED, readOnly = true)
+    public List<GetShippingPolicyBySellerResult> getShippingPolicies(List<Long> sellerIds) {
+        if (FormatValidator.hasNoValue(sellerIds)) {
+            return List.of();
+        }
+
+        List<ShippingPolicy> policies = findShippingPolicyPort.findActiveBySellerIds(sellerIds);
+        return policies.stream()
+                .map(GetShippingPolicyBySellerResult::from)
+                .toList();
     }
 
     private ShippingPolicy findShippingPolicy(Long sellerId) {


### PR DESCRIPTION
## partially addresses #1196
## resolves #1313

## Task
- [x] FindShippingPolicyPort 배치 조회 메서드 추가
- [x] GetShippingPolicyUseCase/Service 배치 조회 구현
- [x] ShippingPolicyPersistenceAdapter 배치 조회 구현
- [x] ShippingPolicyController 관리자 전용 배치 조회 엔드포인트 추가
- [x] FindShippingPolicyBySellerIdsPort 신규 Out Port
- [x] ShippingPolicyServiceClient 신규 HTTP 클라이언트
- [x] RegisterOrderService validateShippingFee 검증 로직 추가
- [x] ShippingFeeMismatchException 신규 예외
- [x] 기존 RegisterOrderUseCaseTest Mock 호환성 수정