### PR TITLE
[#1530][#1540] feat: SAGA Configuration 및 Properties 기능 추가

### DIFF
--- a/commerce-service/commerce-adapters/src/main/resources/application.yml
+++ b/commerce-service/commerce-adapters/src/main/resources/application.yml
@@ -104,6 +104,12 @@ outbox:
   retention-days: ${OUTBOX_RETENTION_DAYS:7}
   cleanup-cron: ${OUTBOX_CLEANUP_CRON:0 0 3 * * ?}
 
+saga:
+  enabled: ${SAGA_ENABLED:false}
+  timeout-ms: ${SAGA_TIMEOUT_MS:60000}
+  compensation-timeout-ms: ${SAGA_COMPENSATION_TIMEOUT_MS:120000}
+  check-interval-ms: ${SAGA_CHECK_INTERVAL_MS:30000}
+
 settlement:
   scheduler:
     enabled: ${SETTLEMENT_SCHEDULER_ENABLED:false}

--- a/common/src/main/java/com/personal/marketnote/common/saga/SagaOrchestrator.java
+++ b/common/src/main/java/com/personal/marketnote/common/saga/SagaOrchestrator.java
@@ -14,6 +14,7 @@ import com.personal.marketnote.common.saga.port.SaveSagaPort;
 import com.personal.marketnote.common.saga.port.UpdateSagaPort;
 import com.personal.marketnote.common.utility.FormatValidator;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,6 +27,7 @@ import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
 @Component
+@ConditionalOnProperty(prefix = "saga", name = "enabled", havingValue = "true")
 @Slf4j
 public class SagaOrchestrator {
 

--- a/common/src/main/java/com/personal/marketnote/common/saga/SagaRepositoryConfiguration.java
+++ b/common/src/main/java/com/personal/marketnote/common/saga/SagaRepositoryConfiguration.java
@@ -1,0 +1,11 @@
+package com.personal.marketnote.common.saga;
+
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+
+@Configuration
+@EnableJpaRepositories(basePackages = "com.personal.marketnote.common.saga.repository")
+@EntityScan(basePackages = "com.personal.marketnote.common.saga.entity")
+public class SagaRepositoryConfiguration {
+}

--- a/common/src/main/java/com/personal/marketnote/common/saga/SagaResponseConsumer.java
+++ b/common/src/main/java/com/personal/marketnote/common/saga/SagaResponseConsumer.java
@@ -7,12 +7,14 @@ import com.personal.marketnote.common.kafka.event.EventPayloadValidator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.stereotype.Component;
 
 @Slf4j
 @Component
+@ConditionalOnProperty(prefix = "saga", name = "enabled", havingValue = "true")
 @RequiredArgsConstructor
 public class SagaResponseConsumer {
 

--- a/common/src/main/java/com/personal/marketnote/common/saga/adapter/SagaPersistenceAdapter.java
+++ b/common/src/main/java/com/personal/marketnote/common/saga/adapter/SagaPersistenceAdapter.java
@@ -16,6 +16,7 @@ import com.personal.marketnote.common.saga.port.UpdateSagaPort;
 import com.personal.marketnote.common.saga.repository.SagaInstanceJpaRepository;
 import com.personal.marketnote.common.saga.repository.SagaStepJpaRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.data.domain.PageRequest;
 
 import java.time.LocalDateTime;
@@ -23,6 +24,7 @@ import java.util.List;
 import java.util.Optional;
 
 @PersistenceAdapter
+@ConditionalOnProperty(prefix = "saga", name = "enabled", havingValue = "true")
 @RequiredArgsConstructor
 public class SagaPersistenceAdapter implements SaveSagaPort, FindSagaPort, UpdateSagaPort {
 


### PR DESCRIPTION
## partially addresses #1530
## resolves #1540

## Task
- [x] SagaRepositoryConfiguration 추가 (JPA repository/entity 스캔)
- [x] SagaOrchestrator @ConditionalOnProperty 추가
- [x] SagaResponseConsumer @ConditionalOnProperty 추가
- [x] SagaPersistenceAdapter @ConditionalOnProperty 추가
- [x] 커머스 서비스 application.yml saga 설정 항목 추가