### PR TITLE
[#929][#1031] refactor: product.product.updated 이벤트 듀얼 라이트 Consumer 처리 검증

### DIFF
--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/event/ProductUpdatedFulfillmentConsumer.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/event/ProductUpdatedFulfillmentConsumer.java
@@ -9,7 +9,6 @@ import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.fulfillment.configuration.FasstoAuthProperties;
 import com.personal.marketnote.fulfillment.domain.FasstoAccessToken;
 import com.personal.marketnote.fulfillment.exception.FasstoAccessTokenIssuanceFailedException;
-import com.personal.marketnote.fulfillment.exception.UpdateFasstoGoodsFailedException;
 import com.personal.marketnote.fulfillment.port.in.command.vendor.UpdateFasstoGoodsCommand;
 import com.personal.marketnote.fulfillment.port.in.command.vendor.UpdateFasstoGoodsItemCommand;
 import com.personal.marketnote.fulfillment.port.in.usecase.vendor.RequestFasstoAuthUseCase;
@@ -52,29 +51,28 @@ public class ProductUpdatedFulfillmentConsumer {
             return;
         }
 
-        try {
-            ProductUpdatedEvent payload = envelope.getPayloadAs(ProductUpdatedEvent.class, objectMapper);
+        ProductUpdatedEvent payload = envelope.getPayloadAs(ProductUpdatedEvent.class, objectMapper);
 
-            log.info("상품 수정 이벤트 수신 (풀필먼트). eventId={}, productId={}",
-                    envelope.eventId(), payload.productId());
+        log.info("상품 수정 이벤트 수신 (풀필먼트). eventId={}, productId={}",
+                envelope.eventId(), payload.productId());
 
-            if (EventPayloadValidator.hasInvalidIds(envelope.eventId(),
-                    EventPayloadValidator.id("productId", payload.productId()))) {
-                acknowledgment.acknowledge();
-                return;
-            }
+        if (EventPayloadValidator.hasInvalidIds(envelope.eventId(),
+                EventPayloadValidator.id("productId", payload.productId()))) {
+            acknowledgment.acknowledge();
+            return;
+        }
 
-            if (FormatValidator.hasNoValue(payload.productName())) {
-                log.error("유효하지 않은 이벤트 페이로드. eventId={}, productName={}",
-                        envelope.eventId(), payload.productName());
-                acknowledgment.acknowledge();
-                return;
-            }
+        if (FormatValidator.hasNoValue(payload.productName())) {
+            log.error("유효하지 않은 이벤트 페이로드. eventId={}, productName={}",
+                    envelope.eventId(), payload.productName());
+            acknowledgment.acknowledge();
+            return;
+        }
 
-            FasstoAccessToken accessToken = requestFasstoAuthUseCase.requestAccessToken();
-            if (FormatValidator.hasNoValue(accessToken) || FormatValidator.hasNoValue(accessToken.getValue())) {
-                throw new FasstoAccessTokenIssuanceFailedException(envelope.eventId(), payload.productId());
-            }
+        FasstoAccessToken accessToken = requestFasstoAuthUseCase.requestAccessToken();
+        if (FormatValidator.hasNoValue(accessToken) || FormatValidator.hasNoValue(accessToken.getValue())) {
+            throw new FasstoAccessTokenIssuanceFailedException(envelope.eventId(), payload.productId());
+        }
 
             UpdateFasstoGoodsItemCommand itemCommand = UpdateFasstoGoodsItemCommand.of(
                     String.valueOf(payload.productId()),
@@ -120,14 +118,10 @@ public class ProductUpdatedFulfillmentConsumer {
                     List.of(itemCommand)
             );
 
-            updateFasstoGoodsUseCase.updateGoods(command);
+        updateFasstoGoodsUseCase.updateGoods(command);
 
-            log.info("Kafka 이벤트로 풀필먼트 상품 수정 완료. productId={}", payload.productId());
-        } catch (UpdateFasstoGoodsFailedException e) {
-            log.warn("풀필먼트 상품 수정 실패 (듀얼 라이트 기간 HTTP 호출로 처리됨). eventId={}, key={}, message={}",
-                    envelope.eventId(), record.key(), e.getMessage());
-        }
-        // 그 외 예외는 DefaultErrorHandler가 재시도 + DLT로 처리
+        log.info("Kafka 이벤트로 풀필먼트 상품 수정 완료. productId={}", payload.productId());
+        // 예외(UpdateFasstoGoodsFailedException 포함)는 DefaultErrorHandler가 재시도 + DLT로 처리
 
         acknowledgment.acknowledge();
     }

--- a/fulfillment-service/fulfillment-adapters/src/test/java/com/personal/marketnote/fulfillment/adapter/in/event/ProductUpdatedFulfillmentConsumerTest.java
+++ b/fulfillment-service/fulfillment-adapters/src/test/java/com/personal/marketnote/fulfillment/adapter/in/event/ProductUpdatedFulfillmentConsumerTest.java
@@ -189,8 +189,8 @@ class ProductUpdatedFulfillmentConsumerTest {
     }
 
     @Test
-    @DisplayName("UpdateFasstoGoodsFailedException 발생 시 warn 로그 후 acknowledge한다")
-    void handleEvent_updateFasstoGoodsFailed_warnsAndAcknowledges() {
+    @DisplayName("UpdateFasstoGoodsFailedException 발생 시 DefaultErrorHandler로 위임되어 예외가 전파된다")
+    void handleEvent_updateFasstoGoodsFailed_propagatesForRetry() {
         // given
         ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, "테스트", "1", "01");
         when(requestFasstoAuthUseCase.requestAccessToken()).thenReturn(buildValidAccessToken());
@@ -198,12 +198,12 @@ class ProductUpdatedFulfillmentConsumerTest {
         doThrow(new UpdateFasstoGoodsFailedException(new IOException("Fassto API 오류")))
                 .when(updateFasstoGoodsUseCase).updateGoods(any(UpdateFasstoGoodsCommand.class));
 
-        // when
-        consumer.handleProductUpdatedEvent(record, acknowledgment);
+        // when & then
+        assertThatThrownBy(() -> consumer.handleProductUpdatedEvent(record, acknowledgment))
+                .isInstanceOf(UpdateFasstoGoodsFailedException.class);
 
-        // then
         verify(updateFasstoGoodsUseCase).updateGoods(any(UpdateFasstoGoodsCommand.class));
-        verify(acknowledgment).acknowledge();
+        verify(acknowledgment, never()).acknowledge();
     }
 
     @Test

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/service/product/UpdateProductService.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/service/product/UpdateProductService.java
@@ -5,20 +5,15 @@ import com.personal.marketnote.common.kafka.event.ProductUpdatedEvent;
 import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.product.domain.product.Product;
 import com.personal.marketnote.product.exception.NotProductOwnerException;
-import com.personal.marketnote.product.mapper.FulfillmentVendorGoodsCommandMapper;
 import com.personal.marketnote.product.mapper.ProductUpdatedEventMapper;
 import com.personal.marketnote.product.port.in.command.UpdateProductCommand;
 import com.personal.marketnote.product.port.in.usecase.product.GetProductUseCase;
 import com.personal.marketnote.product.port.in.usecase.product.UpdateProductUseCase;
 import com.personal.marketnote.product.port.out.event.PublishProductEventPort;
-import com.personal.marketnote.product.port.out.fulfillment.UpdateFulfillmentVendorGoodsCommand;
-import com.personal.marketnote.product.port.out.fulfillment.UpdateFulfillmentVendorGoodsPort;
 import com.personal.marketnote.product.port.out.product.FindProductPort;
 import com.personal.marketnote.product.port.out.product.UpdateProductPort;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.transaction.support.TransactionSynchronization;
-import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import static com.personal.marketnote.common.domain.exception.ExceptionCode.FIRST_ERROR_CODE;
 import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
@@ -30,7 +25,6 @@ public class UpdateProductService implements UpdateProductUseCase {
     private final GetProductUseCase getProductUseCase;
     private final FindProductPort findProductPort;
     private final UpdateProductPort updateProductPort;
-    private final UpdateFulfillmentVendorGoodsPort updateFulfillmentVendorGoodsPort;
     private final PublishProductEventPort publishProductEventPort;
 
     @Override
@@ -49,30 +43,10 @@ public class UpdateProductService implements UpdateProductUseCase {
         updateProductPort.update(product);
 
         if (FormatValidator.hasValue(command.fulfillmentVendorGoods())) {
-            UpdateFulfillmentVendorGoodsCommand updateCommand =
-                    FulfillmentVendorGoodsCommandMapper.mapToUpdateCommand(product, command.fulfillmentVendorGoods());
             ProductUpdatedEvent productUpdatedEvent =
                     ProductUpdatedEventMapper.mapToEvent(product, command.fulfillmentVendorGoods());
 
-            // Outbox 이벤트 저장 (트랜잭션 내)
             publishProductEventPort.publishProductUpdatedEvent(productUpdatedEvent);
-
-            // 트랜잭션 커밋 후 HTTP 호출
-            runAfterCommit(() -> updateFulfillmentVendorGoodsPort.updateFulfillmentVendorGoods(updateCommand));
         }
-    }
-
-    private void runAfterCommit(Runnable action) {
-        if (TransactionSynchronizationManager.isActualTransactionActive()) {
-            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
-                @Override
-                public void afterCommit() {
-                    action.run();
-                }
-            });
-            return;
-        }
-
-        action.run();
     }
 }

