### PR TITLE
[#216][#1582] refactor: 주문 등록 Command에서 OrderAmount 도메인 객체를 Command 레코드로 변경

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/mapper/OrderRequestToCommandMapper.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/mapper/OrderRequestToCommandMapper.java
@@ -2,9 +2,9 @@ package com.personal.marketnote.commerce.adapter.in.web.order.mapper;
 
 import com.personal.marketnote.commerce.adapter.in.web.order.request.ChangeOrderStatusRequest;
 import com.personal.marketnote.commerce.adapter.in.web.order.request.RegisterOrderRequest;
-import com.personal.marketnote.commerce.domain.order.OrderAmount;
 import com.personal.marketnote.commerce.domain.order.ShippingAddress;
 import com.personal.marketnote.commerce.port.in.command.order.ChangeOrderStatusCommand;
+import com.personal.marketnote.commerce.port.in.command.order.OrderAmountCommand;
 import com.personal.marketnote.commerce.port.in.command.order.OrderProductItemCommand;
 import com.personal.marketnote.commerce.port.in.command.order.RegisterOrderCommand;
 
@@ -29,13 +29,12 @@ public class OrderRequestToCommandMapper {
 
         return RegisterOrderCommand.builder()
                 .buyerId(buyerId)
-                .amount(OrderAmount.of(
-                        request.getTotalAmount(),
-                        null,
-                        request.getCouponAmount(),
-                        request.getPointAmount(),
-                        request.getShippingFee()
-                ))
+                .amount(OrderAmountCommand.builder()
+                        .totalAmount(request.getTotalAmount())
+                        .couponAmount(request.getCouponAmount())
+                        .pointAmount(request.getPointAmount())
+                        .shippingFee(request.getShippingFee())
+                        .build())
                 .shippingAddress(ShippingAddress.of(
                         request.getRecipientName(),
                         request.getRecipientPhoneNumber(),

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/command/order/OrderAmountCommand.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/command/order/OrderAmountCommand.java
@@ -1,0 +1,12 @@
+package com.personal.marketnote.commerce.port.in.command.order;
+
+import lombok.Builder;
+
+@Builder
+public record OrderAmountCommand(
+        Long totalAmount,
+        Long couponAmount,
+        Long pointAmount,
+        Long shippingFee
+) {
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/command/order/RegisterOrderCommand.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/command/order/RegisterOrderCommand.java
@@ -1,6 +1,5 @@
 package com.personal.marketnote.commerce.port.in.command.order;
 
-import com.personal.marketnote.commerce.domain.order.OrderAmount;
 import com.personal.marketnote.commerce.domain.order.ShippingAddress;
 import lombok.Builder;
 
@@ -9,7 +8,7 @@ import java.util.List;
 @Builder
 public record RegisterOrderCommand(
         Long buyerId,
-        OrderAmount amount,
+        OrderAmountCommand amount,
         ShippingAddress shippingAddress,
         List<OrderProductItemCommand> orderProducts
 ) {

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/RegisterOrderService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/RegisterOrderService.java
@@ -2,6 +2,8 @@ package com.personal.marketnote.commerce.service.order;
 
 import com.personal.marketnote.commerce.domain.inventory.Inventory;
 import com.personal.marketnote.commerce.domain.order.Order;
+import com.personal.marketnote.commerce.domain.order.OrderAmount;
+import com.personal.marketnote.commerce.domain.order.OrderAmountCreateState;
 import com.personal.marketnote.commerce.domain.order.OrderCreateState;
 import com.personal.marketnote.commerce.domain.order.OrderProductCreateState;
 import com.personal.marketnote.commerce.domain.payment.Payment;
@@ -86,28 +88,37 @@ public class RegisterOrderService implements RegisterOrderUseCase {
                         .build())
                 .toList();
 
+        OrderAmount orderAmount = OrderAmount.from(
+                OrderAmountCreateState.builder()
+                        .totalAmount(command.amount().totalAmount())
+                        .couponAmount(command.amount().couponAmount())
+                        .pointAmount(command.amount().pointAmount())
+                        .shippingFee(command.amount().shippingFee())
+                        .build()
+        );
+
         Order savedOrder = saveOrderPort.save(
                 Order.from(
                         OrderCreateState.builder()
                                 .buyerId(command.buyerId())
-                                .amount(command.amount())
+                                .amount(orderAmount)
                                 .shippingAddress(command.shippingAddress())
                                 .orderProductStates(orderProductStates)
                                 .build()
                 )
         );
 
-        long couponAmount = resolveAmount(command.amount().getCouponAmount());
-        long pointAmount = resolveAmount(command.amount().getPointAmount());
-        long shippingFee = resolveAmount(command.amount().getShippingFee());
-        long payableAmount = Math.addExact(command.amount().getTotalAmount(), shippingFee);
+        long couponAmount = resolveAmount(command.amount().couponAmount());
+        long pointAmount = resolveAmount(command.amount().pointAmount());
+        long shippingFee = resolveAmount(command.amount().shippingFee());
+        long payableAmount = Math.addExact(command.amount().totalAmount(), shippingFee);
         long totalDiscount = Math.addExact(couponAmount, pointAmount);
         long paymentAmount = Math.subtractExact(payableAmount, totalDiscount);
 
         if (paymentAmount < 0) {
             log.error("결제 금액 음수 발생 - totalAmount: {}, shippingFee: {}, coupon: {}, point: {}",
-                    command.amount().getTotalAmount(), shippingFee, couponAmount, pointAmount);
-            throw new ExcessiveDiscountException(command.amount().getTotalAmount(), shippingFee, couponAmount, pointAmount);
+                    command.amount().totalAmount(), shippingFee, couponAmount, pointAmount);
+            throw new ExcessiveDiscountException(command.amount().totalAmount(), shippingFee, couponAmount, pointAmount);
         }
 
         savePaymentPort.save(
@@ -161,34 +172,34 @@ public class RegisterOrderService implements RegisterOrderUseCase {
                 calculatedTotal = Math.addExact(calculatedTotal, itemTotal);
             }
         } catch (ArithmeticException e) {
-            log.warn("주문 금액 오버플로우 발생 - 전송된 총액: {}", command.amount().getTotalAmount());
-            throw new OrderAmountMismatchException(command.amount().getTotalAmount(), -1L);
+            log.warn("주문 금액 오버플로우 발생 - 전송된 총액: {}", command.amount().totalAmount());
+            throw new OrderAmountMismatchException(command.amount().totalAmount(), -1L);
         }
 
-        if (!command.amount().getTotalAmount().equals(calculatedTotal)) {
-            log.warn("주문 금액 불일치 - 전송된 총액: {}, 계산된 합계: {}", command.amount().getTotalAmount(), calculatedTotal);
-            throw new OrderAmountMismatchException(command.amount().getTotalAmount(), calculatedTotal);
+        if (!command.amount().totalAmount().equals(calculatedTotal)) {
+            log.warn("주문 금액 불일치 - 전송된 총액: {}, 계산된 합계: {}", command.amount().totalAmount(), calculatedTotal);
+            throw new OrderAmountMismatchException(command.amount().totalAmount(), calculatedTotal);
         }
     }
 
     private void validateDiscountAmounts(RegisterOrderCommand command) {
-        long couponAmount = resolveAmount(command.amount().getCouponAmount());
-        long pointAmount = resolveAmount(command.amount().getPointAmount());
-        long shippingFee = resolveAmount(command.amount().getShippingFee());
+        long couponAmount = resolveAmount(command.amount().couponAmount());
+        long pointAmount = resolveAmount(command.amount().pointAmount());
+        long shippingFee = resolveAmount(command.amount().shippingFee());
 
         long totalDiscount;
         long payableAmount;
         try {
             totalDiscount = Math.addExact(couponAmount, pointAmount);
-            payableAmount = Math.addExact(command.amount().getTotalAmount(), shippingFee);
+            payableAmount = Math.addExact(command.amount().totalAmount(), shippingFee);
         } catch (ArithmeticException e) {
             log.warn("할인/배송비 금액 오버플로우 - 쿠폰: {}, 포인트: {}, 배송비: {}", couponAmount, pointAmount, shippingFee);
-            throw new ExcessiveDiscountException(command.amount().getTotalAmount(), shippingFee, couponAmount, pointAmount);
+            throw new ExcessiveDiscountException(command.amount().totalAmount(), shippingFee, couponAmount, pointAmount);
         }
 
         if (totalDiscount > payableAmount) {
-            log.warn("할인 금액 초과 - 주문 총액: {}, 배송비: {}, 쿠폰: {}, 포인트: {}", command.amount().getTotalAmount(), shippingFee, couponAmount, pointAmount);
-            throw new ExcessiveDiscountException(command.amount().getTotalAmount(), shippingFee, couponAmount, pointAmount);
+            log.warn("할인 금액 초과 - 주문 총액: {}, 배송비: {}, 쿠폰: {}, 포인트: {}", command.amount().totalAmount(), shippingFee, couponAmount, pointAmount);
+            throw new ExcessiveDiscountException(command.amount().totalAmount(), shippingFee, couponAmount, pointAmount);
         }
     }
 
@@ -234,7 +245,7 @@ public class RegisterOrderService implements RegisterOrderUseCase {
     }
 
     private void validatePointBalance(RegisterOrderCommand command) {
-        long pointAmount = resolveAmount(command.amount().getPointAmount());
+        long pointAmount = resolveAmount(command.amount().pointAmount());
         if (pointAmount <= 0) {
             return;
         }
@@ -248,7 +259,7 @@ public class RegisterOrderService implements RegisterOrderUseCase {
     }
 
     private void validateShippingFee(RegisterOrderCommand command) {
-        long requestedShippingFee = resolveAmount(command.amount().getShippingFee());
+        long requestedShippingFee = resolveAmount(command.amount().shippingFee());
 
         List<Long> sellerIds = command.orderProducts().stream()
                 .map(OrderProductItemCommand::sellerId)

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/RegisterOrderUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/RegisterOrderUseCaseTest.java
@@ -2,7 +2,6 @@ package com.personal.marketnote.commerce.service.order;
 
 import com.personal.marketnote.commerce.domain.inventory.Inventory;
 import com.personal.marketnote.commerce.domain.order.Order;
-import com.personal.marketnote.commerce.domain.order.OrderAmount;
 import com.personal.marketnote.commerce.domain.order.OrderProduct;
 import com.personal.marketnote.commerce.domain.order.OrderStatus;
 import com.personal.marketnote.commerce.domain.payment.Payment;
@@ -10,6 +9,7 @@ import com.personal.marketnote.commerce.domain.settlement.PaymentAllocation;
 import com.personal.marketnote.commerce.domain.settlement.PaymentAllocationTargetType;
 import com.personal.marketnote.commerce.domain.settlement.PaymentAllocationTransactionType;
 import com.personal.marketnote.commerce.exception.*;
+import com.personal.marketnote.commerce.port.in.command.order.OrderAmountCommand;
 import com.personal.marketnote.commerce.port.in.command.order.OrderProductItemCommand;
 import com.personal.marketnote.commerce.port.in.command.order.RegisterOrderCommand;
 import com.personal.marketnote.commerce.port.in.result.order.RegisterOrderResult;
@@ -81,7 +81,7 @@ class RegisterOrderUseCaseTest {
             Long pricePolicyId = 100L;
             RegisterOrderCommand command = RegisterOrderCommand.builder()
                     .buyerId(buyerId)
-                    .amount(OrderAmount.of(50000L, null, 0L, 0L, null))
+                    .amount(OrderAmountCommand.builder().totalAmount(50000L).couponAmount(0L).pointAmount(0L).shippingFee(null).build())
                     .orderProducts(List.of(
                             OrderProductItemCommand.builder()
                                     .productId(100L)
@@ -118,7 +118,7 @@ class RegisterOrderUseCaseTest {
             Long pricePolicyId2 = 200L;
             RegisterOrderCommand command = RegisterOrderCommand.builder()
                     .buyerId(buyerId)
-                    .amount(OrderAmount.of(100000L, null, 5000L, 3000L, null))
+                    .amount(OrderAmountCommand.builder().totalAmount(100000L).couponAmount(5000L).pointAmount(3000L).shippingFee(null).build())
                     .orderProducts(List.of(
                             OrderProductItemCommand.builder()
                                     .productId(100L)
@@ -172,7 +172,7 @@ class RegisterOrderUseCaseTest {
             Long couponAmount = 10000L;
             RegisterOrderCommand command = RegisterOrderCommand.builder()
                     .buyerId(buyerId)
-                    .amount(OrderAmount.of(50000L, null, couponAmount, 0L, null))
+                    .amount(OrderAmountCommand.builder().totalAmount(50000L).couponAmount(couponAmount).pointAmount(0L).shippingFee(null).build())
                     .orderProducts(List.of(
                             OrderProductItemCommand.builder()
                                     .productId(100L)
@@ -210,7 +210,7 @@ class RegisterOrderUseCaseTest {
             Long pointAmount = 5000L;
             RegisterOrderCommand command = RegisterOrderCommand.builder()
                     .buyerId(buyerId)
-                    .amount(OrderAmount.of(50000L, null, 0L, pointAmount, null))
+                    .amount(OrderAmountCommand.builder().totalAmount(50000L).couponAmount(0L).pointAmount(pointAmount).shippingFee(null).build())
                     .orderProducts(List.of(
                             OrderProductItemCommand.builder()
                                     .productId(100L)
@@ -250,7 +250,7 @@ class RegisterOrderUseCaseTest {
             Long pointAmount = 5000L;
             RegisterOrderCommand command = RegisterOrderCommand.builder()
                     .buyerId(buyerId)
-                    .amount(OrderAmount.of(50000L, null, couponAmount, pointAmount, null))
+                    .amount(OrderAmountCommand.builder().totalAmount(50000L).couponAmount(couponAmount).pointAmount(pointAmount).shippingFee(null).build())
                     .orderProducts(List.of(
                             OrderProductItemCommand.builder()
                                     .productId(100L)
@@ -289,7 +289,7 @@ class RegisterOrderUseCaseTest {
             Long pricePolicyId = 100L;
             RegisterOrderCommand command = RegisterOrderCommand.builder()
                     .buyerId(buyerId)
-                    .amount(OrderAmount.of(50000L, null, 0L, 0L, null))
+                    .amount(OrderAmountCommand.builder().totalAmount(50000L).couponAmount(0L).pointAmount(0L).shippingFee(null).build())
                     .orderProducts(List.of(
                             OrderProductItemCommand.builder()
                                     .productId(100L)
@@ -329,7 +329,7 @@ class RegisterOrderUseCaseTest {
             Long pricePolicyId = 100L;
             RegisterOrderCommand command = RegisterOrderCommand.builder()
                     .buyerId(buyerId)
-                    .amount(OrderAmount.of(50000L, null, 0L, 0L, null))
+                    .amount(OrderAmountCommand.builder().totalAmount(50000L).couponAmount(0L).pointAmount(0L).shippingFee(null).build())
                     .orderProducts(List.of(
                             OrderProductItemCommand.builder()
                                     .productId(100L)
@@ -369,7 +369,7 @@ class RegisterOrderUseCaseTest {
             Long pricePolicyId = 100L;
             RegisterOrderCommand command = RegisterOrderCommand.builder()
                     .buyerId(buyerId)
-                    .amount(OrderAmount.of(50000L, null, null, 0L, null))
+                    .amount(OrderAmountCommand.builder().totalAmount(50000L).couponAmount(null).pointAmount(0L).shippingFee(null).build())
                     .orderProducts(List.of(
                             OrderProductItemCommand.builder()
                                     .productId(100L)
@@ -406,7 +406,7 @@ class RegisterOrderUseCaseTest {
             Long pricePolicyId = 100L;
             RegisterOrderCommand command = RegisterOrderCommand.builder()
                     .buyerId(buyerId)
-                    .amount(OrderAmount.of(50000L, null, 0L, null, null))
+                    .amount(OrderAmountCommand.builder().totalAmount(50000L).couponAmount(0L).pointAmount(null).shippingFee(null).build())
                     .orderProducts(List.of(
                             OrderProductItemCommand.builder()
                                     .productId(100L)
@@ -544,7 +544,7 @@ class RegisterOrderUseCaseTest {
             Long sellerId = 99L;
             RegisterOrderCommand command = RegisterOrderCommand.builder()
                     .buyerId(buyerId)
-                    .amount(OrderAmount.of(50000L, null, 0L, 0L, null))
+                    .amount(OrderAmountCommand.builder().totalAmount(50000L).couponAmount(0L).pointAmount(0L).shippingFee(null).build())
                     .orderProducts(List.of(
                             OrderProductItemCommand.builder()
                                     .productId(100L)
@@ -627,7 +627,7 @@ class RegisterOrderUseCaseTest {
             String imageUrl = "https://marketnote.example.com/images/product-123.png";
             RegisterOrderCommand command = RegisterOrderCommand.builder()
                     .buyerId(buyerId)
-                    .amount(OrderAmount.of(50000L, null, 0L, 0L, null))
+                    .amount(OrderAmountCommand.builder().totalAmount(50000L).couponAmount(0L).pointAmount(0L).shippingFee(null).build())
                     .orderProducts(List.of(
                             OrderProductItemCommand.builder()
                                     .productId(100L)
@@ -658,7 +658,7 @@ class RegisterOrderUseCaseTest {
             Long sharerId = 55L;
             RegisterOrderCommand command = RegisterOrderCommand.builder()
                     .buyerId(buyerId)
-                    .amount(OrderAmount.of(50000L, null, 0L, 0L, null))
+                    .amount(OrderAmountCommand.builder().totalAmount(50000L).couponAmount(0L).pointAmount(0L).shippingFee(null).build())
                     .orderProducts(List.of(
                             OrderProductItemCommand.builder()
                                     .productId(100L)
@@ -726,7 +726,7 @@ class RegisterOrderUseCaseTest {
         void registerOrder_totalAmountLessThanCalculated_throwsException() {
             RegisterOrderCommand command = RegisterOrderCommand.builder()
                     .buyerId(1L)
-                    .amount(OrderAmount.of(30000L, null, 0L, 0L, null))
+                    .amount(OrderAmountCommand.builder().totalAmount(30000L).couponAmount(0L).pointAmount(0L).shippingFee(null).build())
                     .orderProducts(List.of(
                             OrderProductItemCommand.builder()
                                     .productId(100L)
@@ -748,7 +748,7 @@ class RegisterOrderUseCaseTest {
         void registerOrder_totalAmountGreaterThanCalculated_throwsException() {
             RegisterOrderCommand command = RegisterOrderCommand.builder()
                     .buyerId(1L)
-                    .amount(OrderAmount.of(100000L, null, 0L, 0L, null))
+                    .amount(OrderAmountCommand.builder().totalAmount(100000L).couponAmount(0L).pointAmount(0L).shippingFee(null).build())
                     .orderProducts(List.of(
                             OrderProductItemCommand.builder()
                                     .productId(100L)
@@ -769,7 +769,7 @@ class RegisterOrderUseCaseTest {
         void registerOrder_zeroTotalAmountWithNonZeroProducts_throwsException() {
             RegisterOrderCommand command = RegisterOrderCommand.builder()
                     .buyerId(1L)
-                    .amount(OrderAmount.of(0L, null, 0L, 0L, null))
+                    .amount(OrderAmountCommand.builder().totalAmount(0L).couponAmount(0L).pointAmount(0L).shippingFee(null).build())
                     .orderProducts(List.of(
                             OrderProductItemCommand.builder()
                                     .productId(100L)
@@ -790,7 +790,7 @@ class RegisterOrderUseCaseTest {
         void registerOrder_multipleProductsMismatch_throwsException() {
             RegisterOrderCommand command = RegisterOrderCommand.builder()
                     .buyerId(1L)
-                    .amount(OrderAmount.of(99999L, null, 0L, 0L, null))
+                    .amount(OrderAmountCommand.builder().totalAmount(99999L).couponAmount(0L).pointAmount(0L).shippingFee(null).build())
                     .orderProducts(List.of(
                             OrderProductItemCommand.builder()
                                     .productId(100L)
@@ -818,7 +818,7 @@ class RegisterOrderUseCaseTest {
         void registerOrder_amountMismatch_doesNotCallSubsequentPorts() {
             RegisterOrderCommand command = RegisterOrderCommand.builder()
                     .buyerId(1L)
-                    .amount(OrderAmount.of(1L, null, 0L, 0L, null))
+                    .amount(OrderAmountCommand.builder().totalAmount(1L).couponAmount(0L).pointAmount(0L).shippingFee(null).build())
                     .orderProducts(List.of(
                             OrderProductItemCommand.builder()
                                     .productId(100L)
@@ -841,7 +841,7 @@ class RegisterOrderUseCaseTest {
         void registerOrder_overflowInMultiplication_throwsException() {
             RegisterOrderCommand command = RegisterOrderCommand.builder()
                     .buyerId(1L)
-                    .amount(OrderAmount.of(Long.MAX_VALUE, null, 0L, 0L, null))
+                    .amount(OrderAmountCommand.builder().totalAmount(Long.MAX_VALUE).couponAmount(0L).pointAmount(0L).shippingFee(null).build())
                     .orderProducts(List.of(
                             OrderProductItemCommand.builder()
                                     .productId(100L)
@@ -862,7 +862,7 @@ class RegisterOrderUseCaseTest {
         void registerOrder_overflowInSum_throwsException() {
             RegisterOrderCommand command = RegisterOrderCommand.builder()
                     .buyerId(1L)
-                    .amount(OrderAmount.of(Long.MAX_VALUE, null, 0L, 0L, null))
+                    .amount(OrderAmountCommand.builder().totalAmount(Long.MAX_VALUE).couponAmount(0L).pointAmount(0L).shippingFee(null).build())
                     .orderProducts(List.of(
                             OrderProductItemCommand.builder()
                                     .productId(100L)
@@ -1006,7 +1006,7 @@ class RegisterOrderUseCaseTest {
             Long sellerId = 10L;
             RegisterOrderCommand command = RegisterOrderCommand.builder()
                     .buyerId(1L)
-                    .amount(OrderAmount.of(50000L, null, 0L, 0L, null))
+                    .amount(OrderAmountCommand.builder().totalAmount(50000L).couponAmount(0L).pointAmount(0L).shippingFee(null).build())
                     .orderProducts(List.of(
                             OrderProductItemCommand.builder()
                                     .productId(100L)
@@ -1033,7 +1033,7 @@ class RegisterOrderUseCaseTest {
             Long actualSellerId = 10L;
             RegisterOrderCommand command = RegisterOrderCommand.builder()
                     .buyerId(1L)
-                    .amount(OrderAmount.of(50000L, null, 0L, 0L, null))
+                    .amount(OrderAmountCommand.builder().totalAmount(50000L).couponAmount(0L).pointAmount(0L).shippingFee(null).build())
                     .orderProducts(List.of(
                             OrderProductItemCommand.builder()
                                     .productId(100L)
@@ -1058,7 +1058,7 @@ class RegisterOrderUseCaseTest {
             Long pricePolicyId = 100L;
             RegisterOrderCommand command = RegisterOrderCommand.builder()
                     .buyerId(1L)
-                    .amount(OrderAmount.of(50000L, null, 0L, 0L, null))
+                    .amount(OrderAmountCommand.builder().totalAmount(50000L).couponAmount(0L).pointAmount(0L).shippingFee(null).build())
                     .orderProducts(List.of(
                             OrderProductItemCommand.builder()
                                     .productId(100L)
@@ -1083,7 +1083,7 @@ class RegisterOrderUseCaseTest {
             Long pricePolicyId = 100L;
             RegisterOrderCommand command = RegisterOrderCommand.builder()
                     .buyerId(1L)
-                    .amount(OrderAmount.of(50000L, null, 0L, 0L, null))
+                    .amount(OrderAmountCommand.builder().totalAmount(50000L).couponAmount(0L).pointAmount(0L).shippingFee(null).build())
                     .orderProducts(List.of(
                             OrderProductItemCommand.builder()
                                     .productId(100L)
@@ -1110,7 +1110,7 @@ class RegisterOrderUseCaseTest {
             Long pricePolicyId2 = 200L;
             RegisterOrderCommand command = RegisterOrderCommand.builder()
                     .buyerId(1L)
-                    .amount(OrderAmount.of(100000L, null, 0L, 0L, null))
+                    .amount(OrderAmountCommand.builder().totalAmount(100000L).couponAmount(0L).pointAmount(0L).shippingFee(null).build())
                     .orderProducts(List.of(
                             OrderProductItemCommand.builder()
                                     .productId(100L)
@@ -1199,7 +1199,7 @@ class RegisterOrderUseCaseTest {
             Long pricePolicyId = 100L;
             RegisterOrderCommand command = RegisterOrderCommand.builder()
                     .buyerId(1L)
-                    .amount(OrderAmount.of(50000L, null, null, null, null))
+                    .amount(OrderAmountCommand.builder().totalAmount(50000L).couponAmount(null).pointAmount(null).shippingFee(null).build())
                     .orderProducts(List.of(
                             OrderProductItemCommand.builder()
                                     .productId(100L)
@@ -1236,7 +1236,7 @@ class RegisterOrderUseCaseTest {
             Long pricePolicyId = 100L;
             RegisterOrderCommand command = RegisterOrderCommand.builder()
                     .buyerId(1L)
-                    .amount(OrderAmount.of(50000L, null, Long.MAX_VALUE / 2 + 1, Long.MAX_VALUE / 2 + 1, null))
+                    .amount(OrderAmountCommand.builder().totalAmount(50000L).couponAmount(Long.MAX_VALUE / 2 + 1).pointAmount(Long.MAX_VALUE / 2 + 1).shippingFee(null).build())
                     .orderProducts(List.of(
                             OrderProductItemCommand.builder()
                                     .productId(100L)
@@ -1357,7 +1357,7 @@ class RegisterOrderUseCaseTest {
             Long pricePolicyId2 = 200L;
             RegisterOrderCommand command = RegisterOrderCommand.builder()
                     .buyerId(1L)
-                    .amount(OrderAmount.of(100000L, null, 0L, 0L, null))
+                    .amount(OrderAmountCommand.builder().totalAmount(100000L).couponAmount(0L).pointAmount(0L).shippingFee(null).build())
                     .orderProducts(List.of(
                             OrderProductItemCommand.builder()
                                     .productId(100L)
@@ -1400,7 +1400,7 @@ class RegisterOrderUseCaseTest {
             Long pricePolicyId = 100L;
             RegisterOrderCommand command = RegisterOrderCommand.builder()
                     .buyerId(1L)
-                    .amount(OrderAmount.of(250000L, null, 0L, 0L, null))
+                    .amount(OrderAmountCommand.builder().totalAmount(250000L).couponAmount(0L).pointAmount(0L).shippingFee(null).build())
                     .orderProducts(List.of(
                             OrderProductItemCommand.builder()
                                     .productId(100L)
@@ -1435,7 +1435,7 @@ class RegisterOrderUseCaseTest {
             int orderQuantity = 10;
             RegisterOrderCommand command = RegisterOrderCommand.builder()
                     .buyerId(1L)
-                    .amount(OrderAmount.of(500000L, null, 0L, 0L, null))
+                    .amount(OrderAmountCommand.builder().totalAmount(500000L).couponAmount(0L).pointAmount(0L).shippingFee(null).build())
                     .orderProducts(List.of(
                             OrderProductItemCommand.builder()
                                     .productId(100L)
@@ -1468,7 +1468,7 @@ class RegisterOrderUseCaseTest {
             Long pricePolicyId = 100L;
             RegisterOrderCommand command = RegisterOrderCommand.builder()
                     .buyerId(1L)
-                    .amount(OrderAmount.of(500000L, null, 0L, 0L, null))
+                    .amount(OrderAmountCommand.builder().totalAmount(500000L).couponAmount(0L).pointAmount(0L).shippingFee(null).build())
                     .orderProducts(List.of(
                             OrderProductItemCommand.builder()
                                     .productId(100L)
@@ -1518,7 +1518,7 @@ class RegisterOrderUseCaseTest {
             Long pricePolicyId2 = 200L;
             RegisterOrderCommand command = RegisterOrderCommand.builder()
                     .buyerId(1L)
-                    .amount(OrderAmount.of(100000L, null, 0L, 0L, null))
+                    .amount(OrderAmountCommand.builder().totalAmount(100000L).couponAmount(0L).pointAmount(0L).shippingFee(null).build())
                     .orderProducts(List.of(
                             OrderProductItemCommand.builder()
                                     .productId(100L)
@@ -1559,7 +1559,7 @@ class RegisterOrderUseCaseTest {
             Long pricePolicyId = 100L;
             RegisterOrderCommand command = RegisterOrderCommand.builder()
                     .buyerId(1L)
-                    .amount(OrderAmount.of(350000L, null, 0L, 0L, null))
+                    .amount(OrderAmountCommand.builder().totalAmount(350000L).couponAmount(0L).pointAmount(0L).shippingFee(null).build())
                     .orderProducts(List.of(
                             OrderProductItemCommand.builder()
                                     .productId(100L)
@@ -1596,7 +1596,7 @@ class RegisterOrderUseCaseTest {
             Long pricePolicyId = 100L;
             RegisterOrderCommand command = RegisterOrderCommand.builder()
                     .buyerId(1L)
-                    .amount(OrderAmount.of(350000L, null, 0L, 0L, null))
+                    .amount(OrderAmountCommand.builder().totalAmount(350000L).couponAmount(0L).pointAmount(0L).shippingFee(null).build())
                     .orderProducts(List.of(
                             OrderProductItemCommand.builder()
                                     .productId(100L)
@@ -1670,7 +1670,7 @@ class RegisterOrderUseCaseTest {
             Long pricePolicyId = 100L;
             RegisterOrderCommand command = RegisterOrderCommand.builder()
                     .buyerId(1L)
-                    .amount(OrderAmount.of(500000L, null, 0L, 0L, null))
+                    .amount(OrderAmountCommand.builder().totalAmount(500000L).couponAmount(0L).pointAmount(0L).shippingFee(null).build())
                     .orderProducts(List.of(
                             OrderProductItemCommand.builder()
                                     .productId(100L)
@@ -1798,7 +1798,7 @@ class RegisterOrderUseCaseTest {
             RegisterOrderCommand command1 = createSingleProductCommand(1L, pricePolicyId, 50000L, 1, 0L, 0L);
             RegisterOrderCommand command2 = RegisterOrderCommand.builder()
                     .buyerId(2L)
-                    .amount(OrderAmount.of(100000L, null, 0L, 0L, null))
+                    .amount(OrderAmountCommand.builder().totalAmount(100000L).couponAmount(0L).pointAmount(0L).shippingFee(null).build())
                     .orderProducts(List.of(
                             OrderProductItemCommand.builder()
                                     .productId(100L)
@@ -1844,7 +1844,7 @@ class RegisterOrderUseCaseTest {
         void registerOrder_emptyOrderProducts_savesEmptyOrder() {
             RegisterOrderCommand command = RegisterOrderCommand.builder()
                     .buyerId(1L)
-                    .amount(OrderAmount.of(0L, null, 0L, 0L, null))
+                    .amount(OrderAmountCommand.builder().totalAmount(0L).couponAmount(0L).pointAmount(0L).shippingFee(null).build())
                     .orderProducts(List.of())
                     .build();
 
@@ -1868,7 +1868,7 @@ class RegisterOrderUseCaseTest {
             Long pricePolicyId = 100L;
             RegisterOrderCommand command = RegisterOrderCommand.builder()
                     .buyerId(1L)
-                    .amount(OrderAmount.of(0L, null, 0L, 0L, null))
+                    .amount(OrderAmountCommand.builder().totalAmount(0L).couponAmount(0L).pointAmount(0L).shippingFee(null).build())
                     .orderProducts(List.of(
                             OrderProductItemCommand.builder()
                                     .productId(100L)
@@ -1904,7 +1904,7 @@ class RegisterOrderUseCaseTest {
             Long largeTotalAmount = Long.MAX_VALUE - 1;
             RegisterOrderCommand command = RegisterOrderCommand.builder()
                     .buyerId(1L)
-                    .amount(OrderAmount.of(largeTotalAmount, null, 0L, 0L, null))
+                    .amount(OrderAmountCommand.builder().totalAmount(largeTotalAmount).couponAmount(0L).pointAmount(0L).shippingFee(null).build())
                     .orderProducts(List.of(
                             OrderProductItemCommand.builder()
                                     .productId(100L)
@@ -1961,7 +1961,7 @@ class RegisterOrderUseCaseTest {
             Long pricePolicyId3 = 300L;
             RegisterOrderCommand command = RegisterOrderCommand.builder()
                     .buyerId(1L)
-                    .amount(OrderAmount.of(300000L, null, 10000L, 5000L, null))
+                    .amount(OrderAmountCommand.builder().totalAmount(300000L).couponAmount(10000L).pointAmount(5000L).shippingFee(null).build())
                     .orderProducts(List.of(
                             OrderProductItemCommand.builder()
                                     .productId(100L)
@@ -2037,7 +2037,7 @@ class RegisterOrderUseCaseTest {
             Long pricePolicyId2 = 200L;
             RegisterOrderCommand command = RegisterOrderCommand.builder()
                     .buyerId(1L)
-                    .amount(OrderAmount.of(100000L, null, 0L, 0L, null))
+                    .amount(OrderAmountCommand.builder().totalAmount(100000L).couponAmount(0L).pointAmount(0L).shippingFee(null).build())
                     .orderProducts(List.of(
                             OrderProductItemCommand.builder()
                                     .productId(100L)
@@ -2087,7 +2087,7 @@ class RegisterOrderUseCaseTest {
             Long sameSellerId = 10L;
             RegisterOrderCommand command = RegisterOrderCommand.builder()
                     .buyerId(1L)
-                    .amount(OrderAmount.of(150000L, null, 0L, 0L, null))
+                    .amount(OrderAmountCommand.builder().totalAmount(150000L).couponAmount(0L).pointAmount(0L).shippingFee(null).build())
                     .orderProducts(List.of(
                             OrderProductItemCommand.builder()
                                     .productId(100L)
@@ -2284,7 +2284,7 @@ class RegisterOrderUseCaseTest {
             Long pricePolicyId = 100L;
             RegisterOrderCommand command = RegisterOrderCommand.builder()
                     .buyerId(1L)
-                    .amount(OrderAmount.of(50000L, null, 0L, 0L, null))
+                    .amount(OrderAmountCommand.builder().totalAmount(50000L).couponAmount(0L).pointAmount(0L).shippingFee(null).build())
                     .orderProducts(List.of(
                             OrderProductItemCommand.builder()
                                     .productId(100L)
@@ -2317,7 +2317,7 @@ class RegisterOrderUseCaseTest {
 
             RegisterOrderCommand command = RegisterOrderCommand.builder()
                     .buyerId(1L)
-                    .amount(OrderAmount.of(unitAmountA + unitAmountB, null, 0L, 0L, shippingFeeA + shippingFeeB))
+                    .amount(OrderAmountCommand.builder().totalAmount(unitAmountA + unitAmountB).couponAmount(0L).pointAmount(0L).shippingFee(shippingFeeA + shippingFeeB).build())
                     .orderProducts(List.of(
                             OrderProductItemCommand.builder()
                                     .productId(1L)
@@ -2365,7 +2365,7 @@ class RegisterOrderUseCaseTest {
 
             RegisterOrderCommand command = RegisterOrderCommand.builder()
                     .buyerId(1L)
-                    .amount(OrderAmount.of(unitAmountA + unitAmountB, null, 0L, 0L, shippingFeeB))
+                    .amount(OrderAmountCommand.builder().totalAmount(unitAmountA + unitAmountB).couponAmount(0L).pointAmount(0L).shippingFee(shippingFeeB).build())
                     .orderProducts(List.of(
                             OrderProductItemCommand.builder()
                                     .productId(1L)
@@ -2413,7 +2413,7 @@ class RegisterOrderUseCaseTest {
 
             RegisterOrderCommand command = RegisterOrderCommand.builder()
                     .buyerId(1L)
-                    .amount(OrderAmount.of(unitAmountA + unitAmountB, null, 0L, 0L, shippingFeeA))
+                    .amount(OrderAmountCommand.builder().totalAmount(unitAmountA + unitAmountB).couponAmount(0L).pointAmount(0L).shippingFee(shippingFeeA).build())
                     .orderProducts(List.of(
                             OrderProductItemCommand.builder()
                                     .productId(1L)
@@ -2458,7 +2458,7 @@ class RegisterOrderUseCaseTest {
 
             RegisterOrderCommand command = RegisterOrderCommand.builder()
                     .buyerId(1L)
-                    .amount(OrderAmount.of(unitAmountA + unitAmountB, null, 0L, 0L, 0L))
+                    .amount(OrderAmountCommand.builder().totalAmount(unitAmountA + unitAmountB).couponAmount(0L).pointAmount(0L).shippingFee(0L).build())
                     .orderProducts(List.of(
                             OrderProductItemCommand.builder()
                                     .productId(1L)
@@ -2575,7 +2575,7 @@ class RegisterOrderUseCaseTest {
     ) {
         return RegisterOrderCommand.builder()
                 .buyerId(buyerId)
-                .amount(OrderAmount.of(unitAmount * quantity, null, couponAmount, pointAmount, null))
+                .amount(OrderAmountCommand.builder().totalAmount(unitAmount * quantity).couponAmount(couponAmount).pointAmount(pointAmount).shippingFee(null).build())
                 .orderProducts(List.of(
                         OrderProductItemCommand.builder()
                                 .productId(100L)
@@ -2648,7 +2648,7 @@ class RegisterOrderUseCaseTest {
     ) {
         return RegisterOrderCommand.builder()
                 .buyerId(buyerId)
-                .amount(OrderAmount.of(unitAmount * quantity, null, couponAmount, pointAmount, shippingFee))
+                .amount(OrderAmountCommand.builder().totalAmount(unitAmount * quantity).couponAmount(couponAmount).pointAmount(pointAmount).shippingFee(shippingFee).build())
                 .orderProducts(List.of(
                         OrderProductItemCommand.builder()
                                 .productId(100L)

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/order/OrderAmount.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/order/OrderAmount.java
@@ -13,6 +13,7 @@ public class OrderAmount {
     private Long pointAmount;
     private Long shippingFee;
 
+    @Deprecated
     public static OrderAmount of(
             Long totalAmount,
             Long paidAmount,
@@ -26,6 +27,25 @@ public class OrderAmount {
                 .couponAmount(couponAmount)
                 .pointAmount(pointAmount)
                 .shippingFee(shippingFee)
+                .build();
+    }
+
+    public static OrderAmount from(OrderAmountCreateState state) {
+        return OrderAmount.builder()
+                .totalAmount(state.getTotalAmount())
+                .couponAmount(state.getCouponAmount())
+                .pointAmount(state.getPointAmount())
+                .shippingFee(state.getShippingFee())
+                .build();
+    }
+
+    public static OrderAmount from(OrderAmountSnapshotState state) {
+        return OrderAmount.builder()
+                .totalAmount(state.getTotalAmount())
+                .paidAmount(state.getPaidAmount())
+                .couponAmount(state.getCouponAmount())
+                .pointAmount(state.getPointAmount())
+                .shippingFee(state.getShippingFee())
                 .build();
     }
 }

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/order/OrderAmountCreateState.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/order/OrderAmountCreateState.java
@@ -1,0 +1,16 @@
+package com.personal.marketnote.commerce.domain.order;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class OrderAmountCreateState {
+    private final Long totalAmount;
+    private final Long couponAmount;
+    private final Long pointAmount;
+    private final Long shippingFee;
+}

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/order/OrderAmountSnapshotState.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/order/OrderAmountSnapshotState.java
@@ -1,0 +1,17 @@
+package com.personal.marketnote.commerce.domain.order;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class OrderAmountSnapshotState {
+    private final Long totalAmount;
+    private final Long paidAmount;
+    private final Long couponAmount;
+    private final Long pointAmount;
+    private final Long shippingFee;
+}


### PR DESCRIPTION
## partially addresses #216
## resolves #1582

## Task
- [x] `OrderAmountCommand` 레코드 생성 (`totalAmount`, `couponAmount`, `pointAmount`, `shippingFee`)
- [x] `OrderAmountCreateState` 생성 (도메인 생성용 State)
- [x] `OrderAmountSnapshotState` 생성 (JPA 복원용 State)
- [x] `RegisterOrderCommand`에서 `OrderAmount` → `OrderAmountCommand`로 변경
- [x] `OrderRequestToCommandMapper`에서 `OrderAmount.of()` → `OrderAmountCommand.builder()`로 변경
- [x] `RegisterOrderService`에서 `OrderAmount.from(OrderAmountCreateState)` 사용으로 변환 로직 이동
- [x] `OrderAmount`에 `from(CreateState)`, `from(SnapshotState)` 추가, 기존 `of()` `@Deprecated` 처리
- [x] `RegisterOrderUseCaseTest` 48개소 `OrderAmountCommand` 치환