### PR TITLE
[#128][#1649] feat: 상품 서비스 리뷰 집계 Read Model 구축

### DIFF
--- a/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/event/ReviewRegisteredCommerceConsumerTest.java
+++ b/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/event/ReviewRegisteredCommerceConsumerTest.java
@@ -38,7 +38,7 @@ class ReviewRegisteredCommerceConsumerTest {
     private Acknowledgment acknowledgment;
 
     private ConsumerRecord<String, EventEnvelope<?>> buildRecord(Long orderId, Long pricePolicyId) {
-        ReviewRegisteredEvent event = new ReviewRegisteredEvent(orderId, pricePolicyId);
+        ReviewRegisteredEvent event = new ReviewRegisteredEvent(orderId, pricePolicyId, null, null, null);
         EventEnvelope<ReviewRegisteredEvent> envelope = new EventEnvelope<>(
                 "test-event-id", "community.review.registered", "community-service",
                 LocalDateTime.of(2026, 3, 2, 10, 0), event
@@ -116,7 +116,7 @@ class ReviewRegisteredCommerceConsumerTest {
     @DisplayName("eventType이 불일치하면 UseCase를 호출하지 않고 acknowledge한다")
     void handleReviewRegisteredEvent_eventTypeMismatch_skipsAndAcknowledges() {
         // given
-        ReviewRegisteredEvent event = new ReviewRegisteredEvent(1L, 2L);
+        ReviewRegisteredEvent event = new ReviewRegisteredEvent(1L, 2L, null, null, null);
         EventEnvelope<ReviewRegisteredEvent> envelope = new EventEnvelope<>(
                 "test-event-id", "wrong.event.type", "community-service",
                 LocalDateTime.of(2026, 3, 2, 10, 0), event

--- a/common/src/main/java/com/personal/marketnote/common/kafka/KafkaTopicConstants.java
+++ b/common/src/main/java/com/personal/marketnote/common/kafka/KafkaTopicConstants.java
@@ -25,6 +25,8 @@ public final class KafkaTopicConstants {
 
     // Community 이벤트
     public static final String REVIEW_REGISTERED = "community.review.registered";
+    public static final String REVIEW_UPDATED = "community.review.updated";
+    public static final String REVIEW_DELETED = "community.review.deleted";
 
     // File 이벤트
     public static final String FILE_IMAGE_CHANGED = "file.image.changed";

--- a/common/src/main/java/com/personal/marketnote/common/kafka/event/ReviewDeletedEvent.java
+++ b/common/src/main/java/com/personal/marketnote/common/kafka/event/ReviewDeletedEvent.java
@@ -1,8 +1,7 @@
 package com.personal.marketnote.common.kafka.event;
 
-public record ReviewRegisteredEvent(
-        Long orderId,
-        Long pricePolicyId,
+public record ReviewDeletedEvent(
+        Long reviewId,
         Long productId,
         Integer totalCount,
         Float averageRating

--- a/common/src/main/java/com/personal/marketnote/common/kafka/event/ReviewUpdatedEvent.java
+++ b/common/src/main/java/com/personal/marketnote/common/kafka/event/ReviewUpdatedEvent.java
@@ -1,8 +1,7 @@
 package com.personal.marketnote.common.kafka.event;
 
-public record ReviewRegisteredEvent(
-        Long orderId,
-        Long pricePolicyId,
+public record ReviewUpdatedEvent(
+        Long reviewId,
         Long productId,
         Integer totalCount,
         Float averageRating

--- a/common/src/test/java/com/personal/marketnote/common/kafka/event/KafkaMessageSerializationSchemaCompatibilityTest.java
+++ b/common/src/test/java/com/personal/marketnote/common/kafka/event/KafkaMessageSerializationSchemaCompatibilityTest.java
@@ -191,7 +191,7 @@ class KafkaMessageSerializationSchemaCompatibilityTest {
         @DisplayName("ReviewRegisteredEvent를 EventEnvelope에 담아 직렬화/역직렬화 라운드트립 시 모든 필드가 보존된다")
         void reviewRegisteredEvent_roundTrip_preservesAllFields() throws Exception {
             // given
-            ReviewRegisteredEvent event = new ReviewRegisteredEvent(50L, 60L);
+            ReviewRegisteredEvent event = new ReviewRegisteredEvent(50L, 60L, 100L, 10, 4.5f);
             EventEnvelope<ReviewRegisteredEvent> envelope = EventEnvelope.of(
                     "community.review.registered", "community-service", event, FIXED_CLOCK);
 
@@ -202,6 +202,9 @@ class KafkaMessageSerializationSchemaCompatibilityTest {
             ReviewRegisteredEvent result = deserialized.getPayloadAs(ReviewRegisteredEvent.class, OBJECT_MAPPER);
             assertThat(result.orderId()).isEqualTo(50L);
             assertThat(result.pricePolicyId()).isEqualTo(60L);
+            assertThat(result.productId()).isEqualTo(100L);
+            assertThat(result.totalCount()).isEqualTo(10);
+            assertThat(result.averageRating()).isEqualTo(4.5f);
         }
 
         @Test

--- a/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/out/event/CommunityEventKafkaProducer.java
+++ b/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/out/event/CommunityEventKafkaProducer.java
@@ -4,7 +4,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.personal.marketnote.common.adapter.out.ServiceAdapter;
 import com.personal.marketnote.common.kafka.KafkaTopicConstants;
 import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.ReviewDeletedEvent;
 import com.personal.marketnote.common.kafka.event.ReviewRegisteredEvent;
+import com.personal.marketnote.common.kafka.event.ReviewUpdatedEvent;
 import com.personal.marketnote.common.outbox.OutboxEvent;
 import com.personal.marketnote.common.outbox.SaveOutboxEventPort;
 import com.personal.marketnote.community.port.out.event.PublishReviewEventPort;
@@ -24,23 +26,45 @@ public class CommunityEventKafkaProducer implements PublishReviewEventPort {
     private final Clock clock;
 
     @Override
-    public void publishReviewRegisteredEvent(Long orderId, Long pricePolicyId) {
-        ReviewRegisteredEvent payload = new ReviewRegisteredEvent(orderId, pricePolicyId);
+    public void publishReviewRegisteredEvent(Long orderId, Long pricePolicyId, Long productId, Integer totalCount, Float averageRating) {
+        ReviewRegisteredEvent payload = new ReviewRegisteredEvent(orderId, pricePolicyId, productId, totalCount, averageRating);
         String topic = KafkaTopicConstants.REVIEW_REGISTERED;
         EventEnvelope<ReviewRegisteredEvent> envelope = EventEnvelope.of(topic, SOURCE, payload, clock);
 
+        saveOutboxEvent(topic, orderId.toString(), envelope);
+    }
+
+    @Override
+    public void publishReviewUpdatedEvent(Long reviewId, Long productId, Integer totalCount, Float averageRating) {
+        ReviewUpdatedEvent payload = new ReviewUpdatedEvent(reviewId, productId, totalCount, averageRating);
+        String topic = KafkaTopicConstants.REVIEW_UPDATED;
+        EventEnvelope<ReviewUpdatedEvent> envelope = EventEnvelope.of(topic, SOURCE, payload, clock);
+
+        saveOutboxEvent(topic, productId.toString(), envelope);
+    }
+
+    @Override
+    public void publishReviewDeletedEvent(Long reviewId, Long productId, Integer totalCount, Float averageRating) {
+        ReviewDeletedEvent payload = new ReviewDeletedEvent(reviewId, productId, totalCount, averageRating);
+        String topic = KafkaTopicConstants.REVIEW_DELETED;
+        EventEnvelope<ReviewDeletedEvent> envelope = EventEnvelope.of(topic, SOURCE, payload, clock);
+
+        saveOutboxEvent(topic, productId.toString(), envelope);
+    }
+
+    private <T> void saveOutboxEvent(String topic, String partitionKey, EventEnvelope<T> envelope) {
         try {
             String payloadJson = objectMapper.writeValueAsString(envelope);
             OutboxEvent outboxEvent = OutboxEvent.of(
-                    envelope.eventId(), topic, orderId.toString(),
+                    envelope.eventId(), topic, partitionKey,
                     envelope.eventType(), SOURCE, payloadJson, clock
             );
             saveOutboxEventPort.save(outboxEvent);
-            log.info("Outbox 이벤트 저장. topic={}, orderId={}, eventId={}",
-                    topic, orderId, envelope.eventId());
+            log.info("Outbox 이벤트 저장. topic={}, partitionKey={}, eventId={}",
+                    topic, partitionKey, envelope.eventId());
         } catch (Exception e) {
-            log.error("Outbox 이벤트 저장 실패. topic={}, orderId={}, error={}",
-                    topic, orderId, e.getMessage(), e);
+            log.error("Outbox 이벤트 저장 실패. topic={}, partitionKey={}, error={}",
+                    topic, partitionKey, e.getMessage(), e);
         }
     }
 }

--- a/community-service/community-adapters/src/test/java/com/personal/marketnote/community/adapter/out/event/CommunityEventKafkaProducerTest.java
+++ b/community-service/community-adapters/src/test/java/com/personal/marketnote/community/adapter/out/event/CommunityEventKafkaProducerTest.java
@@ -3,7 +3,9 @@ package com.personal.marketnote.community.adapter.out.event;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.personal.marketnote.common.kafka.KafkaTopicConstants;
 import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.ReviewDeletedEvent;
 import com.personal.marketnote.common.kafka.event.ReviewRegisteredEvent;
+import com.personal.marketnote.common.kafka.event.ReviewUpdatedEvent;
 import com.personal.marketnote.common.outbox.OutboxEvent;
 import com.personal.marketnote.common.outbox.SaveOutboxEventPort;
 import org.junit.jupiter.api.DisplayName;
@@ -51,7 +53,7 @@ class CommunityEventKafkaProducerTest {
         when(objectMapper.writeValueAsString(any())).thenReturn("{}");
 
         // when
-        communityEventKafkaProducer.publishReviewRegisteredEvent(1L, 2L);
+        communityEventKafkaProducer.publishReviewRegisteredEvent(1L, 2L, 50L, 10, 4.5f);
 
         // then
         ArgumentCaptor<OutboxEvent> outboxCaptor = ArgumentCaptor.forClass(OutboxEvent.class);
@@ -65,7 +67,7 @@ class CommunityEventKafkaProducerTest {
     }
 
     @Test
-    @DisplayName("리뷰 등록 이벤트 발행 시 EventEnvelope에 올바른 페이로드(orderId, pricePolicyId)가 포함된다")
+    @DisplayName("리뷰 등록 이벤트 발행 시 EventEnvelope에 올바른 페이로드가 포함된다")
     @SuppressWarnings("unchecked")
     void publishReviewRegisteredEvent_envelopeContainsCorrectPayload() throws Exception {
         // given
@@ -73,7 +75,7 @@ class CommunityEventKafkaProducerTest {
         when(objectMapper.writeValueAsString(any())).thenReturn("{}");
 
         // when
-        communityEventKafkaProducer.publishReviewRegisteredEvent(10L, 20L);
+        communityEventKafkaProducer.publishReviewRegisteredEvent(10L, 20L, 50L, 5, 4.2f);
 
         // then
         ArgumentCaptor<EventEnvelope> envelopeCaptor = ArgumentCaptor.forClass(EventEnvelope.class);
@@ -88,5 +90,102 @@ class CommunityEventKafkaProducerTest {
         ReviewRegisteredEvent payload = (ReviewRegisteredEvent) capturedEnvelope.payload();
         assertThat(payload.orderId()).isEqualTo(10L);
         assertThat(payload.pricePolicyId()).isEqualTo(20L);
+        assertThat(payload.productId()).isEqualTo(50L);
+        assertThat(payload.totalCount()).isEqualTo(5);
+        assertThat(payload.averageRating()).isEqualTo(4.2f);
+    }
+
+    @Test
+    @DisplayName("리뷰 수정 이벤트 발행 시 올바른 토픽과 파티션 키(productId)로 Outbox에 저장된다")
+    void publishReviewUpdatedEvent_savesToOutboxWithCorrectTopicAndPartitionKey() throws Exception {
+        // given
+        setUpClock("2026-03-02T10:00:00Z");
+        when(objectMapper.writeValueAsString(any())).thenReturn("{}");
+
+        // when
+        communityEventKafkaProducer.publishReviewUpdatedEvent(1L, 50L, 10, 4.5f);
+
+        // then
+        ArgumentCaptor<OutboxEvent> outboxCaptor = ArgumentCaptor.forClass(OutboxEvent.class);
+        verify(saveOutboxEventPort).save(outboxCaptor.capture());
+
+        OutboxEvent captured = outboxCaptor.getValue();
+        assertThat(captured.getTopic()).isEqualTo(KafkaTopicConstants.REVIEW_UPDATED);
+        assertThat(captured.getPartitionKey()).isEqualTo("50");
+        assertThat(captured.getSource()).isEqualTo("community-service");
+        assertThat(captured.getEventId()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("리뷰 수정 이벤트 발행 시 EventEnvelope에 올바른 페이로드가 포함된다")
+    @SuppressWarnings("unchecked")
+    void publishReviewUpdatedEvent_envelopeContainsCorrectPayload() throws Exception {
+        // given
+        setUpClock("2026-03-02T10:00:00Z");
+        when(objectMapper.writeValueAsString(any())).thenReturn("{}");
+
+        // when
+        communityEventKafkaProducer.publishReviewUpdatedEvent(1L, 50L, 8, 3.9f);
+
+        // then
+        ArgumentCaptor<EventEnvelope> envelopeCaptor = ArgumentCaptor.forClass(EventEnvelope.class);
+        verify(objectMapper).writeValueAsString(envelopeCaptor.capture());
+
+        EventEnvelope<?> capturedEnvelope = envelopeCaptor.getValue();
+        assertThat(capturedEnvelope.eventType()).isEqualTo(KafkaTopicConstants.REVIEW_UPDATED);
+        assertThat(capturedEnvelope.source()).isEqualTo("community-service");
+
+        ReviewUpdatedEvent payload = (ReviewUpdatedEvent) capturedEnvelope.payload();
+        assertThat(payload.reviewId()).isEqualTo(1L);
+        assertThat(payload.productId()).isEqualTo(50L);
+        assertThat(payload.totalCount()).isEqualTo(8);
+        assertThat(payload.averageRating()).isEqualTo(3.9f);
+    }
+
+    @Test
+    @DisplayName("리뷰 삭제 이벤트 발행 시 올바른 토픽과 파티션 키(productId)로 Outbox에 저장된다")
+    void publishReviewDeletedEvent_savesToOutboxWithCorrectTopicAndPartitionKey() throws Exception {
+        // given
+        setUpClock("2026-03-02T10:00:00Z");
+        when(objectMapper.writeValueAsString(any())).thenReturn("{}");
+
+        // when
+        communityEventKafkaProducer.publishReviewDeletedEvent(1L, 50L, 9, 4.1f);
+
+        // then
+        ArgumentCaptor<OutboxEvent> outboxCaptor = ArgumentCaptor.forClass(OutboxEvent.class);
+        verify(saveOutboxEventPort).save(outboxCaptor.capture());
+
+        OutboxEvent captured = outboxCaptor.getValue();
+        assertThat(captured.getTopic()).isEqualTo(KafkaTopicConstants.REVIEW_DELETED);
+        assertThat(captured.getPartitionKey()).isEqualTo("50");
+        assertThat(captured.getSource()).isEqualTo("community-service");
+        assertThat(captured.getEventId()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("리뷰 삭제 이벤트 발행 시 EventEnvelope에 올바른 페이로드가 포함된다")
+    @SuppressWarnings("unchecked")
+    void publishReviewDeletedEvent_envelopeContainsCorrectPayload() throws Exception {
+        // given
+        setUpClock("2026-03-02T10:00:00Z");
+        when(objectMapper.writeValueAsString(any())).thenReturn("{}");
+
+        // when
+        communityEventKafkaProducer.publishReviewDeletedEvent(1L, 50L, 7, 3.8f);
+
+        // then
+        ArgumentCaptor<EventEnvelope> envelopeCaptor = ArgumentCaptor.forClass(EventEnvelope.class);
+        verify(objectMapper).writeValueAsString(envelopeCaptor.capture());
+
+        EventEnvelope<?> capturedEnvelope = envelopeCaptor.getValue();
+        assertThat(capturedEnvelope.eventType()).isEqualTo(KafkaTopicConstants.REVIEW_DELETED);
+        assertThat(capturedEnvelope.source()).isEqualTo("community-service");
+
+        ReviewDeletedEvent payload = (ReviewDeletedEvent) capturedEnvelope.payload();
+        assertThat(payload.reviewId()).isEqualTo(1L);
+        assertThat(payload.productId()).isEqualTo(50L);
+        assertThat(payload.totalCount()).isEqualTo(7);
+        assertThat(payload.averageRating()).isEqualTo(3.8f);
     }
 }

--- a/community-service/community-application/src/main/java/com/personal/marketnote/community/port/out/event/PublishReviewEventPort.java
+++ b/community-service/community-application/src/main/java/com/personal/marketnote/community/port/out/event/PublishReviewEventPort.java
@@ -2,5 +2,9 @@ package com.personal.marketnote.community.port.out.event;
 
 public interface PublishReviewEventPort {
 
-    void publishReviewRegisteredEvent(Long orderId, Long pricePolicyId);
+    void publishReviewRegisteredEvent(Long orderId, Long pricePolicyId, Long productId, Integer totalCount, Float averageRating);
+
+    void publishReviewUpdatedEvent(Long reviewId, Long productId, Integer totalCount, Float averageRating);
+
+    void publishReviewDeletedEvent(Long reviewId, Long productId, Integer totalCount, Float averageRating);
 }

--- a/community-service/community-application/src/main/java/com/personal/marketnote/community/service/review/DeleteReviewService.java
+++ b/community-service/community-application/src/main/java/com/personal/marketnote/community/service/review/DeleteReviewService.java
@@ -1,9 +1,11 @@
 package com.personal.marketnote.community.service.review;
 
 import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.community.domain.review.ProductReviewAggregate;
 import com.personal.marketnote.community.domain.review.Review;
 import com.personal.marketnote.community.port.in.usecase.review.DeleteReviewUseCase;
 import com.personal.marketnote.community.port.in.usecase.review.GetReviewUseCase;
+import com.personal.marketnote.community.port.out.event.PublishReviewEventPort;
 import com.personal.marketnote.community.port.out.review.UpdateReviewPort;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,12 +18,27 @@ import static org.springframework.transaction.annotation.Isolation.READ_COMMITTE
 public class DeleteReviewService implements DeleteReviewUseCase {
     private final GetReviewUseCase getReviewUseCase;
     private final UpdateReviewPort updateReviewPort;
+    private final PublishReviewEventPort publishReviewEventPort;
 
     @Override
     public void deleteReview(Long id, Long reviewerId) {
         getReviewUseCase.validateAuthor(id, reviewerId);
         Review review = getReviewUseCase.getReview(id);
+        Float rating = review.getRating();
+        Long productId = review.getProductId();
         review.delete();
         updateReviewPort.update(review);
+
+        // 상품 평점 집계 업데이트
+        ProductReviewAggregate productReviewAggregate = getReviewUseCase.getProductReviewAggregate(productId);
+        productReviewAggregate.reducePoint(rating.intValue());
+        productReviewAggregate.computeRating(-rating);
+        updateReviewPort.update(productReviewAggregate);
+
+        // 리뷰 삭제 이벤트 발행
+        publishReviewEventPort.publishReviewDeletedEvent(
+                review.getId(), productId,
+                productReviewAggregate.getTotalCount(), productReviewAggregate.getAverageRating()
+        );
     }
 }

--- a/community-service/community-application/src/main/java/com/personal/marketnote/community/service/review/RegisterReviewService.java
+++ b/community-service/community-application/src/main/java/com/personal/marketnote/community/service/review/RegisterReviewService.java
@@ -46,21 +46,24 @@ public class RegisterReviewService implements RegisterReviewUseCase {
         );
 
         // 상품 평점 집계
+        ProductReviewAggregate productReviewAggregate;
         try {
-            ProductReviewAggregate productReviewAggregate = getReviewUseCase.getProductReviewAggregate(productId);
+            productReviewAggregate = getReviewUseCase.getProductReviewAggregate(productId);
             Float point = command.rating();
             productReviewAggregate.addPoint(point.intValue());
             productReviewAggregate.computeRating(point);
             updateReviewPort.update(productReviewAggregate);
         } catch (ProductReviewAggregateNotFoundException pranfe) {
-            saveReviewPort.saveAggregate(
-                    ProductReviewAggregate.from(savedReview)
-            );
+            productReviewAggregate = ProductReviewAggregate.from(savedReview);
+            saveReviewPort.saveAggregate(productReviewAggregate);
         }
 
         // Outbox 이벤트 저장 (트랜잭션 내)
         // [#929][#1038] 주문상품 리뷰 상태 업데이트는 Kafka Consumer(ReviewRegisteredCommerceConsumer)로 전환 완료
-        publishReviewEventPort.publishReviewRegisteredEvent(orderId, pricePolicyId);
+        publishReviewEventPort.publishReviewRegisteredEvent(
+                orderId, pricePolicyId, productId,
+                productReviewAggregate.getTotalCount(), productReviewAggregate.getAverageRating()
+        );
 
         return RegisterReviewResult.from(savedReview);
     }

--- a/community-service/community-application/src/main/java/com/personal/marketnote/community/service/review/UpdateReviewService.java
+++ b/community-service/community-application/src/main/java/com/personal/marketnote/community/service/review/UpdateReviewService.java
@@ -10,6 +10,7 @@ import com.personal.marketnote.community.mapper.ReviewCommandToStateMapper;
 import com.personal.marketnote.community.port.in.command.review.UpdateReviewCommand;
 import com.personal.marketnote.community.port.in.usecase.review.GetReviewUseCase;
 import com.personal.marketnote.community.port.in.usecase.review.UpdateReviewUseCase;
+import com.personal.marketnote.community.port.out.event.PublishReviewEventPort;
 import com.personal.marketnote.community.port.out.review.SaveReviewPort;
 import com.personal.marketnote.community.port.out.review.UpdateReviewPort;
 import lombok.RequiredArgsConstructor;
@@ -24,6 +25,7 @@ public class UpdateReviewService implements UpdateReviewUseCase {
     private final GetReviewUseCase getReviewUseCase;
     private final SaveReviewPort saveReviewPort;
     private final UpdateReviewPort updateReviewPort;
+    private final PublishReviewEventPort publishReviewEventPort;
 
     @Override
     public void updateReview(UpdateReviewCommand command) {
@@ -42,12 +44,17 @@ public class UpdateReviewService implements UpdateReviewUseCase {
                 ReviewVersionHistory.from(reviewVersionHistoryCreateState)
         );
 
-        // 상품 평점 재집계
+        // 상품 평점 재집계 + 이벤트 발행
+        ProductReviewAggregate productReviewAggregate = getReviewUseCase.getProductReviewAggregate(review.getProductId());
         if (FormatValidator.notEquals(previousRating, newRating)) {
-            ProductReviewAggregate productReviewAggregate = getReviewUseCase.getProductReviewAggregate(review.getProductId());
             productReviewAggregate.changePoint(previousRating, newRating);
             productReviewAggregate.computeRating(newRating - previousRating);
             updateReviewPort.update(productReviewAggregate);
         }
+
+        publishReviewEventPort.publishReviewUpdatedEvent(
+                review.getId(), review.getProductId(),
+                productReviewAggregate.getTotalCount(), productReviewAggregate.getAverageRating()
+        );
     }
 }

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/event/ReviewDeletedReadModelConsumer.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/event/ReviewDeletedReadModelConsumer.java
@@ -1,0 +1,63 @@
+package com.personal.marketnote.product.adapter.in.event;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.common.kafka.KafkaTopicConstants;
+import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.EventPayloadValidator;
+import com.personal.marketnote.common.kafka.event.ReviewDeletedEvent;
+import com.personal.marketnote.product.port.out.review.SaveReviewAggregateReadModelPort;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ReviewDeletedReadModelConsumer {
+    private final ObjectMapper objectMapper;
+    private final SaveReviewAggregateReadModelPort saveReviewAggregateReadModelPort;
+
+    @KafkaListener(
+            topics = KafkaTopicConstants.REVIEW_DELETED,
+            groupId = "product-review-aggregate-read-model"
+    )
+    public void handleReviewDeletedEvent(
+            ConsumerRecord<String, EventEnvelope<?>> record,
+            Acknowledgment acknowledgment
+    ) {
+        EventEnvelope<?> envelope = record.value();
+
+        if (EventPayloadValidator.hasInvalidEnvelope(envelope, record)) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        if (EventPayloadValidator.hasEventTypeMismatch(envelope, KafkaTopicConstants.REVIEW_DELETED)) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        ReviewDeletedEvent payload = envelope.getPayloadAs(ReviewDeletedEvent.class, objectMapper);
+
+        log.info("리뷰 삭제 Read Model 이벤트 수신. eventId={}, reviewId={}, productId={}, totalCount={}, averageRating={}",
+                envelope.eventId(), payload.reviewId(), payload.productId(),
+                payload.totalCount(), payload.averageRating());
+
+        if (EventPayloadValidator.hasInvalidIds(envelope.eventId(),
+                EventPayloadValidator.id("reviewId", payload.reviewId()),
+                EventPayloadValidator.id("productId", payload.productId()))) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        saveReviewAggregateReadModelPort.upsert(
+                payload.productId(), payload.totalCount(), payload.averageRating()
+        );
+
+        log.info("리뷰 집계 Read Model 업데이트 완료 (삭제 반영). productId={}", payload.productId());
+        acknowledgment.acknowledge();
+    }
+}

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/event/ReviewRegisteredReadModelConsumer.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/event/ReviewRegisteredReadModelConsumer.java
@@ -1,0 +1,68 @@
+package com.personal.marketnote.product.adapter.in.event;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.common.kafka.KafkaTopicConstants;
+import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.EventPayloadValidator;
+import com.personal.marketnote.common.kafka.event.ReviewRegisteredEvent;
+import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.product.port.out.review.SaveReviewAggregateReadModelPort;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ReviewRegisteredReadModelConsumer {
+    private final ObjectMapper objectMapper;
+    private final SaveReviewAggregateReadModelPort saveReviewAggregateReadModelPort;
+
+    @KafkaListener(
+            topics = KafkaTopicConstants.REVIEW_REGISTERED,
+            groupId = "product-review-aggregate-read-model"
+    )
+    public void handleReviewRegisteredEvent(
+            ConsumerRecord<String, EventEnvelope<?>> record,
+            Acknowledgment acknowledgment
+    ) {
+        EventEnvelope<?> envelope = record.value();
+
+        if (EventPayloadValidator.hasInvalidEnvelope(envelope, record)) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        if (EventPayloadValidator.hasEventTypeMismatch(envelope, KafkaTopicConstants.REVIEW_REGISTERED)) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        ReviewRegisteredEvent payload = envelope.getPayloadAs(ReviewRegisteredEvent.class, objectMapper);
+
+        log.info("리뷰 등록 Read Model 이벤트 수신. eventId={}, productId={}, totalCount={}, averageRating={}",
+                envelope.eventId(), payload.productId(), payload.totalCount(), payload.averageRating());
+
+        if (FormatValidator.hasNoValue(payload.productId()) || payload.productId() <= 0) {
+            log.warn("productId가 없는 기존 이벤트 무시. eventId={}", envelope.eventId());
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        if (FormatValidator.hasNoValue(payload.totalCount()) || FormatValidator.hasNoValue(payload.averageRating())) {
+            log.warn("집계 데이터가 없는 이벤트 무시. eventId={}", envelope.eventId());
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        saveReviewAggregateReadModelPort.upsert(
+                payload.productId(), payload.totalCount(), payload.averageRating()
+        );
+
+        log.info("리뷰 집계 Read Model 저장 완료. productId={}", payload.productId());
+        acknowledgment.acknowledge();
+    }
+}

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/event/ReviewUpdatedReadModelConsumer.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/event/ReviewUpdatedReadModelConsumer.java
@@ -1,0 +1,63 @@
+package com.personal.marketnote.product.adapter.in.event;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.common.kafka.KafkaTopicConstants;
+import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.EventPayloadValidator;
+import com.personal.marketnote.common.kafka.event.ReviewUpdatedEvent;
+import com.personal.marketnote.product.port.out.review.SaveReviewAggregateReadModelPort;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ReviewUpdatedReadModelConsumer {
+    private final ObjectMapper objectMapper;
+    private final SaveReviewAggregateReadModelPort saveReviewAggregateReadModelPort;
+
+    @KafkaListener(
+            topics = KafkaTopicConstants.REVIEW_UPDATED,
+            groupId = "product-review-aggregate-read-model"
+    )
+    public void handleReviewUpdatedEvent(
+            ConsumerRecord<String, EventEnvelope<?>> record,
+            Acknowledgment acknowledgment
+    ) {
+        EventEnvelope<?> envelope = record.value();
+
+        if (EventPayloadValidator.hasInvalidEnvelope(envelope, record)) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        if (EventPayloadValidator.hasEventTypeMismatch(envelope, KafkaTopicConstants.REVIEW_UPDATED)) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        ReviewUpdatedEvent payload = envelope.getPayloadAs(ReviewUpdatedEvent.class, objectMapper);
+
+        log.info("리뷰 수정 Read Model 이벤트 수신. eventId={}, reviewId={}, productId={}, totalCount={}, averageRating={}",
+                envelope.eventId(), payload.reviewId(), payload.productId(),
+                payload.totalCount(), payload.averageRating());
+
+        if (EventPayloadValidator.hasInvalidIds(envelope.eventId(),
+                EventPayloadValidator.id("reviewId", payload.reviewId()),
+                EventPayloadValidator.id("productId", payload.productId()))) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        saveReviewAggregateReadModelPort.upsert(
+                payload.productId(), payload.totalCount(), payload.averageRating()
+        );
+
+        log.info("리뷰 집계 Read Model 업데이트 완료. productId={}", payload.productId());
+        acknowledgment.acknowledge();
+    }
+}

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/review/ReviewAggregateReadModelPersistenceAdapter.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/review/ReviewAggregateReadModelPersistenceAdapter.java
@@ -1,0 +1,71 @@
+package com.personal.marketnote.product.adapter.out.persistence.review;
+
+import com.personal.marketnote.common.adapter.out.PersistenceAdapter;
+import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.product.adapter.out.persistence.review.entity.ReviewAggregateReadModelJpaEntity;
+import com.personal.marketnote.product.adapter.out.persistence.review.repository.ReviewAggregateReadModelJpaRepository;
+import com.personal.marketnote.product.port.out.result.ProductReviewAggregateResult;
+import com.personal.marketnote.product.port.out.review.FindProductReviewAggregatesPort;
+import com.personal.marketnote.product.port.out.review.SaveReviewAggregateReadModelPort;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@Slf4j
+@PersistenceAdapter
+@RequiredArgsConstructor
+public class ReviewAggregateReadModelPersistenceAdapter implements FindProductReviewAggregatesPort, SaveReviewAggregateReadModelPort {
+    private final ReviewAggregateReadModelJpaRepository reviewAggregateReadModelJpaRepository;
+
+    @Override
+    public Map<Long, ProductReviewAggregateResult> findByProductIds(List<Long> productIds) {
+        if (FormatValidator.hasNoValue(productIds)) {
+            return Map.of();
+        }
+
+        List<ReviewAggregateReadModelJpaEntity> entities =
+                reviewAggregateReadModelJpaRepository.findByProductIdInAndStatus(productIds, EntityStatus.ACTIVE);
+
+        return entities.stream()
+                .collect(Collectors.toMap(
+                        ReviewAggregateReadModelJpaEntity::getProductId,
+                        entity -> new ProductReviewAggregateResult(
+                                entity.getProductId(),
+                                entity.getTotalCount(),
+                                entity.getAverageRating()
+                        ),
+                        (existing, replacement) -> existing
+                ));
+    }
+
+    @Override
+    @Transactional(isolation = READ_COMMITTED)
+    public void upsert(Long productId, Integer totalCount, Float averageRating) {
+        Optional<ReviewAggregateReadModelJpaEntity> existing =
+                reviewAggregateReadModelJpaRepository.findByProductId(productId);
+
+        if (existing.isPresent()) {
+            existing.get().updateFrom(totalCount, averageRating);
+            return;
+        }
+
+        try {
+            ReviewAggregateReadModelJpaEntity entity =
+                    ReviewAggregateReadModelJpaEntity.of(productId, totalCount, averageRating);
+            reviewAggregateReadModelJpaRepository.saveAndFlush(entity);
+        } catch (DataIntegrityViolationException e) {
+            log.info("리뷰 집계 Read Model 중복 저장 (멱등 처리). productId={}", productId);
+            reviewAggregateReadModelJpaRepository.findByProductId(productId)
+                    .ifPresent(entity -> entity.updateFrom(totalCount, averageRating));
+        }
+    }
+}

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/review/entity/ReviewAggregateReadModelJpaEntity.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/review/entity/ReviewAggregateReadModelJpaEntity.java
@@ -1,0 +1,44 @@
+package com.personal.marketnote.product.adapter.out.persistence.review.entity;
+
+import com.personal.marketnote.common.adapter.out.persistence.audit.BaseGeneralEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(
+        name = "review_aggregate_read_models",
+        uniqueConstraints = @UniqueConstraint(name = "uk_review_aggregate_read_model_product_id", columnNames = "productId")
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+@Getter
+public class ReviewAggregateReadModelJpaEntity extends BaseGeneralEntity {
+
+    @Column(nullable = false, unique = true)
+    private Long productId;
+
+    @Column(nullable = false)
+    private Integer totalCount;
+
+    @Column(nullable = false)
+    private Float averageRating;
+
+    public static ReviewAggregateReadModelJpaEntity of(Long productId, Integer totalCount, Float averageRating) {
+        return ReviewAggregateReadModelJpaEntity.builder()
+                .productId(productId)
+                .totalCount(totalCount)
+                .averageRating(averageRating)
+                .build();
+    }
+
+    public void updateFrom(Integer totalCount, Float averageRating) {
+        this.totalCount = totalCount;
+        this.averageRating = averageRating;
+        activate();
+    }
+
+    public void markInactive() {
+        deactivate();
+    }
+}

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/review/repository/ReviewAggregateReadModelJpaRepository.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/review/repository/ReviewAggregateReadModelJpaRepository.java
@@ -1,0 +1,15 @@
+package com.personal.marketnote.product.adapter.out.persistence.review.repository;
+
+import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.product.adapter.out.persistence.review.entity.ReviewAggregateReadModelJpaEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ReviewAggregateReadModelJpaRepository extends JpaRepository<ReviewAggregateReadModelJpaEntity, Long> {
+
+    Optional<ReviewAggregateReadModelJpaEntity> findByProductId(Long productId);
+
+    List<ReviewAggregateReadModelJpaEntity> findByProductIdInAndStatus(List<Long> productIds, EntityStatus status);
+}

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/out/review/SaveReviewAggregateReadModelPort.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/out/review/SaveReviewAggregateReadModelPort.java
@@ -1,0 +1,6 @@
+package com.personal.marketnote.product.port.out.review;
+
+public interface SaveReviewAggregateReadModelPort {
+
+    void upsert(Long productId, Integer totalCount, Float averageRating);
+}


### PR DESCRIPTION
## partially addresses #128
## resolves #1649

## Task
- [x] ReviewRegisteredEvent 확장 (productId, totalCount, averageRating 추가)
- [x] ReviewUpdatedEvent, ReviewDeletedEvent 신규 이벤트 추가
- [x] KafkaTopicConstants에 REVIEW_UPDATED, REVIEW_DELETED 토픽 추가
- [x] 커뮤니티 서비스에 리뷰 수정/삭제 이벤트 발행 추가
- [x] DeleteReviewService 집계 업데이트 로직 추가
- [x] 리뷰 집계 Read Model JPA 엔티티 + 테이블 생성 (product-adapters)
- [x] ReviewRegisteredReadModelConsumer 구현 (community.review.registered 소비)
- [x] ReviewUpdatedReadModelConsumer 구현 (community.review.updated 소비)
- [x] ReviewDeletedReadModelConsumer 구현 (community.review.deleted 소비)
- [x] ReviewAggregateReadModelPersistenceAdapter 구현 (FindProductReviewAggregatesPort 구현체 교체)
- [x] CommunityServiceClient.findByProductIds() 제거