### PR TITLE
[#1518][#1516] feat: Outbox FAILED 이벤트 관리자 해결 기능 추가

### DIFF
--- a/common/src/main/java/com/personal/marketnote/common/outbox/adapter/OutboxEventCleaner.java
+++ b/common/src/main/java/com/personal/marketnote/common/outbox/adapter/OutboxEventCleaner.java
@@ -31,4 +31,12 @@ public class OutboxEventCleaner {
         outboxEventJpaRepository.deleteByStatusAndPublishedAtBefore(OutboxEventStatus.PUBLISHED, cutoff);
         log.info("Outbox 발행 완료 이벤트 정리 완료 - cutoff: {}", cutoff);
     }
+
+    @Scheduled(cron = "${outbox.discard-cleanup-cron:0 30 3 * * ?}")
+    @Transactional(isolation = READ_COMMITTED)
+    public void cleanupDiscardedEvents() {
+        LocalDateTime cutoff = LocalDateTime.now(clock).minusDays(outboxProperties.getRetentionDays());
+        outboxEventJpaRepository.deleteByStatusAndDiscardedAtBefore(OutboxEventStatus.DISCARDED, cutoff);
+        log.info("Outbox 폐기 이벤트 정리 완료 - cutoff: {}", cutoff);
+    }
 }

--- a/common/src/main/java/com/personal/marketnote/common/outbox/adapter/OutboxResolveService.java
+++ b/common/src/main/java/com/personal/marketnote/common/outbox/adapter/OutboxResolveService.java
@@ -1,0 +1,57 @@
+package com.personal.marketnote.common.outbox.adapter;
+
+import com.personal.marketnote.common.outbox.adapter.command.OutboxResolveCommand;
+import com.personal.marketnote.common.outbox.adapter.command.OutboxResolveResult;
+import com.personal.marketnote.common.outbox.entity.OutboxEventJpaEntity;
+import com.personal.marketnote.common.outbox.exception.OutboxEventNotFoundException;
+import com.personal.marketnote.common.outbox.repository.OutboxEventJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(prefix = "outbox", name = "enabled", havingValue = "true")
+public class OutboxResolveService {
+    private final OutboxEventJpaRepository outboxEventJpaRepository;
+    private final OutboxAuditLogger outboxAuditLogger;
+    private final OutboxMetricsCollector outboxMetricsCollector;
+    private final Clock clock;
+
+    @Transactional(isolation = READ_COMMITTED)
+    public OutboxResolveResult resolve(OutboxResolveCommand command) {
+        OutboxEventJpaEntity entity = outboxEventJpaRepository.findById(command.id())
+                .orElseThrow(() -> new OutboxEventNotFoundException(command.id()));
+
+        if (entity.isAlreadyResolved()) {
+            return new OutboxResolveResult(
+                    entity.getEventId(), entity.getTopic(),
+                    command.action().name(), command.reason(), true
+            );
+        }
+
+        applyAction(entity, command);
+
+        outboxAuditLogger.logResolve(entity.getTopic(), entity.getEventId(), command.action().name(), command.reason());
+        outboxMetricsCollector.incrementResolvedCount(entity.getTopic(), command.action().name());
+
+        return new OutboxResolveResult(
+                entity.getEventId(), entity.getTopic(),
+                command.action().name(), command.reason(), false
+        );
+    }
+
+    private void applyAction(OutboxEventJpaEntity entity, OutboxResolveCommand command) {
+        if (command.action().isRetry()) {
+            entity.resetForRetry();
+            return;
+        }
+        entity.discard(command.reason(), LocalDateTime.now(clock));
+    }
+}

--- a/common/src/main/java/com/personal/marketnote/common/outbox/adapter/command/OutboxResolveCommand.java
+++ b/common/src/main/java/com/personal/marketnote/common/outbox/adapter/command/OutboxResolveCommand.java
@@ -1,0 +1,10 @@
+package com.personal.marketnote.common.outbox.adapter.command;
+
+import com.personal.marketnote.common.outbox.OutboxResolutionAction;
+
+public record OutboxResolveCommand(
+        Long id,
+        OutboxResolutionAction action,
+        String reason
+) {
+}

--- a/common/src/main/java/com/personal/marketnote/common/outbox/adapter/command/OutboxResolveResult.java
+++ b/common/src/main/java/com/personal/marketnote/common/outbox/adapter/command/OutboxResolveResult.java
@@ -1,0 +1,10 @@
+package com.personal.marketnote.common.outbox.adapter.command;
+
+public record OutboxResolveResult(
+        String eventId,
+        String topic,
+        String resolution,
+        String reason,
+        boolean alreadyResolved
+) {
+}

