### PR TITLE
[#929][#1029] refactor: product.product.registered 이벤트 듀얼 라이트 Consumer 처리 검증 (#1509)

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/ProductEventKafkaListener.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/ProductEventKafkaListener.java
@@ -63,7 +63,7 @@ public class ProductEventKafkaListener {
             log.info("Kafka 이벤트로 재고 등록 완료. productId={}, pricePolicyId={}",
                     payload.productId(), payload.pricePolicyId());
         } catch (InventoryAlreadyExistsException e) {
-            log.info("재고가 이미 존재합니다 (듀얼 라이트 중복). eventId={}, key={}",
+            log.info("재고가 이미 존재합니다 (멱등 처리). eventId={}, key={}",
                     envelope.eventId(), record.key());
         }
 

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/event/ProductRegisteredFulfillmentConsumer.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/event/ProductRegisteredFulfillmentConsumer.java
@@ -10,7 +10,6 @@ import com.personal.marketnote.fulfillment.configuration.FasstoAuthProperties;
 import com.personal.marketnote.fulfillment.domain.FasstoAccessToken;
 import com.personal.marketnote.fulfillment.exception.FasstoAccessTokenIssuanceFailedException;
 import com.personal.marketnote.fulfillment.exception.FasstoGoodsAlreadyRegisteredException;
-import com.personal.marketnote.fulfillment.exception.RegisterFasstoGoodsFailedException;
 import com.personal.marketnote.fulfillment.port.in.command.vendor.RegisterFasstoGoodsCommand;
 import com.personal.marketnote.fulfillment.port.in.command.vendor.RegisterFasstoGoodsItemCommand;
 import com.personal.marketnote.fulfillment.port.in.usecase.vendor.RegisterFasstoGoodsUseCase;
@@ -101,11 +100,8 @@ public class ProductRegisteredFulfillmentConsumer {
         } catch (FasstoGoodsAlreadyRegisteredException e) {
             log.warn("이미 Fassto에 등록된 상품입니다 (멱등 처리). eventId={}, key={}, message={}",
                     envelope.eventId(), record.key(), e.getMessage());
-        } catch (RegisterFasstoGoodsFailedException e) {
-            log.warn("풀필먼트 상품 등록 실패 (듀얼 라이트 기간 HTTP 호출로 처리됨). eventId={}, key={}, message={}",
-                    envelope.eventId(), record.key(), e.getMessage());
         }
-        // 그 외 예외는 DefaultErrorHandler가 재시도 + DLT로 처리
+        // 그 외 예외(RegisterFasstoGoodsFailedException 포함)는 DefaultErrorHandler가 재시도 + DLT로 처리
 
         acknowledgment.acknowledge();
     }

--- a/fulfillment-service/fulfillment-adapters/src/test/java/com/personal/marketnote/fulfillment/adapter/in/event/ProductRegisteredFulfillmentConsumerTest.java
+++ b/fulfillment-service/fulfillment-adapters/src/test/java/com/personal/marketnote/fulfillment/adapter/in/event/ProductRegisteredFulfillmentConsumerTest.java
@@ -176,8 +176,8 @@ class ProductRegisteredFulfillmentConsumerTest {
     }
 
     @Test
-    @DisplayName("RegisterFasstoGoodsFailedException 발생 시 warn 로그 후 acknowledge한다")
-    void handleEvent_registerFasstoGoodsFailed_warnsAndAcknowledges() {
+    @DisplayName("RegisterFasstoGoodsFailedException 발생 시 DefaultErrorHandler로 위임되어 예외가 전파된다")
+    void handleEvent_registerFasstoGoodsFailed_propagatesForRetry() {
         // given
         ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, "테스트", "1");
         when(requestFasstoAuthUseCase.requestAccessToken()).thenReturn(buildValidAccessToken());
@@ -185,12 +185,12 @@ class ProductRegisteredFulfillmentConsumerTest {
         doThrow(new RegisterFasstoGoodsFailedException(new IOException("Fassto API 오류")))
                 .when(registerFasstoGoodsUseCase).registerGoodsIdempotent(any(RegisterFasstoGoodsCommand.class));
 
-        // when
-        consumer.handleProductRegisteredEvent(record, acknowledgment);
+        // when & then
+        assertThatThrownBy(() -> consumer.handleProductRegisteredEvent(record, acknowledgment))
+                .isInstanceOf(RegisterFasstoGoodsFailedException.class);
 
-        // then
         verify(registerFasstoGoodsUseCase).registerGoodsIdempotent(any(RegisterFasstoGoodsCommand.class));
-        verify(acknowledgment).acknowledge();
+        verify(acknowledgment, never()).acknowledge();
     }
 
     @Test

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/service/product/RegisterProductService.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/service/product/RegisterProductService.java
@@ -3,7 +3,6 @@ package com.personal.marketnote.product.service.product;
 import com.personal.marketnote.common.application.UseCase;
 import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.product.domain.product.Product;
-import com.personal.marketnote.product.mapper.FulfillmentVendorGoodsCommandMapper;
 import com.personal.marketnote.product.mapper.ProductCommandToStateMapper;
 import com.personal.marketnote.product.port.in.command.FulfillmentVendorGoodsOptionCommand;
 import com.personal.marketnote.product.port.in.command.RegisterPricePolicyCommand;
@@ -13,13 +12,9 @@ import com.personal.marketnote.product.port.in.result.product.RegisterProductRes
 import com.personal.marketnote.product.port.in.usecase.pricepolicy.RegisterPricePolicyUseCase;
 import com.personal.marketnote.product.port.in.usecase.product.RegisterProductUseCase;
 import com.personal.marketnote.product.port.out.event.PublishProductEventPort;
-import com.personal.marketnote.product.port.out.fulfillment.RegisterFulfillmentVendorGoodsPort;
-import com.personal.marketnote.product.port.out.inventory.RegisterInventoryPort;
 import com.personal.marketnote.product.port.out.product.SaveProductPort;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.transaction.support.TransactionSynchronization;
-import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
 
@@ -32,8 +27,6 @@ public class RegisterProductService implements RegisterProductUseCase {
     private final RegisterPricePolicyUseCase registerPricePolicyUseCase;
     private final SaveProductPort saveProductPort;
     private final PublishProductEventPort publishProductEventPort;
-    private final RegisterInventoryPort registerInventoryPort;
-    private final RegisterFulfillmentVendorGoodsPort registerFulfillmentVendorGoodsPort;
 
     @Override
     public RegisterProductResult registerProduct(RegisterProductCommand command) {
@@ -58,34 +51,6 @@ public class RegisterProductService implements RegisterProductUseCase {
                 savedProduct.getId(), registerPricePolicyResult.id(), command.sellerId(), savedProduct.getName(), godType
         );
 
-        // 트랜잭션 커밋 후 외부 시스템 HTTP 호출
-        if (TransactionSynchronizationManager.isActualTransactionActive()) {
-            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
-                @Override
-                public void afterCommit() {
-                    registerExternalSystemsHttp(savedProduct, command, registerPricePolicyResult.id());
-                }
-            });
-
-            return RegisterProductResult.from(savedProduct);
-        }
-
-        registerExternalSystemsHttp(savedProduct, command, registerPricePolicyResult.id());
-
         return RegisterProductResult.from(savedProduct);
-    }
-
-    private void registerExternalSystemsHttp(
-            Product savedProduct,
-            RegisterProductCommand command,
-            Long pricePolicyId
-    ) {
-        // TODO: Kafka 검증 완료 후 HTTP 호출 제거
-        registerInventoryPort.registerInventory(savedProduct.getId(), pricePolicyId);
-
-        // TODO: Kafka 검증 완료 후 HTTP 호출 제거 (#934)
-        registerFulfillmentVendorGoodsPort.registerFulfillmentVendorGoods(
-                FulfillmentVendorGoodsCommandMapper.mapToRegisterCommand(savedProduct, command.fulfillmentVendorGoods())
-        );
     }
 }

