### PR TITLE
[#300][#991] refactor: 제네릭 예외를 도메인 커스텀 예외로 전환 - 커뮤니티 서비스

### DIFF
--- a/community-service/community-application/src/main/java/com/personal/marketnote/community/exception/InvalidBoardException.java
+++ b/community-service/community-application/src/main/java/com/personal/marketnote/community/exception/InvalidBoardException.java
@@ -1,0 +1,10 @@
+package com.personal.marketnote.community.exception;
+
+public class InvalidBoardException extends IllegalArgumentException {
+    private static final String INVALID_BOARD_EXCEPTION_MESSAGE
+            = "유효하지 않은 게시판입니다. 전송된 게시판: %s";
+
+    public InvalidBoardException(String board) {
+        super(String.format(INVALID_BOARD_EXCEPTION_MESSAGE, board));
+    }
+}

--- a/community-service/community-application/src/main/java/com/personal/marketnote/community/exception/PostBoardMismatchException.java
+++ b/community-service/community-application/src/main/java/com/personal/marketnote/community/exception/PostBoardMismatchException.java
@@ -1,0 +1,10 @@
+package com.personal.marketnote.community.exception;
+
+public class PostBoardMismatchException extends IllegalArgumentException {
+    private static final String POST_BOARD_MISMATCH_EXCEPTION_MESSAGE
+            = "요청한 게시판과 실제 게시판이 일치하지 않습니다.";
+
+    public PostBoardMismatchException() {
+        super(POST_BOARD_MISMATCH_EXCEPTION_MESSAGE);
+    }
+}

--- a/community-service/community-application/src/main/java/com/personal/marketnote/community/service/board/GetBoardService.java
+++ b/community-service/community-application/src/main/java/com/personal/marketnote/community/service/board/GetBoardService.java
@@ -2,6 +2,7 @@ package com.personal.marketnote.community.service.board;
 
 import com.personal.marketnote.common.application.UseCase;
 import com.personal.marketnote.community.domain.post.*;
+import com.personal.marketnote.community.exception.InvalidBoardException;
 import com.personal.marketnote.community.port.in.result.board.GetBoardCategoriesResult;
 import com.personal.marketnote.community.port.in.result.board.GetBoardsResult;
 import com.personal.marketnote.community.port.in.usecase.board.GetBoardUseCase;
@@ -32,7 +33,7 @@ public class GetBoardService implements GetBoardUseCase {
             return GetBoardCategoriesResult.from(OneOnOneInqueryPostCategory.values());
         }
 
-        throw new IllegalArgumentException("유효하지 않은 게시판입니다. 전송된 게시판: " + board);
+        throw new InvalidBoardException(board.name());
     }
 
     @Override

--- a/community-service/community-application/src/main/java/com/personal/marketnote/community/service/post/GetPostService.java
+++ b/community-service/community-application/src/main/java/com/personal/marketnote/community/service/post/GetPostService.java
@@ -5,6 +5,7 @@ import com.personal.marketnote.common.application.file.port.in.result.GetFileRes
 import com.personal.marketnote.common.utility.AuthorityValidator;
 import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.community.domain.post.*;
+import com.personal.marketnote.community.exception.PostBoardMismatchException;
 import com.personal.marketnote.community.exception.PostNotFoundException;
 import com.personal.marketnote.community.port.in.command.post.GetPostQuery;
 import com.personal.marketnote.community.port.in.command.post.GetPostsQuery;
