### PR TITLE
[#929][#1177] feat: 결제 취소 시 리워드 서비스 링크 공유 적립 예정 포인트 회수 연동 기능 Kafka 이벤트 전환

### DIFF
--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/CancelPaymentService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/CancelPaymentService.java
@@ -114,7 +114,6 @@ public class CancelPaymentService implements CancelPaymentUseCase {
             );
             restoreInventory(order);
             refundPoints(order);
-            revokePendingSharedPurchasePoints(order);
         } else {
             restorePartialCancelInventory(order, command);
             partialProductPendingDeduction = resolveProportionalDeductionPoint(
@@ -281,20 +280,6 @@ public class CancelPaymentService implements CancelPaymentUseCase {
                         "취소 수량이 주문 수량을 초과합니다. pricePolicyId=" + item.pricePolicyId()
                                 + ", 주문수량=" + orderQuantity + ", 취소수량=" + item.quantity());
             }
-        }
-    }
-
-    private void revokePendingSharedPurchasePoints(Order order) {
-        List<Long> sharerIds = extractSharerIds(order);
-        if (sharerIds.isEmpty()) {
-            return;
-        }
-
-        try {
-            modifyUserPointPort.revokePendingSharedPurchasePoints(sharerIds, order.getId());
-        } catch (Exception e) {
-            log.error("공유 적립 예정 포인트 회수 실패 - orderId: {}, sharerIds: {}, error: {}",
-                    order.getId(), sharerIds, e.getMessage(), e);
         }
     }
 

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/payment/CancelPaymentUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/payment/CancelPaymentUseCaseTest.java
@@ -883,92 +883,6 @@ class CancelPaymentUseCaseTest {
     }
 
     @Nested
