### PR TITLE
[#300][#1825] test: 상품 문의글 등록·수정 시 욕설 필터링 기능 자동화 테스트 추가

### DIFF
--- a/community-service/community-application/src/test/java/com/personal/marketnote/community/service/post/RegisterPostUseCaseTest.java
+++ b/community-service/community-application/src/test/java/com/personal/marketnote/community/service/post/RegisterPostUseCaseTest.java
@@ -3,6 +3,7 @@ package com.personal.marketnote.community.service.post;
 import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
 import com.personal.marketnote.common.utility.ValueMasker;
 import com.personal.marketnote.community.domain.post.*;
+import com.personal.marketnote.community.exception.InvalidPostContentContainsProfanityException;
 import com.personal.marketnote.community.exception.NotProductSellerException;
 import com.personal.marketnote.community.port.in.command.post.RegisterPostCommand;
 import com.personal.marketnote.community.port.in.result.post.RegisterPostResult;
@@ -326,6 +327,108 @@ class RegisterPostUseCaseTest {
 
         assertThat(result.id()).isEqualTo(800L);
         verifyNoInteractions(findProductByPricePolicyPort);
+    }
+
+    @Test
+    @DisplayName("상품 문의글 등록 시 제목에 욕설이 포함되면 InvalidPostContentContainsProfanityException이 발생한다")
+    void registerPost_productInquiryWithProfanityInTitle_throwsException() {
+        RegisterPostCommand command = RegisterPostCommand.builder()
+                .userId(1L)
+                .board(Board.PRODUCT_INQUERY)
+                .category("PRODUCT_QUESTION")
+                .writerName("작성자")
+                .title("욕설제목")
+                .content("정상 내용")
+                .build();
+        when(findProfanityWordPort.containsProfanity("욕설제목")).thenReturn(true);
+
+        assertThatThrownBy(() -> registerPostService.registerPost(false, command))
+                .isInstanceOf(InvalidPostContentContainsProfanityException.class);
+
+        verifyNoInteractions(savePostPort);
+    }
+
+    @Test
+    @DisplayName("상품 문의글 등록 시 내용에 욕설이 포함되면 InvalidPostContentContainsProfanityException이 발생한다")
+    void registerPost_productInquiryWithProfanityInContent_throwsException() {
+        RegisterPostCommand command = RegisterPostCommand.builder()
+                .userId(1L)
+                .board(Board.PRODUCT_INQUERY)
+                .category("PRODUCT_QUESTION")
+                .writerName("작성자")
+                .title("정상 제목")
+                .content("욕설내용")
+                .build();
+        when(findProfanityWordPort.containsProfanity("정상 제목")).thenReturn(false);
+        when(findProfanityWordPort.containsProfanity("욕설내용")).thenReturn(true);
+
+        assertThatThrownBy(() -> registerPostService.registerPost(false, command))
+                .isInstanceOf(InvalidPostContentContainsProfanityException.class);
+
+        verifyNoInteractions(savePostPort);
+    }
+
+    @Test
+    @DisplayName("상품 문의글 등록 시 제목과 내용에 욕설이 없으면 정상 등록된다")
+    void registerPost_productInquiryWithoutProfanity_succeeds() {
+        RegisterPostCommand command = RegisterPostCommand.builder()
+                .userId(1L)
+                .board(Board.PRODUCT_INQUERY)
+                .category("PRODUCT_QUESTION")
+                .writerName("작성자")
+                .title("정상 제목")
+                .content("정상 내용")
+                .build();
+        Post savedPost = buildSavedPost(1100L, command);
+        when(findProfanityWordPort.containsProfanity("정상 제목")).thenReturn(false);
+        when(findProfanityWordPort.containsProfanity("정상 내용")).thenReturn(false);
+        when(savePostPort.save(any(Post.class))).thenReturn(savedPost);
+
+        RegisterPostResult result = registerPostService.registerPost(false, command);
+
+        assertThat(result.id()).isEqualTo(1100L);
+        verify(findProfanityWordPort).containsProfanity("정상 제목");
+        verify(findProfanityWordPort).containsProfanity("정상 내용");
+    }
+
+    @Test
+    @DisplayName("판매자 답글 등록 시 욕설 검증이 실행되지 않는다")
+    void registerPost_sellerReply_skipsProfanityValidation() {
+        Long sellerId = 1L;
+        Long pricePolicyId = 100L;
+        RegisterPostCommand command = buildReplyCommand(sellerId, 10L, pricePolicyId,
+                Board.PRODUCT_INQUERY, "PRODUCT_QUESTION");
+        Post savedPost = buildSavedPost(1200L, command);
+
+        ProductInfoResult productInfo = buildProductInfo(sellerId);
+        when(findProductByPricePolicyPort.findByPricePolicyIds(List.of(pricePolicyId)))
+                .thenReturn(Map.of(pricePolicyId, productInfo));
+        when(savePostPort.save(any(Post.class))).thenReturn(savedPost);
+
+        RegisterPostResult result = registerPostService.registerPost(true, command);
+
+        assertThat(result.id()).isEqualTo(1200L);
+        verifyNoInteractions(findProfanityWordPort);
+    }
+
+    @Test
+    @DisplayName("1:1 문의글 등록 시 욕설 검증이 실행되지 않는다")
+    void registerPost_oneOnOneInquiry_skipsProfanityValidation() {
+        RegisterPostCommand command = RegisterPostCommand.builder()
+                .userId(1L)
+                .board(Board.ONE_ON_ONE_INQUERY)
+                .category("ORDER_PAYMENT")
+                .writerName("작성자")
+                .title("욕설포함제목")
+                .content("욕설포함내용")
+                .build();
+        Post savedPost = buildSavedPost(1300L, command);
+        when(savePostPort.save(any(Post.class))).thenReturn(savedPost);
+
+        RegisterPostResult result = registerPostService.registerPost(false, command);
+
+        assertThat(result.id()).isEqualTo(1300L);
+        verifyNoInteractions(findProfanityWordPort);
     }
 
     private RegisterPostCommand buildCommand(

--- a/community-service/community-application/src/test/java/com/personal/marketnote/community/service/post/UpdatePostUseCaseTest.java
+++ b/community-service/community-application/src/test/java/com/personal/marketnote/community/service/post/UpdatePostUseCaseTest.java
@@ -87,6 +87,49 @@ class UpdatePostUseCaseTest {
         verifyNoInteractions(updatePostPort);
     }
 
+    @Test
+    @DisplayName("상품 문의글 수정 시 수정 불가 예외가 욕설 검증보다 먼저 발생하고 욕설 검증이 실행되지 않는다")
+    void updatePost_productInquiry_throwsNotEditableBeforeProfanityCheck() {
+        Long postId = 1L;
+        Post post = buildPost(postId, Board.PRODUCT_INQUERY);
+        when(getPostUseCase.getPost(postId)).thenReturn(post);
+        UpdatePostCommand command = UpdatePostCommand.of(postId, "욕설제목", "욕설내용");
+
+        assertThatThrownBy(() -> updatePostService.updatePost(command))
+                .isInstanceOf(PostNotEditableException.class);
+
+        verifyNoInteractions(findProfanityWordPort);
+        verifyNoInteractions(updatePostPort);
+    }
+
+    @Test
+    @DisplayName("공지사항 수정 시 욕설 검증이 실행되지 않는다")
+    void updatePost_notice_skipsProfanityValidation() {
+        Long postId = 1L;
+        Post post = buildPost(postId, Board.NOTICE);
+        when(getPostUseCase.getPost(postId)).thenReturn(post);
+        UpdatePostCommand command = UpdatePostCommand.of(postId, "수정된 공지 제목", "수정된 공지 내용");
+
+        updatePostService.updatePost(command);
+
+        verifyNoInteractions(findProfanityWordPort);
+        verify(updatePostPort).update(post);
+    }
+
+    @Test
+    @DisplayName("FAQ 수정 시 욕설 검증이 실행되지 않는다")
+    void updatePost_faq_skipsProfanityValidation() {
+        Long postId = 1L;
+        Post post = buildPost(postId, Board.FAQ);
+        when(getPostUseCase.getPost(postId)).thenReturn(post);
+        UpdatePostCommand command = UpdatePostCommand.of(postId, "수정된 FAQ 제목", "수정된 FAQ 내용");
+
+        updatePostService.updatePost(command);
+
+        verifyNoInteractions(findProfanityWordPort);
+        verify(updatePostPort).update(post);
+    }
+
     private Post buildPost(Long id, Board board) {
         return Post.from(PostSnapshotState.builder()
                 .id(id)


### PR DESCRIPTION
## partially addresses #300
## resolves #1825

## Test Case
- [x] 상품 문의글 등록 시 제목에 욕설이 포함되면 InvalidPostContentContainsProfanityException이 발생한다
- [x] 상품 문의글 등록 시 내용에 욕설이 포함되면 InvalidPostContentContainsProfanityException이 발생한다
- [x] 상품 문의글 등록 시 제목과 내용에 욕설이 없으면 정상 등록된다
- [x] 판매자 답글 등록 시 욕설 검증이 실행되지 않는다
- [x] 1:1 문의글 등록 시 욕설 검증이 실행되지 않는다
- [x] 상품 문의글 수정 시 수정 불가 예외가 욕설 검증보다 먼저 발생하고 욕설 검증이 실행되지 않는다
- [x] 공지사항 수정 시 욕설 검증이 실행되지 않는다
- [x] FAQ 수정 시 욕설 검증이 실행되지 않는다