### PR TITLE
[#387][#1405] feat: 캐시 적립 내역 커서 기반 페이징 기능 추가

### DIFF
--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/point/PointController.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/point/PointController.java
@@ -155,7 +155,9 @@ public class PointController {
             @AuthenticationPrincipal OAuth2AuthenticatedPrincipal principal,
             @RequestParam(value = "filter", required = false) UserPointHistoryFilter filter,
             @RequestParam(value = "start-date", required = false) LocalDate startDate,
-            @RequestParam(value = "end-date", required = false) LocalDate endDate
+            @RequestParam(value = "end-date", required = false) LocalDate endDate,
+            @RequestParam(value = "cursor", required = false) Long cursor,
+            @RequestParam(value = "page-size", required = false, defaultValue = "20") int pageSize
     ) {
         validateAuthentication(userId, principal);
         GetUserPointHistoryResult result = getUserPointHistoryUseCase.getUserPointHistories(
@@ -164,6 +166,8 @@ public class PointController {
                         .filter(filter)
                         .startDate(startDate)
                         .endDate(endDate)
+                        .cursor(cursor)
+                        .pageSize(pageSize)
                         .build()
         );
 

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/point/apidocs/GetUserPointHistoriesApiDocs.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/point/apidocs/GetUserPointHistoriesApiDocs.java
@@ -19,32 +19,36 @@ import java.lang.annotation.*;
         summary = "(관리자/본인) 회원 포인트 내역 조회",
         description = """
                 작성일자: 2026-01-19
-                
+
                 작성자: 성효빈
-                
+
                 ---
-                
+
                 ## Description
-                
+
                 - 회원 포인트 적립/사용 내역을 일자별로 조회합니다.
-                
+
                 - 관리자 또는 본인만 조회할 수 있습니다.
-                
+
+                - 커서 기반 페이징을 지원합니다.
+
                 ---
-                
+
                 ## Request
-                
+
                 | **키** | **타입** | **설명** | **필수 여부** | **예시** |
                 | --- | --- | --- | --- | --- |
                 | userId (path) | number | 회원 ID | Y | 100 |
                 | filter | string | 조회 필터 (ALL/ACCRUAL/DEDUCTION) | 선택 | ACCRUAL |
                 | start-date | string(date) | 조회 시작일 (YYYY-MM-DD) | 선택 | 2026-03-01 |
                 | end-date | string(date) | 조회 종료일 (YYYY-MM-DD) | 선택 | 2026-03-31 |
-                
+                | cursor | number | 이전 페이지 마지막 항목 ID (미입력 시 첫 페이지) | 선택 | 25 |
+                | page-size | number | 페이지 크기 (기본값: 20) | 선택 | 20 |
+
                 ---
-                
+
                 ## Response
-                
+
                 | **키** | **타입** | **설명** | **예시** |
                 | --- | --- | --- | --- |
                 | statusCode | number | HTTP 상태 코드 | 200 |
@@ -52,19 +56,28 @@ import java.lang.annotation.*;
                 | timestamp | string(datetime) | 응답 시간 | "2026-01-19T12:00:00.000" |
                 | content | object | 응답 본문 | { ... } |
                 | message | string | 처리 결과 | "회원 포인트 내역 조회 성공" |
-                
+
                 ---
-                
-                ### Response > content
-                
+
+                ### Response > content > histories (CursorResponse)
+
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | totalElements | number | 전체 건수 (첫 페이지만) | 15 |
+                | hasNext | boolean | 다음 페이지 존재 여부 | true |
+                | nextCursor | number | 다음 커서 (마지막 항목 ID) | 11 |
+                | items | array | 일자별 포인트 내역 | [ ... ] |
+
+                ### Response > content > histories > items
+
                 | **키** | **타입** | **설명** | **예시** |
                 | --- | --- | --- | --- |
                 | date | string(date) | 발생일자 | "2026-01-19" |
                 | count | number | 개수 | 2 |
                 | histories | array | 포인트 내역 | [ ... ] |
-                
-                ### Response > content > histories
-                
+
+                ### Response > content > histories > items > histories
+
                 | **키** | **타입** | **설명** | **예시** |
                 | --- | --- | --- | --- |
                 | id | number | 포인트 내역 ID | 1 |
@@ -98,76 +111,81 @@ import java.lang.annotation.*;
                                           "code": "SUC01",
                                           "timestamp": "2026-01-19T17:15:34.945228",
                                           "content": {
-                                            "histories": [
-                                              {
-                                                "date": "2026-01-19",
-                                                "count": 1,
-                                                "histories": [
-                                                  {
-                                                    "id": 25,
-                                                    "amount": 1000,
-                                                    "isReflected": true,
-                                                    "sourceType": "OFFERWALL",
-                                                    "sourceId": 54,
-                                                    "reason": "애드팝콘 리워드 보상 적립",
-                                                    "accumulatedAt": "2026-01-19T10:01:22.883182",
-                                                    "createdAt": "2026-01-19T10:01:31.375436"
-                                                  }
-                                                ]
-                                              },
-                                              {
-                                                "date": "2026-01-18",
-                                                "count": 1,
-                                                "histories": [
-                                                  {
-                                                    "id": 23,
-                                                    "amount": 5000,
-                                                    "isReflected": true,
-                                                    "sourceType": "USER",
-                                                    "sourceId": 14,
-                                                    "reason": "링크 공유 회원 상품 구매",
-                                                    "accumulatedAt": "2026-01-18T05:39:52.307824",
-                                                    "createdAt": "2026-01-18T17:28:12.709305"
-                                                  }
-                                                ]
-                                              },
-                                              {
-                                                "date": "2026-01-17",
-                                                "count": 3,
-                                                "histories": [
-                                                  {
-                                                    "id": 33,
-                                                    "amount": -500,
-                                                    "isReflected": true,
-                                                    "sourceType": "PRODUCT",
-                                                    "sourceId": 40,
-                                                    "reason": "상품 구매",
-                                                    "accumulatedAt": "2026-01-17T14:28:00.973419",
-                                                    "createdAt": "2026-01-19T17:13:26.722427"
-                                                  },
-                                                  {
-                                                    "id": 14,
-                                                    "amount": 2000,
-                                                    "isReflected": true,
-                                                    "sourceType": "USER",
-                                                    "sourceId": 17,
-                                                    "reason": "추천인 코드 등록 적립",
-                                                    "accumulatedAt": "2026-01-17T14:28:00.946674",
-                                                    "createdAt": "2026-01-17T14:28:00.951884"
-                                                  },
-                                                  {
-                                                    "id": 11,
-                                                    "amount": 0,
-                                                    "isReflected": true,
-                                                    "sourceType": "USER",
-                                                    "sourceId": 17,
-                                                    "reason": "회원 가입",
-                                                    "accumulatedAt": "2026-01-17T05:27:21.418247",
-                                                    "createdAt": "2026-01-17T05:27:21.420814"
-                                                  }
-                                                ]
-                                              }
-                                            ]
+                                            "histories": {
+                                              "totalElements": 15,
+                                              "hasNext": true,
+                                              "nextCursor": 11,
+                                              "items": [
+                                                {
+                                                  "date": "2026-01-19",
+                                                  "count": 1,
+                                                  "histories": [
+                                                    {
+                                                      "id": 25,
+                                                      "amount": 1000,
+                                                      "isReflected": true,
+                                                      "sourceType": "OFFERWALL",
+                                                      "sourceId": 54,
+                                                      "reason": "애드팝콘 리워드 보상 적립",
+                                                      "accumulatedAt": "2026-01-19T10:01:22.883182",
+                                                      "createdAt": "2026-01-19T10:01:31.375436"
+                                                    }
+                                                  ]
+                                                },
+                                                {
+                                                  "date": "2026-01-18",
+                                                  "count": 1,
+                                                  "histories": [
+                                                    {
+                                                      "id": 23,
+                                                      "amount": 5000,
+                                                      "isReflected": true,
+                                                      "sourceType": "USER",
+                                                      "sourceId": 14,
+                                                      "reason": "링크 공유 회원 상품 구매",
+                                                      "accumulatedAt": "2026-01-18T05:39:52.307824",
+                                                      "createdAt": "2026-01-18T17:28:12.709305"
+                                                    }
+                                                  ]
+                                                },
+                                                {
+                                                  "date": "2026-01-17",
+                                                  "count": 3,
+                                                  "histories": [
+                                                    {
+                                                      "id": 14,
+                                                      "amount": 2000,
+                                                      "isReflected": true,
+                                                      "sourceType": "USER",
+                                                      "sourceId": 17,
+                                                      "reason": "추천인 코드 등록 적립",
+                                                      "accumulatedAt": "2026-01-17T14:28:00.946674",
+                                                      "createdAt": "2026-01-17T14:28:00.951884"
+                                                    },
+                                                    {
+                                                      "id": 13,
+                                                      "amount": -500,
+                                                      "isReflected": true,
+                                                      "sourceType": "PRODUCT",
+                                                      "sourceId": 40,
+                                                      "reason": "상품 구매",
+                                                      "accumulatedAt": "2026-01-17T14:28:00.973419",
+                                                      "createdAt": "2026-01-19T17:13:26.722427"
+                                                    },
+                                                    {
+                                                      "id": 11,
+                                                      "amount": 0,
+                                                      "isReflected": true,
+                                                      "sourceType": "USER",
+                                                      "sourceId": 17,
+                                                      "reason": "회원 가입",
+                                                      "accumulatedAt": "2026-01-17T05:27:21.418247",
+                                                      "createdAt": "2026-01-17T05:27:21.420814"
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            }
                                           },
                                           "message": "회원 포인트 내역 조회 성공"
                                         }
@@ -178,4 +196,3 @@ import java.lang.annotation.*;
 )
 public @interface GetUserPointHistoriesApiDocs {
 }
-

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/point/response/GetUserPointHistoryResponse.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/point/response/GetUserPointHistoryResponse.java
@@ -1,18 +1,25 @@
 package com.personal.marketnote.reward.adapter.in.web.point.response;
 
+import com.personal.marketnote.common.adapter.in.response.CursorResponse;
 import com.personal.marketnote.reward.port.in.result.point.GetUserPointHistoryResult;
 
 import java.util.List;
 
 public record GetUserPointHistoryResponse(
-        List<UserPointHistoryByDateResponse> histories
+        CursorResponse<UserPointHistoryByDateResponse> histories
 ) {
     public static GetUserPointHistoryResponse from(GetUserPointHistoryResult result) {
+        List<UserPointHistoryByDateResponse> items = result.histories().stream()
+                .map(UserPointHistoryByDateResponse::from)
+                .toList();
+
         return new GetUserPointHistoryResponse(
-                result.histories().stream()
-                        .map(UserPointHistoryByDateResponse::from)
-                        .toList()
+                new CursorResponse<>(
+                        result.totalElements(),
+                        result.hasNext(),
+                        result.nextCursor(),
+                        items
+                )
         );
     }
 }
-

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/point/UserPointHistoryPersistenceAdapter.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/point/UserPointHistoryPersistenceAdapter.java
@@ -12,6 +12,7 @@ import com.personal.marketnote.reward.port.out.point.SaveUserPointHistoryPort;
 import com.personal.marketnote.reward.port.out.point.UpdateUserPointHistoryPort;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.PageRequest;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -38,17 +39,31 @@ public class UserPointHistoryPersistenceAdapter implements SaveUserPointHistoryP
     }
 
     @Override
-    public List<UserPointHistory> findByUserId(Long userId, UserPointHistoryFilter filter, LocalDate startDate, LocalDate endDate) {
+    public List<UserPointHistory> findByUserId(Long userId, UserPointHistoryFilter filter,
+                                               LocalDate startDate, LocalDate endDate,
+                                               Long cursor, int pageSize) {
         List<UserPointHistoryJpaEntity> histories = repository.findByUserIdAndDateRangeAndFilter(
                 userId,
                 startDate.atStartOfDay(),
                 endDate.plusDays(1).atStartOfDay(),
-                filter.getAmountFilterValue()
+                filter.getAmountFilterValue(),
+                cursor,
+                PageRequest.of(0, pageSize)
         );
 
         return histories.stream()
                 .map(UserPointHistoryJpaEntity::toDomain)
                 .toList();
+    }
+
+    @Override
+    public long countByUserId(Long userId, UserPointHistoryFilter filter, LocalDate startDate, LocalDate endDate) {
+        return repository.countByUserIdAndDateRangeAndFilter(
+                userId,
+                startDate.atStartOfDay(),
+                endDate.plusDays(1).atStartOfDay(),
+                filter.getAmountFilterValue()
+        );
     }
 
     @Override

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/point/repository/UserPointHistoryJpaRepository.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/point/repository/UserPointHistoryJpaRepository.java
@@ -2,6 +2,7 @@ package com.personal.marketnote.reward.adapter.out.persistence.point.repository;
 
 import com.personal.marketnote.reward.adapter.out.persistence.point.entity.UserPointHistoryJpaEntity;
 import com.personal.marketnote.reward.domain.point.UserPointSourceType;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -21,9 +22,30 @@ public interface UserPointHistoryJpaRepository extends JpaRepository<UserPointHi
               AND (:amountFilter = 0
                 OR (:amountFilter = 1 AND h.amount > 0)
                 OR (:amountFilter = -1 AND h.amount < 0))
-            ORDER BY h.accumulatedAt DESC
+              AND (:cursor IS NULL
+                OR h.accumulatedAt < (SELECT h2.accumulatedAt FROM UserPointHistoryJpaEntity h2 WHERE h2.id = :cursor AND h2.userId = :userId)
+                OR (h.accumulatedAt = (SELECT h2.accumulatedAt FROM UserPointHistoryJpaEntity h2 WHERE h2.id = :cursor AND h2.userId = :userId) AND h.id < :cursor))
+            ORDER BY h.accumulatedAt DESC, h.id DESC
             """)
     List<UserPointHistoryJpaEntity> findByUserIdAndDateRangeAndFilter(
+            @Param("userId") Long userId,
+            @Param("startDateTime") LocalDateTime startDateTime,
+            @Param("endDateTime") LocalDateTime endDateTime,
+            @Param("amountFilter") int amountFilter,
+            @Param("cursor") Long cursor,
+            Pageable pageable
+    );
+
+    @Query("""
+            SELECT COUNT(h) FROM UserPointHistoryJpaEntity h
+            WHERE h.userId = :userId
+              AND h.accumulatedAt >= :startDateTime
+              AND h.accumulatedAt < :endDateTime
+              AND (:amountFilter = 0
+                OR (:amountFilter = 1 AND h.amount > 0)
+                OR (:amountFilter = -1 AND h.amount < 0))
+            """)
+    long countByUserIdAndDateRangeAndFilter(
             @Param("userId") Long userId,
             @Param("startDateTime") LocalDateTime startDateTime,
             @Param("endDateTime") LocalDateTime endDateTime,

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/exception/InvalidPointHistoryPageSizeException.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/exception/InvalidPointHistoryPageSizeException.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.reward.exception;
+
+public class InvalidPointHistoryPageSizeException extends IllegalArgumentException {
+    public InvalidPointHistoryPageSizeException(int pageSize) {
+        super("ERR_POINT_HISTORY_02::페이지 크기는 1 이상 100 이하여야 합니다. pageSize=" + pageSize);
+    }
+}

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/command/point/GetUserPointHistoryCommand.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/command/point/GetUserPointHistoryCommand.java
@@ -10,6 +10,8 @@ public record GetUserPointHistoryCommand(
         Long userId,
         UserPointHistoryFilter filter,
         LocalDate startDate,
-        LocalDate endDate
+        LocalDate endDate,
+        Long cursor,
+        int pageSize
 ) {
 }

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/result/point/GetUserPointHistoryResult.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/result/point/GetUserPointHistoryResult.java
@@ -13,9 +13,17 @@ import java.util.Map;
 
 @Builder(access = AccessLevel.PRIVATE)
 public record GetUserPointHistoryResult(
+        Long totalElements,
+        boolean hasNext,
+        Long nextCursor,
         List<UserPointHistoryByDateResult> histories
 ) {
-    public static GetUserPointHistoryResult from(List<UserPointHistory> histories) {
+    public static GetUserPointHistoryResult from(
+            Long totalElements,
+            boolean hasNext,
+            Long nextCursor,
+            List<UserPointHistory> histories
+    ) {
         Map<LocalDate, List<UserPointHistory>> historiesByDate = new LinkedHashMap<>();
 
         for (UserPointHistory history : histories) {
@@ -34,7 +42,6 @@ public record GetUserPointHistoryResult(
                 ))
                 .toList();
 
-        return new GetUserPointHistoryResult(groupedHistories);
+        return new GetUserPointHistoryResult(totalElements, hasNext, nextCursor, groupedHistories);
     }
 }
-

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/out/point/FindUserPointHistoryPort.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/out/point/FindUserPointHistoryPort.java
@@ -20,12 +20,28 @@ public interface FindUserPointHistoryPort {
      * @param filter    포인트 이력 필터
      * @param startDate 조회 시작일
      * @param endDate   조회 종료일
+     * @param cursor    커서 (마지막 조회 항목의 ID, null이면 첫 페이지)
+     * @param pageSize  조회 건수 (pageSize + 1 포함)
      * @return 회원 포인트 이력 목록 {@link UserPointHistory}
      * @Date 2026-01-19
      * @Author 성효빈
-     * @Description 회원 식별자와 필터/기간 조건으로 포인트 이력을 조회합니다.
+     * @Description 회원 식별자와 필터/기간/커서 조건으로 포인트 이력을 페이징 조회합니다.
      */
-    List<UserPointHistory> findByUserId(Long userId, UserPointHistoryFilter filter, LocalDate startDate, LocalDate endDate);
+    List<UserPointHistory> findByUserId(Long userId, UserPointHistoryFilter filter,
+                                        LocalDate startDate, LocalDate endDate,
+                                        Long cursor, int pageSize);
+
+    /**
+     * @param userId    회원 식별자
+     * @param filter    포인트 이력 필터
+     * @param startDate 조회 시작일
+     * @param endDate   조회 종료일
+     * @return 조건에 맞는 전체 포인트 이력 건수
+     * @Date 2026-03-21
+     * @Author 성효빈
+     * @Description 조건에 맞는 포인트 이력 전체 건수를 조회합니다.
+     */
+    long countByUserId(Long userId, UserPointHistoryFilter filter, LocalDate startDate, LocalDate endDate);
 
     /**
      * @param userId     회원 식별자
@@ -38,4 +54,3 @@ public interface FindUserPointHistoryPort {
      */
     List<UserPointHistory> findUnreflectedByUserIdAndSource(Long userId, UserPointSourceType sourceType, Long sourceId);
 }
-

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/service/point/GetUserPointHistoryService.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/service/point/GetUserPointHistoryService.java
@@ -2,8 +2,10 @@ package com.personal.marketnote.reward.service.point;
 
 import com.personal.marketnote.common.application.UseCase;
 import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.reward.domain.point.UserPointHistory;
 import com.personal.marketnote.reward.domain.point.UserPointHistoryFilter;
 import com.personal.marketnote.reward.exception.InvalidPointHistoryDateRangeException;
+import com.personal.marketnote.reward.exception.InvalidPointHistoryPageSizeException;
 import com.personal.marketnote.reward.port.in.command.point.GetUserPointHistoryCommand;
 import com.personal.marketnote.reward.port.in.result.point.GetUserPointHistoryResult;
 import com.personal.marketnote.reward.port.in.usecase.point.GetUserPointHistoryUseCase;
@@ -12,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.util.List;
 
 import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
 
@@ -21,11 +24,14 @@ import static org.springframework.transaction.annotation.Isolation.READ_COMMITTE
 public class GetUserPointHistoryService implements GetUserPointHistoryUseCase {
     static final LocalDate DEFAULT_START_DATE = LocalDate.of(2000, 1, 1);
     static final LocalDate DEFAULT_END_DATE = LocalDate.of(2999, 12, 31);
+    static final int MAX_PAGE_SIZE = 100;
 
     private final FindUserPointHistoryPort findUserPointHistoryPort;
 
     @Override
     public GetUserPointHistoryResult getUserPointHistories(GetUserPointHistoryCommand command) {
+        validatePageSize(command.pageSize());
+
         UserPointHistoryFilter targetFilter = FormatValidator.hasValue(command.filter())
                 ? command.filter()
                 : UserPointHistoryFilter.ALL;
@@ -42,8 +48,41 @@ public class GetUserPointHistoryService implements GetUserPointHistoryUseCase {
             throw new InvalidPointHistoryDateRangeException(startDate, endDate);
         }
 
-        return GetUserPointHistoryResult.from(
-                findUserPointHistoryPort.findByUserId(command.userId(), targetFilter, startDate, endDate)
+        int fetchSize = command.pageSize() + 1;
+        List<UserPointHistory> histories = findUserPointHistoryPort.findByUserId(
+                command.userId(), targetFilter, startDate, endDate, command.cursor(), fetchSize
         );
+
+        boolean hasNext = histories.size() > command.pageSize();
+        List<UserPointHistory> pagedHistories = hasNext
+                ? histories.subList(0, command.pageSize())
+                : histories;
+
+        Long nextCursor = pagedHistories.isEmpty() ? null : pagedHistories.getLast().getId();
+
+        Long totalElements = resolveTotalElements(
+                command, targetFilter, startDate, endDate, hasNext, pagedHistories.size()
+        );
+
+        return GetUserPointHistoryResult.from(totalElements, hasNext, nextCursor, pagedHistories);
+    }
+
+    private void validatePageSize(int pageSize) {
+        if (pageSize < 1 || pageSize > MAX_PAGE_SIZE) {
+            throw new InvalidPointHistoryPageSizeException(pageSize);
+        }
+    }
+
+    private Long resolveTotalElements(GetUserPointHistoryCommand command,
+                                      UserPointHistoryFilter filter,
+                                      LocalDate startDate, LocalDate endDate,
+                                      boolean hasNext, int currentSize) {
+        if (FormatValidator.hasValue(command.cursor())) {
+            return null;
+        }
+        if (!hasNext) {
+            return (long) currentSize;
+        }
+        return findUserPointHistoryPort.countByUserId(command.userId(), filter, startDate, endDate);
     }
 }

--- a/reward-service/reward-application/src/test/java/com/personal/marketnote/reward/service/point/GetUserPointHistoryUseCaseTest.java
+++ b/reward-service/reward-application/src/test/java/com/personal/marketnote/reward/service/point/GetUserPointHistoryUseCaseTest.java
@@ -37,6 +37,8 @@ class GetUserPointHistoryUseCaseTest {
     private FindUserPointHistoryPort findUserPointHistoryPort;
 
     private static final Long USER_ID = 1L;
+    private static final int DEFAULT_PAGE_SIZE = 20;
+    private static final int DEFAULT_FETCH_SIZE = DEFAULT_PAGE_SIZE + 1;
     private static final LocalDateTime NOW = LocalDateTime.of(2026, 3, 5, 10, 0);
     private static final LocalDate DEFAULT_START_DATE = GetUserPointHistoryService.DEFAULT_START_DATE;
     private static final LocalDate DEFAULT_END_DATE = GetUserPointHistoryService.DEFAULT_END_DATE;
@@ -59,6 +61,7 @@ class GetUserPointHistoryUseCaseTest {
         return GetUserPointHistoryCommand.builder()
                 .userId(USER_ID)
                 .filter(filter)
+                .pageSize(DEFAULT_PAGE_SIZE)
                 .build();
     }
 
@@ -68,6 +71,7 @@ class GetUserPointHistoryUseCaseTest {
                 .filter(filter)
                 .startDate(startDate)
                 .endDate(endDate)
+                .pageSize(DEFAULT_PAGE_SIZE)
                 .build();
     }
 
@@ -84,7 +88,7 @@ class GetUserPointHistoryUseCaseTest {
                     createHistory(2L, -200L, UserPointSourceType.ORDER, NOW)
             );
 
-            when(findUserPointHistoryPort.findByUserId(USER_ID, UserPointHistoryFilter.ALL, DEFAULT_START_DATE, DEFAULT_END_DATE))
+            when(findUserPointHistoryPort.findByUserId(USER_ID, UserPointHistoryFilter.ALL, DEFAULT_START_DATE, DEFAULT_END_DATE, null, DEFAULT_FETCH_SIZE))
                     .thenReturn(histories);
 
             // when
@@ -95,7 +99,9 @@ class GetUserPointHistoryUseCaseTest {
             // then
             assertThat(result.histories()).hasSize(1);
             assertThat(result.histories().getFirst().count()).isEqualTo(2);
-            verify(findUserPointHistoryPort).findByUserId(USER_ID, UserPointHistoryFilter.ALL, DEFAULT_START_DATE, DEFAULT_END_DATE);
+            assertThat(result.totalElements()).isEqualTo(2L);
+            assertThat(result.hasNext()).isFalse();
+            verify(findUserPointHistoryPort).findByUserId(USER_ID, UserPointHistoryFilter.ALL, DEFAULT_START_DATE, DEFAULT_END_DATE, null, DEFAULT_FETCH_SIZE);
         }
 
         @Test
@@ -106,7 +112,7 @@ class GetUserPointHistoryUseCaseTest {
                     createHistory(1L, 500L, UserPointSourceType.ORDER, NOW)
             );
 
-            when(findUserPointHistoryPort.findByUserId(USER_ID, UserPointHistoryFilter.ACCRUAL, DEFAULT_START_DATE, DEFAULT_END_DATE))
+            when(findUserPointHistoryPort.findByUserId(USER_ID, UserPointHistoryFilter.ACCRUAL, DEFAULT_START_DATE, DEFAULT_END_DATE, null, DEFAULT_FETCH_SIZE))
                     .thenReturn(histories);
 
             // when
@@ -117,7 +123,7 @@ class GetUserPointHistoryUseCaseTest {
             // then
             assertThat(result.histories()).hasSize(1);
             assertThat(result.histories().getFirst().count()).isEqualTo(1);
-            verify(findUserPointHistoryPort).findByUserId(USER_ID, UserPointHistoryFilter.ACCRUAL, DEFAULT_START_DATE, DEFAULT_END_DATE);
+            verify(findUserPointHistoryPort).findByUserId(USER_ID, UserPointHistoryFilter.ACCRUAL, DEFAULT_START_DATE, DEFAULT_END_DATE, null, DEFAULT_FETCH_SIZE);
         }
 
         @Test
@@ -128,7 +134,7 @@ class GetUserPointHistoryUseCaseTest {
                     createHistory(1L, -300L, UserPointSourceType.ORDER, NOW)
             );
 
-            when(findUserPointHistoryPort.findByUserId(USER_ID, UserPointHistoryFilter.DEDUCTION, DEFAULT_START_DATE, DEFAULT_END_DATE))
+            when(findUserPointHistoryPort.findByUserId(USER_ID, UserPointHistoryFilter.DEDUCTION, DEFAULT_START_DATE, DEFAULT_END_DATE, null, DEFAULT_FETCH_SIZE))
                     .thenReturn(histories);
 
             // when
@@ -138,7 +144,7 @@ class GetUserPointHistoryUseCaseTest {
 
             // then
             assertThat(result.histories()).hasSize(1);
-            verify(findUserPointHistoryPort).findByUserId(USER_ID, UserPointHistoryFilter.DEDUCTION, DEFAULT_START_DATE, DEFAULT_END_DATE);
+            verify(findUserPointHistoryPort).findByUserId(USER_ID, UserPointHistoryFilter.DEDUCTION, DEFAULT_START_DATE, DEFAULT_END_DATE, null, DEFAULT_FETCH_SIZE);
         }
     }
 
@@ -154,7 +160,7 @@ class GetUserPointHistoryUseCaseTest {
                     createHistory(1L, 500L, UserPointSourceType.ORDER, NOW)
             );
 
-            when(findUserPointHistoryPort.findByUserId(USER_ID, UserPointHistoryFilter.ALL, DEFAULT_START_DATE, DEFAULT_END_DATE))
+            when(findUserPointHistoryPort.findByUserId(USER_ID, UserPointHistoryFilter.ALL, DEFAULT_START_DATE, DEFAULT_END_DATE, null, DEFAULT_FETCH_SIZE))
                     .thenReturn(histories);
 
             // when
@@ -164,7 +170,7 @@ class GetUserPointHistoryUseCaseTest {
 
             // then
             assertThat(result.histories()).hasSize(1);
-            verify(findUserPointHistoryPort).findByUserId(USER_ID, UserPointHistoryFilter.ALL, DEFAULT_START_DATE, DEFAULT_END_DATE);
+            verify(findUserPointHistoryPort).findByUserId(USER_ID, UserPointHistoryFilter.ALL, DEFAULT_START_DATE, DEFAULT_END_DATE, null, DEFAULT_FETCH_SIZE);
         }
     }
 
@@ -176,7 +182,7 @@ class GetUserPointHistoryUseCaseTest {
         @DisplayName("이력이 없으면 빈 결과를 반환한다")
         void shouldReturnEmptyResultWhenNoHistories() {
             // given
-            when(findUserPointHistoryPort.findByUserId(USER_ID, UserPointHistoryFilter.ALL, DEFAULT_START_DATE, DEFAULT_END_DATE))
+            when(findUserPointHistoryPort.findByUserId(USER_ID, UserPointHistoryFilter.ALL, DEFAULT_START_DATE, DEFAULT_END_DATE, null, DEFAULT_FETCH_SIZE))
                     .thenReturn(Collections.emptyList());
 
             // when
@@ -186,6 +192,9 @@ class GetUserPointHistoryUseCaseTest {
 
             // then
             assertThat(result.histories()).isEmpty();
+            assertThat(result.hasNext()).isFalse();
+            assertThat(result.nextCursor()).isNull();
+            assertThat(result.totalElements()).isEqualTo(0L);
         }
     }
 
@@ -205,7 +214,7 @@ class GetUserPointHistoryUseCaseTest {
                     createHistory(2L, 300L, UserPointSourceType.ATTENDENCE, afternoon)
             );
 
-            when(findUserPointHistoryPort.findByUserId(USER_ID, UserPointHistoryFilter.ALL, DEFAULT_START_DATE, DEFAULT_END_DATE))
+            when(findUserPointHistoryPort.findByUserId(USER_ID, UserPointHistoryFilter.ALL, DEFAULT_START_DATE, DEFAULT_END_DATE, null, DEFAULT_FETCH_SIZE))
                     .thenReturn(histories);
 
             // when
@@ -230,7 +239,7 @@ class GetUserPointHistoryUseCaseTest {
                     createHistory(2L, 300L, UserPointSourceType.ATTENDENCE, day2)
             );
 
-            when(findUserPointHistoryPort.findByUserId(USER_ID, UserPointHistoryFilter.ALL, DEFAULT_START_DATE, DEFAULT_END_DATE))
+            when(findUserPointHistoryPort.findByUserId(USER_ID, UserPointHistoryFilter.ALL, DEFAULT_START_DATE, DEFAULT_END_DATE, null, DEFAULT_FETCH_SIZE))
                     .thenReturn(histories);
 
             // when
@@ -256,7 +265,7 @@ class GetUserPointHistoryUseCaseTest {
             LocalDate startDate = LocalDate.of(2026, 3, 1);
             LocalDate endDate = LocalDate.of(2026, 3, 31);
 
-            when(findUserPointHistoryPort.findByUserId(USER_ID, UserPointHistoryFilter.ALL, startDate, endDate))
+            when(findUserPointHistoryPort.findByUserId(USER_ID, UserPointHistoryFilter.ALL, startDate, endDate, null, DEFAULT_FETCH_SIZE))
                     .thenReturn(Collections.emptyList());
 
             // when
@@ -265,7 +274,7 @@ class GetUserPointHistoryUseCaseTest {
             );
 
             // then
-            verify(findUserPointHistoryPort).findByUserId(USER_ID, UserPointHistoryFilter.ALL, startDate, endDate);
+            verify(findUserPointHistoryPort).findByUserId(USER_ID, UserPointHistoryFilter.ALL, startDate, endDate, null, DEFAULT_FETCH_SIZE);
         }
 
         @Test
@@ -274,7 +283,7 @@ class GetUserPointHistoryUseCaseTest {
             // given
             LocalDate startDate = LocalDate.of(2026, 3, 1);
 
-            when(findUserPointHistoryPort.findByUserId(USER_ID, UserPointHistoryFilter.ALL, startDate, DEFAULT_END_DATE))
+            when(findUserPointHistoryPort.findByUserId(USER_ID, UserPointHistoryFilter.ALL, startDate, DEFAULT_END_DATE, null, DEFAULT_FETCH_SIZE))
                     .thenReturn(Collections.emptyList());
 
             // when
@@ -283,7 +292,7 @@ class GetUserPointHistoryUseCaseTest {
             );
 
             // then
-            verify(findUserPointHistoryPort).findByUserId(USER_ID, UserPointHistoryFilter.ALL, startDate, DEFAULT_END_DATE);
+            verify(findUserPointHistoryPort).findByUserId(USER_ID, UserPointHistoryFilter.ALL, startDate, DEFAULT_END_DATE, null, DEFAULT_FETCH_SIZE);
         }
 
         @Test
@@ -292,7 +301,7 @@ class GetUserPointHistoryUseCaseTest {
             // given
             LocalDate endDate = LocalDate.of(2026, 3, 31);
 
-            when(findUserPointHistoryPort.findByUserId(USER_ID, UserPointHistoryFilter.ALL, DEFAULT_START_DATE, endDate))
+            when(findUserPointHistoryPort.findByUserId(USER_ID, UserPointHistoryFilter.ALL, DEFAULT_START_DATE, endDate, null, DEFAULT_FETCH_SIZE))
                     .thenReturn(Collections.emptyList());
 
             // when
@@ -301,7 +310,7 @@ class GetUserPointHistoryUseCaseTest {
             );
 
             // then
-            verify(findUserPointHistoryPort).findByUserId(USER_ID, UserPointHistoryFilter.ALL, DEFAULT_START_DATE, endDate);
+            verify(findUserPointHistoryPort).findByUserId(USER_ID, UserPointHistoryFilter.ALL, DEFAULT_START_DATE, endDate, null, DEFAULT_FETCH_SIZE);
         }
 
         @Test
@@ -330,7 +339,7 @@ class GetUserPointHistoryUseCaseTest {
                     createHistory(1L, 500L, UserPointSourceType.ORDER, LocalDateTime.of(2026, 3, 15, 10, 0))
             );
 
-            when(findUserPointHistoryPort.findByUserId(USER_ID, UserPointHistoryFilter.ACCRUAL, startDate, endDate))
+            when(findUserPointHistoryPort.findByUserId(USER_ID, UserPointHistoryFilter.ACCRUAL, startDate, endDate, null, DEFAULT_FETCH_SIZE))
                     .thenReturn(histories);
 
             // when
@@ -340,7 +349,8 @@ class GetUserPointHistoryUseCaseTest {
 
             // then
             assertThat(result.histories()).hasSize(1);
-            verify(findUserPointHistoryPort).findByUserId(USER_ID, UserPointHistoryFilter.ACCRUAL, startDate, endDate);
+            verify(findUserPointHistoryPort).findByUserId(USER_ID, UserPointHistoryFilter.ACCRUAL, startDate, endDate, null, DEFAULT_FETCH_SIZE);
         }
     }
+
 }


### PR DESCRIPTION
## partially addresses #387
## resolves #1405

## Task
- [x] Command에 cursor, pageSize 필드 추가
- [x] Result에 totalElements, hasNext, nextCursor 추가
- [x] Port 시그니처 변경 (int pageSize) + countByUserId 추가
- [x] Service에 커서 처리, pageSize 검증(1~100), count 최적화 추가
- [x] Repository에 커서 tie-breaker JPQL + count 쿼리 추가
- [x] Adapter에 PageRequest 변환 추가
- [x] Response에 CursorResponse 래핑 추가
- [x] Controller에 cursor, page-size 쿼리 파라미터 추가
- [x] ApiDocs 업데이트
- [x] JPQL 서브쿼리에 userId 조건 추가 (IDOR 방지)