-    @DisplayName("공유 적립 예정 포인트 회수 검증")
-    class SharedPurchasePointRevokeTest {
-
-        @Test
-        @DisplayName("전체 취소 시 공유자가 있으면 공유 적립 예정 포인트 회수가 호출된다")
-        void shouldRevokeSharedPendingPointsOnFullCancelWithSharers() {
-            Payment payment = createSuccessPayment(1L, ORDER_KEY, 50000L, "tno_123");
-            PspPaymentEvent event = createCompleteEvent(ORDER_KEY_STR, "tno_123", 50000L);
-            CancelPaymentCommand command = createFullCancelCommand(ORDER_KEY_STR);
-            PaymentCancelVendorResult vendorResult = createSuccessVendorResult();
-            Order order = createOrderWithSharers(1L, BUYER_ID, 0L, List.of(200L, 300L));
-
-            when(findPaymentPort.findByOrderKey(ORDER_KEY)).thenReturn(Optional.of(payment));
-            when(findOrderPort.findById(1L)).thenReturn(Optional.of(order));
-            when(findPspPaymentEventPort.findByOrderKey(ORDER_KEY_STR)).thenReturn(Optional.of(event));
-            when(paymentVendorPort.cancelPayment(any())).thenReturn(vendorResult);
-
-            cancelPaymentService.cancel(command);
-
-            verify(modifyUserPointPort).revokePendingSharedPurchasePoints(
-                    eq(List.of(200L, 300L)), eq(1L)
-            );
-        }
-
-        @Test
-        @DisplayName("전체 취소 시 공유자가 없으면 공유 적립 예정 포인트 회수가 호출되지 않는다")
-        void shouldNotRevokeSharedPendingPointsWhenNoSharers() {
-            Payment payment = createSuccessPayment(1L, ORDER_KEY, 50000L, "tno_123");
-            PspPaymentEvent event = createCompleteEvent(ORDER_KEY_STR, "tno_123", 50000L);
-            CancelPaymentCommand command = createFullCancelCommand(ORDER_KEY_STR);
-            PaymentCancelVendorResult vendorResult = createSuccessVendorResult();
-
-            when(findPaymentPort.findByOrderKey(ORDER_KEY)).thenReturn(Optional.of(payment));
-            when(findOrderPort.findById(1L)).thenReturn(Optional.of(createOrder(1L, BUYER_ID)));
-            when(findPspPaymentEventPort.findByOrderKey(ORDER_KEY_STR)).thenReturn(Optional.of(event));
-            when(paymentVendorPort.cancelPayment(any())).thenReturn(vendorResult);
-
-            cancelPaymentService.cancel(command);
-
-            verify(modifyUserPointPort, never()).revokePendingSharedPurchasePoints(anyList(), anyLong());
-        }
-
-        @Test
-        @DisplayName("부분 취소 시 공유 적립 예정 포인트 회수가 호출되지 않는다")
-        void shouldNotRevokeSharedPendingPointsOnPartialCancel() {
-            Payment payment = createSuccessPayment(1L, ORDER_KEY, 50000L, "tno_123");
-            PspPaymentEvent event = createCompleteEvent(ORDER_KEY_STR, "tno_123", 50000L);
-            CancelPaymentCommand command = createPartialCancelCommand(ORDER_KEY_STR, 20000L);
-            PaymentCancelVendorResult vendorResult = createSuccessVendorResult();
-            Order order = createOrderWithSharers(1L, BUYER_ID, 0L, List.of(200L));
-
-            when(findPaymentPort.findByOrderKey(ORDER_KEY)).thenReturn(Optional.of(payment));
-            when(findOrderPort.findById(1L)).thenReturn(Optional.of(order));
-            when(findPspPaymentEventPort.findByOrderKey(ORDER_KEY_STR)).thenReturn(Optional.of(event));
-            when(paymentVendorPort.cancelPayment(any())).thenReturn(vendorResult);
-
-            cancelPaymentService.cancel(command);
-
-            verify(modifyUserPointPort, never()).revokePendingSharedPurchasePoints(anyList(), anyLong());
-        }
-
-        @Test
-        @DisplayName("공유 적립 예정 포인트 회수 실패 시에도 결제 취소는 정상 완료된다")
-        void shouldCompleteCancelEvenWhenSharedPointRevokeFails() {
-            Payment payment = createSuccessPayment(1L, ORDER_KEY, 50000L, "tno_123");
-            PspPaymentEvent event = createCompleteEvent(ORDER_KEY_STR, "tno_123", 50000L);
-            CancelPaymentCommand command = createFullCancelCommand(ORDER_KEY_STR);
-            PaymentCancelVendorResult vendorResult = createSuccessVendorResult();
-            Order order = createOrderWithSharers(1L, BUYER_ID, 0L, List.of(200L));
-
-            when(findPaymentPort.findByOrderKey(ORDER_KEY)).thenReturn(Optional.of(payment));
-            when(findOrderPort.findById(1L)).thenReturn(Optional.of(order));
-            when(findPspPaymentEventPort.findByOrderKey(ORDER_KEY_STR)).thenReturn(Optional.of(event));
-            when(paymentVendorPort.cancelPayment(any())).thenReturn(vendorResult);
-            doThrow(new RuntimeException("공유 포인트 회수 실패")).when(modifyUserPointPort)
-                    .revokePendingSharedPurchasePoints(anyList(), anyLong());
-
-            cancelPaymentService.cancel(command);
-
-            verify(updatePaymentPort).update(any());
-            verify(updatePspPaymentEventPort).update(any());
-            verify(changeOrderStatusUseCase).changeOrderStatus(any());
-        }
-    }
-
-    @Nested
     @DisplayName("부분 취소 적립 예정 포인트 비례 차감 검증")
     class PartialCancelPendingPointTest {
 
@@ -1243,9 +1157,6 @@ class CancelPaymentUseCaseTest {
 
             cancelPaymentService.cancel(command);
 
-            verify(modifyUserPointPort).revokePendingSharedPurchasePoints(
-                    eq(List.of(200L, 300L)), eq(1L)
-            );
             verify(modifyUserPointPort, never()).reducePartialPendingSharedPurchasePoints(
                     anyList(), anyLong(), anyLong(), anyLong()
             );

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/event/PaymentCancelledPendingSharedPointConsumer.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/event/PaymentCancelledPendingSharedPointConsumer.java
@@ -7,6 +7,9 @@ import com.personal.marketnote.common.kafka.event.EventPayloadValidator;
 import com.personal.marketnote.common.kafka.event.PaymentCancelledEvent;
 import com.personal.marketnote.common.kafka.event.PaymentCancelledEvent.OrderProductItem;
 import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.reward.domain.point.UserPointSourceType;
+import com.personal.marketnote.reward.port.in.command.point.CancelPendingPointCommand;
+import com.personal.marketnote.reward.port.in.usecase.point.CancelPendingPointUseCase;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -21,6 +24,7 @@ import java.util.Objects;
 @Component
 @RequiredArgsConstructor
 public class PaymentCancelledPendingSharedPointConsumer {
+    private final CancelPendingPointUseCase cancelPendingPointUseCase;
     private final ObjectMapper objectMapper;
 
     @KafkaListener(
@@ -70,20 +74,17 @@ public class PaymentCancelledPendingSharedPointConsumer {
                 return;
             }
 
-            // FIXME: [#929][#1177] HTTP 제거 후 CancelPendingPointUseCase 활성화
-            //  현재 듀얼 라이트 기간: CancelPaymentService.revokePendingSharedPurchasePoints()에서 HTTP로 처리 중
-            //  아래 주석 해제 시 활성화:
-            //  for (Long sharerId : sharerIds) {
-            //      CancelPendingPointCommand command = CancelPendingPointCommand.builder()
-            //              .userId(sharerId)
-            //              .sourceType(UserPointSourceType.ORDER)
-            //              .sourceId(payload.orderId())
-            //              .reason("결제 취소 적립 예정 포인트 회수")
-            //              .build();
-            //      cancelPendingPointUseCase.cancelPending(command);
-            //  }
+            for (Long sharerId : sharerIds) {
+                CancelPendingPointCommand command = CancelPendingPointCommand.builder()
+                        .userId(sharerId)
+                        .sourceType(UserPointSourceType.ORDER)
+                        .sourceId(payload.orderId())
+                        .reason("결제 취소 적립 예정 포인트 회수")
+                        .build();
+                cancelPendingPointUseCase.cancelPending(command);
+            }
 
-            log.info("공유 적립 예정 포인트 회수 이벤트 검증 완료 (듀얼 라이트). orderId={}, sharerIds={}",
+            log.info("공유 적립 예정 포인트 회수 완료. orderId={}, sharerIds={}",
                     payload.orderId(), sharerIds);
         } catch (Exception e) {
             log.error("공유 적립 예정 포인트 회수 이벤트 처리 실패. eventId={}, key={}, error={}",

--- a/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/adapter/in/event/PaymentCancelledPendingSharedPointConsumerTest.java
+++ b/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/adapter/in/event/PaymentCancelledPendingSharedPointConsumerTest.java
@@ -4,6 +4,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.personal.marketnote.common.kafka.event.EventEnvelope;
 import com.personal.marketnote.common.kafka.event.PaymentCancelledEvent;
 import com.personal.marketnote.common.kafka.event.PaymentCancelledEvent.OrderProductItem;
+import com.personal.marketnote.reward.domain.point.UserPointSourceType;
+import com.personal.marketnote.reward.port.in.command.point.CancelPendingPointCommand;
+import com.personal.marketnote.reward.port.in.usecase.point.CancelPendingPointUseCase;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -18,8 +21,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("PaymentCancelledPendingSharedPointConsumer 테스트")
@@ -29,6 +31,9 @@ class PaymentCancelledPendingSharedPointConsumerTest {
 
     @Spy
     private ObjectMapper objectMapper = new ObjectMapper();
+
+    @Mock
+    private CancelPendingPointUseCase cancelPendingPointUseCase;
 
     @Mock
     private Acknowledgment acknowledgment;
@@ -47,8 +52,8 @@ class PaymentCancelledPendingSharedPointConsumerTest {
     }
 
     @Test
-    @DisplayName("전체 취소 이벤트 수신 시 공유 적립 예정 포인트 회수 검증 후 acknowledge한다")
-    void handlePaymentCancelledEvent_fullCancelWithSharers_validatesAndAcknowledges() {
+    @DisplayName("전체 취소 이벤트 수신 시 공유자별 적립 예정 포인트를 회수하고 acknowledge한다")
+    void handlePaymentCancelledEvent_fullCancelWithSharers_cancelsPendingPointsAndAcknowledges() {
         // given
         List<OrderProductItem> orderProducts = List.of(
                 new OrderProductItem(1L, 200L, 2, 10000L),
@@ -60,6 +65,20 @@ class PaymentCancelledPendingSharedPointConsumerTest {
         consumer.handlePaymentCancelledEvent(record, acknowledgment);
 
         // then
+        CancelPendingPointCommand expectedCommand200 = CancelPendingPointCommand.builder()
+                .userId(200L)
+                .sourceType(UserPointSourceType.ORDER)
+                .sourceId(1L)
+                .reason("결제 취소 적립 예정 포인트 회수")
+                .build();
+        CancelPendingPointCommand expectedCommand300 = CancelPendingPointCommand.builder()
+                .userId(300L)
+                .sourceType(UserPointSourceType.ORDER)
+                .sourceId(1L)
+                .reason("결제 취소 적립 예정 포인트 회수")
+                .build();
+        verify(cancelPendingPointUseCase).cancelPending(expectedCommand200);
+        verify(cancelPendingPointUseCase).cancelPending(expectedCommand300);
         verify(acknowledgment).acknowledge();
     }
 
@@ -76,6 +95,7 @@ class PaymentCancelledPendingSharedPointConsumerTest {
         consumer.handlePaymentCancelledEvent(record, acknowledgment);
 
         // then
+        verifyNoInteractions(cancelPendingPointUseCase);
         verify(acknowledgment).acknowledge();
     }
 
@@ -92,6 +112,7 @@ class PaymentCancelledPendingSharedPointConsumerTest {
         consumer.handlePaymentCancelledEvent(record, acknowledgment);
 
         // then
+        verifyNoInteractions(cancelPendingPointUseCase);
         verify(acknowledgment).acknowledge();
     }
 
@@ -109,6 +130,7 @@ class PaymentCancelledPendingSharedPointConsumerTest {
         consumer.handlePaymentCancelledEvent(record, acknowledgment);
 
         // then
+        verifyNoInteractions(cancelPendingPointUseCase);
         verify(acknowledgment).acknowledge();
     }
 
@@ -122,6 +144,7 @@ class PaymentCancelledPendingSharedPointConsumerTest {
         consumer.handlePaymentCancelledEvent(record, acknowledgment);
 
         // then
+        verifyNoInteractions(cancelPendingPointUseCase);
         verify(acknowledgment).acknowledge();
     }
 
@@ -148,6 +171,7 @@ class PaymentCancelledPendingSharedPointConsumerTest {
         consumer.handlePaymentCancelledEvent(record, acknowledgment);
 
         // then
+        verifyNoInteractions(cancelPendingPointUseCase);
         verify(acknowledgment).acknowledge();
     }
 
@@ -164,6 +188,7 @@ class PaymentCancelledPendingSharedPointConsumerTest {
         consumer.handlePaymentCancelledEvent(record, acknowledgment);
 
         // then
+        verifyNoInteractions(cancelPendingPointUseCase);
         verify(acknowledgment).acknowledge();
     }
 
@@ -180,6 +205,7 @@ class PaymentCancelledPendingSharedPointConsumerTest {
         consumer.handlePaymentCancelledEvent(record, acknowledgment);
 
         // then
+        verifyNoInteractions(cancelPendingPointUseCase);
         verify(acknowledgment).acknowledge();
     }
 
@@ -195,12 +221,13 @@ class PaymentCancelledPendingSharedPointConsumerTest {
         consumer.handlePaymentCancelledEvent(record, acknowledgment);
 
         // then
+        verifyNoInteractions(cancelPendingPointUseCase);
         verify(acknowledgment).acknowledge();
     }
 
     @Test
-    @DisplayName("중복 공유자가 있으면 중복 제거 후 검증한다")
-    void handlePaymentCancelledEvent_duplicateSharers_deduplicatesAndAcknowledges() {
+    @DisplayName("중복 공유자가 있으면 중복 제거 후 공유자별 적립 예정 포인트를 회수한다")
+    void handlePaymentCancelledEvent_duplicateSharers_deduplicatesAndCancelsPendingPoints() {
         // given
         List<OrderProductItem> orderProducts = List.of(
                 new OrderProductItem(1L, 200L, 2, 10000L),
@@ -213,6 +240,7 @@ class PaymentCancelledPendingSharedPointConsumerTest {
         consumer.handlePaymentCancelledEvent(record, acknowledgment);
 
         // then
+        verify(cancelPendingPointUseCase, times(2)).cancelPending(any(CancelPendingPointCommand.class));
         verify(acknowledgment).acknowledge();
     }
 


### PR DESCRIPTION
## partially addresses #929
## resolves #1177

## Task
- [x] PaymentCancelledPendingSharedPointConsumer FIXME 제거, CancelPendingPointUseCase 활성화
- [x] CancelPaymentService에서 revokePendingSharedPurchasePoints HTTP 호출 제거
- [x] Consumer 테스트 CancelPendingPointUseCase verify 추가
- [x] CancelPaymentUseCaseTest SharedPurchasePointRevokeTest 제거