### PR TITLE
[#300][#1722] feat: (관리자) 회원 1:1 문의 내역 조회 기능 추가

### DIFF
--- a/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/in/web/post/controller/PostController.java
+++ b/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/in/web/post/controller/PostController.java
@@ -8,6 +8,7 @@ import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.common.utility.Role;
 import com.personal.marketnote.community.adapter.in.web.post.controller.apidocs.GetPostApiDocs;
 import com.personal.marketnote.community.adapter.in.web.post.controller.apidocs.GetPostsApiDocs;
+import com.personal.marketnote.community.adapter.in.web.post.controller.apidocs.GetUserOneOnOneInquiryPostsApiDocs;
 import com.personal.marketnote.community.adapter.in.web.post.controller.apidocs.GetUserProductInquiryPostsApiDocs;
 import com.personal.marketnote.community.adapter.in.web.post.controller.apidocs.RegisterPostApiDocs;
 import com.personal.marketnote.community.adapter.in.web.post.controller.apidocs.UpdatePostApiDocs;
@@ -15,18 +16,22 @@ import com.personal.marketnote.community.adapter.in.web.post.mapper.PostRequestT
 import com.personal.marketnote.community.adapter.in.web.post.request.RegisterPostRequest;
 import com.personal.marketnote.community.adapter.in.web.post.request.UpdatePostRequest;
 import com.personal.marketnote.community.adapter.in.web.post.response.GetPostsResponse;
+import com.personal.marketnote.community.adapter.in.web.post.response.GetUserOneOnOneInquiryPostsResponse;
 import com.personal.marketnote.community.adapter.in.web.post.response.GetUserProductInquiryPostsResponse;
 import com.personal.marketnote.community.adapter.in.web.post.response.PostItemResponse;
 import com.personal.marketnote.community.adapter.in.web.post.response.RegisterPostResponse;
 import com.personal.marketnote.community.domain.post.*;
 import com.personal.marketnote.community.port.in.command.post.GetPostQuery;
 import com.personal.marketnote.community.port.in.command.post.GetPostsQuery;
+import com.personal.marketnote.community.port.in.command.post.GetUserOneOnOneInquiryPostsCommand;
 import com.personal.marketnote.community.port.in.command.post.GetUserProductInquiryPostsCommand;
 import com.personal.marketnote.community.port.in.result.post.GetPostsResult;
+import com.personal.marketnote.community.port.in.result.post.GetUserOneOnOneInquiryPostsResult;
 import com.personal.marketnote.community.port.in.result.post.GetUserProductInquiryPostsResult;
 import com.personal.marketnote.community.port.in.result.post.PostItemResult;
 import com.personal.marketnote.community.port.in.result.post.RegisterPostResult;
 import com.personal.marketnote.community.port.in.usecase.post.GetPostUseCase;
+import com.personal.marketnote.community.port.in.usecase.post.GetUserOneOnOneInquiryPostsUseCase;
 import com.personal.marketnote.community.port.in.usecase.post.GetUserProductInquiryPostsUseCase;
 import com.personal.marketnote.community.port.in.usecase.post.RegisterPostUseCase;
 import com.personal.marketnote.community.port.in.usecase.post.UpdatePostUseCase;
@@ -65,6 +70,7 @@ public class PostController {
     private final RegisterPostUseCase registerPostUseCase;
     private final GetPostUseCase getPostUseCase;
     private final GetUserProductInquiryPostsUseCase getUserProductInquiryPostsUseCase;
+    private final GetUserOneOnOneInquiryPostsUseCase getUserOneOnOneInquiryPostsUseCase;
     private final UpdatePostUseCase updatePostUseCase;
 
     /**
@@ -284,6 +290,44 @@ public class PostController {
                         HttpStatus.OK,
                         DEFAULT_SUCCESS_CODE,
                         "회원 상품 문의 내역 조회 성공"
+                ),
+                HttpStatus.OK
+        );
+    }
+
+    /**
+     * (관리자) 회원 1:1 문의 내역 조회
+     *
+     * @param userId        회원 ID
+     * @param page          페이지 번호 (1부터 시작)
+     * @param pageSize      페이지 크기
+     * @param sortDirection 정렬 방향
+     * @param sortProperty  정렬 기준
+     * @return 회원 1:1 문의 내역 조회 응답 {@link GetUserOneOnOneInquiryPostsResponse}
+     * @Author 성효빈
+     * @Date 2026-04-01
+     * @Description 관리자가 특정 회원의 1:1 문의 내역을 조회합니다.
+     */
+    @GetMapping("/admin/users/{userId}/one-on-one-inquiries")
+    @PreAuthorize(ADMIN_POINTCUT)
+    @GetUserOneOnOneInquiryPostsApiDocs
+    public ResponseEntity<BaseResponse<GetUserOneOnOneInquiryPostsResponse>> getUserOneOnOneInquiryPosts(
+            @PathVariable("userId") Long userId,
+            @RequestParam(value = "page", required = false, defaultValue = "1") int page,
+            @RequestParam(value = "page-size", required = false, defaultValue = DEFAULT_PAGE_SIZE) int pageSize,
+            @RequestParam(value = "sort-direction", required = false, defaultValue = "DESC") Sort.Direction sortDirection,
+            @RequestParam(value = "sort-property", required = false, defaultValue = "ID") PostSortProperty sortProperty
+    ) {
+        GetUserOneOnOneInquiryPostsResult result = getUserOneOnOneInquiryPostsUseCase.getUserOneOnOneInquiryPosts(
+                new GetUserOneOnOneInquiryPostsCommand(userId, page, pageSize, sortDirection, sortProperty)
+        );
+
+        return new ResponseEntity<>(
+                BaseResponse.of(
+                        GetUserOneOnOneInquiryPostsResponse.from(result),
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "회원 1:1 문의 내역 조회 성공"
                 ),
                 HttpStatus.OK
         );

--- a/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/in/web/post/controller/apidocs/GetUserOneOnOneInquiryPostsApiDocs.java
+++ b/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/in/web/post/controller/apidocs/GetUserOneOnOneInquiryPostsApiDocs.java
@@ -1,0 +1,177 @@
+package com.personal.marketnote.community.adapter.in.web.post.controller.apidocs;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@SecurityRequirement(name = "bearer")
+@Operation(
+        summary = "(관리자) 회원 1:1 문의 내역 조회",
+        description = """
+                작성일자: 2026-04-01
+
+                작성자: 성효빈
+
+                - 관리자가 특정 회원의 1:1 문의 내역을 오프셋 페이지네이션으로 조회합니다.
+
+                ---
+
+                ## Request
+
+                | **키** | **타입** | **설명** | **필수 여부** | **예시** |
+                | --- | --- | --- | --- | --- |
+                | userId | number (path) | 회원 ID | Y | 1 |
+                | page | number | 페이지 번호 (1부터 시작) | N (기본값: 1) | 1 |
+                | page-size | number | 페이지 크기 | N (기본값: 10) | 10 |
+                | sort-direction | string | 정렬 방향(DESC/ASC) | N (기본값: DESC) | "DESC" |
+                | sort-property | string | 정렬 기준 | N (기본값: ID) | "ID" |
+
+                ---
+
+                ## Response
+
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | statusCode | number | HTTP 상태 코드 | 200 |
+                | code | string | 응답 코드 | "SUC01" |
+                | timestamp | string(datetime) | 응답 일시 | "2026-04-01T10:00:00" |
+                | content | object | 응답 본문 | { ... } |
+                | message | string | 처리 결과 | "회원 1:1 문의 내역 조회 성공" |
+
+                ### Response > content > posts
+
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | page | number | 현재 페이지 | 1 |
+                | pageSize | number | 페이지 크기 | 10 |
+                | totalElements | number | 총 게시글 수 | 25 |
+                | totalPages | number | 총 페이지 수 | 3 |
+                | items | array | 게시글 목록 | [ ... ] |
+                """,
+        parameters = {
+                @Parameter(
+                        name = "userId",
+                        in = ParameterIn.PATH,
+                        required = true,
+                        description = "회원 ID",
+                        schema = @Schema(type = "number", example = "1")
+                ),
+                @Parameter(
+                        name = "page",
+                        in = ParameterIn.QUERY,
+                        description = "페이지 번호 (1부터 시작)",
+                        schema = @Schema(type = "number", example = "1", defaultValue = "1")
+                ),
+                @Parameter(
+                        name = "page-size",
+                        in = ParameterIn.QUERY,
+                        description = "페이지 크기",
+                        schema = @Schema(type = "number", example = "10", defaultValue = "10")
+                ),
+                @Parameter(
+                        name = "sort-direction",
+                        in = ParameterIn.QUERY,
+                        description = "정렬 방향",
+                        schema = @Schema(
+                                type = "string",
+                                example = "DESC",
+                                allowableValues = {"ASC", "DESC"},
+                                defaultValue = "DESC"
+                        )
+                ),
+                @Parameter(
+                        name = "sort-property",
+                        in = ParameterIn.QUERY,
+                        description = "정렬 기준",
+                        schema = @Schema(
+                                type = "string",
+                                example = "ID",
+                                allowableValues = {"ID", "IS_ANSWERED"},
+                                defaultValue = "ID"
+                        )
+                )
+        },
+        responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "회원 1:1 문의 내역 조회 성공",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 200,
+                                          "code": "SUC01",
+                                          "timestamp": "2026-04-01T10:00:00",
+                                          "content": {
+                                            "posts": {
+                                              "page": 1,
+                                              "pageSize": 10,
+                                              "totalElements": 2,
+                                              "totalPages": 1,
+                                              "items": [
+                                                {
+                                                  "id": 10,
+                                                  "userId": 1,
+                                                  "parentId": null,
+                                                  "board": "ONE_ON_ONE_INQUERY",
+                                                  "category": "ORDER_PAYMENT",
+                                                  "targetType": null,
+                                                  "targetId": null,
+                                                  "productImageUrl": null,
+                                                  "writerName": "홍*동",
+                                                  "title": "1:1 문의 제목",
+                                                  "content": "1:1 문의 내용",
+                                                  "isPrivate": true,
+                                                  "isPhoto": false,
+                                                  "images": null,
+                                                  "isMasked": false,
+                                                  "isAnswered": true,
+                                                  "createdAt": "2026-03-29T10:00:00",
+                                                  "modifiedAt": "2026-03-29T10:00:00",
+                                                  "product": null,
+                                                  "replies": [
+                                                    {
+                                                      "id": 11,
+                                                      "userId": 4,
+                                                      "parentId": 10,
+                                                      "board": "ONE_ON_ONE_INQUERY",
+                                                      "category": "ORDER_PAYMENT",
+                                                      "targetType": null,
+                                                      "targetId": null,
+                                                      "productImageUrl": null,
+                                                      "writerName": "관리자",
+                                                      "title": "답변 제목",
+                                                      "content": "답변 내용",
+                                                      "isPrivate": false,
+                                                      "isPhoto": false,
+                                                      "images": null,
+                                                      "isMasked": false,
+                                                      "isAnswered": false,
+                                                      "createdAt": "2026-03-29T11:00:00",
+                                                      "modifiedAt": "2026-03-29T11:00:00",
+                                                      "product": null,
+                                                      "replies": []
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            }
+                                          },
+                                          "message": "회원 1:1 문의 내역 조회 성공"
+                                        }
+                                        """)
+                        )
+                )
+        }
+)
+public @interface GetUserOneOnOneInquiryPostsApiDocs {
+}

--- a/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/in/web/post/response/GetUserOneOnOneInquiryPostsResponse.java
+++ b/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/in/web/post/response/GetUserOneOnOneInquiryPostsResponse.java
@@ -1,0 +1,20 @@
+package com.personal.marketnote.community.adapter.in.web.post.response;
+
+import com.personal.marketnote.common.adapter.in.response.OffsetResponse;
+import com.personal.marketnote.community.port.in.result.post.GetUserOneOnOneInquiryPostsResult;
+
+public record GetUserOneOnOneInquiryPostsResponse(OffsetResponse<PostItemResponse> posts) {
+    public static GetUserOneOnOneInquiryPostsResponse from(GetUserOneOnOneInquiryPostsResult result) {
+        return new GetUserOneOnOneInquiryPostsResponse(
+                new OffsetResponse<>(
+                        result.page(),
+                        result.pageSize(),
+                        result.totalElements(),
+                        result.totalPages(),
+                        result.posts().stream()
+                                .map(PostItemResponse::from)
+                                .toList()
+                )
+        );
+    }
+}

--- a/community-service/community-application/src/main/java/com/personal/marketnote/community/port/in/command/post/GetUserOneOnOneInquiryPostsCommand.java
+++ b/community-service/community-application/src/main/java/com/personal/marketnote/community/port/in/command/post/GetUserOneOnOneInquiryPostsCommand.java
@@ -1,0 +1,13 @@
+package com.personal.marketnote.community.port.in.command.post;
+
+import com.personal.marketnote.community.domain.post.PostSortProperty;
+import org.springframework.data.domain.Sort;
+
+public record GetUserOneOnOneInquiryPostsCommand(
+        Long userId,
+        int page,
+        int pageSize,
+        Sort.Direction sortDirection,
+        PostSortProperty sortProperty
+) {
+}

--- a/community-service/community-application/src/main/java/com/personal/marketnote/community/port/in/result/post/GetUserOneOnOneInquiryPostsResult.java
+++ b/community-service/community-application/src/main/java/com/personal/marketnote/community/port/in/result/post/GetUserOneOnOneInquiryPostsResult.java
@@ -1,0 +1,21 @@
+package com.personal.marketnote.community.port.in.result.post;
+
+import java.util.List;
+
+public record GetUserOneOnOneInquiryPostsResult(
+        int page,
+        int pageSize,
+        long totalElements,
+        int totalPages,
+        List<PostItemResult> posts
+) {
+    public static GetUserOneOnOneInquiryPostsResult of(
+            int page,
+            int pageSize,
+            long totalElements,
+            int totalPages,
+            List<PostItemResult> posts
+    ) {
+        return new GetUserOneOnOneInquiryPostsResult(page, pageSize, totalElements, totalPages, posts);
+    }
+}

--- a/community-service/community-application/src/main/java/com/personal/marketnote/community/port/in/usecase/post/GetUserOneOnOneInquiryPostsUseCase.java
+++ b/community-service/community-application/src/main/java/com/personal/marketnote/community/port/in/usecase/post/GetUserOneOnOneInquiryPostsUseCase.java
@@ -1,0 +1,22 @@
+package com.personal.marketnote.community.port.in.usecase.post;
+
+import com.personal.marketnote.community.port.in.command.post.GetUserOneOnOneInquiryPostsCommand;
+import com.personal.marketnote.community.port.in.result.post.GetUserOneOnOneInquiryPostsResult;
+
+/**
+ * (관리자) 회원 1:1 문의 내역 조회 유스케이스
+ *
+ * @Author 성효빈
+ * @Date 2026-04-01
+ * @Description 관리자가 특정 회원의 1:1 문의 내역을 조회합니다.
+ */
+public interface GetUserOneOnOneInquiryPostsUseCase {
+    /**
+     * @param command 회원 1:1 문의 내역 조회 커맨드
+     * @return 회원 1:1 문의 내역 조회 결과 {@link GetUserOneOnOneInquiryPostsResult}
+     * @Date 2026-04-01
+     * @Author 성효빈
+     * @Description 관리자가 특정 회원의 1:1 문의 내역을 조회합니다.
+     */
+    GetUserOneOnOneInquiryPostsResult getUserOneOnOneInquiryPosts(GetUserOneOnOneInquiryPostsCommand command);
+}

--- a/community-service/community-application/src/main/java/com/personal/marketnote/community/service/post/GetUserOneOnOneInquiryPostsService.java
+++ b/community-service/community-application/src/main/java/com/personal/marketnote/community/service/post/GetUserOneOnOneInquiryPostsService.java
@@ -1,0 +1,120 @@
+package com.personal.marketnote.community.service.post;
+
+import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.common.application.file.port.in.result.GetFileResult;
+import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.community.domain.post.Board;
+import com.personal.marketnote.community.domain.post.Post;
+import com.personal.marketnote.community.domain.post.Posts;
+import com.personal.marketnote.community.port.in.command.post.GetUserOneOnOneInquiryPostsCommand;
+import com.personal.marketnote.community.port.in.result.post.GetUserOneOnOneInquiryPostsResult;
+import com.personal.marketnote.community.port.in.result.post.PostItemResult;
+import com.personal.marketnote.community.port.in.usecase.post.GetUserOneOnOneInquiryPostsUseCase;
+import com.personal.marketnote.community.port.out.file.FindPostImagesPort;
+import com.personal.marketnote.community.port.out.post.FindPostPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Sort;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Stream;
+
+import static com.personal.marketnote.common.domain.file.FileSort.POST_IMAGE;
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional(isolation = READ_COMMITTED, readOnly = true)
+public class GetUserOneOnOneInquiryPostsService implements GetUserOneOnOneInquiryPostsUseCase {
+    private final FindPostPort findPostPort;
+    private final FindPostImagesPort findPostImagesPort;
+
+    @Override
+    public GetUserOneOnOneInquiryPostsResult getUserOneOnOneInquiryPosts(GetUserOneOnOneInquiryPostsCommand command) {
+        boolean isDesc = Sort.Direction.DESC.equals(command.sortDirection());
+
+        Posts posts = findPostPort.findUserPostsByOffset(
+                command.userId(),
+                Board.ONE_ON_ONE_INQUERY,
+                command.page(),
+                command.pageSize(),
+                isDesc,
+                command.sortProperty()
+        );
+
+        long totalElements = findPostPort.countUserPosts(
+                command.userId(), Board.ONE_ON_ONE_INQUERY, null, null
+        );
+
+        int totalPages = computeTotalPages(totalElements, command.pageSize());
+
+        List<Post> postList = posts.getPosts();
+
+        Map<Long, List<GetFileResult>> postImagesByPostId = findPostImages(postList);
+
+        List<PostItemResult> postItems = postList.stream()
+                .map(post -> toPostItemResult(post, postImagesByPostId))
+                .toList();
+
+        return GetUserOneOnOneInquiryPostsResult.of(
+                command.page(),
+                command.pageSize(),
+                totalElements,
+                totalPages,
+                postItems
+        );
+    }
+
+    private PostItemResult toPostItemResult(
+            Post post,
+            Map<Long, List<GetFileResult>> postImagesByPostId
+    ) {
+        List<GetFileResult> images = postImagesByPostId.get(post.getId());
+
+        PostItemResult postItemResult = PostItemResult.from(post, images);
+        if (post.hasReplies()) {
+            postItemResult.addReplies(post, postImagesByPostId);
+        }
+
+        return postItemResult;
+    }
+
+    private int computeTotalPages(long totalElements, int pageSize) {
+        if (totalElements == 0) {
+            return 0;
+        }
+        return (int) Math.ceil((double) totalElements / pageSize);
+    }
+
+    private Map<Long, List<GetFileResult>> findPostImages(List<Post> posts) {
+        if (FormatValidator.hasNoValue(posts)) {
+            return Map.of();
+        }
+
+        Map<Long, List<GetFileResult>> postImages = new ConcurrentHashMap<>();
+
+        List<Post> photoPosts = posts.stream()
+                .flatMap(post -> {
+                    Stream<Post> replies = post.hasReplies() ? post.getReplies().stream() : Stream.empty();
+                    return Stream.concat(Stream.of(post), replies);
+                })
+                .filter(Post::isPhoto)
+                .toList();
+
+        List<CompletableFuture<Void>> futures = photoPosts.stream()
+                .map(post -> CompletableFuture.runAsync(
+                        () -> findPostImagesPort.findImagesByPostIdAndSort(post.getId(), POST_IMAGE)
+                                .ifPresent(result -> postImages.put(post.getId(), result.images()))
+                ))
+                .toList();
+
+        if (FormatValidator.hasValue(futures)) {
+            CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
+        }
+
+        return postImages;
+    }
+}


### PR DESCRIPTION
## partially addresses #300
## resolves #1722

## Task
- [x] GetUserOneOnOneInquiryPostsUseCase 인터페이스 정의
- [x] GetUserOneOnOneInquiryPostsCommand 정의 (userId, page, pageSize, sortDirection, sortProperty)
- [x] GetUserOneOnOneInquiryPostsResult 정의 (오프셋 페이지네이션 기반)
- [x] GetUserOneOnOneInquiryPostsService 구현 (@PreAuthorize 관리자 전용)
- [x] FindPostPort 기존 오프셋 기반 조회 메서드 재사용 (Board.ONE_ON_ONE_INQUERY)
- [x] 관리자 전용 컨트롤러 엔드포인트 추가
- [x] 요청/응답 DTO + 매퍼 작성