### PR TITLE
[#128][#1650] feat: 상품 서비스 재고 수량 Read Model 구축

### DIFF
--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/event/InventoryChangedReadModelConsumer.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/event/InventoryChangedReadModelConsumer.java
@@ -1,0 +1,74 @@
+package com.personal.marketnote.product.adapter.in.event;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.common.kafka.KafkaTopicConstants;
+import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.EventPayloadValidator;
+import com.personal.marketnote.common.kafka.event.InventoryChangedEvent;
+import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.product.port.out.inventory.SaveInventoryReadModelPort;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class InventoryChangedReadModelConsumer {
+
+    private final ObjectMapper objectMapper;
+    private final SaveInventoryReadModelPort saveInventoryReadModelPort;
+
+    @KafkaListener(
+            topics = KafkaTopicConstants.INVENTORY_CHANGED,
+            groupId = "product-inventory-read-model"
+    )
+    public void handleInventoryChangedEvent(
+            ConsumerRecord<String, EventEnvelope<?>> record,
+            Acknowledgment acknowledgment
+    ) {
+        EventEnvelope<?> envelope = record.value();
+
+        if (EventPayloadValidator.hasInvalidEnvelope(envelope, record)) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        if (EventPayloadValidator.hasEventTypeMismatch(envelope, KafkaTopicConstants.INVENTORY_CHANGED)) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        InventoryChangedEvent payload = envelope.getPayloadAs(InventoryChangedEvent.class, objectMapper);
+
+        log.info("재고 변경 이벤트 수신. eventId={}, pricePolicyId={}, productId={}, stockQuantity={}, action={}",
+                envelope.eventId(), payload.pricePolicyId(), payload.productId(),
+                payload.stockQuantity(), payload.action());
+
+        if (EventPayloadValidator.hasInvalidIds(envelope.eventId(),
+                EventPayloadValidator.id("pricePolicyId", payload.pricePolicyId()),
+                EventPayloadValidator.id("productId", payload.productId()))) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        if (FormatValidator.hasNoValue(payload.action())) {
+            log.warn("재고 변경 이벤트 action이 null. eventId={}", envelope.eventId());
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        if (payload.action().isCreated() || payload.action().isUpdated()) {
+            saveInventoryReadModelPort.upsert(
+                    payload.pricePolicyId(), payload.productId(), payload.stockQuantity()
+            );
+            log.info("재고 Read Model 저장 완료. pricePolicyId={}, productId={}",
+                    payload.pricePolicyId(), payload.productId());
+        }
+
+        acknowledgment.acknowledge();
+    }
+}

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/inventory/InventoryReadModelPersistenceAdapter.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/inventory/InventoryReadModelPersistenceAdapter.java
@@ -1,0 +1,70 @@
+package com.personal.marketnote.product.adapter.out.persistence.inventory;
+
+import com.personal.marketnote.common.adapter.out.PersistenceAdapter;
+import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.product.adapter.out.persistence.inventory.entity.InventoryReadModelJpaEntity;
+import com.personal.marketnote.product.adapter.out.persistence.inventory.repository.InventoryReadModelJpaRepository;
+import com.personal.marketnote.product.port.out.inventory.FindStockPort;
+import com.personal.marketnote.product.port.out.inventory.SaveInventoryReadModelPort;
+import com.personal.marketnote.product.port.out.result.GetInventoryResult;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@Slf4j
+@PersistenceAdapter
+@RequiredArgsConstructor
+public class InventoryReadModelPersistenceAdapter implements FindStockPort, SaveInventoryReadModelPort {
+    private final InventoryReadModelJpaRepository inventoryReadModelJpaRepository;
+
+    @Override
+    @Transactional(isolation = READ_COMMITTED, readOnly = true)
+    public Set<GetInventoryResult> findByPricePolicyIds(List<Long> pricePolicyIds) {
+        List<InventoryReadModelJpaEntity> entities =
+                inventoryReadModelJpaRepository.findByPricePolicyIdInAndStatus(pricePolicyIds, EntityStatus.ACTIVE);
+
+        Set<Long> foundPricePolicyIds = entities.stream()
+                .map(InventoryReadModelJpaEntity::getPricePolicyId)
+                .collect(Collectors.toSet());
+
+        Set<GetInventoryResult> results = entities.stream()
+                .map(entity -> GetInventoryResult.of(entity.getPricePolicyId(), entity.getStockQuantity()))
+                .collect(Collectors.toSet());
+
+        pricePolicyIds.stream()
+                .filter(id -> !foundPricePolicyIds.contains(id))
+                .map(GetInventoryResult::generateResultWithoutStock)
+                .forEach(results::add);
+
+        return results;
+    }
+
+    @Override
+    @Transactional(isolation = READ_COMMITTED)
+    public void upsert(Long pricePolicyId, Long productId, Integer stockQuantity) {
+        Optional<InventoryReadModelJpaEntity> existing =
+                inventoryReadModelJpaRepository.findByPricePolicyId(pricePolicyId);
+
+        if (existing.isPresent()) {
+            existing.get().updateFrom(stockQuantity);
+            return;
+        }
+
+        try {
+            InventoryReadModelJpaEntity entity = InventoryReadModelJpaEntity.of(pricePolicyId, productId, stockQuantity);
+            inventoryReadModelJpaRepository.saveAndFlush(entity);
+        } catch (DataIntegrityViolationException e) {
+            log.info("재고 Read Model 중복 저장 (멱등 처리). pricePolicyId={}", pricePolicyId);
+            inventoryReadModelJpaRepository.findByPricePolicyId(pricePolicyId)
+                    .ifPresent(entity -> entity.updateFrom(stockQuantity));
+        }
+    }
+}

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/inventory/entity/InventoryReadModelJpaEntity.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/inventory/entity/InventoryReadModelJpaEntity.java
@@ -1,0 +1,43 @@
+package com.personal.marketnote.product.adapter.out.persistence.inventory.entity;
+
+import com.personal.marketnote.common.adapter.out.persistence.audit.BaseGeneralEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(
+        name = "inventory_read_models",
+        uniqueConstraints = @UniqueConstraint(name = "uk_inventory_read_model_price_policy_id", columnNames = "pricePolicyId")
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+@Getter
+public class InventoryReadModelJpaEntity extends BaseGeneralEntity {
+
+    @Column(nullable = false, unique = true)
+    private Long pricePolicyId;
+
+    @Column(nullable = false)
+    private Long productId;
+
+    @Column(nullable = false)
+    private Integer stockQuantity;
+
+    public static InventoryReadModelJpaEntity of(Long pricePolicyId, Long productId, Integer stockQuantity) {
+        return InventoryReadModelJpaEntity.builder()
+                .pricePolicyId(pricePolicyId)
+                .productId(productId)
+                .stockQuantity(stockQuantity)
+                .build();
+    }
+
+    public void updateFrom(Integer stockQuantity) {
+        this.stockQuantity = stockQuantity;
+        activate();
+    }
+
+    public void markInactive() {
+        deactivate();
+    }
+}

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/inventory/repository/InventoryReadModelJpaRepository.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/inventory/repository/InventoryReadModelJpaRepository.java
@@ -1,0 +1,15 @@
+package com.personal.marketnote.product.adapter.out.persistence.inventory.repository;
+
+import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.product.adapter.out.persistence.inventory.entity.InventoryReadModelJpaEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface InventoryReadModelJpaRepository extends JpaRepository<InventoryReadModelJpaEntity, Long> {
+
+    Optional<InventoryReadModelJpaEntity> findByPricePolicyId(Long pricePolicyId);
+
+    List<InventoryReadModelJpaEntity> findByPricePolicyIdInAndStatus(List<Long> pricePolicyIds, EntityStatus status);
+}

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/web/commerce/CommerceServiceClient.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/web/commerce/CommerceServiceClient.java
@@ -1,24 +1,19 @@
 package com.personal.marketnote.product.adapter.out.web.commerce;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
 import com.personal.marketnote.common.adapter.in.request.RegisterInventoryRequest;
 import com.personal.marketnote.common.adapter.out.ServiceAdapter;
 import com.personal.marketnote.common.exception.CommerceServiceRequestFailedException;
 import com.personal.marketnote.common.security.hmac.HmacServiceAuthHeaderBuilder;
 import com.personal.marketnote.common.utility.FormatValidator;
-import com.personal.marketnote.product.adapter.out.response.GetInventoriesResponse;
 import com.personal.marketnote.product.domain.servicecommunication.ProductServiceCommunicationSenderType;
 import com.personal.marketnote.product.domain.servicecommunication.ProductServiceCommunicationTargetType;
 import com.personal.marketnote.product.domain.servicecommunication.ProductServiceCommunicationType;
-import com.personal.marketnote.product.port.out.inventory.FindStockPort;
 import com.personal.marketnote.product.port.out.inventory.RegisterInventoryPort;
-import com.personal.marketnote.product.port.out.result.GetInventoryResult;
 import com.personal.marketnote.product.utility.ServiceCommunicationPayloadGenerator;
 import com.personal.marketnote.product.utility.ServiceCommunicationRecorder;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -27,17 +22,13 @@ import org.springframework.web.util.UriComponentsBuilder;
 
 import java.io.IOException;
 import java.net.URI;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
-import java.util.stream.Collectors;
 
 import static com.personal.marketnote.common.utility.ApiConstant.*;
 
 @ServiceAdapter
 @Slf4j
-public class CommerceServiceClient implements RegisterInventoryPort, FindStockPort {
+public class CommerceServiceClient implements RegisterInventoryPort {
     private static final ProductServiceCommunicationTargetType TARGET_TYPE =
             ProductServiceCommunicationTargetType.INVENTORY;
     private static final ProductServiceCommunicationSenderType REQUEST_SENDER =
@@ -147,102 +138,6 @@ public class CommerceServiceClient implements RegisterInventoryPort, FindStockPo
         }
 
         log.error("Failed to register inventory: {} with error: {}", uri, error.getMessage(), error);
-        throw new CommerceServiceRequestFailedException(new IOException());
-    }
-
-    @Override
-    public Set<GetInventoryResult> findByPricePolicyIds(List<Long> pricePolicyIds) {
-        URI uri = UriComponentsBuilder
-                .fromUriString(commerceServiceBaseUrl)
-                .path("/api/v1/internal/inventories")
-                .queryParam("pricePolicyIds", pricePolicyIds)
-                .build()
-                .toUri();
-
-        try {
-            return sendFindRequest(uri).inventories();
-        } catch (CommerceServiceRequestFailedException csrfe) {
-            return pricePolicyIds.stream()
-                    .map(GetInventoryResult::generateResultWithoutStock)
-                    .collect(Collectors.toSet());
-        }
-    }
-
-    private GetInventoriesResponse sendFindRequest(URI uri) {
-        Exception error = new Exception();
-
-        for (int i = 0; i < INTER_SERVER_MAX_REQUEST_COUNT; i++) {
-            int attempt = i + 1;
-            try {
-                ResponseEntity<BaseResponse<GetInventoriesResponse>> responseEntity =
-                        restClient.get()
-                                .uri(uri)
-                                .headers(headers -> hmacServiceAuthHeaderBuilder.applyHeaders(headers, "GET", uri.getPath()))
-                                .retrieve()
-                                .toEntity(new ParameterizedTypeReference<>() {
-                                });
-
-                if (responseEntity.getStatusCode().isError()) {
-                    throw new CommerceServiceRequestFailedException(new IOException("Commerce service returned error: " + responseEntity.getStatusCode()));
-                }
-
-                BaseResponse<GetInventoriesResponse> response = responseEntity.getBody();
-
-                if (FormatValidator.hasNoValue(response)) {
-                    throw new CommerceServiceRequestFailedException(new IOException());
-                }
-
-                GetInventoriesResponse getInventoriesResponse = response.getContent();
-                return FormatValidator.hasValue(getInventoriesResponse)
-                        ? getInventoriesResponse
-                        : new GetInventoriesResponse(new HashSet<>());
-            } catch (Exception e) {
-                String exception = e.getClass().getSimpleName();
-                JsonNode requestPayloadJson = serviceCommunicationPayloadGenerator.buildRequestPayloadJson(
-                        HttpMethod.GET,
-                        uri,
-                        null,
-                        attempt
-                );
-                String requestPayload = requestPayloadJson.toString();
-                JsonNode responsePayloadJson = serviceCommunicationPayloadGenerator.buildErrorPayloadJson(
-                        exception,
-                        e.getMessage(),
-                        attempt
-                );
-                String responsePayload = responsePayloadJson.toString();
-                recordCommunication(
-                        TARGET_TYPE,
-                        null,
-                        ProductServiceCommunicationType.REQUEST,
-                        requestPayload,
-                        requestPayloadJson,
-                        exception
-                );
-                recordCommunication(
-                        TARGET_TYPE,
-                        null,
-                        ProductServiceCommunicationType.RESPONSE,
-                        responsePayload,
-                        responsePayloadJson,
-                        exception
-                );
-                log.warn(e.getMessage(), e);
-                if (i == INTER_SERVER_MAX_REQUEST_COUNT - 1) {
-                    error = e;
-                }
-
-                try {
-                    long jitteredSleepMillis = ThreadLocalRandom.current()
-                            .nextLong(Math.max(1L, INTER_SERVER_DEFAULT_RETRIAL_PENDING_MILLI_SECOND) + 1);
-                    Thread.sleep(jitteredSleepMillis);
-                } catch (InterruptedException ie) {
-                    Thread.currentThread().interrupt();
-                }
-            }
-        }
-
-        log.error("Failed to get inventories: {} with error: {}", uri, error.getMessage(), error);
         throw new CommerceServiceRequestFailedException(new IOException());
     }
 

--- a/product-service/product-adapters/src/test/java/com/personal/marketnote/product/adapter/out/web/commerce/CommerceServiceClientTest.java
+++ b/product-service/product-adapters/src/test/java/com/personal/marketnote/product/adapter/out/web/commerce/CommerceServiceClientTest.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.personal.marketnote.common.exception.CommerceServiceRequestFailedException;
 import com.personal.marketnote.common.security.hmac.HmacServiceAuthHeaderBuilder;
 import com.personal.marketnote.common.utility.http.client.restclient.RestClientErrorHandler;
-import com.personal.marketnote.product.port.out.result.GetInventoryResult;
 import com.personal.marketnote.product.utility.ServiceCommunicationPayloadGenerator;
 import com.personal.marketnote.product.utility.ServiceCommunicationRecorder;
 import org.junit.jupiter.api.BeforeEach;
@@ -19,10 +18,6 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.client.MockRestServiceServer;
 import org.springframework.web.client.RestClient;
 
-import java.util.List;
-import java.util.Set;
-
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.lenient;
@@ -100,68 +95,4 @@ class CommerceServiceClientTest {
         }
     }
 
-    @Nested
-    @DisplayName("findByPricePolicyIds")
-    class FindByPricePolicyIds {
-
-        @Test
-        @DisplayName("가격정책 ID 목록으로 재고 조회에 성공하면 재고 결과를 반환한다")
-        void shouldReturnInventoriesWhenRequestSucceeds() {
-            mockServer.expect(requestTo(BASE_URL + "/api/v1/internal/inventories?pricePolicyIds=1&pricePolicyIds=2"))
-                    .andExpect(method(HttpMethod.GET))
-                    .andRespond(withSuccess("""
-                            {
-                                "content": {
-                                    "inventories": [
-                                        {"pricePolicyId": 1, "stock": 100},
-                                        {"pricePolicyId": 2, "stock": 50}
-                                    ]
-                                }
-                            }
-                            """, MediaType.APPLICATION_JSON));
-
-            Set<GetInventoryResult> result =
-                    commerceServiceClient.findByPricePolicyIds(List.of(1L, 2L));
-
-            assertThat(result).hasSize(2);
-
-            mockServer.verify();
-        }
-
-        @Test
-        @DisplayName("응답 바디가 null이면 CommerceServiceRequestFailedException 후 폴백 결과를 반환한다")
-        void shouldReturnFallbackResultsWhenResponseBodyIsNull() {
-            for (int i = 0; i < 5; i++) {
-                mockServer.expect(requestTo(BASE_URL + "/api/v1/internal/inventories?pricePolicyIds=1"))
-                        .andExpect(method(HttpMethod.GET))
-                        .andRespond(withSuccess());
-            }
-
-            Set<GetInventoryResult> result =
-                    commerceServiceClient.findByPricePolicyIds(List.of(1L));
-
-            assertThat(result).hasSize(1);
-            assertThat(result.iterator().next().stock()).isNull();
-
-            mockServer.verify();
-        }
-
-        @Test
-        @DisplayName("모든 재시도가 실패하면 stock이 null인 폴백 결과를 반환한다")
-        void shouldReturnFallbackResultsWhenAllRetriesFail() {
-            for (int i = 0; i < 5; i++) {
-                mockServer.expect(requestTo(BASE_URL + "/api/v1/internal/inventories?pricePolicyIds=1&pricePolicyIds=2"))
-                        .andExpect(method(HttpMethod.GET))
-                        .andRespond(withServerError());
-            }
-
-            Set<GetInventoryResult> result =
-                    commerceServiceClient.findByPricePolicyIds(List.of(1L, 2L));
-
-            assertThat(result).hasSize(2);
-            result.forEach(item -> assertThat(item.stock()).isNull());
-
-            mockServer.verify();
-        }
-    }
 }

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/out/inventory/SaveInventoryReadModelPort.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/out/inventory/SaveInventoryReadModelPort.java
@@ -1,0 +1,5 @@
+package com.personal.marketnote.product.port.out.inventory;
+
+public interface SaveInventoryReadModelPort {
+    void upsert(Long pricePolicyId, Long productId, Integer stockQuantity);
+}


### PR DESCRIPTION
## partially addresses #128
## resolves #1650

## Task
- [x] 재고 수량 Read Model JPA 엔티티 + 테이블 생성 (product-adapters)
- [x] InventoryChangedReadModelConsumer 구현 (commerce.inventory.changed 소비)
- [x] InventoryReadModelPersistenceAdapter 구현 (FindStockPort 구현체 교체)
- [x] CommerceServiceClient.findByPricePolicyIds() 제거