### PR TITLE
[#43][#1409] feat: 배송 요청사항 등록 기능 추가

### DIFF
--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/shippingaddress/request/RegisterShippingAddressRequest.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/shippingaddress/request/RegisterShippingAddressRequest.java
@@ -46,8 +46,8 @@ public class RegisterShippingAddressRequest {
     @Schema(name = "deliveryRequestType", description = "배송 요청사항 타입", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private DeliveryRequestType deliveryRequestType;
 
-    @Schema(name = "deliveryRequestMessage", description = "배송 요청사항 직접입력 메시지 (최대 30자, CUSTOM 타입일 때 필수)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-    @Size(max = 30, message = "배송 요청사항 메시지는 최대 30자까지 입력할 수 있습니다.")
+    @Schema(name = "deliveryRequestMessage", description = "배송 요청사항 직접입력 메시지 (최대 60자, CUSTOM 타입일 때 필수)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @Size(max = 60, message = "배송 요청사항 메시지는 최대 60자까지 입력할 수 있습니다.")
     private String deliveryRequestMessage;
 
     @Schema(name = "isDefault", description = "기본 배송지 여부", requiredMode = Schema.RequiredMode.NOT_REQUIRED)

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/shippingaddress/request/UpdateShippingAddressRequest.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/shippingaddress/request/UpdateShippingAddressRequest.java
@@ -40,7 +40,7 @@ public class UpdateShippingAddressRequest {
     @Schema(name = "deliveryRequestType", description = "배송 요청사항 타입", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private DeliveryRequestType deliveryRequestType;
 
-    @Schema(name = "deliveryRequestMessage", description = "배송 요청사항 직접입력 메시지 (최대 30자, CUSTOM 타입일 때 필수)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-    @Size(max = 30, message = "배송 요청사항 메시지는 최대 30자까지 입력할 수 있습니다.")
+    @Schema(name = "deliveryRequestMessage", description = "배송 요청사항 직접입력 메시지 (최대 60자, CUSTOM 타입일 때 필수)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @Size(max = 60, message = "배송 요청사항 메시지는 최대 60자까지 입력할 수 있습니다.")
     private String deliveryRequestMessage;
 }

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/out/persistence/shippingaddress/entity/ShippingAddressJpaEntity.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/out/persistence/shippingaddress/entity/ShippingAddressJpaEntity.java
@@ -44,7 +44,7 @@ public class ShippingAddressJpaEntity extends BaseGeneralEntity {
     @Column(name = "delivery_request_type", nullable = false, length = 31)
     private DeliveryRequestType deliveryRequestType;
 
-    @Column(name = "delivery_request_message", length = 30)
+    @Column(name = "delivery_request_message", length = 60)
     private String deliveryRequestMessage;
 
     @Column(name = "is_default", nullable = false, columnDefinition = "boolean default false")

--- a/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/shippingaddress/ShippingAddress.java
+++ b/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/shippingaddress/ShippingAddress.java
@@ -114,14 +114,17 @@ public class ShippingAddress extends BaseDomain {
             throw new IllegalArgumentException("기타 배송지에는 주소 별명이 필수입니다.");
         }
 
-        if (FormatValidator.hasValue(deliveryRequestType)
-                && deliveryRequestType.isCustom()
-                && FormatValidator.hasNoValue(deliveryRequestMessage)) {
+        if (FormatValidator.hasNoValue(deliveryRequestType) || !deliveryRequestType.isCustom()) {
+            this.deliveryRequestMessage = null;
+            return;
+        }
+
+        if (FormatValidator.hasNoValue(deliveryRequestMessage)) {
             throw new IllegalArgumentException("직접입력 선택 시 배송 요청사항 메시지는 필수입니다.");
         }
 
-        if (FormatValidator.hasValue(deliveryRequestMessage) && deliveryRequestMessage.length() > 30) {
-            throw new IllegalArgumentException("배송 요청사항 메시지는 최대 30자까지 입력할 수 있습니다.");
+        if (deliveryRequestMessage.length() > 60) {
+            throw new IllegalArgumentException("배송 요청사항 메시지는 최대 60자까지 입력할 수 있습니다.");
         }
     }
 }


### PR DESCRIPTION
## partially addresses #43
## resolves #1409

## Task
- [x] 배송 요청사항 선택 및 직접 입력 등록 기능 구현
- [x] CUSTOM 선택 시 deliveryRequestMessage 필수 검증
- [x] CUSTOM 선택 시 deliveryRequestMessage 최대 60자 검증
- [x] CUSTOM이 아닌 경우 deliveryRequestMessage 무시 처리