### PR TITLE
[#216][#1715] test: 커머스 서비스 배송지 Read Model 자동화 테스트 추가

### DIFF
--- a/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/event/ShippingAddressChangedReadModelConsumerTest.java
+++ b/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/event/ShippingAddressChangedReadModelConsumerTest.java
@@ -1,0 +1,298 @@
+package com.personal.marketnote.commerce.adapter.in.event;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.common.kafka.KafkaTopicConstants;
+import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.ShippingAddressChangeAction;
+import com.personal.marketnote.common.kafka.event.ShippingAddressChangedEvent;
+import com.personal.marketnote.commerce.port.out.user.SaveShippingAddressReadModelPort;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.support.Acknowledgment;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ShippingAddressChangedReadModelConsumer 테스트")
+class ShippingAddressChangedReadModelConsumerTest {
+
+    @InjectMocks
+    private ShippingAddressChangedReadModelConsumer consumer;
+
+    @Spy
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @Mock
+    private SaveShippingAddressReadModelPort saveShippingAddressReadModelPort;
+
+    @Mock
+    private Acknowledgment acknowledgment;
+
+    private ConsumerRecord<String, EventEnvelope<?>> createRecord(EventEnvelope<?> envelope) {
+        return new ConsumerRecord<>(
+                KafkaTopicConstants.SHIPPING_ADDRESS_CHANGED, 0, 0, "100", envelope
+        );
+    }
+
+    private EventEnvelope<ShippingAddressChangedEvent> createEnvelope(ShippingAddressChangedEvent payload) {
+        return new EventEnvelope<>(
+                "test-event-id",
+                KafkaTopicConstants.SHIPPING_ADDRESS_CHANGED,
+                "user-service",
+                LocalDateTime.of(2026, 3, 31, 10, 0),
+                payload
+        );
+    }
+
+    @Test
+    @DisplayName("CREATED 이벤트 수신 시 Read Model을 upsert한다")
+    void handleShippingAddressChangedEvent_created_upsertsReadModel() {
+        // given
+        ShippingAddressChangedEvent payload = new ShippingAddressChangedEvent(
+                1L, 100L, "홍길동", "010-1234-5678", "서울시 강남구 테헤란로 123", "101동 1001호", ShippingAddressChangeAction.CREATED
+        );
+        EventEnvelope<ShippingAddressChangedEvent> envelope = createEnvelope(payload);
+        ConsumerRecord<String, EventEnvelope<?>> record = createRecord(envelope);
+
+        // when
+        consumer.handleShippingAddressChangedEvent(record, acknowledgment);
+
+        // then
+        verify(saveShippingAddressReadModelPort).upsert(1L, 100L, "홍길동", "010-1234-5678", "서울시 강남구 테헤란로 123", "101동 1001호");
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("UPDATED 이벤트 수신 시 Read Model을 upsert한다")
+    void handleShippingAddressChangedEvent_updated_upsertsReadModel() {
+        // given
+        ShippingAddressChangedEvent payload = new ShippingAddressChangedEvent(
+                2L, 200L, "김철수", "010-9876-5432", "서울시 서초구 서초대로 456", "202동 303호", ShippingAddressChangeAction.UPDATED
+        );
+        EventEnvelope<ShippingAddressChangedEvent> envelope = createEnvelope(payload);
+        ConsumerRecord<String, EventEnvelope<?>> record = createRecord(envelope);
+
+        // when
+        consumer.handleShippingAddressChangedEvent(record, acknowledgment);
+
+        // then
+        verify(saveShippingAddressReadModelPort).upsert(2L, 200L, "김철수", "010-9876-5432", "서울시 서초구 서초대로 456", "202동 303호");
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("DELETED 이벤트 수신 시 Read Model을 비활성화한다")
+    void handleShippingAddressChangedEvent_deleted_deactivatesReadModel() {
+        // given
+        ShippingAddressChangedEvent payload = new ShippingAddressChangedEvent(
+                1L, 100L, "홍길동", "010-1234-5678", "서울시 강남구 테헤란로 123", "101동 1001호", ShippingAddressChangeAction.DELETED
+        );
+        EventEnvelope<ShippingAddressChangedEvent> envelope = createEnvelope(payload);
+        ConsumerRecord<String, EventEnvelope<?>> record = createRecord(envelope);
+
+        // when
+        consumer.handleShippingAddressChangedEvent(record, acknowledgment);
+
+        // then
+        verify(saveShippingAddressReadModelPort).deactivateByShippingAddressId(1L);
+        verifyNoMoreInteractions(saveShippingAddressReadModelPort);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("envelope이 null이면 즉시 acknowledge한다")
+    void handleShippingAddressChangedEvent_nullEnvelope_acknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = new ConsumerRecord<>(
+                KafkaTopicConstants.SHIPPING_ADDRESS_CHANGED, 0, 0, "100", null
+        );
+
+        // when
+        consumer.handleShippingAddressChangedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(saveShippingAddressReadModelPort);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("이벤트 타입이 불일치하면 즉시 acknowledge한다")
+    void handleShippingAddressChangedEvent_eventTypeMismatch_acknowledges() {
+        // given
+        ShippingAddressChangedEvent payload = new ShippingAddressChangedEvent(
+                1L, 100L, "홍길동", "010-1234-5678", "서울시 강남구 테헤란로 123", "101동 1001호", ShippingAddressChangeAction.CREATED
+        );
+        EventEnvelope<ShippingAddressChangedEvent> envelope = new EventEnvelope<>(
+                "test-event-id",
+                "wrong.event.type",
+                "user-service",
+                LocalDateTime.of(2026, 3, 31, 10, 0),
+                payload
+        );
+        ConsumerRecord<String, EventEnvelope<?>> record = createRecord(envelope);
+
+        // when
+        consumer.handleShippingAddressChangedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(saveShippingAddressReadModelPort);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("shippingAddressId가 null이면 이벤트를 무시하고 acknowledge한다")
+    void handleShippingAddressChangedEvent_nullShippingAddressId_acknowledges() {
+        // given
+        ShippingAddressChangedEvent payload = new ShippingAddressChangedEvent(
+                null, 100L, "홍길동", "010-1234-5678", "서울시 강남구 테헤란로 123", "101동 1001호", ShippingAddressChangeAction.CREATED
+        );
+        EventEnvelope<ShippingAddressChangedEvent> envelope = createEnvelope(payload);
+        ConsumerRecord<String, EventEnvelope<?>> record = createRecord(envelope);
+
+        // when
+        consumer.handleShippingAddressChangedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(saveShippingAddressReadModelPort);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("userId가 null이면 이벤트를 무시하고 acknowledge한다")
+    void handleShippingAddressChangedEvent_nullUserId_acknowledges() {
+        // given
+        ShippingAddressChangedEvent payload = new ShippingAddressChangedEvent(
+                1L, null, "홍길동", "010-1234-5678", "서울시 강남구 테헤란로 123", "101동 1001호", ShippingAddressChangeAction.CREATED
+        );
+        EventEnvelope<ShippingAddressChangedEvent> envelope = createEnvelope(payload);
+        ConsumerRecord<String, EventEnvelope<?>> record = createRecord(envelope);
+
+        // when
+        consumer.handleShippingAddressChangedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(saveShippingAddressReadModelPort);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("action이 null이면 이벤트를 무시하고 acknowledge한다")
+    void handleShippingAddressChangedEvent_nullAction_acknowledges() {
+        // given
+        ShippingAddressChangedEvent payload = new ShippingAddressChangedEvent(
+                1L, 100L, "홍길동", "010-1234-5678", "서울시 강남구 테헤란로 123", "101동 1001호", null
+        );
+        EventEnvelope<ShippingAddressChangedEvent> envelope = createEnvelope(payload);
+        ConsumerRecord<String, EventEnvelope<?>> record = createRecord(envelope);
+
+        // when
+        consumer.handleShippingAddressChangedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(saveShippingAddressReadModelPort);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("shippingAddressId가 0이면 이벤트를 무시하고 acknowledge한다")
+    void handleShippingAddressChangedEvent_zeroShippingAddressId_acknowledges() {
+        // given
+        ShippingAddressChangedEvent payload = new ShippingAddressChangedEvent(
+                0L, 100L, "홍길동", "010-1234-5678", "서울시 강남구 테헤란로 123", "101동 1001호", ShippingAddressChangeAction.CREATED
+        );
+        EventEnvelope<ShippingAddressChangedEvent> envelope = createEnvelope(payload);
+        ConsumerRecord<String, EventEnvelope<?>> record = createRecord(envelope);
+
+        // when
+        consumer.handleShippingAddressChangedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(saveShippingAddressReadModelPort);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("shippingAddressId가 음수이면 이벤트를 무시하고 acknowledge한다")
+    void handleShippingAddressChangedEvent_negativeShippingAddressId_acknowledges() {
+        // given
+        ShippingAddressChangedEvent payload = new ShippingAddressChangedEvent(
+                -1L, 100L, "홍길동", "010-1234-5678", "서울시 강남구 테헤란로 123", "101동 1001호", ShippingAddressChangeAction.CREATED
+        );
+        EventEnvelope<ShippingAddressChangedEvent> envelope = createEnvelope(payload);
+        ConsumerRecord<String, EventEnvelope<?>> record = createRecord(envelope);
+
+        // when
+        consumer.handleShippingAddressChangedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(saveShippingAddressReadModelPort);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("CREATED 이벤트에서 recipientName이 null이면 이벤트를 무시하고 acknowledge한다")
+    void handleShippingAddressChangedEvent_nullRecipientName_acknowledges() {
+        // given
+        ShippingAddressChangedEvent payload = new ShippingAddressChangedEvent(
+                1L, 100L, null, "010-1234-5678", "서울시 강남구 테헤란로 123", "101동 1001호", ShippingAddressChangeAction.CREATED
+        );
+        EventEnvelope<ShippingAddressChangedEvent> envelope = createEnvelope(payload);
+        ConsumerRecord<String, EventEnvelope<?>> record = createRecord(envelope);
+
+        // when
+        consumer.handleShippingAddressChangedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(saveShippingAddressReadModelPort);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("CREATED 이벤트에서 address가 null이면 이벤트를 무시하고 acknowledge한다")
+    void handleShippingAddressChangedEvent_nullAddress_acknowledges() {
+        // given
+        ShippingAddressChangedEvent payload = new ShippingAddressChangedEvent(
+                1L, 100L, "홍길동", "010-1234-5678", null, "101동 1001호", ShippingAddressChangeAction.CREATED
+        );
+        EventEnvelope<ShippingAddressChangedEvent> envelope = createEnvelope(payload);
+        ConsumerRecord<String, EventEnvelope<?>> record = createRecord(envelope);
+
+        // when
+        consumer.handleShippingAddressChangedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(saveShippingAddressReadModelPort);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("페이로드 역직렬화 실패 시 예외가 전파된다")
+    void handleShippingAddressChangedEvent_deserializationFailure_propagatesException() {
+        // given
+        EventEnvelope<String> envelope = new EventEnvelope<>(
+                "test-event-id",
+                KafkaTopicConstants.SHIPPING_ADDRESS_CHANGED,
+                "user-service",
+                LocalDateTime.of(2026, 3, 31, 10, 0),
+                "invalid-payload"
+        );
+        ConsumerRecord<String, EventEnvelope<?>> record = new ConsumerRecord<>(
+                KafkaTopicConstants.SHIPPING_ADDRESS_CHANGED, 0, 0, "100", envelope
+        );
+
+        // when & then
+        assertThatThrownBy(() -> consumer.handleShippingAddressChangedEvent(record, acknowledgment))
+                .isInstanceOf(IllegalArgumentException.class);
+
+        verify(acknowledgment, never()).acknowledge();
+    }
+}

--- a/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/out/persistence/shipping/ShippingAddressReadModelPersistenceAdapterTest.java
+++ b/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/out/persistence/shipping/ShippingAddressReadModelPersistenceAdapterTest.java
@@ -1,0 +1,180 @@
+package com.personal.marketnote.commerce.adapter.out.persistence.shipping;
+
+import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.configuration.AuditConfig;
+import com.personal.marketnote.commerce.adapter.out.persistence.shipping.entity.ShippingAddressReadModelJpaEntity;
+import com.personal.marketnote.commerce.adapter.out.persistence.shipping.repository.ShippingAddressReadModelJpaRepository;
+import com.personal.marketnote.commerce.exception.ShippingAddressNotFoundException;
+import com.personal.marketnote.commerce.port.out.result.user.ShippingAddressInfoResult;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DataJpaTest
+@ActiveProfiles("test")
+@Import({AuditConfig.class, ShippingAddressReadModelPersistenceAdapter.class})
+@DisplayName("ShippingAddressReadModelPersistenceAdapter 테스트")
+class ShippingAddressReadModelPersistenceAdapterTest {
+
+    @Autowired
+    private ShippingAddressReadModelPersistenceAdapter adapter;
+
+    @Autowired
+    private ShippingAddressReadModelJpaRepository repository;
+
+    @BeforeEach
+    void setUp() {
+        repository.deleteAll();
+    }
+
+    @Nested
+    @DisplayName("findByIdAndUserId")
+    class FindByIdAndUserId {
+
+        @Test
+        @DisplayName("ACTIVE 상태의 배송지를 조회하여 ShippingAddressInfoResult를 반환한다")
+        void returnsActiveShippingAddress() {
+            // given
+            adapter.upsert(1L, 100L, "홍길동", "010-1234-5678", "서울시 강남구 테헤란로 123", "101동 1001호");
+
+            // when
+            ShippingAddressInfoResult result = adapter.findByIdAndUserId(1L, 100L);
+
+            // then
+            assertThat(result.recipientName()).isEqualTo("홍길동");
+            assertThat(result.recipientPhoneNumber()).isEqualTo("010-1234-5678");
+            assertThat(result.address()).isEqualTo("서울시 강남구 테헤란로 123");
+            assertThat(result.addressDetail()).isEqualTo("101동 1001호");
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 배송지 ID로 조회 시 ShippingAddressNotFoundException이 발생한다")
+        void throwsNotFoundForNonExistentId() {
+            // when & then
+            assertThatThrownBy(() -> adapter.findByIdAndUserId(999L, 100L))
+                    .isInstanceOf(ShippingAddressNotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("비활성화된 배송지는 조회되지 않는다")
+        void doesNotReturnInactiveAddress() {
+            // given
+            adapter.upsert(1L, 100L, "홍길동", "010-1234-5678", "서울시 강남구 테헤란로 123", "101동 1001호");
+            adapter.deactivateByShippingAddressId(1L);
+
+            // when & then
+            assertThatThrownBy(() -> adapter.findByIdAndUserId(1L, 100L))
+                    .isInstanceOf(ShippingAddressNotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("userId가 일치하지 않으면 ShippingAddressNotFoundException이 발생한다")
+        void throwsNotFoundForMismatchedUserId() {
+            // given
+            adapter.upsert(1L, 100L, "홍길동", "010-1234-5678", "서울시 강남구 테헤란로 123", "101동 1001호");
+
+            // when & then
+            assertThatThrownBy(() -> adapter.findByIdAndUserId(1L, 999L))
+                    .isInstanceOf(ShippingAddressNotFoundException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("upsert")
+    class Upsert {
+
+        @Test
+        @DisplayName("신규 배송지를 저장한다")
+        void insertsNewAddress() {
+            // when
+            adapter.upsert(1L, 100L, "홍길동", "010-1234-5678", "서울시 강남구 테헤란로 123", "101동 1001호");
+
+            // then
+            Optional<ShippingAddressReadModelJpaEntity> entity =
+                    repository.findByShippingAddressIdAndUserIdAndStatus(1L, 100L, EntityStatus.ACTIVE);
+            assertThat(entity).isPresent();
+            assertThat(entity.get().getShippingAddressId()).isEqualTo(1L);
+            assertThat(entity.get().getUserId()).isEqualTo(100L);
+            assertThat(entity.get().getRecipientName()).isEqualTo("홍길동");
+            assertThat(entity.get().getRecipientPhoneNumber()).isEqualTo("010-1234-5678");
+            assertThat(entity.get().getAddress()).isEqualTo("서울시 강남구 테헤란로 123");
+            assertThat(entity.get().getAddressDetail()).isEqualTo("101동 1001호");
+            assertThat(entity.get().getStatus()).isEqualTo(EntityStatus.ACTIVE);
+        }
+
+        @Test
+        @DisplayName("동일한 shippingAddressId로 upsert 시 기존 데이터를 업데이트한다")
+        void updatesExistingAddress() {
+            // given
+            adapter.upsert(1L, 100L, "홍길동", "010-1234-5678", "서울시 강남구 테헤란로 123", "101동 1001호");
+
+            // when
+            adapter.upsert(1L, 100L, "김철수", "010-9876-5432", "서울시 서초구 서초대로 456", "202동 303호");
+
+            // then
+            Optional<ShippingAddressReadModelJpaEntity> entity =
+                    repository.findByShippingAddressIdAndUserIdAndStatus(1L, 100L, EntityStatus.ACTIVE);
+            assertThat(entity).isPresent();
+            assertThat(entity.get().getRecipientName()).isEqualTo("김철수");
+            assertThat(entity.get().getRecipientPhoneNumber()).isEqualTo("010-9876-5432");
+            assertThat(entity.get().getAddress()).isEqualTo("서울시 서초구 서초대로 456");
+            assertThat(entity.get().getAddressDetail()).isEqualTo("202동 303호");
+        }
+
+        @Test
+        @DisplayName("비활성화된 배송지에 대해 upsert 시 다시 활성화된다")
+        void reactivatesInactiveAddress() {
+            // given
+            adapter.upsert(1L, 100L, "홍길동", "010-1234-5678", "서울시 강남구 테헤란로 123", "101동 1001호");
+            adapter.deactivateByShippingAddressId(1L);
+
+            // when
+            adapter.upsert(1L, 100L, "김철수", "010-9876-5432", "서울시 서초구 서초대로 456", "202동 303호");
+
+            // then
+            Optional<ShippingAddressReadModelJpaEntity> entity =
+                    repository.findByShippingAddressIdAndUserIdAndStatus(1L, 100L, EntityStatus.ACTIVE);
+            assertThat(entity).isPresent();
+            assertThat(entity.get().getRecipientName()).isEqualTo("김철수");
+            assertThat(entity.get().getStatus()).isEqualTo(EntityStatus.ACTIVE);
+        }
+    }
+
+    @Nested
+    @DisplayName("deactivateByShippingAddressId")
+    class DeactivateByShippingAddressId {
+
+        @Test
+        @DisplayName("배송지를 비활성화한다")
+        void deactivatesAddress() {
+            // given
+            adapter.upsert(1L, 100L, "홍길동", "010-1234-5678", "서울시 강남구 테헤란로 123", "101동 1001호");
+
+            // when
+            adapter.deactivateByShippingAddressId(1L);
+
+            // then
+            List<ShippingAddressReadModelJpaEntity> all = repository.findAll();
+            assertThat(all).hasSize(1);
+            assertThat(all.getFirst().getStatus()).isEqualTo(EntityStatus.INACTIVE);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 shippingAddressId 비활성화 시 에러 없이 무시한다")
+        void ignoresNonExistentShippingAddressId() {
+            // when & then — no exception
+            adapter.deactivateByShippingAddressId(999L);
+        }
+    }
+}


### PR DESCRIPTION
## partially addresses #216
## resolves #1715

## Test Case
- [x] CREATED 이벤트 수신 시 Read Model을 upsert한다
- [x] UPDATED 이벤트 수신 시 Read Model을 upsert한다
- [x] DELETED 이벤트 수신 시 Read Model을 비활성화한다
- [x] envelope이 null이면 즉시 acknowledge한다
- [x] 이벤트 타입이 불일치하면 즉시 acknowledge한다
- [x] shippingAddressId가 null이면 이벤트를 무시하고 acknowledge한다
- [x] userId가 null이면 이벤트를 무시하고 acknowledge한다
- [x] action이 null이면 이벤트를 무시하고 acknowledge한다
- [x] shippingAddressId가 0이면 이벤트를 무시하고 acknowledge한다
- [x] shippingAddressId가 음수이면 이벤트를 무시하고 acknowledge한다
- [x] CREATED 이벤트에서 recipientName이 null이면 이벤트를 무시하고 acknowledge한다
- [x] CREATED 이벤트에서 address가 null이면 이벤트를 무시하고 acknowledge한다
- [x] 페이로드 역직렬화 실패 시 예외가 전파된다
- [x] ACTIVE 상태의 배송지를 조회하여 ShippingAddressInfoResult를 반환한다
- [x] 존재하지 않는 배송지 ID로 조회 시 ShippingAddressNotFoundException이 발생한다
- [x] 비활성화된 배송지는 조회되지 않는다
- [x] userId가 일치하지 않으면 ShippingAddressNotFoundException이 발생한다
- [x] 신규 배송지를 저장한다
- [x] 동일한 shippingAddressId로 upsert 시 기존 데이터를 업데이트한다
- [x] 비활성화된 배송지에 대해 upsert 시 다시 활성화된다
- [x] 배송지를 비활성화한다
- [x] 존재하지 않는 shippingAddressId 비활성화 시 에러 없이 무시한다