### PR TITLE
[#1518][#1514] feat: Outbox FAILED 이벤트 관리자 조회 기능 추가

### DIFF
--- a/common/src/main/java/com/personal/marketnote/common/outbox/adapter/OutboxQueryService.java
+++ b/common/src/main/java/com/personal/marketnote/common/outbox/adapter/OutboxQueryService.java
@@ -1,0 +1,44 @@
+package com.personal.marketnote.common.outbox.adapter;
+
+import com.personal.marketnote.common.outbox.OutboxEventStatus;
+import com.personal.marketnote.common.outbox.adapter.in.web.response.OutboxEventResponse;
+import com.personal.marketnote.common.outbox.adapter.in.web.response.OutboxTopicSummaryResponse;
+import com.personal.marketnote.common.outbox.repository.OutboxEventJpaRepository;
+import com.personal.marketnote.common.utility.FormatValidator;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(prefix = "outbox", name = "enabled", havingValue = "true")
+public class OutboxQueryService {
+    private final OutboxEventJpaRepository outboxEventJpaRepository;
+
+    @Transactional(isolation = READ_COMMITTED, readOnly = true)
+    public List<OutboxEventResponse> queryFailedEvents(String topic) {
+        if (FormatValidator.hasNoValue(topic)) {
+            return outboxEventJpaRepository.findByStatusOrderByCreatedAtAsc(OutboxEventStatus.FAILED)
+                    .stream()
+                    .map(OutboxEventResponse::from)
+                    .toList();
+        }
+        return outboxEventJpaRepository.findByStatusAndTopicOrderByCreatedAtAsc(OutboxEventStatus.FAILED, topic)
+                .stream()
+                .map(OutboxEventResponse::from)
+                .toList();
+    }
+
+    @Transactional(isolation = READ_COMMITTED, readOnly = true)
+    public List<OutboxTopicSummaryResponse> queryFailedSummary() {
+        List<Object[]> rows = outboxEventJpaRepository.countByStatusGroupByTopic(OutboxEventStatus.FAILED);
+        return rows.stream()
+                .map(row -> new OutboxTopicSummaryResponse((String) row[0], (Long) row[1]))
+                .toList();
+    }
+}

--- a/common/src/main/java/com/personal/marketnote/common/outbox/adapter/in/web/controller/AdminOutboxController.java
+++ b/common/src/main/java/com/personal/marketnote/common/outbox/adapter/in/web/controller/AdminOutboxController.java
@@ -1,0 +1,72 @@
+package com.personal.marketnote.common.outbox.adapter.in.web.controller;
+
+import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
+import com.personal.marketnote.common.outbox.adapter.OutboxQueryService;
+import com.personal.marketnote.common.outbox.adapter.in.web.controller.apidocs.QueryOutboxFailedEventsApiDocs;
+import com.personal.marketnote.common.outbox.adapter.in.web.controller.apidocs.QueryOutboxFailedSummaryApiDocs;
+import com.personal.marketnote.common.outbox.adapter.in.web.response.OutboxEventResponse;
+import com.personal.marketnote.common.outbox.adapter.in.web.response.OutboxTopicSummaryResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.core.OAuth2AuthenticatedPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+import static com.personal.marketnote.common.domain.exception.ExceptionCode.DEFAULT_SUCCESS_CODE;
+import static com.personal.marketnote.common.utility.ApiConstant.ADMIN_POINTCUT;
+
+@RestController
+@Tag(name = "Outbox API", description = "Outbox 이벤트 관리")
+@RequiredArgsConstructor
+@ConditionalOnProperty(prefix = "outbox", name = "enabled", havingValue = "true")
+public class AdminOutboxController {
+
+    private final OutboxQueryService outboxQueryService;
+
+    @GetMapping("/api/v1/admin/outbox/failed")
+    @PreAuthorize(ADMIN_POINTCUT)
+    @QueryOutboxFailedEventsApiDocs
+    public ResponseEntity<BaseResponse<List<OutboxEventResponse>>> queryFailedEvents(
+            @RequestParam(value = "topic", required = false) String topic,
+            @AuthenticationPrincipal OAuth2AuthenticatedPrincipal principal
+    ) {
+        List<OutboxEventResponse> events = outboxQueryService.queryFailedEvents(topic);
+
+        return new ResponseEntity<>(
+                BaseResponse.of(
+                        events,
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "Outbox FAILED 이벤트 조회 완료"
+                ),
+                HttpStatus.OK
+        );
+    }
+
+    @GetMapping("/api/v1/admin/outbox/failed/summary")
+    @PreAuthorize(ADMIN_POINTCUT)
+    @QueryOutboxFailedSummaryApiDocs
+    public ResponseEntity<BaseResponse<List<OutboxTopicSummaryResponse>>> queryFailedSummary(
+            @AuthenticationPrincipal OAuth2AuthenticatedPrincipal principal
+    ) {
+        List<OutboxTopicSummaryResponse> summaries = outboxQueryService.queryFailedSummary();
+
+        return new ResponseEntity<>(
+                BaseResponse.of(
+                        summaries,
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "Outbox FAILED 토픽별 요약 조회 완료"
+                ),
+                HttpStatus.OK
+        );
+    }
+}

--- a/common/src/main/java/com/personal/marketnote/common/outbox/adapter/in/web/controller/apidocs/QueryOutboxFailedEventsApiDocs.java
+++ b/common/src/main/java/com/personal/marketnote/common/outbox/adapter/in/web/controller/apidocs/QueryOutboxFailedEventsApiDocs.java
@@ -1,0 +1,114 @@
+package com.personal.marketnote.common.outbox.adapter.in.web.controller.apidocs;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.*;
+
+/**
+ * (관리자) Outbox FAILED 이벤트 조회 API 문서 애노테이션.
+ *
+ * @author 성효빈
+ * @since 2026-04-05
+ */
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Operation(
+        summary = "(관리자) Outbox FAILED 이벤트 조회",
+        description = """
+                작성일자: 2026-04-05
+
+                작성자: 성효빈
+
+                ---
+
+                ## Description
+
+                Outbox FAILED 상태의 이벤트 목록을 조회합니다. 토픽 필터를 적용할 수 있습니다.
+
+                ---
+
+                ## Query Parameters
+
+                | **키** | **타입** | **설명** | **필수 여부** | **예시** |
+                | --- | --- | --- | --- | --- |
+                | topic | string | 토픽명 필터 | N | "commerce.payment.approved" |
+
+                ---
+
+                ## Response > content
+
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | content | array | FAILED 이벤트 목록 | - |
+                | content[].id | number | 이벤트 ID | 1 |
+                | content[].eventId | string | 이벤트 UUID | "550e8400-e29b-41d4-a716-446655440000" |
+                | content[].topic | string | 토픽명 | "commerce.payment.approved" |
+                | content[].partitionKey | string | 파티션 키 | "order-123" |
+                | content[].eventType | string | 이벤트 타입 | "PaymentApproved" |
+                | content[].source | string | 소스 서비스 | "commerce-service" |
+                | content[].retryCount | number | 재시도 횟수 | 5 |
+                | content[].maxRetries | number | 최대 재시도 횟수 | 5 |
+                | content[].createdAt | string | 생성 일시 | "2026-04-05T10:00:00" |
+                | content[].failedAt | string | 실패 일시 | "2026-04-05T10:05:00" |
+                | content[].lastErrorMessage | string | 마지막 에러 메시지 | "Kafka send failed" |
+                """,
+        security = {@SecurityRequirement(name = "bearer")},
+        parameters = {
+                @Parameter(
+                        name = "topic",
+                        description = "토픽명 필터",
+                        in = ParameterIn.QUERY,
+                        required = false,
+                        schema = @Schema(type = "string")
+                )
+        },
+        responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "FAILED 이벤트 조회 완료",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 200,
+                                          "code": "SUC01",
+                                          "timestamp": "2026-04-05T12:00:00.000",
+                                          "content": [
+                                            {
+                                              "id": 1,
+                                              "eventId": "550e8400-e29b-41d4-a716-446655440000",
+                                              "topic": "commerce.payment.approved",
+                                              "partitionKey": "order-123",
+                                              "eventType": "PaymentApproved",
+                                              "source": "commerce-service",
+                                              "retryCount": 5,
+                                              "maxRetries": 5,
+                                              "createdAt": "2026-04-05T10:00:00",
+                                              "failedAt": "2026-04-05T10:05:00",
+                                              "lastErrorMessage": "Kafka send failed"
+                                            }
+                                          ],
+                                          "message": "Outbox FAILED 이벤트 조회 완료"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "401",
+                        description = "인증 실패"
+                ),
+                @ApiResponse(
+                        responseCode = "403",
+                        description = "관리자 권한 없음"
+                )
+        }
+)
+public @interface QueryOutboxFailedEventsApiDocs {
+}

