### PR TITLE
[#216][#1765] test: 커머스 서비스 재고 변경 이벤트 발행 기능 자동화 테스트 추가

### DIFF
--- a/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/out/event/InventoryEventKafkaProducerTest.java
+++ b/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/out/event/InventoryEventKafkaProducerTest.java
@@ -1,0 +1,100 @@
+package com.personal.marketnote.commerce.adapter.out.event;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.common.kafka.KafkaTopicConstants;
+import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.InventoryChangeAction;
+import com.personal.marketnote.common.kafka.event.InventoryChangedEvent;
+import com.personal.marketnote.common.outbox.OutboxEvent;
+import com.personal.marketnote.common.outbox.SaveOutboxEventPort;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("InventoryEventKafkaProducer 테스트")
+class InventoryEventKafkaProducerTest {
+    @InjectMocks
+    private InventoryEventKafkaProducer inventoryEventKafkaProducer;
+
+    @Mock
+    private SaveOutboxEventPort saveOutboxEventPort;
+
+    @Mock
+    private ObjectMapper objectMapper;
+
+    @Mock
+    private Clock clock;
+
+    private void setUpClock(String instant) {
+        Clock fixedClock = Clock.fixed(Instant.parse(instant), ZoneId.of("Asia/Seoul"));
+        when(clock.instant()).thenReturn(fixedClock.instant());
+        when(clock.getZone()).thenReturn(fixedClock.getZone());
+    }
+
+    @Test
+    @DisplayName("재고 변경 이벤트 발행 시 올바른 토픽과 파티션 키로 Outbox에 저장된다")
+    void publishInventoryChangedEvent_savesToOutboxWithCorrectTopicAndPartitionKey() throws Exception {
+        // given
+        setUpClock("2026-03-31T10:00:00Z");
+        when(objectMapper.writeValueAsString(any())).thenReturn("{}");
+
+        // when
+        inventoryEventKafkaProducer.publishInventoryChangedEvent(
+                100L, 1L, 50, InventoryChangeAction.UPDATED
+        );
+
+        // then
+        ArgumentCaptor<OutboxEvent> outboxCaptor = ArgumentCaptor.forClass(OutboxEvent.class);
+        verify(saveOutboxEventPort).save(outboxCaptor.capture());
+
+        OutboxEvent captured = outboxCaptor.getValue();
+        assertThat(captured.getTopic()).isEqualTo(KafkaTopicConstants.INVENTORY_CHANGED);
+        assertThat(captured.getPartitionKey()).isEqualTo("100");
+        assertThat(captured.getSource()).isEqualTo("commerce-service");
+        assertThat(captured.getEventId()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("재고 변경 이벤트 발행 시 EventEnvelope에 올바른 페이로드가 포함된다")
+    @SuppressWarnings("unchecked")
+    void publishInventoryChangedEvent_envelopeContainsCorrectPayload() throws Exception {
+        // given
+        setUpClock("2026-03-31T10:00:00Z");
+        when(objectMapper.writeValueAsString(any())).thenReturn("{}");
+
+        // when
+        inventoryEventKafkaProducer.publishInventoryChangedEvent(
+                200L, 10L, 30, InventoryChangeAction.CREATED
+        );
+
+        // then
+        ArgumentCaptor<EventEnvelope> envelopeCaptor = ArgumentCaptor.forClass(EventEnvelope.class);
+        verify(objectMapper).writeValueAsString(envelopeCaptor.capture());
+
+        EventEnvelope<?> capturedEnvelope = envelopeCaptor.getValue();
+        assertThat(capturedEnvelope.eventType()).isEqualTo(KafkaTopicConstants.INVENTORY_CHANGED);
+        assertThat(capturedEnvelope.source()).isEqualTo("commerce-service");
+        assertThat(capturedEnvelope.eventId()).isNotNull();
+        assertThat(capturedEnvelope.timestamp()).isNotNull();
+
+        InventoryChangedEvent payload = (InventoryChangedEvent) capturedEnvelope.payload();
+        assertThat(payload.pricePolicyId()).isEqualTo(200L);
+        assertThat(payload.productId()).isEqualTo(10L);
+        assertThat(payload.stockQuantity()).isEqualTo(30);
+        assertThat(payload.action()).isEqualTo(InventoryChangeAction.CREATED);
+    }
+}

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/inventory/ReduceProductInventoryUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/inventory/ReduceProductInventoryUseCaseTest.java
@@ -11,6 +11,7 @@ import com.personal.marketnote.commerce.exception.InventoryLockInterruptedExcept
 import com.personal.marketnote.commerce.exception.InventoryNotFoundException;
 import com.personal.marketnote.commerce.port.out.event.PublishInventoryEventPort;
 import com.personal.marketnote.commerce.port.out.inventory.*;
+import com.personal.marketnote.common.kafka.event.InventoryChangeAction;
 import com.personal.marketnote.common.domain.exception.illegalargument.invalidvalue.InsufficientQuantityException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -901,5 +902,63 @@ class ReduceProductInventoryUseCaseTest {
 
     private Inventory buildInventory(Long productId, Long pricePolicyId, int stock) {
         return Inventory.of(productId, pricePolicyId, stock, 0L);
+    }
+
+    // ==================================================================================
+    // 이벤트 발행 검증
+    // ==================================================================================
+
+    @Nested
+    @DisplayName("이벤트 발행 검증")
+    class EventPublishingTest {
+
+        @Test
+        @DisplayName("단일 주문 상품 재고 차감 시 차감된 재고 수량으로 UPDATED 이벤트를 발행한다")
+        void reduce_singleOrderProduct_publishesUpdatedEventWithReducedStock() {
+            List<OrderProduct> orderProducts = List.of(buildOrderProduct(100L, 3));
+            Inventory inventory = buildInventory(1L, 100L, 10);
+
+            stubLockToExecuteTask();
+            when(findInventoryPort.findByPricePolicyIds(any())).thenReturn(Set.of(inventory));
+
+            reduceProductInventoryService.reduce(orderProducts, 1L, "결제 완료");
+
+            verify(publishInventoryEventPort).publishInventoryChangedEvent(
+                    100L, 1L, 7, InventoryChangeAction.UPDATED
+            );
+        }
+
+        @Test
+        @DisplayName("서로 다른 가격 정책의 복수 주문 상품 재고 차감 시 각각 UPDATED 이벤트를 발행한다")
+        void reduce_differentPolicies_publishesUpdatedEventForEach() {
+            List<OrderProduct> orderProducts = List.of(
+                    buildOrderProduct(100L, 2),
+                    buildOrderProduct(200L, 5)
+            );
+            Inventory inventory1 = buildInventory(1L, 100L, 10);
+            Inventory inventory2 = buildInventory(2L, 200L, 20);
+
+            stubLockToExecuteTask();
+            when(findInventoryPort.findByPricePolicyIds(any())).thenReturn(Set.of(inventory1, inventory2));
+
+            reduceProductInventoryService.reduce(orderProducts, 1L, "결제 완료");
+
+            verify(publishInventoryEventPort).publishInventoryChangedEvent(
+                    100L, 1L, 8, InventoryChangeAction.UPDATED
+            );
+            verify(publishInventoryEventPort).publishInventoryChangedEvent(
+                    200L, 2L, 15, InventoryChangeAction.UPDATED
+            );
+        }
+
+        @Test
+        @DisplayName("분산 락이 작업을 실행하지 않으면 이벤트를 발행하지 않는다")
+        void reduce_lockNotExecuted_doesNotPublishEvent() {
+            List<OrderProduct> orderProducts = List.of(buildOrderProduct(100L, 3));
+
+            reduceProductInventoryService.reduce(orderProducts, 1L, "결제 완료");
+
+            verifyNoInteractions(publishInventoryEventPort);
+        }
     }
 }

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/inventory/RegisterInventoryUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/inventory/RegisterInventoryUseCaseTest.java
@@ -7,6 +7,7 @@ import com.personal.marketnote.commerce.port.out.event.PublishInventoryEventPort
 import com.personal.marketnote.commerce.port.out.inventory.FindInventoryPort;
 import com.personal.marketnote.commerce.port.out.inventory.SaveCacheStockPort;
 import com.personal.marketnote.commerce.port.out.inventory.SaveInventoryPort;
+import com.personal.marketnote.common.kafka.event.InventoryChangeAction;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -385,6 +386,82 @@ class RegisterInventoryUseCaseTest {
                     .isSameAs(exception);
 
             verify(saveInventoryPort).save(any(Set.class));
+        }
+
+        @Test
+        @DisplayName("복수 재고 등록 시 각 재고마다 CREATED 이벤트를 발행한다")
+        void registerInventories_success_publishesCreatedEventForEach() {
+            Set<RegisterInventoryCommand> commands = new LinkedHashSet<>();
+            commands.add(RegisterInventoryCommand.of(1L, 100L));
+            commands.add(RegisterInventoryCommand.of(2L, 200L));
+
+            registerInventoryService.registerInventories(commands);
+
+            verify(publishInventoryEventPort).publishInventoryChangedEvent(
+                    100L, 1L, 0, InventoryChangeAction.CREATED
+            );
+            verify(publishInventoryEventPort).publishInventoryChangedEvent(
+                    200L, 2L, 0, InventoryChangeAction.CREATED
+            );
+            verify(publishInventoryEventPort, times(2)).publishInventoryChangedEvent(
+                    any(), any(), any(), any()
+            );
+        }
+    }
+
+    // ==================================================================================
+    // 이벤트 발행 검증
+    // ==================================================================================
+
+    @Nested
+    @DisplayName("이벤트 발행 검증")
+    class EventPublishingTest {
+
+        @Test
+        @DisplayName("단건 재고 등록 시 CREATED 이벤트를 발행한다")
+        void registerInventory_success_publishesCreatedEvent() {
+            Long productId = 20L;
+            Long pricePolicyId = 2000L;
+            RegisterInventoryCommand command = RegisterInventoryCommand.of(productId, pricePolicyId);
+
+            when(findInventoryPort.existsByPricePolicyId(pricePolicyId)).thenReturn(false);
+
+            registerInventoryService.registerInventory(command);
+
+            verify(publishInventoryEventPort).publishInventoryChangedEvent(
+                    pricePolicyId, productId, 0, InventoryChangeAction.CREATED
+            );
+        }
+
+        @Test
+        @DisplayName("단건 재고 등록 시 올바른 재고 수량 0으로 이벤트를 발행한다")
+        void registerInventory_success_publishesEventWithZeroStock() {
+            Long productId = 21L;
+            Long pricePolicyId = 2100L;
+            RegisterInventoryCommand command = RegisterInventoryCommand.of(productId, pricePolicyId);
+
+            when(findInventoryPort.existsByPricePolicyId(pricePolicyId)).thenReturn(false);
+
+            registerInventoryService.registerInventory(command);
+
+            verify(publishInventoryEventPort).publishInventoryChangedEvent(
+                    2100L, 21L, 0, InventoryChangeAction.CREATED
+            );
+        }
+
+        @Test
+        @DisplayName("이미 존재하는 재고로 등록 실패 시 이벤트를 발행하지 않는다")
+        void registerInventory_alreadyExists_doesNotPublishEvent() {
+            Long productId = 22L;
+            Long pricePolicyId = 2200L;
+            RegisterInventoryCommand command = RegisterInventoryCommand.of(productId, pricePolicyId);
+
+            when(findInventoryPort.existsByPricePolicyId(pricePolicyId)).thenReturn(true);
+
+            assertThatThrownBy(() -> registerInventoryService.registerInventory(command))
+                    .isInstanceOf(InventoryAlreadyExistsException.class);
+
+            verifyNoInteractions(publishInventoryEventPort);
         }
     }
 }

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/inventory/RestoreProductInventoryUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/inventory/RestoreProductInventoryUseCaseTest.java
@@ -7,6 +7,7 @@ import com.personal.marketnote.commerce.domain.order.OrderProduct;
 import com.personal.marketnote.commerce.domain.order.OrderProductSnapshotState;
 import com.personal.marketnote.commerce.port.out.event.PublishInventoryEventPort;
 import com.personal.marketnote.commerce.port.out.inventory.*;
+import com.personal.marketnote.common.kafka.event.InventoryChangeAction;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -379,5 +380,63 @@ class RestoreProductInventoryUseCaseTest {
 
     private Inventory buildInventory(Long productId, Long pricePolicyId, int stock) {
         return Inventory.of(productId, pricePolicyId, stock, 0L);
+    }
+
+    // ==================================================================================
+    // 이벤트 발행 검증
+    // ==================================================================================
+
+    @Nested
+    @DisplayName("이벤트 발행 검증")
+    class EventPublishingTest {
+
+        @Test
+        @DisplayName("단일 주문 상품 재고 복구 시 복구된 재고 수량으로 UPDATED 이벤트를 발행한다")
+        void restore_singleOrderProduct_publishesUpdatedEventWithRestoredStock() {
+            List<OrderProduct> orderProducts = List.of(buildOrderProduct(100L, 3));
+            Inventory inventory = buildInventory(1L, 100L, 7);
+
+            stubLockToExecuteTask();
+            when(findInventoryPort.findByPricePolicyIds(any())).thenReturn(Set.of(inventory));
+
+            restoreProductInventoryService.restore(orderProducts, 1L, "주문 취소");
+
+            verify(publishInventoryEventPort).publishInventoryChangedEvent(
+                    100L, 1L, 10, InventoryChangeAction.UPDATED
+            );
+        }
+
+        @Test
+        @DisplayName("서로 다른 가격 정책의 복수 주문 상품 재고 복구 시 각각 UPDATED 이벤트를 발행한다")
+        void restore_differentPolicies_publishesUpdatedEventForEach() {
+            List<OrderProduct> orderProducts = List.of(
+                    buildOrderProduct(100L, 2),
+                    buildOrderProduct(200L, 5)
+            );
+            Inventory inventory1 = buildInventory(1L, 100L, 8);
+            Inventory inventory2 = buildInventory(2L, 200L, 15);
+
+            stubLockToExecuteTask();
+            when(findInventoryPort.findByPricePolicyIds(any())).thenReturn(Set.of(inventory1, inventory2));
+
+            restoreProductInventoryService.restore(orderProducts, 1L, "주문 취소");
+
+            verify(publishInventoryEventPort).publishInventoryChangedEvent(
+                    100L, 1L, 10, InventoryChangeAction.UPDATED
+            );
+            verify(publishInventoryEventPort).publishInventoryChangedEvent(
+                    200L, 2L, 20, InventoryChangeAction.UPDATED
+            );
+        }
+
+        @Test
+        @DisplayName("분산 락이 작업을 실행하지 않으면 이벤트를 발행하지 않는다")
+        void restore_lockNotExecuted_doesNotPublishEvent() {
+            List<OrderProduct> orderProducts = List.of(buildOrderProduct(100L, 3));
+
+            restoreProductInventoryService.restore(orderProducts, 1L, "주문 취소");
+
+            verifyNoInteractions(publishInventoryEventPort);
+        }
     }
 }

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/inventory/SyncFulfillmentVendorInventoryUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/inventory/SyncFulfillmentVendorInventoryUseCaseTest.java
@@ -11,6 +11,7 @@ import com.personal.marketnote.commerce.port.out.inventory.FindInventoryPort;
 import com.personal.marketnote.commerce.port.out.inventory.InventoryLockPort;
 import com.personal.marketnote.commerce.port.out.inventory.SaveCacheStockPort;
 import com.personal.marketnote.commerce.port.out.inventory.UpdateInventoryPort;
+import com.personal.marketnote.common.kafka.event.InventoryChangeAction;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -823,5 +824,91 @@ class SyncFulfillmentVendorInventoryUseCaseTest {
 
     private Inventory buildInventory(Long productId, Long pricePolicyId, int stock, Long version) {
         return Inventory.of(productId, pricePolicyId, stock, version);
+    }
+
+    // ==================================================================================
+    // 이벤트 발행 검증
+    // ==================================================================================
+
+    @Nested
+    @DisplayName("이벤트 발행 검증")
+    class EventPublishingTest {
+
+        @Test
+        @DisplayName("단일 상품 재고 동기화 시 동기화된 재고 수량으로 UPDATED 이벤트를 발행한다")
+        void syncInventories_singleProduct_publishesUpdatedEventWithSyncedStock() {
+            SyncFulfillmentVendorInventoryCommand command = buildCommand(
+                    SyncFulfillmentVendorInventoryItemCommand.of(1L, 50)
+            );
+            when(findInventoryPort.findByProductIds(any())).thenReturn(Set.of(
+                    buildInventory(1L, 100L, 10)
+            ));
+            stubLockToExecuteTask();
+            when(findInventoryPort.findByPricePolicyIds(any())).thenReturn(Set.of(
+                    buildInventory(1L, 100L, 10, 1L)
+            ));
+
+            syncFulfillmentVendorInventoryService.syncInventories(command);
+
+            verify(publishInventoryEventPort).publishInventoryChangedEvent(
+                    100L, 1L, 50, InventoryChangeAction.UPDATED
+            );
+        }
+
+        @Test
+        @DisplayName("복수 상품 재고 동기화 시 각 상품에 대해 UPDATED 이벤트를 발행한다")
+        void syncInventories_multipleProducts_publishesUpdatedEventForEach() {
+            SyncFulfillmentVendorInventoryCommand command = buildCommand(
+                    SyncFulfillmentVendorInventoryItemCommand.of(1L, 50),
+                    SyncFulfillmentVendorInventoryItemCommand.of(2L, 30)
+            );
+            when(findInventoryPort.findByProductIds(any())).thenReturn(Set.of(
+                    buildInventory(1L, 100L, 10),
+                    buildInventory(2L, 200L, 20)
+            ));
+            stubLockToExecuteTask();
+            when(findInventoryPort.findByPricePolicyIds(any())).thenReturn(Set.of(
+                    buildInventory(1L, 100L, 10, 1L),
+                    buildInventory(2L, 200L, 20, 2L)
+            ));
+
+            syncFulfillmentVendorInventoryService.syncInventories(command);
+
+            verify(publishInventoryEventPort).publishInventoryChangedEvent(
+                    100L, 1L, 50, InventoryChangeAction.UPDATED
+            );
+            verify(publishInventoryEventPort).publishInventoryChangedEvent(
+                    200L, 2L, 30, InventoryChangeAction.UPDATED
+            );
+        }
+
+        @Test
+        @DisplayName("분산 락이 작업을 실행하지 않으면 이벤트를 발행하지 않는다")
+        void syncInventories_lockNotExecuted_doesNotPublishEvent() {
+            SyncFulfillmentVendorInventoryCommand command = buildCommand(
+                    SyncFulfillmentVendorInventoryItemCommand.of(1L, 50)
+            );
+            when(findInventoryPort.findByProductIds(any())).thenReturn(Set.of(
+                    buildInventory(1L, 100L, 10)
+            ));
+
+            syncFulfillmentVendorInventoryService.syncInventories(command);
+
+            verifyNoInteractions(publishInventoryEventPort);
+        }
+
+        @Test
+        @DisplayName("상품 미존재 시 이벤트를 발행하지 않는다")
+        void syncInventories_productMissing_doesNotPublishEvent() {
+            SyncFulfillmentVendorInventoryCommand command = buildCommand(
+                    SyncFulfillmentVendorInventoryItemCommand.of(1L, 50)
+            );
+            when(findInventoryPort.findByProductIds(any())).thenReturn(Set.of());
+
+            assertThatThrownBy(() -> syncFulfillmentVendorInventoryService.syncInventories(command))
+                    .isInstanceOf(InventoryProductNotFoundException.class);
+
+            verifyNoInteractions(publishInventoryEventPort);
+        }
     }
 }


### PR DESCRIPTION
## partially addresses #216
## resolves #1765

## Task
- [x] InventoryEventKafkaProducer Outbox 저장/페이로드 검증 테스트
- [x] RegisterInventoryService 단건/다건 CREATED 이벤트 발행 검증 테스트
- [x] ReduceProductInventoryService 차감 UPDATED 이벤트 발행 검증 테스트
- [x] RestoreProductInventoryService 복구 UPDATED 이벤트 발행 검증 테스트
- [x] SyncFulfillmentVendorInventoryService 동기화 UPDATED 이벤트 발행 검증 테스트