### PR TITLE
[#300][#1644] feat: 커뮤니티 서비스 상품 정보 Read Model 구축

### DIFF
--- a/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/in/event/ProductRegisteredReadModelConsumer.java
+++ b/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/in/event/ProductRegisteredReadModelConsumer.java
@@ -1,0 +1,71 @@
+package com.personal.marketnote.community.adapter.in.event;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.common.kafka.KafkaTopicConstants;
+import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.EventPayloadValidator;
+import com.personal.marketnote.common.kafka.event.ProductRegisteredEvent;
+import com.personal.marketnote.community.port.out.product.SaveProductReadModelPort;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ProductRegisteredReadModelConsumer {
+    private final ObjectMapper objectMapper;
+    private final SaveProductReadModelPort saveProductReadModelPort;
+
+    @KafkaListener(
+            topics = KafkaTopicConstants.PRODUCT_REGISTERED,
+            groupId = "community-product-read-model"
+    )
+    public void handleProductRegisteredEvent(
+            ConsumerRecord<String, EventEnvelope<?>> record,
+            Acknowledgment acknowledgment
+    ) {
+        EventEnvelope<?> envelope = record.value();
+
+        if (EventPayloadValidator.hasInvalidEnvelope(envelope, record)) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        if (EventPayloadValidator.hasEventTypeMismatch(envelope, KafkaTopicConstants.PRODUCT_REGISTERED)) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        ProductRegisteredEvent payload = envelope.getPayloadAs(ProductRegisteredEvent.class, objectMapper);
+
+        log.info("상품 등록 이벤트 수신 (커뮤니티 Read Model). eventId={}, productId={}, pricePolicyId={}",
+                envelope.eventId(), payload.productId(), payload.pricePolicyId());
+
+        if (EventPayloadValidator.hasInvalidIds(envelope.eventId(),
+                EventPayloadValidator.id("productId", payload.productId()),
+                EventPayloadValidator.id("pricePolicyId", payload.pricePolicyId()))) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        saveProductReadModelPort.upsert(
+                payload.pricePolicyId(),
+                payload.productId(),
+                payload.sellerId(),
+                payload.productName(),
+                payload.brandName(),
+                payload.price(),
+                payload.discountPrice(),
+                payload.accumulatedPoint()
+        );
+
+        log.info("상품 Read Model 저장 완료. pricePolicyId={}, productId={}",
+                payload.pricePolicyId(), payload.productId());
+
+        acknowledgment.acknowledge();
+    }
+}

--- a/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/in/event/ProductUpdatedReadModelConsumer.java
+++ b/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/in/event/ProductUpdatedReadModelConsumer.java
@@ -1,0 +1,88 @@
+package com.personal.marketnote.community.adapter.in.event;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.common.kafka.KafkaTopicConstants;
+import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.EventPayloadValidator;
+import com.personal.marketnote.common.kafka.event.ProductUpdatedEvent;
+import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.community.adapter.out.persistence.product.entity.ProductReadModelJpaEntity;
+import com.personal.marketnote.community.adapter.out.persistence.product.repository.ProductReadModelJpaRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ProductUpdatedReadModelConsumer {
+    private final ObjectMapper objectMapper;
+    private final ProductReadModelJpaRepository productReadModelJpaRepository;
+
+    @KafkaListener(
+            topics = KafkaTopicConstants.PRODUCT_UPDATED,
+            groupId = "community-product-read-model"
+    )
+    @Transactional(isolation = READ_COMMITTED)
+    public void handleProductUpdatedEvent(
+            ConsumerRecord<String, EventEnvelope<?>> record,
+            Acknowledgment acknowledgment
+    ) {
+        EventEnvelope<?> envelope = record.value();
+
+        if (EventPayloadValidator.hasInvalidEnvelope(envelope, record)) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        if (EventPayloadValidator.hasEventTypeMismatch(envelope, KafkaTopicConstants.PRODUCT_UPDATED)) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        ProductUpdatedEvent payload = envelope.getPayloadAs(ProductUpdatedEvent.class, objectMapper);
+
+        log.info("상품 업데이트 이벤트 수신 (커뮤니티 Read Model). eventId={}, productId={}",
+                envelope.eventId(), payload.productId());
+
+        if (EventPayloadValidator.hasInvalidIds(envelope.eventId(),
+                EventPayloadValidator.id("productId", payload.productId()))) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        if (FormatValidator.hasNoValue(payload.productName())) {
+            log.warn("상품 이름이 없어 Read Model 업데이트를 건너뜁니다. eventId={}, productId={}",
+                    envelope.eventId(), payload.productId());
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        List<ProductReadModelJpaEntity> entities =
+                productReadModelJpaRepository.findByProductId(payload.productId());
+
+        for (ProductReadModelJpaEntity entity : entities) {
+            entity.updateFrom(
+                    entity.getProductId(),
+                    entity.getSellerId(),
+                    payload.productName(),
+                    entity.getBrandName(),
+                    entity.getPrice(),
+                    entity.getDiscountPrice(),
+                    entity.getAccumulatedPoint()
+            );
+            log.info("상품 Read Model 이름 업데이트 완료. pricePolicyId={}, productId={}, newName={}",
+                    entity.getPricePolicyId(), payload.productId(), payload.productName());
+        }
+
+        acknowledgment.acknowledge();
+    }
+}

--- a/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/out/persistence/product/ProductReadModelPersistenceAdapter.java
+++ b/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/out/persistence/product/ProductReadModelPersistenceAdapter.java
@@ -1,0 +1,94 @@
+package com.personal.marketnote.community.adapter.out.persistence.product;
+
+import com.personal.marketnote.common.adapter.out.PersistenceAdapter;
+import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.community.adapter.out.persistence.product.entity.ProductReadModelJpaEntity;
+import com.personal.marketnote.community.adapter.out.persistence.product.repository.ProductReadModelJpaRepository;
+import com.personal.marketnote.community.port.out.product.FindProductByPricePolicyPort;
+import com.personal.marketnote.community.port.out.product.SaveProductReadModelPort;
+import com.personal.marketnote.community.port.out.result.product.ProductInfoResult;
+import com.personal.marketnote.community.port.out.result.product.ProductPricePolicyInfoResult;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@Slf4j
+@PersistenceAdapter
+@RequiredArgsConstructor
+public class ProductReadModelPersistenceAdapter implements FindProductByPricePolicyPort, SaveProductReadModelPort {
+    private final ProductReadModelJpaRepository productReadModelJpaRepository;
+
+    @Override
+    public Map<Long, ProductInfoResult> findByPricePolicyIds(List<Long> pricePolicyIds) {
+        if (FormatValidator.hasNoValue(pricePolicyIds)) {
+            return Map.of();
+        }
+
+        List<ProductReadModelJpaEntity> entities =
+                productReadModelJpaRepository.findByPricePolicyIdInAndStatus(pricePolicyIds, EntityStatus.ACTIVE);
+
+        Map<Long, ProductInfoResult> result = new HashMap<>();
+        for (ProductReadModelJpaEntity entity : entities) {
+            ProductPricePolicyInfoResult pricePolicy = new ProductPricePolicyInfoResult(
+                    entity.getPricePolicyId(),
+                    entity.getPrice(),
+                    entity.getDiscountPrice(),
+                    null,
+                    entity.getAccumulatedPoint()
+            );
+
+            ProductInfoResult productInfo = new ProductInfoResult(
+                    entity.getSellerId(),
+                    entity.getName(),
+                    entity.getBrandName(),
+                    pricePolicy,
+                    List.of(),
+                    null
+            );
+
+            result.put(entity.getPricePolicyId(), productInfo);
+        }
+
+        return result;
+    }
+
+    @Override
+    @Transactional(isolation = READ_COMMITTED)
+    public void upsert(Long pricePolicyId, Long productId, Long sellerId, String name,
+                       String brandName, Long price, Long discountPrice, Long accumulatedPoint) {
+        Optional<ProductReadModelJpaEntity> existing =
+                productReadModelJpaRepository.findByPricePolicyId(pricePolicyId);
+
+        if (existing.isPresent()) {
+            existing.get().updateFrom(productId, sellerId, name, brandName, price, discountPrice, accumulatedPoint);
+            return;
+        }
+
+        try {
+            ProductReadModelJpaEntity entity = ProductReadModelJpaEntity.of(
+                    pricePolicyId, productId, sellerId, name, brandName, price, discountPrice, accumulatedPoint
+            );
+            productReadModelJpaRepository.saveAndFlush(entity);
+        } catch (DataIntegrityViolationException e) {
+            log.info("상품 Read Model 중복 저장 (멱등 처리). pricePolicyId={}", pricePolicyId);
+            productReadModelJpaRepository.findByPricePolicyId(pricePolicyId)
+                    .ifPresent(entity -> entity.updateFrom(productId, sellerId, name, brandName, price, discountPrice, accumulatedPoint));
+        }
+    }
+
+    @Override
+    @Transactional(isolation = READ_COMMITTED)
+    public void deactivateByPricePolicyId(Long pricePolicyId) {
+        productReadModelJpaRepository.findByPricePolicyId(pricePolicyId)
+                .ifPresent(ProductReadModelJpaEntity::markInactive);
+    }
+}

--- a/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/out/persistence/product/entity/ProductReadModelJpaEntity.java
+++ b/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/out/persistence/product/entity/ProductReadModelJpaEntity.java
@@ -1,0 +1,70 @@
+package com.personal.marketnote.community.adapter.out.persistence.product.entity;
+
+import com.personal.marketnote.common.adapter.out.persistence.audit.BaseGeneralEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(
+        name = "product_read_models",
+        uniqueConstraints = @UniqueConstraint(name = "uk_product_read_model_price_policy_id", columnNames = "pricePolicyId")
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+@Getter
+public class ProductReadModelJpaEntity extends BaseGeneralEntity {
+
+    @Column(nullable = false, unique = true)
+    private Long pricePolicyId;
+
+    @Column(nullable = false)
+    private Long productId;
+
+    @Column(nullable = false)
+    private Long sellerId;
+
+    @Column(nullable = false, length = 255)
+    private String name;
+
+    @Column(length = 255)
+    private String brandName;
+
+    private Long price;
+
+    private Long discountPrice;
+
+    private Long accumulatedPoint;
+
+    public static ProductReadModelJpaEntity of(
+            Long pricePolicyId, Long productId, Long sellerId, String name,
+            String brandName, Long price, Long discountPrice, Long accumulatedPoint
+    ) {
+        return ProductReadModelJpaEntity.builder()
+                .pricePolicyId(pricePolicyId)
+                .productId(productId)
+                .sellerId(sellerId)
+                .name(name)
+                .brandName(brandName)
+                .price(price)
+                .discountPrice(discountPrice)
+                .accumulatedPoint(accumulatedPoint)
+                .build();
+    }
+
+    public void updateFrom(Long productId, Long sellerId, String name,
+                           String brandName, Long price, Long discountPrice, Long accumulatedPoint) {
+        this.productId = productId;
+        this.sellerId = sellerId;
+        this.name = name;
+        this.brandName = brandName;
+        this.price = price;
+        this.discountPrice = discountPrice;
+        this.accumulatedPoint = accumulatedPoint;
+        activate();
+    }
+
+    public void markInactive() {
+        deactivate();
+    }
+}

--- a/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/out/persistence/product/repository/ProductReadModelJpaRepository.java
+++ b/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/out/persistence/product/repository/ProductReadModelJpaRepository.java
@@ -1,0 +1,17 @@
+package com.personal.marketnote.community.adapter.out.persistence.product.repository;
+
+import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.community.adapter.out.persistence.product.entity.ProductReadModelJpaEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ProductReadModelJpaRepository extends JpaRepository<ProductReadModelJpaEntity, Long> {
+
+    Optional<ProductReadModelJpaEntity> findByPricePolicyId(Long pricePolicyId);
+
+    List<ProductReadModelJpaEntity> findByPricePolicyIdInAndStatus(List<Long> pricePolicyIds, EntityStatus status);
+
+    List<ProductReadModelJpaEntity> findByProductId(Long productId);
+}

--- a/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/out/web/product/ProductServiceClient.java
+++ b/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/out/web/product/ProductServiceClient.java
@@ -1,51 +1,23 @@
 package com.personal.marketnote.community.adapter.out.web.product;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
 import com.personal.marketnote.common.adapter.out.ServiceAdapter;
-import com.personal.marketnote.common.exception.ProductServiceRequestFailedException;
 import com.personal.marketnote.common.security.hmac.HmacServiceAuthHeaderBuilder;
-import com.personal.marketnote.common.utility.FormatValidator;
-import com.personal.marketnote.community.adapter.out.web.product.response.OrderedProductsResponse;
-import com.personal.marketnote.community.adapter.out.web.product.response.ProductsInfoResponse;
-import com.personal.marketnote.community.domain.servicecommunication.CommunityServiceCommunicationSenderType;
-import com.personal.marketnote.community.domain.servicecommunication.CommunityServiceCommunicationTargetType;
-import com.personal.marketnote.community.domain.servicecommunication.CommunityServiceCommunicationType;
-import com.personal.marketnote.community.port.out.product.FindProductByPricePolicyPort;
-import com.personal.marketnote.community.port.out.result.product.ProductInfoResult;
 import com.personal.marketnote.community.utility.ServiceCommunicationPayloadGenerator;
 import com.personal.marketnote.community.utility.ServiceCommunicationRecorder;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.core.ParameterizedTypeReference;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.RestClient;
-import org.springframework.web.util.UriComponentsBuilder;
 
-import java.io.IOException;
-import java.net.URI;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ThreadLocalRandom;
-
-import static com.personal.marketnote.common.utility.ApiConstant.INTER_SERVER_DEFAULT_RETRIAL_PENDING_MILLI_SECOND;
-import static com.personal.marketnote.common.utility.ApiConstant.INTER_SERVER_MAX_REQUEST_COUNT;
-
+/**
+ * 상품 서비스 HTTP 클라이언트
+ *
+ * <p>FindProductByPricePolicyPort 구현을 ProductReadModelPersistenceAdapter로 이관하여
+ * findByPricePolicyIds() 메서드를 제거했습니다.
+ * 향후 다른 상품 서비스 API 호출이 필요하면 이 클래스에 추가합니다.</p>
+ */
 @ServiceAdapter
 @Slf4j
-public class ProductServiceClient implements FindProductByPricePolicyPort {
-    private static final CommunityServiceCommunicationTargetType TARGET_TYPE =
-            CommunityServiceCommunicationTargetType.PRODUCT_INFO;
-    private static final CommunityServiceCommunicationSenderType REQUEST_SENDER =
-            CommunityServiceCommunicationSenderType.COMMUNITY;
-    private static final CommunityServiceCommunicationSenderType RESPONSE_SENDER =
-            CommunityServiceCommunicationSenderType.PRODUCT;
-    private static final ParameterizedTypeReference<BaseResponse<OrderedProductsResponse>> RESPONSE_TYPE =
-            new ParameterizedTypeReference<>() {
-            };
-
+public class ProductServiceClient {
     private final RestClient restClient;
     private final String productServiceBaseUrl;
     private final HmacServiceAuthHeaderBuilder hmacServiceAuthHeaderBuilder;
@@ -64,168 +36,5 @@ public class ProductServiceClient implements FindProductByPricePolicyPort {
         this.hmacServiceAuthHeaderBuilder = hmacServiceAuthHeaderBuilder;
         this.serviceCommunicationRecorder = serviceCommunicationRecorder;
         this.serviceCommunicationPayloadGenerator = serviceCommunicationPayloadGenerator;
-    }
-
-    @Override
-    public Map<Long, ProductInfoResult> findByPricePolicyIds(List<Long> pricePolicyIds) {
-        if (FormatValidator.hasNoValue(pricePolicyIds)) {
-            return Map.of();
-        }
-
-        URI uri = UriComponentsBuilder.fromUriString(productServiceBaseUrl)
-                .path("/api/v1/products")
-                .queryParam("pricePolicyIds", pricePolicyIds.toArray())
-                .queryParam("pageSize", pricePolicyIds.size())
-                .build()
-                .toUri();
-
-        return sendRequest(uri);
-    }
-
-    private Map<Long, ProductInfoResult> sendRequest(URI uri) {
-        Exception lastError = new Exception();
-
-        for (int i = 0; i < INTER_SERVER_MAX_REQUEST_COUNT; i++) {
-            int attempt = i + 1;
-            try {
-                ResponseEntity<BaseResponse<OrderedProductsResponse>> responseEntity = restClient.get()
-                        .uri(uri)
-                        .headers(headers -> hmacServiceAuthHeaderBuilder.applyHeaders(headers, "GET", uri.getPath()))
-                        .retrieve()
-                        .toEntity(RESPONSE_TYPE);
-
-                if (responseEntity.getStatusCode().isError()) {
-                    throw new ProductServiceRequestFailedException(
-                            new IOException("Product service returned error: " + responseEntity.getStatusCode()));
-                }
-
-                Map<Long, ProductInfoResult> productInfoResultsByPricePolicyId = new HashMap<>();
-                List<ProductsInfoResponse> productsInfo = unboxResponse(responseEntity);
-                generateResult(productInfoResultsByPricePolicyId, productsInfo);
-
-                return productInfoResultsByPricePolicyId;
-            } catch (Exception e) {
-                String exception = e.getClass().getSimpleName();
-                JsonNode requestPayloadJson = serviceCommunicationPayloadGenerator.buildRequestPayloadJson(
-                        HttpMethod.GET,
-                        uri,
-                        null,
-                        attempt
-                );
-                String requestPayload = requestPayloadJson.toString();
-                JsonNode responsePayloadJson = serviceCommunicationPayloadGenerator.buildErrorPayloadJson(
-                        exception,
-                        e.getMessage(),
-                        attempt
-                );
-                String responsePayload = responsePayloadJson.toString();
-                recordCommunication(
-                        TARGET_TYPE,
-                        null,
-                        CommunityServiceCommunicationType.REQUEST,
-                        requestPayload,
-                        requestPayloadJson,
-                        exception
-                );
-                recordCommunication(
-                        TARGET_TYPE,
-                        null,
-                        CommunityServiceCommunicationType.RESPONSE,
-                        responsePayload,
-                        responsePayloadJson,
-                        exception
-                );
-
-                log.warn(e.getMessage(), e);
-                if (i == INTER_SERVER_MAX_REQUEST_COUNT - 1) {
-                    lastError = e;
-                }
-
-                if (i < INTER_SERVER_MAX_REQUEST_COUNT - 1) {
-                    sleepWithJitter();
-                }
-            }
-        }
-
-        log.error("Failed to fetch product info from product-service: {} with error: {}", uri, lastError.getMessage(), lastError);
-        return Map.of();
-    }
-
-    private List<ProductsInfoResponse> unboxResponse(ResponseEntity<BaseResponse<OrderedProductsResponse>> responseEntity) {
-        BaseResponse<OrderedProductsResponse> body = responseEntity.getBody();
-        if (FormatValidator.hasNoValue(body)) {
-            return List.of();
-        }
-
-        OrderedProductsResponse content = body.getContent();
-        if (FormatValidator.hasNoValue(content)) {
-            return List.of();
-        }
-
-        if (FormatValidator.hasNoValue(content.products())) {
-            return List.of();
-        }
-
-        return content.products().items();
-    }
-
-    private void generateResult(Map<Long, ProductInfoResult> productInfoResult, List<ProductsInfoResponse> productsInfo) {
-        for (ProductsInfoResponse productInfo : productsInfo) {
-            if (FormatValidator.hasNoValue(productInfo) || FormatValidator.hasNoValue(productInfo.pricePolicy())) {
-                continue;
-            }
-
-            Long policyId = productInfo.getPricePolicyId();
-            if (FormatValidator.hasNoValue(policyId) || productInfoResult.containsKey(policyId)) {
-                continue;
-            }
-
-            productInfoResult.put(
-                    policyId,
-                    new ProductInfoResult(
-                            productInfo.sellerId(),
-                            productInfo.name(),
-                            productInfo.brandName(),
-                            productInfo.pricePolicy(),
-                            productInfo.selectedOptions(),
-                            productInfo.catalogImage()
-                    )
-            );
-        }
-    }
-
-    private void sleepWithJitter() {
-        try {
-            long jitteredSleepMillis = ThreadLocalRandom.current()
-                    .nextLong(Math.max(1L, INTER_SERVER_DEFAULT_RETRIAL_PENDING_MILLI_SECOND) + 1);
-            Thread.sleep(jitteredSleepMillis);
-        } catch (InterruptedException ie) {
-            Thread.currentThread().interrupt();
-        }
-    }
-
-    private void recordCommunication(
-            CommunityServiceCommunicationTargetType targetType,
-            String targetId,
-            CommunityServiceCommunicationType communicationType,
-            String payload,
-            JsonNode payloadJson,
-            String exception
-    ) {
-        if (FormatValidator.hasNoValue(exception)) {
-            return;
-        }
-
-        CommunityServiceCommunicationSenderType sender =
-                communicationType == CommunityServiceCommunicationType.REQUEST ? REQUEST_SENDER : RESPONSE_SENDER;
-        serviceCommunicationRecorder.record(
-                targetType,
-                communicationType,
-                sender,
-                targetId,
-                payload,
-                payloadJson,
-                exception
-        );
     }
 }

--- a/community-service/community-adapters/src/test/java/com/personal/marketnote/community/adapter/out/web/product/ProductServiceClientTest.java
+++ b/community-service/community-adapters/src/test/java/com/personal/marketnote/community/adapter/out/web/product/ProductServiceClientTest.java
@@ -1,161 +1,20 @@
 package com.personal.marketnote.community.adapter.out.web.product;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.personal.marketnote.common.security.hmac.HmacServiceAuthHeaderBuilder;
-import com.personal.marketnote.common.utility.http.client.restclient.RestClientErrorHandler;
-import com.personal.marketnote.community.port.out.result.product.ProductInfoResult;
-import com.personal.marketnote.community.utility.ServiceCommunicationPayloadGenerator;
-import com.personal.marketnote.community.utility.ServiceCommunicationRecorder;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.MediaType;
-import org.springframework.test.web.client.MockRestServiceServer;
-import org.springframework.web.client.RestClient;
-
-import java.util.List;
-import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.lenient;
-import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
-import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
-import static org.springframework.test.web.client.response.MockRestResponseCreators.withServerError;
-import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 
-@ExtendWith(MockitoExtension.class)
+/**
+ * ProductServiceClient는 FindProductByPricePolicyPort 구현을
+ * ProductReadModelPersistenceAdapter로 이관하여 현재 비즈니스 메서드가 없습니다.
+ * 향후 새로운 HTTP 기반 메서드 추가 시 테스트를 작성합니다.
+ */
 class ProductServiceClientTest {
 
-    private static final String BASE_URL = "http://localhost:8081";
-    private static final ObjectMapper objectMapper = new ObjectMapper();
-
-    private MockRestServiceServer mockServer;
-    private ProductServiceClient productServiceClient;
-
-    @Mock
-    private HmacServiceAuthHeaderBuilder hmacServiceAuthHeaderBuilder;
-
-    @Mock
-    private ServiceCommunicationRecorder serviceCommunicationRecorder;
-
-    @Mock
-    private ServiceCommunicationPayloadGenerator serviceCommunicationPayloadGenerator;
-
-    @BeforeEach
-    void setUp() {
-        RestClient.Builder builder = RestClient.builder()
-                .defaultStatusHandler(RestClientErrorHandler::isError, RestClientErrorHandler.noOpErrorHandler());
-        mockServer = MockRestServiceServer.bindTo(builder).build();
-        productServiceClient = new ProductServiceClient(
-                builder,
-                BASE_URL,
-                hmacServiceAuthHeaderBuilder,
-                serviceCommunicationRecorder,
-                serviceCommunicationPayloadGenerator
-        );
-
-        lenient().when(serviceCommunicationPayloadGenerator.buildRequestPayloadJson(any(), any(), any(), anyInt()))
-                .thenReturn(objectMapper.createObjectNode());
-        lenient().when(serviceCommunicationPayloadGenerator.buildErrorPayloadJson(anyString(), any(), anyInt()))
-                .thenReturn(objectMapper.createObjectNode());
-    }
-
-    @Nested
-    @DisplayName("findByPricePolicyIds")
-    class FindByPricePolicyIds {
-
-        @Test
-        @DisplayName("상품 정보 조회에 성공하면 가격정책ID별 ProductInfoResult Map을 반환한다")
-        void shouldReturnProductInfoMapWhenRequestSucceeds() {
-            mockServer.expect(requestTo(BASE_URL + "/api/v1/products?pricePolicyIds=1&pricePolicyIds=2&pageSize=2"))
-                    .andExpect(method(HttpMethod.GET))
-                    .andRespond(withSuccess("""
-                            {
-                                "content": {
-                                    "products": {
-                                        "items": [
-                                            {
-                                                "sellerId": 10,
-                                                "name": "테스트 상품",
-                                                "brandName": "테스트 브랜드",
-                                                "pricePolicy": {
-                                                    "id": 1,
-                                                    "price": 10000,
-                                                    "discountPrice": 8000,
-                                                    "discountRate": 20.0,
-                                                    "accumulatedPoint": 100
-                                                },
-                                                "selectedOptions": [],
-                                                "catalogImage": null
-                                            }
-                                        ],
-                                        "nextCursor": null
-                                    }
-                                }
-                            }
-                            """, MediaType.APPLICATION_JSON));
-
-            Map<Long, ProductInfoResult> result = productServiceClient.findByPricePolicyIds(List.of(1L, 2L));
-
-            assertThat(result).hasSize(1);
-            assertThat(result.get(1L).name()).isEqualTo("테스트 상품");
-            assertThat(result.get(1L).sellerId()).isEqualTo(10L);
-
-            mockServer.verify();
-        }
-
-        @Test
-        @DisplayName("응답에 상품이 없으면 빈 Map을 반환한다")
-        void shouldReturnEmptyMapWhenNoProducts() {
-            mockServer.expect(requestTo(BASE_URL + "/api/v1/products?pricePolicyIds=1&pageSize=1"))
-                    .andExpect(method(HttpMethod.GET))
-                    .andRespond(withSuccess("""
-                            {"content": {"products": {"items": [], "nextCursor": null}}}
-                            """, MediaType.APPLICATION_JSON));
-
-            Map<Long, ProductInfoResult> result = productServiceClient.findByPricePolicyIds(List.of(1L));
-
-            assertThat(result).isEmpty();
-
-            mockServer.verify();
-        }
-
-        @Test
-        @DisplayName("pricePolicyIds가 비어있으면 요청 없이 빈 Map을 반환한다")
-        void shouldReturnEmptyMapWhenPricePolicyIdsEmpty() {
-            Map<Long, ProductInfoResult> result = productServiceClient.findByPricePolicyIds(List.of());
-
-            assertThat(result).isEmpty();
-        }
-
-        @Test
-        @DisplayName("pricePolicyIds가 null이면 요청 없이 빈 Map을 반환한다")
-        void shouldReturnEmptyMapWhenPricePolicyIdsNull() {
-            Map<Long, ProductInfoResult> result = productServiceClient.findByPricePolicyIds(null);
-
-            assertThat(result).isEmpty();
-        }
-
-        @Test
-        @DisplayName("모든 재시도가 실패하면 빈 Map을 반환한다")
-        void shouldReturnEmptyMapWhenAllRetriesFail() {
-            for (int i = 0; i < 5; i++) {
-                mockServer.expect(requestTo(BASE_URL + "/api/v1/products?pricePolicyIds=1&pageSize=1"))
-                        .andExpect(method(HttpMethod.GET))
-                        .andRespond(withServerError());
-            }
-
-            Map<Long, ProductInfoResult> result = productServiceClient.findByPricePolicyIds(List.of(1L));
-
-            assertThat(result).isEmpty();
-
-            mockServer.verify();
-        }
+    @Test
+    @DisplayName("ProductServiceClient 테스트 플레이스홀더")
+    void placeholder() {
+        assertThat(true).isTrue();
     }
 }

--- a/community-service/community-application/src/main/java/com/personal/marketnote/community/port/out/product/SaveProductReadModelPort.java
+++ b/community-service/community-application/src/main/java/com/personal/marketnote/community/port/out/product/SaveProductReadModelPort.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.community.port.out.product;
+
+public interface SaveProductReadModelPort {
+
+    void upsert(Long pricePolicyId, Long productId, Long sellerId, String name, String brandName,
+                Long price, Long discountPrice, Long accumulatedPoint);
+
+    void deactivateByPricePolicyId(Long pricePolicyId);
+}


### PR DESCRIPTION
## partially addresses #300
## resolves #1644

## Task
- [x] 상품 정보 Read Model JPA 엔티티 + 테이블 생성 (community-adapters)
- [x] ProductRegisteredReadModelConsumer 구현 (product.product.registered 소비)
- [x] ProductUpdatedReadModelConsumer 구현 (product.product.updated 소비)
- [x] ProductReadModelPersistenceAdapter 구현 (FindProductByPricePolicyPort 구현체 교체)
- [x] ProductServiceClient.findByPricePolicyIds() 제거