### PR TITLE
[#1][#1496] test: 서비스 간 통신 HMAC MD5 Hash Key 기반 인증 시스템 구축 기능 자동화 테스트 추가

### DIFF
--- a/common/src/test/java/com/personal/marketnote/common/security/hmac/HmacAuthenticationFilterTest.java
+++ b/common/src/test/java/com/personal/marketnote/common/security/hmac/HmacAuthenticationFilterTest.java
@@ -1,0 +1,116 @@
+package com.personal.marketnote.common.security.hmac;
+
+import com.personal.marketnote.common.security.hmac.exception.HmacAuthenticationFailedException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.io.IOException;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+
+import static com.personal.marketnote.common.security.hmac.HmacHeaderConstants.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class HmacAuthenticationFilterTest {
+    private static final String SECRET_KEY = "test-hmac-secret-key";
+    private static final long FIXED_TIME_MILLIS = 1710000000000L;
+    private static final Clock FIXED_CLOCK = Clock.fixed(
+            Instant.ofEpochMilli(FIXED_TIME_MILLIS), ZoneId.of("Asia/Seoul"));
+
+    private HmacAuthenticationFilter hmacAuthenticationFilter;
+
+    @Mock
+    private HmacNonceValidator hmacNonceValidator;
+
+    @Mock
+    private FilterChain filterChain;
+
+    @BeforeEach
+    void setUp() {
+        hmacAuthenticationFilter = new HmacAuthenticationFilter(SECRET_KEY, hmacNonceValidator, FIXED_CLOCK);
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    @DisplayName("Bearer 토큰이 존재하면 필터를 스킵한다")
+    void shouldSkipFilterWhenBearerTokenExists() throws ServletException, IOException {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/v1/products");
+        request.addHeader("Authorization", "Bearer some-jwt-token");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        hmacAuthenticationFilter.doFilter(request, response, filterChain);
+
+        verify(filterChain).doFilter(request, response);
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+    }
+
+    @Test
+    @DisplayName("HMAC 헤더가 모두 없으면 필터를 스킵한다")
+    void shouldSkipFilterWhenNoHmacHeaders() throws ServletException, IOException {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/v1/products");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        hmacAuthenticationFilter.doFilter(request, response, filterChain);
+
+        verify(filterChain).doFilter(request, response);
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+    }
+
+    @Test
+    @DisplayName("유효한 HMAC 헤더로 요청하면 인증에 성공하고 SecurityContext에 인증 정보가 설정된다")
+    void shouldAuthenticateWithValidHmacHeaders() throws ServletException, IOException {
+        String timestamp = String.valueOf(FIXED_TIME_MILLIS);
+        String nonce = "550e8400-e29b-41d4-a716-446655440000";
+        String signature = HmacSignatureGenerator.generate(SECRET_KEY, timestamp, nonce, "GET", "/api/v1/products");
+
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/v1/products");
+        request.addHeader(HEADER_SIGNATURE, signature);
+        request.addHeader(HEADER_TIMESTAMP, timestamp);
+        request.addHeader(HEADER_NONCE, nonce);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        hmacAuthenticationFilter.doFilter(request, response, filterChain);
+
+        verify(filterChain).doFilter(request, response);
+        verify(hmacNonceValidator).validateAndStore(nonce);
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNotNull();
+        assertThat(SecurityContextHolder.getContext().getAuthentication().getName()).isEqualTo("SERVICE");
+    }
+
+    @Test
+    @DisplayName("HMAC 헤더가 일부만 존재하면 HmacAuthenticationFailedException이 발생한다")
+    void shouldThrowWhenPartialHmacHeaders() {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/v1/products");
+        request.addHeader(HEADER_SIGNATURE, "some-signature");
+        request.addHeader(HEADER_TIMESTAMP, "1710000000000");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        assertThatThrownBy(() -> hmacAuthenticationFilter.doFilter(request, response, filterChain))
+                .isInstanceOf(HmacAuthenticationFailedException.class)
+                .hasMessageContaining("필수 헤더가 누락");
+    }
+
+    @Test
+    @DisplayName("Signature만 존재하면 HmacAuthenticationFailedException이 발생한다")
+    void shouldThrowWhenOnlySignaturePresent() {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/v1/products");
+        request.addHeader(HEADER_SIGNATURE, "some-signature");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        assertThatThrownBy(() -> hmacAuthenticationFilter.doFilter(request, response, filterChain))
+                .isInstanceOf(HmacAuthenticationFailedException.class);
+    }
+}

--- a/common/src/test/java/com/personal/marketnote/common/security/hmac/HmacNonceValidatorTest.java
+++ b/common/src/test/java/com/personal/marketnote/common/security/hmac/HmacNonceValidatorTest.java
@@ -1,0 +1,69 @@
+package com.personal.marketnote.common.security.hmac;
+
+import com.personal.marketnote.common.security.hmac.exception.HmacNonceReplayedException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.RedisConnectionFailureException;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+import java.time.Duration;
+
+import static com.personal.marketnote.common.security.hmac.HmacHeaderConstants.REDIS_NONCE_KEY_PREFIX;
+import static com.personal.marketnote.common.security.hmac.HmacHeaderConstants.TIMESTAMP_TOLERANCE_SECONDS;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class HmacNonceValidatorTest {
+    @InjectMocks
+    private HmacNonceValidator hmacNonceValidator;
+
+    @Mock
+    private StringRedisTemplate stringRedisTemplate;
+
+    @Mock
+    private ValueOperations<String, String> valueOperations;
+
+    private static final String NONCE = "550e8400-e29b-41d4-a716-446655440000";
+    private static final String NONCE_KEY = REDIS_NONCE_KEY_PREFIX + NONCE;
+
+    @Test
+    @DisplayName("신규 Nonce는 Redis에 저장되고 검증을 통과한다")
+    void shouldPassForNewNonce() {
+        when(stringRedisTemplate.opsForValue()).thenReturn(valueOperations);
+        when(valueOperations.setIfAbsent(NONCE_KEY, "1", Duration.ofSeconds(TIMESTAMP_TOLERANCE_SECONDS)))
+                .thenReturn(true);
+
+        assertThatCode(() -> hmacNonceValidator.validateAndStore(NONCE))
+                .doesNotThrowAnyException();
+
+        verify(valueOperations).setIfAbsent(NONCE_KEY, "1", Duration.ofSeconds(TIMESTAMP_TOLERANCE_SECONDS));
+    }
+
+    @Test
+    @DisplayName("중복 Nonce는 HmacNonceReplayedException이 발생한다")
+    void shouldThrowForDuplicateNonce() {
+        when(stringRedisTemplate.opsForValue()).thenReturn(valueOperations);
+        when(valueOperations.setIfAbsent(NONCE_KEY, "1", Duration.ofSeconds(TIMESTAMP_TOLERANCE_SECONDS)))
+                .thenReturn(false);
+
+        assertThatThrownBy(() -> hmacNonceValidator.validateAndStore(NONCE))
+                .isInstanceOf(HmacNonceReplayedException.class);
+    }
+
+    @Test
+    @DisplayName("Redis 장애 시 fail-open으로 검증을 통과한다")
+    void shouldFailOpenWhenRedisUnavailable() {
+        when(stringRedisTemplate.opsForValue()).thenThrow(new RedisConnectionFailureException("Connection refused"));
+
+        assertThatCode(() -> hmacNonceValidator.validateAndStore(NONCE))
+                .doesNotThrowAnyException();
+    }
+}

--- a/common/src/test/java/com/personal/marketnote/common/security/hmac/HmacServiceAuthHeaderBuilderTest.java
+++ b/common/src/test/java/com/personal/marketnote/common/security/hmac/HmacServiceAuthHeaderBuilderTest.java
@@ -1,0 +1,66 @@
+package com.personal.marketnote.common.security.hmac;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+
+import static com.personal.marketnote.common.security.hmac.HmacHeaderConstants.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class HmacServiceAuthHeaderBuilderTest {
+    private static final String SECRET_KEY = "test-hmac-secret-key";
+    private static final long FIXED_TIME_MILLIS = 1710000000000L;
+    private static final Clock FIXED_CLOCK = Clock.fixed(
+            Instant.ofEpochMilli(FIXED_TIME_MILLIS), ZoneId.of("Asia/Seoul"));
+
+    @Test
+    @DisplayName("applyHeaders 호출 시 3개의 HMAC 헤더가 설정된다")
+    void shouldApplyThreeHmacHeaders() {
+        HmacServiceAuthHeaderBuilder builder = createBuilder();
+        HttpHeaders headers = new HttpHeaders();
+
+        builder.applyHeaders(headers, "GET", "/api/v1/products");
+
+        assertThat(headers.getFirst(HEADER_SIGNATURE)).isNotNull();
+        assertThat(headers.getFirst(HEADER_TIMESTAMP)).isEqualTo(String.valueOf(FIXED_TIME_MILLIS));
+        assertThat(headers.getFirst(HEADER_NONCE)).isNotNull();
+    }
+
+    @Test
+    @DisplayName("생성된 서명은 검증 가능하다")
+    void shouldGenerateVerifiableSignature() {
+        HmacServiceAuthHeaderBuilder builder = createBuilder();
+        HttpHeaders headers = new HttpHeaders();
+
+        builder.applyHeaders(headers, "POST", "/api/v1/users/1/points");
+
+        String signature = headers.getFirst(HEADER_SIGNATURE);
+        String timestamp = headers.getFirst(HEADER_TIMESTAMP);
+        String nonce = headers.getFirst(HEADER_NONCE);
+
+        String expectedSignature = HmacSignatureGenerator.generate(
+                SECRET_KEY, timestamp, nonce, "POST", "/api/v1/users/1/points");
+        assertThat(signature).isEqualTo(expectedSignature);
+    }
+
+    @Test
+    @DisplayName("매 호출마다 서로 다른 Nonce가 생성된다")
+    void shouldGenerateUniqueNoncePerCall() {
+        HmacServiceAuthHeaderBuilder builder = createBuilder();
+        HttpHeaders headers1 = new HttpHeaders();
+        HttpHeaders headers2 = new HttpHeaders();
+
+        builder.applyHeaders(headers1, "GET", "/api/v1/products");
+        builder.applyHeaders(headers2, "GET", "/api/v1/products");
+
+        assertThat(headers1.getFirst(HEADER_NONCE)).isNotEqualTo(headers2.getFirst(HEADER_NONCE));
+    }
+
+    private HmacServiceAuthHeaderBuilder createBuilder() {
+        return new HmacServiceAuthHeaderBuilder(SECRET_KEY, FIXED_CLOCK);
+    }
+}

--- a/common/src/test/java/com/personal/marketnote/common/security/hmac/HmacSignatureGeneratorTest.java
+++ b/common/src/test/java/com/personal/marketnote/common/security/hmac/HmacSignatureGeneratorTest.java
@@ -1,0 +1,93 @@
+package com.personal.marketnote.common.security.hmac;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class HmacSignatureGeneratorTest {
+    private static final String SECRET_KEY = "test-hmac-secret-key";
+    private static final String TIMESTAMP = "1710000000000";
+    private static final String NONCE = "550e8400-e29b-41d4-a716-446655440000";
+    private static final String HTTP_METHOD = "GET";
+    private static final String REQUEST_PATH = "/api/v1/products";
+
+    @Test
+    @DisplayName("동일한 입력으로 서명을 생성하면 항상 동일한 결과를 반환한다")
+    void shouldGenerateSameSignatureForSameInput() {
+        String signature1 = HmacSignatureGenerator.generate(SECRET_KEY, TIMESTAMP, NONCE, HTTP_METHOD, REQUEST_PATH);
+        String signature2 = HmacSignatureGenerator.generate(SECRET_KEY, TIMESTAMP, NONCE, HTTP_METHOD, REQUEST_PATH);
+
+        assertThat(signature1).isEqualTo(signature2);
+    }
+
+    @Test
+    @DisplayName("서로 다른 시크릿 키로 서명을 생성하면 다른 결과를 반환한다")
+    void shouldGenerateDifferentSignatureForDifferentKey() {
+        String signature1 = HmacSignatureGenerator.generate(SECRET_KEY, TIMESTAMP, NONCE, HTTP_METHOD, REQUEST_PATH);
+        String signature2 = HmacSignatureGenerator.generate("different-key", TIMESTAMP, NONCE, HTTP_METHOD, REQUEST_PATH);
+
+        assertThat(signature1).isNotEqualTo(signature2);
+    }
+
+    @Test
+    @DisplayName("서로 다른 HTTP 메서드로 서명을 생성하면 다른 결과를 반환한다")
+    void shouldGenerateDifferentSignatureForDifferentMethod() {
+        String signatureGet = HmacSignatureGenerator.generate(SECRET_KEY, TIMESTAMP, NONCE, "GET", REQUEST_PATH);
+        String signaturePost = HmacSignatureGenerator.generate(SECRET_KEY, TIMESTAMP, NONCE, "POST", REQUEST_PATH);
+
+        assertThat(signatureGet).isNotEqualTo(signaturePost);
+    }
+
+    @Test
+    @DisplayName("서로 다른 요청 경로로 서명을 생성하면 다른 결과를 반환한다")
+    void shouldGenerateDifferentSignatureForDifferentPath() {
+        String signature1 = HmacSignatureGenerator.generate(SECRET_KEY, TIMESTAMP, NONCE, HTTP_METHOD, "/api/v1/products");
+        String signature2 = HmacSignatureGenerator.generate(SECRET_KEY, TIMESTAMP, NONCE, HTTP_METHOD, "/api/v1/users");
+
+        assertThat(signature1).isNotEqualTo(signature2);
+    }
+
+    @Test
+    @DisplayName("서명은 32자리 Hex 문자열로 반환된다")
+    void shouldReturnHexStringWith32Characters() {
+        String signature = HmacSignatureGenerator.generate(SECRET_KEY, TIMESTAMP, NONCE, HTTP_METHOD, REQUEST_PATH);
+
+        assertThat(signature).hasSize(32);
+        assertThat(signature).matches("[0-9a-f]{32}");
+    }
+
+    @Test
+    @DisplayName("서명 입력값은 콜론으로 구분되어 조합된다")
+    void shouldBuildSigningInputWithColonDelimiter() {
+        String signingInput = HmacSignatureGenerator.buildSigningInput(TIMESTAMP, NONCE, HTTP_METHOD, REQUEST_PATH);
+
+        assertThat(signingInput).isEqualTo(TIMESTAMP + ":" + NONCE + ":" + HTTP_METHOD + ":" + REQUEST_PATH);
+    }
+
+    @Test
+    @DisplayName("constantTimeEquals는 동일한 문자열에 대해 true를 반환한다")
+    void shouldReturnTrueForEqualStrings() {
+        assertThat(HmacSignatureGenerator.constantTimeEquals("abc123", "abc123")).isTrue();
+    }
+
+    @Test
+    @DisplayName("constantTimeEquals는 다른 문자열에 대해 false를 반환한다")
+    void shouldReturnFalseForDifferentStrings() {
+        assertThat(HmacSignatureGenerator.constantTimeEquals("abc123", "abc456")).isFalse();
+    }
+
+    @Test
+    @DisplayName("constantTimeEquals는 null 입력에 대해 false를 반환한다")
+    void shouldReturnFalseForNullInput() {
+        assertThat(HmacSignatureGenerator.constantTimeEquals(null, "abc")).isFalse();
+        assertThat(HmacSignatureGenerator.constantTimeEquals("abc", null)).isFalse();
+        assertThat(HmacSignatureGenerator.constantTimeEquals(null, null)).isFalse();
+    }
+
+    @Test
+    @DisplayName("constantTimeEquals는 길이가 다른 문자열에 대해 false를 반환한다")
+    void shouldReturnFalseForDifferentLengthStrings() {
+        assertThat(HmacSignatureGenerator.constantTimeEquals("abc", "abcd")).isFalse();
+    }
+}

--- a/common/src/test/java/com/personal/marketnote/common/security/hmac/HmacSignatureValidatorTest.java
+++ b/common/src/test/java/com/personal/marketnote/common/security/hmac/HmacSignatureValidatorTest.java
@@ -1,0 +1,120 @@
+package com.personal.marketnote.common.security.hmac;
+
+import com.personal.marketnote.common.security.hmac.exception.HmacSignatureMismatchException;
+import com.personal.marketnote.common.security.hmac.exception.HmacTimestampExpiredException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class HmacSignatureValidatorTest {
+    private static final String SECRET_KEY = "test-hmac-secret-key";
+    private static final String NONCE = "550e8400-e29b-41d4-a716-446655440000";
+    private static final String HTTP_METHOD = "GET";
+    private static final String REQUEST_PATH = "/api/v1/products";
+    private static final long FIXED_TIME_MILLIS = 1710000000000L;
+    private static final Clock FIXED_CLOCK = Clock.fixed(
+            Instant.ofEpochMilli(FIXED_TIME_MILLIS), ZoneId.of("Asia/Seoul"));
+
+    @Test
+    @DisplayName("유효한 서명과 Timestamp로 검증하면 예외가 발생하지 않는다")
+    void shouldPassValidation() {
+        String timestamp = String.valueOf(FIXED_TIME_MILLIS);
+        String signature = HmacSignatureGenerator.generate(SECRET_KEY, timestamp, NONCE, HTTP_METHOD, REQUEST_PATH);
+
+        assertThatCode(() ->
+                HmacSignatureValidator.validate(SECRET_KEY, timestamp, NONCE, HTTP_METHOD, REQUEST_PATH, signature, FIXED_CLOCK)
+        ).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("Timestamp가 허용 오차 범위 내(4분 59초 전)이면 검증을 통과한다")
+    void shouldPassWhenTimestampWithinTolerance() {
+        long fourMinutes59SecondsAgo = FIXED_TIME_MILLIS - (299 * 1000);
+        String timestamp = String.valueOf(fourMinutes59SecondsAgo);
+        String signature = HmacSignatureGenerator.generate(SECRET_KEY, timestamp, NONCE, HTTP_METHOD, REQUEST_PATH);
+
+        assertThatCode(() ->
+                HmacSignatureValidator.validate(SECRET_KEY, timestamp, NONCE, HTTP_METHOD, REQUEST_PATH, signature, FIXED_CLOCK)
+        ).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("Timestamp가 정확히 5분이면 검증을 통과한다")
+    void shouldPassWhenTimestampExactlyAtBoundary() {
+        long exactlyFiveMinutesAgo = FIXED_TIME_MILLIS - (300 * 1000);
+        String timestamp = String.valueOf(exactlyFiveMinutesAgo);
+        String signature = HmacSignatureGenerator.generate(SECRET_KEY, timestamp, NONCE, HTTP_METHOD, REQUEST_PATH);
+
+        assertThatCode(() ->
+                HmacSignatureValidator.validate(SECRET_KEY, timestamp, NONCE, HTTP_METHOD, REQUEST_PATH, signature, FIXED_CLOCK)
+        ).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("Timestamp가 5분 초과이면 HmacTimestampExpiredException이 발생한다")
+    void shouldThrowWhenTimestampExceedsTolerance() {
+        long sixMinutesAgo = FIXED_TIME_MILLIS - (360 * 1000);
+        String timestamp = String.valueOf(sixMinutesAgo);
+        String signature = HmacSignatureGenerator.generate(SECRET_KEY, timestamp, NONCE, HTTP_METHOD, REQUEST_PATH);
+
+        assertThatThrownBy(() ->
+                HmacSignatureValidator.validate(SECRET_KEY, timestamp, NONCE, HTTP_METHOD, REQUEST_PATH, signature, FIXED_CLOCK)
+        ).isInstanceOf(HmacTimestampExpiredException.class);
+    }
+
+    @Test
+    @DisplayName("미래 Timestamp가 5분 초과이면 HmacTimestampExpiredException이 발생한다")
+    void shouldThrowWhenFutureTimestampExceedsTolerance() {
+        long sixMinutesLater = FIXED_TIME_MILLIS + (360 * 1000);
+        String timestamp = String.valueOf(sixMinutesLater);
+        String signature = HmacSignatureGenerator.generate(SECRET_KEY, timestamp, NONCE, HTTP_METHOD, REQUEST_PATH);
+
+        assertThatThrownBy(() ->
+                HmacSignatureValidator.validate(SECRET_KEY, timestamp, NONCE, HTTP_METHOD, REQUEST_PATH, signature, FIXED_CLOCK)
+        ).isInstanceOf(HmacTimestampExpiredException.class);
+    }
+
+    @Test
+    @DisplayName("서명이 일치하지 않으면 HmacSignatureMismatchException이 발생한다")
+    void shouldThrowWhenSignatureMismatch() {
+        String timestamp = String.valueOf(FIXED_TIME_MILLIS);
+        String invalidSignature = "00000000000000000000000000000000";
+
+        assertThatThrownBy(() ->
+                HmacSignatureValidator.validate(SECRET_KEY, timestamp, NONCE, HTTP_METHOD, REQUEST_PATH, invalidSignature, FIXED_CLOCK)
+        ).isInstanceOf(HmacSignatureMismatchException.class);
+    }
+
+    @Test
+    @DisplayName("다른 시크릿 키로 생성된 서명은 검증에 실패한다")
+    void shouldThrowWhenSignatureGeneratedWithDifferentKey() {
+        String timestamp = String.valueOf(FIXED_TIME_MILLIS);
+        String signature = HmacSignatureGenerator.generate("wrong-key", timestamp, NONCE, HTTP_METHOD, REQUEST_PATH);
+
+        assertThatThrownBy(() ->
+                HmacSignatureValidator.validate(SECRET_KEY, timestamp, NONCE, HTTP_METHOD, REQUEST_PATH, signature, FIXED_CLOCK)
+        ).isInstanceOf(HmacSignatureMismatchException.class);
+    }
+
+    @Test
+    @DisplayName("비숫자 Timestamp는 HmacTimestampExpiredException이 발생한다")
+    void shouldThrowWhenTimestampIsNotNumeric() {
+        assertThatThrownBy(() ->
+                HmacSignatureValidator.validateTimestamp("not-a-number", FIXED_CLOCK)
+        ).isInstanceOf(HmacTimestampExpiredException.class);
+    }
+
+    @Test
+    @DisplayName("빈 Timestamp는 HmacTimestampExpiredException이 발생한다")
+    void shouldThrowWhenTimestampIsEmpty() {
+        assertThatThrownBy(() ->
+                HmacSignatureValidator.validateTimestamp("", FIXED_CLOCK)
+        ).isInstanceOf(HmacTimestampExpiredException.class);
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/vendor/RegisterFasstoGoodsItemCommand.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/vendor/RegisterFasstoGoodsItemCommand.java
@@ -1,9 +1,5 @@
 package com.personal.marketnote.fulfillment.port.in.command.vendor;
 
-import lombok.AccessLevel;
-import lombok.Builder;
-
-@Builder(access = AccessLevel.PRIVATE)
 public record RegisterFasstoGoodsItemCommand(
         String cstGodCd,
         String godNm,
@@ -47,12 +43,13 @@ public record RegisterFasstoGoodsItemCommand(
             String godType,
             String giftDiv
     ) {
-        return RegisterFasstoGoodsItemCommand.builder()
-                .cstGodCd(cstGodCd)
-                .godNm(godNm)
-                .godType(godType)
-                .giftDiv(giftDiv)
-                .build();
+        return new RegisterFasstoGoodsItemCommand(
+                cstGodCd, godNm, godType, giftDiv,
+                null, null, null, null, null, null, null, null, null,
+                null, null, null, null, null, null, null, null, null,
+                null, null, null, null, null, null, null, null, null,
+                null, null, null, null
+        );
     }
 
     public static RegisterFasstoGoodsItemCommand of(


### PR DESCRIPTION
## partially addresses #1
## resolves #1496

## Test Case
- HmacSignatureGenerator 단위 테스트 (10개)
- HmacSignatureValidator 단위 테스트 (9개)
- HmacNonceValidator 단위 테스트 (3개)
- HmacAuthenticationFilter 단위 테스트 (5개)
- HmacServiceAuthHeaderBuilder 단위 테스트 (3개)