### PR TITLE
[#216][#989] refactor: 제네릭 예외를 도메인 커스텀 예외로 전환 - 커머스 서비스

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/vendor/kcp/KcpCertificateLoader.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/vendor/kcp/KcpCertificateLoader.java
@@ -1,5 +1,10 @@
 package com.personal.marketnote.commerce.adapter.out.vendor.kcp;
 
+import com.personal.marketnote.commerce.adapter.out.vendor.kcp.exception.InvalidKcpCertificatePathException;
+import com.personal.marketnote.commerce.adapter.out.vendor.kcp.exception.KcpCertificateLoadFailedException;
+import com.personal.marketnote.commerce.adapter.out.vendor.kcp.exception.KcpCertificatePathNotConfiguredException;
+import com.personal.marketnote.commerce.adapter.out.vendor.kcp.exception.KcpPrivateKeyLoadFailedException;
+import com.personal.marketnote.commerce.adapter.out.vendor.kcp.exception.KcpPrivateKeyPathNotConfiguredException;
 import com.personal.marketnote.commerce.configuration.KcpProperties;
 import com.personal.marketnote.common.utility.FormatValidator;
 import lombok.RequiredArgsConstructor;
@@ -26,20 +31,20 @@ public class KcpCertificateLoader {
     public String loadCertInfo() {
         String certInfoPath = kcpProperties.getCertInfoPath();
         if (FormatValidator.hasNoValue(certInfoPath)) {
-            throw new IllegalStateException("KCP 인증서 경로(kcp.cert-info-path)가 설정되지 않았습니다");
+            throw new KcpCertificatePathNotConfiguredException();
         }
 
         try {
             return readContent(certInfoPath);
         } catch (IOException e) {
-            throw new IllegalStateException("KCP 인증서 파일 로드 실패: " + certInfoPath, e);
+            throw new KcpCertificateLoadFailedException(certInfoPath, e);
         }
     }
 
     public PrivateKey loadPrivateKey() {
         String privateKeyPath = kcpProperties.getPrivateKeyPath();
         if (FormatValidator.hasNoValue(privateKeyPath)) {
-            throw new IllegalStateException("KCP 개인키 경로(kcp.private-key-path)가 설정되지 않았습니다");
+            throw new KcpPrivateKeyPathNotConfiguredException();
         }
 
         try {
@@ -54,13 +59,13 @@ public class KcpCertificateLoader {
             KeyFactory keyFactory = KeyFactory.getInstance("RSA");
             return keyFactory.generatePrivate(keySpec);
         } catch (Exception e) {
-            throw new IllegalStateException("KCP 개인키 파일 로드 실패: " + privateKeyPath, e);
+            throw new KcpPrivateKeyLoadFailedException(privateKeyPath, e);
         }
     }
 
     private String readContent(String path) throws IOException {
         if (path.contains("..")) {
-            throw new IllegalStateException("잘못된 인증서 경로입니다: " + path);
+            throw new InvalidKcpCertificatePathException(path);
         }
 
         if (path.startsWith(CLASSPATH_PREFIX)) {

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/vendor/kcp/KcpSignatureGenerator.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/vendor/kcp/KcpSignatureGenerator.java
@@ -1,5 +1,6 @@
 package com.personal.marketnote.commerce.adapter.out.vendor.kcp;
 
+import com.personal.marketnote.commerce.adapter.out.vendor.kcp.exception.KcpSignatureGenerationFailedException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -24,7 +25,7 @@ public class KcpSignatureGenerator {
             byte[] signedBytes = signature.sign();
             return Base64.getEncoder().encodeToString(signedBytes);
         } catch (Exception e) {
-            throw new IllegalStateException("KCP 서명 생성 실패: tno=" + tno, e);
+            throw new KcpSignatureGenerationFailedException(tno, e);
         }
     }
 }

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/vendor/kcp/exception/InvalidKcpCertificatePathException.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/vendor/kcp/exception/InvalidKcpCertificatePathException.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.commerce.adapter.out.vendor.kcp.exception;
+
+public class InvalidKcpCertificatePathException extends IllegalStateException {
+    public InvalidKcpCertificatePathException(String path) {
+        super("잘못된 인증서 경로입니다: " + path);
+    }
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/vendor/kcp/exception/KcpCertificateLoadFailedException.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/vendor/kcp/exception/KcpCertificateLoadFailedException.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.commerce.adapter.out.vendor.kcp.exception;
+
+public class KcpCertificateLoadFailedException extends IllegalStateException {
+    public KcpCertificateLoadFailedException(String certInfoPath, Throwable cause) {
+        super("KCP 인증서 파일 로드 실패: " + certInfoPath, cause);
+    }
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/vendor/kcp/exception/KcpCertificatePathNotConfiguredException.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/vendor/kcp/exception/KcpCertificatePathNotConfiguredException.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.commerce.adapter.out.vendor.kcp.exception;
+
+public class KcpCertificatePathNotConfiguredException extends IllegalStateException {
+    public KcpCertificatePathNotConfiguredException() {
+        super("KCP 인증서 경로(kcp.cert-info-path)가 설정되지 않았습니다");
+    }
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/vendor/kcp/exception/KcpPrivateKeyLoadFailedException.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/vendor/kcp/exception/KcpPrivateKeyLoadFailedException.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.commerce.adapter.out.vendor.kcp.exception;
+
+public class KcpPrivateKeyLoadFailedException extends IllegalStateException {
+    public KcpPrivateKeyLoadFailedException(String privateKeyPath, Throwable cause) {
+        super("KCP 개인키 파일 로드 실패: " + privateKeyPath, cause);
+    }
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/vendor/kcp/exception/KcpPrivateKeyPathNotConfiguredException.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/vendor/kcp/exception/KcpPrivateKeyPathNotConfiguredException.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.commerce.adapter.out.vendor.kcp.exception;
+
+public class KcpPrivateKeyPathNotConfiguredException extends IllegalStateException {
+    public KcpPrivateKeyPathNotConfiguredException() {
+        super("KCP 개인키 경로(kcp.private-key-path)가 설정되지 않았습니다");
+    }
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/vendor/kcp/exception/KcpSignatureGenerationFailedException.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/vendor/kcp/exception/KcpSignatureGenerationFailedException.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.commerce.adapter.out.vendor.kcp.exception;
+
+public class KcpSignatureGenerationFailedException extends IllegalStateException {
+    public KcpSignatureGenerationFailedException(String tno, Throwable cause) {
+        super("KCP 서명 생성 실패: tno=" + tno, cause);
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/exception/InvalidOrderDateRangeException.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/exception/InvalidOrderDateRangeException.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.commerce.exception;
+
+public class InvalidOrderDateRangeException extends IllegalArgumentException {
+    public InvalidOrderDateRangeException() {
+        super("종료일은 시작일 이후여야 합니다.");
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/command/order/GetAdminOrdersQuery.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/command/order/GetAdminOrdersQuery.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.commerce.port.in.command.order;
 
 import com.personal.marketnote.commerce.domain.order.OrderStatus;
+import com.personal.marketnote.commerce.exception.InvalidOrderDateRangeException;
 import com.personal.marketnote.common.utility.FormatValidator;
 
 import java.time.LocalDateTime;
@@ -20,7 +21,7 @@ public record GetAdminOrdersQuery(
         if (FormatValidator.hasValue(startDate)
                 && FormatValidator.hasValue(endDate)
                 && endDate.isBefore(startDate)) {
-            throw new IllegalArgumentException("종료일은 시작일 이후여야 합니다.");
+            throw new InvalidOrderDateRangeException();
         }
         return new GetAdminOrdersQuery(sellerId, startDate, endDate, orderStatus);
     }

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/GetAdminOrdersUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/GetAdminOrdersUseCaseTest.java
@@ -4,6 +4,7 @@ import com.personal.marketnote.commerce.domain.order.Order;
 import com.personal.marketnote.commerce.domain.order.OrderProductSnapshotState;
 import com.personal.marketnote.commerce.domain.order.OrderSnapshotState;
 import com.personal.marketnote.commerce.domain.order.OrderStatus;
+import com.personal.marketnote.commerce.exception.InvalidOrderDateRangeException;
 import com.personal.marketnote.commerce.port.in.command.order.GetAdminOrdersQuery;
 import com.personal.marketnote.commerce.port.in.result.order.GetAdminOrdersResult;
 import com.personal.marketnote.commerce.port.out.order.FindOrderPort;
@@ -296,7 +297,7 @@ class GetAdminOrdersUseCaseTest {
     }
 
     @Test
-    @DisplayName("endDate가 startDate보다 이전이면 IllegalArgumentException이 발생한다")
+    @DisplayName("endDate가 startDate보다 이전이면 InvalidOrderDateRangeException이 발생한다")
     void shouldThrowWhenEndDateBeforeStartDate() {
         // given
         LocalDateTime startDate = LocalDateTime.of(2026, 2, 28, 0, 0);
@@ -304,7 +305,7 @@ class GetAdminOrdersUseCaseTest {
 
         // when & then
         assertThatThrownBy(() -> GetAdminOrdersQuery.of(null, startDate, endDate, null))
-                .isInstanceOf(IllegalArgumentException.class)
+                .isInstanceOf(InvalidOrderDateRangeException.class)
                 .hasMessageContaining("종료일은 시작일 이후여야 합니다");
     }
 

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/refund/InvalidRefundAmountException.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/refund/InvalidRefundAmountException.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.commerce.domain.refund;
+
+public class InvalidRefundAmountException extends IllegalArgumentException {
+    public InvalidRefundAmountException() {
+        super("환불 금액은 0보다 커야 합니다");
+    }
+}

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/refund/Refund.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/refund/Refund.java
@@ -36,7 +36,10 @@ public class Refund {
      *
      * @param state 환불 생성 상태 객체
      * @return 새 환불 도메인 객체
-     * @throws IllegalArgumentException 환불 금액이 0 이하이거나, 환불 유형 또는 결제 ID가 null인 경우
+     * @throws RefundPaymentIdNoValueException 결제 ID가 null인 경우
+     * @throws RefundOrderIdNoValueException 주문 ID가 null인 경우
+     * @throws RefundTypeNoValueException 환불 유형이 null인 경우
+     * @throws InvalidRefundAmountException 환불 금액이 0 이하인 경우
      */
     public static Refund from(RefundCreateState state) {
         validate(state);
@@ -93,16 +96,16 @@ public class Refund {
 
     private static void validate(RefundCreateState state) {
         if (FormatValidator.hasNoValue(state.getPaymentId())) {
-            throw new IllegalArgumentException("결제 ID는 필수입니다");
+            throw new RefundPaymentIdNoValueException();
         }
         if (FormatValidator.hasNoValue(state.getOrderId())) {
-            throw new IllegalArgumentException("주문 ID는 필수입니다");
+            throw new RefundOrderIdNoValueException();
         }
         if (FormatValidator.hasNoValue(state.getRefundType())) {
-            throw new IllegalArgumentException("환불 유형은 필수입니다");
+            throw new RefundTypeNoValueException();
         }
         if (FormatValidator.hasNoValue(state.getRefundAmount()) || state.getRefundAmount() <= 0) {
-            throw new IllegalArgumentException("환불 금액은 0보다 커야 합니다");
+            throw new InvalidRefundAmountException();
         }
     }
 }

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/refund/RefundOrderIdNoValueException.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/refund/RefundOrderIdNoValueException.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.commerce.domain.refund;
+
+public class RefundOrderIdNoValueException extends IllegalArgumentException {
+    public RefundOrderIdNoValueException() {
+        super("주문 ID는 필수입니다");
+    }
+}

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/refund/RefundPaymentIdNoValueException.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/refund/RefundPaymentIdNoValueException.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.commerce.domain.refund;
+
+public class RefundPaymentIdNoValueException extends IllegalArgumentException {
+    public RefundPaymentIdNoValueException() {
+        super("결제 ID는 필수입니다");
+    }
+}

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/refund/RefundTypeNoValueException.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/refund/RefundTypeNoValueException.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.commerce.domain.refund;
+
+public class RefundTypeNoValueException extends IllegalArgumentException {
+    public RefundTypeNoValueException() {
+        super("환불 유형은 필수입니다");
+    }
+}

--- a/commerce-service/commerce-domain/src/test/java/com/personal/marketnote/commerce/domain/refund/RefundTest.java
+++ b/commerce-service/commerce-domain/src/test/java/com/personal/marketnote/commerce/domain/refund/RefundTest.java
@@ -72,7 +72,7 @@ class RefundTest {
     class CreateValidationFailureTest {
 
         @Test
-        @DisplayName("결제 ID가 null이면 IllegalArgumentException이 발생한다")
+        @DisplayName("결제 ID가 null이면 RefundPaymentIdNoValueException이 발생한다")
         void shouldThrowWhenPaymentIdIsNull() {
             // given
             RefundCreateState state = RefundCreateState.builder()
@@ -84,12 +84,12 @@ class RefundTest {
 
             // when & then
             assertThatThrownBy(() -> Refund.from(state))
-                    .isInstanceOf(IllegalArgumentException.class)
+                    .isInstanceOf(RefundPaymentIdNoValueException.class)
                     .hasMessageContaining("결제 ID");
         }
 
         @Test
-        @DisplayName("주문 ID가 null이면 IllegalArgumentException이 발생한다")
+        @DisplayName("주문 ID가 null이면 RefundOrderIdNoValueException이 발생한다")
         void shouldThrowWhenOrderIdIsNull() {
             // given
             RefundCreateState state = RefundCreateState.builder()
@@ -101,12 +101,12 @@ class RefundTest {
 
             // when & then
             assertThatThrownBy(() -> Refund.from(state))
-                    .isInstanceOf(IllegalArgumentException.class)
+                    .isInstanceOf(RefundOrderIdNoValueException.class)
                     .hasMessageContaining("주문 ID");
         }
 
         @Test
-        @DisplayName("환불 유형이 null이면 IllegalArgumentException이 발생한다")
+        @DisplayName("환불 유형이 null이면 RefundTypeNoValueException이 발생한다")
         void shouldThrowWhenRefundTypeIsNull() {
             // given
             RefundCreateState state = RefundCreateState.builder()
@@ -118,12 +118,12 @@ class RefundTest {
 
             // when & then
             assertThatThrownBy(() -> Refund.from(state))
-                    .isInstanceOf(IllegalArgumentException.class)
+                    .isInstanceOf(RefundTypeNoValueException.class)
                     .hasMessageContaining("환불 유형");
         }
 
         @Test
-        @DisplayName("환불 금액이 null이면 IllegalArgumentException이 발생한다")
+        @DisplayName("환불 금액이 null이면 InvalidRefundAmountException이 발생한다")
         void shouldThrowWhenRefundAmountIsNull() {
             // given
             RefundCreateState state = RefundCreateState.builder()
@@ -135,12 +135,12 @@ class RefundTest {
 
             // when & then
             assertThatThrownBy(() -> Refund.from(state))
-                    .isInstanceOf(IllegalArgumentException.class)
+                    .isInstanceOf(InvalidRefundAmountException.class)
                     .hasMessageContaining("환불 금액");
         }
 
         @Test
-        @DisplayName("환불 금액이 0이면 IllegalArgumentException이 발생한다")
+        @DisplayName("환불 금액이 0이면 InvalidRefundAmountException이 발생한다")
         void shouldThrowWhenRefundAmountIsZero() {
             // given
             RefundCreateState state = RefundCreateState.builder()
@@ -152,12 +152,12 @@ class RefundTest {
 
             // when & then
             assertThatThrownBy(() -> Refund.from(state))
-                    .isInstanceOf(IllegalArgumentException.class)
+                    .isInstanceOf(InvalidRefundAmountException.class)
                     .hasMessageContaining("환불 금액");
         }
 
         @Test
-        @DisplayName("환불 금액이 음수이면 IllegalArgumentException이 발생한다")
+        @DisplayName("환불 금액이 음수이면 InvalidRefundAmountException이 발생한다")
         void shouldThrowWhenRefundAmountIsNegative() {
             // given
             RefundCreateState state = RefundCreateState.builder()
@@ -169,7 +169,7 @@ class RefundTest {
 
             // when & then
             assertThatThrownBy(() -> Refund.from(state))
-                    .isInstanceOf(IllegalArgumentException.class)
+                    .isInstanceOf(InvalidRefundAmountException.class)
                     .hasMessageContaining("환불 금액");
         }
     }

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/exception/HashAlgorithmNotAvailableException.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/exception/HashAlgorithmNotAvailableException.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.user.adapter.exception;
+
+public class HashAlgorithmNotAvailableException extends IllegalStateException {
+    private static final String MESSAGE = "SHA-256 algorithm not available";
+
+    public HashAlgorithmNotAvailableException(Throwable cause) {
+        super(MESSAGE, cause);
+    }
+}

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/authentication/controller/AuthenticationController.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/authentication/controller/AuthenticationController.java
@@ -3,6 +3,7 @@ package com.personal.marketnote.user.adapter.in.web.authentication.controller;
 import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
 import com.personal.marketnote.common.domain.exception.token.UnsupportedCodeException;
 import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.user.adapter.exception.HashAlgorithmNotAvailableException;
 import com.personal.marketnote.user.adapter.in.web.authentication.controller.apidocs.Oauth2LoginApiDocs;
 import com.personal.marketnote.user.adapter.in.web.authentication.controller.apidocs.RefreshAccessTokenApiDocs;
 import com.personal.marketnote.user.adapter.in.web.authentication.controller.apidocs.SendEmailVerificationApiDocs;
@@ -159,7 +160,7 @@ public class AuthenticationController {
             }
             return hexString.toString();
         } catch (NoSuchAlgorithmException e) {
-            throw new IllegalStateException("SHA-256 algorithm not available", e);
+            throw new HashAlgorithmNotAvailableException(e);
         }
     }
 

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/user/controller/UserController.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/user/controller/UserController.java
@@ -5,6 +5,7 @@ import com.personal.marketnote.common.utility.ElementExtractor;
 import com.personal.marketnote.common.utility.FormatConverter;
 import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.common.utility.RegularExpressionConstant;
+import com.personal.marketnote.user.adapter.exception.HashAlgorithmNotAvailableException;
 import com.personal.marketnote.user.adapter.in.web.user.controller.apidocs.*;
 import com.personal.marketnote.user.adapter.in.web.user.mapper.UserRequestToCommandMapper;
 import com.personal.marketnote.user.adapter.in.web.user.request.SignInRequest;
@@ -255,7 +256,7 @@ public class UserController {
             }
             return hexString.toString();
         } catch (NoSuchAlgorithmException e) {
-            throw new IllegalStateException("SHA-256 algorithm not available", e);
+            throw new HashAlgorithmNotAvailableException(e);
         }
     }
 

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/out/vendor/authentication/WebBasedAuthenticationServiceAdapter.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/out/vendor/authentication/WebBasedAuthenticationServiceAdapter.java
@@ -4,6 +4,7 @@ import com.personal.marketnote.common.adapter.out.SecurityAdapter;
 import com.personal.marketnote.common.domain.exception.token.InvalidRefreshTokenException;
 import com.personal.marketnote.common.utility.FormatConverter;
 import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.user.adapter.exception.HashAlgorithmNotAvailableException;
 import com.personal.marketnote.common.utility.http.cookie.HttpCookieName;
 import com.personal.marketnote.common.utility.http.cookie.HttpCookieObject;
 import com.personal.marketnote.common.utility.http.cookie.HttpCookieUtils;
@@ -174,7 +175,7 @@ public class WebBasedAuthenticationServiceAdapter {
             }
             return hexString.toString();
         } catch (NoSuchAlgorithmException e) {
-            throw new IllegalStateException("SHA-256 algorithm not available", e);
+            throw new HashAlgorithmNotAvailableException(e);
         }
     }
 }

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/utility/jwt/JwtUtil.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/utility/jwt/JwtUtil.java
@@ -3,6 +3,9 @@ package com.personal.marketnote.user.utility.jwt;
 import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.user.security.token.vendor.AuthVendor;
 import com.personal.marketnote.user.utility.jwt.claims.TokenClaims;
+import com.personal.marketnote.user.utility.jwt.exception.InvalidJwtGenerationParametersException;
+import com.personal.marketnote.user.utility.jwt.exception.InvalidJwtTokenTypeException;
+import com.personal.marketnote.user.utility.jwt.exception.InvalidOAuth2VendorException;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.jackson.io.JacksonDeserializer;
 import org.springframework.beans.factory.annotation.Value;
@@ -111,14 +114,13 @@ public class JwtUtil {
             return apple.toUpperCase();
         }
 
-        throw new IllegalArgumentException("존재하지 않는 OAuth2 공급 업체입니다. issuer: " + iss);
+        throw new InvalidOAuth2VendorException(iss);
     }
 
     private JwtTokenType extractTokenType(Claims claims, JwtTokenType expectedTokenType) {
         JwtTokenType fromClaim = JwtTokenType.from(claims.get(TOKEN_TYPE_CLAIM_KEY, String.class));
         if (expectedTokenType != fromClaim) {
-            throw new IllegalArgumentException(
-                    String.format("Expected parsing %s, but just attempted to parse %s", expectedTokenType, fromClaim));
+            throw new InvalidJwtTokenTypeException(expectedTokenType, fromClaim);
         }
 
         return fromClaim;
@@ -145,7 +147,7 @@ public class JwtUtil {
         }
 
         if (!messages.isEmpty()) {
-            throw new IllegalArgumentException(String.join("\n", messages.toArray(new String[0])));
+            throw new InvalidJwtGenerationParametersException(String.join("\n", messages.toArray(new String[0])));
         }
     }
 

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/utility/jwt/exception/InvalidJwtGenerationParametersException.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/utility/jwt/exception/InvalidJwtGenerationParametersException.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.user.utility.jwt.exception;
+
+public class InvalidJwtGenerationParametersException extends IllegalArgumentException {
+
+    public InvalidJwtGenerationParametersException(String message) {
+        super(message);
+    }
+}

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/utility/jwt/exception/InvalidJwtTokenTypeException.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/utility/jwt/exception/InvalidJwtTokenTypeException.java
@@ -1,0 +1,11 @@
+package com.personal.marketnote.user.utility.jwt.exception;
+
+import com.personal.marketnote.user.utility.jwt.JwtTokenType;
+
+public class InvalidJwtTokenTypeException extends IllegalArgumentException {
+    private static final String MESSAGE = "Expected parsing %s, but just attempted to parse %s";
+
+    public InvalidJwtTokenTypeException(JwtTokenType expected, JwtTokenType actual) {
+        super(String.format(MESSAGE, expected, actual));
+    }
+}

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/utility/jwt/exception/InvalidOAuth2VendorException.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/utility/jwt/exception/InvalidOAuth2VendorException.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.user.utility.jwt.exception;
+
+public class InvalidOAuth2VendorException extends IllegalArgumentException {
+    private static final String MESSAGE = "존재하지 않는 OAuth2 공급 업체입니다. issuer: %s";
+
+    public InvalidOAuth2VendorException(String issuer) {
+        super(String.format(MESSAGE, issuer));
+    }
+}

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/exception/GoogleOAuth2ResponseParsingException.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/exception/GoogleOAuth2ResponseParsingException.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.user.exception;
+
+public class GoogleOAuth2ResponseParsingException extends RuntimeException {
+    private static final String MESSAGE = "구글 로그인 서비스에서 줘야 할 걸 안 줌:\n%s";
+
+    public GoogleOAuth2ResponseParsingException(String responseBody, Throwable cause) {
+        super(String.format(MESSAGE, responseBody), cause);
+    }
+}

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/exception/TooManyOtherAddressesException.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/exception/TooManyOtherAddressesException.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.user.exception;
+
+public class TooManyOtherAddressesException extends IllegalArgumentException {
+    private static final String MESSAGE = "%s:: 기타 배송지는 최대 %d개까지 등록할 수 있습니다.";
+
+    public TooManyOtherAddressesException(String code, long maxCount) {
+        super(String.format(MESSAGE, code, maxCount));
+    }
+}

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/security/token/support/RestTemplateGoogleTokenProcessor.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/security/token/support/RestTemplateGoogleTokenProcessor.java
@@ -3,6 +3,7 @@ package com.personal.marketnote.user.security.token.support;
 import com.personal.marketnote.common.domain.exception.token.InvalidAccessTokenException;
 import com.personal.marketnote.common.domain.exception.token.InvalidRefreshTokenException;
 import com.personal.marketnote.common.domain.exception.token.UnsupportedCodeException;
+import com.personal.marketnote.user.exception.GoogleOAuth2ResponseParsingException;
 import com.personal.marketnote.user.security.token.dto.GrantedTokenInfo;
 import com.personal.marketnote.user.security.token.dto.OAuth2AuthenticationInfo;
 import com.personal.marketnote.user.security.token.dto.OAuth2UserInfo;
@@ -130,7 +131,7 @@ public class RestTemplateGoogleTokenProcessor implements TokenProcessor {
                     .name(jsonObject.getString("name"))
                     .build();
         } catch (JSONException e) {
-            throw new RuntimeException("구글 로그인 서비스에서 줘야 할 걸 안 줌:\n" + jsonObject, e);
+            throw new GoogleOAuth2ResponseParsingException(jsonObject.toString(), e);
         }
     }
 

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/service/shippingaddress/RegisterShippingAddressService.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/service/shippingaddress/RegisterShippingAddressService.java
@@ -12,6 +12,7 @@ import com.personal.marketnote.user.port.in.usecase.shippingaddress.RegisterShip
 import com.personal.marketnote.user.port.out.shippingaddress.FindShippingAddressPort;
 import com.personal.marketnote.user.port.out.shippingaddress.SaveShippingAddressPort;
 import com.personal.marketnote.user.port.out.shippingaddress.UpdateShippingAddressPort;
+import com.personal.marketnote.user.exception.TooManyOtherAddressesException;
 import jakarta.persistence.EntityExistsException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
@@ -92,9 +93,7 @@ public class RegisterShippingAddressService implements RegisterShippingAddressUs
             case OTHER -> {
                 long count = findShippingAddressPort.countByUserIdAndAddressType(userId, ShippingAddressType.OTHER);
                 if (count >= MAX_OTHER_ADDRESS_COUNT) {
-                    throw new IllegalArgumentException(
-                            String.format("%s:: 기타 배송지는 최대 %d개까지 등록할 수 있습니다.", SECOND_ERROR_CODE, MAX_OTHER_ADDRESS_COUNT)
-                    );
+                    throw new TooManyOtherAddressesException(SECOND_ERROR_CODE, MAX_OTHER_ADDRESS_COUNT);
                 }
             }
         }

--- a/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/shippingaddress/ShippingAddress.java
+++ b/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/shippingaddress/ShippingAddress.java
@@ -2,6 +2,10 @@ package com.personal.marketnote.user.domain.shippingaddress;
 
 import com.personal.marketnote.common.domain.BaseDomain;
 import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.user.domain.shippingaddress.exception.DeliveryRequestMessageNoValueException;
+import com.personal.marketnote.user.domain.shippingaddress.exception.InvalidDeliveryRequestMessageLengthException;
+import com.personal.marketnote.user.domain.shippingaddress.exception.InvalidShippingAddressDeletionException;
+import com.personal.marketnote.user.domain.shippingaddress.exception.ShippingAddressCompanyNameNoValueException;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -76,10 +80,10 @@ public class ShippingAddress extends BaseDomain {
 
     public void delete() {
         if (addressType == ShippingAddressType.HOME) {
-            throw new IllegalArgumentException("집 배송지는 삭제할 수 없습니다.");
+            throw new InvalidShippingAddressDeletionException("집 배송지는 삭제할 수 없습니다.");
         }
         if (isDefault) {
-            throw new IllegalArgumentException("기본 배송지는 삭제할 수 없습니다. 다른 배송지를 기본으로 설정한 후 삭제해주세요.");
+            throw new InvalidShippingAddressDeletionException("기본 배송지는 삭제할 수 없습니다. 다른 배송지를 기본으로 설정한 후 삭제해주세요.");
         }
         deactivate();
     }
@@ -107,7 +111,7 @@ public class ShippingAddress extends BaseDomain {
 
     private void validate() {
         if (addressType == ShippingAddressType.COMPANY && FormatValidator.hasNoValue(companyName)) {
-            throw new IllegalArgumentException("회사 배송지에는 회사명이 필수입니다.");
+            throw new ShippingAddressCompanyNameNoValueException();
         }
 
         if (FormatValidator.hasNoValue(deliveryRequestType) || !deliveryRequestType.isCustom()) {
@@ -116,11 +120,11 @@ public class ShippingAddress extends BaseDomain {
         }
 
         if (FormatValidator.hasNoValue(deliveryRequestMessage)) {
-            throw new IllegalArgumentException("직접입력 선택 시 배송 요청사항 메시지는 필수입니다.");
+            throw new DeliveryRequestMessageNoValueException();
         }
 
         if (deliveryRequestMessage.length() > 60) {
-            throw new IllegalArgumentException("배송 요청사항 메시지는 최대 60자까지 입력할 수 있습니다.");
+            throw new InvalidDeliveryRequestMessageLengthException();
         }
     }
 }

--- a/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/shippingaddress/exception/DeliveryRequestMessageNoValueException.java
+++ b/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/shippingaddress/exception/DeliveryRequestMessageNoValueException.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.user.domain.shippingaddress.exception;
+
+public class DeliveryRequestMessageNoValueException extends IllegalArgumentException {
+
+    public DeliveryRequestMessageNoValueException() {
+        super("직접입력 선택 시 배송 요청사항 메시지는 필수입니다.");
+    }
+}

--- a/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/shippingaddress/exception/InvalidDeliveryRequestMessageLengthException.java
+++ b/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/shippingaddress/exception/InvalidDeliveryRequestMessageLengthException.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.user.domain.shippingaddress.exception;
+
+public class InvalidDeliveryRequestMessageLengthException extends IllegalArgumentException {
+
+    public InvalidDeliveryRequestMessageLengthException() {
+        super("배송 요청사항 메시지는 최대 60자까지 입력할 수 있습니다.");
+    }
+}

--- a/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/shippingaddress/exception/InvalidShippingAddressDeletionException.java
+++ b/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/shippingaddress/exception/InvalidShippingAddressDeletionException.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.user.domain.shippingaddress.exception;
+
+public class InvalidShippingAddressDeletionException extends IllegalArgumentException {
+
+    public InvalidShippingAddressDeletionException(String message) {
+        super(message);
+    }
+}

--- a/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/shippingaddress/exception/ShippingAddressCompanyNameNoValueException.java
+++ b/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/shippingaddress/exception/ShippingAddressCompanyNameNoValueException.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.user.domain.shippingaddress.exception;
+
+public class ShippingAddressCompanyNameNoValueException extends IllegalArgumentException {
+
+    public ShippingAddressCompanyNameNoValueException() {
+        super("회사 배송지에는 회사명이 필수입니다.");
+    }
+}


### PR DESCRIPTION
## partially addresses #216
## resolves #989

## Task
- [x] Refund.java — IllegalArgumentException ×4 → RefundPaymentIdNoValueException, RefundOrderIdNoValueException, RefundTypeNoValueException, InvalidRefundAmountException
- [x] GetAdminOrdersQuery.java — IllegalArgumentException → InvalidOrderDateRangeException
- [x] KcpSignatureGenerator.java — RuntimeException → KcpSignatureGenerationFailedException
- [x] KcpCertificateLoader.java — IllegalStateException ×5 → KcpCertificatePathNotConfiguredException, KcpCertificateLoadFailedException, KcpPrivateKeyPathNotConfiguredException, KcpPrivateKeyLoadFailedException, InvalidKcpCertificatePathException