### PR TITLE
[#1530][#1538] feat: SAGA SagaResponseConsumer 기능 추가

### DIFF
--- a/common/src/main/java/com/personal/marketnote/common/kafka/KafkaTopicConstants.java
+++ b/common/src/main/java/com/personal/marketnote/common/kafka/KafkaTopicConstants.java
@@ -25,6 +25,9 @@ public final class KafkaTopicConstants {
     // Community 이벤트
     public static final String REVIEW_REGISTERED = "community.review.registered";
 
+    // SAGA 응답
+    public static final String SAGA_RESPONSE = "saga.response";
+
     // Dead Letter Topic 접미사
     public static final String DLT_SUFFIX = ".dlt";
 }

--- a/common/src/main/java/com/personal/marketnote/common/saga/SagaResponseConsumer.java
+++ b/common/src/main/java/com/personal/marketnote/common/saga/SagaResponseConsumer.java
@@ -1,0 +1,68 @@
+package com.personal.marketnote.common.saga;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.common.kafka.KafkaTopicConstants;
+import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.EventPayloadValidator;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SagaResponseConsumer {
+
+    private final SagaOrchestrator sagaOrchestrator;
+    private final ObjectMapper objectMapper;
+
+    @KafkaListener(
+            topics = KafkaTopicConstants.SAGA_RESPONSE,
+            groupId = "saga-orchestrator"
+    )
+    public void handleSagaResponse(
+            ConsumerRecord<String, EventEnvelope<?>> record,
+            Acknowledgment acknowledgment
+    ) {
+        EventEnvelope<?> envelope = record.value();
+
+        if (EventPayloadValidator.hasInvalidEnvelope(envelope, record)) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        if (EventPayloadValidator.hasEventTypeMismatch(envelope, KafkaTopicConstants.SAGA_RESPONSE)) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        SagaResponseMessage responseMessage = envelope.getPayloadAs(SagaResponseMessage.class, objectMapper);
+
+        log.info("SAGA 응답 수신. eventId={}, sagaId={}, sagaType={}, stepName={}, messageType={}, success={}",
+                envelope.eventId(), responseMessage.sagaId(), responseMessage.sagaType(),
+                responseMessage.stepName(), responseMessage.messageType(), responseMessage.success());
+
+        if (responseMessage.isAction()) {
+            sagaOrchestrator.handleStepResponse(
+                    responseMessage.sagaId(), responseMessage.stepName(),
+                    responseMessage.success(), responseMessage.response());
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        if (responseMessage.isCompensation()) {
+            sagaOrchestrator.handleCompensationResponse(
+                    responseMessage.sagaId(), responseMessage.stepName(),
+                    responseMessage.success(), responseMessage.response());
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        log.warn("알 수 없는 messageType. eventId={}, sagaId={}, messageType={}",
+                envelope.eventId(), responseMessage.sagaId(), responseMessage.messageType());
+        acknowledgment.acknowledge();
+    }
+}

--- a/common/src/main/java/com/personal/marketnote/common/saga/SagaResponseMessage.java
+++ b/common/src/main/java/com/personal/marketnote/common/saga/SagaResponseMessage.java
@@ -1,0 +1,18 @@
+package com.personal.marketnote.common.saga;
+
+public record SagaResponseMessage(
+        String sagaId,
+        String sagaType,
+        String stepName,
+        String messageType,
+        boolean success,
+        String response
+) {
+    public boolean isAction() {
+        return SagaStepMessage.ACTION.equals(messageType);
+    }
+
+    public boolean isCompensation() {
+        return SagaStepMessage.COMPENSATION.equals(messageType);
+    }
+}


### PR DESCRIPTION
## partially addresses #1530
## resolves #1538

## Task
- [x] SagaResponseMessage record 생성 (sagaId, sagaType, stepName, messageType, success, response)
- [x] SagaResponseConsumer Kafka 컨슈머 구현 (saga.response 토픽, ACTION/COMPENSATION 라우팅)
- [x] KafkaTopicConstants에 SAGA_RESPONSE 상수 추가