### PR TITLE
[#387][#1786] fix: 공유 포인트 적립 시 구매자와 공유자 동일 여부 검증 기능 추가

### DIFF
--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/event/OrderPaymentCompletedSharedPointConsumer.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/event/OrderPaymentCompletedSharedPointConsumer.java
@@ -94,7 +94,7 @@ public class OrderPaymentCompletedSharedPointConsumer {
             }
 
             for (UUID sharerKey : sharerKeys) {
-                modifyPendingPointIdempotent(envelope.eventId(), sharerKey, sharePointAmount, payload.orderId());
+                modifyPendingPointIdempotent(envelope.eventId(), payload.buyerId(), sharerKey, sharePointAmount, payload.orderId());
             }
 
             log.info("공유 포인트 적립 완료. orderId={}, sharerKeys={}, sharePointAmount={}",
@@ -108,9 +108,10 @@ public class OrderPaymentCompletedSharedPointConsumer {
         acknowledgment.acknowledge();
     }
 
-    private void modifyPendingPointIdempotent(String eventId, UUID sharerKey, long sharePointAmount, Long orderId) {
+    private void modifyPendingPointIdempotent(String eventId, Long buyerId, UUID sharerKey, long sharePointAmount, Long orderId) {
         try {
             ModifyPendingSharedPointCommand command = ModifyPendingSharedPointCommand.builder()
+                    .buyerId(buyerId)
                     .sharerKey(sharerKey)
                     .changeType(UserPointChangeType.ACCRUAL)
                     .amount(sharePointAmount)

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/event/PaymentCancelledPartialSharedPointConsumer.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/event/PaymentCancelledPartialSharedPointConsumer.java
@@ -94,7 +94,7 @@ public class PaymentCancelledPartialSharedPointConsumer {
             }
 
             for (UUID sharerKey : sharerKeys) {
-                modifyPendingPointIdempotent(envelope.eventId(), sharerKey, proportionalPoint, payload.orderId());
+                modifyPendingPointIdempotent(envelope.eventId(), payload.buyerId(), sharerKey, proportionalPoint, payload.orderId());
             }
 
             log.info("부분 공유 적립 예정 포인트 차감 완료. orderId={}, sharerKeys={}, proportionalPoint={}",
@@ -108,9 +108,10 @@ public class PaymentCancelledPartialSharedPointConsumer {
         acknowledgment.acknowledge();
     }
 
-    private void modifyPendingPointIdempotent(String eventId, UUID sharerKey, Long proportionalPoint, Long orderId) {
+    private void modifyPendingPointIdempotent(String eventId, Long buyerId, UUID sharerKey, Long proportionalPoint, Long orderId) {
         try {
             ModifyPendingSharedPointCommand command = ModifyPendingSharedPointCommand.builder()
+                    .buyerId(buyerId)
                     .sharerKey(sharerKey)
                     .changeType(UserPointChangeType.DEDUCTION)
                     .amount(proportionalPoint)

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/command/point/ModifyPendingSharedPointCommand.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/command/point/ModifyPendingSharedPointCommand.java
@@ -8,6 +8,7 @@ import java.util.UUID;
 
 @Builder
 public record ModifyPendingSharedPointCommand(
+        Long buyerId,
         UUID sharerKey,
         UserPointChangeType changeType,
         Long amount,

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/service/point/ModifyPendingSharedPointService.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/service/point/ModifyPendingSharedPointService.java
@@ -1,6 +1,8 @@
 package com.personal.marketnote.reward.service.point;
 
 import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.reward.domain.point.UserPoint;
 import com.personal.marketnote.reward.port.in.command.point.ModifyPendingPointCommand;
 import com.personal.marketnote.reward.port.in.command.point.ModifyPendingSharedPointCommand;
 import com.personal.marketnote.reward.port.in.result.point.UpdateUserPointResult;
@@ -8,10 +10,14 @@ import com.personal.marketnote.reward.port.in.usecase.point.ModifyPendingPointUs
 import com.personal.marketnote.reward.port.in.usecase.point.ModifyPendingSharedPointUseCase;
 import com.personal.marketnote.reward.port.out.point.FindUserPointPort;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Objects;
 
 import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
 
+@Slf4j
 @UseCase
 @RequiredArgsConstructor
 @Transactional(isolation = READ_COMMITTED)
@@ -21,12 +27,19 @@ public class ModifyPendingSharedPointService implements ModifyPendingSharedPoint
 
     @Override
     public UpdateUserPointResult modifyPending(ModifyPendingSharedPointCommand command) {
-        Long userId = findUserPointPort.findByUserKey(command.sharerKey().toString())
-                .orElseThrow(() -> new com.personal.marketnote.reward.exception.UserPointNotFoundException(command.sharerKey().toString()))
-                .getUserId();
+        UserPoint sharerPoint = findUserPointPort.findByUserKey(command.sharerKey().toString())
+                .orElseThrow(() -> new com.personal.marketnote.reward.exception.UserPointNotFoundException(command.sharerKey().toString()));
+
+        Long sharerId = sharerPoint.getUserId();
+
+        if (FormatValidator.hasValue(command.buyerId()) && Objects.equals(command.buyerId(), sharerId)) {
+            log.info("구매자와 공유자가 동일인 (적립 예정 포인트 변경 스킵). buyerId={}, sharerKey={}",
+                    command.buyerId(), command.sharerKey());
+            return null;
+        }
 
         ModifyPendingPointCommand delegateCommand = ModifyPendingPointCommand.builder()
-                .userId(userId)
+                .userId(sharerId)
                 .changeType(command.changeType())
                 .amount(command.amount())
                 .sourceType(command.sourceType())


### PR DESCRIPTION
## partially addresses #387
## resolves #1786

## Reason
구매자가 자기 자신을 공유자로 지정하여 공유 포인트를 적립받을 수 있다.

## Action
- [x] ModifyPendingSharedPointCommand에 buyerId 필드 추가
- [x] ModifyPendingSharedPointService에서 buyerId == sharerId 동일인 검증 추가 (동일인이면 스킵)
- [x] OrderPaymentCompletedSharedPointConsumer에서 command에 buyerId 전달
- [x] PaymentCancelledPartialSharedPointConsumer에서 command에 buyerId 전달