### PR TITLE
[#1518][#1513] test: Outbox 이벤트 발행 메트릭 모니터링 시스템 자동화 테스트 추가

### DIFF
--- a/common/src/test/java/com/personal/marketnote/common/outbox/adapter/OutboxAuditLoggerTest.java
+++ b/common/src/test/java/com/personal/marketnote/common/outbox/adapter/OutboxAuditLoggerTest.java
@@ -1,0 +1,40 @@
+package com.personal.marketnote.common.outbox.adapter;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+@DisplayName("OutboxAuditLogger 테스트")
+class OutboxAuditLoggerTest {
+
+    private final OutboxAuditLogger outboxAuditLogger = new OutboxAuditLogger();
+
+    @Test
+    @DisplayName("FAILED 전환 감사 로그를 기록한다")
+    void logFailed_logsWithoutException() {
+        // when & then
+        assertThatCode(() -> outboxAuditLogger.logFailed(
+                "commerce.payment.approved", "event-1", 5, "Kafka 전송 실패"
+        )).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("resolve 감사 로그를 기록한다")
+    void logResolve_logsWithoutException() {
+        // when & then
+        assertThatCode(() -> outboxAuditLogger.logResolve(
+                "commerce.payment.approved", "event-1", "RETRY", "일시적 장애 복구"
+        )).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("resolve 에러 감사 로그를 기록한다")
+    void logResolveError_logsWithoutException() {
+        // when & then
+        assertThatCode(() -> outboxAuditLogger.logResolveError(
+                "commerce.payment.approved", "event-1", "RETRY",
+                new RuntimeException("전송 실패")
+        )).doesNotThrowAnyException();
+    }
+}

--- a/common/src/test/java/com/personal/marketnote/common/outbox/adapter/OutboxEventPublisherTest.java
+++ b/common/src/test/java/com/personal/marketnote/common/outbox/adapter/OutboxEventPublisherTest.java
@@ -49,6 +49,12 @@ class OutboxEventPublisherTest {
     @Mock
     private Clock clock;
 
+    @Mock
+    private OutboxMetricsCollector outboxMetricsCollector;
+
+    @Mock
+    private OutboxAuditLogger outboxAuditLogger;
+
     @Test
     @DisplayName("PENDING 이벤트를 Kafka로 발행하고 PUBLISHED 상태로 변경한다")
     void publishPendingEvents_publishesToKafkaAndMarksPublished() throws Exception {
@@ -146,6 +152,9 @@ class OutboxEventPublisherTest {
         assertThat(entity.getRetryCount()).isEqualTo(5);
         assertThat(entity.getStatus()).isEqualTo(OutboxEventStatus.FAILED);
         verify(outboxEventJpaRepository).save(entity);
+        verify(outboxMetricsCollector).incrementFailedCount("commerce.payment.approved");
+        verify(outboxAuditLogger).logFailed(
+                eq("commerce.payment.approved"), eq("event-1"), eq(5), any(String.class));
     }
 
     @Test

--- a/common/src/test/java/com/personal/marketnote/common/outbox/adapter/OutboxMetricsCollectorTest.java
+++ b/common/src/test/java/com/personal/marketnote/common/outbox/adapter/OutboxMetricsCollectorTest.java
@@ -1,0 +1,65 @@
+package com.personal.marketnote.common.outbox.adapter;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+@DisplayName("OutboxMetricsCollector 테스트")
+class OutboxMetricsCollectorTest {
+
+    @Test
+    @DisplayName("FAILED 전환 시 outbox.events.failed.total 카운터가 증가한다")
+    void incrementFailedCount_incrementsCounter() {
+        // given
+        MeterRegistry meterRegistry = new SimpleMeterRegistry();
+        OutboxMetricsCollector collector = new OutboxMetricsCollector(meterRegistry);
+
+        // when
+        collector.incrementFailedCount("commerce.payment.approved");
+        collector.incrementFailedCount("commerce.payment.approved");
+
+        // then
+        Counter counter = meterRegistry.find("outbox.events.failed.total")
+                .tag("topic", "commerce.payment.approved")
+                .counter();
+        assertThat(counter).isNotNull();
+        assertThat(counter.count()).isEqualTo(2.0);
+    }
+
+    @Test
+    @DisplayName("resolve 시 outbox.events.resolved.total 카운터가 증가한다")
+    void incrementResolvedCount_incrementsCounter() {
+        // given
+        MeterRegistry meterRegistry = new SimpleMeterRegistry();
+        OutboxMetricsCollector collector = new OutboxMetricsCollector(meterRegistry);
+
+        // when
+        collector.incrementResolvedCount("commerce.payment.approved", "retry");
+
+        // then
+        Counter counter = meterRegistry.find("outbox.events.resolved.total")
+                .tag("topic", "commerce.payment.approved")
+                .tag("action", "retry")
+                .counter();
+        assertThat(counter).isNotNull();
+        assertThat(counter.count()).isEqualTo(1.0);
+    }
+
+    @Test
+    @DisplayName("MeterRegistry가 null이어도 예외가 발생하지 않는다")
+    void nullMeterRegistry_noException() {
+        // given
+        OutboxMetricsCollector collector = new OutboxMetricsCollector(null);
+
+        // when & then
+        assertThatCode(() -> {
+            collector.incrementFailedCount("commerce.payment.approved");
+            collector.incrementResolvedCount("commerce.payment.approved", "retry");
+        }).doesNotThrowAnyException();
+    }
+}


### PR DESCRIPTION
## partially addresses #1518
## resolves #1513

## Test Case
- [x] FAILED 전환 시 outbox.events.failed.total 카운터가 증가한다
- [x] resolve 시 outbox.events.resolved.total 카운터가 증가한다
- [x] MeterRegistry가 null이어도 예외가 발생하지 않는다
- [x] OutboxEventPublisher에서 이벤트 발행 실패로 FAILED 전환 시 메트릭 카운터가 호출된다