### PR TITLE
[#128][#990] refactor: 제네릭 예외를 도메인 커스텀 예외로 전환 - 상품 서비스

### DIFF
--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/exception/FulfillmentVendorGoodsCustomCodeNoValueException.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/exception/FulfillmentVendorGoodsCustomCodeNoValueException.java
@@ -1,0 +1,11 @@
+package com.personal.marketnote.product.exception;
+
+import com.personal.marketnote.common.domain.exception.illegalargument.novalue.NoValueException;
+
+public class FulfillmentVendorGoodsCustomCodeNoValueException extends NoValueException {
+    private static final String MESSAGE = "ERR_FULFILLMENT_GOODS_01::풀필먼트 상품 고객사 코드(cstGodCd)는 필수입니다.";
+
+    public FulfillmentVendorGoodsCustomCodeNoValueException() {
+        super(MESSAGE);
+    }
+}

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/exception/FulfillmentVendorGoodsGiftDivisionNoValueException.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/exception/FulfillmentVendorGoodsGiftDivisionNoValueException.java
@@ -1,0 +1,11 @@
+package com.personal.marketnote.product.exception;
+
+import com.personal.marketnote.common.domain.exception.illegalargument.novalue.NoValueException;
+
+public class FulfillmentVendorGoodsGiftDivisionNoValueException extends NoValueException {
+    private static final String MESSAGE = "ERR_FULFILLMENT_GOODS_04::풀필먼트 상품 선물 구분(giftDiv)은 필수입니다.";
+
+    public FulfillmentVendorGoodsGiftDivisionNoValueException() {
+        super(MESSAGE);
+    }
+}

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/exception/FulfillmentVendorGoodsNameNoValueException.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/exception/FulfillmentVendorGoodsNameNoValueException.java
@@ -1,0 +1,11 @@
+package com.personal.marketnote.product.exception;
+
+import com.personal.marketnote.common.domain.exception.illegalargument.novalue.NoValueException;
+
+public class FulfillmentVendorGoodsNameNoValueException extends NoValueException {
+    private static final String MESSAGE = "ERR_FULFILLMENT_GOODS_02::풀필먼트 상품명(godNm)은 필수입니다.";
+
+    public FulfillmentVendorGoodsNameNoValueException() {
+        super(MESSAGE);
+    }
+}

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/exception/FulfillmentVendorGoodsTypeNoValueException.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/exception/FulfillmentVendorGoodsTypeNoValueException.java
@@ -1,0 +1,11 @@
+package com.personal.marketnote.product.exception;
+
+import com.personal.marketnote.common.domain.exception.illegalargument.novalue.NoValueException;
+
+public class FulfillmentVendorGoodsTypeNoValueException extends NoValueException {
+    private static final String MESSAGE = "ERR_FULFILLMENT_GOODS_03::풀필먼트 상품 유형(godType)은 필수입니다.";
+
+    public FulfillmentVendorGoodsTypeNoValueException() {
+        super(MESSAGE);
+    }
+}

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/exception/InvalidProductCategoryException.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/exception/InvalidProductCategoryException.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.product.exception;
+
+public class InvalidProductCategoryException extends IllegalArgumentException {
+    private static final String MESSAGE = "ERR_PRODUCT_CATEGORY_01::비활성 상태이거나 존재하지 않는 카테고리 ID가 포함되어 있습니다.";
+
+    public InvalidProductCategoryException() {
+        super(MESSAGE);
+    }
+}

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/out/fulfillment/RegisterFulfillmentVendorGoodsCommand.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/out/fulfillment/RegisterFulfillmentVendorGoodsCommand.java
@@ -1,6 +1,10 @@
 package com.personal.marketnote.product.port.out.fulfillment;
 
 import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.product.exception.FulfillmentVendorGoodsCustomCodeNoValueException;
+import com.personal.marketnote.product.exception.FulfillmentVendorGoodsGiftDivisionNoValueException;
+import com.personal.marketnote.product.exception.FulfillmentVendorGoodsNameNoValueException;
+import com.personal.marketnote.product.exception.FulfillmentVendorGoodsTypeNoValueException;
 import lombok.Builder;
 
 @Builder
@@ -43,16 +47,16 @@ public record RegisterFulfillmentVendorGoodsCommand(
 ) {
     public RegisterFulfillmentVendorGoodsCommand {
         if (FormatValidator.hasNoValue(cstGodCd)) {
-            throw new IllegalArgumentException("cstGodCd is required for Fassto goods registration.");
+            throw new FulfillmentVendorGoodsCustomCodeNoValueException();
         }
         if (FormatValidator.hasNoValue(godNm)) {
-            throw new IllegalArgumentException("godNm is required for Fassto goods registration.");
+            throw new FulfillmentVendorGoodsNameNoValueException();
         }
         if (FormatValidator.hasNoValue(godType)) {
-            throw new IllegalArgumentException("godType is required for Fassto goods registration.");
+            throw new FulfillmentVendorGoodsTypeNoValueException();
         }
         if (FormatValidator.hasNoValue(giftDiv)) {
-            throw new IllegalArgumentException("giftDiv is required for Fassto goods registration.");
+            throw new FulfillmentVendorGoodsGiftDivisionNoValueException();
         }
     }
 }

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/out/fulfillment/UpdateFulfillmentVendorGoodsCommand.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/out/fulfillment/UpdateFulfillmentVendorGoodsCommand.java
@@ -1,6 +1,10 @@
 package com.personal.marketnote.product.port.out.fulfillment;
 
 import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.product.exception.FulfillmentVendorGoodsCustomCodeNoValueException;
+import com.personal.marketnote.product.exception.FulfillmentVendorGoodsGiftDivisionNoValueException;
+import com.personal.marketnote.product.exception.FulfillmentVendorGoodsNameNoValueException;
+import com.personal.marketnote.product.exception.FulfillmentVendorGoodsTypeNoValueException;
 import lombok.Builder;
 
 @Builder
@@ -43,16 +47,16 @@ public record UpdateFulfillmentVendorGoodsCommand(
 ) {
     public UpdateFulfillmentVendorGoodsCommand {
         if (FormatValidator.hasNoValue(cstGodCd)) {
-            throw new IllegalArgumentException("cstGodCd is required for Fassto goods update.");
+            throw new FulfillmentVendorGoodsCustomCodeNoValueException();
         }
         if (FormatValidator.hasNoValue(godNm)) {
-            throw new IllegalArgumentException("godNm is required for Fassto goods update.");
+            throw new FulfillmentVendorGoodsNameNoValueException();
         }
         if (FormatValidator.hasNoValue(godType)) {
-            throw new IllegalArgumentException("godType is required for Fassto goods update.");
+            throw new FulfillmentVendorGoodsTypeNoValueException();
         }
         if (FormatValidator.hasNoValue(giftDiv)) {
-            throw new IllegalArgumentException("giftDiv is required for Fassto goods update.");
+            throw new FulfillmentVendorGoodsGiftDivisionNoValueException();
         }
     }
 }

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/service/category/RegisterProductCategoriesService.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/service/category/RegisterProductCategoriesService.java
@@ -3,6 +3,7 @@ package com.personal.marketnote.product.service.category;
 import com.personal.marketnote.common.application.UseCase;
 import com.personal.marketnote.product.domain.category.Category;
 import com.personal.marketnote.product.domain.product.Product;
+import com.personal.marketnote.product.exception.InvalidProductCategoryException;
 import com.personal.marketnote.product.exception.NotProductOwnerException;
 import com.personal.marketnote.product.port.in.command.RegisterProductCategoriesCommand;
 import com.personal.marketnote.product.port.in.result.category.RegisterProductCategoriesResult;
@@ -47,7 +48,7 @@ public class RegisterProductCategoriesService implements RegisterProductCategori
         Set<Long> foundIds = foundCategories.stream().map(Category::getId).collect(Collectors.toSet());
 
         if (!foundIds.containsAll(categoryIds)) {
-            throw new IllegalArgumentException("ERR02::비활성 상태이거나 존재하지 않는 카테고리 ID가 포함되어 있습니다.");
+            throw new InvalidProductCategoryException();
         }
 
         replaceProductCategoriesPort.replaceProductCategories(product.getId(), categoryIds);

--- a/product-service/product-application/src/test/java/com/personal/marketnote/product/service/category/RegisterProductCategoriesUseCaseTest.java
+++ b/product-service/product-application/src/test/java/com/personal/marketnote/product/service/category/RegisterProductCategoriesUseCaseTest.java
@@ -5,6 +5,7 @@ import com.personal.marketnote.product.domain.category.Category;
 import com.personal.marketnote.product.domain.category.CategorySnapshotState;
 import com.personal.marketnote.product.domain.product.Product;
 import com.personal.marketnote.product.domain.product.ProductSnapshotState;
+import com.personal.marketnote.product.exception.InvalidProductCategoryException;
 import com.personal.marketnote.product.exception.NotProductOwnerException;
 import com.personal.marketnote.product.port.in.command.RegisterProductCategoriesCommand;
 import com.personal.marketnote.product.port.in.result.category.RegisterProductCategoriesResult;
@@ -74,8 +75,8 @@ class RegisterProductCategoriesUseCaseTest {
                 .thenReturn(List.of(buildCategory(1L, "카테고리1"), buildCategory(2L, "카테고리2")));
 
         assertThatThrownBy(() -> registerProductCategoriesService.registerProductCategories(userId, false, command))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("ERR02");
+                .isInstanceOf(InvalidProductCategoryException.class)
+                .hasMessageContaining("ERR_PRODUCT_CATEGORY_01");
 
         verify(replaceProductCategoriesPort, never()).replaceProductCategories(anyLong(), any());
     }

--- a/product-service/product-application/src/test/java/com/personal/marketnote/product/service/product/RegisterProductUseCaseTest.java
+++ b/product-service/product-application/src/test/java/com/personal/marketnote/product/service/product/RegisterProductUseCaseTest.java
@@ -4,6 +4,7 @@ import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus
 import com.personal.marketnote.product.domain.product.Product;
 import com.personal.marketnote.product.domain.product.ProductSnapshotState;
 import com.personal.marketnote.product.domain.product.ProductTag;
+import com.personal.marketnote.product.exception.FulfillmentVendorGoodsTypeNoValueException;
 import com.personal.marketnote.product.exception.ProductInfoNoValueException;
 import com.personal.marketnote.product.port.in.command.FulfillmentVendorGoodsOptionCommand;
 import com.personal.marketnote.product.port.in.command.RegisterPricePolicyCommand;
@@ -193,7 +194,7 @@ class RegisterProductUseCaseTest {
         )).thenReturn(RegisterPricePolicyResult.of(300L));
 
         assertThatThrownBy(() -> registerProductService.registerProduct(command))
