### PR TITLE
[#216][#1581] feat: 주문 등록 API 배송지 전체 필드 전송 방식을 shippingAddressId 기반으로 변경

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/apidocs/RegisterOrderApiDocs.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/apidocs/RegisterOrderApiDocs.java
@@ -38,6 +38,8 @@ import java.lang.annotation.*;
                 | totalAmount | number | 총 주문 금액(원) | Y | 100000 |
                 | couponAmount | number | 쿠폰 할인 금액(원) | N | 5000 |
                 | pointAmount | number | 포인트 사용 금액(원) | N | 5000 |
+                | shippingAddressId | number | 배송지 ID | Y | 1 |
+                | requestMessage | string | 배송 요청사항 | N | "문 앞에 놓아주세요" |
                 | orderProducts | array | 주문 상품 목록 | Y | [ ... ] |
                 
                 ---
@@ -85,6 +87,8 @@ import java.lang.annotation.*;
                                   "totalAmount": 120000,
                                   "couponAmount": 5000,
                                   "pointAmount": 5000,
+                                  "shippingAddressId": 1,
+                                  "requestMessage": "문 앞에 놓아주세요",
                                   "orderProducts": [
                                     {
                                       "productId": 245,

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/mapper/OrderRequestToCommandMapper.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/mapper/OrderRequestToCommandMapper.java
@@ -35,14 +35,8 @@ public class OrderRequestToCommandMapper {
                         .pointAmount(request.getPointAmount())
                         .shippingFee(request.getShippingFee())
                         .build())
-                .shippingAddress(ShippingAddress.of(
-                        request.getRecipientName(),
-                        request.getRecipientPhoneNumber(),
-                        request.getZipCode(),
-                        request.getAddress(),
-                        request.getAddressDetail(),
-                        request.getRequestMessage()
-                ))
+                .shippingAddressId(request.getShippingAddressId())
+                .requestMessage(request.getRequestMessage())
                 .orderProducts(orderProducts)
                 .build();
     }

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/request/RegisterOrderRequest.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/request/RegisterOrderRequest.java
@@ -45,52 +45,12 @@ public class RegisterOrderRequest {
     private Long shippingFee;
 
     @Schema(
-            name = "recipientName",
-            description = "수령인명",
+            name = "shippingAddressId",
+            description = "배송지 ID",
             requiredMode = Schema.RequiredMode.REQUIRED
     )
-    @NotBlank(message = "수령인명은 필수값입니다.")
-    @Size(max = 50, message = "수령인명은 50자를 초과할 수 없습니다.")
-    @Pattern(regexp = RegularExpressionConstant.RECIPIENT_NAME_PATTERN, message = "수령인명 형식이 올바르지 않습니다.")
-    private String recipientName;
-
-    @Schema(
-            name = "recipientPhoneNumber",
-            description = "수령인 전화번호",
-            requiredMode = Schema.RequiredMode.REQUIRED
-    )
-    @NotBlank(message = "수령인 전화번호는 필수값입니다.")
-    @Size(max = 20, message = "수령인 전화번호는 20자를 초과할 수 없습니다.")
-    @Pattern(regexp = RegularExpressionConstant.PHONE_NUMBER_PATTERN, message = "전화번호 형식이 올바르지 않습니다.")
-    private String recipientPhoneNumber;
-
-    @Schema(
-            name = "zipCode",
-            description = "우편번호",
-            requiredMode = Schema.RequiredMode.REQUIRED
-    )
-    @NotBlank(message = "우편번호는 필수값입니다.")
-    @Pattern(regexp = RegularExpressionConstant.ZIP_CODE_PATTERN, message = "우편번호는 5자리 숫자여야 합니다.")
-    private String zipCode;
-
-    @Schema(
-            name = "address",
-            description = "주소",
-            requiredMode = Schema.RequiredMode.REQUIRED
-    )
-    @NotBlank(message = "주소는 필수값입니다.")
-    @Size(max = 255, message = "주소는 255자를 초과할 수 없습니다.")
-    @Pattern(regexp = RegularExpressionConstant.NO_HTML_TAG_PATTERN, message = "주소에 허용되지 않는 문자가 포함되어 있습니다.")
-    private String address;
-
-    @Schema(
-            name = "addressDetail",
-            description = "상세주소",
-            requiredMode = Schema.RequiredMode.NOT_REQUIRED
-    )
-    @Size(max = 255, message = "상세주소는 255자를 초과할 수 없습니다.")
-    @Pattern(regexp = RegularExpressionConstant.NO_HTML_TAG_PATTERN, message = "상세주소에 허용되지 않는 문자가 포함되어 있습니다.")
-    private String addressDetail;
+    @NotNull(message = "배송지 ID는 필수값입니다.")
+    private Long shippingAddressId;
 
     @Schema(
             name = "requestMessage",

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/web/user/UserShippingAddressServiceClient.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/web/user/UserShippingAddressServiceClient.java
@@ -1,0 +1,125 @@
+package com.personal.marketnote.commerce.adapter.out.web.user;
+
+import com.personal.marketnote.commerce.adapter.out.web.user.response.ShippingAddressInfoResponse;
+import com.personal.marketnote.commerce.exception.ShippingAddressNotFoundException;
+import com.personal.marketnote.commerce.port.out.result.user.ShippingAddressInfoResult;
+import com.personal.marketnote.commerce.port.out.user.FindUserShippingAddressPort;
+import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
+import com.personal.marketnote.common.adapter.out.ServiceAdapter;
+import com.personal.marketnote.common.security.hmac.HmacServiceAuthHeaderBuilder;
+import com.personal.marketnote.common.utility.FormatValidator;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+import java.util.concurrent.ThreadLocalRandom;
+
+import static com.personal.marketnote.common.utility.ApiConstant.INTER_SERVER_DEFAULT_RETRIAL_PENDING_MILLI_SECOND;
+import static com.personal.marketnote.common.utility.ApiConstant.INTER_SERVER_MAX_REQUEST_COUNT;
+
+/**
+ * 회원 서비스의 배송지 조회 클라이언트
+ *
+ * @Author 성효빈
+ * @Date 2026-03-27
+ * @Description 커머스 서비스에서 회원 서비스의 배송지를 조회합니다.
+ */
+@ServiceAdapter
+@RequiredArgsConstructor
+@Slf4j
+public class UserShippingAddressServiceClient implements FindUserShippingAddressPort {
+
+    private static final ParameterizedTypeReference<BaseResponse<ShippingAddressInfoResponse>> RESPONSE_TYPE =
+            new ParameterizedTypeReference<>() {
+            };
+
+    @Value("${user-service.base-url:http://localhost:8080}")
+    private String userServiceBaseUrl;
+
+    private final RestTemplate restTemplate;
+    private final HmacServiceAuthHeaderBuilder hmacServiceAuthHeaderBuilder;
+
+    @Override
+    public ShippingAddressInfoResult findByIdAndUserId(Long shippingAddressId, Long userId) {
+        String path = "/api/v1/internal/shipping-addresses/" + shippingAddressId;
+
+        URI uri = UriComponentsBuilder.fromUriString(userServiceBaseUrl)
+                .path(path)
+                .queryParam("userId", userId)
+                .build()
+                .toUri();
+
+        HttpHeaders headers = new HttpHeaders();
+        hmacServiceAuthHeaderBuilder.applyHeaders(headers, "GET", path);
+        HttpEntity<Void> request = new HttpEntity<>(headers);
+
+        return sendRequest(uri, request, shippingAddressId);
+    }
+
+    private ShippingAddressInfoResult sendRequest(URI uri, HttpEntity<Void> request, Long shippingAddressId) {
+        Exception lastError = new Exception();
+
+        for (int i = 0; i < INTER_SERVER_MAX_REQUEST_COUNT; i++) {
+            try {
+                ResponseEntity<BaseResponse<ShippingAddressInfoResponse>> response = restTemplate.exchange(
+                        uri,
+                        HttpMethod.GET,
+                        request,
+                        RESPONSE_TYPE
+                );
+
+                return parseResponse(response, shippingAddressId);
+            } catch (Exception e) {
+                log.warn("배송지 조회 실패 (attempt {}/{}): {}", i + 1, INTER_SERVER_MAX_REQUEST_COUNT, e.getMessage());
+                lastError = e;
+
+                if (i < INTER_SERVER_MAX_REQUEST_COUNT - 1) {
+                    sleepWithJitter();
+                }
+            }
+        }
+
+        log.error("배송지 조회 최종 실패 - URI: {}, error: {}", uri, lastError.getMessage(), lastError);
+        throw new ShippingAddressNotFoundException(shippingAddressId);
+    }
+
+    private ShippingAddressInfoResult parseResponse(
+            ResponseEntity<BaseResponse<ShippingAddressInfoResponse>> response,
+            Long shippingAddressId
+    ) {
+        BaseResponse<ShippingAddressInfoResponse> body = response.getBody();
+        if (FormatValidator.hasNoValue(body)) {
+            throw new ShippingAddressNotFoundException(shippingAddressId);
+        }
+
+        ShippingAddressInfoResponse content = body.getContent();
+        if (FormatValidator.hasNoValue(content)) {
+            throw new ShippingAddressNotFoundException(shippingAddressId);
+        }
+
+        return new ShippingAddressInfoResult(
+                content.recipientName(),
+                content.recipientPhoneNumber(),
+                content.address(),
+                content.addressDetail()
+        );
+    }
+
+    private void sleepWithJitter() {
+        try {
+            long jitteredSleepMillis = ThreadLocalRandom.current()
+                    .nextLong(Math.max(1L, INTER_SERVER_DEFAULT_RETRIAL_PENDING_MILLI_SECOND) + 1);
+            Thread.sleep(jitteredSleepMillis);
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+        }
+    }
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/web/user/response/ShippingAddressInfoResponse.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/web/user/response/ShippingAddressInfoResponse.java
@@ -1,0 +1,16 @@
+package com.personal.marketnote.commerce.adapter.out.web.user.response;
+
+public record ShippingAddressInfoResponse(
+        Long id,
+        String addressType,
+        String address,
+        String addressDetail,
+        String companyName,
+        String addressAlias,
+        String recipientName,
+        String recipientPhoneNumber,
+        String deliveryRequestType,
+        String deliveryRequestMessage,
+        boolean isDefault
+) {
+}

--- a/commerce-service/commerce-adapters/src/main/resources/application.yml
+++ b/commerce-service/commerce-adapters/src/main/resources/application.yml
@@ -75,6 +75,9 @@ kafka:
   slack:
     webhook-url: ${KAFKA_SLACK_WEBHOOK_URL:}
 
+user-service:
+  base-url: ${USER_SERVICE_SERVER_ORIGIN:http://localhost:8080}
+
 product-service:
   base-url: ${PRODUCT_SERVICE_SERVER_ORIGIN:http://localhost:8081}
 

--- a/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/event/saga/OrderPaymentCompletedSagaConsumerTest.java
+++ b/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/event/saga/OrderPaymentCompletedSagaConsumerTest.java
@@ -138,7 +138,7 @@ class OrderPaymentCompletedSagaConsumerTest {
     }
 
     private ConsumerRecord<String, EventEnvelope<?>> createRecord(SagaStepMessage stepMessage) {
-        Clock clock = Clock.fixed(Instant.parse("2026-03-17T01:00:00Z"), ZoneId.of("Asia/Seoul"));
+        Clock clock = Clock.fixed(Instant.parse("2026-03-27T01:00:00Z"), ZoneId.of("Asia/Seoul"));
         EventEnvelope<SagaStepMessage> envelope = EventEnvelope.of(
                 "saga.ORDER_PAYMENT.PUBLISH_PAYMENT_COMPLETED.action", "saga-orchestrator", stepMessage, clock);
 

--- a/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/event/saga/OrderPaymentInventorySagaConsumerTest.java
+++ b/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/event/saga/OrderPaymentInventorySagaConsumerTest.java
@@ -176,7 +176,7 @@ class OrderPaymentInventorySagaConsumerTest {
     }
 
     private ConsumerRecord<String, EventEnvelope<?>> createRecord(SagaStepMessage stepMessage) {
-        Clock clock = Clock.fixed(Instant.parse("2026-03-17T01:00:00Z"), ZoneId.of("Asia/Seoul"));
+        Clock clock = Clock.fixed(Instant.parse("2026-03-27T01:00:00Z"), ZoneId.of("Asia/Seoul"));
         EventEnvelope<SagaStepMessage> envelope = EventEnvelope.of(
                 "saga.ORDER_PAYMENT.DEDUCT_INVENTORY.action", "saga-orchestrator", stepMessage, clock);
 

--- a/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/event/saga/OrderPaymentLedgerSagaConsumerTest.java
+++ b/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/event/saga/OrderPaymentLedgerSagaConsumerTest.java
@@ -189,7 +189,7 @@ class OrderPaymentLedgerSagaConsumerTest {
     }
 
     private ConsumerRecord<String, EventEnvelope<?>> createRecord(SagaStepMessage stepMessage) {
-        Clock clock = Clock.fixed(Instant.parse("2026-03-17T01:00:00Z"), ZoneId.of("Asia/Seoul"));
+        Clock clock = Clock.fixed(Instant.parse("2026-03-27T01:00:00Z"), ZoneId.of("Asia/Seoul"));
         EventEnvelope<SagaStepMessage> envelope = EventEnvelope.of(
                 "saga.ORDER_PAYMENT.RECORD_LEDGER.action", "saga-orchestrator", stepMessage, clock);
 

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/exception/ShippingAddressNotFoundException.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/exception/ShippingAddressNotFoundException.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.commerce.exception;
+
+public class ShippingAddressNotFoundException extends RuntimeException {
+    public ShippingAddressNotFoundException(Long shippingAddressId) {
+        super("ERR_SHIPPING_ADDRESS_01::배송지를 찾을 수 없습니다. shippingAddressId=" + shippingAddressId);
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/command/order/RegisterOrderCommand.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/command/order/RegisterOrderCommand.java
@@ -1,6 +1,5 @@
 package com.personal.marketnote.commerce.port.in.command.order;
 
-import com.personal.marketnote.commerce.domain.order.ShippingAddress;
 import lombok.Builder;
 
 import java.util.List;
@@ -9,7 +8,8 @@ import java.util.List;
 public record RegisterOrderCommand(
         Long buyerId,
         OrderAmountCommand amount,
-        ShippingAddress shippingAddress,
+        Long shippingAddressId,
+        String requestMessage,
         List<OrderProductItemCommand> orderProducts
 ) {
 }

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/result/user/ShippingAddressInfoResult.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/result/user/ShippingAddressInfoResult.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.commerce.port.out.result.user;
+
+public record ShippingAddressInfoResult(
+        String recipientName,
+        String recipientPhoneNumber,
+        String address,
+        String addressDetail
+) {
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/user/FindUserShippingAddressPort.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/user/FindUserShippingAddressPort.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.commerce.port.out.user;
+
+import com.personal.marketnote.commerce.port.out.result.user.ShippingAddressInfoResult;
+
+public interface FindUserShippingAddressPort {
+    ShippingAddressInfoResult findByIdAndUserId(Long shippingAddressId, Long userId);
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/RegisterOrderService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/RegisterOrderService.java
@@ -6,6 +6,7 @@ import com.personal.marketnote.commerce.domain.order.OrderAmount;
 import com.personal.marketnote.commerce.domain.order.OrderAmountCreateState;
 import com.personal.marketnote.commerce.domain.order.OrderCreateState;
 import com.personal.marketnote.commerce.domain.order.OrderProductCreateState;
+import com.personal.marketnote.commerce.domain.order.ShippingAddress;
 import com.personal.marketnote.commerce.domain.payment.Payment;
 import com.personal.marketnote.commerce.domain.payment.PaymentCreateState;
 import com.personal.marketnote.commerce.domain.settlement.PaymentAllocation;
@@ -25,7 +26,9 @@ import com.personal.marketnote.commerce.port.out.result.product.ProductInfoResul
 import com.personal.marketnote.commerce.port.out.result.shipping.ShippingPolicyInfoResult;
 import com.personal.marketnote.commerce.port.out.reward.ModifyUserPointPort;
 import com.personal.marketnote.commerce.port.out.settlement.SavePaymentAllocationPort;
+import com.personal.marketnote.commerce.port.out.result.user.ShippingAddressInfoResult;
 import com.personal.marketnote.commerce.port.out.shipping.FindShippingPolicyBySellerIdsPort;
+import com.personal.marketnote.commerce.port.out.user.FindUserShippingAddressPort;
 import com.personal.marketnote.common.application.UseCase;
 import com.personal.marketnote.common.utility.FormatValidator;
 import lombok.RequiredArgsConstructor;
@@ -51,6 +54,7 @@ public class RegisterOrderService implements RegisterOrderUseCase {
     private final SavePaymentPort savePaymentPort;
     private final SavePaymentAllocationPort savePaymentAllocationPort;
     private final ModifyUserPointPort modifyUserPointPort;
+    private final FindUserShippingAddressPort findUserShippingAddressPort;
 
     @Override
     public RegisterOrderResult registerOrder(RegisterOrderCommand command) {
@@ -97,12 +101,14 @@ public class RegisterOrderService implements RegisterOrderUseCase {
                         .build()
         );
 
+        ShippingAddress shippingAddress = resolveShippingAddress(command);
+
         Order savedOrder = saveOrderPort.save(
                 Order.from(
                         OrderCreateState.builder()
                                 .buyerId(command.buyerId())
                                 .amount(orderAmount)
-                                .shippingAddress(command.shippingAddress())
+                                .shippingAddress(shippingAddress)
                                 .orderProductStates(orderProductStates)
                                 .build()
                 )
@@ -313,6 +319,21 @@ public class RegisterOrderService implements RegisterOrderUseCase {
         }
 
         return totalShippingFee;
+    }
+
+    private ShippingAddress resolveShippingAddress(RegisterOrderCommand command) {
+        ShippingAddressInfoResult addressInfo = findUserShippingAddressPort.findByIdAndUserId(
+                command.shippingAddressId(), command.buyerId()
+        );
+
+        return ShippingAddress.of(
+                addressInfo.recipientName(),
+                addressInfo.recipientPhoneNumber(),
+                null,
+                addressInfo.address(),
+                addressInfo.addressDetail(),
+                command.requestMessage()
+        );
     }
 
     private long resolveAmount(Long amount) {

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/RegisterOrderUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/RegisterOrderUseCaseTest.java
@@ -19,9 +19,11 @@ import com.personal.marketnote.commerce.port.out.payment.SavePaymentPort;
 import com.personal.marketnote.commerce.port.out.product.FindProductByPricePolicyPort;
 import com.personal.marketnote.commerce.port.out.result.product.ProductInfoResult;
 import com.personal.marketnote.commerce.port.out.result.shipping.ShippingPolicyInfoResult;
+import com.personal.marketnote.commerce.port.out.result.user.ShippingAddressInfoResult;
 import com.personal.marketnote.commerce.port.out.reward.ModifyUserPointPort;
 import com.personal.marketnote.commerce.port.out.settlement.SavePaymentAllocationPort;
 import com.personal.marketnote.commerce.port.out.shipping.FindShippingPolicyBySellerIdsPort;
+import com.personal.marketnote.commerce.port.out.user.FindUserShippingAddressPort;
 import com.personal.marketnote.common.domain.exception.illegalargument.invalidvalue.InsufficientQuantityException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -56,6 +58,8 @@ class RegisterOrderUseCaseTest {
     private FindShippingPolicyBySellerIdsPort findShippingPolicyBySellerIdsPort;
     @Mock
     private ModifyUserPointPort modifyUserPointPort;
+    @Mock
+    private FindUserShippingAddressPort findUserShippingAddressPort;
 
     @InjectMocks
     private RegisterOrderService registerOrderService;
@@ -64,6 +68,8 @@ class RegisterOrderUseCaseTest {
     void setUp() {
         lenient().when(findShippingPolicyBySellerIdsPort.findBySellerIds(anyList()))
                 .thenReturn(Map.of());
+        lenient().when(findUserShippingAddressPort.findByIdAndUserId(any(), any()))
+                .thenReturn(new ShippingAddressInfoResult("홍길동", "01012345678", "서울시 강남구", "101호"));
     }
 
     // ==================================================================================

--- a/common/src/test/java/com/personal/marketnote/common/saga/SagaResponsePublisherTest.java
+++ b/common/src/test/java/com/personal/marketnote/common/saga/SagaResponsePublisherTest.java
@@ -34,7 +34,7 @@ class SagaResponsePublisherTest {
     @BeforeEach
     void setUp() {
         Clock clock = Clock.fixed(
-                Instant.parse("2026-03-17T01:00:00Z"),
+                Instant.parse("2026-03-27T01:00:00Z"),
                 ZoneId.of("Asia/Seoul")
         );
         ObjectMapper objectMapper = new ObjectMapper();

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/shippingaddress/controller/InternalShippingAddressController.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/shippingaddress/controller/InternalShippingAddressController.java
@@ -1,0 +1,57 @@
+package com.personal.marketnote.user.adapter.in.web.shippingaddress.controller;
+
+import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
+import com.personal.marketnote.user.adapter.in.web.shippingaddress.response.GetShippingAddressResponse;
+import com.personal.marketnote.user.port.in.result.shippingaddress.GetShippingAddressResult;
+import com.personal.marketnote.user.port.in.usecase.shippingaddress.GetShippingAddressUseCase;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import static com.personal.marketnote.common.domain.exception.ExceptionCode.DEFAULT_SUCCESS_CODE;
+
+/**
+ * 내부 배송지 컨트롤러 (서비스 간 통신용)
+ *
+ * @Author 성효빈
+ * @Date 2026-03-27
+ * @Description HMAC 인증 기반 서비스 간 통신용 배송지 조회 API를 제공합니다.
+ */
+@RestController
+@RequestMapping("/api/v1/internal/shipping-addresses")
+@Tag(
+        name = "내부 배송지 API",
+        description = "서비스 간 통신용 배송지 API"
+)
+@RequiredArgsConstructor
+@Slf4j
+public class InternalShippingAddressController {
+    private final GetShippingAddressUseCase getShippingAddressUseCase;
+
+    /**
+     * 배송지 정보 조회 (서비스 간 통신용)
+     *
+     * @param id     배송지 ID
+     * @param userId 회원 ID
+     * @return 배송지 조회 결과 {@link GetShippingAddressResponse}
+     */
+    @GetMapping("/{id}")
+    public ResponseEntity<BaseResponse<GetShippingAddressResponse>> getShippingAddress(
+            @PathVariable Long id,
+            @RequestParam Long userId
+    ) {
+        GetShippingAddressResult result = getShippingAddressUseCase.getShippingAddress(id, userId);
+
+        return ResponseEntity.ok(
+                BaseResponse.of(
+                        GetShippingAddressResponse.from(result),
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "배송지 조회 성공"
+                )
+        );
+    }
+}


### PR DESCRIPTION
## partially addresses #216
## resolves #1581

## Task
- [x] RegisterOrderRequest에서 배송지 필드 6개 제거, shippingAddressId + requestMessage 추가
- [x] RegisterOrderCommand에서 ShippingAddress 도메인 객체 제거, Long shippingAddressId + String requestMessage로 변경
- [x] RegisterOrderService에서 user-service 배송지 조회 Port 호출 → ShippingAddress 스냅샷 생성
- [x] RegisterOrderApiDocs Description 테이블 및 ExampleObject 예제 JSON 업데이트
- [x] 배송지 조회용 Out Port 추가 (FindUserShippingAddressPort)
- [x] user-service 배송지 조회 HTTP 클라이언트 Adapter 구현
- [x] user-service 내부 배송지 조회 API (InternalShippingAddressController) 추가
- [x] 기존 RegisterOrderUseCaseTest Mock 추가 반영