### PR TITLE
[#300][#1418] feat: 리뷰 작성 대상 주문 상품 목록 조회 시 구매 확정 후 30일 리뷰 작성기한 검증 기능 추가

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/mapper/OrderJpaEntityToDomainMapper.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/mapper/OrderJpaEntityToDomainMapper.java
@@ -85,6 +85,7 @@ public class OrderJpaEntityToDomainMapper {
                         .imageUrl(entity.getImageUrl())
                         .orderStatus(entity.getOrderStatus())
                         .isReviewed(entity.getIsReviewed())
+                        .confirmedAt(entity.getConfirmedAt())
                         .build());
     }
 
@@ -116,6 +117,7 @@ public class OrderJpaEntityToDomainMapper {
                                 .imageUrl(entity.getImageUrl())
                                 .orderStatus(entity.getOrderStatus())
                                 .isReviewed(entity.getIsReviewed())
+                                .confirmedAt(entity.getConfirmedAt())
                                 .build()
                 ));
     }

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/order/entity/OrderProductJpaEntity.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/order/entity/OrderProductJpaEntity.java
@@ -8,6 +8,8 @@ import lombok.*;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
 
+import java.time.LocalDateTime;
+
 import static com.personal.marketnote.common.utility.EntityConstant.BOOLEAN_DEFAULT_FALSE;
 
 @Entity