--- a/product-service/product-application/src/test/java/com/personal/marketnote/product/service/product/UpdateProductUseCaseTest.java
+++ b/product-service/product-application/src/test/java/com/personal/marketnote/product/service/product/UpdateProductUseCaseTest.java
@@ -5,7 +5,6 @@ import com.personal.marketnote.common.kafka.event.ProductUpdatedEvent;
 import com.personal.marketnote.product.domain.product.Product;
 import com.personal.marketnote.product.domain.product.ProductSnapshotState;
 import com.personal.marketnote.product.domain.product.ProductTag;
-import com.personal.marketnote.product.exception.FulfillmentVendorGoodsTypeNoValueException;
 import com.personal.marketnote.product.exception.NotProductOwnerException;
 import com.personal.marketnote.product.exception.ProductInfoNoValueException;
 import com.personal.marketnote.product.exception.ProductNotFoundException;
@@ -13,8 +12,6 @@ import com.personal.marketnote.product.port.in.command.FulfillmentVendorGoodsOpt
 import com.personal.marketnote.product.port.in.command.UpdateProductCommand;
 import com.personal.marketnote.product.port.in.usecase.product.GetProductUseCase;
 import com.personal.marketnote.product.port.out.event.PublishProductEventPort;
-import com.personal.marketnote.product.port.out.fulfillment.UpdateFulfillmentVendorGoodsCommand;
-import com.personal.marketnote.product.port.out.fulfillment.UpdateFulfillmentVendorGoodsPort;
 import com.personal.marketnote.product.port.out.product.FindProductPort;
 import com.personal.marketnote.product.port.out.product.UpdateProductPort;
 import org.junit.jupiter.api.DisplayName;
