### PR TITLE
[#1][#994] refactor: 제네릭 예외를 도메인 커스텀 예외로 전환 - 공통 모듈

### DIFF
--- a/common/src/main/java/com/personal/marketnote/common/adapter/in/InputFormatValidator.java
+++ b/common/src/main/java/com/personal/marketnote/common/adapter/in/InputFormatValidator.java
@@ -1,5 +1,7 @@
 package com.personal.marketnote.common.adapter.in;
 
+import com.personal.marketnote.common.domain.exception.illegalargument.invalidvalue.InvalidIdException;
+import com.personal.marketnote.common.domain.exception.illegalargument.novalue.IdNoValueException;
 import com.personal.marketnote.common.utility.FormatValidator;
 
 import java.util.regex.Pattern;
@@ -8,7 +10,6 @@ import static com.personal.marketnote.common.utility.RegularExpressionConstant.P
 
 public class InputFormatValidator {
     static final String ID_NO_VALUE_EXCEPTION = "ID는 필수값입니다.";
-    static final String INVALID_ID_EXCEPTION = "ID는 양의 정수(1 이상의 숫자값)여야 합니다. 입력된 ID: ";
 
     public static void validateId(String id) {
         checkIdIsNotBlank(id);
@@ -17,13 +18,13 @@ public class InputFormatValidator {
 
     private static void checkIdIsNotBlank(String id) {
         if (FormatValidator.hasNoValue(id)) {
-            throw new IllegalArgumentException(ID_NO_VALUE_EXCEPTION);
+            throw new IdNoValueException(ID_NO_VALUE_EXCEPTION);
         }
     }
 
     private static void checkIdPattern(String id) {
         if (!FormatValidator.isValid(id, Pattern.compile(POSITIVE_INTEGER_PATTERN))) {
-            throw new IllegalArgumentException(INVALID_ID_EXCEPTION + id);
+            throw new InvalidIdException(id);
         }
     }
 }

--- a/common/src/main/java/com/personal/marketnote/common/configuration/kafka/KafkaSaslProperties.java
+++ b/common/src/main/java/com/personal/marketnote/common/configuration/kafka/KafkaSaslProperties.java
@@ -1,5 +1,8 @@
 package com.personal.marketnote.common.configuration.kafka;
 
+import com.personal.marketnote.common.configuration.kafka.exception.KafkaSaslPasswordNotConfiguredException;
+import com.personal.marketnote.common.configuration.kafka.exception.KafkaSaslUsernameNotConfiguredException;
+import com.personal.marketnote.common.configuration.kafka.exception.UnsupportedKafkaSaslMechanismException;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
@@ -38,12 +41,10 @@ public class KafkaSaslProperties {
 
     private void validateCredentials() {
         if (username == null || username.isBlank()) {
-            throw new IllegalStateException(
-                    "Kafka SASL 인증이 활성화되었으나 username이 설정되지 않았습니다. KAFKA_SASL_USERNAME 환경변수를 확인하세요.");
+            throw new KafkaSaslUsernameNotConfiguredException();
         }
         if (password == null || password.isBlank()) {
-            throw new IllegalStateException(
-                    "Kafka SASL 인증이 활성화되었으나 password가 설정되지 않았습니다. KAFKA_SASL_PASSWORD 환경변수를 확인하세요.");
+            throw new KafkaSaslPasswordNotConfiguredException();
         }
     }
 
@@ -63,8 +64,6 @@ public class KafkaSaslProperties {
         if ("PLAIN".equals(mechanism)) {
             return "org.apache.kafka.common.security.plain.PlainLoginModule";
         }
-        throw new IllegalStateException(
-                "지원하지 않는 SASL mechanism입니다: " + mechanism
-                        + ". 지원 목록: " + SUPPORTED_MECHANISMS);
+        throw new UnsupportedKafkaSaslMechanismException(mechanism, SUPPORTED_MECHANISMS);
     }
 }

--- a/common/src/main/java/com/personal/marketnote/common/configuration/kafka/exception/KafkaSaslPasswordNotConfiguredException.java
+++ b/common/src/main/java/com/personal/marketnote/common/configuration/kafka/exception/KafkaSaslPasswordNotConfiguredException.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.common.configuration.kafka.exception;
+
+public class KafkaSaslPasswordNotConfiguredException extends IllegalStateException {
+
+    public KafkaSaslPasswordNotConfiguredException() {
+        super("Kafka SASL 인증이 활성화되었으나 password가 설정되지 않았습니다. KAFKA_SASL_PASSWORD 환경변수를 확인하세요.");
+    }
+}

--- a/common/src/main/java/com/personal/marketnote/common/configuration/kafka/exception/KafkaSaslUsernameNotConfiguredException.java
+++ b/common/src/main/java/com/personal/marketnote/common/configuration/kafka/exception/KafkaSaslUsernameNotConfiguredException.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.common.configuration.kafka.exception;
+
+public class KafkaSaslUsernameNotConfiguredException extends IllegalStateException {
+
+    public KafkaSaslUsernameNotConfiguredException() {
+        super("Kafka SASL 인증이 활성화되었으나 username이 설정되지 않았습니다. KAFKA_SASL_USERNAME 환경변수를 확인하세요.");
+    }
+}

--- a/common/src/main/java/com/personal/marketnote/common/configuration/kafka/exception/UnsupportedKafkaSaslMechanismException.java
+++ b/common/src/main/java/com/personal/marketnote/common/configuration/kafka/exception/UnsupportedKafkaSaslMechanismException.java
@@ -1,0 +1,10 @@
+package com.personal.marketnote.common.configuration.kafka.exception;
+
+import java.util.Set;
+
+public class UnsupportedKafkaSaslMechanismException extends IllegalStateException {
+
+    public UnsupportedKafkaSaslMechanismException(String mechanism, Set<String> supportedMechanisms) {
+        super("지원하지 않는 SASL mechanism입니다: " + mechanism + ". 지원 목록: " + supportedMechanisms);
+    }
+}

--- a/common/src/main/java/com/personal/marketnote/common/configuration/security/SecurityPropertiesValidator.java
+++ b/common/src/main/java/com/personal/marketnote/common/configuration/security/SecurityPropertiesValidator.java
@@ -1,5 +1,6 @@
 package com.personal.marketnote.common.configuration.security;
 
+import com.personal.marketnote.common.configuration.security.exception.SecurityConfigurationValidationException;
 import jakarta.annotation.PostConstruct;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -57,8 +58,7 @@ public class SecurityPropertiesValidator {
 
         if (!violations.isEmpty()) {
             String message = String.join("\n  - ", violations);
-            throw new IllegalStateException(
-                    "보안 설정 검증 실패. 다음 환경변수를 확인하세요:\n  - " + message);
+            throw new SecurityConfigurationValidationException(message);
         }
 
         log.info("보안 설정 검증 완료: 필수 시크릿이 올바르게 설정되었습니다.");

--- a/common/src/main/java/com/personal/marketnote/common/configuration/security/exception/SecurityConfigurationValidationException.java
+++ b/common/src/main/java/com/personal/marketnote/common/configuration/security/exception/SecurityConfigurationValidationException.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.common.configuration.security.exception;
+
+public class SecurityConfigurationValidationException extends IllegalStateException {
+
+    public SecurityConfigurationValidationException(String violations) {
+        super("보안 설정 검증 실패. 다음 환경변수를 확인하세요:\n  - " + violations);
+    }
+}


### PR DESCRIPTION
## partially addresses #1
## resolves #994

## Task
- [x] SecurityPropertiesValidator.java — IllegalStateException → SecurityConfigurationValidationException
- [x] InputFormatValidator.java — IllegalArgumentException → IdNoValueException (기존 재사용), InvalidIdException (기존 재사용)
- [x] KafkaSaslProperties.java — IllegalStateException ×3 → KafkaSaslUsernameNotConfiguredException, KafkaSaslPasswordNotConfiguredException, UnsupportedKafkaSaslMechanismException