### PR TITLE
[#216][#1642] feat: 커머스 서비스 재고 변경 이벤트 발행 기능 추가

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/event/InventoryEventKafkaProducer.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/event/InventoryEventKafkaProducer.java
@@ -1,0 +1,56 @@
+package com.personal.marketnote.commerce.adapter.out.event;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.commerce.port.out.event.PublishInventoryEventPort;
+import com.personal.marketnote.common.adapter.out.ServiceAdapter;
+import com.personal.marketnote.common.kafka.KafkaTopicConstants;
+import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.InventoryChangeAction;
+import com.personal.marketnote.common.kafka.event.InventoryChangedEvent;
+import com.personal.marketnote.common.outbox.OutboxEvent;
+import com.personal.marketnote.common.outbox.SaveOutboxEventPort;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.time.Clock;
+
+@Slf4j
+@ServiceAdapter
+@RequiredArgsConstructor
+public class InventoryEventKafkaProducer implements PublishInventoryEventPort {
+    private static final String SOURCE = "commerce-service";
+
+    private final SaveOutboxEventPort saveOutboxEventPort;
+    private final ObjectMapper objectMapper;
+    private final Clock clock;
+
+    @Override
+    public void publishInventoryChangedEvent(Long pricePolicyId, Long productId, Integer stockQuantity,
+                                             InventoryChangeAction action) {
+        InventoryChangedEvent payload = new InventoryChangedEvent(
+                pricePolicyId, productId, stockQuantity, action
+        );
+        String topic = KafkaTopicConstants.INVENTORY_CHANGED;
+        EventEnvelope<InventoryChangedEvent> envelope = EventEnvelope.of(
+                topic, SOURCE, payload, clock
+        );
+
+        saveToOutbox(envelope, topic, pricePolicyId.toString());
+    }
+
+    private <T> void saveToOutbox(EventEnvelope<T> envelope, String topic, String partitionKey) {
+        try {
+            String payloadJson = objectMapper.writeValueAsString(envelope);
+            OutboxEvent outboxEvent = OutboxEvent.of(
+                    envelope.eventId(), topic, partitionKey,
+                    envelope.eventType(), SOURCE, payloadJson, clock
+            );
+            saveOutboxEventPort.save(outboxEvent);
+            log.info("Outbox 이벤트 저장. topic={}, partitionKey={}, eventId={}",
+                    topic, partitionKey, envelope.eventId());
+        } catch (Exception e) {
+            log.error("Outbox 이벤트 저장 실패. topic={}, partitionKey={}, error={}",
+                    topic, partitionKey, e.getMessage(), e);
+        }
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/event/PublishInventoryEventPort.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/event/PublishInventoryEventPort.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.commerce.port.out.event;
+
+import com.personal.marketnote.common.kafka.event.InventoryChangeAction;
+
+public interface PublishInventoryEventPort {
+
+    void publishInventoryChangedEvent(Long pricePolicyId, Long productId, Integer stockQuantity,
+                                      InventoryChangeAction action);
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/inventory/ReduceProductInventoryService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/inventory/ReduceProductInventoryService.java
@@ -4,8 +4,10 @@ import com.personal.marketnote.commerce.domain.inventory.Inventory;
 import com.personal.marketnote.commerce.domain.inventory.InventoryDeductionHistories;
 import com.personal.marketnote.commerce.domain.order.OrderProduct;
 import com.personal.marketnote.commerce.port.in.usecase.inventory.ReduceProductInventoryUseCase;
+import com.personal.marketnote.commerce.port.out.event.PublishInventoryEventPort;
 import com.personal.marketnote.commerce.port.out.inventory.*;
 import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.common.kafka.event.InventoryChangeAction;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,6 +28,7 @@ public class ReduceProductInventoryService implements ReduceProductInventoryUseC
     private final SaveInventoryDeductionHistoryPort saveInventoryDeductionHistoryPort;
     private final SaveCacheStockPort saveCacheStockPort;
     private final InventoryLockPort inventoryLockPort;
+    private final PublishInventoryEventPort publishInventoryEventPort;
 
     @Override
     public void reduce(List<OrderProduct> orderProducts, Long orderId, String reason) {
@@ -52,6 +55,13 @@ public class ReduceProductInventoryService implements ReduceProductInventoryUseC
                     InventoryDeductionHistories.from(stocksByPricePolicyId, productIdsByPricePolicyId, orderId, reason)
             );
             saveCacheStockPort.save(inventories);
+
+            inventories.forEach(inventory ->
+                    publishInventoryEventPort.publishInventoryChangedEvent(
+                            inventory.getPricePolicyId(), inventory.getProductId(),
+                            inventory.getStockValue(), InventoryChangeAction.UPDATED
+                    )
+            );
         });
     }
 }

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/inventory/RegisterInventoryService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/inventory/RegisterInventoryService.java
@@ -4,10 +4,12 @@ import com.personal.marketnote.commerce.domain.inventory.Inventory;
 import com.personal.marketnote.commerce.exception.InventoryAlreadyExistsException;
 import com.personal.marketnote.commerce.port.in.command.inventory.RegisterInventoryCommand;
 import com.personal.marketnote.commerce.port.in.usecase.inventory.RegisterInventoryUseCase;
