### PR TITLE
[#1575][#1579] feat: 재고 차감 방식을 Consumer 예약 → 실차감 전환 프로세스로 변경

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/saga/OrderPaymentInventorySagaConsumer.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/saga/OrderPaymentInventorySagaConsumer.java
@@ -5,7 +5,7 @@ import com.personal.marketnote.commerce.adapter.in.event.saga.payload.InventoryS
 import com.personal.marketnote.commerce.domain.order.OrderProduct;
 import com.personal.marketnote.commerce.exception.DuplicateInventoryDeductionException;
 import com.personal.marketnote.commerce.port.in.usecase.inventory.ReduceProductInventoryUseCase;
-import com.personal.marketnote.commerce.port.in.usecase.inventory.RestoreProductInventoryUseCase;
+import com.personal.marketnote.commerce.port.in.usecase.inventory.ReleaseInventoryReservationUseCase;
 import com.personal.marketnote.common.kafka.KafkaTopicConstants;
 import com.personal.marketnote.common.kafka.event.EventEnvelope;
 import com.personal.marketnote.common.kafka.event.EventPayloadValidator;
@@ -30,7 +30,7 @@ public class OrderPaymentInventorySagaConsumer {
 
     private final ObjectMapper objectMapper;
     private final ReduceProductInventoryUseCase reduceProductInventoryUseCase;
-    private final RestoreProductInventoryUseCase restoreProductInventoryUseCase;
+    private final ReleaseInventoryReservationUseCase releaseInventoryReservationUseCase;
     private final SagaResponsePublisher sagaResponsePublisher;
 
     @KafkaListener(
@@ -122,7 +122,7 @@ public class OrderPaymentInventorySagaConsumer {
 
             List<OrderProduct> orderProducts = SagaOrderProductMapper.toOrderProducts(payload.orderProducts());
 
-            restoreProductInventoryUseCase.restore(orderProducts, payload.orderId(), "SAGA 보상 - 재고 복구");
+            releaseInventoryReservationUseCase.release(orderProducts, payload.orderId(), "SAGA 보상 - 재고 복구");
 
             sagaResponsePublisher.publishSuccess(
                     stepMessage.sagaId(), stepMessage.sagaType(), stepMessage.stepName(),

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/inventory/InventoryReservationPersistenceAdapter.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/inventory/InventoryReservationPersistenceAdapter.java
@@ -3,17 +3,22 @@ package com.personal.marketnote.commerce.adapter.out.persistence.inventory;
 import com.personal.marketnote.commerce.adapter.out.persistence.inventory.entity.InventoryReservationJpaEntity;
 import com.personal.marketnote.commerce.adapter.out.persistence.inventory.repository.InventoryReservationJpaRepository;
 import com.personal.marketnote.commerce.domain.inventory.InventoryReservation;
+import com.personal.marketnote.commerce.domain.inventory.InventoryReservationSnapshotState;
 import com.personal.marketnote.commerce.exception.DuplicateInventoryReservationException;
+import com.personal.marketnote.commerce.port.out.inventory.DeleteInventoryReservationPort;
+import com.personal.marketnote.commerce.port.out.inventory.FindInventoryReservationPort;
 import com.personal.marketnote.commerce.port.out.inventory.SaveInventoryReservationPort;
 import com.personal.marketnote.common.adapter.out.PersistenceAdapter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
 
 import java.util.List;
+import java.util.Set;
 
 @PersistenceAdapter
 @RequiredArgsConstructor
-public class InventoryReservationPersistenceAdapter implements SaveInventoryReservationPort {
+public class InventoryReservationPersistenceAdapter implements
+        SaveInventoryReservationPort, FindInventoryReservationPort, DeleteInventoryReservationPort {
     private final InventoryReservationJpaRepository inventoryReservationJpaRepository;
 
     @Override
@@ -31,5 +36,24 @@ public class InventoryReservationPersistenceAdapter implements SaveInventoryRese
                     .orElse(null);
             throw new DuplicateInventoryReservationException(orderId);
         }
+    }
+
+    @Override
+    public List<InventoryReservation> findByOrderIdAndPricePolicyIds(Long orderId, Set<Long> pricePolicyIds) {
+        return inventoryReservationJpaRepository.findByOrderIdAndPricePolicyIdIn(orderId, pricePolicyIds)
+                .stream()
+                .map(entity -> InventoryReservation.from(InventoryReservationSnapshotState.builder()
+                        .id(entity.getId())
+                        .orderId(entity.getOrderId())
+                        .pricePolicyId(entity.getPricePolicyId())
+                        .quantity(entity.getQuantity())
+                        .reservedAt(entity.getReservedAt())
+                        .build()))
+                .toList();
+    }
+
+    @Override
+    public void deleteByOrderIdAndPricePolicyIds(Long orderId, Set<Long> pricePolicyIds) {
+        inventoryReservationJpaRepository.deleteByOrderIdAndPricePolicyIdIn(orderId, pricePolicyIds);
     }
 }

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/inventory/repository/InventoryReservationJpaRepository.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/inventory/repository/InventoryReservationJpaRepository.java
@@ -2,6 +2,17 @@ package com.personal.marketnote.commerce.adapter.out.persistence.inventory.repos
 
 import com.personal.marketnote.commerce.adapter.out.persistence.inventory.entity.InventoryReservationJpaEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Set;
 
 public interface InventoryReservationJpaRepository extends JpaRepository<InventoryReservationJpaEntity, Long> {
+    List<InventoryReservationJpaEntity> findByOrderIdAndPricePolicyIdIn(Long orderId, Set<Long> pricePolicyIds);
+
+    @Modifying
+    @Query("DELETE FROM InventoryReservationJpaEntity e WHERE e.orderId = :orderId AND e.pricePolicyId IN :pricePolicyIds")
+    void deleteByOrderIdAndPricePolicyIdIn(@Param("orderId") Long orderId, @Param("pricePolicyIds") Set<Long> pricePolicyIds);
 }

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/inventory/ReleaseInventoryReservationUseCase.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/inventory/ReleaseInventoryReservationUseCase.java
@@ -1,0 +1,16 @@
+package com.personal.marketnote.commerce.port.in.usecase.inventory;
+
+import com.personal.marketnote.commerce.domain.order.OrderProduct;
+
+import java.util.List;
+
+public interface ReleaseInventoryReservationUseCase {
+    /**
+     * @param orderProducts 주문 상품 목록
+     * @param orderId       주문 ID
+     * @param reason        해소 이유
+     * @Description SAGA 보상 시 예약 해소. 예약 레코드가 존재하면 releaseReservation (reserved 감소 + 레코드 삭제),
+     * 이미 confirmReservation 완료(레코드 부재)된 경우 restore (stock 복원)로 fallback.
+     */
+    void release(List<OrderProduct> orderProducts, Long orderId, String reason);
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/inventory/DeleteInventoryReservationPort.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/inventory/DeleteInventoryReservationPort.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.commerce.port.out.inventory;
+
+import java.util.Set;
+
+public interface DeleteInventoryReservationPort {
+    void deleteByOrderIdAndPricePolicyIds(Long orderId, Set<Long> pricePolicyIds);
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/inventory/FindInventoryReservationPort.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/inventory/FindInventoryReservationPort.java
@@ -1,0 +1,10 @@
+package com.personal.marketnote.commerce.port.out.inventory;
+
+import com.personal.marketnote.commerce.domain.inventory.InventoryReservation;
+
+import java.util.List;
+import java.util.Set;
+
+public interface FindInventoryReservationPort {
+    List<InventoryReservation> findByOrderIdAndPricePolicyIds(Long orderId, Set<Long> pricePolicyIds);
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/inventory/ReleaseInventoryReservationService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/inventory/ReleaseInventoryReservationService.java
@@ -1,10 +1,10 @@
 package com.personal.marketnote.commerce.service.inventory;
 
 import com.personal.marketnote.commerce.domain.inventory.Inventory;
-import com.personal.marketnote.commerce.domain.inventory.InventoryDeductionHistories;
 import com.personal.marketnote.commerce.domain.inventory.InventoryReservation;
+import com.personal.marketnote.commerce.domain.inventory.InventoryRestorationHistories;
 import com.personal.marketnote.commerce.domain.order.OrderProduct;
-import com.personal.marketnote.commerce.port.in.usecase.inventory.ReduceProductInventoryUseCase;
+import com.personal.marketnote.commerce.port.in.usecase.inventory.ReleaseInventoryReservationUseCase;
 import com.personal.marketnote.commerce.port.out.event.PublishInventoryEventPort;
 import com.personal.marketnote.commerce.port.out.inventory.*;
 import com.personal.marketnote.common.application.UseCase;
@@ -24,26 +24,23 @@ import static org.springframework.transaction.annotation.Isolation.READ_COMMITTE
 @UseCase
 @RequiredArgsConstructor
 @Transactional(isolation = READ_COMMITTED)
-public class ReduceProductInventoryService implements ReduceProductInventoryUseCase {
+public class ReleaseInventoryReservationService implements ReleaseInventoryReservationUseCase {
     private final FindInventoryPort findInventoryPort;
     private final UpdateInventoryPort updateInventoryPort;
-    private final SaveInventoryDeductionHistoryPort saveInventoryDeductionHistoryPort;
+    private final FindInventoryReservationPort findInventoryReservationPort;
+    private final DeleteInventoryReservationPort deleteInventoryReservationPort;
+    private final SaveInventoryRestorationHistoryPort saveInventoryRestorationHistoryPort;
     private final SaveCacheStockPort saveCacheStockPort;
     private final InventoryLockPort inventoryLockPort;
     private final PublishInventoryEventPort publishInventoryEventPort;
-    private final FindInventoryReservationPort findInventoryReservationPort;
-    private final DeleteInventoryReservationPort deleteInventoryReservationPort;
 
     @Override
-    public void reduce(List<OrderProduct> orderProducts, Long orderId, String reason) {
+    public void release(List<OrderProduct> orderProducts, Long orderId, String reason) {
         Map<Long, Integer> stocksByPricePolicyId = orderProducts.stream()
-                .collect(
-                        Collectors.groupingBy(
-                                OrderProduct::getPricePolicyId, Collectors.summingInt(OrderProduct::getQuantity)
-                        )
-                );
+                .collect(Collectors.groupingBy(
+                        OrderProduct::getPricePolicyId, Collectors.summingInt(OrderProduct::getQuantity)
+                ));
 
-        // Redisson Pub/Sub 모델 분산 락 기반의 동시성 제어
         inventoryLockPort.executeWithLock(stocksByPricePolicyId.keySet(), () -> {
             Set<Inventory> inventories = findInventoryPort.findByPricePolicyIds(stocksByPricePolicyId.keySet());
 
@@ -59,10 +56,10 @@ public class ReduceProductInventoryService implements ReduceProductInventoryUseC
                 int quantity = stocksByPricePolicyId.get(inventory.getPricePolicyId());
                 InventoryReservation reservation = reservationByPricePolicyId.get(inventory.getPricePolicyId());
                 if (FormatValidator.hasValue(reservation)) {
-                    inventory.confirmReservation(reservation.getQuantity());
+                    inventory.releaseReservation(reservation.getQuantity());
                     return;
                 }
-                inventory.reduce(quantity);
+                inventory.restore(quantity);
             });
 
             if (!reservedPricePolicyIds.isEmpty()) {
@@ -70,13 +67,15 @@ public class ReduceProductInventoryService implements ReduceProductInventoryUseC
             }
 
             updateInventoryPort.update(inventories);
+
             Map<Long, Long> productIdsByPricePolicyId = new HashMap<>();
             inventories.forEach(inventory ->
                     productIdsByPricePolicyId.put(inventory.getPricePolicyId(), inventory.getProductId())
             );
-            saveInventoryDeductionHistoryPort.save(
-                    InventoryDeductionHistories.from(stocksByPricePolicyId, productIdsByPricePolicyId, orderId, reason)
+            saveInventoryRestorationHistoryPort.save(
+                    InventoryRestorationHistories.from(stocksByPricePolicyId, productIdsByPricePolicyId, orderId, reason)
             );
+
             saveCacheStockPort.save(inventories);
 
             inventories.forEach(inventory ->


### PR DESCRIPTION
## partially addresses #1575
## resolves #1579

## Task
- [x] ReduceProductInventoryService.reduce()에서 InventoryReservation 레코드 존재 여부로 분기
- [x] FindInventoryReservationPort 인터페이스 정의 (orderId + pricePolicyId 기준 조회)
- [x] DeleteInventoryReservationPort 인터페이스 정의
- [x] InventoryReservationPersistenceAdapter에 find/delete 구현
- [x] DuplicateInventoryDeductionException 멱등성 처리 유지
- [x] SAGA 보상 시 예약 해소: OrderPaymentInventorySagaConsumer 보상 경로에서 releaseReservation 호출