### PR TITLE
[#929][#1176] feat: 결제 취소 시 리워드 서비스 상품 구매 적립 예정 포인트 회수 연동 기능 Kafka 이벤트 전환

### DIFF
--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/CancelPaymentService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/CancelPaymentService.java
@@ -114,7 +114,6 @@ public class CancelPaymentService implements CancelPaymentUseCase {
             );
             restoreInventory(order);
             refundPoints(order);
-            revokePendingProductAccumulationPoints(order);
             revokePendingSharedPurchasePoints(order);
         } else {
             restorePartialCancelInventory(order, command);
@@ -282,15 +281,6 @@ public class CancelPaymentService implements CancelPaymentUseCase {
                         "취소 수량이 주문 수량을 초과합니다. pricePolicyId=" + item.pricePolicyId()
                                 + ", 주문수량=" + orderQuantity + ", 취소수량=" + item.quantity());
             }
-        }
-    }
-
-    private void revokePendingProductAccumulationPoints(Order order) {
-        try {
-            modifyUserPointPort.revokePendingPoints(order.getBuyerId(), order.getId());
-        } catch (Exception e) {
-            log.error("상품 적립 예정 포인트 회수 실패 - orderId: {}, buyerId: {}, error: {}",
-                    order.getId(), order.getBuyerId(), e.getMessage(), e);
         }
     }
 

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/payment/CancelPaymentUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/payment/CancelPaymentUseCaseTest.java
@@ -1134,7 +1134,6 @@ class CancelPaymentUseCaseTest {
 
             cancelPaymentService.cancel(command);
 
-            verify(modifyUserPointPort).revokePendingPoints(BUYER_ID, 1L);
             verify(modifyUserPointPort, never()).reducePartialPendingPoints(anyLong(), anyLong(), anyLong());
         }
     }

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/event/PaymentCancelledPendingProductPointConsumer.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/event/PaymentCancelledPendingProductPointConsumer.java
@@ -5,6 +5,9 @@ import com.personal.marketnote.common.kafka.KafkaTopicConstants;
 import com.personal.marketnote.common.kafka.event.EventEnvelope;
 import com.personal.marketnote.common.kafka.event.EventPayloadValidator;
 import com.personal.marketnote.common.kafka.event.PaymentCancelledEvent;
