### PR TITLE
[#300][#1723] feat: (관리자) 회원 리뷰 내역 조회 기능 추가

### DIFF
--- a/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/in/web/review/controller/ReviewController.java
+++ b/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/in/web/review/controller/ReviewController.java
@@ -11,8 +11,10 @@ import com.personal.marketnote.community.adapter.in.web.review.response.*;
 import com.personal.marketnote.community.domain.review.ReviewSortProperty;
 import com.personal.marketnote.community.exception.ProductReviewAggregateNotFoundException;
 import com.personal.marketnote.community.port.in.result.review.*;
+import com.personal.marketnote.community.port.in.command.review.GetUserReviewsCommand;
 import com.personal.marketnote.community.port.in.usecase.review.DeleteReviewUseCase;
 import com.personal.marketnote.community.port.in.usecase.review.GetReviewUseCase;
+import com.personal.marketnote.community.port.in.usecase.review.GetUserReviewsUseCase;
 import com.personal.marketnote.community.port.in.usecase.review.RegisterReviewUseCase;
 import com.personal.marketnote.community.port.in.usecase.review.UpdateReviewUseCase;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -46,8 +48,11 @@ import static org.apache.commons.lang3.BooleanUtils.FALSE;
 public class ReviewController {
     private static final String GET_PRODUCT_REVIEWS_DEFAULT_PAGE_SIZE = "4";
 
+    private static final String DEFAULT_PAGE_SIZE = "10";
+
     private final RegisterReviewUseCase registerReviewUseCase;
     private final GetReviewUseCase getReviewUseCase;
+    private final GetUserReviewsUseCase getUserReviewsUseCase;
     private final UpdateReviewUseCase updateReviewUseCase;
     private final DeleteReviewUseCase deleteReviewUseCase;
 
@@ -354,6 +359,44 @@ public class ReviewController {
                         HttpStatus.OK,
                         DEFAULT_SUCCESS_CODE,
                         "상품 리뷰 집계 목록 조회 성공"
+                ),
+                HttpStatus.OK
+        );
+    }
+
+    /**
+     * (관리자) 회원 리뷰 내역 조회
+     *
+     * @param userId        회원 ID
+     * @param page          페이지 번호 (1부터 시작)
+     * @param pageSize      페이지 크기
+     * @param sortDirection 정렬 방향
+     * @param sortProperty  정렬 기준
+     * @return 회원 리뷰 내역 조회 응답 {@link GetUserReviewsResponse}
+     * @Author 성효빈
+     * @Date 2026-04-01
+     * @Description 관리자가 특정 회원의 리뷰 내역을 조회합니다.
+     */
+    @GetMapping("/admin/users/{userId}/reviews")
+    @PreAuthorize(ADMIN_POINTCUT)
+    @GetUserReviewsApiDocs
+    public ResponseEntity<BaseResponse<GetUserReviewsResponse>> getUserReviews(
+            @PathVariable("userId") Long userId,
+            @RequestParam(value = "page", required = false, defaultValue = "1") int page,
+            @RequestParam(value = "page-size", required = false, defaultValue = DEFAULT_PAGE_SIZE) int pageSize,
+            @RequestParam(value = "sort-direction", required = false, defaultValue = "DESC") Sort.Direction sortDirection,
+            @RequestParam(value = "sort-property", required = false, defaultValue = "ID") ReviewSortProperty sortProperty
+    ) {
+        GetUserReviewsResult result = getUserReviewsUseCase.getUserReviews(
+                new GetUserReviewsCommand(userId, page, pageSize, sortDirection, sortProperty)
+        );
+
+        return new ResponseEntity<>(
+                BaseResponse.of(
+                        GetUserReviewsResponse.from(result),
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "회원 리뷰 내역 조회 성공"
                 ),
                 HttpStatus.OK
         );

--- a/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/in/web/review/controller/apidocs/GetUserReviewsApiDocs.java
+++ b/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/in/web/review/controller/apidocs/GetUserReviewsApiDocs.java
@@ -1,0 +1,159 @@
+package com.personal.marketnote.community.adapter.in.web.review.controller.apidocs;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@SecurityRequirement(name = "bearer")
+@Operation(
+        summary = "(관리자) 회원 리뷰 내역 조회",
+        description = """
+                작성일자: 2026-04-01
+
+                작성자: 성효빈
+
+                - 관리자가 특정 회원의 리뷰 내역을 오프셋 페이지네이션으로 조회합니다.
+
+                ---
+
+                ## Request
+
+                | **키** | **타입** | **설명** | **필수 여부** | **예시** |
+                | --- | --- | --- | --- | --- |
+                | userId | number (path) | 회원 ID | Y | 1 |
+                | page | number | 페이지 번호 (1부터 시작) | N (기본값: 1) | 1 |
+                | page-size | number | 페이지 크기 | N (기본값: 10) | 10 |
+                | sort-direction | string | 정렬 방향(DESC/ASC) | N (기본값: DESC) | "DESC" |
+                | sort-property | string | 정렬 기준 | N (기본값: ID) | "ID" |
+
+                ---
+
+                ## Response
+
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | statusCode | number | HTTP 상태 코드 | 200 |
+                | code | string | 응답 코드 | "SUC01" |
+                | timestamp | string(datetime) | 응답 일시 | "2026-04-01T10:00:00" |
+                | content | object | 응답 본문 | { ... } |
+                | message | string | 처리 결과 | "회원 리뷰 내역 조회 성공" |
+
+                ### Response > content > reviews
+
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | page | number | 현재 페이지 | 1 |
+                | pageSize | number | 페이지 크기 | 10 |
+                | totalElements | number | 총 리뷰 수 | 25 |
+                | totalPages | number | 총 페이지 수 | 3 |
+                | items | array | 리뷰 목록 | [ ... ] |
+                """,
+        parameters = {
+                @Parameter(
+                        name = "userId",
+                        in = ParameterIn.PATH,
+                        required = true,
+                        description = "회원 ID",
+                        schema = @Schema(type = "number", example = "1")
+                ),
+                @Parameter(
+                        name = "page",
+                        in = ParameterIn.QUERY,
+                        description = "페이지 번호 (1부터 시작)",
+                        schema = @Schema(type = "number", example = "1", defaultValue = "1")
+                ),
+                @Parameter(
+                        name = "page-size",
+                        in = ParameterIn.QUERY,
+                        description = "페이지 크기",
+                        schema = @Schema(type = "number", example = "10", defaultValue = "10")
+                ),
+                @Parameter(
+                        name = "sort-direction",
+                        in = ParameterIn.QUERY,
+                        description = "정렬 방향",
+                        schema = @Schema(
+                                type = "string",
+                                example = "DESC",
+                                allowableValues = {"ASC", "DESC"},
+                                defaultValue = "DESC"
+                        )
+                ),
+                @Parameter(
+                        name = "sort-property",
+                        in = ParameterIn.QUERY,
+                        description = "정렬 기준",
+                        schema = @Schema(
+                                type = "string",
+                                example = "ID",
+                                allowableValues = {"ID", "LIKE", "RATING", "ORDER_NUM"},
+                                defaultValue = "ID"
+                        )
+                )
+        },
+        responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "회원 리뷰 내역 조회 성공",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 200,
+                                          "code": "SUC01",
+                                          "timestamp": "2026-04-01T10:00:00",
+                                          "content": {
+                                            "reviews": {
+                                              "page": 1,
+                                              "pageSize": 10,
+                                              "totalElements": 2,
+                                              "totalPages": 1,
+                                              "items": [
+                                                {
+                                                  "id": 10,
+                                                  "reviewerId": 1,
+                                                  "orderId": 100,
+                                                  "productId": 50,
+                                                  "pricePolicyId": 30,
+                                                  "productImageUrl": "https://s3/product.jpg",
+                                                  "selectedOptions": "색상: 블랙 / 사이즈: M",
+                                                  "quantity": 1,
+                                                  "reviewerName": "홍*동",
+                                                  "rating": 5.0,
+                                                  "content": "좋은 상품입니다",
+                                                  "isPhoto": true,
+                                                  "images": [],
+                                                  "isEdited": false,
+                                                  "likeCount": 3,
+                                                  "isUserLiked": false,
+                                                  "status": "ACTIVE",
+                                                  "createdAt": "2026-03-29T10:00:00",
+                                                  "modifiedAt": "2026-03-29T10:00:00",
+                                                  "orderNum": 10,
+                                                  "product": {
+                                                    "productId": 50,
+                                                    "productName": "테스트 상품",
+                                                    "pricePolicyName": "기본 옵션"
+                                                  }
+                                                }
+                                              ]
+                                            }
+                                          },
+                                          "message": "회원 리뷰 내역 조회 성공"
+                                        }
+                                        """)
+                        )
+                )
+        }
+)
+public @interface GetUserReviewsApiDocs {
+}

--- a/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/in/web/review/response/GetUserReviewsResponse.java
+++ b/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/in/web/review/response/GetUserReviewsResponse.java
@@ -1,0 +1,20 @@
+package com.personal.marketnote.community.adapter.in.web.review.response;
+
+import com.personal.marketnote.common.adapter.in.response.OffsetResponse;
+import com.personal.marketnote.community.port.in.result.review.GetUserReviewsResult;
+
+public record GetUserReviewsResponse(OffsetResponse<ReviewItemResponse> reviews) {
+    public static GetUserReviewsResponse from(GetUserReviewsResult result) {
+        return new GetUserReviewsResponse(
+                new OffsetResponse<>(
+                        result.page(),
+                        result.pageSize(),
+                        result.totalElements(),
+                        result.totalPages(),
+                        result.reviews().stream()
+                                .map(ReviewItemResponse::from)
+                                .toList()
+                )
+        );
+    }
+}

--- a/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/out/persistence/review/ReviewPersistenceAdapter.java
+++ b/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/out/persistence/review/ReviewPersistenceAdapter.java
@@ -18,6 +18,7 @@ import com.personal.marketnote.community.port.out.review.UpdateReviewPort;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 
@@ -162,6 +163,25 @@ public class ReviewPersistenceAdapter implements SaveReviewPort, FindReviewPort,
     @Override
     public long countActive(Long reviewerId) {
         return reviewJpaRepository.countByReviewerId(reviewerId);
+    }
+
+    @Override
+    public Reviews findUserReviewsByOffset(
+            Long reviewerId,
+            int page,
+            int pageSize,
+            boolean isDesc,
+            ReviewSortProperty sortProperty
+    ) {
+        String sortField = sortProperty.getCamelCaseValue();
+        Sort sort = isDesc ? Sort.by(Sort.Direction.DESC, sortField) : Sort.by(Sort.Direction.ASC, sortField);
+        Pageable pageable = PageRequest.of(page - 1, pageSize, sort);
+
+        List<ReviewJpaEntity> entities = reviewJpaRepository.findUserReviewsByOffset(reviewerId, pageable);
+
+        return Reviews.from(entities.stream()
+                .map(entity -> ReviewJpaEntityToDomainMapper.mapToDomain(entity).orElse(null))
+                .toList());
     }
 
     @Override

--- a/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/out/persistence/review/repository/ReviewJpaRepository.java
+++ b/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/out/persistence/review/repository/ReviewJpaRepository.java
@@ -699,4 +699,14 @@ public interface ReviewJpaRepository extends JpaRepository<ReviewJpaEntity, Long
             WHERE r.reviewerId = :reviewerId
             """)
     long countByReviewerId(@Param("reviewerId") Long reviewerId);