--- a/common/src/main/java/com/personal/marketnote/common/outbox/adapter/in/web/controller/apidocs/QueryOutboxFailedSummaryApiDocs.java
+++ b/common/src/main/java/com/personal/marketnote/common/outbox/adapter/in/web/controller/apidocs/QueryOutboxFailedSummaryApiDocs.java
@@ -1,0 +1,80 @@
+package com.personal.marketnote.common.outbox.adapter.in.web.controller.apidocs;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.*;
+
+/**
+ * (관리자) Outbox FAILED 토픽별 요약 조회 API 문서 애노테이션.
+ *
+ * @author 성효빈
+ * @since 2026-04-05
+ */
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Operation(
+        summary = "(관리자) Outbox FAILED 토픽별 요약 조회",
+        description = """
+                작성일자: 2026-04-05
+
+                작성자: 성효빈
+
+                ---
+
+                ## Description
+
+                Outbox FAILED 이벤트의 토픽별 건수 요약을 조회합니다.
+
+                ---
+
+                ## Response > content
+
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | content | array | 토픽별 요약 목록 | - |
+                | content[].topic | string | 토픽명 | "commerce.payment.approved" |
+                | content[].failedCount | number | FAILED 건수 | 3 |
+                """,
+        security = {@SecurityRequirement(name = "bearer")},
+        responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "FAILED 토픽별 요약 조회 완료",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 200,
+                                          "code": "SUC01",
+                                          "timestamp": "2026-04-05T12:00:00.000",
+                                          "content": [
+                                            {
+                                              "topic": "commerce.payment.approved",
+                                              "failedCount": 3
+                                            },
+                                            {
+                                              "topic": "commerce.order.created",
+                                              "failedCount": 1
+                                            }
+                                          ],
+                                          "message": "Outbox FAILED 토픽별 요약 조회 완료"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "401",
+                        description = "인증 실패"
+                ),
+                @ApiResponse(
+                        responseCode = "403",
+                        description = "관리자 권한 없음"
+                )
+        }
+)
+public @interface QueryOutboxFailedSummaryApiDocs {
+}

