### PR TITLE
[#128][#1363] feat: 상품 목록 조회 시 캐시 적립률 높은순 정렬 기능 추가

### DIFF
--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/pricepolicy/repository/PricePolicyJpaRepository.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/pricepolicy/repository/PricePolicyJpaRepository.java
@@ -94,6 +94,11 @@ public interface PricePolicyJpaRepository extends JpaRepository<PricePolicyJpaEn
                            OR (pp.accumulatedPoint = (SELECT pp5.accumulatedPoint FROM PricePolicyJpaEntity pp5 WHERE pp5.id = :cursor)
                                AND pp.id > :cursor)
                         ))
+                     OR (:sortProperty = 'accumulatedPointRate' AND (
+                              pp.accumulationRate > (SELECT pp6.accumulationRate FROM PricePolicyJpaEntity pp6 WHERE pp6.id = :cursor)
+                           OR (pp.accumulationRate = (SELECT pp6.accumulationRate FROM PricePolicyJpaEntity pp6 WHERE pp6.id = :cursor)
+                               AND pp.id > :cursor)
+                        ))
                  )
               )
             ORDER BY
@@ -101,6 +106,7 @@ public interface PricePolicyJpaRepository extends JpaRepository<PricePolicyJpaEn
                 CASE WHEN :sortProperty = 'popularity' THEN pp.popularity END ASC,
                 CASE WHEN :sortProperty = 'discountPrice' THEN pp.discountPrice END ASC,
                 CASE WHEN :sortProperty = 'accumulatedPoint' THEN pp.accumulatedPoint END ASC,
+                CASE WHEN :sortProperty = 'accumulatedPointRate' THEN pp.accumulationRate END ASC,
                 pp.id ASC
             """)
     List<PricePolicyJpaEntity> findAllActiveByCursorAsc(
@@ -195,6 +201,19 @@ public interface PricePolicyJpaRepository extends JpaRepository<PricePolicyJpaEn
                                 )
                                AND pp.id < :cursor)
                         ))
+                     OR (:sortProperty = 'accumulatedPointRate' AND (
+                              pp.accumulationRate < (
+                                  SELECT pp6.accumulationRate
+                                  FROM PricePolicyJpaEntity pp6
+                                  WHERE pp6.id = :cursor
+                              )
+                           OR (pp.accumulationRate = (
+                                    SELECT pp6.accumulationRate
+                                    FROM PricePolicyJpaEntity pp6
+                                    WHERE pp6.id = :cursor
+                                )
+                               AND pp.id < :cursor)
+                        ))
                  )
               )
             ORDER BY
@@ -202,6 +221,7 @@ public interface PricePolicyJpaRepository extends JpaRepository<PricePolicyJpaEn
                 CASE WHEN :sortProperty = 'popularity' THEN pp.popularity END DESC,
                 CASE WHEN :sortProperty = 'discountPrice' THEN pp.discountPrice END DESC,
                 CASE WHEN :sortProperty = 'accumulatedPoint' THEN pp.accumulatedPoint END DESC,
+                CASE WHEN :sortProperty = 'accumulatedPointRate' THEN pp.accumulationRate END DESC,
                 pp.id DESC
             """)
     List<PricePolicyJpaEntity> findAllActiveByCursorDesc(


### PR DESCRIPTION
## partially addresses #128
## resolves #1363

## Task
- [x] PricePolicyJpaRepository.findAllActiveByCursorAsc ORDER BY + 커서 조건에 accumulatedPointRate CASE WHEN 추가
- [x] PricePolicyJpaRepository.findAllActiveByCursorDesc ORDER BY + 커서 조건에 accumulatedPointRate CASE WHEN 추가