### PR TITLE
[#1][#1182] test: RestClient 설정 인프라 구축 자동화 테스트 추가

### DIFF
--- a/common/src/test/java/com/personal/marketnote/common/configuration/RestClientConfigTest.java
+++ b/common/src/test/java/com/personal/marketnote/common/configuration/RestClientConfigTest.java
@@ -1,0 +1,53 @@
+package com.personal.marketnote.common.configuration;
+
+import com.personal.marketnote.common.utility.http.client.restclient.RestClientLoggingInterceptor;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.web.client.RestClientCustomizer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+class RestClientConfigTest {
+
+    @Test
+    @DisplayName("RestClientCustomizer 빈이 정상적으로 생성된다")
+    void shouldCreateRestClientCustomizer() {
+        // given
+        RestClientConfig config = new RestClientConfig(5000, 10000);
+
+        // when
+        RestClientCustomizer customizer = config.restClientCustomizer(new RestClientLoggingInterceptor());
+
+        // then
+        assertThat(customizer).isNotNull();
+    }
+
+    @Test
+    @DisplayName("RestClientCustomizer가 RestClient.Builder에 정상 적용된다")
+    void shouldApplyCustomizerToRestClientBuilder() {
+        // given
+        RestClientConfig config = new RestClientConfig(3000, 8000);
+        RestClientCustomizer customizer = config.restClientCustomizer(new RestClientLoggingInterceptor());
+
+        // when & then
+        assertThatCode(() -> {
+            org.springframework.web.client.RestClient.Builder builder = org.springframework.web.client.RestClient.builder();
+            customizer.customize(builder);
+            builder.build();
+        }).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("RestClientLoggingInterceptor 빈이 정상적으로 생성된다")
+    void shouldCreateRestClientLoggingInterceptor() {
+        // given
+        RestClientConfig config = new RestClientConfig(5000, 10000);
+
+        // when
+        RestClientLoggingInterceptor interceptor = config.restClientLoggingInterceptor();
+
+        // then
+        assertThat(interceptor).isNotNull();
+    }
+}

--- a/common/src/test/java/com/personal/marketnote/common/utility/http/client/restclient/RestClientErrorHandlerTest.java
+++ b/common/src/test/java/com/personal/marketnote/common/utility/http/client/restclient/RestClientErrorHandlerTest.java
@@ -1,0 +1,67 @@
+package com.personal.marketnote.common.utility.http.client.restclient;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.web.client.RestClient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+class RestClientErrorHandlerTest {
+
+    @Test
+    @DisplayName("noOpErrorHandler는 null이 아닌 핸들러를 반환한다")
+    void shouldReturnNonNullHandler() {
+        // when
+        RestClient.ResponseSpec.ErrorHandler handler = RestClientErrorHandler.noOpErrorHandler();
+
+        // then
+        assertThat(handler).isNotNull();
+    }
+
+    @Test
+    @DisplayName("4xx 상태 코드는 에러로 판단한다")
+    void shouldDetect4xxAsError() {
+        // when & then
+        assertThat(RestClientErrorHandler.isError(HttpStatusCode.valueOf(400))).isTrue();
+        assertThat(RestClientErrorHandler.isError(HttpStatusCode.valueOf(404))).isTrue();
+        assertThat(RestClientErrorHandler.isError(HttpStatusCode.valueOf(422))).isTrue();
+    }
+
+    @Test
+    @DisplayName("5xx 상태 코드는 에러로 판단한다")
+    void shouldDetect5xxAsError() {
+        // when & then
+        assertThat(RestClientErrorHandler.isError(HttpStatusCode.valueOf(500))).isTrue();
+        assertThat(RestClientErrorHandler.isError(HttpStatusCode.valueOf(502))).isTrue();
+        assertThat(RestClientErrorHandler.isError(HttpStatusCode.valueOf(503))).isTrue();
+    }
+
+    @Test
+    @DisplayName("2xx 상태 코드는 에러가 아니다")
+    void shouldNotDetect2xxAsError() {
+        // when & then
+        assertThat(RestClientErrorHandler.isError(HttpStatusCode.valueOf(200))).isFalse();
+        assertThat(RestClientErrorHandler.isError(HttpStatusCode.valueOf(201))).isFalse();
+        assertThat(RestClientErrorHandler.isError(HttpStatusCode.valueOf(204))).isFalse();
+    }
+
+    @Test
+    @DisplayName("3xx 상태 코드는 에러가 아니다")
+    void shouldNotDetect3xxAsError() {
+        // when & then
+        assertThat(RestClientErrorHandler.isError(HttpStatusCode.valueOf(301))).isFalse();
+        assertThat(RestClientErrorHandler.isError(HttpStatusCode.valueOf(302))).isFalse();
+    }
+
+    @Test
+    @DisplayName("noOpErrorHandler는 RestClient.Builder에 정상 적용된다")
+    void shouldBeApplicableToRestClientBuilder() {
+        // when & then
+        assertThatCode(() -> RestClient.builder()
+                .defaultStatusHandler(RestClientErrorHandler::isError, RestClientErrorHandler.noOpErrorHandler())
+                .build()
+        ).doesNotThrowAnyException();
+    }
+}

--- a/common/src/test/java/com/personal/marketnote/common/utility/http/client/restclient/RestClientLoggingInterceptorTest.java
+++ b/common/src/test/java/com/personal/marketnote/common/utility/http/client/restclient/RestClientLoggingInterceptorTest.java
@@ -1,0 +1,106 @@
+package com.personal.marketnote.common.utility.http.client.restclient;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpRequest;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.client.ClientHttpRequestExecution;
+import org.springframework.http.client.ClientHttpResponse;
+
+import java.io.IOException;
+import java.net.URI;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RestClientLoggingInterceptorTest {
+
+    private final RestClientLoggingInterceptor interceptor = new RestClientLoggingInterceptor();
+
+    @Test
+    @DisplayName("정상 요청 시 응답을 그대로 반환한다")
+    void shouldReturnResponseWhenRequestSucceeds() throws IOException {
+        // given
+        HttpRequest request = mock(HttpRequest.class);
+        ClientHttpRequestExecution execution = mock(ClientHttpRequestExecution.class);
+        ClientHttpResponse response = mock(ClientHttpResponse.class);
+        byte[] body = new byte[0];
+
+        when(request.getMethod()).thenReturn(HttpMethod.GET);
+        when(request.getURI()).thenReturn(URI.create("http://localhost:8080/api/test"));
+        when(execution.execute(request, body)).thenReturn(response);
+        when(response.getStatusCode()).thenReturn(HttpStatusCode.valueOf(200));
+
+        // when
+        ClientHttpResponse result = interceptor.intercept(request, body, execution);
+
+        // then
+        assertThat(result).isEqualTo(response);
+    }
+
+    @Test
+    @DisplayName("4xx 응답 시에도 응답을 그대로 반환한다")
+    void shouldReturnResponseWhen4xxStatus() throws IOException {
+        // given
+        HttpRequest request = mock(HttpRequest.class);
+        ClientHttpRequestExecution execution = mock(ClientHttpRequestExecution.class);
+        ClientHttpResponse response = mock(ClientHttpResponse.class);
+        byte[] body = new byte[0];
+
+        when(request.getMethod()).thenReturn(HttpMethod.POST);
+        when(request.getURI()).thenReturn(URI.create("http://localhost:8080/api/test"));
+        when(execution.execute(request, body)).thenReturn(response);
+        when(response.getStatusCode()).thenReturn(HttpStatusCode.valueOf(404));
+
+        // when
+        ClientHttpResponse result = interceptor.intercept(request, body, execution);
+
+        // then
+        assertThat(result).isEqualTo(response);
+    }
+
+    @Test
+    @DisplayName("5xx 응답 시에도 응답을 그대로 반환한다")
+    void shouldReturnResponseWhen5xxStatus() throws IOException {
+        // given
+        HttpRequest request = mock(HttpRequest.class);
+        ClientHttpRequestExecution execution = mock(ClientHttpRequestExecution.class);
+        ClientHttpResponse response = mock(ClientHttpResponse.class);
+        byte[] body = new byte[0];
+
+        when(request.getMethod()).thenReturn(HttpMethod.PUT);
+        when(request.getURI()).thenReturn(URI.create("http://localhost:8080/api/test"));
+        when(execution.execute(request, body)).thenReturn(response);
+        when(response.getStatusCode()).thenReturn(HttpStatusCode.valueOf(500));
+
+        // when
+        ClientHttpResponse result = interceptor.intercept(request, body, execution);
+
+        // then
+        assertThat(result).isEqualTo(response);
+    }
+
+    @Test
+    @DisplayName("요청 실행 중 IOException 발생 시 예외를 다시 던진다")
+    void shouldRethrowExceptionWhenRequestFails() throws IOException {
+        // given
+        HttpRequest request = mock(HttpRequest.class);
+        ClientHttpRequestExecution execution = mock(ClientHttpRequestExecution.class);
+        byte[] body = new byte[0];
+
+        when(request.getMethod()).thenReturn(HttpMethod.DELETE);
+        when(request.getURI()).thenReturn(URI.create("http://localhost:8080/api/test"));
+        when(execution.execute(request, body)).thenThrow(new IOException("Connection refused"));
+
+        // when & then
+        assertThatThrownBy(() -> interceptor.intercept(request, body, execution))
+                .isInstanceOf(IOException.class)
+                .hasMessage("Connection refused");
+    }
+}


### PR DESCRIPTION
## partially addresses #1
## resolves #1182

## Test Case
- [x] RestClientLoggingInterceptor 테스트 (정상 응답 반환 / 4xx 응답 반환 / 5xx 응답 반환 / IOException 발생 시 예외 재throw)
- [x] RestClientErrorHandler 테스트 (noOpErrorHandler 반환 / 4xx 에러 판단 / 5xx 에러 판단 / 2xx 비에러 / 3xx 비에러 / Builder 적용)
- [x] RestClientConfig 테스트 (RestClientCustomizer 빈 생성 / Builder 적용 / LoggingInterceptor 빈 생성)