### PR TITLE
[#1196][#1900] feat: 구매 확정 전용 API 추가

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/OrderController.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/OrderController.java
@@ -10,6 +10,7 @@ import com.personal.marketnote.commerce.adapter.in.web.order.response.*;
 import com.personal.marketnote.commerce.domain.order.OrderPeriod;
 import com.personal.marketnote.commerce.domain.order.OrderStatus;
 import com.personal.marketnote.commerce.domain.order.OrderStatusFilter;
+import com.personal.marketnote.commerce.port.in.command.order.ConfirmOrderCommand;
 import com.personal.marketnote.commerce.port.in.command.order.GetBuyerOrderHistoryQuery;
 import com.personal.marketnote.commerce.port.in.command.order.UpdateOrderProductReviewStatusCommand;
 import com.personal.marketnote.commerce.port.in.result.order.*;
@@ -50,6 +51,7 @@ public class OrderController {
     private final UpdateUserShippingAddressDeliveryRequestPort updateUserShippingAddressDeliveryRequestPort;
     private final GetOrderUseCase getOrderUseCase;
     private final CancelOrderUseCase cancelOrderUseCase;
+    private final ConfirmOrderUseCase confirmOrderUseCase;
     private final ChangeOrderStatusUseCase changeOrderStatusUseCase;
     private final UpdateOrderProductUseCase updateOrderProductUseCase;
     private final GetAdminOrdersUseCase getAdminOrdersUseCase;
@@ -270,6 +272,41 @@ public class OrderController {
                         HttpStatus.OK,
                         DEFAULT_SUCCESS_CODE,
                         "주문 취소 요청 성공"
+                ),
+                HttpStatus.OK
+        );
+    }
+
+    /**
+     * 구매 확정
+     *
+     * @param id        주문 ID
+     * @param principal 인증된 사용자 정보
+     * @Author 성효빈
+     * @Date 2026-04-05
+     * @Description 구매자가 구매 확정을 요청합니다. 주문 상태를 CONFIRMED로 변경합니다.
+     */
+    @PostMapping("/api/v1/orders/{id}/confirm")
+    @ConfirmOrderApiDocs
+    public ResponseEntity<BaseResponse<Void>> confirmOrder(
+            @PathVariable("id") Long id,
+            @AuthenticationPrincipal OAuth2AuthenticatedPrincipal principal
+    ) {
+        Long buyerId = ElementExtractor.extractUserId(principal);
+
+        confirmOrderUseCase.confirmOrder(
+                ConfirmOrderCommand.builder()
+                        .id(id)
+                        .buyerId(buyerId)
+                        .build()
+        );
+
+        return new ResponseEntity<>(
+                BaseResponse.of(
+                        null,
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "구매 확정 성공"
                 ),
                 HttpStatus.OK
         );

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/apidocs/ConfirmOrderApiDocs.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/apidocs/ConfirmOrderApiDocs.java
@@ -1,0 +1,126 @@
+package com.personal.marketnote.commerce.adapter.in.web.order.controller.apidocs;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Operation(
+        summary = "구매 확정",
+        description = """
+                작성일자: 2026-04-05
+
+                작성자: 성효빈
+
+                ---
+
+                ## Description
+
+                - 구매자가 구매 확정을 요청합니다.
+
+                - 주문 상태를 CONFIRMED(구매 확정)로 변경합니다.
+
+                - 배송 완료, 부분 구매 확정 상태에서만 구매 확정이 가능합니다.
+
+                - 구매 확정 시 구매 확정 이벤트가 발행됩니다.
+
+                ---
+
+                ## Request
+
+                - Request Body 없음 (Path Variable만 사용)
+
+                ---
+
+                ## Response
+
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | statusCode | number | 상태 코드 | 200: 성공 / 401: 인증 실패 / 409: 충돌 / 500: 그 외 |
+                | code | string | 응답 코드 | "SUC01" / "UNAUTHORIZED" / "CONFLICT" / "INTERNAL_SERVER_ERROR" |
+                | timestamp | string(datetime) | 응답 일시 | "2026-04-05T12:00:00.000" |
+                | content | object | 응답 본문 | null |
+                | message | string | 처리 결과 | "구매 확정 성공" |
+                """, security = {@SecurityRequirement(name = "bearer")},
+        parameters = {
+                @Parameter(
+                        name = "id",
+                        description = "주문 ID",
+                        in = ParameterIn.PATH,
+                        required = true,
+                        schema = @Schema(type = "number")
+                )
+        },
+        responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "구매 확정 성공",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 200,
+                                          "code": "SUC01",
+                                          "timestamp": "2026-04-05T12:00:00.000",
+                                          "content": null,
+                                          "message": "구매 확정 성공"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "401",
+                        description = "토큰 인증 실패",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 401,
+                                          "code": "UNAUTHORIZED",
+                                          "timestamp": "2026-04-05T12:00:00.000",
+                                          "content": null,
+                                          "message": "Invalid token"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "409",
+                        description = "이미 구매 확정됨",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 409,
+                                          "code": "CONFLICT",
+                                          "timestamp": "2026-04-05T12:00:00.000",
+                                          "content": null,
+                                          "message": "이미 해당 주문 상태(구매 확정)로 변경되었습니다."
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "400",
+                        description = "상태 전이 불가",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 400,
+                                          "code": "BAD_REQUEST",
+                                          "timestamp": "2026-04-05T12:00:00.000",
+                                          "content": null,
+                                          "message": "주문 상태를 배송중에서 구매 확정(으)로 변경할 수 없습니다."
+                                        }
+                                        """)
+                        )
+                ),
+        })
+public @interface ConfirmOrderApiDocs {
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/command/order/ConfirmOrderCommand.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/command/order/ConfirmOrderCommand.java
@@ -1,0 +1,10 @@
+package com.personal.marketnote.commerce.port.in.command.order;
+
+import lombok.Builder;
+
+@Builder
+public record ConfirmOrderCommand(
+        Long id,
+        Long buyerId
+) {
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/order/ConfirmOrderUseCase.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/order/ConfirmOrderUseCase.java
@@ -1,0 +1,20 @@
+package com.personal.marketnote.commerce.port.in.usecase.order;
+
+import com.personal.marketnote.commerce.port.in.command.order.ConfirmOrderCommand;
+
+/**
+ * 구매 확정 유스케이스
+ *
+ * @Author 성효빈
+ * @Date 2026-04-05
+ * @Description 구매자의 구매 확정 기능을 제공합니다.
+ */
+public interface ConfirmOrderUseCase {
+    /**
+     * @param command 구매 확정 커맨드
+     * @Date 2026-04-05
+     * @Author 성효빈
+     * @Description 구매자의 주문을 구매 확정 상태로 변경합니다.
+     */
+    void confirmOrder(ConfirmOrderCommand command);
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/ConfirmOrderService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/ConfirmOrderService.java
@@ -1,0 +1,95 @@
+package com.personal.marketnote.commerce.service.order;
+
+import com.personal.marketnote.commerce.domain.order.Order;
+import com.personal.marketnote.commerce.domain.order.OrderProduct;
+import com.personal.marketnote.commerce.domain.order.OrderStatus;
+import com.personal.marketnote.commerce.domain.order.OrderStatusHistory;
+import com.personal.marketnote.commerce.domain.order.OrderStatusHistoryCreateState;
+import com.personal.marketnote.commerce.exception.InvalidOrderStatusTransitionException;
+import com.personal.marketnote.commerce.exception.OrderStatusAlreadyChangedException;
+import com.personal.marketnote.commerce.exception.UnauthorizedOrderAccessException;
+import com.personal.marketnote.commerce.port.in.command.order.ConfirmOrderCommand;
+import com.personal.marketnote.commerce.port.in.usecase.order.ConfirmOrderUseCase;
+import com.personal.marketnote.commerce.port.in.usecase.order.GetOrderUseCase;
+import com.personal.marketnote.commerce.port.out.event.PublishOrderEventPort;
+import com.personal.marketnote.commerce.port.out.order.UpdateOrderPort;
+import com.personal.marketnote.common.application.UseCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional(isolation = READ_COMMITTED)
+@Slf4j
+public class ConfirmOrderService implements ConfirmOrderUseCase {
+    private final GetOrderUseCase getOrderUseCase;
+    private final UpdateOrderPort updateOrderPort;
+    private final PublishOrderEventPort publishOrderEventPort;
+    private final Clock clock;
+
+    private static final OrderStatus TARGET_STATUS = OrderStatus.CONFIRMED;
+
+    @Override
+    public void confirmOrder(ConfirmOrderCommand command) {
+        Order order = getOrderUseCase.getOrder(command.id());
+
+        validateBuyerOwnership(command, order);
+        validateStatusTransition(order);
+
+        LocalDateTime now = LocalDateTime.now(clock);
+        order.changeAllProductsStatus(TARGET_STATUS, now);
+
+        OrderStatusHistory orderStatusHistory = OrderStatusHistory.from(
+                OrderStatusHistoryCreateState.builder()
+                        .orderId(command.id())
+                        .orderStatus(TARGET_STATUS)
+                        .build()
+        );
+
+        updateOrderPort.update(order, orderStatusHistory);
+        publishConfirmedEvent(order);
+    }
+
+    private void validateBuyerOwnership(ConfirmOrderCommand command, Order order) {
+        if (!order.getBuyerId().equals(command.buyerId())) {
+            log.warn("주문 소유자 불일치 - orderId: {}, 주문소유자: {}, 요청자: {}",
+                    command.id(), order.getBuyerId(), command.buyerId());
+            throw new UnauthorizedOrderAccessException();
+        }
+    }
+
+    private void validateStatusTransition(Order order) {
+        if (TARGET_STATUS.isMe(order.getOrderStatus())) {
+            throw new OrderStatusAlreadyChangedException(TARGET_STATUS);
+        }
+
+        if (!order.getOrderStatus().canTransitionTo(TARGET_STATUS)) {
+            throw new InvalidOrderStatusTransitionException(order.getOrderStatus(), TARGET_STATUS);
+        }
+    }
+
+    private void publishConfirmedEvent(Order order) {
+        List<UUID> sharerKeys = order.getOrderProducts().stream()
+                .map(OrderProduct::getSharerKey)
+                .filter(Objects::nonNull)
+                .toList();
+
+        try {
+            publishOrderEventPort.publishOrderPurchaseConfirmedEvent(
+                    order.getId(), order.getBuyerId(), sharerKeys
+            );
+        } catch (Exception e) {
+            log.error("구매 확정 이벤트 발행 실패 - orderId: {}, buyerId: {}, error: {}",
+                    order.getId(), order.getBuyerId(), e.getMessage(), e);
+        }
+    }
+}


### PR DESCRIPTION
## partially addresses #1196
## resolves #1900

## Task
- [x] ConfirmOrderUseCase / ConfirmOrderService 생성
- [x] ConfirmOrderCommand 생성
- [x] POST /api/v1/orders/{id}/confirm 엔드포인트 추가
- [x] API 문서 합성 애노테이션 추가
- [x] 기존 ChangeOrderStatusService에서 구매 확정 로직 이관