--- a/common/src/main/java/com/personal/marketnote/common/outbox/adapter/in/web/response/OutboxEventResponse.java
+++ b/common/src/main/java/com/personal/marketnote/common/outbox/adapter/in/web/response/OutboxEventResponse.java
@@ -1,0 +1,35 @@
+package com.personal.marketnote.common.outbox.adapter.in.web.response;
+
+import com.personal.marketnote.common.outbox.entity.OutboxEventJpaEntity;
+
+import java.time.LocalDateTime;
+
+public record OutboxEventResponse(
+        Long id,
+        String eventId,
+        String topic,
+        String partitionKey,
+        String eventType,
+        String source,
+        int retryCount,
+        int maxRetries,
+        LocalDateTime createdAt,
+        LocalDateTime failedAt,
+        String lastErrorMessage
+) {
+    public static OutboxEventResponse from(OutboxEventJpaEntity entity) {
+        return new OutboxEventResponse(
+                entity.getId(),
+                entity.getEventId(),
+                entity.getTopic(),
+                entity.getPartitionKey(),
+                entity.getEventType(),
+                entity.getSource(),
+                entity.getRetryCount(),
+                entity.getMaxRetries(),
+                entity.getCreatedAt(),
+                entity.getFailedAt(),
+                entity.getLastErrorMessage()
+        );
+    }
+}

--- a/common/src/main/java/com/personal/marketnote/common/outbox/adapter/in/web/response/OutboxTopicSummaryResponse.java
+++ b/common/src/main/java/com/personal/marketnote/common/outbox/adapter/in/web/response/OutboxTopicSummaryResponse.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.common.outbox.adapter.in.web.response;
+
+public record OutboxTopicSummaryResponse(
+        String topic,
+        long failedCount
+) {
+}

--- a/common/src/main/java/com/personal/marketnote/common/outbox/repository/OutboxEventJpaRepository.java
+++ b/common/src/main/java/com/personal/marketnote/common/outbox/repository/OutboxEventJpaRepository.java
@@ -21,6 +21,11 @@ public interface OutboxEventJpaRepository extends JpaRepository<OutboxEventJpaEn
 
     long countByStatus(OutboxEventStatus status);
 
+    long countByStatusAndTopic(OutboxEventStatus status, String topic);
+
+    @Query("SELECT e.topic, COUNT(e) FROM OutboxEventJpaEntity e WHERE e.status = :status GROUP BY e.topic ORDER BY e.topic")
+    List<Object[]> countByStatusGroupByTopic(@Param("status") OutboxEventStatus status);
+
     @Query("SELECT DISTINCT e.topic FROM OutboxEventJpaEntity e WHERE e.status = :status")
     List<String> findDistinctTopicByStatus(@Param("status") OutboxEventStatus status);
 


### PR DESCRIPTION
## partially addresses #1518
## resolves #1514

## Task
- [x] OutboxQueryService 생성 (FAILED 이벤트 목록 조회, 토픽 필터 조회, 토픽별 요약)
- [x] OutboxEventResponse 응답 DTO 생성 (failedAt, lastErrorMessage 포함)
- [x] OutboxTopicSummaryResponse 응답 DTO 생성
- [x] AdminOutboxController에 GET /api/v1/admin/outbox/failed 엔드포인트 추가
- [x] AdminOutboxController에 GET /api/v1/admin/outbox/failed/summary 엔드포인트 추가
- [x] QueryOutboxFailedEventsApiDocs 합성 애노테이션 생성
- [x] QueryOutboxFailedSummaryApiDocs 합성 애노테이션 생성