### PR TITLE
[#43][#988] refactor: 제네릭 예외를 도메인 커스텀 예외로 전환 - 회원 서비스

### DIFF
--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/exception/HashAlgorithmNotAvailableException.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/exception/HashAlgorithmNotAvailableException.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.user.adapter.exception;
+
+public class HashAlgorithmNotAvailableException extends IllegalStateException {
+    private static final String MESSAGE = "SHA-256 algorithm not available";
+
+    public HashAlgorithmNotAvailableException(Throwable cause) {
+        super(MESSAGE, cause);
+    }
+}

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/authentication/controller/AuthenticationController.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/authentication/controller/AuthenticationController.java
@@ -3,6 +3,7 @@ package com.personal.marketnote.user.adapter.in.web.authentication.controller;
 import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
 import com.personal.marketnote.common.domain.exception.token.UnsupportedCodeException;
 import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.user.adapter.exception.HashAlgorithmNotAvailableException;
 import com.personal.marketnote.user.adapter.in.web.authentication.controller.apidocs.Oauth2LoginApiDocs;
 import com.personal.marketnote.user.adapter.in.web.authentication.controller.apidocs.RefreshAccessTokenApiDocs;
 import com.personal.marketnote.user.adapter.in.web.authentication.controller.apidocs.SendEmailVerificationApiDocs;
@@ -159,7 +160,7 @@ public class AuthenticationController {
             }
             return hexString.toString();
         } catch (NoSuchAlgorithmException e) {
-            throw new IllegalStateException("SHA-256 algorithm not available", e);
+            throw new HashAlgorithmNotAvailableException(e);
         }
     }
 

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/user/controller/UserController.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/user/controller/UserController.java
@@ -5,6 +5,7 @@ import com.personal.marketnote.common.utility.ElementExtractor;
 import com.personal.marketnote.common.utility.FormatConverter;
 import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.common.utility.RegularExpressionConstant;
+import com.personal.marketnote.user.adapter.exception.HashAlgorithmNotAvailableException;
 import com.personal.marketnote.user.adapter.in.web.user.controller.apidocs.*;
 import com.personal.marketnote.user.adapter.in.web.user.mapper.UserRequestToCommandMapper;
 import com.personal.marketnote.user.adapter.in.web.user.request.SignInRequest;
@@ -255,7 +256,7 @@ public class UserController {
             }
             return hexString.toString();
         } catch (NoSuchAlgorithmException e) {
-            throw new IllegalStateException("SHA-256 algorithm not available", e);
+            throw new HashAlgorithmNotAvailableException(e);
         }
     }
 

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/out/vendor/authentication/WebBasedAuthenticationServiceAdapter.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/out/vendor/authentication/WebBasedAuthenticationServiceAdapter.java
@@ -4,6 +4,7 @@ import com.personal.marketnote.common.adapter.out.SecurityAdapter;
 import com.personal.marketnote.common.domain.exception.token.InvalidRefreshTokenException;
 import com.personal.marketnote.common.utility.FormatConverter;
 import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.user.adapter.exception.HashAlgorithmNotAvailableException;
 import com.personal.marketnote.common.utility.http.cookie.HttpCookieName;
 import com.personal.marketnote.common.utility.http.cookie.HttpCookieObject;
 import com.personal.marketnote.common.utility.http.cookie.HttpCookieUtils;
@@ -174,7 +175,7 @@ public class WebBasedAuthenticationServiceAdapter {
             }
             return hexString.toString();
         } catch (NoSuchAlgorithmException e) {
-            throw new IllegalStateException("SHA-256 algorithm not available", e);
+            throw new HashAlgorithmNotAvailableException(e);
         }
     }
 }

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/utility/jwt/JwtUtil.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/utility/jwt/JwtUtil.java
@@ -3,6 +3,9 @@ package com.personal.marketnote.user.utility.jwt;
 import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.user.security.token.vendor.AuthVendor;
 import com.personal.marketnote.user.utility.jwt.claims.TokenClaims;
