### PR TITLE
[#128][#1408] feat: 관리자 상품 목록 조회 오프셋 페이지네이션 전환 기능 추가

### DIFF
--- a/common/src/main/java/com/personal/marketnote/common/adapter/in/response/OffsetResponse.java
+++ b/common/src/main/java/com/personal/marketnote/common/adapter/in/response/OffsetResponse.java
@@ -1,0 +1,12 @@
+package com.personal.marketnote.common.adapter.in.response;
+
+import java.util.List;
+
+public record OffsetResponse<T>(
+        int page,
+        int pageSize,
+        long totalElements,
+        int totalPages,
+        List<T> items
+) {
+}

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/product/controller/ProductController.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/product/controller/ProductController.java
@@ -18,6 +18,7 @@ import com.personal.marketnote.product.port.in.result.product.*;
 import com.personal.marketnote.product.port.in.usecase.product.*;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
@@ -187,7 +188,7 @@ public class ProductController {
      *
      * @param categoryId     카테고리 ID
      * @param pricePolicyIds 가격 정책 ID 목록
-     * @param cursor         커서(무한 스크롤 페이지 설정)
+     * @param page           페이지 번호 (0-based)
      * @param pageSize       페이지 크기
      * @param sortDirection  정렬 방향
      * @param sortProperty   정렬 속성
@@ -204,8 +205,8 @@ public class ProductController {
     public ResponseEntity<BaseResponse<GetAdminProductsResponse>> getAdminProducts(
             @RequestParam(value = "categoryId", required = false) Long categoryId,
             @RequestParam(value = "pricePolicyIds", required = false) List<Long> pricePolicyIds,
-            @RequestParam(value = "cursor", required = false) Long cursor,
-            @RequestParam(value = "pageSize", required = false, defaultValue = GET_PRODUCTS_DEFAULT_PAGE_SIZE) int pageSize,
+            @RequestParam(value = "page", required = false, defaultValue = "0") @Min(0) int page,
+            @RequestParam(value = "page-size", required = false, defaultValue = GET_PRODUCTS_DEFAULT_PAGE_SIZE) @Min(1) int pageSize,
             @RequestParam(required = false, defaultValue = "DESC") Sort.Direction sortDirection,
             @RequestParam(required = false, defaultValue = "ORDER_NUM") ProductSortProperty sortProperty,
             @RequestParam(required = false, defaultValue = "NAME") ProductSearchTarget searchTarget,
@@ -214,7 +215,7 @@ public class ProductController {
         GetAdminProductsResult result = getAdminProductsUseCase.getAdminProducts(
                 categoryId,
                 pricePolicyIds,
-                cursor,
+                page,
                 pageSize,
                 sortDirection,
                 sortProperty,

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/product/controller/apidocs/GetAdminProductsApiDocs.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/product/controller/apidocs/GetAdminProductsApiDocs.java
@@ -19,38 +19,36 @@ import java.lang.annotation.*;
         summary = "(관리자) 상품 목록 조회",
         description = """
                 작성일자: 2026-02-03
-                
+
                 작성자: 성효빈
-                
+
                 ---
-                
+
                 ## Description
-                
+
                 - 관리자 페이지에서 상품 목록을 조회합니다.
-                
-                - 페이로드에 cursor 값이 없는 경우(첫 페이지): 총 상품 개수 반환 O
-                
-                - 페이로드에 cursor 값이 있는 경우(더 보기): 총 상품 개수 반환 X
-                
+
+                - 오프셋 기반 페이지네이션을 사용합니다. (page: 0-based)
+
                 ---
-                
+
                 ## Request
-                
+
                 | **키** | **타입** | **설명** | **필수 여부** | **예시** |
                 | --- | --- | --- | --- | --- |
                 | categoryId | number | 카테고리 ID | N | 1001 |
                 | pricePolicyIds | array<number> | 가격 정책 ID 목록 | N | 1, 2 |
-                | cursor | number | 이전 페이지의 nextCursor 값, 전송하지 않는 경우 첫 데이터부터 조회 | N | 1 |
-                | page-size | number | 페이지 크기 | N | 4 |
+                | page | number | 페이지 번호 (0-based) | N | 0 |
+                | page-size | number | 페이지 크기 | N | 10 |
                 | sortDirection | string | 정렬 방향(ASC, DESC) | N | DESC |
                 | sortProperty | string | 정렬 속성(ORDER_NUM, POPULARITY, DISCOUNT_PRICE, ACCUMULATED_POINT) | N | ORDER_NUM |
                 | searchTarget | string | 검색 대상(NAME, BRAND_NAME) | N | NAME |
                 | searchKeyword | string | 검색 키워드 | N | "노트왕" |
-                
+
                 ---
-                
+
                 ## Response
-                
+
                 | **키** | **타입** | **설명** | **예시** |
                 | --- | --- | --- | --- |
                 | statusCode | number | 상태 코드 | 200: 성공 / 400: 클라이언트 요청 오류 / 401: 인증 실패 / 403: 인가 실패 / 404: 리소스 조회 실패 / 409: 충돌 / 500: 그 외 |
@@ -58,30 +56,31 @@ import java.lang.annotation.*;
                 | timestamp | string(datetime) | 응답 일시 | "2026-02-03T12:12:30.013" |
                 | content | object | 응답 본문 | { ... } |
                 | message | string | 처리 결과 | "관리자 상품 목록 조회 성공" |
-                
+
                 ---
-                
+
                 ### Response > content
-                
+
                 | **키** | **타입** | **설명** | **예시** |
                 | --- | --- | --- | --- |
-                | products | object | 상품 목록(CursorResponse) | { ... } |
-                
+                | products | object | 상품 목록(OffsetResponse) | { ... } |
+
                 ---
-                
+
                 ### Response > content > products
-                
+
                 | **키** | **타입** | **설명** | **예시** |
                 | --- | --- | --- | --- |
+                | page | number | 현재 페이지 번호 (0-based) | 0 |
+                | pageSize | number | 페이지 크기 | 10 |
                 | totalElements | number | 총 아이템 수 | 30 |
-                | nextCursor | number | 현재 페이지에서 조회한 마지막 리소스의 식별자 | 18 |
-                | hasNext | boolean | 다음 페이지 존재 여부 | true |
+                | totalPages | number | 총 페이지 수 | 3 |
                 | items | array | 상품 목록 | [ ... ] |
-                
+
                 ---
-                
+
                 ### Response > content > products > items
-                
+
                 | **키** | **타입** | **설명** | **예시** |
                 | --- | --- | --- | --- |
                 | id | number | 상품 ID | 1 |
@@ -98,11 +97,11 @@ import java.lang.annotation.*;
                 | totalCount | number | 리뷰 총 개수 | 8 |
                 | status | string | 상태 | "ACTIVE" |
                 | orderNum | number | 정렬 순서 | 1 |
-                
+
                 ---
-                
+
                 ### Response > content > products > items > pricePolicy
-                
+
                 | **키** | **타입** | **설명** | **예시** |
                 | --- | --- | --- | --- |
                 | id | number | 가격 정책 ID | 22 |
@@ -111,11 +110,11 @@ import java.lang.annotation.*;
                 | accumulatedPoint | number | 적립 포인트 | 2000 |
                 | discountRate | number | 할인율(%, 최대 소수점 1자리) | 20 |
                 | optionIds | array<number> | 옵션 ID 목록 | [8, 11] |
-                
+
                 ---
-                
+
                 ### Response > content > products > items > productTags
-                
+
                 | **키** | **타입** | **설명** | **예시** |
                 | --- | --- | --- | --- |
                 | id | number | 상품 태그 ID | 1 |
@@ -123,11 +122,11 @@ import java.lang.annotation.*;
                 | name | string | 상품 태그명 | "루테인" |
                 | orderNum | number | 정렬 순서 | 1 |
                 | status | string | 상태 | "ACTIVE" |
-                
+
                 ---
-                
+
                 ### Response > content > products > items > catalogImage
-                
+
                 | **키** | **타입** | **설명** | **예시** |
                 | --- | --- | --- | --- |
                 | id | number | 이미지 ID | 1 |
@@ -137,17 +136,17 @@ import java.lang.annotation.*;
                 | s3Url | string | 이미지 S3 URL | "https://marketnote.s3.amazonaws.com/product/30/1763517082648_grafana-icon.png" |
                 | resizedS3Urls | array | 리사이즈 이미지 S3 URL 목록 | [ "https://marketnote.s3.amazonaws.com/product/30/1763517083251_grafana-icon_300x300.png" ] |
                 | orderNum | number | 정렬 순서 | 1 |
-                
+
                 ---
-                
+
                 ### Response > content > products > items > selectedOptions
-                
+
                 | **키** | **타입** | **설명** | **예시** |
                 | --- | --- | --- | --- |
                 | id | number | 옵션 ID | 1 |
                 | content | string | 옵션 내용 | "1박스" |
                 | status | string | 상태 | "ACTIVE" |
-                
+
                 """,
         security = {@SecurityRequirement(name = "bearer")},
         parameters = {
@@ -164,18 +163,22 @@ import java.lang.annotation.*;
                         schema = @Schema(type = "array")
                 ),
                 @Parameter(
-                        name = "cursor",
+                        name = "page",
                         in = ParameterIn.QUERY,
-                        description = "이전 페이지의 nextCursor 값, 전송하지 않는 경우 첫 데이터부터 조회",
-                        schema = @Schema(type = "number")
+                        description = "페이지 번호 (0-based, 기본값: 0)",
+                        schema = @Schema(
+                                type = "number",
+                                example = "0",
+                                defaultValue = "0"
+                        )
                 ),
                 @Parameter(
-                        name = "pageSize",
+                        name = "page-size",
                         in = ParameterIn.QUERY,
                         description = "페이지 크기",
                         schema = @Schema(
                                 type = "number",
-                                example = "4",
+                                example = "10",
                                 defaultValue = "4"
                         )
                 ),
@@ -231,9 +234,10 @@ import java.lang.annotation.*;
                                           "timestamp": "2026-02-03T12:12:30.013",
                                           "content": {
                                             "products": {
+                                              "page": 0,
+                                              "pageSize": 10,
                                               "totalElements": 16,
-                                              "hasNext": true,
-                                              "nextCursor": 20,
+                                              "totalPages": 2,
                                               "items": [
                                                 {
                                                   "id": 1,

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/product/response/GetAdminProductsResponse.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/product/response/GetAdminProductsResponse.java
@@ -1,29 +1,19 @@
 package com.personal.marketnote.product.adapter.in.web.product.response;
 
-import com.personal.marketnote.common.adapter.in.response.CursorResponse;
+import com.personal.marketnote.common.adapter.in.response.OffsetResponse;
 import com.personal.marketnote.product.port.in.result.product.GetAdminProductsResult;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
 
-import java.util.stream.Collectors;
-
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
-@Builder(access = AccessLevel.PRIVATE)
-@Getter
-public class GetAdminProductsResponse {
-    private CursorResponse<ProductItemResponse> products;
-
+public record GetAdminProductsResponse(OffsetResponse<ProductItemResponse> products) {
     public static GetAdminProductsResponse from(GetAdminProductsResult result) {
         return new GetAdminProductsResponse(
-                new CursorResponse<>(
+                new OffsetResponse<>(
+                        result.page(),
+                        result.pageSize(),
                         result.totalElements(),
-                        result.hasNext(),
-                        result.nextCursor(),
+                        result.totalPages(),
                         result.products().stream()
                                 .map(ProductItemResponse::from)
-                                .collect(Collectors.toList())
+                                .toList()
                 )
         );
     }

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/pricepolicy/PricePolicyPersistenceAdapter.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/pricepolicy/PricePolicyPersistenceAdapter.java
@@ -22,6 +22,7 @@ import com.personal.marketnote.product.port.out.pricepolicy.UpdatePopularityPort
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 
@@ -276,6 +277,48 @@ public class PricePolicyPersistenceAdapter implements SavePricePolicyPort, FindP
                 searchTarget.getCamelCaseValue(),
                 searchPattern
         );
+    }
+
+    @Override
+    public List<PricePolicy> findPricePoliciesByOffset(
+            List<Long> pricePolicyIds,
+            int page,
+            int pageSize,
+            Sort.Direction sortDirection,
+            ProductSortProperty sortProperty,
+            ProductSearchTarget searchTarget,
+            String searchKeyword,
+            Long categoryId
+    ) {
+        String pattern = generateSearchPattern(searchKeyword);
+
+        boolean isAsc = sortDirection == Sort.Direction.ASC;
+
+        List<PricePolicyJpaEntity> entities = isAsc
+                ? pricePolicyJpaRepository.findAllActiveByOffsetAsc(
+                pricePolicyIds,
+                PageRequest.of(page, pageSize),
+                sortProperty.getCamelCaseValue(),
+                searchTarget.getCamelCaseValue(),
+                pattern,
+                categoryId
+        )
+                : pricePolicyJpaRepository.findAllActiveByOffsetDesc(
+                pricePolicyIds,
+                PageRequest.of(page, pageSize),
+                sortProperty.getCamelCaseValue(),
+                searchTarget.getCamelCaseValue(),
+                pattern,
+                categoryId
+        );
+
+        return new ArrayList<>(loadPricePoliciesWithAssociations(entities).stream()
+                .map(policyEntity -> PricePolicyJpaEntityToDomainMapper.mapToDomain(
+                        policyEntity, productOptionPricePolicyJpaRepository.findOptionIdsByPricePolicyId(policyEntity.getId())
+                ))
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .toList());
     }
 
     private String generateSearchPattern(String searchKeyword) {

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/pricepolicy/repository/PricePolicyJpaRepository.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/pricepolicy/repository/PricePolicyJpaRepository.java
@@ -240,6 +240,96 @@ public interface PricePolicyJpaRepository extends JpaRepository<PricePolicyJpaEn
     );
 
     @Query("""
+            SELECT pp
+            FROM PricePolicyJpaEntity pp
+              JOIN pp.productJpaEntity p
+            WHERE 1 = 1
+              AND p.status = com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus.ACTIVE
+              AND pp.status = com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus.ACTIVE
+              AND (
+                    :pattern = ''
+                 OR (:searchTarget = 'name' AND p.name LIKE :pattern)
+                 OR (:searchTarget = 'brandName' AND p.brandName LIKE :pattern)
+                 OR (:searchTarget <> 'name' AND :searchTarget <> 'brandName' AND (p.name LIKE :pattern OR p.brandName LIKE :pattern))
+              )
+              AND (
+                    :categoryId IS NULL
+                 OR EXISTS (
+                        SELECT 1
+                        FROM ProductCategoryJpaEntity pc
+                        WHERE pc.productId = p.id
+                          AND pc.categoryId = :categoryId
+                 )
+              )
+              AND (
+                    :pricePolicyIds IS NULL
+                    OR pp.id IN (:pricePolicyIds)
+              )
+            ORDER BY
+                CASE WHEN :sortProperty = 'orderNum' THEN p.orderNum END ASC,
+                CASE WHEN :sortProperty = 'popularity' THEN pp.popularity END ASC,
+                CASE WHEN :sortProperty = 'discountPrice' THEN pp.discountPrice END ASC,
+                CASE WHEN :sortProperty = 'accumulatedPoint' THEN pp.accumulatedPoint END ASC,
+                CASE WHEN :sortProperty = 'accumulatedPoint' THEN p.id END DESC,
+                CASE WHEN :sortProperty = 'accumulatedPointRate' THEN pp.accumulationRate END ASC,
+                CASE WHEN :sortProperty = 'accumulatedPointRate' THEN p.id END DESC,
+                pp.id ASC
+            """)
+    List<PricePolicyJpaEntity> findAllActiveByOffsetAsc(
+            @Param("pricePolicyIds") List<Long> pricePolicyIds,
+            Pageable pageable,
+            @Param("sortProperty") String sortProperty,
+            @Param("searchTarget") String searchTarget,
+            @Param("pattern") String pattern,
+            @Param("categoryId") Long categoryId
+    );
+
+    @Query("""
+            SELECT pp
+            FROM PricePolicyJpaEntity pp
+              JOIN pp.productJpaEntity p
+            WHERE 1 = 1
+              AND p.status = com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus.ACTIVE
+              AND pp.status = com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus.ACTIVE
+              AND (
+                    :pattern = ''
+                 OR (:searchTarget = 'name' AND p.name LIKE :pattern)
+                 OR (:searchTarget = 'brandName' AND p.brandName LIKE :pattern)
+                 OR (:searchTarget <> 'name' AND :searchTarget <> 'brandName' AND (p.name LIKE :pattern OR p.brandName LIKE :pattern))
+              )
+              AND (
+                    :categoryId IS NULL
+                 OR EXISTS (
+                        SELECT 1
+                        FROM ProductCategoryJpaEntity pc
+                        WHERE pc.productId = p.id
+                          AND pc.categoryId = :categoryId
+                 )
+              )
+              AND (
+                    :pricePolicyIds IS NULL
+                    OR pp.id IN :pricePolicyIds
+              )
+            ORDER BY
+                CASE WHEN :sortProperty = 'orderNum' THEN p.orderNum END DESC,
+                CASE WHEN :sortProperty = 'popularity' THEN pp.popularity END DESC,
+                CASE WHEN :sortProperty = 'discountPrice' THEN pp.discountPrice END DESC,
+                CASE WHEN :sortProperty = 'accumulatedPoint' THEN pp.accumulatedPoint END DESC,
+                CASE WHEN :sortProperty = 'accumulatedPoint' THEN p.id END DESC,
+                CASE WHEN :sortProperty = 'accumulatedPointRate' THEN pp.accumulationRate END DESC,
+                CASE WHEN :sortProperty = 'accumulatedPointRate' THEN p.id END DESC,
+                pp.id DESC
+            """)
+    List<PricePolicyJpaEntity> findAllActiveByOffsetDesc(
+            @Param("pricePolicyIds") List<Long> pricePolicyIds,
+            Pageable pageable,
+            @Param("sortProperty") String sortProperty,
+            @Param("searchTarget") String searchTarget,
+            @Param("pattern") String pattern,
+            @Param("categoryId") Long categoryId
+    );
+
+    @Query("""
             SELECT COUNT(pp)
             FROM PricePolicyJpaEntity pp
               JOIN pp.productJpaEntity p

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/result/product/GetAdminProductsResult.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/result/product/GetAdminProductsResult.java
@@ -3,17 +3,19 @@ package com.personal.marketnote.product.port.in.result.product;
 import java.util.List;
 
 public record GetAdminProductsResult(
-        Long totalElements,
-        Long nextCursor,
-        boolean hasNext,
+        int page,
+        int pageSize,
+        long totalElements,
+        int totalPages,
         List<ProductItemResult> products
 ) {
     public static GetAdminProductsResult of(
-            Long totalElements,
-            Long nextCursor,
-            boolean hasNext,
+            int page,
+            int pageSize,
+            long totalElements,
+            int totalPages,
             List<ProductItemResult> products
     ) {
-        return new GetAdminProductsResult(totalElements, nextCursor, hasNext, products);
+        return new GetAdminProductsResult(page, pageSize, totalElements, totalPages, products);
     }
 }

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/usecase/product/GetAdminProductsUseCase.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/usecase/product/GetAdminProductsUseCase.java
@@ -18,7 +18,7 @@ public interface GetAdminProductsUseCase {
     /**
      * @param categoryId     카테고리 ID
      * @param pricePolicyIds 가격 정책 ID 목록
-     * @param cursor         커서(무한 스크롤 페이지 설정)
+     * @param page           페이지 번호
      * @param pageSize       페이지 크기
      * @param sortDirection  정렬 방향
      * @param sortProperty   정렬 속성
@@ -32,7 +32,7 @@ public interface GetAdminProductsUseCase {
     GetAdminProductsResult getAdminProducts(
             Long categoryId,
             List<Long> pricePolicyIds,
-            Long cursor,
+            int page,
             int pageSize,
             Sort.Direction sortDirection,
             ProductSortProperty sortProperty,

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/out/pricepolicy/FindPricePoliciesPort.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/out/pricepolicy/FindPricePoliciesPort.java
@@ -4,6 +4,7 @@ import com.personal.marketnote.product.domain.pricepolicy.PricePolicy;
 import com.personal.marketnote.product.domain.product.ProductSearchTarget;
 import com.personal.marketnote.product.domain.product.ProductSortProperty;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 
 import java.util.List;
 
@@ -87,4 +88,15 @@ public interface FindPricePoliciesPort {
      * @Description 카테고리 가격 정책 총 개수를 조회합니다.
      */
     long countActivePricePoliciesByCategoryId(Long categoryId, ProductSearchTarget searchTarget, String searchKeyword);
+
+    List<PricePolicy> findPricePoliciesByOffset(
+            List<Long> pricePolicyIds,
+            int page,
+            int pageSize,
+            Sort.Direction sortDirection,
+            ProductSortProperty sortProperty,
+            ProductSearchTarget searchTarget,
+            String searchKeyword,
+            Long categoryId
+    );
 }

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/service/product/GetAdminProductsService.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/service/product/GetAdminProductsService.java
@@ -1,53 +1,225 @@
 package com.personal.marketnote.product.service.product;
 
 import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.common.application.file.port.in.result.GetFilesResult;
+import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.product.domain.option.ProductOption;
+import com.personal.marketnote.product.domain.option.ProductOptionCategory;
+import com.personal.marketnote.product.domain.pricepolicy.PricePolicy;
+import com.personal.marketnote.product.domain.product.Product;
 import com.personal.marketnote.product.domain.product.ProductSearchTarget;
 import com.personal.marketnote.product.domain.product.ProductSortProperty;
+import com.personal.marketnote.product.exception.ProductNotFoundException;
 import com.personal.marketnote.product.port.in.result.product.GetAdminProductsResult;
-import com.personal.marketnote.product.port.in.result.product.GetProductsResult;
+import com.personal.marketnote.product.port.in.result.product.ProductItemResult;
 import com.personal.marketnote.product.port.in.usecase.product.GetAdminProductsUseCase;
-import com.personal.marketnote.product.port.in.usecase.product.GetProductUseCase;
+import com.personal.marketnote.product.port.in.usecase.product.GetProductInventoryUseCase;
+import com.personal.marketnote.product.port.out.file.FindProductImagesPort;
+import com.personal.marketnote.product.port.out.pricepolicy.FindPricePoliciesPort;
+import com.personal.marketnote.product.port.out.product.FindProductPort;
+import com.personal.marketnote.product.port.out.productoption.FindProductOptionCategoryPort;
+import com.personal.marketnote.product.port.out.result.ProductReviewAggregateResult;
+import com.personal.marketnote.product.port.out.review.FindProductReviewAggregatesPort;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.domain.Sort;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executor;
+import java.util.stream.Collectors;
 
+import static com.personal.marketnote.common.domain.file.FileSort.PRODUCT_CATALOG_IMAGE;
 import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
 
 @UseCase
 @RequiredArgsConstructor
 @Transactional(isolation = READ_COMMITTED, readOnly = true)
 public class GetAdminProductsService implements GetAdminProductsUseCase {
-    private final GetProductUseCase getProductUseCase;
+    private final FindPricePoliciesPort findPricePoliciesPort;
+    private final FindProductPort findProductPort;
+    private final FindProductImagesPort findProductImagesPort;
+    private final FindProductReviewAggregatesPort findProductReviewAggregatesPort;
+    private final GetProductInventoryUseCase getProductInventoryUseCase;
+    private final FindProductOptionCategoryPort findProductOptionCategoryPort;
+
+    @Qualifier("productImageExecutor")
+    private final Executor productImageExecutor;
 
     @Override
     public GetAdminProductsResult getAdminProducts(
             Long categoryId,
             List<Long> pricePolicyIds,
-            Long cursor,
+            int page,
             int pageSize,
             Sort.Direction sortDirection,
             ProductSortProperty sortProperty,
             ProductSearchTarget searchTarget,
             String searchKeyword
     ) {
-        GetProductsResult products = getProductUseCase.getProducts(
-                categoryId,
-                pricePolicyIds,
-                cursor,
-                pageSize,
-                sortDirection,
-                sortProperty,
-                searchTarget,
-                searchKeyword
+        List<PricePolicy> pricePolicies = findPricePoliciesPort.findPricePoliciesByOffset(
+                pricePolicyIds, page, pageSize, sortDirection,
+                sortProperty, searchTarget, searchKeyword, categoryId
         );
 
-        return GetAdminProductsResult.of(
-                products.totalElements(),
-                products.nextCursor(),
-                products.hasNext(),
-                products.products()
+        long totalElements = findPricePoliciesPort.countActivePricePoliciesByCategoryId(
+                categoryId, searchTarget, searchKeyword
         );
+
+        int totalPages = computeTotalPages(totalElements, pageSize);
+
+        if (FormatValidator.hasNoValue(pricePolicies)) {
+            return GetAdminProductsResult.of(page, pageSize, totalElements, totalPages, List.of());
+        }
+
+        List<ProductItemResult> productItems = pricePolicies.stream()
+                .map(this::toProductItem)
+                .toList();
+
+        Map<Long, ProductReviewAggregateResult> reviewAggregatesByProductId
+                = findReviewAggregatesByProductId(productItems);
+
+        Map<Long, GetFilesResult> productIdToImages = findCatalogImages(productItems);
+
+        Map<Long, Integer> inventories = getProductInventoryUseCase.getProductStocks(
+                pricePolicies.stream()
+                        .map(PricePolicy::getId)
+                        .toList()
+        );
+
+        List<ProductItemResult> enrichedProducts = productItems.stream()
+                .map(item -> ProductItemResult.from(
+                        item,
+                        extractFirstImage(productIdToImages.get(item.getId())),
+                        inventories.get(item.getPricePolicyId()),
+                        getAverageRating(reviewAggregatesByProductId, item.getId()),
+                        getTotalCount(reviewAggregatesByProductId, item.getId())
+                ))
+                .toList();
+
+        return GetAdminProductsResult.of(page, pageSize, totalElements, totalPages, enrichedProducts);
+    }
+
+    private int computeTotalPages(long totalElements, int pageSize) {
+        if (totalElements == 0) {
+            return 0;
+        }
+        return (int) Math.ceil((double) totalElements / pageSize);
+    }
+
+    private ProductItemResult toProductItem(PricePolicy pricePolicy) {
+        Product product = FormatValidator.hasValue(pricePolicy.getProduct())
+                ? pricePolicy.getProduct()
+                : findProductPort.findById(pricePolicy.getProductId())
+                        .orElseThrow(() -> new ProductNotFoundException(pricePolicy.getProductId()));
+
+        if (!product.isFindAllOptionsYn()) {
+            return ProductItemResult.from(product, pricePolicy);
+        }
+
+        List<Long> optionIds = pricePolicy.getOptionIds();
+        if (FormatValidator.hasNoValue(optionIds)) {
+            return ProductItemResult.from(product, pricePolicy);
+        }
+
+        List<ProductOptionCategory> categories =
+                findProductOptionCategoryPort.findActiveWithOptionsByProductId(product.getId());
+
+        if (FormatValidator.hasNoValue(categories)) {
+            return ProductItemResult.from(product, pricePolicy);
+        }
+
+        Map<Long, ProductOption> productOptionsById = categories.stream()
+                .flatMap(c -> c.getOptions().stream())
+                .collect(Collectors.toMap(ProductOption::getId, o -> o, (o1, o2) -> o1));
+
+        List<ProductOption> selectedOptions = optionIds.stream()
+                .map(productOptionsById::get)
+                .filter(Objects::nonNull)
+                .toList();
+
+        return ProductItemResult.from(product, selectedOptions, pricePolicy);
+    }
+
+    private Map<Long, ProductReviewAggregateResult> findReviewAggregatesByProductId(
+            List<ProductItemResult> productItems
+    ) {
+        if (FormatValidator.hasNoValue(productItems)) {
+            return Map.of();
+        }
+
+        List<Long> productIds = productItems.stream()
+                .map(ProductItemResult::getId)
+                .filter(FormatValidator::hasValue)
+                .distinct()
+                .toList();
+
+        if (FormatValidator.hasNoValue(productIds)) {
+            return Map.of();
+        }
+
+        return findProductReviewAggregatesPort.findByProductIds(productIds);
+    }
+
+    private Map<Long, GetFilesResult> findCatalogImages(List<ProductItemResult> productItems) {
+        Map<Long, GetFilesResult> productIdToImages = new ConcurrentHashMap<>();
+        List<CompletableFuture<Void>> futures = productItems.stream()
+                .map(item -> CompletableFuture.runAsync(
+                        () -> findProductImagesPort.findImagesByProductIdAndSort(
+                                        item.getId(), PRODUCT_CATALOG_IMAGE
+                                )
+                                .ifPresent(result -> productIdToImages.put(item.getId(), result)),
+                        productImageExecutor
+                ))
+                .toList();
+        CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
+        return productIdToImages;
+    }
+
+    private com.personal.marketnote.common.application.file.port.in.result.GetFileResult extractFirstImage(
+            GetFilesResult filesResult
+    ) {
+        if (FormatValidator.hasNoValue(filesResult) || FormatValidator.hasNoValue(filesResult.images())) {
+            return null;
+        }
+        return filesResult.images().getFirst();
+    }
+
+    private Float getAverageRating(
+            Map<Long, ProductReviewAggregateResult> reviewAggregatesByProductId,
+            Long productId
+    ) {
+        if (FormatValidator.hasNoValue(reviewAggregatesByProductId)
+                || FormatValidator.hasNoValue(productId)) {
+            return 0f;
+        }
+
+        ProductReviewAggregateResult result = reviewAggregatesByProductId.get(productId);
+        if (FormatValidator.hasNoValue(result) || FormatValidator.hasNoValue(result.averageRating())) {
+            return 0f;
+        }
+
+        return result.averageRating();
+    }
+
+    private Integer getTotalCount(
+            Map<Long, ProductReviewAggregateResult> reviewAggregatesByProductId,
+            Long productId
+    ) {
+        if (FormatValidator.hasNoValue(reviewAggregatesByProductId)
+                || FormatValidator.hasNoValue(productId)) {
+            return 0;
+        }
+
+        ProductReviewAggregateResult result = reviewAggregatesByProductId.get(productId);
+        if (FormatValidator.hasNoValue(result) || FormatValidator.hasNoValue(result.totalCount())) {
+            return 0;
+        }
+
+        return result.totalCount();
     }
 }


### PR DESCRIPTION
## partially addresses #128
## resolves #1408

## Task
- [x] OffsetResponse<T> 공통 응답 레코드 생성
- [x] GetAdminProductsUseCase 시그니처 변경 (cursor → page)
- [x] GetAdminProductsResult 오프셋 필드 전환 (page, pageSize, totalElements, totalPages)
- [x] FindPricePoliciesPort에 findPricePoliciesByOffset 오프셋 메서드 추가
- [x] GetAdminProductsService 독립 구현 (GetProductUseCase 위임 제거)
- [x] PricePolicyJpaRepository 오프셋 JPQL 쿼리 추가
- [x] PricePolicyPersistenceAdapter 오프셋 메서드 구현
- [x] GetAdminProductsResponse CursorResponse → OffsetResponse 전환 (record 변환)
- [x] ProductController cursor → page 파라미터 변경 + @min 검증 추가
- [x] GetAdminProductsApiDocs API 문서 업데이트