### PR TITLE
[#128][#1389] feat: 캐시 적립금 동일값 최신 등록순 정렬 기능 추가

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/apidocs/ChangeOrderStatusApiDocs.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/apidocs/ChangeOrderStatusApiDocs.java
@@ -81,7 +81,7 @@ import java.lang.annotation.*;
                 
                     - "MISTAKE": 주문 실수
                 
-                    - "ETC": 기타
+                    - "ETC": 직접 입력
                 
                 ---
                 

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/apidocs/GetOrderInfoApiDocs.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/apidocs/GetOrderInfoApiDocs.java
@@ -75,7 +75,7 @@ import java.lang.annotation.*;
                 
                     - "MISTAKE": 주문 실수
                 
-                    - "ETC": 기타
+                    - "ETC": 직접 입력
                 
                 ---
                 

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/order/OrderStatusReasonCategory.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/order/OrderStatusReasonCategory.java
@@ -7,7 +7,7 @@ public enum OrderStatusReasonCategory {
     CANCEL_ORDER("구매 의사 취소"),
     CHANGE_OPTION("색상, 사이즈 등 변경"),
     MISTAKE("주문 실수"),
-    ETC("기타");
+    ETC("직접 입력");
 
     private final String description;
 }

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/pricepolicy/repository/PricePolicyJpaRepository.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/pricepolicy/repository/PricePolicyJpaRepository.java
@@ -93,7 +93,7 @@ public interface PricePolicyJpaRepository extends JpaRepository<PricePolicyJpaEn
                      OR (:sortProperty = 'accumulatedPoint' AND (
                               pp.accumulatedPoint > (SELECT pp5.accumulatedPoint FROM PricePolicyJpaEntity pp5 WHERE pp5.id = :cursor)
                            OR (pp.accumulatedPoint = (SELECT pp5.accumulatedPoint FROM PricePolicyJpaEntity pp5 WHERE pp5.id = :cursor)
-                               AND pp.id > :cursor)
+                               AND p.id < (SELECT pp5.productJpaEntity.id FROM PricePolicyJpaEntity pp5 WHERE pp5.id = :cursor))
                         ))
                      OR (:sortProperty = 'accumulatedPointRate' AND (
                               pp.accumulationRate > (SELECT pp6.accumulationRate FROM PricePolicyJpaEntity pp6 WHERE pp6.id = :cursor)
@@ -107,6 +107,7 @@ public interface PricePolicyJpaRepository extends JpaRepository<PricePolicyJpaEn
                 CASE WHEN :sortProperty = 'popularity' THEN pp.popularity END ASC,
                 CASE WHEN :sortProperty = 'discountPrice' THEN pp.discountPrice END ASC,
                 CASE WHEN :sortProperty = 'accumulatedPoint' THEN pp.accumulatedPoint END ASC,
+                CASE WHEN :sortProperty = 'accumulatedPoint' THEN p.id END DESC,
                 CASE WHEN :sortProperty = 'accumulatedPointRate' THEN pp.accumulationRate END ASC,
                 CASE WHEN :sortProperty = 'accumulatedPointRate' THEN p.id END DESC,
                 pp.id ASC
@@ -201,7 +202,7 @@ public interface PricePolicyJpaRepository extends JpaRepository<PricePolicyJpaEn
                                     FROM PricePolicyJpaEntity pp5
                                     WHERE pp5.id = :cursor
                                 )
-                               AND pp.id < :cursor)
+                               AND p.id < (SELECT pp5.productJpaEntity.id FROM PricePolicyJpaEntity pp5 WHERE pp5.id = :cursor))
                         ))
                      OR (:sortProperty = 'accumulatedPointRate' AND (
                               pp.accumulationRate < (
@@ -223,6 +224,7 @@ public interface PricePolicyJpaRepository extends JpaRepository<PricePolicyJpaEn
                 CASE WHEN :sortProperty = 'popularity' THEN pp.popularity END DESC,
                 CASE WHEN :sortProperty = 'discountPrice' THEN pp.discountPrice END DESC,
                 CASE WHEN :sortProperty = 'accumulatedPoint' THEN pp.accumulatedPoint END DESC,
+                CASE WHEN :sortProperty = 'accumulatedPoint' THEN p.id END DESC,
                 CASE WHEN :sortProperty = 'accumulatedPointRate' THEN pp.accumulationRate END DESC,
                 CASE WHEN :sortProperty = 'accumulatedPointRate' THEN p.id END DESC,
                 pp.id DESC


### PR DESCRIPTION
## partially addresses #128
## resolves #1389

## Task
- [x] ASC 커서 조건: accumulatedPoint 동일값 tie-breaker를 pp.id에서 p.id(상품 최신순)로 변경
- [x] ASC ORDER BY: accumulatedPoint 정렬 후 p.id DESC 2차 정렬 추가
- [x] DESC 커서 조건: accumulatedPoint 동일값 tie-breaker를 pp.id에서 p.id(상품 최신순)로 변경
- [x] DESC ORDER BY: accumulatedPoint 정렬 후 p.id DESC 2차 정렬 추가