### PR TITLE
[#723][#1435] fix: 상품/리뷰 목록 조회 첫 페이지 totalElements null 반환 버그 픽스

### DIFF
--- a/common/src/main/java/com/personal/marketnote/common/utility/ApiConstant.java
+++ b/common/src/main/java/com/personal/marketnote/common/utility/ApiConstant.java
@@ -14,4 +14,5 @@ public class ApiConstant {
     public static final byte INTER_SERVER_MAX_REQUEST_COUNT = 5;
     public static final long INTER_SERVER_DEFAULT_RETRIAL_PENDING_MILLI_SECOND = 1000L;
     public static final long INTER_SERVER_DEFAULT_EXPONENTIAL_BACKOFF_VALUE = 2;
+    public static final long FIRST_PAGE_CURSOR_VALUE = -1L;
 }

--- a/community-service/community-application/src/main/java/com/personal/marketnote/community/service/review/GetReviewService.java
+++ b/community-service/community-application/src/main/java/com/personal/marketnote/community/service/review/GetReviewService.java
@@ -33,6 +33,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 
 import static com.personal.marketnote.common.domain.file.FileSort.REVIEW_IMAGE;
+import static com.personal.marketnote.common.utility.ApiConstant.FIRST_PAGE_CURSOR_VALUE;
 import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
 import static org.springframework.transaction.annotation.Propagation.REQUIRES_NEW;
 
@@ -101,7 +102,7 @@ public class GetReviewService implements GetReviewUseCase {
             nextCursor = pagedReviews.getLast().getId();
         }
 
-        boolean isFirstPage = FormatValidator.hasNoValue(cursor);
+        boolean isFirstPage = FormatValidator.equals(cursor, FIRST_PAGE_CURSOR_VALUE);
         Long totalElements = null;
         if (isFirstPage) {
             totalElements = findReviewPort.countActive(productId, isPhoto);
@@ -180,7 +181,7 @@ public class GetReviewService implements GetReviewUseCase {
             nextCursor = pagedReviews.getLast().getId();
         }
 
-        boolean isFirstPage = FormatValidator.hasNoValue(cursor);
+        boolean isFirstPage = FormatValidator.equals(cursor, FIRST_PAGE_CURSOR_VALUE);
         Long totalElements = null;
         if (isFirstPage) {
             totalElements = findReviewPort.countActive(userId);

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/service/product/GetProductService.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/service/product/GetProductService.java
@@ -43,6 +43,7 @@ import java.util.concurrent.Executor;
 import java.util.stream.Collectors;
 
 import static com.personal.marketnote.common.domain.file.FileSort.*;
+import static com.personal.marketnote.common.utility.ApiConstant.FIRST_PAGE_CURSOR_VALUE;
 import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
 
 @UseCase
@@ -175,7 +176,7 @@ public class GetProductService implements GetProductUseCase {
             ProductSearchTarget searchTarget,
             String searchKeyword
     ) {
-        boolean isFirstPage = FormatValidator.hasNoValue(cursor);
+        boolean isFirstPage = FormatValidator.equals(cursor, FIRST_PAGE_CURSOR_VALUE);
 
         Pageable pageable = PageRequest.of(
                 0, pageSize + 1, Sort.by(sortDirection, sortProperty.getCamelCaseValue())


### PR DESCRIPTION
## partially addresses #723
## resolves #1435

## Reason
FormatValidator.hasNoValue(cursor)로 첫 페이지를 판별하는데,
hasNoValue(Number)는 null만 체크하고 커서 기본값 -1을 "값 없음"으로 처리하지 않음

## Action
- [x] ApiConstant에 FIRST_PAGE_CURSOR_VALUE = -1L 상수 추가
- [x] GetProductService 첫 페이지 판별 로직을 FormatValidator.equals(cursor, FIRST_PAGE_CURSOR_VALUE)로 변경
- [x] GetReviewService 동일 패턴 2곳 변경