### PR TITLE
[#929][#1030] refactor: product.price-policy.created 이벤트 듀얼 라이트 Consumer 처리 검증

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/PricePolicyEventKafkaListener.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/PricePolicyEventKafkaListener.java
@@ -63,7 +63,7 @@ public class PricePolicyEventKafkaListener {
             log.info("Kafka 이벤트로 재고 등록 완료. productId={}, pricePolicyId={}",
                     payload.productId(), payload.pricePolicyId());
         } catch (InventoryAlreadyExistsException e) {
-            log.info("재고가 이미 존재합니다 (듀얼 라이트 중복). eventId={}, key={}",
+            log.info("재고가 이미 존재합니다 (멱등 처리). eventId={}, key={}",
                     envelope.eventId(), record.key());
         }
         // 그 외 예외는 DefaultErrorHandler가 재시도 + DLT로 처리

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/vendor/RegisterFasstoGoodsItemCommand.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/vendor/RegisterFasstoGoodsItemCommand.java
@@ -1,9 +1,5 @@
 package com.personal.marketnote.fulfillment.port.in.command.vendor;
 
-import lombok.AccessLevel;
-import lombok.Builder;
-
-@Builder(access = AccessLevel.PRIVATE)
 public record RegisterFasstoGoodsItemCommand(
         String cstGodCd,
         String godNm,
@@ -47,12 +43,13 @@ public record RegisterFasstoGoodsItemCommand(
             String godType,
             String giftDiv
     ) {
-        return RegisterFasstoGoodsItemCommand.builder()
-                .cstGodCd(cstGodCd)
-                .godNm(godNm)
-                .godType(godType)
-                .giftDiv(giftDiv)
-                .build();
+        return new RegisterFasstoGoodsItemCommand(
+                cstGodCd, godNm, godType, giftDiv,
+                null, null, null, null, null, null, null, null, null,
+                null, null, null, null, null, null, null, null, null,
+                null, null, null, null, null, null, null, null, null,
+                null, null, null, null
+        );
     }
 
     public static RegisterFasstoGoodsItemCommand of(

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/service/pricepolicy/RegisterPricePolicyService.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/service/pricepolicy/RegisterPricePolicyService.java
@@ -13,14 +13,11 @@ import com.personal.marketnote.product.port.in.result.pricepolicy.RegisterPriceP
 import com.personal.marketnote.product.port.in.usecase.pricepolicy.RegisterPricePolicyUseCase;
 import com.personal.marketnote.product.port.in.usecase.product.GetProductUseCase;
 import com.personal.marketnote.product.port.out.event.PublishProductEventPort;
-import com.personal.marketnote.product.port.out.inventory.RegisterInventoryPort;
 import com.personal.marketnote.product.port.out.pricepolicy.SavePricePolicyPort;
 import com.personal.marketnote.product.port.out.product.FindProductPort;
 import com.personal.marketnote.product.port.out.productoption.UpdateOptionPricePolicyPort;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.transaction.support.TransactionSynchronization;
-import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import java.util.List;
 
@@ -36,7 +33,6 @@ public class RegisterPricePolicyService implements RegisterPricePolicyUseCase {
     private final SavePricePolicyPort savePricePolicyPort;
     private final UpdateOptionPricePolicyPort updateOptionPricePolicyPort;
     private final PublishProductEventPort publishProductEventPort;
-    private final RegisterInventoryPort registerInventoryPort;
 
     @Override
     public RegisterPricePolicyResult registerPricePolicy(
@@ -63,9 +59,6 @@ public class RegisterPricePolicyService implements RegisterPricePolicyUseCase {
         // Outbox 이벤트 저장 (트랜잭션 내)
         publishProductEventPort.publishPricePolicyCreatedEvent(productId, id);
 
-        // 트랜잭션 커밋 후 HTTP 호출
-        registerInventoryHttpAfterCommit(productId, id);
-
         return RegisterPricePolicyResult.of(id);
     }
 
@@ -82,22 +75,5 @@ public class RegisterPricePolicyService implements RegisterPricePolicyUseCase {
         if (command.accumulatedPoint().compareTo(command.discountPrice()) > 0) {
             throw new InvalidPricePolicyAccumulatedPointException();
         }
-    }
-
-    private void registerInventoryHttpAfterCommit(Long productId, Long pricePolicyId) {
-        if (TransactionSynchronizationManager.isActualTransactionActive()) {
-            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
-                @Override
-                public void afterCommit() {
-                    // TODO: Kafka 검증 완료 후 HTTP 호출 제거 (#1017)
-                    registerInventoryPort.registerInventory(productId, pricePolicyId);
-                }
-            });
-
-            return;
-        }
-
-        // TODO: Kafka 검증 완료 후 HTTP 호출 제거 (#1017)
-        registerInventoryPort.registerInventory(productId, pricePolicyId);
     }
 }

--- a/product-service/product-application/src/test/java/com/personal/marketnote/product/service/pricepolicy/RegisterPricePolicyUseCaseTest.java
+++ b/product-service/product-application/src/test/java/com/personal/marketnote/product/service/pricepolicy/RegisterPricePolicyUseCaseTest.java
@@ -11,7 +11,6 @@ import com.personal.marketnote.product.port.in.command.RegisterPricePolicyComman
 import com.personal.marketnote.product.port.in.result.pricepolicy.RegisterPricePolicyResult;
 import com.personal.marketnote.product.port.in.usecase.product.GetProductUseCase;
 import com.personal.marketnote.product.port.out.event.PublishProductEventPort;
-import com.personal.marketnote.product.port.out.inventory.RegisterInventoryPort;
 import com.personal.marketnote.product.port.out.pricepolicy.SavePricePolicyPort;
 import com.personal.marketnote.product.port.out.product.FindProductPort;
 import com.personal.marketnote.product.port.out.productoption.UpdateOptionPricePolicyPort;
@@ -44,8 +43,6 @@ class RegisterPricePolicyUseCaseTest {
     private UpdateOptionPricePolicyPort updateOptionPricePolicyPort;
     @Mock
     private PublishProductEventPort publishProductEventPort;
-    @Mock
-    private RegisterInventoryPort registerInventoryPort;
 
     @InjectMocks
     private RegisterPricePolicyService registerPricePolicyService;
@@ -67,8 +64,7 @@ class RegisterPricePolicyUseCaseTest {
                 getProductUseCase,
                 savePricePolicyPort,
                 updateOptionPricePolicyPort,
-                publishProductEventPort,
-                registerInventoryPort
+                publishProductEventPort
         );
     }
 
@@ -107,7 +103,6 @@ class RegisterPricePolicyUseCaseTest {
 
         verify(updateOptionPricePolicyPort).assignPricePolicyToOptions(productId, 100L, optionIds);
         verify(publishProductEventPort).publishPricePolicyCreatedEvent(productId, 100L);
-        verify(registerInventoryPort).registerInventory(productId, 100L);
     }
 
     @Test
@@ -125,7 +120,6 @@ class RegisterPricePolicyUseCaseTest {
 
         assertThat(result.id()).isEqualTo(200L);
         verify(publishProductEventPort).publishPricePolicyCreatedEvent(productId, 200L);
-        verify(registerInventoryPort).registerInventory(productId, 200L);
         verify(updateOptionPricePolicyPort, never()).assignPricePolicyToOptions(anyLong(), anyLong(), anyList());
         verifyNoInteractions(findProductPort);
     }
@@ -146,7 +140,6 @@ class RegisterPricePolicyUseCaseTest {
 
         verify(updateOptionPricePolicyPort, never()).assignPricePolicyToOptions(anyLong(), anyLong(), anyList());
         verify(publishProductEventPort).publishPricePolicyCreatedEvent(productId, 250L);
-        verify(registerInventoryPort).registerInventory(productId, 250L);
     }
 
     @Test
@@ -164,7 +157,7 @@ class RegisterPricePolicyUseCaseTest {
                 .isSameAs(exception);
 
         verify(savePricePolicyPort, never()).save(any(PricePolicy.class));
-        verifyNoInteractions(updateOptionPricePolicyPort, publishProductEventPort, registerInventoryPort);
+        verifyNoInteractions(updateOptionPricePolicyPort, publishProductEventPort);
     }
 
     @Test
@@ -184,7 +177,7 @@ class RegisterPricePolicyUseCaseTest {
                 .isSameAs(exception);
 
         verify(updateOptionPricePolicyPort, never()).assignPricePolicyToOptions(anyLong(), anyLong(), anyList());
-        verifyNoInteractions(publishProductEventPort, registerInventoryPort);
+        verifyNoInteractions(publishProductEventPort);
     }
 
     @Test
@@ -205,29 +198,6 @@ class RegisterPricePolicyUseCaseTest {
         assertThatThrownBy(() -> registerPricePolicyService.registerPricePolicy(userId, false, command))
                 .isSameAs(exception);
 
-        verify(registerInventoryPort, never()).registerInventory(anyLong(), anyLong());
-    }
-
-    @Test
-    @DisplayName("가격 정책 등록 시 재고 등록에 실패하면 예외를 전파한다")
-    void registerPricePolicy_registerInventoryFails_propagates() {
-        Long userId = 8L;
-        Long productId = 80L;
-        List<Long> optionIds = List.of(501L);
-        RegisterPricePolicyCommand command = buildCommand(productId, optionIds);
-        Product product = buildProduct(productId, userId);
-        RuntimeException exception = new RuntimeException("inventory fail");
-
-        when(findProductPort.existsByIdAndSellerId(productId, userId)).thenReturn(true);
-        when(getProductUseCase.getProduct(productId)).thenReturn(product);
-        when(savePricePolicyPort.save(any(PricePolicy.class))).thenReturn(400L);
-        doThrow(exception).when(registerInventoryPort).registerInventory(productId, 400L);
-
-        assertThatThrownBy(() -> registerPricePolicyService.registerPricePolicy(userId, false, command))
-                .isSameAs(exception);
-
-        verify(updateOptionPricePolicyPort).assignPricePolicyToOptions(productId, 400L, optionIds);
-        verify(publishProductEventPort).publishPricePolicyCreatedEvent(productId, 400L);
     }
 
     @Test
@@ -328,7 +298,7 @@ class RegisterPricePolicyUseCaseTest {
                 .isInstanceOf(InvalidPricePolicyAccumulatedPointException.class)
                 .hasMessageContaining("적립금이 현재 판매가를 초과할 수 없습니다");
 
-        verifyNoInteractions(getProductUseCase, savePricePolicyPort, updateOptionPricePolicyPort, publishProductEventPort, registerInventoryPort);
+        verifyNoInteractions(getProductUseCase, savePricePolicyPort, updateOptionPricePolicyPort, publishProductEventPort);
     }
 
     @Test
@@ -344,7 +314,7 @@ class RegisterPricePolicyUseCaseTest {
                 .isInstanceOf(InvalidPricePolicyPriceException.class)
                 .hasMessageContaining("현재 판매가가 정가를 초과할 수 없습니다");
 
-        verifyNoInteractions(getProductUseCase, savePricePolicyPort, updateOptionPricePolicyPort, publishProductEventPort, registerInventoryPort);
+        verifyNoInteractions(getProductUseCase, savePricePolicyPort, updateOptionPricePolicyPort, publishProductEventPort);
     }
 
     private RegisterPricePolicyCommand buildCommand(Long productId, List<Long> optionIds) {


### PR DESCRIPTION
## partially addresses #929
## resolves #1030

## Task
- [x] RegisterPricePolicyService에서 RegisterInventoryPort HTTP 호출 제거
- [x] registerInventoryHttpAfterCommit() 메서드 및 TransactionSynchronization.afterCommit() 블록 제거
- [x] TODO 주석 제거
- [x] PricePolicyEventKafkaListener 로그 메시지 수정 ("듀얼 라이트 중복" → "멱등 처리")
- [x] RegisterPricePolicyUseCaseTest HTTP 관련 mock/verify/테스트 정리
- [x] 전체 빌드 검증 (BUILD SUCCESSFUL)