### PR TITLE
[#1625][#1620] feat: 커뮤니티 서비스 리뷰 집계 API 서비스 간 통신용 internal 엔드포인트 분리

### DIFF
--- a/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/in/web/review/controller/InternalReviewController.java
+++ b/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/in/web/review/controller/InternalReviewController.java
@@ -1,0 +1,58 @@
+package com.personal.marketnote.community.adapter.in.web.review.controller;
+
+import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
+import com.personal.marketnote.community.adapter.in.web.review.response.GetProductReviewAggregatesResponse;
+import com.personal.marketnote.community.port.in.usecase.review.GetReviewUseCase;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+import static com.personal.marketnote.common.domain.exception.ExceptionCode.DEFAULT_SUCCESS_CODE;
+
+/**
+ * 내부 리뷰 컨트롤러 (서비스 간 통신용)
+ *
+ * @Author 성효빈
+ * @Date 2026-03-28
+ * @Description HMAC 인증 기반 서비스 간 통신용 리뷰 API를 제공합니다.
+ */
+@RestController
+@RequestMapping("/api/v1/internal")
+@Tag(
+        name = "내부 리뷰 API",
+        description = "서비스 간 통신용 리뷰 API"
+)
+@RequiredArgsConstructor
+public class InternalReviewController {
+    private final GetReviewUseCase getReviewUseCase;
+
+    /**
+     * 상품 리뷰 집계 목록 조회 (서비스 간 통신용)
+     *
+     * @param productIds 상품 ID 목록
+     * @return 상품 리뷰 집계 목록 조회 응답 {@link GetProductReviewAggregatesResponse}
+     */
+    @GetMapping("products/review-aggregates")
+    public ResponseEntity<BaseResponse<GetProductReviewAggregatesResponse>> getProductReviewAggregates(
+            @RequestParam("productIds") List<Long> productIds
+    ) {
+        return new ResponseEntity<>(
+                BaseResponse.of(
+                        GetProductReviewAggregatesResponse.from(
+                                getReviewUseCase.getProductReviewAggregates(productIds)
+                        ),
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "상품 리뷰 집계 목록 조회 성공"
+                ),
+                HttpStatus.OK
+        );
+    }
+}

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/web/community/CommunityServiceClient.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/web/community/CommunityServiceClient.java
@@ -71,7 +71,7 @@ public class CommunityServiceClient implements FindProductReviewAggregatesPort {
 
         URI uri = UriComponentsBuilder
                 .fromUriString(communityServiceBaseUrl)
-                .path("/api/v1/products/review-aggregates")
+                .path("/api/v1/internal/products/review-aggregates")
                 .queryParam("productIds", productIds)
                 .build()
                 .toUri();

--- a/product-service/product-adapters/src/test/java/com/personal/marketnote/product/adapter/out/web/community/CommunityServiceClientTest.java
+++ b/product-service/product-adapters/src/test/java/com/personal/marketnote/product/adapter/out/web/community/CommunityServiceClientTest.java
@@ -75,7 +75,7 @@ class CommunityServiceClientTest {
         @Test
         @DisplayName("상품 ID 목록으로 리뷰 집계 조회에 성공하면 productId별 결과를 반환한다")
         void shouldReturnReviewAggregatesWhenRequestSucceeds() {
-            mockServer.expect(requestTo(BASE_URL + "/api/v1/products/review-aggregates?productIds=1&productIds=2"))
+            mockServer.expect(requestTo(BASE_URL + "/api/v1/internal/products/review-aggregates?productIds=1&productIds=2"))
                     .andExpect(method(HttpMethod.GET))
                     .andRespond(withSuccess("""
                             {
@@ -121,7 +121,7 @@ class CommunityServiceClientTest {
         @Test
         @DisplayName("응답 바디가 null이면 빈 Map을 반환한다")
         void shouldReturnEmptyMapWhenResponseBodyIsNull() {
-            mockServer.expect(requestTo(BASE_URL + "/api/v1/products/review-aggregates?productIds=1"))
+            mockServer.expect(requestTo(BASE_URL + "/api/v1/internal/products/review-aggregates?productIds=1"))
                     .andExpect(method(HttpMethod.GET))
                     .andRespond(withSuccess());
 
@@ -136,7 +136,7 @@ class CommunityServiceClientTest {
         @Test
         @DisplayName("reviewAggregates가 null이면 빈 Map을 반환한다")
         void shouldReturnEmptyMapWhenReviewAggregatesIsNull() {
-            mockServer.expect(requestTo(BASE_URL + "/api/v1/products/review-aggregates?productIds=1"))
+            mockServer.expect(requestTo(BASE_URL + "/api/v1/internal/products/review-aggregates?productIds=1"))
                     .andExpect(method(HttpMethod.GET))
                     .andRespond(withSuccess("""
                             {"content": {"reviewAggregates": null}}
@@ -154,7 +154,7 @@ class CommunityServiceClientTest {
         @DisplayName("모든 재시도가 실패하면 빈 Map을 반환한다")
         void shouldReturnEmptyMapWhenAllRetriesFail() {
             for (int i = 0; i < 5; i++) {
-                mockServer.expect(requestTo(BASE_URL + "/api/v1/products/review-aggregates?productIds=1"))
+                mockServer.expect(requestTo(BASE_URL + "/api/v1/internal/products/review-aggregates?productIds=1"))
                         .andExpect(method(HttpMethod.GET))
                         .andRespond(withServerError());
             }


### PR DESCRIPTION
## partially addresses #1625
## resolves #1620

## Task
- [x] InternalReviewController 추가 (GET /api/v1/internal/products/review-aggregates)
- [x] Product 서비스 CommunityServiceClient URL을 internal 엔드포인트로 변경
- [x] CommunityServiceClientTest URL 변경 반영