### PR TITLE
[#128][#1609] test: 상품 서비스 ServiceClient를 RestClient로 전환 기능 자동화 테스트 추가

### DIFF
--- a/product-service/product-adapters/src/test/java/com/personal/marketnote/product/adapter/out/web/commerce/CommerceServiceClientTest.java
+++ b/product-service/product-adapters/src/test/java/com/personal/marketnote/product/adapter/out/web/commerce/CommerceServiceClientTest.java
@@ -1,0 +1,169 @@
+package com.personal.marketnote.product.adapter.out.web.commerce;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.common.exception.CommerceServiceRequestFailedException;
+import com.personal.marketnote.common.security.hmac.HmacServiceAuthHeaderBuilder;
+import com.personal.marketnote.common.utility.http.client.restclient.RestClientErrorHandler;
+import com.personal.marketnote.product.port.out.result.GetInventoryResult;
+import com.personal.marketnote.product.utility.ServiceCommunicationPayloadGenerator;
+import com.personal.marketnote.product.utility.ServiceCommunicationRecorder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.*;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withServerError;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+@ExtendWith(MockitoExtension.class)
+class CommerceServiceClientTest {
+
+    private static final String BASE_URL = "http://localhost:8083";
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    private MockRestServiceServer mockServer;
+    private CommerceServiceClient commerceServiceClient;
+
+    @Mock
+    private HmacServiceAuthHeaderBuilder hmacServiceAuthHeaderBuilder;
+
+    @Mock
+    private ServiceCommunicationRecorder serviceCommunicationRecorder;
+
+    @Mock
+    private ServiceCommunicationPayloadGenerator serviceCommunicationPayloadGenerator;
+
+    @BeforeEach
+    void setUp() {
+        RestClient.Builder builder = RestClient.builder()
+                .defaultStatusHandler(RestClientErrorHandler::isError, RestClientErrorHandler.noOpErrorHandler());
+        mockServer = MockRestServiceServer.bindTo(builder).build();
+        commerceServiceClient = new CommerceServiceClient(
+                builder,
+                BASE_URL,
+                hmacServiceAuthHeaderBuilder,
+                serviceCommunicationRecorder,
+                serviceCommunicationPayloadGenerator
+        );
+
+        lenient().when(serviceCommunicationPayloadGenerator.buildRequestPayloadJson(any(), any(), any(), anyInt()))
+                .thenReturn(objectMapper.createObjectNode());
+        lenient().when(serviceCommunicationPayloadGenerator.buildErrorPayloadJson(anyString(), any(), anyInt()))
+                .thenReturn(objectMapper.createObjectNode());
+    }
+
+    @Nested
+    @DisplayName("registerInventory")
+    class RegisterInventory {
+
+        @Test
+        @DisplayName("재고 등록 요청이 성공하면 정상적으로 완료된다")
+        void shouldCompleteSuccessfullyWhenRequestSucceeds() {
+            mockServer.expect(requestTo(BASE_URL + "/api/v1/inventories"))
+                    .andExpect(method(HttpMethod.POST))
+                    .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                    .andRespond(withSuccess());
+
+            commerceServiceClient.registerInventory(1L, 100L);
+
+            mockServer.verify();
+        }
+
+        @Test
+        @DisplayName("모든 재시도가 실패하면 CommerceServiceRequestFailedException이 발생한다")
+        void shouldThrowExceptionWhenAllRetriesFail() {
+            for (int i = 0; i < 5; i++) {
+                mockServer.expect(requestTo(BASE_URL + "/api/v1/inventories"))
+                        .andExpect(method(HttpMethod.POST))
+                        .andRespond(withServerError());
+            }
+
+            assertThatThrownBy(() -> commerceServiceClient.registerInventory(1L, 100L))
+                    .isInstanceOf(CommerceServiceRequestFailedException.class);
+
+            mockServer.verify();
+        }
+    }
+
+    @Nested
+    @DisplayName("findByPricePolicyIds")
+    class FindByPricePolicyIds {
+
+        @Test
+        @DisplayName("가격정책 ID 목록으로 재고 조회에 성공하면 재고 결과를 반환한다")
+        void shouldReturnInventoriesWhenRequestSucceeds() {
+            mockServer.expect(requestTo(BASE_URL + "/api/v1/inventories?pricePolicyIds=1&pricePolicyIds=2"))
+                    .andExpect(method(HttpMethod.GET))
+                    .andRespond(withSuccess("""
+                            {
+                                "content": {
+                                    "inventories": [
+                                        {"pricePolicyId": 1, "stock": 100},
+                                        {"pricePolicyId": 2, "stock": 50}
+                                    ]
+                                }
+                            }
+                            """, MediaType.APPLICATION_JSON));
+
+            Set<GetInventoryResult> result =
+                    commerceServiceClient.findByPricePolicyIds(List.of(1L, 2L));
+
+            assertThat(result).hasSize(2);
+
+            mockServer.verify();
+        }
+
+        @Test
+        @DisplayName("응답 바디가 null이면 CommerceServiceRequestFailedException 후 폴백 결과를 반환한다")
+        void shouldReturnFallbackResultsWhenResponseBodyIsNull() {
+            for (int i = 0; i < 5; i++) {
+                mockServer.expect(requestTo(BASE_URL + "/api/v1/inventories?pricePolicyIds=1"))
+                        .andExpect(method(HttpMethod.GET))
+                        .andRespond(withSuccess());
+            }
+
+            Set<GetInventoryResult> result =
+                    commerceServiceClient.findByPricePolicyIds(List.of(1L));
+
+            assertThat(result).hasSize(1);
+            assertThat(result.iterator().next().stock()).isNull();
+
+            mockServer.verify();
+        }
+
+        @Test
+        @DisplayName("모든 재시도가 실패하면 stock이 null인 폴백 결과를 반환한다")
+        void shouldReturnFallbackResultsWhenAllRetriesFail() {
+            for (int i = 0; i < 5; i++) {
+                mockServer.expect(requestTo(BASE_URL + "/api/v1/inventories?pricePolicyIds=1&pricePolicyIds=2"))
+                        .andExpect(method(HttpMethod.GET))
+                        .andRespond(withServerError());
+            }
+
+            Set<GetInventoryResult> result =
+                    commerceServiceClient.findByPricePolicyIds(List.of(1L, 2L));
+
+            assertThat(result).hasSize(2);
+            result.forEach(item -> assertThat(item.stock()).isNull());
+
+            mockServer.verify();
+        }
+    }
+}

--- a/product-service/product-adapters/src/test/java/com/personal/marketnote/product/adapter/out/web/community/CommunityServiceClientTest.java
+++ b/product-service/product-adapters/src/test/java/com/personal/marketnote/product/adapter/out/web/community/CommunityServiceClientTest.java
@@ -1,0 +1,170 @@
+package com.personal.marketnote.product.adapter.out.web.community;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.common.security.hmac.HmacServiceAuthHeaderBuilder;
+import com.personal.marketnote.common.utility.http.client.restclient.RestClientErrorHandler;
+import com.personal.marketnote.product.port.out.result.ProductReviewAggregateResult;
+import com.personal.marketnote.product.utility.ServiceCommunicationPayloadGenerator;
+import com.personal.marketnote.product.utility.ServiceCommunicationRecorder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withServerError;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+@ExtendWith(MockitoExtension.class)
+class CommunityServiceClientTest {
+
+    private static final String BASE_URL = "http://localhost:8082";
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    private MockRestServiceServer mockServer;
+    private CommunityServiceClient communityServiceClient;
+
+    @Mock
+    private HmacServiceAuthHeaderBuilder hmacServiceAuthHeaderBuilder;
+
+    @Mock
+    private ServiceCommunicationRecorder serviceCommunicationRecorder;
+
+    @Mock
+    private ServiceCommunicationPayloadGenerator serviceCommunicationPayloadGenerator;
+
+    @BeforeEach
+    void setUp() {
+        RestClient.Builder builder = RestClient.builder()
+                .defaultStatusHandler(RestClientErrorHandler::isError, RestClientErrorHandler.noOpErrorHandler());
+        mockServer = MockRestServiceServer.bindTo(builder).build();
+        communityServiceClient = new CommunityServiceClient(
+                builder,
+                BASE_URL,
+                hmacServiceAuthHeaderBuilder,
+                serviceCommunicationRecorder,
+                serviceCommunicationPayloadGenerator
+        );
+
+        lenient().when(serviceCommunicationPayloadGenerator.buildRequestPayloadJson(any(), any(), any(), anyInt()))
+                .thenReturn(objectMapper.createObjectNode());
+        lenient().when(serviceCommunicationPayloadGenerator.buildErrorPayloadJson(anyString(), any(), anyInt()))
+                .thenReturn(objectMapper.createObjectNode());
+    }
+
+    @Nested
+    @DisplayName("findByProductIds")
+    class FindByProductIds {
+
+        @Test
+        @DisplayName("상품 ID 목록으로 리뷰 집계 조회에 성공하면 productId별 결과를 반환한다")
+        void shouldReturnReviewAggregatesWhenRequestSucceeds() {
+            mockServer.expect(requestTo(BASE_URL + "/api/v1/products/review-aggregates?productIds=1&productIds=2"))
+                    .andExpect(method(HttpMethod.GET))
+                    .andRespond(withSuccess("""
+                            {
+                                "content": {
+                                    "reviewAggregates": [
+                                        {"productId": 1, "totalCount": 10, "averageRating": 4.5},
+                                        {"productId": 2, "totalCount": 5, "averageRating": 3.0}
+                                    ]
+                                }
+                            }
+                            """, MediaType.APPLICATION_JSON));
+
+            Map<Long, ProductReviewAggregateResult> result =
+                    communityServiceClient.findByProductIds(List.of(1L, 2L));
+
+            assertThat(result).hasSize(2);
+            assertThat(result.get(1L).totalCount()).isEqualTo(10);
+            assertThat(result.get(1L).averageRating()).isEqualTo(4.5f);
+            assertThat(result.get(2L).totalCount()).isEqualTo(5);
+            assertThat(result.get(2L).averageRating()).isEqualTo(3.0f);
+
+            mockServer.verify();
+        }
+
+        @Test
+        @DisplayName("상품 ID 목록이 null이면 빈 Map을 반환한다")
+        void shouldReturnEmptyMapWhenProductIdsIsNull() {
+            Map<Long, ProductReviewAggregateResult> result =
+                    communityServiceClient.findByProductIds(null);
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("상품 ID 목록이 비어있으면 빈 Map을 반환한다")
+        void shouldReturnEmptyMapWhenProductIdsIsEmpty() {
+            Map<Long, ProductReviewAggregateResult> result =
+                    communityServiceClient.findByProductIds(List.of());
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("응답 바디가 null이면 빈 Map을 반환한다")
+        void shouldReturnEmptyMapWhenResponseBodyIsNull() {
+            mockServer.expect(requestTo(BASE_URL + "/api/v1/products/review-aggregates?productIds=1"))
+                    .andExpect(method(HttpMethod.GET))
+                    .andRespond(withSuccess());
+
+            Map<Long, ProductReviewAggregateResult> result =
+                    communityServiceClient.findByProductIds(List.of(1L));
+
+            assertThat(result).isEmpty();
+
+            mockServer.verify();
+        }
+
+        @Test
+        @DisplayName("reviewAggregates가 null이면 빈 Map을 반환한다")
+        void shouldReturnEmptyMapWhenReviewAggregatesIsNull() {
+            mockServer.expect(requestTo(BASE_URL + "/api/v1/products/review-aggregates?productIds=1"))
+                    .andExpect(method(HttpMethod.GET))
+                    .andRespond(withSuccess("""
+                            {"content": {"reviewAggregates": null}}
+                            """, MediaType.APPLICATION_JSON));
+
+            Map<Long, ProductReviewAggregateResult> result =
+                    communityServiceClient.findByProductIds(List.of(1L));
+
+            assertThat(result).isEmpty();
+
+            mockServer.verify();
+        }
+
+        @Test
+        @DisplayName("모든 재시도가 실패하면 빈 Map을 반환한다")
+        void shouldReturnEmptyMapWhenAllRetriesFail() {
+            for (int i = 0; i < 5; i++) {
+                mockServer.expect(requestTo(BASE_URL + "/api/v1/products/review-aggregates?productIds=1"))
+                        .andExpect(method(HttpMethod.GET))
+                        .andRespond(withServerError());
+            }
+
+            Map<Long, ProductReviewAggregateResult> result =
+                    communityServiceClient.findByProductIds(List.of(1L));
+
+            assertThat(result).isEmpty();
+
+            mockServer.verify();
+        }
+    }
+}

--- a/product-service/product-adapters/src/test/java/com/personal/marketnote/product/adapter/out/web/file/FileServiceClientTest.java
+++ b/product-service/product-adapters/src/test/java/com/personal/marketnote/product/adapter/out/web/file/FileServiceClientTest.java
@@ -1,0 +1,174 @@
+package com.personal.marketnote.product.adapter.out.web.file;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.common.application.file.port.in.result.GetFilesResult;
+import com.personal.marketnote.common.domain.file.FileSort;
+import com.personal.marketnote.common.exception.FileServiceRequestFailedException;
+import com.personal.marketnote.common.security.hmac.HmacServiceAuthHeaderBuilder;
+import com.personal.marketnote.common.utility.http.client.restclient.RestClientErrorHandler;
+import com.personal.marketnote.product.utility.ServiceCommunicationPayloadGenerator;
+import com.personal.marketnote.product.utility.ServiceCommunicationRecorder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withServerError;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+@ExtendWith(MockitoExtension.class)
+class FileServiceClientTest {
+
+    private static final String BASE_URL = "http://localhost:9000";
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    private MockRestServiceServer mockServer;
+    private FileServiceClient fileServiceClient;
+
+    @Mock
+    private HmacServiceAuthHeaderBuilder hmacServiceAuthHeaderBuilder;
+
+    @Mock
+    private ServiceCommunicationRecorder serviceCommunicationRecorder;
+
+    @Mock
+    private ServiceCommunicationPayloadGenerator serviceCommunicationPayloadGenerator;
+
+    @BeforeEach
+    void setUp() {
+        RestClient.Builder builder = RestClient.builder()
+                .defaultStatusHandler(RestClientErrorHandler::isError, RestClientErrorHandler.noOpErrorHandler());
+        mockServer = MockRestServiceServer.bindTo(builder).build();
+        fileServiceClient = new FileServiceClient(
+                builder,
+                BASE_URL,
+                hmacServiceAuthHeaderBuilder,
+                serviceCommunicationRecorder,
+                serviceCommunicationPayloadGenerator
+        );
+
+        lenient().when(serviceCommunicationPayloadGenerator.buildRequestPayloadJson(any(), any(), any(), anyInt()))
+                .thenReturn(objectMapper.createObjectNode());
+        lenient().when(serviceCommunicationPayloadGenerator.buildErrorPayloadJson(anyString(), any(), anyInt()))
+                .thenReturn(objectMapper.createObjectNode());
+    }
+
+    @Nested
+    @DisplayName("findImagesByProductIdAndSort")
+    class FindImagesByProductIdAndSort {
+
+        @Test
+        @DisplayName("상품 이미지 조회에 성공하면 GetFilesResult를 반환한다")
+        void shouldReturnFilesResultWhenRequestSucceeds() {
+            mockServer.expect(requestTo(BASE_URL + "/api/v1/files?ownerType=PRODUCT&ownerId=1&sort=PRODUCT_CATALOG_IMAGE"))
+                    .andExpect(method(HttpMethod.GET))
+                    .andRespond(withSuccess("""
+                            {
+                                "content": {
+                                    "files": [
+                                        {
+                                            "id": 1,
+                                            "sort": "PRODUCT_THUMBNAIL",
+                                            "extension": "jpg",
+                                            "name": "image1.jpg",
+                                            "s3Url": "https://s3.example.com/image1.jpg",
+                                            "resizedS3Urls": ["https://s3.example.com/image1_200.jpg"],
+                                            "orderNum": 1
+                                        }
+                                    ]
+                                }
+                            }
+                            """, MediaType.APPLICATION_JSON));
+
+            Optional<GetFilesResult> result =
+                    fileServiceClient.findImagesByProductIdAndSort(1L, FileSort.PRODUCT_CATALOG_IMAGE);
+
+            assertThat(result).isPresent();
+            assertThat(result.get().images()).hasSize(1);
+            assertThat(result.get().images().get(0).name()).isEqualTo("image1.jpg");
+
+            mockServer.verify();
+        }
+
+        @Test
+        @DisplayName("응답에 파일이 없으면 빈 Optional을 반환한다")
+        void shouldReturnEmptyOptionalWhenNoFiles() {
+            mockServer.expect(requestTo(BASE_URL + "/api/v1/files?ownerType=PRODUCT&ownerId=1&sort=PRODUCT_CATALOG_IMAGE"))
+                    .andExpect(method(HttpMethod.GET))
+                    .andRespond(withSuccess("""
+                            {"content": {"files": null}}
+                            """, MediaType.APPLICATION_JSON));
+
+            Optional<GetFilesResult> result =
+                    fileServiceClient.findImagesByProductIdAndSort(1L, FileSort.PRODUCT_CATALOG_IMAGE);
+
+            assertThat(result).isEmpty();
+
+            mockServer.verify();
+        }
+
+        @Test
+        @DisplayName("모든 재시도가 실패하면 빈 Optional을 반환한다")
+        void shouldReturnEmptyOptionalWhenAllRetriesFail() {
+            for (int i = 0; i < 5; i++) {
+                mockServer.expect(requestTo(BASE_URL + "/api/v1/files?ownerType=PRODUCT&ownerId=1&sort=PRODUCT_CATALOG_IMAGE"))
+                        .andExpect(method(HttpMethod.GET))
+                        .andRespond(withServerError());
+            }
+
+            Optional<GetFilesResult> result =
+                    fileServiceClient.findImagesByProductIdAndSort(1L, FileSort.PRODUCT_CATALOG_IMAGE);
+
+            assertThat(result).isEmpty();
+
+            mockServer.verify();
+        }
+    }
+
+    @Nested
+    @DisplayName("delete")
+    class Delete {
+
+        @Test
+        @DisplayName("파일 삭제 요청이 성공하면 정상적으로 완료된다")
+        void shouldCompleteSuccessfullyWhenDeleteSucceeds() {
+            mockServer.expect(requestTo(BASE_URL + "/api/v1/files/1"))
+                    .andExpect(method(HttpMethod.DELETE))
+                    .andRespond(withSuccess());
+
+            fileServiceClient.delete(1L);
+
+            mockServer.verify();
+        }
+
+        @Test
+        @DisplayName("파일 삭제 요청이 실패하면 FileServiceRequestFailedException이 발생한다")
+        void shouldThrowExceptionWhenDeleteFails() {
+            mockServer.expect(requestTo(BASE_URL + "/api/v1/files/1"))
+                    .andExpect(method(HttpMethod.DELETE))
+                    .andRespond(withServerError());
+
+            assertThatThrownBy(() -> fileServiceClient.delete(1L))
+                    .isInstanceOf(FileServiceRequestFailedException.class);
+
+            mockServer.verify();
+        }
+    }
+}

--- a/product-service/product-adapters/src/test/java/com/personal/marketnote/product/adapter/out/web/fulfillment/FulfillmentServiceClientTest.java
+++ b/product-service/product-adapters/src/test/java/com/personal/marketnote/product/adapter/out/web/fulfillment/FulfillmentServiceClientTest.java
@@ -1,0 +1,263 @@
+package com.personal.marketnote.product.adapter.out.web.fulfillment;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.common.exception.FulfillmentServiceRequestFailedException;
+import com.personal.marketnote.common.security.hmac.HmacServiceAuthHeaderBuilder;
+import com.personal.marketnote.common.utility.http.client.restclient.RestClientErrorHandler;
+import com.personal.marketnote.product.port.in.result.fulfillment.GetFulfillmentVendorGoodsElementsResult;
+import com.personal.marketnote.product.port.in.result.fulfillment.GetFulfillmentVendorGoodsResult;
+import com.personal.marketnote.product.port.out.fulfillment.RegisterFulfillmentVendorGoodsCommand;
+import com.personal.marketnote.product.port.out.fulfillment.UpdateFulfillmentVendorGoodsCommand;
+import com.personal.marketnote.product.utility.ServiceCommunicationPayloadGenerator;
+import com.personal.marketnote.product.utility.ServiceCommunicationRecorder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withServerError;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+@ExtendWith(MockitoExtension.class)
+class FulfillmentServiceClientTest {
+
+    private static final String BASE_URL = "http://localhost:8084";
+    private static final String CUSTOMER_CODE = "TEST_CUSTOMER";
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    private MockRestServiceServer mockServer;
+    private FulfillmentServiceClient fulfillmentServiceClient;
+
+    @Mock
+    private HmacServiceAuthHeaderBuilder hmacServiceAuthHeaderBuilder;
+
+    @Mock
+    private ServiceCommunicationRecorder serviceCommunicationRecorder;
+
+    @Mock
+    private ServiceCommunicationPayloadGenerator serviceCommunicationPayloadGenerator;
+
+    @BeforeEach
+    void setUp() {
+        RestClient.Builder builder = RestClient.builder()
+                .defaultStatusHandler(RestClientErrorHandler::isError, RestClientErrorHandler.noOpErrorHandler());
+        mockServer = MockRestServiceServer.bindTo(builder).build();
+        fulfillmentServiceClient = new FulfillmentServiceClient(
+                builder,
+                BASE_URL,
+                CUSTOMER_CODE,
+                hmacServiceAuthHeaderBuilder,
+                serviceCommunicationRecorder,
+                serviceCommunicationPayloadGenerator
+        );
+
+        lenient().when(serviceCommunicationPayloadGenerator.buildRequestPayloadJson(any(), any(), any(), anyInt()))
+                .thenReturn(objectMapper.createObjectNode());
+        lenient().when(serviceCommunicationPayloadGenerator.buildErrorPayloadJson(anyString(), any(), anyInt()))
+                .thenReturn(objectMapper.createObjectNode());
+    }
+
+    private void expectAuthTokenRequest() {
+        mockServer.expect(requestTo(BASE_URL + "/api/v1/vendors/fassto/auth"))
+                .andExpect(method(HttpMethod.POST))
+                .andRespond(withSuccess("""
+                        {
+                            "content": {
+                                "tokenInfo": {
+                                    "accessToken": "test-access-token",
+                                    "expiresAt": "2026-12-31T23:59:59"
+                                }
+                            }
+                        }
+                        """, MediaType.APPLICATION_JSON));
+    }
+
+    @Nested
+    @DisplayName("registerFulfillmentVendorGoods")
+    class RegisterFulfillmentVendorGoods {
+
+        @Test
+        @DisplayName("풀필먼트 벤더 상품 등록 요청이 성공하면 정상적으로 완료된다")
+        void shouldCompleteSuccessfullyWhenRequestSucceeds() {
+            expectAuthTokenRequest();
+
+            mockServer.expect(requestTo(BASE_URL + "/api/v1/vendors/fassto/goods/" + CUSTOMER_CODE))
+                    .andExpect(method(HttpMethod.POST))
+                    .andRespond(withSuccess("""
+                            {
+                                "content": {
+                                    "dataCount": 1,
+                                    "goods": [{"code": "200", "msg": "SUCCESS", "cstGodCd": "CST001"}]
+                                }
+                            }
+                            """, MediaType.APPLICATION_JSON));
+
+            RegisterFulfillmentVendorGoodsCommand command = RegisterFulfillmentVendorGoodsCommand.builder()
+                    .cstGodCd("CST001")
+                    .godNm("테스트 상품")
+                    .godType("01")
+                    .giftDiv("N")
+                    .build();
+
+            fulfillmentServiceClient.registerFulfillmentVendorGoods(command);
+
+            mockServer.verify();
+        }
+
+        @Test
+        @DisplayName("인증 토큰 요청이 모든 재시도 실패하면 FulfillmentServiceRequestFailedException이 발생한다")
+        void shouldThrowExceptionWhenAuthTokenRequestFails() {
+            for (int i = 0; i < 5; i++) {
+                mockServer.expect(requestTo(BASE_URL + "/api/v1/vendors/fassto/auth"))
+                        .andExpect(method(HttpMethod.POST))
+                        .andRespond(withServerError());
+            }
+
+            RegisterFulfillmentVendorGoodsCommand command = RegisterFulfillmentVendorGoodsCommand.builder()
+                    .cstGodCd("CST001")
+                    .godNm("테스트 상품")
+                    .godType("01")
+                    .giftDiv("N")
+                    .build();
+
+            assertThatThrownBy(() -> fulfillmentServiceClient.registerFulfillmentVendorGoods(command))
+                    .isInstanceOf(FulfillmentServiceRequestFailedException.class);
+
+            mockServer.verify();
+        }
+    }
+
+    @Nested
+    @DisplayName("getFulfillmentVendorGoods")
+    class GetFulfillmentVendorGoods {
+
+        @Test
+        @DisplayName("풀필먼트 벤더 상품 목록 조회에 성공하면 결과를 반환한다")
+        void shouldReturnGoodsResultWhenRequestSucceeds() {
+            expectAuthTokenRequest();
+
+            mockServer.expect(requestTo(BASE_URL + "/api/v1/vendors/fassto/goods/detail/" + CUSTOMER_CODE + "?godNm=test"))
+                    .andExpect(method(HttpMethod.GET))
+                    .andRespond(withSuccess("""
+                            {
+                                "content": {
+                                    "dataCount": 1,
+                                    "goods": [{
+                                        "godCd": "GOD001", "godType": "01", "godNm": "test",
+                                        "godTypeNm": "일반", "invGodNmUseYn": "N", "cstGodCd": "CST001",
+                                        "godOptCd1": "", "godOptCd2": "", "cstCd": "C01", "cstNm": "고객",
+                                        "supCd": "", "supNm": "", "cateCd": "", "cateNm": "",
+                                        "seasonCd": "", "genderCd": "", "godPr": "10000", "inPr": "8000",
+                                        "salPr": "12000", "dealTemp": "상온", "pickFac": "",
+                                        "giftDiv": "N", "giftDivNm": "비선물",
+                                        "godWidth": "", "godLength": "", "godHeight": "",
+                                        "makeYr": "", "godBulk": "", "godWeight": "", "godSideSum": "",
+                                        "godVolume": "", "godBarcd": "", "boxWidth": "", "boxLength": "",
+                                        "boxHeight": "", "boxBulk": "", "boxWeight": "",
+                                        "inBoxBarcd": "", "inBoxLength": "", "inBoxHeight": "",
+                                        "inBoxBulk": "", "inBoxWidth": "", "inBoxWeight": "",
+                                        "inBoxSideSum": "", "boxInCnt": "", "inBoxInCnt": "",
+                                        "pltInCnt": "", "origin": "", "distTermMgtYn": "",
+                                        "useTermDay": "", "outCanDay": "", "inCanDay": "",
+                                        "boxDiv": "", "bufGodYn": "", "loadingDirection": "",
+                                        "firstInDt": "", "useYn": "Y", "feeYn": "",
+                                        "saleUnitQty": "", "cstOneDayDeliveryYn": "", "safetyStock": ""
+                                    }]
+                                }
+                            }
+                            """, MediaType.APPLICATION_JSON));
+
+            GetFulfillmentVendorGoodsResult result =
+                    fulfillmentServiceClient.getFulfillmentVendorGoods("test");
+
+            assertThat(result).isNotNull();
+            assertThat(result.dataCount()).isEqualTo(1);
+
+            mockServer.verify();
+        }
+    }
+
+    @Nested
+    @DisplayName("getFulfillmentVendorGoodsElements")
+    class GetFulfillmentVendorGoodsElements {
+
+        @Test
+        @DisplayName("풀필먼트 벤더 상품 구성요소 조회에 성공하면 결과를 반환한다")
+        void shouldReturnGoodsElementsResultWhenRequestSucceeds() {
+            expectAuthTokenRequest();
+
+            mockServer.expect(requestTo(BASE_URL + "/api/v1/vendors/fassto/goods/element/" + CUSTOMER_CODE))
+                    .andExpect(method(HttpMethod.GET))
+                    .andRespond(withSuccess("""
+                            {
+                                "content": {
+                                    "dataCount": 1,
+                                    "elements": [{
+                                        "godCd": "GOD001",
+                                        "cstGodCd": "CST001",
+                                        "godNm": "test",
+                                        "useYn": "Y",
+                                        "elementList": []
+                                    }]
+                                }
+                            }
+                            """, MediaType.APPLICATION_JSON));
+
+            GetFulfillmentVendorGoodsElementsResult result =
+                    fulfillmentServiceClient.getFulfillmentVendorGoodsElements();
+
+            assertThat(result).isNotNull();
+            assertThat(result.dataCount()).isEqualTo(1);
+
+            mockServer.verify();
+        }
+    }
+
+    @Nested
+    @DisplayName("updateFulfillmentVendorGoods")
+    class UpdateFulfillmentVendorGoods {
+
+        @Test
+        @DisplayName("풀필먼트 벤더 상품 수정 요청이 성공하면 정상적으로 완료된다")
+        void shouldCompleteSuccessfullyWhenUpdateSucceeds() {
+            expectAuthTokenRequest();
+
+            mockServer.expect(requestTo(BASE_URL + "/api/v1/vendors/fassto/goods/" + CUSTOMER_CODE))
+                    .andExpect(method(HttpMethod.PUT))
+                    .andRespond(withSuccess("""
+                            {
+                                "content": {
+                                    "dataCount": 1,
+                                    "goods": [{"code": "200", "msg": "SUCCESS"}]
+                                }
+                            }
+                            """, MediaType.APPLICATION_JSON));
+
+            UpdateFulfillmentVendorGoodsCommand command = UpdateFulfillmentVendorGoodsCommand.builder()
+                    .cstGodCd("CST001")
+                    .godNm("수정된 상품")
+                    .godType("01")
+                    .giftDiv("N")
+                    .build();
+
+            fulfillmentServiceClient.updateFulfillmentVendorGoods(command);
+
+            mockServer.verify();
+        }
+    }
+}


### PR DESCRIPTION
## partially addresses #128
## resolves #1609

## Task
- [x] CommerceServiceClient 재고 등록 성공 테스트
- [x] CommerceServiceClient 재고 등록 재시도 실패 테스트
- [x] CommerceServiceClient 재고 조회 성공 테스트
- [x] CommerceServiceClient 재고 조회 응답 null 폴백 테스트
- [x] CommerceServiceClient 재고 조회 재시도 실패 폴백 테스트
- [x] CommunityServiceClient 리뷰 집계 조회 성공 테스트
- [x] CommunityServiceClient productIds null 테스트
- [x] CommunityServiceClient productIds 빈 목록 테스트
- [x] CommunityServiceClient 응답 바디 null 테스트
- [x] CommunityServiceClient reviewAggregates null 테스트
- [x] CommunityServiceClient 재시도 실패 테스트
- [x] FileServiceClient 이미지 조회 성공 테스트
- [x] FileServiceClient 파일 없음 빈 Optional 테스트
- [x] FileServiceClient 이미지 조회 재시도 실패 테스트
- [x] FileServiceClient 파일 삭제 성공 테스트
- [x] FileServiceClient 파일 삭제 실패 예외 테스트
- [x] FulfillmentServiceClient 상품 등록 성공 테스트
- [x] FulfillmentServiceClient 인증 토큰 실패 테스트
- [x] FulfillmentServiceClient 상품 조회 성공 테스트
- [x] FulfillmentServiceClient 구성요소 조회 성공 테스트
- [x] FulfillmentServiceClient 상품 수정 성공 테스트