### PR TITLE
[#300][#1743] feat: 나의 리뷰 내역 조회 시 reviewerName만 조회하도록 응답 분리

### DIFF
--- a/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/in/web/review/controller/ReviewController.java
+++ b/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/in/web/review/controller/ReviewController.java
@@ -147,14 +147,14 @@ public class ReviewController {
      */
     @GetMapping("/reviews/me")
     @GetMyReviewsApiDocs
-    public ResponseEntity<BaseResponse<GetReviewsResponse>> getMyReviews(
+    public ResponseEntity<BaseResponse<GetMyReviewsResponse>> getMyReviews(
             @RequestParam(value = "cursor", required = false) Long cursor,
             @RequestParam(value = "pageSize", required = false, defaultValue = GET_PRODUCT_REVIEWS_DEFAULT_PAGE_SIZE) int pageSize,
             @RequestParam(required = false, defaultValue = "DESC") Sort.Direction sortDirection,
             @RequestParam(required = false, defaultValue = "ID") ReviewSortProperty sortProperty,
             @AuthenticationPrincipal OAuth2AuthenticatedPrincipal principal
     ) {
-        GetReviewsResult result = getReviewUseCase.getWriterReviews(
+        GetMyReviewsResult result = getReviewUseCase.getWriterReviews(
                 ElementExtractor.extractUserId(principal),
                 cursor,
                 pageSize,
@@ -164,7 +164,7 @@ public class ReviewController {
 
         return new ResponseEntity<>(
                 BaseResponse.of(
-                        GetReviewsResponse.from(result),
+                        GetMyReviewsResponse.from(result),
                         HttpStatus.OK,
                         DEFAULT_SUCCESS_CODE,
                         "나의 리뷰 목록 조회 성공"

--- a/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/in/web/review/controller/apidocs/GetMyReviewsApiDocs.java
+++ b/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/in/web/review/controller/apidocs/GetMyReviewsApiDocs.java
@@ -83,8 +83,7 @@ import java.lang.annotation.*;
                 | productImageUrl | string | 상품 이미지 URL | "https://example.com/image.jpg" |
                 | selectedOptions | string | 선택된 옵션 목록 | "30개입, 5박스" |
                 | quantity | number | 주문 수량 | 2 |
-                | reviewerName | string | 리뷰 작성자 이름(원본) | "홍길동" |
-                | reviewerMaskedName | string | 리뷰 작성자 이름(마스킹) | "홍*동" |
+                | reviewerName | string | 리뷰 작성자 이름 | "홍길동" |
                 | rating | number | 평점 | 4 |
                 | content | string | 리뷰 내용 | "배송이 빠르고 포장 상태도 좋았습니다." |
                 | isPhoto | boolean | 포토 리뷰 여부 | false |
@@ -198,7 +197,6 @@ import java.lang.annotation.*;
                                                   "selectedOptions": "30개입, 5박스",
                                                   "quantity": 2,
                                                   "reviewerName": "홍길동",
-                                                  "reviewerMaskedName": "홍*동",
                                                   "rating": 1,
                                                   "content": "배송이 느리고 포장 상태도 나빴습니다.",
                                                   "isPhoto": false,
@@ -243,7 +241,6 @@ import java.lang.annotation.*;
                                                   "selectedOptions": "30개입, 5박스",
                                                   "quantity": 2,
                                                   "reviewerName": "홍길동",
-                                                  "reviewerMaskedName": "홍*동",
                                                   "rating": 5,
                                                   "content": "배송이 빠르고 포장 상태도 좋았습니다.",
                                                   "isPhoto": false,
@@ -288,7 +285,6 @@ import java.lang.annotation.*;
                                                   "selectedOptions": "30개입, 5박스",
                                                   "quantity": 2,
                                                   "reviewerName": "홍길동",
-                                                  "reviewerMaskedName": "홍*동",
                                                   "rating": 5,
                                                   "content": "배송이 빠르고 포장 상태도 좋았습니다.",
                                                   "isPhoto": true,
@@ -352,7 +348,6 @@ import java.lang.annotation.*;
                                                   "selectedOptions": "30개입, 5박스",
                                                   "quantity": 2,
                                                   "reviewerName": "홍길동",
-                                                  "reviewerMaskedName": "홍*동",
                                                   "rating": 5,
                                                   "content": "배송이 빠르고 포장 상태도 좋았습니다.",
                                                   "isPhoto": false,

--- a/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/in/web/review/response/GetMyReviewsResponse.java
+++ b/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/in/web/review/response/GetMyReviewsResponse.java
@@ -1,0 +1,23 @@
+package com.personal.marketnote.community.adapter.in.web.review.response;
+
+import com.personal.marketnote.common.adapter.in.response.CursorResponse;
+import com.personal.marketnote.community.port.in.result.review.GetMyReviewsResult;
+
+import java.util.stream.Collectors;
+
+public record GetMyReviewsResponse(
+        CursorResponse<MyReviewItemResponse> reviews
+) {
+    public static GetMyReviewsResponse from(GetMyReviewsResult result) {
+        return new GetMyReviewsResponse(
+                new CursorResponse<>(
+                        result.totalElements(),
+                        result.hasNext(),
+                        result.nextCursor(),
+                        result.reviews().stream()
+                                .map(MyReviewItemResponse::from)
+                                .collect(Collectors.toList())
+                )
+        );
+    }
+}

--- a/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/in/web/review/response/MyReviewItemResponse.java
+++ b/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/in/web/review/response/MyReviewItemResponse.java
@@ -1,0 +1,60 @@
+package com.personal.marketnote.community.adapter.in.web.review.response;
+
+import com.personal.marketnote.common.application.file.port.in.result.GetFileResult;
+import com.personal.marketnote.community.port.in.result.review.MyReviewItemResult;
+import lombok.AccessLevel;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Builder(access = AccessLevel.PRIVATE)
+public record MyReviewItemResponse(
+        Long id,
+        Long reviewerId,
+        Long orderId,
+        Long productId,
+        Long pricePolicyId,
+        String productImageUrl,
+        String selectedOptions,
+        Integer quantity,
+        String reviewerName,
+        Float rating,
+        String content,
+        Boolean isPhoto,
+        List<GetFileResult> images,
+        Boolean isEdited,
+        Integer likeCount,
+        boolean isUserLiked,
+        String status,
+        LocalDateTime createdAt,
+        LocalDateTime modifiedAt,
+        Long orderNum,
+        ReviewProductInfoResponse product
+) {
+    public static MyReviewItemResponse from(MyReviewItemResult result) {
+        return MyReviewItemResponse.builder()
+                .id(result.id())
+                .reviewerId(result.reviewerId())
+                .orderId(result.orderId())
+                .productId(result.productId())
+                .pricePolicyId(result.pricePolicyId())
+                .productImageUrl(result.productImageUrl())
+                .selectedOptions(result.selectedOptions())
+                .quantity(result.quantity())
+                .reviewerName(result.reviewerName())
+                .rating(result.rating())
+                .content(result.content())
+                .isPhoto(result.isPhoto())
+                .images(result.images())
+                .isEdited(result.isEdited())
+                .likeCount(result.likeCount())
+                .isUserLiked(result.isUserLiked())
+                .status(result.status())
+                .createdAt(result.createdAt())
+                .modifiedAt(result.modifiedAt())
+                .orderNum(result.orderNum())
+                .product(ReviewProductInfoResponse.from(result.product()))
+                .build();
+    }
+}

--- a/community-service/community-application/src/main/java/com/personal/marketnote/community/port/in/result/review/GetMyReviewsResult.java
+++ b/community-service/community-application/src/main/java/com/personal/marketnote/community/port/in/result/review/GetMyReviewsResult.java
@@ -1,0 +1,44 @@
+package com.personal.marketnote.community.port.in.result.review;
+
+import com.personal.marketnote.common.application.file.port.in.result.GetFileResult;
+import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.community.domain.review.Review;
+
+import java.util.List;
+import java.util.Map;
+
+public record GetMyReviewsResult(
+        Long totalElements,
+        Long nextCursor,
+        boolean hasNext,
+        List<MyReviewItemResult> reviews
+) {
+    public static GetMyReviewsResult from(
+            boolean hasNext,
+            Long nextCursor,
+            Long totalElements,
+            List<Review> reviews,
+            Map<Long, List<GetFileResult>> reviewImagesByReviewId,
+            Map<Long, ReviewProductInfoResult> productInfoByPricePolicyId
+    ) {
+        return new GetMyReviewsResult(
+                totalElements,
+                nextCursor,
+                hasNext,
+                reviews.stream()
+                        .map(review -> {
+                            Long pricePolicyId = review.getPricePolicyId();
+                            ReviewProductInfoResult productInfo = FormatValidator.hasValue(pricePolicyId)
+                                    ? productInfoByPricePolicyId.get(pricePolicyId)
+                                    : null;
+
+                            return MyReviewItemResult.from(
+                                    review,
+                                    reviewImagesByReviewId.get(review.getId()),
+                                    productInfo
+                            );
+                        })
+                        .toList()
+        );
+    }
+}

--- a/community-service/community-application/src/main/java/com/personal/marketnote/community/port/in/result/review/MyReviewItemResult.java
+++ b/community-service/community-application/src/main/java/com/personal/marketnote/community/port/in/result/review/MyReviewItemResult.java
@@ -1,0 +1,72 @@
+package com.personal.marketnote.community.port.in.result.review;
+
+import com.personal.marketnote.common.application.file.port.in.result.GetFileResult;
+import com.personal.marketnote.community.domain.review.Review;
+import lombok.AccessLevel;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Builder(access = AccessLevel.PRIVATE)
+public record MyReviewItemResult(
+        Long id,
+        Long reviewerId,
+        Long orderId,
+        Long productId,
+        Long pricePolicyId,
+        String productImageUrl,
+        String selectedOptions,
+        Integer quantity,
+        String reviewerName,
+        Float rating,
+        String content,
+        Boolean isPhoto,
+        List<GetFileResult> images,
+        Boolean isEdited,
+        Integer likeCount,
+        boolean isUserLiked,
+        String status,
+        LocalDateTime createdAt,
+        LocalDateTime modifiedAt,
+        Long orderNum,
+        ReviewProductInfoResult product
+) {
+    public static MyReviewItemResult from(Review review) {
+        return from(review, null, null);
+    }
+
+    public static MyReviewItemResult from(Review review, List<GetFileResult> images) {
+        return from(review, images, null);
+    }
+
+    public static MyReviewItemResult from(
+            Review review,
+            List<GetFileResult> images,
+            ReviewProductInfoResult product
+    ) {
+        return MyReviewItemResult.builder()
+                .id(review.getId())
+                .reviewerId(review.getReviewerId())
+                .orderId(review.getOrderId())
+                .productId(review.getProductId())
+                .pricePolicyId(review.getPricePolicyId())
+                .productImageUrl(review.getProductImageUrl())
+                .selectedOptions(review.getSelectedOptions())
+                .quantity(review.getQuantity())
+                .reviewerName(review.getReviewerName())
+                .rating(review.getRating())
+                .content(review.getContent())
+                .isPhoto(review.getIsPhoto())
+                .images(images)
+                .isEdited(review.getIsEdited())
+                .likeCount(review.getLikeCount())
+                .isUserLiked(review.isUserLiked())
+                .status(review.getStatus().name())
+                .createdAt(review.getCreatedAt())
+                .modifiedAt(review.getModifiedAt())
+                .orderNum(review.getOrderNum())
+                .product(product)
+                .build();
+    }
+}

--- a/community-service/community-application/src/main/java/com/personal/marketnote/community/port/in/usecase/review/GetReviewUseCase.java
+++ b/community-service/community-application/src/main/java/com/personal/marketnote/community/port/in/usecase/review/GetReviewUseCase.java
@@ -5,6 +5,7 @@ import com.personal.marketnote.community.domain.review.Review;
 import com.personal.marketnote.community.domain.review.ReviewSortProperty;
 import com.personal.marketnote.community.port.in.command.review.RegisterReviewCommand;
 import com.personal.marketnote.community.port.in.result.review.GetProductReviewAggregatesResult;
+import com.personal.marketnote.community.port.in.result.review.GetMyReviewsResult;
 import com.personal.marketnote.community.port.in.result.review.GetReviewCountResult;
 import com.personal.marketnote.community.port.in.result.review.GetReviewsResult;
 import org.springframework.data.domain.Sort;
@@ -111,12 +112,12 @@ public interface GetReviewUseCase {
      * @param pageSize      페이지 크기
      * @param sortDirection 정렬 방향
      * @param sortProperty  정렬 속성
-     * @return 회원 리뷰 목록 조회 결과 {@link GetReviewsResult}
+     * @return 나의 리뷰 목록 조회 결과 {@link GetMyReviewsResult}
      * @Date 2026-01-12
      * @Author 성효빈
-     * @Description 회원 리뷰 목록을 조회합니다.
+     * @Description 나의 리뷰 목록을 조회합니다.
      */
-    GetReviewsResult getWriterReviews(
+    GetMyReviewsResult getWriterReviews(
             Long userId, Long cursor, int pageSize, Sort.Direction sortDirection, ReviewSortProperty sortProperty
     );
 

--- a/community-service/community-application/src/main/java/com/personal/marketnote/community/service/review/GetReviewService.java
+++ b/community-service/community-application/src/main/java/com/personal/marketnote/community/service/review/GetReviewService.java
@@ -159,7 +159,7 @@ public class GetReviewService implements GetReviewUseCase {
     }
 
     @Override
-    public GetReviewsResult getWriterReviews(
+    public GetMyReviewsResult getWriterReviews(
             Long userId, Long cursor, int pageSize, Sort.Direction sortDirection, ReviewSortProperty sortProperty
     ) {
         Pageable pageable = PageRequest.of(
@@ -191,7 +191,7 @@ public class GetReviewService implements GetReviewUseCase {
 
         Map<Long, ReviewProductInfoResult> productInfoByPricePolicyId = findReviewProductInfo(pagedReviews);
 
-        return GetReviewsResult.from(
+        return GetMyReviewsResult.from(
                 hasNext,
                 nextCursor,
                 totalElements,


### PR DESCRIPTION
## partially addresses #300
## resolves #1743

## Task
- [x] 나의 리뷰 전용 MyReviewItemResult 분리 (reviewerName만 포함)
- [x] 나의 리뷰 전용 MyReviewItemResponse 분리 (reviewerName만 포함)
- [x] GetMyReviews 컨트롤러/서비스에서 전용 Response 사용
- [x] GetMyReviewsApiDocs 문서에서 reviewerMaskedName 필드 제거