### PR TITLE
[#1][#1634] fix: file-service, fulfillment-service REDIS_HOST_NAME 환경변수 미설정으로 인한 Redis 헬스체크 실패 이슈 대응

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/web/user/UserShippingAddressServiceClient.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/web/user/UserShippingAddressServiceClient.java
@@ -6,8 +6,8 @@ import com.personal.marketnote.commerce.port.out.result.user.ShippingAddressInfo
 import com.personal.marketnote.commerce.port.out.user.FindUserShippingAddressPort;
 import com.personal.marketnote.commerce.port.out.user.UpdateUserShippingAddressDeliveryRequestPort;
 import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
-import com.personal.marketnote.common.domain.delivery.DeliveryRequestType;
 import com.personal.marketnote.common.adapter.out.ServiceAdapter;
+import com.personal.marketnote.common.domain.delivery.DeliveryRequestType;
 import com.personal.marketnote.common.exception.UserServiceRequestFailedException;
 import com.personal.marketnote.common.security.hmac.HmacServiceAuthHeaderBuilder;
 import com.personal.marketnote.common.utility.FormatValidator;

--- a/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/event/saga/OrderPaymentInventorySagaConsumerTest.java
+++ b/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/event/saga/OrderPaymentInventorySagaConsumerTest.java
@@ -1,7 +1,6 @@
 package com.personal.marketnote.commerce.adapter.in.event.saga;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.personal.marketnote.commerce.domain.order.OrderProduct;
 import com.personal.marketnote.commerce.exception.DuplicateInventoryDeductionException;
 import com.personal.marketnote.commerce.port.in.usecase.inventory.ReduceProductInventoryUseCase;
 import com.personal.marketnote.commerce.port.in.usecase.inventory.RestoreProductInventoryUseCase;
@@ -26,7 +25,8 @@ import java.time.ZoneId;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("OrderPaymentInventorySagaConsumer 테스트")

--- a/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/event/saga/OrderPaymentLedgerSagaConsumerTest.java
+++ b/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/event/saga/OrderPaymentLedgerSagaConsumerTest.java
@@ -22,8 +22,10 @@ import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
 
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("OrderPaymentLedgerSagaConsumer 테스트")

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/user/UpdateUserShippingAddressDeliveryRequestPort.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/user/UpdateUserShippingAddressDeliveryRequestPort.java
@@ -11,9 +11,9 @@ import com.personal.marketnote.common.domain.delivery.DeliveryRequestType;
  */
 public interface UpdateUserShippingAddressDeliveryRequestPort {
     /**
-     * @param shippingAddressId    배송지 ID
-     * @param userId               회원 ID
-     * @param deliveryRequestType  배송 요청사항 타입
+     * @param shippingAddressId      배송지 ID
+     * @param userId                 회원 ID
+     * @param deliveryRequestType    배송 요청사항 타입
      * @param deliveryRequestMessage 배송 요청사항 메시지
      * @Date 2026-03-27
      * @Author 성효빈

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/RegisterOrderService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/RegisterOrderService.java
@@ -1,12 +1,7 @@
 package com.personal.marketnote.commerce.service.order;
 
 import com.personal.marketnote.commerce.domain.inventory.Inventory;
-import com.personal.marketnote.commerce.domain.order.Order;
-import com.personal.marketnote.commerce.domain.order.OrderAmount;
-import com.personal.marketnote.commerce.domain.order.OrderAmountCreateState;
-import com.personal.marketnote.commerce.domain.order.OrderCreateState;
-import com.personal.marketnote.commerce.domain.order.OrderProductCreateState;
-import com.personal.marketnote.commerce.domain.order.ShippingAddress;
+import com.personal.marketnote.commerce.domain.order.*;
 import com.personal.marketnote.commerce.domain.payment.Payment;
 import com.personal.marketnote.commerce.domain.payment.PaymentCreateState;
 import com.personal.marketnote.commerce.domain.settlement.PaymentAllocation;
@@ -24,9 +19,9 @@ import com.personal.marketnote.commerce.port.out.payment.SavePaymentPort;
 import com.personal.marketnote.commerce.port.out.product.FindProductByPricePolicyPort;
 import com.personal.marketnote.commerce.port.out.result.product.ProductInfoResult;
 import com.personal.marketnote.commerce.port.out.result.shipping.ShippingPolicyInfoResult;
+import com.personal.marketnote.commerce.port.out.result.user.ShippingAddressInfoResult;
 import com.personal.marketnote.commerce.port.out.reward.ModifyUserPointPort;
 import com.personal.marketnote.commerce.port.out.settlement.SavePaymentAllocationPort;
-import com.personal.marketnote.commerce.port.out.result.user.ShippingAddressInfoResult;
 import com.personal.marketnote.commerce.port.out.shipping.FindShippingPolicyBySellerIdsPort;
 import com.personal.marketnote.commerce.port.out.user.FindUserShippingAddressPort;
 import com.personal.marketnote.common.application.UseCase;

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/PaymentApprovalTransactionHelper.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/PaymentApprovalTransactionHelper.java
@@ -134,7 +134,7 @@ public class PaymentApprovalTransactionHelper {
     }
 
     private ApprovePaymentResult buildApprovePaymentResult(Payment payment,
-                                                            PaymentApprovalVendorResult vendorResult) {
+                                                           PaymentApprovalVendorResult vendorResult) {
         return ApprovePaymentResult.builder()
                 .orderId(payment.getOrderId())
                 .orderKey(payment.getOrderKey().toString())
@@ -243,7 +243,7 @@ public class PaymentApprovalTransactionHelper {
     }
 
     private Long calculateTotalAccumulatedPoint(List<OrderProduct> orderProducts,
-                                                 List<Long> pricePolicyIds) {
+                                                List<Long> pricePolicyIds) {
         Map<Long, ProductInfoResult> productInfoMap = findProductByPricePolicyPort.findByPricePolicyIds(pricePolicyIds);
 
         long totalAccumulatedPoint = 0L;

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/saga/OrderPaymentSagaStarterTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/saga/OrderPaymentSagaStarterTest.java
@@ -2,7 +2,6 @@ package com.personal.marketnote.commerce.service.saga;
 
 import com.personal.marketnote.commerce.port.in.command.saga.OrderPaymentSagaContext;
 import com.personal.marketnote.commerce.port.in.command.saga.OrderPaymentSagaContext.OrderProductItem;
-import com.personal.marketnote.common.saga.SagaInstance;
 import com.personal.marketnote.common.saga.SagaOrchestrator;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/common/src/main/java/com/personal/marketnote/common/saga/SagaOrchestrator.java
+++ b/common/src/main/java/com/personal/marketnote/common/saga/SagaOrchestrator.java
@@ -181,7 +181,7 @@ public class SagaOrchestrator {
     }
 
     private void handleStepFailure(SagaInstance instance, List<SagaStep> steps,
-                                    SagaStep currentStep, String response) {
+                                   SagaStep currentStep, String response) {
         currentStep.fail(response);
         updateSagaPort.updateStep(currentStep);
 
@@ -189,7 +189,7 @@ public class SagaOrchestrator {
     }
 
     private void handleCompensationSuccess(SagaInstance instance, List<SagaStep> steps,
-                                            SagaStep step, String response) {
+                                           SagaStep step, String response) {
         step.completeCompensation(response);
         updateSagaPort.updateStep(step);
 
@@ -209,7 +209,7 @@ public class SagaOrchestrator {
     }
 
     private <T> void processStep(SagaDefinition<T> definition, SagaInstance instance,
-                                  T context, int stepIndex) {
+                                 T context, int stepIndex) {
         SagaStepDefinition<T> stepDef = definition.getSteps().get(stepIndex);
         String actionRequest = stepDef.action().apply(context);
 
@@ -275,7 +275,7 @@ public class SagaOrchestrator {
     }
 
     private <T> void publishActionMessage(SagaInstance instance, SagaStepDefinition<T> stepDef,
-                                           String request) {
+                                          String request) {
         SagaStepMessage message = new SagaStepMessage(
                 instance.getSagaId(), instance.getSagaType(), stepDef.stepName(),
                 SagaStepMessage.ACTION, request);
@@ -284,7 +284,7 @@ public class SagaOrchestrator {
     }
 
     private <T> void publishCompensationMessage(SagaInstance instance, SagaStepDefinition<T> stepDef,
-                                                 String request) {
+                                                String request) {
         SagaStepMessage message = new SagaStepMessage(
                 instance.getSagaId(), instance.getSagaType(), stepDef.stepName(),
                 SagaStepMessage.COMPENSATION, request);

--- a/common/src/main/java/com/personal/marketnote/common/saga/SagaResponsePublisher.java
+++ b/common/src/main/java/com/personal/marketnote/common/saga/SagaResponsePublisher.java
@@ -31,7 +31,7 @@ public class SagaResponsePublisher {
 
     @Transactional(isolation = READ_COMMITTED)
     public void publishSuccess(String sagaId, String sagaType, String stepName,
-                                String messageType, String response) {
+                               String messageType, String response) {
         SagaResponseMessage responseMessage = new SagaResponseMessage(
                 sagaId, sagaType, stepName, messageType, true, response);
         publishToOutbox(responseMessage, sagaId);
@@ -39,7 +39,7 @@ public class SagaResponsePublisher {
 
     @Transactional(isolation = READ_COMMITTED)
     public void publishFailure(String sagaId, String sagaType, String stepName,
-                                String messageType, String errorMessage) {
+                               String messageType, String errorMessage) {
         SagaResponseMessage responseMessage = new SagaResponseMessage(
                 sagaId, sagaType, stepName, messageType, false, errorMessage);
         publishToOutbox(responseMessage, sagaId);

--- a/common/src/main/java/com/personal/marketnote/common/saga/entity/SagaInstanceJpaEntity.java
+++ b/common/src/main/java/com/personal/marketnote/common/saga/entity/SagaInstanceJpaEntity.java
@@ -63,7 +63,7 @@ public class SagaInstanceJpaEntity {
     private LocalDateTime completedAt;
 
     private SagaInstanceJpaEntity(String sagaId, String sagaType, SagaStatus status,
-                                   int currentStepIndex, String payload) {
+                                  int currentStepIndex, String payload) {
         this.sagaId = sagaId;
         this.sagaType = sagaType;
         this.status = status;

--- a/community-service/community-adapters/src/test/java/com/personal/marketnote/community/adapter/out/web/file/FileServiceClientTest.java
+++ b/community-service/community-adapters/src/test/java/com/personal/marketnote/community/adapter/out/web/file/FileServiceClientTest.java
@@ -22,9 +22,7 @@ import org.springframework.web.client.RestClient;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.lenient;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;

--- a/community-service/community-adapters/src/test/java/com/personal/marketnote/community/adapter/out/web/product/ProductServiceClientTest.java
+++ b/community-service/community-adapters/src/test/java/com/personal/marketnote/community/adapter/out/web/product/ProductServiceClientTest.java
@@ -22,9 +22,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.lenient;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;

--- a/file-service/file-adapters/src/main/resources/application.yml
+++ b/file-service/file-adapters/src/main/resources/application.yml
@@ -28,6 +28,12 @@ spring:
       max-lifetime: 1800000
       connection-timeout: 30000
 
+  data:
+    redis:
+      host: ${REDIS_HOST_NAME:localhost}
+      port: 6379
+      password: ${REDIS_PASSWORD:password}
+
   jpa:
     hibernate:
       ddl-auto: none

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/client/FasstoAuthClient.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/client/FasstoAuthClient.java
@@ -22,7 +22,10 @@ import com.personal.marketnote.fulfillment.utility.VendorCommunicationFailureHan
 import com.personal.marketnote.fulfillment.utility.VendorCommunicationPayloadGenerator;
 import com.personal.marketnote.fulfillment.utility.VendorCommunicationRecorder;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.*;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClientResponseException;
 import org.springframework.web.util.UriComponentsBuilder;

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/client/FasstoDeliveryClient.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/client/FasstoDeliveryClient.java
@@ -19,7 +19,10 @@ import com.personal.marketnote.fulfillment.utility.VendorCommunicationFailureHan
 import com.personal.marketnote.fulfillment.utility.VendorCommunicationPayloadGenerator;
 import com.personal.marketnote.fulfillment.utility.VendorCommunicationRecorder;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.*;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClientResponseException;
 import org.springframework.web.util.UriComponentsBuilder;

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/client/FasstoDirectReturnDeliveryClient.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/client/FasstoDirectReturnDeliveryClient.java
@@ -21,7 +21,10 @@ import com.personal.marketnote.fulfillment.utility.VendorCommunicationFailureHan
 import com.personal.marketnote.fulfillment.utility.VendorCommunicationPayloadGenerator;
 import com.personal.marketnote.fulfillment.utility.VendorCommunicationRecorder;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.*;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClientResponseException;
 import org.springframework.web.util.UriComponentsBuilder;

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/client/FasstoGoodsClient.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/client/FasstoGoodsClient.java
@@ -22,7 +22,10 @@ import com.personal.marketnote.fulfillment.utility.VendorCommunicationFailureHan
 import com.personal.marketnote.fulfillment.utility.VendorCommunicationPayloadGenerator;
 import com.personal.marketnote.fulfillment.utility.VendorCommunicationRecorder;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.*;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClientResponseException;
 import org.springframework.web.util.UriComponentsBuilder;

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/client/FasstoReturnDeliveryClient.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/client/FasstoReturnDeliveryClient.java
@@ -22,7 +22,10 @@ import com.personal.marketnote.fulfillment.utility.VendorCommunicationFailureHan
 import com.personal.marketnote.fulfillment.utility.VendorCommunicationPayloadGenerator;
 import com.personal.marketnote.fulfillment.utility.VendorCommunicationRecorder;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.*;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClientResponseException;
 import org.springframework.web.util.UriComponentsBuilder;

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/client/FasstoSettlementClient.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/client/FasstoSettlementClient.java
@@ -22,7 +22,10 @@ import com.personal.marketnote.fulfillment.utility.VendorCommunicationFailureHan
 import com.personal.marketnote.fulfillment.utility.VendorCommunicationPayloadGenerator;
 import com.personal.marketnote.fulfillment.utility.VendorCommunicationRecorder;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.*;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClientResponseException;
 import org.springframework.web.util.UriComponentsBuilder;

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/client/FasstoShopClient.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/client/FasstoShopClient.java
@@ -30,7 +30,10 @@ import com.personal.marketnote.fulfillment.utility.VendorCommunicationFailureHan
 import com.personal.marketnote.fulfillment.utility.VendorCommunicationPayloadGenerator;
 import com.personal.marketnote.fulfillment.utility.VendorCommunicationRecorder;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.*;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClientResponseException;
 import org.springframework.web.util.UriComponentsBuilder;

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/client/FasstoStockClient.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/client/FasstoStockClient.java
@@ -25,7 +25,10 @@ import com.personal.marketnote.fulfillment.utility.VendorCommunicationFailureHan
 import com.personal.marketnote.fulfillment.utility.VendorCommunicationPayloadGenerator;
 import com.personal.marketnote.fulfillment.utility.VendorCommunicationRecorder;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.*;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClientResponseException;
 import org.springframework.web.util.UriComponentsBuilder;

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/client/FasstoSupplierClient.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/client/FasstoSupplierClient.java
@@ -30,7 +30,10 @@ import com.personal.marketnote.fulfillment.utility.VendorCommunicationFailureHan
 import com.personal.marketnote.fulfillment.utility.VendorCommunicationPayloadGenerator;
 import com.personal.marketnote.fulfillment.utility.VendorCommunicationRecorder;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.*;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClientResponseException;
 import org.springframework.web.util.UriComponentsBuilder;

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/client/FasstoWarehousingClient.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/client/FasstoWarehousingClient.java
@@ -19,7 +19,10 @@ import com.personal.marketnote.fulfillment.utility.VendorCommunicationFailureHan
 import com.personal.marketnote.fulfillment.utility.VendorCommunicationPayloadGenerator;
 import com.personal.marketnote.fulfillment.utility.VendorCommunicationRecorder;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.*;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClientResponseException;
 import org.springframework.web.util.UriComponentsBuilder;

--- a/fulfillment-service/fulfillment-adapters/src/main/resources/application.yml
+++ b/fulfillment-service/fulfillment-adapters/src/main/resources/application.yml
@@ -23,6 +23,12 @@ spring:
       max-lifetime: 1800000
       connection-timeout: 30000
 
+  data:
+    redis:
+      host: ${REDIS_HOST_NAME:localhost}
+      port: 6379
+      password: ${REDIS_PASSWORD:password}
+
   jpa:
     hibernate:
       ddl-auto: none

--- a/product-service/product-adapters/src/test/java/com/personal/marketnote/product/adapter/out/web/commerce/CommerceServiceClientTest.java
+++ b/product-service/product-adapters/src/test/java/com/personal/marketnote/product/adapter/out/web/commerce/CommerceServiceClientTest.java
@@ -24,9 +24,7 @@ import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.lenient;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.*;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withServerError;

--- a/product-service/product-adapters/src/test/java/com/personal/marketnote/product/adapter/out/web/community/CommunityServiceClientTest.java
+++ b/product-service/product-adapters/src/test/java/com/personal/marketnote/product/adapter/out/web/community/CommunityServiceClientTest.java
@@ -22,9 +22,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.lenient;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;

--- a/product-service/product-adapters/src/test/java/com/personal/marketnote/product/adapter/out/web/file/FileServiceClientTest.java
+++ b/product-service/product-adapters/src/test/java/com/personal/marketnote/product/adapter/out/web/file/FileServiceClientTest.java
@@ -24,9 +24,7 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.lenient;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;

--- a/product-service/product-adapters/src/test/java/com/personal/marketnote/product/adapter/out/web/fulfillment/FulfillmentServiceClientTest.java
+++ b/product-service/product-adapters/src/test/java/com/personal/marketnote/product/adapter/out/web/fulfillment/FulfillmentServiceClientTest.java
@@ -24,9 +24,7 @@ import org.springframework.web.client.RestClient;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.lenient;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;

--- a/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/adapter/in/web/point/InternalPointControllerTest.java
+++ b/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/adapter/in/web/point/InternalPointControllerTest.java
@@ -1,12 +1,9 @@
 package com.personal.marketnote.reward.adapter.in.web.point;
 
-import com.personal.marketnote.reward.adapter.in.web.point.mapper.PointRequestToCommandMapper;
 import com.personal.marketnote.reward.adapter.in.web.point.request.CancelPendingPointRequest;
 import com.personal.marketnote.reward.adapter.in.web.point.request.ConfirmPendingPointRequest;
 import com.personal.marketnote.reward.adapter.in.web.point.request.ModifyPendingPointRequest;
 import com.personal.marketnote.reward.adapter.in.web.point.request.ModifyUserPointRequest;
-import com.personal.marketnote.reward.adapter.in.web.point.response.GetUserPointByIdResponse;
-import com.personal.marketnote.reward.adapter.in.web.point.response.UpdateUserPointResponse;
 import com.personal.marketnote.reward.domain.point.UserPoint;
 import com.personal.marketnote.reward.domain.point.UserPointChangeType;
 import com.personal.marketnote.reward.domain.point.UserPointSourceType;
@@ -14,7 +11,6 @@ import com.personal.marketnote.reward.port.in.command.point.CancelPendingPointCo
 import com.personal.marketnote.reward.port.in.command.point.ConfirmPendingPointCommand;
 import com.personal.marketnote.reward.port.in.command.point.ModifyPendingPointCommand;
 import com.personal.marketnote.reward.port.in.command.point.ModifyUserPointCommand;
-import com.personal.marketnote.reward.port.in.result.point.GetUserPointResult;
 import com.personal.marketnote.reward.port.in.result.point.UpdateUserPointResult;
 import com.personal.marketnote.reward.port.in.usecase.point.*;
 import org.junit.jupiter.api.DisplayName;

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/shippingaddress/request/UpdateDeliveryRequestRequest.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/shippingaddress/request/UpdateDeliveryRequestRequest.java
@@ -1,7 +1,7 @@
 package com.personal.marketnote.user.adapter.in.web.shippingaddress.request;
 
-import com.personal.marketnote.common.utility.RegularExpressionConstant;
 import com.personal.marketnote.common.domain.delivery.DeliveryRequestType;
+import com.personal.marketnote.common.utility.RegularExpressionConstant;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;

--- a/user-service/user-adapters/src/test/java/com/personal/marketnote/user/adapter/out/oauth/RestClientGoogleTokenProcessorTest.java
+++ b/user-service/user-adapters/src/test/java/com/personal/marketnote/user/adapter/out/oauth/RestClientGoogleTokenProcessorTest.java
@@ -22,7 +22,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hamcrest.Matchers.containsString;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.*;
-import static org.springframework.test.web.client.response.MockRestResponseCreators.*;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withBadRequest;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 
 class RestClientGoogleTokenProcessorTest {
 

--- a/user-service/user-adapters/src/test/java/com/personal/marketnote/user/adapter/out/oauth/RestClientKakaoTokenProcessorTest.java
+++ b/user-service/user-adapters/src/test/java/com/personal/marketnote/user/adapter/out/oauth/RestClientKakaoTokenProcessorTest.java
@@ -21,7 +21,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hamcrest.Matchers.containsString;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.*;
-import static org.springframework.test.web.client.response.MockRestResponseCreators.*;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withBadRequest;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 
 class RestClientKakaoTokenProcessorTest {
 

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/service/shippingaddress/RegisterShippingAddressService.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/service/shippingaddress/RegisterShippingAddressService.java
@@ -1,8 +1,8 @@
 package com.personal.marketnote.user.service.shippingaddress;
 
 import com.personal.marketnote.common.application.UseCase;
-import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.common.domain.delivery.DeliveryRequestType;
+import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.user.domain.shippingaddress.ShippingAddress;
 import com.personal.marketnote.user.domain.shippingaddress.ShippingAddressCreateState;
 import com.personal.marketnote.user.domain.shippingaddress.ShippingAddressType;

--- a/user-service/user-application/src/test/java/com/personal/marketnote/user/service/shippingaddress/UpdateDeliveryRequestUseCaseTest.java
+++ b/user-service/user-application/src/test/java/com/personal/marketnote/user/service/shippingaddress/UpdateDeliveryRequestUseCaseTest.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.user.service.shippingaddress;
 
-import com.personal.marketnote.user.domain.shippingaddress.DeliveryRequestType;
+import com.personal.marketnote.common.domain.delivery.DeliveryRequestType;
 import com.personal.marketnote.user.domain.shippingaddress.ShippingAddress;
 import com.personal.marketnote.user.domain.shippingaddress.ShippingAddressSnapshotState;
 import com.personal.marketnote.user.domain.shippingaddress.ShippingAddressType;


### PR DESCRIPTION
## partially addresses #1
## resolves #1634

## Task
- [x] file-service `application.yml`에 `REDIS_HOST_NAME` 환경변수 설정 추가
- [x] fulfillment-service `application.yml`에 `REDIS_HOST_NAME` 환경변수 설정 추가