### PR TITLE
[#128][#1716] test: 상품 서비스 리뷰 집계 Read Model 자동화 테스트 추가

### DIFF
--- a/product-service/product-adapters/src/test/java/com/personal/marketnote/product/adapter/in/event/ReviewDeletedReadModelConsumerTest.java
+++ b/product-service/product-adapters/src/test/java/com/personal/marketnote/product/adapter/in/event/ReviewDeletedReadModelConsumerTest.java
@@ -1,0 +1,173 @@
+package com.personal.marketnote.product.adapter.in.event;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.common.kafka.KafkaTopicConstants;
+import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.ReviewDeletedEvent;
+import com.personal.marketnote.product.port.out.review.SaveReviewAggregateReadModelPort;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.support.Acknowledgment;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ReviewDeletedReadModelConsumerTest {
+
+    @InjectMocks
+    private ReviewDeletedReadModelConsumer consumer;
+
+    @Spy
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @Mock
+    private SaveReviewAggregateReadModelPort saveReviewAggregateReadModelPort;
+
+    @Mock
+    private Acknowledgment acknowledgment;
+
+    private ConsumerRecord<String, EventEnvelope<?>> createRecord(EventEnvelope<?> envelope) {
+        return new ConsumerRecord<>(
+                KafkaTopicConstants.REVIEW_DELETED, 0, 0, "1", envelope
+        );
+    }
+
+    private EventEnvelope<ReviewDeletedEvent> createEnvelope(ReviewDeletedEvent payload) {
+        return new EventEnvelope<>(
+                "test-event-id",
+                KafkaTopicConstants.REVIEW_DELETED,
+                "community-service",
+                LocalDateTime.now(Clock.fixed(Instant.parse("2026-03-31T10:00:00Z"), ZoneId.of("Asia/Seoul"))),
+                payload
+        );
+    }
+
+    @Test
+    @DisplayName("정상 이벤트 수신 시 Read Model을 upsert한다")
+    void handleReviewDeletedEvent_validEvent_upsertsReadModel() {
+        // given
+        ReviewDeletedEvent payload = new ReviewDeletedEvent(1L, 50L, 9, 4.2f);
+        EventEnvelope<ReviewDeletedEvent> envelope = createEnvelope(payload);
+        ConsumerRecord<String, EventEnvelope<?>> record = createRecord(envelope);
+
+        // when
+        consumer.handleReviewDeletedEvent(record, acknowledgment);
+
+        // then
+        verify(saveReviewAggregateReadModelPort).upsert(50L, 9, 4.2f);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("envelope가 null이면 즉시 acknowledge한다")
+    void handleReviewDeletedEvent_nullEnvelope_acknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = new ConsumerRecord<>(
+                KafkaTopicConstants.REVIEW_DELETED, 0, 0, "1", null
+        );
+
+        // when
+        consumer.handleReviewDeletedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(saveReviewAggregateReadModelPort);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("이벤트 타입이 불일치하면 즉시 acknowledge한다")
+    void handleReviewDeletedEvent_eventTypeMismatch_acknowledges() {
+        // given
+        ReviewDeletedEvent payload = new ReviewDeletedEvent(1L, 50L, 9, 4.2f);
+        EventEnvelope<ReviewDeletedEvent> envelope = new EventEnvelope<>(
+                "test-event-id",
+                "wrong.event.type",
+                "community-service",
+                LocalDateTime.now(),
+                payload
+        );
+        ConsumerRecord<String, EventEnvelope<?>> record = createRecord(envelope);
+
+        // when
+        consumer.handleReviewDeletedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(saveReviewAggregateReadModelPort);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("reviewId가 유효하지 않으면 즉시 acknowledge한다")
+    void handleReviewDeletedEvent_invalidReviewId_acknowledges() {
+        // given
+        ReviewDeletedEvent payload = new ReviewDeletedEvent(-1L, 50L, 9, 4.2f);
+        EventEnvelope<ReviewDeletedEvent> envelope = createEnvelope(payload);
+        ConsumerRecord<String, EventEnvelope<?>> record = createRecord(envelope);
+
+        // when
+        consumer.handleReviewDeletedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(saveReviewAggregateReadModelPort);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("productId가 유효하지 않으면 즉시 acknowledge한다")
+    void handleReviewDeletedEvent_invalidProductId_acknowledges() {
+        // given
+        ReviewDeletedEvent payload = new ReviewDeletedEvent(1L, 0L, 9, 4.2f);
+        EventEnvelope<ReviewDeletedEvent> envelope = createEnvelope(payload);
+        ConsumerRecord<String, EventEnvelope<?>> record = createRecord(envelope);
+
+        // when
+        consumer.handleReviewDeletedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(saveReviewAggregateReadModelPort);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("reviewId가 null이면 즉시 acknowledge한다")
+    void handleReviewDeletedEvent_nullReviewId_acknowledges() {
+        // given
+        ReviewDeletedEvent payload = new ReviewDeletedEvent(null, 50L, 9, 4.2f);
+        EventEnvelope<ReviewDeletedEvent> envelope = createEnvelope(payload);
+        ConsumerRecord<String, EventEnvelope<?>> record = createRecord(envelope);
+
+        // when
+        consumer.handleReviewDeletedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(saveReviewAggregateReadModelPort);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("productId가 null이면 즉시 acknowledge한다")
+    void handleReviewDeletedEvent_nullProductId_acknowledges() {
+        // given
+        ReviewDeletedEvent payload = new ReviewDeletedEvent(1L, null, 9, 4.2f);
+        EventEnvelope<ReviewDeletedEvent> envelope = createEnvelope(payload);
+        ConsumerRecord<String, EventEnvelope<?>> record = createRecord(envelope);
+
+        // when
+        consumer.handleReviewDeletedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(saveReviewAggregateReadModelPort);
+        verify(acknowledgment).acknowledge();
+    }
+}

--- a/product-service/product-adapters/src/test/java/com/personal/marketnote/product/adapter/in/event/ReviewRegisteredReadModelConsumerTest.java
+++ b/product-service/product-adapters/src/test/java/com/personal/marketnote/product/adapter/in/event/ReviewRegisteredReadModelConsumerTest.java
@@ -1,0 +1,173 @@
+package com.personal.marketnote.product.adapter.in.event;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.common.kafka.KafkaTopicConstants;
+import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.ReviewRegisteredEvent;
+import com.personal.marketnote.product.port.out.review.SaveReviewAggregateReadModelPort;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.support.Acknowledgment;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ReviewRegisteredReadModelConsumerTest {
+
+    @InjectMocks
+    private ReviewRegisteredReadModelConsumer consumer;
+
+    @Spy
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @Mock
+    private SaveReviewAggregateReadModelPort saveReviewAggregateReadModelPort;
+
+    @Mock
+    private Acknowledgment acknowledgment;
+
+    private ConsumerRecord<String, EventEnvelope<?>> createRecord(EventEnvelope<?> envelope) {
+        return new ConsumerRecord<>(
+                KafkaTopicConstants.REVIEW_REGISTERED, 0, 0, "1", envelope
+        );
+    }
+
+    private EventEnvelope<ReviewRegisteredEvent> createEnvelope(ReviewRegisteredEvent payload) {
+        return new EventEnvelope<>(
+                "test-event-id",
+                KafkaTopicConstants.REVIEW_REGISTERED,
+                "community-service",
+                LocalDateTime.now(Clock.fixed(Instant.parse("2026-03-31T10:00:00Z"), ZoneId.of("Asia/Seoul"))),
+                payload
+        );
+    }
+
+    @Test
+    @DisplayName("정상 이벤트 수신 시 Read Model을 upsert한다")
+    void handleReviewRegisteredEvent_validEvent_upsertsReadModel() {
+        // given
+        ReviewRegisteredEvent payload = new ReviewRegisteredEvent(1L, 2L, 50L, 10, 4.5f);
+        EventEnvelope<ReviewRegisteredEvent> envelope = createEnvelope(payload);
+        ConsumerRecord<String, EventEnvelope<?>> record = createRecord(envelope);
+
+        // when
+        consumer.handleReviewRegisteredEvent(record, acknowledgment);
+
+        // then
+        verify(saveReviewAggregateReadModelPort).upsert(50L, 10, 4.5f);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("envelope가 null이면 즉시 acknowledge한다")
+    void handleReviewRegisteredEvent_nullEnvelope_acknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = new ConsumerRecord<>(
+                KafkaTopicConstants.REVIEW_REGISTERED, 0, 0, "1", null
+        );
+
+        // when
+        consumer.handleReviewRegisteredEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(saveReviewAggregateReadModelPort);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("이벤트 타입이 불일치하면 즉시 acknowledge한다")
+    void handleReviewRegisteredEvent_eventTypeMismatch_acknowledges() {
+        // given
+        ReviewRegisteredEvent payload = new ReviewRegisteredEvent(1L, 2L, 50L, 10, 4.5f);
+        EventEnvelope<ReviewRegisteredEvent> envelope = new EventEnvelope<>(
+                "test-event-id",
+                "wrong.event.type",
+                "community-service",
+                LocalDateTime.now(),
+                payload
+        );
+        ConsumerRecord<String, EventEnvelope<?>> record = createRecord(envelope);
+
+        // when
+        consumer.handleReviewRegisteredEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(saveReviewAggregateReadModelPort);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("productId가 null이면 기존 이벤트로 간주하고 무시한다")
+    void handleReviewRegisteredEvent_nullProductId_acknowledges() {
+        // given
+        ReviewRegisteredEvent payload = new ReviewRegisteredEvent(1L, 2L, null, 10, 4.5f);
+        EventEnvelope<ReviewRegisteredEvent> envelope = createEnvelope(payload);
+        ConsumerRecord<String, EventEnvelope<?>> record = createRecord(envelope);
+
+        // when
+        consumer.handleReviewRegisteredEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(saveReviewAggregateReadModelPort);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("productId가 0 이하이면 무시한다")
+    void handleReviewRegisteredEvent_invalidProductId_acknowledges() {
+        // given
+        ReviewRegisteredEvent payload = new ReviewRegisteredEvent(1L, 2L, 0L, 10, 4.5f);
+        EventEnvelope<ReviewRegisteredEvent> envelope = createEnvelope(payload);
+        ConsumerRecord<String, EventEnvelope<?>> record = createRecord(envelope);
+
+        // when
+        consumer.handleReviewRegisteredEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(saveReviewAggregateReadModelPort);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("totalCount가 null이면 무시한다")
+    void handleReviewRegisteredEvent_nullTotalCount_acknowledges() {
+        // given
+        ReviewRegisteredEvent payload = new ReviewRegisteredEvent(1L, 2L, 50L, null, 4.5f);
+        EventEnvelope<ReviewRegisteredEvent> envelope = createEnvelope(payload);
+        ConsumerRecord<String, EventEnvelope<?>> record = createRecord(envelope);
+
+        // when
+        consumer.handleReviewRegisteredEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(saveReviewAggregateReadModelPort);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("averageRating이 null이면 무시한다")
+    void handleReviewRegisteredEvent_nullAverageRating_acknowledges() {
+        // given
+        ReviewRegisteredEvent payload = new ReviewRegisteredEvent(1L, 2L, 50L, 10, null);
+        EventEnvelope<ReviewRegisteredEvent> envelope = createEnvelope(payload);
+        ConsumerRecord<String, EventEnvelope<?>> record = createRecord(envelope);
+
+        // when
+        consumer.handleReviewRegisteredEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(saveReviewAggregateReadModelPort);
+        verify(acknowledgment).acknowledge();
+    }
+}

--- a/product-service/product-adapters/src/test/java/com/personal/marketnote/product/adapter/in/event/ReviewUpdatedReadModelConsumerTest.java
+++ b/product-service/product-adapters/src/test/java/com/personal/marketnote/product/adapter/in/event/ReviewUpdatedReadModelConsumerTest.java
@@ -1,0 +1,173 @@
+package com.personal.marketnote.product.adapter.in.event;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.common.kafka.KafkaTopicConstants;
+import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.ReviewUpdatedEvent;
+import com.personal.marketnote.product.port.out.review.SaveReviewAggregateReadModelPort;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.support.Acknowledgment;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ReviewUpdatedReadModelConsumerTest {
+
+    @InjectMocks
+    private ReviewUpdatedReadModelConsumer consumer;
+
+    @Spy
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @Mock
+    private SaveReviewAggregateReadModelPort saveReviewAggregateReadModelPort;
+
+    @Mock
+    private Acknowledgment acknowledgment;
+
+    private ConsumerRecord<String, EventEnvelope<?>> createRecord(EventEnvelope<?> envelope) {
+        return new ConsumerRecord<>(
+                KafkaTopicConstants.REVIEW_UPDATED, 0, 0, "1", envelope
+        );
+    }
+
+    private EventEnvelope<ReviewUpdatedEvent> createEnvelope(ReviewUpdatedEvent payload) {
+        return new EventEnvelope<>(
+                "test-event-id",
+                KafkaTopicConstants.REVIEW_UPDATED,
+                "community-service",
+                LocalDateTime.now(Clock.fixed(Instant.parse("2026-03-31T10:00:00Z"), ZoneId.of("Asia/Seoul"))),
+                payload
+        );
+    }
+
+    @Test
+    @DisplayName("정상 이벤트 수신 시 Read Model을 upsert한다")
+    void handleReviewUpdatedEvent_validEvent_upsertsReadModel() {
+        // given
+        ReviewUpdatedEvent payload = new ReviewUpdatedEvent(1L, 50L, 10, 4.5f);
+        EventEnvelope<ReviewUpdatedEvent> envelope = createEnvelope(payload);
+        ConsumerRecord<String, EventEnvelope<?>> record = createRecord(envelope);
+
+        // when
+        consumer.handleReviewUpdatedEvent(record, acknowledgment);
+
+        // then
+        verify(saveReviewAggregateReadModelPort).upsert(50L, 10, 4.5f);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("envelope가 null이면 즉시 acknowledge한다")
+    void handleReviewUpdatedEvent_nullEnvelope_acknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = new ConsumerRecord<>(
+                KafkaTopicConstants.REVIEW_UPDATED, 0, 0, "1", null
+        );
+
+        // when
+        consumer.handleReviewUpdatedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(saveReviewAggregateReadModelPort);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("이벤트 타입이 불일치하면 즉시 acknowledge한다")
+    void handleReviewUpdatedEvent_eventTypeMismatch_acknowledges() {
+        // given
+        ReviewUpdatedEvent payload = new ReviewUpdatedEvent(1L, 50L, 10, 4.5f);
+        EventEnvelope<ReviewUpdatedEvent> envelope = new EventEnvelope<>(
+                "test-event-id",
+                "wrong.event.type",
+                "community-service",
+                LocalDateTime.now(),
+                payload
+        );
+        ConsumerRecord<String, EventEnvelope<?>> record = createRecord(envelope);
+
+        // when
+        consumer.handleReviewUpdatedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(saveReviewAggregateReadModelPort);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("reviewId가 유효하지 않으면 즉시 acknowledge한다")
+    void handleReviewUpdatedEvent_invalidReviewId_acknowledges() {
+        // given
+        ReviewUpdatedEvent payload = new ReviewUpdatedEvent(-1L, 50L, 10, 4.5f);
+        EventEnvelope<ReviewUpdatedEvent> envelope = createEnvelope(payload);
+        ConsumerRecord<String, EventEnvelope<?>> record = createRecord(envelope);
+
+        // when
+        consumer.handleReviewUpdatedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(saveReviewAggregateReadModelPort);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("productId가 유효하지 않으면 즉시 acknowledge한다")
+    void handleReviewUpdatedEvent_invalidProductId_acknowledges() {
+        // given
+        ReviewUpdatedEvent payload = new ReviewUpdatedEvent(1L, 0L, 10, 4.5f);
+        EventEnvelope<ReviewUpdatedEvent> envelope = createEnvelope(payload);
+        ConsumerRecord<String, EventEnvelope<?>> record = createRecord(envelope);
+
+        // when
+        consumer.handleReviewUpdatedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(saveReviewAggregateReadModelPort);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("reviewId가 null이면 즉시 acknowledge한다")
+    void handleReviewUpdatedEvent_nullReviewId_acknowledges() {
+        // given
+        ReviewUpdatedEvent payload = new ReviewUpdatedEvent(null, 50L, 10, 4.5f);
+        EventEnvelope<ReviewUpdatedEvent> envelope = createEnvelope(payload);
+        ConsumerRecord<String, EventEnvelope<?>> record = createRecord(envelope);
+
+        // when
+        consumer.handleReviewUpdatedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(saveReviewAggregateReadModelPort);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("productId가 null이면 즉시 acknowledge한다")
+    void handleReviewUpdatedEvent_nullProductId_acknowledges() {
+        // given
+        ReviewUpdatedEvent payload = new ReviewUpdatedEvent(1L, null, 10, 4.5f);
+        EventEnvelope<ReviewUpdatedEvent> envelope = createEnvelope(payload);
+        ConsumerRecord<String, EventEnvelope<?>> record = createRecord(envelope);
+
+        // when
+        consumer.handleReviewUpdatedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(saveReviewAggregateReadModelPort);
+        verify(acknowledgment).acknowledge();
+    }
+}

--- a/product-service/product-adapters/src/test/java/com/personal/marketnote/product/adapter/out/persistence/review/ReviewAggregateReadModelPersistenceAdapterTest.java
+++ b/product-service/product-adapters/src/test/java/com/personal/marketnote/product/adapter/out/persistence/review/ReviewAggregateReadModelPersistenceAdapterTest.java
@@ -1,0 +1,154 @@
+package com.personal.marketnote.product.adapter.out.persistence.review;
+
+import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.configuration.AuditConfig;
+import com.personal.marketnote.product.adapter.out.persistence.review.entity.ReviewAggregateReadModelJpaEntity;
+import com.personal.marketnote.product.adapter.out.persistence.review.repository.ReviewAggregateReadModelJpaRepository;
+import com.personal.marketnote.product.port.out.result.ProductReviewAggregateResult;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@ActiveProfiles("test")
+@Import({AuditConfig.class, ReviewAggregateReadModelPersistenceAdapter.class})
+class ReviewAggregateReadModelPersistenceAdapterTest {
+
+    @Autowired
+    private ReviewAggregateReadModelPersistenceAdapter adapter;
+
+    @Autowired
+    private ReviewAggregateReadModelJpaRepository repository;
+
+    @BeforeEach
+    void setUp() {
+        repository.deleteAll();
+    }
+
+    @Nested
+    @DisplayName("upsert")
+    class Upsert {
+
+        @Test
+        @DisplayName("신규 상품의 리뷰 집계를 저장한다")
+        void insertsNewReviewAggregate() {
+            // when
+            adapter.upsert(100L, 10, 4.5f);
+
+            // then
+            Optional<ReviewAggregateReadModelJpaEntity> entity = repository.findByProductId(100L);
+            assertThat(entity).isPresent();
+            assertThat(entity.get().getProductId()).isEqualTo(100L);
+            assertThat(entity.get().getTotalCount()).isEqualTo(10);
+            assertThat(entity.get().getAverageRating()).isEqualTo(4.5f);
+            assertThat(entity.get().getStatus()).isEqualTo(EntityStatus.ACTIVE);
+        }
+
+        @Test
+        @DisplayName("동일한 productId로 upsert 시 기존 데이터를 업데이트한다")
+        void updatesExistingReviewAggregate() {
+            // given
+            adapter.upsert(100L, 10, 4.5f);
+
+            // when
+            adapter.upsert(100L, 11, 4.6f);
+
+            // then
+            Optional<ReviewAggregateReadModelJpaEntity> entity = repository.findByProductId(100L);
+            assertThat(entity).isPresent();
+            assertThat(entity.get().getTotalCount()).isEqualTo(11);
+            assertThat(entity.get().getAverageRating()).isEqualTo(4.6f);
+        }
+
+        @Test
+        @DisplayName("동일한 값으로 upsert 시 멱등하게 처리된다")
+        void idempotentUpsert() {
+            // given
+            adapter.upsert(100L, 10, 4.5f);
+
+            // when
+            adapter.upsert(100L, 10, 4.5f);
+
+            // then
+            Optional<ReviewAggregateReadModelJpaEntity> entity = repository.findByProductId(100L);
+            assertThat(entity).isPresent();
+            assertThat(entity.get().getTotalCount()).isEqualTo(10);
+            assertThat(entity.get().getAverageRating()).isEqualTo(4.5f);
+        }
+    }
+
+    @Nested
+    @DisplayName("findByProductIds")
+    class FindByProductIds {
+
+        @Test
+        @DisplayName("ACTIVE 상태의 리뷰 집계를 productId 목록으로 조회한다")
+        void returnsActiveReviewAggregates() {
+            // given
+            adapter.upsert(100L, 10, 4.5f);
+            adapter.upsert(200L, 5, 3.8f);
+            adapter.upsert(300L, 20, 4.9f);
+
+            // when
+            Map<Long, ProductReviewAggregateResult> result =
+                    adapter.findByProductIds(List.of(100L, 200L, 300L));
+
+            // then
+            assertThat(result).hasSize(3);
+            assertThat(result.get(100L).totalCount()).isEqualTo(10);
+            assertThat(result.get(100L).averageRating()).isEqualTo(4.5f);
+            assertThat(result.get(200L).totalCount()).isEqualTo(5);
+            assertThat(result.get(200L).averageRating()).isEqualTo(3.8f);
+            assertThat(result.get(300L).totalCount()).isEqualTo(20);
+            assertThat(result.get(300L).averageRating()).isEqualTo(4.9f);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 productId는 결과에 포함되지 않는다")
+        void excludesNonExistentProductIds() {
+            // given
+            adapter.upsert(100L, 10, 4.5f);
+
+            // when
+            Map<Long, ProductReviewAggregateResult> result =
+                    adapter.findByProductIds(List.of(100L, 999L));
+
+            // then
+            assertThat(result).hasSize(1);
+            assertThat(result).containsKey(100L);
+            assertThat(result).doesNotContainKey(999L);
+        }
+
+        @Test
+        @DisplayName("빈 productId 목록으로 조회 시 빈 맵을 반환한다")
+        void returnsEmptyMapForEmptyProductIds() {
+            // when
+            Map<Long, ProductReviewAggregateResult> result =
+                    adapter.findByProductIds(List.of());
+
+            // then
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("null productId 목록으로 조회 시 빈 맵을 반환한다")
+        void returnsEmptyMapForNullProductIds() {
+            // when
+            Map<Long, ProductReviewAggregateResult> result = adapter.findByProductIds(null);
+
+            // then
+            assertThat(result).isEmpty();
+        }
+    }
+}


### PR DESCRIPTION
## partially addresses #128
## resolves #1716 

## Test Case
- [x] ReviewRegisteredReadModelConsumer 테스트 (7개)
- [x] ReviewUpdatedReadModelConsumer 테스트 (7개)
- [x] ReviewDeletedReadModelConsumer 테스트 (7개)
- [x] ReviewAggregateReadModelPersistenceAdapter 테스트 (7개)