+import com.personal.marketnote.reward.domain.point.UserPointSourceType;
+import com.personal.marketnote.reward.port.in.command.point.CancelPendingPointCommand;
+import com.personal.marketnote.reward.port.in.usecase.point.CancelPendingPointUseCase;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -16,6 +19,7 @@ import org.springframework.stereotype.Component;
 @Component
 @RequiredArgsConstructor
 public class PaymentCancelledPendingProductPointConsumer {
+    private final CancelPendingPointUseCase cancelPendingPointUseCase;
     private final ObjectMapper objectMapper;
 
     @KafkaListener(
@@ -64,18 +68,15 @@ public class PaymentCancelledPendingProductPointConsumer {
                 return;
             }
 
-            // FIXME: [#929][#1176] HTTP 제거 후 CancelPendingPointUseCase 활성화
-            //  현재 듀얼 라이트 기간: CancelPaymentService.revokePendingProductAccumulationPoints()에서 HTTP로 처리 중
-            //  아래 주석 해제 시 활성화:
-            //  CancelPendingPointCommand command = CancelPendingPointCommand.builder()
-            //          .userId(payload.buyerId())
-            //          .sourceType(UserPointSourceType.ORDER)
-            //          .sourceId(payload.orderId())
-            //          .reason("결제 취소 적립 예정 포인트 회수")
-            //          .build();
-            //  cancelPendingPointUseCase.cancelPending(command);
+            CancelPendingPointCommand command = CancelPendingPointCommand.builder()
+                    .userId(payload.buyerId())
+                    .sourceType(UserPointSourceType.ORDER)
+                    .sourceId(payload.orderId())
+                    .reason("결제 취소 적립 예정 포인트 회수")
+                    .build();
+            cancelPendingPointUseCase.cancelPending(command);
 
-            log.info("상품 적립 예정 포인트 회수 이벤트 검증 완료 (듀얼 라이트). orderId={}, buyerId={}",
+            log.info("상품 적립 예정 포인트 회수 완료. orderId={}, buyerId={}",
                     payload.orderId(), payload.buyerId());
         } catch (Exception e) {
             log.error("상품 적립 예정 포인트 회수 이벤트 처리 실패. eventId={}, key={}, error={}",

--- a/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/adapter/in/event/PaymentCancelledPendingProductPointConsumerTest.java
+++ b/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/adapter/in/event/PaymentCancelledPendingProductPointConsumerTest.java
@@ -3,6 +3,9 @@ package com.personal.marketnote.reward.adapter.in.event;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.personal.marketnote.common.kafka.event.EventEnvelope;
 import com.personal.marketnote.common.kafka.event.PaymentCancelledEvent;
+import com.personal.marketnote.reward.domain.point.UserPointSourceType;
+import com.personal.marketnote.reward.port.in.command.point.CancelPendingPointCommand;
+import com.personal.marketnote.reward.port.in.usecase.point.CancelPendingPointUseCase;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -17,8 +20,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("PaymentCancelledPendingProductPointConsumer 테스트")
@@ -28,6 +30,9 @@ class PaymentCancelledPendingProductPointConsumerTest {
 
     @Spy
     private ObjectMapper objectMapper = new ObjectMapper();
+
+    @Mock
+    private CancelPendingPointUseCase cancelPendingPointUseCase;
 
     @Mock
     private Acknowledgment acknowledgment;
@@ -46,8 +51,8 @@ class PaymentCancelledPendingProductPointConsumerTest {
     }
 
     @Test
-    @DisplayName("전체 취소 이벤트 수신 시 상품 적립 예정 포인트 회수 검증 후 acknowledge한다")
-    void handlePaymentCancelledEvent_fullCancel_validatesAndAcknowledges() {
+    @DisplayName("전체 취소 이벤트 수신 시 상품 적립 예정 포인트를 회수하고 acknowledge한다")
+    void handlePaymentCancelledEvent_fullCancel_cancelsPendingPointAndAcknowledges() {
         // given
         ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, 100L, true);
 
@@ -55,6 +60,13 @@ class PaymentCancelledPendingProductPointConsumerTest {
         consumer.handlePaymentCancelledEvent(record, acknowledgment);
 
         // then
+        CancelPendingPointCommand expectedCommand = CancelPendingPointCommand.builder()
+                .userId(100L)
+                .sourceType(UserPointSourceType.ORDER)
+                .sourceId(1L)
+                .reason("결제 취소 적립 예정 포인트 회수")
+                .build();
+        verify(cancelPendingPointUseCase).cancelPending(expectedCommand);
         verify(acknowledgment).acknowledge();
     }
 
@@ -68,6 +80,7 @@ class PaymentCancelledPendingProductPointConsumerTest {
         consumer.handlePaymentCancelledEvent(record, acknowledgment);
 
         // then
+        verifyNoInteractions(cancelPendingPointUseCase);
         verify(acknowledgment).acknowledge();
     }
 
@@ -81,6 +94,7 @@ class PaymentCancelledPendingProductPointConsumerTest {
         consumer.handlePaymentCancelledEvent(record, acknowledgment);
 
         // then
+        verifyNoInteractions(cancelPendingPointUseCase);
         verify(acknowledgment).acknowledge();
     }
 
@@ -94,6 +108,7 @@ class PaymentCancelledPendingProductPointConsumerTest {
         consumer.handlePaymentCancelledEvent(record, acknowledgment);
 
         // then
+        verifyNoInteractions(cancelPendingPointUseCase);
         verify(acknowledgment).acknowledge();
     }
 
@@ -117,6 +132,7 @@ class PaymentCancelledPendingProductPointConsumerTest {
         consumer.handlePaymentCancelledEvent(record, acknowledgment);
 
         // then
+        verifyNoInteractions(cancelPendingPointUseCase);
         verify(acknowledgment).acknowledge();
     }
 
@@ -130,6 +146,7 @@ class PaymentCancelledPendingProductPointConsumerTest {
         consumer.handlePaymentCancelledEvent(record, acknowledgment);
 
         // then
+        verifyNoInteractions(cancelPendingPointUseCase);
         verify(acknowledgment).acknowledge();
     }
 
@@ -143,6 +160,7 @@ class PaymentCancelledPendingProductPointConsumerTest {
         consumer.handlePaymentCancelledEvent(record, acknowledgment);
 
         // then
+        verifyNoInteractions(cancelPendingPointUseCase);
         verify(acknowledgment).acknowledge();
     }
 
@@ -156,6 +174,7 @@ class PaymentCancelledPendingProductPointConsumerTest {
         consumer.handlePaymentCancelledEvent(record, acknowledgment);
 
         // then
+        verifyNoInteractions(cancelPendingPointUseCase);
         verify(acknowledgment).acknowledge();
     }
 
@@ -169,6 +188,7 @@ class PaymentCancelledPendingProductPointConsumerTest {
         consumer.handlePaymentCancelledEvent(record, acknowledgment);
 
         // then
+        verifyNoInteractions(cancelPendingPointUseCase);
         verify(acknowledgment).acknowledge();
     }
 
@@ -184,6 +204,7 @@ class PaymentCancelledPendingProductPointConsumerTest {
         consumer.handlePaymentCancelledEvent(record, acknowledgment);
 
         // then
+        verifyNoInteractions(cancelPendingPointUseCase);
         verify(acknowledgment).acknowledge();
     }
 


### PR DESCRIPTION
## partially addresses #929
## resolves #1176

## Task
- [x] PaymentCancelledPendingProductPointConsumer FIXME 제거, CancelPendingPointUseCase 활성화
- [x] CancelPaymentService에서 revokePendingProductAccumulationPoints HTTP 호출 제거
- [x] Consumer 테스트 CancelPendingPointUseCase verify 추가
- [x] CancelPaymentUseCaseTest revokePendingPoints verify 제거