### PR TITLE
[#929][#1033] refactor: commerce.payment.approved 이벤트 듀얼 라이트 Consumer 처리 검증

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,0 +1,72 @@
+plugins {
+    base
+    jacoco
+}
+
+repositories {
+    mavenCentral()
+}
+
+jacoco {
+    toolVersion = "0.8.12"
+}
+
+// 모든 서브프로젝트에 JaCoCo 플러그인 적용
+subprojects {
+    apply(plugin = "jacoco")
+    configure<JacocoPluginExtension> {
+        toolVersion = "0.8.12"
+    }
+}
+
+// JaCoCo 집계 리포트 (build/reports/test/html/index.html)
+// 이미 빌드/테스트된 결과물을 파일 시스템에서 직접 수집
+tasks.register<JacocoReport>("jacocoAggregatedReport") {
+    group = "verification"
+    description = "Generates aggregated JaCoCo HTML coverage report for all subprojects"
+    mustRunAfter("testAggregatedReport")
+
+    // exec 파일 수집
+    executionData.from(fileTree(rootDir) { include("**/build/jacoco/test.exec") })
+
+    // 이미 컴파일된 클래스 파일 수집
+    val classDirs = files()
+    val srcDirs = files()
+
+    subprojects.forEach { subproject ->
+        val excludes = mutableListOf("**/Q*.class") // QueryDSL 생성 클래스 제외
+        // -application과 -adapters에 동일 FQCN 클래스(CommonConfig 등) 중복 존재 → -application에서 제외
+        if (subproject.name.endsWith("-application")) {
+            excludes.add("**/configuration/CommonConfig.class")
+        }
+        classDirs.from(fileTree("${subproject.projectDir}/build/classes/java/main") {
+            exclude(excludes)
+        })
+        srcDirs.from("${subproject.projectDir}/src/main/java")
+    }
+
+    classDirectories.from(classDirs)
+    sourceDirectories.from(srcDirs)
+
+    reports {
+        html.required.set(true)
+        html.outputLocation.set(layout.buildDirectory.dir("reports/test/html"))
+        xml.required.set(true)
+        xml.outputLocation.set(layout.buildDirectory.file("reports/test/html/jacoco.xml"))
+    }
+}
+
+// Gradle 테스트 결과 집계 리포트 (build/reports/test/index.html)
+tasks.register<TestReport>("testAggregatedReport") {
+    group = "verification"
+    description = "Generates aggregated Gradle test report for all subprojects"
+    destinationDirectory.set(layout.buildDirectory.dir("reports/test"))
+
+    // 이미 실행된 테스트 바이너리 결과 수집
+    subprojects.forEach { subproject ->
+        val binaryDir = file("${subproject.projectDir}/build/test-results/test/binary")
+        if (binaryDir.exists()) {
+            testResults.from(binaryDir)
+        }
+    }
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/PaymentApprovedLedgerConsumer.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/PaymentApprovedLedgerConsumer.java
@@ -1,6 +1,8 @@
 package com.personal.marketnote.commerce.adapter.in.event;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.commerce.exception.DuplicateLedgerTransactionException;
+import com.personal.marketnote.commerce.port.in.usecase.ledger.RecordLedgerEntryUseCase;
 import com.personal.marketnote.common.kafka.KafkaTopicConstants;
 import com.personal.marketnote.common.kafka.event.EventEnvelope;
 import com.personal.marketnote.common.kafka.event.EventPayloadValidator;
@@ -17,6 +19,7 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class PaymentApprovedLedgerConsumer {
     private final ObjectMapper objectMapper;
+    private final RecordLedgerEntryUseCase recordLedgerEntryUseCase;
 
     @KafkaListener(
             topics = KafkaTopicConstants.PAYMENT_APPROVED,
@@ -38,30 +41,25 @@ public class PaymentApprovedLedgerConsumer {
             return;
         }
 
-        try {
-            PaymentApprovedEvent payload = envelope.getPayloadAs(PaymentApprovedEvent.class, objectMapper);
+        PaymentApprovedEvent payload = envelope.getPayloadAs(PaymentApprovedEvent.class, objectMapper);
 
-            log.info("결제 승인 이벤트 수신 (회계 분개). eventId={}, orderId={}, orderKey={}, paymentAmount={}",
-                    envelope.eventId(), payload.orderId(), payload.orderKey(), payload.paymentAmount());
+        log.info("결제 승인 이벤트 수신 (회계 분개). eventId={}, orderId={}, orderKey={}, paymentAmount={}",
+                envelope.eventId(), payload.orderId(), payload.orderKey(), payload.paymentAmount());
 
-            if (EventPayloadValidator.hasInvalidIds(envelope.eventId(),
-                    EventPayloadValidator.id("orderId", payload.orderId()))) {
-                acknowledgment.acknowledge();
-                return;
-            }
-
-            // FIXME: [#929][#933] HTTP 제거 후 RecordLedgerEntryUseCase.recordPaymentApproval() 활성화
-            //  현재 듀얼 라이트 기간: PaymentApprovalTransactionHelper.commitSuccess()에서 동기로 분개 처리 중
-            //  활성화 시 PaymentApprovedEvent에 paymentId 필드 추가 필요
-            //  recordLedgerEntryUseCase.recordPaymentApproval(paymentId, payload.paymentAmount());
-
-            log.info("결제 승인 분개 이벤트 검증 완료 (듀얼 라이트). orderId={}, orderKey={}, paymentAmount={}",
-                    payload.orderId(), payload.orderKey(), payload.paymentAmount());
-        } catch (Exception e) {
-            log.error("결제 승인 분개 이벤트 처리 실패. eventId={}, key={}, error={}",
-                    envelope.eventId(), record.key(), e.getMessage(), e);
-            throw e;
+        if (EventPayloadValidator.hasInvalidIds(envelope.eventId(),
+                EventPayloadValidator.id("orderId", payload.orderId()))) {
+            acknowledgment.acknowledge();
+            return;
         }
+
+        try {
+            recordLedgerEntryUseCase.recordPaymentApproval(payload.orderId(), payload.paymentAmount());
+            log.info("결제 승인 분개 완료. orderId={}, paymentAmount={}", payload.orderId(), payload.paymentAmount());
+        } catch (DuplicateLedgerTransactionException e) {
+            log.info("이미 처리된 결제 승인 분개 이벤트 (멱등 처리). eventId={}, message={}",
+                    envelope.eventId(), e.getMessage());
+        }
+        // 그 외 예외는 DefaultErrorHandler가 재시도 + DLT로 처리
 
         acknowledgment.acknowledge();
     }

--- a/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/event/PaymentApprovedLedgerConsumerTest.java
+++ b/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/event/PaymentApprovedLedgerConsumerTest.java
@@ -1,6 +1,8 @@
 package com.personal.marketnote.commerce.adapter.in.event;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.commerce.exception.DuplicateLedgerTransactionException;
+import com.personal.marketnote.commerce.port.in.usecase.ledger.RecordLedgerEntryUseCase;
 import com.personal.marketnote.common.kafka.event.EventEnvelope;
 import com.personal.marketnote.common.kafka.event.PaymentApprovedEvent;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -24,6 +26,9 @@ class PaymentApprovedLedgerConsumerTest {
     @InjectMocks
     private PaymentApprovedLedgerConsumer consumer;
 
+    @Mock
+    private RecordLedgerEntryUseCase recordLedgerEntryUseCase;
+
     @Spy
     private ObjectMapper objectMapper = new ObjectMapper();
 
@@ -40,8 +45,8 @@ class PaymentApprovedLedgerConsumerTest {
     }
 
     @Test
-    @DisplayName("듀얼 라이트 기간 중 결제 승인 이벤트 수신 시 페이로드 검증을 완료하고 acknowledge한다")
-    void handlePaymentApprovedEvent_success_validatesAndAcknowledges() {
+    @DisplayName("결제 승인 이벤트 수신 시 분개를 기록하고 acknowledge한다")
+    void handlePaymentApprovedEvent_success_recordsLedgerAndAcknowledges() {
         // given
         ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, "order-key-1", 50000L);
 
@@ -49,8 +54,23 @@ class PaymentApprovedLedgerConsumerTest {
         consumer.handlePaymentApprovedEvent(record, acknowledgment);
 
         // then
-        // TODO: [#929][#933] RecordLedgerEntryUseCase 활성화 시
-        //  recordLedgerEntryUseCase.recordPaymentApproval() 호출 검증 추가
+        verify(recordLedgerEntryUseCase).recordPaymentApproval(1L, 50000L);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("이미 처리된 분개 이벤트는 멱등 처리하고 acknowledge한다")
+    void handlePaymentApprovedEvent_duplicate_idempotentAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, "order-key-1", 50000L);
+        doThrow(new DuplicateLedgerTransactionException("PG_SETTLEMENT:1"))
+                .when(recordLedgerEntryUseCase).recordPaymentApproval(1L, 50000L);
+
+        // when
+        consumer.handlePaymentApprovedEvent(record, acknowledgment);
+
+        // then
+        verify(recordLedgerEntryUseCase).recordPaymentApproval(1L, 50000L);
         verify(acknowledgment).acknowledge();
     }
 
@@ -64,6 +84,7 @@ class PaymentApprovedLedgerConsumerTest {
         consumer.handlePaymentApprovedEvent(record, acknowledgment);
 
         // then
+        verifyNoInteractions(recordLedgerEntryUseCase);
         verify(acknowledgment).acknowledge();
     }
 
@@ -77,6 +98,7 @@ class PaymentApprovedLedgerConsumerTest {
         consumer.handlePaymentApprovedEvent(record, acknowledgment);
 
         // then
+        verifyNoInteractions(recordLedgerEntryUseCase);
         verify(acknowledgment).acknowledge();
     }
 
@@ -90,6 +112,7 @@ class PaymentApprovedLedgerConsumerTest {
         consumer.handlePaymentApprovedEvent(record, acknowledgment);
 
         // then
+        verifyNoInteractions(recordLedgerEntryUseCase);
         verify(acknowledgment).acknowledge();
     }
 
@@ -105,7 +128,7 @@ class PaymentApprovedLedgerConsumerTest {
         consumer.handlePaymentApprovedEvent(record, acknowledgment);
 
         // then
-        verifyNoInteractions(objectMapper);
+        verifyNoInteractions(objectMapper, recordLedgerEntryUseCase);
         verify(acknowledgment).acknowledge();
     }
 
@@ -126,7 +149,7 @@ class PaymentApprovedLedgerConsumerTest {
         consumer.handlePaymentApprovedEvent(record, acknowledgment);
 
         // then
-        verifyNoInteractions(objectMapper);
+        verifyNoInteractions(objectMapper, recordLedgerEntryUseCase);
         verify(acknowledgment).acknowledge();
     }
 

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/PaymentApprovalTransactionHelper.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/PaymentApprovalTransactionHelper.java
@@ -9,7 +9,6 @@ import com.personal.marketnote.commerce.exception.*;
 import com.personal.marketnote.commerce.port.in.command.order.ChangeOrderStatusCommand;
 import com.personal.marketnote.commerce.port.in.command.payment.ApprovePaymentCommand;
 import com.personal.marketnote.commerce.port.in.result.payment.ApprovePaymentResult;
-import com.personal.marketnote.commerce.port.in.usecase.ledger.RecordLedgerEntryUseCase;
 import com.personal.marketnote.commerce.port.in.usecase.order.ChangeOrderStatusUseCase;
 import com.personal.marketnote.commerce.port.out.event.PublishPaymentEventPort;
 import com.personal.marketnote.commerce.port.out.order.FindOrderPort;
@@ -45,7 +44,6 @@ public class PaymentApprovalTransactionHelper {
     private final FindPspPaymentEventPort findPspPaymentEventPort;
     private final UpdatePspPaymentEventPort updatePspPaymentEventPort;
     private final ChangeOrderStatusUseCase changeOrderStatusUseCase;
-    private final RecordLedgerEntryUseCase recordLedgerEntryUseCase;
     private final PublishPaymentEventPort publishPaymentEventPort;
 
     /**
@@ -104,8 +102,7 @@ public class PaymentApprovalTransactionHelper {
                         .build()
         );
 
-        recordLedgerEntryForPaymentApproval(payment);
-
+        // [#929][#1033] 결제 승인 분개는 Kafka Consumer(PaymentApprovedLedgerConsumer)로 전환 완료
         publishPaymentApprovedEvent(payment);
 
         return ApprovePaymentResult.builder()
@@ -210,13 +207,4 @@ public class PaymentApprovalTransactionHelper {
         }
     }
 
-    private void recordLedgerEntryForPaymentApproval(Payment payment) {
-        try {
-            recordLedgerEntryUseCase.recordPaymentApproval(
-                    payment.getOrderId(), payment.getPaymentAmount()
-            );
-        } catch (Exception e) {
-            log.error("결제 승인 분개 기록 실패 - orderId: {}, error: {}", payment.getOrderId(), e.getMessage(), e);
-        }
-    }
 }


### PR DESCRIPTION
## partially addresses #929
## resolves #1033

## Task
- [x] PaymentApprovedLedgerConsumer 활성화 (RecordLedgerEntryUseCase 주입 + recordPaymentApproval 호출)
- [x] DuplicateLedgerTransactionException 멱등성 처리 추가
- [x] PaymentApprovalTransactionHelper에서 동기 분개 호출 제거 (recordLedgerEntryForPaymentApproval 메서드 삭제)
- [x] RecordLedgerEntryUseCase 필드 제거 (PaymentApprovalTransactionHelper)
- [x] 테스트 업데이트 (UseCase mock 추가, verify 추가, 멱등성 테스트 추가)