### PR TITLE
[#929][#1457] feat: DLT 메시지별 선택적 재처리 및 폐기 기능 추가

### DIFF
--- a/common/src/main/java/com/personal/marketnote/common/adapter/in/web/kafka/controller/AdminDltController.java
+++ b/common/src/main/java/com/personal/marketnote/common/adapter/in/web/kafka/controller/AdminDltController.java
@@ -4,14 +4,20 @@ import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
 import com.personal.marketnote.common.adapter.in.web.kafka.controller.apidocs.QueryDltMessagesApiDocs;
 import com.personal.marketnote.common.adapter.in.web.kafka.controller.apidocs.QueryDltTopicSummariesApiDocs;
 import com.personal.marketnote.common.adapter.in.web.kafka.controller.apidocs.ReprocessDltApiDocs;
+import com.personal.marketnote.common.adapter.in.web.kafka.controller.apidocs.ResolveDltApiDocs;
 import com.personal.marketnote.common.adapter.in.web.kafka.request.ReprocessDltRequest;
+import com.personal.marketnote.common.adapter.in.web.kafka.request.ResolveDltRequest;
 import com.personal.marketnote.common.adapter.in.web.kafka.response.DltMessageResponse;
 import com.personal.marketnote.common.adapter.in.web.kafka.response.DltTopicSummaryResponse;
 import com.personal.marketnote.common.adapter.in.web.kafka.response.ReprocessDltResponse;
+import com.personal.marketnote.common.adapter.in.web.kafka.response.ResolveDltResponse;
 import com.personal.marketnote.common.configuration.kafka.DltAuditLogger;
 import com.personal.marketnote.common.configuration.kafka.DltQueryService;
 import com.personal.marketnote.common.configuration.kafka.DltReprocessResult;
 import com.personal.marketnote.common.configuration.kafka.DltReprocessService;
+import com.personal.marketnote.common.configuration.kafka.DltResolveCommand;
+import com.personal.marketnote.common.configuration.kafka.DltResolveResult;
+import com.personal.marketnote.common.configuration.kafka.DltResolveService;
 import com.personal.marketnote.common.utility.FormatValidator;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -41,6 +47,7 @@ import static com.personal.marketnote.common.utility.ApiConstant.ADMIN_POINTCUT;
 public class AdminDltController {
 
     private final DltReprocessService dltReprocessService;
+    private final DltResolveService dltResolveService;
     private final DltQueryService dltQueryService;
     private final DltAuditLogger dltAuditLogger;
 
@@ -60,6 +67,31 @@ public class AdminDltController {
                         HttpStatus.OK,
                         DEFAULT_SUCCESS_CODE,
                         "DLT 메시지 재처리 완료"
+                ),
+                HttpStatus.OK
+        );
+    }
+
+    @PostMapping("/api/v1/admin/kafka/dlt/resolve")
+    @PreAuthorize(ADMIN_POINTCUT)
+    @ResolveDltApiDocs
+    public ResponseEntity<BaseResponse<ResolveDltResponse>> resolveDlt(
+            @Valid @RequestBody ResolveDltRequest request,
+            @AuthenticationPrincipal OAuth2AuthenticatedPrincipal principal
+    ) {
+        String operatorInfo = resolveOperatorInfo(principal);
+        DltResolveCommand command = new DltResolveCommand(
+                request.originalTopic(), request.partition(), request.offset(),
+                request.action(), request.reason()
+        );
+        DltResolveResult result = dltResolveService.resolve(command, operatorInfo);
+
+        return new ResponseEntity<>(
+                BaseResponse.of(
+                        ResolveDltResponse.from(command, result),
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "DLT 메시지 해결 완료"
                 ),
                 HttpStatus.OK
         );

--- a/common/src/main/java/com/personal/marketnote/common/adapter/in/web/kafka/controller/apidocs/ResolveDltApiDocs.java
+++ b/common/src/main/java/com/personal/marketnote/common/adapter/in/web/kafka/controller/apidocs/ResolveDltApiDocs.java
@@ -1,0 +1,116 @@
+package com.personal.marketnote.common.adapter.in.web.kafka.controller.apidocs;
+
+import com.personal.marketnote.common.adapter.in.web.kafka.request.ResolveDltRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.*;
+
+/**
+ * (관리자) DLT 메시지별 선택적 재처리/폐기 API 문서 애노테이션.
+ *
+ * @author 성효빈
+ * @since 2026-03-14
+ */
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Operation(
+        summary = "(관리자) DLT 메시지별 선택적 재처리/폐기",
+        description = """
+                작성일자: 2026-03-14
+
+                작성자: 성효빈
+
+                ---
+
+                ## Description
+
+                지정된 DLT 메시지를 개별적으로 재처리(RETRY) 또는 폐기(DISCARD)합니다.
+                - RETRY: 원본 토픽으로 재발행 후 RETRIED 상태 저장
+                - DISCARD: 재발행 없이 DISCARDED 상태만 저장
+                - 이미 처리된 메시지는 멱등하게 기존 상태를 반환합니다.
+
+                ---
+
+                ## Request Body
+
+                | **키** | **타입** | **설명** | **필수 여부** | **예시** |
+                | --- | --- | --- | --- | --- |
+                | originalTopic | string | 원본 토픽명 | Y | "commerce.order.payment-completed" |
+                | partition | integer | DLT 메시지 파티션 번호 | Y | 0 |
+                | offset | long | DLT 메시지 오프셋 번호 | Y | 5 |
+                | action | string | 처리 액션 (RETRY / DISCARD) | Y | "RETRY" |
+                | reason | string | 처리 사유 (최대 500자) | N | "일시적 DB 타임아웃 복구" |
+
+                ---
+
+                ## Response > content
+
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | originalTopic | string | 원본 토픽명 | "commerce.order.payment-completed" |
+                | dltTopic | string | DLT 토픽명 | "commerce.order.payment-completed.dlt" |
+                | partition | integer | 파티션 번호 | 0 |
+                | offset | long | 오프셋 번호 | 5 |
+                | resolution | string | 해결 상태 (RETRIED / DISCARDED) | "RETRIED" |
+                | reason | string | 처리 사유 | "일시적 DB 타임아웃 복구" |
+                | alreadyResolved | boolean | 이미 처리 여부 | false |
+                """,
+        security = {@SecurityRequirement(name = "bearer")},
+        requestBody = @RequestBody(
+                required = true,
+                content = @Content(
+                        schema = @Schema(implementation = ResolveDltRequest.class),
+                        examples = @ExampleObject("""
+                                {
+                                    "originalTopic": "commerce.order.payment-completed",
+                                    "partition": 0,
+                                    "offset": 5,
+                                    "action": "RETRY",
+                                    "reason": "일시적 DB 타임아웃 복구"
+                                }
+                                """)
+                )
+        ),
+        responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "DLT 메시지 해결 완료",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 200,
+                                          "code": "SUC01",
+                                          "timestamp": "2026-03-14T12:00:00.000",
+                                          "content": {
+                                            "originalTopic": "commerce.order.payment-completed",
+                                            "dltTopic": "commerce.order.payment-completed.dlt",
+                                            "partition": 0,
+                                            "offset": 5,
+                                            "resolution": "RETRIED",
+                                            "reason": "일시적 DB 타임아웃 복구",
+                                            "alreadyResolved": false
+                                          },
+                                          "message": "DLT 메시지 해결 완료"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "401",
+                        description = "인증 실패"
+                ),
+                @ApiResponse(
+                        responseCode = "403",
+                        description = "관리자 권한 없음"
+                )
+        }
+)
+public @interface ResolveDltApiDocs {
+}

