### PR TITLE
[#43][#1641] feat: 회원 서비스 배송지 변경 이벤트 발행 기능 추가

### DIFF
--- a/common/src/main/java/com/personal/marketnote/common/kafka/KafkaTopicConstants.java
+++ b/common/src/main/java/com/personal/marketnote/common/kafka/KafkaTopicConstants.java
@@ -21,6 +21,7 @@ public final class KafkaTopicConstants {
     // User 이벤트
     public static final String USER_SIGNUP_COMPLETED = "user.user.signup-completed";
     public static final String USER_REFERRAL_COMPLETED = "user.user.referral-completed";
+    public static final String SHIPPING_ADDRESS_CHANGED = "user.shipping-address.changed";
 
     // Community 이벤트
     public static final String REVIEW_REGISTERED = "community.review.registered";

--- a/common/src/main/java/com/personal/marketnote/common/kafka/event/ShippingAddressChangeAction.java
+++ b/common/src/main/java/com/personal/marketnote/common/kafka/event/ShippingAddressChangeAction.java
@@ -1,0 +1,11 @@
+package com.personal.marketnote.common.kafka.event;
+
+public enum ShippingAddressChangeAction {
+    CREATED,
+    UPDATED,
+    DELETED;
+
+    public boolean isCreated() { return this == CREATED; }
+    public boolean isUpdated() { return this == UPDATED; }
+    public boolean isDeleted() { return this == DELETED; }
+}

--- a/common/src/main/java/com/personal/marketnote/common/kafka/event/ShippingAddressChangedEvent.java
+++ b/common/src/main/java/com/personal/marketnote/common/kafka/event/ShippingAddressChangedEvent.java
@@ -1,0 +1,11 @@
+package com.personal.marketnote.common.kafka.event;
+
+public record ShippingAddressChangedEvent(
+        Long shippingAddressId,
+        Long userId,
+        String recipientName,
+        String recipientPhoneNumber,
+        String address,
+        ShippingAddressChangeAction action
+) {
+}

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/out/event/ShippingAddressEventKafkaProducer.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/out/event/ShippingAddressEventKafkaProducer.java
@@ -1,0 +1,51 @@
+package com.personal.marketnote.user.adapter.out.event;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.common.adapter.out.ServiceAdapter;
+import com.personal.marketnote.common.kafka.KafkaTopicConstants;
+import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.ShippingAddressChangeAction;
+import com.personal.marketnote.common.kafka.event.ShippingAddressChangedEvent;
+import com.personal.marketnote.common.outbox.OutboxEvent;
+import com.personal.marketnote.common.outbox.SaveOutboxEventPort;
+import com.personal.marketnote.user.port.out.event.PublishShippingAddressEventPort;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.time.Clock;
+
+@Slf4j
+@ServiceAdapter
+@RequiredArgsConstructor
+public class ShippingAddressEventKafkaProducer implements PublishShippingAddressEventPort {
+    private static final String SOURCE = "user-service";
+
+    private final SaveOutboxEventPort saveOutboxEventPort;
+    private final ObjectMapper objectMapper;
+    private final Clock clock;
+
+    @Override
+    public void publishShippingAddressChangedEvent(Long shippingAddressId, Long userId, String recipientName, String recipientPhoneNumber, String address, ShippingAddressChangeAction action) {
+        ShippingAddressChangedEvent payload = new ShippingAddressChangedEvent(shippingAddressId, userId, recipientName, recipientPhoneNumber, address, action);
+        String topic = KafkaTopicConstants.SHIPPING_ADDRESS_CHANGED;
+        EventEnvelope<ShippingAddressChangedEvent> envelope = EventEnvelope.of(topic, SOURCE, payload, clock);
+
+        saveToOutbox(envelope, topic, userId.toString());
+    }
+
+    private <T> void saveToOutbox(EventEnvelope<T> envelope, String topic, String partitionKey) {
+        try {
+            String payloadJson = objectMapper.writeValueAsString(envelope);
+            OutboxEvent outboxEvent = OutboxEvent.of(
+                    envelope.eventId(), topic, partitionKey,
+                    envelope.eventType(), SOURCE, payloadJson, clock
+            );
+            saveOutboxEventPort.save(outboxEvent);
+            log.info("Outbox 이벤트 저장. topic={}, partitionKey={}, eventId={}",
+                    topic, partitionKey, envelope.eventId());
+        } catch (Exception e) {
+            log.error("Outbox 이벤트 저장 실패. topic={}, partitionKey={}, error={}",
+                    topic, partitionKey, e.getMessage(), e);
+        }
+    }
+}

--- a/user-service/user-adapters/src/test/java/com/personal/marketnote/user/adapter/out/oauth/Oauth2AccountClientTest.java
+++ b/user-service/user-adapters/src/test/java/com/personal/marketnote/user/adapter/out/oauth/Oauth2AccountClientTest.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.user.adapter.out.oauth;
 
 import com.personal.marketnote.common.utility.http.client.restclient.RestClientErrorHandler;
+import com.personal.marketnote.user.security.token.vendor.AuthVendor;
 import com.personal.marketnote.user.service.exception.UnlinkOauth2AccountFailedException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -47,7 +48,7 @@ class Oauth2AccountClientTest {
                     .andExpect(content().string(containsString("target_id=12345")))
                     .andRespond(withSuccess());
 
-            assertThatCode(() -> oauth2AccountClient.unlinkKakaoAccount("12345"))
+            assertThatCode(() -> oauth2AccountClient.unlinkAccount(AuthVendor.KAKAO, "12345"))
                     .doesNotThrowAnyException();
 
             mockServer.verify();
@@ -62,7 +63,7 @@ class Oauth2AccountClientTest {
                     .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_FORM_URLENCODED))
                     .andRespond(withBadRequest());
 
-            assertThatThrownBy(() -> oauth2AccountClient.unlinkKakaoAccount("12345"))
+            assertThatThrownBy(() -> oauth2AccountClient.unlinkAccount(AuthVendor.KAKAO, "12345"))
                     .isInstanceOf(UnlinkOauth2AccountFailedException.class);
 
             mockServer.verify();
@@ -82,7 +83,7 @@ class Oauth2AccountClientTest {
                     .andExpect(content().string(containsString("token=google-access-token")))
                     .andRespond(withSuccess());
 
-            assertThatCode(() -> oauth2AccountClient.unlinkGoogleAccount("google-access-token"))
+            assertThatCode(() -> oauth2AccountClient.unlinkAccount(AuthVendor.GOOGLE, "google-access-token"))
                     .doesNotThrowAnyException();
 
             mockServer.verify();
@@ -96,7 +97,7 @@ class Oauth2AccountClientTest {
                     .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_FORM_URLENCODED))
                     .andRespond(withServerError());
 
-            assertThatThrownBy(() -> oauth2AccountClient.unlinkGoogleAccount("google-access-token"))
+            assertThatThrownBy(() -> oauth2AccountClient.unlinkAccount(AuthVendor.GOOGLE, "google-access-token"))
                     .isInstanceOf(UnlinkOauth2AccountFailedException.class);
 
             mockServer.verify();

--- a/user-service/user-adapters/src/test/java/com/personal/marketnote/user/adapter/out/oauth/RestClientGoogleTokenProcessorTest.java
+++ b/user-service/user-adapters/src/test/java/com/personal/marketnote/user/adapter/out/oauth/RestClientGoogleTokenProcessorTest.java
@@ -4,7 +4,7 @@ import com.personal.marketnote.common.domain.exception.token.InvalidAccessTokenE
 import com.personal.marketnote.common.domain.exception.token.InvalidRefreshTokenException;
 import com.personal.marketnote.common.domain.exception.token.UnsupportedCodeException;
 import com.personal.marketnote.common.utility.http.client.restclient.RestClientErrorHandler;
-import com.personal.marketnote.user.exception.GoogleOAuth2ResponseParsingException;
+import com.personal.marketnote.user.exception.OAuth2ResponseParsingException;
 import com.personal.marketnote.user.security.token.dto.GrantedTokenInfo;
 import com.personal.marketnote.user.security.token.dto.OAuth2AuthenticationInfo;
 import com.personal.marketnote.user.security.token.dto.OAuth2UserInfo;
@@ -168,8 +168,8 @@ class RestClientGoogleTokenProcessorTest {
         }
 
         @Test
-        @DisplayName("응답 JSON에 필수 필드가 없으면 GoogleOAuth2ResponseParsingException이 발생한다")
-        void shouldThrowGoogleOAuth2ResponseParsingExceptionWhenRequiredFieldMissing() {
+        @DisplayName("응답 JSON에 필수 필드가 없으면 OAuth2ResponseParsingException이 발생한다")
+        void shouldThrowOAuth2ResponseParsingExceptionWhenRequiredFieldMissing() {
             mockServer.expect(requestTo(GOOGLE_USER_INFO_URL))
                     .andExpect(method(HttpMethod.GET))
                     .andRespond(withSuccess("""
@@ -177,7 +177,7 @@ class RestClientGoogleTokenProcessorTest {
                             """, MediaType.APPLICATION_JSON));
 
             assertThatThrownBy(() -> processor.retrieveUserInfo("test-access-token"))
-                    .isInstanceOf(GoogleOAuth2ResponseParsingException.class);
+                    .isInstanceOf(OAuth2ResponseParsingException.class);
 
             mockServer.verify();
         }

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/port/out/event/PublishShippingAddressEventPort.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/port/out/event/PublishShippingAddressEventPort.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.user.port.out.event;
+
+import com.personal.marketnote.common.kafka.event.ShippingAddressChangeAction;
+
+public interface PublishShippingAddressEventPort {
+
+    void publishShippingAddressChangedEvent(Long shippingAddressId, Long userId, String recipientName, String recipientPhoneNumber, String address, ShippingAddressChangeAction action);
+}

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/service/shippingaddress/DeleteShippingAddressService.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/service/shippingaddress/DeleteShippingAddressService.java
@@ -1,9 +1,11 @@
 package com.personal.marketnote.user.service.shippingaddress;
 
 import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.common.kafka.event.ShippingAddressChangeAction;
 import com.personal.marketnote.user.domain.shippingaddress.ShippingAddress;
 import com.personal.marketnote.user.exception.ShippingAddressNotFoundException;
 import com.personal.marketnote.user.port.in.usecase.shippingaddress.DeleteShippingAddressUseCase;
+import com.personal.marketnote.user.port.out.event.PublishShippingAddressEventPort;
 import com.personal.marketnote.user.port.out.shippingaddress.FindShippingAddressPort;
 import com.personal.marketnote.user.port.out.shippingaddress.UpdateShippingAddressPort;
 import lombok.RequiredArgsConstructor;
@@ -17,6 +19,7 @@ import static org.springframework.transaction.annotation.Isolation.READ_COMMITTE
 public class DeleteShippingAddressService implements DeleteShippingAddressUseCase {
     private final FindShippingAddressPort findShippingAddressPort;
     private final UpdateShippingAddressPort updateShippingAddressPort;
+    private final PublishShippingAddressEventPort publishShippingAddressEventPort;
 
     @Override
     public void deleteShippingAddress(Long shippingAddressId, Long userId) {
@@ -26,5 +29,11 @@ public class DeleteShippingAddressService implements DeleteShippingAddressUseCas
         shippingAddress.delete();
 
         updateShippingAddressPort.update(shippingAddress);
+
+        publishShippingAddressEventPort.publishShippingAddressChangedEvent(
+                shippingAddressId, userId,
+                shippingAddress.getRecipientName(), shippingAddress.getRecipientPhoneNumber(),
+                shippingAddress.getAddress(), ShippingAddressChangeAction.DELETED
+        );
     }
 }

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/service/shippingaddress/RegisterShippingAddressService.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/service/shippingaddress/RegisterShippingAddressService.java
@@ -10,6 +10,8 @@ import com.personal.marketnote.user.exception.TooManyOtherAddressesException;
 import com.personal.marketnote.user.port.in.command.shippingaddress.RegisterShippingAddressCommand;
 import com.personal.marketnote.user.port.in.result.shippingaddress.RegisterShippingAddressResult;
 import com.personal.marketnote.user.port.in.usecase.shippingaddress.RegisterShippingAddressUseCase;
+import com.personal.marketnote.common.kafka.event.ShippingAddressChangeAction;
+import com.personal.marketnote.user.port.out.event.PublishShippingAddressEventPort;
 import com.personal.marketnote.user.port.out.shippingaddress.FindShippingAddressPort;
 import com.personal.marketnote.user.port.out.shippingaddress.SaveShippingAddressPort;
 import com.personal.marketnote.user.port.out.shippingaddress.UpdateShippingAddressPort;
@@ -30,6 +32,7 @@ public class RegisterShippingAddressService implements RegisterShippingAddressUs
     private final FindShippingAddressPort findShippingAddressPort;
     private final SaveShippingAddressPort saveShippingAddressPort;
     private final UpdateShippingAddressPort updateShippingAddressPort;
+    private final PublishShippingAddressEventPort publishShippingAddressEventPort;
 
     @Override
     public RegisterShippingAddressResult registerShippingAddress(RegisterShippingAddressCommand command) {
@@ -70,6 +73,12 @@ public class RegisterShippingAddressService implements RegisterShippingAddressUs
         );
 
         ShippingAddress savedShippingAddress = saveShippingAddressPort.save(shippingAddress);
+
+        publishShippingAddressEventPort.publishShippingAddressChangedEvent(
+                savedShippingAddress.getId(), savedShippingAddress.getUserId(),
+                savedShippingAddress.getRecipientName(), savedShippingAddress.getRecipientPhoneNumber(),
+                savedShippingAddress.getAddress(), ShippingAddressChangeAction.CREATED
+        );
 
         return RegisterShippingAddressResult.from(savedShippingAddress);
     }

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/service/shippingaddress/UpdateShippingAddressService.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/service/shippingaddress/UpdateShippingAddressService.java
@@ -1,10 +1,12 @@
 package com.personal.marketnote.user.service.shippingaddress;
 
 import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.common.kafka.event.ShippingAddressChangeAction;
 import com.personal.marketnote.user.domain.shippingaddress.ShippingAddress;
 import com.personal.marketnote.user.exception.ShippingAddressNotFoundException;
 import com.personal.marketnote.user.port.in.command.shippingaddress.UpdateShippingAddressCommand;
 import com.personal.marketnote.user.port.in.usecase.shippingaddress.UpdateShippingAddressUseCase;
+import com.personal.marketnote.user.port.out.event.PublishShippingAddressEventPort;
 import com.personal.marketnote.user.port.out.shippingaddress.FindShippingAddressPort;
 import com.personal.marketnote.user.port.out.shippingaddress.UpdateShippingAddressPort;
 import lombok.RequiredArgsConstructor;
@@ -18,6 +20,7 @@ import static org.springframework.transaction.annotation.Isolation.READ_COMMITTE
 public class UpdateShippingAddressService implements UpdateShippingAddressUseCase {
     private final FindShippingAddressPort findShippingAddressPort;
     private final UpdateShippingAddressPort updateShippingAddressPort;
+    private final PublishShippingAddressEventPort publishShippingAddressEventPort;
 
     @Override
     public void updateShippingAddress(Long shippingAddressId, Long userId, UpdateShippingAddressCommand command) {
@@ -36,5 +39,11 @@ public class UpdateShippingAddressService implements UpdateShippingAddressUseCas
         );
 
         updateShippingAddressPort.update(shippingAddress);
+
+        publishShippingAddressEventPort.publishShippingAddressChangedEvent(
+                shippingAddressId, userId,
+                shippingAddress.getRecipientName(), shippingAddress.getRecipientPhoneNumber(),
+                shippingAddress.getAddress(), ShippingAddressChangeAction.UPDATED
+        );
     }
 }

--- a/user-service/user-application/src/test/java/com/personal/marketnote/user/service/shippingaddress/DeleteShippingAddressUseCaseTest.java
+++ b/user-service/user-application/src/test/java/com/personal/marketnote/user/service/shippingaddress/DeleteShippingAddressUseCaseTest.java
@@ -1,10 +1,12 @@
 package com.personal.marketnote.user.service.shippingaddress;
 
 import com.personal.marketnote.common.domain.delivery.DeliveryRequestType;
+import com.personal.marketnote.common.kafka.event.ShippingAddressChangeAction;
 import com.personal.marketnote.user.domain.shippingaddress.ShippingAddress;
 import com.personal.marketnote.user.domain.shippingaddress.ShippingAddressSnapshotState;
 import com.personal.marketnote.user.domain.shippingaddress.ShippingAddressType;
 import com.personal.marketnote.user.exception.ShippingAddressNotFoundException;
+import com.personal.marketnote.user.port.out.event.PublishShippingAddressEventPort;
 import com.personal.marketnote.user.port.out.shippingaddress.FindShippingAddressPort;
 import com.personal.marketnote.user.port.out.shippingaddress.UpdateShippingAddressPort;
 import org.junit.jupiter.api.DisplayName;
@@ -29,6 +31,9 @@ class DeleteShippingAddressUseCaseTest {
 
     @Mock
     private UpdateShippingAddressPort updateShippingAddressPort;
+
+    @Mock
+    private PublishShippingAddressEventPort publishShippingAddressEventPort;
 
     @Test
     @DisplayName("배송지가 존재하면 논리적 삭제한다")
@@ -59,6 +64,9 @@ class DeleteShippingAddressUseCaseTest {
         // then
         verify(findShippingAddressPort).findByIdAndUserId(shippingAddressId, userId);
         verify(updateShippingAddressPort).update(shippingAddress);
+        verify(publishShippingAddressEventPort).publishShippingAddressChangedEvent(
+                1L, 100L, "홍길동", "010-1234-5678", "서울시 강남구 테헤란로 123", ShippingAddressChangeAction.DELETED
+        );
         verifyNoMoreInteractions(findShippingAddressPort, updateShippingAddressPort);
     }
 
@@ -79,7 +87,7 @@ class DeleteShippingAddressUseCaseTest {
 
         verify(findShippingAddressPort).findByIdAndUserId(shippingAddressId, userId);
         verifyNoMoreInteractions(findShippingAddressPort);
-        verifyNoInteractions(updateShippingAddressPort);
+        verifyNoInteractions(updateShippingAddressPort, publishShippingAddressEventPort);
     }
 
     @Test
@@ -111,7 +119,7 @@ class DeleteShippingAddressUseCaseTest {
 
         verify(findShippingAddressPort).findByIdAndUserId(shippingAddressId, userId);
         verifyNoMoreInteractions(findShippingAddressPort);
-        verifyNoInteractions(updateShippingAddressPort);
+        verifyNoInteractions(updateShippingAddressPort, publishShippingAddressEventPort);
     }
 
     @Test
@@ -144,6 +152,6 @@ class DeleteShippingAddressUseCaseTest {
 
         verify(findShippingAddressPort).findByIdAndUserId(shippingAddressId, userId);
         verifyNoMoreInteractions(findShippingAddressPort);
-        verifyNoInteractions(updateShippingAddressPort);
+        verifyNoInteractions(updateShippingAddressPort, publishShippingAddressEventPort);
     }
 }

--- a/user-service/user-application/src/test/java/com/personal/marketnote/user/service/shippingaddress/RegisterShippingAddressUseCaseTest.java
+++ b/user-service/user-application/src/test/java/com/personal/marketnote/user/service/shippingaddress/RegisterShippingAddressUseCaseTest.java
@@ -1,11 +1,13 @@
 package com.personal.marketnote.user.service.shippingaddress;
 
 import com.personal.marketnote.common.domain.delivery.DeliveryRequestType;
+import com.personal.marketnote.common.kafka.event.ShippingAddressChangeAction;
 import com.personal.marketnote.user.domain.shippingaddress.ShippingAddress;
 import com.personal.marketnote.user.domain.shippingaddress.ShippingAddressSnapshotState;
 import com.personal.marketnote.user.domain.shippingaddress.ShippingAddressType;
 import com.personal.marketnote.user.port.in.command.shippingaddress.RegisterShippingAddressCommand;
 import com.personal.marketnote.user.port.in.result.shippingaddress.RegisterShippingAddressResult;
+import com.personal.marketnote.user.port.out.event.PublishShippingAddressEventPort;
 import com.personal.marketnote.user.port.out.shippingaddress.FindShippingAddressPort;
 import com.personal.marketnote.user.port.out.shippingaddress.SaveShippingAddressPort;
 import com.personal.marketnote.user.port.out.shippingaddress.UpdateShippingAddressPort;
@@ -37,6 +39,9 @@ class RegisterShippingAddressUseCaseTest {
 
     @Mock
     private UpdateShippingAddressPort updateShippingAddressPort;
+
+    @Mock
+    private PublishShippingAddressEventPort publishShippingAddressEventPort;
 
     @Test
     @DisplayName("첫 번째 배송지 등록 시 기본 배송지로 설정된다")
@@ -75,6 +80,9 @@ class RegisterShippingAddressUseCaseTest {
         verify(findShippingAddressPort).existsByUserId(userId);
         verify(findShippingAddressPort, never()).findDefaultsByUserId(userId);
         verify(saveShippingAddressPort).save(any(ShippingAddress.class));
+        verify(publishShippingAddressEventPort).publishShippingAddressChangedEvent(
+                1L, 1L, "홍길동", "010-1234-5678", "서울시 강남구 테헤란로 123", ShippingAddressChangeAction.CREATED
+        );
         verifyNoInteractions(updateShippingAddressPort);
     }
 
@@ -121,6 +129,9 @@ class RegisterShippingAddressUseCaseTest {
         verify(findShippingAddressPort).findDefaultsByUserId(userId);
         verify(updateShippingAddressPort).update(existingDefault);
         verify(saveShippingAddressPort).save(any(ShippingAddress.class));
+        verify(publishShippingAddressEventPort).publishShippingAddressChangedEvent(
+                2L, 1L, "홍길동", "010-1234-5678", "서울시 강남구 테헤란로 123", ShippingAddressChangeAction.CREATED
+        );
     }
 
     @Test
@@ -148,7 +159,7 @@ class RegisterShippingAddressUseCaseTest {
 
         verify(findShippingAddressPort).existsByUserIdAndAddressType(userId, ShippingAddressType.HOME);
         verifyNoMoreInteractions(findShippingAddressPort);
-        verifyNoInteractions(saveShippingAddressPort, updateShippingAddressPort);
+        verifyNoInteractions(saveShippingAddressPort, updateShippingAddressPort, publishShippingAddressEventPort);
     }
 
     @Test
@@ -177,11 +188,11 @@ class RegisterShippingAddressUseCaseTest {
 
         verify(findShippingAddressPort).existsByUserIdAndAddressType(userId, ShippingAddressType.COMPANY);
         verifyNoMoreInteractions(findShippingAddressPort);
-        verifyNoInteractions(saveShippingAddressPort, updateShippingAddressPort);
+        verifyNoInteractions(saveShippingAddressPort, updateShippingAddressPort, publishShippingAddressEventPort);
     }
 
     @Test
-    @DisplayName("OTHER 타입 배송지가 5개 이상이면 IllegalArgumentException이 발생한다")
+    @DisplayName("OTHER 타입 배송지가 10개 이상이면 IllegalArgumentException이 발생한다")
     void registerShippingAddress_otherLimitExceeded_throwsIllegalArgumentException() {
         // given
         Long userId = 1L;
@@ -197,7 +208,7 @@ class RegisterShippingAddressUseCaseTest {
                 .build();
 
         when(findShippingAddressPort.countByUserIdAndAddressType(userId, ShippingAddressType.OTHER))
-                .thenReturn(5L);
+                .thenReturn(10L);
 
         // when & then
         assertThatThrownBy(() -> registerShippingAddressService.registerShippingAddress(command))
@@ -206,7 +217,7 @@ class RegisterShippingAddressUseCaseTest {
 
         verify(findShippingAddressPort).countByUserIdAndAddressType(userId, ShippingAddressType.OTHER);
         verifyNoMoreInteractions(findShippingAddressPort);
-        verifyNoInteractions(saveShippingAddressPort, updateShippingAddressPort);
+        verifyNoInteractions(saveShippingAddressPort, updateShippingAddressPort, publishShippingAddressEventPort);
     }
 
     @Test
@@ -243,6 +254,9 @@ class RegisterShippingAddressUseCaseTest {
         verify(findShippingAddressPort).existsByUserIdAndAddressType(userId, ShippingAddressType.HOME);
         verify(findShippingAddressPort).existsByUserId(userId);
         verify(saveShippingAddressPort).save(any(ShippingAddress.class));
+        verify(publishShippingAddressEventPort).publishShippingAddressChangedEvent(
+                1L, 1L, "홍길동", "010-1234-5678", "서울시 강남구 테헤란로 123", ShippingAddressChangeAction.CREATED
+        );
         verifyNoInteractions(updateShippingAddressPort);
     }
 
@@ -284,6 +298,9 @@ class RegisterShippingAddressUseCaseTest {
         verify(findShippingAddressPort).existsByUserId(userId);
         verify(findShippingAddressPort, never()).findDefaultsByUserId(userId);
         verify(saveShippingAddressPort).save(any(ShippingAddress.class));
+        verify(publishShippingAddressEventPort).publishShippingAddressChangedEvent(
+                3L, 1L, "홍길동", "010-1234-5678", "서울시 강남구 테헤란로 123", ShippingAddressChangeAction.CREATED
+        );
         verifyNoInteractions(updateShippingAddressPort);
     }
 
@@ -324,6 +341,9 @@ class RegisterShippingAddressUseCaseTest {
                 sa.getDeliveryRequestType() == DeliveryRequestType.CUSTOM
                         && message.equals(sa.getDeliveryRequestMessage())
         ));
+        verify(publishShippingAddressEventPort).publishShippingAddressChangedEvent(
+                1L, 1L, "홍길동", "010-1234-5678", "서울시 강남구 테헤란로 123", ShippingAddressChangeAction.CREATED
+        );
     }
 
     @Test
@@ -354,7 +374,7 @@ class RegisterShippingAddressUseCaseTest {
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("배송 요청사항 메시지는 최대 60자까지 입력할 수 있습니다");
 
-        verifyNoInteractions(saveShippingAddressPort);
+        verifyNoInteractions(saveShippingAddressPort, publishShippingAddressEventPort);
     }
 
     @Test
@@ -391,6 +411,9 @@ class RegisterShippingAddressUseCaseTest {
                 sa.getDeliveryRequestType() == DeliveryRequestType.LEAVE_AT_DOOR
                         && sa.getDeliveryRequestMessage() == null
         ));
+        verify(publishShippingAddressEventPort).publishShippingAddressChangedEvent(
+                1L, 1L, "홍길동", "010-1234-5678", "서울시 강남구 테헤란로 123", ShippingAddressChangeAction.CREATED
+        );
     }
 
     @Test
