### PR TITLE
[#929][#1035] refactor: commerce.settlement.executed 이벤트 듀얼 라이트 Consumer 처리 검증

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/SettlementExecutedLedgerConsumer.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/SettlementExecutedLedgerConsumer.java
@@ -1,6 +1,8 @@
 package com.personal.marketnote.commerce.adapter.in.event;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.commerce.exception.DuplicateLedgerTransactionException;
+import com.personal.marketnote.commerce.port.in.usecase.ledger.RecordLedgerEntryUseCase;
 import com.personal.marketnote.common.kafka.KafkaTopicConstants;
 import com.personal.marketnote.common.kafka.event.EventEnvelope;
 import com.personal.marketnote.common.kafka.event.EventPayloadValidator;
@@ -17,6 +19,7 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class SettlementExecutedLedgerConsumer {
     private final ObjectMapper objectMapper;
+    private final RecordLedgerEntryUseCase recordLedgerEntryUseCase;
 
     @KafkaListener(
             topics = KafkaTopicConstants.SETTLEMENT_EXECUTED,
@@ -38,36 +41,36 @@ public class SettlementExecutedLedgerConsumer {
             return;
         }
 
-        try {
-            SettlementExecutedEvent payload = envelope.getPayloadAs(SettlementExecutedEvent.class, objectMapper);
+        SettlementExecutedEvent payload = envelope.getPayloadAs(SettlementExecutedEvent.class, objectMapper);
 
-            log.info("정산 실행 이벤트 수신 (회계 분개). eventId={}, settlementId={}, sellerId={}",
-                    envelope.eventId(), payload.settlementId(), payload.sellerId());
+        log.info("정산 실행 이벤트 수신 (회계 분개). eventId={}, settlementId={}, sellerId={}",
+                envelope.eventId(), payload.settlementId(), payload.sellerId());
 
-            if (EventPayloadValidator.hasInvalidIds(envelope.eventId(),
-                    EventPayloadValidator.id("settlementId", payload.settlementId()))) {
-                acknowledgment.acknowledge();
-                return;
-            }
-
-            // FIXME: [#929][#1024] HTTP 제거 후 RecordLedgerEntryUseCase 활성화
-            //  현재 듀얼 라이트 기간: ProcessSellerSettlementService.process()에서 동기로 분개 처리 중
-            //  recordLedgerEntryUseCase.recordPgSettlement(
-            //          payload.settlementId(), payload.totalAllocatedAmount(), payload.pgFeeAmount()
-            //  );
-            //  long sellerSettlementDebit = payload.sellerPayoutAmount() + payload.platformFeeAmount();
-            //  recordLedgerEntryUseCase.recordSellerSettlement(
-            //          payload.settlementId(), sellerSettlementDebit,
-            //          payload.sellerPayoutAmount(), payload.platformFeeAmount()
-            //  );
-
-            log.info("정산 실행 분개 이벤트 검증 완료 (듀얼 라이트). settlementId={}, sellerId={}, totalAllocated={}",
-                    payload.settlementId(), payload.sellerId(), payload.totalAllocatedAmount());
-        } catch (Exception e) {
-            log.error("정산 실행 분개 이벤트 처리 실패. eventId={}, key={}, error={}",
-                    envelope.eventId(), record.key(), e.getMessage(), e);
-            throw e;
+        if (EventPayloadValidator.hasInvalidIds(envelope.eventId(),
+                EventPayloadValidator.id("settlementId", payload.settlementId()))) {
+            acknowledgment.acknowledge();
+            return;
         }
+
+        try {
+            recordLedgerEntryUseCase.recordPgSettlement(
+                    payload.settlementId(), payload.totalAllocatedAmount(), payload.pgFeeAmount()
+            );
+
+            long sellerSettlementDebit = Math.addExact(payload.sellerPayoutAmount(), payload.platformFeeAmount());
+            recordLedgerEntryUseCase.recordSellerSettlement(
+                    payload.settlementId(), sellerSettlementDebit,
+                    payload.sellerPayoutAmount(), payload.platformFeeAmount()
+            );
+
+            log.info("정산 분개 완료. settlementId={}, totalAllocated={}, pgFee={}, sellerPayout={}, platformFee={}",
+                    payload.settlementId(), payload.totalAllocatedAmount(), payload.pgFeeAmount(),
+                    payload.sellerPayoutAmount(), payload.platformFeeAmount());
+        } catch (DuplicateLedgerTransactionException e) {
+            log.info("이미 처리된 정산 분개 이벤트 (멱등 처리). eventId={}, message={}",
+                    envelope.eventId(), e.getMessage());
+        }
+        // 그 외 예외는 DefaultErrorHandler가 재시도 + DLT로 처리
 
         acknowledgment.acknowledge();
     }

--- a/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/event/SettlementExecutedLedgerConsumerTest.java
+++ b/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/event/SettlementExecutedLedgerConsumerTest.java
@@ -1,6 +1,8 @@
 package com.personal.marketnote.commerce.adapter.in.event;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.commerce.exception.DuplicateLedgerTransactionException;
+import com.personal.marketnote.commerce.port.in.usecase.ledger.RecordLedgerEntryUseCase;
 import com.personal.marketnote.common.kafka.event.EventEnvelope;
 import com.personal.marketnote.common.kafka.event.SettlementExecutedEvent;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -24,6 +26,9 @@ class SettlementExecutedLedgerConsumerTest {
     @InjectMocks
     private SettlementExecutedLedgerConsumer consumer;
 
+    @Mock
+    private RecordLedgerEntryUseCase recordLedgerEntryUseCase;
+
     @Spy
     private ObjectMapper objectMapper = new ObjectMapper();
 
@@ -42,8 +47,8 @@ class SettlementExecutedLedgerConsumerTest {
     }
 
     @Test
-    @DisplayName("듀얼 라이트 기간 중 정산 실행 이벤트 수신 시 페이로드 검증을 완료하고 acknowledge한다")
-    void handleSettlementExecutedEvent_success_validatesAndAcknowledges() {
+    @DisplayName("정산 실행 이벤트 수신 시 PG/판매자 분개를 기록하고 acknowledge한다")
+    void handleSettlementExecutedEvent_success_recordsLedgerAndAcknowledges() {
         // given
         ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, 100L);
 
@@ -51,8 +56,24 @@ class SettlementExecutedLedgerConsumerTest {
         consumer.handleSettlementExecutedEvent(record, acknowledgment);
 
         // then
-        // TODO: [#929][#1024] RecordLedgerEntryUseCase 활성화 시
-        //  recordLedgerEntryUseCase.recordPgSettlement(), recordSellerSettlement() 호출 검증 추가
+        verify(recordLedgerEntryUseCase).recordPgSettlement(1L, 100000L, 3000L);
+        verify(recordLedgerEntryUseCase).recordSellerSettlement(1L, 97000L, 90000L, 7000L);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("이미 처리된 정산 분개 이벤트는 멱등 처리하고 acknowledge한다")
+    void handleSettlementExecutedEvent_duplicate_idempotentAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, 100L);
+        doThrow(new DuplicateLedgerTransactionException("PG_SETTLEMENT:1"))
+                .when(recordLedgerEntryUseCase).recordPgSettlement(1L, 100000L, 3000L);
+
+        // when
+        consumer.handleSettlementExecutedEvent(record, acknowledgment);
+
+        // then
+        verify(recordLedgerEntryUseCase).recordPgSettlement(1L, 100000L, 3000L);
         verify(acknowledgment).acknowledge();
     }
 
@@ -66,6 +87,7 @@ class SettlementExecutedLedgerConsumerTest {
         consumer.handleSettlementExecutedEvent(record, acknowledgment);
 
         // then
+        verifyNoInteractions(recordLedgerEntryUseCase);
         verify(acknowledgment).acknowledge();
     }
 
@@ -79,6 +101,7 @@ class SettlementExecutedLedgerConsumerTest {
         consumer.handleSettlementExecutedEvent(record, acknowledgment);
 
         // then
+        verifyNoInteractions(recordLedgerEntryUseCase);
         verify(acknowledgment).acknowledge();
     }
 
@@ -92,6 +115,7 @@ class SettlementExecutedLedgerConsumerTest {
         consumer.handleSettlementExecutedEvent(record, acknowledgment);
 
         // then
+        verifyNoInteractions(recordLedgerEntryUseCase);
         verify(acknowledgment).acknowledge();
     }
 
@@ -107,7 +131,7 @@ class SettlementExecutedLedgerConsumerTest {
         consumer.handleSettlementExecutedEvent(record, acknowledgment);
 
         // then
-        verifyNoInteractions(objectMapper);
+        verifyNoInteractions(objectMapper, recordLedgerEntryUseCase);
         verify(acknowledgment).acknowledge();
     }
 
@@ -130,7 +154,7 @@ class SettlementExecutedLedgerConsumerTest {
         consumer.handleSettlementExecutedEvent(record, acknowledgment);
 
         // then
-        verifyNoInteractions(objectMapper);
+        verifyNoInteractions(objectMapper, recordLedgerEntryUseCase);
         verify(acknowledgment).acknowledge();
     }
 

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/settlement/ProcessSellerSettlementService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/settlement/ProcessSellerSettlementService.java
@@ -5,7 +5,6 @@ import com.personal.marketnote.commerce.domain.settlement.Settlement;
 import com.personal.marketnote.commerce.domain.settlement.SettlementCreateState;
 import com.personal.marketnote.commerce.exception.SettlementAlreadyExistsException;
 import com.personal.marketnote.commerce.port.in.command.settlement.ExecuteSettlementCommand;
-import com.personal.marketnote.commerce.port.in.usecase.ledger.RecordLedgerEntryUseCase;
 import com.personal.marketnote.commerce.port.out.event.PublishSettlementEventPort;
 import com.personal.marketnote.commerce.port.out.settlement.FindSettlementPort;
 import com.personal.marketnote.commerce.port.out.settlement.SaveSettlementPort;
@@ -42,7 +41,6 @@ public class ProcessSellerSettlementService {
     private final SaveSettlementPort saveSettlementPort;
     private final UpdateSettlementPort updateSettlementPort;
     private final UpdatePaymentAllocationPort updatePaymentAllocationPort;
-    private final RecordLedgerEntryUseCase recordLedgerEntryUseCase;
     private final PublishSettlementEventPort publishSettlementEventPort;
 
     /**
@@ -95,11 +93,7 @@ public class ProcessSellerSettlementService {
                 .toList();
         updatePaymentAllocationPort.assignSettlement(allocationIds, settlementId);
 
-        recordLedgerEntryUseCase.recordPgSettlement(settlementId, totalAllocatedAmount, pgFeeAmount);
-
-        long sellerSettlementDebit = sellerPayoutAmount + platformFeeAmount;
-        recordLedgerEntryUseCase.recordSellerSettlement(settlementId, sellerSettlementDebit, sellerPayoutAmount, platformFeeAmount);
-
+        // [#929][#1035] 정산 분개는 Kafka Consumer(SettlementExecutedLedgerConsumer)로 전환 완료
         savedSettlement.complete();
         updateSettlementPort.update(savedSettlement);
 

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/settlement/ProcessSellerSettlementServiceTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/settlement/ProcessSellerSettlementServiceTest.java
@@ -3,7 +3,7 @@ package com.personal.marketnote.commerce.service.settlement;
 import com.personal.marketnote.commerce.domain.settlement.*;
 import com.personal.marketnote.commerce.exception.SettlementAlreadyExistsException;
 import com.personal.marketnote.commerce.port.in.command.settlement.ExecuteSettlementCommand;
-import com.personal.marketnote.commerce.port.in.usecase.ledger.RecordLedgerEntryUseCase;
+import com.personal.marketnote.commerce.port.out.event.PublishSettlementEventPort;
 import com.personal.marketnote.commerce.port.out.settlement.FindSettlementPort;
 import com.personal.marketnote.commerce.port.out.settlement.SaveSettlementPort;
 import com.personal.marketnote.commerce.port.out.settlement.UpdatePaymentAllocationPort;
@@ -46,7 +46,7 @@ class ProcessSellerSettlementServiceTest {
     private UpdatePaymentAllocationPort updatePaymentAllocationPort;
 
     @Mock
-    private RecordLedgerEntryUseCase recordLedgerEntryUseCase;
+    private PublishSettlementEventPort publishSettlementEventPort;
 
     @Captor
     private ArgumentCaptor<Settlement> settlementCaptor;
@@ -127,8 +127,7 @@ class ProcessSellerSettlementServiceTest {
             verify(updatePaymentAllocationPort).assignSettlement(allocationIdsCaptor.capture(), eq(1L));
             assertThat(allocationIdsCaptor.getValue()).containsExactlyInAnyOrder(1L, 2L);
 
-            verify(recordLedgerEntryUseCase).recordPgSettlement(1L, 8000L, 240L);
-            verify(recordLedgerEntryUseCase).recordSellerSettlement(1L, 7760L, 7360L, 400L);
+            // [#929][#1035] 분개는 Kafka Consumer로 전환 완료
             verify(updateSettlementPort).update(argThat(Settlement::isCompleted));
         }
 


### PR DESCRIPTION
## partially addresses #929
## resolves #1035

## Task
- [x] SettlementExecutedLedgerConsumer 활성화 (RecordLedgerEntryUseCase 주입 + recordPgSettlement/recordSellerSettlement 호출)
- [x] Math.addExact로 sellerSettlementDebit 계산 (오버플로 방지)
- [x] DuplicateLedgerTransactionException 멱등성 처리 추가
- [x] ProcessSellerSettlementService에서 동기 분개 호출 제거 (recordPgSettlement, recordSellerSettlement)
- [x] RecordLedgerEntryUseCase 필드 제거 (ProcessSellerSettlementService)
- [x] 테스트 업데이트 (Consumer 분개/멱등성 테스트 추가, Service 분개 verify 제거, PublishSettlementEventPort mock 추가)