### PR TITLE
[#128][#1566] fix: 상품 목록 조회 시 Pageable Sort 엔티티 필드 미매칭으로 정렬 실패하는 버그 픽스

### DIFF
--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/pricepolicy/PricePolicyPersistenceAdapter.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/pricepolicy/PricePolicyPersistenceAdapter.java
@@ -157,23 +157,19 @@ public class PricePolicyPersistenceAdapter implements SavePricePolicyPort, FindP
     @Override
     @Cacheable(
             value = "pricePolicy:list:first",
-            key = "#pageable.getPageSize() + ':' + #sortProperty.name() + ':' + #searchTarget.name()",
+            key = "#pageSize + ':' + #isAsc + ':' + #sortProperty.name() + ':' + #searchTarget.name()",
             condition = "#cursor == null && (#searchKeyword == null || #searchKeyword.isBlank())"
     )
     public List<PricePolicy> findPricePolicies(
             List<Long> pricePolicyIds,
             Long cursor,
-            Pageable pageable,
+            int pageSize,
+            boolean isAsc,
             ProductSortProperty sortProperty,
             ProductSearchTarget searchTarget,
             String searchKeyword
     ) {
-        boolean isAsc = pageable.getSort()
-                .stream()
-                .findFirst()
-                .map(Sort.Order::isAscending)
-                .orElse(true);
-
+        Pageable pageable = PageRequest.of(0, pageSize);
         String pattern = generateSearchPattern(searchKeyword);
 
         List<PricePolicyJpaEntity> entities = isAsc
@@ -208,24 +204,20 @@ public class PricePolicyPersistenceAdapter implements SavePricePolicyPort, FindP
     @Override
     @Cacheable(
             value = "pricePolicy:list:first",
-            key = "#categoryId + ':' + #pageable.getPageSize() + ':' + #sortProperty.name() + ':' + #searchTarget.name()",
+            key = "#categoryId + ':' + #pageSize + ':' + #isAsc + ':' + #sortProperty.name() + ':' + #searchTarget.name()",
             condition = "#cursor == null && (#searchKeyword == null || #searchKeyword.isBlank())"
     )
     public List<PricePolicy> findPricePoliciesByCategoryId(
             Long categoryId,
             List<Long> pricePolicyIds,
             Long cursor,
-            Pageable pageable,
+            int pageSize,
+            boolean isAsc,
             ProductSortProperty sortProperty,
             ProductSearchTarget searchTarget,
             String searchKeyword
     ) {
-        boolean isAsc = pageable.getSort()
-                .stream()
-                .findFirst()
-                .map(Sort.Order::isAscending)
-                .orElse(true);
-
+        Pageable pageable = PageRequest.of(0, pageSize);
         String pattern = generateSearchPattern(searchKeyword);
 
         List<PricePolicyJpaEntity> entities = isAsc

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/out/pricepolicy/FindPricePoliciesPort.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/out/pricepolicy/FindPricePoliciesPort.java
@@ -3,7 +3,6 @@ package com.personal.marketnote.product.port.out.pricepolicy;
 import com.personal.marketnote.product.domain.pricepolicy.PricePolicy;
 import com.personal.marketnote.product.domain.product.ProductSearchTarget;
 import com.personal.marketnote.product.domain.product.ProductSortProperty;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 
 import java.util.List;
@@ -37,7 +36,8 @@ public interface FindPricePoliciesPort {
     /**
      * @param pricePolicyIds 가격 정책 ID 목록
      * @param cursor         커서
-     * @param pageable       페이지네이션 정보
+     * @param pageSize       페이지 크기
+     * @param isAsc          오름차순 여부
      * @param sortProperty   정렬 속성
      * @param searchTarget   검색 대상
      * @param searchKeyword  검색 키워드
@@ -49,7 +49,8 @@ public interface FindPricePoliciesPort {
     List<PricePolicy> findPricePolicies(
             List<Long> pricePolicyIds,
             Long cursor,
-            Pageable pageable,
+            int pageSize,
+            boolean isAsc,
             ProductSortProperty sortProperty,
             ProductSearchTarget searchTarget,
             String searchKeyword
@@ -59,7 +60,8 @@ public interface FindPricePoliciesPort {
      * @param categoryId     카테고리 ID
      * @param pricePolicyIds 가격 정책 ID 목록
      * @param cursor         커서
-     * @param pageable       페이지네이션 정보
+     * @param pageSize       페이지 크기
+     * @param isAsc          오름차순 여부
      * @param sortProperty   정렬 속성
      * @param searchTarget   검색 대상
      * @param searchKeyword  검색 키워드
@@ -72,7 +74,8 @@ public interface FindPricePoliciesPort {
             Long categoryId,
             List<Long> pricePolicyIds,
             Long cursor,
-            Pageable pageable,
+            int pageSize,
+            boolean isAsc,
             ProductSortProperty sortProperty,
             ProductSearchTarget searchTarget,
             String searchKeyword

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/service/product/GetProductService.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/service/product/GetProductService.java
@@ -29,8 +29,6 @@ import com.personal.marketnote.product.port.out.review.FindProductReviewAggregat
 import com.personal.marketnote.product.port.out.shipping.FindShippingPolicyPort;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -177,11 +175,7 @@ public class GetProductService implements GetProductUseCase {
             String searchKeyword
     ) {
         boolean isFirstPage = FormatValidator.equals(cursor, FIRST_PAGE_CURSOR_VALUE);
-
-        Pageable pageable = PageRequest.of(
-                0, pageSize + 1, Sort.by(sortDirection, sortProperty.getCamelCaseValue())
-        );
-
+        boolean isAsc = sortDirection.isAscending();
         boolean isCategorized = FormatValidator.hasValue(categoryId);
 
         List<PricePolicy> pricePolicies = isCategorized
@@ -189,7 +183,8 @@ public class GetProductService implements GetProductUseCase {
                 categoryId,
                 pricePolicyIds,
                 cursor,
-                pageable,
+                pageSize + 1,
+                isAsc,
                 sortProperty,
                 searchTarget,
                 searchKeyword
@@ -197,7 +192,8 @@ public class GetProductService implements GetProductUseCase {
                 : findPricePoliciesPort.findPricePolicies(
                 pricePolicyIds,
                 cursor,
-                pageable,
+                pageSize + 1,
+                isAsc,
                 sortProperty,
                 searchTarget,
                 searchKeyword

--- a/product-service/product-application/src/test/java/com/personal/marketnote/product/service/product/GetProductUseCaseTest.java
+++ b/product-service/product-application/src/test/java/com/personal/marketnote/product/service/product/GetProductUseCaseTest.java
@@ -312,7 +312,7 @@ class GetProductUseCaseTest {
         PricePolicy policy3 = buildPricePolicy(300L, product3, null, List.of());
 
         when(findPricePoliciesPort.findPricePolicies(
-                any(), any(), any(), any(), any(), any()
+                any(), any(), anyInt(), anyBoolean(), any(), any(), any()
         )).thenReturn(List.of(policy1, policy2, policy3));
 
         when(findProductPort.findById(10L)).thenReturn(Optional.of(product1));
@@ -375,7 +375,7 @@ class GetProductUseCaseTest {
         PricePolicy policy = buildPricePolicy(400L, product, null, List.of());
 
         when(findPricePoliciesPort.findPricePoliciesByCategoryId(
-                eq(5L), any(), any(), any(), any(), any(), any()
+                eq(5L), any(), any(), anyInt(), anyBoolean(), any(), any(), any()
         )).thenReturn(List.of(policy));
         when(findProductPort.findById(40L)).thenReturn(Optional.of(product));
         when(findProductImagesPort.findImagesByProductIdAndSort(anyLong(), eq(FileSort.PRODUCT_CATALOG_IMAGE)))
@@ -410,7 +410,7 @@ class GetProductUseCaseTest {
         PricePolicy policy = buildPricePolicy(500L, product, null, List.of());
 
         when(findPricePoliciesPort.findPricePolicies(
-                any(), any(), any(), any(), any(), any()
+                any(), any(), anyInt(), anyBoolean(), any(), any(), any()
         )).thenReturn(List.of(policy));
         when(findProductPort.findById(50L)).thenReturn(Optional.of(product));
         when(findProductImagesPort.findImagesByProductIdAndSort(anyLong(), eq(FileSort.PRODUCT_CATALOG_IMAGE)))
@@ -446,7 +446,7 @@ class GetProductUseCaseTest {
         PricePolicy policy = buildPricePolicy(600L, product, List.of(301L, 302L), List.of());
 
         when(findPricePoliciesPort.findPricePolicies(
-                any(), any(), any(), any(), any(), any()
+                any(), any(), anyInt(), anyBoolean(), any(), any(), any()
         )).thenReturn(List.of(policy));
         when(findProductPort.findById(60L)).thenReturn(Optional.of(product));
         when(findProductOptionCategoryPort.findActiveWithOptionsByProductId(60L))
@@ -480,7 +480,7 @@ class GetProductUseCaseTest {
     @DisplayName("상품 목록 조회 결과가 없으면 빈 결과를 반환한다")
     void getProducts_emptyResult_returnsEmpty() {
         when(findPricePoliciesPort.findPricePolicies(
-                any(), any(), any(), any(), any(), any()
+                any(), any(), anyInt(), anyBoolean(), any(), any(), any()
         )).thenReturn(List.of());
         when(getProductInventoryUseCase.getProductStocks(List.of()))
                 .thenReturn(Map.of());
@@ -516,7 +516,7 @@ class GetProductUseCaseTest {
         PricePolicy policy2 = buildPricePolicy(702L, product, null, List.of());
 
         when(findPricePoliciesPort.findPricePoliciesByCategoryId(
-                eq(categoryId), any(), any(), any(), any(), any(), any()
+                eq(categoryId), any(), any(), anyInt(), anyBoolean(), any(), any(), any()
         )).thenReturn(List.of(policy1, policy2));
         when(findProductPort.findById(70L)).thenReturn(Optional.of(product));
         when(getProductInventoryUseCase.getProductStocks(List.of(701L)))
@@ -552,7 +552,7 @@ class GetProductUseCaseTest {
         PricePolicy policy = buildPricePolicy(801L, product, List.of(), List.of());
 
         when(findPricePoliciesPort.findPricePolicies(
-                any(), any(), any(), any(), any(), any()
+                any(), any(), anyInt(), anyBoolean(), any(), any(), any()
         )).thenReturn(List.of(policy));
         when(findProductPort.findById(80L)).thenReturn(Optional.of(product));
         when(getProductInventoryUseCase.getProductStocks(List.of(801L)))
@@ -584,7 +584,7 @@ class GetProductUseCaseTest {
         PricePolicy policy = buildPricePolicy(901L, product, List.of(1L), List.of());
 
         when(findPricePoliciesPort.findPricePolicies(
-                any(), any(), any(), any(), any(), any()
+                any(), any(), anyInt(), anyBoolean(), any(), any(), any()
         )).thenReturn(List.of(policy));
         when(findProductPort.findById(90L)).thenReturn(Optional.of(product));
         when(findProductOptionCategoryPort.findActiveWithOptionsByProductId(90L))
@@ -617,7 +617,7 @@ class GetProductUseCaseTest {
         PricePolicy policy = buildPricePolicy(1001L, product, null, List.of());
 
         when(findPricePoliciesPort.findPricePolicies(
-                any(), any(), any(), any(), any(), any()
+                any(), any(), anyInt(), anyBoolean(), any(), any(), any()
         )).thenReturn(List.of(policy));
         when(findProductPort.findById(100L)).thenReturn(Optional.empty());
 
@@ -645,7 +645,7 @@ class GetProductUseCaseTest {
         PricePolicy cachedPolicy = buildPricePolicyWithProductIdOnly(100L, 10L);
 
         when(findPricePoliciesPort.findPricePolicies(
-                any(), any(), any(), any(), any(), any()
+                any(), any(), anyInt(), anyBoolean(), any(), any(), any()
         )).thenReturn(List.of(cachedPolicy));
         when(findProductPort.findById(10L)).thenReturn(Optional.of(product));
         when(getProductInventoryUseCase.getProductStocks(List.of(100L)))
@@ -682,7 +682,7 @@ class GetProductUseCaseTest {
         PricePolicy policy3 = buildPricePolicy(1401L, product3, null, List.of());
 
         when(findPricePoliciesPort.findPricePolicies(
-                any(), any(), any(), any(), any(), any()
+                any(), any(), anyInt(), anyBoolean(), any(), any(), any()
         )).thenReturn(List.of(policy1, policy2, policy3));
 
         when(findProductPort.findById(120L)).thenReturn(Optional.of(product1));
@@ -718,7 +718,7 @@ class GetProductUseCaseTest {
         assertThat(result.products()).hasSize(2);
 
         verify(findPricePoliciesPort).findPricePolicies(
-                isNull(), eq(-1L), any(), eq(ProductSortProperty.ACCUMULATED_POINT_RATE), any(), isNull()
+                isNull(), eq(-1L), anyInt(), anyBoolean(), eq(ProductSortProperty.ACCUMULATED_POINT_RATE), any(), isNull()
         );
     }
 
@@ -730,7 +730,7 @@ class GetProductUseCaseTest {
         PricePolicy policy = buildPricePolicy(1501L, product, null, List.of());
 
         when(findPricePoliciesPort.findPricePolicies(
-                any(), any(), any(), any(), any(), any()
+                any(), any(), anyInt(), anyBoolean(), any(), any(), any()
         )).thenReturn(List.of(policy));
 
         when(findProductPort.findById(150L)).thenReturn(Optional.of(product));
@@ -760,7 +760,7 @@ class GetProductUseCaseTest {
         assertThat(result.hasNext()).isFalse();
 
         verify(findPricePoliciesPort).findPricePolicies(
-                isNull(), eq(-1L), any(), eq(ProductSortProperty.ACCUMULATED_POINT_RATE), any(), isNull()
+                isNull(), eq(-1L), anyInt(), anyBoolean(), eq(ProductSortProperty.ACCUMULATED_POINT_RATE), any(), isNull()
         );
     }
 
@@ -773,7 +773,7 @@ class GetProductUseCaseTest {
         PricePolicy policy = buildPricePolicy(1601L, product, null, List.of());
 
         when(findPricePoliciesPort.findPricePoliciesByCategoryId(
-                eq(categoryId), any(), any(), any(), any(), any(), any()
+                eq(categoryId), any(), any(), anyInt(), anyBoolean(), any(), any(), any()
         )).thenReturn(List.of(policy));
 
         when(findProductPort.findById(160L)).thenReturn(Optional.of(product));
@@ -803,9 +803,9 @@ class GetProductUseCaseTest {
         assertThat(result.products()).hasSize(1);
 
         verify(findPricePoliciesPort).findPricePoliciesByCategoryId(
-                eq(categoryId), isNull(), eq(-1L), any(), eq(ProductSortProperty.ACCUMULATED_POINT_RATE), any(), isNull()
+                eq(categoryId), isNull(), eq(-1L), anyInt(), anyBoolean(), eq(ProductSortProperty.ACCUMULATED_POINT_RATE), any(), isNull()
         );
-        verify(findPricePoliciesPort, never()).findPricePolicies(any(), any(), any(), any(), any(), any());
+        verify(findPricePoliciesPort, never()).findPricePolicies(any(), any(), anyInt(), anyBoolean(), any(), any(), any());
     }
 
     @Test
@@ -816,7 +816,7 @@ class GetProductUseCaseTest {
         PricePolicy policy = buildPricePolicy(1701L, product, null, List.of());
 
         when(findPricePoliciesPort.findPricePolicies(
-                any(), any(), any(), any(), any(), any()
+                any(), any(), anyInt(), anyBoolean(), any(), any(), any()
         )).thenReturn(List.of(policy));
 
         when(findProductPort.findById(170L)).thenReturn(Optional.of(product));
@@ -854,7 +854,7 @@ class GetProductUseCaseTest {
         PricePolicy policy = buildPricePolicy(1101L, product, null, List.of());
 
         when(findPricePoliciesPort.findPricePolicies(
-                any(), any(), any(), any(), any(), any()
+                any(), any(), anyInt(), anyBoolean(), any(), any(), any()
         )).thenReturn(List.of(policy));
         when(findProductPort.findById(110L)).thenReturn(Optional.of(product));
         when(getProductInventoryUseCase.getProductStocks(List.of(1101L)))


### PR DESCRIPTION
## partially addresses #128
## resolves #1566

## Reason
GetProductService에서 PageRequest.of(0, pageSize + 1, Sort.by(sortDirection, sortProperty.getCamelCaseValue()))로 Pageable을 생성하여 Port를 통해 Adapter까지 전달했다. ACCUMULATED_POINT_RATE의 camelCaseValue는 accumulatedPointRate이지만 PricePolicyJpaEntity의 실제 필드는 accumulationRate이다. Spring Data JPA가 Pageable의 Sort를 JPQL ORDER BY 뒤에 자동 추가하면서 존재하지 않는 필드를 참조하여 UnknownPathException이 발생

## Action
- [x] FindPricePoliciesPort 인터페이스에서 Pageable을 int pageSize + boolean isAsc로 분리
- [x] PricePolicyPersistenceAdapter에서 Sort 없는 PageRequest.of(0, pageSize) 생성으로 변경
- [x] GetProductService에서 Sort 포함 Pageable 생성 제거, sortDirection.isAscending()으로 boolean 변환하여 Port에 전달
- [x] @Cacheable 키에 isAsc 포함하여 정렬 방향별 캐시 분리
- [x] 기존 테스트 mock 스텁 시그니처 업데이트