### PR TITLE
[#43][#1465] feat: 배송지 주소 별명(addressAlias) 제약 조건 수정

### DIFF
--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/shippingaddress/request/RegisterShippingAddressRequest.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/shippingaddress/request/RegisterShippingAddressRequest.java
@@ -29,8 +29,8 @@ public class RegisterShippingAddressRequest {
     @Size(max = 63, message = "회사명은 최대 63자까지 입력할 수 있습니다.")
     private String companyName;
 
-    @Schema(name = "addressAlias", description = "주소 별명 (OTHER 타입일 때 필수, 최대 31자)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-    @Size(max = 31, message = "주소 별명은 최대 31자까지 입력할 수 있습니다.")
+    @Schema(name = "addressAlias", description = "주소 별명 (최대 255자)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @Size(max = 255, message = "주소 별명은 최대 255자까지 입력할 수 있습니다.")
     private String addressAlias;
 
     @Schema(name = "recipientName", description = "받는 분 (최대 31자)", requiredMode = Schema.RequiredMode.REQUIRED)

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/shippingaddress/request/UpdateShippingAddressRequest.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/shippingaddress/request/UpdateShippingAddressRequest.java
@@ -23,8 +23,8 @@ public class UpdateShippingAddressRequest {
     @Size(max = 63, message = "회사명은 최대 63자까지 입력할 수 있습니다.")
     private String companyName;
 
-    @Schema(name = "addressAlias", description = "주소 별명 (OTHER 타입일 때 필수, 최대 31자)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-    @Size(max = 31, message = "주소 별명은 최대 31자까지 입력할 수 있습니다.")
+    @Schema(name = "addressAlias", description = "주소 별명 (최대 255자)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @Size(max = 255, message = "주소 별명은 최대 255자까지 입력할 수 있습니다.")
     private String addressAlias;
 
     @Schema(name = "recipientName", description = "받는 분 (최대 31자)", requiredMode = Schema.RequiredMode.REQUIRED)

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/out/persistence/shippingaddress/entity/ShippingAddressJpaEntity.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/out/persistence/shippingaddress/entity/ShippingAddressJpaEntity.java
@@ -31,7 +31,7 @@ public class ShippingAddressJpaEntity extends BaseGeneralEntity {
     @Column(name = "company_name", length = 63)
     private String companyName;
 
-    @Column(name = "address_alias", length = 31)
+    @Column(name = "address_alias")
     private String addressAlias;
 
     @Column(name = "recipient_name", nullable = false, length = 31)

--- a/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/shippingaddress/ShippingAddress.java
+++ b/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/shippingaddress/ShippingAddress.java
@@ -110,10 +110,6 @@ public class ShippingAddress extends BaseDomain {
             throw new IllegalArgumentException("회사 배송지에는 회사명이 필수입니다.");
         }
 
-        if (addressType == ShippingAddressType.OTHER && FormatValidator.hasNoValue(addressAlias)) {
-            throw new IllegalArgumentException("기타 배송지에는 주소 별명이 필수입니다.");
-        }
-
         if (FormatValidator.hasNoValue(deliveryRequestType) || !deliveryRequestType.isCustom()) {
             this.deliveryRequestMessage = null;
             return;


### PR DESCRIPTION
## partially addresses #43
## resolves #1465

## Task
- [x] Request DTO: @SiZe(max = 31) → @SiZe(max = 255) (Register, Update)
- [x] JPA Entity: @column(length = 31) → @column (기본 255)
- [x] Domain: validate()에서 OTHER 타입 addressAlias 필수 검증 제거