### PR TITLE
[#128][#1717] test: 상품 서비스 재고 수량 Read Model 자동화 테스트 추가

### DIFF
--- a/product-service/product-adapters/src/test/java/com/personal/marketnote/product/adapter/in/event/InventoryChangedReadModelConsumerTest.java
+++ b/product-service/product-adapters/src/test/java/com/personal/marketnote/product/adapter/in/event/InventoryChangedReadModelConsumerTest.java
@@ -1,0 +1,186 @@
+package com.personal.marketnote.product.adapter.in.event;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.common.kafka.KafkaTopicConstants;
+import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.InventoryChangeAction;
+import com.personal.marketnote.common.kafka.event.InventoryChangedEvent;
+import com.personal.marketnote.product.port.out.inventory.SaveInventoryReadModelPort;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.support.Acknowledgment;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class InventoryChangedReadModelConsumerTest {
+
+    @InjectMocks
+    private InventoryChangedReadModelConsumer consumer;
+
+    @Spy
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @Mock
+    private SaveInventoryReadModelPort saveInventoryReadModelPort;
+
+    @Mock
+    private Acknowledgment acknowledgment;
+
+    private ConsumerRecord<String, EventEnvelope<?>> createRecord(EventEnvelope<?> envelope) {
+        return new ConsumerRecord<>(
+                KafkaTopicConstants.INVENTORY_CHANGED, 0, 0, "1", envelope
+        );
+    }
+
+    private EventEnvelope<InventoryChangedEvent> createEnvelope(InventoryChangedEvent payload) {
+        return new EventEnvelope<>(
+                "test-event-id",
+                KafkaTopicConstants.INVENTORY_CHANGED,
+                "commerce-service",
+                LocalDateTime.now(Clock.fixed(Instant.parse("2026-03-31T10:00:00Z"), ZoneId.of("Asia/Seoul"))),
+                payload
+        );
+    }
+
+    @Test
+    @DisplayName("envelope가 null이면 즉시 acknowledge하고 upsert를 호출하지 않는다")
+    void handleInventoryChangedEvent_nullEnvelope_acknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = new ConsumerRecord<>(
+                KafkaTopicConstants.INVENTORY_CHANGED, 0, 0, "1", null
+        );
+
+        // when
+        consumer.handleInventoryChangedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(saveInventoryReadModelPort);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("이벤트 타입이 불일치하면 즉시 acknowledge하고 upsert를 호출하지 않는다")
+    void handleInventoryChangedEvent_eventTypeMismatch_acknowledges() {
+        // given
+        InventoryChangedEvent payload = new InventoryChangedEvent(
+                1L, 100L, 50, InventoryChangeAction.CREATED
+        );
+        EventEnvelope<InventoryChangedEvent> envelope = new EventEnvelope<>(
+                "test-event-id",
+                "wrong.event.type",
+                "commerce-service",
+                LocalDateTime.now(),
+                payload
+        );
+        ConsumerRecord<String, EventEnvelope<?>> record = createRecord(envelope);
+
+        // when
+        consumer.handleInventoryChangedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(saveInventoryReadModelPort);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("pricePolicyId가 null이면 즉시 acknowledge하고 upsert를 호출하지 않는다")
+    void handleInventoryChangedEvent_nullPricePolicyId_acknowledges() {
+        // given
+        InventoryChangedEvent payload = new InventoryChangedEvent(
+                null, 100L, 50, InventoryChangeAction.CREATED
+        );
+        EventEnvelope<InventoryChangedEvent> envelope = createEnvelope(payload);
+        ConsumerRecord<String, EventEnvelope<?>> record = createRecord(envelope);
+
+        // when
+        consumer.handleInventoryChangedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(saveInventoryReadModelPort);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("pricePolicyId가 0이면 즉시 acknowledge하고 upsert를 호출하지 않는다")
+    void handleInventoryChangedEvent_zeroPricePolicyId_acknowledges() {
+        // given
+        InventoryChangedEvent payload = new InventoryChangedEvent(
+                0L, 100L, 50, InventoryChangeAction.CREATED
+        );
+        EventEnvelope<InventoryChangedEvent> envelope = createEnvelope(payload);
+        ConsumerRecord<String, EventEnvelope<?>> record = createRecord(envelope);
+
+        // when
+        consumer.handleInventoryChangedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(saveInventoryReadModelPort);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("action이 null이면 warn 로그 후 acknowledge하고 upsert를 호출하지 않는다")
+    void handleInventoryChangedEvent_nullAction_acknowledges() {
+        // given
+        InventoryChangedEvent payload = new InventoryChangedEvent(
+                1L, 100L, 50, null
+        );
+        EventEnvelope<InventoryChangedEvent> envelope = createEnvelope(payload);
+        ConsumerRecord<String, EventEnvelope<?>> record = createRecord(envelope);
+
+        // when
+        consumer.handleInventoryChangedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(saveInventoryReadModelPort);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("CREATED action 이벤트 수신 시 upsert를 호출한다")
+    void handleInventoryChangedEvent_createdAction_upsertsReadModel() {
+        // given
+        InventoryChangedEvent payload = new InventoryChangedEvent(
+                1L, 100L, 50, InventoryChangeAction.CREATED
+        );
+        EventEnvelope<InventoryChangedEvent> envelope = createEnvelope(payload);
+        ConsumerRecord<String, EventEnvelope<?>> record = createRecord(envelope);
+
+        // when
+        consumer.handleInventoryChangedEvent(record, acknowledgment);
+
+        // then
+        verify(saveInventoryReadModelPort).upsert(1L, 100L, 50);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("UPDATED action 이벤트 수신 시 upsert를 호출한다")
+    void handleInventoryChangedEvent_updatedAction_upsertsReadModel() {
+        // given
+        InventoryChangedEvent payload = new InventoryChangedEvent(
+                2L, 200L, 30, InventoryChangeAction.UPDATED
+        );
+        EventEnvelope<InventoryChangedEvent> envelope = createEnvelope(payload);
+        ConsumerRecord<String, EventEnvelope<?>> record = createRecord(envelope);
+
+        // when
+        consumer.handleInventoryChangedEvent(record, acknowledgment);
+
+        // then
+        verify(saveInventoryReadModelPort).upsert(2L, 200L, 30);
+        verify(acknowledgment).acknowledge();
+    }
+}

--- a/product-service/product-adapters/src/test/java/com/personal/marketnote/product/adapter/out/persistence/inventory/InventoryReadModelPersistenceAdapterTest.java
+++ b/product-service/product-adapters/src/test/java/com/personal/marketnote/product/adapter/out/persistence/inventory/InventoryReadModelPersistenceAdapterTest.java
@@ -1,0 +1,171 @@
+package com.personal.marketnote.product.adapter.out.persistence.inventory;
+
+import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.configuration.AuditConfig;
+import com.personal.marketnote.product.adapter.out.persistence.inventory.entity.InventoryReadModelJpaEntity;
+import com.personal.marketnote.product.adapter.out.persistence.inventory.repository.InventoryReadModelJpaRepository;
+import com.personal.marketnote.product.port.out.result.GetInventoryResult;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@ActiveProfiles("test")
+@Import({AuditConfig.class, InventoryReadModelPersistenceAdapter.class})
+class InventoryReadModelPersistenceAdapterTest {
+
+    @Autowired
+    private InventoryReadModelPersistenceAdapter adapter;
+
+    @Autowired
+    private InventoryReadModelJpaRepository repository;
+
+    @BeforeEach
+    void setUp() {
+        repository.deleteAll();
+    }
+
+    @Nested
+    @DisplayName("upsert")
+    class Upsert {
+
+        @Test
+        @DisplayName("신규 재고를 저장한다")
+        void insertsNewInventory() {
+            // when
+            adapter.upsert(1L, 100L, 50);
+
+            // then
+            Optional<InventoryReadModelJpaEntity> entity = repository.findByPricePolicyId(1L);
+            assertThat(entity).isPresent();
+            assertThat(entity.get().getPricePolicyId()).isEqualTo(1L);
+            assertThat(entity.get().getProductId()).isEqualTo(100L);
+            assertThat(entity.get().getStockQuantity()).isEqualTo(50);
+            assertThat(entity.get().getStatus()).isEqualTo(EntityStatus.ACTIVE);
+        }
+
+        @Test
+        @DisplayName("동일한 pricePolicyId로 upsert 시 기존 stockQuantity를 업데이트한다")
+        void updatesExistingInventory() {
+            // given
+            adapter.upsert(1L, 100L, 50);
+
+            // when
+            adapter.upsert(1L, 100L, 30);
+
+            // then
+            Optional<InventoryReadModelJpaEntity> entity = repository.findByPricePolicyId(1L);
+            assertThat(entity).isPresent();
+            assertThat(entity.get().getStockQuantity()).isEqualTo(30);
+        }
+
+        @Test
+        @DisplayName("비활성화된 재고에 대해 upsert 시 다시 활성화된다")
+        void reactivatesInactiveInventory() {
+            // given
+            adapter.upsert(1L, 100L, 50);
+            InventoryReadModelJpaEntity savedEntity = repository.findByPricePolicyId(1L).get();
+            savedEntity.markInactive();
+            repository.saveAndFlush(savedEntity);
+
+            // when
+            adapter.upsert(1L, 100L, 40);
+
+            // then
+            Optional<InventoryReadModelJpaEntity> entity = repository.findByPricePolicyId(1L);
+            assertThat(entity).isPresent();
+            assertThat(entity.get().getStatus()).isEqualTo(EntityStatus.ACTIVE);
+            assertThat(entity.get().getStockQuantity()).isEqualTo(40);
+        }
+    }
+
+    @Nested
+    @DisplayName("findByPricePolicyIds")
+    class FindByPricePolicyIds {
+
+        @Test
+        @DisplayName("ACTIVE 상태의 재고를 조회한다")
+        void returnsActiveInventories() {
+            // given
+            adapter.upsert(1L, 100L, 50);
+            adapter.upsert(2L, 200L, 30);
+
+            // when
+            Set<GetInventoryResult> results = adapter.findByPricePolicyIds(List.of(1L, 2L));
+
+            // then
+            assertThat(results).hasSize(2);
+            assertThat(results).anySatisfy(result -> {
+                assertThat(result.pricePolicyId()).isEqualTo(1L);
+                assertThat(result.stock()).isEqualTo(50);
+            });
+            assertThat(results).anySatisfy(result -> {
+                assertThat(result.pricePolicyId()).isEqualTo(2L);
+                assertThat(result.stock()).isEqualTo(30);
+            });
+        }
+
+        @Test
+        @DisplayName("Read Model에 없는 pricePolicyId는 stock이 null인 기본값을 반환한다")
+        void returnsDefaultForMissingPricePolicyIds() {
+            // given
+            adapter.upsert(1L, 100L, 50);
+
+            // when
+            Set<GetInventoryResult> results = adapter.findByPricePolicyIds(List.of(1L, 999L));
+
+            // then
+            assertThat(results).hasSize(2);
+            assertThat(results).anySatisfy(result -> {
+                assertThat(result.pricePolicyId()).isEqualTo(1L);
+                assertThat(result.stock()).isEqualTo(50);
+            });
+            assertThat(results).anySatisfy(result -> {
+                assertThat(result.pricePolicyId()).isEqualTo(999L);
+                assertThat(result.stock()).isNull();
+            });
+        }
+
+        @Test
+        @DisplayName("INACTIVE 상태의 재고는 조회하지 않고 기본값을 반환한다")
+        void excludesInactiveInventories() {
+            // given
+            adapter.upsert(1L, 100L, 50);
+            InventoryReadModelJpaEntity savedEntity = repository.findByPricePolicyId(1L).get();
+            savedEntity.markInactive();
+            repository.saveAndFlush(savedEntity);
+
+            // when
+            Set<GetInventoryResult> results = adapter.findByPricePolicyIds(List.of(1L));
+
+            // then
+            assertThat(results).hasSize(1);
+            assertThat(results).anySatisfy(result -> {
+                assertThat(result.pricePolicyId()).isEqualTo(1L);
+                assertThat(result.stock()).isNull();
+            });
+        }
+
+        @Test
+        @DisplayName("모든 pricePolicyId가 Read Model에 없으면 모두 기본값을 반환한다")
+        void returnsAllDefaultsWhenNoneExist() {
+            // when
+            Set<GetInventoryResult> results = adapter.findByPricePolicyIds(List.of(10L, 20L, 30L));
+
+            // then
+            assertThat(results).hasSize(3);
+            results.forEach(result -> assertThat(result.stock()).isNull());
+        }
+    }
+}


### PR DESCRIPTION
## partially addresses #128
## resolves #1717

## Test Case
- [x] InventoryChangedReadModelConsumer 테스트 (7개)
- [x] InventoryReadModelPersistenceAdapter 테스트 (7개)