### PR TITLE
[#128][#1640] feat: 상품 서비스 배송비 정책 변경 이벤트 발행 기능 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,9 @@
 - TNK
 - Adiscope
 
+### Coupon
+- Giftishow
+
 ### Notifications
 
 #### Push Notification

--- a/common/src/main/java/com/personal/marketnote/common/kafka/KafkaTopicConstants.java
+++ b/common/src/main/java/com/personal/marketnote/common/kafka/KafkaTopicConstants.java
@@ -36,6 +36,9 @@ public final class KafkaTopicConstants {
     public static final String SAGA_ORDER_PAYMENT_LEDGER = "saga.order-payment.ledger";
     public static final String SAGA_ORDER_PAYMENT_COMPLETED = "saga.order-payment.completed";
 
+    // Shipping Policy 이벤트
+    public static final String SHIPPING_POLICY_CHANGED = "product.shipping-policy.changed";
+
     // Dead Letter Topic 접미사
     public static final String DLT_SUFFIX = ".dlt";
 }

--- a/common/src/main/java/com/personal/marketnote/common/kafka/event/ShippingPolicyChangeAction.java
+++ b/common/src/main/java/com/personal/marketnote/common/kafka/event/ShippingPolicyChangeAction.java
@@ -1,0 +1,11 @@
+package com.personal.marketnote.common.kafka.event;
+
+public enum ShippingPolicyChangeAction {
+    CREATED,
+    UPDATED,
+    DELETED;
+
+    public boolean isCreated() { return this == CREATED; }
+    public boolean isUpdated() { return this == UPDATED; }
+    public boolean isDeleted() { return this == DELETED; }
+}

--- a/common/src/main/java/com/personal/marketnote/common/kafka/event/ShippingPolicyChangedEvent.java
+++ b/common/src/main/java/com/personal/marketnote/common/kafka/event/ShippingPolicyChangedEvent.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.common.kafka.event;
+
+public record ShippingPolicyChangedEvent(
+        Long sellerId,
+        Long shippingFee,
+        Long freeShippingThreshold,
+        ShippingPolicyChangeAction action
+) {
+}

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/event/ShippingPolicyEventKafkaProducer.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/event/ShippingPolicyEventKafkaProducer.java
@@ -1,0 +1,51 @@
+package com.personal.marketnote.product.adapter.out.event;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.common.adapter.out.ServiceAdapter;
+import com.personal.marketnote.common.kafka.KafkaTopicConstants;
+import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.ShippingPolicyChangeAction;
+import com.personal.marketnote.common.kafka.event.ShippingPolicyChangedEvent;
+import com.personal.marketnote.common.outbox.OutboxEvent;
+import com.personal.marketnote.common.outbox.SaveOutboxEventPort;
+import com.personal.marketnote.product.port.out.event.PublishShippingPolicyEventPort;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.time.Clock;
+
+@Slf4j
+@ServiceAdapter
+@RequiredArgsConstructor
+public class ShippingPolicyEventKafkaProducer implements PublishShippingPolicyEventPort {
+    private static final String SOURCE = "product-service";
+
+    private final SaveOutboxEventPort saveOutboxEventPort;
+    private final ObjectMapper objectMapper;
+    private final Clock clock;
+
+    @Override
+    public void publishShippingPolicyChangedEvent(Long sellerId, Long shippingFee, Long freeShippingThreshold, ShippingPolicyChangeAction action) {
+        ShippingPolicyChangedEvent payload = new ShippingPolicyChangedEvent(sellerId, shippingFee, freeShippingThreshold, action);
+        String topic = KafkaTopicConstants.SHIPPING_POLICY_CHANGED;
+        EventEnvelope<ShippingPolicyChangedEvent> envelope = EventEnvelope.of(topic, SOURCE, payload, clock);
+
+        saveToOutbox(envelope, topic, sellerId.toString());
+    }
+
+    private <T> void saveToOutbox(EventEnvelope<T> envelope, String topic, String partitionKey) {
+        try {
+            String payloadJson = objectMapper.writeValueAsString(envelope);
+            OutboxEvent outboxEvent = OutboxEvent.of(
+                    envelope.eventId(), topic, partitionKey,
+                    envelope.eventType(), SOURCE, payloadJson, clock
+            );
+            saveOutboxEventPort.save(outboxEvent);
+            log.info("Outbox 이벤트 저장. topic={}, partitionKey={}, eventId={}",
+                    topic, partitionKey, envelope.eventId());
+        } catch (Exception e) {
+            log.error("Outbox 이벤트 저장 실패. topic={}, partitionKey={}, error={}",
+                    topic, partitionKey, e.getMessage(), e);
+        }
+    }
+}

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/out/event/PublishShippingPolicyEventPort.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/out/event/PublishShippingPolicyEventPort.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.product.port.out.event;
+
+import com.personal.marketnote.common.kafka.event.ShippingPolicyChangeAction;
+
+public interface PublishShippingPolicyEventPort {
+
+    void publishShippingPolicyChangedEvent(Long sellerId, Long shippingFee, Long freeShippingThreshold, ShippingPolicyChangeAction action);
+}

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/service/shipping/RegisterShippingPolicyService.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/service/shipping/RegisterShippingPolicyService.java
@@ -7,6 +7,8 @@ import com.personal.marketnote.product.exception.ShippingPolicyAlreadyExistsExce
 import com.personal.marketnote.product.port.in.command.RegisterShippingPolicyCommand;
 import com.personal.marketnote.product.port.in.result.shipping.RegisterShippingPolicyResult;
 import com.personal.marketnote.product.port.in.usecase.shipping.RegisterShippingPolicyUseCase;
+import com.personal.marketnote.common.kafka.event.ShippingPolicyChangeAction;
+import com.personal.marketnote.product.port.out.event.PublishShippingPolicyEventPort;
 import com.personal.marketnote.product.port.out.shipping.FindShippingPolicyPort;
 import com.personal.marketnote.product.port.out.shipping.SaveShippingPolicyPort;
 import lombok.RequiredArgsConstructor;
@@ -20,6 +22,7 @@ public class RegisterShippingPolicyService implements RegisterShippingPolicyUseC
 
     private final FindShippingPolicyPort findShippingPolicyPort;
     private final SaveShippingPolicyPort saveShippingPolicyPort;
+    private final PublishShippingPolicyEventPort publishShippingPolicyEventPort;
 
     @Override
     @Transactional(isolation = READ_COMMITTED)
@@ -34,6 +37,11 @@ public class RegisterShippingPolicyService implements RegisterShippingPolicyUseC
                 .build());
 
         Long savedId = saveShippingPolicyPort.save(shippingPolicy);