+
+    @Query("""
+            SELECT r
+            FROM ReviewJpaEntity r
+            WHERE r.reviewerId = :reviewerId
+            """)
+    List<ReviewJpaEntity> findUserReviewsByOffset(
+            @Param("reviewerId") Long reviewerId,
+            Pageable pageable
+    );
 }

--- a/community-service/community-application/src/main/java/com/personal/marketnote/community/port/in/command/review/GetUserReviewsCommand.java
+++ b/community-service/community-application/src/main/java/com/personal/marketnote/community/port/in/command/review/GetUserReviewsCommand.java
@@ -1,0 +1,13 @@
+package com.personal.marketnote.community.port.in.command.review;
+
+import com.personal.marketnote.community.domain.review.ReviewSortProperty;
+import org.springframework.data.domain.Sort;
+
+public record GetUserReviewsCommand(
+        Long userId,
+        int page,
+        int pageSize,
+        Sort.Direction sortDirection,
+        ReviewSortProperty sortProperty
+) {
+}

--- a/community-service/community-application/src/main/java/com/personal/marketnote/community/port/in/result/review/GetUserReviewsResult.java
+++ b/community-service/community-application/src/main/java/com/personal/marketnote/community/port/in/result/review/GetUserReviewsResult.java
@@ -1,0 +1,21 @@
+package com.personal.marketnote.community.port.in.result.review;
+
+import java.util.List;
+
+public record GetUserReviewsResult(
+        int page,
+        int pageSize,
+        long totalElements,
+        int totalPages,
+        List<ReviewItemResult> reviews
+) {
+    public static GetUserReviewsResult of(
+            int page,
+            int pageSize,
+            long totalElements,
+            int totalPages,
+            List<ReviewItemResult> reviews
+    ) {
+        return new GetUserReviewsResult(page, pageSize, totalElements, totalPages, reviews);
+    }
+}

