### PR TITLE
[#300][#1745] feat: (관리자) 회원 리뷰 내역 조회 시 reviewerName만 조회하도록 응답 분리

### DIFF
--- a/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/in/web/review/controller/apidocs/GetUserReviewsApiDocs.java
+++ b/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/in/web/review/controller/apidocs/GetUserReviewsApiDocs.java
@@ -128,7 +128,6 @@ import java.lang.annotation.*;
                                                   "selectedOptions": "색상: 블랙 / 사이즈: M",
                                                   "quantity": 1,
                                                   "reviewerName": "홍길동",
-                                                  "reviewerMaskedName": "홍*동",
                                                   "rating": 5.0,
                                                   "content": "좋은 상품입니다",
                                                   "isPhoto": true,
@@ -141,9 +140,16 @@ import java.lang.annotation.*;
                                                   "modifiedAt": "2026-03-29T10:00:00",
                                                   "orderNum": 10,
                                                   "product": {
-                                                    "productId": 50,
-                                                    "productName": "테스트 상품",
-                                                    "pricePolicyName": "기본 옵션"
+                                                    "name": "테스트 상품",
+                                                    "brandName": "테스트 브랜드",
+                                                    "pricePolicy": {
+                                                      "id": 30,
+                                                      "price": 25000,
+                                                      "discountPrice": 20000,
+                                                      "discountRate": 20.0,
+                                                      "accumulatedPoint": 200
+                                                    },
+                                                    "catalogImage": null
                                                   }
                                                 }
                                               ]

--- a/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/in/web/review/response/GetUserReviewsResponse.java
+++ b/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/in/web/review/response/GetUserReviewsResponse.java
@@ -3,7 +3,7 @@ package com.personal.marketnote.community.adapter.in.web.review.response;
 import com.personal.marketnote.common.adapter.in.response.OffsetResponse;
 import com.personal.marketnote.community.port.in.result.review.GetUserReviewsResult;
 