@@ -40,8 +37,6 @@ class UpdateProductUseCaseTest {
     @Mock
     private UpdateProductPort updateProductPort;
     @Mock
-    private UpdateFulfillmentVendorGoodsPort updateFulfillmentVendorGoodsPort;
-    @Mock
     private PublishProductEventPort publishProductEventPort;
 
     @InjectMocks
@@ -60,7 +55,7 @@ class UpdateProductUseCaseTest {
                 .hasMessageContaining("관리자 또는 상품 판매자가 아닙니다");
 
         verify(findProductPort).existsByIdAndSellerId(10L, userId);
-        verifyNoInteractions(getProductUseCase, updateProductPort, updateFulfillmentVendorGoodsPort, publishProductEventPort);
+        verifyNoInteractions(getProductUseCase, updateProductPort, publishProductEventPort);
     }
 
     @Test
@@ -92,7 +87,7 @@ class UpdateProductUseCaseTest {
                 .containsOnly(11L);
 
         verify(getProductUseCase).getProduct(11L);
-        verifyNoInteractions(findProductPort, updateFulfillmentVendorGoodsPort, publishProductEventPort);
+        verifyNoInteractions(findProductPort, publishProductEventPort);
     }
 
     @Test
@@ -110,14 +105,6 @@ class UpdateProductUseCaseTest {
 
         verify(findProductPort).existsByIdAndSellerId(20L, userId);
         verify(updateProductPort).update(product);
-
-        ArgumentCaptor<UpdateFulfillmentVendorGoodsCommand> fulfillmentCaptor =
-                ArgumentCaptor.forClass(UpdateFulfillmentVendorGoodsCommand.class);
-        verify(updateFulfillmentVendorGoodsPort).updateFulfillmentVendorGoods(fulfillmentCaptor.capture());
-
-        UpdateFulfillmentVendorGoodsCommand expected =
-                buildExpectedUpdateCommand(command.id(), command.name(), options);
-        assertThat(fulfillmentCaptor.getValue()).isEqualTo(expected);
 
         ArgumentCaptor<ProductUpdatedEvent> eventCaptor = ArgumentCaptor.forClass(ProductUpdatedEvent.class);
         verify(publishProductEventPort).publishProductUpdatedEvent(eventCaptor.capture());
@@ -141,7 +128,7 @@ class UpdateProductUseCaseTest {
                 .isSameAs(exception);
 
         verify(getProductUseCase).getProduct(30L);
-        verifyNoInteractions(findProductPort, updateProductPort, updateFulfillmentVendorGoodsPort, publishProductEventPort);
+        verifyNoInteractions(findProductPort, updateProductPort, publishProductEventPort);
     }
 
     @Test
@@ -161,28 +148,7 @@ class UpdateProductUseCaseTest {
                 .isSameAs(exception);
 
         verify(updateProductPort).update(product);
-        verifyNoInteractions(updateFulfillmentVendorGoodsPort, publishProductEventPort);
-    }
-
-    @Test
-    @DisplayName("풀필먼트 서비스 동기화 시 옵션 필수값이 없으면 예외를 던진다")
-    void update_missingFulfillmentRequiredFields_throws() {
-        Long userId = 4L;
-        FulfillmentVendorGoodsOptionCommand options = FulfillmentVendorGoodsOptionCommand.builder()
-                .giftDiv("01")
-                .build();
-        UpdateProductCommand command = buildCommand(50L, options);
-        Product product = buildProduct(50L, "기존 상품");
-
-        when(findProductPort.existsByIdAndSellerId(50L, userId)).thenReturn(true);
-        when(getProductUseCase.getProduct(50L)).thenReturn(product);
-
-        assertThatThrownBy(() -> updateProductService.update(userId, false, command))
-                .isInstanceOf(FulfillmentVendorGoodsTypeNoValueException.class)
-                .hasMessageContaining("godType");
-
-        verify(updateProductPort).update(product);
-        verifyNoInteractions(updateFulfillmentVendorGoodsPort, publishProductEventPort);
+        verifyNoInteractions(publishProductEventPort);
     }
 
     @Test
@@ -199,7 +165,7 @@ class UpdateProductUseCaseTest {
                 .hasMessageContaining("상품 ID가 존재하지 않습니다");
 
         verify(updateProductPort).update(product);
-        verifyNoInteractions(updateFulfillmentVendorGoodsPort, publishProductEventPort);
+        verifyNoInteractions(publishProductEventPort);
     }
 
     @Test
@@ -216,7 +182,7 @@ class UpdateProductUseCaseTest {
                 .hasMessageContaining("상품명이 존재하지 않습니다");
 
         verify(updateProductPort).update(product);
-        verifyNoInteractions(updateFulfillmentVendorGoodsPort, publishProductEventPort);
+        verifyNoInteractions(publishProductEventPort);
     }
 
     private UpdateProductCommand buildCommand(Long id, FulfillmentVendorGoodsOptionCommand fulfillmentVendorGoods) {
@@ -292,47 +258,4 @@ class UpdateProductUseCaseTest {
                 .build();
     }
 
-    private UpdateFulfillmentVendorGoodsCommand buildExpectedUpdateCommand(
-            Long productId,
-            String productName,
-            FulfillmentVendorGoodsOptionCommand options
-    ) {
-        return UpdateFulfillmentVendorGoodsCommand.builder()
-                .cstGodCd(String.valueOf(productId))
-                .godNm(productName)
-                .godType(options.godType())
-                .giftDiv(options.giftDiv())
-                .godOptCd1(options.godOptCd1())
-                .godOptCd2(options.godOptCd2())
-                .invGodNmUseYn(options.invGodNmUseYn())
-                .invGodNm(options.invGodNm())
-                .supCd(options.supCd())
-                .cateCd(options.cateCd())
-                .seasonCd(options.seasonCd())
-                .genderCd(options.genderCd())
-                .makeYr(options.makeYr())
-                .godPr(options.godPr())
-                .inPr(options.inPr())
-                .salPr(options.salPr())
-                .dealTemp(options.dealTemp())
-                .pickFac(options.pickFac())
-                .godBarcd(options.godBarcd())
-                .boxWeight(options.boxWeight())
-                .origin(options.origin())
-                .distTermMgtYn(options.distTermMgtYn())
-                .useTermDay(options.useTermDay())
-                .outCanDay(options.outCanDay())
-                .inCanDay(options.inCanDay())
-                .boxDiv(options.boxDiv())
-                .bufGodYn(options.bufGodYn())
-                .loadingDirection(options.loadingDirection())
-                .subMate(options.subMate())
-                .useYn(options.useYn())
-                .safetyStock(options.safetyStock())
-                .feeYn(options.feeYn())
-                .saleUnitQty(options.saleUnitQty())
-                .cstGodImgUrl(options.cstGodImgUrl())
-                .externalGodImgUrl(options.externalGodImgUrl())
-                .build();
-    }
 }


### PR DESCRIPTION
## partially addresses #929
## resolves #1031

## Task
- [x] UpdateProductService에서 UpdateFulfillmentVendorGoodsPort HTTP 호출 제거
- [x] runAfterCommit() 메서드 및 TransactionSynchronization.afterCommit() 블록 제거
- [x] FulfillmentVendorGoodsCommandMapper HTTP 매핑 호출 제거
- [x] ProductUpdatedFulfillmentConsumer에서 UpdateFasstoGoodsFailedException catch 제거 및 try 블록 평탄화
- [x] UpdateProductUseCaseTest HTTP 관련 mock/verify/테스트 정리
- [x] ProductUpdatedFulfillmentConsumerTest 실패 시 예외 전파 동작 검증 수정
- [x] 전체 빌드 검증 (BUILD SUCCESSFUL)