### PR TITLE
[#387][#1404] feat: 캐시 적립 내역 기간 필터 조회 기능 추가

### DIFF
--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/point/PointController.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/point/PointController.java
@@ -15,6 +15,7 @@ import com.personal.marketnote.reward.adapter.in.web.point.response.GetUserPoint
 import com.personal.marketnote.reward.adapter.in.web.point.response.GetUserPointHistoryResponse;
 import com.personal.marketnote.reward.adapter.in.web.point.response.UpdateUserPointResponse;
 import com.personal.marketnote.reward.domain.point.UserPointHistoryFilter;
+import com.personal.marketnote.reward.port.in.command.point.GetUserPointHistoryCommand;
 import com.personal.marketnote.reward.port.in.command.point.RegisterUserPointCommand;
 import com.personal.marketnote.reward.port.in.result.point.GetUserPointHistoryResult;
 import com.personal.marketnote.reward.port.in.result.point.GetUserPointResult;
@@ -32,6 +33,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.core.OAuth2AuthenticatedPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDate;
 import java.util.List;
 
 import static com.personal.marketnote.common.domain.exception.ExceptionCode.DEFAULT_SUCCESS_CODE;
@@ -151,12 +153,18 @@ public class PointController {
     public ResponseEntity<BaseResponse<GetUserPointHistoryResponse>> getUserPointHistories(
             @PathVariable("userId") Long userId,
             @AuthenticationPrincipal OAuth2AuthenticatedPrincipal principal,
-            @RequestParam(value = "filter", required = false) UserPointHistoryFilter filter
+            @RequestParam(value = "filter", required = false) UserPointHistoryFilter filter,
+            @RequestParam(value = "start-date", required = false) LocalDate startDate,
+            @RequestParam(value = "end-date", required = false) LocalDate endDate
     ) {
         validateAuthentication(userId, principal);
         GetUserPointHistoryResult result = getUserPointHistoryUseCase.getUserPointHistories(
-                userId,
-                filter
+                GetUserPointHistoryCommand.builder()
+                        .userId(userId)
+                        .filter(filter)
+                        .startDate(startDate)
+                        .endDate(endDate)
+                        .build()
         );
 
         return ResponseEntity.ok(

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/point/apidocs/GetUserPointHistoriesApiDocs.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/point/apidocs/GetUserPointHistoriesApiDocs.java
@@ -38,6 +38,8 @@ import java.lang.annotation.*;
                 | --- | --- | --- | --- | --- |
                 | userId (path) | number | 회원 ID | Y | 100 |
                 | filter | string | 조회 필터 (ALL/ACCRUAL/DEDUCTION) | 선택 | ACCRUAL |
+                | start-date | string(date) | 조회 시작일 (YYYY-MM-DD) | 선택 | 2026-03-01 |
+                | end-date | string(date) | 조회 종료일 (YYYY-MM-DD) | 선택 | 2026-03-31 |
                 
                 ---
                 

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/point/UserPointHistoryPersistenceAdapter.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/point/UserPointHistoryPersistenceAdapter.java
@@ -13,6 +13,7 @@ import com.personal.marketnote.reward.port.out.point.UpdateUserPointHistoryPort;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Objects;
 
@@ -37,8 +38,13 @@ public class UserPointHistoryPersistenceAdapter implements SaveUserPointHistoryP
     }
 
     @Override
-    public List<UserPointHistory> findByUserId(Long userId, UserPointHistoryFilter filter) {
-        List<UserPointHistoryJpaEntity> histories = getHistories(userId, filter);
+    public List<UserPointHistory> findByUserId(Long userId, UserPointHistoryFilter filter, LocalDate startDate, LocalDate endDate) {
+        List<UserPointHistoryJpaEntity> histories = repository.findByUserIdAndDateRangeAndFilter(
+                userId,
+                startDate.atStartOfDay(),
+                endDate.plusDays(1).atStartOfDay(),
+                filter.getAmountFilterValue()
+        );
 
         return histories.stream()
                 .map(UserPointHistoryJpaEntity::toDomain)
@@ -61,15 +67,4 @@ public class UserPointHistoryPersistenceAdapter implements SaveUserPointHistoryP
         return repository.markAsReflected(userId, sourceType, sourceId);
     }
 
-    private List<UserPointHistoryJpaEntity> getHistories(Long userId, UserPointHistoryFilter filter) {
-        if (filter.isAccrual()) {
-            return repository.findByUserIdAndAmountGreaterThanOrderByAccumulatedAtDesc(userId, 0L);
-        }
-
-        if (filter.isDeduction()) {
-            return repository.findByUserIdAndAmountLessThanOrderByAccumulatedAtDesc(userId, 0L);
-        }
-
-        return repository.findByUserIdOrderByAccumulatedAtDesc(userId);
-    }
 }

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/point/repository/UserPointHistoryJpaRepository.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/point/repository/UserPointHistoryJpaRepository.java
@@ -7,14 +7,28 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface UserPointHistoryJpaRepository extends JpaRepository<UserPointHistoryJpaEntity, Long> {
-    List<UserPointHistoryJpaEntity> findByUserIdOrderByAccumulatedAtDesc(Long userId);
 
-    List<UserPointHistoryJpaEntity> findByUserIdAndAmountGreaterThanOrderByAccumulatedAtDesc(Long userId, Long amount);
-
-    List<UserPointHistoryJpaEntity> findByUserIdAndAmountLessThanOrderByAccumulatedAtDesc(Long userId, Long amount);
+    // amountFilter: 0=ALL, 1=ACCRUAL(적립, amount>0), -1=DEDUCTION(사용, amount<0)
+    @Query("""
+            SELECT h FROM UserPointHistoryJpaEntity h
+            WHERE h.userId = :userId
+              AND h.accumulatedAt >= :startDateTime
+              AND h.accumulatedAt < :endDateTime
+              AND (:amountFilter = 0
+                OR (:amountFilter = 1 AND h.amount > 0)
+                OR (:amountFilter = -1 AND h.amount < 0))
+            ORDER BY h.accumulatedAt DESC
+            """)
+    List<UserPointHistoryJpaEntity> findByUserIdAndDateRangeAndFilter(
+            @Param("userId") Long userId,
+            @Param("startDateTime") LocalDateTime startDateTime,
+            @Param("endDateTime") LocalDateTime endDateTime,
+            @Param("amountFilter") int amountFilter
+    );
 
     List<UserPointHistoryJpaEntity> findByUserIdAndIsReflectedAndSourceTypeAndSourceId(
             Long userId, Boolean isReflected, UserPointSourceType sourceType, Long sourceId

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/exception/InvalidPointHistoryDateRangeException.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/exception/InvalidPointHistoryDateRangeException.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.reward.exception;
+
+import java.time.LocalDate;
+
+public class InvalidPointHistoryDateRangeException extends IllegalArgumentException {
+    public InvalidPointHistoryDateRangeException(LocalDate startDate, LocalDate endDate) {
+        super("ERR_POINT_HISTORY_01::조회 시작일이 종료일보다 늦을 수 없습니다. startDate=" + startDate + ", endDate=" + endDate);
+    }
+}

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/command/point/GetUserPointHistoryCommand.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/command/point/GetUserPointHistoryCommand.java
@@ -1,0 +1,15 @@
+package com.personal.marketnote.reward.port.in.command.point;
+
+import com.personal.marketnote.reward.domain.point.UserPointHistoryFilter;
+import lombok.Builder;
+
+import java.time.LocalDate;
+
+@Builder
+public record GetUserPointHistoryCommand(
+        Long userId,
+        UserPointHistoryFilter filter,
+        LocalDate startDate,
+        LocalDate endDate
+) {
+}

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/usecase/point/GetUserPointHistoryUseCase.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/usecase/point/GetUserPointHistoryUseCase.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.reward.port.in.usecase.point;
 
-import com.personal.marketnote.reward.domain.point.UserPointHistoryFilter;
+import com.personal.marketnote.reward.port.in.command.point.GetUserPointHistoryCommand;
 import com.personal.marketnote.reward.port.in.result.point.GetUserPointHistoryResult;
 
 /**
@@ -12,13 +12,12 @@ import com.personal.marketnote.reward.port.in.result.point.GetUserPointHistoryRe
  */
 public interface GetUserPointHistoryUseCase {
     /**
-     * @param userId 회원 ID
-     * @param filter 포인트 이력 필터
+     * @param command 포인트 이력 조회 커맨드 {@link GetUserPointHistoryCommand}
      * @return 회원 포인트 이력 {@link GetUserPointHistoryResult}
      * @Date 2026-01-19
      * @Author 성효빈
      * @Description 회원 포인트 이력을 조회합니다.
      */
-    GetUserPointHistoryResult getUserPointHistories(Long userId, UserPointHistoryFilter filter);
+    GetUserPointHistoryResult getUserPointHistories(GetUserPointHistoryCommand command);
 }
 

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/out/point/FindUserPointHistoryPort.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/out/point/FindUserPointHistoryPort.java
@@ -4,6 +4,7 @@ import com.personal.marketnote.reward.domain.point.UserPointHistory;
 import com.personal.marketnote.reward.domain.point.UserPointHistoryFilter;
 import com.personal.marketnote.reward.domain.point.UserPointSourceType;
 
+import java.time.LocalDate;
 import java.util.List;
 
 /**
@@ -15,14 +16,16 @@ import java.util.List;
  */
 public interface FindUserPointHistoryPort {
     /**
-     * @param userId 회원 식별자
-     * @param filter 포인트 이력 필터
+     * @param userId    회원 식별자
+     * @param filter    포인트 이력 필터
+     * @param startDate 조회 시작일
+     * @param endDate   조회 종료일
      * @return 회원 포인트 이력 목록 {@link UserPointHistory}
      * @Date 2026-01-19
      * @Author 성효빈
-     * @Description 회원 식별자와 필터 조건으로 포인트 이력을 조회합니다.
+     * @Description 회원 식별자와 필터/기간 조건으로 포인트 이력을 조회합니다.
      */
-    List<UserPointHistory> findByUserId(Long userId, UserPointHistoryFilter filter);
+    List<UserPointHistory> findByUserId(Long userId, UserPointHistoryFilter filter, LocalDate startDate, LocalDate endDate);
 
     /**
      * @param userId     회원 식별자

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/service/point/GetUserPointHistoryService.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/service/point/GetUserPointHistoryService.java
@@ -3,11 +3,15 @@ package com.personal.marketnote.reward.service.point;
 import com.personal.marketnote.common.application.UseCase;
 import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.reward.domain.point.UserPointHistoryFilter;
+import com.personal.marketnote.reward.exception.InvalidPointHistoryDateRangeException;
+import com.personal.marketnote.reward.port.in.command.point.GetUserPointHistoryCommand;
 import com.personal.marketnote.reward.port.in.result.point.GetUserPointHistoryResult;
 import com.personal.marketnote.reward.port.in.usecase.point.GetUserPointHistoryUseCase;
 import com.personal.marketnote.reward.port.out.point.FindUserPointHistoryPort;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
 
 import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
 
@@ -15,17 +19,31 @@ import static org.springframework.transaction.annotation.Isolation.READ_COMMITTE
 @RequiredArgsConstructor
 @Transactional(isolation = READ_COMMITTED, readOnly = true)
 public class GetUserPointHistoryService implements GetUserPointHistoryUseCase {
+    static final LocalDate DEFAULT_START_DATE = LocalDate.of(2000, 1, 1);
+    static final LocalDate DEFAULT_END_DATE = LocalDate.of(2999, 12, 31);
+
     private final FindUserPointHistoryPort findUserPointHistoryPort;
 
     @Override
-    public GetUserPointHistoryResult getUserPointHistories(Long userId, UserPointHistoryFilter filter) {
-        UserPointHistoryFilter targetFilter = FormatValidator.hasValue(filter)
-                ? filter
+    public GetUserPointHistoryResult getUserPointHistories(GetUserPointHistoryCommand command) {
+        UserPointHistoryFilter targetFilter = FormatValidator.hasValue(command.filter())
+                ? command.filter()
                 : UserPointHistoryFilter.ALL;
 
+        LocalDate startDate = FormatValidator.hasValue(command.startDate())
+                ? command.startDate()
+                : DEFAULT_START_DATE;
+
+        LocalDate endDate = FormatValidator.hasValue(command.endDate())
+                ? command.endDate()
+                : DEFAULT_END_DATE;
+
+        if (startDate.isAfter(endDate)) {
+            throw new InvalidPointHistoryDateRangeException(startDate, endDate);
+        }
+
         return GetUserPointHistoryResult.from(
-                findUserPointHistoryPort.findByUserId(userId, targetFilter)
+                findUserPointHistoryPort.findByUserId(command.userId(), targetFilter, startDate, endDate)
         );
     }
 }
-

--- a/reward-service/reward-application/src/test/java/com/personal/marketnote/reward/service/point/GetUserPointHistoryUseCaseTest.java
+++ b/reward-service/reward-application/src/test/java/com/personal/marketnote/reward/service/point/GetUserPointHistoryUseCaseTest.java
@@ -4,6 +4,7 @@ import com.personal.marketnote.reward.domain.point.UserPointHistory;
 import com.personal.marketnote.reward.domain.point.UserPointHistoryFilter;
 import com.personal.marketnote.reward.domain.point.UserPointHistorySnapshotState;
 import com.personal.marketnote.reward.domain.point.UserPointSourceType;
+import com.personal.marketnote.reward.port.in.command.point.GetUserPointHistoryCommand;
 import com.personal.marketnote.reward.port.in.result.point.GetUserPointHistoryResult;
 import com.personal.marketnote.reward.port.out.point.FindUserPointHistoryPort;
 import org.junit.jupiter.api.DisplayName;
@@ -14,6 +15,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
@@ -33,6 +35,8 @@ class GetUserPointHistoryUseCaseTest {
 
     private static final Long USER_ID = 1L;
     private static final LocalDateTime NOW = LocalDateTime.of(2026, 3, 5, 10, 0);
+    private static final LocalDate DEFAULT_START_DATE = GetUserPointHistoryService.DEFAULT_START_DATE;
+    private static final LocalDate DEFAULT_END_DATE = GetUserPointHistoryService.DEFAULT_END_DATE;
 
     private UserPointHistory createHistory(Long id, Long amount, UserPointSourceType sourceType, LocalDateTime accumulatedAt) {
         return UserPointHistory.from(UserPointHistorySnapshotState.builder()
@@ -48,6 +52,22 @@ class GetUserPointHistoryUseCaseTest {
                 .build());
     }
 
+    private GetUserPointHistoryCommand createCommand(UserPointHistoryFilter filter) {
+        return GetUserPointHistoryCommand.builder()
+                .userId(USER_ID)
+                .filter(filter)
+                .build();
+    }
+
+    private GetUserPointHistoryCommand createCommand(UserPointHistoryFilter filter, LocalDate startDate, LocalDate endDate) {
+        return GetUserPointHistoryCommand.builder()
+                .userId(USER_ID)
+                .filter(filter)
+                .startDate(startDate)
+                .endDate(endDate)
+                .build();
+    }
+
     @Nested
     @DisplayName("필터 지정 조회")
     class FilterSpecifiedTest {
@@ -61,18 +81,18 @@ class GetUserPointHistoryUseCaseTest {
                     createHistory(2L, -200L, UserPointSourceType.ORDER, NOW)
             );
 
-            when(findUserPointHistoryPort.findByUserId(USER_ID, UserPointHistoryFilter.ALL))
+            when(findUserPointHistoryPort.findByUserId(USER_ID, UserPointHistoryFilter.ALL, DEFAULT_START_DATE, DEFAULT_END_DATE))
                     .thenReturn(histories);
 
             // when
             GetUserPointHistoryResult result = getUserPointHistoryService.getUserPointHistories(
-                    USER_ID, UserPointHistoryFilter.ALL
+                    createCommand(UserPointHistoryFilter.ALL)
             );
 
             // then
             assertThat(result.histories()).hasSize(1);
             assertThat(result.histories().getFirst().count()).isEqualTo(2);
-            verify(findUserPointHistoryPort).findByUserId(USER_ID, UserPointHistoryFilter.ALL);
+            verify(findUserPointHistoryPort).findByUserId(USER_ID, UserPointHistoryFilter.ALL, DEFAULT_START_DATE, DEFAULT_END_DATE);
         }
 
         @Test
@@ -83,18 +103,18 @@ class GetUserPointHistoryUseCaseTest {
                     createHistory(1L, 500L, UserPointSourceType.ORDER, NOW)
             );
 
-            when(findUserPointHistoryPort.findByUserId(USER_ID, UserPointHistoryFilter.ACCRUAL))
+            when(findUserPointHistoryPort.findByUserId(USER_ID, UserPointHistoryFilter.ACCRUAL, DEFAULT_START_DATE, DEFAULT_END_DATE))
                     .thenReturn(histories);
 
             // when
             GetUserPointHistoryResult result = getUserPointHistoryService.getUserPointHistories(
-                    USER_ID, UserPointHistoryFilter.ACCRUAL
+                    createCommand(UserPointHistoryFilter.ACCRUAL)
             );
 
             // then
             assertThat(result.histories()).hasSize(1);
             assertThat(result.histories().getFirst().count()).isEqualTo(1);
-            verify(findUserPointHistoryPort).findByUserId(USER_ID, UserPointHistoryFilter.ACCRUAL);
+            verify(findUserPointHistoryPort).findByUserId(USER_ID, UserPointHistoryFilter.ACCRUAL, DEFAULT_START_DATE, DEFAULT_END_DATE);
         }
 
         @Test
@@ -105,17 +125,17 @@ class GetUserPointHistoryUseCaseTest {
                     createHistory(1L, -300L, UserPointSourceType.ORDER, NOW)
             );
 
-            when(findUserPointHistoryPort.findByUserId(USER_ID, UserPointHistoryFilter.DEDUCTION))
+            when(findUserPointHistoryPort.findByUserId(USER_ID, UserPointHistoryFilter.DEDUCTION, DEFAULT_START_DATE, DEFAULT_END_DATE))
                     .thenReturn(histories);
 
             // when
             GetUserPointHistoryResult result = getUserPointHistoryService.getUserPointHistories(
-                    USER_ID, UserPointHistoryFilter.DEDUCTION
+                    createCommand(UserPointHistoryFilter.DEDUCTION)
             );
 
             // then
             assertThat(result.histories()).hasSize(1);
-            verify(findUserPointHistoryPort).findByUserId(USER_ID, UserPointHistoryFilter.DEDUCTION);
+            verify(findUserPointHistoryPort).findByUserId(USER_ID, UserPointHistoryFilter.DEDUCTION, DEFAULT_START_DATE, DEFAULT_END_DATE);
         }
     }
 
@@ -131,15 +151,17 @@ class GetUserPointHistoryUseCaseTest {
                     createHistory(1L, 500L, UserPointSourceType.ORDER, NOW)
             );
 
-            when(findUserPointHistoryPort.findByUserId(USER_ID, UserPointHistoryFilter.ALL))
+            when(findUserPointHistoryPort.findByUserId(USER_ID, UserPointHistoryFilter.ALL, DEFAULT_START_DATE, DEFAULT_END_DATE))
                     .thenReturn(histories);
 
             // when
-            GetUserPointHistoryResult result = getUserPointHistoryService.getUserPointHistories(USER_ID, null);
+            GetUserPointHistoryResult result = getUserPointHistoryService.getUserPointHistories(
+                    createCommand(null)
+            );
 
             // then
             assertThat(result.histories()).hasSize(1);
-            verify(findUserPointHistoryPort).findByUserId(USER_ID, UserPointHistoryFilter.ALL);
+            verify(findUserPointHistoryPort).findByUserId(USER_ID, UserPointHistoryFilter.ALL, DEFAULT_START_DATE, DEFAULT_END_DATE);
         }
     }
 
@@ -151,12 +173,12 @@ class GetUserPointHistoryUseCaseTest {
         @DisplayName("이력이 없으면 빈 결과를 반환한다")
         void shouldReturnEmptyResultWhenNoHistories() {
             // given
-            when(findUserPointHistoryPort.findByUserId(USER_ID, UserPointHistoryFilter.ALL))
+            when(findUserPointHistoryPort.findByUserId(USER_ID, UserPointHistoryFilter.ALL, DEFAULT_START_DATE, DEFAULT_END_DATE))
                     .thenReturn(Collections.emptyList());
 
             // when
             GetUserPointHistoryResult result = getUserPointHistoryService.getUserPointHistories(
-                    USER_ID, UserPointHistoryFilter.ALL
+                    createCommand(UserPointHistoryFilter.ALL)
             );
 
             // then
@@ -180,12 +202,12 @@ class GetUserPointHistoryUseCaseTest {
                     createHistory(2L, 300L, UserPointSourceType.ATTENDENCE, afternoon)
             );
 
-            when(findUserPointHistoryPort.findByUserId(USER_ID, UserPointHistoryFilter.ALL))
+            when(findUserPointHistoryPort.findByUserId(USER_ID, UserPointHistoryFilter.ALL, DEFAULT_START_DATE, DEFAULT_END_DATE))
                     .thenReturn(histories);
 
             // when
             GetUserPointHistoryResult result = getUserPointHistoryService.getUserPointHistories(
-                    USER_ID, UserPointHistoryFilter.ALL
+                    createCommand(UserPointHistoryFilter.ALL)
             );
 
             // then
@@ -205,12 +227,12 @@ class GetUserPointHistoryUseCaseTest {
                     createHistory(2L, 300L, UserPointSourceType.ATTENDENCE, day2)
             );
 
-            when(findUserPointHistoryPort.findByUserId(USER_ID, UserPointHistoryFilter.ALL))
+            when(findUserPointHistoryPort.findByUserId(USER_ID, UserPointHistoryFilter.ALL, DEFAULT_START_DATE, DEFAULT_END_DATE))
                     .thenReturn(histories);
 
             // when
             GetUserPointHistoryResult result = getUserPointHistoryService.getUserPointHistories(
-                    USER_ID, UserPointHistoryFilter.ALL
+                    createCommand(UserPointHistoryFilter.ALL)
             );
 
             // then
@@ -219,4 +241,5 @@ class GetUserPointHistoryUseCaseTest {
             assertThat(result.histories().get(1).count()).isEqualTo(1);
         }
     }
+
 }

--- a/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/point/UserPointHistoryFilter.java
+++ b/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/point/UserPointHistoryFilter.java
@@ -5,16 +5,18 @@ import lombok.Getter;
 
 @Getter
 public enum UserPointHistoryFilter {
-    ALL("전체"),
-    ACCRUAL("적립"),
-    DEDUCTION("사용");
+    ALL("전체", 0),
+    ACCRUAL("적립", 1),
+    DEDUCTION("사용", -1);
 
     private final String description;
     private final String camelCaseValue;
+    private final int amountFilterValue;
 
-    UserPointHistoryFilter(String description) {
+    UserPointHistoryFilter(String description, int amountFilterValue) {
         this.description = description;
         this.camelCaseValue = FormatConverter.snakeToCamel(name());
+        this.amountFilterValue = amountFilterValue;
     }
 
     public boolean isAll() {


### PR DESCRIPTION
## partially addresses #387
## resolves #1404

## Task
- [x] GetUserPointHistoryCommand record 생성 (userId, filter, startDate, endDate)
- [x] GetUserPointHistoryUseCase/FindUserPointHistoryPort 시그니처 변경
- [x] GetUserPointHistoryService 기간 기본값 처리 + 날짜 역전 검증
- [x] UserPointHistoryFilter amountFilterValue 필드 추가
- [x] UserPointHistoryJpaRepository JPQL 통합 쿼리 추가 + 미사용 메서드 삭제
- [x] UserPointHistoryPersistenceAdapter LocalDate→LocalDateTime 변환
- [x] PointController start-date/end-date 쿼리 파라미터 추가
- InvalidPointHistoryDateRangeException 커스텀 예외 생성