### PR TITLE
[#929][#1453] feat: DLT 메시지 조회 응답에 처리 상태 포함 기능 추가

### DIFF
--- a/common/src/main/java/com/personal/marketnote/common/adapter/in/web/kafka/controller/apidocs/QueryDltMessagesApiDocs.java
+++ b/common/src/main/java/com/personal/marketnote/common/adapter/in/web/kafka/controller/apidocs/QueryDltMessagesApiDocs.java
@@ -57,6 +57,7 @@ import java.lang.annotation.*;
                 | content[].errorFqcn | string | 예외 클래스명 | "NullPointerException" |
                 | content[].errorMessage | string | 에러 메시지 (최대 200자) | "Cannot invoke method on null" |
                 | content[].timestamp | number | 메시지 타임스탬프 (epoch millis) | 1710144000000 |
+                | content[].resolution | string | 처리 상태 (UNRESOLVED / RETRIED / DISCARDED) | "UNRESOLVED" |
                 """,
         security = {@SecurityRequirement(name = "bearer")},
         parameters = {
@@ -94,7 +95,8 @@ import java.lang.annotation.*;
                                               "originalTopic": "order-payment-completed",
                                               "errorFqcn": "NullPointerException",
                                               "errorMessage": "Cannot invoke method on null",
-                                              "timestamp": 1710144000000
+                                              "timestamp": 1710144000000,
+                                              "resolution": "UNRESOLVED"
                                             }
                                           ],
                                           "message": "DLT 메시지 조회 완료"

--- a/common/src/main/java/com/personal/marketnote/common/adapter/in/web/kafka/controller/apidocs/ReprocessDltApiDocs.java
+++ b/common/src/main/java/com/personal/marketnote/common/adapter/in/web/kafka/controller/apidocs/ReprocessDltApiDocs.java
@@ -51,6 +51,7 @@ import java.lang.annotation.*;
                 | dltTopic | string | DLT 토픽명 | "order-payment-completed.DLT" |
                 | reprocessedCount | number | 재처리 성공 건수 | 5 |
                 | failedCount | number | 재처리 실패 건수 | 0 |
+                | skippedCount | number | 이미 처리되어 스킵된 건수 | 2 |
                 """,
         security = {@SecurityRequirement(name = "bearer")},
         requestBody = @RequestBody(
@@ -78,7 +79,8 @@ import java.lang.annotation.*;
                                             "originalTopic": "order-payment-completed",
                                             "dltTopic": "order-payment-completed.DLT",
                                             "reprocessedCount": 5,
-                                            "failedCount": 0
+                                            "failedCount": 0,
+                                            "skippedCount": 2
                                           },
                                           "message": "DLT 메시지 재처리 완료"
                                         }

--- a/common/src/main/java/com/personal/marketnote/common/adapter/in/web/kafka/response/DltMessageResponse.java
+++ b/common/src/main/java/com/personal/marketnote/common/adapter/in/web/kafka/response/DltMessageResponse.java
@@ -11,11 +11,12 @@ public record DltMessageResponse(
         String originalTopic,
         String errorFqcn,
         String errorMessage,
-        long timestamp
+        long timestamp,
+        String resolution
 ) {
     private static final int MAX_ERROR_MESSAGE_LENGTH = 200;
 
-    public static DltMessageResponse from(ConsumerRecord<String, Object> record) {
+    public static DltMessageResponse from(ConsumerRecord<String, Object> record, String resolution) {
         String fqcn = DltHeaderExtractor.extractExceptionFqcn(record);
         String simpleName = fqcn.contains(".") ? fqcn.substring(fqcn.lastIndexOf('.') + 1) : fqcn;
         String message = DltHeaderExtractor.extractExceptionMessage(record);
@@ -31,7 +32,8 @@ public record DltMessageResponse(
                 DltHeaderExtractor.extractOriginalTopic(record),
                 simpleName,
                 truncatedMessage,
-                record.timestamp()
+                record.timestamp(),
+                resolution
         );
     }
 }

--- a/common/src/main/java/com/personal/marketnote/common/adapter/in/web/kafka/response/ReprocessDltResponse.java
+++ b/common/src/main/java/com/personal/marketnote/common/adapter/in/web/kafka/response/ReprocessDltResponse.java
@@ -7,14 +7,16 @@ public record ReprocessDltResponse(
         String originalTopic,
         String dltTopic,
         int reprocessedCount,
-        int failedCount
+        int failedCount,
+        int skippedCount
 ) {
     public static ReprocessDltResponse from(String originalTopic, DltReprocessResult result) {
         return new ReprocessDltResponse(
                 originalTopic,
                 originalTopic + KafkaTopicConstants.DLT_SUFFIX,
                 result.reprocessedCount(),
-                result.failedCount()
+                result.failedCount(),
+                result.skippedCount()
         );
     }
 }

--- a/common/src/main/java/com/personal/marketnote/common/configuration/kafka/DltMessageResolutionJpaEntity.java
+++ b/common/src/main/java/com/personal/marketnote/common/configuration/kafka/DltMessageResolutionJpaEntity.java
@@ -1,0 +1,81 @@
+package com.personal.marketnote.common.configuration.kafka;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+
+@Entity
+@Table(
+        name = "dlt_message_resolution",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_dlt_resolution_topic_partition_offset",
+                columnNames = {"dlt_topic", "partition_number", "offset_number"}
+        ),
+        indexes = @Index(
+                name = "idx_dlt_resolution_original_topic",
+                columnList = "original_topic"
+        )
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class DltMessageResolutionJpaEntity {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @Column(name = "original_topic", nullable = false, length = 100)
+    private String originalTopic;
+
+    @Column(name = "dlt_topic", nullable = false, length = 100)
+    private String dltTopic;
+
+    @Column(name = "partition_number", nullable = false)
+    private int partitionNumber;
+
+    @Column(name = "offset_number", nullable = false)
+    private long offsetNumber;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "resolution", nullable = false, length = 20)
+    private DltResolutionStatus resolution;
+
+    @Column(name = "resolved_by", length = 100)
+    private String resolvedBy;
+
+    @Column(name = "resolved_at")
+    private LocalDateTime resolvedAt;
+
+    private DltMessageResolutionJpaEntity(String originalTopic, String dltTopic,
+                                          int partitionNumber, long offsetNumber,
+                                          DltResolutionStatus resolution,
+                                          String resolvedBy, LocalDateTime resolvedAt) {
+        this.originalTopic = originalTopic;
+        this.dltTopic = dltTopic;
+        this.partitionNumber = partitionNumber;
+        this.offsetNumber = offsetNumber;
+        this.resolution = resolution;
+        this.resolvedBy = resolvedBy;
+        this.resolvedAt = resolvedAt;
+    }
+
+    public static DltMessageResolutionJpaEntity of(String originalTopic, String dltTopic,
+                                                    int partitionNumber, long offsetNumber,
+                                                    DltResolutionStatus resolution,
+                                                    String resolvedBy, LocalDateTime resolvedAt) {
+        return new DltMessageResolutionJpaEntity(
+                originalTopic, dltTopic, partitionNumber, offsetNumber,
+                resolution, resolvedBy, resolvedAt
+        );
+    }
+
+    public String toResolutionKey() {
+        return partitionNumber + ":" + offsetNumber;
+    }
+}

