### PR TITLE
[#1575][#1578] feat: 결제 승인 전 재고 예약 기능 추가

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/inventory/InventoryReservationPersistenceAdapter.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/inventory/InventoryReservationPersistenceAdapter.java
@@ -1,0 +1,35 @@
+package com.personal.marketnote.commerce.adapter.out.persistence.inventory;
+
+import com.personal.marketnote.commerce.adapter.out.persistence.inventory.entity.InventoryReservationJpaEntity;
+import com.personal.marketnote.commerce.adapter.out.persistence.inventory.repository.InventoryReservationJpaRepository;
+import com.personal.marketnote.commerce.domain.inventory.InventoryReservation;
+import com.personal.marketnote.commerce.exception.DuplicateInventoryReservationException;
+import com.personal.marketnote.commerce.port.out.inventory.SaveInventoryReservationPort;
+import com.personal.marketnote.common.adapter.out.PersistenceAdapter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+
+import java.util.List;
+
+@PersistenceAdapter
+@RequiredArgsConstructor
+public class InventoryReservationPersistenceAdapter implements SaveInventoryReservationPort {
+    private final InventoryReservationJpaRepository inventoryReservationJpaRepository;
+
+    @Override
+    public void save(List<InventoryReservation> inventoryReservations) {
+        try {
+            inventoryReservationJpaRepository.saveAllAndFlush(
+                    inventoryReservations.stream()
+                            .map(InventoryReservationJpaEntity::from)
+                            .toList()
+            );
+        } catch (DataIntegrityViolationException e) {
+            Long orderId = inventoryReservations.stream()
+                    .findFirst()
+                    .map(InventoryReservation::getOrderId)
+                    .orElse(null);
+            throw new DuplicateInventoryReservationException(orderId);
+        }
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/exception/DuplicateInventoryReservationException.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/exception/DuplicateInventoryReservationException.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.commerce.exception;
+
+public class DuplicateInventoryReservationException extends RuntimeException {
+    public DuplicateInventoryReservationException(Long orderId) {
+        super("이미 처리된 재고 예약입니다. orderId=" + orderId);
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/command/inventory/ReserveInventoryCommand.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/command/inventory/ReserveInventoryCommand.java
@@ -1,0 +1,18 @@
+package com.personal.marketnote.commerce.port.in.command.inventory;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record ReserveInventoryCommand(
+        Long orderId,
+        List<OrderProductItem> orderProducts
+) {
+    @Builder
+    public record OrderProductItem(
+            Long pricePolicyId,
+            int quantity
+    ) {
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/inventory/ReserveInventoryUseCase.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/inventory/ReserveInventoryUseCase.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.commerce.port.in.usecase.inventory;
+
+import com.personal.marketnote.commerce.port.in.command.inventory.ReserveInventoryCommand;
+
+public interface ReserveInventoryUseCase {
+    void reserveInventory(ReserveInventoryCommand command);
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/inventory/SaveInventoryReservationPort.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/inventory/SaveInventoryReservationPort.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.commerce.port.out.inventory;
+
+import com.personal.marketnote.commerce.domain.inventory.InventoryReservation;
+
+import java.util.List;
+
+public interface SaveInventoryReservationPort {
+    void save(List<InventoryReservation> inventoryReservations);
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/inventory/ReserveInventoryService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/inventory/ReserveInventoryService.java
@@ -1,0 +1,90 @@
+package com.personal.marketnote.commerce.service.inventory;
+
+import com.personal.marketnote.commerce.domain.inventory.Inventory;
+import com.personal.marketnote.commerce.domain.inventory.InventoryReservation;
+import com.personal.marketnote.commerce.domain.inventory.InventoryReservationCreateState;
+import com.personal.marketnote.commerce.exception.InventoryNotFoundException;
+import com.personal.marketnote.commerce.port.in.command.inventory.ReserveInventoryCommand;
+import com.personal.marketnote.commerce.port.in.usecase.inventory.ReserveInventoryUseCase;
+import com.personal.marketnote.commerce.port.out.inventory.*;
+import com.personal.marketnote.common.application.UseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional(isolation = READ_COMMITTED)
+public class ReserveInventoryService implements ReserveInventoryUseCase {
+    private final FindInventoryPort findInventoryPort;
+    private final UpdateInventoryPort updateInventoryPort;
+    private final SaveInventoryReservationPort saveInventoryReservationPort;
+    private final SaveCacheStockPort saveCacheStockPort;
+    private final InventoryLockPort inventoryLockPort;
+    private final Clock clock;
+
+    @Override
+    public void reserveInventory(ReserveInventoryCommand command) {
+        Map<Long, Integer> quantitiesByPricePolicyId = command.orderProducts().stream()
+                .collect(Collectors.groupingBy(
+                        ReserveInventoryCommand.OrderProductItem::pricePolicyId,
+                        Collectors.summingInt(ReserveInventoryCommand.OrderProductItem::quantity)
+                ));
+
+        inventoryLockPort.executeWithLock(quantitiesByPricePolicyId.keySet(), () -> {
+            Set<Inventory> inventories = findInventoryPort.findByPricePolicyIds(quantitiesByPricePolicyId.keySet());
+
+            validateAllInventoriesFound(inventories, quantitiesByPricePolicyId.keySet());
+
+            inventories.forEach(inventory ->
+                    inventory.reserve(quantitiesByPricePolicyId.get(inventory.getPricePolicyId()))
+            );
+
+            updateInventoryPort.update(inventories);
+
+            List<InventoryReservation> reservations = createReservations(
+                    command.orderId(), quantitiesByPricePolicyId
+            );
+            saveInventoryReservationPort.save(reservations);
+
+            saveCacheStockPort.save(inventories);
+        });
+    }
+
+    private void validateAllInventoriesFound(Set<Inventory> inventories, Set<Long> requestedPricePolicyIds) {
+        if (inventories.size() == requestedPricePolicyIds.size()) {
+            return;
+        }
+        Set<Long> foundPricePolicyIds = inventories.stream()
+                .map(Inventory::getPricePolicyId)
+                .collect(Collectors.toSet());
+        Long missingPricePolicyId = requestedPricePolicyIds.stream()
+                .filter(id -> !foundPricePolicyIds.contains(id))
+                .findFirst()
+                .orElseThrow();
+        throw new InventoryNotFoundException(missingPricePolicyId);
+    }
+
+    private List<InventoryReservation> createReservations(Long orderId,
+                                                           Map<Long, Integer> quantitiesByPricePolicyId) {
+        LocalDateTime reservedAt = LocalDateTime.now(clock);
+        return quantitiesByPricePolicyId.entrySet().stream()
+                .map(entry -> InventoryReservation.from(
+                        InventoryReservationCreateState.builder()
+                                .orderId(orderId)
+                                .pricePolicyId(entry.getKey())
+                                .quantity(entry.getValue())
+                                .reservedAt(reservedAt)
+                                .build()
+                ))
+                .toList();
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/PaymentApprovalTransactionHelper.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/PaymentApprovalTransactionHelper.java
@@ -7,10 +7,12 @@ import com.personal.marketnote.commerce.domain.payment.Payment;
 import com.personal.marketnote.commerce.domain.payment.PaymentApprovalInfo;
 import com.personal.marketnote.commerce.domain.payment.PspPaymentEvent;
 import com.personal.marketnote.commerce.exception.*;
+import com.personal.marketnote.commerce.port.in.command.inventory.ReserveInventoryCommand;
 import com.personal.marketnote.commerce.port.in.command.order.ChangeOrderStatusCommand;
 import com.personal.marketnote.commerce.port.in.command.payment.ApprovePaymentCommand;
 import com.personal.marketnote.commerce.port.in.command.saga.OrderPaymentSagaContext;
 import com.personal.marketnote.commerce.port.in.result.payment.ApprovePaymentResult;
+import com.personal.marketnote.commerce.port.in.usecase.inventory.ReserveInventoryUseCase;
 import com.personal.marketnote.commerce.port.in.usecase.order.ChangeOrderStatusUseCase;
 import com.personal.marketnote.commerce.port.out.event.PublishPaymentEventPort;
 import com.personal.marketnote.commerce.port.out.order.FindOrderPort;
@@ -52,6 +54,7 @@ public class PaymentApprovalTransactionHelper {
     private final FindPspPaymentEventPort findPspPaymentEventPort;
     private final UpdatePspPaymentEventPort updatePspPaymentEventPort;
     private final ChangeOrderStatusUseCase changeOrderStatusUseCase;
+    private final ReserveInventoryUseCase reserveInventoryUseCase;
     private final PublishPaymentEventPort publishPaymentEventPort;
     private final FindProductByPricePolicyPort findProductByPricePolicyPort;
     private final Optional<OrderPaymentSagaStarter> orderPaymentSagaStarter;
@@ -67,6 +70,8 @@ public class PaymentApprovalTransactionHelper {
 
         Order order = findVerifiedOrder(payment.getOrderId(), command.buyerId());
         verifyPaymentAmount(order, payment);
+
+        reserveInventory(order);
 
         PspPaymentEvent event = findPspPaymentEventPort.findByOrderKey(command.orderKey())
                 .orElseThrow(() -> new PaymentEventNotFoundException(command.orderKey()));
@@ -179,6 +184,22 @@ public class PaymentApprovalTransactionHelper {
 
         event.markUnknown(resultCode, resultMessage);
         updatePspPaymentEventPort.update(event);
+    }
+
+    private void reserveInventory(Order order) {
+        List<ReserveInventoryCommand.OrderProductItem> orderProductItems = order.getOrderProducts().stream()
+                .map(op -> ReserveInventoryCommand.OrderProductItem.builder()
+                        .pricePolicyId(op.getPricePolicyId())
+                        .quantity(op.getQuantity())
+                        .build())
+                .toList();
+
+        reserveInventoryUseCase.reserveInventory(
+                ReserveInventoryCommand.builder()
+                        .orderId(order.getId())
+                        .orderProducts(orderProductItems)
+                        .build()
+        );
     }
 
     private void verifyPaymentAmount(Order order, Payment payment) {


### PR DESCRIPTION
## partially addresses #1575
## resolves #1578

## Task
- [x] ReserveInventoryCommand (Command 레코드) 정의
- [x] ReserveInventoryUseCase (In Port) 인터페이스 정의
- [x] SaveInventoryReservationPort (Out Port) 인터페이스 정의
- [x] ReserveInventoryService 구현 (Redisson 분산 락 기반, 전체 상품 일괄 예약)
- [x] InventoryReservationPersistenceAdapter 구현 (UNIQUE 위반 시 DuplicateInventoryReservationException)
- [x] DuplicateInventoryReservationException 예외 정의
- [x] PaymentApprovalTransactionHelper.prepareExecution()에서 재고 예약 호출 추가
- [x] 조회된 Inventory와 요청된 pricePolicyIds 불일치 검증 추가