### PR TITLE
[#475][#1481] feat: 풀필먼트 서비스 벤더 통신 클라이언트를 RestClient로 전환

### DIFF
--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/client/FasstoAuthClient.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/client/FasstoAuthClient.java
@@ -21,11 +21,10 @@ import com.personal.marketnote.fulfillment.port.out.vendor.RequestFasstoAuthPort
 import com.personal.marketnote.fulfillment.utility.VendorCommunicationFailureHandler;
 import com.personal.marketnote.fulfillment.utility.VendorCommunicationPayloadGenerator;
 import com.personal.marketnote.fulfillment.utility.VendorCommunicationRecorder;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.*;
+import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClientResponseException;
-import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.io.IOException;
@@ -38,24 +37,38 @@ import java.util.concurrent.ThreadLocalRandom;
 import static com.personal.marketnote.common.utility.ApiConstant.*;
 
 @VendorAdapter
-@RequiredArgsConstructor
 @Slf4j
 public class FasstoAuthClient implements RequestFasstoAuthPort, DisconnectFasstoAuthPort {
     private static final String API_CD_PARAM = "apiCd";
     private static final String API_KEY_PARAM = "apiKey";
     private static final String ACCESS_TOKEN_HEADER = "accessToken";
 
-    private final RestTemplate restTemplate;
+    private final RestClient restClient;
     private final ObjectMapper objectMapper;
     private final FasstoAuthProperties properties;
     private final VendorCommunicationRecorder vendorCommunicationRecorder;
     private final VendorCommunicationPayloadGenerator vendorCommunicationPayloadGenerator;
     private final VendorCommunicationFailureHandler vendorCommunicationFailureHandler;
 
+    public FasstoAuthClient(
+            RestClient.Builder restClientBuilder,
+            ObjectMapper objectMapper,
+            FasstoAuthProperties properties,
+            VendorCommunicationRecorder vendorCommunicationRecorder,
+            VendorCommunicationPayloadGenerator vendorCommunicationPayloadGenerator,
+            VendorCommunicationFailureHandler vendorCommunicationFailureHandler
+    ) {
+        this.restClient = restClientBuilder.build();
+        this.objectMapper = objectMapper;
+        this.properties = properties;
+        this.vendorCommunicationRecorder = vendorCommunicationRecorder;
+        this.vendorCommunicationPayloadGenerator = vendorCommunicationPayloadGenerator;
+        this.vendorCommunicationFailureHandler = vendorCommunicationFailureHandler;
+    }
+
     @Override
     public FasstoAccessToken requestAccessToken() {
         URI uri = buildAuthUri();
-        HttpEntity<Void> request = new HttpEntity<>(buildHeaders());
 
         Exception error = new Exception();
         String failureMessage = null;
@@ -70,12 +83,11 @@ public class FasstoAuthClient implements RequestFasstoAuthPort, DisconnectFassto
 
             ResponseEntity<FasstoAuthResponse> response;
             try {
-                response = restTemplate.exchange(
-                        uri,
-                        HttpMethod.POST,
-                        request,
-                        FasstoAuthResponse.class
-                );
+                response = restClient.post()
+                        .uri(uri)
+                        .headers(h -> h.addAll(buildHeaders()))
+                        .retrieve()
+                        .toEntity(FasstoAuthResponse.class);
             } catch (Exception e) {
                 Map<String, Object> errorPayload = new LinkedHashMap<>();
                 errorPayload.put("error", e.getClass().getSimpleName());
@@ -163,9 +175,6 @@ public class FasstoAuthClient implements RequestFasstoAuthPort, DisconnectFassto
         }
 
         URI uri = buildDisconnectUri();
-        HttpHeaders headers = buildHeaders();
-        headers.add(ACCESS_TOKEN_HEADER, accessToken);
-        HttpEntity<Void> request = new HttpEntity<>(headers);
 
         Exception error = new Exception();
         String failureMessage = null;
@@ -180,12 +189,14 @@ public class FasstoAuthClient implements RequestFasstoAuthPort, DisconnectFassto
 
             ResponseEntity<String> response;
             try {
-                response = restTemplate.exchange(
-                        uri,
-                        HttpMethod.GET,
-                        request,
-                        String.class
-                );
+                response = restClient.get()
+                        .uri(uri)
+                        .headers(h -> {
+                            h.addAll(buildHeaders());
+                            h.add(ACCESS_TOKEN_HEADER, accessToken);
+                        })
+                        .retrieve()
+                        .toEntity(String.class);
             } catch (Exception e) {
                 Map<String, Object> errorPayload = new LinkedHashMap<>();
                 errorPayload.put("error", e.getClass().getSimpleName());

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/client/FasstoDeliveryClient.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/client/FasstoDeliveryClient.java
@@ -18,11 +18,10 @@ import com.personal.marketnote.fulfillment.port.out.vendor.*;
 import com.personal.marketnote.fulfillment.utility.VendorCommunicationFailureHandler;
 import com.personal.marketnote.fulfillment.utility.VendorCommunicationPayloadGenerator;
 import com.personal.marketnote.fulfillment.utility.VendorCommunicationRecorder;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.*;
+import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClientResponseException;
-import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.io.IOException;
@@ -35,18 +34,33 @@ import java.util.concurrent.ThreadLocalRandom;
 import static com.personal.marketnote.common.utility.ApiConstant.*;
 
 @VendorAdapter
-@RequiredArgsConstructor
 @Slf4j
 public class FasstoDeliveryClient implements RegisterFasstoDeliveryPort, UpdateFasstoDeliveryPort, RegisterFasstoDeliveryCarPort, UpdateFasstoDeliveryCarPort, RegisterFasstoDeliveryIcsPort, CompleteFasstoDeliveryIcsPort, GetFasstoDeliveriesPort, GetFasstoDeliveryStatusesPort, GetFasstoDeliveryDetailPort, GetFasstoDeliveryOutOrdGoodsDetailPort, GetFasstoDeliveryOutOrdGoodsByOrdNoPort, GetFasstoDeliveryGoodDetailPort, CancelFasstoDeliveryPort {
     private static final String ACCESS_TOKEN_HEADER = "accessToken";
     private static final String CUSTOMER_CODE_PLACEHOLDER = "{customerCode}";
 
-    private final RestTemplate restTemplate;
+    private final RestClient restClient;
     private final ObjectMapper objectMapper;
     private final FasstoAuthProperties properties;
     private final VendorCommunicationRecorder vendorCommunicationRecorder;
     private final VendorCommunicationPayloadGenerator vendorCommunicationPayloadGenerator;
     private final VendorCommunicationFailureHandler vendorCommunicationFailureHandler;
+
+    public FasstoDeliveryClient(
+            RestClient.Builder restClientBuilder,
+            ObjectMapper objectMapper,
+            FasstoAuthProperties properties,
+            VendorCommunicationRecorder vendorCommunicationRecorder,
+            VendorCommunicationPayloadGenerator vendorCommunicationPayloadGenerator,
+            VendorCommunicationFailureHandler vendorCommunicationFailureHandler
+    ) {
+        this.restClient = restClientBuilder.build();
+        this.objectMapper = objectMapper;
+        this.properties = properties;
+        this.vendorCommunicationRecorder = vendorCommunicationRecorder;
+        this.vendorCommunicationPayloadGenerator = vendorCommunicationPayloadGenerator;
+        this.vendorCommunicationFailureHandler = vendorCommunicationFailureHandler;
+    }
 
     @Override
     public RegisterFasstoDeliveryResult registerDelivery(FasstoDeliveryMapper request) {
@@ -104,8 +118,6 @@ public class FasstoDeliveryClient implements RegisterFasstoDeliveryPort, UpdateF
                 query.getOutDiv(),
                 query.getOrdNo()
         );
-        HttpEntity<Void> httpEntity = new HttpEntity<>(buildHeaders(query.getAccessToken(), false));
-
         Exception error = new Exception();
         String failureMessage = null;
         long sleepMillis = INTER_SERVER_DEFAULT_RETRIAL_PENDING_MILLI_SECOND;
@@ -119,12 +131,11 @@ public class FasstoDeliveryClient implements RegisterFasstoDeliveryPort, UpdateF
 
             ResponseEntity<String> response;
             try {
-                response = restTemplate.exchange(
-                        uri,
-                        HttpMethod.GET,
-                        httpEntity,
-                        String.class
-                );
+                response = restClient.get()
+                        .uri(uri)
+                        .headers(h -> h.addAll(buildHeaders(query.getAccessToken(), false)))
+                        .retrieve()
+                        .toEntity(String.class);
             } catch (Exception e) {
                 Map<String, Object> errorPayload = new LinkedHashMap<>();
                 errorPayload.put("error", e.getClass().getSimpleName());
@@ -222,8 +233,6 @@ public class FasstoDeliveryClient implements RegisterFasstoDeliveryPort, UpdateF
                 query.getEndDate(),
                 query.getOutDiv()
         );
-        HttpEntity<Void> httpEntity = new HttpEntity<>(buildHeaders(query.getAccessToken(), false));
-
         Exception error = new Exception();
         String failureMessage = null;
         long sleepMillis = INTER_SERVER_DEFAULT_RETRIAL_PENDING_MILLI_SECOND;
@@ -237,12 +246,11 @@ public class FasstoDeliveryClient implements RegisterFasstoDeliveryPort, UpdateF
 
             ResponseEntity<String> response;
             try {
-                response = restTemplate.exchange(
-                        uri,
-                        HttpMethod.GET,
-                        httpEntity,
-                        String.class
-                );
+                response = restClient.get()
+                        .uri(uri)
+                        .headers(h -> h.addAll(buildHeaders(query.getAccessToken(), false)))
+                        .retrieve()
+                        .toEntity(String.class);
             } catch (Exception e) {
                 Map<String, Object> errorPayload = new LinkedHashMap<>();
                 errorPayload.put("error", e.getClass().getSimpleName());
@@ -335,7 +343,6 @@ public class FasstoDeliveryClient implements RegisterFasstoDeliveryPort, UpdateF
         }
 
         URI uri = buildOutOrdGoodsDetailUri(query.getCustomerCode(), query.getOutOrdSlipNo());
-        HttpEntity<Void> httpEntity = new HttpEntity<>(buildHeaders(query.getAccessToken(), false));
 
         Exception error = new Exception();
         String failureMessage = null;
@@ -350,12 +357,11 @@ public class FasstoDeliveryClient implements RegisterFasstoDeliveryPort, UpdateF
 
             ResponseEntity<String> response;
             try {
-                response = restTemplate.exchange(
-                        uri,
-                        HttpMethod.GET,
-                        httpEntity,
-                        String.class
-                );
+                response = restClient.get()
+                        .uri(uri)
+                        .headers(h -> h.addAll(buildHeaders(query.getAccessToken(), false)))
+                        .retrieve()
+                        .toEntity(String.class);
             } catch (Exception e) {
                 Map<String, Object> errorPayload = new LinkedHashMap<>();
                 errorPayload.put("error", e.getClass().getSimpleName());
@@ -457,8 +463,6 @@ public class FasstoDeliveryClient implements RegisterFasstoDeliveryPort, UpdateF
                 query.getEndDate(),
                 query.getOrdNo()
         );
-        HttpEntity<Void> httpEntity = new HttpEntity<>(buildHeaders(query.getAccessToken(), false));
-
         Exception error = new Exception();
         String failureMessage = null;
         long sleepMillis = INTER_SERVER_DEFAULT_RETRIAL_PENDING_MILLI_SECOND;
@@ -472,12 +476,11 @@ public class FasstoDeliveryClient implements RegisterFasstoDeliveryPort, UpdateF
 
             ResponseEntity<String> response;
             try {
-                response = restTemplate.exchange(
-                        uri,
-                        HttpMethod.GET,
-                        httpEntity,
-                        String.class
-                );
+                response = restClient.get()
+                        .uri(uri)
+                        .headers(h -> h.addAll(buildHeaders(query.getAccessToken(), false)))
+                        .retrieve()
+                        .toEntity(String.class);
             } catch (Exception e) {
                 Map<String, Object> errorPayload = new LinkedHashMap<>();
                 errorPayload.put("error", e.getClass().getSimpleName());
@@ -575,8 +578,6 @@ public class FasstoDeliveryClient implements RegisterFasstoDeliveryPort, UpdateF
                 query.getEndDate(),
                 query.getOrdNo()
         );
-        HttpEntity<Void> httpEntity = new HttpEntity<>(buildHeaders(query.getAccessToken(), false));
-
         Exception error = new Exception();
         String failureMessage = null;
         long sleepMillis = INTER_SERVER_DEFAULT_RETRIAL_PENDING_MILLI_SECOND;
@@ -590,12 +591,11 @@ public class FasstoDeliveryClient implements RegisterFasstoDeliveryPort, UpdateF
 
             ResponseEntity<String> response;
             try {
-                response = restTemplate.exchange(
-                        uri,
-                        HttpMethod.GET,
-                        httpEntity,
-                        String.class
-                );
+                response = restClient.get()
+                        .uri(uri)
+                        .headers(h -> h.addAll(buildHeaders(query.getAccessToken(), false)))
+                        .retrieve()
+                        .toEntity(String.class);
             } catch (Exception e) {
                 Map<String, Object> errorPayload = new LinkedHashMap<>();
                 errorPayload.put("error", e.getClass().getSimpleName());
@@ -692,8 +692,6 @@ public class FasstoDeliveryClient implements RegisterFasstoDeliveryPort, UpdateF
                 query.getSlipNo(),
                 query.getOrdNo()
         );
-        HttpEntity<Void> httpEntity = new HttpEntity<>(buildHeaders(query.getAccessToken(), false));
-
         Exception error = new Exception();
         String failureMessage = null;
         long sleepMillis = INTER_SERVER_DEFAULT_RETRIAL_PENDING_MILLI_SECOND;
@@ -707,12 +705,11 @@ public class FasstoDeliveryClient implements RegisterFasstoDeliveryPort, UpdateF
 
             ResponseEntity<String> response;
             try {
-                response = restTemplate.exchange(
-                        uri,
-                        HttpMethod.GET,
-                        httpEntity,
-                        String.class
-                );
+                response = restClient.get()
+                        .uri(uri)
+                        .headers(h -> h.addAll(buildHeaders(query.getAccessToken(), false)))
+                        .retrieve()
+                        .toEntity(String.class);
             } catch (Exception e) {
                 Map<String, Object> errorPayload = new LinkedHashMap<>();
                 errorPayload.put("error", e.getClass().getSimpleName());
@@ -809,10 +806,6 @@ public class FasstoDeliveryClient implements RegisterFasstoDeliveryPort, UpdateF
         }
 
         URI uri = buildDeliveryUri(request.getCustomerCode());
-        HttpEntity<List<Map<String, Object>>> httpEntity = new HttpEntity<>(
-                request.toPayload(),
-                buildHeaders(request.getAccessToken())
-        );
 
         Exception error = new Exception();
         String failureMessage = null;
@@ -827,12 +820,12 @@ public class FasstoDeliveryClient implements RegisterFasstoDeliveryPort, UpdateF
 
             ResponseEntity<String> response;
             try {
-                response = restTemplate.exchange(
-                        uri,
-                        method,
-                        httpEntity,
-                        String.class
-                );
+                response = restClient.method(method)
+                        .uri(uri)
+                        .headers(h -> h.addAll(buildHeaders(request.getAccessToken())))
+                        .body(request.toPayload())
+                        .retrieve()
+                        .toEntity(String.class);
             } catch (Exception e) {
                 Map<String, Object> errorPayload = new LinkedHashMap<>();
                 errorPayload.put("error", e.getClass().getSimpleName());
@@ -948,10 +941,6 @@ public class FasstoDeliveryClient implements RegisterFasstoDeliveryPort, UpdateF
         }
 
         URI uri = buildDeliveryCarUri(request.getCustomerCode());
-        HttpEntity<List<Map<String, Object>>> httpEntity = new HttpEntity<>(
-                request.toPayload(),
-                buildHeaders(request.getAccessToken())
-        );
 
         Exception error = new Exception();
         String failureMessage = null;
@@ -966,12 +955,12 @@ public class FasstoDeliveryClient implements RegisterFasstoDeliveryPort, UpdateF
 
             ResponseEntity<String> response;
             try {
-                response = restTemplate.exchange(
-                        uri,
-                        method,
-                        httpEntity,
-                        String.class
-                );
+                response = restClient.method(method)
+                        .uri(uri)
+                        .headers(h -> h.addAll(buildHeaders(request.getAccessToken())))
+                        .body(request.toPayload())
+                        .retrieve()
+                        .toEntity(String.class);
             } catch (Exception e) {
                 Map<String, Object> errorPayload = new LinkedHashMap<>();
                 errorPayload.put("error", e.getClass().getSimpleName());
@@ -1084,10 +1073,6 @@ public class FasstoDeliveryClient implements RegisterFasstoDeliveryPort, UpdateF
         }
 
         URI uri = buildDeliveryIcsUri(request.getCustomerCode());
-        HttpEntity<List<Map<String, Object>>> httpEntity = new HttpEntity<>(
-                request.toPayload(),
-                buildHeaders(request.getAccessToken())
-        );
 
         Exception error = new Exception();
         String failureMessage = null;
@@ -1102,12 +1087,12 @@ public class FasstoDeliveryClient implements RegisterFasstoDeliveryPort, UpdateF
 
             ResponseEntity<String> response;
             try {
-                response = restTemplate.exchange(
-                        uri,
-                        method,
-                        httpEntity,
-                        String.class
-                );
+                response = restClient.method(method)
+                        .uri(uri)
+                        .headers(h -> h.addAll(buildHeaders(request.getAccessToken())))
+                        .body(request.toPayload())
+                        .retrieve()
+                        .toEntity(String.class);
             } catch (Exception e) {
                 Map<String, Object> errorPayload = new LinkedHashMap<>();
                 errorPayload.put("error", e.getClass().getSimpleName());
@@ -1216,10 +1201,6 @@ public class FasstoDeliveryClient implements RegisterFasstoDeliveryPort, UpdateF
         }
 
         URI uri = buildDeliveryIcsCompletedUri(request.getCustomerCode());
-        HttpEntity<List<Map<String, Object>>> httpEntity = new HttpEntity<>(
-                request.toPayload(),
-                buildHeaders(request.getAccessToken())
-        );
 
         Exception error = new Exception();
         String failureMessage = null;
@@ -1234,12 +1215,12 @@ public class FasstoDeliveryClient implements RegisterFasstoDeliveryPort, UpdateF
 
             ResponseEntity<String> response;
             try {
-                response = restTemplate.exchange(
-                        uri,
-                        HttpMethod.PATCH,
-                        httpEntity,
-                        String.class
-                );
+                response = restClient.method(HttpMethod.PATCH)
+                        .uri(uri)
+                        .headers(h -> h.addAll(buildHeaders(request.getAccessToken())))
+                        .body(request.toPayload())
+                        .retrieve()
+                        .toEntity(String.class);
             } catch (Exception e) {
                 Map<String, Object> errorPayload = new LinkedHashMap<>();
                 errorPayload.put("error", e.getClass().getSimpleName());
@@ -1348,10 +1329,6 @@ public class FasstoDeliveryClient implements RegisterFasstoDeliveryPort, UpdateF
         }
 
         URI uri = buildDeliveryCancelUri(request.getCustomerCode());
-        HttpEntity<List<Map<String, Object>>> httpEntity = new HttpEntity<>(
-                request.toPayload(),
-                buildHeaders(request.getAccessToken())
-        );
 
         Exception error = new Exception();
         String failureMessage = null;
@@ -1366,12 +1343,12 @@ public class FasstoDeliveryClient implements RegisterFasstoDeliveryPort, UpdateF
 
             ResponseEntity<String> response;
             try {
-                response = restTemplate.exchange(
-                        uri,
-                        HttpMethod.PATCH,
-                        httpEntity,
-                        String.class
-                );
+                response = restClient.method(HttpMethod.PATCH)
+                        .uri(uri)
+                        .headers(h -> h.addAll(buildHeaders(request.getAccessToken())))
+                        .body(request.toPayload())
+                        .retrieve()
+                        .toEntity(String.class);
             } catch (Exception e) {
                 Map<String, Object> errorPayload = new LinkedHashMap<>();
                 errorPayload.put("error", e.getClass().getSimpleName());

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/client/FasstoDirectReturnDeliveryClient.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/client/FasstoDirectReturnDeliveryClient.java
@@ -20,11 +20,10 @@ import com.personal.marketnote.fulfillment.port.out.vendor.RegisterFasstoDirectR
 import com.personal.marketnote.fulfillment.utility.VendorCommunicationFailureHandler;
 import com.personal.marketnote.fulfillment.utility.VendorCommunicationPayloadGenerator;
 import com.personal.marketnote.fulfillment.utility.VendorCommunicationRecorder;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.*;
+import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClientResponseException;
-import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.io.IOException;
@@ -37,18 +36,33 @@ import java.util.concurrent.ThreadLocalRandom;
 import static com.personal.marketnote.common.utility.ApiConstant.*;
 
 @VendorAdapter
-@RequiredArgsConstructor
 @Slf4j
 public class FasstoDirectReturnDeliveryClient implements RegisterFasstoDirectReturnDeliveryPort {
     private static final String ACCESS_TOKEN_HEADER = "accessToken";
     private static final String CUSTOMER_CODE_PLACEHOLDER = "{customerCode}";
 
-    private final RestTemplate restTemplate;
+    private final RestClient restClient;
     private final ObjectMapper objectMapper;
     private final FasstoAuthProperties properties;
     private final VendorCommunicationRecorder vendorCommunicationRecorder;
     private final VendorCommunicationPayloadGenerator vendorCommunicationPayloadGenerator;
     private final VendorCommunicationFailureHandler vendorCommunicationFailureHandler;
+
+    public FasstoDirectReturnDeliveryClient(
+            RestClient.Builder restClientBuilder,
+            ObjectMapper objectMapper,
+            FasstoAuthProperties properties,
+            VendorCommunicationRecorder vendorCommunicationRecorder,
+            VendorCommunicationPayloadGenerator vendorCommunicationPayloadGenerator,
+            VendorCommunicationFailureHandler vendorCommunicationFailureHandler
+    ) {
+        this.restClient = restClientBuilder.build();
+        this.objectMapper = objectMapper;
+        this.properties = properties;
+        this.vendorCommunicationRecorder = vendorCommunicationRecorder;
+        this.vendorCommunicationPayloadGenerator = vendorCommunicationPayloadGenerator;
+        this.vendorCommunicationFailureHandler = vendorCommunicationFailureHandler;
+    }
 
     @Override
     public RegisterFasstoDeliveryResult registerDirectReturnDelivery(FasstoDirectReturnDeliveryMapper request) {
@@ -65,10 +79,6 @@ public class FasstoDirectReturnDeliveryClient implements RegisterFasstoDirectRet
         }
 
         URI uri = buildDirectReturnDeliveryUri(request.getCustomerCode());
-        HttpEntity<List<Map<String, Object>>> httpEntity = new HttpEntity<>(
-                request.toPayload(),
-                buildHeaders(request.getAccessToken())
-        );
 
         Exception error = new Exception();
         String failureMessage = null;
@@ -83,12 +93,12 @@ public class FasstoDirectReturnDeliveryClient implements RegisterFasstoDirectRet
 
             ResponseEntity<String> response;
             try {
-                response = restTemplate.exchange(
-                        uri,
-                        HttpMethod.POST,
-                        httpEntity,
-                        String.class
-                );
+                response = restClient.post()
+                        .uri(uri)
+                        .headers(h -> h.addAll(buildHeaders(request.getAccessToken())))
+                        .body(request.toPayload())
+                        .retrieve()
+                        .toEntity(String.class);
             } catch (Exception e) {
                 Map<String, Object> errorPayload = new LinkedHashMap<>();
                 errorPayload.put("error", e.getClass().getSimpleName());

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/client/FasstoGoodsClient.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/client/FasstoGoodsClient.java
@@ -21,11 +21,10 @@ import com.personal.marketnote.fulfillment.port.out.vendor.*;
 import com.personal.marketnote.fulfillment.utility.VendorCommunicationFailureHandler;
 import com.personal.marketnote.fulfillment.utility.VendorCommunicationPayloadGenerator;
 import com.personal.marketnote.fulfillment.utility.VendorCommunicationRecorder;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.*;
+import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClientResponseException;
-import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.io.IOException;
@@ -38,18 +37,33 @@ import java.util.concurrent.ThreadLocalRandom;
 import static com.personal.marketnote.common.utility.ApiConstant.*;
 
 @VendorAdapter
-@RequiredArgsConstructor
 @Slf4j
 public class FasstoGoodsClient implements RegisterFasstoGoodsPort, GetFasstoGoodsPort, GetFasstoGoodsDetailPort, UpdateFasstoGoodsPort, GetFasstoGoodsElementsPort {
     private static final String ACCESS_TOKEN_HEADER = "accessToken";
     private static final String CUSTOMER_CODE_PLACEHOLDER = "{customerCode}";
 
-    private final RestTemplate restTemplate;
+    private final RestClient restClient;
     private final ObjectMapper objectMapper;
     private final FasstoAuthProperties properties;
     private final VendorCommunicationRecorder vendorCommunicationRecorder;
     private final VendorCommunicationPayloadGenerator vendorCommunicationPayloadGenerator;
     private final VendorCommunicationFailureHandler vendorCommunicationFailureHandler;
+
+    public FasstoGoodsClient(
+            RestClient.Builder restClientBuilder,
+            ObjectMapper objectMapper,
+            FasstoAuthProperties properties,
+            VendorCommunicationRecorder vendorCommunicationRecorder,
+            VendorCommunicationPayloadGenerator vendorCommunicationPayloadGenerator,
+            VendorCommunicationFailureHandler vendorCommunicationFailureHandler
+    ) {
+        this.restClient = restClientBuilder.build();
+        this.objectMapper = objectMapper;
+        this.properties = properties;
+        this.vendorCommunicationRecorder = vendorCommunicationRecorder;
+        this.vendorCommunicationPayloadGenerator = vendorCommunicationPayloadGenerator;
+        this.vendorCommunicationFailureHandler = vendorCommunicationFailureHandler;
+    }
 
     @Override
     public RegisterFasstoGoodsResult registerGoods(FasstoGoodsMapper request) {
@@ -95,7 +109,6 @@ public class FasstoGoodsClient implements RegisterFasstoGoodsPort, GetFasstoGood
         }
 
         URI uri = buildGoodsElementUri(query.getCustomerCode());
-        HttpEntity<Void> httpEntity = new HttpEntity<>(buildHeaders(query.getAccessToken(), false));
 
         Exception error = new Exception();
         String failureMessage = null;
@@ -110,12 +123,11 @@ public class FasstoGoodsClient implements RegisterFasstoGoodsPort, GetFasstoGood
 
             ResponseEntity<String> response;
             try {
-                response = restTemplate.exchange(
-                        uri,
-                        HttpMethod.GET,
-                        httpEntity,
-                        String.class
-                );
+                response = restClient.get()
+                        .uri(uri)
+                        .headers(h -> h.addAll(buildHeaders(query.getAccessToken(), false)))
+                        .retrieve()
+                        .toEntity(String.class);
             } catch (Exception e) {
                 Map<String, Object> errorPayload = new LinkedHashMap<>();
                 errorPayload.put("error", e.getClass().getSimpleName());
@@ -212,8 +224,6 @@ public class FasstoGoodsClient implements RegisterFasstoGoodsPort, GetFasstoGood
             String godNm,
             boolean isDetail
     ) {
-        HttpEntity<Void> httpEntity = new HttpEntity<>(buildHeaders(accessToken, false));
-
         Exception error = new Exception();
         String failureMessage = null;
         long sleepMillis = INTER_SERVER_DEFAULT_RETRIAL_PENDING_MILLI_SECOND;
@@ -228,12 +238,11 @@ public class FasstoGoodsClient implements RegisterFasstoGoodsPort, GetFasstoGood
 
             ResponseEntity<String> response;
             try {
-                response = restTemplate.exchange(
-                        uri,
-                        HttpMethod.GET,
-                        httpEntity,
-                        String.class
-                );
+                response = restClient.get()
+                        .uri(uri)
+                        .headers(h -> h.addAll(buildHeaders(accessToken, false)))
+                        .retrieve()
+                        .toEntity(String.class);
             } catch (Exception e) {
                 Map<String, Object> errorPayload = new LinkedHashMap<>();
                 errorPayload.put("error", e.getClass().getSimpleName());
@@ -340,10 +349,6 @@ public class FasstoGoodsClient implements RegisterFasstoGoodsPort, GetFasstoGood
         }
 
         URI uri = buildGoodsUri(request.getCustomerCode());
-        HttpEntity<List<Map<String, Object>>> httpEntity = new HttpEntity<>(
-                request.toPayload(),
-                buildHeaders(request.getAccessToken())
-        );
 
         Exception error = new Exception();
         String failureMessage = null;
@@ -358,12 +363,12 @@ public class FasstoGoodsClient implements RegisterFasstoGoodsPort, GetFasstoGood
 
             ResponseEntity<String> response;
             try {
-                response = restTemplate.exchange(
-                        uri,
-                        HttpMethod.POST,
-                        httpEntity,
-                        String.class
-                );
+                response = restClient.post()
+                        .uri(uri)
+                        .headers(h -> h.addAll(buildHeaders(request.getAccessToken())))
+                        .body(request.toPayload())
+                        .retrieve()
+                        .toEntity(String.class);
             } catch (Exception e) {
                 Map<String, Object> errorPayload = new LinkedHashMap<>();
                 errorPayload.put("error", e.getClass().getSimpleName());
@@ -466,10 +471,6 @@ public class FasstoGoodsClient implements RegisterFasstoGoodsPort, GetFasstoGood
         }
 
         URI uri = buildGoodsUri(request.getCustomerCode());
-        HttpEntity<List<Map<String, Object>>> httpEntity = new HttpEntity<>(
-                request.toPayload(),
-                buildHeaders(request.getAccessToken())
-        );
 
         Exception error = new Exception();
         String failureMessage = null;
@@ -484,12 +485,12 @@ public class FasstoGoodsClient implements RegisterFasstoGoodsPort, GetFasstoGood
 
             ResponseEntity<String> response;
             try {
-                response = restTemplate.exchange(
-                        uri,
-                        HttpMethod.PATCH,
-                        httpEntity,
-                        String.class
-                );
+                response = restClient.method(HttpMethod.PATCH)
+                        .uri(uri)
+                        .headers(h -> h.addAll(buildHeaders(request.getAccessToken())))
+                        .body(request.toPayload())
+                        .retrieve()
+                        .toEntity(String.class);
             } catch (Exception e) {
                 Map<String, Object> errorPayload = new LinkedHashMap<>();
                 errorPayload.put("error", e.getClass().getSimpleName());

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/client/FasstoReturnDeliveryClient.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/client/FasstoReturnDeliveryClient.java
@@ -21,11 +21,10 @@ import com.personal.marketnote.fulfillment.port.out.vendor.RegisterFasstoReturnD
 import com.personal.marketnote.fulfillment.utility.VendorCommunicationFailureHandler;
 import com.personal.marketnote.fulfillment.utility.VendorCommunicationPayloadGenerator;
 import com.personal.marketnote.fulfillment.utility.VendorCommunicationRecorder;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.*;
+import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClientResponseException;
-import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.io.IOException;
@@ -38,18 +37,33 @@ import java.util.concurrent.ThreadLocalRandom;
 import static com.personal.marketnote.common.utility.ApiConstant.*;
 
 @VendorAdapter
-@RequiredArgsConstructor
 @Slf4j
 public class FasstoReturnDeliveryClient implements RegisterFasstoReturnDeliveryPort, GetFasstoReturnGodDetailPort {
     private static final String ACCESS_TOKEN_HEADER = "accessToken";
     private static final String CUSTOMER_CODE_PLACEHOLDER = "{customerCode}";
 
-    private final RestTemplate restTemplate;
+    private final RestClient restClient;
     private final ObjectMapper objectMapper;
     private final FasstoAuthProperties properties;
     private final VendorCommunicationRecorder vendorCommunicationRecorder;
     private final VendorCommunicationPayloadGenerator vendorCommunicationPayloadGenerator;
     private final VendorCommunicationFailureHandler vendorCommunicationFailureHandler;
+
+    public FasstoReturnDeliveryClient(
+            RestClient.Builder restClientBuilder,
+            ObjectMapper objectMapper,
+            FasstoAuthProperties properties,
+            VendorCommunicationRecorder vendorCommunicationRecorder,
+            VendorCommunicationPayloadGenerator vendorCommunicationPayloadGenerator,
+            VendorCommunicationFailureHandler vendorCommunicationFailureHandler
+    ) {
+        this.restClient = restClientBuilder.build();
+        this.objectMapper = objectMapper;
+        this.properties = properties;
+        this.vendorCommunicationRecorder = vendorCommunicationRecorder;
+        this.vendorCommunicationPayloadGenerator = vendorCommunicationPayloadGenerator;
+        this.vendorCommunicationFailureHandler = vendorCommunicationFailureHandler;
+    }
 
     @Override
     public RegisterFasstoDeliveryResult registerReturnDelivery(FasstoReturnDeliveryMapper request) {
@@ -64,7 +78,6 @@ public class FasstoReturnDeliveryClient implements RegisterFasstoReturnDeliveryP
         }
 
         URI uri = buildReturnGodDetailUri(query);
-        HttpEntity<Void> httpEntity = new HttpEntity<>(buildHeaders(query.getAccessToken(), false));
 
         Exception error = new Exception();
         String failureMessage = null;
@@ -79,12 +92,11 @@ public class FasstoReturnDeliveryClient implements RegisterFasstoReturnDeliveryP
 
             ResponseEntity<String> response;
             try {
-                response = restTemplate.exchange(
-                        uri,
-                        HttpMethod.GET,
-                        httpEntity,
-                        String.class
-                );
+                response = restClient.get()
+                        .uri(uri)
+                        .headers(h -> h.addAll(buildHeaders(query.getAccessToken(), false)))
+                        .retrieve()
+                        .toEntity(String.class);
             } catch (Exception e) {
                 Map<String, Object> errorPayload = new LinkedHashMap<>();
                 errorPayload.put("error", e.getClass().getSimpleName());
@@ -181,10 +193,6 @@ public class FasstoReturnDeliveryClient implements RegisterFasstoReturnDeliveryP
         }
 
         URI uri = buildReturnDeliveryUri(request.getCustomerCode());
-        HttpEntity<List<Map<String, Object>>> httpEntity = new HttpEntity<>(
-                request.toPayload(),
-                buildHeaders(request.getAccessToken())
-        );
 
         Exception error = new Exception();
         String failureMessage = null;
@@ -199,12 +207,12 @@ public class FasstoReturnDeliveryClient implements RegisterFasstoReturnDeliveryP
 
             ResponseEntity<String> response;
             try {
-                response = restTemplate.exchange(
-                        uri,
-                        HttpMethod.POST,
-                        httpEntity,
-                        String.class
-                );
+                response = restClient.post()
+                        .uri(uri)
+                        .headers(h -> h.addAll(buildHeaders(request.getAccessToken())))
+                        .body(request.toPayload())
+                        .retrieve()
+                        .toEntity(String.class);
             } catch (Exception e) {
                 Map<String, Object> errorPayload = new LinkedHashMap<>();
                 errorPayload.put("error", e.getClass().getSimpleName());

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/client/FasstoSettlementClient.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/client/FasstoSettlementClient.java
@@ -21,11 +21,10 @@ import com.personal.marketnote.fulfillment.port.out.vendor.GetFasstoSettlementDa
 import com.personal.marketnote.fulfillment.utility.VendorCommunicationFailureHandler;
 import com.personal.marketnote.fulfillment.utility.VendorCommunicationPayloadGenerator;
 import com.personal.marketnote.fulfillment.utility.VendorCommunicationRecorder;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.*;
+import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClientResponseException;
-import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.io.IOException;
@@ -38,7 +37,6 @@ import java.util.concurrent.ThreadLocalRandom;
 import static com.personal.marketnote.common.utility.ApiConstant.*;
 
 @VendorAdapter
-@RequiredArgsConstructor
 @Slf4j
 public class FasstoSettlementClient implements GetFasstoSettlementDailyCostsPort {
     private static final String ACCESS_TOKEN_HEADER = "accessToken";
@@ -46,12 +44,28 @@ public class FasstoSettlementClient implements GetFasstoSettlementDailyCostsPort
     private static final String WH_CODE_PLACEHOLDER = "{whCd}";
     private static final String CUSTOMER_CODE_PLACEHOLDER = "{customerCode}";
 
-    private final RestTemplate restTemplate;
+    private final RestClient restClient;
     private final ObjectMapper objectMapper;
     private final FasstoAuthProperties properties;
     private final VendorCommunicationRecorder vendorCommunicationRecorder;
     private final VendorCommunicationPayloadGenerator vendorCommunicationPayloadGenerator;
     private final VendorCommunicationFailureHandler vendorCommunicationFailureHandler;
+
+    public FasstoSettlementClient(
+            RestClient.Builder restClientBuilder,
+            ObjectMapper objectMapper,
+            FasstoAuthProperties properties,
+            VendorCommunicationRecorder vendorCommunicationRecorder,
+            VendorCommunicationPayloadGenerator vendorCommunicationPayloadGenerator,
+            VendorCommunicationFailureHandler vendorCommunicationFailureHandler
+    ) {
+        this.restClient = restClientBuilder.build();
+        this.objectMapper = objectMapper;
+        this.properties = properties;
+        this.vendorCommunicationRecorder = vendorCommunicationRecorder;
+        this.vendorCommunicationPayloadGenerator = vendorCommunicationPayloadGenerator;
+        this.vendorCommunicationFailureHandler = vendorCommunicationFailureHandler;
+    }
 
     @Override
     public GetFasstoSettlementDailyCostsResult getDailyCosts(FasstoSettlementDailyCostQuery query) {
@@ -60,7 +74,6 @@ public class FasstoSettlementClient implements GetFasstoSettlementDailyCostsPort
         }
 
         URI uri = buildSettlementDailyCostUri(query.getYearMonth(), query.getWhCd(), query.getCustomerCode());
-        HttpEntity<Void> httpEntity = new HttpEntity<>(buildHeaders(query.getAccessToken(), false));
 
         Exception error = new Exception();
         String failureMessage = null;
@@ -75,12 +88,11 @@ public class FasstoSettlementClient implements GetFasstoSettlementDailyCostsPort
 
             ResponseEntity<String> response;
             try {
-                response = restTemplate.exchange(
-                        uri,
-                        HttpMethod.GET,
-                        httpEntity,
-                        String.class
-                );
+                response = restClient.get()
+                        .uri(uri)
+                        .headers(h -> h.addAll(buildHeaders(query.getAccessToken(), false)))
+                        .retrieve()
+                        .toEntity(String.class);
             } catch (Exception e) {
                 Map<String, Object> errorPayload = new LinkedHashMap<>();
                 errorPayload.put("error", e.getClass().getSimpleName());

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/client/FasstoShopClient.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/client/FasstoShopClient.java
@@ -29,11 +29,10 @@ import com.personal.marketnote.fulfillment.port.out.vendor.UpdateFasstoShopPort;
 import com.personal.marketnote.fulfillment.utility.VendorCommunicationFailureHandler;
 import com.personal.marketnote.fulfillment.utility.VendorCommunicationPayloadGenerator;
 import com.personal.marketnote.fulfillment.utility.VendorCommunicationRecorder;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.*;
+import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClientResponseException;
-import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.io.IOException;
@@ -46,18 +45,33 @@ import java.util.concurrent.ThreadLocalRandom;
 import static com.personal.marketnote.common.utility.ApiConstant.*;
 
 @VendorAdapter
-@RequiredArgsConstructor
 @Slf4j
 public class FasstoShopClient implements RegisterFasstoShopPort, GetFasstoShopsPort, UpdateFasstoShopPort {
     private static final String ACCESS_TOKEN_HEADER = "accessToken";
     private static final String CUSTOMER_CODE_PLACEHOLDER = "{customerCode}";
 
-    private final RestTemplate restTemplate;
+    private final RestClient restClient;
     private final ObjectMapper objectMapper;
     private final FasstoAuthProperties properties;
     private final VendorCommunicationRecorder vendorCommunicationRecorder;
     private final VendorCommunicationPayloadGenerator vendorCommunicationPayloadGenerator;
     private final VendorCommunicationFailureHandler vendorCommunicationFailureHandler;
+
+    public FasstoShopClient(
+            RestClient.Builder restClientBuilder,
+            ObjectMapper objectMapper,
+            FasstoAuthProperties properties,
+            VendorCommunicationRecorder vendorCommunicationRecorder,
+            VendorCommunicationPayloadGenerator vendorCommunicationPayloadGenerator,
+            VendorCommunicationFailureHandler vendorCommunicationFailureHandler
+    ) {
+        this.restClient = restClientBuilder.build();
+        this.objectMapper = objectMapper;
+        this.properties = properties;
+        this.vendorCommunicationRecorder = vendorCommunicationRecorder;
+        this.vendorCommunicationPayloadGenerator = vendorCommunicationPayloadGenerator;
+        this.vendorCommunicationFailureHandler = vendorCommunicationFailureHandler;
+    }
 
     @Override
     public RegisterFasstoShopResult registerShop(FasstoShopMapper request) {
@@ -77,7 +91,6 @@ public class FasstoShopClient implements RegisterFasstoShopPort, GetFasstoShopsP
         }
 
         URI uri = buildShopUri(query.getCustomerCode());
-        HttpEntity<Void> httpEntity = new HttpEntity<>(buildHeaders(query.getAccessToken(), false));
 
         Exception error = new Exception();
         String failureMessage = null;
@@ -92,12 +105,11 @@ public class FasstoShopClient implements RegisterFasstoShopPort, GetFasstoShopsP
 
             ResponseEntity<String> response;
             try {
-                response = restTemplate.exchange(
-                        uri,
-                        HttpMethod.GET,
-                        httpEntity,
-                        String.class
-                );
+                response = restClient.get()
+                        .uri(uri)
+                        .headers(h -> h.addAll(buildHeaders(query.getAccessToken(), false)))
+                        .retrieve()
+                        .toEntity(String.class);
             } catch (Exception e) {
                 Map<String, Object> errorPayload = new LinkedHashMap<>();
                 errorPayload.put("error", e.getClass().getSimpleName());
@@ -339,7 +351,6 @@ public class FasstoShopClient implements RegisterFasstoShopPort, GetFasstoShopsP
         }
 
         URI uri = buildShopUri(request.getCustomerCode());
-        HttpEntity<Map<String, Object>> httpEntity = new HttpEntity<>(request.toPayload(), buildHeaders(request.getAccessToken()));
 
         Exception error = new Exception();
         String failureMessage = null;
@@ -354,12 +365,12 @@ public class FasstoShopClient implements RegisterFasstoShopPort, GetFasstoShopsP
 
             ResponseEntity<String> response;
             try {
-                response = restTemplate.exchange(
-                        uri,
-                        HttpMethod.PATCH,
-                        httpEntity,
-                        String.class
-                );
+                response = restClient.method(HttpMethod.PATCH)
+                        .uri(uri)
+                        .headers(h -> h.addAll(buildHeaders(request.getAccessToken())))
+                        .body(request.toPayload())
+                        .retrieve()
+                        .toEntity(String.class);
             } catch (Exception e) {
                 Map<String, Object> errorPayload = new LinkedHashMap<>();
                 errorPayload.put("error", e.getClass().getSimpleName());

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/client/FasstoStockClient.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/client/FasstoStockClient.java
@@ -24,11 +24,10 @@ import com.personal.marketnote.fulfillment.port.out.vendor.GetFasstoStocksPort;
 import com.personal.marketnote.fulfillment.utility.VendorCommunicationFailureHandler;
 import com.personal.marketnote.fulfillment.utility.VendorCommunicationPayloadGenerator;
 import com.personal.marketnote.fulfillment.utility.VendorCommunicationRecorder;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.*;
+import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClientResponseException;
-import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.io.IOException;
@@ -41,18 +40,33 @@ import java.util.concurrent.ThreadLocalRandom;
 import static com.personal.marketnote.common.utility.ApiConstant.*;
 
 @VendorAdapter
-@RequiredArgsConstructor
 @Slf4j
 public class FasstoStockClient implements GetFasstoStocksPort, GetFasstoStockDetailPort {
     private static final String ACCESS_TOKEN_HEADER = "accessToken";
     private static final String CUSTOMER_CODE_PLACEHOLDER = "{customerCode}";
 
-    private final RestTemplate restTemplate;
+    private final RestClient restClient;
     private final ObjectMapper objectMapper;
     private final FasstoAuthProperties properties;
     private final VendorCommunicationRecorder vendorCommunicationRecorder;
     private final VendorCommunicationPayloadGenerator vendorCommunicationPayloadGenerator;
     private final VendorCommunicationFailureHandler vendorCommunicationFailureHandler;
+
+    public FasstoStockClient(
+            RestClient.Builder restClientBuilder,
+            ObjectMapper objectMapper,
+            FasstoAuthProperties properties,
+            VendorCommunicationRecorder vendorCommunicationRecorder,
+            VendorCommunicationPayloadGenerator vendorCommunicationPayloadGenerator,
+            VendorCommunicationFailureHandler vendorCommunicationFailureHandler
+    ) {
+        this.restClient = restClientBuilder.build();
+        this.objectMapper = objectMapper;
+        this.properties = properties;
+        this.vendorCommunicationRecorder = vendorCommunicationRecorder;
+        this.vendorCommunicationPayloadGenerator = vendorCommunicationPayloadGenerator;
+        this.vendorCommunicationFailureHandler = vendorCommunicationFailureHandler;
+    }
 
     @Override
     public GetFasstoStocksResult getStocks(FasstoStockQuery query) {
@@ -99,8 +113,6 @@ public class FasstoStockClient implements GetFasstoStocksPort, GetFasstoStockDet
             String cstGodCd,
             boolean isDetail
     ) {
-        HttpEntity<Void> httpEntity = new HttpEntity<>(buildHeaders(accessToken, false));
-
         Exception error = new Exception();
         String failureMessage = null;
         long sleepMillis = INTER_SERVER_DEFAULT_RETRIAL_PENDING_MILLI_SECOND;
@@ -123,12 +135,11 @@ public class FasstoStockClient implements GetFasstoStocksPort, GetFasstoStockDet
 
             ResponseEntity<String> response;
             try {
-                response = restTemplate.exchange(
-                        uri,
-                        HttpMethod.GET,
-                        httpEntity,
-                        String.class
-                );
+                response = restClient.get()
+                        .uri(uri)
+                        .headers(h -> h.addAll(buildHeaders(accessToken, false)))
+                        .retrieve()
+                        .toEntity(String.class);
             } catch (Exception e) {
                 Map<String, Object> errorPayload = new LinkedHashMap<>();
                 errorPayload.put("error", e.getClass().getSimpleName());

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/client/FasstoSupplierClient.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/client/FasstoSupplierClient.java
@@ -29,11 +29,10 @@ import com.personal.marketnote.fulfillment.port.out.vendor.UpdateFasstoSupplierP
 import com.personal.marketnote.fulfillment.utility.VendorCommunicationFailureHandler;
 import com.personal.marketnote.fulfillment.utility.VendorCommunicationPayloadGenerator;
 import com.personal.marketnote.fulfillment.utility.VendorCommunicationRecorder;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.*;
+import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClientResponseException;
-import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.io.IOException;
@@ -46,18 +45,33 @@ import java.util.concurrent.ThreadLocalRandom;
 import static com.personal.marketnote.common.utility.ApiConstant.*;
 
 @VendorAdapter
-@RequiredArgsConstructor
 @Slf4j
 public class FasstoSupplierClient implements RegisterFasstoSupplierPort, GetFasstoSuppliersPort, UpdateFasstoSupplierPort {
     private static final String ACCESS_TOKEN_HEADER = "accessToken";
     private static final String CUSTOMER_CODE_PLACEHOLDER = "{customerCode}";
 
-    private final RestTemplate restTemplate;
+    private final RestClient restClient;
     private final ObjectMapper objectMapper;
     private final FasstoAuthProperties properties;
     private final VendorCommunicationRecorder vendorCommunicationRecorder;
     private final VendorCommunicationPayloadGenerator vendorCommunicationPayloadGenerator;
     private final VendorCommunicationFailureHandler vendorCommunicationFailureHandler;
+
+    public FasstoSupplierClient(
+            RestClient.Builder restClientBuilder,
+            ObjectMapper objectMapper,
+            FasstoAuthProperties properties,
+            VendorCommunicationRecorder vendorCommunicationRecorder,
+            VendorCommunicationPayloadGenerator vendorCommunicationPayloadGenerator,
+            VendorCommunicationFailureHandler vendorCommunicationFailureHandler
+    ) {
+        this.restClient = restClientBuilder.build();
+        this.objectMapper = objectMapper;
+        this.properties = properties;
+        this.vendorCommunicationRecorder = vendorCommunicationRecorder;
+        this.vendorCommunicationPayloadGenerator = vendorCommunicationPayloadGenerator;
+        this.vendorCommunicationFailureHandler = vendorCommunicationFailureHandler;
+    }
 
     @Override
     public RegisterFasstoSupplierResult registerSupplier(FasstoSupplierMapper request) {
@@ -77,7 +91,6 @@ public class FasstoSupplierClient implements RegisterFasstoSupplierPort, GetFass
         }
 
         URI uri = buildSupplierUri(query.getCustomerCode());
-        HttpEntity<Void> httpEntity = new HttpEntity<>(buildHeaders(query.getAccessToken(), false));
 
         Exception error = new Exception();
         String failureMessage = null;
@@ -92,12 +105,11 @@ public class FasstoSupplierClient implements RegisterFasstoSupplierPort, GetFass
 
             ResponseEntity<String> response;
             try {
-                response = restTemplate.exchange(
-                        uri,
-                        HttpMethod.GET,
-                        httpEntity,
-                        String.class
-                );
+                response = restClient.get()
+                        .uri(uri)
+                        .headers(h -> h.addAll(buildHeaders(query.getAccessToken(), false)))
+                        .retrieve()
+                        .toEntity(String.class);
             } catch (Exception e) {
                 Map<String, Object> errorPayload = new LinkedHashMap<>();
                 errorPayload.put("error", e.getClass().getSimpleName());
@@ -195,7 +207,6 @@ public class FasstoSupplierClient implements RegisterFasstoSupplierPort, GetFass
         }
 
         URI uri = buildSupplierUri(request.getCustomerCode());
-        HttpEntity<Map<String, Object>> httpEntity = new HttpEntity<>(request.toPayload(), buildHeaders(request.getAccessToken()));
 
         Exception error = new Exception();
         String failureMessage = null;
@@ -210,12 +221,12 @@ public class FasstoSupplierClient implements RegisterFasstoSupplierPort, GetFass
 
             ResponseEntity<String> response;
             try {
-                response = restTemplate.exchange(
-                        uri,
-                        HttpMethod.PATCH,
-                        httpEntity,
-                        String.class
-                );
+                response = restClient.method(HttpMethod.PATCH)
+                        .uri(uri)
+                        .headers(h -> h.addAll(buildHeaders(request.getAccessToken())))
+                        .body(request.toPayload())
+                        .retrieve()
+                        .toEntity(String.class);
             } catch (Exception e) {
                 Map<String, Object> errorPayload = new LinkedHashMap<>();
                 errorPayload.put("error", e.getClass().getSimpleName());

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/client/FasstoWarehousingClient.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/client/FasstoWarehousingClient.java
@@ -18,11 +18,10 @@ import com.personal.marketnote.fulfillment.port.out.vendor.*;
 import com.personal.marketnote.fulfillment.utility.VendorCommunicationFailureHandler;
 import com.personal.marketnote.fulfillment.utility.VendorCommunicationPayloadGenerator;
 import com.personal.marketnote.fulfillment.utility.VendorCommunicationRecorder;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.*;
+import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClientResponseException;
-import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.io.IOException;
@@ -35,18 +34,33 @@ import java.util.concurrent.ThreadLocalRandom;
 import static com.personal.marketnote.common.utility.ApiConstant.*;
 
 @VendorAdapter
-@RequiredArgsConstructor
 @Slf4j
 public class FasstoWarehousingClient implements RegisterFasstoWarehousingPort, GetFasstoWarehousingPort, GetFasstoWarehousingDetailPort, GetFasstoWarehousingInspecDetailPort, GetFasstoWarehousingAbnormalPort, GetFasstoWarehousingAbnormalImagePort, UpdateFasstoWarehousingPort {
     private static final String ACCESS_TOKEN_HEADER = "accessToken";
     private static final String CUSTOMER_CODE_PLACEHOLDER = "{customerCode}";
 
-    private final RestTemplate restTemplate;
+    private final RestClient restClient;
     private final ObjectMapper objectMapper;
     private final FasstoAuthProperties properties;
     private final VendorCommunicationRecorder vendorCommunicationRecorder;
     private final VendorCommunicationPayloadGenerator vendorCommunicationPayloadGenerator;
     private final VendorCommunicationFailureHandler vendorCommunicationFailureHandler;
+
+    public FasstoWarehousingClient(
+            RestClient.Builder restClientBuilder,
+            ObjectMapper objectMapper,
+            FasstoAuthProperties properties,
+            VendorCommunicationRecorder vendorCommunicationRecorder,
+            VendorCommunicationPayloadGenerator vendorCommunicationPayloadGenerator,
+            VendorCommunicationFailureHandler vendorCommunicationFailureHandler
+    ) {
+        this.restClient = restClientBuilder.build();
+        this.objectMapper = objectMapper;
+        this.properties = properties;
+        this.vendorCommunicationRecorder = vendorCommunicationRecorder;
+        this.vendorCommunicationPayloadGenerator = vendorCommunicationPayloadGenerator;
+        this.vendorCommunicationFailureHandler = vendorCommunicationFailureHandler;
+    }
 
     @Override
     public RegisterFasstoWarehousingResult registerWarehousing(FasstoWarehousingMapper request) {
@@ -84,8 +98,6 @@ public class FasstoWarehousingClient implements RegisterFasstoWarehousingPort, G
                 query.getOrdNo(),
                 query.getWrkStat()
         );
-        HttpEntity<Void> httpEntity = new HttpEntity<>(buildHeaders(query.getAccessToken(), false));
-
         Exception error = new Exception();
         String failureMessage = null;
         long sleepMillis = INTER_SERVER_DEFAULT_RETRIAL_PENDING_MILLI_SECOND;
@@ -99,12 +111,11 @@ public class FasstoWarehousingClient implements RegisterFasstoWarehousingPort, G
 
             ResponseEntity<String> response;
             try {
-                response = restTemplate.exchange(
-                        uri,
-                        HttpMethod.GET,
-                        httpEntity,
-                        String.class
-                );
+                response = restClient.get()
+                        .uri(uri)
+                        .headers(h -> h.addAll(buildHeaders(query.getAccessToken(), false)))
+                        .retrieve()
+                        .toEntity(String.class);
             } catch (Exception e) {
                 Map<String, Object> errorPayload = new LinkedHashMap<>();
                 errorPayload.put("error", e.getClass().getSimpleName());
@@ -202,7 +213,6 @@ public class FasstoWarehousingClient implements RegisterFasstoWarehousingPort, G
         }
 
         URI uri = buildWarehousingDetailUri(query.getCustomerCode(), query.getSlipNo(), query.getOrdNo());
-        HttpEntity<Void> httpEntity = new HttpEntity<>(buildHeaders(query.getAccessToken(), false));
 
         Exception error = new Exception();
         String failureMessage = null;
@@ -217,12 +227,11 @@ public class FasstoWarehousingClient implements RegisterFasstoWarehousingPort, G
 
             ResponseEntity<String> response;
             try {
-                response = restTemplate.exchange(
-                        uri,
-                        HttpMethod.GET,
-                        httpEntity,
-                        String.class
-                );
+                response = restClient.get()
+                        .uri(uri)
+                        .headers(h -> h.addAll(buildHeaders(query.getAccessToken(), false)))
+                        .retrieve()
+                        .toEntity(String.class);
             } catch (Exception e) {
                 Map<String, Object> errorPayload = new LinkedHashMap<>();
                 errorPayload.put("error", e.getClass().getSimpleName());
@@ -324,8 +333,6 @@ public class FasstoWarehousingClient implements RegisterFasstoWarehousingPort, G
                 query.getSlipNo(),
                 query.getWhCd()
         );
-        HttpEntity<Void> httpEntity = new HttpEntity<>(buildHeaders(query.getAccessToken(), false));
-
         Exception error = new Exception();
         String failureMessage = null;
         long sleepMillis = INTER_SERVER_DEFAULT_RETRIAL_PENDING_MILLI_SECOND;
@@ -339,12 +346,11 @@ public class FasstoWarehousingClient implements RegisterFasstoWarehousingPort, G
 
             ResponseEntity<String> response;
             try {
-                response = restTemplate.exchange(
-                        uri,
-                        HttpMethod.GET,
-                        httpEntity,
-                        String.class
-                );
+                response = restClient.get()
+                        .uri(uri)
+                        .headers(h -> h.addAll(buildHeaders(query.getAccessToken(), false)))
+                        .retrieve()
+                        .toEntity(String.class);
             } catch (Exception e) {
                 Map<String, Object> errorPayload = new LinkedHashMap<>();
                 errorPayload.put("error", e.getClass().getSimpleName());
@@ -437,7 +443,6 @@ public class FasstoWarehousingClient implements RegisterFasstoWarehousingPort, G
         }
 
         URI uri = buildWarehousingAbnormalUri(query.getCustomerCode(), query.getWhCd(), query.getSlipNo());
-        HttpEntity<Void> httpEntity = new HttpEntity<>(buildHeaders(query.getAccessToken(), false));
 
         Exception error = new Exception();
         String failureMessage = null;
@@ -452,12 +457,11 @@ public class FasstoWarehousingClient implements RegisterFasstoWarehousingPort, G
 
             ResponseEntity<String> response;
             try {
-                response = restTemplate.exchange(
-                        uri,
-                        HttpMethod.GET,
-                        httpEntity,
-                        String.class
-                );
+                response = restClient.get()
+                        .uri(uri)
+                        .headers(h -> h.addAll(buildHeaders(query.getAccessToken(), false)))
+                        .retrieve()
+                        .toEntity(String.class);
             } catch (Exception e) {
                 Map<String, Object> errorPayload = new LinkedHashMap<>();
                 errorPayload.put("error", e.getClass().getSimpleName());
@@ -556,8 +560,6 @@ public class FasstoWarehousingClient implements RegisterFasstoWarehousingPort, G
                 query.getFileSeq(),
                 query.getImgNo()
         );
-        HttpEntity<Void> httpEntity = new HttpEntity<>(buildHeaders(query.getAccessToken(), false));
-
         Exception error = new Exception();
         String failureMessage = null;
         long sleepMillis = INTER_SERVER_DEFAULT_RETRIAL_PENDING_MILLI_SECOND;
@@ -571,12 +573,11 @@ public class FasstoWarehousingClient implements RegisterFasstoWarehousingPort, G
 
             ResponseEntity<String> response;
             try {
-                response = restTemplate.exchange(
-                        uri,
-                        HttpMethod.GET,
-                        httpEntity,
-                        String.class
-                );
+                response = restClient.get()
+                        .uri(uri)
+                        .headers(h -> h.addAll(buildHeaders(query.getAccessToken(), false)))
+                        .retrieve()
+                        .toEntity(String.class);
             } catch (Exception e) {
                 Map<String, Object> errorPayload = new LinkedHashMap<>();
                 errorPayload.put("error", e.getClass().getSimpleName());
@@ -673,10 +674,6 @@ public class FasstoWarehousingClient implements RegisterFasstoWarehousingPort, G
         }
 
         URI uri = buildWarehousingUri(request.getCustomerCode());
-        HttpEntity<List<Map<String, Object>>> httpEntity = new HttpEntity<>(
-                request.toPayload(),
-                buildHeaders(request.getAccessToken())
-        );
 
         Exception error = new Exception();
         String failureMessage = null;
@@ -691,12 +688,12 @@ public class FasstoWarehousingClient implements RegisterFasstoWarehousingPort, G
 
             ResponseEntity<String> response;
             try {
-                response = restTemplate.exchange(
-                        uri,
-                        method,
-                        httpEntity,
-                        String.class
-                );
+                response = restClient.method(method)
+                        .uri(uri)
+                        .headers(h -> h.addAll(buildHeaders(request.getAccessToken())))
+                        .body(request.toPayload())
+                        .retrieve()
+                        .toEntity(String.class);
             } catch (Exception e) {
                 Map<String, Object> errorPayload = new LinkedHashMap<>();
                 errorPayload.put("error", e.getClass().getSimpleName());

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/web/commerce/CommerceServiceClient.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/web/commerce/CommerceServiceClient.java
@@ -14,13 +14,10 @@ import com.personal.marketnote.fulfillment.port.out.commerce.UpdateCommerceInven
 import com.personal.marketnote.fulfillment.port.out.commerce.UpdateCommerceInventoryPort;
 import com.personal.marketnote.fulfillment.utility.ServiceCommunicationPayloadGenerator;
 import com.personal.marketnote.fulfillment.utility.ServiceCommunicationRecorder;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
-import org.springframework.web.client.RestTemplate;
+import org.springframework.web.client.RestClient;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.io.IOException;
@@ -32,7 +29,6 @@ import java.util.stream.Collectors;
 import static com.personal.marketnote.common.utility.ApiConstant.*;
 
 @ServiceAdapter
-@RequiredArgsConstructor
 @Slf4j
 public class CommerceServiceClient implements UpdateCommerceInventoryPort {
     private static final FulfillmentServiceCommunicationTargetType TARGET_TYPE =
@@ -42,13 +38,25 @@ public class CommerceServiceClient implements UpdateCommerceInventoryPort {
     private static final FulfillmentServiceCommunicationSenderType RESPONSE_SENDER =
             FulfillmentServiceCommunicationSenderType.COMMERCE;
 
-    @Value("${commerce-service.base-url}")
-    private String commerceServiceBaseUrl;
-
-    private final RestTemplate restTemplate;
+    private final RestClient restClient;
+    private final String commerceServiceBaseUrl;
     private final HmacServiceAuthHeaderBuilder hmacServiceAuthHeaderBuilder;
     private final ServiceCommunicationRecorder serviceCommunicationRecorder;
     private final ServiceCommunicationPayloadGenerator serviceCommunicationPayloadGenerator;
+
+    public CommerceServiceClient(
+            RestClient.Builder restClientBuilder,
+            @Value("${commerce-service.base-url}") String commerceServiceBaseUrl,
+            HmacServiceAuthHeaderBuilder hmacServiceAuthHeaderBuilder,
+            ServiceCommunicationRecorder serviceCommunicationRecorder,
+            ServiceCommunicationPayloadGenerator serviceCommunicationPayloadGenerator
+    ) {
+        this.restClient = restClientBuilder.build();
+        this.commerceServiceBaseUrl = commerceServiceBaseUrl;
+        this.hmacServiceAuthHeaderBuilder = hmacServiceAuthHeaderBuilder;
+        this.serviceCommunicationRecorder = serviceCommunicationRecorder;
+        this.serviceCommunicationPayloadGenerator = serviceCommunicationPayloadGenerator;
+    }
 
     @Override
     public void updateInventories(UpdateCommerceInventoryCommand command) {
@@ -67,19 +75,15 @@ public class CommerceServiceClient implements UpdateCommerceInventoryPort {
                 .build()
                 .toUri();
 
-        HttpHeaders headers = new HttpHeaders();
-        hmacServiceAuthHeaderBuilder.applyHeaders(headers, "POST", uri.getPath());
-
         SyncFulfillmentVendorInventoryRequest request = SyncFulfillmentVendorInventoryRequest.from(command);
-        HttpEntity<SyncFulfillmentVendorInventoryRequest> httpEntity = new HttpEntity<>(request, headers);
 
         String targetId = resolveTargetId(command);
-        sendRequest(uri, httpEntity, targetId);
+        sendRequest(uri, request, targetId);
     }
 
     private void sendRequest(
             URI uri,
-            HttpEntity<SyncFulfillmentVendorInventoryRequest> httpEntity,
+            SyncFulfillmentVendorInventoryRequest request,
             String targetId
     ) {
         long sleepMillis = INTER_SERVER_DEFAULT_RETRIAL_PENDING_MILLI_SECOND;
@@ -90,14 +94,19 @@ public class CommerceServiceClient implements UpdateCommerceInventoryPort {
         for (int i = 0; i < INTER_SERVER_MAX_REQUEST_COUNT; i++) {
             int attempt = i + 1;
             try {
-                restTemplate.exchange(requestUri, method, httpEntity, Void.class);
+                restClient.post()
+                        .uri(requestUri)
+                        .headers(h -> hmacServiceAuthHeaderBuilder.applyHeaders(h, "POST", requestUri.getPath()))
+                        .body(request)
+                        .retrieve()
+                        .toBodilessEntity();
                 return;
             } catch (Exception e) {
                 String exception = e.getClass().getSimpleName();
                 JsonNode requestPayloadJson = serviceCommunicationPayloadGenerator.buildRequestPayloadJson(
                         method,
                         requestUri,
-                        httpEntity.getBody(),
+                        request,
                         attempt
                 );
                 String requestPayload = requestPayloadJson.toString();


### PR DESCRIPTION
## partially addresses #475
## resolves #1481

## Task
- [x] CommerceServiceClient RestClient 전환
- [x] FasstoAuthClient RestClient 전환
- [x] FasstoDeliveryClient RestClient 전환
- [x] FasstoDirectReturnDeliveryClient RestClient 전환
- [x] FasstoGoodsClient RestClient 전환
- [x] FasstoReturnDeliveryClient RestClient 전환
- [x] FasstoSettlementClient RestClient 전환
- [x] FasstoShopClient RestClient 전환
- [x] FasstoStockClient RestClient 전환
- [x] FasstoSupplierClient RestClient 전환
- [x] FasstoWarehousingClient RestClient 전환