### PR TITLE
[#1530][#1535] feat: SAGA JPA 엔티티 및 Repository 추가

### DIFF
--- a/common/src/main/java/com/personal/marketnote/common/saga/entity/SagaInstanceJpaEntity.java
+++ b/common/src/main/java/com/personal/marketnote/common/saga/entity/SagaInstanceJpaEntity.java
@@ -1,0 +1,91 @@
+package com.personal.marketnote.common.saga.entity;
+
+import com.personal.marketnote.common.saga.SagaStatus;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+
+@Entity
+@Table(
+        name = "saga_instance",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_saga_instance_saga_id",
+                columnNames = {"saga_id"}
+        ),
+        indexes = @Index(
+                name = "idx_saga_instance_type_status",
+                columnList = "saga_type, status"
+        )
+)
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class SagaInstanceJpaEntity {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @Column(name = "saga_id", nullable = false, length = 100)
+    private String sagaId;
+
+    @Column(name = "saga_type", nullable = false, length = 100)
+    private String sagaType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private SagaStatus status;
+
+    @Column(name = "current_step_index", nullable = false)
+    private int currentStepIndex;
+
+    @Column(name = "payload", columnDefinition = "TEXT")
+    private String payload;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "modified_at")
+    private LocalDateTime modifiedAt;
+
+    @Column(name = "completed_at")
+    private LocalDateTime completedAt;
+
+    private SagaInstanceJpaEntity(String sagaId, String sagaType, SagaStatus status,
+                                   int currentStepIndex, String payload) {
+        this.sagaId = sagaId;
+        this.sagaType = sagaType;
+        this.status = status;
+        this.currentStepIndex = currentStepIndex;
+        this.payload = payload;
+    }
+
+    public static SagaInstanceJpaEntity from(com.personal.marketnote.common.saga.SagaInstance instance) {
+        SagaInstanceJpaEntity entity = new SagaInstanceJpaEntity(
+                instance.getSagaId(),
+                instance.getSagaType(),
+                instance.getStatus(),
+                instance.getCurrentStepIndex(),
+                instance.getPayload()
+        );
+        entity.completedAt = instance.getCompletedAt();
+        return entity;
+    }
+
+    public void updateFrom(com.personal.marketnote.common.saga.SagaInstance instance) {
+        this.status = instance.getStatus();
+        this.currentStepIndex = instance.getCurrentStepIndex();
+        this.completedAt = instance.getCompletedAt();
+    }
+}

--- a/common/src/main/java/com/personal/marketnote/common/saga/entity/SagaStepJpaEntity.java
+++ b/common/src/main/java/com/personal/marketnote/common/saga/entity/SagaStepJpaEntity.java
@@ -1,0 +1,92 @@
+package com.personal.marketnote.common.saga.entity;
+
+import com.personal.marketnote.common.saga.SagaStepStatus;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+
+@Entity
+@Table(
+        name = "saga_step",
+        indexes = @Index(
+                name = "idx_saga_step_instance_id_index",
+                columnList = "saga_instance_id, step_index"
+        )
+)
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class SagaStepJpaEntity {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @Column(name = "saga_instance_id", nullable = false)
+    private Long sagaInstanceId;
+
+    @Column(name = "step_name", nullable = false, length = 100)
+    private String stepName;
+
+    @Column(name = "step_index", nullable = false)
+    private int stepIndex;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private SagaStepStatus status;
+
+    @Column(name = "request", nullable = false, columnDefinition = "TEXT")
+    private String request;
+
+    @Column(name = "response", columnDefinition = "TEXT")
+    private String response;
+
+    @Column(name = "compensation_request", columnDefinition = "TEXT")
+    private String compensationRequest;
+
+    @Column(name = "compensation_response", columnDefinition = "TEXT")
+    private String compensationResponse;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "modified_at")
+    private LocalDateTime modifiedAt;
+
+    private SagaStepJpaEntity(Long sagaInstanceId, String stepName, int stepIndex,
+                               SagaStepStatus status, String request) {
+        this.sagaInstanceId = sagaInstanceId;
+        this.stepName = stepName;
+        this.stepIndex = stepIndex;
+        this.status = status;
+        this.request = request;
+    }
+
+    public static SagaStepJpaEntity from(com.personal.marketnote.common.saga.SagaStep step) {
+        return new SagaStepJpaEntity(
+                step.getSagaInstanceId(),
+                step.getStepName(),
+                step.getStepIndex(),
+                step.getStatus(),
+                step.getRequest()
+        );
+    }
+
+    public void updateFrom(com.personal.marketnote.common.saga.SagaStep step) {
+        this.status = step.getStatus();
+        this.response = step.getResponse();
+        this.compensationRequest = step.getCompensationRequest();
+        this.compensationResponse = step.getCompensationResponse();
+    }
+}

--- a/common/src/main/java/com/personal/marketnote/common/saga/repository/SagaInstanceJpaRepository.java
+++ b/common/src/main/java/com/personal/marketnote/common/saga/repository/SagaInstanceJpaRepository.java
@@ -1,0 +1,15 @@
+package com.personal.marketnote.common.saga.repository;
+
+import com.personal.marketnote.common.saga.SagaStatus;
+import com.personal.marketnote.common.saga.entity.SagaInstanceJpaEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface SagaInstanceJpaRepository extends JpaRepository<SagaInstanceJpaEntity, Long> {
+
+    Optional<SagaInstanceJpaEntity> findBySagaId(String sagaId);
+
+    List<SagaInstanceJpaEntity> findBySagaTypeAndStatus(String sagaType, SagaStatus status);
+}

--- a/common/src/main/java/com/personal/marketnote/common/saga/repository/SagaStepJpaRepository.java
+++ b/common/src/main/java/com/personal/marketnote/common/saga/repository/SagaStepJpaRepository.java
@@ -1,0 +1,11 @@
+package com.personal.marketnote.common.saga.repository;
+
+import com.personal.marketnote.common.saga.entity.SagaStepJpaEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface SagaStepJpaRepository extends JpaRepository<SagaStepJpaEntity, Long> {
+
+    List<SagaStepJpaEntity> findBySagaInstanceIdOrderByStepIndexAsc(Long sagaInstanceId);
+}


### PR DESCRIPTION
## partially addresses #1530
## resolves #1535

## Task
- [x] SagaInstanceJpaEntity 추가 (saga_instance 테이블, UK(saga_id), IDX(saga_type, status))
- [x] SagaStepJpaEntity 추가 (saga_step 테이블, IDX(saga_instance_id, step_index))
- [x] SagaInstanceJpaRepository 추가 (findBySagaId, findBySagaTypeAndStatus)
- [x] SagaStepJpaRepository 추가 (findBySagaInstanceIdOrderByStepIndexAsc)