### PR TITLE
[#387][#1694] refactor: 리워드 서비스 application/domain 레이어 오퍼월 벤더 종속 정보 제거

### DIFF
--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/offerwall/OfferwallSignatureValidationAdapter.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/offerwall/OfferwallSignatureValidationAdapter.java
@@ -1,0 +1,133 @@
+package com.personal.marketnote.reward.adapter.out.offerwall;
+
+import com.personal.marketnote.common.domain.exception.token.VendorVerificationFailedException;
+import com.personal.marketnote.common.security.vendor.VendorVerificationProcessor;
+import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.reward.configuration.AdiscopeHashKeyProperties;
+import com.personal.marketnote.reward.configuration.AdpopcornHashKeyProperties;
+import com.personal.marketnote.reward.configuration.TnkHashKeyProperties;
+import com.personal.marketnote.reward.domain.offerwall.OfferwallType;
+import com.personal.marketnote.reward.domain.offerwall.UserDeviceType;
+import com.personal.marketnote.reward.exception.InvalidOfferwallTypeException;
+import com.personal.marketnote.reward.exception.RewardTargetInfoNotFoundException;
+import com.personal.marketnote.reward.port.out.offerwall.ValidateOfferwallSignaturePort;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.stereotype.Component;
+
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.function.Function;
+
+@Component
+@RequiredArgsConstructor
+public class OfferwallSignatureValidationAdapter implements ValidateOfferwallSignaturePort {
+    private final AdpopcornHashKeyProperties adpopcornHashKeyProperties;
+    private final TnkHashKeyProperties tnkHashKeyProperties;
+    private final AdiscopeHashKeyProperties adiscopeHashKeyProperties;
+
+    @Override
+    public void validateSignature(
+            OfferwallType offerwallType,
+            UserDeviceType userDeviceType,
+            String signedValue,
+            String userKey,
+            String rewardKey,
+            Long quantity,
+            String campaignKey,
+            String rewardUnit
+    ) {
+        String hashKey = resolveHashKey(offerwallType, userDeviceType);
+        String plainText = buildPlainText(offerwallType, hashKey, userKey, rewardKey, quantity, campaignKey, rewardUnit);
+
+        Map<OfferwallType, Runnable> signatureValidators = buildSignatureValidators(
+                hashKey, plainText, signedValue
+        );
+
+        Runnable validator = signatureValidators.get(offerwallType);
+        if (FormatValidator.hasNoValue(validator)) {
+            throw new InvalidOfferwallTypeException(offerwallType.name());
+        }
+
+        validator.run();
+    }
+
+    private Map<OfferwallType, Runnable> buildSignatureValidators(
+            String hashKey,
+            String plainText,
+            String signedValue
+    ) {
+        Map<OfferwallType, Runnable> validators = new EnumMap<>(OfferwallType.class);
+        validators.put(OfferwallType.ADPOPCORN, () -> VendorVerificationProcessor.validateSignature(hashKey, plainText, signedValue));
+        validators.put(OfferwallType.TNK, () -> VendorVerificationProcessor.validateSignature(plainText, signedValue));
+        validators.put(OfferwallType.ADISCOPE, () -> VendorVerificationProcessor.validateSignature(hashKey, plainText, signedValue));
+        return validators;
+    }
+
+    private String buildPlainText(
+            OfferwallType offerwallType,
+            String hashKey,
+            String userKey,
+            String rewardKey,
+            Long quantity,
+            String campaignKey,
+            String rewardUnit
+    ) {
+        Map<OfferwallType, Function<Void, String>> plainTextBuilders = new EnumMap<>(OfferwallType.class);
+        plainTextBuilders.put(OfferwallType.ADPOPCORN, unused -> userKey + rewardKey + quantity + campaignKey);
+        plainTextBuilders.put(OfferwallType.TNK, unused -> hashKey + userKey + rewardKey);
+        plainTextBuilders.put(OfferwallType.ADISCOPE, unused -> userKey + rewardUnit + quantity + rewardKey);
+
+        Function<Void, String> builder = plainTextBuilders.get(offerwallType);
+        if (FormatValidator.hasNoValue(builder)) {
+            throw new InvalidOfferwallTypeException(offerwallType.name());
+        }
+
+        return builder.apply(null);
+    }
+
+    private String resolveHashKey(OfferwallType offerwallType, UserDeviceType userDeviceType) {
+        Map<OfferwallType, Map<UserDeviceType, String>> hashKeyMap = buildHashKeyMap();
+
+        Map<UserDeviceType, String> deviceHashKeys = hashKeyMap.get(offerwallType);
+        if (FormatValidator.hasNoValue(deviceHashKeys)) {
+            throw new InvalidOfferwallTypeException(offerwallType.name());
+        }
+
+        String hashKey = deviceHashKeys.get(userDeviceType);
+        if (FormatValidator.hasNoValue(hashKey)) {
+            throw new RewardTargetInfoNotFoundException("오퍼월 리워드 지급 대상 디바이스 정보가 없습니다.");
+        }
+
+        return requireHashKey(hashKey);
+    }
+
+    private Map<OfferwallType, Map<UserDeviceType, String>> buildHashKeyMap() {
+        Map<OfferwallType, Map<UserDeviceType, String>> hashKeyMap = new EnumMap<>(OfferwallType.class);
+
+        Map<UserDeviceType, String> adpopcornKeys = new EnumMap<>(UserDeviceType.class);
+        adpopcornKeys.put(UserDeviceType.ANDROID, adpopcornHashKeyProperties.getAndroid());
+        adpopcornKeys.put(UserDeviceType.IOS, adpopcornHashKeyProperties.getIos());
+        hashKeyMap.put(OfferwallType.ADPOPCORN, adpopcornKeys);
+
+        Map<UserDeviceType, String> tnkKeys = new EnumMap<>(UserDeviceType.class);
+        tnkKeys.put(UserDeviceType.ANDROID, tnkHashKeyProperties.getAndroid());
+        tnkKeys.put(UserDeviceType.IOS, tnkHashKeyProperties.getIos());
+        hashKeyMap.put(OfferwallType.TNK, tnkKeys);
+
+        Map<UserDeviceType, String> adiscopeKeys = new EnumMap<>(UserDeviceType.class);
+        adiscopeKeys.put(UserDeviceType.ANDROID, adiscopeHashKeyProperties.getAndroid());
+        adiscopeKeys.put(UserDeviceType.IOS, adiscopeHashKeyProperties.getIos());
+        hashKeyMap.put(OfferwallType.ADISCOPE, adiscopeKeys);
+
+        return hashKeyMap;
+    }
+
+    private String requireHashKey(String hashKey) {
+        if (FormatValidator.hasValue(hashKey)) {
+            return hashKey;
+        }
+
+        throw new VendorVerificationFailedException("오퍼월 해시 키가 설정되지 않았습니다.");
+    }
+}

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/configuration/AdiscopeHashKeyProperties.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/configuration/AdiscopeHashKeyProperties.java
@@ -1,0 +1,15 @@
+package com.personal.marketnote.reward.configuration;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "vendor.offerwall.adiscope.hash-key")
+public class AdiscopeHashKeyProperties {
+    private String android;
+    private String ios;
+}

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/configuration/AdpopcornHashKeyProperties.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/configuration/AdpopcornHashKeyProperties.java
@@ -1,0 +1,15 @@
+package com.personal.marketnote.reward.configuration;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "vendor.offerwall.adpopcorn.hash-key")
+public class AdpopcornHashKeyProperties {
+    private String android;
+    private String ios;
+}

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/configuration/TnkHashKeyProperties.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/configuration/TnkHashKeyProperties.java
@@ -1,0 +1,15 @@
+package com.personal.marketnote.reward.configuration;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "vendor.offerwall.tnk.hash-key")
+public class TnkHashKeyProperties {
+    private String android;
+    private String ios;
+}

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/command/offerwall/RegisterOfferwallRewardCommand.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/command/offerwall/RegisterOfferwallRewardCommand.java
@@ -2,7 +2,6 @@ package com.personal.marketnote.reward.port.in.command.offerwall;
 
 import com.personal.marketnote.reward.domain.offerwall.OfferwallType;
 import com.personal.marketnote.reward.domain.offerwall.UserDeviceType;