--- a/community-service/community-application/src/main/java/com/personal/marketnote/community/port/in/usecase/review/GetUserReviewsUseCase.java
+++ b/community-service/community-application/src/main/java/com/personal/marketnote/community/port/in/usecase/review/GetUserReviewsUseCase.java
@@ -1,0 +1,22 @@
+package com.personal.marketnote.community.port.in.usecase.review;
+
+import com.personal.marketnote.community.port.in.command.review.GetUserReviewsCommand;
+import com.personal.marketnote.community.port.in.result.review.GetUserReviewsResult;
+
+/**
+ * (관리자) 회원 리뷰 내역 조회 유스케이스
+ *
+ * @Author 성효빈
+ * @Date 2026-04-01
+ * @Description 관리자가 특정 회원의 리뷰 내역을 조회합니다.
+ */
+public interface GetUserReviewsUseCase {
+    /**
+     * @param command 회원 리뷰 내역 조회 커맨드
+     * @return 회원 리뷰 내역 조회 결과 {@link GetUserReviewsResult}
+     * @Date 2026-04-01
+     * @Author 성효빈
+     * @Description 관리자가 특정 회원의 리뷰 내역을 조회합니다.
+     */
+    GetUserReviewsResult getUserReviews(GetUserReviewsCommand command);
+}

