### PR TITLE
[#1196][#1111] test: 주문 결제 완료 시 상품 구매 적립 포인트를 적립 예정 포인트로 추가하도록 변경 기능 자동화 테스트 추가

### DIFF
--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/ChangeOrderStatusPaidProcessUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/ChangeOrderStatusPaidProcessUseCaseTest.java
@@ -145,12 +145,182 @@ class ChangeOrderStatusPaidProcessUseCaseTest {
         }
     }
 
+    @Nested
+    @DisplayName("PAID 상태 변경 시 상품 구매 적립 예정 포인트 추가")
+    class ProductAccumulationPendingPointTest {
+
+        @Test
+        @DisplayName("상품 적립 포인트가 있는 주문이 PAID로 변경되면 addPendingProductAccumulationPoints가 호출된다")
+        void shouldCallAddPendingProductAccumulationPointsWhenAccumulatedPointExists() {
+            // given
+            Long orderId = 1L;
+            Long buyerId = 100L;
+            Long pricePolicyId = 10L;
+            Long accumulatedPoint = 500L;
+
+            Order order = createOrderWithoutSharer(orderId, buyerId, pricePolicyId);
+            when(getOrderUseCase.getOrder(orderId)).thenReturn(order);
+            when(findProductByPricePolicyPort.findByPricePolicyIds(List.of(pricePolicyId)))
+                    .thenReturn(Map.of(pricePolicyId, createProductInfoResultWithPoint(accumulatedPoint)));
+
+            ChangeOrderStatusCommand command = ChangeOrderStatusCommand.builder()
+                    .id(orderId)
+                    .orderStatus(OrderStatus.PAID)
+                    .build();
+
+            // when
+            changeOrderStatusService.changeOrderStatus(command);
+
+            // then
+            verify(modifyUserPointPort).addPendingProductAccumulationPoints(buyerId, accumulatedPoint, orderId);
+        }
+
+        @Test
+        @DisplayName("여러 상품의 적립 포인트가 수량에 비례하여 합산된다")
+        void shouldSumAccumulatedPointsByQuantity() {
+            // given
+            Long orderId = 1L;
+            Long buyerId = 100L;
+            Long pricePolicyId1 = 10L;
+            Long pricePolicyId2 = 20L;
+
+            Order order = createOrderWithMultipleProducts(orderId, buyerId, pricePolicyId1, 2, pricePolicyId2, 3);
+            when(getOrderUseCase.getOrder(orderId)).thenReturn(order);
+            when(findProductByPricePolicyPort.findByPricePolicyIds(List.of(pricePolicyId1, pricePolicyId2)))
+                    .thenReturn(Map.of(
+                            pricePolicyId1, createProductInfoResultWithPoint(500L),
+                            pricePolicyId2, createProductInfoResultWithPoint(300L)
+                    ));
+
+            ChangeOrderStatusCommand command = ChangeOrderStatusCommand.builder()
+                    .id(orderId)
+                    .orderStatus(OrderStatus.PAID)
+                    .build();
+
+            // when
+            changeOrderStatusService.changeOrderStatus(command);
+
+            // then
+            Long expectedTotal = 500L * 2 + 300L * 3;
+            verify(modifyUserPointPort).addPendingProductAccumulationPoints(buyerId, expectedTotal, orderId);
+        }
+
+        @Test
+        @DisplayName("상품 정보 조회 결과에 해당 상품이 없으면 해당 상품의 적립 포인트를 건너뛴다")
+        void shouldSkipWhenProductInfoNotFound() {
+            // given
+            Long orderId = 1L;
+            Long buyerId = 100L;
+            Long pricePolicyId1 = 10L;
+            Long pricePolicyId2 = 20L;
+
+            Order order = createOrderWithMultipleProducts(orderId, buyerId, pricePolicyId1, 1, pricePolicyId2, 1);
+            when(getOrderUseCase.getOrder(orderId)).thenReturn(order);
+            when(findProductByPricePolicyPort.findByPricePolicyIds(List.of(pricePolicyId1, pricePolicyId2)))
+                    .thenReturn(Map.of(pricePolicyId1, createProductInfoResultWithPoint(500L)));
+
+            ChangeOrderStatusCommand command = ChangeOrderStatusCommand.builder()
+                    .id(orderId)
+                    .orderStatus(OrderStatus.PAID)
+                    .build();
+
+            // when
+            changeOrderStatusService.changeOrderStatus(command);
+
+            // then
+            verify(modifyUserPointPort).addPendingProductAccumulationPoints(buyerId, 500L, orderId);
+        }
+
+        @Test
+        @DisplayName("상품의 적립 포인트가 null이면 해당 상품의 적립 포인트를 건너뛴다")
+        void shouldSkipWhenAccumulatedPointIsNull() {
+            // given
+            Long orderId = 1L;
+            Long buyerId = 100L;
+            Long pricePolicyId1 = 10L;
+            Long pricePolicyId2 = 20L;
+
+            Order order = createOrderWithMultipleProducts(orderId, buyerId, pricePolicyId1, 1, pricePolicyId2, 1);
+            when(getOrderUseCase.getOrder(orderId)).thenReturn(order);
+            when(findProductByPricePolicyPort.findByPricePolicyIds(List.of(pricePolicyId1, pricePolicyId2)))
+                    .thenReturn(Map.of(
+                            pricePolicyId1, createProductInfoResultWithPoint(500L),
+                            pricePolicyId2, createProductInfoResultWithPoint(null)
+                    ));
+
+            ChangeOrderStatusCommand command = ChangeOrderStatusCommand.builder()
+                    .id(orderId)
+                    .orderStatus(OrderStatus.PAID)
+                    .build();
+
+            // when
+            changeOrderStatusService.changeOrderStatus(command);
+
+            // then
+            verify(modifyUserPointPort).addPendingProductAccumulationPoints(buyerId, 500L, orderId);
+        }
+
+        @Test
+        @DisplayName("모든 상품의 적립 포인트가 0이면 addPendingProductAccumulationPoints가 호출되지 않는다")
+        void shouldNotCallWhenTotalAccumulatedPointIsZero() {
+            // given
+            Long orderId = 1L;
+            Long buyerId = 100L;
+            Long pricePolicyId = 10L;
+
+            Order order = createOrderWithoutSharer(orderId, buyerId, pricePolicyId);
+            when(getOrderUseCase.getOrder(orderId)).thenReturn(order);
+            when(findProductByPricePolicyPort.findByPricePolicyIds(List.of(pricePolicyId)))
+                    .thenReturn(Map.of(pricePolicyId, createProductInfoResultWithPoint(0L)));
+
+            ChangeOrderStatusCommand command = ChangeOrderStatusCommand.builder()
+                    .id(orderId)
+                    .orderStatus(OrderStatus.PAID)
+                    .build();
+
+            // when
+            changeOrderStatusService.changeOrderStatus(command);
+
+            // then
+            verify(modifyUserPointPort, never()).addPendingProductAccumulationPoints(anyLong(), anyLong(), anyLong());
+        }
+
+        @Test
+        @DisplayName("addPendingProductAccumulationPoints 호출 실패 시 예외가 전파되지 않는다")
+        void shouldNotPropagateExceptionWhenAddPendingProductAccumulationPointsFails() {
+            // given
+            Long orderId = 1L;
+            Long buyerId = 100L;
+            Long pricePolicyId = 10L;
+
+            Order order = createOrderWithoutSharer(orderId, buyerId, pricePolicyId);
+            when(getOrderUseCase.getOrder(orderId)).thenReturn(order);
+            when(findProductByPricePolicyPort.findByPricePolicyIds(List.of(pricePolicyId)))
+                    .thenReturn(Map.of(pricePolicyId, createProductInfoResultWithPoint(500L)));
+            doThrow(new RuntimeException("리워드 서비스 요청 실패"))
+                    .when(modifyUserPointPort).addPendingProductAccumulationPoints(anyLong(), anyLong(), anyLong());
+
+            ChangeOrderStatusCommand command = ChangeOrderStatusCommand.builder()
+                    .id(orderId)
+                    .orderStatus(OrderStatus.PAID)
+                    .build();
+
+            // when & then
+            assertThatCode(() -> changeOrderStatusService.changeOrderStatus(command))
+                    .doesNotThrowAnyException();
+        }
+    }
+
     // ==================================================================================
     // 헬퍼 메서드
     // ==================================================================================
 
     private ProductInfoResult createProductInfoResult() {
         return new ProductInfoResult(1L, 1L, "테스트 상품", "브랜드", 50000L, null, 500L, List.of());
+    }
+
+    private ProductInfoResult createProductInfoResultWithPoint(Long accumulatedPoint) {
+        return new ProductInfoResult(1L, 1L, "테스트 상품", "브랜드", 50000L, null, accumulatedPoint, List.of());
     }
 
     private Order createOrderWithSharer(Long orderId, Long buyerId, Long sharerId, Long pricePolicyId, Long totalAmount) {
@@ -200,6 +370,45 @@ class ChangeOrderStatusPaidProcessUseCaseTest {
                 .orderNumber("ORD-" + orderId)
                 .orderStatus(OrderStatus.PAYMENT_PENDING)
                 .totalAmount(50000L)
+                .couponAmount(0L)
+                .pointAmount(0L)
+                .orderProductStates(productStates)
+                .createdAt(LocalDateTime.now())
+                .modifiedAt(LocalDateTime.now())
+                .build());
+    }
+
+    private Order createOrderWithMultipleProducts(
+            Long orderId, Long buyerId,
+            Long pricePolicyId1, int quantity1,
+            Long pricePolicyId2, int quantity2
+    ) {
+        List<OrderProductSnapshotState> productStates = List.of(
+                OrderProductSnapshotState.builder()
+                        .orderId(orderId)
+                        .sellerId(10L)
+                        .pricePolicyId(pricePolicyId1)
+                        .quantity(quantity1)
+                        .unitAmount(50000L)
+                        .orderStatus(OrderStatus.PAYMENT_PENDING)
+                        .build(),
+                OrderProductSnapshotState.builder()
+                        .orderId(orderId)
+                        .sellerId(10L)
+                        .pricePolicyId(pricePolicyId2)
+                        .quantity(quantity2)
+                        .unitAmount(30000L)
+                        .orderStatus(OrderStatus.PAYMENT_PENDING)
+                        .build()
+        );
+
+        return Order.from(OrderSnapshotState.builder()
+                .id(orderId)
+                .buyerId(buyerId)
+                .orderKey(UUID.randomUUID())
+                .orderNumber("ORD-" + orderId)
+                .orderStatus(OrderStatus.PAYMENT_PENDING)
+                .totalAmount(130000L)
                 .couponAmount(0L)
                 .pointAmount(0L)
                 .orderProductStates(productStates)


### PR DESCRIPTION
## partially addresses #1196
## resolves #1111

## Test Case
- [x] 상품 적립 포인트가 있는 주문이 PAID로 변경되면 addPendingProductAccumulationPoints가 호출된다
- [x] 여러 상품의 적립 포인트가 수량에 비례하여 합산된다
- [x] 상품 정보 조회 결과에 해당 상품이 없으면 해당 상품의 적립 포인트를 건너뛴다
- [x] 상품의 적립 포인트가 null이면 해당 상품의 적립 포인트를 건너뛴다
- [x] 모든 상품의 적립 포인트가 0이면 addPendingProductAccumulationPoints가 호출되지 않는다
- [x] addPendingProductAccumulationPoints 호출 실패 시 예외가 전파되지 않는다