### PR TITLE
[#216][#1690] refactor: 결제 서비스 application/domain 레이어 KCP 벤더 종속 정보 제거

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/vendor/kcp/KcpPaymentVendorAdapter.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/vendor/kcp/KcpPaymentVendorAdapter.java
@@ -43,7 +43,12 @@ public class KcpPaymentVendorAdapter implements PaymentVendorPort {
     private final VendorCommunicationRecorder vendorCommunicationRecorder;
 
     @Override
-    public String getVendorSiteCd() {
+    public String getVendorKey() {
+        return "NHN_KCP";
+    }
+
+    @Override
+    public String getShopCode() {
         return kcpProperties.getSiteCd();
     }
 
@@ -54,7 +59,7 @@ public class KcpPaymentVendorAdapter implements PaymentVendorPort {
         KcpTradeRegisterRequest request = KcpTradeRegisterRequest.builder()
                 .siteCd(kcpProperties.getSiteCd())
                 .ordrIdxx(command.orderKey())
-                .goodMny(command.goodMny())
+                .goodMny(command.orderAmount())
                 .payMethod(mobilePayMethod)
                 .goodName(command.goodName())
                 .retUrl(kcpProperties.getRetUrl())
@@ -66,13 +71,15 @@ public class KcpPaymentVendorAdapter implements PaymentVendorPort {
             KcpTradeRegisterResponse response = kcpApiClient.registerTrade(request);
             recordResponse(CommerceVendorCommunicationTargetType.TRADE_REGISTER, command.orderKey(), response);
 
-            if (!response.isSuccess()) {
+            boolean isSuccess = response.isSuccess();
+            if (!isSuccess) {
                 log.error("KCP 거래등록 실패: resCd={}, resMsg={}", response.resCd(), response.resMsg());
             }
 
             return TradeRegisterVendorResult.builder()
-                    .resCd(response.resCd())
-                    .resMsg(response.resMsg())
+                    .success(isSuccess)
+                    .resultCode(response.resCd())
+                    .resultMessage(response.resMsg())
                     .approvalKey(response.approvalKey())
                     .payUrl(response.payUrl())
                     .traceNo(response.traceNo())
@@ -94,14 +101,14 @@ public class KcpPaymentVendorAdapter implements PaymentVendorPort {
                 .encInfo(command.encInfo())
                 .tranCd(PAYMENT_APPROVAL_TRAN_CD)
                 .kcpCertInfo(certInfo)
-                .ordrMony(command.ordrMony())
-                .ordrNo(command.ordrNo())
+                .ordrMony(command.orderAmount())
+                .ordrNo(command.orderNumber())
                 .payType(command.payType())
                 .build();
 
-        recordRequest(CommerceVendorCommunicationTargetType.PAYMENT_APPROVAL, command.ordrNo(), request);
+        recordRequest(CommerceVendorCommunicationTargetType.PAYMENT_APPROVAL, command.orderNumber(), request);
 
-        return executeApprovalWithRetry(request, command.ordrNo());
+        return executeApprovalWithRetry(request, command.orderNumber());
     }
 
     private PaymentApprovalVendorResult executeApprovalWithRetry(
@@ -158,23 +165,24 @@ public class KcpPaymentVendorAdapter implements PaymentVendorPort {
 
     private PaymentApprovalVendorResult buildApprovalResult(KcpPaymentApprovalResponse response) {
         return PaymentApprovalVendorResult.builder()
-                .resCd(response.resCd())
-                .resMsg(response.resMsg())
-                .resEnMsg(response.resEnMsg())
-                .tno(response.tno())
+                .success(response.isSuccess())
+                .resultCode(response.resCd())
+                .resultMessage(response.resMsg())
+                .resultEnMessage(response.resEnMsg())
+                .transactionId(response.tno())
                 .amount(response.amount())
                 .payMethod(response.payMethod())
-                .cardCd(response.cardCd())
+                .cardCode(response.cardCd())
                 .cardName(response.cardName())
-                .cardNo(response.cardNo())
-                .appNo(response.appNo())
-                .appTime(response.appTime())
-                .noinf(response.noinf())
-                .noinfType(response.noinfType())
-                .quota(response.quota())
-                .cardMny(response.cardMny())
-                .couponMny(response.couponMny())
-                .partcancYn(response.partcancYn())
+                .cardNumber(response.cardNo())
+                .approvalNumber(response.appNo())
+                .approvalTime(response.appTime())
+                .installmentInfo(response.noinf())
+                .installmentType(response.noinfType())
+                .installmentMonths(response.quota())
+                .cardAmount(response.cardMny())
+                .couponAmount(response.couponMny())
+                .partialCancelYn(response.partcancYn())
                 .cardBinType01(response.cardBinType01())
                 .cardBinType02(response.cardBinType02())
                 .rawResponse(kcpApiClient.toJsonNode(response).toString())
@@ -216,39 +224,41 @@ public class KcpPaymentVendorAdapter implements PaymentVendorPort {
         String certInfo = kcpCertificateLoader.loadCertInfo();
         String signData = kcpSignatureGenerator.generateSignData(
                 kcpProperties.getSiteCd(),
-                command.tno(),
-                command.modType()
+                command.transactionId(),
+                command.cancelType()
         );
 
         KcpPaymentCancelRequest request = KcpPaymentCancelRequest.builder()
                 .siteCd(kcpProperties.getSiteCd())
-                .tno(command.tno())
+                .tno(command.transactionId())
                 .kcpCertInfo(certInfo)
                 .kcpSignData(signData)
-                .modType(command.modType())
-                .modMny(String.valueOf(command.modMny()))
-                .remMny(String.valueOf(command.remMny()))
-                .modDesc(command.modDesc())
+                .modType(command.cancelType())
+                .modMny(String.valueOf(command.cancelAmount()))
+                .remMny(String.valueOf(command.remainAmount()))
+                .modDesc(command.cancelReason())
                 .build();
 
-        recordRequest(CommerceVendorCommunicationTargetType.PAYMENT_CANCEL, command.tno(), request);
+        recordRequest(CommerceVendorCommunicationTargetType.PAYMENT_CANCEL, command.transactionId(), request);
 
         try {
             KcpPaymentCancelResponse response = kcpApiClient.cancelPayment(request);
-            recordResponse(CommerceVendorCommunicationTargetType.PAYMENT_CANCEL, command.tno(), response);
+            recordResponse(CommerceVendorCommunicationTargetType.PAYMENT_CANCEL, command.transactionId(), response);
 
-            if (!response.isSuccess()) {
+            boolean isSuccess = response.isSuccess();
+            if (!isSuccess) {
                 log.error("KCP 결제취소 실패: resCd={}, resMsg={}", response.resCd(), response.resMsg());
             }
 
             return PaymentCancelVendorResult.builder()
-                    .resCd(response.resCd())
-                    .resMsg(response.resMsg())
+                    .success(isSuccess)
+                    .resultCode(response.resCd())
+                    .resultMessage(response.resMsg())
                     .amount(response.amount())
                     .rawResponse(kcpApiClient.toJsonNode(response).toString())
                     .build();
         } catch (KcpCommunicationException e) {
-            recordError(CommerceVendorCommunicationTargetType.PAYMENT_CANCEL, command.tno(), e);
+            recordError(CommerceVendorCommunicationTargetType.PAYMENT_CANCEL, command.transactionId(), e);
             throw e;
         }
     }

--- a/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/out/vendor/kcp/KcpPaymentVendorAdapterRetryTest.java
+++ b/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/out/vendor/kcp/KcpPaymentVendorAdapterRetryTest.java
@@ -80,8 +80,8 @@ class KcpPaymentVendorAdapterRetryTest {
 
             PaymentApprovalVendorResult result = adapter.approvePayment(createCommand());
 
-            assertThat(result.resCd()).isEqualTo("0000");
-            assertThat(result.tno()).isEqualTo("tno_123");
+            assertThat(result.resultCode()).isEqualTo("0000");
+            assertThat(result.transactionId()).isEqualTo("tno_123");
             verify(kcpApiClient, times(1)).approvePayment(any());
         }
 
@@ -93,7 +93,7 @@ class KcpPaymentVendorAdapterRetryTest {
 
             PaymentApprovalVendorResult result = adapter.approvePayment(createCommand());
 
-            assertThat(result.resCd()).isEqualTo("8001");
+            assertThat(result.resultCode()).isEqualTo("8001");
             verify(kcpApiClient, times(1)).approvePayment(any());
         }
     }
@@ -131,7 +131,7 @@ class KcpPaymentVendorAdapterRetryTest {
 
             PaymentApprovalVendorResult result = adapter.approvePayment(createCommand());
 
-            assertThat(result.resCd()).isEqualTo("0000");
+            assertThat(result.resultCode()).isEqualTo("0000");
             verify(kcpApiClient, times(3)).approvePayment(any());
         }
     }
@@ -188,7 +188,7 @@ class KcpPaymentVendorAdapterRetryTest {
 
             PaymentApprovalVendorResult result = adapter.approvePayment(createCommand());
 
-            assertThat(result.resCd()).isEqualTo("0000");
+            assertThat(result.resultCode()).isEqualTo("0000");
             verify(kcpApiClient, times(2)).approvePayment(any());
         }
 
@@ -206,7 +206,7 @@ class KcpPaymentVendorAdapterRetryTest {
 
             PaymentApprovalVendorResult result = adapter.approvePayment(createCommand());
 
-            assertThat(result.resCd()).isEqualTo("8001");
+            assertThat(result.resultCode()).isEqualTo("8001");
             verify(kcpApiClient, times(2)).approvePayment(any());
         }
     }
@@ -271,8 +271,8 @@ class KcpPaymentVendorAdapterRetryTest {
         return PaymentApprovalVendorCommand.builder()
                 .encData("enc_data_test")
                 .encInfo("enc_info_test")
-                .ordrMony("50000")
-                .ordrNo(ORDER_NO)
+                .orderAmount("50000")
+                .orderNumber(ORDER_NO)
                 .payType("PACA")
                 .build();
     }

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/exception/PaymentApprovalException.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/exception/PaymentApprovalException.java
@@ -1,9 +1,9 @@
 package com.personal.marketnote.commerce.exception;
 
 public class PaymentApprovalException extends IllegalStateException {
-    private static final String KCP_TRADE_REGISTER_FAILED = "KCP 거래등록 실패 [%s]: %s";
-    private static final String KCP_APPROVAL_REQUEST_FAILED = "KCP 결제 승인 요청 실패";
-    private static final String KCP_APPROVAL_FAILED = "KCP 결제 승인 실패 [%s]: %s";
+    private static final String TRADE_REGISTER_FAILED = "거래등록 실패 [%s]: %s";
+    private static final String APPROVAL_REQUEST_FAILED = "결제 승인 요청 실패";
+    private static final String APPROVAL_FAILED = "결제 승인 실패 [%s]: %s";
 
     private PaymentApprovalException(String message) {
         super(message);
@@ -13,15 +13,15 @@ public class PaymentApprovalException extends IllegalStateException {
         super(message, cause);
     }
 
-    public static PaymentApprovalException kcpTradeRegisterFailed(String resCd, String resMsg) {
-        return new PaymentApprovalException(String.format(KCP_TRADE_REGISTER_FAILED, resCd, resMsg));
+    public static PaymentApprovalException tradeRegisterFailed(String resultCode, String resultMessage) {
+        return new PaymentApprovalException(String.format(TRADE_REGISTER_FAILED, resultCode, resultMessage));
     }
 
-    public static PaymentApprovalException kcpApprovalRequestFailed(Throwable cause) {
-        return new PaymentApprovalException(KCP_APPROVAL_REQUEST_FAILED, cause);
+    public static PaymentApprovalException approvalRequestFailed(Throwable cause) {
+        return new PaymentApprovalException(APPROVAL_REQUEST_FAILED, cause);
     }
 
-    public static PaymentApprovalException kcpApprovalFailed(String resCd, String resMsg) {
-        return new PaymentApprovalException(String.format(KCP_APPROVAL_FAILED, resCd, resMsg));
+    public static PaymentApprovalException approvalFailed(String resultCode, String resultMessage) {
+        return new PaymentApprovalException(String.format(APPROVAL_FAILED, resultCode, resultMessage));
     }
 }

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/payment/PaymentVendorPort.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/payment/PaymentVendorPort.java
@@ -11,12 +11,20 @@ import com.personal.marketnote.commerce.port.out.payment.vendor.*;
  */
 public interface PaymentVendorPort {
     /**
-     * @return 결제 대행사 사이트 코드 {@link String}
+     * @return 결제 대행사 식별 키 {@link String}
      * @Date 2026-02-25
      * @Author 성효빈
-     * @Description 결제 대행사 사이트 코드를 조회합니다.
+     * @Description 결제 대행사 식별 키를 조회합니다. (예: "NHN_KCP")
      */
-    String getVendorSiteCd();
+    String getVendorKey();
+
+    /**
+     * @return 결제 대행사 가맹점 코드 {@link String}
+     * @Date 2026-02-25
+     * @Author 성효빈
+     * @Description 결제 대행사 가맹점 코드를 조회합니다.
+     */
+    String getShopCode();
 
     /**
      * @param command 거래 등록 요청 정보 {@link TradeRegisterVendorCommand}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/payment/vendor/PaymentApprovalVendorCommand.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/payment/vendor/PaymentApprovalVendorCommand.java
@@ -6,8 +6,8 @@ import lombok.Builder;
 public record PaymentApprovalVendorCommand(
         String encData,
         String encInfo,
-        String ordrMony,
-        String ordrNo,
+        String orderAmount,
+        String orderNumber,
         String payType
 ) {
 }

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/payment/vendor/PaymentApprovalVendorResult.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/payment/vendor/PaymentApprovalVendorResult.java
@@ -1,32 +1,29 @@
 package com.personal.marketnote.commerce.port.out.payment.vendor;
 
-import com.personal.marketnote.common.utility.FormatValidator;
 import lombok.Builder;
 
 @Builder
 public record PaymentApprovalVendorResult(
-        String resCd,
-        String resMsg,
-        String resEnMsg,
-        String tno,
+        boolean success,
+        String resultCode,
+        String resultMessage,
+        String resultEnMessage,
+        String transactionId,
         String amount,
         String payMethod,
-        String cardCd,
+        String cardCode,
         String cardName,
-        String cardNo,
-        String appNo,
-        String appTime,
-        String noinf,
-        String noinfType,
-        String quota,
-        String cardMny,
-        String couponMny,
-        String partcancYn,
+        String cardNumber,
+        String approvalNumber,
+        String approvalTime,
+        String installmentInfo,
+        String installmentType,
+        String installmentMonths,
+        String cardAmount,
+        String couponAmount,
+        String partialCancelYn,
         String cardBinType01,
         String cardBinType02,
         String rawResponse
 ) {
-    public boolean isSuccess() {
-        return FormatValidator.equals(resCd, "0000");
-    }
 }

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/payment/vendor/PaymentCancelVendorCommand.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/payment/vendor/PaymentCancelVendorCommand.java
@@ -4,10 +4,10 @@ import lombok.Builder;
 
 @Builder
 public record PaymentCancelVendorCommand(
-        String tno,
-        String modType,
-        Long modMny,
-        Long remMny,
-        String modDesc
+        String transactionId,
+        String cancelType,
+        Long cancelAmount,
+        Long remainAmount,
+        String cancelReason
 ) {
 }

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/payment/vendor/PaymentCancelVendorResult.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/payment/vendor/PaymentCancelVendorResult.java
@@ -4,12 +4,10 @@ import lombok.Builder;
 
 @Builder
 public record PaymentCancelVendorResult(
-        String resCd,
-        String resMsg,
+        boolean success,
+        String resultCode,
+        String resultMessage,
         String amount,
         String rawResponse
 ) {
-    public boolean isSuccess() {
-        return "0000".equals(resCd);
-    }
 }

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/payment/vendor/TradeRegisterVendorCommand.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/payment/vendor/TradeRegisterVendorCommand.java
@@ -5,7 +5,7 @@ import lombok.Builder;
 @Builder
 public record TradeRegisterVendorCommand(
         String orderKey,
-        String goodMny,
+        String orderAmount,
         String payMethod,
         String goodName
 ) {

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/payment/vendor/TradeRegisterVendorResult.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/payment/vendor/TradeRegisterVendorResult.java
@@ -4,14 +4,12 @@ import lombok.Builder;
 
 @Builder
 public record TradeRegisterVendorResult(
-        String resCd,
-        String resMsg,
+        boolean success,
+        String resultCode,
+        String resultMessage,
         String approvalKey,
         String payUrl,
         String traceNo,
         String rawResponse
 ) {
-    public boolean isSuccess() {
-        return "0000".equals(resCd);
-    }
 }

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/ApprovePaymentService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/ApprovePaymentService.java
@@ -18,7 +18,7 @@ import lombok.extern.slf4j.Slf4j;
  * <p>트랜잭션을 3단계로 분리하여 오케스트레이션만 수행한다:
  * <ol>
  *   <li>TX-1: 검증 + EXECUTING 커밋 (prepareExecution)</li>
- *   <li>KCP 호출 (트랜잭션 외부)</li>
+ *   <li>PG사 호출 (트랜잭션 외부)</li>
  *   <li>TX-2: 결과 반영 커밋 (commitSuccess / commitFailure / commitUnknown)</li>
  * </ol>
  *
@@ -39,29 +39,29 @@ public class ApprovePaymentService implements ApprovePaymentUseCase {
         PaymentApprovalVendorResult vendorResult = requestPaymentApprovalToPsp(command, context);
 
         // TX-2: 성공 또는 실패 커밋
-        if (vendorResult.isSuccess()) {
-            Short installment = parseInstallment(vendorResult.quota());
+        if (vendorResult.success()) {
+            Short installment = parseInstallment(vendorResult.installmentMonths());
             return txHelper.commitSuccess(context, vendorResult, installment);
         }
 
-        txHelper.commitFailure(context, vendorResult.resCd(), vendorResult.resMsg());
-        throw PaymentApprovalException.kcpApprovalFailed(vendorResult.resCd(), vendorResult.resMsg());
+        txHelper.commitFailure(context, vendorResult.resultCode(), vendorResult.resultMessage());
+        throw PaymentApprovalException.approvalFailed(vendorResult.resultCode(), vendorResult.resultMessage());
     }
 
     private PaymentApprovalVendorResult requestPaymentApprovalToPsp(
             ApprovePaymentCommand command, PaymentApprovalContext context
     ) {
-        // KCP 호출 (트랜잭션 외부 — 어댑터에서 재시도 수행)
+        // PG사 호출 (트랜잭션 외부 — 어댑터에서 재시도 수행)
         try {
             return paymentVendorPort.approvePayment(buildVendorCommand(command, context));
         } catch (PaymentVendorConnectionFailedException e) {
-            // TX-2: 연결 실패 → FAILED (요청이 KCP에 도달하지 않음)
+            // TX-2: 연결 실패 → FAILED (요청이 PG사에 도달하지 않음)
             txHelper.commitFailure(context, "CONN_FAIL", e.getMessage());
-            throw PaymentApprovalException.kcpApprovalRequestFailed(e);
+            throw PaymentApprovalException.approvalRequestFailed(e);
         } catch (Exception e) {
-            // TX-2: 기타 통신 오류 → UNKNOWN (요청이 KCP에 도달했을 수 있음)
-            txHelper.commitUnknown(context, "UNKNOWN", "KCP 통신 오류: " + e.getMessage());
-            throw PaymentApprovalException.kcpApprovalRequestFailed(e);
+            // TX-2: 기타 통신 오류 → UNKNOWN (요청이 PG사에 도달했을 수 있음)
+            txHelper.commitUnknown(context, "UNKNOWN", "PG사 통신 오류: " + e.getMessage());
+            throw PaymentApprovalException.approvalRequestFailed(e);
         }
     }
 
@@ -71,8 +71,8 @@ public class ApprovePaymentService implements ApprovePaymentUseCase {
         return PaymentApprovalVendorCommand.builder()
                 .encData(command.encData())
                 .encInfo(command.encInfo())
-                .ordrMony(String.valueOf(context.paymentAmount()))
-                .ordrNo(command.orderKey())
+                .orderAmount(String.valueOf(context.paymentAmount()))
+                .orderNumber(command.orderKey())
                 .payType(command.payType())
                 .build();
     }

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/CancelPaymentService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/CancelPaymentService.java
@@ -88,9 +88,9 @@ public class CancelPaymentService implements CancelPaymentUseCase {
                 transactionNumber, modType, cancelAmount, remainAmount, command.cancelReason()
         );
 
-        if (!vendorResult.isSuccess()) {
+        if (!vendorResult.success()) {
             throw new PaymentCancelException(
-                    "KCP 결제 취소 실패 [" + vendorResult.resCd() + "]: " + vendorResult.resMsg()
+                    "결제 취소 실패 [" + vendorResult.resultCode() + "]: " + vendorResult.resultMessage()
             );
         }
 
@@ -149,14 +149,14 @@ public class CancelPaymentService implements CancelPaymentUseCase {
     }
 
     private PaymentCancelVendorResult requestPaymentCancellationToPsp(
-            String transactionNumber, String modType, Long cancelAmount, Long remainAmount, String cancelReason
+            String transactionNumber, String cancelType, Long cancelAmount, Long remainAmount, String cancelReason
     ) {
         PaymentCancelVendorCommand vendorCommand = PaymentCancelVendorCommand.builder()
-                .tno(transactionNumber)
-                .modType(modType)
-                .modMny(cancelAmount)
-                .remMny(remainAmount)
-                .modDesc(cancelReason)
+                .transactionId(transactionNumber)
+                .cancelType(cancelType)
+                .cancelAmount(cancelAmount)
+                .remainAmount(remainAmount)
+                .cancelReason(cancelReason)
                 .build();
 
         return paymentVendorPort.cancelPayment(vendorCommand);

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/PaymentApprovalTransactionHelper.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/PaymentApprovalTransactionHelper.java
@@ -86,21 +86,21 @@ public class PaymentApprovalTransactionHelper {
         Payment payment = context.payment();
         PspPaymentEvent event = context.event();
 
-        payment.markAsSuccess(vendorResult.tno());
+        payment.markAsSuccess(vendorResult.transactionId());
         updatePaymentPort.update(payment);
 
         PaymentApprovalInfo approvalInfo = PaymentApprovalInfo.builder()
-                .pgPaymentKey(vendorResult.tno())
+                .pgPaymentKey(vendorResult.transactionId())
                 .method(vendorResult.payMethod())
-                .cardNumber(vendorResult.cardNo())
-                .approvalNumber(vendorResult.appNo())
+                .cardNumber(vendorResult.cardNumber())
+                .approvalNumber(vendorResult.approvalNumber())
                 .installment(installment)
-                .issueCompanyCode(vendorResult.cardCd())
+                .issueCompanyCode(vendorResult.cardCode())
                 .issueCompanyName(vendorResult.cardName())
-                .resultCode(vendorResult.resCd())
-                .resultMessage(vendorResult.resMsg())
+                .resultCode(vendorResult.resultCode())
+                .resultMessage(vendorResult.resultMessage())
                 .pgApprovalResult(vendorResult.rawResponse())
-                .appTime(vendorResult.appTime())
+                .appTime(vendorResult.approvalTime())
                 .build();
         event.completeWithApproval(approvalInfo);
         updatePspPaymentEventPort.update(event);
@@ -138,10 +138,10 @@ public class PaymentApprovalTransactionHelper {
         return ApprovePaymentResult.builder()
                 .orderId(payment.getOrderId())
                 .orderKey(payment.getOrderKey().toString())
-                .pgPaymentKey(vendorResult.tno())
+                .pgPaymentKey(vendorResult.transactionId())
                 .amount(payment.getPaymentAmount())
-                .resultCode(vendorResult.resCd())
-                .resultMessage(vendorResult.resMsg())
+                .resultCode(vendorResult.resultCode())
+                .resultMessage(vendorResult.resultMessage())
                 .payMethod(vendorResult.payMethod())
                 .build();
     }

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/ReadyPaymentService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/ReadyPaymentService.java
@@ -48,15 +48,15 @@ public class ReadyPaymentService implements ReadyPaymentUseCase {
 
         TradeRegisterVendorCommand vendorCommand = TradeRegisterVendorCommand.builder()
                 .orderKey(payment.getOrderKey().toString())
-                .goodMny(String.valueOf(payment.getPaymentAmount()))
+                .orderAmount(String.valueOf(payment.getPaymentAmount()))
                 .payMethod(command.payMethod())
                 .goodName(command.goodName())
                 .build();
 
         TradeRegisterVendorResult vendorResult = paymentVendorPort.registerTrade(vendorCommand);
 
-        if (!vendorResult.isSuccess()) {
-            throw PaymentApprovalException.kcpTradeRegisterFailed(vendorResult.resCd(), vendorResult.resMsg());
+        if (!vendorResult.success()) {
+            throw PaymentApprovalException.tradeRegisterFailed(vendorResult.resultCode(), vendorResult.resultMessage());
         }
 
         return ReadyPaymentResult.builder()
@@ -92,8 +92,9 @@ public class ReadyPaymentService implements ReadyPaymentUseCase {
     }
 
     private void saveReadyEvent(Payment payment, String payMethod) {
-        String vendorSiteCd = paymentVendorPort.getVendorSiteCd();
-        PspPaymentEvent readyEvent = PspPaymentEvent.createReady(payment, vendorSiteCd, payMethod);
+        String vendorKey = paymentVendorPort.getVendorKey();
+        String shopCode = paymentVendorPort.getShopCode();
+        PspPaymentEvent readyEvent = PspPaymentEvent.createReady(payment, vendorKey, shopCode, payMethod);
 
         try {
             savePspPaymentEventPort.save(readyEvent);

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/payment/ApprovePaymentUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/payment/ApprovePaymentUseCaseTest.java
@@ -77,8 +77,9 @@ class ApprovePaymentUseCaseTest {
             ApprovePaymentCommand command = createApproveCommand(ORDER_KEY_STR);
             PaymentApprovalContext context = createContext();
             PaymentApprovalVendorResult vendorResult = PaymentApprovalVendorResult.builder()
-                    .resCd("8001")
-                    .resMsg("카드 인증 실패")
+                    .success(false)
+                    .resultCode("8001")
+                    .resultMessage("카드 인증 실패")
                     .rawResponse("{}")
                     .build();
 
@@ -299,20 +300,21 @@ class ApprovePaymentUseCaseTest {
                 .build();
     }
 
-    private PaymentApprovalVendorResult createSuccessVendorResult(String tno, String amount) {
+    private PaymentApprovalVendorResult createSuccessVendorResult(String transactionId, String amount) {
         return PaymentApprovalVendorResult.builder()
-                .resCd("0000")
-                .resMsg("승인 성공")
-                .tno(tno)
+                .success(true)
+                .resultCode("0000")
+                .resultMessage("승인 성공")
+                .transactionId(transactionId)
                 .amount(amount)
                 .payMethod("PACA")
-                .cardCd("CCLG")
+                .cardCode("CCLG")
                 .cardName("신한카드")
-                .cardNo("1234-****-****-5678")
-                .appNo("12345678")
-                .appTime("20260210153000")
-                .quota("00")
-                .partcancYn("Y")
+                .cardNumber("1234-****-****-5678")
+                .approvalNumber("12345678")
+                .approvalTime("20260210153000")
+                .installmentMonths("00")
+                .partialCancelYn("Y")
                 .rawResponse("{\"res_cd\":\"0000\"}")
                 .build();
     }

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/payment/CancelPaymentUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/payment/CancelPaymentUseCaseTest.java
@@ -113,10 +113,10 @@ class CancelPaymentUseCaseTest {
             cancelPaymentService.cancel(command);
 
             verify(paymentVendorPort).cancelPayment(argThat(c ->
-                    "STSC".equals(c.modType())
-                            && c.modMny().equals(50000L)
-                            && c.remMny().equals(0L)
-                            && "tno_123".equals(c.tno())
+                    "STSC".equals(c.cancelType())
+                            && c.cancelAmount().equals(50000L)
+                            && c.remainAmount().equals(0L)
+                            && "tno_123".equals(c.transactionId())
             ));
         }
 
@@ -137,7 +137,7 @@ class CancelPaymentUseCaseTest {
             cancelPaymentService.cancel(command);
 
             verify(paymentVendorPort).cancelPayment(argThat(c ->
-                    c.modMny().equals(40000L) && c.remMny().equals(0L)
+                    c.cancelAmount().equals(40000L) && c.remainAmount().equals(0L)
             ));
         }
     }
@@ -182,9 +182,9 @@ class CancelPaymentUseCaseTest {
             cancelPaymentService.cancel(command);
 
             verify(paymentVendorPort).cancelPayment(argThat(c ->
-                    "STPC".equals(c.modType())
-                            && c.modMny().equals(20000L)
-                            && c.remMny().equals(30000L)
+                    "STPC".equals(c.cancelType())
+                            && c.cancelAmount().equals(20000L)
+                            && c.remainAmount().equals(30000L)
             ));
         }
 
@@ -601,8 +601,9 @@ class CancelPaymentUseCaseTest {
             PspPaymentEvent event = createCompleteEvent(ORDER_KEY_STR, "tno_123", 50000L);
             CancelPaymentCommand command = createFullCancelCommand(ORDER_KEY_STR);
             PaymentCancelVendorResult vendorResult = PaymentCancelVendorResult.builder()
-                    .resCd("8001")
-                    .resMsg("취소 불가")
+                    .success(false)
+                    .resultCode("8001")
+                    .resultMessage("취소 불가")
                     .rawResponse("{}")
                     .build();
 
@@ -1277,8 +1278,9 @@ class CancelPaymentUseCaseTest {
 
     private PaymentCancelVendorResult createSuccessVendorResult() {
         return PaymentCancelVendorResult.builder()
-                .resCd("0000")
-                .resMsg("취소 성공")
+                .success(true)
+                .resultCode("0000")
+                .resultMessage("취소 성공")
                 .amount("50000")
                 .rawResponse("{\"res_cd\":\"0000\"}")
                 .build();

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/payment/ReadyPaymentUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/payment/ReadyPaymentUseCaseTest.java
@@ -70,7 +70,8 @@ class ReadyPaymentUseCaseTest {
             when(findPaymentPort.findByOrderKey(ORDER_KEY)).thenReturn(Optional.of(payment));
             when(findOrderPort.findById(1L)).thenReturn(Optional.of(order));
             when(findPspPaymentEventPort.findByOrderKey(ORDER_KEY_STR)).thenReturn(Optional.empty());
-            when(paymentVendorPort.getVendorSiteCd()).thenReturn("T0000");
+            when(paymentVendorPort.getVendorKey()).thenReturn("NHN_KCP");
+            when(paymentVendorPort.getShopCode()).thenReturn("T0000");
             when(paymentVendorPort.registerTrade(any())).thenReturn(vendorResult);
 
             ReadyPaymentResult result = readyPaymentService.ready(command);
@@ -92,13 +93,14 @@ class ReadyPaymentUseCaseTest {
             when(findPaymentPort.findByOrderKey(ORDER_KEY)).thenReturn(Optional.of(payment));
             when(findOrderPort.findById(1L)).thenReturn(Optional.of(order));
             when(findPspPaymentEventPort.findByOrderKey(ORDER_KEY_STR)).thenReturn(Optional.empty());
-            when(paymentVendorPort.getVendorSiteCd()).thenReturn("T0000");
+            when(paymentVendorPort.getVendorKey()).thenReturn("NHN_KCP");
+            when(paymentVendorPort.getShopCode()).thenReturn("T0000");
             when(paymentVendorPort.registerTrade(any())).thenReturn(vendorResult);
 
             readyPaymentService.ready(command);
 
             verify(paymentVendorPort).registerTrade(argThat(c ->
-                    "77000".equals(c.goodMny()) && ORDER_KEY_STR.equals(c.orderKey())
+                    "77000".equals(c.orderAmount()) && ORDER_KEY_STR.equals(c.orderKey())
             ));
         }
 
@@ -118,7 +120,8 @@ class ReadyPaymentUseCaseTest {
             when(findPaymentPort.findByOrderKey(ORDER_KEY)).thenReturn(Optional.of(payment));
             when(findOrderPort.findById(1L)).thenReturn(Optional.of(order));
             when(findPspPaymentEventPort.findByOrderKey(ORDER_KEY_STR)).thenReturn(Optional.empty());
-            when(paymentVendorPort.getVendorSiteCd()).thenReturn("T0000");
+            when(paymentVendorPort.getVendorKey()).thenReturn("NHN_KCP");
+            when(paymentVendorPort.getShopCode()).thenReturn("T0000");
             when(paymentVendorPort.registerTrade(any())).thenReturn(vendorResult);
 
             readyPaymentService.ready(command);
@@ -406,7 +409,8 @@ class ReadyPaymentUseCaseTest {
             when(findPaymentPort.findByOrderKey(ORDER_KEY)).thenReturn(Optional.of(payment));
             when(findOrderPort.findById(1L)).thenReturn(Optional.of(order));
             when(findPspPaymentEventPort.findByOrderKey(ORDER_KEY_STR)).thenReturn(Optional.empty());
-            when(paymentVendorPort.getVendorSiteCd()).thenReturn("T0000");
+            when(paymentVendorPort.getVendorKey()).thenReturn("NHN_KCP");
+            when(paymentVendorPort.getShopCode()).thenReturn("T0000");
             when(paymentVendorPort.registerTrade(any())).thenThrow(new RuntimeException("KCP 거래등록 실패"));
 
             assertThatThrownBy(() -> readyPaymentService.ready(command))
@@ -429,7 +433,8 @@ class ReadyPaymentUseCaseTest {
             when(findPaymentPort.findByOrderKey(ORDER_KEY)).thenReturn(Optional.of(payment));
             when(findOrderPort.findById(1L)).thenReturn(Optional.of(order));
             when(findPspPaymentEventPort.findByOrderKey(ORDER_KEY_STR)).thenReturn(Optional.empty());
-            when(paymentVendorPort.getVendorSiteCd()).thenReturn("T0000");
+            when(paymentVendorPort.getVendorKey()).thenReturn("NHN_KCP");
+            when(paymentVendorPort.getShopCode()).thenReturn("T0000");
             when(savePspPaymentEventPort.save(any())).thenThrow(
                     new DataIntegrityViolationException("duplicate key value violates unique constraint"));
 
@@ -449,7 +454,8 @@ class ReadyPaymentUseCaseTest {
             when(findPaymentPort.findByOrderKey(ORDER_KEY)).thenReturn(Optional.of(payment));
             when(findOrderPort.findById(1L)).thenReturn(Optional.of(order));
             when(findPspPaymentEventPort.findByOrderKey(ORDER_KEY_STR)).thenReturn(Optional.empty());
-            when(paymentVendorPort.getVendorSiteCd()).thenReturn("T0000");
+            when(paymentVendorPort.getVendorKey()).thenReturn("NHN_KCP");
+            when(paymentVendorPort.getShopCode()).thenReturn("T0000");
             when(savePspPaymentEventPort.save(any())).thenThrow(
                     new DataIntegrityViolationException("duplicate key"));
 
@@ -503,8 +509,9 @@ class ReadyPaymentUseCaseTest {
 
     private TradeRegisterVendorResult createVendorResult() {
         return TradeRegisterVendorResult.builder()
-                .resCd("0000")
-                .resMsg("성공")
+                .success(true)
+                .resultCode("0000")
+                .resultMessage("성공")
                 .approvalKey("approval_key_123")
                 .payUrl("https://pay.kcp.co.kr/test")
                 .traceNo("trace_001")

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/payment/PaymentMethod.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/payment/PaymentMethod.java
@@ -6,21 +6,11 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum PaymentMethod {
-    CARD("PACA", "CARD", "신용카드"),
-    BANK_TRANSFER("PABK", "BANK", "계좌이체"),
-    VIRTUAL_ACCOUNT("PAVC", "PAVC", "가상계좌"),
-    MOBILE("PAMC", "MOBX", "휴대폰결제");
+    CARD("CARD", "신용카드"),
+    BANK_TRANSFER("BANK", "계좌이체"),
+    VIRTUAL_ACCOUNT("PAVC", "가상계좌"),
+    MOBILE("MOBX", "휴대폰결제");
 
-    private final String kcpCode;
     private final String mobileCode;
     private final String description;
-
-    public static PaymentMethod fromKcpCode(String kcpCode) {
-        for (PaymentMethod method : values()) {
-            if (method.kcpCode.equals(kcpCode)) {
-                return method;
-            }
-        }
-        throw new UnknownPaymentMethodCodeException(kcpCode);
-    }
 }

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/payment/PspPaymentEvent.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/payment/PspPaymentEvent.java
@@ -45,12 +45,12 @@ public class PspPaymentEvent {
     private LocalDateTime createdAt;
     private LocalDateTime modifiedAt;
 
-    public static PspPaymentEvent createReady(Payment payment, String siteCd, String payType) {
+    public static PspPaymentEvent createReady(Payment payment, String pgCompanyKey, String pgShopKey, String payType) {
         return PspPaymentEvent.builder()
                 .orderId(payment.getOrderId())
                 .orderKey(payment.getOrderKey().toString())
-                .pgCompanyKey("NHN_KCP")
-                .pgShopKey(siteCd)
+                .pgCompanyKey(pgCompanyKey)
+                .pgShopKey(pgShopKey)
                 .poStatus(PaymentEventStatus.READY)
                 .method(payType)
                 .amount(payment.getPaymentAmount())

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/payment/UnknownPaymentMethodCodeException.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/payment/UnknownPaymentMethodCodeException.java
@@ -1,7 +1,7 @@
 package com.personal.marketnote.commerce.domain.payment;
 
 public class UnknownPaymentMethodCodeException extends IllegalArgumentException {
-    public UnknownPaymentMethodCodeException(String kcpCode) {
-        super("알 수 없는 KCP 결제수단 코드: " + kcpCode);
+    public UnknownPaymentMethodCodeException(String vendorCode) {
+        super("알 수 없는 결제수단 코드: " + vendorCode);
     }
 }

--- a/commerce-service/commerce-domain/src/test/java/com/personal/marketnote/commerce/domain/payment/PspPaymentEventTest.java
+++ b/commerce-service/commerce-domain/src/test/java/com/personal/marketnote/commerce/domain/payment/PspPaymentEventTest.java
@@ -21,7 +21,7 @@ class PspPaymentEventTest {
         void shouldCreateReadyEvent() {
             Payment payment = createPayment(1L, UUID.randomUUID(), 50000L);
 
-            PspPaymentEvent event = PspPaymentEvent.createReady(payment, "T0000", "PACA");
+            PspPaymentEvent event = PspPaymentEvent.createReady(payment, "NHN_KCP", "T0000", "PACA");
 
             assertThat(event.getOrderId()).isEqualTo(1L);
             assertThat(event.getOrderKey()).isEqualTo(payment.getOrderKey().toString());
@@ -365,7 +365,7 @@ class PspPaymentEventTest {
 
     private PspPaymentEvent createReadyEvent() {
         Payment payment = createPayment(1L, UUID.randomUUID(), 50000L);
-        return PspPaymentEvent.createReady(payment, "T0000", "PACA");
+        return PspPaymentEvent.createReady(payment, "NHN_KCP", "T0000", "PACA");
     }
 
     private PspPaymentEvent createExecutingEvent() {


### PR DESCRIPTION
## partially addresses #216
## resolves #1690

## Task
- [x] PaymentMethod.kcpCode 필드를 adapter 레이어 매핑으로 이동
- [x] PspPaymentEvent.pgCompanyKey = "NHN_KCP" 하드코딩 제거
- [x] PaymentVendorPort.getVendorSiteCd() 벤더 비종속적 메서드로 추상화
- [x] PaymentApprovalVendorResult 필드명 벤더 비종속적 이름으로 변경
- [x] TradeRegisterVendorResult.isSuccess() 성공 코드 판단을 adapter로 이동
- [x] PaymentApprovalException 벤더 비종속적 팩토리 메서드로 변경
- [x] adapter에서 KCP 응답 → 벤더 비종속적 Result 변환 매퍼 구현