### PR TITLE
[#1575][#1576] feat: Inventory 도메인 reserved/reservedAt 필드 및 가용재고 모델 추가

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/mapper/InventoryJpaEntityToDomainMapper.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/mapper/InventoryJpaEntityToDomainMapper.java
@@ -2,6 +2,7 @@ package com.personal.marketnote.commerce.adapter.out.mapper;
 
 import com.personal.marketnote.commerce.adapter.out.persistence.inventory.entity.InventoryJpaEntity;
 import com.personal.marketnote.commerce.domain.inventory.Inventory;
+import com.personal.marketnote.commerce.domain.inventory.InventorySnapshotState;
 import com.personal.marketnote.common.utility.FormatValidator;
 
 import java.util.Optional;
@@ -14,7 +15,16 @@ public class InventoryJpaEntityToDomainMapper {
                     if (FormatValidator.hasNoValue(version)) {
                         version = 0L;
                     }
-                    return Inventory.of(entity.getProductId(), entity.getPricePolicyId(), entity.getStock(), version);
+                    Integer reserved = entity.getReserved();
+                    int reservedValue = FormatValidator.hasNoValue(reserved) ? 0 : reserved;
+                    InventorySnapshotState state = InventorySnapshotState.builder()
+                            .productId(entity.getProductId())
+                            .pricePolicyId(entity.getPricePolicyId())
+                            .stock(entity.getStock())
+                            .version(version)
+                            .reserved(reservedValue)
+                            .build();
+                    return Inventory.from(state);
                 });
     }
 }

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/inventory/entity/InventoryJpaEntity.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/inventory/entity/InventoryJpaEntity.java
@@ -29,6 +29,9 @@ public class InventoryJpaEntity extends BaseEntity {
     @Column(name = "stock", nullable = false, columnDefinition = "INT DEFAULT 0")
     private Integer stock;
 
+    @Column(name = "reserved", nullable = false, columnDefinition = "INT DEFAULT 0")
+    private Integer reserved;
+
     // RDBMS 낙관적 락 기반의 동시성 제어
     @Version
     @Column(name = "version", nullable = false, columnDefinition = "BIGINT DEFAULT 0")
@@ -39,12 +42,14 @@ public class InventoryJpaEntity extends BaseEntity {
                 inventory.getProductId(),
                 inventory.getPricePolicyId(),
                 inventory.getStockValue(),
+                inventory.getReserved(),
                 inventory.getVersion()
         );
     }
 
     public void updateFrom(Inventory inventory) {
         stock = inventory.getStockValue();
+        reserved = inventory.getReserved();
     }
 
     @PostLoad

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/inventory/entity/InventoryReservationJpaEntity.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/inventory/entity/InventoryReservationJpaEntity.java
@@ -1,0 +1,66 @@
+package com.personal.marketnote.commerce.adapter.out.persistence.inventory.entity;
+
+import com.personal.marketnote.commerce.domain.inventory.InventoryReservation;
+import com.personal.marketnote.common.adapter.out.persistence.audit.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
+
+import java.time.LocalDateTime;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+
+@Entity
+@Table(
+        name = "inventory_reservation",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_inventory_reservation_order_policy",
+                columnNames = {"order_id", "price_policy_id"}
+        )
+)
+@DynamicInsert
+@DynamicUpdate
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class InventoryReservationJpaEntity extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @Column(name = "order_id", nullable = false)
+    private Long orderId;
+
+    @Column(name = "price_policy_id", nullable = false)
+    private Long pricePolicyId;
+
+    @Column(name = "quantity", nullable = false)
+    private Integer quantity;
+
+    @Column(name = "reserved_at", nullable = false)
+    private LocalDateTime reservedAt;
+
+    private InventoryReservationJpaEntity(
+            Long orderId,
+            Long pricePolicyId,
+            Integer quantity,
+            LocalDateTime reservedAt
+    ) {
+        this.orderId = orderId;
+        this.pricePolicyId = pricePolicyId;
+        this.quantity = quantity;
+        this.reservedAt = reservedAt;
+    }
+
+    public static InventoryReservationJpaEntity from(InventoryReservation inventoryReservation) {
+        return new InventoryReservationJpaEntity(
+                inventoryReservation.getOrderId(),
+                inventoryReservation.getPricePolicyId(),
+                inventoryReservation.getQuantity(),
+                inventoryReservation.getReservedAt()
+        );
+    }
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/inventory/repository/InventoryReservationJpaRepository.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/inventory/repository/InventoryReservationJpaRepository.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.commerce.adapter.out.persistence.inventory.repository;
+
+import com.personal.marketnote.commerce.adapter.out.persistence.inventory.entity.InventoryReservationJpaEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface InventoryReservationJpaRepository extends JpaRepository<InventoryReservationJpaEntity, Long> {
+}

