### PR TITLE
[#387][#1816] test: 공유 적립 예정 포인트 변경 시 구매자와 공유자 동일 여부 검증 기능 자동화 테스트 추가

### DIFF
--- a/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/adapter/in/event/OrderPaymentCompletedSharedPointConsumerTest.java
+++ b/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/adapter/in/event/OrderPaymentCompletedSharedPointConsumerTest.java
@@ -90,6 +90,7 @@ class OrderPaymentCompletedSharedPointConsumerTest {
 
         // 첫 번째 공유자 (SHARER_KEY_1)
         ModifyPendingSharedPointCommand firstCommand = commands.get(0);
+        assertThat(firstCommand.buyerId()).isEqualTo(100L);
         assertThat(firstCommand.sharerKey()).isEqualTo(SHARER_KEY_1);
         assertThat(firstCommand.changeType()).isEqualTo(UserPointChangeType.ACCRUAL);
         assertThat(firstCommand.amount()).isEqualTo(expectedAmount);
@@ -99,6 +100,7 @@ class OrderPaymentCompletedSharedPointConsumerTest {
 
         // 두 번째 공유자 (SHARER_KEY_2)
         ModifyPendingSharedPointCommand secondCommand = commands.get(1);
+        assertThat(secondCommand.buyerId()).isEqualTo(100L);
         assertThat(secondCommand.sharerKey()).isEqualTo(SHARER_KEY_2);
         assertThat(secondCommand.changeType()).isEqualTo(UserPointChangeType.ACCRUAL);
         assertThat(secondCommand.amount()).isEqualTo(expectedAmount);

--- a/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/adapter/in/event/PaymentCancelledPartialSharedPointConsumerTest.java
+++ b/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/adapter/in/event/PaymentCancelledPartialSharedPointConsumerTest.java
@@ -91,6 +91,7 @@ class PaymentCancelledPartialSharedPointConsumerTest {
         long expectedProportionalPoint = (30000L * expectedOriginalSharePoint + 80000L / 2) / 80000L;
 
         ModifyPendingSharedPointCommand firstCommand = commands.get(0);
+        assertThat(firstCommand.buyerId()).isEqualTo(100L);
         assertThat(firstCommand.sharerKey()).isEqualTo(SHARER_KEY_1);
         assertThat(firstCommand.changeType()).isEqualTo(UserPointChangeType.DEDUCTION);
         assertThat(firstCommand.amount()).isEqualTo(expectedProportionalPoint);
@@ -99,6 +100,7 @@ class PaymentCancelledPartialSharedPointConsumerTest {
         assertThat(firstCommand.reason()).isEqualTo("부분 결제 취소 공유 적립 예정 포인트 차감");
 
         ModifyPendingSharedPointCommand secondCommand = commands.get(1);
+        assertThat(secondCommand.buyerId()).isEqualTo(100L);
         assertThat(secondCommand.sharerKey()).isEqualTo(SHARER_KEY_2);
         assertThat(secondCommand.changeType()).isEqualTo(UserPointChangeType.DEDUCTION);
         assertThat(secondCommand.amount()).isEqualTo(expectedProportionalPoint);

--- a/reward-service/reward-application/src/test/java/com/personal/marketnote/reward/service/point/ModifyPendingSharedPointServiceTest.java
+++ b/reward-service/reward-application/src/test/java/com/personal/marketnote/reward/service/point/ModifyPendingSharedPointServiceTest.java
@@ -53,8 +53,9 @@ class ModifyPendingSharedPointServiceTest {
                 .build());
     }
 
-    private ModifyPendingSharedPointCommand createCommand(UserPointChangeType changeType, Long amount) {
+    private ModifyPendingSharedPointCommand createCommand(Long buyerId, UserPointChangeType changeType, Long amount) {
         return ModifyPendingSharedPointCommand.builder()
+                .buyerId(buyerId)
                 .sharerKey(SHARER_KEY)
                 .changeType(changeType)
                 .amount(amount)
@@ -74,7 +75,7 @@ class ModifyPendingSharedPointServiceTest {
         UpdateUserPointResult expectedResult = UpdateUserPointResult.from(userPoint);
         when(modifyPendingPointUseCase.modifyPending(any(ModifyPendingPointCommand.class))).thenReturn(expectedResult);
 
-        ModifyPendingSharedPointCommand command = createCommand(UserPointChangeType.ACCRUAL, 500L);
+        ModifyPendingSharedPointCommand command = createCommand(999L, UserPointChangeType.ACCRUAL, 500L);
 
         // when
         UpdateUserPointResult result = modifyPendingSharedPointService.modifyPending(command);
@@ -100,13 +101,50 @@ class ModifyPendingSharedPointServiceTest {
         // given
         when(findUserPointPort.findByUserKey(SHARER_KEY.toString())).thenReturn(Optional.empty());
 
-        ModifyPendingSharedPointCommand command = createCommand(UserPointChangeType.ACCRUAL, 500L);
+        ModifyPendingSharedPointCommand command = createCommand(999L, UserPointChangeType.ACCRUAL, 500L);
 
         // expect
         assertThatThrownBy(() -> modifyPendingSharedPointService.modifyPending(command))
                 .isInstanceOf(UserPointNotFoundException.class);
 
         verify(modifyPendingPointUseCase, never()).modifyPending(any());
+    }
+
+    @Test
+    @DisplayName("구매자와 공유자가 동일인이면 적립 예정 포인트를 변경하지 않고 null을 반환한다")
+    void shouldReturnNullWhenBuyerAndSharerAreSamePerson() {
+        // given
+        UserPoint userPoint = createUserPoint();
+        when(findUserPointPort.findByUserKey(SHARER_KEY.toString())).thenReturn(Optional.of(userPoint));
+
+        ModifyPendingSharedPointCommand command = createCommand(RESOLVED_USER_ID, UserPointChangeType.ACCRUAL, 500L);
+
+        // when
+        UpdateUserPointResult result = modifyPendingSharedPointService.modifyPending(command);
+
+        // then
+        assertThat(result).isNull();
+        verify(modifyPendingPointUseCase, never()).modifyPending(any());
+    }
+
+    @Test
+    @DisplayName("buyerId가 null이면 동일인 검증을 건너뛰고 적립 예정 포인트를 변경한다")
+    void shouldProceedWhenBuyerIdIsNull() {
+        // given
+        UserPoint userPoint = createUserPoint();
+        when(findUserPointPort.findByUserKey(SHARER_KEY.toString())).thenReturn(Optional.of(userPoint));
+
+        UpdateUserPointResult expectedResult = UpdateUserPointResult.from(userPoint);
+        when(modifyPendingPointUseCase.modifyPending(any(ModifyPendingPointCommand.class))).thenReturn(expectedResult);
+
+        ModifyPendingSharedPointCommand command = createCommand(null, UserPointChangeType.ACCRUAL, 500L);
+
+        // when
+        UpdateUserPointResult result = modifyPendingSharedPointService.modifyPending(command);
+
+        // then
+        assertThat(result.userId()).isEqualTo(RESOLVED_USER_ID);
+        verify(modifyPendingPointUseCase).modifyPending(any(ModifyPendingPointCommand.class));
     }
 
     @Test
@@ -119,7 +157,7 @@ class ModifyPendingSharedPointServiceTest {
         UpdateUserPointResult expectedResult = UpdateUserPointResult.from(userPoint);
         when(modifyPendingPointUseCase.modifyPending(any(ModifyPendingPointCommand.class))).thenReturn(expectedResult);
 
-        ModifyPendingSharedPointCommand command = createCommand(UserPointChangeType.DEDUCTION, 300L);
+        ModifyPendingSharedPointCommand command = createCommand(999L, UserPointChangeType.DEDUCTION, 300L);
 
         // when
         modifyPendingSharedPointService.modifyPending(command);


### PR DESCRIPTION
## partially addresses #387
## resolves #1816

## Test Case
- [x] 구매자와 공유자가 동일인이면 적립 예정 포인트를 변경하지 않고 null을 반환한다
- [x] buyerId가 null이면 동일인 검증을 건너뛰고 적립 예정 포인트를 변경한다
- [x] OrderPaymentCompletedSharedPointConsumer command에 buyerId 전달 검증
- [x] PaymentCancelledPartialSharedPointConsumer command에 buyerId 전달 검증