--- a/product-service/product-application/src/test/java/com/personal/marketnote/product/service/product/RegisterProductUseCaseTest.java
+++ b/product-service/product-application/src/test/java/com/personal/marketnote/product/service/product/RegisterProductUseCaseTest.java
@@ -4,8 +4,6 @@ import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus
 import com.personal.marketnote.product.domain.product.Product;
 import com.personal.marketnote.product.domain.product.ProductSnapshotState;
 import com.personal.marketnote.product.domain.product.ProductTag;
-import com.personal.marketnote.product.exception.FulfillmentVendorGoodsTypeNoValueException;
-import com.personal.marketnote.product.exception.ProductInfoNoValueException;
 import com.personal.marketnote.product.port.in.command.FulfillmentVendorGoodsOptionCommand;
 import com.personal.marketnote.product.port.in.command.RegisterPricePolicyCommand;
 import com.personal.marketnote.product.port.in.command.RegisterProductCommand;
@@ -13,9 +11,6 @@ import com.personal.marketnote.product.port.in.result.pricepolicy.RegisterPriceP
 import com.personal.marketnote.product.port.in.result.product.RegisterProductResult;
 import com.personal.marketnote.product.port.in.usecase.pricepolicy.RegisterPricePolicyUseCase;
 import com.personal.marketnote.product.port.out.event.PublishProductEventPort;
