### PR TITLE
[#929][#1034] refactor: commerce.payment.cancelled 이벤트 듀얼 라이트 Consumer 처리 검증

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/PaymentCancelledLedgerConsumer.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/PaymentCancelledLedgerConsumer.java
@@ -1,10 +1,13 @@
 package com.personal.marketnote.commerce.adapter.in.event;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.commerce.exception.DuplicateLedgerTransactionException;
+import com.personal.marketnote.commerce.port.in.usecase.ledger.RecordLedgerEntryUseCase;
 import com.personal.marketnote.common.kafka.KafkaTopicConstants;
 import com.personal.marketnote.common.kafka.event.EventEnvelope;
 import com.personal.marketnote.common.kafka.event.EventPayloadValidator;
 import com.personal.marketnote.common.kafka.event.PaymentCancelledEvent;
+import com.personal.marketnote.common.utility.FormatValidator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -17,6 +20,7 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class PaymentCancelledLedgerConsumer {
     private final ObjectMapper objectMapper;
+    private final RecordLedgerEntryUseCase recordLedgerEntryUseCase;
 
     @KafkaListener(
             topics = KafkaTopicConstants.PAYMENT_CANCELLED,
@@ -38,39 +42,39 @@ public class PaymentCancelledLedgerConsumer {
             return;
         }
 
-        try {
-            PaymentCancelledEvent payload = envelope.getPayloadAs(PaymentCancelledEvent.class, objectMapper);
+        PaymentCancelledEvent payload = envelope.getPayloadAs(PaymentCancelledEvent.class, objectMapper);
 
-            log.info("결제 취소 이벤트 수신 (회계 역분개). eventId={}, orderId={}, isFullCancel={}, cancelAmount={}",
-                    envelope.eventId(), payload.orderId(), payload.isFullCancel(), payload.cancelAmount());
+        log.info("결제 취소 이벤트 수신 (회계 역분개). eventId={}, orderId={}, isFullCancel={}, cancelAmount={}",
+                envelope.eventId(), payload.orderId(), payload.isFullCancel(), payload.cancelAmount());
 
-            if (EventPayloadValidator.hasInvalidIds(envelope.eventId(),
-                    EventPayloadValidator.id("orderId", payload.orderId()))) {
-                acknowledgment.acknowledge();
-                return;
-            }
-
-            // FIXME: [#929][#1023] HTTP 제거 후 RecordLedgerEntryUseCase.recordPaymentCancellation() 활성화
-            //  현재 듀얼 라이트 기간: CancelPaymentService.recordLedgerEntryForCancellation()에서 동기로 역분개 처리 중
-            //  String idempotencyKey;
-            //  if (payload.isFullCancel()) {
-            //      idempotencyKey = "PAYMENT_CANCELLATION:" + payload.orderId();
-            //  } else {
-            //      idempotencyKey = "PAYMENT_PARTIAL_REFUND:" + payload.orderId()
-            //              + ":" + payload.cancelId();
-            //  }
-            //  recordLedgerEntryUseCase.recordPaymentCancellation(
-            //          payload.orderId(), payload.cancelAmount(), idempotencyKey
-            //  );
-
-            log.info("결제 취소 역분개 이벤트 검증 완료 (듀얼 라이트). orderId={}, isFullCancel={}, cancelAmount={}",
-                    payload.orderId(), payload.isFullCancel(), payload.cancelAmount());
-        } catch (Exception e) {
-            log.error("결제 취소 역분개 이벤트 처리 실패. eventId={}, key={}, error={}",
-                    envelope.eventId(), record.key(), e.getMessage(), e);
-            throw e;
+        if (EventPayloadValidator.hasInvalidIds(envelope.eventId(),
+                EventPayloadValidator.id("orderId", payload.orderId()))) {
+            acknowledgment.acknowledge();
+            return;
         }
 
+        String idempotencyKey = resolveIdempotencyKey(payload);
+
+        try {
+            recordLedgerEntryUseCase.recordPaymentCancellation(
+                    payload.orderId(), payload.cancelAmount(), idempotencyKey
+            );
+            log.info("결제 취소 역분개 완료. orderId={}, isFullCancel={}, cancelAmount={}, idempotencyKey={}",
+                    payload.orderId(), payload.isFullCancel(), payload.cancelAmount(), idempotencyKey);
+        } catch (DuplicateLedgerTransactionException e) {
+            log.info("이미 처리된 결제 취소 역분개 이벤트 (멱등 처리). eventId={}, message={}",
+                    envelope.eventId(), e.getMessage());
+        }
+        // 그 외 예외는 DefaultErrorHandler가 재시도 + DLT로 처리
+
         acknowledgment.acknowledge();
+    }
+
+    private String resolveIdempotencyKey(PaymentCancelledEvent payload) {
+        if (payload.isFullCancel()) {
+            return "PAYMENT_CANCELLATION:" + payload.orderId();
+        }
+        return "PAYMENT_PARTIAL_REFUND:" + payload.orderId()
+                + ":" + (FormatValidator.hasValue(payload.cancelId()) ? payload.cancelId() : "unknown");
     }
 }

--- a/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/event/PaymentCancelledLedgerConsumerTest.java
+++ b/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/event/PaymentCancelledLedgerConsumerTest.java
@@ -1,6 +1,8 @@
 package com.personal.marketnote.commerce.adapter.in.event;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.commerce.exception.DuplicateLedgerTransactionException;
+import com.personal.marketnote.commerce.port.in.usecase.ledger.RecordLedgerEntryUseCase;
 import com.personal.marketnote.common.kafka.event.EventEnvelope;
 import com.personal.marketnote.common.kafka.event.PaymentCancelledEvent;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -25,6 +27,9 @@ class PaymentCancelledLedgerConsumerTest {
     @InjectMocks
     private PaymentCancelledLedgerConsumer consumer;
 
+    @Mock
+    private RecordLedgerEntryUseCase recordLedgerEntryUseCase;
+
     @Spy
     private ObjectMapper objectMapper = new ObjectMapper();
 
@@ -32,9 +37,15 @@ class PaymentCancelledLedgerConsumerTest {
     private Acknowledgment acknowledgment;
 
     private ConsumerRecord<String, EventEnvelope<?>> buildRecord(Long orderId, boolean isFullCancel) {
+        return buildRecord(orderId, isFullCancel, 50000L, "cancel-id-1");
+    }
+
+    private ConsumerRecord<String, EventEnvelope<?>> buildRecord(
+            Long orderId, boolean isFullCancel, Long cancelAmount, String cancelId
+    ) {
         PaymentCancelledEvent event = new PaymentCancelledEvent(
-                orderId, "order-key-1", 1L, 50000L, 100000L, 0L,
-                isFullCancel, 0L, "cancel-id-1",
+                orderId, "order-key-1", 1L, cancelAmount, 100000L, 0L,
+                isFullCancel, 0L, cancelId,
                 List.of(new PaymentCancelledEvent.OrderProductItem(1L, null, 2, 50000L)),
                 null, null
         );
@@ -46,8 +57,8 @@ class PaymentCancelledLedgerConsumerTest {
     }
 
     @Test
-    @DisplayName("듀얼 라이트 기간 중 전체 취소 이벤트 수신 시 페이로드 검증을 완료하고 acknowledge한다")
-    void handlePaymentCancelledEvent_fullCancel_validatesAndAcknowledges() {
+    @DisplayName("전체 취소 이벤트 수신 시 역분개를 기록하고 acknowledge한다")
+    void handlePaymentCancelledEvent_fullCancel_recordsLedgerAndAcknowledges() {
         // given
         ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, true);
 
@@ -55,21 +66,41 @@ class PaymentCancelledLedgerConsumerTest {
         consumer.handlePaymentCancelledEvent(record, acknowledgment);
 
         // then
-        // TODO: [#929][#1023] RecordLedgerEntryUseCase 활성화 시
-        //  recordLedgerEntryUseCase.recordPaymentCancellation() 호출 검증 추가
+        verify(recordLedgerEntryUseCase).recordPaymentCancellation(
+                1L, 50000L, "PAYMENT_CANCELLATION:1"
+        );
         verify(acknowledgment).acknowledge();
     }
 
     @Test
-    @DisplayName("듀얼 라이트 기간 중 부분 취소 이벤트 수신 시 페이로드 검증을 완료하고 acknowledge한다")
-    void handlePaymentCancelledEvent_partialCancel_validatesAndAcknowledges() {
+    @DisplayName("부분 취소 이벤트 수신 시 역분개를 기록하고 acknowledge한다")
+    void handlePaymentCancelledEvent_partialCancel_recordsLedgerAndAcknowledges() {
         // given
-        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, false);
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, false, 30000L, "cancel-id-abc");
 
         // when
         consumer.handlePaymentCancelledEvent(record, acknowledgment);
 
         // then
+        verify(recordLedgerEntryUseCase).recordPaymentCancellation(
+                1L, 30000L, "PAYMENT_PARTIAL_REFUND:1:cancel-id-abc"
+        );
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("이미 처리된 역분개 이벤트는 멱등 처리하고 acknowledge한다")
+    void handlePaymentCancelledEvent_duplicate_idempotentAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, true);
+        doThrow(new DuplicateLedgerTransactionException("PAYMENT_CANCELLATION:1"))
+                .when(recordLedgerEntryUseCase).recordPaymentCancellation(1L, 50000L, "PAYMENT_CANCELLATION:1");
+
+        // when
+        consumer.handlePaymentCancelledEvent(record, acknowledgment);
+
+        // then
+        verify(recordLedgerEntryUseCase).recordPaymentCancellation(1L, 50000L, "PAYMENT_CANCELLATION:1");
         verify(acknowledgment).acknowledge();
     }
 
@@ -83,6 +114,7 @@ class PaymentCancelledLedgerConsumerTest {
         consumer.handlePaymentCancelledEvent(record, acknowledgment);
 
         // then
+        verifyNoInteractions(recordLedgerEntryUseCase);
         verify(acknowledgment).acknowledge();
     }
 
@@ -96,6 +128,7 @@ class PaymentCancelledLedgerConsumerTest {
         consumer.handlePaymentCancelledEvent(record, acknowledgment);
 
         // then
+        verifyNoInteractions(recordLedgerEntryUseCase);
         verify(acknowledgment).acknowledge();
     }
 
@@ -109,6 +142,7 @@ class PaymentCancelledLedgerConsumerTest {
         consumer.handlePaymentCancelledEvent(record, acknowledgment);
 
         // then
+        verifyNoInteractions(recordLedgerEntryUseCase);
         verify(acknowledgment).acknowledge();
     }
 
@@ -124,7 +158,7 @@ class PaymentCancelledLedgerConsumerTest {
         consumer.handlePaymentCancelledEvent(record, acknowledgment);
 
         // then
-        verifyNoInteractions(objectMapper);
+        verifyNoInteractions(objectMapper, recordLedgerEntryUseCase);
         verify(acknowledgment).acknowledge();
     }
 
@@ -150,7 +184,7 @@ class PaymentCancelledLedgerConsumerTest {
         consumer.handlePaymentCancelledEvent(record, acknowledgment);
 
         // then
-        verifyNoInteractions(objectMapper);
+        verifyNoInteractions(objectMapper, recordLedgerEntryUseCase);
         verify(acknowledgment).acknowledge();
     }
 

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/CancelPaymentService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/CancelPaymentService.java
@@ -13,7 +13,6 @@ import com.personal.marketnote.commerce.exception.*;
 import com.personal.marketnote.commerce.port.in.command.order.ChangeOrderStatusCommand;
 import com.personal.marketnote.commerce.port.in.command.payment.CancelPaymentCommand;
 import com.personal.marketnote.commerce.port.in.usecase.inventory.RestoreProductInventoryUseCase;
-import com.personal.marketnote.commerce.port.in.usecase.ledger.RecordLedgerEntryUseCase;
 import com.personal.marketnote.commerce.port.in.usecase.order.ChangeOrderStatusUseCase;
 import com.personal.marketnote.commerce.port.in.usecase.payment.CancelPaymentUseCase;
 import com.personal.marketnote.commerce.port.out.event.PublishPaymentEventPort;
@@ -56,7 +55,6 @@ public class CancelPaymentService implements CancelPaymentUseCase {
     private final UpdatePspPaymentEventPort updatePspPaymentEventPort;
     private final PaymentVendorPort paymentVendorPort;
     private final ChangeOrderStatusUseCase changeOrderStatusUseCase;
-    private final RecordLedgerEntryUseCase recordLedgerEntryUseCase;
     private final RestoreProductInventoryUseCase restoreProductInventoryUseCase;
     private final ModifyUserPointPort modifyUserPointPort;
     private final SaveRefundPort saveRefundPort;
@@ -131,8 +129,8 @@ public class CancelPaymentService implements CancelPaymentUseCase {
                     order, payment.getPaymentAmount(), cancelAmount));
         }
 
+        // [#929][#1034] 결제 취소 역분개는 Kafka Consumer(PaymentCancelledLedgerConsumer)로 전환 완료
         String cancelId = isFullCancel ? null : UUID.randomUUID().toString();
-        recordLedgerEntryForCancellation(payment, isFullCancel, cancelAmount, cancelId);
 
         List<OrderProduct> cancelTargetProducts = resolveCancelProducts(isFullCancel, command);
 
@@ -210,26 +208,6 @@ public class CancelPaymentService implements CancelPaymentUseCase {
             saveRefundPort.save(refund);
         } catch (Exception e) {
             log.error("환불 상세 기록 저장 실패 - orderId: {}, error: {}",
-                    payment.getOrderId(), e.getMessage(), e);
-        }
-    }
-
-    private void recordLedgerEntryForCancellation(
-            Payment payment, boolean isFullCancel, Long cancelAmount, String cancelId
-    ) {
-        try {
-            String idempotencyKey;
-            if (isFullCancel) {
-                idempotencyKey = "PAYMENT_CANCELLATION:" + payment.getOrderId();
-            } else {
-                idempotencyKey = "PAYMENT_PARTIAL_REFUND:" + payment.getOrderId()
-                        + ":" + cancelId;
-            }
-            recordLedgerEntryUseCase.recordPaymentCancellation(
-                    payment.getOrderId(), cancelAmount, idempotencyKey
-            );
-        } catch (Exception e) {
-            log.error("결제 취소 역분개 기록 실패 - orderId: {}, error: {}",
                     payment.getOrderId(), e.getMessage(), e);
         }
     }

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/payment/CancelPaymentUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/payment/CancelPaymentUseCaseTest.java
@@ -15,7 +15,6 @@ import com.personal.marketnote.commerce.exception.PaymentNotFoundException;
 import com.personal.marketnote.commerce.exception.UnauthorizedOrderAccessException;
 import com.personal.marketnote.commerce.port.in.command.payment.CancelPaymentCommand;
 import com.personal.marketnote.commerce.port.in.usecase.inventory.RestoreProductInventoryUseCase;
-import com.personal.marketnote.commerce.port.in.usecase.ledger.RecordLedgerEntryUseCase;
 import com.personal.marketnote.commerce.port.in.usecase.order.ChangeOrderStatusUseCase;
 import com.personal.marketnote.commerce.port.out.order.FindOrderPort;
 import com.personal.marketnote.commerce.port.out.payment.*;
@@ -66,9 +65,6 @@ class CancelPaymentUseCaseTest {
 
     @Mock
     private ChangeOrderStatusUseCase changeOrderStatusUseCase;
-
-    @Mock
-    private RecordLedgerEntryUseCase recordLedgerEntryUseCase;
 
     @Mock
     private RestoreProductInventoryUseCase restoreProductInventoryUseCase;
@@ -382,109 +378,7 @@ class CancelPaymentUseCaseTest {
         }
     }
 
-    @Nested
-    @DisplayName("분개 기록 검증")
-    class LedgerEntryRecordingTest {
-
-        @Test
-        @DisplayName("전체 취소 성공 시 역분개가 기록된다")
-        void shouldRecordReverseLedgerEntryOnFullCancel() {
-            Payment payment = createSuccessPayment(1L, ORDER_KEY, 50000L, "tno_123");
-            PspPaymentEvent event = createCompleteEvent(ORDER_KEY_STR, "tno_123", 50000L);
-            CancelPaymentCommand command = createFullCancelCommand(ORDER_KEY_STR);
-            PaymentCancelVendorResult vendorResult = createSuccessVendorResult();
-
-            when(findPaymentPort.findByOrderKey(ORDER_KEY)).thenReturn(Optional.of(payment));
-            when(findOrderPort.findById(1L)).thenReturn(Optional.of(createOrder(1L, BUYER_ID)));
-            when(findPspPaymentEventPort.findByOrderKey(ORDER_KEY_STR)).thenReturn(Optional.of(event));
-            when(paymentVendorPort.cancelPayment(any())).thenReturn(vendorResult);
-
-            cancelPaymentService.cancel(command);
-
-            verify(recordLedgerEntryUseCase).recordPaymentCancellation(
-                    eq(1L), eq(50000L), eq("PAYMENT_CANCELLATION:1")
-            );
-        }
-
-        @Test
-        @DisplayName("부분 취소 성공 시 cancelId 기반 멱등성 키로 역분개가 기록된다")
-        void shouldRecordReverseLedgerEntryOnPartialCancelWithCancelId() {
-            Payment payment = createSuccessPayment(1L, ORDER_KEY, 50000L, "tno_123");
-            PspPaymentEvent event = createCompleteEvent(ORDER_KEY_STR, "tno_123", 50000L);
-            CancelPaymentCommand command = createPartialCancelCommand(ORDER_KEY_STR, 20000L);
-            PaymentCancelVendorResult vendorResult = createSuccessVendorResult();
-
-            when(findPaymentPort.findByOrderKey(ORDER_KEY)).thenReturn(Optional.of(payment));
-            when(findOrderPort.findById(1L)).thenReturn(Optional.of(createOrder(1L, BUYER_ID)));
-            when(findPspPaymentEventPort.findByOrderKey(ORDER_KEY_STR)).thenReturn(Optional.of(event));
-            when(paymentVendorPort.cancelPayment(any())).thenReturn(vendorResult);
-
-            cancelPaymentService.cancel(command);
-
-            verify(recordLedgerEntryUseCase).recordPaymentCancellation(
-                    eq(1L), eq(20000L), argThat(key -> {
-                        String prefix = "PAYMENT_PARTIAL_REFUND:1:";
-                        if (!key.startsWith(prefix)) {
-                            return false;
-                        }
-                        String cancelId = key.substring(prefix.length());
-                        try {
-                            UUID.fromString(cancelId);
-                            return true;
-                        } catch (IllegalArgumentException e) {
-                            return false;
-                        }
-                    })
-            );
-        }
-
-        @Test
-        @DisplayName("이미 부분환불된 상태에서 추가 부분 취소 시에도 cancelId 기반 멱등성 키가 사용된다")
-        void shouldUseCancelIdBasedKeyRegardlessOfPriorRefundHistory() {
-            Payment payment = createSuccessPayment(1L, ORDER_KEY, 50000L, "tno_123");
-            payment.markAsPartiallyRefunded(10000L);
-            PspPaymentEvent event = createCompleteEvent(ORDER_KEY_STR, "tno_123", 50000L);
-            CancelPaymentCommand command = createPartialCancelCommand(ORDER_KEY_STR, 20000L);
-            PaymentCancelVendorResult vendorResult = createSuccessVendorResult();
-
-            when(findPaymentPort.findByOrderKey(ORDER_KEY)).thenReturn(Optional.of(payment));
-            when(findOrderPort.findById(1L)).thenReturn(Optional.of(createOrder(1L, BUYER_ID)));
-            when(findPspPaymentEventPort.findByOrderKey(ORDER_KEY_STR)).thenReturn(Optional.of(event));
-            when(paymentVendorPort.cancelPayment(any())).thenReturn(vendorResult);
-
-            cancelPaymentService.cancel(command);
-
-            verify(recordLedgerEntryUseCase).recordPaymentCancellation(
-                    eq(1L), eq(20000L), argThat(key ->
-                            key.startsWith("PAYMENT_PARTIAL_REFUND:1:")
-                                    && !key.contains("10000")
-                                    && !key.contains("20000")
-                    )
-            );
-        }
-
-        @Test
-        @DisplayName("역분개 실패 시에도 결제 취소는 정상 완료된다")
-        void shouldCompleteCancelEvenWhenLedgerRecordingFails() {
-            Payment payment = createSuccessPayment(1L, ORDER_KEY, 50000L, "tno_123");
-            PspPaymentEvent event = createCompleteEvent(ORDER_KEY_STR, "tno_123", 50000L);
-            CancelPaymentCommand command = createFullCancelCommand(ORDER_KEY_STR);
-            PaymentCancelVendorResult vendorResult = createSuccessVendorResult();
-
-            when(findPaymentPort.findByOrderKey(ORDER_KEY)).thenReturn(Optional.of(payment));
-            when(findOrderPort.findById(1L)).thenReturn(Optional.of(createOrder(1L, BUYER_ID)));
-            when(findPspPaymentEventPort.findByOrderKey(ORDER_KEY_STR)).thenReturn(Optional.of(event));
-            when(paymentVendorPort.cancelPayment(any())).thenReturn(vendorResult);
-            doThrow(new RuntimeException("분개 실패")).when(recordLedgerEntryUseCase)
-                    .recordPaymentCancellation(anyLong(), anyLong(), anyString());
-
-            cancelPaymentService.cancel(command);
-
-            verify(updatePaymentPort).update(any());
-            verify(updatePspPaymentEventPort).update(any());
-            verify(changeOrderStatusUseCase).changeOrderStatus(any());
-        }
-    }
+    // [#929][#1034] 분개 기록은 Kafka Consumer(PaymentCancelledLedgerConsumer)로 전환 완료
 
     @Nested
     @DisplayName("재고 복구 검증")


### PR DESCRIPTION
## partially addresses #929
## resolves #1034

## Task
- [x] PaymentCancelledLedgerConsumer 활성화 (RecordLedgerEntryUseCase 주입 + recordPaymentCancellation 호출)
- [x] 전체/부분 취소 idempotencyKey 생성 로직 구현 (resolveIdempotencyKey 메서드, early return 적용)
- [x] DuplicateLedgerTransactionException 멱등성 처리 추가
- [x] CancelPaymentService에서 동기 역분개 호출 제거 (recordLedgerEntryForCancellation 메서드 삭제)
- [x] RecordLedgerEntryUseCase 필드 제거 (CancelPaymentService)
- [x] 테스트 업데이트 (Consumer 전체/부분취소/멱등성 테스트 추가, Service LedgerEntryRecordingTest 삭제)