### PR TITLE
[#216][#1647] feat: 커머스 서비스 배송비 정책 Read Model 구축

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/ShippingPolicyChangedReadModelConsumer.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/ShippingPolicyChangedReadModelConsumer.java
@@ -1,0 +1,70 @@
+package com.personal.marketnote.commerce.adapter.in.event;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.common.kafka.KafkaTopicConstants;
+import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.EventPayloadValidator;
+import com.personal.marketnote.common.kafka.event.ShippingPolicyChangedEvent;
+import com.personal.marketnote.commerce.port.out.shipping.SaveShippingPolicyReadModelPort;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ShippingPolicyChangedReadModelConsumer {
+
+    private final ObjectMapper objectMapper;
+    private final SaveShippingPolicyReadModelPort saveShippingPolicyReadModelPort;
+
+    @KafkaListener(
+            topics = KafkaTopicConstants.SHIPPING_POLICY_CHANGED,
+            groupId = "commerce-shipping-policy-read-model"
+    )
+    public void handleShippingPolicyChangedEvent(
+            ConsumerRecord<String, EventEnvelope<?>> record,
+            Acknowledgment acknowledgment
+    ) {
+        EventEnvelope<?> envelope = record.value();
+
+        if (EventPayloadValidator.hasInvalidEnvelope(envelope, record)) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        if (EventPayloadValidator.hasEventTypeMismatch(envelope, KafkaTopicConstants.SHIPPING_POLICY_CHANGED)) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        ShippingPolicyChangedEvent payload = envelope.getPayloadAs(ShippingPolicyChangedEvent.class, objectMapper);
+
+        log.info("배송비 정책 변경 이벤트 수신. eventId={}, sellerId={}, action={}",
+                envelope.eventId(), payload.sellerId(), payload.action());
+
+        if (EventPayloadValidator.hasInvalidIds(envelope.eventId(),
+                EventPayloadValidator.id("sellerId", payload.sellerId()))) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        if (payload.action().isDeleted()) {
+            saveShippingPolicyReadModelPort.deactivateBySellerId(payload.sellerId());
+            log.info("배송비 정책 Read Model 비활성화 완료. sellerId={}", payload.sellerId());
+        }
+
+        if (payload.action().isCreated() || payload.action().isUpdated()) {
+            saveShippingPolicyReadModelPort.upsert(
+                    payload.sellerId(), payload.shippingFee(), payload.freeShippingThreshold()
+            );
+            log.info("배송비 정책 Read Model 저장 완료. sellerId={}, shippingFee={}, freeShippingThreshold={}",
+                    payload.sellerId(), payload.shippingFee(), payload.freeShippingThreshold());
+        }
+
+        acknowledgment.acknowledge();
+    }
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/shipping/ShippingPolicyReadModelPersistenceAdapter.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/shipping/ShippingPolicyReadModelPersistenceAdapter.java
@@ -1,0 +1,80 @@
+package com.personal.marketnote.commerce.adapter.out.persistence.shipping;
+
+import com.personal.marketnote.common.adapter.out.PersistenceAdapter;
+import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.commerce.adapter.out.persistence.shipping.entity.ShippingPolicyReadModelJpaEntity;
+import com.personal.marketnote.commerce.adapter.out.persistence.shipping.repository.ShippingPolicyReadModelJpaRepository;
+import com.personal.marketnote.commerce.port.out.result.shipping.ShippingPolicyInfoResult;
+import com.personal.marketnote.commerce.port.out.shipping.FindShippingPolicyBySellerIdsPort;
+import com.personal.marketnote.commerce.port.out.shipping.SaveShippingPolicyReadModelPort;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@Slf4j
+@PersistenceAdapter
+@RequiredArgsConstructor
+public class ShippingPolicyReadModelPersistenceAdapter implements FindShippingPolicyBySellerIdsPort, SaveShippingPolicyReadModelPort {
+
+    private final ShippingPolicyReadModelJpaRepository shippingPolicyReadModelJpaRepository;
+
+    @Override
+    @Transactional(isolation = READ_COMMITTED, readOnly = true)
+    public Map<Long, ShippingPolicyInfoResult> findBySellerIds(List<Long> sellerIds) {
+        if (FormatValidator.hasNoValue(sellerIds)) {
+            return Map.of();
+        }
+
+        List<ShippingPolicyReadModelJpaEntity> entities =
+                shippingPolicyReadModelJpaRepository.findAllBySellerIdInAndStatus(sellerIds, EntityStatus.ACTIVE);
+
+        Map<Long, ShippingPolicyInfoResult> result = new HashMap<>();
+        for (ShippingPolicyReadModelJpaEntity entity : entities) {
+            result.put(entity.getSellerId(), new ShippingPolicyInfoResult(
+                    entity.getSellerId(),
+                    entity.getShippingFee(),
+                    entity.getFreeShippingThreshold()
+            ));
+        }
+
+        return result;
+    }
+
+    @Override
+    @Transactional(isolation = READ_COMMITTED)
+    public void upsert(Long sellerId, Long shippingFee, Long freeShippingThreshold) {
+        Optional<ShippingPolicyReadModelJpaEntity> existing = shippingPolicyReadModelJpaRepository.findBySellerId(sellerId);
+
+        if (existing.isPresent()) {
+            existing.get().updateFrom(shippingFee, freeShippingThreshold);
+            return;
+        }
+
+        try {
+            ShippingPolicyReadModelJpaEntity entity = ShippingPolicyReadModelJpaEntity.of(
+                    sellerId, shippingFee, freeShippingThreshold
+            );
+            shippingPolicyReadModelJpaRepository.saveAndFlush(entity);
+        } catch (DataIntegrityViolationException e) {
+            log.info("배송비 정책 Read Model 중복 저장 (멱등 처리). sellerId={}", sellerId);
+            shippingPolicyReadModelJpaRepository.findBySellerId(sellerId)
+                    .ifPresent(entity -> entity.updateFrom(shippingFee, freeShippingThreshold));
+        }
+    }
+
+    @Override
+    @Transactional(isolation = READ_COMMITTED)
+    public void deactivateBySellerId(Long sellerId) {
+        shippingPolicyReadModelJpaRepository.findBySellerId(sellerId)
+                .ifPresent(ShippingPolicyReadModelJpaEntity::markInactive);
+    }
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/shipping/entity/ShippingPolicyReadModelJpaEntity.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/shipping/entity/ShippingPolicyReadModelJpaEntity.java
@@ -1,0 +1,47 @@
+package com.personal.marketnote.commerce.adapter.out.persistence.shipping.entity;
+
+import com.personal.marketnote.common.adapter.out.persistence.audit.BaseGeneralEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(
+        name = "shipping_policy_read_models",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_shipping_policy_read_model_seller_id",
+                columnNames = "seller_id"
+        )
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+@Getter
+public class ShippingPolicyReadModelJpaEntity extends BaseGeneralEntity {
+
+    @Column(name = "seller_id", nullable = false, unique = true)
+    private Long sellerId;
+
+    @Column(name = "shipping_fee", nullable = false)
+    private Long shippingFee;
+
+    @Column(name = "free_shipping_threshold", nullable = false)
+    private Long freeShippingThreshold;
+
+    public static ShippingPolicyReadModelJpaEntity of(Long sellerId, Long shippingFee, Long freeShippingThreshold) {
+        return ShippingPolicyReadModelJpaEntity.builder()
+                .sellerId(sellerId)
+                .shippingFee(shippingFee)
+                .freeShippingThreshold(freeShippingThreshold)
+                .build();
+    }
+
+    public void updateFrom(Long shippingFee, Long freeShippingThreshold) {
+        this.shippingFee = shippingFee;
+        this.freeShippingThreshold = freeShippingThreshold;
+        activate();
+    }
+
+    public void markInactive() {
+        deactivate();
+    }
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/shipping/repository/ShippingPolicyReadModelJpaRepository.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/shipping/repository/ShippingPolicyReadModelJpaRepository.java
@@ -1,0 +1,17 @@
+package com.personal.marketnote.commerce.adapter.out.persistence.shipping.repository;
+
+import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.commerce.adapter.out.persistence.shipping.entity.ShippingPolicyReadModelJpaEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ShippingPolicyReadModelJpaRepository extends JpaRepository<ShippingPolicyReadModelJpaEntity, Long> {
+
+    Optional<ShippingPolicyReadModelJpaEntity> findBySellerId(Long sellerId);
+
+    Optional<ShippingPolicyReadModelJpaEntity> findBySellerIdAndStatus(Long sellerId, EntityStatus status);
+
+    List<ShippingPolicyReadModelJpaEntity> findAllBySellerIdInAndStatus(List<Long> sellerIds, EntityStatus status);
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/shipping/SaveShippingPolicyReadModelPort.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/shipping/SaveShippingPolicyReadModelPort.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.commerce.port.out.shipping;
+
+public interface SaveShippingPolicyReadModelPort {
+
+    void upsert(Long sellerId, Long shippingFee, Long freeShippingThreshold);
+
+    void deactivateBySellerId(Long sellerId);
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/RegisterOrderService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/RegisterOrderService.java
@@ -73,7 +73,7 @@ public class RegisterOrderService implements RegisterOrderUseCase {
                 .distinct()
                 .toList();
 
-        // 두 Port 모두 HTTP 클라이언트이므로 @Transactional 컨텍스트 전파 불필요. DB 조회로 변경 시 재검토 필요.
+        // 상품 정보는 HTTP, 배송비 정책은 로컬 Read Model DB 조회. Virtual Thread 병렬 조회 유지.
         CompletableFuture<Map<Long, ProductInfoResult>> productInfoFuture =
                 CompletableFuture.supplyAsync(() -> fetchProductInfoByPricePolicyIds(pricePolicyIds), VIRTUAL_EXECUTOR);
         CompletableFuture<Map<Long, ShippingPolicyInfoResult>> shippingPolicyFuture =


### PR DESCRIPTION
## partially addresses #216
## resolves #1647

## Task
- [x] 배송비 정책 Read Model JPA 엔티티 + 테이블 생성 (commerce-adapters)
- [x] ShippingPolicyReadModelConsumer 구현 (product.shipping-policy.changed 소비)
- [x] ShippingPolicyReadModelAdapter 구현 (FindShippingPolicyBySellerIdsPort 구현체 교체)
- [x] ShippingPolicyServiceClient.findBySellerIds() 제거
- [x] 초기 데이터 마이그레이션 (기존 운영 데이터 Read Model 적재)