+import com.personal.marketnote.commerce.port.out.event.PublishInventoryEventPort;
 import com.personal.marketnote.commerce.port.out.inventory.FindInventoryPort;
 import com.personal.marketnote.commerce.port.out.inventory.SaveCacheStockPort;
 import com.personal.marketnote.commerce.port.out.inventory.SaveInventoryPort;
 import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.common.kafka.event.InventoryChangeAction;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,6 +26,7 @@ public class RegisterInventoryService implements RegisterInventoryUseCase {
     private final SaveInventoryPort saveInventoryPort;
     private final SaveCacheStockPort saveCacheStockPort;
     private final FindInventoryPort findInventoryPort;
+    private final PublishInventoryEventPort publishInventoryEventPort;
 
     @Override
     public void registerInventory(RegisterInventoryCommand command) {
@@ -36,6 +39,10 @@ public class RegisterInventoryService implements RegisterInventoryUseCase {
         saveInventoryPort.save(inventory);
 
         saveCacheStockPort.save(command.pricePolicyId(), 0);
+
+        publishInventoryEventPort.publishInventoryChangedEvent(
+                command.pricePolicyId(), command.productId(), 0, InventoryChangeAction.CREATED
+        );
     }
 
     @Override
@@ -46,6 +53,12 @@ public class RegisterInventoryService implements RegisterInventoryUseCase {
 
         saveInventoryPort.save(inventories);
         saveCacheStockPort.save(inventories);
+
+        inventories.forEach(inventory ->
+                publishInventoryEventPort.publishInventoryChangedEvent(
+                        inventory.getPricePolicyId(), inventory.getProductId(), 0, InventoryChangeAction.CREATED
+                )
+        );
 
         return inventories;
     }

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/inventory/RestoreProductInventoryService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/inventory/RestoreProductInventoryService.java
@@ -4,8 +4,10 @@ import com.personal.marketnote.commerce.domain.inventory.Inventory;
 import com.personal.marketnote.commerce.domain.inventory.InventoryRestorationHistories;
 import com.personal.marketnote.commerce.domain.order.OrderProduct;
 import com.personal.marketnote.commerce.port.in.usecase.inventory.RestoreProductInventoryUseCase;
+import com.personal.marketnote.commerce.port.out.event.PublishInventoryEventPort;
 import com.personal.marketnote.commerce.port.out.inventory.*;
 import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.common.kafka.event.InventoryChangeAction;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,6 +28,7 @@ public class RestoreProductInventoryService implements RestoreProductInventoryUs
     private final SaveInventoryRestorationHistoryPort saveInventoryRestorationHistoryPort;
     private final SaveCacheStockPort saveCacheStockPort;
     private final InventoryLockPort inventoryLockPort;
+    private final PublishInventoryEventPort publishInventoryEventPort;
 
     @Override
     public void restore(List<OrderProduct> orderProducts, Long orderId, String reason) {
@@ -53,6 +56,13 @@ public class RestoreProductInventoryService implements RestoreProductInventoryUs
             );
 
             saveCacheStockPort.save(inventories);
+
+            inventories.forEach(inventory ->
+                    publishInventoryEventPort.publishInventoryChangedEvent(
+                            inventory.getPricePolicyId(), inventory.getProductId(),
+                            inventory.getStockValue(), InventoryChangeAction.UPDATED
+                    )
+            );
         });
     }
 }

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/inventory/SyncFulfillmentVendorInventoryService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/inventory/SyncFulfillmentVendorInventoryService.java
@@ -6,11 +6,13 @@ import com.personal.marketnote.commerce.exception.InventoryProductNotFoundExcept
 import com.personal.marketnote.commerce.port.in.command.inventory.SyncFulfillmentVendorInventoryCommand;
 import com.personal.marketnote.commerce.port.in.command.inventory.SyncFulfillmentVendorInventoryItemCommand;
 import com.personal.marketnote.commerce.port.in.usecase.inventory.SyncFulfillmentVendorInventoryUseCase;