-import com.personal.marketnote.product.port.out.fulfillment.RegisterFulfillmentVendorGoodsCommand;
-import com.personal.marketnote.product.port.out.fulfillment.RegisterFulfillmentVendorGoodsPort;
-import com.personal.marketnote.product.port.out.inventory.RegisterInventoryPort;
 import com.personal.marketnote.product.port.out.product.SaveProductPort;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -31,7 +26,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class RegisterProductUseCaseTest {
@@ -41,10 +39,6 @@ class RegisterProductUseCaseTest {
     private SaveProductPort saveProductPort;
     @Mock
     private PublishProductEventPort publishProductEventPort;
-    @Mock
-    private RegisterInventoryPort registerInventoryPort;
-    @Mock
-    private RegisterFulfillmentVendorGoodsPort registerFulfillmentVendorGoodsPort;
 
     @InjectMocks
     private RegisterProductService registerProductService;
@@ -92,25 +86,11 @@ class RegisterProductUseCaseTest {
         assertThat(pricePolicyCommand.optionIds()).isNull();
 
         verify(publishProductEventPort).publishProductRegisteredEvent(10L, 100L, command.sellerId(), "테스트 상품", "1");
-        verify(registerInventoryPort).registerInventory(10L, 100L);
-
-        ArgumentCaptor<RegisterFulfillmentVendorGoodsCommand> fulfillmentCaptor =
-                ArgumentCaptor.forClass(RegisterFulfillmentVendorGoodsCommand.class);
-        verify(registerFulfillmentVendorGoodsPort).registerFulfillmentVendorGoods(fulfillmentCaptor.capture());
-        RegisterFulfillmentVendorGoodsCommand fulfillmentCommand = fulfillmentCaptor.getValue();
-        assertThat(fulfillmentCommand.cstGodCd()).isEqualTo(String.valueOf(savedProduct.getId()));
-        assertThat(fulfillmentCommand.godNm()).isEqualTo(savedProduct.getName());
-        assertThat(fulfillmentCommand.godType()).isEqualTo("1");
-        assertThat(fulfillmentCommand.giftDiv()).isEqualTo("01");
-        assertThat(fulfillmentCommand.godOptCd1()).isNull();
-        assertThat(fulfillmentCommand.externalGodImgUrl()).isNull();
 
         verifyNoMoreInteractions(
                 registerPricePolicyUseCase,
                 saveProductPort,
-                publishProductEventPort,
-                registerInventoryPort,
-                registerFulfillmentVendorGoodsPort
+                publishProductEventPort
         );
     }
 
@@ -129,13 +109,6 @@ class RegisterProductUseCaseTest {
         registerProductService.registerProduct(command);
 
         verify(publishProductEventPort).publishProductRegisteredEvent(11L, 101L, command.sellerId(), "테스트 상품", "2");
-
-        ArgumentCaptor<RegisterFulfillmentVendorGoodsCommand> fulfillmentCaptor =
-                ArgumentCaptor.forClass(RegisterFulfillmentVendorGoodsCommand.class);
-        verify(registerFulfillmentVendorGoodsPort).registerFulfillmentVendorGoods(fulfillmentCaptor.capture());
-
-        RegisterFulfillmentVendorGoodsCommand expected = buildExpectedFulfillmentCommand(savedProduct, options);
-        assertThat(fulfillmentCaptor.getValue()).isEqualTo(expected);
     }
 
     @Test
@@ -156,70 +129,7 @@ class RegisterProductUseCaseTest {
         verify(registerPricePolicyUseCase).registerPricePolicy(
                 eq(command.sellerId()), eq(false), any(RegisterPricePolicyCommand.class)
         );
-        verifyNoInteractions(publishProductEventPort, registerInventoryPort, registerFulfillmentVendorGoodsPort);
-    }
-
-    @Test
-    @DisplayName("상품 등록 시 재고 등록이 실패하면 풀필먼트 등록을 시도하지 않는다")
-    void registerProduct_inventoryRegistrationFails() {
-        RegisterProductCommand command = buildCommand(null);
-        Product savedProduct = buildSavedProduct(30L, command);
-
-        when(saveProductPort.save(any(Product.class))).thenReturn(savedProduct);
-        when(registerPricePolicyUseCase.registerPricePolicy(
-                eq(command.sellerId()), eq(false), any(RegisterPricePolicyCommand.class)
-        )).thenReturn(RegisterPricePolicyResult.of(200L));
-        doThrow(new IllegalStateException("inventory fail"))
-                .when(registerInventoryPort).registerInventory(30L, 200L);
-
-        assertThatThrownBy(() -> registerProductService.registerProduct(command))
-                .isInstanceOf(IllegalStateException.class);
-
-        verify(publishProductEventPort).publishProductRegisteredEvent(30L, 200L, command.sellerId(), "테스트 상품", "1");
-        verify(registerFulfillmentVendorGoodsPort, never()).registerFulfillmentVendorGoods(any());
-    }
-
-    @Test
-    @DisplayName("상품 등록 시 풀필먼트 필수 옵션이 누락되면 예외를 던진다")
-    void registerProduct_missingFulfillmentRequiredFields_throws() {
-        FulfillmentVendorGoodsOptionCommand options = FulfillmentVendorGoodsOptionCommand.builder()
-                .giftDiv("01")
-                .build();
-        RegisterProductCommand command = buildCommand(options);
-        Product savedProduct = buildSavedProduct(40L, command);
-
-        when(saveProductPort.save(any(Product.class))).thenReturn(savedProduct);
-        when(registerPricePolicyUseCase.registerPricePolicy(
-                eq(command.sellerId()), eq(false), any(RegisterPricePolicyCommand.class)
-        )).thenReturn(RegisterPricePolicyResult.of(300L));
-
-        assertThatThrownBy(() -> registerProductService.registerProduct(command))
-                .isInstanceOf(FulfillmentVendorGoodsTypeNoValueException.class)
-                .hasMessageContaining("godType");
-
-        verify(publishProductEventPort).publishProductRegisteredEvent(40L, 300L, command.sellerId(), "테스트 상품", "1");
-        verify(registerInventoryPort).registerInventory(40L, 300L);
-        verify(registerFulfillmentVendorGoodsPort, never()).registerFulfillmentVendorGoods(any());
-    }
-
-    @Test
-    @DisplayName("상품 등록 시 저장된 상품에 ID가 없으면 풀필먼트 매핑에서 예외를 던진다")
-    void registerProduct_missingProductId_throws() {
-        RegisterProductCommand command = buildCommand(null);
-        Product savedProduct = buildSavedProduct(null, command);
-
-        when(saveProductPort.save(any(Product.class))).thenReturn(savedProduct);
-        when(registerPricePolicyUseCase.registerPricePolicy(
-                eq(command.sellerId()), eq(false), any(RegisterPricePolicyCommand.class)
-        )).thenReturn(RegisterPricePolicyResult.of(400L));
-
-        assertThatThrownBy(() -> registerProductService.registerProduct(command))
-                .isInstanceOf(ProductInfoNoValueException.class)
-                .hasMessageContaining("상품 ID가 존재하지 않습니다.");
-
-        verify(publishProductEventPort).publishProductRegisteredEvent(null, 400L, command.sellerId(), "테스트 상품", "1");
-        verify(registerInventoryPort).registerInventory(null, 400L);
-        verify(registerFulfillmentVendorGoodsPort, never()).registerFulfillmentVendorGoods(any());
+        verifyNoInteractions(publishProductEventPort);
     }
 
     private RegisterProductCommand buildCommand(FulfillmentVendorGoodsOptionCommand fulfillmentVendorGoods) {
@@ -255,81 +165,6 @@ class RegisterProductUseCaseTest {
     private FulfillmentVendorGoodsOptionCommand buildFulfillmentOptions() {
         return FulfillmentVendorGoodsOptionCommand.builder()
                 .godType("2")
-                .giftDiv("99")
-                .godOptCd1("opt1")
-                .godOptCd2("opt2")
-                .invGodNmUseYn("Y")
-                .invGodNm("상품명")
-                .supCd("SUP")
-                .cateCd("CATE")
-                .seasonCd("2024")
-                .genderCd("M")
-                .makeYr("2024")
-                .godPr("12000")
-                .inPr("9000")
-                .salPr("10000")
-                .dealTemp("ROOM")
-                .pickFac("A1")
-                .godBarcd("BARCODE")
-                .boxWeight("2.5")
-                .origin("KR")
-                .distTermMgtYn("Y")
-                .useTermDay("30")
-                .outCanDay("7")
-                .inCanDay("7")
-                .boxDiv("BOX")
-                .bufGodYn("N")
-                .loadingDirection("UP")
-                .subMate("COTTON")
-                .useYn("Y")
-                .safetyStock("10")
-                .feeYn("N")
-                .saleUnitQty("1")
-                .cstGodImgUrl("https://example.com/image.jpg")
-                .externalGodImgUrl("https://example.com/external.jpg")
-                .build();
-    }
-
-    private RegisterFulfillmentVendorGoodsCommand buildExpectedFulfillmentCommand(
-            Product product,
-            FulfillmentVendorGoodsOptionCommand options
-    ) {
-        return RegisterFulfillmentVendorGoodsCommand.builder()
-                .cstGodCd(String.valueOf(product.getId()))
-                .godNm(product.getName())
-                .godType(options.godType())
-                .giftDiv(options.giftDiv())
-                .godOptCd1(options.godOptCd1())
-                .godOptCd2(options.godOptCd2())
-                .invGodNmUseYn(options.invGodNmUseYn())
-                .invGodNm(options.invGodNm())
-                .supCd(options.supCd())
-                .cateCd(options.cateCd())
-                .seasonCd(options.seasonCd())
-                .genderCd(options.genderCd())
-                .makeYr(options.makeYr())
-                .godPr(options.godPr())
-                .inPr(options.inPr())
-                .salPr(options.salPr())
-                .dealTemp(options.dealTemp())
-                .pickFac(options.pickFac())
-                .godBarcd(options.godBarcd())
-                .boxWeight(options.boxWeight())
-                .origin(options.origin())
-                .distTermMgtYn(options.distTermMgtYn())
-                .useTermDay(options.useTermDay())
-                .outCanDay(options.outCanDay())
-                .inCanDay(options.inCanDay())
-                .boxDiv(options.boxDiv())
-                .bufGodYn(options.bufGodYn())
-                .loadingDirection(options.loadingDirection())
-                .subMate(options.subMate())
-                .useYn(options.useYn())
-                .safetyStock(options.safetyStock())
-                .feeYn(options.feeYn())
-                .saleUnitQty(options.saleUnitQty())
-                .cstGodImgUrl(options.cstGodImgUrl())
-                .externalGodImgUrl(options.externalGodImgUrl())
                 .build();
     }
 }


### PR DESCRIPTION
## partially addresses #929
## resolves #1029

## Task
- [x] RegisterProductService에서 RegisterInventoryPort, RegisterFulfillmentVendorGoodsPort HTTP 호출 제거
- [x] TransactionSynchronization.afterCommit() 블록 제거
- [x] TODO 주석 제거
- [x] ProductRegisteredFulfillmentConsumer에서 RegisterFasstoGoodsFailedException catch 제거 (재시도 + DLT 전환)
- [x] ProductEventKafkaListener 로그 메시지 수정 ("듀얼 라이트 중복" → "멱등 처리")
- [x] RegisterProductUseCaseTest HTTP 관련 mock/verify/테스트 정리
- [x] ProductRegisteredFulfillmentConsumerTest 실패 시 예외 전파 동작 검증 수정
- [x] 전체 빌드 검증 (BUILD SUCCESSFUL)