### PR TITLE
[#128][#1763] test: 상품 서비스 배송비 정책 변경 이벤트 발행 기능 자동화 테스트 추가

### DIFF
--- a/product-service/product-adapters/src/test/java/com/personal/marketnote/product/adapter/out/event/ShippingPolicyEventKafkaProducerTest.java
+++ b/product-service/product-adapters/src/test/java/com/personal/marketnote/product/adapter/out/event/ShippingPolicyEventKafkaProducerTest.java
@@ -1,0 +1,125 @@
+package com.personal.marketnote.product.adapter.out.event;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.common.kafka.KafkaTopicConstants;
+import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.ShippingPolicyChangeAction;
+import com.personal.marketnote.common.kafka.event.ShippingPolicyChangedEvent;
+import com.personal.marketnote.common.outbox.OutboxEvent;
+import com.personal.marketnote.common.outbox.SaveOutboxEventPort;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ShippingPolicyEventKafkaProducer 테스트")
+class ShippingPolicyEventKafkaProducerTest {
+
+    @InjectMocks
+    private ShippingPolicyEventKafkaProducer shippingPolicyEventKafkaProducer;
+
+    @Mock
+    private SaveOutboxEventPort saveOutboxEventPort;
+
+    @Mock
+    private ObjectMapper objectMapper;
+
+    @Mock
+    private Clock clock;
+
+    private void setUpClock(String instant) {
+        Clock fixedClock = Clock.fixed(Instant.parse(instant), ZoneId.of("Asia/Seoul"));
+        when(clock.instant()).thenReturn(fixedClock.instant());
+        when(clock.getZone()).thenReturn(fixedClock.getZone());
+    }
+
+    @Test
+    @DisplayName("배송비 정책 변경 이벤트 발행 시 올바른 토픽과 파티션 키로 Outbox에 저장된다")
+    void publishShippingPolicyChangedEvent_savesToOutboxWithCorrectTopicAndPartitionKey() throws Exception {
+        // given
+        setUpClock("2026-03-31T10:00:00Z");
+        when(objectMapper.writeValueAsString(any())).thenReturn("{}");
+
+        // when
+        shippingPolicyEventKafkaProducer.publishShippingPolicyChangedEvent(
+                10L, 3000L, 20000L, ShippingPolicyChangeAction.CREATED
+        );
+
+        // then
+        ArgumentCaptor<OutboxEvent> outboxCaptor = ArgumentCaptor.forClass(OutboxEvent.class);
+        verify(saveOutboxEventPort).save(outboxCaptor.capture());
+
+        OutboxEvent captured = outboxCaptor.getValue();
+        assertThat(captured.getTopic()).isEqualTo(KafkaTopicConstants.SHIPPING_POLICY_CHANGED);
+        assertThat(captured.getPartitionKey()).isEqualTo("10");
+        assertThat(captured.getSource()).isEqualTo("product-service");
+        assertThat(captured.getEventId()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("배송비 정책 변경 이벤트 발행 시 EventEnvelope에 올바른 페이로드가 포함된다")
+    @SuppressWarnings("unchecked")
+    void publishShippingPolicyChangedEvent_envelopeContainsCorrectPayload() throws Exception {
+        // given
+        setUpClock("2026-03-31T10:00:00Z");
+        when(objectMapper.writeValueAsString(any())).thenReturn("{}");
+
+        // when
+        shippingPolicyEventKafkaProducer.publishShippingPolicyChangedEvent(
+                10L, 3000L, 20000L, ShippingPolicyChangeAction.CREATED
+        );
+
+        // then
+        ArgumentCaptor<EventEnvelope> envelopeCaptor = ArgumentCaptor.forClass(EventEnvelope.class);
+        verify(objectMapper).writeValueAsString(envelopeCaptor.capture());
+
+        EventEnvelope<?> capturedEnvelope = envelopeCaptor.getValue();
+        assertThat(capturedEnvelope.eventType()).isEqualTo(KafkaTopicConstants.SHIPPING_POLICY_CHANGED);
+        assertThat(capturedEnvelope.source()).isEqualTo("product-service");
+        assertThat(capturedEnvelope.eventId()).isNotNull();
+        assertThat(capturedEnvelope.timestamp()).isNotNull();
+
+        ShippingPolicyChangedEvent payload = (ShippingPolicyChangedEvent) capturedEnvelope.payload();
+        assertThat(payload.sellerId()).isEqualTo(10L);
+        assertThat(payload.shippingFee()).isEqualTo(3000L);
+        assertThat(payload.freeShippingThreshold()).isEqualTo(20000L);
+        assertThat(payload.action()).isEqualTo(ShippingPolicyChangeAction.CREATED);
+    }
+
+    @Test
+    @DisplayName("배송비 정책 수정 이벤트 발행 시 UPDATED 액션으로 Outbox에 저장된다")
+    @SuppressWarnings("unchecked")
+    void publishShippingPolicyChangedEvent_updatedAction_envelopeContainsUpdatedPayload() throws Exception {
+        // given
+        setUpClock("2026-03-31T10:00:00Z");
+        when(objectMapper.writeValueAsString(any())).thenReturn("{}");
+
+        // when
+        shippingPolicyEventKafkaProducer.publishShippingPolicyChangedEvent(
+                20L, 2500L, 30000L, ShippingPolicyChangeAction.UPDATED
+        );
+
+        // then
+        ArgumentCaptor<EventEnvelope> envelopeCaptor = ArgumentCaptor.forClass(EventEnvelope.class);
+        verify(objectMapper).writeValueAsString(envelopeCaptor.capture());
+
+        ShippingPolicyChangedEvent payload = (ShippingPolicyChangedEvent) envelopeCaptor.getValue().payload();
+        assertThat(payload.sellerId()).isEqualTo(20L);
+        assertThat(payload.shippingFee()).isEqualTo(2500L);
+        assertThat(payload.freeShippingThreshold()).isEqualTo(30000L);
+        assertThat(payload.action()).isEqualTo(ShippingPolicyChangeAction.UPDATED);
+    }
+}

--- a/product-service/product-application/src/test/java/com/personal/marketnote/product/service/shipping/RegisterShippingPolicyUseCaseTest.java
+++ b/product-service/product-application/src/test/java/com/personal/marketnote/product/service/shipping/RegisterShippingPolicyUseCaseTest.java
@@ -8,6 +8,8 @@ import com.personal.marketnote.product.domain.shipping.ShippingPolicySnapshotSta
 import com.personal.marketnote.product.exception.ShippingPolicyAlreadyExistsException;
 import com.personal.marketnote.product.port.in.command.RegisterShippingPolicyCommand;
 import com.personal.marketnote.product.port.in.result.shipping.RegisterShippingPolicyResult;
+import com.personal.marketnote.common.kafka.event.ShippingPolicyChangeAction;
+import com.personal.marketnote.product.port.out.event.PublishShippingPolicyEventPort;
 import com.personal.marketnote.product.port.out.shipping.FindShippingPolicyPort;
 import com.personal.marketnote.product.port.out.shipping.SaveShippingPolicyPort;
 import org.junit.jupiter.api.DisplayName;
@@ -38,6 +40,9 @@ class RegisterShippingPolicyUseCaseTest {
 
     @Mock
     private SaveShippingPolicyPort saveShippingPolicyPort;
+
+    @Mock
+    private PublishShippingPolicyEventPort publishShippingPolicyEventPort;
 
     private ShippingPolicy createSavedPolicy(Long sellerId) {
         return ShippingPolicy.from(ShippingPolicySnapshotState.builder()
@@ -134,5 +139,45 @@ class RegisterShippingPolicyUseCaseTest {
                 .isInstanceOf(InvalidFreeShippingThresholdException.class);
 
         verify(saveShippingPolicyPort, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("배송비 정책 등록 성공 시 CREATED 이벤트를 발행한다")
+    void shouldPublishCreatedEventWhenPolicyRegistered() {
+        // given
+        Long sellerId = 10L;
+        when(findShippingPolicyPort.findActiveBySellerId(sellerId)).thenReturn(Optional.empty());
+        when(saveShippingPolicyPort.save(any(ShippingPolicy.class))).thenReturn(1L);
+
+        RegisterShippingPolicyCommand command = new RegisterShippingPolicyCommand(
+                "한진택배", 3000L, 20000L
+        );
+
+        // when
+        registerShippingPolicyService.registerShippingPolicy(sellerId, command);
+
+        // then
+        verify(publishShippingPolicyEventPort).publishShippingPolicyChangedEvent(
+                sellerId, 3000L, 20000L, ShippingPolicyChangeAction.CREATED
+        );
+    }
+
+    @Test
+    @DisplayName("배송비 정책 등록 실패 시 이벤트를 발행하지 않는다")
+    void shouldNotPublishEventWhenRegistrationFails() {
+        // given
+        Long sellerId = 10L;
+        when(findShippingPolicyPort.findActiveBySellerId(sellerId))
+                .thenReturn(Optional.of(createSavedPolicy(sellerId)));
+
+        RegisterShippingPolicyCommand command = new RegisterShippingPolicyCommand(
+                "한진택배", 3000L, 20000L
+        );
+
+        // when & then
+        assertThatThrownBy(() -> registerShippingPolicyService.registerShippingPolicy(sellerId, command))
+                .isInstanceOf(ShippingPolicyAlreadyExistsException.class);
+
+        verifyNoInteractions(publishShippingPolicyEventPort);
     }
 }

--- a/product-service/product-application/src/test/java/com/personal/marketnote/product/service/shipping/UpdateShippingPolicyUseCaseTest.java
+++ b/product-service/product-application/src/test/java/com/personal/marketnote/product/service/shipping/UpdateShippingPolicyUseCaseTest.java
@@ -8,6 +8,8 @@ import com.personal.marketnote.product.domain.shipping.ShippingPolicySnapshotSta
 import com.personal.marketnote.product.exception.ShippingPolicyNotFoundException;
 import com.personal.marketnote.product.port.in.command.UpdateShippingPolicyCommand;
 import com.personal.marketnote.product.port.in.result.shipping.UpdateShippingPolicyResult;
+import com.personal.marketnote.common.kafka.event.ShippingPolicyChangeAction;
+import com.personal.marketnote.product.port.out.event.PublishShippingPolicyEventPort;
 import com.personal.marketnote.product.port.out.shipping.FindShippingPolicyPort;
 import com.personal.marketnote.product.port.out.shipping.UpdateShippingPolicyPort;
 import org.junit.jupiter.api.DisplayName;
@@ -37,6 +39,9 @@ class UpdateShippingPolicyUseCaseTest {
 
     @Mock
     private UpdateShippingPolicyPort updateShippingPolicyPort;
+
+    @Mock
+    private PublishShippingPolicyEventPort publishShippingPolicyEventPort;
 
     private ShippingPolicy createExistingPolicy(Long sellerId) {
         return ShippingPolicy.from(ShippingPolicySnapshotState.builder()
@@ -133,5 +138,46 @@ class UpdateShippingPolicyUseCaseTest {
                 .isInstanceOf(InvalidFreeShippingThresholdException.class);
 
         verify(updateShippingPolicyPort, never()).update(any());
+    }
+
+    @Test
+    @DisplayName("배송비 정책 수정 성공 시 UPDATED 이벤트를 발행한다")
+    void shouldPublishUpdatedEventWhenPolicyUpdated() {
+        // given
+        Long sellerId = 10L;
+        ShippingPolicy existingPolicy = createExistingPolicy(sellerId);
+        when(findShippingPolicyPort.findActiveBySellerId(sellerId))
+                .thenReturn(Optional.of(existingPolicy));
+
+        UpdateShippingPolicyCommand command = new UpdateShippingPolicyCommand(
+                "CJ대한통운", 2500L, 30000L
+        );
+
+        // when
+        updateShippingPolicyService.updateShippingPolicy(sellerId, command);
+
+        // then
+        verify(publishShippingPolicyEventPort).publishShippingPolicyChangedEvent(
+                sellerId, 2500L, 30000L, ShippingPolicyChangeAction.UPDATED
+        );
+    }
+
+    @Test
+    @DisplayName("배송비 정책 수정 실패 시 이벤트를 발행하지 않는다")
+    void shouldNotPublishEventWhenUpdateFails() {
+        // given
+        Long sellerId = 10L;
+        when(findShippingPolicyPort.findActiveBySellerId(sellerId))
+                .thenReturn(Optional.empty());
+
+        UpdateShippingPolicyCommand command = new UpdateShippingPolicyCommand(
+                "CJ대한통운", 2500L, 30000L
+        );
+
+        // when & then
+        assertThatThrownBy(() -> updateShippingPolicyService.updateShippingPolicy(sellerId, command))
+                .isInstanceOf(ShippingPolicyNotFoundException.class);
+
+        verifyNoInteractions(publishShippingPolicyEventPort);
     }
 }


### PR DESCRIPTION
## partially addresses #128
## resolves #1763

## Test Case
- [x] 배송비 정책 변경 이벤트 발행 시 올바른 토픽과 파티션 키로 Outbox에 저장된다
- [x] 배송비 정책 변경 이벤트 발행 시 EventEnvelope에 올바른 페이로드가 포함된다
- [x] 배송비 정책 수정 이벤트 발행 시 UPDATED 액션으로 Outbox에 저장된다
- [x] 배송비 정책 등록 성공 시 CREATED 이벤트를 발행한다
- [x] 배송비 정책 등록 실패 시 이벤트를 발행하지 않는다
- [x] 배송비 정책 수정 성공 시 UPDATED 이벤트를 발행한다
- [x] 배송비 정책 수정 실패 시 이벤트를 발행하지 않는다