### PR TITLE
[#475][#992] refactor: 제네릭 예외를 도메인 커스텀 예외로 전환 - 풀필먼트 서비스

### DIFF
--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/commerce/UpdateCommerceInventoryCommand.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/commerce/UpdateCommerceInventoryCommand.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.fulfillment.port.out.commerce;
 
 import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.fulfillment.domain.exception.FasstoQueryParameterNoValueException;
 
 import java.util.List;
 
@@ -9,7 +10,7 @@ public record UpdateCommerceInventoryCommand(
 ) {
     public UpdateCommerceInventoryCommand {
         if (FormatValidator.hasNoValue(inventories)) {
-            throw new IllegalArgumentException("Inventory sync items are required for commerce inventory sync.");
+            throw new FasstoQueryParameterNoValueException("Inventory sync items", "commerce inventory sync");
         }
     }
 

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/commerce/UpdateCommerceInventoryItemCommand.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/commerce/UpdateCommerceInventoryItemCommand.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.fulfillment.port.out.commerce;
 
 import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.fulfillment.domain.exception.FasstoQueryParameterNoValueException;
 
 public record UpdateCommerceInventoryItemCommand(
         Long productId,
@@ -8,13 +9,13 @@ public record UpdateCommerceInventoryItemCommand(
 ) {
     public UpdateCommerceInventoryItemCommand {
         if (FormatValidator.hasNoValue(productId)) {
-            throw new IllegalArgumentException("Product id is required for commerce inventory sync.");
+            throw new FasstoQueryParameterNoValueException("Product id", "commerce inventory sync");
         }
         if (FormatValidator.hasNoValue(stock)) {
-            throw new IllegalArgumentException("Stock is required for commerce inventory sync.");
+            throw new FasstoQueryParameterNoValueException("Stock", "commerce inventory sync");
         }
         if (stock < 0) {
-            throw new IllegalArgumentException("Stock cannot be negative for commerce inventory sync.");
+            throw new FasstoQueryParameterNoValueException("Stock (non-negative)", "commerce inventory sync");
         }
     }
 

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/vendor/SyncFasstoStockService.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/vendor/SyncFasstoStockService.java
@@ -2,6 +2,7 @@ package com.personal.marketnote.fulfillment.service.vendor;
 
 import com.personal.marketnote.common.application.UseCase;
 import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.fulfillment.domain.exception.FasstoQueryParameterNoValueException;
 import com.personal.marketnote.fulfillment.domain.FasstoAccessToken;
 import com.personal.marketnote.fulfillment.port.in.command.vendor.GetFasstoStockDetailCommand;
 import com.personal.marketnote.fulfillment.port.in.command.vendor.GetFasstoStocksCommand;
@@ -37,13 +38,13 @@ public class SyncFasstoStockService implements SyncFasstoStockUseCase, SyncFasst
     @Override
     public void sync(SyncFasstoStockCommand command) {
         if (FormatValidator.hasNoValue(command)) {
-            throw new IllegalArgumentException("Sync Fassto stock command is required.");
+            throw new FasstoQueryParameterNoValueException("Sync Fassto stock command");
         }
         if (FormatValidator.hasNoValue(command.customerCode())) {
-            throw new IllegalArgumentException("Customer code is required for Fassto stock sync.");
+            throw new FasstoQueryParameterNoValueException("Customer code", "Fassto stock sync");
         }
         if (FormatValidator.hasNoValue(command.productIds())) {
-            throw new IllegalArgumentException("Product ids are required for Fassto stock sync.");
+            throw new FasstoQueryParameterNoValueException("Product ids", "Fassto stock sync");
         }
 
         List<Long> productIds = command.productIds().stream()
@@ -51,12 +52,12 @@ public class SyncFasstoStockService implements SyncFasstoStockUseCase, SyncFasst
                 .distinct()
                 .toList();
         if (FormatValidator.hasNoValue(productIds)) {
-            throw new IllegalArgumentException("Valid product ids are required for Fassto stock sync.");
+            throw new FasstoQueryParameterNoValueException("Valid product ids", "Fassto stock sync");
         }
 
         FasstoAccessToken accessToken = requestFasstoAuthUseCase.requestAccessToken();
         if (FormatValidator.hasNoValue(accessToken) || FormatValidator.hasNoValue(accessToken.getValue())) {
-            throw new IllegalArgumentException("Fassto access token is required for stock sync.");
+            throw new FasstoQueryParameterNoValueException("Fassto access token", "stock sync");
         }
 
         List<UpdateCommerceInventoryItemCommand> inventories = new ArrayList<>();
@@ -79,15 +80,15 @@ public class SyncFasstoStockService implements SyncFasstoStockUseCase, SyncFasst
     @Override
     public void syncAll(SyncFasstoAllStockCommand command) {
         if (FormatValidator.hasNoValue(command)) {
-            throw new IllegalArgumentException("Sync all Fassto stock command is required.");
+            throw new FasstoQueryParameterNoValueException("Sync all Fassto stock command");
         }
         if (FormatValidator.hasNoValue(command.customerCode())) {
-            throw new IllegalArgumentException("Customer code is required for Fassto stock sync.");
+            throw new FasstoQueryParameterNoValueException("Customer code", "Fassto stock sync");
         }
 
         FasstoAccessToken accessToken = requestFasstoAuthUseCase.requestAccessToken();
         if (FormatValidator.hasNoValue(accessToken) || FormatValidator.hasNoValue(accessToken.getValue())) {
-            throw new IllegalArgumentException("Fassto access token is required for stock sync.");
+            throw new FasstoQueryParameterNoValueException("Fassto access token", "stock sync");
         }
 
         GetFasstoStocksResult stocksResult = getFasstoStocksUseCase.getStocks(

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/FasstoAccessToken.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/FasstoAccessToken.java
@@ -2,6 +2,7 @@ package com.personal.marketnote.fulfillment.domain;
 
 import com.personal.marketnote.common.domain.exception.illegalargument.invalidvalue.ParsingLocalDateTimeException;
 import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.fulfillment.domain.exception.FasstoQueryParameterNoValueException;
 import lombok.*;
 
 import java.time.LocalDateTime;
@@ -20,10 +21,10 @@ public class FasstoAccessToken {
 
     public static FasstoAccessToken of(String value, String expreDatetime) {
         if (FormatValidator.hasNoValue(value)) {
-            throw new IllegalArgumentException("Fassto access token value is required.");
+            throw new FasstoQueryParameterNoValueException("Fassto access token value");
         }
         if (FormatValidator.hasNoValue(expreDatetime)) {
-            throw new IllegalArgumentException("Fassto access token expiration is required.");
+            throw new FasstoQueryParameterNoValueException("Fassto access token expiration");
         }
 
         return FasstoAccessToken.builder()

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/delivery/FasstoDeliveryRegistration.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/delivery/FasstoDeliveryRegistration.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.fulfillment.domain.delivery;
 
 import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.fulfillment.domain.exception.FasstoQueryParameterNoValueException;
 import lombok.*;
 
 import java.time.LocalDateTime;
@@ -16,7 +17,7 @@ public class FasstoDeliveryRegistration {
 
     public static FasstoDeliveryRegistration from(FasstoDeliveryRegistrationCreateState state) {
         if (FormatValidator.hasNoValue(state.getOrderId())) {
-            throw new IllegalArgumentException("orderId는 필수입니다.");
+            throw new FasstoQueryParameterNoValueException("orderId");
         }
         return FasstoDeliveryRegistration.builder()
                 .orderId(state.getOrderId())

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/exception/FasstoQueryParameterNoValueException.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/exception/FasstoQueryParameterNoValueException.java
@@ -1,0 +1,11 @@
+package com.personal.marketnote.fulfillment.domain.exception;
+
+public class FasstoQueryParameterNoValueException extends IllegalArgumentException {
+    public FasstoQueryParameterNoValueException(String parameterName) {
+        super(parameterName + " is required.");
+    }
+
+    public FasstoQueryParameterNoValueException(String parameterName, String context) {
+        super(parameterName + " is required for " + context + ".");
+    }
+}

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/goods/FasstoGoodsRegistration.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/goods/FasstoGoodsRegistration.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.fulfillment.domain.goods;
 
 import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.fulfillment.domain.exception.FasstoQueryParameterNoValueException;
 import lombok.*;
 
 import java.time.LocalDateTime;
@@ -16,7 +17,7 @@ public class FasstoGoodsRegistration {
 
     public static FasstoGoodsRegistration from(FasstoGoodsRegistrationCreateState state) {
         if (FormatValidator.hasNoValue(state.getProductId())) {
-            throw new IllegalArgumentException("productId는 필수입니다.");
+            throw new FasstoQueryParameterNoValueException("productId");
         }
         return FasstoGoodsRegistration.builder()
                 .productId(state.getProductId())

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/delivery/FasstoDeliveryCancelItemMapper.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/delivery/FasstoDeliveryCancelItemMapper.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.fulfillment.domain.vendor.fassto.delivery;
 
 import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.fulfillment.domain.exception.FasstoQueryParameterNoValueException;
 import lombok.*;
 
 import java.util.LinkedHashMap;
@@ -35,10 +36,10 @@ public class FasstoDeliveryCancelItemMapper {
 
     private void validate() {
         if (FormatValidator.hasNoValue(slipNo)) {
-            throw new IllegalArgumentException("slipNo is required for delivery cancel request.");
+            throw new FasstoQueryParameterNoValueException("slipNo", "delivery cancel request");
         }
         if (FormatValidator.hasNoValue(ordNo)) {
-            throw new IllegalArgumentException("ordNo is required for delivery cancel request.");
+            throw new FasstoQueryParameterNoValueException("ordNo", "delivery cancel request");
         }
     }
 }

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/delivery/FasstoDeliveryCancelMapper.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/delivery/FasstoDeliveryCancelMapper.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.fulfillment.domain.vendor.fassto.delivery;
 
 import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.fulfillment.domain.exception.FasstoQueryParameterNoValueException;
 import lombok.*;
 
 import java.util.List;
@@ -37,13 +38,13 @@ public class FasstoDeliveryCancelMapper {
 
     private void validate() {
         if (FormatValidator.hasNoValue(customerCode)) {
-            throw new IllegalArgumentException("customerCode is required.");
+            throw new FasstoQueryParameterNoValueException("customerCode");
         }
         if (FormatValidator.hasNoValue(accessToken)) {
-            throw new IllegalArgumentException("accessToken is required.");
+            throw new FasstoQueryParameterNoValueException("accessToken");
         }
         if (FormatValidator.hasNoValue(cancelRequests)) {
-            throw new IllegalArgumentException("cancelRequests is required.");
+            throw new FasstoQueryParameterNoValueException("cancelRequests");
         }
     }
 }

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/delivery/FasstoDeliveryCarItemMapper.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/delivery/FasstoDeliveryCarItemMapper.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.fulfillment.domain.vendor.fassto.delivery;
 
 import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.fulfillment.domain.exception.FasstoQueryParameterNoValueException;
 import lombok.*;
 
 import java.util.LinkedHashMap;
@@ -82,26 +83,26 @@ public class FasstoDeliveryCarItemMapper {
 
     private void validate() {
         if (FormatValidator.hasNoValue(ordDt)) {
-            throw new IllegalArgumentException("ordDt is required for delivery car request.");
+            throw new FasstoQueryParameterNoValueException("ordDt", "delivery car request");
         }
         if (FormatValidator.hasNoValue(ordNo)) {
-            throw new IllegalArgumentException("ordNo is required for delivery car request.");
+            throw new FasstoQueryParameterNoValueException("ordNo", "delivery car request");
         }
         if (FormatValidator.hasNoValue(outWay)) {
-            throw new IllegalArgumentException("outWay is required for delivery car request.");
+            throw new FasstoQueryParameterNoValueException("outWay", "delivery car request");
         }
         if (FormatValidator.hasNoValue(cstShopCd)) {
-            throw new IllegalArgumentException("cstShopCd is required for delivery car request.");
+            throw new FasstoQueryParameterNoValueException("cstShopCd", "delivery car request");
         }
         if (FormatValidator.hasNoValue(godCds)) {
-            throw new IllegalArgumentException("godCds is required for delivery car request.");
+            throw new FasstoQueryParameterNoValueException("godCds", "delivery car request");
         }
     }
 
     private void validateForUpdate() {
         validate();
         if (FormatValidator.hasNoValue(slipNo)) {
-            throw new IllegalArgumentException("slipNo is required for delivery car update request.");
+            throw new FasstoQueryParameterNoValueException("slipNo", "delivery car update request");
         }
     }
 

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/delivery/FasstoDeliveryCarMapper.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/delivery/FasstoDeliveryCarMapper.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.fulfillment.domain.vendor.fassto.delivery;
 
 import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.fulfillment.domain.exception.FasstoQueryParameterNoValueException;
 import lombok.*;
 
 import java.util.List;
@@ -58,13 +59,13 @@ public class FasstoDeliveryCarMapper {
 
     private void validate() {
         if (FormatValidator.hasNoValue(customerCode)) {
-            throw new IllegalArgumentException("customerCode is required.");
+            throw new FasstoQueryParameterNoValueException("customerCode");
         }
         if (FormatValidator.hasNoValue(accessToken)) {
-            throw new IllegalArgumentException("accessToken is required.");
+            throw new FasstoQueryParameterNoValueException("accessToken");
         }
         if (FormatValidator.hasNoValue(deliveryRequests)) {
-            throw new IllegalArgumentException("deliveryRequests is required.");
+            throw new FasstoQueryParameterNoValueException("deliveryRequests");
         }
     }
 }

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/delivery/FasstoDeliveryDetailQuery.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/delivery/FasstoDeliveryDetailQuery.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.fulfillment.domain.vendor.fassto.delivery;
 
 import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.fulfillment.domain.exception.FasstoQueryParameterNoValueException;
 import lombok.*;
 
 @Getter
@@ -39,13 +40,13 @@ public class FasstoDeliveryDetailQuery {
 
     private void validate() {
         if (FormatValidator.hasNoValue(customerCode)) {
-            throw new IllegalArgumentException("customerCode is required.");
+            throw new FasstoQueryParameterNoValueException("customerCode");
         }
         if (FormatValidator.hasNoValue(accessToken)) {
-            throw new IllegalArgumentException("accessToken is required.");
+            throw new FasstoQueryParameterNoValueException("accessToken");
         }
         if (FormatValidator.hasNoValue(slipNo)) {
-            throw new IllegalArgumentException("slipNo is required.");
+            throw new FasstoQueryParameterNoValueException("slipNo");
         }
     }
 }

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/delivery/FasstoDeliveryGoodDetailQuery.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/delivery/FasstoDeliveryGoodDetailQuery.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.fulfillment.domain.vendor.fassto.delivery;
 
 import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.fulfillment.domain.exception.FasstoQueryParameterNoValueException;
 import lombok.*;
 
 @Getter
@@ -34,16 +35,16 @@ public class FasstoDeliveryGoodDetailQuery {
 
     private void validate() {
         if (FormatValidator.hasNoValue(customerCode)) {
-            throw new IllegalArgumentException("customerCode is required.");
+            throw new FasstoQueryParameterNoValueException("customerCode");
         }
         if (FormatValidator.hasNoValue(accessToken)) {
-            throw new IllegalArgumentException("accessToken is required.");
+            throw new FasstoQueryParameterNoValueException("accessToken");
         }
         if (FormatValidator.hasNoValue(startDate)) {
-            throw new IllegalArgumentException("startDate is required.");
+            throw new FasstoQueryParameterNoValueException("startDate");
         }
         if (FormatValidator.hasNoValue(endDate)) {
-            throw new IllegalArgumentException("endDate is required.");
+            throw new FasstoQueryParameterNoValueException("endDate");
         }
     }
 }

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/delivery/FasstoDeliveryGoodsMapper.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/delivery/FasstoDeliveryGoodsMapper.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.fulfillment.domain.vendor.fassto.delivery;
 
 import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.fulfillment.domain.exception.FasstoQueryParameterNoValueException;
 import lombok.*;
 
 import java.util.LinkedHashMap;
@@ -41,10 +42,10 @@ public class FasstoDeliveryGoodsMapper {
 
     private void validate() {
         if (FormatValidator.hasNoValue(cstGodCd)) {
-            throw new IllegalArgumentException("cstGodCd is required for delivery goods request.");
+            throw new FasstoQueryParameterNoValueException("cstGodCd", "delivery goods request");
         }
         if (FormatValidator.hasNoValue(ordQty)) {
-            throw new IllegalArgumentException("ordQty is required for delivery goods request.");
+            throw new FasstoQueryParameterNoValueException("ordQty", "delivery goods request");
         }
     }
 

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/delivery/FasstoDeliveryIcsCompletionItemMapper.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/delivery/FasstoDeliveryIcsCompletionItemMapper.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.fulfillment.domain.vendor.fassto.delivery;
 
 import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.fulfillment.domain.exception.FasstoQueryParameterNoValueException;
 import lombok.*;
 
 import java.util.LinkedHashMap;
@@ -30,7 +31,7 @@ public class FasstoDeliveryIcsCompletionItemMapper {
 
     private void validate() {
         if (FormatValidator.hasNoValue(ordNoList)) {
-            throw new IllegalArgumentException("ordNoList is required for delivery ics completion request.");
+            throw new FasstoQueryParameterNoValueException("ordNoList", "delivery ics completion request");
         }
     }
 }

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/delivery/FasstoDeliveryIcsCompletionMapper.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/delivery/FasstoDeliveryIcsCompletionMapper.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.fulfillment.domain.vendor.fassto.delivery;
 
 import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.fulfillment.domain.exception.FasstoQueryParameterNoValueException;
 import lombok.*;
 
 import java.util.List;
@@ -37,13 +38,13 @@ public class FasstoDeliveryIcsCompletionMapper {
 
     private void validate() {
         if (FormatValidator.hasNoValue(customerCode)) {
-            throw new IllegalArgumentException("customerCode is required.");
+            throw new FasstoQueryParameterNoValueException("customerCode");
         }
         if (FormatValidator.hasNoValue(accessToken)) {
-            throw new IllegalArgumentException("accessToken is required.");
+            throw new FasstoQueryParameterNoValueException("accessToken");
         }
         if (FormatValidator.hasNoValue(completionRequests)) {
-            throw new IllegalArgumentException("completionRequests is required.");
+            throw new FasstoQueryParameterNoValueException("completionRequests");
         }
     }
 }

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/delivery/FasstoDeliveryIcsItemMapper.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/delivery/FasstoDeliveryIcsItemMapper.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.fulfillment.domain.vendor.fassto.delivery;
 
 import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.fulfillment.domain.exception.FasstoQueryParameterNoValueException;
 import lombok.*;
 
 import java.util.LinkedHashMap;
@@ -88,22 +89,22 @@ public class FasstoDeliveryIcsItemMapper {
 
     private void validate() {
         if (FormatValidator.hasNoValue(ordDt)) {
-            throw new IllegalArgumentException("ordDt is required for delivery ics request.");
+            throw new FasstoQueryParameterNoValueException("ordDt", "delivery ics request");
         }
         if (FormatValidator.hasNoValue(ordNo)) {
-            throw new IllegalArgumentException("ordNo is required for delivery ics request.");
+            throw new FasstoQueryParameterNoValueException("ordNo", "delivery ics request");
         }
         if (FormatValidator.hasNoValue(platform)) {
-            throw new IllegalArgumentException("platform is required for delivery ics request.");
+            throw new FasstoQueryParameterNoValueException("platform", "delivery ics request");
         }
         if (FormatValidator.hasNoValue(logiCenter)) {
-            throw new IllegalArgumentException("logiCenter is required for delivery ics request.");
+            throw new FasstoQueryParameterNoValueException("logiCenter", "delivery ics request");
         }
         if (FormatValidator.hasNoValue(invoiceNo)) {
-            throw new IllegalArgumentException("invoiceNo is required for delivery ics request.");
+            throw new FasstoQueryParameterNoValueException("invoiceNo", "delivery ics request");
         }
         if (FormatValidator.hasNoValue(godCds)) {
-            throw new IllegalArgumentException("godCds is required for delivery ics request.");
+            throw new FasstoQueryParameterNoValueException("godCds", "delivery ics request");
         }
     }
 

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/delivery/FasstoDeliveryIcsMapper.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/delivery/FasstoDeliveryIcsMapper.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.fulfillment.domain.vendor.fassto.delivery;
 
 import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.fulfillment.domain.exception.FasstoQueryParameterNoValueException;
 import lombok.*;
 
 import java.util.List;
@@ -44,13 +45,13 @@ public class FasstoDeliveryIcsMapper {
 
     private void validate() {
         if (FormatValidator.hasNoValue(customerCode)) {
-            throw new IllegalArgumentException("customerCode is required.");
+            throw new FasstoQueryParameterNoValueException("customerCode");
         }
         if (FormatValidator.hasNoValue(accessToken)) {
-            throw new IllegalArgumentException("accessToken is required.");
+            throw new FasstoQueryParameterNoValueException("accessToken");
         }
         if (FormatValidator.hasNoValue(deliveryRequests)) {
-            throw new IllegalArgumentException("deliveryRequests is required.");
+            throw new FasstoQueryParameterNoValueException("deliveryRequests");
         }
     }
 }

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/delivery/FasstoDeliveryItemMapper.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/delivery/FasstoDeliveryItemMapper.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.fulfillment.domain.vendor.fassto.delivery;
 
 import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.fulfillment.domain.exception.FasstoQueryParameterNoValueException;
 import lombok.*;
 
 import java.util.LinkedHashMap;
@@ -132,32 +133,32 @@ public class FasstoDeliveryItemMapper {
 
     private void validate() {
         if (FormatValidator.hasNoValue(ordDt)) {
-            throw new IllegalArgumentException("ordDt is required for delivery request.");
+            throw new FasstoQueryParameterNoValueException("ordDt", "delivery request");
         }
         if (FormatValidator.hasNoValue(ordNo)) {
-            throw new IllegalArgumentException("ordNo is required for delivery request.");
+            throw new FasstoQueryParameterNoValueException("ordNo", "delivery request");
         }
         if (FormatValidator.hasNoValue(custNm)) {
-            throw new IllegalArgumentException("custNm is required for delivery request.");
+            throw new FasstoQueryParameterNoValueException("custNm", "delivery request");
         }
         if (FormatValidator.hasNoValue(custTelNo)) {
-            throw new IllegalArgumentException("custTelNo is required for delivery request.");
+            throw new FasstoQueryParameterNoValueException("custTelNo", "delivery request");
         }
         if (FormatValidator.hasNoValue(custAddr)) {
-            throw new IllegalArgumentException("custAddr is required for delivery request.");
+            throw new FasstoQueryParameterNoValueException("custAddr", "delivery request");
         }
         if (FormatValidator.hasNoValue(outWay)) {
-            throw new IllegalArgumentException("outWay is required for delivery request.");
+            throw new FasstoQueryParameterNoValueException("outWay", "delivery request");
         }
         if (FormatValidator.hasNoValue(godCds)) {
-            throw new IllegalArgumentException("godCds is required for delivery request.");
+            throw new FasstoQueryParameterNoValueException("godCds", "delivery request");
         }
     }
 
     private void validateForUpdate() {
         validate();
         if (FormatValidator.hasNoValue(slipNo)) {
-            throw new IllegalArgumentException("slipNo is required for delivery update request.");
+            throw new FasstoQueryParameterNoValueException("slipNo", "delivery update request");
         }
     }
 

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/delivery/FasstoDeliveryMapper.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/delivery/FasstoDeliveryMapper.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.fulfillment.domain.vendor.fassto.delivery;
 
 import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.fulfillment.domain.exception.FasstoQueryParameterNoValueException;
 import lombok.*;
 
 import java.util.List;
@@ -58,13 +59,13 @@ public class FasstoDeliveryMapper {
 
     private void validate() {
         if (FormatValidator.hasNoValue(customerCode)) {
-            throw new IllegalArgumentException("customerCode is required.");
+            throw new FasstoQueryParameterNoValueException("customerCode");
         }
         if (FormatValidator.hasNoValue(accessToken)) {
-            throw new IllegalArgumentException("accessToken is required.");
+            throw new FasstoQueryParameterNoValueException("accessToken");
         }
         if (FormatValidator.hasNoValue(deliveryRequests)) {
-            throw new IllegalArgumentException("deliveryRequests is required.");
+            throw new FasstoQueryParameterNoValueException("deliveryRequests");
         }
     }
 }

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/delivery/FasstoDeliveryOutOrdGoodsByOrdNoQuery.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/delivery/FasstoDeliveryOutOrdGoodsByOrdNoQuery.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.fulfillment.domain.vendor.fassto.delivery;
 
 import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.fulfillment.domain.exception.FasstoQueryParameterNoValueException;
 import lombok.*;
 
 @Getter
@@ -34,16 +35,16 @@ public class FasstoDeliveryOutOrdGoodsByOrdNoQuery {
 
     private void validate() {
         if (FormatValidator.hasNoValue(customerCode)) {
-            throw new IllegalArgumentException("customerCode is required.");
+            throw new FasstoQueryParameterNoValueException("customerCode");
         }
         if (FormatValidator.hasNoValue(accessToken)) {
-            throw new IllegalArgumentException("accessToken is required.");
+            throw new FasstoQueryParameterNoValueException("accessToken");
         }
         if (FormatValidator.hasNoValue(startDate)) {
-            throw new IllegalArgumentException("startDate is required.");
+            throw new FasstoQueryParameterNoValueException("startDate");
         }
         if (FormatValidator.hasNoValue(endDate)) {
-            throw new IllegalArgumentException("endDate is required.");
+            throw new FasstoQueryParameterNoValueException("endDate");
         }
     }
 }

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/delivery/FasstoDeliveryOutOrdGoodsDetailQuery.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/delivery/FasstoDeliveryOutOrdGoodsDetailQuery.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.fulfillment.domain.vendor.fassto.delivery;
 
 import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.fulfillment.domain.exception.FasstoQueryParameterNoValueException;
 import lombok.*;
 
 @Getter
@@ -28,13 +29,13 @@ public class FasstoDeliveryOutOrdGoodsDetailQuery {
 
     private void validate() {
         if (FormatValidator.hasNoValue(customerCode)) {
-            throw new IllegalArgumentException("customerCode is required.");
+            throw new FasstoQueryParameterNoValueException("customerCode");
         }
         if (FormatValidator.hasNoValue(accessToken)) {
-            throw new IllegalArgumentException("accessToken is required.");
+            throw new FasstoQueryParameterNoValueException("accessToken");
         }
         if (FormatValidator.hasNoValue(outOrdSlipNo)) {
-            throw new IllegalArgumentException("outOrdSlipNo is required.");
+            throw new FasstoQueryParameterNoValueException("outOrdSlipNo");
         }
     }
 }

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/delivery/FasstoDeliveryQuery.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/delivery/FasstoDeliveryQuery.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.fulfillment.domain.vendor.fassto.delivery;
 
 import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.fulfillment.domain.exception.FasstoQueryParameterNoValueException;
 import lombok.*;
 
 @Getter
@@ -51,22 +52,22 @@ public class FasstoDeliveryQuery {
 
     private void validate() {
         if (FormatValidator.hasNoValue(customerCode)) {
-            throw new IllegalArgumentException("customerCode is required.");
+            throw new FasstoQueryParameterNoValueException("customerCode");
         }
         if (FormatValidator.hasNoValue(accessToken)) {
-            throw new IllegalArgumentException("accessToken is required.");
+            throw new FasstoQueryParameterNoValueException("accessToken");
         }
         if (FormatValidator.hasNoValue(startDate)) {
-            throw new IllegalArgumentException("startDate is required.");
+            throw new FasstoQueryParameterNoValueException("startDate");
         }
         if (FormatValidator.hasNoValue(endDate)) {
-            throw new IllegalArgumentException("endDate is required.");
+            throw new FasstoQueryParameterNoValueException("endDate");
         }
         if (FormatValidator.hasNoValue(status)) {
-            throw new IllegalArgumentException("status is required.");
+            throw new FasstoQueryParameterNoValueException("status");
         }
         if (FormatValidator.hasNoValue(outDiv)) {
-            throw new IllegalArgumentException("outDiv is required.");
+            throw new FasstoQueryParameterNoValueException("outDiv");
         }
     }
 }

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/delivery/FasstoDeliveryStatusQuery.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/delivery/FasstoDeliveryStatusQuery.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.fulfillment.domain.vendor.fassto.delivery;
 
 import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.fulfillment.domain.exception.FasstoQueryParameterNoValueException;
 import lombok.*;
 
 @Getter
@@ -34,19 +35,19 @@ public class FasstoDeliveryStatusQuery {
 
     private void validate() {
         if (FormatValidator.hasNoValue(customerCode)) {
-            throw new IllegalArgumentException("customerCode is required.");
+            throw new FasstoQueryParameterNoValueException("customerCode");
         }
         if (FormatValidator.hasNoValue(accessToken)) {
-            throw new IllegalArgumentException("accessToken is required.");
+            throw new FasstoQueryParameterNoValueException("accessToken");
         }
         if (FormatValidator.hasNoValue(startDate)) {
-            throw new IllegalArgumentException("startDate is required.");
+            throw new FasstoQueryParameterNoValueException("startDate");
         }
         if (FormatValidator.hasNoValue(endDate)) {
-            throw new IllegalArgumentException("endDate is required.");
+            throw new FasstoQueryParameterNoValueException("endDate");
         }
         if (FormatValidator.hasNoValue(outDiv)) {
-            throw new IllegalArgumentException("outDiv is required.");
+            throw new FasstoQueryParameterNoValueException("outDiv");
         }
     }
 }

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/goods/FasstoGoodsDetailQuery.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/goods/FasstoGoodsDetailQuery.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.fulfillment.domain.vendor.fassto.goods;
 
 import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.fulfillment.domain.exception.FasstoQueryParameterNoValueException;
 import lombok.*;
 
 @Getter
@@ -28,13 +29,13 @@ public class FasstoGoodsDetailQuery {
 
     private void validate() {
         if (FormatValidator.hasNoValue(customerCode)) {
-            throw new IllegalArgumentException("customerCode is required.");
+            throw new FasstoQueryParameterNoValueException("customerCode");
         }
         if (FormatValidator.hasNoValue(accessToken)) {
-            throw new IllegalArgumentException("accessToken is required.");
+            throw new FasstoQueryParameterNoValueException("accessToken");
         }
         if (FormatValidator.hasNoValue(godNm)) {
-            throw new IllegalArgumentException("godNm is required.");
+            throw new FasstoQueryParameterNoValueException("godNm");
         }
     }
 }

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/goods/FasstoGoodsElementQuery.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/goods/FasstoGoodsElementQuery.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.fulfillment.domain.vendor.fassto.goods;
 
 import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.fulfillment.domain.exception.FasstoQueryParameterNoValueException;
 import lombok.*;
 
 @Getter
@@ -22,10 +23,10 @@ public class FasstoGoodsElementQuery {
 
     private void validate() {
         if (FormatValidator.hasNoValue(customerCode)) {
-            throw new IllegalArgumentException("customerCode is required.");
+            throw new FasstoQueryParameterNoValueException("customerCode");
         }
         if (FormatValidator.hasNoValue(accessToken)) {
-            throw new IllegalArgumentException("accessToken is required.");
+            throw new FasstoQueryParameterNoValueException("accessToken");
         }
     }
 }

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/goods/FasstoGoodsItemMapper.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/goods/FasstoGoodsItemMapper.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.fulfillment.domain.vendor.fassto.goods;
 
 import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.fulfillment.domain.exception.FasstoQueryParameterNoValueException;
 import lombok.*;
 
 import java.util.LinkedHashMap;
@@ -167,16 +168,16 @@ public class FasstoGoodsItemMapper {
 
     private void validate() {
         if (FormatValidator.hasNoValue(cstGodCd)) {
-            throw new IllegalArgumentException("cstGodCd is required for goods request.");
+            throw new FasstoQueryParameterNoValueException("cstGodCd", "goods request");
         }
         if (FormatValidator.hasNoValue(godNm)) {
-            throw new IllegalArgumentException("godNm is required for goods request.");
+            throw new FasstoQueryParameterNoValueException("godNm", "goods request");
         }
         if (FormatValidator.hasNoValue(godType)) {
-            throw new IllegalArgumentException("godType is required for goods request.");
+            throw new FasstoQueryParameterNoValueException("godType", "goods request");
         }
         if (FormatValidator.hasNoValue(giftDiv)) {
-            throw new IllegalArgumentException("giftDiv is required for goods request.");
+            throw new FasstoQueryParameterNoValueException("giftDiv", "goods request");
         }
     }
 

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/goods/FasstoGoodsMapper.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/goods/FasstoGoodsMapper.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.fulfillment.domain.vendor.fassto.goods;
 
 import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.fulfillment.domain.exception.FasstoQueryParameterNoValueException;
 import lombok.*;
 
 import java.util.List;
@@ -32,13 +33,13 @@ public class FasstoGoodsMapper {
 
     private void validate() {
         if (FormatValidator.hasNoValue(customerCode)) {
-            throw new IllegalArgumentException("customerCode is required.");
+            throw new FasstoQueryParameterNoValueException("customerCode");
         }
         if (FormatValidator.hasNoValue(accessToken)) {
-            throw new IllegalArgumentException("accessToken is required.");
+            throw new FasstoQueryParameterNoValueException("accessToken");
         }
         if (FormatValidator.hasNoValue(goods)) {
-            throw new IllegalArgumentException("goods is required.");
+            throw new FasstoQueryParameterNoValueException("goods");
         }
     }
 

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/goods/FasstoGoodsQuery.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/goods/FasstoGoodsQuery.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.fulfillment.domain.vendor.fassto.goods;
 
 import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.fulfillment.domain.exception.FasstoQueryParameterNoValueException;
 import lombok.*;
 
 @Getter
@@ -22,10 +23,10 @@ public class FasstoGoodsQuery {
 
     private void validate() {
         if (FormatValidator.hasNoValue(customerCode)) {
-            throw new IllegalArgumentException("customerCode is required.");
+            throw new FasstoQueryParameterNoValueException("customerCode");
         }
         if (FormatValidator.hasNoValue(accessToken)) {
-            throw new IllegalArgumentException("accessToken is required.");
+            throw new FasstoQueryParameterNoValueException("accessToken");
         }
     }
 }

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/returndelivery/FasstoDirectReturnDeliveryItemMapper.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/returndelivery/FasstoDirectReturnDeliveryItemMapper.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.fulfillment.domain.vendor.fassto.returndelivery;
 
 import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.fulfillment.domain.exception.FasstoQueryParameterNoValueException;
 import com.personal.marketnote.fulfillment.domain.vendor.fassto.delivery.FasstoDeliveryGoodsMapper;
 import lombok.*;
 
@@ -85,25 +86,25 @@ public class FasstoDirectReturnDeliveryItemMapper {
 
     private void validate() {
         if (FormatValidator.hasNoValue(ordDt)) {
-            throw new IllegalArgumentException("ordDt is required for direct return delivery request.");
+            throw new FasstoQueryParameterNoValueException("ordDt", "direct return delivery request");
         }
         if (FormatValidator.hasNoValue(orgParcelCd)) {
-            throw new IllegalArgumentException("orgParcelCd is required for direct return delivery request.");
+            throw new FasstoQueryParameterNoValueException("orgParcelCd", "direct return delivery request");
         }
         if (FormatValidator.hasNoValue(orgInvoiceNo)) {
-            throw new IllegalArgumentException("orgInvoiceNo is required for direct return delivery request.");
+            throw new FasstoQueryParameterNoValueException("orgInvoiceNo", "direct return delivery request");
         }
         if (FormatValidator.hasNoValue(inWay)) {
-            throw new IllegalArgumentException("inWay is required for direct return delivery request.");
+            throw new FasstoQueryParameterNoValueException("inWay", "direct return delivery request");
         }
         if (FormatValidator.hasNoValue(custNm)) {
-            throw new IllegalArgumentException("custNm is required for direct return delivery request.");
+            throw new FasstoQueryParameterNoValueException("custNm", "direct return delivery request");
         }
         if (FormatValidator.hasNoValue(rtnGubun)) {
-            throw new IllegalArgumentException("rtnGubun is required for direct return delivery request.");
+            throw new FasstoQueryParameterNoValueException("rtnGubun", "direct return delivery request");
         }
         if (FormatValidator.hasNoValue(rtnReason)) {
-            throw new IllegalArgumentException("rtnReason is required for direct return delivery request.");
+            throw new FasstoQueryParameterNoValueException("rtnReason", "direct return delivery request");
         }
     }
 

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/returndelivery/FasstoDirectReturnDeliveryMapper.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/returndelivery/FasstoDirectReturnDeliveryMapper.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.fulfillment.domain.vendor.fassto.returndelivery;
 
 import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.fulfillment.domain.exception.FasstoQueryParameterNoValueException;
 import lombok.*;
 
 import java.util.List;
@@ -37,13 +38,13 @@ public class FasstoDirectReturnDeliveryMapper {
 
     private void validate() {
         if (FormatValidator.hasNoValue(customerCode)) {
-            throw new IllegalArgumentException("customerCode is required.");
+            throw new FasstoQueryParameterNoValueException("customerCode");
         }
         if (FormatValidator.hasNoValue(accessToken)) {
-            throw new IllegalArgumentException("accessToken is required.");
+            throw new FasstoQueryParameterNoValueException("accessToken");
         }
         if (FormatValidator.hasNoValue(directReturnDeliveryRequests)) {
-            throw new IllegalArgumentException("directReturnDeliveryRequests is required.");
+            throw new FasstoQueryParameterNoValueException("directReturnDeliveryRequests");
         }
     }
 }

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/returndelivery/FasstoReturnDeliveryItemMapper.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/returndelivery/FasstoReturnDeliveryItemMapper.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.fulfillment.domain.vendor.fassto.returndelivery;
 
 import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.fulfillment.domain.exception.FasstoQueryParameterNoValueException;
 import com.personal.marketnote.fulfillment.domain.vendor.fassto.delivery.FasstoDeliveryGoodsMapper;
 import lombok.*;
 
@@ -101,22 +102,22 @@ public class FasstoReturnDeliveryItemMapper {
 
     private void validate() {
         if (FormatValidator.hasNoValue(ordDt)) {
-            throw new IllegalArgumentException("ordDt is required for return delivery request.");
+            throw new FasstoQueryParameterNoValueException("ordDt", "return delivery request");
         }
         if (FormatValidator.hasNoValue(parcelCd)) {
-            throw new IllegalArgumentException("parcelCd is required for return delivery request.");
+            throw new FasstoQueryParameterNoValueException("parcelCd", "return delivery request");
         }
         if (FormatValidator.hasNoValue(invoiceNo)) {
-            throw new IllegalArgumentException("invoiceNo is required for return delivery request.");
+            throw new FasstoQueryParameterNoValueException("invoiceNo", "return delivery request");
         }
         if (FormatValidator.hasNoValue(custNm)) {
-            throw new IllegalArgumentException("custNm is required for return delivery request.");
+            throw new FasstoQueryParameterNoValueException("custNm", "return delivery request");
         }
         if (FormatValidator.hasNoValue(custTelNo)) {
-            throw new IllegalArgumentException("custTelNo is required for return delivery request.");
+            throw new FasstoQueryParameterNoValueException("custTelNo", "return delivery request");
         }
         if (FormatValidator.hasNoValue(custAddr)) {
-            throw new IllegalArgumentException("custAddr is required for return delivery request.");
+            throw new FasstoQueryParameterNoValueException("custAddr", "return delivery request");
         }
     }
 

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/returndelivery/FasstoReturnDeliveryMapper.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/returndelivery/FasstoReturnDeliveryMapper.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.fulfillment.domain.vendor.fassto.returndelivery;
 
 import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.fulfillment.domain.exception.FasstoQueryParameterNoValueException;
 import lombok.*;
 
 import java.util.List;
@@ -44,13 +45,13 @@ public class FasstoReturnDeliveryMapper {
 
     private void validate() {
         if (FormatValidator.hasNoValue(customerCode)) {
-            throw new IllegalArgumentException("customerCode is required.");
+            throw new FasstoQueryParameterNoValueException("customerCode");
         }
         if (FormatValidator.hasNoValue(accessToken)) {
-            throw new IllegalArgumentException("accessToken is required.");
+            throw new FasstoQueryParameterNoValueException("accessToken");
         }
         if (FormatValidator.hasNoValue(returnDeliveryRequests)) {
-            throw new IllegalArgumentException("returnDeliveryRequests is required.");
+            throw new FasstoQueryParameterNoValueException("returnDeliveryRequests");
         }
     }
 }

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/returndelivery/FasstoReturnGodDetailQuery.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/returndelivery/FasstoReturnGodDetailQuery.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.fulfillment.domain.vendor.fassto.returndelivery;
 
 import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.fulfillment.domain.exception.FasstoQueryParameterNoValueException;
 import lombok.*;
 
 @Getter
@@ -37,17 +38,17 @@ public class FasstoReturnGodDetailQuery {
 
     private void validate() {
         if (FormatValidator.hasNoValue(customerCode)) {
-            throw new IllegalArgumentException("customerCode is required.");
+            throw new FasstoQueryParameterNoValueException("customerCode");
         }
         if (FormatValidator.hasNoValue(accessToken)) {
-            throw new IllegalArgumentException("accessToken is required.");
+            throw new FasstoQueryParameterNoValueException("accessToken");
         }
         if (FormatValidator.hasNoValue(rtnSlipNoList)) {
             if (FormatValidator.hasNoValue(startDate)) {
-                throw new IllegalArgumentException("startDate is required when rtnSlipNoList is not provided.");
+                throw new FasstoQueryParameterNoValueException("startDate", "rtnSlipNoList is not provided");
             }
             if (FormatValidator.hasNoValue(endDate)) {
-                throw new IllegalArgumentException("endDate is required when rtnSlipNoList is not provided.");
+                throw new FasstoQueryParameterNoValueException("endDate", "rtnSlipNoList is not provided");
             }
         }
     }

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/settlement/FasstoSettlementDailyCostQuery.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/settlement/FasstoSettlementDailyCostQuery.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.fulfillment.domain.vendor.fassto.settlement;
 
 import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.fulfillment.domain.exception.FasstoQueryParameterNoValueException;
 import lombok.*;
 
 @Getter
@@ -31,16 +32,16 @@ public class FasstoSettlementDailyCostQuery {
 
     private void validate() {
         if (FormatValidator.hasNoValue(yearMonth)) {
-            throw new IllegalArgumentException("yearMonth is required.");
+            throw new FasstoQueryParameterNoValueException("yearMonth");
         }
         if (FormatValidator.hasNoValue(whCd)) {
-            throw new IllegalArgumentException("whCd is required.");
+            throw new FasstoQueryParameterNoValueException("whCd");
         }
         if (FormatValidator.hasNoValue(customerCode)) {
-            throw new IllegalArgumentException("customerCode is required.");
+            throw new FasstoQueryParameterNoValueException("customerCode");
         }
         if (FormatValidator.hasNoValue(accessToken)) {
-            throw new IllegalArgumentException("accessToken is required.");
+            throw new FasstoQueryParameterNoValueException("accessToken");
         }
     }
 }

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/shop/FasstoShopMapper.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/shop/FasstoShopMapper.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.fulfillment.domain.vendor.fassto.shop;
 
 import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.fulfillment.domain.exception.FasstoQueryParameterNoValueException;
 import lombok.*;
 
 import java.util.LinkedHashMap;
@@ -158,16 +159,16 @@ public class FasstoShopMapper {
 
     private void validate() {
         if (FormatValidator.hasNoValue(customerCode)) {
-            throw new IllegalArgumentException("customerCode is required.");
+            throw new FasstoQueryParameterNoValueException("customerCode");
         }
         if (FormatValidator.hasNoValue(accessToken)) {
-            throw new IllegalArgumentException("accessToken is required.");
+            throw new FasstoQueryParameterNoValueException("accessToken");
         }
         if (FormatValidator.hasNoValue(shopCd)) {
-            throw new IllegalArgumentException("shopCd is required for shop request.");
+            throw new FasstoQueryParameterNoValueException("shopCd", "shop request");
         }
         if (FormatValidator.hasNoValue(shopNm)) {
-            throw new IllegalArgumentException("shopNm is required for shop request.");
+            throw new FasstoQueryParameterNoValueException("shopNm", "shop request");
         }
     }
 

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/shop/FasstoShopQuery.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/shop/FasstoShopQuery.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.fulfillment.domain.vendor.fassto.shop;
 
 import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.fulfillment.domain.exception.FasstoQueryParameterNoValueException;
 import lombok.*;
 
 @Getter
@@ -22,10 +23,10 @@ public class FasstoShopQuery {
 
     private void validate() {
         if (FormatValidator.hasNoValue(customerCode)) {
-            throw new IllegalArgumentException("customerCode is required.");
+            throw new FasstoQueryParameterNoValueException("customerCode");
         }
         if (FormatValidator.hasNoValue(accessToken)) {
-            throw new IllegalArgumentException("accessToken is required.");
+            throw new FasstoQueryParameterNoValueException("accessToken");
         }
     }
 }

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/stock/FasstoStockDetailQuery.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/stock/FasstoStockDetailQuery.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.fulfillment.domain.vendor.fassto.stock;
 
 import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.fulfillment.domain.exception.FasstoQueryParameterNoValueException;
 import lombok.*;
 
 @Getter
@@ -31,13 +32,13 @@ public class FasstoStockDetailQuery {
 
     private void validate() {
         if (FormatValidator.hasNoValue(customerCode)) {
-            throw new IllegalArgumentException("customerCode is required.");
+            throw new FasstoQueryParameterNoValueException("customerCode");
         }
         if (FormatValidator.hasNoValue(accessToken)) {
-            throw new IllegalArgumentException("accessToken is required.");
+            throw new FasstoQueryParameterNoValueException("accessToken");
         }
         if (FormatValidator.hasNoValue(cstGodCd)) {
-            throw new IllegalArgumentException("cstGodCd is required.");
+            throw new FasstoQueryParameterNoValueException("cstGodCd");
         }
     }
 }

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/stock/FasstoStockQuery.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/stock/FasstoStockQuery.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.fulfillment.domain.vendor.fassto.stock;
 
 import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.fulfillment.domain.exception.FasstoQueryParameterNoValueException;
 import lombok.*;
 
 @Getter
@@ -39,10 +40,10 @@ public class FasstoStockQuery {
 
     private void validate() {
         if (FormatValidator.hasNoValue(customerCode)) {
-            throw new IllegalArgumentException("customerCode is required.");
+            throw new FasstoQueryParameterNoValueException("customerCode");
         }
         if (FormatValidator.hasNoValue(accessToken)) {
-            throw new IllegalArgumentException("accessToken is required.");
+            throw new FasstoQueryParameterNoValueException("accessToken");
         }
     }
 }

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/supplier/FasstoSupplierMapper.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/supplier/FasstoSupplierMapper.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.fulfillment.domain.vendor.fassto.supplier;
 
 import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.fulfillment.domain.exception.FasstoQueryParameterNoValueException;
 import lombok.*;
 
 import java.util.LinkedHashMap;
@@ -182,16 +183,16 @@ public class FasstoSupplierMapper {
 
     private void validate() {
         if (FormatValidator.hasNoValue(customerCode)) {
-            throw new IllegalArgumentException("customerCode is required.");
+            throw new FasstoQueryParameterNoValueException("customerCode");
         }
         if (FormatValidator.hasNoValue(accessToken)) {
-            throw new IllegalArgumentException("accessToken is required.");
+            throw new FasstoQueryParameterNoValueException("accessToken");
         }
         if (FormatValidator.hasNoValue(supCd)) {
-            throw new IllegalArgumentException("supCd is required for supplier request.");
+            throw new FasstoQueryParameterNoValueException("supCd", "supplier request");
         }
         if (FormatValidator.hasNoValue(supNm)) {
-            throw new IllegalArgumentException("supNm is required for supplier request.");
+            throw new FasstoQueryParameterNoValueException("supNm", "supplier request");
         }
     }
 

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/supplier/FasstoSupplierQuery.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/supplier/FasstoSupplierQuery.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.fulfillment.domain.vendor.fassto.supplier;
 
 import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.fulfillment.domain.exception.FasstoQueryParameterNoValueException;
 import lombok.*;
 
 @Getter
@@ -22,10 +23,10 @@ public class FasstoSupplierQuery {
 
     private void validate() {
         if (FormatValidator.hasNoValue(customerCode)) {
-            throw new IllegalArgumentException("customerCode is required.");
+            throw new FasstoQueryParameterNoValueException("customerCode");
         }
         if (FormatValidator.hasNoValue(accessToken)) {
-            throw new IllegalArgumentException("accessToken is required.");
+            throw new FasstoQueryParameterNoValueException("accessToken");
         }
     }
 }

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/warehousing/FasstoWarehousingAbnormalImageQuery.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/warehousing/FasstoWarehousingAbnormalImageQuery.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.fulfillment.domain.vendor.fassto.warehousing;
 
 import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.fulfillment.domain.exception.FasstoQueryParameterNoValueException;
 import lombok.*;
 
 @Getter
@@ -37,22 +38,22 @@ public class FasstoWarehousingAbnormalImageQuery {
 
     private void validate() {
         if (FormatValidator.hasNoValue(accessToken)) {
-            throw new IllegalArgumentException("accessToken is required.");
+            throw new FasstoQueryParameterNoValueException("accessToken");
         }
         if (FormatValidator.hasNoValue(slipNo)) {
-            throw new IllegalArgumentException("slipNo is required.");
+            throw new FasstoQueryParameterNoValueException("slipNo");
         }
         if (FormatValidator.hasNoValue(godCd)) {
-            throw new IllegalArgumentException("godCd is required.");
+            throw new FasstoQueryParameterNoValueException("godCd");
         }
         if (FormatValidator.hasNoValue(goodsSerialNo)) {
-            throw new IllegalArgumentException("goodsSerialNo is required.");
+            throw new FasstoQueryParameterNoValueException("goodsSerialNo");
         }
         if (FormatValidator.hasNoValue(fileSeq)) {
-            throw new IllegalArgumentException("fileSeq is required.");
+            throw new FasstoQueryParameterNoValueException("fileSeq");
         }
         if (FormatValidator.hasNoValue(imgNo)) {
-            throw new IllegalArgumentException("imgNo is required.");
+            throw new FasstoQueryParameterNoValueException("imgNo");
         }
     }
 }

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/warehousing/FasstoWarehousingAbnormalQuery.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/warehousing/FasstoWarehousingAbnormalQuery.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.fulfillment.domain.vendor.fassto.warehousing;
 
 import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.fulfillment.domain.exception.FasstoQueryParameterNoValueException;
 import lombok.*;
 
 @Getter
@@ -31,16 +32,16 @@ public class FasstoWarehousingAbnormalQuery {
 
     private void validate() {
         if (FormatValidator.hasNoValue(customerCode)) {
-            throw new IllegalArgumentException("customerCode is required.");
+            throw new FasstoQueryParameterNoValueException("customerCode");
         }
         if (FormatValidator.hasNoValue(accessToken)) {
-            throw new IllegalArgumentException("accessToken is required.");
+            throw new FasstoQueryParameterNoValueException("accessToken");
         }
         if (FormatValidator.hasNoValue(whCd)) {
-            throw new IllegalArgumentException("whCd is required.");
+            throw new FasstoQueryParameterNoValueException("whCd");
         }
         if (FormatValidator.hasNoValue(slipNo)) {
-            throw new IllegalArgumentException("slipNo is required.");
+            throw new FasstoQueryParameterNoValueException("slipNo");
         }
     }
 }

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/warehousing/FasstoWarehousingDetailQuery.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/warehousing/FasstoWarehousingDetailQuery.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.fulfillment.domain.vendor.fassto.warehousing;
 
 import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.fulfillment.domain.exception.FasstoQueryParameterNoValueException;
 import lombok.*;
 
 @Getter
@@ -31,13 +32,13 @@ public class FasstoWarehousingDetailQuery {
 
     private void validate() {
         if (FormatValidator.hasNoValue(customerCode)) {
-            throw new IllegalArgumentException("customerCode is required.");
+            throw new FasstoQueryParameterNoValueException("customerCode");
         }
         if (FormatValidator.hasNoValue(accessToken)) {
-            throw new IllegalArgumentException("accessToken is required.");
+            throw new FasstoQueryParameterNoValueException("accessToken");
         }
         if (FormatValidator.hasNoValue(slipNo)) {
-            throw new IllegalArgumentException("slipNo is required.");
+            throw new FasstoQueryParameterNoValueException("slipNo");
         }
     }
 }

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/warehousing/FasstoWarehousingGoodsMapper.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/warehousing/FasstoWarehousingGoodsMapper.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.fulfillment.domain.vendor.fassto.warehousing;
 
 import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.fulfillment.domain.exception.FasstoQueryParameterNoValueException;
 import lombok.*;
 
 import java.util.LinkedHashMap;
@@ -41,10 +42,10 @@ public class FasstoWarehousingGoodsMapper {
 
     private void validate() {
         if (FormatValidator.hasNoValue(cstGodCd)) {
-            throw new IllegalArgumentException("cstGodCd is required for warehousing goods request.");
+            throw new FasstoQueryParameterNoValueException("cstGodCd", "warehousing goods request");
         }
         if (FormatValidator.hasNoValue(ordQty)) {
-            throw new IllegalArgumentException("ordQty is required for warehousing goods request.");
+            throw new FasstoQueryParameterNoValueException("ordQty", "warehousing goods request");
         }
     }
 

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/warehousing/FasstoWarehousingInspecDetailQuery.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/warehousing/FasstoWarehousingInspecDetailQuery.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.fulfillment.domain.vendor.fassto.warehousing;
 
 import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.fulfillment.domain.exception.FasstoQueryParameterNoValueException;
 import lombok.*;
 
 @Getter
@@ -31,16 +32,16 @@ public class FasstoWarehousingInspecDetailQuery {
 
     private void validate() {
         if (FormatValidator.hasNoValue(customerCode)) {
-            throw new IllegalArgumentException("customerCode is required.");
+            throw new FasstoQueryParameterNoValueException("customerCode");
         }
         if (FormatValidator.hasNoValue(accessToken)) {
-            throw new IllegalArgumentException("accessToken is required.");
+            throw new FasstoQueryParameterNoValueException("accessToken");
         }
         if (FormatValidator.hasNoValue(slipNo)) {
-            throw new IllegalArgumentException("slipNo is required.");
+            throw new FasstoQueryParameterNoValueException("slipNo");
         }
         if (FormatValidator.hasNoValue(whCd)) {
-            throw new IllegalArgumentException("whCd is required.");
+            throw new FasstoQueryParameterNoValueException("whCd");
         }
     }
 }

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/warehousing/FasstoWarehousingItemMapper.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/warehousing/FasstoWarehousingItemMapper.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.fulfillment.domain.vendor.fassto.warehousing;
 
 import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.fulfillment.domain.exception.FasstoQueryParameterNoValueException;
 import lombok.*;
 
 import java.util.LinkedHashMap;
@@ -112,20 +113,20 @@ public class FasstoWarehousingItemMapper {
 
     private void validate() {
         if (FormatValidator.hasNoValue(ordDt)) {
-            throw new IllegalArgumentException("ordDt is required for warehousing request.");
+            throw new FasstoQueryParameterNoValueException("ordDt", "warehousing request");
         }
         if (FormatValidator.hasNoValue(inWay)) {
-            throw new IllegalArgumentException("inWay is required for warehousing request.");
+            throw new FasstoQueryParameterNoValueException("inWay", "warehousing request");
         }
         if (FormatValidator.hasNoValue(godCds)) {
-            throw new IllegalArgumentException("godCds is required for warehousing request.");
+            throw new FasstoQueryParameterNoValueException("godCds", "warehousing request");
         }
     }
 
     private void validateForUpdate() {
         validate();
         if (FormatValidator.hasNoValue(slipNo)) {
-            throw new IllegalArgumentException("slipNo is required for warehousing update.");
+            throw new FasstoQueryParameterNoValueException("slipNo", "warehousing update");
         }
     }
 

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/warehousing/FasstoWarehousingMapper.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/warehousing/FasstoWarehousingMapper.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.fulfillment.domain.vendor.fassto.warehousing;
 
 import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.fulfillment.domain.exception.FasstoQueryParameterNoValueException;
 import lombok.*;
 
 import java.util.List;
@@ -39,13 +40,13 @@ public class FasstoWarehousingMapper {
 
     private void validate() {
         if (FormatValidator.hasNoValue(customerCode)) {
-            throw new IllegalArgumentException("customerCode is required.");
+            throw new FasstoQueryParameterNoValueException("customerCode");
         }
         if (FormatValidator.hasNoValue(accessToken)) {
-            throw new IllegalArgumentException("accessToken is required.");
+            throw new FasstoQueryParameterNoValueException("accessToken");
         }
         if (FormatValidator.hasNoValue(warehousingRequests)) {
-            throw new IllegalArgumentException("warehousingRequests is required.");
+            throw new FasstoQueryParameterNoValueException("warehousingRequests");
         }
     }
 

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/warehousing/FasstoWarehousingQuery.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/vendor/fassto/warehousing/FasstoWarehousingQuery.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.fulfillment.domain.vendor.fassto.warehousing;
 
 import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.fulfillment.domain.exception.FasstoQueryParameterNoValueException;
 import lombok.*;
 
 @Getter
@@ -49,16 +50,16 @@ public class FasstoWarehousingQuery {
 
     private void validate() {
         if (FormatValidator.hasNoValue(customerCode)) {
-            throw new IllegalArgumentException("customerCode is required.");
+            throw new FasstoQueryParameterNoValueException("customerCode");
         }
         if (FormatValidator.hasNoValue(accessToken)) {
-            throw new IllegalArgumentException("accessToken is required.");
+            throw new FasstoQueryParameterNoValueException("accessToken");
         }
         if (FormatValidator.hasNoValue(startDate)) {
-            throw new IllegalArgumentException("startDate is required.");
+            throw new FasstoQueryParameterNoValueException("startDate");
         }
         if (FormatValidator.hasNoValue(endDate)) {
-            throw new IllegalArgumentException("endDate is required.");
+            throw new FasstoQueryParameterNoValueException("endDate");
         }
     }
 }


### PR DESCRIPTION
## partially addresses #475
## resolves #992

## Task
- [x] FasstoQueryParameterNoValueException 기반 예외 클래스 생성
- [x] Domain Query 20개 — IllegalArgumentException → FasstoQueryParameterNoValueException
- [x] Domain Mapper 22개 — IllegalArgumentException → FasstoQueryParameterNoValueException
- [x] FasstoAccessToken.java — IllegalArgumentException → FasstoQueryParameterNoValueException
- [x] FasstoGoodsRegistration.java — IllegalArgumentException → FasstoQueryParameterNoValueException
- [x] FasstoDeliveryRegistration.java — IllegalArgumentException → FasstoQueryParameterNoValueException
- [x] SyncFasstoStockService.java — IllegalArgumentException → FasstoQueryParameterNoValueException
- [x] UpdateCommerceInventoryCommand.java — IllegalArgumentException → FasstoQueryParameterNoValueException
- [x] UpdateCommerceInventoryItemCommand.java — IllegalArgumentException → FasstoQueryParameterNoValueException