--- a/common/src/main/java/com/personal/marketnote/common/outbox/adapter/in/web/controller/AdminOutboxController.java
+++ b/common/src/main/java/com/personal/marketnote/common/outbox/adapter/in/web/controller/AdminOutboxController.java
@@ -2,11 +2,18 @@ package com.personal.marketnote.common.outbox.adapter.in.web.controller;
 
 import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
 import com.personal.marketnote.common.outbox.adapter.OutboxQueryService;
+import com.personal.marketnote.common.outbox.adapter.OutboxResolveService;
+import com.personal.marketnote.common.outbox.adapter.command.OutboxResolveCommand;
+import com.personal.marketnote.common.outbox.adapter.command.OutboxResolveResult;
 import com.personal.marketnote.common.outbox.adapter.in.web.controller.apidocs.QueryOutboxFailedEventsApiDocs;
 import com.personal.marketnote.common.outbox.adapter.in.web.controller.apidocs.QueryOutboxFailedSummaryApiDocs;
+import com.personal.marketnote.common.outbox.adapter.in.web.controller.apidocs.ResolveOutboxApiDocs;
+import com.personal.marketnote.common.outbox.adapter.in.web.request.ResolveOutboxRequest;
 import com.personal.marketnote.common.outbox.adapter.in.web.response.OutboxEventResponse;
 import com.personal.marketnote.common.outbox.adapter.in.web.response.OutboxTopicSummaryResponse;
+import com.personal.marketnote.common.outbox.adapter.in.web.response.ResolveOutboxResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.HttpStatus;
@@ -14,9 +21,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.core.OAuth2AuthenticatedPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -30,6 +35,7 @@ import static com.personal.marketnote.common.utility.ApiConstant.ADMIN_POINTCUT;
 public class AdminOutboxController {
 
     private final OutboxQueryService outboxQueryService;
+    private final OutboxResolveService outboxResolveService;
 
     @GetMapping("/api/v1/admin/outbox/failed")
     @PreAuthorize(ADMIN_POINTCUT)
@@ -46,6 +52,27 @@ public class AdminOutboxController {
                         HttpStatus.OK,
                         DEFAULT_SUCCESS_CODE,
                         "Outbox FAILED 이벤트 조회 완료"
+                ),
+                HttpStatus.OK
+        );
+    }
+
+    @PostMapping("/api/v1/admin/outbox/resolve")
+    @PreAuthorize(ADMIN_POINTCUT)
+    @ResolveOutboxApiDocs
+    public ResponseEntity<BaseResponse<ResolveOutboxResponse>> resolveFailedEvent(
+            @Valid @RequestBody ResolveOutboxRequest request,
+            @AuthenticationPrincipal OAuth2AuthenticatedPrincipal principal
+    ) {
+        OutboxResolveCommand command = new OutboxResolveCommand(request.id(), request.action(), request.reason());
+        OutboxResolveResult result = outboxResolveService.resolve(command);
+
+        return new ResponseEntity<>(
+                BaseResponse.of(
+                        ResolveOutboxResponse.from(command, result),
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "Outbox FAILED 이벤트 해결 완료"
                 ),
                 HttpStatus.OK
         );

--- a/common/src/main/java/com/personal/marketnote/common/outbox/adapter/in/web/controller/apidocs/ResolveOutboxApiDocs.java
+++ b/common/src/main/java/com/personal/marketnote/common/outbox/adapter/in/web/controller/apidocs/ResolveOutboxApiDocs.java
@@ -1,0 +1,95 @@
+package com.personal.marketnote.common.outbox.adapter.in.web.controller.apidocs;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.*;
+
+/**
+ * (관리자) Outbox FAILED 이벤트 해결 API 문서 애노테이션.
+ *
+ * @author 성효빈
+ * @since 2026-04-05
+ */
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Operation(
+        summary = "(관리자) Outbox FAILED 이벤트 해결",
+        description = """
+                작성일자: 2026-04-05
+
+                작성자: 성효빈
+
+                ---
+
+                ## Description
+
+                Outbox FAILED 이벤트를 RETRY(재시도) 또는 DISCARD(폐기)로 해결합니다.
+
+                ---
+
+                ## Request Body
+
+                | **키** | **타입** | **설명** | **필수 여부** | **예시** |
+                | --- | --- | --- | --- | --- |
+                | id | number | 이벤트 ID | Y | 1 |
+                | action | string | 처리 액션 (RETRY / DISCARD) | Y | "RETRY" |
+                | reason | string | 처리 사유 (최대 500자) | N | "수동 재시도" |
+
+                ---
+
+                ## Response > content
+
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | id | number | 이벤트 ID | 1 |
+                | eventId | string | 이벤트 UUID | "550e8400-e29b-41d4-a716-446655440000" |
+                | topic | string | 토픽명 | "commerce.payment.approved" |
+                | resolution | string | 처리 결과 (RETRY / DISCARD) | "RETRY" |
+                | reason | string | 처리 사유 | "수동 재시도" |
+                | alreadyResolved | boolean | 이미 해결된 이벤트 여부 | false |
+                """,
+        security = {@SecurityRequirement(name = "bearer")},
+        responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "FAILED 이벤트 해결 완료",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 200,
+                                          "code": "SUC01",
+                                          "timestamp": "2026-04-05T12:00:00.000",
+                                          "content": {
+                                            "id": 1,
+                                            "eventId": "550e8400-e29b-41d4-a716-446655440000",
+                                            "topic": "commerce.payment.approved",
+                                            "resolution": "RETRY",
+                                            "reason": "수동 재시도",
+                                            "alreadyResolved": false
+                                          },
+                                          "message": "Outbox FAILED 이벤트 해결 완료"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "401",
+                        description = "인증 실패"
+                ),
+                @ApiResponse(
+                        responseCode = "403",
+                        description = "관리자 권한 없음"
+                ),
+                @ApiResponse(
+                        responseCode = "404",
+                        description = "이벤트를 찾을 수 없음"
+                )
+        }
+)
+public @interface ResolveOutboxApiDocs {
+}