@@ -250,7 +251,7 @@ public class GetPostService implements GetPostUseCase {
 
     private void validateQueryMatchesPost(GetPostQuery query, Post post) {
         if (!Objects.equals(query.board(), post.getBoard())) {
-            throw new IllegalArgumentException("요청한 게시판과 실제 게시판이 일치하지 않습니다.");
+            throw new PostBoardMismatchException();
         }
     }
 

--- a/community-service/community-application/src/test/java/com/personal/marketnote/community/service/post/GetPostUseCaseTest.java
+++ b/community-service/community-application/src/test/java/com/personal/marketnote/community/service/post/GetPostUseCaseTest.java
@@ -7,6 +7,7 @@ import com.personal.marketnote.community.domain.post.Board;
 import com.personal.marketnote.community.domain.post.Post;
 import com.personal.marketnote.community.domain.post.PostSnapshotState;
 import com.personal.marketnote.community.domain.post.PostTargetType;
+import com.personal.marketnote.community.exception.PostBoardMismatchException;
 import com.personal.marketnote.community.exception.PostNotFoundException;
 import com.personal.marketnote.community.port.in.command.post.GetPostQuery;
 import com.personal.marketnote.community.port.in.result.post.PostItemResult;
@@ -86,15 +87,15 @@ class GetPostUseCaseTest {
     }
 
     @Test
-    @DisplayName("요청한 게시판과 게시글의 게시판이 일치하지 않으면 IllegalArgumentException이 발생한다")
-    void getPost_boardMismatch_throwsIllegalArgumentException() {
+    @DisplayName("요청한 게시판과 게시글의 게시판이 일치하지 않으면 PostBoardMismatchException이 발생한다")
+    void getPost_boardMismatch_throwsPostBoardMismatchException() {
         Long postId = 1L;
         Post post = buildOneOnOnePost(postId, 1L);
         mockFindByIdWithReplies(postId, post);
         GetPostQuery query = buildQuery(Board.NOTICE, null, 1L, postId);
 
         assertThatThrownBy(() -> getPostService.getPost(query))
-                .isInstanceOf(IllegalArgumentException.class)
+                .isInstanceOf(PostBoardMismatchException.class)
                 .hasMessageContaining("게시판");
     }
 

--- a/community-service/community-domain/src/main/java/com/personal/marketnote/community/domain/post/Board.java
+++ b/community-service/community-domain/src/main/java/com/personal/marketnote/community/domain/post/Board.java
@@ -1,6 +1,8 @@
 package com.personal.marketnote.community.domain.post;
 
 import com.personal.marketnote.common.utility.FormatConverter;
+import com.personal.marketnote.community.domain.post.exception.InvalidPostCategoryException;
+import com.personal.marketnote.community.domain.post.exception.InvalidPostCategoryForBoardException;
 import lombok.Getter;
 
 import java.util.Arrays;
@@ -25,31 +27,31 @@ public enum Board {
             return Arrays.stream(NoticePostCategory.values())
                     .filter(category -> category.isMe(categoryCode))
                     .findFirst()
-                    .orElseThrow(() -> new IllegalArgumentException("게시판에 맞지 않는 카테고리입니다. 카테고리명: " + categoryCode));
+                    .orElseThrow(() -> new InvalidPostCategoryForBoardException(categoryCode));
         }
 
         if (this == FAQ) {
             return Arrays.stream(FaqPostCategory.values())
                     .filter(category -> category.isMe(categoryCode))
                     .findFirst()
-                    .orElseThrow(() -> new IllegalArgumentException("게시판에 맞지 않는 카테고리입니다. 카테고리명: " + categoryCode));
+                    .orElseThrow(() -> new InvalidPostCategoryForBoardException(categoryCode));
         }
 
         if (this == PRODUCT_INQUERY) {
             return Arrays.stream(ProductInqueryPostCategory.values())
                     .filter(category -> category.isMe(categoryCode))
                     .findFirst()
-                    .orElseThrow(() -> new IllegalArgumentException("게시판에 맞지 않는 카테고리입니다. 카테고리명: " + categoryCode));
+                    .orElseThrow(() -> new InvalidPostCategoryForBoardException(categoryCode));
         }
 
         if (this == ONE_ON_ONE_INQUERY) {
             return Arrays.stream(OneOnOneInqueryPostCategory.values())
                     .filter(category -> category.isMe(categoryCode))
                     .findFirst()
-                    .orElseThrow(() -> new IllegalArgumentException("게시판에 맞지 않는 카테고리입니다. 카테고리명: " + categoryCode));
+                    .orElseThrow(() -> new InvalidPostCategoryForBoardException(categoryCode));
         }
 
-        throw new IllegalArgumentException("유효하지 않은 카테고리명입니다. 카테고리명: " + categoryCode);
+        throw new InvalidPostCategoryException(categoryCode);
     }
 
     public boolean isAdminRequired() {

--- a/community-service/community-domain/src/main/java/com/personal/marketnote/community/domain/post/PostCategoryResolver.java
+++ b/community-service/community-domain/src/main/java/com/personal/marketnote/community/domain/post/PostCategoryResolver.java
@@ -1,11 +1,12 @@
 package com.personal.marketnote.community.domain.post;
 
 import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.community.domain.post.exception.BoardOrCategoryNoValueException;
 
 public class PostCategoryResolver {
     public static PostCategory resolve(Board board, String categoryCode) {
         if (FormatValidator.hasNoValue(board) || FormatValidator.hasNoValue(categoryCode)) {
-            throw new IllegalArgumentException("게시판 또는 카테고리가 없습니다.");
+            throw new BoardOrCategoryNoValueException();
         }
 
         return board.resolveCategory(categoryCode);

--- a/community-service/community-domain/src/main/java/com/personal/marketnote/community/domain/post/exception/BoardOrCategoryNoValueException.java
+++ b/community-service/community-domain/src/main/java/com/personal/marketnote/community/domain/post/exception/BoardOrCategoryNoValueException.java
@@ -1,0 +1,10 @@
+package com.personal.marketnote.community.domain.post.exception;
+
+public class BoardOrCategoryNoValueException extends IllegalArgumentException {
+    private static final String BOARD_OR_CATEGORY_NO_VALUE_EXCEPTION_MESSAGE
+            = "게시판 또는 카테고리가 없습니다.";
+
+    public BoardOrCategoryNoValueException() {
+        super(BOARD_OR_CATEGORY_NO_VALUE_EXCEPTION_MESSAGE);
+    }
+}

--- a/community-service/community-domain/src/main/java/com/personal/marketnote/community/domain/post/exception/InvalidPostCategoryException.java
+++ b/community-service/community-domain/src/main/java/com/personal/marketnote/community/domain/post/exception/InvalidPostCategoryException.java
@@ -1,0 +1,10 @@
+package com.personal.marketnote.community.domain.post.exception;
+
+public class InvalidPostCategoryException extends IllegalArgumentException {
+    private static final String INVALID_POST_CATEGORY_EXCEPTION_MESSAGE
+            = "유효하지 않은 카테고리명입니다. 카테고리명: %s";
+
+    public InvalidPostCategoryException(String categoryCode) {
+        super(String.format(INVALID_POST_CATEGORY_EXCEPTION_MESSAGE, categoryCode));
+    }
+}

--- a/community-service/community-domain/src/main/java/com/personal/marketnote/community/domain/post/exception/InvalidPostCategoryForBoardException.java
+++ b/community-service/community-domain/src/main/java/com/personal/marketnote/community/domain/post/exception/InvalidPostCategoryForBoardException.java
@@ -1,0 +1,10 @@
+package com.personal.marketnote.community.domain.post.exception;
+
+public class InvalidPostCategoryForBoardException extends IllegalArgumentException {
+    private static final String INVALID_POST_CATEGORY_FOR_BOARD_EXCEPTION_MESSAGE
+            = "게시판에 맞지 않는 카테고리입니다. 카테고리명: %s";
+
+    public InvalidPostCategoryForBoardException(String categoryCode) {
+        super(String.format(INVALID_POST_CATEGORY_FOR_BOARD_EXCEPTION_MESSAGE, categoryCode));
+    }
+}

--- a/community-service/community-domain/src/main/java/com/personal/marketnote/community/domain/review/ProductReviewAggregate.java
+++ b/community-service/community-domain/src/main/java/com/personal/marketnote/community/domain/review/ProductReviewAggregate.java
@@ -1,5 +1,6 @@
 package com.personal.marketnote.community.domain.review;
 
+import com.personal.marketnote.community.domain.review.exception.InvalidRatingPointException;
 import lombok.*;
 
 import java.time.LocalDateTime;
@@ -81,7 +82,7 @@ public class ProductReviewAggregate {
             return;
         }
 
-        throw new IllegalArgumentException("평점은 1 이상 5 이하의 정수만 가능합니다. 전송된 평점: " + point);
+        throw new InvalidRatingPointException(point);
     }
 
     public void addPoint(int point) {
@@ -112,7 +113,7 @@ public class ProductReviewAggregate {
             return;
         }
 
-        throw new IllegalArgumentException("평점은 1 이상 5 이하의 정수만 가능합니다. 전송된 평점: " + point);
+        throw new InvalidRatingPointException(point);
     }
 
     public void computeRating(Float point) {

--- a/community-service/community-domain/src/main/java/com/personal/marketnote/community/domain/review/exception/InvalidRatingPointException.java
+++ b/community-service/community-domain/src/main/java/com/personal/marketnote/community/domain/review/exception/InvalidRatingPointException.java
@@ -1,0 +1,10 @@
+package com.personal.marketnote.community.domain.review.exception;
+
+public class InvalidRatingPointException extends IllegalArgumentException {
+    private static final String INVALID_RATING_POINT_EXCEPTION_MESSAGE
+            = "평점은 1 이상 5 이하의 정수만 가능합니다. 전송된 평점: %d";
+
+    public InvalidRatingPointException(int point) {
+        super(String.format(INVALID_RATING_POINT_EXCEPTION_MESSAGE, point));
+    }
+}


### PR DESCRIPTION
## partially addresses #300
## resolves #991

## Task
- [x] Board.java — IllegalArgumentException ×2 → InvalidPostCategoryForBoardException, InvalidPostCategoryException
- [x] PostCategoryResolver.java — IllegalArgumentException → BoardOrCategoryNoValueException
- [x] ProductReviewAggregate.java — IllegalArgumentException ×2 → InvalidRatingPointException
- [x] GetBoardService.java — IllegalArgumentException → InvalidBoardException
- [x] GetPostService.java — IllegalArgumentException → PostBoardMismatchException