### PR TITLE
[#1530][#1536] feat: SAGA Port 및 PersistenceAdapter 추가

### DIFF
--- a/common/src/main/java/com/personal/marketnote/common/saga/adapter/SagaPersistenceAdapter.java
+++ b/common/src/main/java/com/personal/marketnote/common/saga/adapter/SagaPersistenceAdapter.java
@@ -1,0 +1,69 @@
+package com.personal.marketnote.common.saga.adapter;
+
+import com.personal.marketnote.common.adapter.out.PersistenceAdapter;
+import com.personal.marketnote.common.saga.SagaInstance;
+import com.personal.marketnote.common.saga.SagaStep;
+import com.personal.marketnote.common.saga.entity.SagaInstanceJpaEntity;
+import com.personal.marketnote.common.saga.entity.SagaStepJpaEntity;
+import com.personal.marketnote.common.saga.exception.SagaInstanceNotFoundException;
+import com.personal.marketnote.common.saga.exception.SagaStepNotFoundException;
+import com.personal.marketnote.common.saga.mapper.SagaInstanceJpaEntityToDomainMapper;
+import com.personal.marketnote.common.saga.mapper.SagaStepJpaEntityToDomainMapper;
+import com.personal.marketnote.common.saga.port.FindSagaPort;
+import com.personal.marketnote.common.saga.port.SaveSagaPort;
+import com.personal.marketnote.common.saga.port.UpdateSagaPort;
+import com.personal.marketnote.common.saga.repository.SagaInstanceJpaRepository;
+import com.personal.marketnote.common.saga.repository.SagaStepJpaRepository;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+import java.util.Optional;
+
+@PersistenceAdapter
+@RequiredArgsConstructor
+public class SagaPersistenceAdapter implements SaveSagaPort, FindSagaPort, UpdateSagaPort {
+
+    private final SagaInstanceJpaRepository sagaInstanceJpaRepository;
+    private final SagaStepJpaRepository sagaStepJpaRepository;
+
+    @Override
+    public SagaInstance save(SagaInstance instance) {
+        SagaInstanceJpaEntity entity = SagaInstanceJpaEntity.from(instance);
+        SagaInstanceJpaEntity saved = sagaInstanceJpaRepository.save(entity);
+        return SagaInstanceJpaEntityToDomainMapper.toDomain(saved);
+    }
+
+    @Override
+    public SagaStep saveStep(SagaStep step) {
+        SagaStepJpaEntity entity = SagaStepJpaEntity.from(step);
+        SagaStepJpaEntity saved = sagaStepJpaRepository.save(entity);
+        return SagaStepJpaEntityToDomainMapper.toDomain(saved);
+    }
+
+    @Override
+    public Optional<SagaInstance> findBySagaId(String sagaId) {
+        return sagaInstanceJpaRepository.findBySagaId(sagaId)
+                .map(SagaInstanceJpaEntityToDomainMapper::toDomain);
+    }
+
+    @Override
+    public List<SagaStep> findStepsBySagaInstanceId(Long sagaInstanceId) {
+        List<SagaStepJpaEntity> entities = sagaStepJpaRepository
+                .findBySagaInstanceIdOrderByStepIndexAsc(sagaInstanceId);
+        return SagaStepJpaEntityToDomainMapper.toDomainList(entities);
+    }
+
+    @Override
+    public void update(SagaInstance instance) {
+        SagaInstanceJpaEntity entity = sagaInstanceJpaRepository.findById(instance.getId())
+                .orElseThrow(() -> new SagaInstanceNotFoundException(instance.getId()));
+        entity.updateFrom(instance);
+    }
+
+    @Override
+    public void updateStep(SagaStep step) {
+        SagaStepJpaEntity entity = sagaStepJpaRepository.findById(step.getId())
+                .orElseThrow(() -> new SagaStepNotFoundException(step.getId()));
+        entity.updateFrom(step);
+    }
+}

--- a/common/src/main/java/com/personal/marketnote/common/saga/exception/SagaInstanceNotFoundException.java
+++ b/common/src/main/java/com/personal/marketnote/common/saga/exception/SagaInstanceNotFoundException.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.common.saga.exception;
+
+public class SagaInstanceNotFoundException extends RuntimeException {
+    public SagaInstanceNotFoundException(Long id) {
+        super("SagaInstance를 찾을 수 없습니다. id: " + id);
+    }
+}

--- a/common/src/main/java/com/personal/marketnote/common/saga/exception/SagaStepNotFoundException.java
+++ b/common/src/main/java/com/personal/marketnote/common/saga/exception/SagaStepNotFoundException.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.common.saga.exception;
+
+public class SagaStepNotFoundException extends RuntimeException {
+    public SagaStepNotFoundException(Long id) {
+        super("SagaStep을 찾을 수 없습니다. id: " + id);
+    }
+}

--- a/common/src/main/java/com/personal/marketnote/common/saga/mapper/SagaInstanceJpaEntityToDomainMapper.java
+++ b/common/src/main/java/com/personal/marketnote/common/saga/mapper/SagaInstanceJpaEntityToDomainMapper.java
@@ -1,0 +1,22 @@
+package com.personal.marketnote.common.saga.mapper;
+
+import com.personal.marketnote.common.saga.SagaInstance;
+import com.personal.marketnote.common.saga.SagaInstanceSnapshotState;
+import com.personal.marketnote.common.saga.entity.SagaInstanceJpaEntity;
+
+public class SagaInstanceJpaEntityToDomainMapper {
+
+    public static SagaInstance toDomain(SagaInstanceJpaEntity entity) {
+        return SagaInstance.from(new SagaInstanceSnapshotState(
+                entity.getId(),
+                entity.getSagaId(),
+                entity.getSagaType(),
+                entity.getStatus(),
+                entity.getCurrentStepIndex(),
+                entity.getPayload(),
+                entity.getCreatedAt(),
+                entity.getModifiedAt(),
+                entity.getCompletedAt()
+        ));
+    }
+}

--- a/common/src/main/java/com/personal/marketnote/common/saga/mapper/SagaStepJpaEntityToDomainMapper.java
+++ b/common/src/main/java/com/personal/marketnote/common/saga/mapper/SagaStepJpaEntityToDomainMapper.java
@@ -1,0 +1,32 @@
+package com.personal.marketnote.common.saga.mapper;
+
+import com.personal.marketnote.common.saga.SagaStep;
+import com.personal.marketnote.common.saga.SagaStepSnapshotState;
+import com.personal.marketnote.common.saga.entity.SagaStepJpaEntity;
+
+import java.util.List;
+
+public class SagaStepJpaEntityToDomainMapper {
+
+    public static SagaStep toDomain(SagaStepJpaEntity entity) {
+        return SagaStep.from(new SagaStepSnapshotState(
+                entity.getId(),
+                entity.getSagaInstanceId(),
+                entity.getStepName(),
+                entity.getStepIndex(),
+                entity.getStatus(),
+                entity.getRequest(),
+                entity.getResponse(),
+                entity.getCompensationRequest(),
+                entity.getCompensationResponse(),
+                entity.getCreatedAt(),
+                entity.getModifiedAt()
+        ));
+    }
+
+    public static List<SagaStep> toDomainList(List<SagaStepJpaEntity> entities) {
+        return entities.stream()
+                .map(SagaStepJpaEntityToDomainMapper::toDomain)
+                .toList();
+    }
+}

--- a/common/src/main/java/com/personal/marketnote/common/saga/port/FindSagaPort.java
+++ b/common/src/main/java/com/personal/marketnote/common/saga/port/FindSagaPort.java
@@ -1,0 +1,14 @@
+package com.personal.marketnote.common.saga.port;
+
+import com.personal.marketnote.common.saga.SagaInstance;
+import com.personal.marketnote.common.saga.SagaStep;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface FindSagaPort {
+
+    Optional<SagaInstance> findBySagaId(String sagaId);
+
+    List<SagaStep> findStepsBySagaInstanceId(Long sagaInstanceId);
+}

--- a/common/src/main/java/com/personal/marketnote/common/saga/port/SaveSagaPort.java
+++ b/common/src/main/java/com/personal/marketnote/common/saga/port/SaveSagaPort.java
@@ -1,0 +1,11 @@
+package com.personal.marketnote.common.saga.port;
+
+import com.personal.marketnote.common.saga.SagaInstance;
+import com.personal.marketnote.common.saga.SagaStep;
+
+public interface SaveSagaPort {
+
+    SagaInstance save(SagaInstance instance);
+
+    SagaStep saveStep(SagaStep step);
+}

--- a/common/src/main/java/com/personal/marketnote/common/saga/port/UpdateSagaPort.java
+++ b/common/src/main/java/com/personal/marketnote/common/saga/port/UpdateSagaPort.java
@@ -1,0 +1,11 @@
+package com.personal.marketnote.common.saga.port;
+
+import com.personal.marketnote.common.saga.SagaInstance;
+import com.personal.marketnote.common.saga.SagaStep;
+
+public interface UpdateSagaPort {
+
+    void update(SagaInstance instance);
+
+    void updateStep(SagaStep step);
+}


### PR DESCRIPTION
## partially addresses #1530
## resolves #1536

## Task
- [x] SaveSagaPort 인터페이스 추가 (save, saveStep)
- [x] FindSagaPort 인터페이스 추가 (findBySagaId, findStepsBySagaInstanceId)
- [x] UpdateSagaPort 인터페이스 추가 (update, updateStep)
- [x] SagaInstanceJpaEntityToDomainMapper 추가 (JpaEntity → SnapshotState → Domain)
- [x] SagaStepJpaEntityToDomainMapper 추가 (toDomain, toDomainList)
- [x] SagaPersistenceAdapter 추가 (SaveSagaPort, FindSagaPort, UpdateSagaPort 구현)
- [x] SagaInstanceNotFoundException, SagaStepNotFoundException 커스텀 예외 추가