--- a/common/src/main/java/com/personal/marketnote/common/outbox/adapter/in/web/request/ResolveOutboxRequest.java
+++ b/common/src/main/java/com/personal/marketnote/common/outbox/adapter/in/web/request/ResolveOutboxRequest.java
@@ -1,0 +1,17 @@
+package com.personal.marketnote.common.outbox.adapter.in.web.request;
+
+import com.personal.marketnote.common.outbox.OutboxResolutionAction;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record ResolveOutboxRequest(
+        @NotNull(message = "이벤트 ID는 필수입니다")
+        Long id,
+
+        @NotNull(message = "처리 액션은 필수입니다")
+        OutboxResolutionAction action,
+
+        @Size(max = 500, message = "처리 사유는 500자를 초과할 수 없습니다")
+        String reason
+) {
+}

--- a/common/src/main/java/com/personal/marketnote/common/outbox/adapter/in/web/response/ResolveOutboxResponse.java
+++ b/common/src/main/java/com/personal/marketnote/common/outbox/adapter/in/web/response/ResolveOutboxResponse.java
@@ -1,0 +1,24 @@
+package com.personal.marketnote.common.outbox.adapter.in.web.response;
+
+import com.personal.marketnote.common.outbox.adapter.command.OutboxResolveCommand;
+import com.personal.marketnote.common.outbox.adapter.command.OutboxResolveResult;
+
+public record ResolveOutboxResponse(
+        Long id,
+        String eventId,
+        String topic,
+        String resolution,
+        String reason,
+        boolean alreadyResolved
+) {
+    public static ResolveOutboxResponse from(OutboxResolveCommand command, OutboxResolveResult result) {
+        return new ResolveOutboxResponse(
+                command.id(),
+                result.eventId(),
+                result.topic(),
+                result.resolution(),
+                result.reason(),
+                result.alreadyResolved()
+        );
+    }
+}

--- a/common/src/main/java/com/personal/marketnote/common/outbox/entity/OutboxEventJpaEntity.java
+++ b/common/src/main/java/com/personal/marketnote/common/outbox/entity/OutboxEventJpaEntity.java
@@ -143,6 +143,10 @@ public class OutboxEventJpaEntity {
         this.discardedAt = discardedAt;
     }
 
+    public boolean isAlreadyResolved() {
+        return this.status.isDiscarded() || this.status.isPublished();
+    }
+
     private static String truncate(String value, int maxLength) {
         if (value == null || value.length() <= maxLength) {
             return value;


### PR DESCRIPTION
## partially addresses #1518
## resolves #1516

## Task
- [x] OutboxResolveCommand record 생성
- [x] OutboxResolveResult record 생성
- [x] ResolveOutboxRequest 요청 DTO 생성
- [x] ResolveOutboxResponse 응답 DTO 생성
- [x] OutboxResolveService 생성 (개별 RETRY/DISCARD 처리, 멱등성 보장)
- [x] AdminOutboxController에 POST /api/v1/admin/outbox/resolve 엔드포인트 추가
- [x] ResolveOutboxApiDocs 합성 애노테이션 생성
- [x] OutboxEventCleaner에 DISCARDED 이벤트 discardedAt 기준 보존기간 경과 자동 정리 추가
- [x] OutboxEventJpaEntity에 isAlreadyResolved() 술어 메서드 추가