### PR TITLE
[#128][#1388] feat: 캐시 적립률 동일값 최신 등록순 정렬 기능 추가

### DIFF
--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/pricepolicy/repository/PricePolicyJpaRepository.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/pricepolicy/repository/PricePolicyJpaRepository.java
@@ -98,7 +98,7 @@ public interface PricePolicyJpaRepository extends JpaRepository<PricePolicyJpaEn
                      OR (:sortProperty = 'accumulatedPointRate' AND (
                               pp.accumulationRate > (SELECT pp6.accumulationRate FROM PricePolicyJpaEntity pp6 WHERE pp6.id = :cursor)
                            OR (pp.accumulationRate = (SELECT pp6.accumulationRate FROM PricePolicyJpaEntity pp6 WHERE pp6.id = :cursor)
-                               AND pp.id > :cursor)
+                               AND p.id < (SELECT pp6.productJpaEntity.id FROM PricePolicyJpaEntity pp6 WHERE pp6.id = :cursor))
                         ))
                  )
               )
@@ -108,6 +108,7 @@ public interface PricePolicyJpaRepository extends JpaRepository<PricePolicyJpaEn
                 CASE WHEN :sortProperty = 'discountPrice' THEN pp.discountPrice END ASC,
                 CASE WHEN :sortProperty = 'accumulatedPoint' THEN pp.accumulatedPoint END ASC,
                 CASE WHEN :sortProperty = 'accumulatedPointRate' THEN pp.accumulationRate END ASC,
+                CASE WHEN :sortProperty = 'accumulatedPointRate' THEN p.id END DESC,
                 pp.id ASC
             """)
     List<PricePolicyJpaEntity> findAllActiveByCursorAsc(
@@ -213,7 +214,7 @@ public interface PricePolicyJpaRepository extends JpaRepository<PricePolicyJpaEn
                                     FROM PricePolicyJpaEntity pp6
                                     WHERE pp6.id = :cursor
                                 )
-                               AND pp.id < :cursor)
+                               AND p.id < (SELECT pp6.productJpaEntity.id FROM PricePolicyJpaEntity pp6 WHERE pp6.id = :cursor))
                         ))
                  )
               )
@@ -223,6 +224,7 @@ public interface PricePolicyJpaRepository extends JpaRepository<PricePolicyJpaEn
                 CASE WHEN :sortProperty = 'discountPrice' THEN pp.discountPrice END DESC,
                 CASE WHEN :sortProperty = 'accumulatedPoint' THEN pp.accumulatedPoint END DESC,
                 CASE WHEN :sortProperty = 'accumulatedPointRate' THEN pp.accumulationRate END DESC,
+                CASE WHEN :sortProperty = 'accumulatedPointRate' THEN p.id END DESC,
                 pp.id DESC
             """)
     List<PricePolicyJpaEntity> findAllActiveByCursorDesc(


### PR DESCRIPTION
## partially addresses #128
## resolves #1388

## Task
- [x] ASC 쿼리 적립률 동일값 tie-breaker를 pp.id → p.id DESC(상품 최신 등록순)로 변경
- [x] ASC 쿼리 ORDER BY에 p.id DESC 조건부 tie-breaker 추가
- [x] DESC 쿼리 적립률 동일값 tie-breaker를 pp.id → p.id DESC(상품 최신 등록순)로 변경
- [x] DESC 쿼리 ORDER BY에 p.id DESC 조건부 tie-breaker 추가