### PR TITLE
[#1196][#1901] feat: 환불(반품) 요청 전용 API 추가

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/OrderController.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/OrderController.java
@@ -6,6 +6,7 @@ import com.personal.marketnote.commerce.adapter.in.web.order.mapper.OrderRequest
 import com.personal.marketnote.commerce.adapter.in.web.order.request.CancelOrderRequest;
 import com.personal.marketnote.commerce.adapter.in.web.order.request.ChangeOrderStatusRequest;
 import com.personal.marketnote.commerce.adapter.in.web.order.request.RegisterOrderRequest;
+import com.personal.marketnote.commerce.adapter.in.web.order.request.RequestRefundRequest;
 import com.personal.marketnote.commerce.adapter.in.web.order.response.*;
 import com.personal.marketnote.commerce.domain.order.OrderPeriod;
 import com.personal.marketnote.commerce.domain.order.OrderStatus;
@@ -51,6 +52,7 @@ public class OrderController {
     private final UpdateUserShippingAddressDeliveryRequestPort updateUserShippingAddressDeliveryRequestPort;
     private final GetOrderUseCase getOrderUseCase;
     private final CancelOrderUseCase cancelOrderUseCase;
+    private final RequestRefundUseCase requestRefundUseCase;
     private final ConfirmOrderUseCase confirmOrderUseCase;
     private final ChangeOrderStatusUseCase changeOrderStatusUseCase;
     private final UpdateOrderProductUseCase updateOrderProductUseCase;
@@ -272,6 +274,40 @@ public class OrderController {
                         HttpStatus.OK,
                         DEFAULT_SUCCESS_CODE,
                         "주문 취소 요청 성공"
+                ),
+                HttpStatus.OK
+        );
+    }
+
+    /**
+     * 환불(반품) 요청
+     *
+     * @param id        주문 ID
+     * @param request   환불 요청
+     * @param principal 인증된 사용자 정보
+     * @Author 성효빈
+     * @Date 2026-04-05
+     * @Description 구매자가 환불(반품)을 요청합니다. 주문 상태를 REFUND_REQUESTED로 변경합니다.
+     */
+    @PostMapping("/api/v1/orders/{id}/refund-request")
+    @RequestRefundApiDocs
+    public ResponseEntity<BaseResponse<Void>> requestRefund(
+            @PathVariable("id") Long id,
+            @Valid @RequestBody RequestRefundRequest request,
+            @AuthenticationPrincipal OAuth2AuthenticatedPrincipal principal
+    ) {
+        Long buyerId = ElementExtractor.extractUserId(principal);
+
+        requestRefundUseCase.requestRefund(
+                OrderRequestToCommandMapper.mapToRefundRequestCommand(id, request, buyerId)
+        );
+
+        return new ResponseEntity<>(
+                BaseResponse.of(
+                        null,
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "환불(반품) 요청 성공"
                 ),
                 HttpStatus.OK
         );

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/apidocs/RequestRefundApiDocs.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/apidocs/RequestRefundApiDocs.java
@@ -1,0 +1,165 @@
+package com.personal.marketnote.commerce.adapter.in.web.order.controller.apidocs;
+
+import com.personal.marketnote.commerce.adapter.in.web.order.request.RequestRefundRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Operation(
+        summary = "환불(반품) 요청",
+        description = """
+                작성일자: 2026-04-05
+
+                작성자: 성효빈
+
+                ---
+
+                ## Description
+
+                - 구매자가 환불(반품)을 요청합니다.
+
+                - 주문 상태를 REFUND_REQUESTED(환불 요청됨)로 변경합니다.
+
+                - 배송 완료, 부분 구매 확정, 부분 환불됨 상태에서만 환불 요청이 가능합니다.
+
+                - 회수지 주소를 입력하면 입력값이 적용되고, 미입력 시 배송지가 회수지 기본값으로 적용됩니다.
+
+                - 환불 사유 카테고리 목록
+
+                    - "CANCEL_ORDER": 구매 의사 취소
+
+                    - "CHANGE_OPTION": 색상, 사이즈 등 변경
+
+                    - "MISTAKE": 주문 실수
+
+                    - "ETC": 직접 입력
+
+                ---
+
+                ## Request
+
+                | **키** | **타입** | **설명** | **필수 여부** | **예시** |
+                | --- | --- | --- | --- | --- |
+                | reasonCategory | string | 환불 사유 카테고리 | N | "ETC" |
+                | reason | string | 환불 사유 | N | "상품 불량" |
+                | pickupRecipientName | string | 회수지 수령인명 | N | "홍길동" |
+                | pickupRecipientPhoneNumber | string | 회수지 연락처 | N | "010-1234-5678" |
+                | pickupZipCode | string | 회수지 우편번호 | N | "12345" |
+                | pickupAddress | string | 회수지 주소 | N | "서울시 강남구" |
+                | pickupAddressDetail | string | 회수지 상세주소 | N | "테헤란로 123" |
+                | pickupRequestMessage | string | 회수 요청사항 | N | "부재시 경비실에 맡겨주세요" |
+
+                ---
+
+                ## Response
+
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | statusCode | number | 상태 코드 | 200: 성공 / 400: 클라이언트 요청 오류 / 401: 인증 실패 / 403: 인가 실패 / 409: 충돌 / 500: 그 외 |
+                | code | string | 응답 코드 | "SUC01" / "BAD_REQUEST" / "UNAUTHORIZED" / "CONFLICT" / "INTERNAL_SERVER_ERROR" |
+                | timestamp | string(datetime) | 응답 일시 | "2026-04-05T12:00:00.000" |
+                | content | object | 응답 본문 | null |
+                | message | string | 처리 결과 | "환불(반품) 요청 성공" |
+                """, security = {@SecurityRequirement(name = "bearer")},
+        parameters = {
+                @Parameter(
+                        name = "id",
+                        description = "주문 ID",
+                        in = ParameterIn.PATH,
+                        required = true,
+                        schema = @Schema(type = "number")
+                )
+        },
+        requestBody = @RequestBody(
+                required = true,
+                content = @Content(
+                        schema = @Schema(implementation = RequestRefundRequest.class),
+                        examples = @ExampleObject("""
+                                {
+                                  "reasonCategory": "ETC",
+                                  "reason": "상품 불량",
+                                  "pickupRecipientName": "홍길동",
+                                  "pickupRecipientPhoneNumber": "010-1234-5678",
+                                  "pickupZipCode": "12345",
+                                  "pickupAddress": "서울시 강남구",
+                                  "pickupAddressDetail": "테헤란로 123",
+                                  "pickupRequestMessage": "부재시 경비실에 맡겨주세요"
+                                }
+                                """)
+                )
+        ),
+        responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "환불(반품) 요청 성공",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 200,
+                                          "code": "SUC01",
+                                          "timestamp": "2026-04-05T12:00:00.000",
+                                          "content": null,
+                                          "message": "환불(반품) 요청 성공"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "401",
+                        description = "토큰 인증 실패",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 401,
+                                          "code": "UNAUTHORIZED",
+                                          "timestamp": "2026-04-05T12:00:00.000",
+                                          "content": null,
+                                          "message": "Invalid token"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "409",
+                        description = "이미 환불 요청됨",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 409,
+                                          "code": "CONFLICT",
+                                          "timestamp": "2026-04-05T12:00:00.000",
+                                          "content": null,
+                                          "message": "이미 해당 주문 상태(환불 요청됨)로 변경되었습니다."
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "400",
+                        description = "상태 전이 불가",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 400,
+                                          "code": "BAD_REQUEST",
+                                          "timestamp": "2026-04-05T12:00:00.000",
+                                          "content": null,
+                                          "message": "주문 상태를 배송중에서 환불 요청됨(으)로 변경할 수 없습니다."
+                                        }
+                                        """)
+                        )
+                ),
+        })
+public @interface RequestRefundApiDocs {
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/mapper/OrderRequestToCommandMapper.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/mapper/OrderRequestToCommandMapper.java
@@ -3,6 +3,7 @@ package com.personal.marketnote.commerce.adapter.in.web.order.mapper;
 import com.personal.marketnote.commerce.adapter.in.web.order.request.CancelOrderRequest;
 import com.personal.marketnote.commerce.adapter.in.web.order.request.ChangeOrderStatusRequest;
 import com.personal.marketnote.commerce.adapter.in.web.order.request.RegisterOrderRequest;
+import com.personal.marketnote.commerce.adapter.in.web.order.request.RequestRefundRequest;
 import com.personal.marketnote.commerce.domain.order.ShippingAddress;
 import com.personal.marketnote.commerce.port.in.command.order.*;
 
@@ -46,6 +47,21 @@ public class OrderRequestToCommandMapper {
                 .reasonCategory(request.getReasonCategory())
                 .reason(request.getReason())
                 .buyerId(buyerId)
+                .build();
+    }
+
+    public static RequestRefundCommand mapToRefundRequestCommand(Long id, RequestRefundRequest request, Long buyerId) {
+        return RequestRefundCommand.builder()
+                .id(id)
+                .reasonCategory(request.getReasonCategory())
+                .reason(request.getReason())
+                .buyerId(buyerId)
+                .pickupRecipientName(request.getPickupRecipientName())
+                .pickupRecipientPhoneNumber(request.getPickupRecipientPhoneNumber())
+                .pickupZipCode(request.getPickupZipCode())
+                .pickupAddress(request.getPickupAddress())
+                .pickupAddressDetail(request.getPickupAddressDetail())
+                .pickupRequestMessage(request.getPickupRequestMessage())
                 .build();
     }
 

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/request/RequestRefundRequest.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/request/RequestRefundRequest.java
@@ -1,0 +1,79 @@
+package com.personal.marketnote.commerce.adapter.in.web.order.request;
+
+import com.personal.marketnote.commerce.domain.order.OrderStatusReasonCategory;
+import com.personal.marketnote.common.utility.RegularExpressionConstant;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+@Getter
+public class RequestRefundRequest {
+    @Schema(
+            name = "reasonCategory",
+            description = "환불 사유 카테고리",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    private OrderStatusReasonCategory reasonCategory;
+
+    @Schema(
+            name = "reason",
+            description = "환불 사유",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    @Size(max = 500, message = "환불 사유는 500자 이내여야 합니다.")
+    private String reason;
+
+    @Schema(
+            name = "pickupRecipientName",
+            description = "회수지 수령인명 (미입력 시 배송지 기본값)",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    @Size(max = 50, message = "회수지 수령인명은 50자 이내여야 합니다.")
+    @Pattern(regexp = RegularExpressionConstant.RECIPIENT_NAME_PATTERN, message = "회수지 수령인명 형식이 올바르지 않습니다.")
+    private String pickupRecipientName;
+
+    @Schema(
+            name = "pickupRecipientPhoneNumber",
+            description = "회수지 연락처 (미입력 시 배송지 기본값)",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    @Size(max = 20, message = "회수지 연락처는 20자 이내여야 합니다.")
+    @Pattern(regexp = RegularExpressionConstant.PHONE_NUMBER_PATTERN, message = "회수지 연락처 형식이 올바르지 않습니다.")
+    private String pickupRecipientPhoneNumber;
+
+    @Schema(
+            name = "pickupZipCode",
+            description = "회수지 우편번호 (미입력 시 배송지 기본값)",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    @Pattern(regexp = RegularExpressionConstant.ZIP_CODE_PATTERN, message = "회수지 우편번호는 5자리 숫자여야 합니다.")
+    private String pickupZipCode;
+
+    @Schema(
+            name = "pickupAddress",
+            description = "회수지 주소 (미입력 시 배송지 기본값)",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    @Size(max = 255, message = "회수지 주소는 255자 이내여야 합니다.")
+    @Pattern(regexp = RegularExpressionConstant.NO_HTML_TAG_PATTERN, message = "회수지 주소에 허용되지 않는 문자가 포함되어 있습니다.")
+    private String pickupAddress;
+
+    @Schema(
+            name = "pickupAddressDetail",
+            description = "회수지 상세주소 (미입력 시 배송지 기본값)",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    @Size(max = 255, message = "회수지 상세주소는 255자 이내여야 합니다.")
+    @Pattern(regexp = RegularExpressionConstant.NO_HTML_TAG_PATTERN, message = "회수지 상세주소에 허용되지 않는 문자가 포함되어 있습니다.")
+    private String pickupAddressDetail;
+
+    @Schema(
+            name = "pickupRequestMessage",
+            description = "회수 요청사항 (60자 제한)",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    @Size(max = 60, message = "회수 요청사항은 60자 이내여야 합니다.")
+    @Pattern(regexp = RegularExpressionConstant.NO_HTML_TAG_PATTERN, message = "회수 요청사항에 허용되지 않는 문자가 포함되어 있습니다.")
+    private String pickupRequestMessage;
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/command/order/RequestRefundCommand.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/command/order/RequestRefundCommand.java
@@ -1,0 +1,19 @@
+package com.personal.marketnote.commerce.port.in.command.order;
+
+import com.personal.marketnote.commerce.domain.order.OrderStatusReasonCategory;
+import lombok.Builder;
+
+@Builder
+public record RequestRefundCommand(
+        Long id,
+        OrderStatusReasonCategory reasonCategory,
+        String reason,
+        Long buyerId,
+        String pickupRecipientName,
+        String pickupRecipientPhoneNumber,
+        String pickupZipCode,
+        String pickupAddress,
+        String pickupAddressDetail,
+        String pickupRequestMessage
+) {
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/order/RequestRefundUseCase.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/order/RequestRefundUseCase.java
@@ -1,0 +1,20 @@
+package com.personal.marketnote.commerce.port.in.usecase.order;
+
+import com.personal.marketnote.commerce.port.in.command.order.RequestRefundCommand;
+
+/**
+ * 환불(반품) 요청 유스케이스
+ *
+ * @Author 성효빈
+ * @Date 2026-04-05
+ * @Description 구매자의 환불(반품) 요청 기능을 제공합니다.
+ */
+public interface RequestRefundUseCase {
+    /**
+     * @param command 환불 요청 커맨드
+     * @Date 2026-04-05
+     * @Author 성효빈
+     * @Description 구매자의 주문을 환불 요청 상태로 변경합니다.
+     */
+    void requestRefund(RequestRefundCommand command);
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/RequestRefundService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/RequestRefundService.java
@@ -1,0 +1,88 @@
+package com.personal.marketnote.commerce.service.order;
+
+import com.personal.marketnote.commerce.domain.order.Order;
+import com.personal.marketnote.commerce.domain.order.OrderStatus;
+import com.personal.marketnote.commerce.domain.order.OrderStatusHistory;
+import com.personal.marketnote.commerce.domain.order.OrderStatusHistoryCreateState;
+import com.personal.marketnote.commerce.domain.order.ShippingAddress;
+import com.personal.marketnote.commerce.exception.InvalidOrderStatusTransitionException;
+import com.personal.marketnote.commerce.exception.OrderStatusAlreadyChangedException;
+import com.personal.marketnote.commerce.exception.UnauthorizedOrderAccessException;
+import com.personal.marketnote.commerce.port.in.command.order.RequestRefundCommand;
+import com.personal.marketnote.commerce.port.in.usecase.order.GetOrderUseCase;
+import com.personal.marketnote.commerce.port.in.usecase.order.RequestRefundUseCase;
+import com.personal.marketnote.commerce.port.out.order.UpdateOrderPort;
+import com.personal.marketnote.common.application.UseCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional(isolation = READ_COMMITTED)
+@Slf4j
+public class RequestRefundService implements RequestRefundUseCase {
+    private final GetOrderUseCase getOrderUseCase;
+    private final UpdateOrderPort updateOrderPort;
+    private final Clock clock;
+
+    private static final OrderStatus TARGET_STATUS = OrderStatus.REFUND_REQUESTED;
+
+    @Override
+    public void requestRefund(RequestRefundCommand command) {
+        Order order = getOrderUseCase.getOrder(command.id());
+
+        validateBuyerOwnership(command, order);
+        validateStatusTransition(order);
+
+        LocalDateTime now = LocalDateTime.now(clock);
+        order.changeAllProductsStatus(TARGET_STATUS, now);
+        order.applyPickupAddress(buildPickupAddress(command));
+
+        OrderStatusHistory orderStatusHistory = OrderStatusHistory.from(
+                OrderStatusHistoryCreateState.builder()
+                        .orderId(command.id())
+                        .orderStatus(TARGET_STATUS)
+                        .reasonCategory(command.reasonCategory())
+                        .reason(command.reason())
+                        .build()
+        );
+
+        updateOrderPort.update(order, orderStatusHistory);
+    }
+
+    private void validateBuyerOwnership(RequestRefundCommand command, Order order) {
+        if (!order.getBuyerId().equals(command.buyerId())) {
+            log.warn("주문 소유자 불일치 - orderId: {}, 주문소유자: {}, 요청자: {}",
+                    command.id(), order.getBuyerId(), command.buyerId());
+            throw new UnauthorizedOrderAccessException();
+        }
+    }
+
+    private void validateStatusTransition(Order order) {
+        if (TARGET_STATUS.isMe(order.getOrderStatus())) {
+            throw new OrderStatusAlreadyChangedException(TARGET_STATUS);
+        }
+
+        if (!order.getOrderStatus().canTransitionTo(TARGET_STATUS)) {
+            throw new InvalidOrderStatusTransitionException(order.getOrderStatus(), TARGET_STATUS);
+        }
+    }
+
+    private ShippingAddress buildPickupAddress(RequestRefundCommand command) {
+        return ShippingAddress.of(
+                command.pickupRecipientName(),
+                command.pickupRecipientPhoneNumber(),
+                command.pickupZipCode(),
+                command.pickupAddress(),
+                command.pickupAddressDetail(),
+                null,
+                command.pickupRequestMessage()
+        );
+    }
+}


### PR DESCRIPTION
## partially addresses #1196
## resolves #1901

## Task
- [x] RequestRefundUseCase / RequestRefundService 생성
- [x] RequestRefundCommand (사유 + 회수지 정보) 생성
- [x] POST /api/v1/orders/{id}/refund-request 엔드포인트 추가
- [x] RequestRefundRequest DTO 생성 (사유 + 회수지 필드)
- [x] API 문서 합성 애노테이션 추가
- [x] 기존 ChangeOrderStatusService에서 환불 요청 로직 이관