### PR TITLE
[#387][#1462] test: 친구 초대 누적 보너스 기능 자동화 테스트 추가

### DIFF
--- a/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/adapter/in/event/UserReferralCompletedRewardConsumerTest.java
+++ b/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/adapter/in/event/UserReferralCompletedRewardConsumerTest.java
@@ -3,10 +3,12 @@ package com.personal.marketnote.reward.adapter.in.event;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.personal.marketnote.common.kafka.event.EventEnvelope;
 import com.personal.marketnote.common.kafka.event.UserReferralCompletedEvent;
+import com.personal.marketnote.reward.domain.point.ReferralBonusTier;
 import com.personal.marketnote.reward.domain.point.UserPointChangeType;
 import com.personal.marketnote.reward.domain.point.UserPointSourceType;
 import com.personal.marketnote.reward.exception.DuplicateUserPointHistoryException;
 import com.personal.marketnote.reward.port.in.command.point.ModifyUserPointCommand;
+import com.personal.marketnote.reward.port.in.usecase.point.GetReferralStatusUseCase;
 import com.personal.marketnote.reward.port.in.usecase.point.ModifyUserPointUseCase;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.junit.jupiter.api.DisplayName;
@@ -22,8 +24,7 @@ import org.springframework.kafka.support.Acknowledgment;
 import java.time.LocalDateTime;
 import java.util.List;
 
-import static com.personal.marketnote.common.utility.AccrualPointAmountConstant.REFERRED_USER_POINT_AMOUNT;
-import static com.personal.marketnote.common.utility.AccrualPointAmountConstant.REFERRER_USER_POINT_AMOUNT;
+import static com.personal.marketnote.common.utility.AccrualPointAmountConstant.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -36,6 +37,9 @@ class UserReferralCompletedRewardConsumerTest {
 
     @Mock
     private ModifyUserPointUseCase modifyUserPointUseCase;
+
+    @Mock
+    private GetReferralStatusUseCase getReferralStatusUseCase;
 
     @Spy
     private ObjectMapper objectMapper = new ObjectMapper();
@@ -57,6 +61,7 @@ class UserReferralCompletedRewardConsumerTest {
     void handleUserReferralCompletedEvent_success_accruesBothAndAcknowledges() {
         // given
         ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, 2L);
+        when(getReferralStatusUseCase.countCompletedReferrals(2L)).thenReturn(0L);
 
         // when
         userReferralCompletedRewardConsumer.handleUserReferralCompletedEvent(record, acknowledgment);
@@ -67,23 +72,23 @@ class UserReferralCompletedRewardConsumerTest {
 
         List<ModifyUserPointCommand> commands = captor.getAllValues();
 
-        // 추천인 포인트 적립 (referredUserId=2에게 2,000원)
+        // 추천인 포인트 적립 (referredUserId=2에게 500원)
         ModifyUserPointCommand referrerCommand = commands.get(0);
         assertThat(referrerCommand.userId()).isEqualTo(2L);
         assertThat(referrerCommand.changeType()).isEqualTo(UserPointChangeType.ACCRUAL);
         assertThat(referrerCommand.amount()).isEqualTo((long) REFERRER_USER_POINT_AMOUNT);
         assertThat(referrerCommand.sourceType()).isEqualTo(UserPointSourceType.USER);
         assertThat(referrerCommand.sourceId()).isEqualTo(1L);
-        assertThat(referrerCommand.reason()).isEqualTo("추천인 코드 등록 적립");
+        assertThat(referrerCommand.reason()).isEqualTo(REFERRER_POINT_REASON);
 
-        // 피추천인 포인트 적립 (requestUserId=1에게 3,000원)
+        // 피추천인 포인트 적립 (requestUserId=1에게 500원)
         ModifyUserPointCommand referredCommand = commands.get(1);
         assertThat(referredCommand.userId()).isEqualTo(1L);
         assertThat(referredCommand.changeType()).isEqualTo(UserPointChangeType.ACCRUAL);
         assertThat(referredCommand.amount()).isEqualTo((long) REFERRED_USER_POINT_AMOUNT);
         assertThat(referredCommand.sourceType()).isEqualTo(UserPointSourceType.USER);
         assertThat(referredCommand.sourceId()).isEqualTo(2L);
-        assertThat(referredCommand.reason()).isEqualTo("신규 회원 초대 적립");
+        assertThat(referredCommand.reason()).isEqualTo(REFERRED_POINT_REASON);
 
         verify(acknowledgment).acknowledge();
     }
@@ -214,6 +219,7 @@ class UserReferralCompletedRewardConsumerTest {
     void handleUserReferralCompletedEvent_referrerAccrualFails_propagatesWithoutAcknowledge() {
         // given
         ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, 2L);
+        when(getReferralStatusUseCase.countCompletedReferrals(2L)).thenReturn(0L);
         doThrow(new RuntimeException("DB 연결 실패"))
                 .when(modifyUserPointUseCase).modify(any(ModifyUserPointCommand.class));
 
@@ -232,6 +238,7 @@ class UserReferralCompletedRewardConsumerTest {
     void handleUserReferralCompletedEvent_referredAccrualFails_propagatesWithoutAcknowledge() {
         // given
         ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, 2L);
+        when(getReferralStatusUseCase.countCompletedReferrals(2L)).thenReturn(0L);
         when(modifyUserPointUseCase.modify(any(ModifyUserPointCommand.class)))
                 .thenReturn(null)
                 .thenThrow(new RuntimeException("포인트 잔액 부족"));
@@ -251,8 +258,9 @@ class UserReferralCompletedRewardConsumerTest {
     void handleUserReferralCompletedEvent_referrerDuplicate_idempotentAndContinuesReferred() {
         // given
         ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, 2L);
+        when(getReferralStatusUseCase.countCompletedReferrals(2L)).thenReturn(0L);
         when(modifyUserPointUseCase.modify(any(ModifyUserPointCommand.class)))
-                .thenThrow(new DuplicateUserPointHistoryException(2L, UserPointSourceType.USER, 1L, "추천인 코드 등록 적립"))
+                .thenThrow(new DuplicateUserPointHistoryException(2L, UserPointSourceType.USER, 1L, REFERRER_POINT_REASON))
                 .thenReturn(null);
 
         // when
@@ -268,9 +276,10 @@ class UserReferralCompletedRewardConsumerTest {
     void handleUserReferralCompletedEvent_referredDuplicate_idempotentAndAcknowledges() {
         // given
         ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, 2L);
+        when(getReferralStatusUseCase.countCompletedReferrals(2L)).thenReturn(0L);
         when(modifyUserPointUseCase.modify(any(ModifyUserPointCommand.class)))
                 .thenReturn(null)
-                .thenThrow(new DuplicateUserPointHistoryException(1L, UserPointSourceType.USER, 2L, "신규 회원 초대 적립"));
+                .thenThrow(new DuplicateUserPointHistoryException(1L, UserPointSourceType.USER, 2L, REFERRED_POINT_REASON));
 
         // when
         userReferralCompletedRewardConsumer.handleUserReferralCompletedEvent(record, acknowledgment);
@@ -285,15 +294,156 @@ class UserReferralCompletedRewardConsumerTest {
     void handleUserReferralCompletedEvent_bothDuplicate_idempotentAndAcknowledges() {
         // given
         ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, 2L);
+        when(getReferralStatusUseCase.countCompletedReferrals(2L)).thenReturn(0L);
         when(modifyUserPointUseCase.modify(any(ModifyUserPointCommand.class)))
-                .thenThrow(new DuplicateUserPointHistoryException(2L, UserPointSourceType.USER, 1L, "추천인 코드 등록 적립"))
-                .thenThrow(new DuplicateUserPointHistoryException(1L, UserPointSourceType.USER, 2L, "신규 회원 초대 적립"));
+                .thenThrow(new DuplicateUserPointHistoryException(2L, UserPointSourceType.USER, 1L, REFERRER_POINT_REASON))
+                .thenThrow(new DuplicateUserPointHistoryException(1L, UserPointSourceType.USER, 2L, REFERRED_POINT_REASON));
 
         // when
         userReferralCompletedRewardConsumer.handleUserReferralCompletedEvent(record, acknowledgment);
 
         // then
         verify(modifyUserPointUseCase, times(2)).modify(any(ModifyUserPointCommand.class));
+        verify(acknowledgment).acknowledge();
+    }
+
+    // === 누적 보너스 관련 테스트 ===
+
+    @Test
+    @DisplayName("최대 초대 수(20명)에 도달한 추천인은 추천인 포인트를 적립하지 않고 피추천인만 적립한다")
+    void handleUserReferralCompletedEvent_maxReached_skipsReferrerAndAccruesReferred() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, 2L);
+        when(getReferralStatusUseCase.countCompletedReferrals(2L)).thenReturn(20L);
+
+        // when
+        userReferralCompletedRewardConsumer.handleUserReferralCompletedEvent(record, acknowledgment);
+
+        // then
+        ArgumentCaptor<ModifyUserPointCommand> captor = ArgumentCaptor.forClass(ModifyUserPointCommand.class);
+        verify(modifyUserPointUseCase, times(1)).modify(captor.capture());
+
+        ModifyUserPointCommand referredCommand = captor.getValue();
+        assertThat(referredCommand.userId()).isEqualTo(1L);
+        assertThat(referredCommand.reason()).isEqualTo(REFERRED_POINT_REASON);
+
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("초대 수가 정확히 5가 되면 TIER_1 보너스를 추가 적립한다")
+    void handleUserReferralCompletedEvent_count5_accruesTier1Bonus() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, 2L);
+        when(getReferralStatusUseCase.countCompletedReferrals(2L)).thenReturn(4L);
+
+        // when
+        userReferralCompletedRewardConsumer.handleUserReferralCompletedEvent(record, acknowledgment);
+
+        // then
+        ArgumentCaptor<ModifyUserPointCommand> captor = ArgumentCaptor.forClass(ModifyUserPointCommand.class);
+        verify(modifyUserPointUseCase, times(3)).modify(captor.capture());
+
+        List<ModifyUserPointCommand> commands = captor.getAllValues();
+
+        // 추천인 기본 적립
+        assertThat(commands.get(0).userId()).isEqualTo(2L);
+        assertThat(commands.get(0).amount()).isEqualTo((long) REFERRER_USER_POINT_AMOUNT);
+        assertThat(commands.get(0).reason()).isEqualTo(REFERRER_POINT_REASON);
+
+        // TIER_1 보너스 적립
+        assertThat(commands.get(1).userId()).isEqualTo(2L);
+        assertThat(commands.get(1).amount()).isEqualTo((long) ReferralBonusTier.TIER_1.getBonusAmount());
+        assertThat(commands.get(1).sourceId()).isEqualTo(2L);
+        assertThat(commands.get(1).reason()).isEqualTo(ReferralBonusTier.TIER_1.getReason());
+
+        // 피추천인 기본 적립
+        assertThat(commands.get(2).userId()).isEqualTo(1L);
+        assertThat(commands.get(2).reason()).isEqualTo(REFERRED_POINT_REASON);
+
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("초대 수가 정확히 10이 되면 TIER_2 보너스를 추가 적립한다")
+    void handleUserReferralCompletedEvent_count10_accruesTier2Bonus() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, 2L);
+        when(getReferralStatusUseCase.countCompletedReferrals(2L)).thenReturn(9L);
+
+        // when
+        userReferralCompletedRewardConsumer.handleUserReferralCompletedEvent(record, acknowledgment);
+
+        // then
+        ArgumentCaptor<ModifyUserPointCommand> captor = ArgumentCaptor.forClass(ModifyUserPointCommand.class);
+        verify(modifyUserPointUseCase, times(3)).modify(captor.capture());
+
+        List<ModifyUserPointCommand> commands = captor.getAllValues();
+
+        // TIER_2 보너스 적립
+        assertThat(commands.get(1).userId()).isEqualTo(2L);
+        assertThat(commands.get(1).amount()).isEqualTo((long) ReferralBonusTier.TIER_2.getBonusAmount());
+        assertThat(commands.get(1).reason()).isEqualTo(ReferralBonusTier.TIER_2.getReason());
+
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("초대 수가 정확히 20이 되면 TIER_3 보너스를 추가 적립한다")
+    void handleUserReferralCompletedEvent_count20_accruesTier3Bonus() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, 2L);
+        when(getReferralStatusUseCase.countCompletedReferrals(2L)).thenReturn(19L);
+
+        // when
+        userReferralCompletedRewardConsumer.handleUserReferralCompletedEvent(record, acknowledgment);
+
+        // then
+        ArgumentCaptor<ModifyUserPointCommand> captor = ArgumentCaptor.forClass(ModifyUserPointCommand.class);
+        verify(modifyUserPointUseCase, times(3)).modify(captor.capture());
+
+        List<ModifyUserPointCommand> commands = captor.getAllValues();
+
+        // TIER_3 보너스 적립
+        assertThat(commands.get(1).userId()).isEqualTo(2L);
+        assertThat(commands.get(1).amount()).isEqualTo((long) ReferralBonusTier.TIER_3.getBonusAmount());
+        assertThat(commands.get(1).reason()).isEqualTo(ReferralBonusTier.TIER_3.getReason());
+
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("보너스 단계에 해당하지 않는 초대 수이면 보너스를 적립하지 않는다")
+    void handleUserReferralCompletedEvent_nonTierCount_noBonusAccrued() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, 2L);
+        when(getReferralStatusUseCase.countCompletedReferrals(2L)).thenReturn(6L);
+
+        // when
+        userReferralCompletedRewardConsumer.handleUserReferralCompletedEvent(record, acknowledgment);
+
+        // then
+        verify(modifyUserPointUseCase, times(2)).modify(any(ModifyUserPointCommand.class));
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("보너스 적립 시 DuplicateUserPointHistoryException이 발생하면 멱등 처리하고 피추천인 적립은 정상 진행한다")
+    void handleUserReferralCompletedEvent_bonusDuplicate_idempotentAndContinues() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, 2L);
+        when(getReferralStatusUseCase.countCompletedReferrals(2L)).thenReturn(4L);
+        when(modifyUserPointUseCase.modify(any(ModifyUserPointCommand.class)))
+                .thenReturn(null)  // 추천인 기본 적립 성공
+                .thenThrow(new DuplicateUserPointHistoryException(
+                        2L, UserPointSourceType.USER, 2L, ReferralBonusTier.TIER_1.getReason()))  // 보너스 중복
+                .thenReturn(null);  // 피추천인 적립 성공
+
+        // when
+        userReferralCompletedRewardConsumer.handleUserReferralCompletedEvent(record, acknowledgment);
+
+        // then
+        verify(modifyUserPointUseCase, times(3)).modify(any(ModifyUserPointCommand.class));
         verify(acknowledgment).acknowledge();
     }
 }