+import com.personal.marketnote.commerce.port.out.event.PublishInventoryEventPort;
 import com.personal.marketnote.commerce.port.out.inventory.FindInventoryPort;
 import com.personal.marketnote.commerce.port.out.inventory.InventoryLockPort;
 import com.personal.marketnote.commerce.port.out.inventory.SaveCacheStockPort;
 import com.personal.marketnote.commerce.port.out.inventory.UpdateInventoryPort;
 import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.common.kafka.event.InventoryChangeAction;
 import com.personal.marketnote.common.utility.FormatValidator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
@@ -30,6 +32,7 @@ public class SyncFulfillmentVendorInventoryService implements SyncFulfillmentVen
     private final UpdateInventoryPort updateInventoryPort;
     private final SaveCacheStockPort saveCacheStockPort;
     private final InventoryLockPort inventoryLockPort;
+    private final PublishInventoryEventPort publishInventoryEventPort;
 
     @Override
     public void syncInventories(SyncFulfillmentVendorInventoryCommand command) {
@@ -60,6 +63,13 @@ public class SyncFulfillmentVendorInventoryService implements SyncFulfillmentVen
 
             updateInventoryPort.update(updatedInventories);
             saveCacheStockPort.save(updatedInventories);
+
+            updatedInventories.forEach(inventory ->
+                    publishInventoryEventPort.publishInventoryChangedEvent(
+                            inventory.getPricePolicyId(), inventory.getProductId(),
+                            inventory.getStockValue(), InventoryChangeAction.UPDATED
+                    )
+            );
         });
     }
 

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/inventory/ReduceProductInventoryUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/inventory/ReduceProductInventoryUseCaseTest.java
@@ -9,6 +9,7 @@ import com.personal.marketnote.commerce.exception.DuplicateInventoryDeductionExc
 import com.personal.marketnote.commerce.exception.InventoryLockAcquisitionException;
 import com.personal.marketnote.commerce.exception.InventoryLockInterruptedException;
 import com.personal.marketnote.commerce.exception.InventoryNotFoundException;
+import com.personal.marketnote.commerce.port.out.event.PublishInventoryEventPort;
 import com.personal.marketnote.commerce.port.out.inventory.*;
 import com.personal.marketnote.common.domain.exception.illegalargument.invalidvalue.InsufficientQuantityException;
 import org.junit.jupiter.api.DisplayName;