--- a/common/src/main/java/com/personal/marketnote/common/adapter/in/web/kafka/request/ResolveDltRequest.java
+++ b/common/src/main/java/com/personal/marketnote/common/adapter/in/web/kafka/request/ResolveDltRequest.java
@@ -1,0 +1,27 @@
+package com.personal.marketnote.common.adapter.in.web.kafka.request;
+
+import com.personal.marketnote.common.configuration.kafka.DltResolutionAction;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record ResolveDltRequest(
+        @NotBlank(message = "원본 토픽명은 필수입니다")
+        String originalTopic,
+
+        @NotNull(message = "파티션 번호는 필수입니다")
+        @Min(value = 0, message = "파티션 번호는 0 이상이어야 합니다")
+        Integer partition,
+
+        @NotNull(message = "오프셋 번호는 필수입니다")
+        @Min(value = 0, message = "오프셋 번호는 0 이상이어야 합니다")
+        Long offset,
+
+        @NotNull(message = "처리 액션은 필수입니다")
+        DltResolutionAction action,
+
+        @Size(max = 500, message = "처리 사유는 500자를 초과할 수 없습니다")
+        String reason
+) {
+}

--- a/common/src/main/java/com/personal/marketnote/common/adapter/in/web/kafka/response/ResolveDltResponse.java
+++ b/common/src/main/java/com/personal/marketnote/common/adapter/in/web/kafka/response/ResolveDltResponse.java
@@ -1,0 +1,27 @@
+package com.personal.marketnote.common.adapter.in.web.kafka.response;
+
+import com.personal.marketnote.common.configuration.kafka.DltResolveCommand;
+import com.personal.marketnote.common.configuration.kafka.DltResolveResult;
+import com.personal.marketnote.common.kafka.DltTopicRegistry;
+
+public record ResolveDltResponse(
+        String originalTopic,
+        String dltTopic,
+        int partition,
+        long offset,
+        String resolution,
+        String reason,
+        boolean alreadyResolved
+) {
+    public static ResolveDltResponse from(DltResolveCommand command, DltResolveResult result) {
+        return new ResolveDltResponse(
+                command.originalTopic(),
+                DltTopicRegistry.toDltTopic(command.originalTopic()),
+                command.partition(),
+                command.offset(),
+                result.resolution().name(),
+                command.reason(),
+                result.alreadyResolved()
+        );
+    }
+}