+
+        publishShippingPolicyEventPort.publishShippingPolicyChangedEvent(
+                sellerId, command.shippingFee(), command.freeShippingThreshold(), ShippingPolicyChangeAction.CREATED
+        );
+
         return RegisterShippingPolicyResult.of(savedId);
     }
 

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/service/shipping/UpdateShippingPolicyService.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/service/shipping/UpdateShippingPolicyService.java
@@ -6,6 +6,8 @@ import com.personal.marketnote.product.exception.ShippingPolicyNotFoundException
 import com.personal.marketnote.product.port.in.command.UpdateShippingPolicyCommand;
 import com.personal.marketnote.product.port.in.result.shipping.UpdateShippingPolicyResult;
 import com.personal.marketnote.product.port.in.usecase.shipping.UpdateShippingPolicyUseCase;
+import com.personal.marketnote.common.kafka.event.ShippingPolicyChangeAction;
+import com.personal.marketnote.product.port.out.event.PublishShippingPolicyEventPort;
 import com.personal.marketnote.product.port.out.shipping.FindShippingPolicyPort;
 import com.personal.marketnote.product.port.out.shipping.UpdateShippingPolicyPort;
 import lombok.RequiredArgsConstructor;
@@ -19,6 +21,7 @@ public class UpdateShippingPolicyService implements UpdateShippingPolicyUseCase 
 
     private final FindShippingPolicyPort findShippingPolicyPort;
     private final UpdateShippingPolicyPort updateShippingPolicyPort;
+    private final PublishShippingPolicyEventPort publishShippingPolicyEventPort;
 
     @Override
     @Transactional(isolation = READ_COMMITTED)
@@ -32,6 +35,11 @@ public class UpdateShippingPolicyService implements UpdateShippingPolicyUseCase 
         );
 
         updateShippingPolicyPort.update(shippingPolicy);
+
+        publishShippingPolicyEventPort.publishShippingPolicyChangedEvent(
+                sellerId, shippingPolicy.getShippingFee(), shippingPolicy.getFreeShippingThreshold(), ShippingPolicyChangeAction.UPDATED
+        );
+
         return UpdateShippingPolicyResult.from(shippingPolicy);
     }
 


### PR DESCRIPTION
## partially addresses #128
## resolves #1640

## Task
- [x] product.shipping-policy.changed 토픽 정의
- [x] ShippingPolicyChangedEvent 정의 (sellerId, shippingFee, freeShippingThreshold, action: CREATED/UPDATED/DELETED)
- [x] PublishShippingPolicyEventPort + ShippingPolicyEventKafkaProducer 구현
- [x] 배송비 정책 등록/수정 Service에 이벤트 발행 추가