+import com.personal.marketnote.user.utility.jwt.exception.InvalidJwtGenerationParametersException;
+import com.personal.marketnote.user.utility.jwt.exception.InvalidJwtTokenTypeException;
+import com.personal.marketnote.user.utility.jwt.exception.InvalidOAuth2VendorException;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.jackson.io.JacksonDeserializer;
 import org.springframework.beans.factory.annotation.Value;
@@ -111,14 +114,13 @@ public class JwtUtil {
             return apple.toUpperCase();
         }
 
-        throw new IllegalArgumentException("존재하지 않는 OAuth2 공급 업체입니다. issuer: " + iss);
+        throw new InvalidOAuth2VendorException(iss);
     }
 
     private JwtTokenType extractTokenType(Claims claims, JwtTokenType expectedTokenType) {
         JwtTokenType fromClaim = JwtTokenType.from(claims.get(TOKEN_TYPE_CLAIM_KEY, String.class));
         if (expectedTokenType != fromClaim) {
-            throw new IllegalArgumentException(
-                    String.format("Expected parsing %s, but just attempted to parse %s", expectedTokenType, fromClaim));
+            throw new InvalidJwtTokenTypeException(expectedTokenType, fromClaim);
         }
 
         return fromClaim;
@@ -145,7 +147,7 @@ public class JwtUtil {
         }
 
         if (!messages.isEmpty()) {
-            throw new IllegalArgumentException(String.join("\n", messages.toArray(new String[0])));
+            throw new InvalidJwtGenerationParametersException(String.join("\n", messages.toArray(new String[0])));
         }
     }
 

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/utility/jwt/exception/InvalidJwtGenerationParametersException.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/utility/jwt/exception/InvalidJwtGenerationParametersException.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.user.utility.jwt.exception;
+
+public class InvalidJwtGenerationParametersException extends IllegalArgumentException {
+
+    public InvalidJwtGenerationParametersException(String message) {
+        super(message);
+    }
+}

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/utility/jwt/exception/InvalidJwtTokenTypeException.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/utility/jwt/exception/InvalidJwtTokenTypeException.java
@@ -1,0 +1,11 @@
+package com.personal.marketnote.user.utility.jwt.exception;
+
+import com.personal.marketnote.user.utility.jwt.JwtTokenType;
+
+public class InvalidJwtTokenTypeException extends IllegalArgumentException {
+    private static final String MESSAGE = "Expected parsing %s, but just attempted to parse %s";
+
+    public InvalidJwtTokenTypeException(JwtTokenType expected, JwtTokenType actual) {
+        super(String.format(MESSAGE, expected, actual));
+    }
+}

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/utility/jwt/exception/InvalidOAuth2VendorException.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/utility/jwt/exception/InvalidOAuth2VendorException.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.user.utility.jwt.exception;
+
+public class InvalidOAuth2VendorException extends IllegalArgumentException {
+    private static final String MESSAGE = "존재하지 않는 OAuth2 공급 업체입니다. issuer: %s";
+
+    public InvalidOAuth2VendorException(String issuer) {
+        super(String.format(MESSAGE, issuer));
+    }
+}

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/exception/GoogleOAuth2ResponseParsingException.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/exception/GoogleOAuth2ResponseParsingException.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.user.exception;
+
+public class GoogleOAuth2ResponseParsingException extends RuntimeException {
+    private static final String MESSAGE = "구글 로그인 서비스에서 줘야 할 걸 안 줌:\n%s";
+
+    public GoogleOAuth2ResponseParsingException(String responseBody, Throwable cause) {
+        super(String.format(MESSAGE, responseBody), cause);
+    }
+}

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/exception/TooManyOtherAddressesException.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/exception/TooManyOtherAddressesException.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.user.exception;
+
+public class TooManyOtherAddressesException extends IllegalArgumentException {
+    private static final String MESSAGE = "%s:: 기타 배송지는 최대 %d개까지 등록할 수 있습니다.";
+
+    public TooManyOtherAddressesException(String code, long maxCount) {
+        super(String.format(MESSAGE, code, maxCount));
+    }
+}

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/security/token/support/RestTemplateGoogleTokenProcessor.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/security/token/support/RestTemplateGoogleTokenProcessor.java
@@ -3,6 +3,7 @@ package com.personal.marketnote.user.security.token.support;
 import com.personal.marketnote.common.domain.exception.token.InvalidAccessTokenException;
 import com.personal.marketnote.common.domain.exception.token.InvalidRefreshTokenException;
 import com.personal.marketnote.common.domain.exception.token.UnsupportedCodeException;
