### PR TITLE
[#929][#1189] refactor: commerce.payment.failed 이벤트 듀얼 라이트 Consumer 처리 검증 

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/PaymentFailedOrderStatusConsumer.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/PaymentFailedOrderStatusConsumer.java
@@ -64,7 +64,7 @@ public class PaymentFailedOrderStatusConsumer {
             log.info("Kafka 이벤트로 주문 상태 FAILED 변경 완료. orderId={}, orderKey={}",
                     payload.orderId(), payload.orderKey());
         } catch (OrderStatusAlreadyChangedException e) {
-            log.warn("듀얼 라이트: 이미 주문 상태가 변경됨. eventId={}, key={}, message={}",
+            log.info("이미 주문 상태가 변경됨 (멱등 처리). eventId={}, key={}, message={}",
                     envelope.eventId(), record.key(), e.getMessage());
         } catch (Exception e) {
             log.error("주문 상태 FAILED 변경 실패. eventId={}, key={}, error={}",

--- a/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/event/PaymentFailedOrderStatusConsumerTest.java
+++ b/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/event/PaymentFailedOrderStatusConsumerTest.java
@@ -85,7 +85,7 @@ class PaymentFailedOrderStatusConsumerTest {
     }
 
     @Test
-    @DisplayName("듀얼 라이트 기간 중 이미 FAILED 상태인 주문에 대해 OrderStatusAlreadyChangedException 발생 시 정상 acknowledge한다")
+    @DisplayName("이미 FAILED 상태인 주문에 대해 OrderStatusAlreadyChangedException 발생 시 멱등 처리하고 acknowledge한다")
     void handlePaymentFailedEvent_alreadyChanged_acknowledgesGracefully() {
         // given
         ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, "order-key-1", "CARD_ERROR", "카드 잔액 부족");


### PR DESCRIPTION
## partially addresses #929
## resolves #1189

## Task
- [x] PaymentFailedOrderStatusConsumer 듀얼 라이트 로그 → 멱등 처리 로그로 정리 (warn → info)
- [x] 테스트 DisplayName 정리