--- a/commerce-service/commerce-adapters/src/main/resources/db/migration/V905__add_inventory_reserved_and_create_inventory_reservation.sql
+++ b/commerce-service/commerce-adapters/src/main/resources/db/migration/V905__add_inventory_reserved_and_create_inventory_reservation.sql
@@ -1,0 +1,15 @@
+ALTER TABLE inventory ADD COLUMN reserved INT NOT NULL DEFAULT 0;
+
+CREATE TABLE inventory_reservation (
+    id               BIGSERIAL       PRIMARY KEY,
+    order_id         BIGINT          NOT NULL,
+    price_policy_id  BIGINT          NOT NULL,
+    quantity         INT             NOT NULL,
+    reserved_at      TIMESTAMP       NOT NULL,
+    created_at       TIMESTAMP       NOT NULL DEFAULT NOW(),
+    modified_at      TIMESTAMP       NOT NULL DEFAULT NOW(),
+    CONSTRAINT uk_inventory_reservation_order_policy UNIQUE (order_id, price_policy_id)
+);
+
+CREATE INDEX idx_inventory_reservation_price_policy_id ON inventory_reservation (price_policy_id);
+CREATE INDEX idx_inventory_reservation_reserved_at ON inventory_reservation (reserved_at);

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/inventory/InsufficientAvailableStockException.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/inventory/InsufficientAvailableStockException.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.commerce.domain.inventory;
+
+public class InsufficientAvailableStockException extends IllegalArgumentException {
+    private static final String MESSAGE = "가용재고가 부족합니다. 현재 가용재고: %d, 요청 수량: %d";
+
+    public InsufficientAvailableStockException(int availableStock, int requestedQuantity) {
+        super(String.format(MESSAGE, availableStock, requestedQuantity));
+    }
+}

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/inventory/InvalidInventoryReservationQuantityException.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/inventory/InvalidInventoryReservationQuantityException.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.commerce.domain.inventory;
+
+public class InvalidInventoryReservationQuantityException extends IllegalStateException {
+    private static final String MESSAGE = "예약 확정 수량이 현재 예약 수량을 초과합니다. 현재 예약: %d, 확정 요청: %d";
+
+    public InvalidInventoryReservationQuantityException(int currentReserved, int requestedQuantity) {
+        super(String.format(MESSAGE, currentReserved, requestedQuantity));
+    }
+}

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/inventory/Inventory.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/inventory/Inventory.java
@@ -1,5 +1,6 @@
 package com.personal.marketnote.commerce.domain.inventory;
 
+import com.personal.marketnote.common.domain.exception.illegalargument.invalidvalue.InvalidQuantityException;
 import com.personal.marketnote.common.utility.FormatValidator;
 import lombok.*;
 
@@ -12,6 +13,7 @@ public class Inventory {
     private Long pricePolicyId;
     private Stock stock;
     private Long version;
+    private int reserved;
 
     public static Inventory of(Long productId, Long pricePolicyId) {
         return Inventory.builder()
@@ -41,6 +43,19 @@ public class Inventory {
                         String.valueOf(stock)
                 ))
                 .version(version)
+                .reserved(0)
+                .build();
+    }
+
+    public static Inventory from(InventorySnapshotState state) {
+        return Inventory.builder()
+                .productId(state.getProductId())
+                .pricePolicyId(state.getPricePolicyId())
+                .stock(Stock.of(
+                        String.valueOf(state.getStock())
+                ))
+                .version(state.getVersion())
+                .reserved(state.getReserved())
                 .build();
     }
 