--- a/reward-service/reward-application/src/test/java/com/personal/marketnote/reward/service/point/GetReferralStatusUseCaseTest.java
+++ b/reward-service/reward-application/src/test/java/com/personal/marketnote/reward/service/point/GetReferralStatusUseCaseTest.java
@@ -1,0 +1,117 @@
+package com.personal.marketnote.reward.service.point;
+
+import com.personal.marketnote.reward.domain.point.ReferralBonusTier;
+import com.personal.marketnote.reward.port.in.result.point.GetReferralStatusResult;
+import com.personal.marketnote.reward.port.out.point.CountReferralPort;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class GetReferralStatusUseCaseTest {
+    @InjectMocks
+    private GetReferralStatusService getReferralStatusService;
+
+    @Mock
+    private CountReferralPort countReferralPort;
+
+    private static final Long USER_ID = 1L;
+
+    @Test
+    @DisplayName("초대 완료 건수가 7이면 TIER_1만 달성된 현황을 반환한다")
+    void shouldReturnStatusWithTier1AchievedWhenCount7() {
+        // given
+        when(countReferralPort.countCompletedReferrals(USER_ID)).thenReturn(7L);
+        when(countReferralPort.sumReferralEarnedAmount(USER_ID)).thenReturn(4_500L);
+
+        // when
+        GetReferralStatusResult result = getReferralStatusService.getReferralStatus(USER_ID);
+
+        // then
+        assertThat(result.totalInvitedCount()).isEqualTo(7L);
+        assertThat(result.totalEarnedCash()).isEqualTo(4_500L);
+        assertThat(result.maxInviteCount()).isEqualTo(20);
+        assertThat(result.tiers()).hasSize(3);
+        assertThat(result.tiers().get(0).requiredCount()).isEqualTo(5);
+        assertThat(result.tiers().get(0).achieved()).isTrue();
+        assertThat(result.tiers().get(1).requiredCount()).isEqualTo(10);
+        assertThat(result.tiers().get(1).achieved()).isFalse();
+        assertThat(result.tiers().get(2).requiredCount()).isEqualTo(20);
+        assertThat(result.tiers().get(2).achieved()).isFalse();
+
+        verify(countReferralPort).countCompletedReferrals(USER_ID);
+        verify(countReferralPort).sumReferralEarnedAmount(USER_ID);
+    }
+
+    @Test
+    @DisplayName("초대 완료 건수가 0이면 달성된 단계가 없는 현황을 반환한다")
+    void shouldReturnStatusWithNoTiersAchievedWhenCount0() {
+        // given
+        when(countReferralPort.countCompletedReferrals(USER_ID)).thenReturn(0L);
+        when(countReferralPort.sumReferralEarnedAmount(USER_ID)).thenReturn(0L);
+
+        // when
+        GetReferralStatusResult result = getReferralStatusService.getReferralStatus(USER_ID);
+
+        // then
+        assertThat(result.totalInvitedCount()).isEqualTo(0L);
+        assertThat(result.totalEarnedCash()).isEqualTo(0L);
+        assertThat(result.tiers()).hasSize(3);
+        assertThat(result.tiers()).allSatisfy(tier -> assertThat(tier.achieved()).isFalse());
+    }
+
+    @Test
+    @DisplayName("초대 완료 건수가 20이면 모든 단계가 달성된 현황을 반환한다")
+    void shouldReturnStatusWithAllTiersAchievedWhenCount20() {
+        // given
+        long expectedTotalCash = 20L * 500L + 1_000L + 1_500L + 2_000L;
+        when(countReferralPort.countCompletedReferrals(USER_ID)).thenReturn(20L);
+        when(countReferralPort.sumReferralEarnedAmount(USER_ID)).thenReturn(expectedTotalCash);
+
+        // when
+        GetReferralStatusResult result = getReferralStatusService.getReferralStatus(USER_ID);
+
+        // then
+        assertThat(result.totalInvitedCount()).isEqualTo(20L);
+        assertThat(result.totalEarnedCash()).isEqualTo(expectedTotalCash);
+        assertThat(result.tiers()).hasSize(3);
+        assertThat(result.tiers()).allSatisfy(tier -> assertThat(tier.achieved()).isTrue());
+    }
+
+    @Test
+    @DisplayName("보너스 단계별 금액이 올바르게 반환된다")
+    void shouldReturnCorrectBonusAmountsForEachTier() {
+        // given
+        when(countReferralPort.countCompletedReferrals(USER_ID)).thenReturn(10L);
+        when(countReferralPort.sumReferralEarnedAmount(USER_ID)).thenReturn(6_500L);
+
+        // when
+        GetReferralStatusResult result = getReferralStatusService.getReferralStatus(USER_ID);
+
+        // then
+        assertThat(result.tiers().get(0).bonusAmount()).isEqualTo(ReferralBonusTier.TIER_1.getBonusAmount());
+        assertThat(result.tiers().get(1).bonusAmount()).isEqualTo(ReferralBonusTier.TIER_2.getBonusAmount());
+        assertThat(result.tiers().get(2).bonusAmount()).isEqualTo(ReferralBonusTier.TIER_3.getBonusAmount());
+    }
+
+    @Test
+    @DisplayName("완료된 초대 건수를 조회한다")
+    void shouldReturnCompletedReferralCount() {
+        // given
+        when(countReferralPort.countCompletedReferrals(USER_ID)).thenReturn(12L);
+
+        // when
+        long count = getReferralStatusService.countCompletedReferrals(USER_ID);
+
+        // then
+        assertThat(count).isEqualTo(12L);
+        verify(countReferralPort).countCompletedReferrals(USER_ID);
+    }
+}

