### PR TITLE
[#128][#1645] feat: 상품 서비스 이미지 Read Model 구축

### DIFF
--- a/common/src/main/java/com/personal/marketnote/common/kafka/event/ImageChangedEvent.java
+++ b/common/src/main/java/com/personal/marketnote/common/kafka/event/ImageChangedEvent.java
@@ -4,6 +4,7 @@ public record ImageChangedEvent(
         Long imageId,
         Long targetId,
         String targetType,
+        String fileSort,
         String imageUrl,
         Integer sortOrder,
         ImageChangeAction action

--- a/file-service/file-adapters/src/main/java/com/personal/marketnote/file/adapter/out/event/ImageEventKafkaProducer.java
+++ b/file-service/file-adapters/src/main/java/com/personal/marketnote/file/adapter/out/event/ImageEventKafkaProducer.java
@@ -40,7 +40,7 @@ public class ImageEventKafkaProducer implements PublishImageEventPort {
         for (ImageEventCommand event : events) {
             ImageChangedEvent payload = new ImageChangedEvent(
                     event.imageId(), event.targetId(), event.targetType(),
-                    event.imageUrl(), event.sortOrder(), action
+                    event.fileSort(), event.imageUrl(), event.sortOrder(), action
             );
             String topic = KafkaTopicConstants.FILE_IMAGE_CHANGED;
             EventEnvelope<ImageChangedEvent> envelope = EventEnvelope.of(topic, SOURCE, payload, clock);

--- a/file-service/file-adapters/src/test/java/com/personal/marketnote/file/adapter/out/event/ImageEventKafkaProducerTest.java
+++ b/file-service/file-adapters/src/test/java/com/personal/marketnote/file/adapter/out/event/ImageEventKafkaProducerTest.java
@@ -52,7 +52,7 @@ class ImageEventKafkaProducerTest {
         setUpClock("2026-03-27T10:00:00Z");
         when(objectMapper.writeValueAsString(any())).thenReturn("{}");
 
-        ImageEventCommand command = new ImageEventCommand(1L, 100L, "PRODUCT", "https://cdn.example.com/image.png", 1);
+        ImageEventCommand command = new ImageEventCommand(1L, 100L, "PRODUCT", "PRODUCT_CATALOG_IMAGE", "https://cdn.example.com/image.png", 1);
         List<ImageEventCommand> commands = List.of(command);
 
         // when
@@ -77,7 +77,7 @@ class ImageEventKafkaProducerTest {
         setUpClock("2026-03-27T10:00:00Z");
         when(objectMapper.writeValueAsString(any())).thenReturn("{}");
 
-        ImageEventCommand command = new ImageEventCommand(10L, 200L, "PRODUCT", "https://cdn.example.com/image.png", 2);
+        ImageEventCommand command = new ImageEventCommand(10L, 200L, "PRODUCT", "PRODUCT_REPRESENTATIVE_IMAGE", "https://cdn.example.com/image.png", 2);
         List<ImageEventCommand> commands = List.of(command);
 
         // when
@@ -95,6 +95,7 @@ class ImageEventKafkaProducerTest {
         assertThat(payload.imageId()).isEqualTo(10L);
         assertThat(payload.targetId()).isEqualTo(200L);
         assertThat(payload.targetType()).isEqualTo("PRODUCT");
+        assertThat(payload.fileSort()).isEqualTo("PRODUCT_REPRESENTATIVE_IMAGE");
         assertThat(payload.imageUrl()).isEqualTo("https://cdn.example.com/image.png");
         assertThat(payload.sortOrder()).isEqualTo(2);
         assertThat(payload.action()).isEqualTo(ImageChangeAction.CREATED);
@@ -108,7 +109,7 @@ class ImageEventKafkaProducerTest {
         setUpClock("2026-03-27T10:00:00Z");
         when(objectMapper.writeValueAsString(any())).thenReturn("{}");
 
-        ImageEventCommand command = new ImageEventCommand(5L, 300L, "POST", "https://cdn.example.com/post.png", 0);
+        ImageEventCommand command = new ImageEventCommand(5L, 300L, "POST", "POST_IMAGE", "https://cdn.example.com/post.png", 0);
         List<ImageEventCommand> commands = List.of(command);
 
         // when
@@ -134,9 +135,9 @@ class ImageEventKafkaProducerTest {
         when(objectMapper.writeValueAsString(any())).thenReturn("{}");
 
         List<ImageEventCommand> commands = List.of(
-                new ImageEventCommand(1L, 100L, "PRODUCT", "https://cdn.example.com/1.png", 1),
-                new ImageEventCommand(2L, 100L, "PRODUCT", "https://cdn.example.com/2.png", 2),
-                new ImageEventCommand(3L, 100L, "PRODUCT", "https://cdn.example.com/3.png", 3)
+                new ImageEventCommand(1L, 100L, "PRODUCT", "PRODUCT_CATALOG_IMAGE", "https://cdn.example.com/1.png", 1),
+                new ImageEventCommand(2L, 100L, "PRODUCT", "PRODUCT_CATALOG_IMAGE", "https://cdn.example.com/2.png", 2),
+                new ImageEventCommand(3L, 100L, "PRODUCT", "PRODUCT_CATALOG_IMAGE", "https://cdn.example.com/3.png", 3)
         );
 
         // when
@@ -169,8 +170,8 @@ class ImageEventKafkaProducerTest {
                 .thenReturn("{}");
 
         List<ImageEventCommand> commands = List.of(
-                new ImageEventCommand(1L, 100L, "PRODUCT", "https://cdn.example.com/1.png", 1),
-                new ImageEventCommand(2L, 100L, "PRODUCT", "https://cdn.example.com/2.png", 2)
+                new ImageEventCommand(1L, 100L, "PRODUCT", "PRODUCT_CATALOG_IMAGE", "https://cdn.example.com/1.png", 1),
+                new ImageEventCommand(2L, 100L, "PRODUCT", "PRODUCT_CATALOG_IMAGE", "https://cdn.example.com/2.png", 2)
         );
 
         // when

--- a/file-service/file-application/src/main/java/com/personal/marketnote/file/port/out/event/ImageEventCommand.java
+++ b/file-service/file-application/src/main/java/com/personal/marketnote/file/port/out/event/ImageEventCommand.java
@@ -7,6 +7,7 @@ public record ImageEventCommand(
         Long imageId,
         Long targetId,
         String targetType,
+        String fileSort,
         String imageUrl,
         Integer sortOrder
 ) {
@@ -16,6 +17,7 @@ public record ImageEventCommand(
                 file.getId(),
                 file.getOwnerId(),
                 file.getOwnerType().name(),
+                file.getSort().name(),
                 file.getStorageUrl(),
                 FormatValidator.hasValue(file.getOrderNum()) ? file.getOrderNum().intValue() : 0
         );

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/event/ImageChangedReadModelConsumer.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/event/ImageChangedReadModelConsumer.java
@@ -1,0 +1,82 @@
+package com.personal.marketnote.product.adapter.in.event;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.common.kafka.KafkaTopicConstants;
+import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.EventPayloadValidator;
+import com.personal.marketnote.common.kafka.event.ImageChangeAction;
+import com.personal.marketnote.common.kafka.event.ImageChangedEvent;
+import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.product.port.out.file.SaveImageReadModelPort;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ImageChangedReadModelConsumer {
+    private static final String TARGET_TYPE_PRODUCT = "PRODUCT";
+
+    private final ObjectMapper objectMapper;
+    private final SaveImageReadModelPort saveImageReadModelPort;
+
+    @KafkaListener(
+            topics = KafkaTopicConstants.FILE_IMAGE_CHANGED,
+            groupId = "product-image-read-model"
+    )
+    public void handleImageChangedEvent(
+            ConsumerRecord<String, EventEnvelope<?>> record,
+            Acknowledgment acknowledgment
+    ) {
+        EventEnvelope<?> envelope = record.value();
+
+        if (EventPayloadValidator.hasInvalidEnvelope(envelope, record)) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        if (EventPayloadValidator.hasEventTypeMismatch(envelope, KafkaTopicConstants.FILE_IMAGE_CHANGED)) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        ImageChangedEvent payload = envelope.getPayloadAs(ImageChangedEvent.class, objectMapper);
+
+        log.info("이미지 변경 이벤트 수신. eventId={}, imageId={}, targetId={}, targetType={}, action={}",
+                envelope.eventId(), payload.imageId(), payload.targetId(),
+                payload.targetType(), payload.action());
+
+        if (EventPayloadValidator.hasInvalidIds(envelope.eventId(),
+                EventPayloadValidator.id("imageId", payload.imageId()),
+                EventPayloadValidator.id("targetId", payload.targetId()))) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        if (!FormatValidator.equals(payload.targetType(), TARGET_TYPE_PRODUCT)) {
+            log.debug("PRODUCT 타입이 아닌 이벤트 무시. targetType={}", payload.targetType());
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        if (payload.action() == ImageChangeAction.CREATED) {
+            saveImageReadModelPort.upsert(
+                    payload.imageId(), payload.targetId(), payload.targetType(),
+                    payload.fileSort(), payload.imageUrl(), payload.sortOrder()
+            );
+            log.info("이미지 Read Model 저장 완료. imageId={}, targetId={}",
+                    payload.imageId(), payload.targetId());
+        }
+
+        if (payload.action() == ImageChangeAction.DELETED) {
+            saveImageReadModelPort.deactivateByImageId(payload.imageId());
+            log.info("이미지 Read Model 비활성화 완료. imageId={}", payload.imageId());
+        }
+
+        acknowledgment.acknowledge();
+    }
+}

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/image/ImageReadModelPersistenceAdapter.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/image/ImageReadModelPersistenceAdapter.java
@@ -1,0 +1,84 @@
+package com.personal.marketnote.product.adapter.out.persistence.image;
+
+import com.personal.marketnote.common.adapter.out.PersistenceAdapter;
+import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.application.file.port.in.result.GetFileResult;
+import com.personal.marketnote.common.application.file.port.in.result.GetFilesResult;
+import com.personal.marketnote.common.domain.file.FileSort;
+import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.product.adapter.out.persistence.image.entity.ImageReadModelJpaEntity;
+import com.personal.marketnote.product.adapter.out.persistence.image.repository.ImageReadModelJpaRepository;
+import com.personal.marketnote.product.port.out.file.FindProductImagesPort;
+import com.personal.marketnote.product.port.out.file.SaveImageReadModelPort;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@Slf4j
+@PersistenceAdapter
+@RequiredArgsConstructor
+public class ImageReadModelPersistenceAdapter implements FindProductImagesPort, SaveImageReadModelPort {
+    private final ImageReadModelJpaRepository imageReadModelJpaRepository;
+
+    @Override
+    public Optional<GetFilesResult> findImagesByProductIdAndSort(Long productId, FileSort sort) {
+        List<ImageReadModelJpaEntity> entities =
+                imageReadModelJpaRepository.findByTargetIdAndFileSortAndStatusOrderBySortOrderAsc(
+                        productId, sort.name(), EntityStatus.ACTIVE
+                );
+
+        if (FormatValidator.hasNoValue(entities)) {
+            return Optional.empty();
+        }
+
+        List<GetFileResult> fileResults = entities.stream()
+                .map(entity -> new GetFileResult(
+                        entity.getImageId(),
+                        entity.getFileSort(),
+                        null,
+                        null,
+                        entity.getImageUrl(),
+                        List.of(),
+                        entity.getSortOrder().longValue()
+                ))
+                .toList();
+
+        return Optional.of(new GetFilesResult(fileResults));
+    }
+
+    @Override
+    @Transactional(isolation = READ_COMMITTED)
+    public void upsert(Long imageId, Long targetId, String targetType,
+                        String fileSort, String imageUrl, Integer sortOrder) {
+        Optional<ImageReadModelJpaEntity> existing = imageReadModelJpaRepository.findByImageId(imageId);
+
+        if (existing.isPresent()) {
+            existing.get().updateFrom(targetId, targetType, fileSort, imageUrl, sortOrder);
+            return;
+        }
+
+        try {
+            ImageReadModelJpaEntity entity = ImageReadModelJpaEntity.of(
+                    imageId, targetId, targetType, fileSort, imageUrl, sortOrder
+            );
+            imageReadModelJpaRepository.saveAndFlush(entity);
+        } catch (DataIntegrityViolationException e) {
+            log.info("이미지 Read Model 중복 저장 (멱등 처리). imageId={}", imageId);
+            imageReadModelJpaRepository.findByImageId(imageId)
+                    .ifPresent(entity -> entity.updateFrom(targetId, targetType, fileSort, imageUrl, sortOrder));
+        }
+    }
+
+    @Override
+    @Transactional(isolation = READ_COMMITTED)
+    public void deactivateByImageId(Long imageId) {
+        imageReadModelJpaRepository.findByImageId(imageId)
+                .ifPresent(ImageReadModelJpaEntity::markInactive);
+    }
+}

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/image/entity/ImageReadModelJpaEntity.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/image/entity/ImageReadModelJpaEntity.java
@@ -1,0 +1,68 @@
+package com.personal.marketnote.product.adapter.out.persistence.image.entity;
+
+import com.personal.marketnote.common.adapter.out.persistence.audit.BaseGeneralEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(
+        name = "image_read_models",
+        uniqueConstraints = @UniqueConstraint(name = "uk_image_read_model_image_id", columnNames = "imageId"),
+        indexes = @Index(name = "idx_image_read_model_target_sort", columnList = "targetId, fileSort, status")
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+@Getter
+public class ImageReadModelJpaEntity extends BaseGeneralEntity {
+
+    @Column(nullable = false, unique = true)
+    private Long imageId;
+
+    @Column(nullable = false)
+    private Long targetId;
+
+    @Column(nullable = false, length = 31)
+    private String targetType;
+
+    @Column(nullable = false, length = 63)
+    private String fileSort;
+
+    @Column(nullable = false, length = 511)
+    private String imageUrl;
+
+    @Column(nullable = false)
+    private Integer sortOrder;
+
+    public static ImageReadModelJpaEntity of(
+            Long imageId, Long targetId, String targetType,
+            String fileSort, String imageUrl, Integer sortOrder
+    ) {
+        return ImageReadModelJpaEntity.builder()
+                .imageId(imageId)
+                .targetId(targetId)
+                .targetType(targetType)
+                .fileSort(fileSort)
+                .imageUrl(imageUrl)
+                .sortOrder(sortOrder)
+                .build();
+    }
+
+    public void updateFrom(Long targetId, String targetType, String fileSort,
+                           String imageUrl, Integer sortOrder) {
+        this.targetId = targetId;
+        this.targetType = targetType;
+        this.fileSort = fileSort;
+        this.imageUrl = imageUrl;
+        this.sortOrder = sortOrder;
+        activate();
+    }
+
+    public void markInactive() {
+        deactivate();
+    }
+}

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/image/repository/ImageReadModelJpaRepository.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/image/repository/ImageReadModelJpaRepository.java
@@ -1,0 +1,17 @@
+package com.personal.marketnote.product.adapter.out.persistence.image.repository;
+
+import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.product.adapter.out.persistence.image.entity.ImageReadModelJpaEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ImageReadModelJpaRepository extends JpaRepository<ImageReadModelJpaEntity, Long> {
+
+    Optional<ImageReadModelJpaEntity> findByImageId(Long imageId);
+
+    List<ImageReadModelJpaEntity> findByTargetIdAndFileSortAndStatusOrderBySortOrderAsc(
+            Long targetId, String fileSort, EntityStatus status
+    );
+}

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/web/file/FileServiceClient.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/web/file/FileServiceClient.java
@@ -1,12 +1,7 @@
 package com.personal.marketnote.product.adapter.out.web.file;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.personal.marketnote.common.adapter.out.ServiceAdapter;
-import com.personal.marketnote.common.application.file.port.in.result.GetFileResult;
-import com.personal.marketnote.common.application.file.port.in.result.GetFilesResult;
-import com.personal.marketnote.common.domain.file.FileSort;
 import com.personal.marketnote.common.exception.FileServiceRequestFailedException;
 import com.personal.marketnote.common.security.hmac.HmacServiceAuthHeaderBuilder;
 import com.personal.marketnote.common.utility.FormatValidator;
@@ -14,12 +9,10 @@ import com.personal.marketnote.product.domain.servicecommunication.ProductServic
 import com.personal.marketnote.product.domain.servicecommunication.ProductServiceCommunicationTargetType;
 import com.personal.marketnote.product.domain.servicecommunication.ProductServiceCommunicationType;
 import com.personal.marketnote.product.port.out.file.DeleteProductImagesPort;
-import com.personal.marketnote.product.port.out.file.FindProductImagesPort;
 import com.personal.marketnote.product.utility.ServiceCommunicationPayloadGenerator;
 import com.personal.marketnote.product.utility.ServiceCommunicationRecorder;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.RestClient;
@@ -27,16 +20,10 @@ import org.springframework.web.util.UriComponentsBuilder;
 
 import java.io.IOException;
 import java.net.URI;
-import java.util.List;
-import java.util.Optional;
-import java.util.concurrent.ThreadLocalRandom;
-
-import static com.personal.marketnote.common.domain.file.OwnerType.PRODUCT;
-import static com.personal.marketnote.common.utility.ApiConstant.INTER_SERVER_MAX_REQUEST_COUNT;
 
 @ServiceAdapter
 @Slf4j
-public class FileServiceClient implements FindProductImagesPort, DeleteProductImagesPort {
+public class FileServiceClient implements DeleteProductImagesPort {
     private static final ProductServiceCommunicationTargetType TARGET_TYPE =
             ProductServiceCommunicationTargetType.PRODUCT_IMAGE;
     private static final ProductServiceCommunicationSenderType REQUEST_SENDER =
@@ -65,107 +52,6 @@ public class FileServiceClient implements FindProductImagesPort, DeleteProductIm
     }
 
     @Override
-    public Optional<GetFilesResult> findImagesByProductIdAndSort(Long productId, FileSort sort) {
-        URI uri = UriComponentsBuilder
-                .fromUriString(fileServiceBaseUrl)
-                .path("/api/v1/files")
-                .queryParam("ownerType", PRODUCT)
-                .queryParam("ownerId", productId)
-                .queryParam("sort", sort)
-                .build()
-                .toUri();
-
-        return sendFindRequest(uri, productId, sort);
-    }
-
-    private Optional<GetFilesResult> sendFindRequest(URI uri, Long productId, FileSort sort) {
-        for (int i = 0; i < INTER_SERVER_MAX_REQUEST_COUNT; i++) {
-            int attempt = i + 1;
-            try {
-                ResponseEntity<BaseResponse<FilesContent>> response =
-                        restClient.get()
-                                .uri(uri)
-                                .headers(headers -> hmacServiceAuthHeaderBuilder.applyHeaders(headers, "GET", uri.getPath()))
-                                .retrieve()
-                                .toEntity(new ParameterizedTypeReference<>() {
-                                });
-
-                if (response.getStatusCode().isError()) {
-                    throw new FileServiceRequestFailedException(new IOException("File service returned error: " + response.getStatusCode()));
-                }
-
-                BaseResponse<FilesContent> body = response.getBody();
-                FilesContent filesContent = null;
-                if (FormatValidator.hasValue(body)) {
-                    filesContent = body.content;
-                }
-
-                if (FormatValidator.hasNoValue(filesContent) || FormatValidator.hasNoValue(filesContent.files)) {
-                    return Optional.empty();
-                }
-
-                List<GetFileResult> getFileResults = filesContent.files
-                        .stream()
-                        .map(getFileResult -> new GetFileResult(
-                                getFileResult.id,
-                                getFileResult.sort,
-                                getFileResult.extension,
-                                getFileResult.name,
-                                getFileResult.storageUrl,
-                                getFileResult.resizedStorageUrls,
-                                getFileResult.orderNum
-                        ))
-                        .toList();
-
-                return Optional.of(new GetFilesResult(getFileResults));
-            } catch (Exception e) {
-                String exception = e.getClass().getSimpleName();
-                JsonNode requestPayloadJson = serviceCommunicationPayloadGenerator.buildRequestPayloadJson(
-                        HttpMethod.GET,
-                        uri,
-                        null,
-                        attempt
-                );
-                String requestPayload = requestPayloadJson.toString();
-                JsonNode responsePayloadJson = serviceCommunicationPayloadGenerator.buildErrorPayloadJson(
-                        exception,
-                        e.getMessage(),
-                        attempt
-                );
-                String responsePayload = responsePayloadJson.toString();
-                recordCommunication(
-                        TARGET_TYPE,
-                        String.valueOf(productId),
-                        ProductServiceCommunicationType.REQUEST,
-                        requestPayload,
-                        requestPayloadJson,
-                        exception
-                );
-                recordCommunication(
-                        TARGET_TYPE,
-                        String.valueOf(productId),
-                        ProductServiceCommunicationType.RESPONSE,
-                        responsePayload,
-                        responsePayloadJson,
-                        exception
-                );
-                log.warn(e.getMessage(), e);
-
-                try {
-                    long jitteredSleepMillis = ThreadLocalRandom.current()
-                            .nextLong(Math.max(1L, 2000L) + 1);
-                    Thread.sleep(jitteredSleepMillis);
-                } catch (InterruptedException ie) {
-                    Thread.currentThread().interrupt();
-                }
-            }
-        }
-
-        log.error("Failed to find images by product id: {} and sort: {}", productId, sort);
-        return Optional.empty();
-    }
-
-    @Override
     public void delete(Long fileId) {
         URI uri = UriComponentsBuilder
                 .fromUriString(fileServiceBaseUrl)
@@ -185,7 +71,7 @@ public class FileServiceClient implements FindProductImagesPort, DeleteProductIm
                     .toBodilessEntity();
 
             if (responseEntity.getStatusCode().isError()) {
-                throw new RuntimeException("File service returned error: " + responseEntity.getStatusCode());
+                throw new FileServiceRequestFailedException(new IOException("File service returned error: " + responseEntity.getStatusCode()));
             }
         } catch (Exception e) {
             String exception = e.getClass().getSimpleName();
@@ -246,41 +132,5 @@ public class FileServiceClient implements FindProductImagesPort, DeleteProductIm
                 payloadJson,
                 exception
         );
-    }
-
-    @JsonIgnoreProperties(ignoreUnknown = true)
-    private static class BaseResponse<T> {
-        @JsonProperty("content")
-        T content;
-    }
-
-    @JsonIgnoreProperties(ignoreUnknown = true)
-    private static class FilesContent {
-        @JsonProperty("files")
-        List<FileItem> files;
-    }
-
-    @JsonIgnoreProperties(ignoreUnknown = true)
-    private static class FileItem {
-        @JsonProperty("id")
-        Long id;
-
-        @JsonProperty("sort")
-        String sort;
-
-        @JsonProperty("extension")
-        String extension;
-
-        @JsonProperty("name")
-        String name;
-
-        @JsonProperty("storageUrl")
-        String storageUrl;
-
-        @JsonProperty("resizedStorageUrls")
-        List<String> resizedStorageUrls;
-
-        @JsonProperty("orderNum")
-        Long orderNum;
     }
 }

--- a/product-service/product-adapters/src/test/java/com/personal/marketnote/product/adapter/out/web/file/FileServiceClientTest.java
+++ b/product-service/product-adapters/src/test/java/com/personal/marketnote/product/adapter/out/web/file/FileServiceClientTest.java
@@ -1,8 +1,6 @@
 package com.personal.marketnote.product.adapter.out.web.file;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.personal.marketnote.common.application.file.port.in.result.GetFilesResult;
-import com.personal.marketnote.common.domain.file.FileSort;
 import com.personal.marketnote.common.exception.FileServiceRequestFailedException;
 import com.personal.marketnote.common.security.hmac.HmacServiceAuthHeaderBuilder;
 import com.personal.marketnote.common.utility.http.client.restclient.RestClientErrorHandler;
@@ -16,13 +14,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpMethod;
-import org.springframework.http.MediaType;
 import org.springframework.test.web.client.MockRestServiceServer;
 import org.springframework.web.client.RestClient;
 
-import java.util.Optional;
-
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.lenient;
@@ -66,78 +60,6 @@ class FileServiceClientTest {
                 .thenReturn(objectMapper.createObjectNode());
         lenient().when(serviceCommunicationPayloadGenerator.buildErrorPayloadJson(anyString(), any(), anyInt()))
                 .thenReturn(objectMapper.createObjectNode());
-    }
-
-    @Nested
-    @DisplayName("findImagesByProductIdAndSort")
-    class FindImagesByProductIdAndSort {
-
-        @Test
-        @DisplayName("상품 이미지 조회에 성공하면 GetFilesResult를 반환한다")
-        void shouldReturnFilesResultWhenRequestSucceeds() {
-            mockServer.expect(requestTo(BASE_URL + "/api/v1/files?ownerType=PRODUCT&ownerId=1&sort=PRODUCT_CATALOG_IMAGE"))
-                    .andExpect(method(HttpMethod.GET))
-                    .andRespond(withSuccess("""
-                            {
-                                "content": {
-                                    "files": [
-                                        {
-                                            "id": 1,
-                                            "sort": "PRODUCT_THUMBNAIL",
-                                            "extension": "jpg",
-                                            "name": "image1.jpg",
-                                            "storageUrl": "https://s3.example.com/image1.jpg",
-                                            "resizedStorageUrls": ["https://s3.example.com/image1_200.jpg"],
-                                            "orderNum": 1
-                                        }
-                                    ]
-                                }
-                            }
-                            """, MediaType.APPLICATION_JSON));
-
-            Optional<GetFilesResult> result =
-                    fileServiceClient.findImagesByProductIdAndSort(1L, FileSort.PRODUCT_CATALOG_IMAGE);
-
-            assertThat(result).isPresent();
-            assertThat(result.get().images()).hasSize(1);
-            assertThat(result.get().images().get(0).name()).isEqualTo("image1.jpg");
-
-            mockServer.verify();
-        }
-
-        @Test
-        @DisplayName("응답에 파일이 없으면 빈 Optional을 반환한다")
-        void shouldReturnEmptyOptionalWhenNoFiles() {
-            mockServer.expect(requestTo(BASE_URL + "/api/v1/files?ownerType=PRODUCT&ownerId=1&sort=PRODUCT_CATALOG_IMAGE"))
-                    .andExpect(method(HttpMethod.GET))
-                    .andRespond(withSuccess("""
-                            {"content": {"files": null}}
-                            """, MediaType.APPLICATION_JSON));
-
-            Optional<GetFilesResult> result =
-                    fileServiceClient.findImagesByProductIdAndSort(1L, FileSort.PRODUCT_CATALOG_IMAGE);
-
-            assertThat(result).isEmpty();
-
-            mockServer.verify();
-        }
-
-        @Test
-        @DisplayName("모든 재시도가 실패하면 빈 Optional을 반환한다")
-        void shouldReturnEmptyOptionalWhenAllRetriesFail() {
-            for (int i = 0; i < 5; i++) {
-                mockServer.expect(requestTo(BASE_URL + "/api/v1/files?ownerType=PRODUCT&ownerId=1&sort=PRODUCT_CATALOG_IMAGE"))
-                        .andExpect(method(HttpMethod.GET))
-                        .andRespond(withServerError());
-            }
-
-            Optional<GetFilesResult> result =
-                    fileServiceClient.findImagesByProductIdAndSort(1L, FileSort.PRODUCT_CATALOG_IMAGE);
-
-            assertThat(result).isEmpty();
-
-            mockServer.verify();
-        }
     }
 
     @Nested

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/out/file/SaveImageReadModelPort.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/out/file/SaveImageReadModelPort.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.product.port.out.file;
+
+public interface SaveImageReadModelPort {
+
+    void upsert(Long imageId, Long targetId, String targetType,
+                String fileSort, String imageUrl, Integer sortOrder);
+
+    void deactivateByImageId(Long imageId);
+}


### PR DESCRIPTION
## partially addresses #128
## resolves #1645

## Task
- [x] ImageChangedEvent에 fileSort 필드 추가 (common)
- [x] ImageEventCommand에 fileSort 필드 추가 + Producer 수정 (file-service)
- [x] 이미지 Read Model JPA 엔티티 + 테이블 생성 (product-adapters)
- [x] ImageReadModelPersistenceAdapter 구현 (FindProductImagesPort 교체)
- [x] ImageChangedReadModelConsumer 구현 (file.image.changed 소비)
- [x] FileServiceClient.findImagesByProductIdAndSort() 제거