--- a/common/src/main/java/com/personal/marketnote/common/configuration/kafka/DltMessageResolutionJpaRepository.java
+++ b/common/src/main/java/com/personal/marketnote/common/configuration/kafka/DltMessageResolutionJpaRepository.java
@@ -1,0 +1,10 @@
+package com.personal.marketnote.common.configuration.kafka;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface DltMessageResolutionJpaRepository extends JpaRepository<DltMessageResolutionJpaEntity, Long> {
+
+    List<DltMessageResolutionJpaEntity> findByOriginalTopic(String originalTopic);
+}

--- a/common/src/main/java/com/personal/marketnote/common/configuration/kafka/DltQueryService.java
+++ b/common/src/main/java/com/personal/marketnote/common/configuration/kafka/DltQueryService.java
@@ -15,10 +15,7 @@ import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.stereotype.Component;
 
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
 
 @Slf4j
 @Component
@@ -30,6 +27,7 @@ public class DltQueryService {
     private static final int MAX_POLL_ITERATIONS = 50;
 
     private final ConsumerFactory<String, Object> consumerFactory;
+    private final DltMessageResolutionJpaRepository resolutionRepository;
 
     public List<DltMessageResponse> queryDltMessages(String originalTopic, int limit) {
         if (!DltTopicRegistry.isAllowed(originalTopic)) {
@@ -38,6 +36,7 @@ public class DltQueryService {
 
         String dltTopic = DltTopicRegistry.toDltTopic(originalTopic);
         String groupId = "dlt-query-" + UUID.randomUUID();
+        Map<String, String> resolutionMap = buildResolutionMap(originalTopic);
 
         try (Consumer<String, Object> consumer = consumerFactory.createConsumer(groupId, "")) {
             List<PartitionInfo> partitionInfos = consumer.partitionsFor(dltTopic);
@@ -61,7 +60,8 @@ public class DltQueryService {
                     if (messages.size() >= limit) {
                         break;
                     }
-                    messages.add(DltMessageResponse.from(record));
+                    String resolution = resolveStatus(resolutionMap, record.partition(), record.offset());
+                    messages.add(DltMessageResponse.from(record, resolution));
                 }
                 pollIteration++;
                 if (messages.size() >= limit) {
@@ -88,6 +88,20 @@ public class DltQueryService {
 
             return summaries;
         }
+    }
+
+    private Map<String, String> buildResolutionMap(String originalTopic) {
+        List<DltMessageResolutionJpaEntity> resolutions = resolutionRepository.findByOriginalTopic(originalTopic);
+        Map<String, String> map = new HashMap<>();
+        for (DltMessageResolutionJpaEntity entity : resolutions) {
+            map.put(entity.toResolutionKey(), entity.getResolution().name());
+        }
+        return map;
+    }
+
+    private String resolveStatus(Map<String, String> resolutionMap, int partition, long offset) {
+        String key = partition + ":" + offset;
+        return resolutionMap.getOrDefault(key, DltResolutionStatus.UNRESOLVED);
     }
 
     private long calculateMessageCount(Consumer<String, Object> consumer, String dltTopic) {

--- a/common/src/main/java/com/personal/marketnote/common/configuration/kafka/DltReprocessResult.java
+++ b/common/src/main/java/com/personal/marketnote/common/configuration/kafka/DltReprocessResult.java
@@ -2,6 +2,7 @@ package com.personal.marketnote.common.configuration.kafka;
 
 public record DltReprocessResult(
         int reprocessedCount,
-        int failedCount
+        int failedCount,
+        int skippedCount
 ) {
 }

--- a/common/src/main/java/com/personal/marketnote/common/configuration/kafka/DltReprocessService.java
+++ b/common/src/main/java/com/personal/marketnote/common/configuration/kafka/DltReprocessService.java
@@ -14,7 +14,10 @@ import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Component;
 
 import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
@@ -34,6 +37,7 @@ public class DltReprocessService {
     private final KafkaTemplate<String, Object> kafkaTemplate;
     private final DltAuditLogger dltAuditLogger;
     private final DltMetricsCollector dltMetricsCollector;
+    private final DltMessageResolutionJpaRepository resolutionRepository;
 
     public DltReprocessResult reprocess(String originalTopic, String operatorInfo) {
         if (!DltTopicRegistry.isAllowed(originalTopic)) {
@@ -54,6 +58,7 @@ public class DltReprocessService {
     private DltReprocessResult doReprocess(String originalTopic, String operatorInfo) {
         String dltTopic = DltTopicRegistry.toDltTopic(originalTopic);
         String groupId = "dlt-reprocessor-" + UUID.randomUUID();
+        Set<String> resolvedKeys = buildResolvedKeySet(originalTopic);
 
         dltAuditLogger.logReprocessStart(originalTopic, operatorInfo);
 
@@ -62,7 +67,7 @@ public class DltReprocessService {
             if (partitionInfos == null || partitionInfos.isEmpty()) {
                 log.info("DLT 토픽 파티션 없음. dltTopic={}", dltTopic);
                 dltAuditLogger.logReprocessComplete(originalTopic, operatorInfo, 0, 0);
-                return new DltReprocessResult(0, 0);
+                return new DltReprocessResult(0, 0, 0);
             }
 
             List<TopicPartition> partitions = partitionInfos.stream()
@@ -74,16 +79,32 @@ public class DltReprocessService {
 
             int reprocessedCount = 0;
             int failedCount = 0;
+            int skippedCount = 0;
             int pollIteration = 0;
 
             ConsumerRecords<String, Object> records = consumer.poll(POLL_TIMEOUT);
             while (!records.isEmpty() && pollIteration < MAX_POLL_ITERATIONS) {
                 for (ConsumerRecord<String, Object> record : records) {
+                    String key = record.partition() + ":" + record.offset();
+                    if (resolvedKeys.contains(key)) {
+                        skippedCount++;
+                        log.info("이미 처리된 DLT 메시지 스킵. originalTopic={}, partition={}, offset={}",
+                                originalTopic, record.partition(), record.offset());
+                        continue;
+                    }
+
                     try {
                         kafkaTemplate.send(originalTopic, record.key(), record.value())
                                 .get(SEND_TIMEOUT_SECONDS, TimeUnit.SECONDS);
                         reprocessedCount++;
                         dltMetricsCollector.incrementDltReprocessCount(originalTopic, "success");
+                        try {
+                            saveResolution(originalTopic, dltTopic, record.partition(), record.offset(),
+                                    DltResolutionStatus.RETRIED, operatorInfo);
+                        } catch (Exception se) {
+                            log.warn("DLT resolution 저장 실패. originalTopic={}, partition={}, offset={}",
+                                    originalTopic, record.partition(), record.offset(), se);
+                        }
                         log.info("DLT 메시지 재처리 성공. originalTopic={}, key={}, offset={}",
                                 originalTopic, record.key(), record.offset());
                     } catch (Exception e) {
@@ -97,15 +118,34 @@ public class DltReprocessService {
                 records = consumer.poll(POLL_TIMEOUT);
             }
 
-            log.info("DLT 재처리 완료. dltTopic={}, reprocessed={}, failed={}",
-                    dltTopic, reprocessedCount, failedCount);
+            log.info("DLT 재처리 완료. dltTopic={}, reprocessed={}, failed={}, skipped={}",
+                    dltTopic, reprocessedCount, failedCount, skippedCount);
             dltAuditLogger.logReprocessComplete(originalTopic, operatorInfo, reprocessedCount, failedCount);
-            return new DltReprocessResult(reprocessedCount, failedCount);
+            return new DltReprocessResult(reprocessedCount, failedCount, skippedCount);
         } catch (InvalidDltTopicException e) {
             throw e;
         } catch (Exception e) {
             dltAuditLogger.logReprocessError(originalTopic, operatorInfo, e);
             throw new DltReprocessFailedException(originalTopic);
         }
+    }
+
+    private Set<String> buildResolvedKeySet(String originalTopic) {
+        List<DltMessageResolutionJpaEntity> resolutions = resolutionRepository.findByOriginalTopic(originalTopic);
+        Set<String> keys = new HashSet<>();
+        for (DltMessageResolutionJpaEntity entity : resolutions) {
+            keys.add(entity.toResolutionKey());
+        }
+        return keys;
+    }
+
+    private void saveResolution(String originalTopic, String dltTopic,
+                                int partition, long offset,
+                                DltResolutionStatus resolution, String operatorInfo) {
+        DltMessageResolutionJpaEntity entity = DltMessageResolutionJpaEntity.of(
+                originalTopic, dltTopic, partition, offset,
+                resolution, operatorInfo, LocalDateTime.now()
+        );
+        resolutionRepository.save(entity);
     }
 }

--- a/common/src/main/java/com/personal/marketnote/common/configuration/kafka/DltResolutionStatus.java
+++ b/common/src/main/java/com/personal/marketnote/common/configuration/kafka/DltResolutionStatus.java
@@ -1,0 +1,20 @@
+package com.personal.marketnote.common.configuration.kafka;
+
+public enum DltResolutionStatus {
+    RETRIED,
+    DISCARDED;
+
+    public static final String UNRESOLVED = "UNRESOLVED";
+
+    public boolean isRetried() {
+        return this == RETRIED;
+    }
+
+    public boolean isDiscarded() {
+        return this == DISCARDED;
+    }
+
+    public boolean isResolved() {
+        return this == RETRIED || this == DISCARDED;
+    }
+}

--- a/common/src/test/java/com/personal/marketnote/common/configuration/kafka/DltQueryServiceTest.java
+++ b/common/src/test/java/com/personal/marketnote/common/configuration/kafka/DltQueryServiceTest.java
@@ -17,6 +17,7 @@ import org.springframework.kafka.core.ConsumerFactory;
 
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -38,11 +39,14 @@ class DltQueryServiceTest {
     private ConsumerFactory<String, Object> consumerFactory;
 
     @Mock
+    private DltMessageResolutionJpaRepository resolutionRepository;
+
+    @Mock
     private Consumer<String, Object> consumer;
 
     @Test
-    @DisplayName("DLT 토픽에서 메시지를 조회한다")
-    void queryDltMessages_returnsMessages() {
+    @DisplayName("DLT 토픽에서 메시지를 조회하면 UNRESOLVED 상태를 반환한다")
+    void queryDltMessages_returnsMessagesWithUnresolvedStatus() {
         // given
         String originalTopic = "commerce.order.payment-completed";
         String dltTopic = originalTopic + ".dlt";
@@ -53,7 +57,7 @@ class DltQueryServiceTest {
         when(consumer.partitionsFor(dltTopic)).thenReturn(List.of(partitionInfo));
 
         TopicPartition topicPartition = new TopicPartition(dltTopic, 0);
-        ConsumerRecord<String, Object> record = buildDltRecord(dltTopic, "key-1", originalTopic,
+        ConsumerRecord<String, Object> record = buildDltRecord(dltTopic, 0, 0L, "key-1", originalTopic,
                 "java.lang.RuntimeException", "DB 연결 오류");
         ConsumerRecords<String, Object> records = new ConsumerRecords<>(
                 Map.of(topicPartition, List.of(record))
@@ -63,6 +67,8 @@ class DltQueryServiceTest {
         when(consumer.poll(any(Duration.class)))
                 .thenReturn(records)
                 .thenReturn(emptyRecords);
+
+        when(resolutionRepository.findByOriginalTopic(originalTopic)).thenReturn(List.of());
 
         // when
         List<DltMessageResponse> result = dltQueryService.queryDltMessages(originalTopic, 100);
@@ -74,6 +80,7 @@ class DltQueryServiceTest {
         assertThat(result.get(0).originalTopic()).isEqualTo(originalTopic);
         assertThat(result.get(0).errorFqcn()).isEqualTo("RuntimeException");
         assertThat(result.get(0).errorMessage()).isEqualTo("DB 연결 오류");
+        assertThat(result.get(0).resolution()).isEqualTo("UNRESOLVED");
         verify(consumer).close();
     }
 
@@ -91,6 +98,8 @@ class DltQueryServiceTest {
 
         ConsumerRecords<String, Object> emptyRecords = new ConsumerRecords<>(Collections.emptyMap());
         when(consumer.poll(any(Duration.class))).thenReturn(emptyRecords);
+
+        when(resolutionRepository.findByOriginalTopic(originalTopic)).thenReturn(List.of());
 
         // when
         List<DltMessageResponse> result = dltQueryService.queryDltMessages(originalTopic, 100);
@@ -143,20 +152,23 @@ class DltQueryServiceTest {
         when(consumer.partitionsFor(dltTopic)).thenReturn(List.of(partitionInfo));
 
         TopicPartition topicPartition = new TopicPartition(dltTopic, 0);
-        ConsumerRecord<String, Object> record1 = buildDltRecord(dltTopic, "key-1", originalTopic, "Error", "msg1");
-        ConsumerRecord<String, Object> record2 = buildDltRecord(dltTopic, "key-2", originalTopic, "Error", "msg2");
-        ConsumerRecord<String, Object> record3 = buildDltRecord(dltTopic, "key-3", originalTopic, "Error", "msg3");
+        ConsumerRecord<String, Object> record1 = buildDltRecord(dltTopic, 0, 0L, "key-1", originalTopic, "Error", "msg1");
+        ConsumerRecord<String, Object> record2 = buildDltRecord(dltTopic, 0, 1L, "key-2", originalTopic, "Error", "msg2");
+        ConsumerRecord<String, Object> record3 = buildDltRecord(dltTopic, 0, 2L, "key-3", originalTopic, "Error", "msg3");
         ConsumerRecords<String, Object> records = new ConsumerRecords<>(
                 Map.of(topicPartition, List.of(record1, record2, record3))
         );
 
         when(consumer.poll(any(Duration.class))).thenReturn(records);
 
+        when(resolutionRepository.findByOriginalTopic(originalTopic)).thenReturn(List.of());
+
         // when
         List<DltMessageResponse> result = dltQueryService.queryDltMessages(originalTopic, 2);
 
         // then
         assertThat(result).hasSize(2);
+        assertThat(result).allSatisfy(msg -> assertThat(msg.resolution()).isEqualTo("UNRESOLVED"));
         verify(consumer).close();
     }
 
@@ -169,7 +181,6 @@ class DltQueryServiceTest {
         TopicPartition partition = new TopicPartition("commerce.order.payment-completed.dlt", 0);
         PartitionInfo partitionInfo = new PartitionInfo("commerce.order.payment-completed.dlt", 0, null, null, null);
 
-        // 모든 DLT 토픽에 대해 partitionsFor 호출 시 반환
         when(consumer.partitionsFor(anyString()))
                 .thenReturn(List.of(partitionInfo));
 
@@ -190,10 +201,101 @@ class DltQueryServiceTest {
         verify(consumer).close();
     }
 
+    @Test
+    @DisplayName("DB에 RETRIED 해결 상태가 있으면 해당 메시지의 resolution은 RETRIED를 반환한다")
+    void queryDltMessages_withRetriedResolution_returnsRetriedStatus() {
+        // given
+        String originalTopic = "commerce.order.payment-completed";
+        String dltTopic = originalTopic + ".dlt";
+
+        when(consumerFactory.createConsumer(anyString(), eq(""))).thenReturn(consumer);
+
+        PartitionInfo partitionInfo = new PartitionInfo(dltTopic, 0, null, null, null);
+        when(consumer.partitionsFor(dltTopic)).thenReturn(List.of(partitionInfo));
+
+        TopicPartition topicPartition = new TopicPartition(dltTopic, 0);
+        ConsumerRecord<String, Object> record1 = buildDltRecord(dltTopic, 0, 0L, "key-1", originalTopic,
+                "RuntimeException", "에러 1");
+        ConsumerRecord<String, Object> record2 = buildDltRecord(dltTopic, 0, 1L, "key-2", originalTopic,
+                "RuntimeException", "에러 2");
+        ConsumerRecords<String, Object> records = new ConsumerRecords<>(
+                Map.of(topicPartition, List.of(record1, record2))
+        );
+        ConsumerRecords<String, Object> emptyRecords = new ConsumerRecords<>(Collections.emptyMap());
+
+        when(consumer.poll(any(Duration.class)))
+                .thenReturn(records)
+                .thenReturn(emptyRecords);
+
+        DltMessageResolutionJpaEntity retriedEntity = DltMessageResolutionJpaEntity.of(
+                originalTopic, dltTopic, 0, 0L,
+                DltResolutionStatus.RETRIED, "admin@personal.com", LocalDateTime.now()
+        );
+        when(resolutionRepository.findByOriginalTopic(originalTopic)).thenReturn(List.of(retriedEntity));
+
+        // when
+        List<DltMessageResponse> result = dltQueryService.queryDltMessages(originalTopic, 100);
+
+        // then
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).resolution()).isEqualTo("RETRIED");
+        assertThat(result.get(1).resolution()).isEqualTo("UNRESOLVED");
+    }
+
+    @Test
+    @DisplayName("DB에 RETRIED와 DISCARDED 해결 상태가 혼합되어 있으면 각각의 상태를 반환한다")
+    void queryDltMessages_withMixedResolutions_returnsCorrectStatuses() {
+        // given
+        String originalTopic = "commerce.payment.cancelled";
+        String dltTopic = originalTopic + ".dlt";
+
+        when(consumerFactory.createConsumer(anyString(), eq(""))).thenReturn(consumer);
+
+        PartitionInfo partitionInfo = new PartitionInfo(dltTopic, 0, null, null, null);
+        when(consumer.partitionsFor(dltTopic)).thenReturn(List.of(partitionInfo));
+
+        TopicPartition topicPartition = new TopicPartition(dltTopic, 0);
+        ConsumerRecord<String, Object> record1 = buildDltRecord(dltTopic, 0, 0L, "key-1", originalTopic,
+                "RuntimeException", "에러 1");
+        ConsumerRecord<String, Object> record2 = buildDltRecord(dltTopic, 0, 1L, "key-2", originalTopic,
+                "RuntimeException", "에러 2");
+        ConsumerRecord<String, Object> record3 = buildDltRecord(dltTopic, 0, 2L, "key-3", originalTopic,
+                "RuntimeException", "에러 3");
+        ConsumerRecords<String, Object> records = new ConsumerRecords<>(
+                Map.of(topicPartition, List.of(record1, record2, record3))
+        );
+        ConsumerRecords<String, Object> emptyRecords = new ConsumerRecords<>(Collections.emptyMap());
+
+        when(consumer.poll(any(Duration.class)))
+                .thenReturn(records)
+                .thenReturn(emptyRecords);
+
+        DltMessageResolutionJpaEntity retriedEntity = DltMessageResolutionJpaEntity.of(
+                originalTopic, dltTopic, 0, 0L,
+                DltResolutionStatus.RETRIED, "admin@personal.com", LocalDateTime.now()
+        );
+        DltMessageResolutionJpaEntity discardedEntity = DltMessageResolutionJpaEntity.of(
+                originalTopic, dltTopic, 0, 1L,
+                DltResolutionStatus.DISCARDED, "admin@personal.com", LocalDateTime.now()
+        );
+        when(resolutionRepository.findByOriginalTopic(originalTopic))
+                .thenReturn(List.of(retriedEntity, discardedEntity));
+
+        // when
+        List<DltMessageResponse> result = dltQueryService.queryDltMessages(originalTopic, 100);
+
+        // then
+        assertThat(result).hasSize(3);
+        assertThat(result.get(0).resolution()).isEqualTo("RETRIED");
+        assertThat(result.get(1).resolution()).isEqualTo("DISCARDED");
+        assertThat(result.get(2).resolution()).isEqualTo("UNRESOLVED");
+    }
+
     private ConsumerRecord<String, Object> buildDltRecord(
-            String dltTopic, String key, String originalTopic, String errorFqcn, String errorMessage
+            String dltTopic, int partition, long offset, String key,
+            String originalTopic, String errorFqcn, String errorMessage
     ) {
-        ConsumerRecord<String, Object> record = new ConsumerRecord<>(dltTopic, 0, 0L, key, "value");
+        ConsumerRecord<String, Object> record = new ConsumerRecord<>(dltTopic, partition, offset, key, "value");
         record.headers()
                 .add("kafka_dlt-original-topic", originalTopic.getBytes(StandardCharsets.UTF_8))
                 .add("kafka_dlt-exception-fqcn", errorFqcn.getBytes(StandardCharsets.UTF_8))

--- a/common/src/test/java/com/personal/marketnote/common/configuration/kafka/DltReprocessServiceTest.java
+++ b/common/src/test/java/com/personal/marketnote/common/configuration/kafka/DltReprocessServiceTest.java
@@ -16,6 +16,7 @@ import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.support.SendResult;
 
 import java.time.Duration;
+import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -45,12 +46,15 @@ class DltReprocessServiceTest {
     private DltMetricsCollector dltMetricsCollector;
 
     @Mock
+    private DltMessageResolutionJpaRepository resolutionRepository;
+
+    @Mock
     private Consumer<String, Object> consumer;
 
     private static final String OPERATOR = "admin@personal.com";
 
     @Test
-    @DisplayName("DLT 토픽에서 메시지를 읽어 원본 토픽으로 재전송한다")
+    @DisplayName("DLT 토픽에서 메시지를 읽어 원본 토픽으로 재전송하고 RETRIED 상태를 저장한다")
     void reprocess_pollsFromDltAndSendsToOriginalTopic() {
         // given
         String originalTopic = "commerce.order.payment-completed";
@@ -76,22 +80,26 @@ class DltReprocessServiceTest {
         CompletableFuture<SendResult<String, Object>> future = CompletableFuture.completedFuture(null);
         when(kafkaTemplate.send(anyString(), anyString(), any())).thenReturn(future);
 
+        when(resolutionRepository.findByOriginalTopic(originalTopic)).thenReturn(List.of());
+
         // when
         DltReprocessResult result = dltReprocessService.reprocess(originalTopic, OPERATOR);
 
         // then
         assertThat(result.reprocessedCount()).isEqualTo(2);
         assertThat(result.failedCount()).isEqualTo(0);
+        assertThat(result.skippedCount()).isEqualTo(0);
         verify(kafkaTemplate).send(originalTopic, "key-1", "value-1");
         verify(kafkaTemplate).send(originalTopic, "key-2", "value-2");
         verify(dltAuditLogger).logReprocessStart(originalTopic, OPERATOR);
         verify(dltAuditLogger).logReprocessComplete(originalTopic, OPERATOR, 2, 0);
         verify(dltMetricsCollector, times(2)).incrementDltReprocessCount(originalTopic, "success");
+        verify(resolutionRepository, times(2)).save(any(DltMessageResolutionJpaEntity.class));
         verify(consumer).close();
     }
 
     @Test
-    @DisplayName("DLT 토픽에 메시지가 없으면 reprocessedCount 0, failedCount 0을 반환한다")
+    @DisplayName("DLT 토픽에 메시지가 없으면 reprocessedCount 0, failedCount 0, skippedCount 0을 반환한다")
     void reprocess_emptyDlt_returnsZero() {
         // given
         String originalTopic = "commerce.payment.approved";
@@ -105,19 +113,22 @@ class DltReprocessServiceTest {
         ConsumerRecords<String, Object> emptyRecords = new ConsumerRecords<>(Collections.emptyMap());
         when(consumer.poll(any(Duration.class))).thenReturn(emptyRecords);
 
+        when(resolutionRepository.findByOriginalTopic(originalTopic)).thenReturn(List.of());
+
         // when
         DltReprocessResult result = dltReprocessService.reprocess(originalTopic, OPERATOR);
 
         // then
         assertThat(result.reprocessedCount()).isEqualTo(0);
         assertThat(result.failedCount()).isEqualTo(0);
+        assertThat(result.skippedCount()).isEqualTo(0);
         verify(kafkaTemplate, never()).send(anyString(), anyString(), any());
         verify(dltAuditLogger).logReprocessStart(originalTopic, OPERATOR);
         verify(consumer).close();
     }
 
     @Test
-    @DisplayName("DLT 토픽 파티션이 없으면 reprocessedCount 0, failedCount 0을 반환한다")
+    @DisplayName("DLT 토픽 파티션이 없으면 reprocessedCount 0, failedCount 0, skippedCount 0을 반환한다")
     void reprocess_noPartitions_returnsZero() {
         // given
         String originalTopic = "commerce.settlement.executed";
@@ -132,6 +143,7 @@ class DltReprocessServiceTest {
         // then
         assertThat(result.reprocessedCount()).isEqualTo(0);
         assertThat(result.failedCount()).isEqualTo(0);
+        assertThat(result.skippedCount()).isEqualTo(0);
         verify(kafkaTemplate, never()).send(anyString(), anyString(), any());
         verify(dltAuditLogger).logReprocessStart(originalTopic, OPERATOR);
         verify(dltAuditLogger).logReprocessComplete(originalTopic, OPERATOR, 0, 0);
@@ -151,8 +163,8 @@ class DltReprocessServiceTest {
     }
 
     @Test
-    @DisplayName("메시지 재전송 실패 시 failedCount가 증가하고 실패 메트릭이 기록된다")
-    void reprocess_sendFailure_incrementsFailedCountAndMetrics() {
+    @DisplayName("메시지 재전송 실패 시 failedCount가 증가하고 RETRIED 상태를 저장하지 않는다")
+    void reprocess_sendFailure_incrementsFailedCountAndDoesNotSaveResolution() {
         // given
         String originalTopic = "commerce.payment.cancelled";
         String dltTopic = originalTopic + ".dlt";
@@ -177,14 +189,111 @@ class DltReprocessServiceTest {
         failedFuture.completeExceptionally(new RuntimeException("전송 실패"));
         when(kafkaTemplate.send(anyString(), anyString(), any())).thenReturn(failedFuture);
 
+        when(resolutionRepository.findByOriginalTopic(originalTopic)).thenReturn(List.of());
+
         // when
         DltReprocessResult result = dltReprocessService.reprocess(originalTopic, OPERATOR);
 
         // then
         assertThat(result.reprocessedCount()).isEqualTo(0);
         assertThat(result.failedCount()).isEqualTo(1);
+        assertThat(result.skippedCount()).isEqualTo(0);
         verify(dltMetricsCollector).incrementDltReprocessCount(originalTopic, "failure");
         verify(dltAuditLogger).logReprocessComplete(originalTopic, OPERATOR, 0, 1);
+        verify(resolutionRepository, never()).save(any(DltMessageResolutionJpaEntity.class));
         verify(consumer).close();
+    }
+
+    @Test
+    @DisplayName("이미 처리된 메시지는 스킵하고 미처리 메시지만 재전송한다")
+    void reprocess_skipsAlreadyResolvedMessages() {
+        // given
+        String originalTopic = "commerce.order.payment-completed";
+        String dltTopic = originalTopic + ".dlt";
+
+        when(consumerFactory.createConsumer(anyString(), eq(""))).thenReturn(consumer);
+
+        PartitionInfo partitionInfo = new PartitionInfo(dltTopic, 0, null, null, null);
+        when(consumer.partitionsFor(dltTopic)).thenReturn(List.of(partitionInfo));
+
+        TopicPartition topicPartition = new TopicPartition(dltTopic, 0);
+        ConsumerRecord<String, Object> record1 = new ConsumerRecord<>(dltTopic, 0, 0L, "key-1", "value-1");
+        ConsumerRecord<String, Object> record2 = new ConsumerRecord<>(dltTopic, 0, 1L, "key-2", "value-2");
+        ConsumerRecord<String, Object> record3 = new ConsumerRecord<>(dltTopic, 0, 2L, "key-3", "value-3");
+        ConsumerRecords<String, Object> records = new ConsumerRecords<>(
+                Map.of(topicPartition, List.of(record1, record2, record3))
+        );
+        ConsumerRecords<String, Object> emptyRecords = new ConsumerRecords<>(Collections.emptyMap());
+
+        when(consumer.poll(any(Duration.class)))
+                .thenReturn(records)
+                .thenReturn(emptyRecords);
+
+        CompletableFuture<SendResult<String, Object>> future = CompletableFuture.completedFuture(null);
+        when(kafkaTemplate.send(anyString(), anyString(), any())).thenReturn(future);
+
+        DltMessageResolutionJpaEntity resolvedEntity = DltMessageResolutionJpaEntity.of(
+                originalTopic, dltTopic, 0, 0L,
+                DltResolutionStatus.RETRIED, OPERATOR, LocalDateTime.now()
+        );
+        when(resolutionRepository.findByOriginalTopic(originalTopic)).thenReturn(List.of(resolvedEntity));
+
+        // when
+        DltReprocessResult result = dltReprocessService.reprocess(originalTopic, OPERATOR);
+
+        // then
+        assertThat(result.reprocessedCount()).isEqualTo(2);
+        assertThat(result.failedCount()).isEqualTo(0);
+        assertThat(result.skippedCount()).isEqualTo(1);
+        verify(kafkaTemplate).send(originalTopic, "key-2", "value-2");
+        verify(kafkaTemplate).send(originalTopic, "key-3", "value-3");
+        verify(kafkaTemplate, never()).send(originalTopic, "key-1", "value-1");
+        verify(resolutionRepository, times(2)).save(any(DltMessageResolutionJpaEntity.class));
+    }
+
+    @Test
+    @DisplayName("모든 메시지가 이미 처리된 경우 skippedCount만 증가한다")
+    void reprocess_allMessagesAlreadyResolved_skipsAll() {
+        // given
+        String originalTopic = "commerce.payment.approved";
+        String dltTopic = originalTopic + ".dlt";
+
+        when(consumerFactory.createConsumer(anyString(), eq(""))).thenReturn(consumer);
+
+        PartitionInfo partitionInfo = new PartitionInfo(dltTopic, 0, null, null, null);
+        when(consumer.partitionsFor(dltTopic)).thenReturn(List.of(partitionInfo));
+
+        TopicPartition topicPartition = new TopicPartition(dltTopic, 0);
+        ConsumerRecord<String, Object> record1 = new ConsumerRecord<>(dltTopic, 0, 0L, "key-1", "value-1");
+        ConsumerRecord<String, Object> record2 = new ConsumerRecord<>(dltTopic, 0, 1L, "key-2", "value-2");
+        ConsumerRecords<String, Object> records = new ConsumerRecords<>(
+                Map.of(topicPartition, List.of(record1, record2))
+        );
+        ConsumerRecords<String, Object> emptyRecords = new ConsumerRecords<>(Collections.emptyMap());
+
+        when(consumer.poll(any(Duration.class)))
+                .thenReturn(records)
+                .thenReturn(emptyRecords);
+
+        DltMessageResolutionJpaEntity resolved1 = DltMessageResolutionJpaEntity.of(
+                originalTopic, dltTopic, 0, 0L,
+                DltResolutionStatus.RETRIED, OPERATOR, LocalDateTime.now()
+        );
+        DltMessageResolutionJpaEntity resolved2 = DltMessageResolutionJpaEntity.of(
+                originalTopic, dltTopic, 0, 1L,
+                DltResolutionStatus.DISCARDED, OPERATOR, LocalDateTime.now()
+        );
+        when(resolutionRepository.findByOriginalTopic(originalTopic))
+                .thenReturn(List.of(resolved1, resolved2));
+
+        // when
+        DltReprocessResult result = dltReprocessService.reprocess(originalTopic, OPERATOR);
+
+        // then
+        assertThat(result.reprocessedCount()).isEqualTo(0);
+        assertThat(result.failedCount()).isEqualTo(0);
+        assertThat(result.skippedCount()).isEqualTo(2);
+        verify(kafkaTemplate, never()).send(anyString(), anyString(), any());
+        verify(resolutionRepository, never()).save(any(DltMessageResolutionJpaEntity.class));
     }
 }


### PR DESCRIPTION
## partially addresses #929
## resolves #1453

## Task
- [x] DltResolutionStatus enum 추가 (RETRIED, DISCARDED + UNRESOLVED 상수)
- [x] DltMessageResolutionJpaEntity 추가 (dlt_topic, partition, offset UNIQUE)
- [x] DltMessageResolutionJpaRepository 추가
- [x] DltMessageResponse에 resolution 필드 추가
- [x] DltQueryService에 DB 해결 상태 조회 + 응답 매핑
- [x] DltReprocessService에 이미 처리된 offset 스킵 + RETRIED 저장
- [x] DltReprocessResult/ReprocessDltResponse에 skippedCount 추가
- [x] QueryDltMessagesApiDocs/ReprocessDltApiDocs 문서 갱신
- [x] 기존 테스트 수정 (DltQueryServiceTest, DltReprocessServiceTest)