-import com.personal.marketnote.reward.exception.InvalidOfferwallTypeException;
 import lombok.Builder;
 
 import java.time.LocalDateTime;
@@ -25,39 +24,4 @@ public record RegisterOfferwallRewardCommand(
         String idfa,
         LocalDateTime attendedAt
 ) {
-    public boolean isAdpopcorn() {
-        return offerwallType.isAdpopcorn();
-    }
-
-    public boolean isTnk() {
-        return offerwallType.isTnk();
-    }
-
-    public boolean isAdiscope() {
-        return offerwallType.isAdiscope();
-    }
-
-    public boolean isAndroid() {
-        return userDeviceType.isAndroid();
-    }
-
-    public boolean isIos() {
-        return userDeviceType.isIos();
-    }
-
-    public String buildPlainText(String hashKey) {
-        if (isAdpopcorn()) {
-            return userKey + rewardKey + quantity + campaignKey;
-        }
-
-        if (isTnk()) {
-            return hashKey + userKey + rewardKey;
-        }
-
-        if (isAdiscope()) {
-            return userKey + rewardUnit + quantity + rewardKey;
-        }
-
-        throw new InvalidOfferwallTypeException(offerwallType.name());
-    }
 }

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/out/offerwall/ValidateOfferwallSignaturePort.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/out/offerwall/ValidateOfferwallSignaturePort.java
@@ -1,0 +1,37 @@
+package com.personal.marketnote.reward.port.out.offerwall;
+
+import com.personal.marketnote.reward.domain.offerwall.OfferwallType;
+import com.personal.marketnote.reward.domain.offerwall.UserDeviceType;
+
+/**
+ * 오퍼월 서명 검증 포트
+ *
+ * @Author 성효빈
+ * @Date 2026-03-27
+ * @Description 오퍼월 벤더별 서명 검증 기능을 제공합니다. 벤더별 구현 세부사항은 adapter에서 처리합니다.
+ */
+public interface ValidateOfferwallSignaturePort {
+    /**
+     * @param offerwallType  오퍼월 타입
+     * @param userDeviceType 사용자 디바이스 타입
+     * @param signedValue    서명 값
+     * @param userKey        회원 키
+     * @param rewardKey      리워드 키
+     * @param quantity       수량
+     * @param campaignKey    캠페인 키
+     * @param rewardUnit     보상 화폐 단위
+     * @Date 2026-03-27
+     * @Author 성효빈
+     * @Description 오퍼월 벤더별 서명을 검증합니다.
+     */
+    void validateSignature(
+            OfferwallType offerwallType,
+            UserDeviceType userDeviceType,
+            String signedValue,
+            String userKey,
+            String rewardKey,
+            Long quantity,
+            String campaignKey,
+            String rewardUnit
+    );
+}

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/service/offerwall/RegisterOfferwallRewardService.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/service/offerwall/RegisterOfferwallRewardService.java
@@ -1,19 +1,12 @@
 package com.personal.marketnote.reward.service.offerwall;
 
 import com.personal.marketnote.common.application.UseCase;