-public record GetUserReviewsResponse(OffsetResponse<ReviewItemResponse> reviews) {
+public record GetUserReviewsResponse(OffsetResponse<UserReviewItemResponse> reviews) {
     public static GetUserReviewsResponse from(GetUserReviewsResult result) {
         return new GetUserReviewsResponse(
                 new OffsetResponse<>(
@@ -12,7 +12,7 @@ public record GetUserReviewsResponse(OffsetResponse<ReviewItemResponse> reviews)
                         result.totalElements(),
                         result.totalPages(),
                         result.reviews().stream()
-                                .map(ReviewItemResponse::from)
+                                .map(UserReviewItemResponse::from)
                                 .toList()
                 )
         );

--- a/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/in/web/review/response/UserReviewItemResponse.java
+++ b/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/in/web/review/response/UserReviewItemResponse.java
@@ -1,0 +1,60 @@
+package com.personal.marketnote.community.adapter.in.web.review.response;
+
+import com.personal.marketnote.common.application.file.port.in.result.GetFileResult;
+import com.personal.marketnote.community.port.in.result.review.UserReviewItemResult;
+import lombok.AccessLevel;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Builder(access = AccessLevel.PRIVATE)
+public record UserReviewItemResponse(
+        Long id,
+        Long reviewerId,
+        Long orderId,
+        Long productId,
+        Long pricePolicyId,
+        String productImageUrl,
+        String selectedOptions,
+        Integer quantity,
+        String reviewerName,
+        Float rating,
+        String content,
+        Boolean isPhoto,
+        List<GetFileResult> images,
+        Boolean isEdited,
+        Integer likeCount,
+        boolean isUserLiked,
+        String status,
+        LocalDateTime createdAt,
+        LocalDateTime modifiedAt,
+        Long orderNum,
+        ReviewProductInfoResponse product
+) {
+    public static UserReviewItemResponse from(UserReviewItemResult result) {
+        return UserReviewItemResponse.builder()
+                .id(result.id())
+                .reviewerId(result.reviewerId())
+                .orderId(result.orderId())
+                .productId(result.productId())
+                .pricePolicyId(result.pricePolicyId())
+                .productImageUrl(result.productImageUrl())
+                .selectedOptions(result.selectedOptions())
+                .quantity(result.quantity())
+                .reviewerName(result.reviewerName())
+                .rating(result.rating())
+                .content(result.content())
+                .isPhoto(result.isPhoto())
+                .images(result.images())
+                .isEdited(result.isEdited())
+                .likeCount(result.likeCount())
+                .isUserLiked(result.isUserLiked())
+                .status(result.status())
+                .createdAt(result.createdAt())
+                .modifiedAt(result.modifiedAt())
+                .orderNum(result.orderNum())
+                .product(ReviewProductInfoResponse.from(result.product()))
+                .build();
+    }
+}

--- a/community-service/community-application/src/main/java/com/personal/marketnote/community/port/in/result/review/GetUserReviewsResult.java
+++ b/community-service/community-application/src/main/java/com/personal/marketnote/community/port/in/result/review/GetUserReviewsResult.java
@@ -7,14 +7,14 @@ public record GetUserReviewsResult(
         int pageSize,
         long totalElements,
         int totalPages,
-        List<ReviewItemResult> reviews
+        List<UserReviewItemResult> reviews
 ) {
     public static GetUserReviewsResult of(
             int page,
             int pageSize,
             long totalElements,
             int totalPages,
-            List<ReviewItemResult> reviews
+            List<UserReviewItemResult> reviews
     ) {
         return new GetUserReviewsResult(page, pageSize, totalElements, totalPages, reviews);
     }

--- a/community-service/community-application/src/main/java/com/personal/marketnote/community/port/in/result/review/UserReviewItemResult.java
+++ b/community-service/community-application/src/main/java/com/personal/marketnote/community/port/in/result/review/UserReviewItemResult.java
@@ -1,0 +1,72 @@
+package com.personal.marketnote.community.port.in.result.review;
+
+import com.personal.marketnote.common.application.file.port.in.result.GetFileResult;
+import com.personal.marketnote.community.domain.review.Review;
+import lombok.AccessLevel;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Builder(access = AccessLevel.PRIVATE)
+public record UserReviewItemResult(
+        Long id,
+        Long reviewerId,
+        Long orderId,
+        Long productId,
+        Long pricePolicyId,
+        String productImageUrl,
+        String selectedOptions,
+        Integer quantity,
+        String reviewerName,
+        Float rating,
+        String content,
+        Boolean isPhoto,
+        List<GetFileResult> images,
+        Boolean isEdited,
+        Integer likeCount,
+        boolean isUserLiked,
+        String status,
+        LocalDateTime createdAt,
+        LocalDateTime modifiedAt,
+        Long orderNum,
+        ReviewProductInfoResult product
+) {
+    public static UserReviewItemResult from(Review review) {
+        return from(review, null, null);
+    }
+
+    public static UserReviewItemResult from(Review review, List<GetFileResult> images) {
+        return from(review, images, null);
+    }
+
+    public static UserReviewItemResult from(
+            Review review,
+            List<GetFileResult> images,
+            ReviewProductInfoResult product
+    ) {
+        return UserReviewItemResult.builder()
+                .id(review.getId())
+                .reviewerId(review.getReviewerId())
+                .orderId(review.getOrderId())
+                .productId(review.getProductId())
+                .pricePolicyId(review.getPricePolicyId())
+                .productImageUrl(review.getProductImageUrl())
+                .selectedOptions(review.getSelectedOptions())
+                .quantity(review.getQuantity())
+                .reviewerName(review.getReviewerName())
+                .rating(review.getRating())
+                .content(review.getContent())
+                .isPhoto(review.getIsPhoto())
+                .images(images)
+                .isEdited(review.getIsEdited())
+                .likeCount(review.getLikeCount())
+                .isUserLiked(review.isUserLiked())
+                .status(review.getStatus().name())
+                .createdAt(review.getCreatedAt())
+                .modifiedAt(review.getModifiedAt())
+                .orderNum(review.getOrderNum())
+                .product(product)
+                .build();
+    }
+}

--- a/community-service/community-application/src/main/java/com/personal/marketnote/community/service/review/GetUserReviewsService.java
+++ b/community-service/community-application/src/main/java/com/personal/marketnote/community/service/review/GetUserReviewsService.java
@@ -7,7 +7,7 @@ import com.personal.marketnote.community.domain.review.Review;
 import com.personal.marketnote.community.domain.review.Reviews;
 import com.personal.marketnote.community.port.in.command.review.GetUserReviewsCommand;
 import com.personal.marketnote.community.port.in.result.review.GetUserReviewsResult;
-import com.personal.marketnote.community.port.in.result.review.ReviewItemResult;
+import com.personal.marketnote.community.port.in.result.review.UserReviewItemResult;
 import com.personal.marketnote.community.port.in.result.review.ReviewProductInfoResult;
 import com.personal.marketnote.community.port.in.usecase.review.GetUserReviewsUseCase;
 import com.personal.marketnote.community.port.out.file.FindReviewImagesPort;
@@ -57,14 +57,14 @@ public class GetUserReviewsService implements GetUserReviewsUseCase {
 
         Map<Long, ReviewProductInfoResult> productInfoByPricePolicyId = findReviewProductInfo(reviewList);
 
-        List<ReviewItemResult> reviewItems = reviewList.stream()
+        List<UserReviewItemResult> reviewItems = reviewList.stream()
                 .map(review -> {
                     Long pricePolicyId = review.getPricePolicyId();
                     ReviewProductInfoResult productInfo = FormatValidator.hasValue(pricePolicyId)
                             ? productInfoByPricePolicyId.get(pricePolicyId)
                             : null;
 
-                    return ReviewItemResult.from(
+                    return UserReviewItemResult.from(
                             review,
                             reviewImagesByReviewId.get(review.getId()),
                             productInfo


### PR DESCRIPTION
## partially addresses #300
## resolves #1745

## Task
- [x] 관리자 회원 리뷰 전용 UserReviewItemResult 분리 (reviewerName만 포함)
- [x] 관리자 회원 리뷰 전용 UserReviewItemResponse 분리 (reviewerName만 포함)
- [x] GetUserReviewsResult/Service/Response에서 전용 타입 사용
- [x] GetUserReviewsApiDocs 예시에서 reviewerMaskedName 제거 및 product 구조 수정