+import com.personal.marketnote.user.exception.GoogleOAuth2ResponseParsingException;
 import com.personal.marketnote.user.security.token.dto.GrantedTokenInfo;
 import com.personal.marketnote.user.security.token.dto.OAuth2AuthenticationInfo;
 import com.personal.marketnote.user.security.token.dto.OAuth2UserInfo;
@@ -130,7 +131,7 @@ public class RestTemplateGoogleTokenProcessor implements TokenProcessor {
                     .name(jsonObject.getString("name"))
                     .build();
         } catch (JSONException e) {
-            throw new RuntimeException("구글 로그인 서비스에서 줘야 할 걸 안 줌:\n" + jsonObject, e);
+            throw new GoogleOAuth2ResponseParsingException(jsonObject.toString(), e);
         }
     }
 

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/service/shippingaddress/RegisterShippingAddressService.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/service/shippingaddress/RegisterShippingAddressService.java
@@ -12,6 +12,7 @@ import com.personal.marketnote.user.port.in.usecase.shippingaddress.RegisterShip
 import com.personal.marketnote.user.port.out.shippingaddress.FindShippingAddressPort;
 import com.personal.marketnote.user.port.out.shippingaddress.SaveShippingAddressPort;
 import com.personal.marketnote.user.port.out.shippingaddress.UpdateShippingAddressPort;
+import com.personal.marketnote.user.exception.TooManyOtherAddressesException;
 import jakarta.persistence.EntityExistsException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
@@ -92,9 +93,7 @@ public class RegisterShippingAddressService implements RegisterShippingAddressUs
             case OTHER -> {
                 long count = findShippingAddressPort.countByUserIdAndAddressType(userId, ShippingAddressType.OTHER);
                 if (count >= MAX_OTHER_ADDRESS_COUNT) {
-                    throw new IllegalArgumentException(
-                            String.format("%s:: 기타 배송지는 최대 %d개까지 등록할 수 있습니다.", SECOND_ERROR_CODE, MAX_OTHER_ADDRESS_COUNT)
-                    );
+                    throw new TooManyOtherAddressesException(SECOND_ERROR_CODE, MAX_OTHER_ADDRESS_COUNT);
                 }
             }
         }

--- a/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/shippingaddress/ShippingAddress.java
+++ b/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/shippingaddress/ShippingAddress.java
@@ -2,6 +2,10 @@ package com.personal.marketnote.user.domain.shippingaddress;
 
 import com.personal.marketnote.common.domain.BaseDomain;
 import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.user.domain.shippingaddress.exception.DeliveryRequestMessageNoValueException;
