### PR TITLE
[#128][#1387] feat: 인기순 정렬 최근 7일 범위 적용 기능 추가

### DIFF
--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/scheduler/PopularityScheduler.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/scheduler/PopularityScheduler.java
@@ -1,0 +1,28 @@
+package com.personal.marketnote.product.adapter.in.scheduler;
+
+import com.personal.marketnote.product.port.in.usecase.popularity.UpdatePopularityUseCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(name = "popularity.scheduler.enabled", havingValue = "true", matchIfMissing = false)
+public class PopularityScheduler {
+    private final UpdatePopularityUseCase updatePopularityUseCase;
+
+    @Scheduled(cron = "${popularity.scheduler.cron:0 0 * * * *}", zone = "Asia/Seoul")
+    public void updateWeeklyPopularity() {
+        log.info("주간 인기도 갱신 스케줄러 실행 시작");
+
+        try {
+            updatePopularityUseCase.updateWeeklyPopularity();
+            log.info("주간 인기도 갱신 스케줄러 실행 완료");
+        } catch (Exception e) {
+            log.error("주간 인기도 갱신 스케줄러 실행 실패", e);
+        }
+    }
+}

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/pricepolicy/PricePolicyPersistenceAdapter.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/pricepolicy/PricePolicyPersistenceAdapter.java
@@ -18,17 +18,19 @@ import com.personal.marketnote.product.port.out.pricepolicy.DeletePricePolicyPor
 import com.personal.marketnote.product.port.out.pricepolicy.FindPricePoliciesPort;
 import com.personal.marketnote.product.port.out.pricepolicy.FindPricePolicyPort;
 import com.personal.marketnote.product.port.out.pricepolicy.SavePricePolicyPort;
+import com.personal.marketnote.product.port.out.pricepolicy.UpdatePopularityPort;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 
+import java.time.LocalDateTime;
 import java.util.*;
 
 @PersistenceAdapter
 @RequiredArgsConstructor
-public class PricePolicyPersistenceAdapter implements SavePricePolicyPort, FindPricePolicyPort, FindPricePoliciesPort, DeletePricePolicyPort {
+public class PricePolicyPersistenceAdapter implements SavePricePolicyPort, FindPricePolicyPort, FindPricePoliciesPort, DeletePricePolicyPort, UpdatePopularityPort {
     private final ProductJpaRepository productJpaRepository;
     private final PricePolicyJpaRepository pricePolicyJpaRepository;
     private final ProductOptionPricePolicyJpaRepository productOptionPricePolicyJpaRepository;
@@ -296,6 +298,12 @@ public class PricePolicyPersistenceAdapter implements SavePricePolicyPort, FindP
     public void deleteByIdInternal(Long productId, Long pricePolicyId) {
         productOptionPricePolicyJpaRepository.deleteByPricePolicyId(pricePolicyId);
         pricePolicyJpaRepository.findById(pricePolicyId).ifPresent(PricePolicyJpaEntity::deactivate);
+    }
+
+    @Override
+    @CacheEvict(value = "pricePolicy:list:first", allEntries = true)
+    public void updateWeeklyPopularity(LocalDateTime since) {
+        pricePolicyJpaRepository.updateWeeklyPopularity(since);
     }
 
     private List<PricePolicyJpaEntity> loadPricePoliciesWithAssociations(List<PricePolicyJpaEntity> baseEntities) {

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/pricepolicy/repository/PricePolicyJpaRepository.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/pricepolicy/repository/PricePolicyJpaRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -297,4 +298,18 @@ public interface PricePolicyJpaRepository extends JpaRepository<PricePolicyJpaEn
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Transactional
     void deactivateByProductId(@Param("productId") Long productId);
+
+    @Query(value = """
+            UPDATE price_policy
+            SET popularity = COALESCE(
+                (SELECT SUM(op.quantity)
+                 FROM order_product op
+                 WHERE op.price_policy_id = price_policy.id
+                   AND op.confirmed_at >= :since
+                   AND op.order_status = 'CONFIRMED'),
+                0)
+            """, nativeQuery = true)
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Transactional
+    void updateWeeklyPopularity(@Param("since") LocalDateTime since);
 }

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/usecase/popularity/UpdatePopularityUseCase.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/usecase/popularity/UpdatePopularityUseCase.java
@@ -1,0 +1,17 @@
+package com.personal.marketnote.product.port.in.usecase.popularity;
+
+/**
+ * 인기도 갱신 유스케이스
+ *
+ * @Author 성효빈
+ * @Date 2026-03-21
+ * @Description 상품 인기도 갱신 기능을 제공합니다.
+ */
+public interface UpdatePopularityUseCase {
+    /**
+     * @Date 2026-03-21
+     * @Author 성효빈
+     * @Description 최근 7일 구매확정 수량 기준으로 인기도를 갱신합니다.
+     */
+    void updateWeeklyPopularity();
+}

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/out/pricepolicy/UpdatePopularityPort.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/out/pricepolicy/UpdatePopularityPort.java
@@ -1,0 +1,20 @@
+package com.personal.marketnote.product.port.out.pricepolicy;
+
+import java.time.LocalDateTime;
+
+/**
+ * 인기도 갱신 포트
+ *
+ * @Author 성효빈
+ * @Date 2026-03-21
+ * @Description 가격 정책의 인기도 갱신 기능을 제공합니다.
+ */
+public interface UpdatePopularityPort {
+    /**
+     * @param since 인기도 집계 시작 시간 (이 시간 이후의 구매확정 수량을 집계)
+     * @Date 2026-03-21
+     * @Author 성효빈
+     * @Description 최근 구매확정 수량 기준으로 가격 정책의 인기도를 갱신합니다.
+     */
+    void updateWeeklyPopularity(LocalDateTime since);
+}

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/service/popularity/UpdatePopularityService.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/service/popularity/UpdatePopularityService.java
@@ -1,0 +1,26 @@
+package com.personal.marketnote.product.service.popularity;
+
+import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.product.port.in.usecase.popularity.UpdatePopularityUseCase;
+import com.personal.marketnote.product.port.out.pricepolicy.UpdatePopularityPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional(isolation = READ_COMMITTED)
+public class UpdatePopularityService implements UpdatePopularityUseCase {
+    private final UpdatePopularityPort updatePopularityPort;
+    private final Clock productClock;
+
+    @Override
+    public void updateWeeklyPopularity() {
+        LocalDateTime since = LocalDateTime.now(productClock).minusDays(7);
+        updatePopularityPort.updateWeeklyPopularity(since);
+    }
+}


### PR DESCRIPTION
## partially addresses #128
## resolves #1387

## Task
- [x] UpdatePopularityUseCase / UpdatePopularityService 추가
- [x] UpdatePopularityPort 추가
- [x] PricePolicyJpaRepository에 네이티브 SQL UPDATE 쿼리 추가
- [x] PricePolicyPersistenceAdapter에 UpdatePopularityPort 구현 + 캐시 evict
- [x] PopularityScheduler 추가 (@scheduled, @ConditionalOnProperty)