### PR TITLE
[#194][#1639] feat: 파일 서비스 이미지 갱신 이벤트 발행 기능 추가

### DIFF
--- a/common/src/main/java/com/personal/marketnote/common/kafka/KafkaTopicConstants.java
+++ b/common/src/main/java/com/personal/marketnote/common/kafka/KafkaTopicConstants.java
@@ -25,6 +25,9 @@ public final class KafkaTopicConstants {
     // Community 이벤트
     public static final String REVIEW_REGISTERED = "community.review.registered";
 
+    // File 이벤트
+    public static final String FILE_IMAGE_CHANGED = "file.image.changed";
+
     // SAGA 응답
     public static final String SAGA_RESPONSE = "saga.response";
 

--- a/common/src/main/java/com/personal/marketnote/common/kafka/event/ImageChangeAction.java
+++ b/common/src/main/java/com/personal/marketnote/common/kafka/event/ImageChangeAction.java
@@ -1,0 +1,6 @@
+package com.personal.marketnote.common.kafka.event;
+
+public enum ImageChangeAction {
+    CREATED,
+    DELETED;
+}

--- a/common/src/main/java/com/personal/marketnote/common/kafka/event/ImageChangedEvent.java
+++ b/common/src/main/java/com/personal/marketnote/common/kafka/event/ImageChangedEvent.java
@@ -1,0 +1,11 @@
+package com.personal.marketnote.common.kafka.event;
+
+public record ImageChangedEvent(
+        Long imageId,
+        Long targetId,
+        String targetType,
+        String imageUrl,
+        Integer sortOrder,
+        ImageChangeAction action
+) {
+}

--- a/file-service/file-adapters/src/main/java/com/personal/marketnote/file/adapter/out/event/ImageEventKafkaProducer.java
+++ b/file-service/file-adapters/src/main/java/com/personal/marketnote/file/adapter/out/event/ImageEventKafkaProducer.java
@@ -1,0 +1,67 @@
+package com.personal.marketnote.file.adapter.out.event;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.common.adapter.out.ServiceAdapter;
+import com.personal.marketnote.common.kafka.KafkaTopicConstants;
+import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.ImageChangeAction;
+import com.personal.marketnote.common.kafka.event.ImageChangedEvent;
+import com.personal.marketnote.common.outbox.OutboxEvent;
+import com.personal.marketnote.common.outbox.SaveOutboxEventPort;
+import com.personal.marketnote.file.port.out.event.ImageEventCommand;
+import com.personal.marketnote.file.port.out.event.PublishImageEventPort;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.time.Clock;
+import java.util.List;
+
+@Slf4j
+@ServiceAdapter
+@RequiredArgsConstructor
+public class ImageEventKafkaProducer implements PublishImageEventPort {
+    private static final String SOURCE = "file-service";
+
+    private final SaveOutboxEventPort saveOutboxEventPort;
+    private final ObjectMapper objectMapper;
+    private final Clock clock;
+
+    @Override
+    public void publishImageCreatedEvents(List<ImageEventCommand> events) {
+        publishEvents(events, ImageChangeAction.CREATED);
+    }
+
+    @Override
+    public void publishImageDeletedEvents(List<ImageEventCommand> events) {
+        publishEvents(events, ImageChangeAction.DELETED);
+    }
+
+    private void publishEvents(List<ImageEventCommand> events, ImageChangeAction action) {
+        for (ImageEventCommand event : events) {
+            ImageChangedEvent payload = new ImageChangedEvent(
+                    event.imageId(), event.targetId(), event.targetType(),
+                    event.imageUrl(), event.sortOrder(), action
+            );
+            String topic = KafkaTopicConstants.FILE_IMAGE_CHANGED;
+            EventEnvelope<ImageChangedEvent> envelope = EventEnvelope.of(topic, SOURCE, payload, clock);
+
+            saveToOutbox(envelope, topic, event.imageId().toString());
+        }
+    }
+
+    private <T> void saveToOutbox(EventEnvelope<T> envelope, String topic, String partitionKey) {
+        try {
+            String payloadJson = objectMapper.writeValueAsString(envelope);
+            OutboxEvent outboxEvent = OutboxEvent.of(
+                    envelope.eventId(), topic, partitionKey,
+                    envelope.eventType(), SOURCE, payloadJson, clock
+            );
+            saveOutboxEventPort.save(outboxEvent);
+            log.info("Outbox 이벤트 저장. topic={}, partitionKey={}, eventId={}",
+                    topic, partitionKey, envelope.eventId());
+        } catch (Exception e) {
+            log.error("Outbox 이벤트 저장 실패. topic={}, partitionKey={}, error={}",
+                    topic, partitionKey, e.getMessage(), e);
+        }
+    }
+}

--- a/file-service/file-application/src/main/java/com/personal/marketnote/file/port/out/event/ImageEventCommand.java
+++ b/file-service/file-application/src/main/java/com/personal/marketnote/file/port/out/event/ImageEventCommand.java
@@ -1,0 +1,23 @@
+package com.personal.marketnote.file.port.out.event;
+
+import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.file.domain.file.FileDomain;
+
+public record ImageEventCommand(
+        Long imageId,
+        Long targetId,
+        String targetType,
+        String imageUrl,
+        Integer sortOrder
+) {
+
+    public static ImageEventCommand from(FileDomain file) {
+        return new ImageEventCommand(
+                file.getId(),
+                file.getOwnerId(),
+                file.getOwnerType().name(),
+                file.getStorageUrl(),
+                FormatValidator.hasValue(file.getOrderNum()) ? file.getOrderNum().intValue() : 0
+        );
+    }
+}

--- a/file-service/file-application/src/main/java/com/personal/marketnote/file/port/out/event/PublishImageEventPort.java
+++ b/file-service/file-application/src/main/java/com/personal/marketnote/file/port/out/event/PublishImageEventPort.java
@@ -1,0 +1,10 @@
+package com.personal.marketnote.file.port.out.event;
+
+import java.util.List;
+
+public interface PublishImageEventPort {
+
+    void publishImageCreatedEvents(List<ImageEventCommand> events);
+
+    void publishImageDeletedEvents(List<ImageEventCommand> events);
+}

--- a/file-service/file-application/src/main/java/com/personal/marketnote/file/service/file/DeleteFileService.java
+++ b/file-service/file-application/src/main/java/com/personal/marketnote/file/service/file/DeleteFileService.java
@@ -4,9 +4,13 @@ import com.personal.marketnote.common.application.UseCase;
 import com.personal.marketnote.file.domain.file.FileDomain;
 import com.personal.marketnote.file.port.in.usecase.file.DeleteFileUseCase;
 import com.personal.marketnote.file.port.in.usecase.file.GetFileUseCase;
+import com.personal.marketnote.file.port.out.event.ImageEventCommand;
+import com.personal.marketnote.file.port.out.event.PublishImageEventPort;
 import com.personal.marketnote.file.port.out.file.UpdateFilePort;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
 
@@ -16,11 +20,14 @@ import static org.springframework.transaction.annotation.Isolation.READ_COMMITTE
 public class DeleteFileService implements DeleteFileUseCase {
     private final GetFileUseCase getFileUseCase;
     private final UpdateFilePort updateFilePort;
+    private final PublishImageEventPort publishImageEventPort;
 
     @Override
     public void delete(Long id) {
         FileDomain file = getFileUseCase.getFile(id);
         file.delete();
         updateFilePort.update(file);
+
+        publishImageEventPort.publishImageDeletedEvents(List.of(ImageEventCommand.from(file)));
     }
 }

--- a/file-service/file-application/src/main/java/com/personal/marketnote/file/service/file/UpdateFilesService.java
+++ b/file-service/file-application/src/main/java/com/personal/marketnote/file/service/file/UpdateFilesService.java
@@ -12,6 +12,8 @@ import com.personal.marketnote.file.port.in.command.UpdateFileCommand;
 import com.personal.marketnote.file.port.in.command.UpdateFilesCommand;
 import com.personal.marketnote.file.port.in.usecase.file.GetFileUseCase;
 import com.personal.marketnote.file.port.in.usecase.file.UpdateFileUseCase;
+import com.personal.marketnote.file.port.out.event.ImageEventCommand;
+import com.personal.marketnote.file.port.out.event.PublishImageEventPort;
 import com.personal.marketnote.file.port.out.file.SaveFilesPort;
 import com.personal.marketnote.file.port.out.file.UpdateFilesPort;
 import com.personal.marketnote.file.port.out.resized.SaveResizedFilesPort;
@@ -44,6 +46,7 @@ public class UpdateFilesService implements UpdateFileUseCase {
     private final SaveFilesPort saveFilesPort;
     private final SaveResizedFilesPort saveResizedFilesPort;
     private final UpdateFilesPort updateFilesPort;
+    private final PublishImageEventPort publishImageEventPort;
 
     public void updateFiles(UpdateFilesCommand updateFilesCommand) {
         String ownerType = updateFilesCommand.ownerType();
@@ -60,10 +63,12 @@ public class UpdateFilesService implements UpdateFileUseCase {
         // 기존 파일 목록이 존재하는 경우 비활성화
         List<FileDomain> currentFiles = getFileUseCase.getFiles(OwnerType.from(ownerType), ownerId, sort);
         if (FormatValidator.hasValue(currentFiles)) {
+            List<ImageEventCommand> deletedEvents = buildImageEventCommands(currentFiles);
             currentFiles.forEach(FileDomain::delete);
             List<ResizedFile> resizedFiles = getFileUseCase.getResizedFiles(currentFiles);
             resizedFiles.forEach(ResizedFile::delete);
             updateFilesPort.update(currentFiles, resizedFiles);
+            publishImageEventPort.publishImageDeletedEvents(deletedEvents);
         }
 
         List<FileDomain> newFiles = FileCommandToDomainMapper.mapToDomain(updateFilesCommand);
@@ -104,6 +109,15 @@ public class UpdateFilesService implements UpdateFileUseCase {
                 saveResizedFilesPort.saveAll(resizedWithUrls);
             }
         }
+
+        List<ImageEventCommand> createdEvents = buildImageEventCommands(savedFiles);
+        publishImageEventPort.publishImageCreatedEvents(createdEvents);
+    }
+
+    private List<ImageEventCommand> buildImageEventCommands(List<FileDomain> files) {
+        return files.stream()
+                .map(ImageEventCommand::from)
+                .toList();
     }
 
     private void resize(


### PR DESCRIPTION
## partially addresses #194
## resolves #1639

## Task
- [x] file.image.changed 토픽 정의
- [x] ImageChangedEvent 정의 (imageId, targetId, targetType, imageUrl, sortOrder, action: CREATED/DELETED)
- [x] ImageChangeAction enum 정의
- [x] PublishImageEventPort + ImageEventKafkaProducer 구현 (Transactional Outbox 패턴)
- [x] ImageEventCommand record + from(FileDomain) 팩토리 메서드
- [x] UpdateFilesService에 DELETED + CREATED 이벤트 발행 추가
- [x] DeleteFileService에 DELETED 이벤트 발행 추가