--- a/reward-service/reward-domain/src/test/java/com/personal/marketnote/reward/domain/point/ReferralBonusTierTest.java
+++ b/reward-service/reward-domain/src/test/java/com/personal/marketnote/reward/domain/point/ReferralBonusTierTest.java
@@ -1,0 +1,130 @@
+package com.personal.marketnote.reward.domain.point;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ReferralBonusTierTest {
+
+    @Test
+    @DisplayName("TIER_1은 5명 초대 시 1,000캐시 보너스이다")
+    void tier1HasCorrectValues() {
+        assertThat(ReferralBonusTier.TIER_1.getRequiredCount()).isEqualTo(5);
+        assertThat(ReferralBonusTier.TIER_1.getBonusAmount()).isEqualTo(1_000);
+        assertThat(ReferralBonusTier.TIER_1.getReason()).isEqualTo("친구 초대 누적 보너스 (5명)");
+    }
+
+    @Test
+    @DisplayName("TIER_2는 10명 초대 시 1,500캐시 보너스이다")
+    void tier2HasCorrectValues() {
+        assertThat(ReferralBonusTier.TIER_2.getRequiredCount()).isEqualTo(10);
+        assertThat(ReferralBonusTier.TIER_2.getBonusAmount()).isEqualTo(1_500);
+        assertThat(ReferralBonusTier.TIER_2.getReason()).isEqualTo("친구 초대 누적 보너스 (10명)");
+    }
+
+    @Test
+    @DisplayName("TIER_3은 20명 초대 시 2,000캐시 보너스이다")
+    void tier3HasCorrectValues() {
+        assertThat(ReferralBonusTier.TIER_3.getRequiredCount()).isEqualTo(20);
+        assertThat(ReferralBonusTier.TIER_3.getBonusAmount()).isEqualTo(2_000);
+        assertThat(ReferralBonusTier.TIER_3.getReason()).isEqualTo("친구 초대 누적 보너스 (20명)");
+    }
+
+    @ParameterizedTest
+    @CsvSource({"4, false", "5, true", "6, true", "10, true"})
+    @DisplayName("TIER_1은 초대 수가 5 이상이면 달성된다")
+    void tier1IsAchievedWhenCountIsAtLeast5(long count, boolean expected) {
+        assertThat(ReferralBonusTier.TIER_1.isAchieved(count)).isEqualTo(expected);
+    }
+
+    @ParameterizedTest
+    @CsvSource({"9, false", "10, true", "15, true", "20, true"})
+    @DisplayName("TIER_2는 초대 수가 10 이상이면 달성된다")
+    void tier2IsAchievedWhenCountIsAtLeast10(long count, boolean expected) {
+        assertThat(ReferralBonusTier.TIER_2.isAchieved(count)).isEqualTo(expected);
+    }
+
+    @ParameterizedTest
+    @CsvSource({"19, false", "20, true", "25, true"})
+    @DisplayName("TIER_3은 초대 수가 20 이상이면 달성된다")
+    void tier3IsAchievedWhenCountIsAtLeast20(long count, boolean expected) {
+        assertThat(ReferralBonusTier.TIER_3.isAchieved(count)).isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("초대 수가 정확히 5이면 TIER_1이 새로 달성된다")
+    void findNewlyAchievedTierReturnsTier1WhenCount5() {
+        Optional<ReferralBonusTier> tier = ReferralBonusTier.findNewlyAchievedTier(5);
+        assertThat(tier).isPresent().contains(ReferralBonusTier.TIER_1);
+    }
+
+    @Test
+    @DisplayName("초대 수가 정확히 10이면 TIER_2가 새로 달성된다")
+    void findNewlyAchievedTierReturnsTier2WhenCount10() {
+        Optional<ReferralBonusTier> tier = ReferralBonusTier.findNewlyAchievedTier(10);
+        assertThat(tier).isPresent().contains(ReferralBonusTier.TIER_2);
+    }
+
+    @Test
+    @DisplayName("초대 수가 정확히 20이면 TIER_3이 새로 달성된다")
+    void findNewlyAchievedTierReturnsTier3WhenCount20() {
+        Optional<ReferralBonusTier> tier = ReferralBonusTier.findNewlyAchievedTier(20);
+        assertThat(tier).isPresent().contains(ReferralBonusTier.TIER_3);
+    }
+
+    @Test
+    @DisplayName("초대 수가 단계에 해당하지 않으면 빈 결과를 반환한다")
+    void findNewlyAchievedTierReturnsEmptyWhenNoTierMatch() {
+        assertThat(ReferralBonusTier.findNewlyAchievedTier(7)).isEmpty();
+        assertThat(ReferralBonusTier.findNewlyAchievedTier(1)).isEmpty();
+        assertThat(ReferralBonusTier.findNewlyAchievedTier(15)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("초대 수가 10이면 TIER_1과 TIER_2가 달성된다")
+    void findAllAchievedTiersReturns2TiersWhenCount10() {
+        List<ReferralBonusTier> tiers = ReferralBonusTier.findAllAchievedTiers(10);
+        assertThat(tiers).containsExactly(ReferralBonusTier.TIER_1, ReferralBonusTier.TIER_2);
+    }
+
+    @Test
+    @DisplayName("초대 수가 20이면 모든 단계가 달성된다")
+    void findAllAchievedTiersReturnsAllWhenCount20() {
+        List<ReferralBonusTier> tiers = ReferralBonusTier.findAllAchievedTiers(20);
+        assertThat(tiers).containsExactly(
+                ReferralBonusTier.TIER_1, ReferralBonusTier.TIER_2, ReferralBonusTier.TIER_3
+        );
+    }
+
+    @Test
+    @DisplayName("초대 수가 3이면 달성된 단계가 없다")
+    void findAllAchievedTiersReturnsEmptyWhenCount3() {
+        assertThat(ReferralBonusTier.findAllAchievedTiers(3)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("초대 수가 20 이상이면 최대 초대 수 도달이다")
+    void isMaxReachedReturnsTrueWhenCount20OrMore() {
+        assertThat(ReferralBonusTier.isMaxReached(20)).isTrue();
+        assertThat(ReferralBonusTier.isMaxReached(21)).isTrue();
+    }
+
+    @Test
+    @DisplayName("초대 수가 19 이하이면 최대 초대 수 미도달이다")
+    void isMaxReachedReturnsFalseWhenCountBelow20() {
+        assertThat(ReferralBonusTier.isMaxReached(19)).isFalse();
+        assertThat(ReferralBonusTier.isMaxReached(0)).isFalse();
+    }
+
+    @Test
+    @DisplayName("최대 초대 가능 인원은 20이다")
+    void getMaxInviteCountReturns20() {
+        assertThat(ReferralBonusTier.getMaxInviteCount()).isEqualTo(20);
+    }
+}


### PR DESCRIPTION
## partially addresses #387
## resolves #1462

## Test Case
- [x] TIER_1은 5명, 1000캐시, 올바른 reason을 가진다
- [x] TIER_2는 10명, 1500캐시, 올바른 reason을 가진다
- [x] TIER_3은 20명, 2000캐시, 올바른 reason을 가진다
- [x] 카운트가 requiredCount 이상이면 isAchieved가 true를 반환한다
- [x] 카운트가 requiredCount 미만이면 isAchieved가 false를 반환한다
- [x] 카운트가 정확히 requiredCount와 같으면 해당 tier를 반환한다
- [x] 카운트가 어떤 tier의 requiredCount와도 다르면 빈 Optional을 반환한다
- [x] 카운트에 따라 달성한 tier 목록을 반환한다
- [x] 카운트가 0이면 달성한 tier가 없다
- [x] 카운트가 20 이상이면 isMaxReached가 true를 반환한다
- [x] 카운트가 20 미만이면 isMaxReached가 false를 반환한다
- [x] getMaxInviteCount는 20을 반환한다
- [x] 초대 7명일 때 TIER_1만 달성된 현황을 반환한다
- [x] 초대 0명일 때 달성된 tier가 없는 현황을 반환한다
- [x] 초대 20명일 때 모든 tier가 달성된 현황을 반환한다
- [x] 보너스 금액이 올바르게 계산된다
- [x] countCompletedReferrals를 Port에 위임한다
- [x] 최대 초대 인원 도달 시 추천인 적립을 건너뛴다
- [x] 5명 초대 완료 시 TIER_1 보너스 1000캐시를 지급한다
- [x] 10명 초대 완료 시 TIER_2 보너스 1500캐시를 지급한다
- [x] 20명 초대 완료 시 TIER_3 보너스 2000캐시를 지급한다
- [x] 보너스 단계에 해당하지 않는 초대 횟수에는 보너스를 지급하지 않는다
- [x] 보너스 중복 적립 시도 시 DuplicateUserPointHistoryException을 무시하고 정상 진행한다