### PR TITLE
[#300][#1721] feat: (관리자) 회원 상품 문의 내역 조회 기능 추가

### DIFF
--- a/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/in/web/post/controller/PostController.java
+++ b/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/in/web/post/controller/PostController.java
@@ -8,21 +8,26 @@ import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.common.utility.Role;
 import com.personal.marketnote.community.adapter.in.web.post.controller.apidocs.GetPostApiDocs;
 import com.personal.marketnote.community.adapter.in.web.post.controller.apidocs.GetPostsApiDocs;
+import com.personal.marketnote.community.adapter.in.web.post.controller.apidocs.GetUserProductInquiryPostsApiDocs;
 import com.personal.marketnote.community.adapter.in.web.post.controller.apidocs.RegisterPostApiDocs;
 import com.personal.marketnote.community.adapter.in.web.post.controller.apidocs.UpdatePostApiDocs;
 import com.personal.marketnote.community.adapter.in.web.post.mapper.PostRequestToCommandMapper;
 import com.personal.marketnote.community.adapter.in.web.post.request.RegisterPostRequest;
 import com.personal.marketnote.community.adapter.in.web.post.request.UpdatePostRequest;
 import com.personal.marketnote.community.adapter.in.web.post.response.GetPostsResponse;
+import com.personal.marketnote.community.adapter.in.web.post.response.GetUserProductInquiryPostsResponse;
 import com.personal.marketnote.community.adapter.in.web.post.response.PostItemResponse;
 import com.personal.marketnote.community.adapter.in.web.post.response.RegisterPostResponse;
 import com.personal.marketnote.community.domain.post.*;
 import com.personal.marketnote.community.port.in.command.post.GetPostQuery;
 import com.personal.marketnote.community.port.in.command.post.GetPostsQuery;
+import com.personal.marketnote.community.port.in.command.post.GetUserProductInquiryPostsCommand;
 import com.personal.marketnote.community.port.in.result.post.GetPostsResult;
+import com.personal.marketnote.community.port.in.result.post.GetUserProductInquiryPostsResult;
 import com.personal.marketnote.community.port.in.result.post.PostItemResult;
 import com.personal.marketnote.community.port.in.result.post.RegisterPostResult;
 import com.personal.marketnote.community.port.in.usecase.post.GetPostUseCase;
+import com.personal.marketnote.community.port.in.usecase.post.GetUserProductInquiryPostsUseCase;
 import com.personal.marketnote.community.port.in.usecase.post.RegisterPostUseCase;
 import com.personal.marketnote.community.port.in.usecase.post.UpdatePostUseCase;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -59,6 +64,7 @@ public class PostController {
 
     private final RegisterPostUseCase registerPostUseCase;
     private final GetPostUseCase getPostUseCase;
+    private final GetUserProductInquiryPostsUseCase getUserProductInquiryPostsUseCase;
     private final UpdatePostUseCase updatePostUseCase;
 
     /**
@@ -243,6 +249,44 @@ public class PostController {
         if (FormatValidator.hasNoValue(principal) || FormatValidator.equals(principal.getName(), "-1")) {
             throw new AuthenticationFailedException(INVALID_ACCESS_TOKEN_EXCEPTION_MESSAGE);
         }
+    }
+
+    /**
+     * (관리자) 회원 상품 문의 내역 조회
+     *
+     * @param userId        회원 ID
+     * @param page          페이지 번호 (1부터 시작)
+     * @param pageSize      페이지 크기
+     * @param sortDirection 정렬 방향
+     * @param sortProperty  정렬 기준
+     * @return 회원 상품 문의 내역 조회 응답 {@link GetUserProductInquiryPostsResponse}
+     * @Author 성효빈
+     * @Date 2026-04-01
+     * @Description 관리자가 특정 회원의 상품 문의 내역을 조회합니다.
+     */
+    @GetMapping("/admin/users/{userId}/product-inquiries")
+    @PreAuthorize(ADMIN_POINTCUT)
+    @GetUserProductInquiryPostsApiDocs
+    public ResponseEntity<BaseResponse<GetUserProductInquiryPostsResponse>> getUserProductInquiryPosts(
+            @PathVariable("userId") Long userId,
+            @RequestParam(value = "page", required = false, defaultValue = "1") int page,
+            @RequestParam(value = "page-size", required = false, defaultValue = DEFAULT_PAGE_SIZE) int pageSize,
+            @RequestParam(value = "sort-direction", required = false, defaultValue = "DESC") Sort.Direction sortDirection,
+            @RequestParam(value = "sort-property", required = false, defaultValue = "ID") PostSortProperty sortProperty
+    ) {
+        GetUserProductInquiryPostsResult result = getUserProductInquiryPostsUseCase.getUserProductInquiryPosts(
+                new GetUserProductInquiryPostsCommand(userId, page, pageSize, sortDirection, sortProperty)
+        );
+
+        return new ResponseEntity<>(
+                BaseResponse.of(
+                        GetUserProductInquiryPostsResponse.from(result),
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "회원 상품 문의 내역 조회 성공"
+                ),
+                HttpStatus.OK
+        );
     }
 
     /**

--- a/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/in/web/post/controller/apidocs/GetUserProductInquiryPostsApiDocs.java
+++ b/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/in/web/post/controller/apidocs/GetUserProductInquiryPostsApiDocs.java
@@ -1,0 +1,181 @@
+package com.personal.marketnote.community.adapter.in.web.post.controller.apidocs;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@SecurityRequirement(name = "bearer")
+@Operation(
+        summary = "(관리자) 회원 상품 문의 내역 조회",
+        description = """
+                작성일자: 2026-04-01
+
+                작성자: 성효빈
+
+                - 관리자가 특정 회원의 상품 문의 내역을 오프셋 페이지네이션으로 조회합니다.
+
+                ---
+
+                ## Request
+
+                | **키** | **타입** | **설명** | **필수 여부** | **예시** |
+                | --- | --- | --- | --- | --- |
+                | userId | number (path) | 회원 ID | Y | 1 |
+                | page | number | 페이지 번호 (1부터 시작) | N (기본값: 1) | 1 |
+                | page-size | number | 페이지 크기 | N (기본값: 10) | 10 |
+                | sort-direction | string | 정렬 방향(DESC/ASC) | N (기본값: DESC) | "DESC" |
+                | sort-property | string | 정렬 기준 | N (기본값: ID) | "ID" |
+
+                ---
+
+                ## Response
+
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | statusCode | number | HTTP 상태 코드 | 200 |
+                | code | string | 응답 코드 | "SUC01" |
+                | timestamp | string(datetime) | 응답 일시 | "2026-04-01T10:00:00" |
+                | content | object | 응답 본문 | { ... } |
+                | message | string | 처리 결과 | "회원 상품 문의 내역 조회 성공" |
+
+                ### Response > content > posts
+
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | page | number | 현재 페이지 | 1 |
+                | pageSize | number | 페이지 크기 | 10 |
+                | totalElements | number | 총 게시글 수 | 25 |
+                | totalPages | number | 총 페이지 수 | 3 |
+                | items | array | 게시글 목록 | [ ... ] |
+                """,
+        parameters = {
+                @Parameter(
+                        name = "userId",
+                        in = ParameterIn.PATH,
+                        required = true,
+                        description = "회원 ID",
+                        schema = @Schema(type = "number", example = "1")
+                ),
+                @Parameter(
+                        name = "page",
+                        in = ParameterIn.QUERY,
+                        description = "페이지 번호 (1부터 시작)",
+                        schema = @Schema(type = "number", example = "1", defaultValue = "1")
+                ),
+                @Parameter(
+                        name = "page-size",
+                        in = ParameterIn.QUERY,
+                        description = "페이지 크기",
+                        schema = @Schema(type = "number", example = "10", defaultValue = "10")
+                ),
+                @Parameter(
+                        name = "sort-direction",
+                        in = ParameterIn.QUERY,
+                        description = "정렬 방향",
+                        schema = @Schema(
+                                type = "string",
+                                example = "DESC",
+                                allowableValues = {"ASC", "DESC"},
+                                defaultValue = "DESC"
+                        )
+                ),
+                @Parameter(
+                        name = "sort-property",
+                        in = ParameterIn.QUERY,
+                        description = "정렬 기준",
+                        schema = @Schema(
+                                type = "string",
+                                example = "ID",
+                                allowableValues = {"ID", "IS_ANSWERED"},
+                                defaultValue = "ID"
+                        )
+                )
+        },
+        responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "회원 상품 문의 내역 조회 성공",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 200,
+                                          "code": "SUC01",
+                                          "timestamp": "2026-04-01T10:00:00",
+                                          "content": {
+                                            "posts": {
+                                              "page": 1,
+                                              "pageSize": 10,
+                                              "totalElements": 2,
+                                              "totalPages": 1,
+                                              "items": [
+                                                {
+                                                  "id": 10,
+                                                  "userId": 1,
+                                                  "parentId": null,
+                                                  "board": "PRODUCT_INQUERY",
+                                                  "category": "PRODUCT_QUESTION",
+                                                  "targetType": "PRICE_POLICY",
+                                                  "targetId": 100,
+                                                  "productImageUrl": null,
+                                                  "writerName": "홍*동",
+                                                  "title": "상품 문의 제목",
+                                                  "content": "상품 문의 내용",
+                                                  "isPrivate": false,
+                                                  "isPhoto": false,
+                                                  "images": null,
+                                                  "isMasked": false,
+                                                  "isAnswered": true,
+                                                  "createdAt": "2026-03-29T10:00:00",
+                                                  "modifiedAt": "2026-03-29T10:00:00",
+                                                  "product": {
+                                                    "name": "스프링노트",
+                                                    "brandName": "노트왕",
+                                                    "selectedOptions": []
+                                                  },
+                                                  "replies": [
+                                                    {
+                                                      "id": 11,
+                                                      "userId": 4,
+                                                      "parentId": 10,
+                                                      "board": "PRODUCT_INQUERY",
+                                                      "category": "PRODUCT_QUESTION",
+                                                      "targetType": "PRICE_POLICY",
+                                                      "targetId": 100,
+                                                      "productImageUrl": null,
+                                                      "writerName": "관리자",
+                                                      "title": "답변 제목",
+                                                      "content": "답변 내용",
+                                                      "isPrivate": false,
+                                                      "isPhoto": false,
+                                                      "images": null,
+                                                      "isMasked": false,
+                                                      "isAnswered": false,
+                                                      "createdAt": "2026-03-29T11:00:00",
+                                                      "modifiedAt": "2026-03-29T11:00:00",
+                                                      "product": null,
+                                                      "replies": []
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            }
+                                          },
+                                          "message": "회원 상품 문의 내역 조회 성공"
+                                        }
+                                        """)
+                        )
+                )
+        }
+)
+public @interface GetUserProductInquiryPostsApiDocs {
+}

--- a/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/in/web/post/response/GetUserProductInquiryPostsResponse.java
+++ b/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/in/web/post/response/GetUserProductInquiryPostsResponse.java
@@ -1,0 +1,20 @@
+package com.personal.marketnote.community.adapter.in.web.post.response;
+
+import com.personal.marketnote.common.adapter.in.response.OffsetResponse;
+import com.personal.marketnote.community.port.in.result.post.GetUserProductInquiryPostsResult;
+
+public record GetUserProductInquiryPostsResponse(OffsetResponse<PostItemResponse> posts) {
+    public static GetUserProductInquiryPostsResponse from(GetUserProductInquiryPostsResult result) {
+        return new GetUserProductInquiryPostsResponse(
+                new OffsetResponse<>(
+                        result.page(),
+                        result.pageSize(),
+                        result.totalElements(),
+                        result.totalPages(),
+                        result.posts().stream()
+                                .map(PostItemResponse::from)
+                                .toList()
+                )
+        );
+    }
+}

--- a/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/out/persistence/post/PostPersistenceAdapter.java
+++ b/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/out/persistence/post/PostPersistenceAdapter.java
@@ -12,7 +12,9 @@ import com.personal.marketnote.community.port.out.post.FindPostPort;
 import com.personal.marketnote.community.port.out.post.SavePostPort;
 import com.personal.marketnote.community.port.out.post.UpdatePostPort;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 
 import java.util.Collections;
 import java.util.List;
@@ -182,6 +184,33 @@ public class PostPersistenceAdapter implements SavePostPort, FindPostPort, Updat
         return postJpaRepository.countByUserIdAndBoard(
                 userId, board, searchInTitle, searchInContent, searchKeywordPattern, EntityStatus.ACTIVE
         );
+    }
+
+    @Override
+    public Posts findUserPostsByOffset(
+            Long userId,
+            Board board,
+            int page,
+            int pageSize,
+            boolean isDesc,
+            PostSortProperty sortProperty
+    ) {
+        String sortField = getSortField(sortProperty);
+        Sort sort = isDesc ? Sort.by(Sort.Direction.DESC, sortField) : Sort.by(Sort.Direction.ASC, sortField);
+        Pageable pageable = PageRequest.of(page - 1, pageSize, sort);
+
+        return mapToPostsWithReplies(
+                postJpaRepository.findByUserIdAndBoardByOffset(
+                        userId, board, EntityStatus.ACTIVE, pageable
+                )
+        );
+    }
+
+    private String getSortField(PostSortProperty sortProperty) {
+        return switch (sortProperty) {
+            case ORDER_NUM -> "orderNum";
+            case IS_ANSWERED, ID -> "id";
+        };
     }
 
     @Override

--- a/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/out/persistence/post/repository/PostJpaRepository.java
+++ b/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/out/persistence/post/repository/PostJpaRepository.java
@@ -259,6 +259,21 @@ public interface PostJpaRepository extends JpaRepository<PostJpaEntity, Long> {
     );
 
     @Query("""
+            SELECT p
+            FROM PostJpaEntity p
+            WHERE p.status = :status
+              AND p.board = :board
+              AND p.userId = :userId
+              AND p.parentId IS NULL
+            """)
+    List<PostJpaEntity> findByUserIdAndBoardByOffset(
+            @Param("userId") Long userId,
+            @Param("board") Board board,
+            @Param("status") EntityStatus status,
+            Pageable pageable
+    );
+
+    @Query("""
                 SELECT p
                 FROM PostJpaEntity p
                 WHERE p.id IN (

--- a/community-service/community-application/src/main/java/com/personal/marketnote/community/port/in/command/post/GetUserProductInquiryPostsCommand.java
+++ b/community-service/community-application/src/main/java/com/personal/marketnote/community/port/in/command/post/GetUserProductInquiryPostsCommand.java
@@ -1,0 +1,13 @@
+package com.personal.marketnote.community.port.in.command.post;
+
+import com.personal.marketnote.community.domain.post.PostSortProperty;
+import org.springframework.data.domain.Sort;
+
+public record GetUserProductInquiryPostsCommand(
+        Long userId,
+        int page,
+        int pageSize,
+        Sort.Direction sortDirection,
+        PostSortProperty sortProperty
+) {
+}

--- a/community-service/community-application/src/main/java/com/personal/marketnote/community/port/in/result/post/GetUserProductInquiryPostsResult.java
+++ b/community-service/community-application/src/main/java/com/personal/marketnote/community/port/in/result/post/GetUserProductInquiryPostsResult.java
@@ -1,0 +1,21 @@
+package com.personal.marketnote.community.port.in.result.post;
+
+import java.util.List;
+
+public record GetUserProductInquiryPostsResult(
+        int page,
+        int pageSize,
+        long totalElements,
+        int totalPages,
+        List<PostItemResult> posts
+) {
+    public static GetUserProductInquiryPostsResult of(
+            int page,
+            int pageSize,
+            long totalElements,
+            int totalPages,
+            List<PostItemResult> posts
+    ) {
+        return new GetUserProductInquiryPostsResult(page, pageSize, totalElements, totalPages, posts);
+    }
+}

--- a/community-service/community-application/src/main/java/com/personal/marketnote/community/port/in/usecase/post/GetUserProductInquiryPostsUseCase.java
+++ b/community-service/community-application/src/main/java/com/personal/marketnote/community/port/in/usecase/post/GetUserProductInquiryPostsUseCase.java
@@ -1,0 +1,22 @@
+package com.personal.marketnote.community.port.in.usecase.post;
+
+import com.personal.marketnote.community.port.in.command.post.GetUserProductInquiryPostsCommand;
+import com.personal.marketnote.community.port.in.result.post.GetUserProductInquiryPostsResult;
+
+/**
+ * (관리자) 회원 상품 문의 내역 조회 유스케이스
+ *
+ * @Author 성효빈
+ * @Date 2026-04-01
+ * @Description 관리자가 특정 회원의 상품 문의 내역을 조회합니다.
+ */
+public interface GetUserProductInquiryPostsUseCase {
+    /**
+     * @param command 회원 상품 문의 내역 조회 커맨드
+     * @return 회원 상품 문의 내역 조회 결과 {@link GetUserProductInquiryPostsResult}
+     * @Date 2026-04-01
+     * @Author 성효빈
+     * @Description 관리자가 특정 회원의 상품 문의 내역을 조회합니다.
+     */
+    GetUserProductInquiryPostsResult getUserProductInquiryPosts(GetUserProductInquiryPostsCommand command);
+}

--- a/community-service/community-application/src/main/java/com/personal/marketnote/community/port/out/post/FindPostPort.java
+++ b/community-service/community-application/src/main/java/com/personal/marketnote/community/port/out/post/FindPostPort.java
@@ -122,6 +122,27 @@ public interface FindPostPort {
     long countUserPosts(Long userId, Board board, PostSearchTarget searchTarget, String searchKeyword);
 
     /**
+     * @param userId       회원 ID
+     * @param board        게시판
+     * @param page         페이지 번호 (1부터 시작)
+     * @param pageSize     페이지 크기
+     * @param isDesc       내림차순 여부
+     * @param sortProperty 정렬 속성
+     * @return 게시글 목록 {@link Posts}
+     * @Date 2026-04-01
+     * @Author 성효빈
+     * @Description 회원 게시글 목록을 오프셋 기반으로 조회합니다.
+     */
+    Posts findUserPostsByOffset(
+            Long userId,
+            Board board,
+            int page,
+            int pageSize,
+            boolean isDesc,
+            PostSortProperty sortProperty
+    );
+
+    /**
      * @param id 게시글 ID
      * @return 게시글 {@link Post}
      * @Date 2026-01-29

--- a/community-service/community-application/src/main/java/com/personal/marketnote/community/service/post/GetUserProductInquiryPostsService.java
+++ b/community-service/community-application/src/main/java/com/personal/marketnote/community/service/post/GetUserProductInquiryPostsService.java
@@ -1,0 +1,150 @@
+package com.personal.marketnote.community.service.post;
+
+import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.common.application.file.port.in.result.GetFileResult;
+import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.community.domain.post.*;
+import com.personal.marketnote.community.port.in.command.post.GetUserProductInquiryPostsCommand;
+import com.personal.marketnote.community.port.in.result.post.GetUserProductInquiryPostsResult;
+import com.personal.marketnote.community.port.in.result.post.PostItemResult;
+import com.personal.marketnote.community.port.in.result.post.PostProductInfoResult;
+import com.personal.marketnote.community.port.in.usecase.post.GetUserProductInquiryPostsUseCase;
+import com.personal.marketnote.community.port.out.file.FindPostImagesPort;
+import com.personal.marketnote.community.port.out.post.FindPostPort;
+import com.personal.marketnote.community.port.out.product.FindProductByPricePolicyPort;
+import com.personal.marketnote.community.port.out.result.product.ProductInfoResult;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Sort;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Stream;
+
+import static com.personal.marketnote.common.domain.file.FileSort.POST_IMAGE;
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional(isolation = READ_COMMITTED, readOnly = true)
+public class GetUserProductInquiryPostsService implements GetUserProductInquiryPostsUseCase {
+    private final FindPostPort findPostPort;
+    private final FindProductByPricePolicyPort findProductByPricePolicyPort;
+    private final FindPostImagesPort findPostImagesPort;
+
+    @Override
+    public GetUserProductInquiryPostsResult getUserProductInquiryPosts(GetUserProductInquiryPostsCommand command) {
+        boolean isDesc = Sort.Direction.DESC.equals(command.sortDirection());
+
+        Posts posts = findPostPort.findUserPostsByOffset(
+                command.userId(),
+                Board.PRODUCT_INQUERY,
+                command.page(),
+                command.pageSize(),
+                isDesc,
+                command.sortProperty()
+        );
+
+        long totalElements = findPostPort.countUserPosts(
+                command.userId(), Board.PRODUCT_INQUERY, null, null
+        );
+
+        int totalPages = computeTotalPages(totalElements, command.pageSize());
+
+        List<Post> postList = posts.getPosts();
+
+        Map<Long, ProductInfoResult> productInfoMap = getProductInfo(postList);
+
+        Map<Long, List<GetFileResult>> postImagesByPostId = findPostImages(postList);
+
+        List<PostItemResult> postItems = postList.stream()
+                .map(post -> toPostItemResult(post, productInfoMap, postImagesByPostId))
+                .toList();
+
+        return GetUserProductInquiryPostsResult.of(
+                command.page(),
+                command.pageSize(),
+                totalElements,
+                totalPages,
+                postItems
+        );
+    }
+
+    private PostItemResult toPostItemResult(
+            Post post,
+            Map<Long, ProductInfoResult> productInfoMap,
+            Map<Long, List<GetFileResult>> postImagesByPostId
+    ) {
+        List<GetFileResult> images = postImagesByPostId.get(post.getId());
+
+        if (FormatValidator.hasNoValue(post.getTargetId())) {
+            PostItemResult postItemResult = PostItemResult.from(post, images);
+            if (post.hasReplies()) {
+                postItemResult.addReplies(post, postImagesByPostId);
+            }
+            return postItemResult;
+        }
+
+        ProductInfoResult productInfoResult = productInfoMap.get(post.getTargetId());
+        PostItemResult postItemResult = PostItemResult.from(
+                post,
+                PostProductInfoResult.from(productInfoResult),
+                images
+        );
+
+        if (post.hasReplies()) {
+            postItemResult.addReplies(post, postImagesByPostId);
+        }
+
+        return postItemResult;
+    }
+
+    private int computeTotalPages(long totalElements, int pageSize) {
+        if (totalElements == 0) {
+            return 0;
+        }
+        return (int) Math.ceil((double) totalElements / pageSize);
+    }
+
+    private Map<Long, ProductInfoResult> getProductInfo(List<Post> posts) {
+        List<Long> pricePolicyIds = posts.stream()
+                .filter(post -> PostTargetType.PRICE_POLICY.equals(post.getTargetType()))
+                .map(Post::getTargetId)
+                .filter(FormatValidator::hasValue)
+                .distinct()
+                .toList();
+
+        return findProductByPricePolicyPort.findByPricePolicyIds(pricePolicyIds);
+    }
+
+    private Map<Long, List<GetFileResult>> findPostImages(List<Post> posts) {
+        if (FormatValidator.hasNoValue(posts)) {
+            return Map.of();
+        }
+
+        Map<Long, List<GetFileResult>> postImages = new ConcurrentHashMap<>();
+
+        List<Post> photoPosts = posts.stream()
+                .flatMap(post -> {
+                    Stream<Post> replies = post.hasReplies() ? post.getReplies().stream() : Stream.empty();
+                    return Stream.concat(Stream.of(post), replies);
+                })
+                .filter(Post::isPhoto)
+                .toList();
+
+        List<CompletableFuture<Void>> futures = photoPosts.stream()
+                .map(post -> CompletableFuture.runAsync(
+                        () -> findPostImagesPort.findImagesByPostIdAndSort(post.getId(), POST_IMAGE)
+                                .ifPresent(result -> postImages.put(post.getId(), result.images()))
+                ))
+                .toList();
+
+        if (FormatValidator.hasValue(futures)) {
+            CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
+        }
+
+        return postImages;
+    }
+}


### PR DESCRIPTION
## partially addresses #300
## resolves #1721

## Task
- [x] GetUserProductInquiryPostsUseCase 인터페이스 정의
- [x] GetUserProductInquiryPostsCommand 정의 (userId, page, pageSize, sortDirection, sortProperty)
- [x] GetUserProductInquiryPostsResult 정의 (오프셋 페이지네이션 기반)
- [x] GetUserProductInquiryPostsService 구현 (@PreAuthorize 관리자 전용)
- [x] FindPostPort에 오프셋 기반 조회 메서드 추가
- [x] PostPersistenceAdapter에 userId + board 조건 쿼리 구현
- [x] 관리자 전용 컨트롤러 엔드포인트 추가
- [x] 요청/응답 DTO + 매퍼 작성