### PR TITLE
[#1][#1495] feat: 서비스 간 통신 HMAC MD5 Hash Key 기반 인증 시스템 구축 기능 추가

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/web/cart/CartServiceClient.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/web/cart/CartServiceClient.java
@@ -8,6 +8,7 @@ import com.personal.marketnote.commerce.port.out.order.DeleteOrderedCartProducts
 import com.personal.marketnote.commerce.utility.ServiceCommunicationPayloadGenerator;
 import com.personal.marketnote.commerce.utility.ServiceCommunicationRecorder;
 import com.personal.marketnote.common.adapter.out.ServiceAdapter;
+import com.personal.marketnote.common.security.hmac.HmacServiceAuthHeaderBuilder;
 import com.personal.marketnote.common.utility.FormatValidator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -39,10 +40,8 @@ public class CartServiceClient implements DeleteOrderedCartProductsPort {
     @Value("${product-service.base-url:http://localhost:8081}")
     private String cartServiceBaseUrl;
 
-    @Value("${spring.jwt.admin-access-token}")
-    private String adminAccessToken;
-
     private final RestTemplate restTemplate;
+    private final HmacServiceAuthHeaderBuilder hmacServiceAuthHeaderBuilder;
     private final ServiceCommunicationRecorder serviceCommunicationRecorder;
     private final ServiceCommunicationPayloadGenerator serviceCommunicationPayloadGenerator;
 
@@ -56,7 +55,7 @@ public class CartServiceClient implements DeleteOrderedCartProductsPort {
                 .toUri();
 
         HttpHeaders headers = new HttpHeaders();
-        headers.setBearerAuth(adminAccessToken);
+        hmacServiceAuthHeaderBuilder.applyHeaders(headers, "DELETE", uri.getPath());
         HttpEntity<Void> httpEntity = new HttpEntity<>(headers);
 
         sendRequest(uri, httpEntity, pricePolicyIds);

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/web/product/ProductServiceClient.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/web/product/ProductServiceClient.java
@@ -13,6 +13,7 @@ import com.personal.marketnote.commerce.utility.ServiceCommunicationRecorder;
 import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
 import com.personal.marketnote.common.adapter.in.response.CursorResponse;
 import com.personal.marketnote.common.adapter.out.ServiceAdapter;
+import com.personal.marketnote.common.security.hmac.HmacServiceAuthHeaderBuilder;
 import com.personal.marketnote.common.utility.FormatValidator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -48,10 +49,8 @@ public class ProductServiceClient implements FindProductByPricePolicyPort {
     @Value("${product-service.base-url:http://localhost:8081}")
     private String productServiceBaseUrl;
 
-    @Value("${spring.jwt.admin-access-token}")
-    private String adminAccessToken;
-
     private final RestTemplate restTemplate;
+    private final HmacServiceAuthHeaderBuilder hmacServiceAuthHeaderBuilder;
     private final ServiceCommunicationRecorder serviceCommunicationRecorder;
     private final ServiceCommunicationPayloadGenerator serviceCommunicationPayloadGenerator;
 
@@ -69,7 +68,7 @@ public class ProductServiceClient implements FindProductByPricePolicyPort {
                 .toUri();
 
         HttpHeaders headers = new HttpHeaders();
-        headers.setBearerAuth(adminAccessToken);
+        hmacServiceAuthHeaderBuilder.applyHeaders(headers, "GET", uri.getPath());
         HttpEntity<Void> request = new HttpEntity<>(headers);
 
         return sendRequest(uri, request);

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/web/product/ShippingPolicyServiceClient.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/web/product/ShippingPolicyServiceClient.java
@@ -6,6 +6,7 @@ import com.personal.marketnote.commerce.port.out.result.shipping.ShippingPolicyI
 import com.personal.marketnote.commerce.port.out.shipping.FindShippingPolicyBySellerIdsPort;
 import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
 import com.personal.marketnote.common.adapter.out.ServiceAdapter;
+import com.personal.marketnote.common.security.hmac.HmacServiceAuthHeaderBuilder;
 import com.personal.marketnote.common.utility.FormatValidator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -46,10 +47,8 @@ public class ShippingPolicyServiceClient implements FindShippingPolicyBySellerId
     @Value("${product-service.base-url:http://localhost:8081}")
     private String productServiceBaseUrl;
 
-    @Value("${spring.jwt.admin-access-token}")
-    private String adminAccessToken;
-
     private final RestTemplate restTemplate;
+    private final HmacServiceAuthHeaderBuilder hmacServiceAuthHeaderBuilder;
 
     @Override
     public Map<Long, ShippingPolicyInfoResult> findBySellerIds(List<Long> sellerIds) {
@@ -64,7 +63,7 @@ public class ShippingPolicyServiceClient implements FindShippingPolicyBySellerId
                 .toUri();
 
         HttpHeaders headers = new HttpHeaders();
-        headers.setBearerAuth(adminAccessToken);
+        hmacServiceAuthHeaderBuilder.applyHeaders(headers, "GET", uri.getPath());
         HttpEntity<Void> request = new HttpEntity<>(headers);
 
         return sendRequest(uri, request);

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/web/reward/RewardServiceClient.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/web/reward/RewardServiceClient.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.personal.marketnote.commerce.port.out.reward.ModifyUserPointPort;
 import com.personal.marketnote.common.adapter.out.ServiceAdapter;
 import com.personal.marketnote.common.exception.RewardServiceRequestFailedException;
+import com.personal.marketnote.common.security.hmac.HmacServiceAuthHeaderBuilder;
 import com.personal.marketnote.common.utility.FormatValidator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -39,18 +40,16 @@ public class RewardServiceClient implements ModifyUserPointPort {
     @Value("${reward-service.base-url}")
     private String rewardServiceBaseUrl;
 
-    @Value("${spring.jwt.admin-access-token}")
-    private String adminAccessToken;
-
     @Value("${reward-service.share-point-rate}")
     private float sharePointRate;
 
     private final RestTemplate restTemplate;
+    private final HmacServiceAuthHeaderBuilder hmacServiceAuthHeaderBuilder;
 
     @Override
     public Long getAvailablePoints(Long userId) {
         URI uri = buildUserPointUri(userId);
-        HttpHeaders headers = buildHeaders();
+        HttpHeaders headers = buildHeaders("GET", uri.getPath());
 
         long sleepMillis = INTER_SERVER_DEFAULT_RETRIAL_PENDING_MILLI_SECOND;
         Exception lastError = null;
@@ -90,7 +89,7 @@ public class RewardServiceClient implements ModifyUserPointPort {
         }
 
         URI uri = buildUserPointUri(userId);
-        HttpHeaders headers = buildHeaders();
+        HttpHeaders headers = buildHeaders("PATCH", uri.getPath());
 
         ModifyUserPointRequest request = ModifyUserPointRequest.deduction(amount, orderId);
         HttpEntity<ModifyUserPointRequest> httpEntity = new HttpEntity<>(request, headers);
@@ -105,7 +104,7 @@ public class RewardServiceClient implements ModifyUserPointPort {
         }
 
         URI uri = buildUserPointUri(userId);
-        HttpHeaders headers = buildHeaders();
+        HttpHeaders headers = buildHeaders("PATCH", uri.getPath());
 
         ModifyUserPointRequest request = ModifyUserPointRequest.refund(amount, orderId);
         HttpEntity<ModifyUserPointRequest> httpEntity = new HttpEntity<>(request, headers);
@@ -120,7 +119,7 @@ public class RewardServiceClient implements ModifyUserPointPort {
         }
 
         URI uri = buildPendingPointUri(userId);
-        HttpHeaders headers = buildHeaders();
+        HttpHeaders headers = buildHeaders("PATCH", uri.getPath());
 
         ModifyUserPointRequest request = ModifyUserPointRequest.pendingAccrual(amount, orderId, PRODUCT_ACCUMULATION_REASON);
         HttpEntity<ModifyUserPointRequest> httpEntity = new HttpEntity<>(request, headers);
@@ -135,7 +134,7 @@ public class RewardServiceClient implements ModifyUserPointPort {
         }
 
         URI uri = buildPendingPointConfirmUri(userId);
-        HttpHeaders headers = buildHeaders();
+        HttpHeaders headers = buildHeaders("POST", uri.getPath());
 
         ConfirmPendingPointRequest request = new ConfirmPendingPointRequest(
                 SOURCE_TYPE_ORDER, orderId, PENDING_POINT_CONFIRM_REASON
@@ -152,7 +151,7 @@ public class RewardServiceClient implements ModifyUserPointPort {
         }
 
         URI uri = buildPendingPointCancelUri(userId);
-        HttpHeaders headers = buildHeaders();
+        HttpHeaders headers = buildHeaders("POST", uri.getPath());
 
         CancelPendingPointRequest request = new CancelPendingPointRequest(
                 SOURCE_TYPE_ORDER, orderId, PENDING_POINT_CANCEL_REASON
@@ -169,7 +168,7 @@ public class RewardServiceClient implements ModifyUserPointPort {
         }
 
         URI uri = buildPendingPointUri(userId);
-        HttpHeaders headers = buildHeaders();
+        HttpHeaders headers = buildHeaders("PATCH", uri.getPath());
 
         ModifyUserPointRequest request = ModifyUserPointRequest.pendingDeduction(
                 amount, orderId, PARTIAL_CANCEL_PRODUCT_ACCUMULATION_REASON
@@ -206,7 +205,7 @@ public class RewardServiceClient implements ModifyUserPointPort {
 
     private void reduceSharerPartialPendingPoint(Long sharerId, Long amount, Long orderId) {
         URI uri = buildPendingPointUri(sharerId);
-        HttpHeaders headers = buildHeaders();
+        HttpHeaders headers = buildHeaders("PATCH", uri.getPath());
 
         ModifyUserPointRequest request = ModifyUserPointRequest.pendingDeduction(
                 amount, orderId, PARTIAL_CANCEL_SHARED_PURCHASE_REASON
@@ -230,7 +229,7 @@ public class RewardServiceClient implements ModifyUserPointPort {
 
     private void revokeSharerPendingPoint(Long sharerId, Long orderId) {
         URI uri = buildPendingPointCancelUri(sharerId);
-        HttpHeaders headers = buildHeaders();
+        HttpHeaders headers = buildHeaders("POST", uri.getPath());
 
         CancelPendingPointRequest request = new CancelPendingPointRequest(
                 SOURCE_TYPE_ORDER, orderId, PENDING_POINT_CANCEL_REASON
@@ -257,7 +256,7 @@ public class RewardServiceClient implements ModifyUserPointPort {
         }
 
         URI uri = buildPendingPointUri(sharerId);
-        HttpHeaders headers = buildHeaders();
+        HttpHeaders headers = buildHeaders("PATCH", uri.getPath());
 
         long sharePointAmount = Math.round(totalAmount * sharePointRate);
         ModifyUserPointRequest request = ModifyUserPointRequest.pendingAccrual(sharePointAmount, orderId, SHARE_PURCHASE_REASON);
@@ -298,9 +297,9 @@ public class RewardServiceClient implements ModifyUserPointPort {
                 .toUri();
     }
 
-    private HttpHeaders buildHeaders() {
+    private HttpHeaders buildHeaders(String httpMethod, String requestPath) {
         HttpHeaders headers = new HttpHeaders();
-        headers.setBearerAuth(adminAccessToken);
+        hmacServiceAuthHeaderBuilder.applyHeaders(headers, httpMethod, requestPath);
         headers.setContentType(MediaType.APPLICATION_JSON);
 
         return headers;

--- a/commerce-service/commerce-adapters/src/main/resources/application.yml
+++ b/commerce-service/commerce-adapters/src/main/resources/application.yml
@@ -8,6 +8,9 @@ spring:
     secret: ${JWT_SECRET_KEY:dev-secret-change-me}
     admin-access-token: ${JWT_ADMIN_ACCESS_TOKEN:abc}
 
+  hmac:
+    secret-key: ${HMAC_SECRET_KEY:dev-hmac-secret-change-me}
+
   datasource:
     driver-class-name: org.postgresql.Driver
     url: ${DB_URL:jdbc:postgresql://localhost:5432/marketnote_commerce}

--- a/commerce-service/commerce-adapters/src/test/resources/application-test.yml
+++ b/commerce-service/commerce-adapters/src/test/resources/application-test.yml
@@ -16,6 +16,8 @@ spring:
     redis:
       host: localhost
       port: 6379
+  hmac:
+    secret-key: test-hmac-secret-key
   sql:
     init:
       mode: never

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -45,6 +45,7 @@ dependencies {
 
     // data
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+    implementation("org.springframework.boot:spring-boot-starter-data-redis")
 
     // validation
     implementation("org.springframework.boot:spring-boot-starter-validation")

--- a/common/src/main/java/com/personal/marketnote/common/configuration/ClockConfig.java
+++ b/common/src/main/java/com/personal/marketnote/common/configuration/ClockConfig.java
@@ -1,0 +1,16 @@
+package com.personal.marketnote.common.configuration;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Clock;
+
+@Configuration
+public class ClockConfig {
+    @Bean
+    @ConditionalOnMissingBean
+    public Clock clock() {
+        return Clock.systemDefaultZone();
+    }
+}

--- a/common/src/main/java/com/personal/marketnote/common/configuration/HmacConfig.java
+++ b/common/src/main/java/com/personal/marketnote/common/configuration/HmacConfig.java
@@ -1,0 +1,18 @@
+package com.personal.marketnote.common.configuration;
+
+import com.personal.marketnote.common.security.hmac.HmacServiceAuthHeaderBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Clock;
+
+@Configuration
+public class HmacConfig {
+    @Bean
+    public HmacServiceAuthHeaderBuilder hmacServiceAuthHeaderBuilder(
+            @Value("${spring.hmac.secret-key}") String hmacSecretKey,
+            Clock clock) {
+        return new HmacServiceAuthHeaderBuilder(hmacSecretKey, clock);
+    }
+}

--- a/common/src/main/java/com/personal/marketnote/common/configuration/security/OpaqueTokenIntrospectorConfig.java
+++ b/common/src/main/java/com/personal/marketnote/common/configuration/security/OpaqueTokenIntrospectorConfig.java
@@ -1,6 +1,9 @@
 package com.personal.marketnote.common.configuration.security;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.common.security.hmac.HmacAuthenticationFilter;
+import com.personal.marketnote.common.security.hmac.HmacHeaderConstants;
+import com.personal.marketnote.common.security.hmac.HmacNonceValidator;
 import com.personal.marketnote.common.security.token.resolver.JsonBearerTokenResolver;
 import com.personal.marketnote.common.utility.http.client.resttemplate.RestTemplateErrorHandler;
 import org.springframework.beans.factory.annotation.Value;
@@ -14,6 +17,7 @@ import org.springframework.security.config.annotation.method.configuration.Enabl
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.oauth2.server.resource.web.BearerTokenAuthenticationFilter;
 import org.springframework.security.oauth2.server.resource.web.BearerTokenResolver;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
@@ -22,6 +26,9 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+import java.time.Clock;
 import java.util.Arrays;
 import java.util.List;
 
@@ -30,6 +37,19 @@ import java.util.List;
 @EnableMethodSecurity
 @Profile({"qa.test", "prod"})
 public class OpaqueTokenIntrospectorConfig {
+    @Bean
+    public HmacNonceValidator hmacNonceValidator(StringRedisTemplate stringRedisTemplate) {
+        return new HmacNonceValidator(stringRedisTemplate);
+    }
+
+    @Bean
+    public HmacAuthenticationFilter hmacAuthenticationFilter(
+            @Value("${spring.hmac.secret-key}") String hmacSecretKey,
+            HmacNonceValidator hmacNonceValidator,
+            Clock clock) {
+        return new HmacAuthenticationFilter(hmacSecretKey, hmacNonceValidator, clock);
+    }
+
     @Bean
     public BearerTokenResolver bearerTokenResolver() {
         return new JsonBearerTokenResolver();
@@ -43,8 +63,10 @@ public class OpaqueTokenIntrospectorConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http,
                                                    BearerTokenResolver resolver,
-                                                   AuthenticationEntryPoint entryPoint) throws Exception {
-        http.csrf(csrf -> csrf.disable())
+                                                   AuthenticationEntryPoint entryPoint,
+                                                   HmacAuthenticationFilter hmacAuthenticationFilter) throws Exception {
+        http.addFilterBefore(hmacAuthenticationFilter, BearerTokenAuthenticationFilter.class)
+                .csrf(csrf -> csrf.disable())
                 .cors(Customizer.withDefaults())
                 .headers(headers -> headers
                         .frameOptions(frame -> frame.deny())
@@ -95,7 +117,10 @@ public class OpaqueTokenIntrospectorConfig {
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
         config.setAllowedHeaders(List.of(
                 "Authorization", "Content-Type", "Accept",
-                "X-Requested-With", "X-HTTP-Method-Override"));
+                "X-Requested-With", "X-HTTP-Method-Override",
+                HmacHeaderConstants.HEADER_SIGNATURE,
+                HmacHeaderConstants.HEADER_TIMESTAMP,
+                HmacHeaderConstants.HEADER_NONCE));
         config.setAllowCredentials(true);
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", config);

--- a/common/src/main/java/com/personal/marketnote/common/configuration/security/SecurityPropertiesValidator.java
+++ b/common/src/main/java/com/personal/marketnote/common/configuration/security/SecurityPropertiesValidator.java
@@ -18,7 +18,8 @@ public class SecurityPropertiesValidator {
     private static final Logger log = LoggerFactory.getLogger(SecurityPropertiesValidator.class);
 
     private static final Set<String> WEAK_DEFAULTS = Set.of(
-            "dev-secret-change-me", "abc", "def", "ghi",
+            "dev-secret-change-me", "dev-hmac-secret-change-me",
+            "abc", "def", "ghi",
             "change-me", "password", "root", "secret", "test"
     );
 
@@ -33,6 +34,9 @@ public class SecurityPropertiesValidator {
 
     @Value("${spring.data.redis.password:#{null}}")
     private String redisPassword;
+
+    @Value("${spring.hmac.secret-key:}")
+    private String hmacSecretKey;
 
     @Value("${spring.kafka.sasl.enabled:false}")
     private boolean kafkaSaslEnabled;
@@ -50,6 +54,7 @@ public class SecurityPropertiesValidator {
         validateRequired(violations, "spring.jwt.secret (JWT_SECRET_KEY)", jwtSecret);
         validateRequired(violations, "spring.jwt.admin-access-token (JWT_ADMIN_ACCESS_TOKEN)", adminAccessToken);
         validateRequired(violations, "spring.datasource.password (DB_PASSWORD)", dbPassword);
+        validateRequired(violations, "spring.hmac.secret-key (HMAC_SECRET_KEY)", hmacSecretKey);
 
         if (kafkaSaslEnabled) {
             validateRequired(violations, "spring.kafka.sasl.username (KAFKA_SASL_USERNAME)", kafkaSaslUsername);

--- a/common/src/main/java/com/personal/marketnote/common/security/hmac/HmacAuthenticationFilter.java
+++ b/common/src/main/java/com/personal/marketnote/common/security/hmac/HmacAuthenticationFilter.java
@@ -1,0 +1,85 @@
+package com.personal.marketnote.common.security.hmac;
+
+import com.personal.marketnote.common.security.hmac.exception.HmacAuthenticationFailedException;
+import com.personal.marketnote.common.utility.FormatValidator;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.time.Clock;
+import java.util.List;
+
+import static com.personal.marketnote.common.security.hmac.HmacHeaderConstants.*;
+import static com.personal.marketnote.common.security.token.utility.TokenConstant.AUTHENTICATION_SCHEME;
+
+@RequiredArgsConstructor
+@Slf4j
+public class HmacAuthenticationFilter extends OncePerRequestFilter {
+    private final String secretKey;
+    private final HmacNonceValidator hmacNonceValidator;
+    private final Clock clock;
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        String authorization = request.getHeader(HttpHeaders.AUTHORIZATION);
+        if (FormatValidator.hasNoValue(authorization)) {
+            return false;
+        }
+        return authorization.startsWith(AUTHENTICATION_SCHEME);
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        String signature = request.getHeader(HEADER_SIGNATURE);
+        String timestamp = request.getHeader(HEADER_TIMESTAMP);
+        String nonce = request.getHeader(HEADER_NONCE);
+
+        if (!hasAnyHmacHeader(signature, timestamp, nonce)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        if (!hasAllHmacHeaders(signature, timestamp, nonce)) {
+            throw new HmacAuthenticationFailedException(
+                    "HMAC 인증 실패: 필수 헤더가 누락되었습니다. 3개 헤더(X-HMAC-Signature, X-HMAC-Timestamp, X-HMAC-Nonce)를 모두 포함해야 합니다.");
+        }
+
+        String httpMethod = request.getMethod();
+        String requestPath = request.getRequestURI();
+
+        HmacSignatureValidator.validate(secretKey, timestamp, nonce, httpMethod, requestPath, signature, clock);
+        hmacNonceValidator.validateAndStore(nonce);
+
+        PreAuthenticatedAuthenticationToken authentication = new PreAuthenticatedAuthenticationToken(
+                "SERVICE",
+                null,
+                List.of(new SimpleGrantedAuthority("ROLE_SERVICE"))
+        );
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        filterChain.doFilter(request, response);
+    }
+
+    private boolean hasAnyHmacHeader(String signature, String timestamp, String nonce) {
+        return FormatValidator.hasValue(signature)
+                || FormatValidator.hasValue(timestamp)
+                || FormatValidator.hasValue(nonce);
+    }
+
+    private boolean hasAllHmacHeaders(String signature, String timestamp, String nonce) {
+        return FormatValidator.hasValue(signature)
+                && FormatValidator.hasValue(timestamp)
+                && FormatValidator.hasValue(nonce);
+    }
+}

--- a/common/src/main/java/com/personal/marketnote/common/security/hmac/HmacHeaderConstants.java
+++ b/common/src/main/java/com/personal/marketnote/common/security/hmac/HmacHeaderConstants.java
@@ -1,0 +1,13 @@
+package com.personal.marketnote.common.security.hmac;
+
+public final class HmacHeaderConstants {
+    public static final String HEADER_SIGNATURE = "X-HMAC-Signature";
+    public static final String HEADER_TIMESTAMP = "X-HMAC-Timestamp";
+    public static final String HEADER_NONCE = "X-HMAC-Nonce";
+    public static final long TIMESTAMP_TOLERANCE_SECONDS = 300L;
+    public static final String SIGNING_INPUT_DELIMITER = ":";
+    public static final String REDIS_NONCE_KEY_PREFIX = "hmac:nonce:";
+
+    private HmacHeaderConstants() {
+    }
+}

--- a/common/src/main/java/com/personal/marketnote/common/security/hmac/HmacNonceValidator.java
+++ b/common/src/main/java/com/personal/marketnote/common/security/hmac/HmacNonceValidator.java
@@ -1,0 +1,32 @@
+package com.personal.marketnote.common.security.hmac;
+
+import com.personal.marketnote.common.security.hmac.exception.HmacNonceReplayedException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+import java.time.Duration;
+
+import static com.personal.marketnote.common.security.hmac.HmacHeaderConstants.REDIS_NONCE_KEY_PREFIX;
+import static com.personal.marketnote.common.security.hmac.HmacHeaderConstants.TIMESTAMP_TOLERANCE_SECONDS;
+
+@RequiredArgsConstructor
+@Slf4j
+public class HmacNonceValidator {
+    private final StringRedisTemplate stringRedisTemplate;
+
+    public void validateAndStore(String nonce) {
+        String key = REDIS_NONCE_KEY_PREFIX + nonce;
+        try {
+            Boolean isNewKey = stringRedisTemplate.opsForValue()
+                    .setIfAbsent(key, "1", Duration.ofSeconds(TIMESTAMP_TOLERANCE_SECONDS));
+            if (Boolean.FALSE.equals(isNewKey)) {
+                throw new HmacNonceReplayedException(nonce);
+            }
+        } catch (HmacNonceReplayedException e) {
+            throw e;
+        } catch (Exception e) {
+            log.warn("Redis Nonce 검증 실패 (fail-open): nonce={}, error={}", nonce, e.getMessage());
+        }
+    }
+}

--- a/common/src/main/java/com/personal/marketnote/common/security/hmac/HmacServiceAuthHeaderBuilder.java
+++ b/common/src/main/java/com/personal/marketnote/common/security/hmac/HmacServiceAuthHeaderBuilder.java
@@ -1,0 +1,28 @@
+package com.personal.marketnote.common.security.hmac;
+
+import org.springframework.http.HttpHeaders;
+
+import java.time.Clock;
+import java.util.UUID;
+
+import static com.personal.marketnote.common.security.hmac.HmacHeaderConstants.*;
+
+public class HmacServiceAuthHeaderBuilder {
+    private final String secretKey;
+    private final Clock clock;
+
+    public HmacServiceAuthHeaderBuilder(String secretKey, Clock clock) {
+        this.secretKey = secretKey;
+        this.clock = clock;
+    }
+
+    public void applyHeaders(HttpHeaders headers, String httpMethod, String requestPath) {
+        String timestamp = String.valueOf(clock.millis());
+        String nonce = UUID.randomUUID().toString();
+        String signature = HmacSignatureGenerator.generate(secretKey, timestamp, nonce, httpMethod, requestPath);
+
+        headers.set(HEADER_SIGNATURE, signature);
+        headers.set(HEADER_TIMESTAMP, timestamp);
+        headers.set(HEADER_NONCE, nonce);
+    }
+}

--- a/common/src/main/java/com/personal/marketnote/common/security/hmac/HmacSignatureGenerator.java
+++ b/common/src/main/java/com/personal/marketnote/common/security/hmac/HmacSignatureGenerator.java
@@ -1,0 +1,64 @@
+package com.personal.marketnote.common.security.hmac;
+
+import com.personal.marketnote.common.security.hmac.exception.HmacSignatureGenerationFailedException;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+
+import static com.personal.marketnote.common.security.hmac.HmacHeaderConstants.SIGNING_INPUT_DELIMITER;
+
+public final class HmacSignatureGenerator {
+    private static final String HMAC_MD5_ALGORITHM = "HmacMD5";
+
+    private HmacSignatureGenerator() {
+    }
+
+    public static String generate(String secretKey,
+                                  String timestamp,
+                                  String nonce,
+                                  String httpMethod,
+                                  String requestPath) {
+        String signingInput = buildSigningInput(timestamp, nonce, httpMethod, requestPath);
+        return computeHmacMd5(secretKey, signingInput);
+    }
+
+    public static boolean constantTimeEquals(String a, String b) {
+        if (a == null || b == null) {
+            return false;
+        }
+        return MessageDigest.isEqual(
+                a.getBytes(StandardCharsets.UTF_8),
+                b.getBytes(StandardCharsets.UTF_8));
+    }
+
+    static String buildSigningInput(String timestamp,
+                                    String nonce,
+                                    String httpMethod,
+                                    String requestPath) {
+        return timestamp
+                + SIGNING_INPUT_DELIMITER + nonce
+                + SIGNING_INPUT_DELIMITER + httpMethod
+                + SIGNING_INPUT_DELIMITER + requestPath;
+    }
+
+    private static String computeHmacMd5(String secretKey, String data) {
+        try {
+            Mac mac = Mac.getInstance(HMAC_MD5_ALGORITHM);
+            mac.init(new SecretKeySpec(secretKey.getBytes(StandardCharsets.UTF_8), HMAC_MD5_ALGORITHM));
+            byte[] result = mac.doFinal(data.getBytes(StandardCharsets.UTF_8));
+            return toHex(result);
+        } catch (Exception e) {
+            throw new HmacSignatureGenerationFailedException(e);
+        }
+    }
+
+    private static String toHex(byte[] bytes) {
+        StringBuilder sb = new StringBuilder(bytes.length * 2);
+        for (byte b : bytes) {
+            sb.append(String.format("%02x", b));
+        }
+        return sb.toString();
+    }
+}

--- a/common/src/main/java/com/personal/marketnote/common/security/hmac/HmacSignatureValidator.java
+++ b/common/src/main/java/com/personal/marketnote/common/security/hmac/HmacSignatureValidator.java
@@ -1,0 +1,52 @@
+package com.personal.marketnote.common.security.hmac;
+
+import com.personal.marketnote.common.security.hmac.exception.HmacSignatureMismatchException;
+import com.personal.marketnote.common.security.hmac.exception.HmacTimestampExpiredException;
+
+import java.time.Clock;
+import java.time.Instant;
+
+import static com.personal.marketnote.common.security.hmac.HmacHeaderConstants.TIMESTAMP_TOLERANCE_SECONDS;
+
+public final class HmacSignatureValidator {
+
+    private HmacSignatureValidator() {
+    }
+
+    public static void validate(String secretKey,
+                                String timestamp,
+                                String nonce,
+                                String httpMethod,
+                                String requestPath,
+                                String signature,
+                                Clock clock) {
+        validateTimestamp(timestamp, clock);
+        validateSignature(secretKey, timestamp, nonce, httpMethod, requestPath, signature);
+    }
+
+    static void validateTimestamp(String timestamp, Clock clock) {
+        long requestTimeMillis;
+        try {
+            requestTimeMillis = Long.parseLong(timestamp);
+        } catch (NumberFormatException e) {
+            throw new HmacTimestampExpiredException(timestamp);
+        }
+        long currentTimeMillis = Instant.now(clock).toEpochMilli();
+        long differenceSeconds = Math.abs(currentTimeMillis - requestTimeMillis) / 1000;
+        if (differenceSeconds > TIMESTAMP_TOLERANCE_SECONDS) {
+            throw new HmacTimestampExpiredException(timestamp);
+        }
+    }
+
+    static void validateSignature(String secretKey,
+                                  String timestamp,
+                                  String nonce,
+                                  String httpMethod,
+                                  String requestPath,
+                                  String signature) {
+        String expected = HmacSignatureGenerator.generate(secretKey, timestamp, nonce, httpMethod, requestPath);
+        if (!HmacSignatureGenerator.constantTimeEquals(expected, signature)) {
+            throw new HmacSignatureMismatchException();
+        }
+    }
+}

--- a/common/src/main/java/com/personal/marketnote/common/security/hmac/exception/HmacAuthenticationFailedException.java
+++ b/common/src/main/java/com/personal/marketnote/common/security/hmac/exception/HmacAuthenticationFailedException.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.common.security.hmac.exception;
+
+import org.springframework.security.authentication.BadCredentialsException;
+
+public class HmacAuthenticationFailedException extends BadCredentialsException {
+    public HmacAuthenticationFailedException(String message) {
+        super(message);
+    }
+}

--- a/common/src/main/java/com/personal/marketnote/common/security/hmac/exception/HmacNonceReplayedException.java
+++ b/common/src/main/java/com/personal/marketnote/common/security/hmac/exception/HmacNonceReplayedException.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.common.security.hmac.exception;
+
+import org.springframework.security.authentication.BadCredentialsException;
+
+public class HmacNonceReplayedException extends BadCredentialsException {
+    public HmacNonceReplayedException(String nonce) {
+        super("HMAC 인증 실패: 이미 사용된 Nonce입니다. nonce=" + nonce);
+    }
+}

--- a/common/src/main/java/com/personal/marketnote/common/security/hmac/exception/HmacSignatureGenerationFailedException.java
+++ b/common/src/main/java/com/personal/marketnote/common/security/hmac/exception/HmacSignatureGenerationFailedException.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.common.security.hmac.exception;
+
+public class HmacSignatureGenerationFailedException extends RuntimeException {
+    public HmacSignatureGenerationFailedException(Throwable cause) {
+        super("HMAC 서명 생성에 실패했습니다.", cause);
+    }
+}

--- a/common/src/main/java/com/personal/marketnote/common/security/hmac/exception/HmacSignatureMismatchException.java
+++ b/common/src/main/java/com/personal/marketnote/common/security/hmac/exception/HmacSignatureMismatchException.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.common.security.hmac.exception;
+
+import org.springframework.security.authentication.BadCredentialsException;
+
+public class HmacSignatureMismatchException extends BadCredentialsException {
+    public HmacSignatureMismatchException() {
+        super("HMAC 인증 실패: 서명이 일치하지 않습니다.");
+    }
+}

--- a/common/src/main/java/com/personal/marketnote/common/security/hmac/exception/HmacTimestampExpiredException.java
+++ b/common/src/main/java/com/personal/marketnote/common/security/hmac/exception/HmacTimestampExpiredException.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.common.security.hmac.exception;
+
+import org.springframework.security.authentication.BadCredentialsException;
+
+public class HmacTimestampExpiredException extends BadCredentialsException {
+    public HmacTimestampExpiredException(String timestamp) {
+        super("HMAC 인증 실패: Timestamp가 허용 범위를 초과했습니다. timestamp=" + timestamp);
+    }
+}

--- a/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/out/web/commerce/CommerceServiceClient.java
+++ b/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/out/web/commerce/CommerceServiceClient.java
@@ -2,6 +2,7 @@ package com.personal.marketnote.community.adapter.out.web.commerce;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.personal.marketnote.common.adapter.out.ServiceAdapter;
+import com.personal.marketnote.common.security.hmac.HmacServiceAuthHeaderBuilder;
 import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.community.domain.servicecommunication.CommunityServiceCommunicationSenderType;
 import com.personal.marketnote.community.domain.servicecommunication.CommunityServiceCommunicationTargetType;
@@ -38,10 +39,8 @@ public class CommerceServiceClient implements UpdateOrderProductReviewStatusPort
     @Value("${commerce-service.base-url}")
     private String commerceServiceBaseUrl;
 
-    @Value("${spring.jwt.admin-access-token}")
-    private String adminAccessToken;
-
     private final RestTemplate restTemplate;
+    private final HmacServiceAuthHeaderBuilder hmacServiceAuthHeaderBuilder;
     private final ServiceCommunicationRecorder serviceCommunicationRecorder;
     private final ServiceCommunicationPayloadGenerator serviceCommunicationPayloadGenerator;
 
@@ -56,7 +55,7 @@ public class CommerceServiceClient implements UpdateOrderProductReviewStatusPort
                 .toUri();
 
         HttpHeaders headers = new HttpHeaders();
-        headers.setBearerAuth(adminAccessToken);
+        hmacServiceAuthHeaderBuilder.applyHeaders(headers, "PATCH", uri.getPath());
         HttpEntity<Void> httpEntity = new HttpEntity<>(headers);
 
         String targetId = orderId + ":" + pricePolicyId;

--- a/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/out/web/file/FileServiceClient.java
+++ b/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/out/web/file/FileServiceClient.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.personal.marketnote.common.adapter.out.ServiceAdapter;
+import com.personal.marketnote.common.security.hmac.HmacServiceAuthHeaderBuilder;
 import com.personal.marketnote.common.application.file.port.in.result.GetFileResult;
 import com.personal.marketnote.common.application.file.port.in.result.GetFilesResult;
 import com.personal.marketnote.common.domain.file.FileSort;
@@ -49,10 +50,8 @@ public class FileServiceClient implements FindReviewImagesPort, FindPostImagesPo
     @Value("${file-service.base-url:http://localhost:9000}")
     private String fileServiceBaseUrl;
 
-    @Value("${spring.jwt.admin-access-token}")
-    private String adminAccessToken;
-
     private final RestTemplate restTemplate;
+    private final HmacServiceAuthHeaderBuilder hmacServiceAuthHeaderBuilder;
     private final ServiceCommunicationRecorder serviceCommunicationRecorder;
     private final ServiceCommunicationPayloadGenerator serviceCommunicationPayloadGenerator;
 
@@ -77,7 +76,7 @@ public class FileServiceClient implements FindReviewImagesPort, FindPostImagesPo
                 .toUri();
 
         HttpHeaders headers = new HttpHeaders();
-        headers.setBearerAuth(adminAccessToken);
+        hmacServiceAuthHeaderBuilder.applyHeaders(headers, "GET", uri.getPath());
         HttpEntity<Void> httpEntity = new HttpEntity<>(headers);
 
         return sendRequest(uri, httpEntity, ownerId, sort, ownerType);

--- a/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/out/web/product/ProductServiceClient.java
+++ b/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/out/web/product/ProductServiceClient.java
@@ -3,6 +3,7 @@ package com.personal.marketnote.community.adapter.out.web.product;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
 import com.personal.marketnote.common.adapter.out.ServiceAdapter;
+import com.personal.marketnote.common.security.hmac.HmacServiceAuthHeaderBuilder;
 import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.community.adapter.out.web.product.response.OrderedProductsResponse;
 import com.personal.marketnote.community.adapter.out.web.product.response.ProductsInfoResponse;
@@ -47,10 +48,8 @@ public class ProductServiceClient implements FindProductByPricePolicyPort {
     @Value("${product-service.base-url:http://localhost:8081}")
     private String productServiceBaseUrl;
 
-    @Value("${spring.jwt.admin-access-token}")
-    private String adminAccessToken;
-
     private final RestTemplate restTemplate;
+    private final HmacServiceAuthHeaderBuilder hmacServiceAuthHeaderBuilder;
     private final ServiceCommunicationRecorder serviceCommunicationRecorder;
     private final ServiceCommunicationPayloadGenerator serviceCommunicationPayloadGenerator;
 
@@ -68,7 +67,7 @@ public class ProductServiceClient implements FindProductByPricePolicyPort {
                 .toUri();
 
         HttpHeaders headers = new HttpHeaders();
-        headers.setBearerAuth(adminAccessToken);
+        hmacServiceAuthHeaderBuilder.applyHeaders(headers, "GET", uri.getPath());
         HttpEntity<Void> request = new HttpEntity<>(headers);
 
         return sendRequest(uri, request);

--- a/community-service/community-adapters/src/main/resources/application.yml
+++ b/community-service/community-adapters/src/main/resources/application.yml
@@ -8,6 +8,9 @@ spring:
     secret: ${JWT_SECRET_KEY:dev-secret-change-me}
     admin-access-token: ${JWT_ADMIN_ACCESS_TOKEN:abc}
 
+  hmac:
+    secret-key: ${HMAC_SECRET_KEY:dev-hmac-secret-change-me}
+
   datasource:
     driver-class-name: org.postgresql.Driver
     url: ${DB_URL:jdbc:postgresql://localhost:5432/marketnote_community}

--- a/community-service/community-adapters/src/test/resources/application-test.yml
+++ b/community-service/community-adapters/src/test/resources/application-test.yml
@@ -16,6 +16,8 @@ spring:
     redis:
       host: localhost
       port: 6379
+  hmac:
+    secret-key: test-hmac-secret-key
   sql:
     init:
       mode: never

--- a/file-service/file-adapters/src/main/resources/application.yml
+++ b/file-service/file-adapters/src/main/resources/application.yml
@@ -13,6 +13,9 @@ spring:
     secret: ${JWT_SECRET_KEY:dev-secret-change-me}
     admin-access-token: ${JWT_ADMIN_ACCESS_TOKEN:abc}
 
+  hmac:
+    secret-key: ${HMAC_SECRET_KEY:dev-hmac-secret-change-me}
+
   datasource:
     driver-class-name: org.postgresql.Driver
     url: ${DB_URL:jdbc:postgresql://localhost:5432/marketnote_file}

--- a/file-service/file-adapters/src/test/resources/application-test.yml
+++ b/file-service/file-adapters/src/test/resources/application-test.yml
@@ -16,6 +16,8 @@ spring:
     redis:
       host: localhost
       port: 6379
+  hmac:
+    secret-key: test-hmac-secret-key
   sql:
     init:
       mode: never

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/web/commerce/CommerceServiceClient.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/web/commerce/CommerceServiceClient.java
@@ -3,6 +3,7 @@ package com.personal.marketnote.fulfillment.adapter.out.web.commerce;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.personal.marketnote.common.adapter.out.ServiceAdapter;
 import com.personal.marketnote.common.exception.CommerceServiceRequestFailedException;
+import com.personal.marketnote.common.security.hmac.HmacServiceAuthHeaderBuilder;
 import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.fulfillment.adapter.out.web.commerce.request.SyncFulfillmentVendorInventoryRequest;
 import com.personal.marketnote.fulfillment.domain.servicecommunication.FulfillmentServiceCommunicationSenderType;
@@ -44,10 +45,8 @@ public class CommerceServiceClient implements UpdateCommerceInventoryPort {
     @Value("${commerce-service.base-url}")
     private String commerceServiceBaseUrl;
 
-    @Value("${spring.jwt.admin-access-token}")
-    private String adminAccessToken;
-
     private final RestTemplate restTemplate;
+    private final HmacServiceAuthHeaderBuilder hmacServiceAuthHeaderBuilder;
     private final ServiceCommunicationRecorder serviceCommunicationRecorder;
     private final ServiceCommunicationPayloadGenerator serviceCommunicationPayloadGenerator;
 
@@ -56,12 +55,11 @@ public class CommerceServiceClient implements UpdateCommerceInventoryPort {
         if (FormatValidator.hasNoValue(command) || FormatValidator.hasNoValue(command.inventories())) {
             throw new IllegalArgumentException("Update commerce inventory command is required.");
         }
-        if (FormatValidator.hasNoValue(commerceServiceBaseUrl) || FormatValidator.hasNoValue(adminAccessToken)) {
+        if (FormatValidator.hasNoValue(commerceServiceBaseUrl)) {
             throw new CommerceServiceRequestFailedException(new IOException());
         }
 
         String baseUrl = Objects.requireNonNull(commerceServiceBaseUrl, "commerceServiceBaseUrl");
-        String accessToken = Objects.requireNonNull(adminAccessToken, "adminAccessToken");
 
         URI uri = UriComponentsBuilder
                 .fromUriString(baseUrl)
@@ -70,7 +68,7 @@ public class CommerceServiceClient implements UpdateCommerceInventoryPort {
                 .toUri();
 
         HttpHeaders headers = new HttpHeaders();
-        headers.setBearerAuth(accessToken);
+        hmacServiceAuthHeaderBuilder.applyHeaders(headers, "POST", uri.getPath());
 
         SyncFulfillmentVendorInventoryRequest request = SyncFulfillmentVendorInventoryRequest.from(command);
         HttpEntity<SyncFulfillmentVendorInventoryRequest> httpEntity = new HttpEntity<>(request, headers);

--- a/fulfillment-service/fulfillment-adapters/src/main/resources/application.yml
+++ b/fulfillment-service/fulfillment-adapters/src/main/resources/application.yml
@@ -8,6 +8,9 @@ spring:
     secret: ${JWT_SECRET_KEY:dev-secret-change-me}
     admin-access-token: ${JWT_ADMIN_ACCESS_TOKEN:abc}
 
+  hmac:
+    secret-key: ${HMAC_SECRET_KEY:dev-hmac-secret-change-me}
+
   datasource:
     driver-class-name: org.postgresql.Driver
     url: ${DB_URL:jdbc:postgresql://localhost:5432/marketnote_fulfillment}

--- a/fulfillment-service/fulfillment-adapters/src/test/resources/application-test.yml
+++ b/fulfillment-service/fulfillment-adapters/src/test/resources/application-test.yml
@@ -16,6 +16,8 @@ spring:
     redis:
       host: localhost
       port: 6379
+  hmac:
+    secret-key: test-hmac-secret-key
   sql:
     init:
       mode: never

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/web/commerce/CommerceServiceClient.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/web/commerce/CommerceServiceClient.java
@@ -5,6 +5,7 @@ import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
 import com.personal.marketnote.common.adapter.in.request.RegisterInventoryRequest;
 import com.personal.marketnote.common.adapter.out.ServiceAdapter;
 import com.personal.marketnote.common.exception.CommerceServiceRequestFailedException;
+import com.personal.marketnote.common.security.hmac.HmacServiceAuthHeaderBuilder;
 import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.product.adapter.out.response.GetInventoriesResponse;
 import com.personal.marketnote.product.domain.servicecommunication.ProductServiceCommunicationSenderType;
@@ -50,10 +51,8 @@ public class CommerceServiceClient implements RegisterInventoryPort, FindStockPo
     @Value("${commerce-service.base-url}")
     private String commerceServiceBaseUrl;
 
-    @Value("${spring.jwt.admin-access-token}")
-    private String adminAccessToken;
-
     private final RestTemplate restTemplate;
+    private final HmacServiceAuthHeaderBuilder hmacServiceAuthHeaderBuilder;
     private final ServiceCommunicationRecorder serviceCommunicationRecorder;
     private final ServiceCommunicationPayloadGenerator serviceCommunicationPayloadGenerator;
 
@@ -66,7 +65,7 @@ public class CommerceServiceClient implements RegisterInventoryPort, FindStockPo
                 .toUri();
 
         HttpHeaders headers = new HttpHeaders();
-        headers.setBearerAuth(adminAccessToken);
+        hmacServiceAuthHeaderBuilder.applyHeaders(headers, "POST", uri.getPath());
         HttpEntity<RegisterInventoryRequest> httpEntity
                 = new HttpEntity<>(new RegisterInventoryRequest(productId, pricePolicyId), headers);
 
@@ -148,7 +147,7 @@ public class CommerceServiceClient implements RegisterInventoryPort, FindStockPo
                 .toUri();
 
         HttpHeaders headers = new HttpHeaders();
-        headers.setBearerAuth(adminAccessToken);
+        hmacServiceAuthHeaderBuilder.applyHeaders(headers, "GET", uri.getPath());
 
         try {
             return sendRequest(uri, headers).inventories();

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/web/community/CommunityServiceClient.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/web/community/CommunityServiceClient.java
@@ -3,6 +3,7 @@ package com.personal.marketnote.product.adapter.out.web.community;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
 import com.personal.marketnote.common.adapter.out.ServiceAdapter;
+import com.personal.marketnote.common.security.hmac.HmacServiceAuthHeaderBuilder;
 import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.product.adapter.out.response.GetProductReviewAggregatesResponse;
 import com.personal.marketnote.product.adapter.out.response.ProductReviewAggregateItemResponse;
@@ -47,10 +48,8 @@ public class CommunityServiceClient implements FindProductReviewAggregatesPort {
     @Value("${community-service.base-url}")
     private String communityServiceBaseUrl;
 
-    @Value("${spring.jwt.admin-access-token}")
-    private String adminAccessToken;
-
     private final RestTemplate restTemplate;
+    private final HmacServiceAuthHeaderBuilder hmacServiceAuthHeaderBuilder;
     private final ServiceCommunicationRecorder serviceCommunicationRecorder;
     private final ServiceCommunicationPayloadGenerator serviceCommunicationPayloadGenerator;
 
@@ -68,7 +67,7 @@ public class CommunityServiceClient implements FindProductReviewAggregatesPort {
                 .toUri();
 
         HttpHeaders headers = new HttpHeaders();
-        headers.setBearerAuth(adminAccessToken);
+        hmacServiceAuthHeaderBuilder.applyHeaders(headers, "GET", uri.getPath());
 
         return sendRequest(uri, new HttpEntity<>(headers));
     }

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/web/file/FileServiceClient.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/web/file/FileServiceClient.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.personal.marketnote.common.adapter.out.ServiceAdapter;
+import com.personal.marketnote.common.security.hmac.HmacServiceAuthHeaderBuilder;
 import com.personal.marketnote.common.application.file.port.in.result.GetFileResult;
 import com.personal.marketnote.common.application.file.port.in.result.GetFilesResult;
 import com.personal.marketnote.common.domain.file.FileSort;
@@ -50,10 +51,8 @@ public class FileServiceClient implements FindProductImagesPort, DeleteProductIm
     @Value("${file-service.base-url:http://localhost:9000}")
     private String fileServiceBaseUrl;
 
-    @Value("${spring.jwt.admin-access-token}")
-    private String adminAccessToken;
-
     private final RestTemplate restTemplate;
+    private final HmacServiceAuthHeaderBuilder hmacServiceAuthHeaderBuilder;
     private final ServiceCommunicationRecorder serviceCommunicationRecorder;
     private final ServiceCommunicationPayloadGenerator serviceCommunicationPayloadGenerator;
 
@@ -69,7 +68,7 @@ public class FileServiceClient implements FindProductImagesPort, DeleteProductIm
                 .toUri();
 
         HttpHeaders headers = new HttpHeaders();
-        headers.setBearerAuth(adminAccessToken);
+        hmacServiceAuthHeaderBuilder.applyHeaders(headers, "GET", uri.getPath());
         HttpEntity<Void> httpEntity = new HttpEntity<>(headers);
 
         return sendRequest(uri, httpEntity, productId, sort);
@@ -169,7 +168,7 @@ public class FileServiceClient implements FindProductImagesPort, DeleteProductIm
                 .toUri();
 
         HttpHeaders headers = new HttpHeaders();
-        headers.setBearerAuth(adminAccessToken);
+        hmacServiceAuthHeaderBuilder.applyHeaders(headers, "DELETE", uri.getPath());
         sendRequest(uri, new HttpEntity<>(headers), String.valueOf(fileId));
     }
 

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/web/fulfillment/FulfillmentServiceClient.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/web/fulfillment/FulfillmentServiceClient.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
 import com.personal.marketnote.common.adapter.out.ServiceAdapter;
 import com.personal.marketnote.common.exception.FulfillmentServiceRequestFailedException;
+import com.personal.marketnote.common.security.hmac.HmacServiceAuthHeaderBuilder;
 import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.product.adapter.out.web.fulfillment.request.RegisterFasstoGoodsItemRequest;
 import com.personal.marketnote.product.adapter.out.web.fulfillment.request.UpdateFasstoGoodsItemRequest;
@@ -52,10 +53,8 @@ public class FulfillmentServiceClient implements
     @Value("${fulfillment-service.fassto.customer-code}")
     private String fulfillmentVendorCustomerCode;
 
-    @Value("${spring.jwt.admin-access-token}")
-    private String adminAccessToken;
-
     private final RestTemplate restTemplate;
+    private final HmacServiceAuthHeaderBuilder hmacServiceAuthHeaderBuilder;
     private final ServiceCommunicationRecorder serviceCommunicationRecorder;
     private final ServiceCommunicationPayloadGenerator serviceCommunicationPayloadGenerator;
 
@@ -73,7 +72,7 @@ public class FulfillmentServiceClient implements
                 .toUri();
 
         HttpHeaders headers = new HttpHeaders();
-        headers.setBearerAuth(adminAccessToken);
+        hmacServiceAuthHeaderBuilder.applyHeaders(headers, "POST", uri.getPath());
         headers.add("accessToken", fulfillmentVendorAccessToken);
 
         List<RegisterFasstoGoodsItemRequest> payload = List.of(RegisterFasstoGoodsItemRequest.from(command));
@@ -99,7 +98,7 @@ public class FulfillmentServiceClient implements
                 .toUri();
 
         HttpHeaders headers = new HttpHeaders();
-        headers.setBearerAuth(adminAccessToken);
+        hmacServiceAuthHeaderBuilder.applyHeaders(headers, "GET", uri.getPath());
         headers.add("accessToken", fulfillmentVendorAccessToken);
         HttpEntity<Void> httpEntity = new HttpEntity<>(headers);
 
@@ -125,7 +124,7 @@ public class FulfillmentServiceClient implements
                 .toUri();
 
         HttpHeaders headers = new HttpHeaders();
-        headers.setBearerAuth(adminAccessToken);
+        hmacServiceAuthHeaderBuilder.applyHeaders(headers, "GET", uri.getPath());
         headers.add("accessToken", fulfillmentVendorAccessToken);
         HttpEntity<Void> httpEntity = new HttpEntity<>(headers);
 
@@ -151,7 +150,7 @@ public class FulfillmentServiceClient implements
                 .toUri();
 
         HttpHeaders headers = new HttpHeaders();
-        headers.setBearerAuth(adminAccessToken);
+        hmacServiceAuthHeaderBuilder.applyHeaders(headers, "PUT", uri.getPath());
         headers.add("accessToken", fulfillmentVendorAccessToken);
 
         List<UpdateFasstoGoodsItemRequest> payload = List.of(UpdateFasstoGoodsItemRequest.from(command));
@@ -168,7 +167,7 @@ public class FulfillmentServiceClient implements
                 .toUri();
 
         HttpHeaders headers = new HttpHeaders();
-        headers.setBearerAuth(adminAccessToken);
+        hmacServiceAuthHeaderBuilder.applyHeaders(headers, "POST", uri.getPath());
         HttpEntity<Void> httpEntity = new HttpEntity<>(headers);
 
         long sleepMillis = INTER_SERVER_DEFAULT_RETRIAL_PENDING_MILLI_SECOND;

--- a/product-service/product-adapters/src/main/resources/application.yml
+++ b/product-service/product-adapters/src/main/resources/application.yml
@@ -8,6 +8,9 @@ spring:
     secret: ${JWT_SECRET_KEY:dev-secret-change-me}
     admin-access-token: ${JWT_ADMIN_ACCESS_TOKEN:abc}
 
+  hmac:
+    secret-key: ${HMAC_SECRET_KEY:dev-hmac-secret-change-me}
+
   datasource:
     driver-class-name: org.postgresql.Driver
     url: ${DB_URL:jdbc:postgresql://localhost:5432/marketnote_product}

--- a/product-service/product-adapters/src/test/resources/application-test.yml
+++ b/product-service/product-adapters/src/test/resources/application-test.yml
@@ -16,6 +16,8 @@ spring:
     redis:
       host: localhost
       port: 6379
+  hmac:
+    secret-key: test-hmac-secret-key
   sql:
     init:
       mode: never

--- a/reward-service/reward-adapters/src/main/resources/application.yml
+++ b/reward-service/reward-adapters/src/main/resources/application.yml
@@ -8,6 +8,9 @@ spring:
     secret: ${JWT_SECRET_KEY:dev-secret-change-me}
     admin-access-token: ${JWT_ADMIN_ACCESS_TOKEN:abc}
 
+  hmac:
+    secret-key: ${HMAC_SECRET_KEY:dev-hmac-secret-change-me}
+
   datasource:
     driver-class-name: org.postgresql.Driver
     url: ${DB_URL:jdbc:postgresql://localhost:5432/marketnote_reward}

--- a/reward-service/reward-adapters/src/test/resources/application-test.yml
+++ b/reward-service/reward-adapters/src/test/resources/application-test.yml
@@ -16,6 +16,8 @@ spring:
     redis:
       host: localhost
       port: 6379
+  hmac:
+    secret-key: test-hmac-secret-key
   sql:
     init:
       mode: never

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/out/web/reward/RewardServiceClient.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/out/web/reward/RewardServiceClient.java
@@ -3,6 +3,7 @@ package com.personal.marketnote.user.adapter.out.web.reward;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.personal.marketnote.common.adapter.out.ServiceAdapter;
 import com.personal.marketnote.common.exception.RewardServiceRequestFailedException;
+import com.personal.marketnote.common.security.hmac.HmacServiceAuthHeaderBuilder;
 import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.user.domain.servicecommunication.UserServiceCommunicationSenderType;
 import com.personal.marketnote.user.domain.servicecommunication.UserServiceCommunicationTargetType;
@@ -39,10 +40,8 @@ public class RewardServiceClient implements ModifyUserPointPort {
     @Value("${reward-service.base-url}")
     private String rewardServiceBaseUrl;
 
-    @Value("${spring.jwt.admin-access-token}")
-    private String adminAccessToken;
-
     private final RestTemplate restTemplate;
+    private final HmacServiceAuthHeaderBuilder hmacServiceAuthHeaderBuilder;
     private final ServiceCommunicationRecorder serviceCommunicationRecorder;
     private final ServiceCommunicationPayloadGenerator serviceCommunicationPayloadGenerator;
 
@@ -53,7 +52,7 @@ public class RewardServiceClient implements ModifyUserPointPort {
         }
 
         URI uri = buildRegisterUserPointUri(userId, userKey);
-        HttpHeaders headers = buildHeaders();
+        HttpHeaders headers = buildHeaders("POST", uri.getPath());
         HttpEntity<Void> httpEntity = new HttpEntity<>(headers);
 
         for (int i = 0; i < INTER_SERVER_MAX_REQUEST_COUNT; i++) {
@@ -165,12 +164,13 @@ public class RewardServiceClient implements ModifyUserPointPort {
         }
 
         URI uri = buildUserPointUri(userId);
-        HttpHeaders headers = buildHeaders();
+        HttpHeaders postHeaders = buildHeaders("POST", uri.getPath());
 
-        ensureUserPointExists(uri, headers, userId);
+        ensureUserPointExists(uri, postHeaders, userId);
 
+        HttpHeaders patchHeaders = buildHeaders("PATCH", uri.getPath());
         ModifyUserPointRequest request = ModifyUserPointRequest.from(userId, amount, reason);
-        HttpEntity<ModifyUserPointRequest> httpEntity = new HttpEntity<>(request, headers);
+        HttpEntity<ModifyUserPointRequest> httpEntity = new HttpEntity<>(request, patchHeaders);
 
         sendRequest(uri, httpEntity, userId, amount);
     }
@@ -328,9 +328,9 @@ public class RewardServiceClient implements ModifyUserPointPort {
                 .toUri();
     }
 
-    private HttpHeaders buildHeaders() {
+    private HttpHeaders buildHeaders(String httpMethod, String requestPath) {
         HttpHeaders headers = new HttpHeaders();
-        headers.setBearerAuth(adminAccessToken);
+        hmacServiceAuthHeaderBuilder.applyHeaders(headers, httpMethod, requestPath);
         headers.setContentType(MediaType.APPLICATION_JSON);
         return headers;
     }

--- a/user-service/user-adapters/src/main/resources/application.yml
+++ b/user-service/user-adapters/src/main/resources/application.yml
@@ -52,6 +52,9 @@ spring:
     refresh-token:
       ttl: ${REFRESH_TOKEN_EXPIRATION_TIME:1209600000}
 
+  hmac:
+    secret-key: ${HMAC_SECRET_KEY:dev-hmac-secret-change-me}
+
   mail:
     host: ${SES_SMTP_HOST:email-smtp.${SES_REGION:ap-northeast-2}.amazonaws.com}
     port: ${SES_SMTP_PORT:587}

--- a/user-service/user-adapters/src/test/resources/application-test.yml
+++ b/user-service/user-adapters/src/test/resources/application-test.yml
@@ -16,6 +16,8 @@ spring:
     redis:
       host: localhost
       port: 6379
+  hmac:
+    secret-key: test-hmac-secret-key
   sql:
     init:
       mode: never


### PR DESCRIPTION
## partially addresses #1
## resolves #1495

## Task
- [x] HMAC MD5 서명 생성/검증 유틸리티 구현 (common 모듈)
- [x] HMAC 인증 커스텀 예외 정의 (5개)
- [x] Redis SET NX EX 기반 Nonce 중복 검증 구현
- [x] HMAC 인증 Security Filter 추가 (Bearer 토큰 없을 때 동작)
- [x] OpaqueTokenIntrospectorConfig에 HMAC Filter 등록
- [x] HMAC 헤더 빌더 컴포넌트 구현 (ServiceClient용)
- [x] ServiceClient 13개 인증 헤더 변경 (Bearer -> HMAC)
- [x] application.yml 7개 서비스에 spring.hmac.secret-key 설정 추가
- [x] SecurityPropertiesValidator에 HMAC 시크릿 검증 추가
- [x] Clock 빈 및 HmacConfig 설정 추가