### PR TITLE
[#128][#1710] test: 상품 서비스 이미지 Read Model 구축 기능 자동화 테스트 추가

### DIFF
--- a/product-service/product-adapters/src/test/java/com/personal/marketnote/product/adapter/in/event/ImageChangedReadModelConsumerTest.java
+++ b/product-service/product-adapters/src/test/java/com/personal/marketnote/product/adapter/in/event/ImageChangedReadModelConsumerTest.java
@@ -1,0 +1,196 @@
+package com.personal.marketnote.product.adapter.in.event;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.common.kafka.KafkaTopicConstants;
+import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.ImageChangeAction;
+import com.personal.marketnote.common.kafka.event.ImageChangedEvent;
+import com.personal.marketnote.product.port.out.file.SaveImageReadModelPort;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.support.Acknowledgment;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ImageChangedReadModelConsumerTest {
+
+    @InjectMocks
+    private ImageChangedReadModelConsumer consumer;
+
+    @Spy
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @Mock
+    private SaveImageReadModelPort saveImageReadModelPort;
+
+    @Mock
+    private Acknowledgment acknowledgment;
+
+    private ConsumerRecord<String, EventEnvelope<?>> createRecord(EventEnvelope<?> envelope) {
+        return new ConsumerRecord<>(
+                KafkaTopicConstants.FILE_IMAGE_CHANGED, 0, 0, "1", envelope
+        );
+    }
+
+    private EventEnvelope<ImageChangedEvent> createEnvelope(ImageChangedEvent payload) {
+        return new EventEnvelope<>(
+                "test-event-id",
+                KafkaTopicConstants.FILE_IMAGE_CHANGED,
+                "file-service",
+                LocalDateTime.now(Clock.fixed(Instant.parse("2026-03-27T10:00:00Z"), ZoneId.of("Asia/Seoul"))),
+                payload
+        );
+    }
+
+    @Test
+    @DisplayName("PRODUCT 타입 CREATED 이벤트 수신 시 Read Model을 upsert한다")
+    void handleImageChangedEvent_createdProduct_upsertsReadModel() {
+        // given
+        ImageChangedEvent payload = new ImageChangedEvent(
+                1L, 100L, "PRODUCT", "PRODUCT_CATALOG_IMAGE",
+                "https://cdn.example.com/image.png", 1, ImageChangeAction.CREATED
+        );
+        EventEnvelope<ImageChangedEvent> envelope = createEnvelope(payload);
+        ConsumerRecord<String, EventEnvelope<?>> record = createRecord(envelope);
+
+        // when
+        consumer.handleImageChangedEvent(record, acknowledgment);
+
+        // then
+        verify(saveImageReadModelPort).upsert(
+                1L, 100L, "PRODUCT", "PRODUCT_CATALOG_IMAGE",
+                "https://cdn.example.com/image.png", 1
+        );
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("PRODUCT 타입 DELETED 이벤트 수신 시 Read Model을 비활성화한다")
+    void handleImageChangedEvent_deletedProduct_deactivatesReadModel() {
+        // given
+        ImageChangedEvent payload = new ImageChangedEvent(
+                2L, 100L, "PRODUCT", "PRODUCT_REPRESENTATIVE_IMAGE",
+                "https://cdn.example.com/image.png", 1, ImageChangeAction.DELETED
+        );
+        EventEnvelope<ImageChangedEvent> envelope = createEnvelope(payload);
+        ConsumerRecord<String, EventEnvelope<?>> record = createRecord(envelope);
+
+        // when
+        consumer.handleImageChangedEvent(record, acknowledgment);
+
+        // then
+        verify(saveImageReadModelPort).deactivateByImageId(2L);
+        verifyNoMoreInteractions(saveImageReadModelPort);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("PRODUCT 타입이 아닌 이벤트는 무시한다")
+    void handleImageChangedEvent_nonProductType_ignoresEvent() {
+        // given
+        ImageChangedEvent payload = new ImageChangedEvent(
+                3L, 200L, "POST", "POST_IMAGE",
+                "https://cdn.example.com/post.png", 1, ImageChangeAction.CREATED
+        );
+        EventEnvelope<ImageChangedEvent> envelope = createEnvelope(payload);
+        ConsumerRecord<String, EventEnvelope<?>> record = createRecord(envelope);
+
+        // when
+        consumer.handleImageChangedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(saveImageReadModelPort);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("envelope가 null이면 즉시 acknowledge한다")
+    void handleImageChangedEvent_nullEnvelope_acknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = new ConsumerRecord<>(
+                KafkaTopicConstants.FILE_IMAGE_CHANGED, 0, 0, "1", null
+        );
+
+        // when
+        consumer.handleImageChangedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(saveImageReadModelPort);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("이벤트 타입이 불일치하면 즉시 acknowledge한다")
+    void handleImageChangedEvent_eventTypeMismatch_acknowledges() {
+        // given
+        ImageChangedEvent payload = new ImageChangedEvent(
+                4L, 100L, "PRODUCT", "PRODUCT_CATALOG_IMAGE",
+                "https://cdn.example.com/image.png", 1, ImageChangeAction.CREATED
+        );
+        EventEnvelope<ImageChangedEvent> envelope = new EventEnvelope<>(
+                "test-event-id",
+                "wrong.event.type",
+                "file-service",
+                LocalDateTime.now(),
+                payload
+        );
+        ConsumerRecord<String, EventEnvelope<?>> record = createRecord(envelope);
+
+        // when
+        consumer.handleImageChangedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(saveImageReadModelPort);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("imageId가 유효하지 않으면 즉시 acknowledge한다")
+    void handleImageChangedEvent_invalidImageId_acknowledges() {
+        // given
+        ImageChangedEvent payload = new ImageChangedEvent(
+                -1L, 100L, "PRODUCT", "PRODUCT_CATALOG_IMAGE",
+                "https://cdn.example.com/image.png", 1, ImageChangeAction.CREATED
+        );
+        EventEnvelope<ImageChangedEvent> envelope = createEnvelope(payload);
+        ConsumerRecord<String, EventEnvelope<?>> record = createRecord(envelope);
+
+        // when
+        consumer.handleImageChangedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(saveImageReadModelPort);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("targetId가 유효하지 않으면 즉시 acknowledge한다")
+    void handleImageChangedEvent_invalidTargetId_acknowledges() {
+        // given
+        ImageChangedEvent payload = new ImageChangedEvent(
+                5L, 0L, "PRODUCT", "PRODUCT_CATALOG_IMAGE",
+                "https://cdn.example.com/image.png", 1, ImageChangeAction.CREATED
+        );
+        EventEnvelope<ImageChangedEvent> envelope = createEnvelope(payload);
+        ConsumerRecord<String, EventEnvelope<?>> record = createRecord(envelope);
+
+        // when
+        consumer.handleImageChangedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(saveImageReadModelPort);
+        verify(acknowledgment).acknowledge();
+    }
+}

--- a/product-service/product-adapters/src/test/java/com/personal/marketnote/product/adapter/out/persistence/image/ImageReadModelPersistenceAdapterTest.java
+++ b/product-service/product-adapters/src/test/java/com/personal/marketnote/product/adapter/out/persistence/image/ImageReadModelPersistenceAdapterTest.java
@@ -1,0 +1,199 @@
+package com.personal.marketnote.product.adapter.out.persistence.image;
+
+import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.application.file.port.in.result.GetFileResult;
+import com.personal.marketnote.common.application.file.port.in.result.GetFilesResult;
+import com.personal.marketnote.common.configuration.AuditConfig;
+import com.personal.marketnote.common.domain.file.FileSort;
+import com.personal.marketnote.product.adapter.out.persistence.image.entity.ImageReadModelJpaEntity;
+import com.personal.marketnote.product.adapter.out.persistence.image.repository.ImageReadModelJpaRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@ActiveProfiles("test")
+@Import({AuditConfig.class, ImageReadModelPersistenceAdapter.class})
+class ImageReadModelPersistenceAdapterTest {
+
+    @Autowired
+    private ImageReadModelPersistenceAdapter adapter;
+
+    @Autowired
+    private ImageReadModelJpaRepository repository;
+
+    @BeforeEach
+    void setUp() {
+        repository.deleteAll();
+    }
+
+    @Nested
+    @DisplayName("findImagesByProductIdAndSort")
+    class FindImagesByProductIdAndSort {
+
+        @Test
+        @DisplayName("ACTIVE 상태의 이미지를 sortOrder 오름차순으로 조회한다")
+        void returnsActiveImagesSortedBySortOrder() {
+            // given
+            adapter.upsert(1L, 100L, "PRODUCT", "PRODUCT_CATALOG_IMAGE", "https://cdn.example.com/2.png", 2);
+            adapter.upsert(2L, 100L, "PRODUCT", "PRODUCT_CATALOG_IMAGE", "https://cdn.example.com/1.png", 1);
+            adapter.upsert(3L, 100L, "PRODUCT", "PRODUCT_CATALOG_IMAGE", "https://cdn.example.com/3.png", 3);
+
+            // when
+            Optional<GetFilesResult> result = adapter.findImagesByProductIdAndSort(100L, FileSort.PRODUCT_CATALOG_IMAGE);
+
+            // then
+            assertThat(result).isPresent();
+            assertThat(result.get().images()).hasSize(3);
+            assertThat(result.get().images().get(0).orderNum()).isEqualTo(1L);
+            assertThat(result.get().images().get(1).orderNum()).isEqualTo(2L);
+            assertThat(result.get().images().get(2).orderNum()).isEqualTo(3L);
+        }
+
+        @Test
+        @DisplayName("INACTIVE 상태의 이미지는 조회하지 않는다")
+        void excludesInactiveImages() {
+            // given
+            adapter.upsert(1L, 100L, "PRODUCT", "PRODUCT_CATALOG_IMAGE", "https://cdn.example.com/1.png", 1);
+            adapter.deactivateByImageId(1L);
+
+            // when
+            Optional<GetFilesResult> result = adapter.findImagesByProductIdAndSort(100L, FileSort.PRODUCT_CATALOG_IMAGE);
+
+            // then
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("다른 fileSort의 이미지는 조회하지 않는다")
+        void excludesDifferentFileSort() {
+            // given
+            adapter.upsert(1L, 100L, "PRODUCT", "PRODUCT_CATALOG_IMAGE", "https://cdn.example.com/1.png", 1);
+            adapter.upsert(2L, 100L, "PRODUCT", "PRODUCT_REPRESENTATIVE_IMAGE", "https://cdn.example.com/2.png", 1);
+
+            // when
+            Optional<GetFilesResult> result = adapter.findImagesByProductIdAndSort(100L, FileSort.PRODUCT_CATALOG_IMAGE);
+
+            // then
+            assertThat(result).isPresent();
+            assertThat(result.get().images()).hasSize(1);
+            assertThat(result.get().images().getFirst().id()).isEqualTo(1L);
+        }
+
+        @Test
+        @DisplayName("해당 상품의 이미지가 없으면 empty를 반환한다")
+        void returnsEmptyWhenNoImages() {
+            // when
+            Optional<GetFilesResult> result = adapter.findImagesByProductIdAndSort(999L, FileSort.PRODUCT_CATALOG_IMAGE);
+
+            // then
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("조회 결과에 imageUrl과 fileSort가 올바르게 매핑된다")
+        void mapsFieldsCorrectly() {
+            // given
+            adapter.upsert(10L, 200L, "PRODUCT", "PRODUCT_REPRESENTATIVE_IMAGE", "https://cdn.example.com/rep.png", 5);
+
+            // when
+            Optional<GetFilesResult> result = adapter.findImagesByProductIdAndSort(200L, FileSort.PRODUCT_REPRESENTATIVE_IMAGE);
+
+            // then
+            assertThat(result).isPresent();
+            GetFileResult fileResult = result.get().images().getFirst();
+            assertThat(fileResult.id()).isEqualTo(10L);
+            assertThat(fileResult.sort()).isEqualTo("PRODUCT_REPRESENTATIVE_IMAGE");
+            assertThat(fileResult.storageUrl()).isEqualTo("https://cdn.example.com/rep.png");
+            assertThat(fileResult.orderNum()).isEqualTo(5L);
+            assertThat(fileResult.resizedStorageUrls()).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("upsert")
+    class Upsert {
+
+        @Test
+        @DisplayName("신규 이미지를 저장한다")
+        void insertsNewImage() {
+            // when
+            adapter.upsert(1L, 100L, "PRODUCT", "PRODUCT_CATALOG_IMAGE", "https://cdn.example.com/1.png", 1);
+
+            // then
+            Optional<ImageReadModelJpaEntity> entity = repository.findByImageId(1L);
+            assertThat(entity).isPresent();
+            assertThat(entity.get().getTargetId()).isEqualTo(100L);
+            assertThat(entity.get().getFileSort()).isEqualTo("PRODUCT_CATALOG_IMAGE");
+            assertThat(entity.get().getStatus()).isEqualTo(EntityStatus.ACTIVE);
+        }
+
+        @Test
+        @DisplayName("동일한 imageId로 upsert 시 기존 데이터를 업데이트한다")
+        void updatesExistingImage() {
+            // given
+            adapter.upsert(1L, 100L, "PRODUCT", "PRODUCT_CATALOG_IMAGE", "https://cdn.example.com/old.png", 1);
+
+            // when
+            adapter.upsert(1L, 100L, "PRODUCT", "PRODUCT_CATALOG_IMAGE", "https://cdn.example.com/new.png", 2);
+
+            // then
+            Optional<ImageReadModelJpaEntity> entity = repository.findByImageId(1L);
+            assertThat(entity).isPresent();
+            assertThat(entity.get().getImageUrl()).isEqualTo("https://cdn.example.com/new.png");
+            assertThat(entity.get().getSortOrder()).isEqualTo(2);
+        }
+
+        @Test
+        @DisplayName("비활성화된 이미지에 대해 upsert 시 다시 활성화된다")
+        void reactivatesInactiveImage() {
+            // given
+            adapter.upsert(1L, 100L, "PRODUCT", "PRODUCT_CATALOG_IMAGE", "https://cdn.example.com/1.png", 1);
+            adapter.deactivateByImageId(1L);
+
+            // when
+            adapter.upsert(1L, 100L, "PRODUCT", "PRODUCT_CATALOG_IMAGE", "https://cdn.example.com/1.png", 1);
+
+            // then
+            Optional<ImageReadModelJpaEntity> entity = repository.findByImageId(1L);
+            assertThat(entity).isPresent();
+            assertThat(entity.get().getStatus()).isEqualTo(EntityStatus.ACTIVE);
+        }
+    }
+
+    @Nested
+    @DisplayName("deactivateByImageId")
+    class DeactivateByImageId {
+
+        @Test
+        @DisplayName("이미지를 비활성화한다")
+        void deactivatesImage() {
+            // given
+            adapter.upsert(1L, 100L, "PRODUCT", "PRODUCT_CATALOG_IMAGE", "https://cdn.example.com/1.png", 1);
+
+            // when
+            adapter.deactivateByImageId(1L);
+
+            // then
+            Optional<ImageReadModelJpaEntity> entity = repository.findByImageId(1L);
+            assertThat(entity).isPresent();
+            assertThat(entity.get().getStatus()).isEqualTo(EntityStatus.INACTIVE);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 imageId 비활성화 시 에러 없이 무시한다")
+        void ignoresNonExistentImage() {
+            // when & then — no exception
+            adapter.deactivateByImageId(999L);
+        }
+    }
+}


### PR DESCRIPTION
## partially addresses #128
## resolves #1710

## Test Case
- [x] PRODUCT 타입 CREATED 이벤트 수신 시 Read Model을 upsert한다
- [x] PRODUCT 타입 DELETED 이벤트 수신 시 Read Model을 비활성화한다
- [x] PRODUCT 타입이 아닌 이벤트는 무시한다
- [x] envelope가 null이면 즉시 acknowledge한다
- [x] 이벤트 타입이 불일치하면 즉시 acknowledge한다
- [x] imageId가 유효하지 않으면 즉시 acknowledge한다
- [x] targetId가 유효하지 않으면 즉시 acknowledge한다
- [x] ACTIVE 상태의 이미지를 sortOrder 오름차순으로 조회한다
- [x] INACTIVE 상태의 이미지는 조회하지 않는다
- [x] 다른 fileSort의 이미지는 조회하지 않는다
- [x] 해당 상품의 이미지가 없으면 empty를 반환한다
- [x] 조회 결과에 imageUrl과 fileSort가 올바르게 매핑된다
- [x] 신규 이미지를 저장한다
- [x] 동일한 imageId로 upsert 시 기존 데이터를 업데이트한다
- [x] 비활성화된 이미지에 대해 upsert 시 다시 활성화된다