### PR TITLE
[#929][#1100] feat: 결제 취소 시 주문 상태 변경 연동 기능 Kafka 이벤트 전환

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/PaymentCancelledOrderStatusConsumer.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/PaymentCancelledOrderStatusConsumer.java
@@ -62,8 +62,6 @@ public class PaymentCancelledOrderStatusConsumer {
                 return;
             }
 
-            // FIXME: [#929][#1100] HTTP 제거 후 ChangeOrderStatusUseCase.changeOrderStatus(CANCEL_REQUESTED) 활성화
-            //  현재 듀얼 라이트 기간: CancelPaymentService.cancel()에서 동기로 주문 상태 변경 처리 중
             ChangeOrderStatusCommand command = ChangeOrderStatusCommand.builder()
                     .id(payload.orderId())
                     .orderStatus(OrderStatus.CANCEL_REQUESTED)
@@ -73,7 +71,7 @@ public class PaymentCancelledOrderStatusConsumer {
             log.info("Kafka 이벤트로 주문 상태 CANCEL_REQUESTED 변경 완료. orderId={}",
                     payload.orderId());
         } catch (OrderStatusAlreadyChangedException e) {
-            log.warn("듀얼 라이트: 이미 주문 상태가 변경됨. eventId={}, key={}, message={}",
+            log.warn("멱등 처리: 이미 주문 상태가 변경됨. eventId={}, key={}, message={}",
                     envelope.eventId(), record.key(), e.getMessage());
         } catch (Exception e) {
             log.error("주문 상태 CANCEL_REQUESTED 변경 실패. eventId={}, key={}, error={}",

--- a/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/event/PaymentCancelledOrderStatusConsumerTest.java
+++ b/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/event/PaymentCancelledOrderStatusConsumerTest.java
@@ -103,7 +103,7 @@ class PaymentCancelledOrderStatusConsumerTest {
     }
 
     @Test
-    @DisplayName("듀얼 라이트 기간 중 이미 상태가 변경된 주문에 대해 OrderStatusAlreadyChangedException 발생 시 정상 acknowledge한다")
+    @DisplayName("이미 상태가 변경된 주문에 대해 OrderStatusAlreadyChangedException 발생 시 멱등 처리로 정상 acknowledge한다")
     void handlePaymentCancelledEvent_alreadyChanged_acknowledgesGracefully() {
         // given
         ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, "order-key-1", true, 50000L);

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/CancelPaymentService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/CancelPaymentService.java
@@ -3,17 +3,14 @@ package com.personal.marketnote.commerce.service.payment;
 import com.personal.marketnote.commerce.domain.order.Order;
 import com.personal.marketnote.commerce.domain.order.OrderProduct;
 import com.personal.marketnote.commerce.domain.order.OrderProductSnapshotState;
-import com.personal.marketnote.commerce.domain.order.OrderStatus;
 import com.personal.marketnote.commerce.domain.payment.Payment;
 import com.personal.marketnote.commerce.domain.payment.PspPaymentEvent;
 import com.personal.marketnote.commerce.domain.refund.Refund;
 import com.personal.marketnote.commerce.domain.refund.RefundCreateState;
 import com.personal.marketnote.commerce.domain.refund.RefundType;
 import com.personal.marketnote.commerce.exception.*;
-import com.personal.marketnote.commerce.port.in.command.order.ChangeOrderStatusCommand;
 import com.personal.marketnote.commerce.port.in.command.payment.CancelPaymentCommand;
 import com.personal.marketnote.commerce.port.in.usecase.inventory.RestoreProductInventoryUseCase;
-import com.personal.marketnote.commerce.port.in.usecase.order.ChangeOrderStatusUseCase;
 import com.personal.marketnote.commerce.port.in.usecase.payment.CancelPaymentUseCase;
 import com.personal.marketnote.commerce.port.out.event.PublishPaymentEventPort;
 import com.personal.marketnote.commerce.port.out.order.FindOrderPort;
@@ -54,7 +51,6 @@ public class CancelPaymentService implements CancelPaymentUseCase {
     private final FindPspPaymentEventPort findPspPaymentEventPort;
     private final UpdatePspPaymentEventPort updatePspPaymentEventPort;
     private final PaymentVendorPort paymentVendorPort;
-    private final ChangeOrderStatusUseCase changeOrderStatusUseCase;
     private final RestoreProductInventoryUseCase restoreProductInventoryUseCase;
     private final ModifyUserPointPort modifyUserPointPort;
     private final SaveRefundPort saveRefundPort;
@@ -106,12 +102,6 @@ public class CancelPaymentService implements CancelPaymentUseCase {
 
         Long partialProductPendingDeduction = null;
         if (isFullCancel) {
-            changeOrderStatusUseCase.changeOrderStatus(
-                    ChangeOrderStatusCommand.builder()
-                            .id(payment.getOrderId())
-                            .orderStatus(OrderStatus.CANCEL_REQUESTED)
-                            .build()
-            );
             restoreInventory(order);
             refundPoints(order);
         } else {

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/payment/CancelPaymentUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/payment/CancelPaymentUseCaseTest.java
@@ -10,7 +10,6 @@ import com.personal.marketnote.commerce.exception.PaymentNotFoundException;
 import com.personal.marketnote.commerce.exception.UnauthorizedOrderAccessException;
 import com.personal.marketnote.commerce.port.in.command.payment.CancelPaymentCommand;
 import com.personal.marketnote.commerce.port.in.usecase.inventory.RestoreProductInventoryUseCase;
-import com.personal.marketnote.commerce.port.in.usecase.order.ChangeOrderStatusUseCase;
 import com.personal.marketnote.commerce.port.out.order.FindOrderPort;
 import com.personal.marketnote.commerce.port.out.payment.*;
 import com.personal.marketnote.commerce.port.out.payment.vendor.PaymentCancelVendorResult;
@@ -57,9 +56,6 @@ class CancelPaymentUseCaseTest {
 
     @Mock
     private PaymentVendorPort paymentVendorPort;
-
-    @Mock
-    private ChangeOrderStatusUseCase changeOrderStatusUseCase;
 
     @Mock
     private RestoreProductInventoryUseCase restoreProductInventoryUseCase;
@@ -121,26 +117,6 @@ class CancelPaymentUseCaseTest {
                             && c.modMny().equals(50000L)
                             && c.remMny().equals(0L)
                             && "tno_123".equals(c.tno())
-            ));
-        }
-
-        @Test
-        @DisplayName("전체 취소 성공 시 주문 상태가 CANCEL_REQUESTED로 변경된다")
-        void shouldChangeOrderStatusToCancelRequested() {
-            Payment payment = createSuccessPayment(1L, ORDER_KEY, 50000L, "tno_123");
-            PspPaymentEvent event = createCompleteEvent(ORDER_KEY_STR, "tno_123", 50000L);
-            CancelPaymentCommand command = createFullCancelCommand(ORDER_KEY_STR);
-            PaymentCancelVendorResult vendorResult = createSuccessVendorResult();
-
-            when(findPaymentPort.findByOrderKey(ORDER_KEY)).thenReturn(Optional.of(payment));
-            when(findOrderPort.findById(1L)).thenReturn(Optional.of(createOrder(1L, BUYER_ID)));
-            when(findPspPaymentEventPort.findByOrderKey(ORDER_KEY_STR)).thenReturn(Optional.of(event));
-            when(paymentVendorPort.cancelPayment(any())).thenReturn(vendorResult);
-
-            cancelPaymentService.cancel(command);
-
-            verify(changeOrderStatusUseCase).changeOrderStatus(argThat(c ->
-                    c.orderStatus() == OrderStatus.CANCEL_REQUESTED && c.id().equals(1L)
             ));
         }
 
@@ -212,23 +188,6 @@ class CancelPaymentUseCaseTest {
             ));
         }
 
-        @Test
-        @DisplayName("부분 취소 시 주문 상태는 변경되지 않는다")
-        void shouldNotChangeOrderStatusOnPartialCancel() {
-            Payment payment = createSuccessPayment(1L, ORDER_KEY, 50000L, "tno_123");
-            PspPaymentEvent event = createCompleteEvent(ORDER_KEY_STR, "tno_123", 50000L);
-            CancelPaymentCommand command = createPartialCancelCommand(ORDER_KEY_STR, 20000L);
-            PaymentCancelVendorResult vendorResult = createSuccessVendorResult();
-
-            when(findPaymentPort.findByOrderKey(ORDER_KEY)).thenReturn(Optional.of(payment));
-            when(findOrderPort.findById(1L)).thenReturn(Optional.of(createOrder(1L, BUYER_ID)));
-            when(findPspPaymentEventPort.findByOrderKey(ORDER_KEY_STR)).thenReturn(Optional.of(event));
-            when(paymentVendorPort.cancelPayment(any())).thenReturn(vendorResult);
-
-            cancelPaymentService.cancel(command);
-
-            verify(changeOrderStatusUseCase, never()).changeOrderStatus(any());
-        }
     }
 
     @Nested
@@ -558,7 +517,7 @@ class CancelPaymentUseCaseTest {
 
             verify(updatePaymentPort).update(any());
             verify(updatePspPaymentEventPort).update(any());
-            verify(changeOrderStatusUseCase).changeOrderStatus(any());
+
         }
     }
 
@@ -772,7 +731,7 @@ class CancelPaymentUseCaseTest {
 
             verify(updatePaymentPort).update(any());
             verify(updatePspPaymentEventPort).update(any());
-            verify(changeOrderStatusUseCase).changeOrderStatus(any());
+
         }
     }
 
@@ -878,7 +837,7 @@ class CancelPaymentUseCaseTest {
 
             verify(updatePaymentPort).update(any());
             verify(updatePspPaymentEventPort).update(any());
-            verify(changeOrderStatusUseCase).changeOrderStatus(any());
+
         }
     }
 


### PR DESCRIPTION
## partially addresses #929
## resolves #1100

## Task
- [x] PaymentCancelledOrderStatusConsumer FIXME 제거, 듀얼 라이트 → 멱등 처리 로그 수정
- [x] CancelPaymentService에서 changeOrderStatusUseCase 동기 호출 제거
- [x] CancelPaymentUseCaseTest changeOrderStatusUseCase Mock 및 verify 제거
- [x] PaymentCancelledOrderStatusConsumerTest DisplayName 수정