### PR TITLE
[#1530][#1541] feat: OrderPayment SAGA 정의

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/saga/OrderPaymentCompletedSagaConsumer.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/saga/OrderPaymentCompletedSagaConsumer.java
@@ -1,0 +1,104 @@
+package com.personal.marketnote.commerce.adapter.in.event.saga;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.commerce.adapter.in.event.saga.payload.PaymentCompletedSagaPayload;
+import com.personal.marketnote.commerce.domain.order.OrderProduct;
+import com.personal.marketnote.commerce.port.out.event.PublishOrderEventPort;
+import com.personal.marketnote.common.kafka.KafkaTopicConstants;
+import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.EventPayloadValidator;
+import com.personal.marketnote.common.saga.SagaResponsePublisher;
+import com.personal.marketnote.common.saga.SagaStepMessage;
+import com.personal.marketnote.common.utility.FormatValidator;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Slf4j
+@Component
+@ConditionalOnProperty(prefix = "saga", name = "enabled", havingValue = "true")
+@RequiredArgsConstructor
+public class OrderPaymentCompletedSagaConsumer {
+
+    private final ObjectMapper objectMapper;
+    private final PublishOrderEventPort publishOrderEventPort;
+    private final SagaResponsePublisher sagaResponsePublisher;
+
+    @KafkaListener(
+            topics = KafkaTopicConstants.SAGA_ORDER_PAYMENT_COMPLETED,
+            groupId = "saga-order-payment-completed"
+    )
+    public void handlePaymentCompletedStep(
+            ConsumerRecord<String, EventEnvelope<?>> record,
+            Acknowledgment acknowledgment
+    ) {
+        EventEnvelope<?> envelope = record.value();
+
+        if (EventPayloadValidator.hasInvalidEnvelope(envelope, record)) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        SagaStepMessage stepMessage = envelope.getPayloadAs(SagaStepMessage.class, objectMapper);
+
+        log.info("SAGA 결제 완료 이벤트 발행 스텝 수신. sagaId={}, messageType={}",
+                stepMessage.sagaId(), stepMessage.messageType());
+
+        if (SagaStepMessage.ACTION.equals(stepMessage.messageType())) {
+            handleAction(stepMessage);
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        log.warn("결제 완료 스텝은 보상이 없습니다. sagaId={}, messageType={}",
+                stepMessage.sagaId(), stepMessage.messageType());
+        acknowledgment.acknowledge();
+    }
+
+    private void handleAction(SagaStepMessage stepMessage) {
+        try {
+            PaymentCompletedSagaPayload payload = objectMapper.readValue(
+                    stepMessage.payload(), PaymentCompletedSagaPayload.class);
+
+            if (FormatValidator.hasNoValue(payload.orderId()) || FormatValidator.hasNoValue(payload.buyerId())) {
+                publishValidationFailure(stepMessage, "orderId 또는 buyerId 누락");
+                return;
+            }
+            if (FormatValidator.hasNoValue(payload.orderProducts()) || payload.orderProducts().isEmpty()) {
+                publishValidationFailure(stepMessage, "orderProducts 누락");
+                return;
+            }
+
+            List<OrderProduct> orderProducts = SagaOrderProductMapper.toOrderProducts(payload.orderProducts());
+
+            publishOrderEventPort.publishOrderPaymentCompletedEvent(
+                    payload.orderId(), payload.buyerId(), payload.totalAmount(),
+                    payload.pointAmount(), orderProducts, payload.totalAccumulatedPoint());
+
+            sagaResponsePublisher.publishSuccess(
+                    stepMessage.sagaId(), stepMessage.sagaType(), stepMessage.stepName(),
+                    stepMessage.messageType(), "{\"success\":true}");
+
+            log.info("SAGA 결제 완료 이벤트 발행 성공. sagaId={}, orderId={}", stepMessage.sagaId(), payload.orderId());
+        } catch (Exception e) {
+            log.error("SAGA 결제 완료 이벤트 발행 실패. sagaId={}, error={}",
+                    stepMessage.sagaId(), e.getMessage(), e);
+            sagaResponsePublisher.publishFailure(
+                    stepMessage.sagaId(), stepMessage.sagaType(), stepMessage.stepName(),
+                    stepMessage.messageType(), "결제 완료 이벤트 발행 실패");
+        }
+    }
+
+    private void publishValidationFailure(SagaStepMessage stepMessage, String reason) {
+        log.warn("SAGA 결제 완료 스텝 페이로드 검증 실패. sagaId={}, reason={}", stepMessage.sagaId(), reason);
+        sagaResponsePublisher.publishFailure(
+                stepMessage.sagaId(), stepMessage.sagaType(), stepMessage.stepName(),
+                stepMessage.messageType(), "페이로드 검증 실패: " + reason);
+    }
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/saga/OrderPaymentInventorySagaConsumer.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/saga/OrderPaymentInventorySagaConsumer.java
@@ -1,0 +1,146 @@
+package com.personal.marketnote.commerce.adapter.in.event.saga;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.commerce.adapter.in.event.saga.payload.InventorySagaPayload;
+import com.personal.marketnote.commerce.domain.order.OrderProduct;
+import com.personal.marketnote.commerce.exception.DuplicateInventoryDeductionException;
+import com.personal.marketnote.commerce.port.in.usecase.inventory.ReduceProductInventoryUseCase;
+import com.personal.marketnote.commerce.port.in.usecase.inventory.RestoreProductInventoryUseCase;
+import com.personal.marketnote.common.kafka.KafkaTopicConstants;
+import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.EventPayloadValidator;
+import com.personal.marketnote.common.saga.SagaResponsePublisher;
+import com.personal.marketnote.common.saga.SagaStepMessage;
+import com.personal.marketnote.common.utility.FormatValidator;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Slf4j
+@Component
+@ConditionalOnProperty(prefix = "saga", name = "enabled", havingValue = "true")
+@RequiredArgsConstructor
+public class OrderPaymentInventorySagaConsumer {
+
+    private final ObjectMapper objectMapper;
+    private final ReduceProductInventoryUseCase reduceProductInventoryUseCase;
+    private final RestoreProductInventoryUseCase restoreProductInventoryUseCase;
+    private final SagaResponsePublisher sagaResponsePublisher;
+
+    @KafkaListener(
+            topics = KafkaTopicConstants.SAGA_ORDER_PAYMENT_INVENTORY,
+            groupId = "saga-order-payment-inventory"
+    )
+    public void handleInventoryStep(
+            ConsumerRecord<String, EventEnvelope<?>> record,
+            Acknowledgment acknowledgment
+    ) {
+        EventEnvelope<?> envelope = record.value();
+
+        if (EventPayloadValidator.hasInvalidEnvelope(envelope, record)) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        SagaStepMessage stepMessage = envelope.getPayloadAs(SagaStepMessage.class, objectMapper);
+
+        log.info("SAGA 재고 스텝 수신. sagaId={}, messageType={}",
+                stepMessage.sagaId(), stepMessage.messageType());
+
+        if (SagaStepMessage.ACTION.equals(stepMessage.messageType())) {
+            handleAction(stepMessage);
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        if (SagaStepMessage.COMPENSATION.equals(stepMessage.messageType())) {
+            handleCompensation(stepMessage);
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        log.warn("알 수 없는 messageType. sagaId={}, messageType={}",
+                stepMessage.sagaId(), stepMessage.messageType());
+        acknowledgment.acknowledge();
+    }
+
+    private void handleAction(SagaStepMessage stepMessage) {
+        try {
+            InventorySagaPayload payload = objectMapper.readValue(
+                    stepMessage.payload(), InventorySagaPayload.class);
+
+            if (FormatValidator.hasNoValue(payload.orderId())) {
+                publishValidationFailure(stepMessage, "orderId 누락");
+                return;
+            }
+            if (FormatValidator.hasNoValue(payload.orderProducts()) || payload.orderProducts().isEmpty()) {
+                publishValidationFailure(stepMessage, "orderProducts 누락");
+                return;
+            }
+
+            List<OrderProduct> orderProducts = SagaOrderProductMapper.toOrderProducts(payload.orderProducts());
+
+            reduceProductInventoryUseCase.reduce(orderProducts, payload.orderId(), "SAGA 결제 완료 재고 차감");
+
+            sagaResponsePublisher.publishSuccess(
+                    stepMessage.sagaId(), stepMessage.sagaType(), stepMessage.stepName(),
+                    stepMessage.messageType(), "{\"success\":true}");
+
+            log.info("SAGA 재고 차감 성공. sagaId={}, orderId={}", stepMessage.sagaId(), payload.orderId());
+        } catch (DuplicateInventoryDeductionException e) {
+            log.info("이미 처리된 SAGA 재고 차감 (멱등 처리). sagaId={}", stepMessage.sagaId());
+            sagaResponsePublisher.publishSuccess(
+                    stepMessage.sagaId(), stepMessage.sagaType(), stepMessage.stepName(),
+                    stepMessage.messageType(), "{\"success\":true,\"idempotent\":true}");
+        } catch (Exception e) {
+            log.error("SAGA 재고 차감 실패. sagaId={}, error={}", stepMessage.sagaId(), e.getMessage(), e);
+            sagaResponsePublisher.publishFailure(
+                    stepMessage.sagaId(), stepMessage.sagaType(), stepMessage.stepName(),
+                    stepMessage.messageType(), "재고 차감 처리 실패");
+        }
+    }
+
+    private void handleCompensation(SagaStepMessage stepMessage) {
+        try {
+            InventorySagaPayload payload = objectMapper.readValue(
+                    stepMessage.payload(), InventorySagaPayload.class);
+
+            if (FormatValidator.hasNoValue(payload.orderId())) {
+                publishValidationFailure(stepMessage, "orderId 누락");
+                return;
+            }
+            if (FormatValidator.hasNoValue(payload.orderProducts()) || payload.orderProducts().isEmpty()) {
+                publishValidationFailure(stepMessage, "orderProducts 누락");
+                return;
+            }
+
+            List<OrderProduct> orderProducts = SagaOrderProductMapper.toOrderProducts(payload.orderProducts());
+
+            restoreProductInventoryUseCase.restore(orderProducts, payload.orderId(), "SAGA 보상 - 재고 복구");
+
+            sagaResponsePublisher.publishSuccess(
+                    stepMessage.sagaId(), stepMessage.sagaType(), stepMessage.stepName(),
+                    stepMessage.messageType(), "{\"compensated\":true}");
+
+            log.info("SAGA 재고 복구 완료. sagaId={}, orderId={}", stepMessage.sagaId(), payload.orderId());
+        } catch (Exception e) {
+            log.error("SAGA 재고 복구 실패. sagaId={}, error={}", stepMessage.sagaId(), e.getMessage(), e);
+            sagaResponsePublisher.publishFailure(
+                    stepMessage.sagaId(), stepMessage.sagaType(), stepMessage.stepName(),
+                    stepMessage.messageType(), "재고 복구 처리 실패");
+        }
+    }
+
+    private void publishValidationFailure(SagaStepMessage stepMessage, String reason) {
+        log.warn("SAGA 재고 스텝 페이로드 검증 실패. sagaId={}, reason={}", stepMessage.sagaId(), reason);
+        sagaResponsePublisher.publishFailure(
+                stepMessage.sagaId(), stepMessage.sagaType(), stepMessage.stepName(),
+                stepMessage.messageType(), "페이로드 검증 실패: " + reason);
+    }
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/saga/OrderPaymentLedgerSagaConsumer.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/saga/OrderPaymentLedgerSagaConsumer.java
@@ -1,0 +1,138 @@
+package com.personal.marketnote.commerce.adapter.in.event.saga;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.commerce.adapter.in.event.saga.payload.LedgerActionSagaPayload;
+import com.personal.marketnote.commerce.adapter.in.event.saga.payload.LedgerCompensationSagaPayload;
+import com.personal.marketnote.commerce.exception.DuplicateLedgerTransactionException;
+import com.personal.marketnote.commerce.port.in.usecase.ledger.RecordLedgerEntryUseCase;
+import com.personal.marketnote.common.kafka.KafkaTopicConstants;
+import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.EventPayloadValidator;
+import com.personal.marketnote.common.saga.SagaResponsePublisher;
+import com.personal.marketnote.common.saga.SagaStepMessage;
+import com.personal.marketnote.common.utility.FormatValidator;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@ConditionalOnProperty(prefix = "saga", name = "enabled", havingValue = "true")
+@RequiredArgsConstructor
+public class OrderPaymentLedgerSagaConsumer {
+
+    private final ObjectMapper objectMapper;
+    private final RecordLedgerEntryUseCase recordLedgerEntryUseCase;
+    private final SagaResponsePublisher sagaResponsePublisher;
+
+    @KafkaListener(
+            topics = KafkaTopicConstants.SAGA_ORDER_PAYMENT_LEDGER,
+            groupId = "saga-order-payment-ledger"
+    )
+    public void handleLedgerStep(
+            ConsumerRecord<String, EventEnvelope<?>> record,
+            Acknowledgment acknowledgment
+    ) {
+        EventEnvelope<?> envelope = record.value();
+
+        if (EventPayloadValidator.hasInvalidEnvelope(envelope, record)) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        SagaStepMessage stepMessage = envelope.getPayloadAs(SagaStepMessage.class, objectMapper);
+
+        log.info("SAGA 분개 스텝 수신. sagaId={}, messageType={}",
+                stepMessage.sagaId(), stepMessage.messageType());
+
+        if (SagaStepMessage.ACTION.equals(stepMessage.messageType())) {
+            handleAction(stepMessage);
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        if (SagaStepMessage.COMPENSATION.equals(stepMessage.messageType())) {
+            handleCompensation(stepMessage);
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        log.warn("알 수 없는 messageType. sagaId={}, messageType={}",
+                stepMessage.sagaId(), stepMessage.messageType());
+        acknowledgment.acknowledge();
+    }
+
+    private void handleAction(SagaStepMessage stepMessage) {
+        try {
+            LedgerActionSagaPayload payload = objectMapper.readValue(
+                    stepMessage.payload(), LedgerActionSagaPayload.class);
+
+            if (FormatValidator.hasNoValue(payload.orderId()) || FormatValidator.hasNoValue(payload.paymentAmount())) {
+                publishValidationFailure(stepMessage, "orderId 또는 paymentAmount 누락");
+                return;
+            }
+
+            recordLedgerEntryUseCase.recordPaymentApproval(payload.orderId(), payload.paymentAmount());
+
+            sagaResponsePublisher.publishSuccess(
+                    stepMessage.sagaId(), stepMessage.sagaType(), stepMessage.stepName(),
+                    stepMessage.messageType(), "{\"success\":true}");
+
+            log.info("SAGA 결제 승인 분개 성공. sagaId={}, orderId={}, paymentAmount={}",
+                    stepMessage.sagaId(), payload.orderId(), payload.paymentAmount());
+        } catch (DuplicateLedgerTransactionException e) {
+            log.info("이미 처리된 SAGA 분개 (멱등 처리). sagaId={}", stepMessage.sagaId());
+            sagaResponsePublisher.publishSuccess(
+                    stepMessage.sagaId(), stepMessage.sagaType(), stepMessage.stepName(),
+                    stepMessage.messageType(), "{\"success\":true,\"idempotent\":true}");
+        } catch (Exception e) {
+            log.error("SAGA 분개 실패. sagaId={}, error={}", stepMessage.sagaId(), e.getMessage(), e);
+            sagaResponsePublisher.publishFailure(
+                    stepMessage.sagaId(), stepMessage.sagaType(), stepMessage.stepName(),
+                    stepMessage.messageType(), "분개 처리 실패");
+        }
+    }
+
+    private void handleCompensation(SagaStepMessage stepMessage) {
+        try {
+            LedgerCompensationSagaPayload payload = objectMapper.readValue(
+                    stepMessage.payload(), LedgerCompensationSagaPayload.class);
+
+            if (FormatValidator.hasNoValue(payload.orderId()) || FormatValidator.hasNoValue(payload.cancelAmount())
+                    || FormatValidator.hasNoValue(payload.idempotencyKey())) {
+                publishValidationFailure(stepMessage, "orderId, cancelAmount 또는 idempotencyKey 누락");
+                return;
+            }
+
+            recordLedgerEntryUseCase.recordPaymentCancellation(
+                    payload.orderId(), payload.cancelAmount(), payload.idempotencyKey());
+
+            sagaResponsePublisher.publishSuccess(
+                    stepMessage.sagaId(), stepMessage.sagaType(), stepMessage.stepName(),
+                    stepMessage.messageType(), "{\"compensated\":true}");
+
+            log.info("SAGA 역분개 완료. sagaId={}, orderId={}", stepMessage.sagaId(), payload.orderId());
+        } catch (DuplicateLedgerTransactionException e) {
+            log.info("이미 처리된 SAGA 역분개 (멱등 처리). sagaId={}", stepMessage.sagaId());
+            sagaResponsePublisher.publishSuccess(
+                    stepMessage.sagaId(), stepMessage.sagaType(), stepMessage.stepName(),
+                    stepMessage.messageType(), "{\"compensated\":true,\"idempotent\":true}");
+        } catch (Exception e) {
+            log.error("SAGA 역분개 실패. sagaId={}, error={}", stepMessage.sagaId(), e.getMessage(), e);
+            sagaResponsePublisher.publishFailure(
+                    stepMessage.sagaId(), stepMessage.sagaType(), stepMessage.stepName(),
+                    stepMessage.messageType(), "역분개 처리 실패");
+        }
+    }
+
+    private void publishValidationFailure(SagaStepMessage stepMessage, String reason) {
+        log.warn("SAGA 분개 스텝 페이로드 검증 실패. sagaId={}, reason={}", stepMessage.sagaId(), reason);
+        sagaResponsePublisher.publishFailure(
+                stepMessage.sagaId(), stepMessage.sagaType(), stepMessage.stepName(),
+                stepMessage.messageType(), "페이로드 검증 실패: " + reason);
+    }
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/saga/SagaOrderProductMapper.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/saga/SagaOrderProductMapper.java
@@ -1,0 +1,26 @@
+package com.personal.marketnote.commerce.adapter.in.event.saga;
+
+import com.personal.marketnote.commerce.adapter.in.event.saga.payload.SagaOrderProductItem;
+import com.personal.marketnote.commerce.domain.order.OrderProduct;
+import com.personal.marketnote.commerce.domain.order.OrderProductSnapshotState;
+
+import java.util.List;
+
+public final class SagaOrderProductMapper {
+
+    private SagaOrderProductMapper() {
+    }
+
+    public static List<OrderProduct> toOrderProducts(List<SagaOrderProductItem> items) {
+        return items.stream()
+                .map(item -> OrderProduct.from(
+                        OrderProductSnapshotState.builder()
+                                .pricePolicyId(item.pricePolicyId())
+                                .quantity(item.quantity())
+                                .unitAmount(item.unitAmount())
+                                .sharerId(item.sharerId())
+                                .build()
+                ))
+                .toList();
+    }
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/saga/payload/InventorySagaPayload.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/saga/payload/InventorySagaPayload.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.commerce.adapter.in.event.saga.payload;
+
+import java.util.List;
+
+public record InventorySagaPayload(
+        Long orderId,
+        List<SagaOrderProductItem> orderProducts
+) {
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/saga/payload/LedgerActionSagaPayload.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/saga/payload/LedgerActionSagaPayload.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.commerce.adapter.in.event.saga.payload;
+
+public record LedgerActionSagaPayload(
+        Long orderId,
+        Long paymentAmount
+) {
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/saga/payload/LedgerCompensationSagaPayload.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/saga/payload/LedgerCompensationSagaPayload.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.commerce.adapter.in.event.saga.payload;
+
+public record LedgerCompensationSagaPayload(
+        Long orderId,
+        Long cancelAmount,
+        String idempotencyKey
+) {
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/saga/payload/PaymentCompletedSagaPayload.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/saga/payload/PaymentCompletedSagaPayload.java
@@ -1,0 +1,13 @@
+package com.personal.marketnote.commerce.adapter.in.event.saga.payload;
+
+import java.util.List;
+
+public record PaymentCompletedSagaPayload(
+        Long orderId,
+        Long buyerId,
+        Long totalAmount,
+        Long pointAmount,
+        Long totalAccumulatedPoint,
+        List<SagaOrderProductItem> orderProducts
+) {
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/saga/payload/SagaOrderProductItem.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/saga/payload/SagaOrderProductItem.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.commerce.adapter.in.event.saga.payload;
+
+public record SagaOrderProductItem(
+        Long pricePolicyId,
+        Long sharerId,
+        Integer quantity,
+        Long unitAmount
+) {
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/command/order/ChangeOrderStatusCommand.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/command/order/ChangeOrderStatusCommand.java
@@ -17,7 +17,8 @@ public record ChangeOrderStatusCommand(
         String reason,
         String role,
         Long buyerId,
-        ShippingAddress pickupAddress
+        ShippingAddress pickupAddress,
+        Boolean skipSubsequentProcesses
 ) {
     private static final String BUYER_ROLE = "BUYER";
 
@@ -42,5 +43,9 @@ public record ChangeOrderStatusCommand(
      */
     public boolean isInternalCall() {
         return FormatValidator.hasNoValue(role);
+    }
+
+    public boolean shouldSkipSubsequentProcesses() {
+        return Boolean.TRUE.equals(skipSubsequentProcesses);
     }
 }

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/command/saga/OrderPaymentSagaContext.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/command/saga/OrderPaymentSagaContext.java
@@ -1,0 +1,22 @@
+package com.personal.marketnote.commerce.port.in.command.saga;
+
+import java.util.List;
+
+public record OrderPaymentSagaContext(
+        Long orderId,
+        String orderKey,
+        Long buyerId,
+        Long paymentAmount,
+        Long totalAmount,
+        Long pointAmount,
+        Long totalAccumulatedPoint,
+        List<OrderProductItem> orderProducts
+) {
+    public record OrderProductItem(
+            Long pricePolicyId,
+            Long sharerId,
+            Integer quantity,
+            Long unitAmount
+    ) {
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/ChangeOrderStatusService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/ChangeOrderStatusService.java
@@ -66,7 +66,7 @@ public class ChangeOrderStatusService implements ChangeOrderStatusUseCase {
         OrderStatusHistory orderStatusHistory = OrderStatusHistory.from(OrderCommandToStateMapper.mapToState(command));
         updateOrderPort.update(order, orderStatusHistory);
 
-        if (status.isPaid()) {
+        if (status.isPaid() && !command.shouldSkipSubsequentProcesses()) {
             updatePaymentSubsequentProcesses(order);
         }
 

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/PaymentApprovalTransactionHelper.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/PaymentApprovalTransactionHelper.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.commerce.service.payment;
 
 import com.personal.marketnote.commerce.domain.order.Order;
+import com.personal.marketnote.commerce.domain.order.OrderProduct;
 import com.personal.marketnote.commerce.domain.order.OrderStatus;
 import com.personal.marketnote.commerce.domain.payment.Payment;
 import com.personal.marketnote.commerce.domain.payment.PaymentApprovalInfo;
@@ -8,6 +9,7 @@ import com.personal.marketnote.commerce.domain.payment.PspPaymentEvent;
 import com.personal.marketnote.commerce.exception.*;
 import com.personal.marketnote.commerce.port.in.command.order.ChangeOrderStatusCommand;
 import com.personal.marketnote.commerce.port.in.command.payment.ApprovePaymentCommand;
+import com.personal.marketnote.commerce.port.in.command.saga.OrderPaymentSagaContext;
 import com.personal.marketnote.commerce.port.in.result.payment.ApprovePaymentResult;
 import com.personal.marketnote.commerce.port.in.usecase.order.ChangeOrderStatusUseCase;
 import com.personal.marketnote.commerce.port.out.event.PublishPaymentEventPort;
@@ -17,12 +19,18 @@ import com.personal.marketnote.commerce.port.out.payment.FindPspPaymentEventPort
 import com.personal.marketnote.commerce.port.out.payment.UpdatePaymentPort;
 import com.personal.marketnote.commerce.port.out.payment.UpdatePspPaymentEventPort;
 import com.personal.marketnote.commerce.port.out.payment.vendor.PaymentApprovalVendorResult;
+import com.personal.marketnote.commerce.port.out.product.FindProductByPricePolicyPort;
+import com.personal.marketnote.commerce.port.out.result.product.ProductInfoResult;
+import com.personal.marketnote.commerce.service.saga.OrderPaymentSagaStarter;
 import com.personal.marketnote.common.utility.FormatValidator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 
 import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
@@ -45,6 +53,8 @@ public class PaymentApprovalTransactionHelper {
     private final UpdatePspPaymentEventPort updatePspPaymentEventPort;
     private final ChangeOrderStatusUseCase changeOrderStatusUseCase;
     private final PublishPaymentEventPort publishPaymentEventPort;
+    private final FindProductByPricePolicyPort findProductByPricePolicyPort;
+    private final Optional<OrderPaymentSagaStarter> orderPaymentSagaStarter;
 
     /**
      * TX-1: 검증 + EXECUTING 상태 커밋
@@ -95,6 +105,21 @@ public class PaymentApprovalTransactionHelper {
         event.completeWithApproval(approvalInfo);
         updatePspPaymentEventPort.update(event);
 
+        Order order = findOrderPort.findById(payment.getOrderId())
+                .orElseThrow(() -> new OrderNotFoundException(payment.getOrderId()));
+
+        if (orderPaymentSagaStarter.isPresent()) {
+            changeOrderStatusUseCase.changeOrderStatus(
+                    ChangeOrderStatusCommand.builder()
+                            .id(payment.getOrderId())
+                            .orderStatus(OrderStatus.PAID)
+                            .skipSubsequentProcesses(true)
+                            .build()
+            );
+            startOrderPaymentSaga(order, payment);
+            return buildApprovePaymentResult(payment, vendorResult);
+        }
+
         changeOrderStatusUseCase.changeOrderStatus(
                 ChangeOrderStatusCommand.builder()
                         .id(payment.getOrderId())
@@ -105,6 +130,11 @@ public class PaymentApprovalTransactionHelper {
         // [#929][#1033] 결제 승인 분개는 Kafka Consumer(PaymentApprovedLedgerConsumer)로 전환 완료
         publishPaymentApprovedEvent(payment);
 
+        return buildApprovePaymentResult(payment, vendorResult);
+    }
+
+    private ApprovePaymentResult buildApprovePaymentResult(Payment payment,
+                                                            PaymentApprovalVendorResult vendorResult) {
         return ApprovePaymentResult.builder()
                 .orderId(payment.getOrderId())
                 .orderKey(payment.getOrderKey().toString())
@@ -180,6 +210,56 @@ public class PaymentApprovalTransactionHelper {
             throw new UnauthorizedOrderAccessException();
         }
         return order;
+    }
+
+    private void startOrderPaymentSaga(Order order, Payment payment) {
+        List<OrderProduct> orderProducts = order.getOrderProducts();
+        List<Long> pricePolicyIds = orderProducts.stream()
+                .map(OrderProduct::getPricePolicyId)
+                .toList();
+        Long totalAccumulatedPoint = calculateTotalAccumulatedPoint(orderProducts, pricePolicyIds);
+
+        List<OrderPaymentSagaContext.OrderProductItem> sagaOrderProducts = orderProducts.stream()
+                .map(op -> new OrderPaymentSagaContext.OrderProductItem(
+                        op.getPricePolicyId(), op.getSharerId(), op.getQuantity(), op.getUnitAmount()))
+                .toList();
+
+        Long pointAmount = FormatValidator.hasValue(order.getAmount().getPointAmount())
+                ? order.getAmount().getPointAmount()
+                : 0L;
+
+        OrderPaymentSagaContext sagaContext = new OrderPaymentSagaContext(
+                order.getId(),
+                order.getOrderKey().toString(),
+                order.getBuyerId(),
+                payment.getPaymentAmount(),
+                order.getAmount().getTotalAmount(),
+                pointAmount,
+                totalAccumulatedPoint,
+                sagaOrderProducts
+        );
+
+        orderPaymentSagaStarter.get().start(sagaContext);
+    }
+
+    private Long calculateTotalAccumulatedPoint(List<OrderProduct> orderProducts,
+                                                 List<Long> pricePolicyIds) {
+        Map<Long, ProductInfoResult> productInfoMap = findProductByPricePolicyPort.findByPricePolicyIds(pricePolicyIds);
+
+        long totalAccumulatedPoint = 0L;
+        for (OrderProduct orderProduct : orderProducts) {
+            ProductInfoResult productInfo = productInfoMap.get(orderProduct.getPricePolicyId());
+            if (FormatValidator.hasNoValue(productInfo)) {
+                continue;
+            }
+            if (FormatValidator.hasNoValue(productInfo.accumulatedPoint())) {
+                continue;
+            }
+            totalAccumulatedPoint = Math.addExact(totalAccumulatedPoint,
+                    Math.multiplyExact(productInfo.accumulatedPoint(), orderProduct.getQuantity()));
+        }
+
+        return totalAccumulatedPoint;
     }
 
     private void publishPaymentApprovedEvent(Payment payment) {

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/saga/OrderPaymentSagaDefinition.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/saga/OrderPaymentSagaDefinition.java
@@ -1,0 +1,110 @@
+package com.personal.marketnote.commerce.service.saga;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.commerce.port.in.command.saga.OrderPaymentSagaContext;
+import com.personal.marketnote.common.kafka.KafkaTopicConstants;
+import com.personal.marketnote.common.saga.SagaDefinition;
+import com.personal.marketnote.common.saga.SagaStepDefinition;
+import com.personal.marketnote.common.saga.exception.SagaSerializationException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+
+@Component
+@ConditionalOnProperty(prefix = "saga", name = "enabled", havingValue = "true")
+@RequiredArgsConstructor
+public class OrderPaymentSagaDefinition implements SagaDefinition<OrderPaymentSagaContext> {
+
+    public static final String SAGA_TYPE = "ORDER_PAYMENT";
+    public static final String STEP_DEDUCT_INVENTORY = "DEDUCT_INVENTORY";
+    public static final String STEP_RECORD_LEDGER = "RECORD_LEDGER";
+    public static final String STEP_PUBLISH_PAYMENT_COMPLETED = "PUBLISH_PAYMENT_COMPLETED";
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public String getSagaType() {
+        return SAGA_TYPE;
+    }
+
+    @Override
+    public Class<OrderPaymentSagaContext> getContextType() {
+        return OrderPaymentSagaContext.class;
+    }
+
+    @Override
+    public List<SagaStepDefinition<OrderPaymentSagaContext>> getSteps() {
+        return List.of(
+                new SagaStepDefinition<>(
+                        STEP_DEDUCT_INVENTORY,
+                        KafkaTopicConstants.SAGA_ORDER_PAYMENT_INVENTORY,
+                        this::buildInventoryDeductionAction,
+                        this::buildInventoryRestorationCompensation
+                ),
+                new SagaStepDefinition<>(
+                        STEP_RECORD_LEDGER,
+                        KafkaTopicConstants.SAGA_ORDER_PAYMENT_LEDGER,
+                        this::buildLedgerRecordAction,
+                        this::buildLedgerReverseCompensation
+                ),
+                new SagaStepDefinition<>(
+                        STEP_PUBLISH_PAYMENT_COMPLETED,
+                        KafkaTopicConstants.SAGA_ORDER_PAYMENT_COMPLETED,
+                        this::buildPaymentCompletedAction,
+                        null
+                )
+        );
+    }
+
+    private String buildInventoryDeductionAction(OrderPaymentSagaContext context) {
+        return serialize(Map.of(
+                "orderId", context.orderId(),
+                "orderProducts", context.orderProducts()
+        ));
+    }
+
+    private String buildInventoryRestorationCompensation(OrderPaymentSagaContext context) {
+        return serialize(Map.of(
+                "orderId", context.orderId(),
+                "orderProducts", context.orderProducts()
+        ));
+    }
+
+    private String buildLedgerRecordAction(OrderPaymentSagaContext context) {
+        return serialize(Map.of(
+                "orderId", context.orderId(),
+                "paymentAmount", context.paymentAmount()
+        ));
+    }
+
+    private String buildLedgerReverseCompensation(OrderPaymentSagaContext context) {
+        return serialize(Map.of(
+                "orderId", context.orderId(),
+                "cancelAmount", context.paymentAmount(),
+                "idempotencyKey", "SAGA_COMP:" + context.orderId()
+        ));
+    }
+
+    private String buildPaymentCompletedAction(OrderPaymentSagaContext context) {
+        return serialize(Map.of(
+                "orderId", context.orderId(),
+                "buyerId", context.buyerId(),
+                "totalAmount", context.totalAmount(),
+                "pointAmount", context.pointAmount(),
+                "orderProducts", context.orderProducts(),
+                "totalAccumulatedPoint", context.totalAccumulatedPoint()
+        ));
+    }
+
+    private String serialize(Object value) {
+        try {
+            return objectMapper.writeValueAsString(value);
+        } catch (JsonProcessingException e) {
+            throw new SagaSerializationException("OrderPayment SAGA 페이로드 직렬화에 실패했습니다.", e);
+        }
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/saga/OrderPaymentSagaStarter.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/saga/OrderPaymentSagaStarter.java
@@ -1,0 +1,29 @@
+package com.personal.marketnote.commerce.service.saga;
+
+import com.personal.marketnote.commerce.port.in.command.saga.OrderPaymentSagaContext;
+import com.personal.marketnote.common.saga.SagaOrchestrator;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@ConditionalOnProperty(prefix = "saga", name = "enabled", havingValue = "true")
+@RequiredArgsConstructor
+public class OrderPaymentSagaStarter {
+
+    private static final String SAGA_ID_PREFIX = "ORDER_PAYMENT:";
+
+    private final SagaOrchestrator sagaOrchestrator;
+    private final OrderPaymentSagaDefinition orderPaymentSagaDefinition;
+
+    public void start(OrderPaymentSagaContext context) {
+        String sagaId = SAGA_ID_PREFIX + context.orderId();
+
+        log.info("OrderPayment SAGA 시작. sagaId={}, orderId={}, paymentAmount={}",
+                sagaId, context.orderId(), context.paymentAmount());
+
+        sagaOrchestrator.start(orderPaymentSagaDefinition, sagaId, context);
+    }
+}

--- a/common/src/main/java/com/personal/marketnote/common/kafka/KafkaTopicConstants.java
+++ b/common/src/main/java/com/personal/marketnote/common/kafka/KafkaTopicConstants.java
@@ -28,6 +28,11 @@ public final class KafkaTopicConstants {
     // SAGA 응답
     public static final String SAGA_RESPONSE = "saga.response";
 
+    // OrderPayment SAGA 스텝
+    public static final String SAGA_ORDER_PAYMENT_INVENTORY = "saga.order-payment.inventory";
+    public static final String SAGA_ORDER_PAYMENT_LEDGER = "saga.order-payment.ledger";
+    public static final String SAGA_ORDER_PAYMENT_COMPLETED = "saga.order-payment.completed";
+
     // Dead Letter Topic 접미사
     public static final String DLT_SUFFIX = ".dlt";
 }

--- a/common/src/main/java/com/personal/marketnote/common/saga/SagaResponsePublisher.java
+++ b/common/src/main/java/com/personal/marketnote/common/saga/SagaResponsePublisher.java
@@ -1,0 +1,65 @@
+package com.personal.marketnote.common.saga;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.common.kafka.KafkaTopicConstants;
+import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.outbox.OutboxEvent;
+import com.personal.marketnote.common.outbox.SaveOutboxEventPort;
+import com.personal.marketnote.common.saga.exception.SagaSerializationException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@Slf4j
+@Component
+@ConditionalOnProperty(prefix = "saga", name = "enabled", havingValue = "true")
+@RequiredArgsConstructor
+public class SagaResponsePublisher {
+
+    private static final String SOURCE = "saga-step-handler";
+
+    private final SaveOutboxEventPort saveOutboxEventPort;
+    private final ObjectMapper objectMapper;
+    private final Clock clock;
+
+    @Transactional(isolation = READ_COMMITTED)
+    public void publishSuccess(String sagaId, String sagaType, String stepName,
+                                String messageType, String response) {
+        SagaResponseMessage responseMessage = new SagaResponseMessage(
+                sagaId, sagaType, stepName, messageType, true, response);
+        publishToOutbox(responseMessage, sagaId);
+    }
+
+    @Transactional(isolation = READ_COMMITTED)
+    public void publishFailure(String sagaId, String sagaType, String stepName,
+                                String messageType, String errorMessage) {
+        SagaResponseMessage responseMessage = new SagaResponseMessage(
+                sagaId, sagaType, stepName, messageType, false, errorMessage);
+        publishToOutbox(responseMessage, sagaId);
+    }
+
+    private void publishToOutbox(SagaResponseMessage message, String partitionKey) {
+        EventEnvelope<SagaResponseMessage> envelope = EventEnvelope.of(
+                KafkaTopicConstants.SAGA_RESPONSE, SOURCE, message, clock);
+        String envelopeJson = serialize(envelope);
+        OutboxEvent event = OutboxEvent.of(
+                envelope.eventId(), KafkaTopicConstants.SAGA_RESPONSE, partitionKey,
+                envelope.eventType(), SOURCE, envelopeJson, clock);
+        saveOutboxEventPort.save(event);
+    }
+
+    private String serialize(Object value) {
+        try {
+            return objectMapper.writeValueAsString(value);
+        } catch (JsonProcessingException e) {
+            throw new SagaSerializationException("SAGA 응답 직렬화에 실패했습니다.", e);
+        }
+    }
+}


### PR DESCRIPTION
## partially addresses #1530
## resolves #1541

## Task
- [x] OrderPaymentSagaContext record 정의
- [x] OrderPaymentSagaDefinition 구현 (3스텝: 재고 차감 → 분개 → 결제 완료 이벤트 발행)
- [x] OrderPaymentSagaStarter 구현
- [x] SagaResponsePublisher 구현
- [x] OrderPaymentInventorySagaConsumer 구현
- [x] OrderPaymentLedgerSagaConsumer 구현
- [x] OrderPaymentCompletedSagaConsumer 구현
- [x] PaymentApprovalTransactionHelper SAGA 통합
- [x] ChangeOrderStatusCommand skipSubsequentProcesses 플래그
- [x] KafkaTopicConstants SAGA 토픽 추가
- [x] 타입 안전한 payload record + SagaOrderProductMapper
- [x] Consumer 페이로드 필수 필드 검증 + 에러 메시지 도메인 수준 제한