@@ -41,6 +42,8 @@ class ReduceProductInventoryUseCaseTest {
     private SaveCacheStockPort saveCacheStockPort;
     @Mock
     private InventoryLockPort inventoryLockPort;
+    @Mock
+    private PublishInventoryEventPort publishInventoryEventPort;
 
     @InjectMocks
     private ReduceProductInventoryService reduceProductInventoryService;

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/inventory/RegisterInventoryUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/inventory/RegisterInventoryUseCaseTest.java
@@ -3,6 +3,7 @@ package com.personal.marketnote.commerce.service.inventory;
 import com.personal.marketnote.commerce.domain.inventory.Inventory;
 import com.personal.marketnote.commerce.exception.InventoryAlreadyExistsException;
 import com.personal.marketnote.commerce.port.in.command.inventory.RegisterInventoryCommand;
+import com.personal.marketnote.commerce.port.out.event.PublishInventoryEventPort;
 import com.personal.marketnote.commerce.port.out.inventory.FindInventoryPort;
 import com.personal.marketnote.commerce.port.out.inventory.SaveCacheStockPort;
 import com.personal.marketnote.commerce.port.out.inventory.SaveInventoryPort;
@@ -31,6 +32,8 @@ class RegisterInventoryUseCaseTest {
     private SaveCacheStockPort saveCacheStockPort;
     @Mock
     private FindInventoryPort findInventoryPort;
+    @Mock
+    private PublishInventoryEventPort publishInventoryEventPort;
 
     @InjectMocks
     private RegisterInventoryService registerInventoryService;

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/inventory/RestoreProductInventoryUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/inventory/RestoreProductInventoryUseCaseTest.java
@@ -5,6 +5,7 @@ import com.personal.marketnote.commerce.domain.inventory.InventoryRestorationHis
 import com.personal.marketnote.commerce.domain.inventory.InventoryRestorationHistory;
 import com.personal.marketnote.commerce.domain.order.OrderProduct;
 import com.personal.marketnote.commerce.domain.order.OrderProductSnapshotState;
+import com.personal.marketnote.commerce.port.out.event.PublishInventoryEventPort;
 import com.personal.marketnote.commerce.port.out.inventory.*;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -36,6 +37,8 @@ class RestoreProductInventoryUseCaseTest {
     private SaveCacheStockPort saveCacheStockPort;
     @Mock
     private InventoryLockPort inventoryLockPort;
+    @Mock
+    private PublishInventoryEventPort publishInventoryEventPort;
 
     @InjectMocks
     private RestoreProductInventoryService restoreProductInventoryService;

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/inventory/SyncFulfillmentVendorInventoryUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/inventory/SyncFulfillmentVendorInventoryUseCaseTest.java
@@ -6,6 +6,7 @@ import com.personal.marketnote.commerce.exception.InventoryLockInterruptedExcept
 import com.personal.marketnote.commerce.exception.InventoryProductNotFoundException;
 import com.personal.marketnote.commerce.port.in.command.inventory.SyncFulfillmentVendorInventoryCommand;
 import com.personal.marketnote.commerce.port.in.command.inventory.SyncFulfillmentVendorInventoryItemCommand;
+import com.personal.marketnote.commerce.port.out.event.PublishInventoryEventPort;
 import com.personal.marketnote.commerce.port.out.inventory.FindInventoryPort;
 import com.personal.marketnote.commerce.port.out.inventory.InventoryLockPort;
 import com.personal.marketnote.commerce.port.out.inventory.SaveCacheStockPort;
@@ -38,6 +39,8 @@ class SyncFulfillmentVendorInventoryUseCaseTest {
     private SaveCacheStockPort saveCacheStockPort;
     @Mock
     private InventoryLockPort inventoryLockPort;
+    @Mock
+    private PublishInventoryEventPort publishInventoryEventPort;
 
     @InjectMocks
     private SyncFulfillmentVendorInventoryService syncFulfillmentVendorInventoryService;

--- a/common/src/main/java/com/personal/marketnote/common/kafka/KafkaTopicConstants.java
+++ b/common/src/main/java/com/personal/marketnote/common/kafka/KafkaTopicConstants.java
@@ -37,6 +37,9 @@ public final class KafkaTopicConstants {
     public static final String SAGA_ORDER_PAYMENT_LEDGER = "saga.order-payment.ledger";
     public static final String SAGA_ORDER_PAYMENT_COMPLETED = "saga.order-payment.completed";
 
+    // Inventory 이벤트
+    public static final String INVENTORY_CHANGED = "commerce.inventory.changed";
+
     // Shipping Policy 이벤트
     public static final String SHIPPING_POLICY_CHANGED = "product.shipping-policy.changed";
 

--- a/common/src/main/java/com/personal/marketnote/common/kafka/event/InventoryChangeAction.java
+++ b/common/src/main/java/com/personal/marketnote/common/kafka/event/InventoryChangeAction.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.common.kafka.event;
+
+public enum InventoryChangeAction {
+    CREATED,
+    UPDATED;
+
+    public boolean isCreated() { return this == CREATED; }
+    public boolean isUpdated() { return this == UPDATED; }
+}

--- a/common/src/main/java/com/personal/marketnote/common/kafka/event/InventoryChangedEvent.java
+++ b/common/src/main/java/com/personal/marketnote/common/kafka/event/InventoryChangedEvent.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.common.kafka.event;
+
+public record InventoryChangedEvent(
+        Long pricePolicyId,
+        Long productId,
+        Integer stockQuantity,
+        InventoryChangeAction action
+) {
+}


### PR DESCRIPTION
## partially addresses #216
## resolves #1642

## Task
- [x] commerce.inventory.changed 토픽 정의
- [x] InventoryChangedEvent 정의 (pricePolicyId, productId, stockQuantity, action: CREATED/UPDATED)
- [x] PublishInventoryEventPort + InventoryEventKafkaProducer 구현
- [x] 재고 등록/차감/복구/수정 Service에 이벤트 발행 추가