### PR TITLE
[#1575][#1577] feat: 주문 생성 시 가용재고 기반 검증으로 변경

### DIFF
--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/RegisterOrderUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/RegisterOrderUseCaseTest.java
@@ -24,7 +24,7 @@ import com.personal.marketnote.commerce.port.out.reward.ModifyUserPointPort;
 import com.personal.marketnote.commerce.port.out.settlement.SavePaymentAllocationPort;
 import com.personal.marketnote.commerce.port.out.shipping.FindShippingPolicyBySellerIdsPort;
 import com.personal.marketnote.commerce.port.out.user.FindUserShippingAddressPort;
-import com.personal.marketnote.common.domain.exception.illegalargument.invalidvalue.InsufficientQuantityException;
+import com.personal.marketnote.commerce.domain.inventory.InsufficientAvailableStockException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -1469,7 +1469,7 @@ class RegisterOrderUseCaseTest {
         }
 
         @Test
-        @DisplayName("재고가 부족하면 InsufficientQuantityException이 발생한다")
+        @DisplayName("재고가 부족하면 InsufficientAvailableStockException이 발생한다")
         void registerOrder_insufficientStock_throwsException() {
             Long pricePolicyId = 100L;
             RegisterOrderCommand command = RegisterOrderCommand.builder()
@@ -1493,14 +1493,14 @@ class RegisterOrderUseCaseTest {
                     .thenReturn(Set.of(inventory));
 
             assertThatThrownBy(() -> registerOrderService.registerOrder(command))
-                    .isInstanceOf(InsufficientQuantityException.class)
-                    .hasMessageContaining("재고 수량이 부족합니다");
+                    .isInstanceOf(InsufficientAvailableStockException.class)
+                    .hasMessageContaining("가용재고가 부족합니다");
 
             verify(saveOrderPort, never()).save(any(Order.class));
         }
 
         @Test
-        @DisplayName("재고가 0이고 주문 수량이 1 이상이면 InsufficientQuantityException이 발생한다")
+        @DisplayName("재고가 0이고 주문 수량이 1 이상이면 InsufficientAvailableStockException이 발생한다")
         void registerOrder_zeroStock_throwsException() {
             Long pricePolicyId = 100L;
             RegisterOrderCommand command = createSingleProductCommand(1L, pricePolicyId, 50000L, 1, 0L, 0L);
@@ -1512,13 +1512,13 @@ class RegisterOrderUseCaseTest {
                     .thenReturn(Set.of(inventory));
 
             assertThatThrownBy(() -> registerOrderService.registerOrder(command))
-                    .isInstanceOf(InsufficientQuantityException.class);
+                    .isInstanceOf(InsufficientAvailableStockException.class);
 
             verify(saveOrderPort, never()).save(any(Order.class));
         }
 
         @Test
-        @DisplayName("복수 상품 중 하나라도 재고가 부족하면 InsufficientQuantityException이 발생한다")
+        @DisplayName("복수 상품 중 하나라도 재고가 부족하면 InsufficientAvailableStockException이 발생한다")
         void registerOrder_oneProductInsufficientStock_throwsException() {
             Long pricePolicyId1 = 100L;
             Long pricePolicyId2 = 200L;
@@ -1554,7 +1554,7 @@ class RegisterOrderUseCaseTest {
                     .thenReturn(Set.of(inventory1, inventory2));
 
             assertThatThrownBy(() -> registerOrderService.registerOrder(command))
-                    .isInstanceOf(InsufficientQuantityException.class);
+                    .isInstanceOf(InsufficientAvailableStockException.class);
 
             verify(saveOrderPort, never()).save(any(Order.class));
         }
@@ -1591,9 +1591,9 @@ class RegisterOrderUseCaseTest {
                     .thenReturn(Set.of(inventory));
 
             assertThatThrownBy(() -> registerOrderService.registerOrder(command))
-                    .isInstanceOf(InsufficientQuantityException.class)
-                    .hasMessageContaining("현재 재고 수량: 6")
-                    .hasMessageContaining("주문 수량: 7");
+                    .isInstanceOf(InsufficientAvailableStockException.class)
+                    .hasMessageContaining("현재 가용재고: 6")
+                    .hasMessageContaining("요청 수량: 7");
         }
 
         @Test
@@ -1697,7 +1697,7 @@ class RegisterOrderUseCaseTest {
                     .thenReturn(Set.of(inventory));
 
             assertThatThrownBy(() -> registerOrderService.registerOrder(command))
-                    .isInstanceOf(InsufficientQuantityException.class);
+                    .isInstanceOf(InsufficientAvailableStockException.class);
 
             verify(getInventoryUseCase).getOrCreateInventories(anyMap());
             verifyNoInteractions(saveOrderPort);

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/inventory/Inventory.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/inventory/Inventory.java
@@ -117,6 +117,9 @@ public class Inventory {
     }
 
     public void validateIsSufficient(int orderQuantity) {
-        stock.validateIsSufficient(orderQuantity);
+        int available = availableStock();
+        if (available < orderQuantity) {
+            throw new InsufficientAvailableStockException(available, orderQuantity);
+        }
     }
 }

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/inventory/Stock.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/inventory/Stock.java
@@ -83,9 +83,4 @@ public class Stock {
         return this.stock + quantity;
     }
 
-    public void validateIsSufficient(int orderQuantity) {
-        if (stock < orderQuantity) {
-            throw new InsufficientQuantityException(stock, orderQuantity);
-        }
-    }
 }


### PR DESCRIPTION
## partially addresses #1575
## resolves #1577

## Task
- [x] Inventory.validateIsSufficient()에서 stock 대신 availableStock() 기준으로 검증하도록 변경
- [x] InsufficientAvailableStockException으로 예외 변경 (메시지에 가용재고 반영)
- [x] Stock.validateIsSufficient() dead code 제거
- [x] RegisterOrderUseCaseTest 예외 클래스 5개소 변경