--- a/common/src/main/java/com/personal/marketnote/common/configuration/kafka/DltAuditLogger.java
+++ b/common/src/main/java/com/personal/marketnote/common/configuration/kafka/DltAuditLogger.java
@@ -32,4 +32,22 @@ public class DltAuditLogger {
     public void logSummaryQuery(String operatorInfo) {
         log.info("[DLT-AUDIT] action=SUMMARY_QUERY, operator={}", operatorInfo);
     }
+
+    public void logResolve(String originalTopic, int partition, long offset,
+                            String action, String reason, String operatorInfo) {
+        log.info("[DLT-AUDIT] action=RESOLVE, topic={}, partition={}, offset={}, resolution={}, reason={}, operator={}",
+                originalTopic, partition, offset, action, reason, operatorInfo);
+    }
+
+    public void logResolveAlreadyResolved(String originalTopic, int partition, long offset,
+                                           String existingResolution, String operatorInfo) {
+        log.info("[DLT-AUDIT] action=RESOLVE_ALREADY_RESOLVED, topic={}, partition={}, offset={}, existingResolution={}, operator={}",
+                originalTopic, partition, offset, existingResolution, operatorInfo);
+    }
+
+    public void logResolveError(String originalTopic, int partition, long offset,
+                                 String action, String operatorInfo, Exception ex) {
+        log.error("[DLT-AUDIT] action=RESOLVE_ERROR, topic={}, partition={}, offset={}, resolution={}, operator={}, error={}",
+                originalTopic, partition, offset, action, operatorInfo, ex.getMessage(), ex);
+    }
 }

--- a/common/src/main/java/com/personal/marketnote/common/configuration/kafka/DltMessageNotFoundException.java
+++ b/common/src/main/java/com/personal/marketnote/common/configuration/kafka/DltMessageNotFoundException.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.common.configuration.kafka;
+
+public class DltMessageNotFoundException extends RuntimeException {
+    public DltMessageNotFoundException(String dltTopic, int partition, long offset) {
+        super("DLT 메시지를 찾을 수 없습니다. dltTopic=" + dltTopic +
+                ", partition=" + partition + ", offset=" + offset);
+    }
+}

