### PR TITLE
[#216][#1583] feat: 주문 등록 시 배송 요청사항을 배송지에 저장하여 다음 주문 시 기본 선택값으로 노출

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/OrderController.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/OrderController.java
@@ -13,8 +13,10 @@ import com.personal.marketnote.commerce.port.in.command.order.GetBuyerOrderHisto
 import com.personal.marketnote.commerce.port.in.command.order.UpdateOrderProductReviewStatusCommand;
 import com.personal.marketnote.commerce.port.in.result.order.*;
 import com.personal.marketnote.commerce.port.in.usecase.order.*;
+import com.personal.marketnote.commerce.port.out.user.UpdateUserShippingAddressDeliveryRequestPort;
 import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
 import com.personal.marketnote.common.utility.ElementExtractor;
+import com.personal.marketnote.common.utility.FormatValidator;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -44,6 +46,7 @@ import static com.personal.marketnote.common.utility.ApiConstant.ADMIN_POINTCUT;
 @Validated
 public class OrderController {
     private final RegisterOrderUseCase registerOrderUseCase;
+    private final UpdateUserShippingAddressDeliveryRequestPort updateUserShippingAddressDeliveryRequestPort;
     private final GetOrderUseCase getOrderUseCase;
     private final ChangeOrderStatusUseCase changeOrderStatusUseCase;
     private final UpdateOrderProductUseCase updateOrderProductUseCase;
@@ -72,6 +75,8 @@ public class OrderController {
                 OrderRequestToCommandMapper.mapToCommand(request, buyerId)
         );
 
+        updateDeliveryRequestIfPresent(request, buyerId);
+
         return new ResponseEntity<>(
                 BaseResponse.of(
                         RegisterOrderResponse.from(result),
@@ -80,6 +85,19 @@ public class OrderController {
                         "주문 등록 성공"
                 ),
                 HttpStatus.CREATED
+        );
+    }
+
+    private void updateDeliveryRequestIfPresent(RegisterOrderRequest request, Long buyerId) {
+        if (FormatValidator.hasNoValue(request.getDeliveryRequestType())) {
+            return;
+        }
+
+        updateUserShippingAddressDeliveryRequestPort.updateDeliveryRequest(
+                request.getShippingAddressId(),
+                buyerId,
+                request.getDeliveryRequestType(),
+                request.getDeliveryRequestMessage()
         );
     }
 

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/request/RegisterOrderRequest.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/request/RegisterOrderRequest.java
@@ -62,6 +62,26 @@ public class RegisterOrderRequest {
     private String requestMessage;
 
     @Schema(
+            name = "deliveryRequestType",
+            description = "배송 요청사항 타입 (NONE, LEAVE_AT_DOOR, RECEIVE_OR_LEAVE_AT_DOOR, LEAVE_AT_SECURITY, LEAVE_AT_DELIVERY_BOX, CUSTOM)",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    @Pattern(
+            regexp = "NONE|LEAVE_AT_DOOR|RECEIVE_OR_LEAVE_AT_DOOR|LEAVE_AT_SECURITY|LEAVE_AT_DELIVERY_BOX|CUSTOM",
+            message = "유효하지 않은 배송 요청사항 타입입니다."
+    )
+    private String deliveryRequestType;
+
+    @Schema(
+            name = "deliveryRequestMessage",
+            description = "배송 요청사항 직접입력 메시지 (최대 60자, CUSTOM 타입일 때 필수)",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    @Size(max = 60, message = "배송 요청사항 메시지는 최대 60자까지 입력할 수 있습니다.")
+    @Pattern(regexp = RegularExpressionConstant.NO_HTML_TAG_PATTERN, message = "배송 요청사항 메시지에 허용되지 않는 문자가 포함되어 있습니다.")
+    private String deliveryRequestMessage;
+
+    @Schema(
             name = "orderProducts",
             description = "주문 상품 목록",
             requiredMode = Schema.RequiredMode.REQUIRED

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/web/user/UserShippingAddressServiceClient.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/web/user/UserShippingAddressServiceClient.java
@@ -4,6 +4,7 @@ import com.personal.marketnote.commerce.adapter.out.web.user.response.ShippingAd
 import com.personal.marketnote.commerce.exception.ShippingAddressNotFoundException;
 import com.personal.marketnote.commerce.port.out.result.user.ShippingAddressInfoResult;
 import com.personal.marketnote.commerce.port.out.user.FindUserShippingAddressPort;
+import com.personal.marketnote.commerce.port.out.user.UpdateUserShippingAddressDeliveryRequestPort;
 import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
 import com.personal.marketnote.common.adapter.out.ServiceAdapter;
 import com.personal.marketnote.common.security.hmac.HmacServiceAuthHeaderBuilder;
@@ -12,14 +13,13 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.ParameterizedTypeReference;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.*;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
 
 import static com.personal.marketnote.common.utility.ApiConstant.INTER_SERVER_DEFAULT_RETRIAL_PENDING_MILLI_SECOND;
@@ -35,7 +35,7 @@ import static com.personal.marketnote.common.utility.ApiConstant.INTER_SERVER_MA
 @ServiceAdapter
 @RequiredArgsConstructor
 @Slf4j
-public class UserShippingAddressServiceClient implements FindUserShippingAddressPort {
+public class UserShippingAddressServiceClient implements FindUserShippingAddressPort, UpdateUserShippingAddressDeliveryRequestPort {
 
     private static final ParameterizedTypeReference<BaseResponse<ShippingAddressInfoResponse>> RESPONSE_TYPE =
             new ParameterizedTypeReference<>() {
@@ -111,6 +111,36 @@ public class UserShippingAddressServiceClient implements FindUserShippingAddress
                 content.address(),
                 content.addressDetail()
         );
+    }
+
+    @Override
+    public void updateDeliveryRequest(Long shippingAddressId, Long userId, String deliveryRequestType, String deliveryRequestMessage) {
+        String path = "/api/v1/internal/shipping-addresses/" + shippingAddressId + "/delivery-request";
+
+        URI uri = UriComponentsBuilder.fromUriString(userServiceBaseUrl)
+                .path(path)
+                .queryParam("userId", userId)
+                .build()
+                .toUri();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        hmacServiceAuthHeaderBuilder.applyHeaders(headers, "PATCH", path);
+
+        Map<String, String> body = new HashMap<>();
+        body.put("deliveryRequestType", deliveryRequestType);
+        if (FormatValidator.hasValue(deliveryRequestMessage)) {
+            body.put("deliveryRequestMessage", deliveryRequestMessage);
+        }
+
+        HttpEntity<Map<String, String>> request = new HttpEntity<>(body, headers);
+
+        try {
+            restTemplate.exchange(uri, HttpMethod.PATCH, request, Void.class);
+        } catch (Exception e) {
+            log.warn("배송 요청사항 업데이트 실패 - shippingAddressId: {}, userId: {}, error: {}",
+                    shippingAddressId, userId, e.getMessage());
+        }
     }
 
     private void sleepWithJitter() {

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/user/UpdateUserShippingAddressDeliveryRequestPort.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/user/UpdateUserShippingAddressDeliveryRequestPort.java
@@ -1,0 +1,21 @@
+package com.personal.marketnote.commerce.port.out.user;
+
+/**
+ * 회원 서비스의 배송지 배송 요청사항 수정 포트
+ *
+ * @Author 성효빈
+ * @Date 2026-03-27
+ * @Description 커머스 서비스에서 회원 서비스의 배송지 배송 요청사항을 수정합니다.
+ */
+public interface UpdateUserShippingAddressDeliveryRequestPort {
+    /**
+     * @param shippingAddressId    배송지 ID
+     * @param userId               회원 ID
+     * @param deliveryRequestType  배송 요청사항 타입
+     * @param deliveryRequestMessage 배송 요청사항 메시지
+     * @Date 2026-03-27
+     * @Author 성효빈
+     * @Description 배송지의 배송 요청사항을 수정합니다.
+     */
+    void updateDeliveryRequest(Long shippingAddressId, Long userId, String deliveryRequestType, String deliveryRequestMessage);
+}

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/shippingaddress/controller/InternalShippingAddressController.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/shippingaddress/controller/InternalShippingAddressController.java
@@ -1,10 +1,14 @@
 package com.personal.marketnote.user.adapter.in.web.shippingaddress.controller;
 
 import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
+import com.personal.marketnote.user.adapter.in.web.shippingaddress.request.UpdateDeliveryRequestRequest;
 import com.personal.marketnote.user.adapter.in.web.shippingaddress.response.GetShippingAddressResponse;
+import com.personal.marketnote.user.port.in.command.shippingaddress.UpdateDeliveryRequestCommand;
 import com.personal.marketnote.user.port.in.result.shippingaddress.GetShippingAddressResult;
 import com.personal.marketnote.user.port.in.usecase.shippingaddress.GetShippingAddressUseCase;
+import com.personal.marketnote.user.port.in.usecase.shippingaddress.UpdateDeliveryRequestUseCase;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -30,6 +34,7 @@ import static com.personal.marketnote.common.domain.exception.ExceptionCode.DEFA
 @Slf4j
 public class InternalShippingAddressController {
     private final GetShippingAddressUseCase getShippingAddressUseCase;
+    private final UpdateDeliveryRequestUseCase updateDeliveryRequestUseCase;
 
     /**
      * 배송지 정보 조회 (서비스 간 통신용)
@@ -52,6 +57,39 @@ public class InternalShippingAddressController {
                         DEFAULT_SUCCESS_CODE,
                         "배송지 조회 성공"
                 )
+        );
+    }
+
+    /**
+     * 배송 요청사항 수정 (서비스 간 통신용)
+     *
+     * @param id      배송지 ID
+     * @param userId  회원 ID
+     * @param request 배송 요청사항 수정 요청
+     */
+    @PatchMapping("/{id}/delivery-request")
+    public ResponseEntity<BaseResponse<Void>> updateDeliveryRequest(
+            @PathVariable Long id,
+            @RequestParam Long userId,
+            @Valid @RequestBody UpdateDeliveryRequestRequest request
+    ) {
+        updateDeliveryRequestUseCase.updateDeliveryRequest(
+                id,
+                userId,
+                UpdateDeliveryRequestCommand.builder()
+                        .deliveryRequestType(request.getDeliveryRequestType())
+                        .deliveryRequestMessage(request.getDeliveryRequestMessage())
+                        .build()
+        );
+
+        return new ResponseEntity<>(
+                BaseResponse.of(
+                        null,
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "배송 요청사항 수정 성공"
+                ),
+                HttpStatus.OK
         );
     }
 }

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/shippingaddress/request/UpdateDeliveryRequestRequest.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/shippingaddress/request/UpdateDeliveryRequestRequest.java
@@ -1,0 +1,20 @@
+package com.personal.marketnote.user.adapter.in.web.shippingaddress.request;
+
+import com.personal.marketnote.common.utility.RegularExpressionConstant;
+import com.personal.marketnote.user.domain.shippingaddress.DeliveryRequestType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+@Getter
+public class UpdateDeliveryRequestRequest {
+
+    @Schema(name = "deliveryRequestType", description = "배송 요청사항 타입", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    private DeliveryRequestType deliveryRequestType;
+
+    @Schema(name = "deliveryRequestMessage", description = "배송 요청사항 직접입력 메시지 (최대 60자, CUSTOM 타입일 때 필수)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @Size(max = 60, message = "배송 요청사항 메시지는 최대 60자까지 입력할 수 있습니다.")
+    @Pattern(regexp = RegularExpressionConstant.NO_HTML_TAG_PATTERN, message = "배송 요청사항 메시지에 허용되지 않는 문자가 포함되어 있습니다.")
+    private String deliveryRequestMessage;
+}

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/port/in/command/shippingaddress/UpdateDeliveryRequestCommand.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/port/in/command/shippingaddress/UpdateDeliveryRequestCommand.java
@@ -1,0 +1,11 @@
+package com.personal.marketnote.user.port.in.command.shippingaddress;
+
+import com.personal.marketnote.user.domain.shippingaddress.DeliveryRequestType;
+import lombok.Builder;
+
+@Builder
+public record UpdateDeliveryRequestCommand(
+        DeliveryRequestType deliveryRequestType,
+        String deliveryRequestMessage
+) {
+}

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/port/in/usecase/shippingaddress/UpdateDeliveryRequestUseCase.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/port/in/usecase/shippingaddress/UpdateDeliveryRequestUseCase.java
@@ -1,0 +1,22 @@
+package com.personal.marketnote.user.port.in.usecase.shippingaddress;
+
+import com.personal.marketnote.user.port.in.command.shippingaddress.UpdateDeliveryRequestCommand;
+
+/**
+ * 배송 요청사항 수정 유스케이스
+ *
+ * @Author 성효빈
+ * @Date 2026-03-27
+ * @Description 배송지의 배송 요청사항만 부분 수정하는 기능을 제공합니다.
+ */
+public interface UpdateDeliveryRequestUseCase {
+    /**
+     * @param shippingAddressId 배송지 ID
+     * @param userId            회원 ID
+     * @param command           배송 요청사항 수정 커맨드
+     * @Date 2026-03-27
+     * @Author 성효빈
+     * @Description 배송지의 배송 요청사항을 수정합니다.
+     */
+    void updateDeliveryRequest(Long shippingAddressId, Long userId, UpdateDeliveryRequestCommand command);
+}

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/service/shippingaddress/UpdateDeliveryRequestService.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/service/shippingaddress/UpdateDeliveryRequestService.java
@@ -1,0 +1,34 @@
+package com.personal.marketnote.user.service.shippingaddress;
+
+import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.user.domain.shippingaddress.ShippingAddress;
+import com.personal.marketnote.user.exception.ShippingAddressNotFoundException;
+import com.personal.marketnote.user.port.in.command.shippingaddress.UpdateDeliveryRequestCommand;
+import com.personal.marketnote.user.port.in.usecase.shippingaddress.UpdateDeliveryRequestUseCase;
+import com.personal.marketnote.user.port.out.shippingaddress.FindShippingAddressPort;
+import com.personal.marketnote.user.port.out.shippingaddress.UpdateShippingAddressPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@RequiredArgsConstructor
+@UseCase
+@Transactional(isolation = READ_COMMITTED)
+public class UpdateDeliveryRequestService implements UpdateDeliveryRequestUseCase {
+    private final FindShippingAddressPort findShippingAddressPort;
+    private final UpdateShippingAddressPort updateShippingAddressPort;
+
+    @Override
+    public void updateDeliveryRequest(Long shippingAddressId, Long userId, UpdateDeliveryRequestCommand command) {
+        ShippingAddress shippingAddress = findShippingAddressPort.findByIdAndUserId(shippingAddressId, userId)
+                .orElseThrow(() -> new ShippingAddressNotFoundException(shippingAddressId));
+
+        shippingAddress.updateDeliveryRequest(
+                command.deliveryRequestType(),
+                command.deliveryRequestMessage()
+        );
+
+        updateShippingAddressPort.update(shippingAddress);
+    }
+}

--- a/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/shippingaddress/ShippingAddress.java
+++ b/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/shippingaddress/ShippingAddress.java
@@ -109,11 +109,20 @@ public class ShippingAddress extends BaseDomain {
         validate();
     }
 
+    public void updateDeliveryRequest(DeliveryRequestType deliveryRequestType, String deliveryRequestMessage) {
+        this.deliveryRequestType = deliveryRequestType;
+        this.deliveryRequestMessage = deliveryRequestMessage;
+        validateDeliveryRequest();
+    }
+
     private void validate() {
         if (addressType == ShippingAddressType.COMPANY && FormatValidator.hasNoValue(companyName)) {
             throw new ShippingAddressCompanyNameNoValueException();
         }
+        validateDeliveryRequest();
+    }
 
+    private void validateDeliveryRequest() {
         if (FormatValidator.hasNoValue(deliveryRequestType) || !deliveryRequestType.isCustom()) {
             this.deliveryRequestMessage = null;
             return;


### PR DESCRIPTION
## partially addresses #216
## resolves #1583

## Task
- [x] user-service ShippingAddress 도메인에 updateDeliveryRequest() 메서드 추가
- [x] user-service UpdateDeliveryRequestUseCase/Service 구현
- [x] user-service InternalShippingAddressController에 PATCH /delivery-request 엔드포인트 추가
- [x] commerce-service RegisterOrderRequest에 deliveryRequestType, deliveryRequestMessage 필드 추가
- [x] commerce-service UpdateUserShippingAddressDeliveryRequestPort 정의 및 ServiceClient 구현
- [x] commerce-service OrderController에서 주문 등록 완료 후 fire-and-forget 배송 요청사항 업데이트 호출