@@ -49,6 +51,9 @@ public class OrderProductJpaEntity extends BaseEntity {
     @Column(name = "review_yn", nullable = false, columnDefinition = BOOLEAN_DEFAULT_FALSE)
     private Boolean isReviewed;
 
+    @Column(name = "confirmed_at")
+    private LocalDateTime confirmedAt;
+
     public static OrderProductJpaEntity from(OrderProduct orderProduct, OrderJpaEntity orderJpaEntity) {
         return OrderProductJpaEntity.builder()
                 .id(new OrderProductId(orderProduct.getPricePolicyId(), orderJpaEntity.getId()))
@@ -59,6 +64,7 @@ public class OrderProductJpaEntity extends BaseEntity {
                 .unitAmount(orderProduct.getUnitAmount())
                 .imageUrl(orderProduct.getImageUrl())
                 .orderStatus(orderProduct.getOrderStatus())
+                .confirmedAt(orderProduct.getConfirmedAt())
                 .build();
     }
 
@@ -68,6 +74,7 @@ public class OrderProductJpaEntity extends BaseEntity {
         imageUrl = orderProduct.getImageUrl();
         orderStatus = orderProduct.getOrderStatus();
         isReviewed = orderProduct.getIsReviewed();
+        confirmedAt = orderProduct.getConfirmedAt();
     }
 
     public Long getPricePolicyId() {

--- a/commerce-service/commerce-adapters/src/main/resources/db/migration/V900__add_confirmed_at_to_order_product.sql
+++ b/commerce-service/commerce-adapters/src/main/resources/db/migration/V900__add_confirmed_at_to_order_product.sql
@@ -1,0 +1,1 @@
+ALTER TABLE order_product ADD COLUMN confirmed_at TIMESTAMP;

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/ChangeOrderStatusService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/ChangeOrderStatusService.java
@@ -27,6 +27,8 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
+import java.time.Clock;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -45,6 +47,7 @@ public class ChangeOrderStatusService implements ChangeOrderStatusUseCase {
     private final FindProductByPricePolicyPort findProductByPricePolicyPort;
     private final ModifyUserPointPort modifyUserPointPort;
     private final PublishOrderEventPort publishOrderEventPort;
+    private final Clock clock;
 
     @Override
     public void changeOrderStatus(ChangeOrderStatusCommand command) {
@@ -101,13 +104,14 @@ public class ChangeOrderStatusService implements ChangeOrderStatusUseCase {
 
     private void changeOrderStatus(ChangeOrderStatusCommand command, Order order) {
         OrderStatus status = command.orderStatus();
+        LocalDateTime now = LocalDateTime.now(clock);
 
         if (command.isPartialProductChange()) {
-            order.changeProductsStatus(command.pricePolicyIds(), status);
+            order.changeProductsStatus(command.pricePolicyIds(), status, now);
             return;
         }
 
-        order.changeAllProductsStatus(status);
+        order.changeAllProductsStatus(status, now);
     }
 
     private void updatePaymentSubsequentProcesses(Order order, OrderStatus status) {

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/GetOrderService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/GetOrderService.java
@@ -19,7 +19,9 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Clock;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -36,6 +38,7 @@ public class GetOrderService implements GetOrderUseCase {
     private final FindOrderPort findOrderPort;
     private final FindOrderProductPort findOrderProductPort;
     private final FindProductByPricePolicyPort findProductByPricePolicyPort;
+    private final Clock clock;
 
     @Override
     public GetOrderResult getOrderAndOrderProducts(Long id) {
@@ -98,8 +101,10 @@ public class GetOrderService implements GetOrderUseCase {
             return GetBuyerOrderProductsResult.of(List.of());
         }
 
+        LocalDateTime reviewDeadlineNow = LocalDateTime.now(clock);
         Predicate<OrderProduct> orderProductFilter = orderProduct
                 -> orderProduct.isConfirmed()
+                && orderProduct.isWithinReviewDeadline(reviewDeadlineNow)
                 && query.matchesReviewStatus(orderProduct.getIsReviewed());
         Map<Long, ProductInfoResult> orderedProductsByPricePolicyId
                 = findOrderedProductsByPricePolicyId(orders, orderProductFilter);

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/ChangeOrderStatusConfirmProcessUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/ChangeOrderStatusConfirmProcessUseCaseTest.java
@@ -18,9 +18,13 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.Clock;
+import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -44,6 +48,8 @@ class ChangeOrderStatusConfirmProcessUseCaseTest {
     private ModifyUserPointPort modifyUserPointPort;
     @Mock
     private PublishOrderEventPort publishOrderEventPort;
+    @Spy
+    private Clock clock = Clock.fixed(Instant.parse("2026-03-01T00:00:00Z"), ZoneId.of("Asia/Seoul"));
 
     @InjectMocks
     private ChangeOrderStatusService changeOrderStatusService;

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/ChangeOrderStatusPaidProcessUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/ChangeOrderStatusPaidProcessUseCaseTest.java
@@ -19,9 +19,13 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.Clock;
+import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -47,6 +51,8 @@ class ChangeOrderStatusPaidProcessUseCaseTest {
     private ModifyUserPointPort modifyUserPointPort;
     @Mock
     private PublishOrderEventPort publishOrderEventPort;
+    @Spy
+    private Clock clock = Clock.fixed(Instant.parse("2026-03-01T00:00:00Z"), ZoneId.of("Asia/Seoul"));
 
     @InjectMocks
     private ChangeOrderStatusService changeOrderStatusService;

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/ChangeOrderStatusRoleValidationUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/ChangeOrderStatusRoleValidationUseCaseTest.java
@@ -20,9 +20,13 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.Clock;
+import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.UUID;
 
@@ -47,6 +51,8 @@ class ChangeOrderStatusRoleValidationUseCaseTest {
     private ModifyUserPointPort modifyUserPointPort;
     @Mock
     private PublishOrderEventPort publishOrderEventPort;
+    @Spy
+    private Clock clock = Clock.fixed(Instant.parse("2026-03-01T00:00:00Z"), ZoneId.of("Asia/Seoul"));
 
     @InjectMocks
     private ChangeOrderStatusService changeOrderStatusService;

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/GetBuyerOrderCountUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/GetBuyerOrderCountUseCaseTest.java
@@ -15,11 +15,15 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.Clock;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -36,6 +40,9 @@ class GetBuyerOrderCountUseCaseTest {
     private FindOrderProductPort findOrderProductPort;
     @Mock
     private FindProductByPricePolicyPort findProductByPricePolicyPort;
+
+    @Spy
+    private Clock clock = Clock.fixed(Instant.parse("2026-03-01T00:00:00Z"), ZoneId.of("Asia/Seoul"));
 
     @InjectMocks
     private GetOrderService getOrderService;

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/GetBuyerOrderHistoryUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/GetBuyerOrderHistoryUseCaseTest.java
@@ -15,11 +15,15 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.Clock;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -36,6 +40,9 @@ class GetBuyerOrderHistoryUseCaseTest {
     private FindOrderProductPort findOrderProductPort;
     @Mock
     private FindProductByPricePolicyPort findProductByPricePolicyPort;
+
+    @Spy
+    private Clock clock = Clock.fixed(Instant.parse("2026-03-01T00:00:00Z"), ZoneId.of("Asia/Seoul"));
 
     @InjectMocks
     private GetOrderService getOrderService;

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/GetBuyerOrderProductsUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/GetBuyerOrderProductsUseCaseTest.java
@@ -19,9 +19,13 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.Clock;
+import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -38,6 +42,8 @@ class GetBuyerOrderProductsUseCaseTest {
     private FindOrderProductPort findOrderProductPort;
     @Mock
     private FindProductByPricePolicyPort findProductByPricePolicyPort;
+    @Spy
+    private Clock clock = Clock.fixed(Instant.parse("2026-03-01T00:00:00Z"), ZoneId.of("Asia/Seoul"));
 
     @InjectMocks
     private GetOrderService getOrderService;

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/GetOrderAndOrderProductsUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/GetOrderAndOrderProductsUseCaseTest.java
@@ -16,9 +16,13 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InOrder;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.Clock;
+import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -34,6 +38,9 @@ class GetOrderAndOrderProductsUseCaseTest {
     private FindOrderProductPort findOrderProductPort;
     @Mock
     private FindProductByPricePolicyPort findProductByPricePolicyPort;
+
+    @Spy
+    private Clock clock = Clock.fixed(Instant.parse("2026-03-01T00:00:00Z"), ZoneId.of("Asia/Seoul"));
 
     @InjectMocks
     private GetOrderService getOrderService;

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/GetOrderUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/GetOrderUseCaseTest.java
@@ -11,9 +11,13 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.Clock;
+import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -30,6 +34,9 @@ class GetOrderUseCaseTest {
     private FindOrderProductPort findOrderProductPort;
     @Mock
     private FindProductByPricePolicyPort findProductByPricePolicyPort;
+
+    @Spy
+    private Clock clock = Clock.fixed(Instant.parse("2026-03-01T00:00:00Z"), ZoneId.of("Asia/Seoul"));
 
     @InjectMocks
     private GetOrderService getOrderService;

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/GetOrderWithBuyerVerificationUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/GetOrderWithBuyerVerificationUseCaseTest.java
@@ -18,9 +18,13 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.Clock;
+import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -40,6 +44,9 @@ class GetOrderWithBuyerVerificationUseCaseTest {
     private FindOrderProductPort findOrderProductPort;
     @Mock
     private FindProductByPricePolicyPort findProductByPricePolicyPort;
+
+    @Spy
+    private Clock clock = Clock.fixed(Instant.parse("2026-03-01T00:00:00Z"), ZoneId.of("Asia/Seoul"));
 
     @InjectMocks
     private GetOrderService getOrderService;

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/order/Order.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/order/Order.java
@@ -79,10 +79,10 @@ public class Order {
         return this.orderStatus.isPending();
     }
 
-    public void changeProductsStatus(List<Long> pricePolicyIds, OrderStatus orderStatus) {
+    public void changeProductsStatus(List<Long> pricePolicyIds, OrderStatus orderStatus, LocalDateTime now) {
         orderProducts.stream()
                 .filter(orderProduct -> pricePolicyIds.contains(orderProduct.getPricePolicyId()))
-                .forEach(orderProduct -> orderProduct.changeOrderStatus(orderStatus));
+                .forEach(orderProduct -> orderProduct.changeOrderStatus(orderStatus, now));
 
         if (
                 orderStatus.isRefunded()
@@ -105,8 +105,8 @@ public class Order {
         this.orderStatus = orderStatus;
     }
 
-    public void changeAllProductsStatus(OrderStatus orderStatus) {
-        orderProducts.forEach(orderProduct -> orderProduct.changeOrderStatus(orderStatus));
+    public void changeAllProductsStatus(OrderStatus orderStatus, LocalDateTime now) {
+        orderProducts.forEach(orderProduct -> orderProduct.changeOrderStatus(orderStatus, now));
         this.orderStatus = orderStatus;
     }
 

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/order/OrderProduct.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/order/OrderProduct.java
@@ -3,11 +3,15 @@ package com.personal.marketnote.commerce.domain.order;
 import com.personal.marketnote.common.utility.FormatValidator;
 import lombok.*;
 
+import java.time.LocalDateTime;
+
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder(access = AccessLevel.PRIVATE)
 @Getter
 public class OrderProduct {
+    private static final long REVIEW_DEADLINE_DAYS = 30;
+
     private Long orderId;
     private Long sellerId;
     private Long pricePolicyId;
@@ -17,6 +21,7 @@ public class OrderProduct {
     private String imageUrl;
     private OrderStatus orderStatus;
     private Boolean isReviewed;
+    private LocalDateTime confirmedAt;
 
     public static OrderProduct from(OrderProductCreateState state) {
         return OrderProduct.builder()
@@ -41,10 +46,11 @@ public class OrderProduct {
                 .imageUrl(state.getImageUrl())
                 .orderStatus(state.getOrderStatus())
                 .isReviewed(state.getIsReviewed())
+                .confirmedAt(state.getConfirmedAt())
                 .build();
     }
 
-    public void changeOrderStatus(OrderStatus orderStatus) {
+    public void changeOrderStatus(OrderStatus orderStatus, LocalDateTime now) {
         if (this.orderStatus == orderStatus) {
             return;
         }
@@ -52,10 +58,21 @@ public class OrderProduct {
             throw new InvalidOrderProductStatusTransitionException(this.orderStatus, orderStatus);
         }
         this.orderStatus = orderStatus;
+        if (orderStatus.isConfirmed()) {
+            this.confirmedAt = now;
+        }
     }
 
     public boolean isConfirmed() {
         return FormatValidator.hasValue(this.orderStatus) && this.orderStatus.isConfirmed();
+    }
+
+    public boolean isWithinReviewDeadline(LocalDateTime now) {
+        // confirmedAt이 null인 기존 데이터는 기한 내로 간주 (마이그레이션 전 데이터 호환)
+        if (FormatValidator.hasNoValue(confirmedAt)) {
+            return true;
+        }
+        return !confirmedAt.plusDays(REVIEW_DEADLINE_DAYS).isBefore(now);
     }
 
     public void updateReviewStatus(Boolean isReviewed) {

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/order/OrderProductSnapshotState.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/order/OrderProductSnapshotState.java
@@ -5,6 +5,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDateTime;
+
 @Getter
 @Builder
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
@@ -18,5 +20,6 @@ public class OrderProductSnapshotState {
     private final String imageUrl;
     private final OrderStatus orderStatus;
     private final Boolean isReviewed;
+    private final LocalDateTime confirmedAt;
 }
 


### PR DESCRIPTION
## partially addresses #300
## resolves #1418

## Task
- [x] OrderProduct 도메인에 confirmedAt 필드 및 isWithinReviewDeadline() 술어 메서드 추가
- [x] OrderProduct.changeOrderStatus()에서 CONFIRMED 전이 시 confirmedAt 기록
- [x] Order.changeProductsStatus/changeAllProductsStatus에 LocalDateTime now 파라미터 추가
- [x] GetOrderService에 Clock 주입 및 Predicate에 30일 기한 조건 AND 결합
- [x] ChangeOrderStatusService에 Clock 주입 및 now 전달
- [x] OrderProductJpaEntity에 confirmed_at 컬럼 추가
- [x] OrderJpaEntityToDomainMapper에 confirmedAt 매핑 추가
- [x] Flyway V900 마이그레이션 스크립트 추가
- [x] 기존 테스트 Clock @SPY 추가 (9개 파일)