-                .isInstanceOf(IllegalArgumentException.class)
+                .isInstanceOf(FulfillmentVendorGoodsTypeNoValueException.class)
                 .hasMessageContaining("godType");
 
         verify(publishProductEventPort).publishProductRegisteredEvent(40L, 300L, command.sellerId(), "테스트 상품", "1");

--- a/product-service/product-application/src/test/java/com/personal/marketnote/product/service/product/UpdateProductUseCaseTest.java
+++ b/product-service/product-application/src/test/java/com/personal/marketnote/product/service/product/UpdateProductUseCaseTest.java
@@ -5,6 +5,7 @@ import com.personal.marketnote.common.kafka.event.ProductUpdatedEvent;
 import com.personal.marketnote.product.domain.product.Product;
 import com.personal.marketnote.product.domain.product.ProductSnapshotState;
 import com.personal.marketnote.product.domain.product.ProductTag;
+import com.personal.marketnote.product.exception.FulfillmentVendorGoodsTypeNoValueException;
 import com.personal.marketnote.product.exception.NotProductOwnerException;
 import com.personal.marketnote.product.exception.ProductInfoNoValueException;
 import com.personal.marketnote.product.exception.ProductNotFoundException;
@@ -177,7 +178,7 @@ class UpdateProductUseCaseTest {
         when(getProductUseCase.getProduct(50L)).thenReturn(product);
 
         assertThatThrownBy(() -> updateProductService.update(userId, false, command))
-                .isInstanceOf(IllegalArgumentException.class)
+                .isInstanceOf(FulfillmentVendorGoodsTypeNoValueException.class)
                 .hasMessageContaining("godType");
 
         verify(updateProductPort).update(product);


### PR DESCRIPTION
## partially addresses #128
## resolves #990

## Task
- [x] RegisterProductCategoriesService.java — IllegalArgumentException → InvalidProductCategoryException
- [x] RegisterFulfillmentVendorGoodsCommand.java — IllegalArgumentException ×4 → FulfillmentVendorGoodsCustomCodeNoValueException, FulfillmentVendorGoodsNameNoValueException, FulfillmentVendorGoodsTypeNoValueException, FulfillmentVendorGoodsGiftDivisionNoValueException
- [x] UpdateFulfillmentVendorGoodsCommand.java — IllegalArgumentException ×4 → 동일 예외 클래스 재사용