### PR TITLE
[#300][#1738] test: 1:1 문의 등록 시 마스킹 없이 원본 작성자명을 저장하도록 변경 기능 자동화 테스트 추가

### DIFF
--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/inventory/ReduceProductInventoryUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/inventory/ReduceProductInventoryUseCaseTest.java
@@ -9,8 +9,8 @@ import com.personal.marketnote.commerce.exception.DuplicateInventoryDeductionExc
 import com.personal.marketnote.commerce.exception.InventoryLockAcquisitionException;
 import com.personal.marketnote.commerce.exception.InventoryLockInterruptedException;
 import com.personal.marketnote.commerce.exception.InventoryNotFoundException;
-import com.personal.marketnote.common.domain.exception.illegalargument.invalidvalue.InsufficientQuantityException;
 import com.personal.marketnote.commerce.port.out.inventory.*;
+import com.personal.marketnote.common.domain.exception.illegalargument.invalidvalue.InsufficientQuantityException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;

--- a/community-service/community-application/src/test/java/com/personal/marketnote/community/service/post/GetUserProductInquiryPostsUseCaseTest.java
+++ b/community-service/community-application/src/test/java/com/personal/marketnote/community/service/post/GetUserProductInquiryPostsUseCaseTest.java
@@ -6,7 +6,6 @@ import com.personal.marketnote.common.application.file.port.in.result.GetFilesRe
 import com.personal.marketnote.community.domain.post.*;
 import com.personal.marketnote.community.port.in.command.post.GetUserProductInquiryPostsCommand;
 import com.personal.marketnote.community.port.in.result.post.GetUserProductInquiryPostsResult;
-import com.personal.marketnote.community.port.in.result.post.PostItemResult;
 import com.personal.marketnote.community.port.out.file.FindPostImagesPort;
 import com.personal.marketnote.community.port.out.post.FindPostPort;
 import com.personal.marketnote.community.port.out.product.FindProductByPricePolicyPort;

--- a/community-service/community-application/src/test/java/com/personal/marketnote/community/service/post/RegisterPostUseCaseTest.java
+++ b/community-service/community-application/src/test/java/com/personal/marketnote/community/service/post/RegisterPostUseCaseTest.java
@@ -258,6 +258,52 @@ class RegisterPostUseCaseTest {
     }
 
     @Test
+    @DisplayName("1:1 문의 등록 시 writerMaskedName에 마스킹 없이 원본 작성자명이 저장된다")
+    void registerPost_oneOnOneInquery_writerMaskedNameIsOriginal() {
+        RegisterPostCommand command = RegisterPostCommand.builder()
+                .userId(14L)
+                .parentId(null)
+                .board(Board.ONE_ON_ONE_INQUERY)
+                .category("ORDER_PAYMENT")
+                .writerName("테스트유저")
+                .content("1:1 문의 내용입니다")
+                .build();
+        Post savedPost = buildSavedPost(900L, command);
+        when(savePostPort.save(any(Post.class))).thenReturn(savedPost);
+
+        registerPostService.registerPost(false, command);
+
+        ArgumentCaptor<Post> postCaptor = ArgumentCaptor.forClass(Post.class);
+        verify(savePostPort).save(postCaptor.capture());
+        Post captured = postCaptor.getValue();
+
+        assertThat(captured.getWriterMaskedName()).isEqualTo("테스트유저");
+    }
+
+    @Test
+    @DisplayName("상품 문의 등록 시 writerMaskedName에 마스킹된 작성자명이 저장된다")
+    void registerPost_productInquery_writerMaskedNameIsMasked() {
+        RegisterPostCommand command = RegisterPostCommand.builder()
+                .userId(15L)
+                .parentId(null)
+                .board(Board.PRODUCT_INQUERY)
+                .category("PRODUCT_QUESTION")
+                .writerName("테스트유저")
+                .content("상품 문의 내용입니다")
+                .build();
+        Post savedPost = buildSavedPost(1000L, command);
+        when(savePostPort.save(any(Post.class))).thenReturn(savedPost);
+
+        registerPostService.registerPost(false, command);
+
+        ArgumentCaptor<Post> postCaptor = ArgumentCaptor.forClass(Post.class);
+        verify(savePostPort).save(postCaptor.capture());
+        Post captured = postCaptor.getValue();
+
+        assertThat(captured.getWriterMaskedName()).isEqualTo(ValueMasker.mask("테스트유저"));
+    }
+
+    @Test
     @DisplayName("parentId가 null이면 판매자여도 상품 소유권 검증을 건너뛴다")
     void registerPost_sellerNullParentId_skipsValidation() {
         RegisterPostCommand command = RegisterPostCommand.builder()
@@ -310,6 +356,9 @@ class RegisterPostUseCaseTest {
     }
 
     private Post buildSavedPost(Long id, RegisterPostCommand command) {
+        String maskedName = command.board().requiresWriterMasking()
+                ? ValueMasker.mask(command.writerName())
+                : command.writerName();
         return Post.from(
                 PostSnapshotState.builder()
                         .id(id)
@@ -323,7 +372,7 @@ class RegisterPostUseCaseTest {
                         .targetId(command.targetId())
                         .productImageUrl(command.productImageUrl())
                         .writerName(command.writerName())
-                        .writerMaskedName(ValueMasker.mask(command.writerName()))
+                        .writerMaskedName(maskedName)
                         .title(command.title())
                         .content(command.content())
                         .isPrivate(command.isPrivate())

--- a/fulfillment-service/fulfillment-adapters/src/test/java/com/personal/marketnote/fulfillment/adapter/out/web/commerce/CommerceServiceClientTest.java
+++ b/fulfillment-service/fulfillment-adapters/src/test/java/com/personal/marketnote/fulfillment/adapter/out/web/commerce/CommerceServiceClientTest.java
@@ -24,7 +24,8 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.lenient;
-import static org.springframework.test.web.client.match.MockRestRequestMatchers.*;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withServerError;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 

--- a/user-service/user-application/src/test/java/com/personal/marketnote/user/service/shippingaddress/RegisterShippingAddressUseCaseTest.java
+++ b/user-service/user-application/src/test/java/com/personal/marketnote/user/service/shippingaddress/RegisterShippingAddressUseCaseTest.java
@@ -202,7 +202,7 @@ class RegisterShippingAddressUseCaseTest {
         // when & then
         assertThatThrownBy(() -> registerShippingAddressService.registerShippingAddress(command))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("기타 배송지는 최대 5개까지 등록할 수 있습니다");
+                .hasMessageContaining("기타 배송지는 최대 10개까지 등록할 수 있습니다");
 
         verify(findShippingAddressPort).countByUserIdAndAddressType(userId, ShippingAddressType.OTHER);
         verifyNoMoreInteractions(findShippingAddressPort);


### PR DESCRIPTION
## partially addresses #300
## resolves #1738

## Test Case
- [x] 1:1 문의 등록 시 writerMaskedName에 마스킹 없이 원본 작성자명이 저장된다
- [x] 상품 문의 등록 시 writerMaskedName에 마스킹된 작성자명이 저장된다