@@ -64,6 +79,41 @@ public class Inventory {
 
     public boolean isMe(Long targetPricePolicyId) {
         return FormatValidator.equals(this.pricePolicyId, targetPricePolicyId);
+    }
+
+    public int availableStock() {
+        return stock.getValue() - reserved;
+    }
+
+    public void reserve(int quantity) {
+        validatePositiveQuantity(quantity);
+        int available = availableStock();
+        if (available < quantity) {
+            throw new InsufficientAvailableStockException(available, quantity);
+        }
+        this.reserved = Math.addExact(this.reserved, quantity);
+    }
+
+    public void confirmReservation(int quantity) {
+        validatePositiveQuantity(quantity);
+        if (quantity > this.reserved) {
+            throw new InvalidInventoryReservationQuantityException(this.reserved, quantity);
+        }
+        this.reserved -= quantity;
+        reduce(quantity);
+    }
+
+    public void releaseReservation(int quantity) {
+        validatePositiveQuantity(quantity);
+        this.reserved = Math.max(0, this.reserved - quantity);
+    }
+
+    private void validatePositiveQuantity(int quantity) {
+        if (quantity <= 0) {
+            throw new InvalidQuantityException(
+                    String.format("수량은 1 이상이어야 합니다. 전송된 수량: %d", quantity)
+            );
+        }
     }
 
     public void validateIsSufficient(int orderQuantity) {

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/inventory/InventoryReservation.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/inventory/InventoryReservation.java
@@ -1,0 +1,50 @@
+package com.personal.marketnote.commerce.domain.inventory;
+
+import com.personal.marketnote.common.domain.exception.illegalargument.invalidvalue.InvalidQuantityException;
+import com.personal.marketnote.common.domain.exception.illegalargument.novalue.IdNoValueException;
+import com.personal.marketnote.common.utility.FormatValidator;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+@Getter
+public class InventoryReservation {
+    private Long id;
+    private Long orderId;
+    private Long pricePolicyId;
+    private int quantity;
+    private LocalDateTime reservedAt;
+
+    public static InventoryReservation from(InventoryReservationCreateState state) {
+        if (FormatValidator.hasNoValue(state.getOrderId())) {
+            throw new IdNoValueException("주문 ID는 필수값입니다.");
+        }
+        if (FormatValidator.hasNoValue(state.getPricePolicyId())) {
+            throw new IdNoValueException("가격 정책 ID는 필수값입니다.");
+        }
+        if (state.getQuantity() <= 0) {
+            throw new InvalidQuantityException(
+                    String.format("예약 수량은 1 이상이어야 합니다. 전송된 수량: %d", state.getQuantity())
+            );
+        }
+        return InventoryReservation.builder()
+                .orderId(state.getOrderId())
+                .pricePolicyId(state.getPricePolicyId())
+                .quantity(state.getQuantity())
+                .reservedAt(state.getReservedAt())
+                .build();
+    }
+
+    public static InventoryReservation from(InventoryReservationSnapshotState state) {
+        return InventoryReservation.builder()
+                .id(state.getId())
+                .orderId(state.getOrderId())
+                .pricePolicyId(state.getPricePolicyId())
+                .quantity(state.getQuantity())
+                .reservedAt(state.getReservedAt())
+                .build();
+    }
+}

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/inventory/InventoryReservationCreateState.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/inventory/InventoryReservationCreateState.java
@@ -1,0 +1,18 @@
+package com.personal.marketnote.commerce.domain.inventory;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class InventoryReservationCreateState {
+    private final Long orderId;
+    private final Long pricePolicyId;
+    private final int quantity;
+    private final LocalDateTime reservedAt;
+}

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/inventory/InventoryReservationSnapshotState.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/inventory/InventoryReservationSnapshotState.java
@@ -1,0 +1,19 @@
+package com.personal.marketnote.commerce.domain.inventory;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class InventoryReservationSnapshotState {
+    private final Long id;
+    private final Long orderId;
+    private final Long pricePolicyId;
+    private final int quantity;
+    private final LocalDateTime reservedAt;
+}

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/inventory/InventorySnapshotState.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/inventory/InventorySnapshotState.java
@@ -1,0 +1,17 @@
+package com.personal.marketnote.commerce.domain.inventory;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class InventorySnapshotState {
+    private final Long productId;
+    private final Long pricePolicyId;
+    private final Integer stock;
+    private final Long version;
+    private final int reserved;
+}


### PR DESCRIPTION
## partially addresses #1575
## resolves #1576

## Task
- [x] Inventory 도메인에 reserved(int) 필드 추가
- [x] Inventory.availableStock() 메서드 추가 (stock - reserved)
- [x] Inventory.reserve(int quantity) 메서드 추가 (가용재고 검증 후 reserved 증가)
- [x] Inventory.confirmReservation(int quantity) 메서드 추가 (reserved 감소 + stock 감소)
- [x] Inventory.releaseReservation(int quantity) 메서드 추가 (reserved 감소, 0 이하 방어)
- [x] InventoryReservation 도메인 모델 생성 (orderId, pricePolicyId, quantity, reservedAt)
- [x] InventoryReservationJpaEntity 생성 (UNIQUE(order_id, price_policy_id))
- [x] InventoryReservationJpaRepository 생성
- [x] InventoryJpaEntity에 reserved 컬럼 추가
- [x] InventorySnapshotState 추가 및 Inventory.from(SnapshotState) 팩토리 메서드 전환
- [x] Mapper(InventoryJpaEntityToDomainMapper) 수정
- [x] DB 마이그레이션 스크립트 작성 (inventory.reserved 컬럼 + inventory_reservation 테이블)