@@ -427,6 +450,9 @@ class RegisterShippingAddressUseCaseTest {
         assertThat(result.addressType()).isEqualTo(ShippingAddressType.OTHER);
 
         verify(saveShippingAddressPort).save(any(ShippingAddress.class));
+        verify(publishShippingAddressEventPort).publishShippingAddressChangedEvent(
+                5L, 1L, "홍길동", "010-1234-5678", "서울시 강남구 테헤란로 123", ShippingAddressChangeAction.CREATED
+        );
     }
 
     private ShippingAddress createShippingAddress(

--- a/user-service/user-application/src/test/java/com/personal/marketnote/user/service/shippingaddress/UpdateShippingAddressUseCaseTest.java
+++ b/user-service/user-application/src/test/java/com/personal/marketnote/user/service/shippingaddress/UpdateShippingAddressUseCaseTest.java
@@ -1,11 +1,13 @@
 package com.personal.marketnote.user.service.shippingaddress;
 
 import com.personal.marketnote.common.domain.delivery.DeliveryRequestType;
+import com.personal.marketnote.common.kafka.event.ShippingAddressChangeAction;
 import com.personal.marketnote.user.domain.shippingaddress.ShippingAddress;
 import com.personal.marketnote.user.domain.shippingaddress.ShippingAddressSnapshotState;
 import com.personal.marketnote.user.domain.shippingaddress.ShippingAddressType;
 import com.personal.marketnote.user.exception.ShippingAddressNotFoundException;
 import com.personal.marketnote.user.port.in.command.shippingaddress.UpdateShippingAddressCommand;
+import com.personal.marketnote.user.port.out.event.PublishShippingAddressEventPort;
 import com.personal.marketnote.user.port.out.shippingaddress.FindShippingAddressPort;
 import com.personal.marketnote.user.port.out.shippingaddress.UpdateShippingAddressPort;
 import org.junit.jupiter.api.DisplayName;
@@ -31,6 +33,9 @@ class UpdateShippingAddressUseCaseTest {
 
     @Mock
     private UpdateShippingAddressPort updateShippingAddressPort;
+
+    @Mock
+    private PublishShippingAddressEventPort publishShippingAddressEventPort;
 
     @Test
     @DisplayName("배송지가 존재하면 수정된 정보로 업데이트한다")
@@ -80,6 +85,9 @@ class UpdateShippingAddressUseCaseTest {
 
         verify(findShippingAddressPort).findByIdAndUserId(shippingAddressId, userId);
         verify(updateShippingAddressPort).update(shippingAddress);
+        verify(publishShippingAddressEventPort).publishShippingAddressChangedEvent(
+                1L, 100L, "김철수", "010-9876-5432", "서울시 서초구 서초대로 456", ShippingAddressChangeAction.UPDATED
+        );
         verifyNoMoreInteractions(findShippingAddressPort, updateShippingAddressPort);
     }
 
@@ -111,7 +119,7 @@ class UpdateShippingAddressUseCaseTest {
 
         verify(findShippingAddressPort).findByIdAndUserId(shippingAddressId, userId);
         verifyNoMoreInteractions(findShippingAddressPort);
-        verifyNoInteractions(updateShippingAddressPort);
+        verifyNoInteractions(updateShippingAddressPort, publishShippingAddressEventPort);
     }
 
     @Test
@@ -155,6 +163,9 @@ class UpdateShippingAddressUseCaseTest {
         assertThat(shippingAddress.getDeliveryRequestMessage()).isEqualTo(message);
 
         verify(updateShippingAddressPort).update(shippingAddress);
+        verify(publishShippingAddressEventPort).publishShippingAddressChangedEvent(
+                3L, 300L, "홍길동", "010-1234-5678", "서울시 강남구 테헤란로 123", ShippingAddressChangeAction.UPDATED
+        );
     }
 
     @Test
@@ -197,6 +208,9 @@ class UpdateShippingAddressUseCaseTest {
         assertThat(shippingAddress.getDeliveryRequestMessage()).isNull();
 
         verify(updateShippingAddressPort).update(shippingAddress);
+        verify(publishShippingAddressEventPort).publishShippingAddressChangedEvent(
+                4L, 400L, "홍길동", "010-1234-5678", "서울시 강남구 테헤란로 123", ShippingAddressChangeAction.UPDATED
+        );
     }
 
     @Test
@@ -241,6 +255,9 @@ class UpdateShippingAddressUseCaseTest {
         // then
         verify(findShippingAddressPort).findByIdAndUserId(shippingAddressId, userId);
         verify(updateShippingAddressPort).update(shippingAddress);
+        verify(publishShippingAddressEventPort).publishShippingAddressChangedEvent(
+                2L, 200L, "박민수", "010-7777-8888", "서울시 강남구 선릉로 100", ShippingAddressChangeAction.UPDATED
+        );
         verifyNoMoreInteractions(findShippingAddressPort, updateShippingAddressPort);
     }
 }

--- a/user-service/user-application/src/test/java/com/personal/marketnote/user/service/user/WithdrawUseCaseTest.java
+++ b/user-service/user-application/src/test/java/com/personal/marketnote/user/service/user/WithdrawUseCaseTest.java
@@ -147,7 +147,7 @@ class WithdrawUseCaseTest {
         User user = mock(User.class);
 
         when(getUserUseCase.getAllStatusUser(id)).thenReturn(user);
-        when(user.getOidcIdByVendor(AuthVendor.GOOGLE)).thenReturn(googleOidcId);
+        lenient().when(user.getOidcIdByVendor(AuthVendor.GOOGLE)).thenReturn(googleOidcId);
 
         // when
         WithdrawResult result = withdrawService.withdrawUser(id, Map.of());
@@ -199,7 +199,7 @@ class WithdrawUseCaseTest {
         User user = mock(User.class);
 
         when(getUserUseCase.getAllStatusUser(id)).thenReturn(user);
-        when(user.getOidcIdByVendor(AuthVendor.APPLE)).thenReturn(appleOidcId);
+        lenient().when(user.getOidcIdByVendor(AuthVendor.APPLE)).thenReturn(appleOidcId);
 
         // when
         WithdrawResult result = withdrawService.withdrawUser(id, Map.of());


### PR DESCRIPTION
## partially addresses #43
## resolves #1641

## Task
- [x] user.shipping-address.changed 토픽 정의
- [x] ShippingAddressChangedEvent 정의 (shippingAddressId, userId, recipientName, recipientPhoneNumber, address, action: CREATED/UPDATED/DELETED)
- [x] PublishShippingAddressEventPort + ShippingAddressEventKafkaProducer 구현
- [x] 배송지 등록/수정/삭제 Service에 이벤트 발행 추가