### PR TITLE
[#929][#1036] refactor: user.user.signup-completed 이벤트 듀얼 라이트 Consumer 처리 검증

### DIFF
--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/event/UserSignupCompletedRewardConsumer.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/event/UserSignupCompletedRewardConsumer.java
@@ -69,7 +69,7 @@ public class UserSignupCompletedRewardConsumer {
 
             log.info("Kafka 이벤트로 포인트 초기화 완료. userId={}", payload.userId());
         } catch (DuplicateUserPointException e) {
-            log.info("포인트가 이미 존재합니다 (듀얼 라이트 중복). eventId={}, key={}",
+            log.info("포인트가 이미 존재합니다 (멱등 처리). eventId={}, key={}",
                     envelope.eventId(), record.key());
         }
         // 그 외 예외는 DefaultErrorHandler가 재시도 + DLT로 처리

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/out/web/reward/RewardServiceClient.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/out/web/reward/RewardServiceClient.java
@@ -46,104 +46,6 @@ public class RewardServiceClient implements ModifyUserPointPort {
     private final ServiceCommunicationPayloadGenerator serviceCommunicationPayloadGenerator;
 
     @Override
-    public void registerUserPoint(Long userId, String userKey) {
-        if (FormatValidator.hasNoValue(userId) || FormatValidator.hasNoValue(userKey)) {
-            return;
-        }
-
-        URI uri = buildRegisterUserPointUri(userId, userKey);
-        HttpHeaders headers = buildHeaders("POST", uri.getPath());
-        HttpEntity<Void> httpEntity = new HttpEntity<>(headers);
-
-        for (int i = 0; i < INTER_SERVER_MAX_REQUEST_COUNT; i++) {
-            int attempt = i + 1;
-            try {
-                ResponseEntity<Void> response = restTemplate.exchange(uri, HttpMethod.POST, httpEntity, Void.class);
-
-                if (FormatValidator.hasValue(response) && response.getStatusCode().is2xxSuccessful()) {
-                    return;
-                }
-
-                HttpStatusCode statusCode = null;
-                if (FormatValidator.hasValue(response)) {
-                    statusCode = response.getStatusCode();
-                }
-
-                String exception = FormatValidator.hasValue(statusCode) ? statusCode.toString() : "EmptyResponse";
-                JsonNode requestPayloadJson = serviceCommunicationPayloadGenerator.buildRequestPayloadJson(
-                        HttpMethod.POST,
-                        uri,
-                        null,
-                        attempt
-                );
-                String requestPayload = requestPayloadJson.toString();
-                JsonNode responsePayloadJson =
-                        serviceCommunicationPayloadGenerator.buildResponsePayloadJson(response, attempt);
-                String responsePayload = responsePayloadJson.toString();
-                recordCommunication(
-                        TARGET_TYPE,
-                        String.valueOf(userId),
-                        UserServiceCommunicationType.REQUEST,
-                        requestPayload,
-                        requestPayloadJson,
-                        exception
-                );
-                recordCommunication(
-                        TARGET_TYPE,
-                        String.valueOf(userId),
-                        UserServiceCommunicationType.RESPONSE,
-                        responsePayload,
-                        responsePayloadJson,
-                        exception
-                );
-                log.warn(
-                        "Reward service responded with non-2xx status for userId={}, status={}",
-                        userId, statusCode
-                );
-            } catch (Exception e) {
-                String exception = e.getClass().getSimpleName();
-                JsonNode requestPayloadJson = serviceCommunicationPayloadGenerator.buildRequestPayloadJson(
-                        HttpMethod.POST,
-                        uri,
-                        null,
-                        attempt
-                );
-                String requestPayload = requestPayloadJson.toString();
-                JsonNode responsePayloadJson = serviceCommunicationPayloadGenerator.buildErrorPayloadJson(
-                        exception,
-                        e.getMessage(),
-                        attempt
-                );
-                String responsePayload = responsePayloadJson.toString();
-                recordCommunication(
-                        TARGET_TYPE,
-                        String.valueOf(userId),
-                        UserServiceCommunicationType.REQUEST,
-                        requestPayload,
-                        requestPayloadJson,
-                        exception
-                );
-                recordCommunication(
-                        TARGET_TYPE,
-                        String.valueOf(userId),
-                        UserServiceCommunicationType.RESPONSE,
-                        responsePayload,
-                        responsePayloadJson,
-                        exception
-                );
-                log.warn(
-                        "Failed to register user point on reward-service: userId={}, attempt={}, message={}",
-                        userId, i + 1, e.getMessage(), e
-                );
-            }
-
-            sleep(1000);
-        }
-
-        throw new RewardServiceRequestFailedException(new IOException());
-    }
-
-    @Override
     public void accrueReferralPoints(Long referrerUserId, Long referredUserId) {
         accrueUserPoint(
                 referrerUserId,
@@ -319,14 +221,7 @@ public class RewardServiceClient implements ModifyUserPointPort {
                 .toUri();
     }
 
-    private URI buildRegisterUserPointUri(Long userId, String userKey) {
-        return UriComponentsBuilder
-                .fromUriString(rewardServiceBaseUrl)
-                .path("/api/v1/users/{userId}/points")
-                .queryParam("userKey", userKey)
-                .buildAndExpand(userId)
-                .toUri();
-    }
+
 
     private HttpHeaders buildHeaders(String httpMethod, String requestPath) {
         HttpHeaders headers = new HttpHeaders();

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/port/out/reward/ModifyUserPointPort.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/port/out/reward/ModifyUserPointPort.java
@@ -9,15 +9,6 @@ package com.personal.marketnote.user.port.out.reward;
  */
 public interface ModifyUserPointPort {
     /**
-     * @param userId  회원 ID
-     * @param userKey 회원 고유 키
-     * @Date 2026-01-31
-     * @Author 성효빈
-     * @Description 회원 포인트 도메인을 생성합니다.
-     */
-    void registerUserPoint(Long userId, String userKey);
-
-    /**
      * @param referrerUserId 추천한 회원 ID
      * @param referredUserId 추천받은 회원 ID
      * @Date 2026-01-31

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/service/user/SignUpService.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/service/user/SignUpService.java
@@ -16,14 +16,11 @@ import com.personal.marketnote.user.port.in.usecase.user.GetUserUseCase;
 import com.personal.marketnote.user.port.in.usecase.user.SignUpUseCase;
 import com.personal.marketnote.user.port.out.authentication.VerifyCodePort;
 import com.personal.marketnote.user.port.out.event.PublishUserEventPort;
-import com.personal.marketnote.user.port.out.reward.ModifyUserPointPort;
 import com.personal.marketnote.user.port.out.user.*;
 import com.personal.marketnote.user.security.token.vendor.AuthVendor;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.transaction.support.TransactionSynchronization;
-import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -44,7 +41,6 @@ public class SignUpService implements SignUpUseCase {
     private final UpdateUserPort updateUserPort;
     private final VerifyCodePort verifyCodePort;
     private final SaveLoginHistoryPort saveLoginHistoryPort;
-    private final ModifyUserPointPort modifyUserPointPort;
     private final PublishUserEventPort publishUserEventPort;
 
     @Override
@@ -79,12 +75,10 @@ public class SignUpService implements SignUpUseCase {
         );
 
         // Outbox 이벤트 저장 (트랜잭션 내)
+        // [#929][#1036] 포인트 초기화는 Kafka Consumer(UserSignupCompletedRewardConsumer)로 전환 완료
         publishUserEventPort.publishUserSignupCompletedEvent(
                 signedUpUser.getId(), signedUpUser.getUserKey().toString()
         );
-
-        // 트랜잭션 커밋 후 HTTP 호출
-        registerUserPointHttpAfterCommit(signedUpUser.getId(), signedUpUser.getUserKey().toString());
 
         saveLoginHistoryPort.saveLoginHistory(
                 LoginHistory.of(signedUpUser, authVendor, ipAddress)
@@ -150,17 +144,4 @@ public class SignUpService implements SignUpUseCase {
         throw new UserNotActiveException(SIXTH_ERROR_CODE, email);
     }
 
-    private void registerUserPointHttpAfterCommit(Long userId, String userKey) {
-        if (TransactionSynchronizationManager.isActualTransactionActive()) {
-            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
-                @Override
-                public void afterCommit() {
-                    modifyUserPointPort.registerUserPoint(userId, userKey); // TODO: Kafka 검증 완료 후 HTTP 호출 제거
-                }
-            });
-            return;
-        }
-
-        modifyUserPointPort.registerUserPoint(userId, userKey); // TODO: Kafka 검증 완료 후 HTTP 호출 제거
-    }
 }

--- a/user-service/user-application/src/test/java/com/personal/marketnote/user/service/user/SignUpUseCaseTest.java
+++ b/user-service/user-application/src/test/java/com/personal/marketnote/user/service/user/SignUpUseCaseTest.java
@@ -13,7 +13,6 @@ import com.personal.marketnote.user.port.in.result.SignUpResult;
 import com.personal.marketnote.user.port.in.usecase.user.GetUserUseCase;
 import com.personal.marketnote.user.port.out.authentication.VerifyCodePort;
 import com.personal.marketnote.user.port.out.event.PublishUserEventPort;
-import com.personal.marketnote.user.port.out.reward.ModifyUserPointPort;
 import com.personal.marketnote.user.port.out.user.*;
 import com.personal.marketnote.user.security.token.vendor.AuthVendor;
 import org.junit.jupiter.api.DisplayName;
@@ -50,8 +49,6 @@ class SignUpUseCaseTest {
     private VerifyCodePort verifyCodePort;
     @Mock
     private SaveLoginHistoryPort saveLoginHistoryPort;
-    @Mock
-    private ModifyUserPointPort modifyUserPointPort;
     @Mock
     private PublishUserEventPort publishUserEventPort;
 
@@ -91,7 +88,7 @@ class SignUpUseCaseTest {
 
         verify(saveUserPort).save(any(User.class));
         verify(publishUserEventPort).publishUserSignupCompletedEvent(1L, userKey.toString());
-        verify(modifyUserPointPort).registerUserPoint(1L, userKey.toString());
+
         verify(saveLoginHistoryPort).saveLoginHistory(any(LoginHistory.class));
         verify(updateUserPort, never()).update(any());
     }
@@ -126,7 +123,7 @@ class SignUpUseCaseTest {
         verify(updateUserPort).update(existingUser);
         verify(saveLoginHistoryPort).saveLoginHistory(any(LoginHistory.class));
         verify(publishUserEventPort, never()).publishUserSignupCompletedEvent(anyLong(), anyString());
-        verify(modifyUserPointPort, never()).registerUserPoint(anyLong(), anyString());
+
         verify(saveUserPort, never()).save(any());
     }
 
@@ -140,7 +137,7 @@ class SignUpUseCaseTest {
         assertThatThrownBy(() -> signUpService.signUp(command, AuthVendor.NATIVE, null, "127.0.0.1"))
                 .isInstanceOf(PasswordNoValueException.class);
 
-        verifyNoInteractions(saveUserPort, updateUserPort, saveLoginHistoryPort, modifyUserPointPort, publishUserEventPort, findTermsPort, verifyCodePort, getUserUseCase);
+        verifyNoInteractions(saveUserPort, updateUserPort, saveLoginHistoryPort, publishUserEventPort, findTermsPort, verifyCodePort, getUserUseCase);
     }
 
     @Test
@@ -158,7 +155,7 @@ class SignUpUseCaseTest {
                 .isInstanceOf(UserExistsException.class);
 
         verify(verifyCodePort, never()).verify(anyString(), anyString());
-        verifyNoInteractions(saveUserPort, updateUserPort, saveLoginHistoryPort, modifyUserPointPort, publishUserEventPort, findTermsPort, getUserUseCase);
+        verifyNoInteractions(saveUserPort, updateUserPort, saveLoginHistoryPort, publishUserEventPort, findTermsPort, getUserUseCase);
     }
 
     @Test
@@ -176,7 +173,7 @@ class SignUpUseCaseTest {
                 .isInstanceOf(UserExistsException.class);
 
         verify(verifyCodePort, never()).verify(anyString(), anyString());
-        verifyNoInteractions(saveUserPort, updateUserPort, saveLoginHistoryPort, modifyUserPointPort, publishUserEventPort, findTermsPort, getUserUseCase);
+        verifyNoInteractions(saveUserPort, updateUserPort, saveLoginHistoryPort, publishUserEventPort, findTermsPort, getUserUseCase);
     }
 
     @Test
@@ -196,7 +193,7 @@ class SignUpUseCaseTest {
                 .isInstanceOf(UserExistsException.class);
 
         verify(verifyCodePort, never()).verify(anyString(), anyString());
-        verifyNoInteractions(saveUserPort, updateUserPort, saveLoginHistoryPort, modifyUserPointPort, publishUserEventPort, findTermsPort, getUserUseCase);
+        verifyNoInteractions(saveUserPort, updateUserPort, saveLoginHistoryPort, publishUserEventPort, findTermsPort, getUserUseCase);
     }
 
     @Test
@@ -216,7 +213,7 @@ class SignUpUseCaseTest {
 
         verify(saveUserPort, never()).save(any());
         verify(publishUserEventPort, never()).publishUserSignupCompletedEvent(anyLong(), anyString());
-        verify(modifyUserPointPort, never()).registerUserPoint(anyLong(), anyString());
+
         verify(saveLoginHistoryPort, never()).saveLoginHistory(any());
     }
 
@@ -244,7 +241,7 @@ class SignUpUseCaseTest {
         verify(updateUserPort, never()).update(any());
         verify(saveUserPort, never()).save(any());
         verify(publishUserEventPort, never()).publishUserSignupCompletedEvent(anyLong(), anyString());
-        verify(modifyUserPointPort, never()).registerUserPoint(anyLong(), anyString());
+
     }
 
     private SignUpCommand createCommand(


### PR DESCRIPTION
## partially addresses #929
## resolves #1036

## Task
- [x] SignUpService에서 registerUserPointHttpAfterCommit() 호출 + 메서드 삭제
- [x] ModifyUserPointPort.registerUserPoint() 메서드 시그니처 삭제 (accrueReferralPoints 유지)
- [x] RewardServiceClient.registerUserPoint() 구현 + buildRegisterUserPointUri() 삭제
- [x] ModifyUserPointPort 필드 제거 (SignUpService)
- [x] UserSignupCompletedRewardConsumer 듀얼 라이트 로그 정리
- [x] 테스트 업데이트 (SignUpUseCaseTest에서 ModifyUserPointPort Mock/verify 제거)