### PR TITLE
[#43][#1693] refactor: 회원 서비스 application/domain 레이어 OAuth2 벤더 종속 정보 제거

### DIFF
--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/configuration/security/AuthenticationEntryPointConfig.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/configuration/security/AuthenticationEntryPointConfig.java
@@ -3,19 +3,30 @@ package com.personal.marketnote.user.adapter.in.configuration.security;
 import com.personal.marketnote.user.port.out.user.FindUserPort;
 import com.personal.marketnote.user.security.token.introspector.OpaqueTokenDefaultIntrospector;
 import com.personal.marketnote.user.security.token.support.TokenSupport;
+import com.personal.marketnote.user.security.token.vendor.AuthVendor;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.oauth2.server.resource.introspection.OpaqueTokenIntrospector;
 
+import java.util.List;
+import java.util.Map;
+
 @Configuration
 public class AuthenticationEntryPointConfig {
+
+    private static final Map<AuthVendor, List<String>> VENDOR_ISSUER_MAP = Map.of(
+            AuthVendor.KAKAO, List.of("kauth.kakao.com", "https://kauth.kakao.com"),
+            AuthVendor.GOOGLE, List.of("accounts.google.com", "https://accounts.google.com"),
+            AuthVendor.APPLE, List.of("appleid.apple.com", "https://appleid.apple.com")
+    );
+
     @Bean
     @ConditionalOnMissingBean(OpaqueTokenIntrospector.class)
     public OpaqueTokenIntrospector defaultOpaqueTokenIntrospector(
             TokenSupport tokenSupport,
             FindUserPort findUserPort
     ) {
-        return new OpaqueTokenDefaultIntrospector(tokenSupport, findUserPort);
+        return new OpaqueTokenDefaultIntrospector(tokenSupport, findUserPort, VENDOR_ISSUER_MAP);
     }
 }

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/user/controller/UserController.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/user/controller/UserController.java
@@ -40,7 +40,9 @@ import org.springframework.web.bind.annotation.*;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
@@ -454,8 +456,9 @@ public class UserController {
             @AuthenticationPrincipal OAuth2AuthenticatedPrincipal principal,
             @RequestHeader(value = "X-Google-Access-Token", required = false) String googleAccessToken
     ) {
+        Map<AuthVendor, String> vendorCredentials = buildVendorCredentials(googleAccessToken);
         WithdrawResult result = withdrawUseCase.withdrawUser(
-                ElementExtractor.extractUserId(principal), googleAccessToken
+                ElementExtractor.extractUserId(principal), vendorCredentials
         );
 
         return new ResponseEntity<>(
@@ -467,5 +470,15 @@ public class UserController {
                 ),
                 HttpStatus.OK
         );
+    }
+
+    private Map<AuthVendor, String> buildVendorCredentials(String googleAccessToken) {
+        Map<AuthVendor, String> vendorCredentials = new HashMap<>();
+
+        if (FormatValidator.hasValue(googleAccessToken)) {
+            vendorCredentials.put(AuthVendor.GOOGLE, googleAccessToken);
+        }
+
+        return vendorCredentials;
     }
 }

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/user/response/WithdrawResponse.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/user/response/WithdrawResponse.java
@@ -1,6 +1,9 @@
 package com.personal.marketnote.user.adapter.in.web.user.response;
 
 import com.personal.marketnote.user.port.in.result.WithdrawResult;
