### PR TITLE
[#1][#1182] feat: RestClient 설정 인프라 구축

### DIFF
--- a/common/src/main/java/com/personal/marketnote/common/configuration/RestClientConfig.java
+++ b/common/src/main/java/com/personal/marketnote/common/configuration/RestClientConfig.java
@@ -1,0 +1,44 @@
+package com.personal.marketnote.common.configuration;
+
+import com.personal.marketnote.common.utility.http.client.restclient.RestClientErrorHandler;
+import com.personal.marketnote.common.utility.http.client.restclient.RestClientLoggingInterceptor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.client.RestClientCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+
+import java.time.Duration;
+
+@Configuration
+public class RestClientConfig {
+
+    private final int connectTimeout;
+    private final int readTimeout;
+
+    public RestClientConfig(
+            @Value("${rest-client.connect-timeout:5000}") int connectTimeout,
+            @Value("${rest-client.read-timeout:10000}") int readTimeout
+    ) {
+        this.connectTimeout = connectTimeout;
+        this.readTimeout = readTimeout;
+    }
+
+    @Bean
+    public RestClientLoggingInterceptor restClientLoggingInterceptor() {
+        return new RestClientLoggingInterceptor();
+    }
+
+    @Bean
+    public RestClientCustomizer restClientCustomizer(RestClientLoggingInterceptor loggingInterceptor) {
+        return builder -> {
+            SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
+            requestFactory.setConnectTimeout(Duration.ofMillis(connectTimeout));
+            requestFactory.setReadTimeout(Duration.ofMillis(readTimeout));
+
+            builder.requestFactory(requestFactory)
+                    .requestInterceptor(loggingInterceptor)
+                    .defaultStatusHandler(RestClientErrorHandler::isError, RestClientErrorHandler.noOpErrorHandler());
+        };
+    }
+}

--- a/common/src/main/java/com/personal/marketnote/common/utility/http/client/restclient/RestClientErrorHandler.java
+++ b/common/src/main/java/com/personal/marketnote/common/utility/http/client/restclient/RestClientErrorHandler.java
@@ -1,0 +1,23 @@
+package com.personal.marketnote.common.utility.http.client.restclient;
+
+import org.springframework.http.HttpStatusCode;
+import org.springframework.web.client.RestClient;
+
+public class RestClientErrorHandler {
+
+    private RestClientErrorHandler() {
+    }
+
+    /**
+     * 4xx/5xx 응답 시 예외를 던지지 않는 no-op 에러 핸들러를 반환한다.
+     * 호출자는 반드시 응답 상태 코드를 직접 확인하여 에러를 처리해야 한다.
+     */
+    public static RestClient.ResponseSpec.ErrorHandler noOpErrorHandler() {
+        return (request, response) -> {
+        };
+    }
+
+    public static boolean isError(HttpStatusCode statusCode) {
+        return statusCode.is4xxClientError() || statusCode.is5xxServerError();
+    }
+}

--- a/common/src/main/java/com/personal/marketnote/common/utility/http/client/restclient/RestClientLoggingInterceptor.java
+++ b/common/src/main/java/com/personal/marketnote/common/utility/http/client/restclient/RestClientLoggingInterceptor.java
@@ -1,0 +1,48 @@
+package com.personal.marketnote.common.utility.http.client.restclient;
+
+import com.personal.marketnote.common.utility.PerformanceMeasurer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.client.ClientHttpRequestExecution;
+import org.springframework.http.client.ClientHttpRequestInterceptor;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.http.HttpRequest;
+
+import java.io.IOException;
+import java.net.URI;
+
+public class RestClientLoggingInterceptor implements ClientHttpRequestInterceptor {
+
+    private static final Logger log = LoggerFactory.getLogger(RestClientLoggingInterceptor.class);
+
+    private static final String OUTBOUND_REQUEST = "Outbound request: {} {}";
+    private static final String OUTBOUND_RESPONSE = "Outbound response: {} {} -> status={}, elapsed={}ms";
+    private static final String OUTBOUND_ERROR = "Outbound request failed: {} {} -> error={}, elapsed={}ms";
+
+    @Override
+    public ClientHttpResponse intercept(HttpRequest request, byte[] body, ClientHttpRequestExecution execution)
+            throws IOException {
+        HttpMethod method = request.getMethod();
+        URI uri = request.getURI();
+
+        log.info(OUTBOUND_REQUEST, method, uri);
+
+        long startedAt = PerformanceMeasurer.computeElapsedTime(0);
+
+        try {
+            ClientHttpResponse response = execution.execute(request, body);
+            long elapsedTime = PerformanceMeasurer.computeElapsedTime(startedAt);
+
+            log.info(OUTBOUND_RESPONSE, method, uri, response.getStatusCode().value(), elapsedTime);
+
+            return response;
+        } catch (IOException exception) {
+            long elapsedTime = PerformanceMeasurer.computeElapsedTime(startedAt);
+
+            log.error(OUTBOUND_ERROR, method, uri, exception.getMessage(), elapsedTime);
+
+            throw exception;
+        }
+    }
+}


### PR DESCRIPTION
## partially addresses #1
## resolves #1182

## Task
- [x] RestClientConfig 빈 설정 생성 (타임아웃, 인터셉터 등 기존 RestTemplateConfig 설정 이관)
- [x] RestClient용 에러 핸들러 구현 (기존 RestTemplateErrorHandler 대응)
- [x] 공통 인터셉터/로깅 설정 이관