--- a/community-service/community-application/src/main/java/com/personal/marketnote/community/port/out/review/FindReviewPort.java
+++ b/community-service/community-application/src/main/java/com/personal/marketnote/community/port/out/review/FindReviewPort.java
@@ -119,4 +119,23 @@ public interface FindReviewPort {
      * @Description 총 리뷰 개수를 조회합니다.
      */
     long countActive(Long reviewerId);
+
+    /**
+     * @param reviewerId   리뷰 작성자 ID
+     * @param page         페이지 번호 (1부터 시작)
+     * @param pageSize     페이지 크기
+     * @param isDesc       내림차순 여부
+     * @param sortProperty 정렬 속성
+     * @return 회원 리뷰 목록 {@link Reviews}
+     * @Date 2026-04-01
+     * @Author 성효빈
+     * @Description 회원 리뷰 목록을 오프셋 기반으로 조회합니다.
+     */
+    Reviews findUserReviewsByOffset(
+            Long reviewerId,
+            int page,
+            int pageSize,
+            boolean isDesc,
+            ReviewSortProperty sortProperty
+    );
 }

--- a/community-service/community-application/src/main/java/com/personal/marketnote/community/service/review/GetUserReviewsService.java
+++ b/community-service/community-application/src/main/java/com/personal/marketnote/community/service/review/GetUserReviewsService.java
@@ -1,0 +1,147 @@
+package com.personal.marketnote.community.service.review;
+
+import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.common.application.file.port.in.result.GetFileResult;
+import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.community.domain.review.Review;
+import com.personal.marketnote.community.domain.review.Reviews;
+import com.personal.marketnote.community.port.in.command.review.GetUserReviewsCommand;
+import com.personal.marketnote.community.port.in.result.review.GetUserReviewsResult;
+import com.personal.marketnote.community.port.in.result.review.ReviewItemResult;
+import com.personal.marketnote.community.port.in.result.review.ReviewProductInfoResult;
+import com.personal.marketnote.community.port.in.usecase.review.GetUserReviewsUseCase;
+import com.personal.marketnote.community.port.out.file.FindReviewImagesPort;
+import com.personal.marketnote.community.port.out.product.FindProductByPricePolicyPort;
+import com.personal.marketnote.community.port.out.result.product.ProductInfoResult;
+import com.personal.marketnote.community.port.out.review.FindReviewPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Sort;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static com.personal.marketnote.common.domain.file.FileSort.REVIEW_IMAGE;
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional(isolation = READ_COMMITTED, readOnly = true)
+public class GetUserReviewsService implements GetUserReviewsUseCase {
+    private final FindReviewPort findReviewPort;
+    private final FindReviewImagesPort findReviewImagesPort;
+    private final FindProductByPricePolicyPort findProductByPricePolicyPort;
+
+    @Override
+    public GetUserReviewsResult getUserReviews(GetUserReviewsCommand command) {
+        boolean isDesc = Sort.Direction.DESC.equals(command.sortDirection());
+
+        Reviews reviews = findReviewPort.findUserReviewsByOffset(
+                command.userId(),
+                command.page(),
+                command.pageSize(),
+                isDesc,
+                command.sortProperty()
+        );
+
+        long totalElements = findReviewPort.countActive(command.userId());
+
+        int totalPages = computeTotalPages(totalElements, command.pageSize());
+
+        List<Review> reviewList = reviews.getReviews();
+
+        Map<Long, List<GetFileResult>> reviewImagesByReviewId = findReviewImages(reviewList);
+
+        Map<Long, ReviewProductInfoResult> productInfoByPricePolicyId = findReviewProductInfo(reviewList);
+
+        List<ReviewItemResult> reviewItems = reviewList.stream()
+                .map(review -> {
+                    Long pricePolicyId = review.getPricePolicyId();
+                    ReviewProductInfoResult productInfo = FormatValidator.hasValue(pricePolicyId)
+                            ? productInfoByPricePolicyId.get(pricePolicyId)
+                            : null;
+
+                    return ReviewItemResult.from(
+                            review,
+                            reviewImagesByReviewId.get(review.getId()),
+                            productInfo
+                    );
+                })
+                .toList();
+
+        return GetUserReviewsResult.of(
+                command.page(),
+                command.pageSize(),
+                totalElements,
+                totalPages,
+                reviewItems
+        );
+    }
+
+    private int computeTotalPages(long totalElements, int pageSize) {
+        if (totalElements == 0) {
+            return 0;
+        }
+        return (int) Math.ceil((double) totalElements / pageSize);
+    }
+
+    private Map<Long, List<GetFileResult>> findReviewImages(List<Review> reviews) {
+        if (FormatValidator.hasNoValue(reviews)) {
+            return Map.of();
+        }
+
+        Map<Long, List<GetFileResult>> reviewImagesByReviewId = new ConcurrentHashMap<>();
+
+        List<CompletableFuture<Void>> futures = reviews.stream()
+                .filter(review -> Boolean.TRUE.equals(review.getIsPhoto()))
+                .map(review -> CompletableFuture.runAsync(
+                        () -> findReviewImagesPort.findImagesByReviewIdAndSort(review.getId(), REVIEW_IMAGE)
+                                .ifPresent(result -> reviewImagesByReviewId.put(review.getId(), result.images()))
+                ))
+                .toList();
+
+        if (FormatValidator.hasValue(futures)) {
+            CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
+        }
+
+        return reviewImagesByReviewId;
+    }
+
+    private Map<Long, ReviewProductInfoResult> findReviewProductInfo(List<Review> reviews) {
+        List<Long> pricePolicyIds = extractPricePolicyIds(reviews);
+        if (FormatValidator.hasNoValue(pricePolicyIds)) {
+            return Map.of();
+        }
+
+        Map<Long, ProductInfoResult> productInfoByPricePolicyId
+                = findProductByPricePolicyPort.findByPricePolicyIds(pricePolicyIds);
+        if (FormatValidator.hasNoValue(productInfoByPricePolicyId)) {
+            return Map.of();
+        }
+
+        Map<Long, ReviewProductInfoResult> results = new HashMap<>();
+        productInfoByPricePolicyId.forEach(
+                (pricePolicyId, productInfo) -> results.put(
+                        pricePolicyId,
+                        ReviewProductInfoResult.from(productInfo)
+                )
+        );
+
+        return results;
+    }
+
+    private List<Long> extractPricePolicyIds(List<Review> reviews) {
+        if (FormatValidator.hasNoValue(reviews)) {
+            return List.of();
+        }
+
+        return reviews.stream()
+                .map(Review::getPricePolicyId)
+                .filter(FormatValidator::hasValue)
+                .distinct()
+                .toList();
+    }
+}


### PR DESCRIPTION
## partially addresses #300
## resolves #1723

## Task
- [x] `GetUserReviewsUseCase` 인터페이스 정의
- [x] `GetUserReviewsCommand` 정의 (userId, page, pageSize, sortDirection, sortProperty)
- [x] `GetUserReviewsResult` 정의 (오프셋 페이지네이션 기반)
- [x] `GetUserReviewsService` 구현 (`@PreAuthorize` 관리자 전용)
- [x] `FindReviewPort`에 오프셋 기반 조회 메서드 추가
- [x] `ReviewPersistenceAdapter`에 userId 조건 쿼리 구현
- [x] 관리자 전용 컨트롤러 엔드포인트 추가
- [x] 요청/응답 DTO + 매퍼 작성