### PR TITLE
[#1196][#1899] feat: 주문 취소 요청 전용 API 추가

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/OrderController.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/OrderController.java
@@ -3,6 +3,7 @@ package com.personal.marketnote.commerce.adapter.in.web.order.controller;
 import com.personal.marketnote.commerce.adapter.in.web.order.controller.apidocs.*;
 import com.personal.marketnote.commerce.adapter.in.web.order.mapper.AdminOrderRequestToCommandMapper;
 import com.personal.marketnote.commerce.adapter.in.web.order.mapper.OrderRequestToCommandMapper;
+import com.personal.marketnote.commerce.adapter.in.web.order.request.CancelOrderRequest;
 import com.personal.marketnote.commerce.adapter.in.web.order.request.ChangeOrderStatusRequest;
 import com.personal.marketnote.commerce.adapter.in.web.order.request.RegisterOrderRequest;
 import com.personal.marketnote.commerce.adapter.in.web.order.response.*;
@@ -48,6 +49,7 @@ public class OrderController {
     private final RegisterOrderUseCase registerOrderUseCase;
     private final UpdateUserShippingAddressDeliveryRequestPort updateUserShippingAddressDeliveryRequestPort;
     private final GetOrderUseCase getOrderUseCase;
+    private final CancelOrderUseCase cancelOrderUseCase;
     private final ChangeOrderStatusUseCase changeOrderStatusUseCase;
     private final UpdateOrderProductUseCase updateOrderProductUseCase;
     private final GetAdminOrdersUseCase getAdminOrdersUseCase;
@@ -234,6 +236,40 @@ public class OrderController {
                         HttpStatus.OK,
                         DEFAULT_SUCCESS_CODE,
                         "나의 주문 내역 개수 조회 성공"
+                ),
+                HttpStatus.OK
+        );
+    }
+
+    /**
+     * 주문 취소 요청
+     *
+     * @param id        주문 ID
+     * @param request   주문 취소 요청
+     * @param principal 인증된 사용자 정보
+     * @Author 성효빈
+     * @Date 2026-04-05
+     * @Description 구매자가 주문 취소를 요청합니다. 주문 상태를 CANCEL_REQUESTED로 변경합니다.
+     */
+    @PostMapping("/api/v1/orders/{id}/cancel")
+    @CancelOrderApiDocs
+    public ResponseEntity<BaseResponse<Void>> cancelOrder(
+            @PathVariable("id") Long id,
+            @Valid @RequestBody CancelOrderRequest request,
+            @AuthenticationPrincipal OAuth2AuthenticatedPrincipal principal
+    ) {
+        Long buyerId = ElementExtractor.extractUserId(principal);
+
+        cancelOrderUseCase.cancelOrder(
+                OrderRequestToCommandMapper.mapToCancelCommand(id, request, buyerId)
+        );
+
+        return new ResponseEntity<>(
+                BaseResponse.of(
+                        null,
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "주문 취소 요청 성공"
                 ),
                 HttpStatus.OK
         );

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/apidocs/CancelOrderApiDocs.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/apidocs/CancelOrderApiDocs.java
@@ -1,0 +1,151 @@
+package com.personal.marketnote.commerce.adapter.in.web.order.controller.apidocs;
+
+import com.personal.marketnote.commerce.adapter.in.web.order.request.CancelOrderRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Operation(
+        summary = "주문 취소 요청",
+        description = """
+                작성일자: 2026-04-05
+
+                작성자: 성효빈
+
+                ---
+
+                ## Description
+
+                - 구매자가 주문 취소를 요청합니다.
+
+                - 주문 상태를 CANCEL_REQUESTED(주문 취소 요청됨)로 변경합니다.
+
+                - 결제 대기, 결제 완료, 상품 준비중, 상품 준비 완료 상태에서만 취소 요청이 가능합니다.
+
+                - 취소 사유 카테고리 목록
+
+                    - "CANCEL_ORDER": 구매 의사 취소
+
+                    - "CHANGE_OPTION": 색상, 사이즈 등 변경
+
+                    - "MISTAKE": 주문 실수
+
+                    - "ETC": 직접 입력
+
+                ---
+
+                ## Request
+
+                | **키** | **타입** | **설명** | **필수 여부** | **예시** |
+                | --- | --- | --- | --- | --- |
+                | reasonCategory | string | 취소 사유 카테고리 | N | "CANCEL_ORDER" |
+                | reason | string | 취소 사유 | N | "단순 변심" |
+
+                ---
+
+                ## Response
+
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | statusCode | number | 상태 코드 | 200: 성공 / 400: 클라이언트 요청 오류 / 401: 인증 실패 / 403: 인가 실패 / 409: 충돌 / 500: 그 외 |
+                | code | string | 응답 코드 | "SUC01" / "BAD_REQUEST" / "UNAUTHORIZED" / "CONFLICT" / "INTERNAL_SERVER_ERROR" |
+                | timestamp | string(datetime) | 응답 일시 | "2026-04-05T12:00:00.000" |
+                | content | object | 응답 본문 | null |
+                | message | string | 처리 결과 | "주문 취소 요청 성공" |
+                """, security = {@SecurityRequirement(name = "bearer")},
+        parameters = {
+                @Parameter(
+                        name = "id",
+                        description = "주문 ID",
+                        in = ParameterIn.PATH,
+                        required = true,
+                        schema = @Schema(type = "number")
+                )
+        },
+        requestBody = @RequestBody(
+                required = true,
+                content = @Content(
+                        schema = @Schema(implementation = CancelOrderRequest.class),
+                        examples = @ExampleObject("""
+                                {
+                                  "reasonCategory": "CANCEL_ORDER",
+                                  "reason": "단순 변심"
+                                }
+                                """)
+                )
+        ),
+        responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "주문 취소 요청 성공",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 200,
+                                          "code": "SUC01",
+                                          "timestamp": "2026-04-05T12:00:00.000",
+                                          "content": null,
+                                          "message": "주문 취소 요청 성공"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "401",
+                        description = "토큰 인증 실패",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 401,
+                                          "code": "UNAUTHORIZED",
+                                          "timestamp": "2026-04-05T12:00:00.000",
+                                          "content": null,
+                                          "message": "Invalid token"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "409",
+                        description = "이미 주문 취소 요청됨",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 409,
+                                          "code": "CONFLICT",
+                                          "timestamp": "2026-04-05T12:00:00.000",
+                                          "content": null,
+                                          "message": "이미 해당 주문 상태(주문 취소 요청됨)로 변경되었습니다."
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "400",
+                        description = "상태 전이 불가",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 400,
+                                          "code": "BAD_REQUEST",
+                                          "timestamp": "2026-04-05T12:00:00.000",
+                                          "content": null,
+                                          "message": "주문 상태를 배송중에서 주문 취소 요청됨(으)로 변경할 수 없습니다."
+                                        }
+                                        """)
+                        )
+                ),
+        })
+public @interface CancelOrderApiDocs {
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/mapper/OrderRequestToCommandMapper.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/mapper/OrderRequestToCommandMapper.java
@@ -1,8 +1,10 @@
 package com.personal.marketnote.commerce.adapter.in.web.order.mapper;
 
+import com.personal.marketnote.commerce.adapter.in.web.order.request.CancelOrderRequest;
 import com.personal.marketnote.commerce.adapter.in.web.order.request.ChangeOrderStatusRequest;
 import com.personal.marketnote.commerce.adapter.in.web.order.request.RegisterOrderRequest;
 import com.personal.marketnote.commerce.domain.order.ShippingAddress;
+import com.personal.marketnote.commerce.port.in.command.order.CancelOrderCommand;
 import com.personal.marketnote.commerce.port.in.command.order.ChangeOrderStatusCommand;
 import com.personal.marketnote.commerce.port.in.command.order.OrderAmountCommand;
 import com.personal.marketnote.commerce.port.in.command.order.OrderProductItemCommand;
@@ -39,6 +41,15 @@ public class OrderRequestToCommandMapper {
                 .deliveryRequestType(request.getDeliveryRequestType())
                 .deliveryRequestMessage(request.getDeliveryRequestMessage())
                 .orderProducts(orderProducts)
+                .build();
+    }
+
+    public static CancelOrderCommand mapToCancelCommand(Long id, CancelOrderRequest request, Long buyerId) {
+        return CancelOrderCommand.builder()
+                .id(id)
+                .reasonCategory(request.getReasonCategory())
+                .reason(request.getReason())
+                .buyerId(buyerId)
                 .build();
     }
 

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/request/CancelOrderRequest.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/request/CancelOrderRequest.java
@@ -1,0 +1,24 @@
+package com.personal.marketnote.commerce.adapter.in.web.order.request;
+
+import com.personal.marketnote.commerce.domain.order.OrderStatusReasonCategory;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+@Getter
+public class CancelOrderRequest {
+    @Schema(
+            name = "reasonCategory",
+            description = "취소 사유 카테고리",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private OrderStatusReasonCategory reasonCategory;
+
+    @Schema(
+            name = "reason",
+            description = "취소 사유",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    @Size(max = 500, message = "취소 사유는 500자 이내여야 합니다.")
+    private String reason;
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/command/order/CancelOrderCommand.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/command/order/CancelOrderCommand.java
@@ -1,0 +1,13 @@
+package com.personal.marketnote.commerce.port.in.command.order;
+
+import com.personal.marketnote.commerce.domain.order.OrderStatusReasonCategory;
+import lombok.Builder;
+
+@Builder
+public record CancelOrderCommand(
+        Long id,
+        OrderStatusReasonCategory reasonCategory,
+        String reason,
+        Long buyerId
+) {
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/order/CancelOrderUseCase.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/order/CancelOrderUseCase.java
@@ -1,0 +1,20 @@
+package com.personal.marketnote.commerce.port.in.usecase.order;
+
+import com.personal.marketnote.commerce.port.in.command.order.CancelOrderCommand;
+
+/**
+ * 주문 취소 요청 유스케이스
+ *
+ * @Author 성효빈
+ * @Date 2026-04-05
+ * @Description 구매자의 주문 취소 요청 기능을 제공합니다.
+ */
+public interface CancelOrderUseCase {
+    /**
+     * @param command 주문 취소 요청 커맨드
+     * @Date 2026-04-05
+     * @Author 성효빈
+     * @Description 구매자의 주문을 취소 요청 상태로 변경합니다.
+     */
+    void cancelOrder(CancelOrderCommand command);
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/CancelOrderService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/CancelOrderService.java
@@ -1,0 +1,74 @@
+package com.personal.marketnote.commerce.service.order;
+
+import com.personal.marketnote.commerce.domain.order.Order;
+import com.personal.marketnote.commerce.domain.order.OrderStatus;
+import com.personal.marketnote.commerce.domain.order.OrderStatusHistory;
+import com.personal.marketnote.commerce.domain.order.OrderStatusHistoryCreateState;
+import com.personal.marketnote.commerce.exception.InvalidOrderStatusTransitionException;
+import com.personal.marketnote.commerce.exception.OrderStatusAlreadyChangedException;
+import com.personal.marketnote.commerce.exception.UnauthorizedOrderAccessException;
+import com.personal.marketnote.commerce.port.in.command.order.CancelOrderCommand;
+import com.personal.marketnote.commerce.port.in.usecase.order.CancelOrderUseCase;
+import com.personal.marketnote.commerce.port.in.usecase.order.GetOrderUseCase;
+import com.personal.marketnote.commerce.port.out.order.UpdateOrderPort;
+import com.personal.marketnote.common.application.UseCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional(isolation = READ_COMMITTED)
+@Slf4j
+public class CancelOrderService implements CancelOrderUseCase {
+    private final GetOrderUseCase getOrderUseCase;
+    private final UpdateOrderPort updateOrderPort;
+    private final Clock clock;
+
+    private static final OrderStatus TARGET_STATUS = OrderStatus.CANCEL_REQUESTED;
+
+    @Override
+    public void cancelOrder(CancelOrderCommand command) {
+        Order order = getOrderUseCase.getOrder(command.id());
+
+        validateBuyerOwnership(command, order);
+        validateStatusTransition(order);
+
+        LocalDateTime now = LocalDateTime.now(clock);
+        order.changeAllProductsStatus(TARGET_STATUS, now);
+
+        OrderStatusHistory orderStatusHistory = OrderStatusHistory.from(
+                OrderStatusHistoryCreateState.builder()
+                        .orderId(command.id())
+                        .orderStatus(TARGET_STATUS)
+                        .reasonCategory(command.reasonCategory())
+                        .reason(command.reason())
+                        .build()
+        );
+
+        updateOrderPort.update(order, orderStatusHistory);
+    }
+
+    private void validateBuyerOwnership(CancelOrderCommand command, Order order) {
+        if (!order.getBuyerId().equals(command.buyerId())) {
+            log.warn("주문 소유자 불일치 - orderId: {}, 주문소유자: {}, 요청자: {}",
+                    command.id(), order.getBuyerId(), command.buyerId());
+            throw new UnauthorizedOrderAccessException();
+        }
+    }
+
+    private void validateStatusTransition(Order order) {
+        if (TARGET_STATUS.isMe(order.getOrderStatus())) {
+            throw new OrderStatusAlreadyChangedException(TARGET_STATUS);
+        }
+
+        if (!order.getOrderStatus().canTransitionTo(TARGET_STATUS)) {
+            throw new InvalidOrderStatusTransitionException(order.getOrderStatus(), TARGET_STATUS);
+        }
+    }
+}


### PR DESCRIPTION
## partially addresses #1196
## resolves #1899

## Task
- [x] CancelOrderUseCase / CancelOrderService 생성
- [x] CancelOrderCommand (사유 카테고리, 사유) 생성
- [x] POST /api/v1/orders/{id}/cancel 엔드포인트 추가
- [x] CancelOrderRequest DTO 생성 (사유 관련 필드만)
- [x] API 문서 합성 애노테이션 추가