### PR TITLE
[#1575][#1907] test: 재고 차감 방식을 Consumer 예약 → 실차감 전환 프로세스로 변경하는 기능 자동화 테스트 추가

### DIFF
--- a/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/event/saga/OrderPaymentInventorySagaConsumerTest.java
+++ b/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/event/saga/OrderPaymentInventorySagaConsumerTest.java
@@ -3,7 +3,7 @@ package com.personal.marketnote.commerce.adapter.in.event.saga;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.personal.marketnote.commerce.exception.DuplicateInventoryDeductionException;
 import com.personal.marketnote.commerce.port.in.usecase.inventory.ReduceProductInventoryUseCase;
-import com.personal.marketnote.commerce.port.in.usecase.inventory.RestoreProductInventoryUseCase;
+import com.personal.marketnote.commerce.port.in.usecase.inventory.ReleaseInventoryReservationUseCase;
 import com.personal.marketnote.common.kafka.event.EventEnvelope;
 import com.personal.marketnote.common.saga.SagaResponsePublisher;
 import com.personal.marketnote.common.saga.SagaStepMessage;
@@ -46,7 +46,7 @@ class OrderPaymentInventorySagaConsumerTest {
     private ReduceProductInventoryUseCase reduceProductInventoryUseCase;
 
     @Mock
-    private RestoreProductInventoryUseCase restoreProductInventoryUseCase;
+    private ReleaseInventoryReservationUseCase releaseInventoryReservationUseCase;
 
     @Mock
     private SagaResponsePublisher sagaResponsePublisher;
@@ -148,7 +148,7 @@ class OrderPaymentInventorySagaConsumerTest {
             consumer.handleInventoryStep(record, acknowledgment);
 
             // then
-            verify(restoreProductInventoryUseCase).restore(anyList(), eq(1L), anyString());
+            verify(releaseInventoryReservationUseCase).release(anyList(), eq(1L), anyString());
             verify(sagaResponsePublisher).publishSuccess(
                     SAGA_ID, SAGA_TYPE, STEP_NAME, SagaStepMessage.COMPENSATION, "{\"compensated\":true}");
             verify(acknowledgment).acknowledge();
@@ -163,7 +163,7 @@ class OrderPaymentInventorySagaConsumerTest {
             ConsumerRecord<String, EventEnvelope<?>> record = createRecord(stepMessage);
 
             doThrow(new RuntimeException("복구 실패"))
-                    .when(restoreProductInventoryUseCase).restore(anyList(), eq(1L), anyString());
+                    .when(releaseInventoryReservationUseCase).release(anyList(), eq(1L), anyString());
 
             // when
             consumer.handleInventoryStep(record, acknowledgment);

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/inventory/ReduceProductInventoryUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/inventory/ReduceProductInventoryUseCaseTest.java
@@ -3,6 +3,9 @@ package com.personal.marketnote.commerce.service.inventory;
 import com.personal.marketnote.commerce.domain.inventory.Inventory;
 import com.personal.marketnote.commerce.domain.inventory.InventoryDeductionHistories;
 import com.personal.marketnote.commerce.domain.inventory.InventoryDeductionHistory;
+import com.personal.marketnote.commerce.domain.inventory.InventoryReservation;
+import com.personal.marketnote.commerce.domain.inventory.InventoryReservationSnapshotState;
+import com.personal.marketnote.commerce.domain.inventory.InventorySnapshotState;
 import com.personal.marketnote.commerce.domain.order.OrderProduct;
 import com.personal.marketnote.commerce.domain.order.OrderProductSnapshotState;
 import com.personal.marketnote.commerce.exception.DuplicateInventoryDeductionException;
@@ -23,12 +26,14 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -45,6 +50,10 @@ class ReduceProductInventoryUseCaseTest {
     private InventoryLockPort inventoryLockPort;
     @Mock
     private PublishInventoryEventPort publishInventoryEventPort;
+    @Mock
+    private FindInventoryReservationPort findInventoryReservationPort;
+    @Mock
+    private DeleteInventoryReservationPort deleteInventoryReservationPort;
 
     @InjectMocks
     private ReduceProductInventoryService reduceProductInventoryService;
@@ -880,6 +889,155 @@ class ReduceProductInventoryUseCaseTest {
     }
 
     // ==================================================================================
+    // 예약→실차감 전환 (confirmReservation / fallback reduce)
+    // ==================================================================================
+
+    @Nested
+    @DisplayName("예약→실차감 전환")
+    class ConfirmReservationTest {
+
+        @Test
+        @DisplayName("예약 레코드가 존재하면 confirmReservation으로 재고를 차감한다 (reserved 감소 + stock 감소)")
+        void reduce_withReservation_callsConfirmReservation() {
+            List<OrderProduct> orderProducts = List.of(buildOrderProduct(100L, 3));
+            Inventory inventory = buildInventoryWithReserved(1L, 100L, 10, 3);
+            InventoryReservation reservation = buildReservation(1L, 100L, 3);
+
+            stubLockToExecuteTask();
+            when(findInventoryPort.findByPricePolicyIds(any())).thenReturn(Set.of(inventory));
+            when(findInventoryReservationPort.findByOrderIdAndPricePolicyIds(eq(1L), any()))
+                    .thenReturn(List.of(reservation));
+
+            reduceProductInventoryService.reduce(orderProducts, 1L, "결제 완료");
+
+            assertThat(inventory.getStockValue()).isEqualTo(7);
+            assertThat(inventory.getReserved()).isEqualTo(0);
+        }
+
+        @Test
+        @DisplayName("예약 레코드가 존재하면 예약 레코드를 삭제한다")
+        void reduce_withReservation_deletesReservationRecords() {
+            List<OrderProduct> orderProducts = List.of(buildOrderProduct(100L, 3));
+            Inventory inventory = buildInventoryWithReserved(1L, 100L, 10, 3);
+            InventoryReservation reservation = buildReservation(1L, 100L, 3);
+
+            stubLockToExecuteTask();
+            when(findInventoryPort.findByPricePolicyIds(any())).thenReturn(Set.of(inventory));
+            when(findInventoryReservationPort.findByOrderIdAndPricePolicyIds(eq(1L), any()))
+                    .thenReturn(List.of(reservation));
+
+            reduceProductInventoryService.reduce(orderProducts, 1L, "결제 완료");
+
+            verify(deleteInventoryReservationPort).deleteByOrderIdAndPricePolicyIds(eq(1L), eq(Set.of(100L)));
+        }
+
+        @Test
+        @DisplayName("예약 레코드가 없으면 기존 reduce()로 fallback하여 stock만 감소한다")
+        void reduce_withoutReservation_fallsBackToReduce() {
+            List<OrderProduct> orderProducts = List.of(buildOrderProduct(100L, 3));
+            Inventory inventory = buildInventory(1L, 100L, 10);
+
+            stubLockToExecuteTask();
+            when(findInventoryPort.findByPricePolicyIds(any())).thenReturn(Set.of(inventory));
+            when(findInventoryReservationPort.findByOrderIdAndPricePolicyIds(eq(1L), any()))
+                    .thenReturn(List.of());
+
+            reduceProductInventoryService.reduce(orderProducts, 1L, "결제 완료");
+
+            assertThat(inventory.getStockValue()).isEqualTo(7);
+            assertThat(inventory.getReserved()).isEqualTo(0);
+        }
+
+        @Test
+        @DisplayName("예약 레코드가 없으면 예약 레코드를 삭제하지 않는다")
+        void reduce_withoutReservation_doesNotDeleteReservation() {
+            List<OrderProduct> orderProducts = List.of(buildOrderProduct(100L, 3));
+            Inventory inventory = buildInventory(1L, 100L, 10);
+
+            stubLockToExecuteTask();
+            when(findInventoryPort.findByPricePolicyIds(any())).thenReturn(Set.of(inventory));
+            when(findInventoryReservationPort.findByOrderIdAndPricePolicyIds(eq(1L), any()))
+                    .thenReturn(List.of());
+
+            reduceProductInventoryService.reduce(orderProducts, 1L, "결제 완료");
+
+            verifyNoInteractions(deleteInventoryReservationPort);
+        }
+
+        @Test
+        @DisplayName("복수 가격 정책 중 일부만 예약 레코드가 있으면 해당 건만 confirmReservation, 나머지는 reduce로 처리한다")
+        void reduce_partialReservation_mixesConfirmAndReduce() {
+            List<OrderProduct> orderProducts = List.of(
+                    buildOrderProduct(100L, 2),
+                    buildOrderProduct(200L, 5)
+            );
+            Inventory inventory1 = buildInventoryWithReserved(1L, 100L, 10, 2);
+            Inventory inventory2 = buildInventory(2L, 200L, 20);
+            InventoryReservation reservation = buildReservation(1L, 100L, 2);
+
+            stubLockToExecuteTask();
+            when(findInventoryPort.findByPricePolicyIds(any())).thenReturn(Set.of(inventory1, inventory2));
+            when(findInventoryReservationPort.findByOrderIdAndPricePolicyIds(eq(1L), any()))
+                    .thenReturn(List.of(reservation));
+
+            reduceProductInventoryService.reduce(orderProducts, 1L, "결제 완료");
+
+            assertThat(inventory1.getStockValue()).isEqualTo(8);
+            assertThat(inventory1.getReserved()).isEqualTo(0);
+            assertThat(inventory2.getStockValue()).isEqualTo(15);
+            assertThat(inventory2.getReserved()).isEqualTo(0);
+        }
+
+        @Test
+        @DisplayName("예약→실차감 후에도 이력 저장, 캐시 저장, 이벤트 발행이 정상 수행된다")
+        void reduce_withReservation_callsAllSubsequentPorts() {
+            List<OrderProduct> orderProducts = List.of(buildOrderProduct(100L, 3));
+            Inventory inventory = buildInventoryWithReserved(1L, 100L, 10, 3);
+            InventoryReservation reservation = buildReservation(1L, 100L, 3);
+
+            stubLockToExecuteTask();
+            when(findInventoryPort.findByPricePolicyIds(any())).thenReturn(Set.of(inventory));
+            when(findInventoryReservationPort.findByOrderIdAndPricePolicyIds(eq(1L), any()))
+                    .thenReturn(List.of(reservation));
+
+            reduceProductInventoryService.reduce(orderProducts, 1L, "결제 완료");
+
+            verify(updateInventoryPort).update(any());
+            verify(saveInventoryDeductionHistoryPort).save(any(InventoryDeductionHistories.class));
+            verify(saveCacheStockPort).save(any(Set.class));
+            verify(publishInventoryEventPort).publishInventoryChangedEvent(
+                    100L, 1L, 7, InventoryChangeAction.UPDATED
+            );
+        }
+
+        @Test
+        @DisplayName("예약→실차감 시 예약 조회 → 차감/확정 → 예약 삭제 → 업데이트 순서로 호출한다")
+        @SuppressWarnings("unchecked")
+        void reduce_withReservation_callsInCorrectOrder() {
+            List<OrderProduct> orderProducts = List.of(buildOrderProduct(100L, 3));
+            Inventory inventory = buildInventoryWithReserved(1L, 100L, 10, 3);
+            InventoryReservation reservation = buildReservation(1L, 100L, 3);
+
+            stubLockToExecuteTask();
+            when(findInventoryPort.findByPricePolicyIds(any())).thenReturn(Set.of(inventory));
+            when(findInventoryReservationPort.findByOrderIdAndPricePolicyIds(eq(1L), any()))
+                    .thenReturn(List.of(reservation));
+
+            reduceProductInventoryService.reduce(orderProducts, 1L, "결제 완료");
+
+            InOrder inOrder = inOrder(findInventoryPort, findInventoryReservationPort,
+                    deleteInventoryReservationPort, updateInventoryPort,
+                    saveInventoryDeductionHistoryPort, saveCacheStockPort);
+            inOrder.verify(findInventoryPort).findByPricePolicyIds(any());
+            inOrder.verify(findInventoryReservationPort).findByOrderIdAndPricePolicyIds(eq(1L), any());
+            inOrder.verify(deleteInventoryReservationPort).deleteByOrderIdAndPricePolicyIds(eq(1L), any());
+            inOrder.verify(updateInventoryPort).update(any());
+            inOrder.verify(saveInventoryDeductionHistoryPort).save(any(InventoryDeductionHistories.class));
+            inOrder.verify(saveCacheStockPort).save(any(Set.class));
+        }
+    }
+
+    // ==================================================================================
     // 헬퍼 메서드
     // ==================================================================================
 
@@ -902,6 +1060,26 @@ class ReduceProductInventoryUseCaseTest {
 
     private Inventory buildInventory(Long productId, Long pricePolicyId, int stock) {
         return Inventory.of(productId, pricePolicyId, stock, 0L);
+    }
+
+    private Inventory buildInventoryWithReserved(Long productId, Long pricePolicyId, int stock, int reserved) {
+        return Inventory.from(InventorySnapshotState.builder()
+                .productId(productId)
+                .pricePolicyId(pricePolicyId)
+                .stock(stock)
+                .version(0L)
+                .reserved(reserved)
+                .build());
+    }
+
+    private InventoryReservation buildReservation(Long orderId, Long pricePolicyId, int quantity) {
+        return InventoryReservation.from(InventoryReservationSnapshotState.builder()
+                .id(1L)
+                .orderId(orderId)
+                .pricePolicyId(pricePolicyId)
+                .quantity(quantity)
+                .reservedAt(LocalDateTime.now())
+                .build());
     }
 
     // ==================================================================================

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/inventory/ReleaseInventoryReservationUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/inventory/ReleaseInventoryReservationUseCaseTest.java
@@ -1,0 +1,271 @@
+package com.personal.marketnote.commerce.service.inventory;
+
+import com.personal.marketnote.commerce.domain.inventory.Inventory;
+import com.personal.marketnote.commerce.domain.inventory.InventoryReservation;
+import com.personal.marketnote.commerce.domain.inventory.InventoryReservationSnapshotState;
+import com.personal.marketnote.commerce.domain.inventory.InventoryRestorationHistories;
+import com.personal.marketnote.commerce.domain.inventory.InventorySnapshotState;
+import com.personal.marketnote.commerce.domain.order.OrderProduct;
+import com.personal.marketnote.commerce.domain.order.OrderProductSnapshotState;
+import com.personal.marketnote.commerce.port.out.event.PublishInventoryEventPort;
+import com.personal.marketnote.commerce.port.out.inventory.*;
+import com.personal.marketnote.common.kafka.event.InventoryChangeAction;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ReleaseInventoryReservationUseCaseTest {
+    @Mock
+    private FindInventoryPort findInventoryPort;
+    @Mock
+    private UpdateInventoryPort updateInventoryPort;
+    @Mock
+    private FindInventoryReservationPort findInventoryReservationPort;
+    @Mock
+    private DeleteInventoryReservationPort deleteInventoryReservationPort;
+    @Mock
+    private SaveInventoryRestorationHistoryPort saveInventoryRestorationHistoryPort;
+    @Mock
+    private SaveCacheStockPort saveCacheStockPort;
+    @Mock
+    private InventoryLockPort inventoryLockPort;
+    @Mock
+    private PublishInventoryEventPort publishInventoryEventPort;
+
+    @InjectMocks
+    private ReleaseInventoryReservationService releaseInventoryReservationService;
+
+    // ==================================================================================
+    // 예약 해소 (예약 레코드 존재 시 — releaseReservation)
+    // ==================================================================================
+
+    @Nested
+    @DisplayName("예약 레코드 존재 시 예약 해소 (releaseReservation)")
+    class ReleaseWithReservationTest {
+
+        @Test
+        @DisplayName("예약 레코드가 존재하면 reserved를 감소시키고 stock은 유지한다")
+        void release_withReservation_decreasesReservedAndKeepsStock() {
+            List<OrderProduct> orderProducts = List.of(buildOrderProduct(100L, 3));
+            Inventory inventory = buildInventoryWithReserved(1L, 100L, 10, 3);
+            InventoryReservation reservation = buildReservation(1L, 100L, 3);
+
+            stubLockToExecuteTask();
+            when(findInventoryPort.findByPricePolicyIds(any())).thenReturn(Set.of(inventory));
+            when(findInventoryReservationPort.findByOrderIdAndPricePolicyIds(eq(1L), any()))
+                    .thenReturn(List.of(reservation));
+
+            releaseInventoryReservationService.release(orderProducts, 1L, "SAGA 보상 - 예약 해소");
+
+            assertThat(inventory.getStockValue()).isEqualTo(10);
+            assertThat(inventory.getReserved()).isEqualTo(0);
+        }
+
+        @Test
+        @DisplayName("예약 레코드가 존재하면 예약 레코드를 삭제한다")
+        void release_withReservation_deletesReservationRecords() {
+            List<OrderProduct> orderProducts = List.of(buildOrderProduct(100L, 3));
+            Inventory inventory = buildInventoryWithReserved(1L, 100L, 10, 3);
+            InventoryReservation reservation = buildReservation(1L, 100L, 3);
+
+            stubLockToExecuteTask();
+            when(findInventoryPort.findByPricePolicyIds(any())).thenReturn(Set.of(inventory));
+            when(findInventoryReservationPort.findByOrderIdAndPricePolicyIds(eq(1L), any()))
+                    .thenReturn(List.of(reservation));
+
+            releaseInventoryReservationService.release(orderProducts, 1L, "SAGA 보상 - 예약 해소");
+
+            verify(deleteInventoryReservationPort).deleteByOrderIdAndPricePolicyIds(eq(1L), eq(Set.of(100L)));
+        }
+
+        @Test
+        @DisplayName("예약 해소 후 복원 이력을 저장한다")
+        void release_withReservation_savesRestorationHistory() {
+            List<OrderProduct> orderProducts = List.of(buildOrderProduct(100L, 3));
+            Inventory inventory = buildInventoryWithReserved(1L, 100L, 10, 3);
+            InventoryReservation reservation = buildReservation(1L, 100L, 3);
+
+            stubLockToExecuteTask();
+            when(findInventoryPort.findByPricePolicyIds(any())).thenReturn(Set.of(inventory));
+            when(findInventoryReservationPort.findByOrderIdAndPricePolicyIds(eq(1L), any()))
+                    .thenReturn(List.of(reservation));
+
+            releaseInventoryReservationService.release(orderProducts, 1L, "SAGA 보상 - 예약 해소");
+
+            verify(saveInventoryRestorationHistoryPort).save(any(InventoryRestorationHistories.class));
+        }
+
+        @Test
+        @DisplayName("예약 해소 후 캐시와 이벤트를 갱신한다")
+        void release_withReservation_updatesCacheAndPublishesEvent() {
+            List<OrderProduct> orderProducts = List.of(buildOrderProduct(100L, 3));
+            Inventory inventory = buildInventoryWithReserved(1L, 100L, 10, 3);
+            InventoryReservation reservation = buildReservation(1L, 100L, 3);
+
+            stubLockToExecuteTask();
+            when(findInventoryPort.findByPricePolicyIds(any())).thenReturn(Set.of(inventory));
+            when(findInventoryReservationPort.findByOrderIdAndPricePolicyIds(eq(1L), any()))
+                    .thenReturn(List.of(reservation));
+
+            releaseInventoryReservationService.release(orderProducts, 1L, "SAGA 보상 - 예약 해소");
+
+            verify(saveCacheStockPort).save(any(Set.class));
+            verify(publishInventoryEventPort).publishInventoryChangedEvent(
+                    100L, 1L, 10, InventoryChangeAction.UPDATED
+            );
+        }
+    }
+
+    // ==================================================================================
+    // 예약 레코드 미존재 시 — restore fallback
+    // ==================================================================================
+
+    @Nested
+    @DisplayName("예약 레코드 미존재 시 restore fallback")
+    class RestoreFallbackTest {
+
+        @Test
+        @DisplayName("예약 레코드가 없으면 restore()로 stock을 복원한다")
+        void release_withoutReservation_restoresStock() {
+            List<OrderProduct> orderProducts = List.of(buildOrderProduct(100L, 3));
+            Inventory inventory = buildInventory(1L, 100L, 7);
+
+            stubLockToExecuteTask();
+            when(findInventoryPort.findByPricePolicyIds(any())).thenReturn(Set.of(inventory));
+            when(findInventoryReservationPort.findByOrderIdAndPricePolicyIds(eq(1L), any()))
+                    .thenReturn(List.of());
+
+            releaseInventoryReservationService.release(orderProducts, 1L, "SAGA 보상 - 재고 복구");
+
+            assertThat(inventory.getStockValue()).isEqualTo(10);
+        }
+
+        @Test
+        @DisplayName("예약 레코드가 없으면 예약 삭제를 호출하지 않는다")
+        void release_withoutReservation_doesNotDeleteReservation() {
+            List<OrderProduct> orderProducts = List.of(buildOrderProduct(100L, 3));
+            Inventory inventory = buildInventory(1L, 100L, 7);
+
+            stubLockToExecuteTask();
+            when(findInventoryPort.findByPricePolicyIds(any())).thenReturn(Set.of(inventory));
+            when(findInventoryReservationPort.findByOrderIdAndPricePolicyIds(eq(1L), any()))
+                    .thenReturn(List.of());
+
+            releaseInventoryReservationService.release(orderProducts, 1L, "SAGA 보상 - 재고 복구");
+
+            verifyNoInteractions(deleteInventoryReservationPort);
+        }
+
+        @Test
+        @DisplayName("restore fallback 후 복원 이력과 캐시를 저장한다")
+        void release_withoutReservation_savesHistoryAndCache() {
+            List<OrderProduct> orderProducts = List.of(buildOrderProduct(100L, 3));
+            Inventory inventory = buildInventory(1L, 100L, 7);
+
+            stubLockToExecuteTask();
+            when(findInventoryPort.findByPricePolicyIds(any())).thenReturn(Set.of(inventory));
+            when(findInventoryReservationPort.findByOrderIdAndPricePolicyIds(eq(1L), any()))
+                    .thenReturn(List.of());
+
+            releaseInventoryReservationService.release(orderProducts, 1L, "SAGA 보상 - 재고 복구");
+
+            verify(saveInventoryRestorationHistoryPort).save(any(InventoryRestorationHistories.class));
+            verify(saveCacheStockPort).save(any(Set.class));
+            verify(publishInventoryEventPort).publishInventoryChangedEvent(
+                    100L, 1L, 10, InventoryChangeAction.UPDATED
+            );
+        }
+    }
+
+    // ==================================================================================
+    // 혼합 케이스
+    // ==================================================================================
+
+    @Nested
+    @DisplayName("복수 가격 정책 혼합 케이스")
+    class MixedCaseTest {
+
+        @Test
+        @DisplayName("일부 예약 있고 일부 없는 경우 각각 releaseReservation과 restore로 처리한다")
+        void release_partialReservation_mixesReleaseAndRestore() {
+            List<OrderProduct> orderProducts = List.of(
+                    buildOrderProduct(100L, 2),
+                    buildOrderProduct(200L, 5)
+            );
+            Inventory inventory1 = buildInventoryWithReserved(1L, 100L, 10, 2);
+            Inventory inventory2 = buildInventory(2L, 200L, 15);
+            InventoryReservation reservation = buildReservation(1L, 100L, 2);
+
+            stubLockToExecuteTask();
+            when(findInventoryPort.findByPricePolicyIds(any())).thenReturn(Set.of(inventory1, inventory2));
+            when(findInventoryReservationPort.findByOrderIdAndPricePolicyIds(eq(1L), any()))
+                    .thenReturn(List.of(reservation));
+
+            releaseInventoryReservationService.release(orderProducts, 1L, "SAGA 보상");
+
+            assertThat(inventory1.getStockValue()).isEqualTo(10);
+            assertThat(inventory1.getReserved()).isEqualTo(0);
+            assertThat(inventory2.getStockValue()).isEqualTo(20);
+        }
+    }
+
+    // ==================================================================================
+    // 헬퍼 메서드
+    // ==================================================================================
+
+    private void stubLockToExecuteTask() {
+        doAnswer(invocation -> {
+            Runnable task = invocation.getArgument(1);
+            task.run();
+            return null;
+        }).when(inventoryLockPort).executeWithLock(any(), any());
+    }
+
+    private OrderProduct buildOrderProduct(Long pricePolicyId, int quantity) {
+        return OrderProduct.from(
+                OrderProductSnapshotState.builder()
+                        .pricePolicyId(pricePolicyId)
+                        .quantity(quantity)
+                        .build()
+        );
+    }
+
+    private Inventory buildInventory(Long productId, Long pricePolicyId, int stock) {
+        return Inventory.of(productId, pricePolicyId, stock, 0L);
+    }
+
+    private Inventory buildInventoryWithReserved(Long productId, Long pricePolicyId, int stock, int reserved) {
+        return Inventory.from(InventorySnapshotState.builder()
+                .productId(productId)
+                .pricePolicyId(pricePolicyId)
+                .stock(stock)
+                .version(0L)
+                .reserved(reserved)
+                .build());
+    }
+
+    private InventoryReservation buildReservation(Long orderId, Long pricePolicyId, int quantity) {
+        return InventoryReservation.from(InventoryReservationSnapshotState.builder()
+                .id(1L)
+                .orderId(orderId)
+                .pricePolicyId(pricePolicyId)
+                .quantity(quantity)
+                .reservedAt(LocalDateTime.now())
+                .build());
+    }
+}


### PR DESCRIPTION
## partially addresses #1575
## resolves #1907

## Test Case
- [x] ReduceProductInventoryUseCaseTest 예약→실차감 전환 7개 테스트 케이스 추가
- [x] ReleaseInventoryReservationUseCaseTest 신규 8개 테스트 케이스 추가
- [x] OrderPaymentInventorySagaConsumerTest 보상 경로 변경 반영