### PR TITLE
[#300][#1420] feat: 리뷰 작성 대상 주문 상품 목록 응답에 리뷰 작성기한 정보 포함 기능 추가

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/apidocs/GetOrderProductsApiDocs.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/apidocs/GetOrderProductsApiDocs.java
@@ -78,7 +78,8 @@ import java.lang.annotation.*;
                 | productName | string | 상품명 | "공책" |
                 | selectedOptions | array | 선택 옵션 목록 | [ ... ] |
                 | isReviewed | boolean | 리뷰 작성 여부 | false |
-                
+                | reviewDeadline | string(datetime) | 리뷰 작성기한 (구매 확정 후 30일) | "2026-02-25T14:30:00" |
+
                 ---
                 
                 ### Response > content > orderProducts > selectedOptions
@@ -132,7 +133,8 @@ import java.lang.annotation.*;
                                                     "status": "ACTIVE"
                                                   }
                                                 ],
-                                                "isReviewed": false
+                                                "isReviewed": false,
+                                                "reviewDeadline": "2026-02-25T14:30:00"
                                               }
                                             ]
                                           },

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/result/order/GetBuyerOrderProductResult.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/result/order/GetBuyerOrderProductResult.java
@@ -10,6 +10,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Builder(access = AccessLevel.PRIVATE)
@@ -28,7 +29,8 @@ public record GetBuyerOrderProductResult(
         String brandName,
         String productName,
         List<ProductOptionInfoResult> selectedOptions,
-        Boolean isReviewed
+        Boolean isReviewed,
+        LocalDateTime reviewDeadline
 ) {
     public static GetBuyerOrderProductResult from(
             Order order,
@@ -60,6 +62,7 @@ public record GetBuyerOrderProductResult(
                 .productName(orderProductResult.productName())
                 .selectedOptions(orderProductResult.selectedOptions())
                 .isReviewed(orderProductResult.isReviewed())
+                .reviewDeadline(orderProduct.calculateReviewDeadline())
                 .build();
     }
 }

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/order/OrderProduct.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/order/OrderProduct.java
@@ -72,7 +72,15 @@ public class OrderProduct {
         if (FormatValidator.hasNoValue(confirmedAt)) {
             return true;
         }
-        return !confirmedAt.plusDays(REVIEW_DEADLINE_DAYS).isBefore(now);
+        LocalDateTime deadline = calculateReviewDeadline();
+        return !deadline.isBefore(now);
+    }
+
+    public LocalDateTime calculateReviewDeadline() {
+        if (FormatValidator.hasNoValue(confirmedAt)) {
+            return null;
+        }
+        return confirmedAt.plusDays(REVIEW_DEADLINE_DAYS);
     }
 
     public void updateReviewStatus(Boolean isReviewed) {


### PR DESCRIPTION
## partially addresses #300
## resolves #1420

## Task
- [x] OrderProduct 도메인에 calculateReviewDeadline() 메서드 추가 (confirmedAt + 30일, null-safe)
- [x] GetBuyerOrderProductResult에 reviewDeadline(LocalDateTime) 필드 추가 및 from() 매핑
- [x] API 문서(GetOrderProductsApiDocs)에 reviewDeadline 필드 설명 및 예시 JSON 반영