### PR TITLE
[#1625][#1619] feat: 리워드 서비스 포인트 API 서비스 간 통신용 internal 엔드포인트 분리

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/inventory/controller/InternalInventoryController.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/inventory/controller/InternalInventoryController.java
@@ -29,7 +29,7 @@ import static com.personal.marketnote.common.domain.exception.ExceptionCode.DEFA
  * 내부 재고 컨트롤러 (서비스 간 통신용)
  *
  * @Author 성효빈
- * @Date 2026-03-18
+ * @Date 2026-03-28
  * @Description HMAC 인증 기반 서비스 간 통신용 재고 API를 제공합니다.
  */
 @RestController

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/web/reward/RewardServiceClient.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/web/reward/RewardServiceClient.java
@@ -247,7 +247,7 @@ public class RewardServiceClient implements ModifyUserPointPort {
     private URI buildPendingPointCancelUri(Long userId) {
         return UriComponentsBuilder
                 .fromUriString(rewardServiceBaseUrl)
-                .path("/api/v1/users/{userId}/points/pending/cancel")
+                .path("/api/v1/internal/users/{userId}/points/pending/cancel")
                 .buildAndExpand(userId)
                 .toUri();
     }
@@ -255,7 +255,7 @@ public class RewardServiceClient implements ModifyUserPointPort {
     private URI buildPendingPointConfirmUri(Long userId) {
         return UriComponentsBuilder
                 .fromUriString(rewardServiceBaseUrl)
-                .path("/api/v1/users/{userId}/points/pending/confirm")
+                .path("/api/v1/internal/users/{userId}/points/pending/confirm")
                 .buildAndExpand(userId)
                 .toUri();
     }
@@ -263,7 +263,7 @@ public class RewardServiceClient implements ModifyUserPointPort {
     private URI buildPendingPointUri(Long userId) {
         return UriComponentsBuilder
                 .fromUriString(rewardServiceBaseUrl)
-                .path("/api/v1/users/{userId}/points/pending")
+                .path("/api/v1/internal/users/{userId}/points/pending")
                 .buildAndExpand(userId)
                 .toUri();
     }
@@ -271,7 +271,7 @@ public class RewardServiceClient implements ModifyUserPointPort {
     private URI buildUserPointUri(Long userId) {
         return UriComponentsBuilder
                 .fromUriString(rewardServiceBaseUrl)
-                .path("/api/v1/users/{userId}/points")
+                .path("/api/v1/internal/users/{userId}/points")
                 .buildAndExpand(userId)
                 .toUri();
     }

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/shipping/controller/InternalShippingPolicyController.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/shipping/controller/InternalShippingPolicyController.java
@@ -24,7 +24,7 @@ import static com.personal.marketnote.common.domain.exception.ExceptionCode.DEFA
  * 내부 배송비 정책 컨트롤러 (서비스 간 통신용)
  *
  * @Author 성효빈
- * @Date 2026-03-18
+ * @Date 2026-03-28
  * @Description HMAC 인증 기반 서비스 간 통신용 배송비 정책 조회 API를 제공합니다.
  */
 @RestController

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/point/InternalPointController.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/point/InternalPointController.java
@@ -1,0 +1,173 @@
+package com.personal.marketnote.reward.adapter.in.web.point;
+
+import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
+import com.personal.marketnote.reward.adapter.in.web.point.mapper.PointRequestToCommandMapper;
+import com.personal.marketnote.reward.adapter.in.web.point.request.CancelPendingPointRequest;
+import com.personal.marketnote.reward.adapter.in.web.point.request.ConfirmPendingPointRequest;
+import com.personal.marketnote.reward.adapter.in.web.point.request.ModifyPendingPointRequest;
+import com.personal.marketnote.reward.adapter.in.web.point.request.ModifyUserPointRequest;
+import com.personal.marketnote.reward.adapter.in.web.point.response.GetUserPointByIdResponse;
+import com.personal.marketnote.reward.adapter.in.web.point.response.UpdateUserPointResponse;
+import com.personal.marketnote.reward.port.in.result.point.GetUserPointResult;
+import com.personal.marketnote.reward.port.in.result.point.UpdateUserPointResult;
+import com.personal.marketnote.reward.port.in.usecase.point.*;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import static com.personal.marketnote.common.domain.exception.ExceptionCode.DEFAULT_SUCCESS_CODE;
+
+/**
+ * 내부 포인트 컨트롤러 (서비스 간 통신용)
+ *
+ * @Author 성효빈
+ * @Date 2026-03-28
+ * @Description HMAC 인증 기반 서비스 간 통신용 포인트 API를 제공합니다.
+ */
+@RestController
+@RequestMapping("/api/v1/internal/users")
+@Tag(
+        name = "내부 포인트 API",
+        description = "서비스 간 통신용 포인트 API"
+)
+@RequiredArgsConstructor
+@Slf4j
+public class InternalPointController {
+    private final GetUserPointUseCase getUserPointUseCase;
+    private final ModifyUserPointUseCase modifyUserPointUseCase;
+    private final ModifyPendingPointUseCase modifyPendingPointUseCase;
+    private final ConfirmPendingPointUseCase confirmPendingPointUseCase;
+    private final CancelPendingPointUseCase cancelPendingPointUseCase;
+
+    /**
+     * 회원 포인트 정보 조회 (서비스 간 통신용)
+     *
+     * @param userId 회원 ID
+     * @return 회원 포인트 정보 조회 응답 {@link GetUserPointByIdResponse}
+     */
+    @GetMapping("/{userId}/points")
+    public ResponseEntity<BaseResponse<GetUserPointByIdResponse>> getUserPoint(
+            @PathVariable("userId") Long userId
+    ) {
+        GetUserPointResult result = GetUserPointResult.from(
+                getUserPointUseCase.getUserPoint(userId)
+        );
+
+        return ResponseEntity.ok(
+                BaseResponse.of(
+                        GetUserPointByIdResponse.from(result),
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "회원 포인트 정보 조회 성공"
+                )
+        );
+    }
+
+    /**
+     * 회원 포인트 적립/차감 (서비스 간 통신용)
+     *
+     * @param userId  회원 ID
+     * @param request 회원 포인트 수정 요청 {@link ModifyUserPointRequest}
+     * @return 회원 포인트 수정 응답 {@link UpdateUserPointResponse}
+     */
+    @PatchMapping("/{userId}/points")
+    public ResponseEntity<BaseResponse<UpdateUserPointResponse>> modifyUserPoint(
+            @PathVariable("userId") Long userId,
+            @RequestBody @Valid ModifyUserPointRequest request
+    ) {
+        UpdateUserPointResult result = modifyUserPointUseCase.modify(
+                PointRequestToCommandMapper.mapToModifyUserPointCommand(userId, request)
+        );
+
+        return ResponseEntity.ok(
+                BaseResponse.of(
+                        UpdateUserPointResponse.from(result),
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "회원 포인트 수정 성공"
+                )
+        );
+    }
+
+    /**
+     * 적립 예정 포인트 추가/차감 (서비스 간 통신용)
+     *
+     * @param userId  회원 ID
+     * @param request 적립 예정 포인트 수정 요청 {@link ModifyPendingPointRequest}
+     * @return 적립 예정 포인트 수정 응답 {@link UpdateUserPointResponse}
+     */
+    @PatchMapping("/{userId}/points/pending")
+    public ResponseEntity<BaseResponse<UpdateUserPointResponse>> modifyPendingPoint(
+            @PathVariable("userId") Long userId,
+            @RequestBody @Valid ModifyPendingPointRequest request
+    ) {
+        UpdateUserPointResult result = modifyPendingPointUseCase.modifyPending(
+                PointRequestToCommandMapper.mapToModifyPendingPointCommand(userId, request)
+        );
+
+        return ResponseEntity.ok(
+                BaseResponse.of(
+                        UpdateUserPointResponse.from(result),
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "적립 예정 포인트 수정 성공"
+                )
+        );
+    }
+
+    /**
+     * 적립 예정 포인트 확정 (서비스 간 통신용)
+     *
+     * @param userId  회원 ID
+     * @param request 적립 예정 포인트 확정 요청 {@link ConfirmPendingPointRequest}
+     * @return 적립 예정 포인트 확정 응답 {@link UpdateUserPointResponse}
+     */
+    @PostMapping("/{userId}/points/pending/confirm")
+    public ResponseEntity<BaseResponse<UpdateUserPointResponse>> confirmPendingPoint(
+            @PathVariable("userId") Long userId,
+            @RequestBody @Valid ConfirmPendingPointRequest request
+    ) {
+        UpdateUserPointResult result = confirmPendingPointUseCase.confirmPending(
+                PointRequestToCommandMapper.mapToConfirmPendingPointCommand(userId, request)
+        );
+
+        return ResponseEntity.ok(
+                BaseResponse.of(
+                        UpdateUserPointResponse.from(result),
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "적립 예정 포인트 확정 성공"
+                )
+        );
+    }
+
+    /**
+     * 적립 예정 포인트 취소 (서비스 간 통신용)
+     *
+     * @param userId  회원 ID
+     * @param request 적립 예정 포인트 취소 요청 {@link CancelPendingPointRequest}
+     * @return 적립 예정 포인트 취소 응답 {@link UpdateUserPointResponse}
+     */
+    @PostMapping("/{userId}/points/pending/cancel")
+    public ResponseEntity<BaseResponse<UpdateUserPointResponse>> cancelPendingPoint(
+            @PathVariable("userId") Long userId,
+            @RequestBody @Valid CancelPendingPointRequest request
+    ) {
+        UpdateUserPointResult result = cancelPendingPointUseCase.cancelPending(
+                PointRequestToCommandMapper.mapToCancelPendingPointCommand(userId, request)
+        );
+
+        return ResponseEntity.ok(
+                BaseResponse.of(
+                        UpdateUserPointResponse.from(result),
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "적립 예정 포인트 취소 성공"
+                )
+        );
+    }
+}

--- a/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/adapter/in/web/point/InternalPointControllerTest.java
+++ b/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/adapter/in/web/point/InternalPointControllerTest.java
@@ -1,0 +1,191 @@
+package com.personal.marketnote.reward.adapter.in.web.point;
+
+import com.personal.marketnote.reward.adapter.in.web.point.mapper.PointRequestToCommandMapper;
+import com.personal.marketnote.reward.adapter.in.web.point.request.CancelPendingPointRequest;
+import com.personal.marketnote.reward.adapter.in.web.point.request.ConfirmPendingPointRequest;
+import com.personal.marketnote.reward.adapter.in.web.point.request.ModifyPendingPointRequest;
+import com.personal.marketnote.reward.adapter.in.web.point.request.ModifyUserPointRequest;
+import com.personal.marketnote.reward.adapter.in.web.point.response.GetUserPointByIdResponse;
+import com.personal.marketnote.reward.adapter.in.web.point.response.UpdateUserPointResponse;
+import com.personal.marketnote.reward.domain.point.UserPoint;
+import com.personal.marketnote.reward.domain.point.UserPointChangeType;
+import com.personal.marketnote.reward.domain.point.UserPointSourceType;
+import com.personal.marketnote.reward.port.in.command.point.CancelPendingPointCommand;
+import com.personal.marketnote.reward.port.in.command.point.ConfirmPendingPointCommand;
+import com.personal.marketnote.reward.port.in.command.point.ModifyPendingPointCommand;
+import com.personal.marketnote.reward.port.in.command.point.ModifyUserPointCommand;
+import com.personal.marketnote.reward.port.in.result.point.GetUserPointResult;
+import com.personal.marketnote.reward.port.in.result.point.UpdateUserPointResult;
+import com.personal.marketnote.reward.port.in.usecase.point.*;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("InternalPointController 테스트")
+class InternalPointControllerTest {
+    @InjectMocks
+    private InternalPointController internalPointController;
+
+    @Mock
+    private GetUserPointUseCase getUserPointUseCase;
+
+    @Mock
+    private ModifyUserPointUseCase modifyUserPointUseCase;
+
+    @Mock
+    private ModifyPendingPointUseCase modifyPendingPointUseCase;
+
+    @Mock
+    private ConfirmPendingPointUseCase confirmPendingPointUseCase;
+
+    @Mock
+    private CancelPendingPointUseCase cancelPendingPointUseCase;
+
+    private static final Long USER_ID = 1L;
+    private static final LocalDateTime NOW = LocalDateTime.of(2026, 3, 18, 10, 0, 0);
+
+    @Nested
+    @DisplayName("getUserPoint")
+    class GetUserPoint {
+        @Test
+        @DisplayName("회원 포인트 정보를 조회하고 200 OK를 반환한다")
+        void shouldReturnUserPointAndOkStatus() {
+            // given
+            UserPoint userPoint = mock(UserPoint.class);
+            when(userPoint.getUserId()).thenReturn(USER_ID);
+            when(userPoint.getAmountValue()).thenReturn(5000L);
+            when(userPoint.getAddExpectedAmount()).thenReturn(1000L);
+            when(userPoint.getExpireExpectedAmount()).thenReturn(0L);
+            when(userPoint.getCreatedAt()).thenReturn(NOW);
+            when(userPoint.getModifiedAt()).thenReturn(NOW);
+            when(getUserPointUseCase.getUserPoint(USER_ID)).thenReturn(userPoint);
+
+            // when
+            ResponseEntity<?> response = internalPointController.getUserPoint(USER_ID);
+
+            // then
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+            verify(getUserPointUseCase).getUserPoint(USER_ID);
+        }
+    }
+
+    @Nested
+    @DisplayName("modifyUserPoint")
+    class ModifyUserPoint {
+        @Test
+        @DisplayName("회원 포인트를 수정하고 200 OK를 반환한다")
+        void shouldModifyUserPointAndReturnOkStatus() {
+            // given
+            ModifyUserPointRequest request = new ModifyUserPointRequest();
+            request.setChangeType(UserPointChangeType.ACCRUAL);
+            request.setAmount(1000L);
+            request.setSourceType(UserPointSourceType.ORDER);
+            request.setSourceId(100L);
+            request.setReason("주문 포인트 적립");
+
+            UpdateUserPointResult result = new UpdateUserPointResult(
+                    USER_ID, 6000L, 1000L, 0L, NOW, NOW
+            );
+            when(modifyUserPointUseCase.modify(any(ModifyUserPointCommand.class))).thenReturn(result);
+
+            // when
+            ResponseEntity<?> response = internalPointController.modifyUserPoint(USER_ID, request);
+
+            // then
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+            verify(modifyUserPointUseCase).modify(any(ModifyUserPointCommand.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("modifyPendingPoint")
+    class ModifyPendingPoint {
+        @Test
+        @DisplayName("적립 예정 포인트를 수정하고 200 OK를 반환한다")
+        void shouldModifyPendingPointAndReturnOkStatus() {
+            // given
+            ModifyPendingPointRequest request = new ModifyPendingPointRequest();
+            request.setChangeType(UserPointChangeType.ACCRUAL);
+            request.setAmount(500L);
+            request.setSourceType(UserPointSourceType.ORDER);
+            request.setSourceId(200L);
+            request.setReason("상품 구매 적립");
+
+            UpdateUserPointResult result = new UpdateUserPointResult(
+                    USER_ID, 5000L, 1500L, 0L, NOW, NOW
+            );
+            when(modifyPendingPointUseCase.modifyPending(any(ModifyPendingPointCommand.class))).thenReturn(result);
+
+            // when
+            ResponseEntity<?> response = internalPointController.modifyPendingPoint(USER_ID, request);
+
+            // then
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+            verify(modifyPendingPointUseCase).modifyPending(any(ModifyPendingPointCommand.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("confirmPendingPoint")
+    class ConfirmPendingPoint {
+        @Test
+        @DisplayName("적립 예정 포인트를 확정하고 200 OK를 반환한다")
+        void shouldConfirmPendingPointAndReturnOkStatus() {
+            // given
+            ConfirmPendingPointRequest request = new ConfirmPendingPointRequest();
+            request.setSourceType(UserPointSourceType.ORDER);
+            request.setSourceId(300L);
+            request.setReason("구매 확정 포인트 적립");
+
+            UpdateUserPointResult result = new UpdateUserPointResult(
+                    USER_ID, 6500L, 500L, 0L, NOW, NOW
+            );
+            when(confirmPendingPointUseCase.confirmPending(any(ConfirmPendingPointCommand.class))).thenReturn(result);
+
+            // when
+            ResponseEntity<?> response = internalPointController.confirmPendingPoint(USER_ID, request);
+
+            // then
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+            verify(confirmPendingPointUseCase).confirmPending(any(ConfirmPendingPointCommand.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("cancelPendingPoint")
+    class CancelPendingPoint {
+        @Test
+        @DisplayName("적립 예정 포인트를 취소하고 200 OK를 반환한다")
+        void shouldCancelPendingPointAndReturnOkStatus() {
+            // given
+            CancelPendingPointRequest request = new CancelPendingPointRequest();
+            request.setSourceType(UserPointSourceType.ORDER);
+            request.setSourceId(400L);
+            request.setReason("결제 취소 적립 예정 포인트 회수");
+
+            UpdateUserPointResult result = new UpdateUserPointResult(
+                    USER_ID, 5000L, 0L, 0L, NOW, NOW
+            );
+            when(cancelPendingPointUseCase.cancelPending(any(CancelPendingPointCommand.class))).thenReturn(result);
+
+            // when
+            ResponseEntity<?> response = internalPointController.cancelPendingPoint(USER_ID, request);
+
+            // then
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+            verify(cancelPendingPointUseCase).cancelPending(any(CancelPendingPointCommand.class));
+        }
+    }
+}


### PR DESCRIPTION
## partially addresses #1625
## resolves #1619

## Task
- [x] InternalPointController 추가 (GET/PATCH /api/v1/internal/users/{userId}/points, PATCH .../pending, POST .../pending/confirm, POST .../pending/cancel)
- [x] Commerce 서비스 RewardServiceClient URI builder 메서드 4개 internal 경로로 변경
- [x] InternalPointControllerTest 추가 (5개 엔드포인트 UseCase 위임 검증)