### PR TITLE
[#475][#1046] refactor: RegisterFasstoGoodsItemCommand 최소 필드 팩토리 메서드 추가

### DIFF
--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/event/ProductRegisteredFulfillmentConsumer.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/event/ProductRegisteredFulfillmentConsumer.java
@@ -82,15 +82,11 @@ public class ProductRegisteredFulfillmentConsumer {
 
             String godType = FormatValidator.hasValue(payload.godType()) ? payload.godType() : DEFAULT_GOD_TYPE;
 
-            RegisterFasstoGoodsItemCommand itemCommand = RegisterFasstoGoodsItemCommand.of(
+            RegisterFasstoGoodsItemCommand itemCommand = RegisterFasstoGoodsItemCommand.ofMinimal(
                     String.valueOf(payload.productId()),
                     payload.productName(),
                     godType,
-                    DEFAULT_GIFT_DIV,
-                    null, null, null, null, null, null, null, null, null,
-                    null, null, null, null, null, null, null, null, null,
-                    null, null, null, null, null, null, null, null, null,
-                    null, null, null, null
+                    DEFAULT_GIFT_DIV
             );
 
             RegisterFasstoGoodsCommand command = RegisterFasstoGoodsCommand.of(

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/vendor/RegisterFasstoGoodsItemCommand.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/vendor/RegisterFasstoGoodsItemCommand.java
@@ -1,5 +1,9 @@
 package com.personal.marketnote.fulfillment.port.in.command.vendor;
 
+import lombok.AccessLevel;
+import lombok.Builder;
+
+@Builder(access = AccessLevel.PRIVATE)
 public record RegisterFasstoGoodsItemCommand(
         String cstGodCd,
         String godNm,
@@ -37,6 +41,20 @@ public record RegisterFasstoGoodsItemCommand(
         String cstGodImgUrl,
         String externalGodImgUrl
 ) {
+    public static RegisterFasstoGoodsItemCommand ofMinimal(
+            String cstGodCd,
+            String godNm,
+            String godType,
+            String giftDiv
+    ) {
+        return RegisterFasstoGoodsItemCommand.builder()
+                .cstGodCd(cstGodCd)
+                .godNm(godNm)
+                .godType(godType)
+                .giftDiv(giftDiv)
+                .build();
+    }
+
     public static RegisterFasstoGoodsItemCommand of(
             String cstGodCd,
             String godNm,


### PR DESCRIPTION
## partially addresses #475
## resolves #1046

## Task
- [x] RegisterFasstoGoodsItemCommand에 ofMinimal(cstGodCd, godNm, godType, giftDiv) 팩토리 메서드 추가
- [x] ProductRegisteredFulfillmentConsumer에서 ofMinimal 사용으로 전환