### PR TITLE
[#723][#1567] fix: GlobalExceptionHandler catch-all 핸들러 추가하여 미처리 예외 내부 정보 노출 방지

### DIFF
--- a/commerce-service/commerce-adapters/src/main/resources/application.yml
+++ b/commerce-service/commerce-adapters/src/main/resources/application.yml
@@ -62,6 +62,7 @@ server:
   error:
     include-exception: false
     include-stacktrace: NEVER
+    include-message: NEVER
     whitelabel:
       enabled: false
 

--- a/common/src/main/java/com/personal/marketnote/common/domain/exception/GlobalExceptionHandler.java
+++ b/common/src/main/java/com/personal/marketnote/common/domain/exception/GlobalExceptionHandler.java
@@ -244,4 +244,11 @@ public class GlobalExceptionHandler {
         log.error(LOG_ERROR_MESSAGE, e.getMessage(), e);
         return buildErrorResponse(httpStatus, httpStatus.name(), "데이터 무결성 제약 조건을 위반했습니다.");
     }
+
+    @ExceptionHandler(Exception.class)
+    ResponseEntity<ErrorResponse> handleException(Exception e) {
+        HttpStatus httpStatus = HttpStatus.INTERNAL_SERVER_ERROR;
+        log.error(LOG_ERROR_MESSAGE, e.getMessage(), e);
+        return buildErrorResponse(httpStatus, httpStatus.name(), "서버 내부 오류가 발생했습니다.");
+    }
 }

--- a/community-service/community-adapters/src/main/resources/application.yml
+++ b/community-service/community-adapters/src/main/resources/application.yml
@@ -62,6 +62,7 @@ server:
   error:
     include-exception: false
     include-stacktrace: NEVER
+    include-message: NEVER
     whitelabel:
       enabled: false
 

--- a/file-service/file-adapters/src/main/resources/application.yml
+++ b/file-service/file-adapters/src/main/resources/application.yml
@@ -61,6 +61,7 @@ server:
   error:
     include-exception: false
     include-stacktrace: NEVER
+    include-message: NEVER
     whitelabel:
       enabled: false
 

--- a/fulfillment-service/fulfillment-adapters/src/main/resources/application.yml
+++ b/fulfillment-service/fulfillment-adapters/src/main/resources/application.yml
@@ -56,6 +56,7 @@ server:
   error:
     include-exception: false
     include-stacktrace: NEVER
+    include-message: NEVER
     whitelabel:
       enabled: false
 

--- a/product-service/product-adapters/src/main/resources/application.yml
+++ b/product-service/product-adapters/src/main/resources/application.yml
@@ -62,6 +62,7 @@ server:
   error:
     include-exception: false
     include-stacktrace: NEVER
+    include-message: NEVER
     whitelabel:
       enabled: false
 

--- a/reward-service/reward-adapters/src/main/resources/application.yml
+++ b/reward-service/reward-adapters/src/main/resources/application.yml
@@ -62,6 +62,7 @@ server:
   error:
     include-exception: false
     include-stacktrace: NEVER
+    include-message: NEVER
     whitelabel:
       enabled: false
 

--- a/user-service/user-adapters/src/main/resources/application.yml
+++ b/user-service/user-adapters/src/main/resources/application.yml
@@ -82,6 +82,7 @@ server:
   error:
     include-exception: false
     include-stacktrace: NEVER
+    include-message: NEVER
     whitelabel:
       enabled: false
 


### PR DESCRIPTION
## partially addresses #723
## resolves #1567

## Task
- [x] GlobalExceptionHandler에 @ExceptionHandler(Exception.class) catch-all 핸들러 추가
- [x] catch-all 응답: 500 INTERNAL_SERVER_ERROR + "서버 내부 오류가 발생했습니다." (고정 메시지)
- [x] 원본 예외는 log.error()로 서버 로그에만 기록
- [x] 전체 서비스 server.error.include-message: NEVER 명시 설정 추가 (2중 방어)