### PR TITLE
[#300][#1646] feat: 커뮤니티 서비스 이미지 Read Model 구축

### DIFF
--- a/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/in/event/ImageChangedReadModelConsumer.java
+++ b/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/in/event/ImageChangedReadModelConsumer.java
@@ -1,0 +1,84 @@
+package com.personal.marketnote.community.adapter.in.event;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.common.kafka.KafkaTopicConstants;
+import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.EventPayloadValidator;
+import com.personal.marketnote.common.kafka.event.ImageChangeAction;
+import com.personal.marketnote.common.kafka.event.ImageChangedEvent;
+import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.community.port.out.file.SaveImageReadModelPort;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ImageChangedReadModelConsumer {
+    private static final String TARGET_TYPE_POST = "POST";
+    private static final String TARGET_TYPE_REVIEW = "REVIEW";
+
+    private final ObjectMapper objectMapper;
+    private final SaveImageReadModelPort saveImageReadModelPort;
+
+    @KafkaListener(
+            topics = KafkaTopicConstants.FILE_IMAGE_CHANGED,
+            groupId = "community-image-read-model"
+    )
+    public void handleImageChangedEvent(
+            ConsumerRecord<String, EventEnvelope<?>> record,
+            Acknowledgment acknowledgment
+    ) {
+        EventEnvelope<?> envelope = record.value();
+
+        if (EventPayloadValidator.hasInvalidEnvelope(envelope, record)) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        if (EventPayloadValidator.hasEventTypeMismatch(envelope, KafkaTopicConstants.FILE_IMAGE_CHANGED)) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        ImageChangedEvent payload = envelope.getPayloadAs(ImageChangedEvent.class, objectMapper);
+
+        log.info("이미지 변경 이벤트 수신. eventId={}, imageId={}, targetId={}, targetType={}, action={}",
+                envelope.eventId(), payload.imageId(), payload.targetId(),
+                payload.targetType(), payload.action());
+
+        if (EventPayloadValidator.hasInvalidIds(envelope.eventId(),
+                EventPayloadValidator.id("imageId", payload.imageId()),
+                EventPayloadValidator.id("targetId", payload.targetId()))) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        if (!FormatValidator.equals(payload.targetType(), TARGET_TYPE_POST)
+                && !FormatValidator.equals(payload.targetType(), TARGET_TYPE_REVIEW)) {
+            log.debug("POST/REVIEW 타입이 아닌 이벤트 무시. targetType={}", payload.targetType());
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        if (payload.action() == ImageChangeAction.CREATED) {
+            saveImageReadModelPort.upsert(
+                    payload.imageId(), payload.targetId(), payload.targetType(),
+                    payload.fileSort(), payload.imageUrl(), payload.sortOrder()
+            );
+            log.info("이미지 Read Model 저장 완료. imageId={}, targetId={}",
+                    payload.imageId(), payload.targetId());
+        }
+
+        if (payload.action() == ImageChangeAction.DELETED) {
+            saveImageReadModelPort.deactivateByImageId(payload.imageId());
+            log.info("이미지 Read Model 비활성화 완료. imageId={}", payload.imageId());
+        }
+
+        acknowledgment.acknowledge();
+    }
+}

--- a/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/out/persistence/image/ImageReadModelPersistenceAdapter.java
+++ b/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/out/persistence/image/ImageReadModelPersistenceAdapter.java
@@ -1,0 +1,94 @@
+package com.personal.marketnote.community.adapter.out.persistence.image;
+
+import com.personal.marketnote.common.adapter.out.PersistenceAdapter;
+import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.application.file.port.in.result.GetFileResult;
+import com.personal.marketnote.common.application.file.port.in.result.GetFilesResult;
+import com.personal.marketnote.common.domain.file.FileSort;
+import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.community.adapter.out.persistence.image.entity.ImageReadModelJpaEntity;
+import com.personal.marketnote.community.adapter.out.persistence.image.repository.ImageReadModelJpaRepository;
+import com.personal.marketnote.community.port.out.file.FindPostImagesPort;
+import com.personal.marketnote.community.port.out.file.FindReviewImagesPort;
+import com.personal.marketnote.community.port.out.file.SaveImageReadModelPort;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@Slf4j
+@PersistenceAdapter
+@RequiredArgsConstructor
+public class ImageReadModelPersistenceAdapter implements FindPostImagesPort, FindReviewImagesPort, SaveImageReadModelPort {
+    private final ImageReadModelJpaRepository imageReadModelJpaRepository;
+
+    @Override
+    public Optional<GetFilesResult> findImagesByPostIdAndSort(Long postId, FileSort sort) {
+        return findImagesByTargetIdAndSort(postId, sort);
+    }
+
+    @Override
+    public Optional<GetFilesResult> findImagesByReviewIdAndSort(Long reviewId, FileSort sort) {
+        return findImagesByTargetIdAndSort(reviewId, sort);
+    }
+
+    private Optional<GetFilesResult> findImagesByTargetIdAndSort(Long targetId, FileSort sort) {
+        List<ImageReadModelJpaEntity> entities =
+                imageReadModelJpaRepository.findByTargetIdAndFileSortAndStatusOrderBySortOrderAsc(
+                        targetId, sort.name(), EntityStatus.ACTIVE
+                );
+
+        if (FormatValidator.hasNoValue(entities)) {
+            return Optional.empty();
+        }
+
+        List<GetFileResult> fileResults = entities.stream()
+                .map(entity -> new GetFileResult(
+                        entity.getImageId(),
+                        entity.getFileSort(),
+                        null,
+                        null,
+                        entity.getImageUrl(),
+                        List.of(),
+                        entity.getSortOrder().longValue()
+                ))
+                .toList();
+
+        return Optional.of(new GetFilesResult(fileResults));
+    }
+
+    @Override
+    @Transactional(isolation = READ_COMMITTED)
+    public void upsert(Long imageId, Long targetId, String targetType,
+                        String fileSort, String imageUrl, Integer sortOrder) {
+        Optional<ImageReadModelJpaEntity> existing = imageReadModelJpaRepository.findByImageId(imageId);
+
+        if (existing.isPresent()) {
+            existing.get().updateFrom(targetId, targetType, fileSort, imageUrl, sortOrder);
+            return;
+        }
+
+        try {
+            ImageReadModelJpaEntity entity = ImageReadModelJpaEntity.of(
+                    imageId, targetId, targetType, fileSort, imageUrl, sortOrder
+            );
+            imageReadModelJpaRepository.saveAndFlush(entity);
+        } catch (DataIntegrityViolationException e) {
+            log.info("이미지 Read Model 중복 저장 (멱등 처리). imageId={}", imageId);
+            imageReadModelJpaRepository.findByImageId(imageId)
+                    .ifPresent(entity -> entity.updateFrom(targetId, targetType, fileSort, imageUrl, sortOrder));
+        }
+    }
+
+    @Override
+    @Transactional(isolation = READ_COMMITTED)
+    public void deactivateByImageId(Long imageId) {
+        imageReadModelJpaRepository.findByImageId(imageId)
+                .ifPresent(ImageReadModelJpaEntity::markInactive);
+    }
+}

--- a/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/out/persistence/image/entity/ImageReadModelJpaEntity.java
+++ b/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/out/persistence/image/entity/ImageReadModelJpaEntity.java
@@ -1,0 +1,68 @@
+package com.personal.marketnote.community.adapter.out.persistence.image.entity;
+
+import com.personal.marketnote.common.adapter.out.persistence.audit.BaseGeneralEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(
+        name = "image_read_models",
+        uniqueConstraints = @UniqueConstraint(name = "uk_image_read_model_image_id", columnNames = "imageId"),
+        indexes = @Index(name = "idx_image_read_model_target_sort", columnList = "targetId, fileSort, status")
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+@Getter
+public class ImageReadModelJpaEntity extends BaseGeneralEntity {
+
+    @Column(nullable = false, unique = true)
+    private Long imageId;
+
+    @Column(nullable = false)
+    private Long targetId;
+
+    @Column(nullable = false, length = 31)
+    private String targetType;
+
+    @Column(nullable = false, length = 63)
+    private String fileSort;
+
+    @Column(nullable = false, length = 511)
+    private String imageUrl;
+
+    @Column(nullable = false)
+    private Integer sortOrder;
+
+    public static ImageReadModelJpaEntity of(
+            Long imageId, Long targetId, String targetType,
+            String fileSort, String imageUrl, Integer sortOrder
+    ) {
+        return ImageReadModelJpaEntity.builder()
+                .imageId(imageId)
+                .targetId(targetId)
+                .targetType(targetType)
+                .fileSort(fileSort)
+                .imageUrl(imageUrl)
+                .sortOrder(sortOrder)
+                .build();
+    }
+
+    public void updateFrom(Long targetId, String targetType, String fileSort,
+                           String imageUrl, Integer sortOrder) {
+        this.targetId = targetId;
+        this.targetType = targetType;
+        this.fileSort = fileSort;
+        this.imageUrl = imageUrl;
+        this.sortOrder = sortOrder;
+        activate();
+    }
+
+    public void markInactive() {
+        deactivate();
+    }
+}

--- a/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/out/persistence/image/repository/ImageReadModelJpaRepository.java
+++ b/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/out/persistence/image/repository/ImageReadModelJpaRepository.java
@@ -1,0 +1,17 @@
+package com.personal.marketnote.community.adapter.out.persistence.image.repository;
+
+import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.community.adapter.out.persistence.image.entity.ImageReadModelJpaEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ImageReadModelJpaRepository extends JpaRepository<ImageReadModelJpaEntity, Long> {
+
+    Optional<ImageReadModelJpaEntity> findByImageId(Long imageId);
+
+    List<ImageReadModelJpaEntity> findByTargetIdAndFileSortAndStatusOrderBySortOrderAsc(
+            Long targetId, String fileSort, EntityStatus status
+    );
+}

--- a/community-service/community-application/src/main/java/com/personal/marketnote/community/port/out/file/SaveImageReadModelPort.java
+++ b/community-service/community-application/src/main/java/com/personal/marketnote/community/port/out/file/SaveImageReadModelPort.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.community.port.out.file;
+
+public interface SaveImageReadModelPort {
+
+    void upsert(Long imageId, Long targetId, String targetType,
+                String fileSort, String imageUrl, Integer sortOrder);
+
+    void deactivateByImageId(Long imageId);
+}


### PR DESCRIPTION
## partially addresses #300
## resolves #1646

## Task
- [x] 이미지 Read Model JPA 엔티티 + 테이블 생성 (community-adapters)
- [x] ImageReadModelConsumer 구현 (file.image.changed 소비)
- [x] ImageReadModelAdapter 구현 (FindImagePort 구현체 교체)
- [x] FileServiceClient.findImagesByReviewIdAndSort(), findImagesByPostIdAndSort() 제거