### PR TITLE
[#1530][#1532] feat: SagaInstance 도메인 모델 추가

### DIFF
--- a/common/src/main/java/com/personal/marketnote/common/saga/SagaInstance.java
+++ b/common/src/main/java/com/personal/marketnote/common/saga/SagaInstance.java
@@ -1,0 +1,113 @@
+package com.personal.marketnote.common.saga;
+
+import com.personal.marketnote.common.saga.exception.InvalidSagaStatusTransitionException;
+import com.personal.marketnote.common.utility.FormatValidator;
+import lombok.*;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+@Getter
+public class SagaInstance {
+
+    private Long id;
+    private String sagaId;
+    private String sagaType;
+    private SagaStatus status;
+    private int currentStepIndex;
+    private String payload;
+    private LocalDateTime createdAt;
+    private LocalDateTime modifiedAt;
+    private LocalDateTime completedAt;
+
+    public static SagaInstance from(SagaInstanceCreateState state, Clock clock) {
+        if (FormatValidator.hasNoValue(state.sagaId())) {
+            throw new IllegalArgumentException("sagaId는 필수입니다.");
+        }
+        if (FormatValidator.hasNoValue(state.sagaType())) {
+            throw new IllegalArgumentException("sagaType은 필수입니다.");
+        }
+        LocalDateTime now = LocalDateTime.now(clock);
+        return SagaInstance.builder()
+                .sagaId(state.sagaId())
+                .sagaType(state.sagaType())
+                .status(SagaStatus.STARTED)
+                .currentStepIndex(0)
+                .payload(state.payload())
+                .createdAt(now)
+                .modifiedAt(now)
+                .build();
+    }
+
+    public static SagaInstance from(SagaInstanceSnapshotState state) {
+        return SagaInstance.builder()
+                .id(state.id())
+                .sagaId(state.sagaId())
+                .sagaType(state.sagaType())
+                .status(state.status())
+                .currentStepIndex(state.currentStepIndex())
+                .payload(state.payload())
+                .createdAt(state.createdAt())
+                .modifiedAt(state.modifiedAt())
+                .completedAt(state.completedAt())
+                .build();
+    }
+
+    public void process() {
+        if (!status.canProcess()) {
+            throw new InvalidSagaStatusTransitionException(status);
+        }
+        this.status = SagaStatus.PROCESSING;
+    }
+
+    public void advanceStep() {
+        if (!status.isProcessing()) {
+            throw new InvalidSagaStatusTransitionException(status);
+        }
+        this.currentStepIndex++;
+    }
+
+    public void complete(Clock clock) {
+        if (!status.isProcessing()) {
+            throw new InvalidSagaStatusTransitionException(status);
+        }
+        this.status = SagaStatus.SUCCEEDED;
+        this.completedAt = LocalDateTime.now(clock);
+    }
+
+    public void fail() {
+        if (!status.isProcessing()) {
+            throw new InvalidSagaStatusTransitionException(status);
+        }
+        this.status = SagaStatus.FAILED;
+    }
+
+    public void rollback() {
+        if (!status.canCompensate()) {
+            throw new InvalidSagaStatusTransitionException(status);
+        }
+        this.status = SagaStatus.COMPENSATING;
+    }
+
+    public void compensate(Clock clock) {
+        if (!status.isCompensating()) {
+            throw new InvalidSagaStatusTransitionException(status);
+        }
+        this.status = SagaStatus.COMPENSATED;
+        this.completedAt = LocalDateTime.now(clock);
+    }
+
+    public void failCompensation() {
+        if (!status.isCompensating()) {
+            throw new InvalidSagaStatusTransitionException(status);
+        }
+        this.status = SagaStatus.FAILED;
+    }
+
+    public boolean isTerminal() {
+        return status.isTerminal();
+    }
+}

--- a/common/src/main/java/com/personal/marketnote/common/saga/SagaInstanceCreateState.java
+++ b/common/src/main/java/com/personal/marketnote/common/saga/SagaInstanceCreateState.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.common.saga;
+
+public record SagaInstanceCreateState(
+        String sagaId,
+        String sagaType,
+        String payload
+) {
+}

--- a/common/src/main/java/com/personal/marketnote/common/saga/SagaInstanceSnapshotState.java
+++ b/common/src/main/java/com/personal/marketnote/common/saga/SagaInstanceSnapshotState.java
@@ -1,0 +1,16 @@
+package com.personal.marketnote.common.saga;
+
+import java.time.LocalDateTime;
+
+public record SagaInstanceSnapshotState(
+        Long id,
+        String sagaId,
+        String sagaType,
+        SagaStatus status,
+        int currentStepIndex,
+        String payload,
+        LocalDateTime createdAt,
+        LocalDateTime modifiedAt,
+        LocalDateTime completedAt
+) {
+}

--- a/common/src/main/java/com/personal/marketnote/common/saga/exception/InvalidSagaStatusTransitionException.java
+++ b/common/src/main/java/com/personal/marketnote/common/saga/exception/InvalidSagaStatusTransitionException.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.common.saga.exception;
+
+import com.personal.marketnote.common.saga.SagaStatus;
+
+public class InvalidSagaStatusTransitionException extends IllegalStateException {
+    public InvalidSagaStatusTransitionException(SagaStatus currentStatus) {
+        super("현재 상태에서는 전이할 수 없습니다. 현재 상태: " + currentStatus);
+    }
+}


### PR DESCRIPTION
## partially addresses #1530
## resolves #1532

## Task
- [x] SagaInstanceCreateState record 추가
- [x] SagaInstanceSnapshotState record 추가
- [x] SagaInstance 도메인 클래스 추가 (상태 머신 포함)
- [x] InvalidSagaStatusTransitionException 추가
- [x] 팩토리 메서드 추가 (from(CreateState), from(SnapshotState))
- [x] 상태 전이 메서드 추가 (process, advanceStep, complete, fail, rollback, compensate, failCompensation)