--- a/common/src/main/java/com/personal/marketnote/common/configuration/kafka/DltMessageResolutionJpaEntity.java
+++ b/common/src/main/java/com/personal/marketnote/common/configuration/kafka/DltMessageResolutionJpaEntity.java
@@ -52,10 +52,14 @@ public class DltMessageResolutionJpaEntity {
     @Column(name = "resolved_at")
     private LocalDateTime resolvedAt;
 
+    @Column(name = "reason", length = 500)
+    private String reason;
+
     private DltMessageResolutionJpaEntity(String originalTopic, String dltTopic,
                                           int partitionNumber, long offsetNumber,
                                           DltResolutionStatus resolution,
-                                          String resolvedBy, LocalDateTime resolvedAt) {
+                                          String resolvedBy, LocalDateTime resolvedAt,
+                                          String reason) {
         this.originalTopic = originalTopic;
         this.dltTopic = dltTopic;
         this.partitionNumber = partitionNumber;
@@ -63,15 +67,17 @@ public class DltMessageResolutionJpaEntity {
         this.resolution = resolution;
         this.resolvedBy = resolvedBy;
         this.resolvedAt = resolvedAt;
+        this.reason = reason;
     }
 
     public static DltMessageResolutionJpaEntity of(String originalTopic, String dltTopic,
                                                     int partitionNumber, long offsetNumber,
                                                     DltResolutionStatus resolution,
-                                                    String resolvedBy, LocalDateTime resolvedAt) {
+                                                    String resolvedBy, LocalDateTime resolvedAt,
+                                                    String reason) {
         return new DltMessageResolutionJpaEntity(
                 originalTopic, dltTopic, partitionNumber, offsetNumber,
-                resolution, resolvedBy, resolvedAt
+                resolution, resolvedBy, resolvedAt, reason
         );
     }
 

--- a/common/src/main/java/com/personal/marketnote/common/configuration/kafka/DltMessageResolutionJpaRepository.java
+++ b/common/src/main/java/com/personal/marketnote/common/configuration/kafka/DltMessageResolutionJpaRepository.java
@@ -3,8 +3,12 @@ package com.personal.marketnote.common.configuration.kafka;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface DltMessageResolutionJpaRepository extends JpaRepository<DltMessageResolutionJpaEntity, Long> {
 
     List<DltMessageResolutionJpaEntity> findByOriginalTopic(String originalTopic);
+
+    Optional<DltMessageResolutionJpaEntity> findByDltTopicAndPartitionNumberAndOffsetNumber(
+            String dltTopic, int partitionNumber, long offsetNumber);
 }

--- a/common/src/main/java/com/personal/marketnote/common/configuration/kafka/DltMetricsCollector.java
+++ b/common/src/main/java/com/personal/marketnote/common/configuration/kafka/DltMetricsCollector.java
@@ -38,4 +38,16 @@ public class DltMetricsCollector {
                 .register(meterRegistry)
                 .increment();
     }
+
+    public void incrementDltResolveCount(String originalTopic, String action) {
+        if (FormatValidator.hasNoValue(meterRegistry)) {
+            return;
+        }
+        Counter.builder("kafka.dlt.resolve.total")
+                .tag("original_topic", originalTopic)
+                .tag("action", action)
+                .description("DLT 메시지 해결 건수")
+                .register(meterRegistry)
+                .increment();
+    }
 }

--- a/common/src/main/java/com/personal/marketnote/common/configuration/kafka/DltReprocessService.java
+++ b/common/src/main/java/com/personal/marketnote/common/configuration/kafka/DltReprocessService.java
@@ -100,7 +100,7 @@ public class DltReprocessService {
                         dltMetricsCollector.incrementDltReprocessCount(originalTopic, "success");
                         try {
                             saveResolution(originalTopic, dltTopic, record.partition(), record.offset(),
-                                    DltResolutionStatus.RETRIED, operatorInfo);
+                                    DltResolutionStatus.RETRIED, operatorInfo, null);
                         } catch (Exception se) {
                             log.warn("DLT resolution 저장 실패. originalTopic={}, partition={}, offset={}",
                                     originalTopic, record.partition(), record.offset(), se);
@@ -141,10 +141,11 @@ public class DltReprocessService {
 
     private void saveResolution(String originalTopic, String dltTopic,
                                 int partition, long offset,
-                                DltResolutionStatus resolution, String operatorInfo) {
+                                DltResolutionStatus resolution, String operatorInfo,
+                                String reason) {
         DltMessageResolutionJpaEntity entity = DltMessageResolutionJpaEntity.of(
                 originalTopic, dltTopic, partition, offset,
-                resolution, operatorInfo, LocalDateTime.now()
+                resolution, operatorInfo, LocalDateTime.now(), reason
         );
         resolutionRepository.save(entity);
     }

--- a/common/src/main/java/com/personal/marketnote/common/configuration/kafka/DltResolutionAction.java
+++ b/common/src/main/java/com/personal/marketnote/common/configuration/kafka/DltResolutionAction.java
@@ -1,0 +1,21 @@
+package com.personal.marketnote.common.configuration.kafka;
+
+public enum DltResolutionAction {
+    RETRY,
+    DISCARD;
+
+    public boolean isRetry() {
+        return this == RETRY;
+    }
+
+    public boolean isDiscard() {
+        return this == DISCARD;
+    }
+
+    public DltResolutionStatus toResolutionStatus() {
+        if (isRetry()) {
+            return DltResolutionStatus.RETRIED;
+        }
+        return DltResolutionStatus.DISCARDED;
+    }
+}

--- a/common/src/main/java/com/personal/marketnote/common/configuration/kafka/DltResolveCommand.java
+++ b/common/src/main/java/com/personal/marketnote/common/configuration/kafka/DltResolveCommand.java
@@ -1,0 +1,10 @@
+package com.personal.marketnote.common.configuration.kafka;
+
+public record DltResolveCommand(
+        String originalTopic,
+        int partition,
+        long offset,
+        DltResolutionAction action,
+        String reason
+) {
+}

--- a/common/src/main/java/com/personal/marketnote/common/configuration/kafka/DltResolveFailedException.java
+++ b/common/src/main/java/com/personal/marketnote/common/configuration/kafka/DltResolveFailedException.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.common.configuration.kafka;
+
+public class DltResolveFailedException extends RuntimeException {
+    public DltResolveFailedException(String topic, int partition, long offset) {
+        super("DLT 메시지 해결 중 오류가 발생했습니다. topic=" + topic +
+                ", partition=" + partition + ", offset=" + offset);
+    }
+}

--- a/common/src/main/java/com/personal/marketnote/common/configuration/kafka/DltResolveResult.java
+++ b/common/src/main/java/com/personal/marketnote/common/configuration/kafka/DltResolveResult.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.common.configuration.kafka;
+
+public record DltResolveResult(
+        DltResolutionStatus resolution,
+        boolean alreadyResolved
+) {
+}

--- a/common/src/main/java/com/personal/marketnote/common/configuration/kafka/DltResolveService.java
+++ b/common/src/main/java/com/personal/marketnote/common/configuration/kafka/DltResolveService.java
@@ -1,0 +1,130 @@
+package com.personal.marketnote.common.configuration.kafka;
+
+import com.personal.marketnote.common.kafka.DltTopicRegistry;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.common.TopicPartition;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(prefix = "spring.kafka", name = "bootstrap-servers")
+public class DltResolveService {
+    private static final Duration POLL_TIMEOUT = Duration.ofSeconds(5);
+    private static final long SEND_TIMEOUT_SECONDS = 10L;
+
+    private final ConsumerFactory<String, Object> consumerFactory;
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+    private final DltAuditLogger dltAuditLogger;
+    private final DltMetricsCollector dltMetricsCollector;
+    private final DltMessageResolutionJpaRepository resolutionRepository;
+
+    public DltResolveResult resolve(DltResolveCommand command, String operatorInfo) {
+        if (!DltTopicRegistry.isAllowed(command.originalTopic())) {
+            throw new InvalidDltTopicException(command.originalTopic());
+        }
+
+        String dltTopic = DltTopicRegistry.toDltTopic(command.originalTopic());
+
+        Optional<DltMessageResolutionJpaEntity> existing =
+                resolutionRepository.findByDltTopicAndPartitionNumberAndOffsetNumber(
+                        dltTopic, command.partition(), command.offset());
+
+        if (existing.isPresent()) {
+            dltAuditLogger.logResolveAlreadyResolved(
+                    command.originalTopic(), command.partition(), command.offset(),
+                    existing.get().getResolution().name(), operatorInfo);
+            return new DltResolveResult(existing.get().getResolution(), true);
+        }
+
+        DltResolutionStatus resolution = command.action().toResolutionStatus();
+
+        try {
+            if (command.action().isRetry()) {
+                retryMessage(command.originalTopic(), dltTopic, command.partition(), command.offset());
+            }
+
+            DltResolveResult duplicateResult = saveResolution(command.originalTopic(), dltTopic,
+                    command.partition(), command.offset(), resolution, command.reason(), operatorInfo);
+            if (duplicateResult != null) {
+                return duplicateResult;
+            }
+
+            dltAuditLogger.logResolve(command.originalTopic(), command.partition(), command.offset(),
+                    command.action().name(), command.reason(), operatorInfo);
+            dltMetricsCollector.incrementDltResolveCount(
+                    command.originalTopic(), command.action().name().toLowerCase());
+
+            return new DltResolveResult(resolution, false);
+        } catch (DltMessageNotFoundException e) {
+            throw e;
+        } catch (Exception e) {
+            dltAuditLogger.logResolveError(command.originalTopic(), command.partition(), command.offset(),
+                    command.action().name(), operatorInfo, e);
+            throw new DltResolveFailedException(
+                    command.originalTopic(), command.partition(), command.offset());
+        }
+    }
+
+    private void retryMessage(String originalTopic, String dltTopic,
+                               int partition, long offset) throws Exception {
+        ConsumerRecord<String, Object> record = readDltMessage(dltTopic, partition, offset);
+        kafkaTemplate.send(originalTopic, record.key(), record.value())
+                .get(SEND_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+    }
+
+    private ConsumerRecord<String, Object> readDltMessage(String dltTopic, int partition, long offset) {
+        String groupId = "dlt-resolver-" + UUID.randomUUID();
+        try (Consumer<String, Object> consumer = consumerFactory.createConsumer(groupId, "")) {
+            TopicPartition topicPartition = new TopicPartition(dltTopic, partition);
+            consumer.assign(List.of(topicPartition));
+            consumer.seek(topicPartition, offset);
+
+            ConsumerRecords<String, Object> records = consumer.poll(POLL_TIMEOUT);
+            for (ConsumerRecord<String, Object> record : records) {
+                if (record.offset() == offset) {
+                    return record;
+                }
+            }
+            throw new DltMessageNotFoundException(dltTopic, partition, offset);
+        }
+    }
+
+    private DltResolveResult saveResolution(String originalTopic, String dltTopic,
+                                             int partition, long offset,
+                                             DltResolutionStatus resolution, String reason,
+                                             String operatorInfo) {
+        DltMessageResolutionJpaEntity entity = DltMessageResolutionJpaEntity.of(
+                originalTopic, dltTopic, partition, offset,
+                resolution, operatorInfo, LocalDateTime.now(), reason
+        );
+        try {
+            resolutionRepository.save(entity);
+        } catch (DataIntegrityViolationException dive) {
+            log.info("동시 요청에 의한 DLT resolution 중복 저장. dltTopic={}, partition={}, offset={}",
+                    dltTopic, partition, offset);
+            Optional<DltMessageResolutionJpaEntity> existing =
+                    resolutionRepository.findByDltTopicAndPartitionNumberAndOffsetNumber(
+                            dltTopic, partition, offset);
+            if (existing.isPresent()) {
+                return new DltResolveResult(existing.get().getResolution(), true);
+            }
+        }
+        return null;
+    }
+}

--- a/common/src/test/java/com/personal/marketnote/common/configuration/kafka/DltQueryServiceTest.java
+++ b/common/src/test/java/com/personal/marketnote/common/configuration/kafka/DltQueryServiceTest.java
@@ -229,7 +229,7 @@ class DltQueryServiceTest {
 
         DltMessageResolutionJpaEntity retriedEntity = DltMessageResolutionJpaEntity.of(
                 originalTopic, dltTopic, 0, 0L,
-                DltResolutionStatus.RETRIED, "admin@personal.com", LocalDateTime.now()
+                DltResolutionStatus.RETRIED, "admin@personal.com", LocalDateTime.now(), null
         );
         when(resolutionRepository.findByOriginalTopic(originalTopic)).thenReturn(List.of(retriedEntity));
 
@@ -272,11 +272,11 @@ class DltQueryServiceTest {
 
         DltMessageResolutionJpaEntity retriedEntity = DltMessageResolutionJpaEntity.of(
                 originalTopic, dltTopic, 0, 0L,
-                DltResolutionStatus.RETRIED, "admin@personal.com", LocalDateTime.now()
+                DltResolutionStatus.RETRIED, "admin@personal.com", LocalDateTime.now(), null
         );
         DltMessageResolutionJpaEntity discardedEntity = DltMessageResolutionJpaEntity.of(
                 originalTopic, dltTopic, 0, 1L,
-                DltResolutionStatus.DISCARDED, "admin@personal.com", LocalDateTime.now()
+                DltResolutionStatus.DISCARDED, "admin@personal.com", LocalDateTime.now(), null
         );
         when(resolutionRepository.findByOriginalTopic(originalTopic))
                 .thenReturn(List.of(retriedEntity, discardedEntity));

--- a/common/src/test/java/com/personal/marketnote/common/configuration/kafka/DltReprocessServiceTest.java
+++ b/common/src/test/java/com/personal/marketnote/common/configuration/kafka/DltReprocessServiceTest.java
@@ -234,7 +234,7 @@ class DltReprocessServiceTest {
 
         DltMessageResolutionJpaEntity resolvedEntity = DltMessageResolutionJpaEntity.of(
                 originalTopic, dltTopic, 0, 0L,
-                DltResolutionStatus.RETRIED, OPERATOR, LocalDateTime.now()
+                DltResolutionStatus.RETRIED, OPERATOR, LocalDateTime.now(), null
         );
         when(resolutionRepository.findByOriginalTopic(originalTopic)).thenReturn(List.of(resolvedEntity));
 
@@ -277,11 +277,11 @@ class DltReprocessServiceTest {
 
         DltMessageResolutionJpaEntity resolved1 = DltMessageResolutionJpaEntity.of(
                 originalTopic, dltTopic, 0, 0L,
-                DltResolutionStatus.RETRIED, OPERATOR, LocalDateTime.now()
+                DltResolutionStatus.RETRIED, OPERATOR, LocalDateTime.now(), null
         );
         DltMessageResolutionJpaEntity resolved2 = DltMessageResolutionJpaEntity.of(
                 originalTopic, dltTopic, 0, 1L,
-                DltResolutionStatus.DISCARDED, OPERATOR, LocalDateTime.now()
+                DltResolutionStatus.DISCARDED, OPERATOR, LocalDateTime.now(), null
         );
         when(resolutionRepository.findByOriginalTopic(originalTopic))
                 .thenReturn(List.of(resolved1, resolved2));


### PR DESCRIPTION
## partially addresses #929
## resolves #1457

## Task
- [x] DltResolutionAction enum 추가 (RETRY → RETRIED, DISCARD → DISCARDED 매핑)
- [x] DltResolveCommand/DltResolveResult record 추가
- [x] DltResolveService 구현 (메시지 읽기, 재발행, resolution 저장, 멱등성, 동시성 방어)
- [x] DltMessageResolutionJpaEntity에 reason 필드 추가
- [x] DltMessageResolutionJpaRepository에 findBy 메서드 추가
- [x] POST /api/v1/admin/kafka/dlt/resolve API 추가 (@PreAuthorize, @Valid)
- [x] DltAuditLogger에 resolve 감사 로그 메서드 추가
- [x] DltMetricsCollector에 kafka.dlt.resolve.total 메트릭 추가
- [x] ResolveDltApiDocs Swagger 합성 애노테이션 추가
- [x] DltMessageNotFoundException, DltResolveFailedException 예외 추가
- [x] DataIntegrityViolationException 멱등 처리 (동시 요청 방어)
- [x] ResolveDltRequest에 @Min(0) 입력 검증 추가