### PR TITLE
[#215][#1714] test: 커머스 서비스 배송비 정책 Read Model 자동화 테스트 추가

### DIFF
--- a/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/event/ShippingPolicyChangedReadModelConsumerTest.java
+++ b/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/event/ShippingPolicyChangedReadModelConsumerTest.java
@@ -1,0 +1,226 @@
+package com.personal.marketnote.commerce.adapter.in.event;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.common.kafka.KafkaTopicConstants;
+import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.ShippingPolicyChangeAction;
+import com.personal.marketnote.common.kafka.event.ShippingPolicyChangedEvent;
+import com.personal.marketnote.commerce.port.out.shipping.SaveShippingPolicyReadModelPort;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.support.Acknowledgment;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ShippingPolicyChangedReadModelConsumer 테스트")
+class ShippingPolicyChangedReadModelConsumerTest {
+
+    @InjectMocks
+    private ShippingPolicyChangedReadModelConsumer consumer;
+
+    @Spy
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @Mock
+    private SaveShippingPolicyReadModelPort saveShippingPolicyReadModelPort;
+
+    @Mock
+    private Acknowledgment acknowledgment;
+
+    private ConsumerRecord<String, EventEnvelope<?>> createRecord(EventEnvelope<?> envelope) {
+        return new ConsumerRecord<>(
+                KafkaTopicConstants.SHIPPING_POLICY_CHANGED, 0, 0, "10", envelope
+        );
+    }
+
+    private EventEnvelope<ShippingPolicyChangedEvent> createEnvelope(ShippingPolicyChangedEvent payload) {
+        return new EventEnvelope<>(
+                "test-event-id",
+                KafkaTopicConstants.SHIPPING_POLICY_CHANGED,
+                "product-service",
+                LocalDateTime.of(2026, 3, 31, 10, 0),
+                payload
+        );
+    }
+
+    @Test
+    @DisplayName("CREATED 이벤트 수신 시 Read Model을 upsert한다")
+    void handleShippingPolicyChangedEvent_created_upsertsReadModel() {
+        // given
+        ShippingPolicyChangedEvent payload = new ShippingPolicyChangedEvent(
+                10L, 3000L, 20000L, ShippingPolicyChangeAction.CREATED
+        );
+        EventEnvelope<ShippingPolicyChangedEvent> envelope = createEnvelope(payload);
+        ConsumerRecord<String, EventEnvelope<?>> record = createRecord(envelope);
+
+        // when
+        consumer.handleShippingPolicyChangedEvent(record, acknowledgment);
+
+        // then
+        verify(saveShippingPolicyReadModelPort).upsert(10L, 3000L, 20000L);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("UPDATED 이벤트 수신 시 Read Model을 upsert한다")
+    void handleShippingPolicyChangedEvent_updated_upsertsReadModel() {
+        // given
+        ShippingPolicyChangedEvent payload = new ShippingPolicyChangedEvent(
+                20L, 2500L, 30000L, ShippingPolicyChangeAction.UPDATED
+        );
+        EventEnvelope<ShippingPolicyChangedEvent> envelope = createEnvelope(payload);
+        ConsumerRecord<String, EventEnvelope<?>> record = createRecord(envelope);
+
+        // when
+        consumer.handleShippingPolicyChangedEvent(record, acknowledgment);
+
+        // then
+        verify(saveShippingPolicyReadModelPort).upsert(20L, 2500L, 30000L);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("DELETED 이벤트 수신 시 Read Model을 비활성화한다")
+    void handleShippingPolicyChangedEvent_deleted_deactivatesReadModel() {
+        // given
+        ShippingPolicyChangedEvent payload = new ShippingPolicyChangedEvent(
+                10L, 3000L, 20000L, ShippingPolicyChangeAction.DELETED
+        );
+        EventEnvelope<ShippingPolicyChangedEvent> envelope = createEnvelope(payload);
+        ConsumerRecord<String, EventEnvelope<?>> record = createRecord(envelope);
+
+        // when
+        consumer.handleShippingPolicyChangedEvent(record, acknowledgment);
+
+        // then
+        verify(saveShippingPolicyReadModelPort).deactivateBySellerId(10L);
+        verifyNoMoreInteractions(saveShippingPolicyReadModelPort);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("envelope이 null이면 즉시 acknowledge한다")
+    void handleShippingPolicyChangedEvent_nullEnvelope_acknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = new ConsumerRecord<>(
+                KafkaTopicConstants.SHIPPING_POLICY_CHANGED, 0, 0, "10", null
+        );
+
+        // when
+        consumer.handleShippingPolicyChangedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(saveShippingPolicyReadModelPort);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("이벤트 타입이 불일치하면 즉시 acknowledge한다")
+    void handleShippingPolicyChangedEvent_eventTypeMismatch_acknowledges() {
+        // given
+        ShippingPolicyChangedEvent payload = new ShippingPolicyChangedEvent(
+                10L, 3000L, 20000L, ShippingPolicyChangeAction.CREATED
+        );
+        EventEnvelope<ShippingPolicyChangedEvent> envelope = new EventEnvelope<>(
+                "test-event-id",
+                "wrong.event.type",
+                "product-service",
+                LocalDateTime.of(2026, 3, 31, 10, 0),
+                payload
+        );
+        ConsumerRecord<String, EventEnvelope<?>> record = createRecord(envelope);
+
+        // when
+        consumer.handleShippingPolicyChangedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(saveShippingPolicyReadModelPort);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("sellerId가 null이면 이벤트를 무시하고 acknowledge한다")
+    void handleShippingPolicyChangedEvent_nullSellerId_acknowledges() {
+        // given
+        ShippingPolicyChangedEvent payload = new ShippingPolicyChangedEvent(
+                null, 3000L, 20000L, ShippingPolicyChangeAction.CREATED
+        );
+        EventEnvelope<ShippingPolicyChangedEvent> envelope = createEnvelope(payload);
+        ConsumerRecord<String, EventEnvelope<?>> record = createRecord(envelope);
+
+        // when
+        consumer.handleShippingPolicyChangedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(saveShippingPolicyReadModelPort);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("sellerId가 0이면 이벤트를 무시하고 acknowledge한다")
+    void handleShippingPolicyChangedEvent_zeroSellerId_acknowledges() {
+        // given
+        ShippingPolicyChangedEvent payload = new ShippingPolicyChangedEvent(
+                0L, 3000L, 20000L, ShippingPolicyChangeAction.CREATED
+        );
+        EventEnvelope<ShippingPolicyChangedEvent> envelope = createEnvelope(payload);
+        ConsumerRecord<String, EventEnvelope<?>> record = createRecord(envelope);
+
+        // when
+        consumer.handleShippingPolicyChangedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(saveShippingPolicyReadModelPort);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("sellerId가 음수이면 이벤트를 무시하고 acknowledge한다")
+    void handleShippingPolicyChangedEvent_negativeSellerId_acknowledges() {
+        // given
+        ShippingPolicyChangedEvent payload = new ShippingPolicyChangedEvent(
+                -1L, 3000L, 20000L, ShippingPolicyChangeAction.CREATED
+        );
+        EventEnvelope<ShippingPolicyChangedEvent> envelope = createEnvelope(payload);
+        ConsumerRecord<String, EventEnvelope<?>> record = createRecord(envelope);
+
+        // when
+        consumer.handleShippingPolicyChangedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(saveShippingPolicyReadModelPort);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("페이로드 역직렬화 실패 시 예외가 전파된다")
+    void handleShippingPolicyChangedEvent_deserializationFailure_propagatesException() {
+        // given
+        EventEnvelope<String> envelope = new EventEnvelope<>(
+                "test-event-id",
+                KafkaTopicConstants.SHIPPING_POLICY_CHANGED,
+                "product-service",
+                LocalDateTime.of(2026, 3, 31, 10, 0),
+                "invalid-payload"
+        );
+        ConsumerRecord<String, EventEnvelope<?>> record = new ConsumerRecord<>(
+                KafkaTopicConstants.SHIPPING_POLICY_CHANGED, 0, 0, "10", envelope
+        );
+
+        // when & then
+        assertThatThrownBy(() -> consumer.handleShippingPolicyChangedEvent(record, acknowledgment))
+                .isInstanceOf(IllegalArgumentException.class);
+
+        verify(acknowledgment, never()).acknowledge();
+    }
+}

--- a/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/out/persistence/shipping/ShippingPolicyReadModelPersistenceAdapterTest.java
+++ b/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/out/persistence/shipping/ShippingPolicyReadModelPersistenceAdapterTest.java
@@ -1,0 +1,193 @@
+package com.personal.marketnote.commerce.adapter.out.persistence.shipping;
+
+import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.configuration.AuditConfig;
+import com.personal.marketnote.commerce.adapter.out.persistence.shipping.entity.ShippingPolicyReadModelJpaEntity;
+import com.personal.marketnote.commerce.adapter.out.persistence.shipping.repository.ShippingPolicyReadModelJpaRepository;
+import com.personal.marketnote.commerce.port.out.result.shipping.ShippingPolicyInfoResult;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@ActiveProfiles("test")
+@Import({AuditConfig.class, ShippingPolicyReadModelPersistenceAdapter.class})
+@DisplayName("ShippingPolicyReadModelPersistenceAdapter 테스트")
+class ShippingPolicyReadModelPersistenceAdapterTest {
+
+    @Autowired
+    private ShippingPolicyReadModelPersistenceAdapter adapter;
+
+    @Autowired
+    private ShippingPolicyReadModelJpaRepository repository;
+
+    @BeforeEach
+    void setUp() {
+        repository.deleteAll();
+    }
+
+    @Nested
+    @DisplayName("findBySellerIds")
+    class FindBySellerIds {
+
+        @Test
+        @DisplayName("ACTIVE 상태의 배송비 정책을 판매자 ID별 맵으로 반환한다")
+        void returnsActivePoliciesAsMap() {
+            // given
+            adapter.upsert(10L, 3000L, 20000L);
+            adapter.upsert(20L, 2500L, 30000L);
+
+            // when
+            Map<Long, ShippingPolicyInfoResult> result = adapter.findBySellerIds(List.of(10L, 20L));
+
+            // then
+            assertThat(result).hasSize(2);
+            assertThat(result.get(10L).sellerId()).isEqualTo(10L);
+            assertThat(result.get(10L).shippingFee()).isEqualTo(3000L);
+            assertThat(result.get(10L).freeShippingThreshold()).isEqualTo(20000L);
+            assertThat(result.get(20L).sellerId()).isEqualTo(20L);
+            assertThat(result.get(20L).shippingFee()).isEqualTo(2500L);
+            assertThat(result.get(20L).freeShippingThreshold()).isEqualTo(30000L);
+        }
+
+        @Test
+        @DisplayName("빈 sellerIds 목록이면 빈 맵을 반환한다")
+        void returnsEmptyMapForEmptySellerIds() {
+            // when
+            Map<Long, ShippingPolicyInfoResult> result = adapter.findBySellerIds(List.of());
+
+            // then
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("null sellerIds이면 빈 맵을 반환한다")
+        void returnsEmptyMapForNullSellerIds() {
+            // when
+            Map<Long, ShippingPolicyInfoResult> result = adapter.findBySellerIds(null);
+
+            // then
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("INACTIVE 상태의 배송비 정책은 조회하지 않는다")
+        void excludesInactivePolicies() {
+            // given
+            adapter.upsert(10L, 3000L, 20000L);
+            adapter.deactivateBySellerId(10L);
+
+            // when
+            Map<Long, ShippingPolicyInfoResult> result = adapter.findBySellerIds(List.of(10L));
+
+            // then
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 sellerId는 결과에 포함하지 않는다")
+        void excludesNonExistentSellerIds() {
+            // given
+            adapter.upsert(10L, 3000L, 20000L);
+
+            // when
+            Map<Long, ShippingPolicyInfoResult> result = adapter.findBySellerIds(List.of(10L, 999L));
+
+            // then
+            assertThat(result).hasSize(1);
+            assertThat(result).containsKey(10L);
+            assertThat(result).doesNotContainKey(999L);
+        }
+    }
+
+    @Nested
+    @DisplayName("upsert")
+    class Upsert {
+
+        @Test
+        @DisplayName("신규 배송비 정책을 저장한다")
+        void insertsNewPolicy() {
+            // when
+            adapter.upsert(10L, 3000L, 20000L);
+
+            // then
+            Optional<ShippingPolicyReadModelJpaEntity> entity = repository.findBySellerIdAndStatus(10L, EntityStatus.ACTIVE);
+            assertThat(entity).isPresent();
+            assertThat(entity.get().getSellerId()).isEqualTo(10L);
+            assertThat(entity.get().getShippingFee()).isEqualTo(3000L);
+            assertThat(entity.get().getFreeShippingThreshold()).isEqualTo(20000L);
+            assertThat(entity.get().getStatus()).isEqualTo(EntityStatus.ACTIVE);
+        }
+
+        @Test
+        @DisplayName("동일한 sellerId로 upsert 시 기존 데이터를 업데이트한다")
+        void updatesExistingPolicy() {
+            // given
+            adapter.upsert(10L, 3000L, 20000L);
+
+            // when
+            adapter.upsert(10L, 5000L, 50000L);
+
+            // then
+            Optional<ShippingPolicyReadModelJpaEntity> entity = repository.findBySellerIdAndStatus(10L, EntityStatus.ACTIVE);
+            assertThat(entity).isPresent();
+            assertThat(entity.get().getShippingFee()).isEqualTo(5000L);
+            assertThat(entity.get().getFreeShippingThreshold()).isEqualTo(50000L);
+        }
+
+        @Test
+        @DisplayName("비활성화된 정책에 대해 upsert 시 다시 활성화된다")
+        void reactivatesInactivePolicy() {
+            // given
+            adapter.upsert(10L, 3000L, 20000L);
+            adapter.deactivateBySellerId(10L);
+
+            // when
+            adapter.upsert(10L, 5000L, 50000L);
+
+            // then
+            Optional<ShippingPolicyReadModelJpaEntity> entity = repository.findBySellerIdAndStatus(10L, EntityStatus.ACTIVE);
+            assertThat(entity).isPresent();
+            assertThat(entity.get().getShippingFee()).isEqualTo(5000L);
+            assertThat(entity.get().getStatus()).isEqualTo(EntityStatus.ACTIVE);
+        }
+    }
+
+    @Nested
+    @DisplayName("deactivateBySellerId")
+    class DeactivateBySellerId {
+
+        @Test
+        @DisplayName("배송비 정책을 비활성화한다")
+        void deactivatesPolicy() {
+            // given
+            adapter.upsert(10L, 3000L, 20000L);
+
+            // when
+            adapter.deactivateBySellerId(10L);
+
+            // then
+            List<ShippingPolicyReadModelJpaEntity> all = repository.findAll();
+            assertThat(all).hasSize(1);
+            assertThat(all.getFirst().getStatus()).isEqualTo(EntityStatus.INACTIVE);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 sellerId 비활성화 시 에러 없이 무시한다")
+        void ignoresNonExistentSellerId() {
+            // when & then — no exception
+            adapter.deactivateBySellerId(999L);
+        }
+    }
+}


### PR DESCRIPTION
## partially addresses #216
## resolves #1714

## Test Case
- [x] CREATED 이벤트 수신 시 Read Model을 upsert한다
- [x] UPDATED 이벤트 수신 시 Read Model을 upsert한다
- [x] DELETED 이벤트 수신 시 Read Model을 비활성화한다
- [x] envelope이 null이면 즉시 acknowledge한다
- [x] 이벤트 타입이 불일치하면 즉시 acknowledge한다
- [x] sellerId가 null이면 이벤트를 무시하고 acknowledge한다
- [x] sellerId가 0이면 이벤트를 무시하고 acknowledge한다
- [x] sellerId가 음수이면 이벤트를 무시하고 acknowledge한다
- [x] 페이로드 역직렬화 실패 시 예외가 전파된다
- [x] ACTIVE 상태의 배송비 정책을 판매자 ID별 맵으로 반환한다
- [x] 빈 sellerIds 목록이면 빈 맵을 반환한다
- [x] null sellerIds이면 빈 맵을 반환한다
- [x] INACTIVE 상태의 배송비 정책은 조회하지 않는다
- [x] 존재하지 않는 sellerId는 결과에 포함하지 않는다
- [x] 신규 배송비 정책을 저장한다
- [x] 동일한 sellerId로 upsert 시 기존 데이터를 업데이트한다
- [x] 비활성화된 정책에 대해 upsert 시 다시 활성화된다
- [x] 배송비 정책을 비활성화한다
- [x] 존재하지 않는 sellerId 비활성화 시 에러 없이 무시한다