### PR TITLE
[#194][#1695] refactor: 파일 서비스 application/domain 레이어 AWS S3 벤더 종속 정보 제거

### DIFF
--- a/common/src/main/java/com/personal/marketnote/common/application/file/port/in/result/GetFileResult.java
+++ b/common/src/main/java/com/personal/marketnote/common/application/file/port/in/result/GetFileResult.java
@@ -7,8 +7,8 @@ public record GetFileResult(
         String sort,
         String extension,
         String name,
-        String s3Url,
-        List<String> resizedS3Urls,
+        String storageUrl,
+        List<String> resizedStorageUrls,
         Long orderNum
 ) {
 }

--- a/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/in/web/post/controller/apidocs/GetPostsApiDocs.java
+++ b/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/in/web/post/controller/apidocs/GetPostsApiDocs.java
@@ -143,8 +143,8 @@ import java.lang.annotation.*;
                 | sort | string | 이미지 정렬 순서 | "POST_IMAGE" |
                 | extension | string | 이미지 확장자 | "jpg" |
                 | name | string | 이미지 이름 | "게시글 이미지" |
-                | s3Url | string | S3 URL | "https://marketnote.s3.amazonaws.com/post/1/1765528094927_image.png" |
-                | resizedS3Urls | array | 리사이즈 이미지 S3 URL 목록 | [] |
+                | storageUrl | string | 스토리지 URL | "https://marketnote.s3.amazonaws.com/post/1/1765528094927_image.png" |
+                | resizedStorageUrls | array | 리사이즈 이미지 스토리지 URL 목록 | [] |
                 | orderNum | number | 정렬 순서 | 1 |
                 """,
         parameters = {
@@ -289,8 +289,8 @@ import java.lang.annotation.*;
                                                       "sort": "POST_IMAGE",
                                                       "extension": "jpg",
                                                       "name": "게시글 이미지",
-                                                      "s3Url": "https://marketnote.s3.amazonaws.com/post/1/1765528094927_image.png",
-                                                      "resizedS3Urls": [],
+                                                      "storageUrl": "https://marketnote.s3.amazonaws.com/post/1/1765528094927_image.png",
+                                                      "resizedStorageUrls": [],
                                                       "orderNum": 1
                                                     }
                                                   ],

--- a/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/in/web/review/controller/apidocs/GetMyReviewsApiDocs.java
+++ b/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/in/web/review/controller/apidocs/GetMyReviewsApiDocs.java
@@ -127,8 +127,8 @@ import java.lang.annotation.*;
                 | sort | string | 이미지 정렬 순서 | "REVIEW_IMAGE" |
                 | extension | string | 이미지 확장자 | "png" |
                 | name | string | 이미지 이름 | "리뷰2" |
-                | s3Url | string | S3 URL | "https://marketnote.s3.amazonaws.com/review/35/1765528094927_image.png" |
-                | resizedS3Urls | array | 리사이즈 이미지 S3 URL 목록 | ["https://bucket.s3.amazonaws.com/product/1/300x300_original.jpg", "https://bucket.s3.amazonaws.com/product/1/500x500_original.jpg"] |
+                | storageUrl | string | 스토리지 URL | "https://marketnote.s3.amazonaws.com/review/35/1765528094927_image.png" |
+                | resizedStorageUrls | array | 리사이즈 이미지 스토리지 URL 목록 | ["https://bucket.s3.amazonaws.com/product/1/300x300_original.jpg", "https://bucket.s3.amazonaws.com/product/1/500x500_original.jpg"] |
                 | orderNum | number | 정렬 순서 | 79 |
                 """,
         parameters = {
@@ -223,8 +223,8 @@ import java.lang.annotation.*;
                                                       "sort": "PRODUCT_CATALOG_IMAGE",
                                                       "extension": "jpg",
                                                       "name": "스프링노트1",
-                                                      "s3Url": "https://marketnote.s3.amazonaws.com/product/30/1763521042462_grafana-icon.png",
-                                                      "resizedS3Urls": [
+                                                      "storageUrl": "https://marketnote.s3.amazonaws.com/product/30/1763521042462_grafana-icon.png",
+                                                      "resizedStorageUrls": [
                                                         "https://marketnote.s3.amazonaws.com/product/30/1763521042802_grafana-icon_300x300.png"
                                                       ],
                                                       "orderNum": 28
@@ -267,8 +267,8 @@ import java.lang.annotation.*;
                                                       "sort": "PRODUCT_CATALOG_IMAGE",
                                                       "extension": "jpg",
                                                       "name": "스프링노트1",
-                                                      "s3Url": "https://marketnote.s3.amazonaws.com/product/30/1763521042462_grafana-icon.png",
-                                                      "resizedS3Urls": [
+                                                      "storageUrl": "https://marketnote.s3.amazonaws.com/product/30/1763521042462_grafana-icon.png",
+                                                      "resizedStorageUrls": [
                                                         "https://marketnote.s3.amazonaws.com/product/30/1763521042802_grafana-icon_300x300.png"
                                                       ],
                                                       "orderNum": 28
@@ -294,8 +294,8 @@ import java.lang.annotation.*;
                                                       "sort": "REVIEW_IMAGE",
                                                       "extension": "png",
                                                       "name": "리뷰2",
-                                                      "s3Url": "https://marketnote.s3.amazonaws.com/review/35/1765528094927_image.png",
-                                                      "resizedS3Urls": [],
+                                                      "storageUrl": "https://marketnote.s3.amazonaws.com/review/35/1765528094927_image.png",
+                                                      "resizedStorageUrls": [],
                                                       "orderNum": 79
                                                     },
                                                     {
@@ -303,8 +303,8 @@ import java.lang.annotation.*;
                                                       "sort": "REVIEW_IMAGE",
                                                       "extension": "jpg",
                                                       "name": "리뷰1",
-                                                      "s3Url": "https://marketnote.s3.amazonaws.com/review/35/1765528092213_grafana-icon.png",
-                                                      "resizedS3Urls": [],
+                                                      "storageUrl": "https://marketnote.s3.amazonaws.com/review/35/1765528092213_grafana-icon.png",
+                                                      "resizedStorageUrls": [],
                                                       "orderNum": 78
                                                     }
                                                   ],
@@ -330,8 +330,8 @@ import java.lang.annotation.*;
                                                       "sort": "PRODUCT_CATALOG_IMAGE",
                                                       "extension": "jpg",
                                                       "name": "스프링노트1",
-                                                      "s3Url": "https://marketnote.s3.amazonaws.com/product/30/1763521042462_grafana-icon.png",
-                                                      "resizedS3Urls": [
+                                                      "storageUrl": "https://marketnote.s3.amazonaws.com/product/30/1763521042462_grafana-icon.png",
+                                                      "resizedStorageUrls": [
                                                         "https://marketnote.s3.amazonaws.com/product/30/1763521042802_grafana-icon_300x300.png"
                                                       ],
                                                       "orderNum": 28
@@ -374,8 +374,8 @@ import java.lang.annotation.*;
                                                       "sort": "PRODUCT_CATALOG_IMAGE",
                                                       "extension": "jpg",
                                                       "name": "스프링노트1",
-                                                      "s3Url": "https://marketnote.s3.amazonaws.com/product/30/1763521042462_grafana-icon.png",
-                                                      "resizedS3Urls": [
+                                                      "storageUrl": "https://marketnote.s3.amazonaws.com/product/30/1763521042462_grafana-icon.png",
+                                                      "resizedStorageUrls": [
                                                         "https://marketnote.s3.amazonaws.com/product/30/1763521042802_grafana-icon_300x300.png"
                                                       ],
                                                       "orderNum": 28

--- a/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/in/web/review/controller/apidocs/GetProductReviewsApiDocs.java
+++ b/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/in/web/review/controller/apidocs/GetProductReviewsApiDocs.java
@@ -109,8 +109,8 @@ import java.lang.annotation.*;
                 | sort | string | 이미지 정렬 순서 | "REVIEW_IMAGE" |
                 | extension | string | 이미지 확장자 | "png" |
                 | name | string | 이미지 이름 | "리뷰2" |
-                | s3Url | string | S3 URL | "https://marketnote.s3.amazonaws.com/review/35/1765528094927_image.png" |
-                | resizedS3Urls | array | 리사이즈 이미지 S3 URL 목록 | ["https://bucket.s3.amazonaws.com/product/1/300x300_original.jpg", "https://bucket.s3.amazonaws.com/product/1/500x500_original.jpg"] |
+                | storageUrl | string | 스토리지 URL | "https://marketnote.s3.amazonaws.com/review/35/1765528094927_image.png" |
+                | resizedStorageUrls | array | 리사이즈 이미지 스토리지 URL 목록 | ["https://bucket.s3.amazonaws.com/product/1/300x300_original.jpg", "https://bucket.s3.amazonaws.com/product/1/500x500_original.jpg"] |
                 | orderNum | number | 정렬 순서 | 79 |
                 """,
         parameters = {
@@ -200,8 +200,8 @@ import java.lang.annotation.*;
                                                       "sort": "REVIEW_IMAGE",
                                                       "extension": "png",
                                                       "name": "리뷰2",
-                                                      "s3Url": "https://marketnote.s3.amazonaws.com/review/35/1765528094927_image.png",
-                                                      "resizedS3Urls": [],
+                                                      "storageUrl": "https://marketnote.s3.amazonaws.com/review/35/1765528094927_image.png",
+                                                      "resizedStorageUrls": [],
                                                       "orderNum": 79
                                                     },
                                                     {
@@ -209,8 +209,8 @@ import java.lang.annotation.*;
                                                       "sort": "REVIEW_IMAGE",
                                                       "extension": "jpg",
                                                       "name": "리뷰1",
-                                                      "s3Url": "https://marketnote.s3.amazonaws.com/review/35/1765528092213_grafana-icon.png",
-                                                      "resizedS3Urls": [],
+                                                      "storageUrl": "https://marketnote.s3.amazonaws.com/review/35/1765528092213_grafana-icon.png",
+                                                      "resizedStorageUrls": [],
                                                       "orderNum": 78
                                                     }
                                                   ],

--- a/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/in/web/review/controller/apidocs/GetReviewApiDocs.java
+++ b/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/in/web/review/controller/apidocs/GetReviewApiDocs.java
@@ -96,8 +96,8 @@ import java.lang.annotation.*;
                                                 "sort": "REVIEW_IMAGE",
                                                 "extension": "png",
                                                 "name": "리뷰2",
-                                                "s3Url": "https://marketnote.s3.amazonaws.com/review/35/1765528094927_image.png",
-                                                "resizedS3Urls": [],
+                                                "storageUrl": "https://marketnote.s3.amazonaws.com/review/35/1765528094927_image.png",
+                                                "resizedStorageUrls": [],
                                                 "orderNum": 79
                                               },
                                               {
@@ -105,8 +105,8 @@ import java.lang.annotation.*;
                                                 "sort": "REVIEW_IMAGE",
                                                 "extension": "jpg",
                                                 "name": "리뷰1",
-                                                "s3Url": "https://marketnote.s3.amazonaws.com/review/35/1765528092213_grafana-icon.png",
-                                                "resizedS3Urls": [],
+                                                "storageUrl": "https://marketnote.s3.amazonaws.com/review/35/1765528092213_grafana-icon.png",
+                                                "resizedStorageUrls": [],
                                                 "orderNum": 78
                                               }
                                             ],

--- a/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/out/web/file/FileServiceClient.java
+++ b/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/out/web/file/FileServiceClient.java
@@ -124,8 +124,8 @@ public class FileServiceClient implements FindReviewImagesPort, FindPostImagesPo
                                 getFileResult.sort,
                                 getFileResult.extension,
                                 getFileResult.name,
-                                getFileResult.s3Url,
-                                getFileResult.resizedS3Urls,
+                                getFileResult.storageUrl,
+                                getFileResult.resizedStorageUrls,
                                 getFileResult.orderNum
                         ))
                         .toList();
@@ -242,11 +242,11 @@ public class FileServiceClient implements FindReviewImagesPort, FindPostImagesPo
         @JsonProperty("name")
         String name;
 
-        @JsonProperty("s3Url")
-        String s3Url;
+        @JsonProperty("storageUrl")
+        String storageUrl;
 
-        @JsonProperty("resizedS3Urls")
-        List<String> resizedS3Urls;
+        @JsonProperty("resizedStorageUrls")
+        List<String> resizedStorageUrls;
 
         @JsonProperty("orderNum")
         Long orderNum;

--- a/community-service/community-adapters/src/test/java/com/personal/marketnote/community/adapter/out/web/file/FileServiceClientTest.java
+++ b/community-service/community-adapters/src/test/java/com/personal/marketnote/community/adapter/out/web/file/FileServiceClientTest.java
@@ -84,8 +84,8 @@ class FileServiceClientTest {
                                             "sort": "REVIEW_IMAGE",
                                             "extension": "jpg",
                                             "name": "review1.jpg",
-                                            "s3Url": "https://s3.example.com/review1.jpg",
-                                            "resizedS3Urls": ["https://s3.example.com/review1_200.jpg"],
+                                            "storageUrl": "https://s3.example.com/review1.jpg",
+                                            "resizedStorageUrls": ["https://s3.example.com/review1_200.jpg"],
                                             "orderNum": 1
                                         }
                                     ]
@@ -156,8 +156,8 @@ class FileServiceClientTest {
                                             "sort": "POST_IMAGE",
                                             "extension": "png",
                                             "name": "post1.png",
-                                            "s3Url": "https://s3.example.com/post1.png",
-                                            "resizedS3Urls": [],
+                                            "storageUrl": "https://s3.example.com/post1.png",
+                                            "resizedStorageUrls": [],
                                             "orderNum": 1
                                         }
                                     ]

--- a/file-service/file-adapters/src/main/java/com/personal/marketnote/file/adapter/in/client/file/controller/apidocs/GetFilesApiDocs.java
+++ b/file-service/file-adapters/src/main/java/com/personal/marketnote/file/adapter/in/client/file/controller/apidocs/GetFilesApiDocs.java
@@ -89,8 +89,8 @@ import java.lang.annotation.*;
                 | sort | string | 파일 종류 | "PRODUCT_CATALOG_IMAGE" |
                 | extension | string | 파일 확장자 | "jpg" |
                 | name | string | 파일명 | "스프링노트1" |
-                | s3Url | string | S3 URL | "https://bucket.s3.amazonaws.com/product/1/original.jpg" |
-                | resizedS3Urls | array | 리사이즈 이미지 S3 URL 목록 | ["https://bucket.s3.amazonaws.com/product/1/300x300_original.jpg", "https://bucket.s3.amazonaws.com/product/1/500x500_original.jpg"] |
+                | storageUrl | string | 스토리지 URL | "https://bucket.s3.amazonaws.com/product/1/original.jpg" |
+                | resizedStorageUrls | array | 리사이즈 이미지 스토리지 URL 목록 | ["https://bucket.s3.amazonaws.com/product/1/300x300_original.jpg", "https://bucket.s3.amazonaws.com/product/1/500x500_original.jpg"] |
                 """,
         security = {@SecurityRequirement(name = "bearer")},
         parameters = {
@@ -124,8 +124,8 @@ import java.lang.annotation.*;
                                                 "sort": "PRODUCT_CATALOG_IMAGE",
                                                 "extension": "png",
                                                 "name": "스프링노트1",
-                                                "s3Url": "https://marketnote.s3.amazonaws.com/product/1/1763456309061_gungisick1.png",
-                                                "resizedS3Urls": [
+                                                "storageUrl": "https://marketnote.s3.amazonaws.com/product/1/1763456309061_gungisick1.png",
+                                                "resizedStorageUrls": [
                                                   "https://marketnote.s3.amazonaws.com/product/1/1763456309061_gungisick1_300x300.png",
                                                   "https://marketnote.s3.amazonaws.com/product/1/1763456309061_gungisick1_500x500.png"
                                                 ]
@@ -135,8 +135,8 @@ import java.lang.annotation.*;
                                                 "sort": "PRODUCT_CATALOG_IMAGE",
                                                 "extension": "png",
                                                 "name": "스프링노트2",
-                                                "s3Url": "https://marketnote.s3.amazonaws.com/product/1/1763456845957_gungisick2.png",
-                                                "resizedS3Urls": [
+                                                "storageUrl": "https://marketnote.s3.amazonaws.com/product/1/1763456845957_gungisick2.png",
+                                                "resizedStorageUrls": [
                                                   "https://marketnote.s3.amazonaws.com/product/1/1763456845957_gungisick2_300x300.png",
                                                   "https://marketnote.s3.amazonaws.com/product/1/1763456845957_gungisick2_500x500.png"
                                                 ]

--- a/file-service/file-adapters/src/main/java/com/personal/marketnote/file/adapter/out/mapper/FileJpaEntityToDomainMapper.java
+++ b/file-service/file-adapters/src/main/java/com/personal/marketnote/file/adapter/out/mapper/FileJpaEntityToDomainMapper.java
@@ -18,7 +18,7 @@ public class FileJpaEntityToDomainMapper {
                                 .sort(FileSort.from(entity.getSort()))
                                 .extension(entity.getExtension())
                                 .name(entity.getName())
-                                .s3Url(entity.getS3Url())
+                                .storageUrl(entity.getStorageUrl())
                                 .createdAt(entity.getCreatedAt())
                                 .status(entity.getStatus())
                                 .orderNum(entity.getOrderNum())

--- a/file-service/file-adapters/src/main/java/com/personal/marketnote/file/adapter/out/persistence/file/FilePersistenceAdapter.java
+++ b/file-service/file-adapters/src/main/java/com/personal/marketnote/file/adapter/out/persistence/file/FilePersistenceAdapter.java
@@ -12,7 +12,7 @@ import com.personal.marketnote.file.adapter.out.persistence.file.repository.Resi
 import com.personal.marketnote.file.domain.file.FileDomain;
 import com.personal.marketnote.file.domain.file.ResizedFile;
 import com.personal.marketnote.file.exception.FileNotFoundException;
-import com.personal.marketnote.file.exception.InvalidFileS3UrlsSizeException;
+import com.personal.marketnote.file.exception.InvalidFileStorageUrlsSizeException;
 import com.personal.marketnote.file.port.out.file.FindFilePort;
 import com.personal.marketnote.file.port.out.file.SaveFilesPort;
 import com.personal.marketnote.file.port.out.file.UpdateFilePort;
@@ -31,17 +31,17 @@ public class FilePersistenceAdapter implements SaveFilesPort, FindFilePort, Upda
     private final ResizedFileJpaRepository resizedFileJpaRepository;
 
     @Override
-    public List<FileDomain> saveAll(List<FileDomain> files, List<String> s3Urls) {
+    public List<FileDomain> saveAll(List<FileDomain> files, List<String> storageUrls) {
         if (FormatValidator.hasNoValue(files)) {
             return List.of();
         }
-        if (FormatValidator.hasNoValue(s3Urls) || s3Urls.size() != files.size()) {
-            throw new InvalidFileS3UrlsSizeException();
+        if (FormatValidator.hasNoValue(storageUrls) || storageUrls.size() != files.size()) {
+            throw new InvalidFileStorageUrlsSizeException();
         }
 
         List<FileJpaEntity> toSave = new ArrayList<>(files.size());
         for (int i = 0; i < files.size(); i++) {
-            toSave.add(FileJpaEntity.from(files.get(i), s3Urls.get(i)));
+            toSave.add(FileJpaEntity.from(files.get(i), storageUrls.get(i)));
         }
 
         List<FileJpaEntity> savedList = fileJpaRepository.saveAll(toSave);

--- a/file-service/file-adapters/src/main/java/com/personal/marketnote/file/adapter/out/persistence/file/ResizedFilePersistenceAdapter.java
+++ b/file-service/file-adapters/src/main/java/com/personal/marketnote/file/adapter/out/persistence/file/ResizedFilePersistenceAdapter.java
@@ -29,7 +29,7 @@ public class ResizedFilePersistenceAdapter implements SaveResizedFilesPort, Find
         List<ResizedFileJpaEntity> toSave = new ArrayList<>(resizedFiles.size());
         for (ResizedFile f : resizedFiles) {
             FileJpaEntity fileRef = fileJpaRepository.getReferenceById(f.getFileId());
-            toSave.add(ResizedFileJpaEntity.of(fileRef, f.getSize(), f.getS3Url()));
+            toSave.add(ResizedFileJpaEntity.of(fileRef, f.getSize(), f.getStorageUrl()));
         }
 
         resizedFileJpaRepository.saveAll(toSave);
@@ -43,7 +43,7 @@ public class ResizedFilePersistenceAdapter implements SaveResizedFilesPort, Find
                             e.getId(),
                             e.getFile().getId(),
                             e.getSize(),
-                            e.getS3Url(),
+                            e.getStorageUrl(),
                             e.getCreatedAt(),
                             e.getStatus()
                     )).toList();

--- a/file-service/file-adapters/src/main/java/com/personal/marketnote/file/adapter/out/persistence/file/entity/FileJpaEntity.java
+++ b/file-service/file-adapters/src/main/java/com/personal/marketnote/file/adapter/out/persistence/file/entity/FileJpaEntity.java
@@ -38,18 +38,18 @@ public class FileJpaEntity extends BaseGeneralEntity {
     private String name;
 
     @Column(name = "s3_url", nullable = false, length = 511)
-    private String s3Url;
+    private String storageUrl;
 
     private Long orderNum;
 
-    public static FileJpaEntity from(FileDomain domain, String s3Url) {
+    public static FileJpaEntity from(FileDomain domain, String storageUrl) {
         return FileJpaEntity.builder()
                 .ownerType(domain.getOwnerType())
                 .ownerId(domain.getOwnerId())
                 .sort(domain.getSort().name())
                 .extension(domain.getExtension())
                 .name(domain.getName())
-                .s3Url(s3Url)
+                .storageUrl(storageUrl)
                 .build();
     }
 
@@ -59,7 +59,7 @@ public class FileJpaEntity extends BaseGeneralEntity {
 
     public void updateFrom(FileDomain file) {
         updateActivation(file);
-        s3Url = file.getS3Url();
+        storageUrl = file.getStorageUrl();
         name = file.getName();
         extension = file.getExtension();
         sort = file.getSort().name();

--- a/file-service/file-adapters/src/main/java/com/personal/marketnote/file/adapter/out/persistence/file/entity/ResizedFileJpaEntity.java
+++ b/file-service/file-adapters/src/main/java/com/personal/marketnote/file/adapter/out/persistence/file/entity/ResizedFileJpaEntity.java
@@ -28,7 +28,7 @@ public class ResizedFileJpaEntity extends BaseGeneralEntity {
     private String size;
 
     @Column(name = "s3_url", nullable = false, length = 1024)
-    private String s3Url;
+    private String storageUrl;
 
     public static ResizedFileJpaEntity of(FileJpaEntity file, String size) {
         return ResizedFileJpaEntity.builder()
@@ -37,11 +37,11 @@ public class ResizedFileJpaEntity extends BaseGeneralEntity {
                 .build();
     }
 
-    public static ResizedFileJpaEntity of(FileJpaEntity file, String size, String s3Url) {
+    public static ResizedFileJpaEntity of(FileJpaEntity file, String size, String storageUrl) {
         return ResizedFileJpaEntity.builder()
                 .file(file)
                 .size(size)
-                .s3Url(s3Url)
+                .storageUrl(storageUrl)
                 .build();
     }
 

--- a/file-service/file-application/src/main/java/com/personal/marketnote/file/exception/InvalidFileStorageUrlsSizeException.java
+++ b/file-service/file-application/src/main/java/com/personal/marketnote/file/exception/InvalidFileStorageUrlsSizeException.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.file.exception;
+
+public class InvalidFileStorageUrlsSizeException extends IllegalArgumentException {
+
+    public InvalidFileStorageUrlsSizeException() {
+        super("storageUrls size must match fileDomains size");
+    }
+}

--- a/file-service/file-application/src/main/java/com/personal/marketnote/file/port/in/result/GetFilesResult.java
+++ b/file-service/file-application/src/main/java/com/personal/marketnote/file/port/in/result/GetFilesResult.java
@@ -14,8 +14,8 @@ public record GetFilesResult(List<FileItem> files) {
             String sort,
             String extension,
             String name,
-            String s3Url,
-            List<String> resizedS3Urls,
+            String storageUrl,
+            List<String> resizedStorageUrls,
             Long orderNum
     ) {
         public static GetFilesResult.FileItem from(FileDomain file, Map<Long, List<String>> fileIdToUrls) {
@@ -24,8 +24,8 @@ public record GetFilesResult(List<FileItem> files) {
                     .sort(file.getSort().name())
                     .extension(file.getExtension())
                     .name(file.getName())
-                    .s3Url(file.getS3Url())
-                    .resizedS3Urls(fileIdToUrls.getOrDefault(file.getId(), List.of()))
+                    .storageUrl(file.getStorageUrl())
+                    .resizedStorageUrls(fileIdToUrls.getOrDefault(file.getId(), List.of()))
                     .orderNum(file.getOrderNum())
                     .build();
         }

--- a/file-service/file-application/src/main/java/com/personal/marketnote/file/port/out/file/SaveFilesPort.java
+++ b/file-service/file-application/src/main/java/com/personal/marketnote/file/port/out/file/SaveFilesPort.java
@@ -13,14 +13,14 @@ import java.util.List;
  */
 public interface SaveFilesPort {
     /**
-     * @param files  파일 도메인 목록
-     * @param s3Urls S3 업로드 URL 목록
+     * @param files       파일 도메인 목록
+     * @param storageUrls 스토리지 업로드 URL 목록
      * @return 저장된 파일 도메인 목록 {@link FileDomain}
      * @Date 2026-01-03
      * @Author 성효빈
      * @Description 파일 목록을 저장합니다.
      */
-    List<FileDomain> saveAll(List<FileDomain> files, List<String> s3Urls);
+    List<FileDomain> saveAll(List<FileDomain> files, List<String> storageUrls);
 }
 
 

--- a/file-service/file-application/src/main/java/com/personal/marketnote/file/service/file/GetFileService.java
+++ b/file-service/file-application/src/main/java/com/personal/marketnote/file/service/file/GetFileService.java
@@ -40,7 +40,7 @@ public class GetFileService implements GetFileUseCase {
 
         Map<Long, List<String>> fileIdToUrls = resizedFiles.stream()
                 .collect(Collectors.groupingBy(ResizedFile::getFileId,
-                        Collectors.mapping(ResizedFile::getS3Url, Collectors.toList())));
+                        Collectors.mapping(ResizedFile::getStorageUrl, Collectors.toList())));
 
         List<GetFilesResult.FileItem> items = files.stream()
                 .map(

--- a/file-service/file-application/src/main/java/com/personal/marketnote/file/service/file/UpdateFilesService.java
+++ b/file-service/file-application/src/main/java/com/personal/marketnote/file/service/file/UpdateFilesService.java
@@ -73,13 +73,13 @@ public class UpdateFilesService implements UpdateFileUseCase {
                 .map(UpdateFileCommand::file)
                 .toList();
 
-        List<String> s3Urls = uploadFilesPort.uploadFiles(
+        List<String> storageUrls = uploadFilesPort.uploadFiles(
                 originals,
                 OwnerType.from(updateFilesCommand.ownerType()),
                 updateFilesCommand.ownerId()
         );
 
-        List<FileDomain> savedFiles = saveFilesPort.saveAll(newFiles, s3Urls);
+        List<FileDomain> savedFiles = saveFilesPort.saveAll(newFiles, storageUrls);
 
         List<MultipartFile> resizedToUpload = new ArrayList<>();
         List<ResizedFile> resizedToSave = new ArrayList<>();
@@ -89,7 +89,7 @@ public class UpdateFilesService implements UpdateFileUseCase {
         }
 
         if (FormatValidator.hasValue(resizedToUpload)) {
-            List<String> resizedS3Urls = uploadFilesPort.uploadFiles(
+            List<String> resizedStorageUrls = uploadFilesPort.uploadFiles(
                     resizedToUpload,
                     OwnerType.from(updateFilesCommand.ownerType()),
                     updateFilesCommand.ownerId()
@@ -99,7 +99,7 @@ public class UpdateFilesService implements UpdateFileUseCase {
                 List<ResizedFile> resizedWithUrls = new ArrayList<>(resizedToSave.size());
                 for (int i = 0; i < resizedToSave.size(); i++) {
                     ResizedFile base = resizedToSave.get(i);
-                    resizedWithUrls.add(ResizedFile.of(base.getFileId(), base.getSize(), resizedS3Urls.get(i)));
+                    resizedWithUrls.add(ResizedFile.of(base.getFileId(), base.getSize(), resizedStorageUrls.get(i)));
                 }
                 saveResizedFilesPort.saveAll(resizedWithUrls);
             }

--- a/file-service/file-domain/src/main/java/com/personal/marketnote/file/domain/file/FileDomain.java
+++ b/file-service/file-domain/src/main/java/com/personal/marketnote/file/domain/file/FileDomain.java
@@ -20,7 +20,7 @@ public class FileDomain {
     private FileSort sort;
     private String extension;
     private String name;
-    private String s3Url;
+    private String storageUrl;
     private LocalDateTime createdAt;
     private EntityStatus status;
     private Long orderNum;
@@ -43,7 +43,7 @@ public class FileDomain {
                 .sort(state.getSort())
                 .extension(state.getExtension())
                 .name(state.getName())
-                .s3Url(state.getS3Url())
+                .storageUrl(state.getStorageUrl())
                 .createdAt(state.getCreatedAt())
                 .status(state.getStatus())
                 .orderNum(state.getOrderNum())

--- a/file-service/file-domain/src/main/java/com/personal/marketnote/file/domain/file/FileDomainSnapshotState.java
+++ b/file-service/file-domain/src/main/java/com/personal/marketnote/file/domain/file/FileDomainSnapshotState.java
@@ -20,7 +20,7 @@ public class FileDomainSnapshotState {
     private final FileSort sort;
     private final String extension;
     private final String name;
-    private final String s3Url;
+    private final String storageUrl;
     private final LocalDateTime createdAt;
     private final EntityStatus status;
     private final Long orderNum;

--- a/file-service/file-domain/src/main/java/com/personal/marketnote/file/domain/file/ResizedFile.java
+++ b/file-service/file-domain/src/main/java/com/personal/marketnote/file/domain/file/ResizedFile.java
@@ -15,7 +15,7 @@ public class ResizedFile {
     private Long id;
     private Long fileId;
     private String size;
-    private String s3Url;
+    private String storageUrl;
     private LocalDateTime createdAt;
     private EntityStatus status;
 
@@ -26,11 +26,11 @@ public class ResizedFile {
                 .build();
     }
 
-    public static ResizedFile of(Long fileId, String size, String s3Url) {
+    public static ResizedFile of(Long fileId, String size, String storageUrl) {
         return ResizedFile.builder()
                 .fileId(fileId)
                 .size(size)
-                .s3Url(s3Url)
+                .storageUrl(storageUrl)
                 .build();
     }
 
@@ -44,12 +44,12 @@ public class ResizedFile {
                 .build();
     }
 
-    public static ResizedFile of(Long id, Long fileId, String size, String s3Url, LocalDateTime createdAt, EntityStatus status) {
+    public static ResizedFile of(Long id, Long fileId, String size, String storageUrl, LocalDateTime createdAt, EntityStatus status) {
         return ResizedFile.builder()
                 .id(id)
                 .fileId(fileId)
                 .size(size)
-                .s3Url(s3Url)
+                .storageUrl(storageUrl)
                 .createdAt(createdAt)
                 .status(status)
                 .build();

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/product/controller/apidocs/GetAdminProductsApiDocs.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/product/controller/apidocs/GetAdminProductsApiDocs.java
@@ -133,8 +133,8 @@ import java.lang.annotation.*;
                 | sort | string | 이미지 종류 | "PRODUCT_CATALOG_IMAGE" |
                 | extension | string | 이미지 확장자 | "jpg" |
                 | name | string | 이미지명 | "스프링노트1" |
-                | s3Url | string | 이미지 S3 URL | "https://marketnote.s3.amazonaws.com/product/30/1763517082648_grafana-icon.png" |
-                | resizedS3Urls | array | 리사이즈 이미지 S3 URL 목록 | [ "https://marketnote.s3.amazonaws.com/product/30/1763517083251_grafana-icon_300x300.png" ] |
+                | storageUrl | string | 이미지 스토리지 URL | "https://marketnote.s3.amazonaws.com/product/30/1763517082648_grafana-icon.png" |
+                | resizedStorageUrls | array | 리사이즈 이미지 스토리지 URL 목록 | [ "https://marketnote.s3.amazonaws.com/product/30/1763517083251_grafana-icon_300x300.png" ] |
                 | orderNum | number | 정렬 순서 | 1 |
                 
                 ---

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/product/controller/apidocs/GetProductInfoApiDocs.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/product/controller/apidocs/GetProductInfoApiDocs.java
@@ -145,8 +145,8 @@ import java.lang.annotation.*;
                 | sort | string | 이미지 종류 | "PRODUCT_REPRESENTATIVE_IMAGE" |
                 | extension | string | 이미지 확장자 | "png" |
                 | name | string | 이미지명 | "상품대표이미지1" |
-                | s3Url | string | 이미지 S3 URL | "https://marketnote.s3.amazonaws.com/product/30/1763534195681_image.png" |
-                | resizedS3Urls | array | 리사이즈 이미지 S3 URL 목록 | [ "https://marketnote.s3.amazonaws.com/product/30/1763534195922_image_600.png", "https://marketnote.s3.amazonaws.com/product/30/1763534195988_image_800.png" ] |
+                | storageUrl | string | 이미지 스토리지 URL | "https://marketnote.s3.amazonaws.com/product/30/1763534195681_image.png" |
+                | resizedStorageUrls | array | 리사이즈 이미지 스토리지 URL 목록 | [ "https://marketnote.s3.amazonaws.com/product/30/1763534195922_image_600.png", "https://marketnote.s3.amazonaws.com/product/30/1763534195988_image_800.png" ] |
                 | orderNum | number | 정렬 순서 | 41 |
                 
                 ---
@@ -159,8 +159,8 @@ import java.lang.annotation.*;
                 | sort | string | 이미지 종류 | "PRODUCT_CONTENT_IMAGE" |
                 | extension | string | 이미지 확장자 | "jpg" |
                 | name | string | 이미지명 | "상품본문이미지1" |
-                | s3Url | string | 이미지 S3 URL | "https://marketnote.s3.amazonaws.com/product/30/1763534195623_image.png" |
-                | resizedS3Urls | array | 리사이즈 이미지 S3 URL 목록(없음) | [] |
+                | storageUrl | string | 이미지 스토리지 URL | "https://marketnote.s3.amazonaws.com/product/30/1763534195623_image.png" |
+                | resizedStorageUrls | array | 리사이즈 이미지 스토리지 URL 목록(없음) | [] |
                 | orderNum | number | 정렬 순서 | 40 |
                 
                 ---
@@ -288,8 +288,8 @@ import java.lang.annotation.*;
                                                 "sort": "PRODUCT_REPRESENTATIVE_IMAGE",
                                                 "extension": "png",
                                                 "name": "스프링노트2",
-                                                "s3Url": "https://marketnote.s3.amazonaws.com/product/30/1763534195681_image.png",
-                                                "resizedS3Urls": [
+                                                "storageUrl": "https://marketnote.s3.amazonaws.com/product/30/1763534195681_image.png",
+                                                "resizedStorageUrls": [
                                                   "https://marketnote.s3.amazonaws.com/product/30/1763534195922_image_600.png",
                                                   "https://marketnote.s3.amazonaws.com/product/30/1763534195988_image_800.png"
                                                 ],
@@ -300,8 +300,8 @@ import java.lang.annotation.*;
                                                 "sort": "PRODUCT_REPRESENTATIVE_IMAGE",
                                                 "extension": "png",
                                                 "name": "스프링노트2",
-                                                "s3Url": "https://marketnote.s3.amazonaws.com/product/30/1763534193377_image.png",
-                                                "resizedS3Urls": [
+                                                "storageUrl": "https://marketnote.s3.amazonaws.com/product/30/1763534193377_image.png",
+                                                "resizedStorageUrls": [
                                                   "https://marketnote.s3.amazonaws.com/product/30/1763534193688_image_600.png",
                                                   "https://marketnote.s3.amazonaws.com/product/30/1763534193761_image_800.png"
                                                 ],
@@ -312,8 +312,8 @@ import java.lang.annotation.*;
                                                 "sort": "PRODUCT_REPRESENTATIVE_IMAGE",
                                                 "extension": "png",
                                                 "name": "스프링노트2",
-                                                "s3Url": "https://marketnote.s3.amazonaws.com/product/30/1763533915880_image.png",
-                                                "resizedS3Urls": [
+                                                "storageUrl": "https://marketnote.s3.amazonaws.com/product/30/1763533915880_image.png",
+                                                "resizedStorageUrls": [
                                                   "https://marketnote.s3.amazonaws.com/product/30/1763533916081_image_600.png",
                                                   "https://marketnote.s3.amazonaws.com/product/30/1763533916187_image_800.png"
                                                 ],
@@ -324,8 +324,8 @@ import java.lang.annotation.*;
                                                 "sort": "PRODUCT_REPRESENTATIVE_IMAGE",
                                                 "extension": "png",
                                                 "name": "스프링노트2",
-                                                "s3Url": "https://marketnote.s3.amazonaws.com/product/30/1763533914726_image.png",
-                                                "resizedS3Urls": [
+                                                "storageUrl": "https://marketnote.s3.amazonaws.com/product/30/1763533914726_image.png",
+                                                "resizedStorageUrls": [
                                                   "https://marketnote.s3.amazonaws.com/product/30/1763533914954_image_600.png",
                                                   "https://marketnote.s3.amazonaws.com/product/30/1763533915038_image_800.png"
                                                 ],
@@ -336,8 +336,8 @@ import java.lang.annotation.*;
                                                 "sort": "PRODUCT_REPRESENTATIVE_IMAGE",
                                                 "extension": "png",
                                                 "name": "스프링노트2",
-                                                "s3Url": "https://marketnote.s3.amazonaws.com/product/30/1763533911501_image.png",
-                                                "resizedS3Urls": [
+                                                "storageUrl": "https://marketnote.s3.amazonaws.com/product/30/1763533911501_image.png",
+                                                "resizedStorageUrls": [
                                                   "https://marketnote.s3.amazonaws.com/product/30/1763533911804_image_600.png",
                                                   "https://marketnote.s3.amazonaws.com/product/30/1763533911854_image_800.png"
                                                 ],
@@ -350,8 +350,8 @@ import java.lang.annotation.*;
                                                 "sort": "PRODUCT_CONTENT_IMAGE",
                                                 "extension": "jpg",
                                                 "name": "스프링노트1",
-                                                "s3Url": "https://marketnote.s3.amazonaws.com/product/30/1763534195623_grafana-icon.png",
-                                                "resizedS3Urls": [],
+                                                "storageUrl": "https://marketnote.s3.amazonaws.com/product/30/1763534195623_grafana-icon.png",
+                                                "resizedStorageUrls": [],
                                                 "orderNum": 40
                                               },
                                               {
@@ -359,8 +359,8 @@ import java.lang.annotation.*;
                                                 "sort": "PRODUCT_CONTENT_IMAGE",
                                                 "extension": "jpg",
                                                 "name": "스프링노트1",
-                                                "s3Url": "https://marketnote.s3.amazonaws.com/product/30/1763534193258_grafana-icon.png",
-                                                "resizedS3Urls": [],
+                                                "storageUrl": "https://marketnote.s3.amazonaws.com/product/30/1763534193258_grafana-icon.png",
+                                                "resizedStorageUrls": [],
                                                 "orderNum": 38
                                               },
                                               {
@@ -368,8 +368,8 @@ import java.lang.annotation.*;
                                                 "sort": "PRODUCT_CONTENT_IMAGE",
                                                 "extension": "jpg",
                                                 "name": "스프링노트1",
-                                                "s3Url": "https://marketnote.s3.amazonaws.com/product/30/1763533915837_grafana-icon.png",
-                                                "resizedS3Urls": [],
+                                                "storageUrl": "https://marketnote.s3.amazonaws.com/product/30/1763533915837_grafana-icon.png",
+                                                "resizedStorageUrls": [],
                                                 "orderNum": 36
                                               },
                                               {
@@ -377,8 +377,8 @@ import java.lang.annotation.*;
                                                 "sort": "PRODUCT_CONTENT_IMAGE",
                                                 "extension": "jpg",
                                                 "name": "스프링노트1",
-                                                "s3Url": "https://marketnote.s3.amazonaws.com/product/30/1763533914674_grafana-icon.png",
-                                                "resizedS3Urls": [],
+                                                "storageUrl": "https://marketnote.s3.amazonaws.com/product/30/1763533914674_grafana-icon.png",
+                                                "resizedStorageUrls": [],
                                                 "orderNum": 34
                                               },
                                               {
@@ -386,8 +386,8 @@ import java.lang.annotation.*;
                                                 "sort": "PRODUCT_CONTENT_IMAGE",
                                                 "extension": "jpg",
                                                 "name": "스프링노트1",
-                                                "s3Url": "https://marketnote.s3.amazonaws.com/product/30/1763533911286_grafana-icon.png",
-                                                "resizedS3Urls": [],
+                                                "storageUrl": "https://marketnote.s3.amazonaws.com/product/30/1763533911286_grafana-icon.png",
+                                                "resizedStorageUrls": [],
                                                 "orderNum": 32
                                               }
                                             ],

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/product/controller/apidocs/GetProductInfoByPricePolicyIdApiDocs.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/product/controller/apidocs/GetProductInfoByPricePolicyIdApiDocs.java
@@ -142,8 +142,8 @@ import java.lang.annotation.*;
                 | sort | string | 이미지 종류 | "PRODUCT_REPRESENTATIVE_IMAGE" |
                 | extension | string | 이미지 확장자 | "png" |
                 | name | string | 이미지명 | "상품대표이미지1" |
-                | s3Url | string | 이미지 S3 URL | "https://marketnote.s3.amazonaws.com/product/30/1763534195681_image.png" |
-                | resizedS3Urls | array | 리사이즈 이미지 S3 URL 목록 | [ "https://marketnote.s3.amazonaws.com/product/30/1763534195922_image_600.png", "https://marketnote.s3.amazonaws.com/product/30/1763534195988_image_800.png" ] |
+                | storageUrl | string | 이미지 스토리지 URL | "https://marketnote.s3.amazonaws.com/product/30/1763534195681_image.png" |
+                | resizedStorageUrls | array | 리사이즈 이미지 스토리지 URL 목록 | [ "https://marketnote.s3.amazonaws.com/product/30/1763534195922_image_600.png", "https://marketnote.s3.amazonaws.com/product/30/1763534195988_image_800.png" ] |
                 | orderNum | number | 정렬 순서 | 41 |
                 
                 ---
@@ -156,8 +156,8 @@ import java.lang.annotation.*;
                 | sort | string | 이미지 종류 | "PRODUCT_CONTENT_IMAGE" |
                 | extension | string | 이미지 확장자 | "jpg" |
                 | name | string | 이미지명 | "상품본문이미지1" |
-                | s3Url | string | 이미지 S3 URL | "https://marketnote.s3.amazonaws.com/product/30/1763534195623_image.png" |
-                | resizedS3Urls | array | 리사이즈 이미지 S3 URL 목록(없음) | [] |
+                | storageUrl | string | 이미지 스토리지 URL | "https://marketnote.s3.amazonaws.com/product/30/1763534195623_image.png" |
+                | resizedStorageUrls | array | 리사이즈 이미지 스토리지 URL 목록(없음) | [] |
                 | orderNum | number | 정렬 순서 | 40 |
                 
                 ---
@@ -279,8 +279,8 @@ import java.lang.annotation.*;
                                                 "sort": "PRODUCT_REPRESENTATIVE_IMAGE",
                                                 "extension": "png",
                                                 "name": "스프링노트2",
-                                                "s3Url": "https://marketnote.s3.amazonaws.com/product/30/1763534195681_image.png",
-                                                "resizedS3Urls": [
+                                                "storageUrl": "https://marketnote.s3.amazonaws.com/product/30/1763534195681_image.png",
+                                                "resizedStorageUrls": [
                                                   "https://marketnote.s3.amazonaws.com/product/30/1763534195922_image_600.png",
                                                   "https://marketnote.s3.amazonaws.com/product/30/1763534195988_image_800.png"
                                                 ],
@@ -291,8 +291,8 @@ import java.lang.annotation.*;
                                                 "sort": "PRODUCT_REPRESENTATIVE_IMAGE",
                                                 "extension": "png",
                                                 "name": "스프링노트2",
-                                                "s3Url": "https://marketnote.s3.amazonaws.com/product/30/1763534193377_image.png",
-                                                "resizedS3Urls": [
+                                                "storageUrl": "https://marketnote.s3.amazonaws.com/product/30/1763534193377_image.png",
+                                                "resizedStorageUrls": [
                                                   "https://marketnote.s3.amazonaws.com/product/30/1763534193688_image_600.png",
                                                   "https://marketnote.s3.amazonaws.com/product/30/1763534193761_image_800.png"
                                                 ],
@@ -303,8 +303,8 @@ import java.lang.annotation.*;
                                                 "sort": "PRODUCT_REPRESENTATIVE_IMAGE",
                                                 "extension": "png",
                                                 "name": "스프링노트2",
-                                                "s3Url": "https://marketnote.s3.amazonaws.com/product/30/1763533915880_image.png",
-                                                "resizedS3Urls": [
+                                                "storageUrl": "https://marketnote.s3.amazonaws.com/product/30/1763533915880_image.png",
+                                                "resizedStorageUrls": [
                                                   "https://marketnote.s3.amazonaws.com/product/30/1763533916081_image_600.png",
                                                   "https://marketnote.s3.amazonaws.com/product/30/1763533916187_image_800.png"
                                                 ],
@@ -315,8 +315,8 @@ import java.lang.annotation.*;
                                                 "sort": "PRODUCT_REPRESENTATIVE_IMAGE",
                                                 "extension": "png",
                                                 "name": "스프링노트2",
-                                                "s3Url": "https://marketnote.s3.amazonaws.com/product/30/1763533914726_image.png",
-                                                "resizedS3Urls": [
+                                                "storageUrl": "https://marketnote.s3.amazonaws.com/product/30/1763533914726_image.png",
+                                                "resizedStorageUrls": [
                                                   "https://marketnote.s3.amazonaws.com/product/30/1763533914954_image_600.png",
                                                   "https://marketnote.s3.amazonaws.com/product/30/1763533915038_image_800.png"
                                                 ],
@@ -327,8 +327,8 @@ import java.lang.annotation.*;
                                                 "sort": "PRODUCT_REPRESENTATIVE_IMAGE",
                                                 "extension": "png",
                                                 "name": "스프링노트2",
-                                                "s3Url": "https://marketnote.s3.amazonaws.com/product/30/1763533911501_image.png",
-                                                "resizedS3Urls": [
+                                                "storageUrl": "https://marketnote.s3.amazonaws.com/product/30/1763533911501_image.png",
+                                                "resizedStorageUrls": [
                                                   "https://marketnote.s3.amazonaws.com/product/30/1763533911804_image_600.png",
                                                   "https://marketnote.s3.amazonaws.com/product/30/1763533911854_image_800.png"
                                                 ],
@@ -341,8 +341,8 @@ import java.lang.annotation.*;
                                                 "sort": "PRODUCT_CONTENT_IMAGE",
                                                 "extension": "jpg",
                                                 "name": "스프링노트1",
-                                                "s3Url": "https://marketnote.s3.amazonaws.com/product/30/1763534195623_grafana-icon.png",
-                                                "resizedS3Urls": [],
+                                                "storageUrl": "https://marketnote.s3.amazonaws.com/product/30/1763534195623_grafana-icon.png",
+                                                "resizedStorageUrls": [],
                                                 "orderNum": 40
                                               },
                                               {
@@ -350,8 +350,8 @@ import java.lang.annotation.*;
                                                 "sort": "PRODUCT_CONTENT_IMAGE",
                                                 "extension": "jpg",
                                                 "name": "스프링노트1",
-                                                "s3Url": "https://marketnote.s3.amazonaws.com/product/30/1763534193258_grafana-icon.png",
-                                                "resizedS3Urls": [],
+                                                "storageUrl": "https://marketnote.s3.amazonaws.com/product/30/1763534193258_grafana-icon.png",
+                                                "resizedStorageUrls": [],
                                                 "orderNum": 38
                                               },
                                               {
@@ -359,8 +359,8 @@ import java.lang.annotation.*;
                                                 "sort": "PRODUCT_CONTENT_IMAGE",
                                                 "extension": "jpg",
                                                 "name": "스프링노트1",
-                                                "s3Url": "https://marketnote.s3.amazonaws.com/product/30/1763533915837_grafana-icon.png",
-                                                "resizedS3Urls": [],
+                                                "storageUrl": "https://marketnote.s3.amazonaws.com/product/30/1763533915837_grafana-icon.png",
+                                                "resizedStorageUrls": [],
                                                 "orderNum": 36
                                               },
                                               {
@@ -368,8 +368,8 @@ import java.lang.annotation.*;
                                                 "sort": "PRODUCT_CONTENT_IMAGE",
                                                 "extension": "jpg",
                                                 "name": "스프링노트1",
-                                                "s3Url": "https://marketnote.s3.amazonaws.com/product/30/1763533914674_grafana-icon.png",
-                                                "resizedS3Urls": [],
+                                                "storageUrl": "https://marketnote.s3.amazonaws.com/product/30/1763533914674_grafana-icon.png",
+                                                "resizedStorageUrls": [],
                                                 "orderNum": 34
                                               },
                                               {
@@ -377,8 +377,8 @@ import java.lang.annotation.*;
                                                 "sort": "PRODUCT_CONTENT_IMAGE",
                                                 "extension": "jpg",
                                                 "name": "스프링노트1",
-                                                "s3Url": "https://marketnote.s3.amazonaws.com/product/30/1763533911286_grafana-icon.png",
-                                                "resizedS3Urls": [],
+                                                "storageUrl": "https://marketnote.s3.amazonaws.com/product/30/1763533911286_grafana-icon.png",
+                                                "resizedStorageUrls": [],
                                                 "orderNum": 32
                                               }
                                             ],

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/product/controller/apidocs/GetProductsApiDocs.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/product/controller/apidocs/GetProductsApiDocs.java
@@ -134,8 +134,8 @@ import java.lang.annotation.*;
                 | sort | string | 이미지 종류 | "PRODUCT_CATALOG_IMAGE" |
                 | extension | string | 이미지 확장자 | "jpg" |
                 | name | string | 이미지명 | "스프링노트1" |
-                | s3Url | string | 이미지 S3 URL | "https://marketnote.s3.amazonaws.com/product/30/1763517082648_grafana-icon.png" |
-                | resizedS3Urls | array | 리사이즈 이미지 S3 URL 목록 | [ "https://marketnote.s3.amazonaws.com/product/30/1763517083251_grafana-icon_300x300.png" ] |
+                | storageUrl | string | 이미지 스토리지 URL | "https://marketnote.s3.amazonaws.com/product/30/1763517082648_grafana-icon.png" |
+                | resizedStorageUrls | array | 리사이즈 이미지 스토리지 URL 목록 | [ "https://marketnote.s3.amazonaws.com/product/30/1763517083251_grafana-icon_300x300.png" ] |
                 | orderNum | number | 정렬 순서 | 1 |
                 
                 ---
@@ -343,8 +343,8 @@ import java.lang.annotation.*;
                                                     "sort": "PRODUCT_CATALOG_IMAGE",
                                                     "extension": "jpg",
                                                     "name": "스프링노트1",
-                                                    "s3Url": "https://marketnote.s3.amazonaws.com/product/30/1763521042462_grafana-icon.png",
-                                                    "resizedS3Urls": [
+                                                    "storageUrl": "https://marketnote.s3.amazonaws.com/product/30/1763521042462_grafana-icon.png",
+                                                    "resizedStorageUrls": [
                                                       "https://marketnote.s3.amazonaws.com/product/30/1763521042802_grafana-icon_300x300.png"
                                                     ],
                                                     "orderNum": 28
@@ -401,8 +401,8 @@ import java.lang.annotation.*;
                                                     "sort": "PRODUCT_CATALOG_IMAGE",
                                                     "extension": "jpg",
                                                     "name": "스프링노트1",
-                                                    "s3Url": "https://marketnote.s3.amazonaws.com/product/30/1763521042462_grafana-icon.png",
-                                                    "resizedS3Urls": [
+                                                    "storageUrl": "https://marketnote.s3.amazonaws.com/product/30/1763521042462_grafana-icon.png",
+                                                    "resizedStorageUrls": [
                                                       "https://marketnote.s3.amazonaws.com/product/30/1763521042802_grafana-icon_300x300.png"
                                                     ],
                                                     "orderNum": 28

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/web/file/FileServiceClient.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/web/file/FileServiceClient.java
@@ -111,8 +111,8 @@ public class FileServiceClient implements FindProductImagesPort, DeleteProductIm
                                 getFileResult.sort,
                                 getFileResult.extension,
                                 getFileResult.name,
-                                getFileResult.s3Url,
-                                getFileResult.resizedS3Urls,
+                                getFileResult.storageUrl,
+                                getFileResult.resizedStorageUrls,
                                 getFileResult.orderNum
                         ))
                         .toList();
@@ -274,11 +274,11 @@ public class FileServiceClient implements FindProductImagesPort, DeleteProductIm
         @JsonProperty("name")
         String name;
 
-        @JsonProperty("s3Url")
-        String s3Url;
+        @JsonProperty("storageUrl")
+        String storageUrl;
 
-        @JsonProperty("resizedS3Urls")
-        List<String> resizedS3Urls;
+        @JsonProperty("resizedStorageUrls")
+        List<String> resizedStorageUrls;
 
         @JsonProperty("orderNum")
         Long orderNum;

--- a/product-service/product-adapters/src/test/java/com/personal/marketnote/product/adapter/out/web/file/FileServiceClientTest.java
+++ b/product-service/product-adapters/src/test/java/com/personal/marketnote/product/adapter/out/web/file/FileServiceClientTest.java
@@ -86,8 +86,8 @@ class FileServiceClientTest {
                                             "sort": "PRODUCT_THUMBNAIL",
                                             "extension": "jpg",
                                             "name": "image1.jpg",
-                                            "s3Url": "https://s3.example.com/image1.jpg",
-                                            "resizedS3Urls": ["https://s3.example.com/image1_200.jpg"],
+                                            "storageUrl": "https://s3.example.com/image1.jpg",
+                                            "resizedStorageUrls": ["https://s3.example.com/image1_200.jpg"],
                                             "orderNum": 1
                                         }
                                     ]


### PR DESCRIPTION
## partially addresses #194
## resolves #1695

## Task
- [x] Domain: FileDomain.s3Url → storageUrl, FileDomainSnapshotState.s3Url → storageUrl, ResizedFile.s3Url → storageUrl
- [x] Application: InvalidFileS3UrlsSizeException → InvalidFileStorageUrlsSizeException 변경
- [x] Application: SaveFilesPort 파라미터명 s3Urls → storageUrls 변경
- [x] Application: GetFilesResult에서 s3Url, resizedS3Urls 벤더 비종속적 필드명으로 변경
- [x] Application: UpdateFilesService에서 S3 변수명 벤더 비종속적으로 변경
- [x] Adapters: JPA 엔티티 필드명 변경 + @column(name = "s3_url") 유지 (DB 스키마 변경 없음)
- [x] Common: GetFileResult s3Url → storageUrl 변경
- [x] 연쇄 변경: product-service, community-service FileServiceClient/테스트/API docs 수정