### PR TITLE
[#1530][#1533] feat: SagaStep 도메인 모델 추가

### DIFF
--- a/common/src/main/java/com/personal/marketnote/common/saga/SagaStep.java
+++ b/common/src/main/java/com/personal/marketnote/common/saga/SagaStep.java
@@ -1,0 +1,150 @@
+package com.personal.marketnote.common.saga;
+
+import com.personal.marketnote.common.saga.exception.*;
+import com.personal.marketnote.common.utility.FormatValidator;
+import lombok.*;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+@Getter
+public class SagaStep {
+
+    private Long id;
+    private Long sagaInstanceId;
+    private String stepName;
+    private int stepIndex;
+    private SagaStepStatus status;
+    private String request;
+    private String response;
+    private String compensationRequest;
+    private String compensationResponse;
+    private LocalDateTime createdAt;
+    private LocalDateTime modifiedAt;
+
+    public static SagaStep from(SagaStepCreateState state, Clock clock) {
+        if (FormatValidator.hasNoValue(state.sagaInstanceId())) {
+            throw new SagaInstanceIdNoValueException();
+        }
+        if (FormatValidator.hasNoValue(state.stepName())) {
+            throw new SagaStepNameNoValueException();
+        }
+        if (FormatValidator.hasNoValue(state.request())) {
+            throw new SagaStepRequestNoValueException();
+        }
+        if (state.stepIndex() < 0) {
+            throw new InvalidSagaStepIndexException(state.stepIndex());
+        }
+        LocalDateTime now = LocalDateTime.now(clock);
+        return SagaStep.builder()
+                .sagaInstanceId(state.sagaInstanceId())
+                .stepName(state.stepName())
+                .stepIndex(state.stepIndex())
+                .status(SagaStepStatus.PENDING)
+                .request(state.request())
+                .createdAt(now)
+                .modifiedAt(now)
+                .build();
+    }
+
+    public static SagaStep from(SagaStepSnapshotState state) {
+        return SagaStep.builder()
+                .id(state.id())
+                .sagaInstanceId(state.sagaInstanceId())
+                .stepName(state.stepName())
+                .stepIndex(state.stepIndex())
+                .status(state.status())
+                .request(state.request())
+                .response(state.response())
+                .compensationRequest(state.compensationRequest())
+                .compensationResponse(state.compensationResponse())
+                .createdAt(state.createdAt())
+                .modifiedAt(state.modifiedAt())
+                .build();
+    }
+
+    public void process() {
+        if (!status.canProcess()) {
+            throw new InvalidSagaStepStatusTransitionException(status);
+        }
+        this.status = SagaStepStatus.PROCESSING;
+    }
+
+    public void succeed(String response) {
+        if (!status.isProcessing()) {
+            throw new InvalidSagaStepStatusTransitionException(status);
+        }
+        this.status = SagaStepStatus.SUCCEEDED;
+        this.response = response;
+    }
+
+    public void fail(String response) {
+        if (!status.isProcessing()) {
+            throw new InvalidSagaStepStatusTransitionException(status);
+        }
+        this.status = SagaStepStatus.FAILED;
+        this.response = response;
+    }
+
+    public void compensate(String compensationRequest) {
+        if (FormatValidator.hasNoValue(compensationRequest)) {
+            throw new SagaStepCompensationRequestNoValueException();
+        }
+        if (!status.canCompensate()) {
+            throw new InvalidSagaStepStatusTransitionException(status);
+        }
+        this.status = SagaStepStatus.COMPENSATING;
+        this.compensationRequest = compensationRequest;
+    }
+
+    public void completeCompensation(String compensationResponse) {
+        if (!status.isCompensating()) {
+            throw new InvalidSagaStepStatusTransitionException(status);
+        }
+        this.status = SagaStepStatus.COMPENSATED;
+        this.compensationResponse = compensationResponse;
+    }
+
+    public void failCompensation(String compensationResponse) {
+        if (!status.isCompensating()) {
+            throw new InvalidSagaStepStatusTransitionException(status);
+        }
+        this.status = SagaStepStatus.FAILED;
+        this.compensationResponse = compensationResponse;
+    }
+
+    public boolean isPending() {
+        return status.isPending();
+    }
+
+    public boolean isProcessing() {
+        return status.isProcessing();
+    }
+
+    public boolean isSucceeded() {
+        return status.isSucceeded();
+    }
+
+    public boolean isFailed() {
+        return status.isFailed();
+    }
+
+    public boolean isCompensating() {
+        return status.isCompensating();
+    }
+
+    public boolean isCompensated() {
+        return status.isCompensated();
+    }
+
+    public boolean isTerminal() {
+        return status.isTerminal();
+    }
+
+    public boolean requiresCompensation() {
+        return status.isSucceeded();
+    }
+}

--- a/common/src/main/java/com/personal/marketnote/common/saga/SagaStepCreateState.java
+++ b/common/src/main/java/com/personal/marketnote/common/saga/SagaStepCreateState.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.common.saga;
+
+public record SagaStepCreateState(
+        Long sagaInstanceId,
+        String stepName,
+        int stepIndex,
+        String request
+) {
+}

--- a/common/src/main/java/com/personal/marketnote/common/saga/SagaStepSnapshotState.java
+++ b/common/src/main/java/com/personal/marketnote/common/saga/SagaStepSnapshotState.java
@@ -1,0 +1,18 @@
+package com.personal.marketnote.common.saga;
+
+import java.time.LocalDateTime;
+
+public record SagaStepSnapshotState(
+        Long id,
+        Long sagaInstanceId,
+        String stepName,
+        int stepIndex,
+        SagaStepStatus status,
+        String request,
+        String response,
+        String compensationRequest,
+        String compensationResponse,
+        LocalDateTime createdAt,
+        LocalDateTime modifiedAt
+) {
+}

--- a/common/src/main/java/com/personal/marketnote/common/saga/SagaStepStatus.java
+++ b/common/src/main/java/com/personal/marketnote/common/saga/SagaStepStatus.java
@@ -31,4 +31,16 @@ public enum SagaStepStatus {
     public boolean isCompensated() {
         return this == COMPENSATED;
     }
+
+    public boolean isTerminal() {
+        return this == SUCCEEDED || this == COMPENSATED;
+    }
+
+    public boolean canProcess() {
+        return this == PENDING;
+    }
+
+    public boolean canCompensate() {
+        return this == SUCCEEDED || this == FAILED;
+    }
 }

--- a/common/src/main/java/com/personal/marketnote/common/saga/exception/InvalidSagaStepIndexException.java
+++ b/common/src/main/java/com/personal/marketnote/common/saga/exception/InvalidSagaStepIndexException.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.common.saga.exception;
+
+public class InvalidSagaStepIndexException extends IllegalArgumentException {
+    public InvalidSagaStepIndexException(int stepIndex) {
+        super("stepIndex는 0 이상이어야 합니다. stepIndex: " + stepIndex);
+    }
+}

--- a/common/src/main/java/com/personal/marketnote/common/saga/exception/InvalidSagaStepStatusTransitionException.java
+++ b/common/src/main/java/com/personal/marketnote/common/saga/exception/InvalidSagaStepStatusTransitionException.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.common.saga.exception;
+
+import com.personal.marketnote.common.saga.SagaStepStatus;
+
+public class InvalidSagaStepStatusTransitionException extends IllegalStateException {
+    public InvalidSagaStepStatusTransitionException(SagaStepStatus currentStatus) {
+        super("현재 SagaStep 상태에서는 전이할 수 없습니다. 현재 상태: " + currentStatus);
+    }
+}

--- a/common/src/main/java/com/personal/marketnote/common/saga/exception/SagaInstanceIdNoValueException.java
+++ b/common/src/main/java/com/personal/marketnote/common/saga/exception/SagaInstanceIdNoValueException.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.common.saga.exception;
+
+public class SagaInstanceIdNoValueException extends IllegalArgumentException {
+    public SagaInstanceIdNoValueException() {
+        super("sagaInstanceId는 필수입니다.");
+    }
+}

--- a/common/src/main/java/com/personal/marketnote/common/saga/exception/SagaStepCompensationRequestNoValueException.java
+++ b/common/src/main/java/com/personal/marketnote/common/saga/exception/SagaStepCompensationRequestNoValueException.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.common.saga.exception;
+
+public class SagaStepCompensationRequestNoValueException extends IllegalArgumentException {
+    public SagaStepCompensationRequestNoValueException() {
+        super("compensationRequest는 필수입니다.");
+    }
+}

--- a/common/src/main/java/com/personal/marketnote/common/saga/exception/SagaStepNameNoValueException.java
+++ b/common/src/main/java/com/personal/marketnote/common/saga/exception/SagaStepNameNoValueException.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.common.saga.exception;
+
+public class SagaStepNameNoValueException extends IllegalArgumentException {
+    public SagaStepNameNoValueException() {
+        super("stepName은 필수입니다.");
+    }
+}

--- a/common/src/main/java/com/personal/marketnote/common/saga/exception/SagaStepRequestNoValueException.java
+++ b/common/src/main/java/com/personal/marketnote/common/saga/exception/SagaStepRequestNoValueException.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.common.saga.exception;
+
+public class SagaStepRequestNoValueException extends IllegalArgumentException {
+    public SagaStepRequestNoValueException() {
+        super("request는 필수입니다.");
+    }
+}


### PR DESCRIPTION
## partially addresses #1530
## resolves #1533

## Task
- [x] SagaStepCreateState record 추가
- [x] SagaStepSnapshotState record 추가
- [x] SagaStep 도메인 클래스 추가 (상태 머신 포함)
- [x] SagaStepStatus enum에 canProcess(), canCompensate(), isTerminal() 술어 보강
- [x] InvalidSagaStepStatusTransitionException 추가
- [x] SagaInstanceIdNoValueException, SagaStepNameNoValueException, SagaStepRequestNoValueException, InvalidSagaStepIndexException, SagaStepCompensationRequestNoValueException 커스텀 예외 추가
- [x] 팩토리 메서드 추가 (from(CreateState), from(SnapshotState))
- [x] 상태 전이 메서드 추가 (process, succeed, fail, compensate, completeCompensation, failCompensation)
- [x] 술어 메서드 추가 (isPending, isProcessing, isSucceeded, isFailed, isCompensating, isCompensated, isTerminal, requiresCompensation)