-import com.personal.marketnote.common.domain.exception.token.VendorVerificationFailedException;
 import com.personal.marketnote.common.exception.UserNotFoundException;
-import com.personal.marketnote.common.security.vendor.VendorVerificationProcessor;
 import com.personal.marketnote.common.utility.FormatValidator;
-import com.personal.marketnote.reward.configuration.AdiscopeHashKeyProperties;
-import com.personal.marketnote.reward.configuration.AdpopcornHashKeyProperties;
-import com.personal.marketnote.reward.configuration.TnkHashKeyProperties;
 import com.personal.marketnote.reward.domain.offerwall.OfferwallMapper;
 import com.personal.marketnote.reward.domain.point.UserPointChangeType;
 import com.personal.marketnote.reward.domain.point.UserPointSourceType;
 import com.personal.marketnote.reward.exception.DuplicateOfferwallRewardException;
-import com.personal.marketnote.reward.exception.InvalidOfferwallTypeException;
-import com.personal.marketnote.reward.exception.RewardTargetInfoNotFoundException;
 import com.personal.marketnote.reward.mapper.RewardCommandToStateMapper;
 import com.personal.marketnote.reward.port.in.command.offerwall.RegisterOfferwallRewardCommand;
 import com.personal.marketnote.reward.port.in.command.point.ModifyUserPointCommand;
@@ -21,6 +14,7 @@ import com.personal.marketnote.reward.port.in.usecase.offerwall.GetOfferwallMapp
 import com.personal.marketnote.reward.port.in.usecase.offerwall.RegisterOfferwallRewardUseCase;
 import com.personal.marketnote.reward.port.in.usecase.point.GetUserPointUseCase;
 import com.personal.marketnote.reward.port.out.offerwall.SaveOfferwallMapperPort;