+import com.personal.marketnote.user.domain.shippingaddress.exception.InvalidDeliveryRequestMessageLengthException;
+import com.personal.marketnote.user.domain.shippingaddress.exception.InvalidShippingAddressDeletionException;
+import com.personal.marketnote.user.domain.shippingaddress.exception.ShippingAddressCompanyNameNoValueException;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -76,10 +80,10 @@ public class ShippingAddress extends BaseDomain {
 
     public void delete() {
         if (addressType == ShippingAddressType.HOME) {
-            throw new IllegalArgumentException("집 배송지는 삭제할 수 없습니다.");
+            throw new InvalidShippingAddressDeletionException("집 배송지는 삭제할 수 없습니다.");
         }
         if (isDefault) {
-            throw new IllegalArgumentException("기본 배송지는 삭제할 수 없습니다. 다른 배송지를 기본으로 설정한 후 삭제해주세요.");
+            throw new InvalidShippingAddressDeletionException("기본 배송지는 삭제할 수 없습니다. 다른 배송지를 기본으로 설정한 후 삭제해주세요.");
         }
         deactivate();
     }
@@ -107,7 +111,7 @@ public class ShippingAddress extends BaseDomain {
 
     private void validate() {
         if (addressType == ShippingAddressType.COMPANY && FormatValidator.hasNoValue(companyName)) {
-            throw new IllegalArgumentException("회사 배송지에는 회사명이 필수입니다.");
+            throw new ShippingAddressCompanyNameNoValueException();
         }
 
         if (FormatValidator.hasNoValue(deliveryRequestType) || !deliveryRequestType.isCustom()) {
@@ -116,11 +120,11 @@ public class ShippingAddress extends BaseDomain {
         }
 
         if (FormatValidator.hasNoValue(deliveryRequestMessage)) {
-            throw new IllegalArgumentException("직접입력 선택 시 배송 요청사항 메시지는 필수입니다.");
+            throw new DeliveryRequestMessageNoValueException();
         }
 
         if (deliveryRequestMessage.length() > 60) {
-            throw new IllegalArgumentException("배송 요청사항 메시지는 최대 60자까지 입력할 수 있습니다.");
+            throw new InvalidDeliveryRequestMessageLengthException();
         }
     }
 }

--- a/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/shippingaddress/exception/DeliveryRequestMessageNoValueException.java
+++ b/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/shippingaddress/exception/DeliveryRequestMessageNoValueException.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.user.domain.shippingaddress.exception;
+
+public class DeliveryRequestMessageNoValueException extends IllegalArgumentException {
+
+    public DeliveryRequestMessageNoValueException() {
+        super("직접입력 선택 시 배송 요청사항 메시지는 필수입니다.");
+    }
+}

--- a/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/shippingaddress/exception/InvalidDeliveryRequestMessageLengthException.java
+++ b/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/shippingaddress/exception/InvalidDeliveryRequestMessageLengthException.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.user.domain.shippingaddress.exception;
+
+public class InvalidDeliveryRequestMessageLengthException extends IllegalArgumentException {
+
+    public InvalidDeliveryRequestMessageLengthException() {
+        super("배송 요청사항 메시지는 최대 60자까지 입력할 수 있습니다.");
+    }
+}

--- a/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/shippingaddress/exception/InvalidShippingAddressDeletionException.java
+++ b/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/shippingaddress/exception/InvalidShippingAddressDeletionException.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.user.domain.shippingaddress.exception;
+
+public class InvalidShippingAddressDeletionException extends IllegalArgumentException {
+
+    public InvalidShippingAddressDeletionException(String message) {
+        super(message);
+    }
+}

--- a/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/shippingaddress/exception/ShippingAddressCompanyNameNoValueException.java
+++ b/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/shippingaddress/exception/ShippingAddressCompanyNameNoValueException.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.user.domain.shippingaddress.exception;
+
+public class ShippingAddressCompanyNameNoValueException extends IllegalArgumentException {
+
+    public ShippingAddressCompanyNameNoValueException() {
+        super("회사 배송지에는 회사명이 필수입니다.");
+    }
+}


### PR DESCRIPTION
## partially addresses #43
## resolves #988

## Task
- [x] ShippingAddress.java: IllegalArgumentException → InvalidShippingAddressDeletionException, ShippingAddressCompanyNameNoValueException, DeliveryRequestMessageNoValueException, InvalidDeliveryRequestMessageLengthException
- [x] RegisterShippingAddressService.java: IllegalArgumentException → TooManyOtherAddressesException
- [x] JwtUtil.java: IllegalArgumentException → InvalidOAuth2VendorException, InvalidJwtTokenTypeException, InvalidJwtGenerationParametersException
- [x] UserController.java: IllegalStateException → HashAlgorithmNotAvailableException
- [x] AuthenticationController.java: IllegalStateException → HashAlgorithmNotAvailableException
- [x] WebBasedAuthenticationServiceAdapter.java: IllegalStateException → HashAlgorithmNotAvailableException
- [x] RestTemplateGoogleTokenProcessor.java: RuntimeException → GoogleOAuth2ResponseParsingException