### PR TITLE
[#387][#1460] feat: 친구 초대 누적 보너스 기능 추가

### DIFF
--- a/common/src/main/java/com/personal/marketnote/common/utility/AccrualPointAmountConstant.java
+++ b/common/src/main/java/com/personal/marketnote/common/utility/AccrualPointAmountConstant.java
@@ -1,6 +1,10 @@
 package com.personal.marketnote.common.utility;
 
 public class AccrualPointAmountConstant {
-    public static final int REFERRER_USER_POINT_AMOUNT = 2_000;
-    public static final int REFERRED_USER_POINT_AMOUNT = 3_000;
+    public static final int REFERRER_USER_POINT_AMOUNT = 500;
+    public static final int REFERRED_USER_POINT_AMOUNT = 500;
+
+    public static final String REFERRER_POINT_REASON = "추천인 코드 등록 적립";
+    public static final String REFERRED_POINT_REASON = "신규 회원 초대 적립";
+    public static final String REFERRAL_BONUS_REASON_PREFIX = "친구 초대 누적 보너스%";
 }

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/event/UserReferralCompletedRewardConsumer.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/event/UserReferralCompletedRewardConsumer.java
@@ -5,10 +5,12 @@ import com.personal.marketnote.common.kafka.KafkaTopicConstants;
 import com.personal.marketnote.common.kafka.event.EventEnvelope;
 import com.personal.marketnote.common.kafka.event.EventPayloadValidator;
 import com.personal.marketnote.common.kafka.event.UserReferralCompletedEvent;
+import com.personal.marketnote.reward.domain.point.ReferralBonusTier;
 import com.personal.marketnote.reward.domain.point.UserPointChangeType;
 import com.personal.marketnote.reward.domain.point.UserPointSourceType;
 import com.personal.marketnote.reward.exception.DuplicateUserPointHistoryException;
 import com.personal.marketnote.reward.port.in.command.point.ModifyUserPointCommand;
+import com.personal.marketnote.reward.port.in.usecase.point.GetReferralStatusUseCase;
 import com.personal.marketnote.reward.port.in.usecase.point.ModifyUserPointUseCase;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -17,14 +19,14 @@ import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.stereotype.Component;
 
-import static com.personal.marketnote.common.utility.AccrualPointAmountConstant.REFERRED_USER_POINT_AMOUNT;
-import static com.personal.marketnote.common.utility.AccrualPointAmountConstant.REFERRER_USER_POINT_AMOUNT;
+import static com.personal.marketnote.common.utility.AccrualPointAmountConstant.*;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class UserReferralCompletedRewardConsumer {
     private final ModifyUserPointUseCase modifyUserPointUseCase;
+    private final GetReferralStatusUseCase getReferralStatusUseCase;
     private final ObjectMapper objectMapper;
 
     @KafkaListener(
@@ -62,13 +64,15 @@ public class UserReferralCompletedRewardConsumer {
                 return;
             }
 
-            accrueReferrerPointIdempotent(envelope.eventId(), payload.referredUserId(), payload.requestUserId());
-            accrueReferredPointIdempotent(envelope.eventId(), payload.requestUserId(), payload.referredUserId());
+            Long referrerId = payload.referredUserId();
+            Long referredId = payload.requestUserId();
+
+            accrueReferrerPointWithBonus(envelope.eventId(), referrerId, referredId);
+            accrueReferredPointIdempotent(envelope.eventId(), referredId, referrerId);
 
             log.info("Kafka 이벤트로 추천 포인트 적립 완료. requestUserId={}, referredUserId={}",
                     payload.requestUserId(), payload.referredUserId());
         } catch (Exception e) {
-            // 예외 전파 → DefaultErrorHandler가 재시도 + DLT로 처리 (acknowledge 하지 않음)
             log.error("추천 포인트 적립 실패. eventId={}, key={}, error={}",
                     envelope.eventId(), record.key(), e.getMessage(), e);
             throw e;
@@ -77,45 +81,82 @@ public class UserReferralCompletedRewardConsumer {
         acknowledgment.acknowledge();
     }
 
-    private void accrueReferrerPointIdempotent(String eventId, Long referredUserId, Long requestUserId) {
+    private void accrueReferrerPointWithBonus(String eventId, Long referrerId, Long referredId) {
+        long referralCount = getReferralStatusUseCase.countCompletedReferrals(referrerId);
+
+        if (ReferralBonusTier.isMaxReached(referralCount)) {
+            log.info("최대 초대 수 도달, 추천인 포인트 적립 생략. eventId={}, referrerId={}, count={}",
+                    eventId, referrerId, referralCount);
+            return;
+        }
+
+        accrueReferrerPointIdempotent(eventId, referrerId, referredId);
+
+        long newCount = referralCount + 1;
+        ReferralBonusTier.findNewlyAchievedTier(newCount)
+                .ifPresent(tier -> accrueBonusIdempotent(eventId, referrerId, tier));
+    }
+
+    private void accrueReferrerPointIdempotent(String eventId, Long referrerId, Long referredId) {
         try {
-            accrueReferrerPoint(referredUserId, requestUserId);
+            accrueReferrerPoint(referrerId, referredId);
         } catch (DuplicateUserPointHistoryException e) {
             log.info("이미 처리된 추천인 포인트 적립 이벤트 (멱등 처리). eventId={}, message={}",
                     eventId, e.getMessage());
         }
     }
 
-    private void accrueReferredPointIdempotent(String eventId, Long requestUserId, Long referredUserId) {
+    private void accrueReferredPointIdempotent(String eventId, Long referredId, Long referrerId) {
         try {
-            accrueReferredPoint(requestUserId, referredUserId);
+            accrueReferredPoint(referredId, referrerId);
         } catch (DuplicateUserPointHistoryException e) {
             log.info("이미 처리된 피추천인 포인트 적립 이벤트 (멱등 처리). eventId={}, message={}",
                     eventId, e.getMessage());
         }
     }
 
-    private void accrueReferrerPoint(Long referredUserId, Long requestUserId) {
+    private void accrueBonusIdempotent(String eventId, Long userId, ReferralBonusTier tier) {
+        try {
+            accrueBonus(userId, tier);
+        } catch (DuplicateUserPointHistoryException e) {
+            log.info("이미 처리된 누적 보너스 적립 이벤트 (멱등 처리). eventId={}, tier={}, message={}",
+                    eventId, tier, e.getMessage());
+        }
+    }
+
+    private void accrueReferrerPoint(Long referrerId, Long referredId) {
         ModifyUserPointCommand referrerCommand = ModifyUserPointCommand.builder()
-                .userId(referredUserId)
+                .userId(referrerId)
                 .changeType(UserPointChangeType.ACCRUAL)
                 .amount((long) REFERRER_USER_POINT_AMOUNT)
                 .sourceType(UserPointSourceType.USER)
-                .sourceId(requestUserId)
-                .reason("추천인 코드 등록 적립")
+                .sourceId(referredId)
+                .reason(REFERRER_POINT_REASON)
                 .build();
         modifyUserPointUseCase.modify(referrerCommand);
     }
 
-    private void accrueReferredPoint(Long requestUserId, Long referredUserId) {
+    private void accrueReferredPoint(Long referredId, Long referrerId) {
         ModifyUserPointCommand referredCommand = ModifyUserPointCommand.builder()
-                .userId(requestUserId)
+                .userId(referredId)
                 .changeType(UserPointChangeType.ACCRUAL)
                 .amount((long) REFERRED_USER_POINT_AMOUNT)
                 .sourceType(UserPointSourceType.USER)
-                .sourceId(referredUserId)
-                .reason("신규 회원 초대 적립")
+                .sourceId(referrerId)
+                .reason(REFERRED_POINT_REASON)
                 .build();
         modifyUserPointUseCase.modify(referredCommand);
+    }
+
+    private void accrueBonus(Long userId, ReferralBonusTier tier) {
+        ModifyUserPointCommand bonusCommand = ModifyUserPointCommand.builder()
+                .userId(userId)
+                .changeType(UserPointChangeType.ACCRUAL)
+                .amount((long) tier.getBonusAmount())
+                .sourceType(UserPointSourceType.USER)
+                .sourceId(userId)
+                .reason(tier.getReason())
+                .build();
+        modifyUserPointUseCase.modify(bonusCommand);
     }
 }

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/point/PointController.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/point/PointController.java
@@ -11,12 +11,14 @@ import com.personal.marketnote.reward.adapter.in.web.point.request.ConfirmPendin
 import com.personal.marketnote.reward.adapter.in.web.point.request.ModifyPendingPointRequest;
 import com.personal.marketnote.reward.adapter.in.web.point.request.ModifyUserPointRequest;
 import com.personal.marketnote.reward.adapter.in.web.point.response.GetMyPointReponse;
+import com.personal.marketnote.reward.adapter.in.web.point.response.GetReferralStatusResponse;
 import com.personal.marketnote.reward.adapter.in.web.point.response.GetUserPointByIdResponse;
 import com.personal.marketnote.reward.adapter.in.web.point.response.GetUserPointHistoryResponse;
 import com.personal.marketnote.reward.adapter.in.web.point.response.UpdateUserPointResponse;
 import com.personal.marketnote.reward.domain.point.UserPointHistoryFilter;
 import com.personal.marketnote.reward.port.in.command.point.GetUserPointHistoryCommand;
 import com.personal.marketnote.reward.port.in.command.point.RegisterUserPointCommand;
+import com.personal.marketnote.reward.port.in.result.point.GetReferralStatusResult;
 import com.personal.marketnote.reward.port.in.result.point.GetUserPointHistoryResult;
 import com.personal.marketnote.reward.port.in.result.point.GetUserPointResult;
 import com.personal.marketnote.reward.port.in.result.point.UpdateUserPointResult;
@@ -51,6 +53,7 @@ public class PointController {
     private final CancelPendingPointUseCase cancelPendingPointUseCase;
     private final GetUserPointUseCase getUserPointUseCase;
     private final GetUserPointHistoryUseCase getUserPointHistoryUseCase;
+    private final GetReferralStatusUseCase getReferralStatusUseCase;
 
     /**
      * (관리자) 회원 포인트 정보 생성
@@ -280,6 +283,34 @@ public class PointController {
                         HttpStatus.OK,
                         DEFAULT_SUCCESS_CODE,
                         "적립 예정 포인트 취소 성공"
+                )
+        );
+    }
+
+    /**
+     * 친구 초대 현황 조회
+     *
+     * @param principal 인증된 사용자 정보
+     * @return 친구 초대 현황 응답 {@link GetReferralStatusResponse}
+     * @Author 성효빈
+     * @Date 2026-03-21
+     * @Description 나의 친구 초대 현황(초대 수, 총 캐시, 보너스 달성 현황)을 조회합니다.
+     */
+    @GetMapping("/me/referral-status")
+    @GetReferralStatusApiDocs
+    public ResponseEntity<BaseResponse<GetReferralStatusResponse>> getReferralStatus(
+            @AuthenticationPrincipal OAuth2AuthenticatedPrincipal principal
+    ) {
+        GetReferralStatusResult result = getReferralStatusUseCase.getReferralStatus(
+                ElementExtractor.extractUserId(principal)
+        );
+
+        return ResponseEntity.ok(
+                BaseResponse.of(
+                        GetReferralStatusResponse.from(result),
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "친구 초대 현황 조회 성공"
                 )
         );
     }

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/point/apidocs/GetReferralStatusApiDocs.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/point/apidocs/GetReferralStatusApiDocs.java
@@ -1,0 +1,99 @@
+package com.personal.marketnote.reward.adapter.in.web.point.apidocs;
+
+import com.personal.marketnote.reward.adapter.in.web.point.response.GetReferralStatusResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Operation(
+        summary = "친구 초대 현황 조회",
+        description = """
+                작성일자: 2026-03-21
+
+                작성자: 성효빈
+
+                ---
+
+                ## Description
+
+                나의 친구 초대 현황을 조회합니다. 초대한 친구 수, 받은 총 캐시, 누적 보너스 달성 현황을 포함합니다.
+
+                ---
+
+                ## Request
+
+                | **키** | **타입** | **설명** | **필수 여부** | **예시** |
+                | --- | --- | --- | --- | --- |
+
+                ---
+
+                ## Response
+
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | statusCode | number | HTTP 상태 코드 | 200 |
+                | code | string | 응답 코드 | "SUC01" |
+                | timestamp | string(datetime) | 응답 시간 | "2026-03-21T12:00:00.000" |
+                | content | object | 응답 본문 | { ... } |
+                | message | string | 처리 결과 | "친구 초대 현황 조회 성공" |
+
+                ---
+
+                ### Response > content
+
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | totalInvitedCount | number | 내가 초대한 친구 수 | 7 |
+                | totalEarnedCash | number | 받은 총 캐시 | 4500 |
+                | maxInviteCount | number | 최대 초대 가능 인원 | 20 |
+                | tiers | array | 누적 보너스 단계 목록 | [ ... ] |
+
+                ---
+
+                ### Response > content > tiers[]
+
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | requiredCount | number | 달성 필요 초대 수 | 5 |
+                | bonusAmount | number | 보너스 캐시 | 1000 |
+                | achieved | boolean | 달성 여부 | true |
+                """,
+        security = {@SecurityRequirement(name = "bearer")},
+        responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "친구 초대 현황 조회 성공",
+                        content = @Content(
+                                schema = @Schema(implementation = GetReferralStatusResponse.class),
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 200,
+                                          "code": "SUC01",
+                                          "timestamp": "2026-03-21T18:01:50.214036",
+                                          "content": {
+                                            "totalInvitedCount": 7,
+                                            "totalEarnedCash": 4500,
+                                            "maxInviteCount": 20,
+                                            "tiers": [
+                                              { "requiredCount": 5, "bonusAmount": 1000, "achieved": true },
+                                              { "requiredCount": 10, "bonusAmount": 1500, "achieved": false },
+                                              { "requiredCount": 20, "bonusAmount": 2000, "achieved": false }
+                                            ]
+                                          },
+                                          "message": "친구 초대 현황 조회 성공"
+                                        }
+                                        """)
+                        )
+                )
+        }
+)
+public @interface GetReferralStatusApiDocs {
+}

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/point/response/GetReferralStatusResponse.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/point/response/GetReferralStatusResponse.java
@@ -1,0 +1,41 @@
+package com.personal.marketnote.reward.adapter.in.web.point.response;
+
+import com.personal.marketnote.reward.port.in.result.point.GetReferralStatusResult;
+import lombok.AccessLevel;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder(access = AccessLevel.PRIVATE)
+public record GetReferralStatusResponse(
+        long totalInvitedCount,
+        long totalEarnedCash,
+        int maxInviteCount,
+        List<BonusTierResponse> tiers
+) {
+    @Builder(access = AccessLevel.PRIVATE)
+    public record BonusTierResponse(
+            int requiredCount,
+            int bonusAmount,
+            boolean achieved
+    ) {
+        public static BonusTierResponse from(GetReferralStatusResult.BonusTierStatus status) {
+            return BonusTierResponse.builder()
+                    .requiredCount(status.requiredCount())
+                    .bonusAmount(status.bonusAmount())
+                    .achieved(status.achieved())
+                    .build();
+        }
+    }
+
+    public static GetReferralStatusResponse from(GetReferralStatusResult result) {
+        return GetReferralStatusResponse.builder()
+                .totalInvitedCount(result.totalInvitedCount())
+                .totalEarnedCash(result.totalEarnedCash())
+                .maxInviteCount(result.maxInviteCount())
+                .tiers(result.tiers().stream()
+                        .map(BonusTierResponse::from)
+                        .toList())
+                .build();
+    }
+}

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/point/UserPointHistoryPersistenceAdapter.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/point/UserPointHistoryPersistenceAdapter.java
@@ -7,6 +7,7 @@ import com.personal.marketnote.reward.domain.point.UserPointHistory;
 import com.personal.marketnote.reward.domain.point.UserPointHistoryFilter;
 import com.personal.marketnote.reward.domain.point.UserPointSourceType;
 import com.personal.marketnote.reward.exception.DuplicateUserPointHistoryException;
+import com.personal.marketnote.reward.port.out.point.CountReferralPort;
 import com.personal.marketnote.reward.port.out.point.FindUserPointHistoryPort;
 import com.personal.marketnote.reward.port.out.point.SaveUserPointHistoryPort;
 import com.personal.marketnote.reward.port.out.point.UpdateUserPointHistoryPort;
@@ -18,9 +19,11 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Objects;
 
+import static com.personal.marketnote.common.utility.AccrualPointAmountConstant.*;
+
 @PersistenceAdapter
 @RequiredArgsConstructor
-public class UserPointHistoryPersistenceAdapter implements SaveUserPointHistoryPort, FindUserPointHistoryPort, UpdateUserPointHistoryPort {
+public class UserPointHistoryPersistenceAdapter implements SaveUserPointHistoryPort, FindUserPointHistoryPort, UpdateUserPointHistoryPort, CountReferralPort {
     private final UserPointHistoryJpaRepository repository;
 
     @Override
@@ -82,4 +85,17 @@ public class UserPointHistoryPersistenceAdapter implements SaveUserPointHistoryP
         return repository.markAsReflected(userId, sourceType, sourceId);
     }
 
+    @Override
+    public long countCompletedReferrals(Long userId) {
+        return repository.countByUserIdAndSourceTypeAndReason(
+                userId, UserPointSourceType.USER, REFERRER_POINT_REASON
+        );
+    }
+
+    @Override
+    public long sumReferralEarnedAmount(Long userId) {
+        return repository.sumReferralEarnedAmount(
+                userId, UserPointSourceType.USER, REFERRER_POINT_REASON, REFERRAL_BONUS_REASON_PREFIX
+        );
+    }
 }

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/point/repository/UserPointHistoryJpaRepository.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/point/repository/UserPointHistoryJpaRepository.java
@@ -70,4 +70,21 @@ public interface UserPointHistoryJpaRepository extends JpaRepository<UserPointHi
             @Param("sourceType") UserPointSourceType sourceType,
             @Param("sourceId") Long sourceId
     );
+
+    long countByUserIdAndSourceTypeAndReason(
+            Long userId, UserPointSourceType sourceType, String reason
+    );
+
+    @Query("""
+            SELECT COALESCE(SUM(h.amount), 0) FROM UserPointHistoryJpaEntity h
+            WHERE h.userId = :userId
+              AND h.sourceType = :sourceType
+              AND (h.reason = :basicReason OR h.reason LIKE :bonusReasonPattern)
+            """)
+    long sumReferralEarnedAmount(
+            @Param("userId") Long userId,
+            @Param("sourceType") UserPointSourceType sourceType,
+            @Param("basicReason") String basicReason,
+            @Param("bonusReasonPattern") String bonusReasonPattern
+    );
 }

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/result/point/GetReferralStatusResult.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/result/point/GetReferralStatusResult.java
@@ -1,0 +1,44 @@
+package com.personal.marketnote.reward.port.in.result.point;
+
+import com.personal.marketnote.reward.domain.point.ReferralBonusTier;
+import lombok.AccessLevel;
+import lombok.Builder;
+
+import java.util.Arrays;
+import java.util.List;
+
+@Builder(access = AccessLevel.PRIVATE)
+public record GetReferralStatusResult(
+        long totalInvitedCount,
+        long totalEarnedCash,
+        int maxInviteCount,
+        List<BonusTierStatus> tiers
+) {
+    @Builder(access = AccessLevel.PRIVATE)
+    public record BonusTierStatus(
+            int requiredCount,
+            int bonusAmount,
+            boolean achieved
+    ) {
+        public static BonusTierStatus of(ReferralBonusTier tier, boolean achieved) {
+            return BonusTierStatus.builder()
+                    .requiredCount(tier.getRequiredCount())
+                    .bonusAmount(tier.getBonusAmount())
+                    .achieved(achieved)
+                    .build();
+        }
+    }
+
+    public static GetReferralStatusResult of(long totalInvitedCount, long totalEarnedCash) {
+        List<BonusTierStatus> tiers = Arrays.stream(ReferralBonusTier.values())
+                .map(tier -> BonusTierStatus.of(tier, tier.isAchieved(totalInvitedCount)))
+                .toList();
+
+        return GetReferralStatusResult.builder()
+                .totalInvitedCount(totalInvitedCount)
+                .totalEarnedCash(totalEarnedCash)
+                .maxInviteCount(ReferralBonusTier.getMaxInviteCount())
+                .tiers(tiers)
+                .build();
+    }
+}

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/usecase/point/GetReferralStatusUseCase.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/usecase/point/GetReferralStatusUseCase.java
@@ -1,0 +1,30 @@
+package com.personal.marketnote.reward.port.in.usecase.point;
+
+import com.personal.marketnote.reward.port.in.result.point.GetReferralStatusResult;
+
+/**
+ * 친구 초대 현황 조회 유스케이스
+ *
+ * @Author 성효빈
+ * @Date 2026-03-21
+ * @Description 친구 초대 현황 조회 및 누적 초대 건수 관련 기능을 제공합니다.
+ */
+public interface GetReferralStatusUseCase {
+    /**
+     * @param userId 회원 식별자 (추천인)
+     * @return 친구 초대 현황 {@link GetReferralStatusResult}
+     * @Date 2026-03-21
+     * @Author 성효빈
+     * @Description 추천인의 초대 현황(초대 수, 총 캐시, 보너스 달성 현황)을 조회합니다.
+     */
+    GetReferralStatusResult getReferralStatus(Long userId);
+
+    /**
+     * @param userId 회원 식별자 (추천인)
+     * @return 완료된 초대 건수
+     * @Date 2026-03-21
+     * @Author 성효빈
+     * @Description 추천인의 완료된 초대 건수를 조회합니다.
+     */
+    long countCompletedReferrals(Long userId);
+}

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/out/point/CountReferralPort.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/out/point/CountReferralPort.java
@@ -1,0 +1,28 @@
+package com.personal.marketnote.reward.port.out.point;
+
+/**
+ * 친구 초대 누적 현황 조회 포트
+ *
+ * @Author 성효빈
+ * @Date 2026-03-21
+ * @Description 친구 초대 완료 건수 및 누적 캐시를 조회합니다.
+ */
+public interface CountReferralPort {
+    /**
+     * @param userId 회원 식별자 (추천인)
+     * @return 완료된 초대 건수
+     * @Date 2026-03-21
+     * @Author 성효빈
+     * @Description 추천인의 초대 완료 건수를 조회합니다.
+     */
+    long countCompletedReferrals(Long userId);
+
+    /**
+     * @param userId 회원 식별자 (추천인)
+     * @return 초대로 적립된 총 캐시 (기본 보상 + 누적 보너스)
+     * @Date 2026-03-21
+     * @Author 성효빈
+     * @Description 추천인이 초대로 적립받은 총 캐시를 조회합니다.
+     */
+    long sumReferralEarnedAmount(Long userId);
+}

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/service/point/GetReferralStatusService.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/service/point/GetReferralStatusService.java
@@ -1,0 +1,30 @@
+package com.personal.marketnote.reward.service.point;
+
+import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.reward.port.in.result.point.GetReferralStatusResult;
+import com.personal.marketnote.reward.port.in.usecase.point.GetReferralStatusUseCase;
+import com.personal.marketnote.reward.port.out.point.CountReferralPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional(isolation = READ_COMMITTED, readOnly = true)
+public class GetReferralStatusService implements GetReferralStatusUseCase {
+    private final CountReferralPort countReferralPort;
+
+    @Override
+    public GetReferralStatusResult getReferralStatus(Long userId) {
+        long totalInvitedCount = countReferralPort.countCompletedReferrals(userId);
+        long totalEarnedCash = countReferralPort.sumReferralEarnedAmount(userId);
+
+        return GetReferralStatusResult.of(totalInvitedCount, totalEarnedCash);
+    }
+
+    @Override
+    public long countCompletedReferrals(Long userId) {
+        return countReferralPort.countCompletedReferrals(userId);
+    }
+}

--- a/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/point/ReferralBonusTier.java
+++ b/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/point/ReferralBonusTier.java
@@ -1,0 +1,46 @@
+package com.personal.marketnote.reward.domain.point;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+@Getter
+@RequiredArgsConstructor
+public enum ReferralBonusTier {
+    TIER_1(5, 1_000, "친구 초대 누적 보너스 (5명)"),
+    TIER_2(10, 1_500, "친구 초대 누적 보너스 (10명)"),
+    TIER_3(20, 2_000, "친구 초대 누적 보너스 (20명)");
+
+    private static final int MAX_INVITE_COUNT = TIER_3.requiredCount;
+
+    private final int requiredCount;
+    private final int bonusAmount;
+    private final String reason;
+
+    public boolean isAchieved(long count) {
+        return count >= requiredCount;
+    }
+
+    public static Optional<ReferralBonusTier> findNewlyAchievedTier(long count) {
+        return Arrays.stream(values())
+                .filter(tier -> tier.requiredCount == count)
+                .findFirst();
+    }
+
+    public static List<ReferralBonusTier> findAllAchievedTiers(long count) {
+        return Arrays.stream(values())
+                .filter(tier -> tier.isAchieved(count))
+                .toList();
+    }
+
+    public static boolean isMaxReached(long count) {
+        return count >= MAX_INVITE_COUNT;
+    }
+
+    public static int getMaxInviteCount() {
+        return MAX_INVITE_COUNT;
+    }
+}


### PR DESCRIPTION
## partially addresses #387
## resolves #1460

## Task
- [x] 기본 초대 보상 금액 변경 (추천인 2,000→500, 피추천인 3,000→500)
- [x] 누적 보너스 단계 도메인 모델 설계 (5명→1,000캐시, 10명→1,500캐시, 20명→2,000캐시)
- [x] 초대 완료 시 누적 횟수 확인 및 보너스 자동 지급 로직 추가
- [x] 최대 초대 인원(20명) 제한 적용
- [x] 친구 초대 현황 조회 API (GET /api/v1/users/me/referral-status)