+import com.personal.marketnote.reward.port.out.offerwall.ValidateOfferwallSignaturePort;
 import com.personal.marketnote.reward.service.point.ModifyUserPointService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -38,9 +32,7 @@ public class RegisterOfferwallRewardService implements RegisterOfferwallRewardUs
     private final ModifyUserPointService modifyUserPointService;
     private final SaveOfferwallMapperPort saveOfferwallMapperPort;
     private final GetOfferwallMapperUseCase getOfferwallMapperUseCase;
-    private final AdpopcornHashKeyProperties adpopcornHashKeyProperties;
-    private final TnkHashKeyProperties tnkHashKeyProperties;
-    private final AdiscopeHashKeyProperties adiscopeHashKeyProperties;
+    private final ValidateOfferwallSignaturePort validateOfferwallSignaturePort;
 
     @Override
     public Long register(RegisterOfferwallRewardCommand command) {
@@ -77,65 +69,16 @@ public class RegisterOfferwallRewardService implements RegisterOfferwallRewardUs
     }
 
     private void validateSignature(RegisterOfferwallRewardCommand command) {
-        String hashKey = resolveHashKey(command);
-        String plainText = command.buildPlainText(hashKey);
-
-        if (command.isAdpopcorn()) {
-            VendorVerificationProcessor.validateSignature(hashKey, plainText, command.signedValue());
-            return;
-        }
-
-        if (command.isTnk()) {
-            VendorVerificationProcessor.validateSignature(plainText, command.signedValue());
-            return;
-        }
-
-        if (command.isAdiscope()) {
-            VendorVerificationProcessor.validateSignature(hashKey, plainText, command.signedValue());
-            return;
-        }
-
-        throw new InvalidOfferwallTypeException(String.valueOf(command.offerwallType()));
-    }
-
-    private String resolveHashKey(RegisterOfferwallRewardCommand command) {
-        if (command.isAndroid()) {
-            if (command.isAdpopcorn()) {
-                return requireHashKey(adpopcornHashKeyProperties.getAndroid());
-            }
-
-            if (command.isTnk()) {
-                return requireHashKey(tnkHashKeyProperties.getAndroid());
-            }
-
-            if (command.isAdiscope()) {
-                return requireHashKey(adiscopeHashKeyProperties.getAndroid());
-            }
-        }
-
-        if (command.isIos()) {
-            if (command.isAdpopcorn()) {
-                return requireHashKey(adpopcornHashKeyProperties.getIos());
-            }
-
-            if (command.isTnk()) {
-                return requireHashKey(tnkHashKeyProperties.getIos());
-            }
-
-            if (command.isAdiscope()) {
-                return requireHashKey(adiscopeHashKeyProperties.getIos());
-            }
-        }
-
-        throw new RewardTargetInfoNotFoundException("오퍼월 리워드 지급 대상 디바이스 정보가 없습니다.");
-    }
-
-    private String requireHashKey(String hashKey) {
-        if (FormatValidator.hasValue(hashKey)) {
-            return hashKey;
-        }
-
-        throw new VendorVerificationFailedException("오퍼월 해시 키가 설정되지 않았습니다.");
+        validateOfferwallSignaturePort.validateSignature(
+                command.offerwallType(),
+                command.userDeviceType(),
+                command.signedValue(),
+                command.userKey(),
+                command.rewardKey(),
+                command.quantity(),
+                command.campaignKey(),
+                command.rewardUnit()
+        );
     }
 
     private void validateUser(RegisterOfferwallRewardCommand command) {

--- a/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/offerwall/OfferwallType.java
+++ b/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/offerwall/OfferwallType.java
@@ -11,16 +11,4 @@ public enum OfferwallType {
     ADISCOPE("애디스콥");
 
     private final String description;
-
-    public boolean isAdpopcorn() {
-        return this == ADPOPCORN;
-    }
-
-    public boolean isTnk() {
-        return this == TNK;
-    }
-
-    public boolean isAdiscope() {
-        return this == ADISCOPE;
-    }
 }


### PR DESCRIPTION
## partially addresses #387
## resolves #1694

## Task
- [x] Domain: OfferwallType enum에서 벤더별 술어 메서드 제거
- [x] Application: 3개 HashKey Properties 설정 클래스를 adapter 레이어로 이동
- [x] Application: RegisterOfferwallRewardCommand에서 벤더별 서명 로직 제거
- [x] Application: RegisterOfferwallRewardService에서 벤더별 분기 로직을 ValidateOfferwallSignaturePort에 위임
- [x] Adapter: OfferwallSignatureValidationAdapter 구현체 신규 생성 (EnumMap 기반 벤더별 서명 검증)