### PR TITLE
[#194][#1639] test: 파일 서비스 이미지 갱신 이벤트 발행 기능 자동화 테스트 추가

### DIFF
--- a/file-service/file-adapters/src/test/java/com/personal/marketnote/file/adapter/out/event/ImageEventKafkaProducerTest.java
+++ b/file-service/file-adapters/src/test/java/com/personal/marketnote/file/adapter/out/event/ImageEventKafkaProducerTest.java
@@ -1,0 +1,182 @@
+package com.personal.marketnote.file.adapter.out.event;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.common.kafka.KafkaTopicConstants;
+import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.ImageChangeAction;
+import com.personal.marketnote.common.kafka.event.ImageChangedEvent;
+import com.personal.marketnote.common.outbox.OutboxEvent;
+import com.personal.marketnote.common.outbox.SaveOutboxEventPort;
+import com.personal.marketnote.file.port.out.event.ImageEventCommand;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ImageEventKafkaProducerTest {
+    @InjectMocks
+    private ImageEventKafkaProducer imageEventKafkaProducer;
+
+    @Mock
+    private SaveOutboxEventPort saveOutboxEventPort;
+
+    @Mock
+    private ObjectMapper objectMapper;
+
+    @Mock
+    private Clock clock;
+
+    private void setUpClock(String instant) {
+        Clock fixedClock = Clock.fixed(Instant.parse(instant), ZoneId.of("Asia/Seoul"));
+        when(clock.instant()).thenReturn(fixedClock.instant());
+        when(clock.getZone()).thenReturn(fixedClock.getZone());
+    }
+
+    @Test
+    @DisplayName("이미지 생성 이벤트 발행 시 올바른 토픽과 파티션 키로 Outbox에 저장된다")
+    void publishImageCreatedEvents_savesToOutboxWithCorrectTopicAndPartitionKey() throws Exception {
+        // given
+        setUpClock("2026-03-27T10:00:00Z");
+        when(objectMapper.writeValueAsString(any())).thenReturn("{}");
+
+        ImageEventCommand command = new ImageEventCommand(1L, 100L, "PRODUCT", "https://cdn.example.com/image.png", 1);
+        List<ImageEventCommand> commands = List.of(command);
+
+        // when
+        imageEventKafkaProducer.publishImageCreatedEvents(commands);
+
+        // then
+        ArgumentCaptor<OutboxEvent> outboxCaptor = ArgumentCaptor.forClass(OutboxEvent.class);
+        verify(saveOutboxEventPort).save(outboxCaptor.capture());
+
+        OutboxEvent captured = outboxCaptor.getValue();
+        assertThat(captured.getTopic()).isEqualTo(KafkaTopicConstants.FILE_IMAGE_CHANGED);
+        assertThat(captured.getPartitionKey()).isEqualTo("1");
+        assertThat(captured.getSource()).isEqualTo("file-service");
+        assertThat(captured.getEventId()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("이미지 생성 이벤트 발행 시 EventEnvelope에 CREATED 액션이 포함된다")
+    @SuppressWarnings("unchecked")
+    void publishImageCreatedEvents_envelopeContainsCreatedAction() throws Exception {
+        // given
+        setUpClock("2026-03-27T10:00:00Z");
+        when(objectMapper.writeValueAsString(any())).thenReturn("{}");
+
+        ImageEventCommand command = new ImageEventCommand(10L, 200L, "PRODUCT", "https://cdn.example.com/image.png", 2);
+        List<ImageEventCommand> commands = List.of(command);
+
+        // when
+        imageEventKafkaProducer.publishImageCreatedEvents(commands);
+
+        // then
+        ArgumentCaptor<EventEnvelope> envelopeCaptor = ArgumentCaptor.forClass(EventEnvelope.class);
+        verify(objectMapper).writeValueAsString(envelopeCaptor.capture());
+
+        EventEnvelope<?> capturedEnvelope = envelopeCaptor.getValue();
+        assertThat(capturedEnvelope.eventType()).isEqualTo(KafkaTopicConstants.FILE_IMAGE_CHANGED);
+        assertThat(capturedEnvelope.source()).isEqualTo("file-service");
+
+        ImageChangedEvent payload = (ImageChangedEvent) capturedEnvelope.payload();
+        assertThat(payload.imageId()).isEqualTo(10L);
+        assertThat(payload.targetId()).isEqualTo(200L);
+        assertThat(payload.targetType()).isEqualTo("PRODUCT");
+        assertThat(payload.imageUrl()).isEqualTo("https://cdn.example.com/image.png");
+        assertThat(payload.sortOrder()).isEqualTo(2);
+        assertThat(payload.action()).isEqualTo(ImageChangeAction.CREATED);
+    }
+
+    @Test
+    @DisplayName("이미지 삭제 이벤트 발행 시 EventEnvelope에 DELETED 액션이 포함된다")
+    @SuppressWarnings("unchecked")
+    void publishImageDeletedEvents_envelopeContainsDeletedAction() throws Exception {
+        // given
+        setUpClock("2026-03-27T10:00:00Z");
+        when(objectMapper.writeValueAsString(any())).thenReturn("{}");
+
+        ImageEventCommand command = new ImageEventCommand(5L, 300L, "POST", "https://cdn.example.com/post.png", 0);
+        List<ImageEventCommand> commands = List.of(command);
+
+        // when
+        imageEventKafkaProducer.publishImageDeletedEvents(commands);
+
+        // then
+        ArgumentCaptor<EventEnvelope> envelopeCaptor = ArgumentCaptor.forClass(EventEnvelope.class);
+        verify(objectMapper).writeValueAsString(envelopeCaptor.capture());
+
+        EventEnvelope<?> capturedEnvelope = envelopeCaptor.getValue();
+        ImageChangedEvent payload = (ImageChangedEvent) capturedEnvelope.payload();
+        assertThat(payload.imageId()).isEqualTo(5L);
+        assertThat(payload.targetId()).isEqualTo(300L);
+        assertThat(payload.targetType()).isEqualTo("POST");
+        assertThat(payload.action()).isEqualTo(ImageChangeAction.DELETED);
+    }
+
+    @Test
+    @DisplayName("여러 이미지 생성 이벤트 발행 시 이벤트 수만큼 Outbox에 저장된다")
+    void publishImageCreatedEvents_multipleImages_savesMultipleOutboxEvents() throws Exception {
+        // given
+        setUpClock("2026-03-27T10:00:00Z");
+        when(objectMapper.writeValueAsString(any())).thenReturn("{}");
+
+        List<ImageEventCommand> commands = List.of(
+                new ImageEventCommand(1L, 100L, "PRODUCT", "https://cdn.example.com/1.png", 1),
+                new ImageEventCommand(2L, 100L, "PRODUCT", "https://cdn.example.com/2.png", 2),
+                new ImageEventCommand(3L, 100L, "PRODUCT", "https://cdn.example.com/3.png", 3)
+        );
+
+        // when
+        imageEventKafkaProducer.publishImageCreatedEvents(commands);
+
+        // then
+        verify(saveOutboxEventPort, times(3)).save(any(OutboxEvent.class));
+    }
+
+    @Test
+    @DisplayName("빈 이벤트 목록 발행 시 Outbox에 저장하지 않는다")
+    void publishImageCreatedEvents_emptyList_doesNotSaveToOutbox() {
+        // given
+        List<ImageEventCommand> commands = List.of();
+
+        // when
+        imageEventKafkaProducer.publishImageCreatedEvents(commands);
+
+        // then
+        verifyNoInteractions(saveOutboxEventPort, objectMapper);
+    }
+
+    @Test
+    @DisplayName("Outbox 저장 중 예외 발생 시 나머지 이벤트를 계속 처리한다")
+    void publishImageCreatedEvents_outboxSaveFailure_continuesProcessing() throws Exception {
+        // given
+        setUpClock("2026-03-27T10:00:00Z");
+        when(objectMapper.writeValueAsString(any()))
+                .thenThrow(new RuntimeException("직렬화 실패"))
+                .thenReturn("{}");
+
+        List<ImageEventCommand> commands = List.of(
+                new ImageEventCommand(1L, 100L, "PRODUCT", "https://cdn.example.com/1.png", 1),
+                new ImageEventCommand(2L, 100L, "PRODUCT", "https://cdn.example.com/2.png", 2)
+        );
+
+        // when
+        imageEventKafkaProducer.publishImageCreatedEvents(commands);
+
+        // then
+        verify(saveOutboxEventPort, times(1)).save(any(OutboxEvent.class));
+    }
+}

--- a/file-service/file-application/src/test/java/com/personal/marketnote/file/service/file/DeleteFileUseCaseTest.java
+++ b/file-service/file-application/src/test/java/com/personal/marketnote/file/service/file/DeleteFileUseCaseTest.java
@@ -1,0 +1,70 @@
+package com.personal.marketnote.file.service.file;
+
+import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.file.FileSort;
+import com.personal.marketnote.common.domain.file.OwnerType;
+import com.personal.marketnote.file.domain.file.FileDomain;
+import com.personal.marketnote.file.domain.file.FileDomainSnapshotState;
+import com.personal.marketnote.file.port.in.usecase.file.GetFileUseCase;
+import com.personal.marketnote.file.port.out.event.PublishImageEventPort;
+import com.personal.marketnote.file.port.out.file.UpdateFilePort;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DeleteFileUseCaseTest {
+    @InjectMocks
+    private DeleteFileService deleteFileService;
+
+    @Mock
+    private GetFileUseCase getFileUseCase;
+
+    @Mock
+    private UpdateFilePort updateFilePort;
+
+    @Mock
+    private PublishImageEventPort publishImageEventPort;
+
+    @Test
+    @DisplayName("파일 삭제 시 DELETED 이벤트를 발행한다")
+    void delete_publishesDeletedEvent() {
+        // given
+        Long fileId = 1L;
+        FileDomain file = FileDomain.from(FileDomainSnapshotState.builder()
+                .id(fileId)
+                .ownerType(OwnerType.PRODUCT)
+                .ownerId(100L)
+                .sort(FileSort.PRODUCT_REPRESENTATIVE_IMAGE)
+                .extension("png")
+                .name("test.png")
+                .storageUrl("https://cdn.example.com/test.png")
+                .createdAt(LocalDateTime.of(2026, 3, 27, 10, 0))
+                .status(EntityStatus.ACTIVE)
+                .orderNum(1L)
+                .build());
+        when(getFileUseCase.getFile(fileId)).thenReturn(file);
+
+        // when
+        deleteFileService.delete(fileId);
+
+        // then
+        verify(updateFilePort).update(file);
+        verify(publishImageEventPort).publishImageDeletedEvents(argThat(events ->
+                events.size() == 1
+                        && events.getFirst().imageId().equals(fileId)
+                        && events.getFirst().targetId().equals(100L)
+                        && events.getFirst().targetType().equals("PRODUCT")
+                        && events.getFirst().imageUrl().equals("https://cdn.example.com/test.png")
+        ));
+    }
+}

--- a/file-service/file-application/src/test/java/com/personal/marketnote/file/service/file/UpdateFilesUseCaseTest.java
+++ b/file-service/file-application/src/test/java/com/personal/marketnote/file/service/file/UpdateFilesUseCaseTest.java
@@ -5,6 +5,7 @@ import com.personal.marketnote.file.exception.InvalidFileCountLimitException;
 import com.personal.marketnote.file.port.in.command.UpdateFileCommand;
 import com.personal.marketnote.file.port.in.command.UpdateFilesCommand;
 import com.personal.marketnote.file.port.in.usecase.file.GetFileUseCase;
+import com.personal.marketnote.file.port.out.event.PublishImageEventPort;
 import com.personal.marketnote.file.port.out.file.SaveFilesPort;
 import com.personal.marketnote.file.port.out.file.UpdateFilesPort;
 import com.personal.marketnote.file.port.out.resized.SaveResizedFilesPort;
@@ -35,6 +36,8 @@ class UpdateFilesUseCaseTest {
     private SaveResizedFilesPort saveResizedFilesPort;
     @Mock
     private UpdateFilesPort updateFilesPort;
+    @Mock
+    private PublishImageEventPort publishImageEventPort;
 
     @InjectMocks
     private UpdateFilesService updateFilesService;


### PR DESCRIPTION
## partially addresses #194
## resolves #1639

## Test Case
- [x] 이미지 생성 이벤트 발행 시 올바른 토픽과 파티션 키로 Outbox에 저장된다
- [x] 이미지 생성 이벤트 발행 시 EventEnvelope에 CREATED 액션이 포함된다
- [x] 이미지 삭제 이벤트 발행 시 EventEnvelope에 DELETED 액션이 포함된다
- [x] 여러 이미지 생성 이벤트 발행 시 이벤트 수만큼 Outbox에 저장된다
- [x] 빈 이벤트 목록 발행 시 Outbox에 저장하지 않는다
- [x] Outbox 저장 중 예외 발생 시 나머지 이벤트를 계속 처리한다
- [x] 파일 삭제 시 DELETED 이벤트를 발행한다
- [x] 기존 UpdateFilesUseCaseTest PublishImageEventPort Mock 추가