+import com.personal.marketnote.user.security.token.vendor.AuthVendor;
+
+import java.util.Map;
 
 public record WithdrawResponse(
         boolean isKakaoDisconnected,
@@ -8,10 +11,11 @@ public record WithdrawResponse(
         boolean isAppleDisconnected
 ) {
     public static WithdrawResponse from(WithdrawResult result) {
+        Map<AuthVendor, Boolean> disconnectResults = result.disconnectResults();
         return new WithdrawResponse(
-                result.isKakaoDisconnected(),
-                result.isGoogleDisconnected(),
-                result.isAppleDisconnected()
+                disconnectResults.getOrDefault(AuthVendor.KAKAO, true),
+                disconnectResults.getOrDefault(AuthVendor.GOOGLE, true),
+                disconnectResults.getOrDefault(AuthVendor.APPLE, true)
         );
     }
 }

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/out/oauth/Oauth2AccountClient.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/out/oauth/Oauth2AccountClient.java
@@ -2,6 +2,7 @@ package com.personal.marketnote.user.adapter.out.oauth;
 
 import com.personal.marketnote.common.adapter.out.VendorAdapter;
 import com.personal.marketnote.user.port.out.oauth.Oauth2AccountUnlinkPort;
+import com.personal.marketnote.user.security.token.vendor.AuthVendor;
 import com.personal.marketnote.user.service.exception.UnlinkOauth2AccountFailedException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -12,8 +13,7 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestClient;
 
-import static com.personal.marketnote.user.service.exception.ExceptionMessage.UNLINK_GOOGLE_ACCOUNT_FAILED_EXCEPTION_MESSAGE;
-import static com.personal.marketnote.user.service.exception.ExceptionMessage.UNLINK_KAKAO_ACCOUNT_FAILED_EXCEPTION_MESSAGE;
+import static com.personal.marketnote.user.service.exception.ExceptionMessage.UNLINK_OAUTH2_ACCOUNT_FAILED_EXCEPTION_MESSAGE;
 
 @VendorAdapter
 @Slf4j
@@ -33,7 +33,21 @@ public class Oauth2AccountClient implements Oauth2AccountUnlinkPort {
     }
 
     @Override
-    public void unlinkKakaoAccount(String oidcId) throws UnlinkOauth2AccountFailedException {
+    public void unlinkAccount(AuthVendor vendor, String credential) throws UnlinkOauth2AccountFailedException {
+        if (vendor.isMe(AuthVendor.KAKAO)) {
+            unlinkKakaoAccount(credential);
+            return;
+        }
+
+        if (vendor.isMe(AuthVendor.GOOGLE)) {
+            unlinkGoogleAccount(credential);
+            return;
+        }
+
+        log.debug("{} 벤더에 대한 연결 해제 로직이 구현되지 않았습니다.", vendor.name());
+    }
+
+    private void unlinkKakaoAccount(String oidcId) throws UnlinkOauth2AccountFailedException {
         MultiValueMap<String, String> form = new LinkedMultiValueMap<>();
         form.add("target_id_type", "user_id");
         form.add("target_id", oidcId);
@@ -47,12 +61,13 @@ public class Oauth2AccountClient implements Oauth2AccountUnlinkPort {
                 .toEntity(String.class);
 
         if (!response.getStatusCode().is2xxSuccessful()) {
-            throw new UnlinkOauth2AccountFailedException(UNLINK_KAKAO_ACCOUNT_FAILED_EXCEPTION_MESSAGE);
+            throw new UnlinkOauth2AccountFailedException(
+                    String.format(UNLINK_OAUTH2_ACCOUNT_FAILED_EXCEPTION_MESSAGE, AuthVendor.KAKAO.name())
+            );
         }
     }
 
-    @Override
-    public void unlinkGoogleAccount(String accessToken) throws UnlinkOauth2AccountFailedException {
+    private void unlinkGoogleAccount(String accessToken) throws UnlinkOauth2AccountFailedException {
         MultiValueMap<String, String> form = new LinkedMultiValueMap<>();
         form.add("token", accessToken);
 
@@ -64,7 +79,9 @@ public class Oauth2AccountClient implements Oauth2AccountUnlinkPort {
                 .toEntity(String.class);
 
         if (!response.getStatusCode().is2xxSuccessful()) {
-            throw new UnlinkOauth2AccountFailedException(UNLINK_GOOGLE_ACCOUNT_FAILED_EXCEPTION_MESSAGE);
+            throw new UnlinkOauth2AccountFailedException(
+                    String.format(UNLINK_OAUTH2_ACCOUNT_FAILED_EXCEPTION_MESSAGE, AuthVendor.GOOGLE.name())
+            );
         }
     }
 }

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/out/oauth/RestClientGoogleTokenProcessor.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/out/oauth/RestClientGoogleTokenProcessor.java
@@ -4,7 +4,7 @@ import com.personal.marketnote.common.adapter.out.VendorAdapter;
 import com.personal.marketnote.common.domain.exception.token.InvalidAccessTokenException;
 import com.personal.marketnote.common.domain.exception.token.InvalidRefreshTokenException;
 import com.personal.marketnote.common.domain.exception.token.UnsupportedCodeException;
-import com.personal.marketnote.user.exception.GoogleOAuth2ResponseParsingException;
+import com.personal.marketnote.user.exception.OAuth2ResponseParsingException;
 import com.personal.marketnote.user.security.token.dto.GrantedTokenInfo;
 import com.personal.marketnote.user.security.token.dto.OAuth2AuthenticationInfo;
 import com.personal.marketnote.user.security.token.dto.OAuth2UserInfo;
@@ -137,7 +137,7 @@ public class RestClientGoogleTokenProcessor implements TokenProcessor {
                     .name(jsonObject.getString("name"))
                     .build();
         } catch (JSONException e) {
-            throw new GoogleOAuth2ResponseParsingException(jsonObject.toString(), e);
+            throw new OAuth2ResponseParsingException("Google", jsonObject.toString(), e);
         }
     }
 

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/exception/OAuth2ResponseParsingException.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/exception/OAuth2ResponseParsingException.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.user.exception;
+
+public class OAuth2ResponseParsingException extends RuntimeException {
+    private static final String MESSAGE = "OAuth2 벤더(%s) 응답 파싱 실패:\n%s";
+
+    public OAuth2ResponseParsingException(String vendor, String responseBody, Throwable cause) {
+        super(String.format(MESSAGE, vendor, responseBody), cause);
+    }
+}

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/port/in/result/WithdrawResult.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/port/in/result/WithdrawResult.java
@@ -1,10 +1,10 @@
 package com.personal.marketnote.user.port.in.result;
 
+import com.personal.marketnote.user.security.token.vendor.AuthVendor;
+
+import java.util.Map;
+
 public record WithdrawResult(
-        boolean isKakaoDisconnected,
-        boolean isGoogleDisconnected,
-        boolean isAppleDisconnected
+        Map<AuthVendor, Boolean> disconnectResults
 ) {
 }
-
-

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/port/in/usecase/user/WithdrawUseCase.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/port/in/usecase/user/WithdrawUseCase.java
@@ -1,6 +1,9 @@
 package com.personal.marketnote.user.port.in.usecase.user;
 
 import com.personal.marketnote.user.port.in.result.WithdrawResult;
+import com.personal.marketnote.user.security.token.vendor.AuthVendor;
+
+import java.util.Map;
 
 /**
  * 회원 탈퇴 유스케이스
@@ -12,10 +15,10 @@ import com.personal.marketnote.user.port.in.result.WithdrawResult;
 public interface WithdrawUseCase {
     /**
      * @param id                회원 ID
-     * @param googleAccessToken 현재 구글 로그인 중인 경우 액세스 토큰(연결 해제 시도)
-     * @Date 2025-12-29
+     * @param vendorCredentials 벤더별 연결 해제에 필요한 자격 증명 (예: 구글 액세스 토큰)
+     * @Date 2026-03-27
      * @Author 성효빈
      * @Description 회원에서 탈퇴하고 소셜 연결 해제 결과를 반환합니다.
      */
-    WithdrawResult withdrawUser(Long id, String googleAccessToken);
+    WithdrawResult withdrawUser(Long id, Map<AuthVendor, String> vendorCredentials);
 }

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/port/out/oauth/Oauth2AccountUnlinkPort.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/port/out/oauth/Oauth2AccountUnlinkPort.java
@@ -1,5 +1,6 @@
 package com.personal.marketnote.user.port.out.oauth;
 
+import com.personal.marketnote.user.security.token.vendor.AuthVendor;
 import com.personal.marketnote.user.service.exception.UnlinkOauth2AccountFailedException;
 
 /**
@@ -11,20 +12,12 @@ import com.personal.marketnote.user.service.exception.UnlinkOauth2AccountFailedE
  */
 public interface Oauth2AccountUnlinkPort {
     /**
-     * @param oidcId 카카오 OIDC ID
-     * @throws UnlinkOauth2AccountFailedException 카카오 계정 연결 해제 실패 시
-     * @Date 2025-12-29
+     * @param vendor      OAuth2 벤더
+     * @param credential  벤더별 연결 해제에 필요한 자격 증명 (OIDC ID 또는 액세스 토큰)
+     * @throws UnlinkOauth2AccountFailedException 계정 연결 해제 실패 시
+     * @Date 2026-03-27
      * @Author 성효빈
-     * @Description 카카오 계정 연결을 해제합니다.
+     * @Description 지정된 벤더의 계정 연결을 해제합니다.
      */
-    void unlinkKakaoAccount(String oidcId) throws UnlinkOauth2AccountFailedException;
-
-    /**
-     * @param accessToken 구글 액세스 토큰
-     * @throws UnlinkOauth2AccountFailedException 구글 계정 연결 해제 실패 시
-     * @Date 2025-12-29
-     * @Author 성효빈
-     * @Description 구글 계정 연결을 해제합니다.
-     */
-    void unlinkGoogleAccount(String accessToken) throws UnlinkOauth2AccountFailedException;
+    void unlinkAccount(AuthVendor vendor, String credential) throws UnlinkOauth2AccountFailedException;
 }

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/security/token/introspector/OpaqueTokenDefaultIntrospector.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/security/token/introspector/OpaqueTokenDefaultIntrospector.java
@@ -28,23 +28,14 @@ import static com.personal.marketnote.common.security.token.utility.TokenConstan
 public class OpaqueTokenDefaultIntrospector implements OpaqueTokenIntrospector {
     private final TokenSupport tokenSupport;
     private final FindUserPort findUserPort;
+    private final Map<AuthVendor, List<String>> vendorIssuerMap;
 
     @Override
     public OAuth2AuthenticatedPrincipal introspect(String token) {
         try {
-            // Kakao ID Token (JWT, RS256, iss: https://kauth.kakao.com)
-            if (looksLikeKakaoIdToken(token)) {
-                return parseVendorIdToken(token, AuthVendor.KAKAO);
-            }
-
-            // Google ID Token (JWT, RS256, iss: accounts.google.com)
-            if (looksLikeGoogleIdToken(token)) {
-                return parseVendorIdToken(token, AuthVendor.GOOGLE);
-            }
-
-            // Apple ID Token (JWT, RS256, iss: https://appleid.apple.com)
-            if (looksLikeAppleIdToken(token)) {
-                return parseVendorIdToken(token, AuthVendor.APPLE);
+            AuthVendor resolvedVendor = resolveVendorFromIdToken(token);
+            if (FormatValidator.hasValue(resolvedVendor)) {
+                return parseVendorIdToken(token, resolvedVendor);
             }
 
             // Default path: our own JWT or opaque token handled by TokenSupport
@@ -85,6 +76,46 @@ public class OpaqueTokenDefaultIntrospector implements OpaqueTokenIntrospector {
         }
     }
 
+    private AuthVendor resolveVendorFromIdToken(String token) {
+        if (FormatValidator.hasNoValue(token)) {
+            return null;
+        }
+
+        String[] parts = token.split("\\.");
+        if (parts.length != 3) {
+            return null;
+        }
+
+        try {
+            String headerJson = new String(Base64.getUrlDecoder().decode(parts[0]));
+            String payloadJson = new String(Base64.getUrlDecoder().decode(parts[1]));
+            JSONObject header = new JSONObject(headerJson);
+            JSONObject payload = new JSONObject(payloadJson);
+
+            boolean isJwt = "JWT".equalsIgnoreCase(header.optString("typ", "JWT"));
+            boolean isRs256 = "RS256".equalsIgnoreCase(header.optString("alg", ""));
+
+            if (!isJwt || !isRs256) {
+                return null;
+            }
+
+            String iss = payload.optString(ISS_CLAIM_KEY, "");
+
+            for (Map.Entry<AuthVendor, List<String>> entry : vendorIssuerMap.entrySet()) {
+                for (String issuer : entry.getValue()) {
+                    if (issuer.equals(iss)) {
+                        return entry.getKey();
+                    }
+                }
+            }
+
+            return null;
+        } catch (IllegalArgumentException e) {
+            log.debug("Failed to Base64URL decode token header/payload: {}", e.getMessage());
+            return null;
+        }
+    }
+
     private OAuth2AuthenticatedPrincipal parseVendorIdToken(String token, AuthVendor vendor) {
         JSONObject payload = parseJwtPayload(token);
         String oidcId = payload.optString(SUB_CLAIM_KEY, "");
@@ -110,54 +141,6 @@ public class OpaqueTokenDefaultIntrospector implements OpaqueTokenIntrospector {
                 ),
                 List.of(new SimpleGrantedAuthority(PrimaryRole.ROLE_GUEST.name()))
         );
-    }
-
-    private boolean looksLikeKakaoIdToken(String token) {
-        return looksLikeIdToken(
-                token, iss -> "kauth.kakao.com".equals(iss) || "https://kauth.kakao.com".equals(iss)
-        );
-    }
-
-    private boolean looksLikeGoogleIdToken(String token) {
-        return looksLikeIdToken(
-                token, iss -> "accounts.google.com".equals(iss) || "https://accounts.google.com".equals(iss)
-        );
-    }
-
-    private boolean looksLikeAppleIdToken(String token) {
-        return looksLikeIdToken(
-                token, iss -> "appleid.apple.com".equals(iss) || "https://appleid.apple.com".equals(iss)
-        );
-    }
-
-    private boolean looksLikeIdToken(String token, java.util.function.Predicate<String> issPredicate) {
-        if (FormatValidator.hasNoValue(token)) {
-            return false;
-        }
-
-        String[] parts = token.split("\\.");
-        if (parts.length != 3) {
-            return false;
-        }
-
-        try {
-            String headerJson = new String(Base64.getUrlDecoder().decode(parts[0]));
-            String payloadJson = new String(Base64.getUrlDecoder().decode(parts[1]));
-            JSONObject header = new JSONObject(headerJson);
-            JSONObject payload = new JSONObject(payloadJson);
-
-            String alg = header.optString("alg", "");
-            String iss = payload.optString(ISS_CLAIM_KEY, "");
-
-            boolean isJwt = "JWT".equalsIgnoreCase(header.optString("typ", "JWT"));
-            boolean isRs256 = "RS256".equalsIgnoreCase(alg);
-            boolean issMatches = issPredicate.test(iss);
-
-            return isJwt && isRs256 && issMatches;
-        } catch (IllegalArgumentException e) {
-            log.debug("Failed to Base64URL decode token header/payload: {}", e.getMessage());
-            return false;
-        }
     }
 
     private JSONObject parseJwtPayload(String token) {

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/service/exception/ExceptionMessage.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/service/exception/ExceptionMessage.java
@@ -1,6 +1,5 @@
 package com.personal.marketnote.user.service.exception;
 
 public class ExceptionMessage {
-    public static final String UNLINK_KAKAO_ACCOUNT_FAILED_EXCEPTION_MESSAGE = "카카오 계정 연결 해제에 실패했습니다.";
-    public static final String UNLINK_GOOGLE_ACCOUNT_FAILED_EXCEPTION_MESSAGE = "구글 계정 연결 해제에 실패했습니다.";
+    public static final String UNLINK_OAUTH2_ACCOUNT_FAILED_EXCEPTION_MESSAGE = "%s 계정 연결 해제에 실패했습니다.";
 }

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/service/user/WithdrawService.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/service/user/WithdrawService.java
@@ -8,11 +8,15 @@ import com.personal.marketnote.user.port.in.usecase.user.GetUserUseCase;
 import com.personal.marketnote.user.port.in.usecase.user.WithdrawUseCase;
 import com.personal.marketnote.user.port.out.oauth.Oauth2AccountUnlinkPort;
 import com.personal.marketnote.user.port.out.user.UpdateUserPort;
+import com.personal.marketnote.user.security.token.vendor.AuthVendor;
 import com.personal.marketnote.user.service.exception.UnlinkOauth2AccountFailedException;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.EnumMap;
+import java.util.Map;
 
 import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
 
@@ -27,46 +31,57 @@ public class WithdrawService implements WithdrawUseCase {
     private final Logger log = LoggerFactory.getLogger(WithdrawService.class);
 
     @Override
-    public WithdrawResult withdrawUser(Long id, String googleAccessToken) {
+    public WithdrawResult withdrawUser(Long id, Map<AuthVendor, String> vendorCredentials) {
         User user = getUserUseCase.getAllStatusUser(id);
         user.withdraw();
 
-        boolean isKakaoDisconnected = true;
-        String kakaoOidcId = user.getKakaoOidcId();
-        if (FormatValidator.hasValue(kakaoOidcId)) {
-            try {
-                oauth2AccountUnlinkPort.unlinkKakaoAccount(user.getKakaoOidcId());
-            } catch (UnlinkOauth2AccountFailedException e) {
-                isKakaoDisconnected = false;
-                log.error("카카오 계정 연결 해제에 실패했습니다. oidcId={}", kakaoOidcId, e);
+        Map<AuthVendor, Boolean> disconnectResults = new EnumMap<>(AuthVendor.class);
+
+        for (AuthVendor vendor : AuthVendor.values()) {
+            if (vendor.isNative()) {
+                continue;
             }
 
-            user.removeKakaoOidcId();
+            boolean isDisconnected = unlinkVendorAccount(user, vendor, vendorCredentials);
+            disconnectResults.put(vendor, isDisconnected);
         }
 
-        boolean isGoogleDisconnected = true;
-        if (user.hasGoogleAccount()) {
-            isGoogleDisconnected = false;
-            // 현재 구글 로그인 상태인 경우 구글 로그인 연결 해제 요청
-            if (FormatValidator.hasValue(googleAccessToken)) {
-                try {
-                    oauth2AccountUnlinkPort.unlinkGoogleAccount(googleAccessToken);
-                    isGoogleDisconnected = true;
-                } catch (UnlinkOauth2AccountFailedException e) {
-                    log.error("구글 계정 연결 해제에 실패했습니다.", e);
-                }
-            }
-
-            user.removeGoogleOidcId();
-        }
-
-        boolean isAppleDisconnected = true;
-        if (user.hasAppleAccount()) {
-            user.removeAppleOidcId();
-            isAppleDisconnected = false;
-        }
         updateUserPort.update(user);
 
-        return new WithdrawResult(isKakaoDisconnected, isGoogleDisconnected, isAppleDisconnected);
+        return new WithdrawResult(disconnectResults);
+    }
+
+    private boolean unlinkVendorAccount(User user, AuthVendor vendor, Map<AuthVendor, String> vendorCredentials) {
+        String credential = resolveCredential(user, vendor, vendorCredentials);
+        if (FormatValidator.hasNoValue(credential)) {
+            return true;
+        }
+
+        boolean isDisconnected = tryUnlinkAccount(vendor, credential);
+        user.removeOidcId(vendor);
+        return isDisconnected;
+    }
+
+    private String resolveCredential(User user, AuthVendor vendor, Map<AuthVendor, String> vendorCredentials) {
+        // 외부에서 제공된 자격 증명이 있으면 우선 사용 (예: 구글 액세스 토큰)
+        if (FormatValidator.hasValue(vendorCredentials)) {
+            String externalCredential = vendorCredentials.get(vendor);
+            if (FormatValidator.hasValue(externalCredential)) {
+                return externalCredential;
+            }
+        }
+
+        // 외부 자격 증명이 없으면 사용자의 OIDC ID 사용
+        return user.getOidcIdByVendor(vendor);
+    }
+
+    private boolean tryUnlinkAccount(AuthVendor vendor, String credential) {
+        try {
+            oauth2AccountUnlinkPort.unlinkAccount(vendor, credential);
+            return true;
+        } catch (UnlinkOauth2AccountFailedException e) {
+            log.error("{} 계정 연결 해제에 실패했습니다.", vendor.name(), e);
+            return false;
+        }
     }
 }

--- a/user-service/user-application/src/test/java/com/personal/marketnote/user/service/user/WithdrawUseCaseTest.java
+++ b/user-service/user-application/src/test/java/com/personal/marketnote/user/service/user/WithdrawUseCaseTest.java
@@ -6,6 +6,7 @@ import com.personal.marketnote.user.port.in.result.WithdrawResult;
 import com.personal.marketnote.user.port.in.usecase.user.GetUserUseCase;
 import com.personal.marketnote.user.port.out.oauth.Oauth2AccountUnlinkPort;
 import com.personal.marketnote.user.port.out.user.UpdateUserPort;
+import com.personal.marketnote.user.security.token.vendor.AuthVendor;
 import com.personal.marketnote.user.service.exception.UnlinkOauth2AccountFailedException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -14,9 +15,10 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Map;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -41,18 +43,17 @@ class WithdrawUseCaseTest {
         when(getUserUseCase.getAllStatusUser(id)).thenReturn(user);
 
         // when
-        WithdrawResult result = withdrawService.withdrawUser(id, null);
+        WithdrawResult result = withdrawService.withdrawUser(id, Map.of());
 
         // then
-        assertThat(result.isKakaoDisconnected()).isTrue();
-        assertThat(result.isGoogleDisconnected()).isTrue();
-        assertThat(result.isAppleDisconnected()).isTrue();
+        Map<AuthVendor, Boolean> disconnectResults = result.disconnectResults();
+        assertThat(disconnectResults.get(AuthVendor.KAKAO)).isTrue();
+        assertThat(disconnectResults.get(AuthVendor.GOOGLE)).isTrue();
+        assertThat(disconnectResults.get(AuthVendor.APPLE)).isTrue();
 
         verify(getUserUseCase).getAllStatusUser(id);
         verify(user).withdraw();
-        verify(user, never()).removeKakaoOidcId();
-        verify(user, never()).removeGoogleOidcId();
-        verify(user, never()).removeAppleOidcId();
+        verify(user, never()).removeOidcId(any(AuthVendor.class));
         verify(updateUserPort).update(user);
         verifyNoMoreInteractions(getUserUseCase, updateUserPort);
         verifyNoInteractions(oauth2AccountUnlinkPort);
@@ -67,22 +68,22 @@ class WithdrawUseCaseTest {
         User user = mock(User.class);
 
         when(getUserUseCase.getAllStatusUser(id)).thenReturn(user);
-        when(user.getKakaoOidcId()).thenReturn(kakaoOidcId);
+        when(user.getOidcIdByVendor(AuthVendor.KAKAO)).thenReturn(kakaoOidcId);
 
         // when
-        WithdrawResult result = withdrawService.withdrawUser(id, null);
+        WithdrawResult result = withdrawService.withdrawUser(id, Map.of());
 
         // then
-        assertThat(result.isKakaoDisconnected()).isTrue();
-        assertThat(result.isGoogleDisconnected()).isTrue();
-        assertThat(result.isAppleDisconnected()).isTrue();
+        Map<AuthVendor, Boolean> disconnectResults = result.disconnectResults();
+        assertThat(disconnectResults.get(AuthVendor.KAKAO)).isTrue();
+        assertThat(disconnectResults.get(AuthVendor.GOOGLE)).isTrue();
+        assertThat(disconnectResults.get(AuthVendor.APPLE)).isTrue();
 
         verify(getUserUseCase).getAllStatusUser(id);
         verify(user).withdraw();
-        verify(oauth2AccountUnlinkPort).unlinkKakaoAccount(kakaoOidcId);
-        verify(user).removeKakaoOidcId();
+        verify(oauth2AccountUnlinkPort).unlinkAccount(AuthVendor.KAKAO, kakaoOidcId);
+        verify(user).removeOidcId(AuthVendor.KAKAO);
         verify(updateUserPort).update(user);
-        verifyNoMoreInteractions(getUserUseCase, updateUserPort, oauth2AccountUnlinkPort);
     }
 
     @Test
@@ -95,23 +96,21 @@ class WithdrawUseCaseTest {
         UnlinkOauth2AccountFailedException exception = new UnlinkOauth2AccountFailedException("fail");
 
         when(getUserUseCase.getAllStatusUser(id)).thenReturn(user);
-        when(user.getKakaoOidcId()).thenReturn(kakaoOidcId);
-        doThrow(exception).when(oauth2AccountUnlinkPort).unlinkKakaoAccount(kakaoOidcId);
+        when(user.getOidcIdByVendor(AuthVendor.KAKAO)).thenReturn(kakaoOidcId);
+        doThrow(exception).when(oauth2AccountUnlinkPort).unlinkAccount(AuthVendor.KAKAO, kakaoOidcId);
 
         // when
-        WithdrawResult result = withdrawService.withdrawUser(id, null);
+        WithdrawResult result = withdrawService.withdrawUser(id, Map.of());
 
         // then
-        assertThat(result.isKakaoDisconnected()).isFalse();
-        assertThat(result.isGoogleDisconnected()).isTrue();
-        assertThat(result.isAppleDisconnected()).isTrue();
+        Map<AuthVendor, Boolean> disconnectResults = result.disconnectResults();
+        assertThat(disconnectResults.get(AuthVendor.KAKAO)).isFalse();
 
         verify(getUserUseCase).getAllStatusUser(id);
         verify(user).withdraw();
-        verify(oauth2AccountUnlinkPort).unlinkKakaoAccount(kakaoOidcId);
-        verify(user).removeKakaoOidcId();
+        verify(oauth2AccountUnlinkPort).unlinkAccount(AuthVendor.KAKAO, kakaoOidcId);
+        verify(user).removeOidcId(AuthVendor.KAKAO);
         verify(updateUserPort).update(user);
-        verifyNoMoreInteractions(getUserUseCase, updateUserPort, oauth2AccountUnlinkPort);
     }
 
     @Test
@@ -121,50 +120,47 @@ class WithdrawUseCaseTest {
         Long id = 4L;
         String googleAccessToken = "google-token";
         User user = mock(User.class);
+        Map<AuthVendor, String> vendorCredentials = Map.of(AuthVendor.GOOGLE, googleAccessToken);
 
         when(getUserUseCase.getAllStatusUser(id)).thenReturn(user);
-        when(user.hasGoogleAccount()).thenReturn(true);
 
         // when
-        WithdrawResult result = withdrawService.withdrawUser(id, googleAccessToken);
+        WithdrawResult result = withdrawService.withdrawUser(id, vendorCredentials);
 
         // then
-        assertThat(result.isKakaoDisconnected()).isTrue();
-        assertThat(result.isGoogleDisconnected()).isTrue();
-        assertThat(result.isAppleDisconnected()).isTrue();
+        Map<AuthVendor, Boolean> disconnectResults = result.disconnectResults();
+        assertThat(disconnectResults.get(AuthVendor.GOOGLE)).isTrue();
 
         verify(getUserUseCase).getAllStatusUser(id);
         verify(user).withdraw();
-        verify(oauth2AccountUnlinkPort).unlinkGoogleAccount(googleAccessToken);
-        verify(user).removeGoogleOidcId();
+        verify(oauth2AccountUnlinkPort).unlinkAccount(AuthVendor.GOOGLE, googleAccessToken);
+        verify(user).removeOidcId(AuthVendor.GOOGLE);
         verify(updateUserPort).update(user);
-        verifyNoMoreInteractions(getUserUseCase, updateUserPort, oauth2AccountUnlinkPort);
     }
 
     @Test
-    @DisplayName("회원 탈퇴 요청 시 구글 계정이 있지만 토큰이 없으면 연결 해제 결과가 실패로 반환된다")
-    void withdrawUser_googleTokenMissing_returnsGoogleFalse() throws Exception {
+    @DisplayName("회원 탈퇴 요청 시 구글 계정이 있지만 토큰이 없으면 OIDC ID로 연결 해제를 시도한다")
+    void withdrawUser_googleNoToken_usesOidcId() throws Exception {
         // given
         Long id = 5L;
+        String googleOidcId = "google-oidc";
         User user = mock(User.class);
 
         when(getUserUseCase.getAllStatusUser(id)).thenReturn(user);
-        when(user.hasGoogleAccount()).thenReturn(true);
+        when(user.getOidcIdByVendor(AuthVendor.GOOGLE)).thenReturn(googleOidcId);
 
         // when
-        WithdrawResult result = withdrawService.withdrawUser(id, null);
+        WithdrawResult result = withdrawService.withdrawUser(id, Map.of());
 
         // then
-        assertThat(result.isKakaoDisconnected()).isTrue();
-        assertThat(result.isGoogleDisconnected()).isFalse();
-        assertThat(result.isAppleDisconnected()).isTrue();
+        Map<AuthVendor, Boolean> disconnectResults = result.disconnectResults();
+        assertThat(disconnectResults.get(AuthVendor.GOOGLE)).isTrue();
 
         verify(getUserUseCase).getAllStatusUser(id);
         verify(user).withdraw();
-        verify(oauth2AccountUnlinkPort, never()).unlinkGoogleAccount(anyString());
-        verify(user).removeGoogleOidcId();
+        verify(oauth2AccountUnlinkPort).unlinkAccount(AuthVendor.GOOGLE, googleOidcId);
+        verify(user).removeOidcId(AuthVendor.GOOGLE);
         verify(updateUserPort).update(user);
-        verifyNoMoreInteractions(getUserUseCase, updateUserPort, oauth2AccountUnlinkPort);
     }
 
     @Test
@@ -174,52 +170,49 @@ class WithdrawUseCaseTest {
         Long id = 6L;
         String googleAccessToken = "google-token";
         User user = mock(User.class);
+        Map<AuthVendor, String> vendorCredentials = Map.of(AuthVendor.GOOGLE, googleAccessToken);
         UnlinkOauth2AccountFailedException exception = new UnlinkOauth2AccountFailedException("fail");
 
         when(getUserUseCase.getAllStatusUser(id)).thenReturn(user);
-        when(user.hasGoogleAccount()).thenReturn(true);
-        doThrow(exception).when(oauth2AccountUnlinkPort).unlinkGoogleAccount(googleAccessToken);
+        doThrow(exception).when(oauth2AccountUnlinkPort).unlinkAccount(AuthVendor.GOOGLE, googleAccessToken);
 
         // when
-        WithdrawResult result = withdrawService.withdrawUser(id, googleAccessToken);
+        WithdrawResult result = withdrawService.withdrawUser(id, vendorCredentials);
 
         // then
-        assertThat(result.isKakaoDisconnected()).isTrue();
-        assertThat(result.isGoogleDisconnected()).isFalse();
-        assertThat(result.isAppleDisconnected()).isTrue();
+        Map<AuthVendor, Boolean> disconnectResults = result.disconnectResults();
+        assertThat(disconnectResults.get(AuthVendor.GOOGLE)).isFalse();
 
         verify(getUserUseCase).getAllStatusUser(id);
         verify(user).withdraw();
-        verify(oauth2AccountUnlinkPort).unlinkGoogleAccount(googleAccessToken);
-        verify(user).removeGoogleOidcId();
+        verify(oauth2AccountUnlinkPort).unlinkAccount(AuthVendor.GOOGLE, googleAccessToken);
+        verify(user).removeOidcId(AuthVendor.GOOGLE);
         verify(updateUserPort).update(user);
-        verifyNoMoreInteractions(getUserUseCase, updateUserPort, oauth2AccountUnlinkPort);
     }
 
     @Test
-    @DisplayName("회원 탈퇴 요청 시 애플 계정이 있으면 연결 해제 결과가 실패로 반환된다")
-    void withdrawUser_appleAccount_returnsAppleFalse() {
+    @DisplayName("회원 탈퇴 요청 시 애플 계정이 있으면 OIDC ID를 제거하고 연결 해제를 시도한다")
+    void withdrawUser_appleAccount_attemptsUnlink() throws Exception {
         // given
         Long id = 7L;
+        String appleOidcId = "apple-oidc";
         User user = mock(User.class);
 
         when(getUserUseCase.getAllStatusUser(id)).thenReturn(user);
-        when(user.hasAppleAccount()).thenReturn(true);
+        when(user.getOidcIdByVendor(AuthVendor.APPLE)).thenReturn(appleOidcId);
 
         // when
-        WithdrawResult result = withdrawService.withdrawUser(id, null);
+        WithdrawResult result = withdrawService.withdrawUser(id, Map.of());
 
         // then
-        assertThat(result.isKakaoDisconnected()).isTrue();
-        assertThat(result.isGoogleDisconnected()).isTrue();
-        assertThat(result.isAppleDisconnected()).isFalse();
+        Map<AuthVendor, Boolean> disconnectResults = result.disconnectResults();
+        assertThat(disconnectResults.get(AuthVendor.APPLE)).isTrue();
 
         verify(getUserUseCase).getAllStatusUser(id);
         verify(user).withdraw();
-        verify(user).removeAppleOidcId();
+        verify(oauth2AccountUnlinkPort).unlinkAccount(AuthVendor.APPLE, appleOidcId);
+        verify(user).removeOidcId(AuthVendor.APPLE);
         verify(updateUserPort).update(user);
-        verifyNoMoreInteractions(getUserUseCase, updateUserPort);
-        verifyNoInteractions(oauth2AccountUnlinkPort);
     }
 
     @Test
@@ -232,7 +225,7 @@ class WithdrawUseCaseTest {
         when(getUserUseCase.getAllStatusUser(id)).thenThrow(exception);
 
         // expect
-        assertThatThrownBy(() -> withdrawService.withdrawUser(id, "token"))
+        assertThatThrownBy(() -> withdrawService.withdrawUser(id, Map.of(AuthVendor.GOOGLE, "token")))
                 .isSameAs(exception);
 
         verify(getUserUseCase).getAllStatusUser(id);

--- a/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/user/User.java
+++ b/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/user/User.java
@@ -243,39 +243,22 @@ public class User extends BaseDomain {
         return withdrawalYn;
     }
 
-    public String getKakaoOidcId() {
+    public String getOidcIdByVendor(AuthVendor vendor) {
         return userOauth2Vendors.stream()
-                .filter(UserOauth2Vendor::isKakao)
+                .filter(v -> v.isVendor(vendor))
                 .findFirst()
-                .get()
-                .getOidcId();
+                .map(UserOauth2Vendor::getOidcId)
+                .orElse(null);
     }
 
-    public void removeKakaoOidcId() {
-        userOauth2Vendors.stream()
-                .filter(UserOauth2Vendor::isKakao)
-                .forEach(UserOauth2Vendor::removeOidcId);
-    }
-
-    public boolean hasGoogleAccount() {
+    public boolean hasAccount(AuthVendor vendor) {
         return userOauth2Vendors.stream()
-                .anyMatch(UserOauth2Vendor::hasGoogleAccount);
+                .anyMatch(v -> v.hasAccount(vendor));
     }
 
-    public void removeGoogleOidcId() {
+    public void removeOidcId(AuthVendor vendor) {
         userOauth2Vendors.stream()
-                .filter(UserOauth2Vendor::isGoogle)
-                .forEach(UserOauth2Vendor::removeOidcId);
-    }
-
-    public boolean hasAppleAccount() {
-        return userOauth2Vendors.stream()
-                .anyMatch(UserOauth2Vendor::hasAppleAccount);
-    }
-
-    public void removeAppleOidcId() {
-        userOauth2Vendors.stream()
-                .filter(UserOauth2Vendor::isApple)
+                .filter(v -> v.isVendor(vendor))
                 .forEach(UserOauth2Vendor::removeOidcId);
     }
 }

--- a/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/user/UserOauth2Vendor.java
+++ b/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/user/UserOauth2Vendor.java
@@ -59,24 +59,12 @@ public class UserOauth2Vendor {
         this.oidcId = oidcId;
     }
 
-    public boolean hasGoogleAccount() {
-        return isGoogle() && FormatValidator.hasValue(oidcId);
+    public boolean isVendor(AuthVendor vendor) {
+        return this.authVendor.isMe(vendor);
     }
 
-    public boolean hasAppleAccount() {
-        return isApple() && FormatValidator.hasValue(oidcId);
-    }
-
-    public boolean isKakao() {
-        return authVendor.isKakao();
-    }
-
-    public boolean isGoogle() {
-        return authVendor.isGoogle();
-    }
-
-    public boolean isApple() {
-        return authVendor.isApple();
+    public boolean hasAccount(AuthVendor vendor) {
+        return isVendor(vendor) && FormatValidator.hasValue(oidcId);
     }
 
     public void removeOidcId() {

--- a/user-service/user-domain/src/main/java/com/personal/marketnote/user/security/token/vendor/AuthVendor.java
+++ b/user-service/user-domain/src/main/java/com/personal/marketnote/user/security/token/vendor/AuthVendor.java
@@ -43,15 +43,4 @@ public enum AuthVendor {
         return this == authVendor;
     }
 
-    public boolean isKakao() {
-        return this == KAKAO;
-    }
-
-    public boolean isGoogle() {
-        return this == GOOGLE;
-    }
-
-    public boolean isApple() {
-        return this == APPLE;
-    }
 }


### PR DESCRIPTION
## partially addresses #43
## resolves #1693

## Task
- [x] Domain: User 벤더별 메서드를 벤더 비종속적 메서드로 통합 (getOidcIdByVendor, removeOidcId, hasAccount)
- [x] Domain: UserOauth2Vendor, AuthVendor 벤더별 술어 메서드 통합 (isVendor)
- [x] Application: OpaqueTokenDefaultIntrospector 벤더 issuer 하드코딩 제거, Map 주입 방식 전환
- [x] Application: Oauth2AccountUnlinkPort 벤더별 메서드를 단일 메서드로 통합
- [x] Application: WithdrawService 카카오/구글/애플 분기를 AuthVendor 반복으로 전환
- [x] Application: GoogleOAuth2ResponseParsingException을 OAuth2ResponseParsingException으로 변경
- [x] Application: WithdrawUseCase googleAccessToken을 Map vendorCredentials로 변경