### PR TITLE
[#1625][#1618] feat: 상품 서비스 배송비 정책 API 서비스 간 통신용 internal 엔드포인트 분리

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/web/product/ShippingPolicyServiceClient.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/web/product/ShippingPolicyServiceClient.java
@@ -62,7 +62,7 @@ public class ShippingPolicyServiceClient implements FindShippingPolicyBySellerId
         }
 
         URI uri = UriComponentsBuilder.fromUriString(productServiceBaseUrl)
-                .path("/api/v1/shipping-policies/sellers")
+                .path("/api/v1/internal/shipping-policies/sellers")
                 .queryParam("sellerIds", sellerIds.toArray())
                 .build()
                 .toUri();

--- a/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/out/web/product/ShippingPolicyServiceClientTest.java
+++ b/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/out/web/product/ShippingPolicyServiceClientTest.java
@@ -1,0 +1,141 @@
+package com.personal.marketnote.commerce.adapter.out.web.product;
+
+import com.personal.marketnote.commerce.port.out.result.shipping.ShippingPolicyInfoResult;
+import com.personal.marketnote.common.security.hmac.HmacServiceAuthHeaderBuilder;
+import com.personal.marketnote.common.utility.http.client.restclient.RestClientErrorHandler;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withServerError;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+@ExtendWith(MockitoExtension.class)
+class ShippingPolicyServiceClientTest {
+
+    private static final String BASE_URL = "http://localhost:8081";
+
+    private MockRestServiceServer mockServer;
+    private ShippingPolicyServiceClient shippingPolicyServiceClient;
+
+    @Mock
+    private HmacServiceAuthHeaderBuilder hmacServiceAuthHeaderBuilder;
+
+    @BeforeEach
+    void setUp() {
+        RestClient.Builder builder = RestClient.builder()
+                .defaultStatusHandler(RestClientErrorHandler::isError, RestClientErrorHandler.noOpErrorHandler());
+        mockServer = MockRestServiceServer.bindTo(builder).build();
+        shippingPolicyServiceClient = new ShippingPolicyServiceClient(
+                builder,
+                BASE_URL,
+                hmacServiceAuthHeaderBuilder
+        );
+    }
+
+    @Nested
+    @DisplayName("findBySellerIds")
+    class FindBySellerIds {
+
+        @Test
+        @DisplayName("판매자 ID 목록으로 배송비 정책 조회에 성공하면 sellerId별 ShippingPolicyInfoResult Map을 반환한다")
+        void shouldReturnShippingPolicyMapWhenRequestSucceeds() {
+            mockServer.expect(requestTo(BASE_URL + "/api/v1/internal/shipping-policies/sellers?sellerIds=10&sellerIds=20"))
+                    .andExpect(method(HttpMethod.GET))
+                    .andRespond(withSuccess("""
+                            {
+                                "content": {
+                                    "shippingPolicies": [
+                                        {
+                                            "sellerId": 10,
+                                            "shippingFee": 3000,
+                                            "freeShippingThreshold": 20000
+                                        },
+                                        {
+                                            "sellerId": 20,
+                                            "shippingFee": 2500,
+                                            "freeShippingThreshold": 30000
+                                        }
+                                    ]
+                                }
+                            }
+                            """, MediaType.APPLICATION_JSON));
+
+            Map<Long, ShippingPolicyInfoResult> result = shippingPolicyServiceClient.findBySellerIds(List.of(10L, 20L));
+
+            assertThat(result).hasSize(2);
+            assertThat(result.get(10L).shippingFee()).isEqualTo(3000L);
+            assertThat(result.get(10L).freeShippingThreshold()).isEqualTo(20000L);
+            assertThat(result.get(20L).shippingFee()).isEqualTo(2500L);
+            assertThat(result.get(20L).freeShippingThreshold()).isEqualTo(30000L);
+
+            mockServer.verify();
+        }
+
+        @Test
+        @DisplayName("sellerIds가 null이면 요청 없이 빈 Map을 반환한다")
+        void shouldReturnEmptyMapWhenSellerIdsNull() {
+            Map<Long, ShippingPolicyInfoResult> result = shippingPolicyServiceClient.findBySellerIds(null);
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("sellerIds가 비어있으면 요청 없이 빈 Map을 반환한다")
+        void shouldReturnEmptyMapWhenSellerIdsEmpty() {
+            Map<Long, ShippingPolicyInfoResult> result = shippingPolicyServiceClient.findBySellerIds(List.of());
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("응답 본문이 빈 경우 빈 Map을 반환한다")
+        void shouldReturnEmptyMapWhenResponseBodyIsEmpty() {
+            mockServer.expect(requestTo(BASE_URL + "/api/v1/internal/shipping-policies/sellers?sellerIds=10"))
+                    .andExpect(method(HttpMethod.GET))
+                    .andRespond(withSuccess("""
+                            {
+                                "content": {
+                                    "shippingPolicies": []
+                                }
+                            }
+                            """, MediaType.APPLICATION_JSON));
+
+            Map<Long, ShippingPolicyInfoResult> result = shippingPolicyServiceClient.findBySellerIds(List.of(10L));
+
+            assertThat(result).isEmpty();
+
+            mockServer.verify();
+        }
+
+        @Test
+        @DisplayName("모든 재시도가 실패하면 빈 Map을 반환한다")
+        void shouldReturnEmptyMapWhenAllRetriesFail() {
+            for (int i = 0; i < 5; i++) {
+                mockServer.expect(requestTo(BASE_URL + "/api/v1/internal/shipping-policies/sellers?sellerIds=10"))
+                        .andExpect(method(HttpMethod.GET))
+                        .andRespond(withServerError());
+            }
+
+            Map<Long, ShippingPolicyInfoResult> result = shippingPolicyServiceClient.findBySellerIds(List.of(10L));
+
+            assertThat(result).isEmpty();
+
+            mockServer.verify();
+        }
+    }
+}

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/shipping/controller/InternalShippingPolicyController.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/shipping/controller/InternalShippingPolicyController.java
@@ -1,0 +1,65 @@
+package com.personal.marketnote.product.adapter.in.web.shipping.controller;
+
+import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
+import com.personal.marketnote.product.adapter.in.web.shipping.response.GetShippingPoliciesBySellerIdsResponse;
+import com.personal.marketnote.product.port.in.result.shipping.GetShippingPolicyBySellerResult;
+import com.personal.marketnote.product.port.in.usecase.shipping.GetShippingPolicyUseCase;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Size;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+import static com.personal.marketnote.common.domain.exception.ExceptionCode.DEFAULT_SUCCESS_CODE;
+
+/**
+ * 내부 배송비 정책 컨트롤러 (서비스 간 통신용)
+ *
+ * @Author 성효빈
+ * @Date 2026-03-18
+ * @Description HMAC 인증 기반 서비스 간 통신용 배송비 정책 조회 API를 제공합니다.
+ */
+@RestController
+@RequestMapping("/api/v1/internal/shipping-policies")
+@Tag(
+        name = "내부 배송비 정책 API",
+        description = "서비스 간 통신용 배송비 정책 API"
+)
+@RequiredArgsConstructor
+@Validated
+@Slf4j
+public class InternalShippingPolicyController {
+
+    private final GetShippingPolicyUseCase getShippingPolicyUseCase;
+
+    /**
+     * 판매자별 배송비 정책 배치 조회 (서비스 간 통신용)
+     *
+     * @param sellerIds 판매자 ID 목록
+     * @return 배송비 정책 배치 조회 응답 {@link GetShippingPoliciesBySellerIdsResponse}
+     */
+    @GetMapping("/sellers")
+    public ResponseEntity<BaseResponse<GetShippingPoliciesBySellerIdsResponse>> getShippingPoliciesBySellerIds(
+            @RequestParam @Size(max = 100, message = "판매자 ID는 최대 100개까지 조회 가능합니다") List<Long> sellerIds
+    ) {
+        List<GetShippingPolicyBySellerResult> results = getShippingPolicyUseCase.getShippingPolicies(sellerIds);
+
+        return new ResponseEntity<>(
+                BaseResponse.of(
+                        GetShippingPoliciesBySellerIdsResponse.from(results),
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "판매자별 배송비 정책 배치 조회 성공"
+                ),
+                HttpStatus.OK
+        );
+    }
+}


### PR DESCRIPTION
## partially addresses #1625
## resolves #1618

## Task
- [x] InternalShippingPolicyController 추가 (GET /api/v1/internal/shipping-policies/sellers)
- [x] @Validated 적용하여 @Size(max = 100) 검증 활성화
- [x] Commerce 서비스 ShippingPolicyServiceClient URL을 internal 엔드포인트로 변경
- [x] ShippingPolicyServiceClientTest 추가 (MockRestServiceServer 기반 5개 테스트)