### PR TITLE
[#1575][#1580] feat: 예약 만료 스케줄러 추가

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/scheduler/InventoryReservationTimeoutChecker.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/scheduler/InventoryReservationTimeoutChecker.java
@@ -1,0 +1,29 @@
+package com.personal.marketnote.commerce.adapter.in.scheduler;
+
+import com.personal.marketnote.commerce.configuration.InventoryReservationSchedulerProperties;
+import com.personal.marketnote.commerce.port.in.usecase.inventory.ExpireInventoryReservationUseCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(name = "inventory.reservation.scheduler.enabled", havingValue = "true", matchIfMissing = false)
+public class InventoryReservationTimeoutChecker {
+    private final ExpireInventoryReservationUseCase expireInventoryReservationUseCase;
+    private final InventoryReservationSchedulerProperties properties;
+    private final Clock commerceClock;
+
+    @Scheduled(fixedDelayString = "${inventory.reservation.scheduler.check-interval-ms:60000}")
+    public void checkExpiredReservations() {
+        LocalDateTime cutoff = LocalDateTime.now(commerceClock)
+                .minusMinutes(properties.getTimeoutMinutes());
+        expireInventoryReservationUseCase.expireTimedOutReservations(cutoff);
+    }
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/inventory/InventoryReservationPersistenceAdapter.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/inventory/InventoryReservationPersistenceAdapter.java
@@ -6,19 +6,23 @@ import com.personal.marketnote.commerce.domain.inventory.InventoryReservation;
 import com.personal.marketnote.commerce.domain.inventory.InventoryReservationSnapshotState;
 import com.personal.marketnote.commerce.exception.DuplicateInventoryReservationException;
 import com.personal.marketnote.commerce.port.out.inventory.DeleteInventoryReservationPort;
+import com.personal.marketnote.commerce.port.out.inventory.FindExpiredInventoryReservationPort;
 import com.personal.marketnote.commerce.port.out.inventory.FindInventoryReservationPort;
 import com.personal.marketnote.commerce.port.out.inventory.SaveInventoryReservationPort;
 import com.personal.marketnote.common.adapter.out.PersistenceAdapter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.PageRequest;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Set;
 
 @PersistenceAdapter
 @RequiredArgsConstructor
 public class InventoryReservationPersistenceAdapter implements
-        SaveInventoryReservationPort, FindInventoryReservationPort, DeleteInventoryReservationPort {
+        SaveInventoryReservationPort, FindInventoryReservationPort, FindExpiredInventoryReservationPort, DeleteInventoryReservationPort {
+    private static final int EXPIRED_RESERVATION_BATCH_SIZE = 500;
     private final InventoryReservationJpaRepository inventoryReservationJpaRepository;
 
     @Override
@@ -42,14 +46,27 @@ public class InventoryReservationPersistenceAdapter implements
     public List<InventoryReservation> findByOrderIdAndPricePolicyIds(Long orderId, Set<Long> pricePolicyIds) {
         return inventoryReservationJpaRepository.findByOrderIdAndPricePolicyIdIn(orderId, pricePolicyIds)
                 .stream()
-                .map(entity -> InventoryReservation.from(InventoryReservationSnapshotState.builder()
-                        .id(entity.getId())
-                        .orderId(entity.getOrderId())
-                        .pricePolicyId(entity.getPricePolicyId())
-                        .quantity(entity.getQuantity())
-                        .reservedAt(entity.getReservedAt())
-                        .build()))
+                .map(this::mapToDomain)
                 .toList();
+    }
+
+    @Override
+    public List<InventoryReservation> findExpiredBefore(LocalDateTime cutoff) {
+        return inventoryReservationJpaRepository
+                .findByReservedAtBefore(cutoff, PageRequest.of(0, EXPIRED_RESERVATION_BATCH_SIZE))
+                .stream()
+                .map(this::mapToDomain)
+                .toList();
+    }
+
+    private InventoryReservation mapToDomain(InventoryReservationJpaEntity entity) {
+        return InventoryReservation.from(InventoryReservationSnapshotState.builder()
+                .id(entity.getId())
+                .orderId(entity.getOrderId())
+                .pricePolicyId(entity.getPricePolicyId())
+                .quantity(entity.getQuantity())
+                .reservedAt(entity.getReservedAt())
+                .build());
     }
 
     @Override

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/inventory/repository/InventoryReservationJpaRepository.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/inventory/repository/InventoryReservationJpaRepository.java
@@ -1,16 +1,21 @@
 package com.personal.marketnote.commerce.adapter.out.persistence.inventory.repository;
 
 import com.personal.marketnote.commerce.adapter.out.persistence.inventory.entity.InventoryReservationJpaEntity;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Set;
 
 public interface InventoryReservationJpaRepository extends JpaRepository<InventoryReservationJpaEntity, Long> {
     List<InventoryReservationJpaEntity> findByOrderIdAndPricePolicyIdIn(Long orderId, Set<Long> pricePolicyIds);
+
+    @Query("SELECT e FROM InventoryReservationJpaEntity e WHERE e.reservedAt < :cutoff ORDER BY e.reservedAt ASC")
+    List<InventoryReservationJpaEntity> findByReservedAtBefore(@Param("cutoff") LocalDateTime cutoff, Pageable pageable);
 
     @Modifying
     @Query("DELETE FROM InventoryReservationJpaEntity e WHERE e.orderId = :orderId AND e.pricePolicyId IN :pricePolicyIds")

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/configuration/InventoryReservationSchedulerProperties.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/configuration/InventoryReservationSchedulerProperties.java
@@ -1,0 +1,16 @@
+package com.personal.marketnote.commerce.configuration;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationProperties(prefix = "inventory.reservation.scheduler")
+@Getter
+@Setter
+public class InventoryReservationSchedulerProperties {
+    private boolean enabled;
+    private long timeoutMinutes = 10;
+    private long checkIntervalMs = 60000;
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/configuration/SchedulingConfig.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/configuration/SchedulingConfig.java
@@ -1,6 +1,5 @@
 package com.personal.marketnote.commerce.configuration;
 
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableScheduling;
@@ -8,7 +7,6 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 
 @Configuration
 @EnableScheduling
-@ConditionalOnProperty(name = "settlement.scheduler.enabled", havingValue = "true", matchIfMissing = false)
 public class SchedulingConfig {
     @Bean
     public ThreadPoolTaskScheduler taskScheduler() {

--- a/commerce-service/commerce-adapters/src/main/resources/application.yml
+++ b/commerce-service/commerce-adapters/src/main/resources/application.yml
@@ -124,6 +124,13 @@ settlement:
     default-pg-fee-rate: ${SETTLEMENT_DEFAULT_PG_FEE_RATE:300}
     default-platform-fee-rate: ${SETTLEMENT_DEFAULT_PLATFORM_FEE_RATE:500}
 
+inventory:
+  reservation:
+    scheduler:
+      enabled: ${INVENTORY_RESERVATION_SCHEDULER_ENABLED:false}
+      timeout-minutes: ${INVENTORY_RESERVATION_TIMEOUT_MINUTES:10}
+      check-interval-ms: ${INVENTORY_RESERVATION_CHECK_INTERVAL_MS:60000}
+
 management:
   endpoints:
     web:

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/inventory/ExpireInventoryReservationUseCase.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/inventory/ExpireInventoryReservationUseCase.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.commerce.port.in.usecase.inventory;
+
+import java.time.LocalDateTime;
+
+public interface ExpireInventoryReservationUseCase {
+    void expireTimedOutReservations(LocalDateTime cutoff);
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/inventory/FindExpiredInventoryReservationPort.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/inventory/FindExpiredInventoryReservationPort.java
@@ -1,0 +1,10 @@
+package com.personal.marketnote.commerce.port.out.inventory;
+
+import com.personal.marketnote.commerce.domain.inventory.InventoryReservation;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface FindExpiredInventoryReservationPort {
+    List<InventoryReservation> findExpiredBefore(LocalDateTime cutoff);
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/inventory/ExpireInventoryReservationService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/inventory/ExpireInventoryReservationService.java
@@ -1,0 +1,117 @@
+package com.personal.marketnote.commerce.service.inventory;
+
+import com.personal.marketnote.commerce.domain.inventory.Inventory;
+import com.personal.marketnote.commerce.domain.inventory.InventoryReservation;
+import com.personal.marketnote.commerce.domain.inventory.InventoryRestorationHistories;
+import com.personal.marketnote.commerce.port.in.usecase.inventory.ExpireInventoryReservationUseCase;
+import com.personal.marketnote.commerce.port.out.event.PublishInventoryEventPort;
+import com.personal.marketnote.commerce.port.out.inventory.*;
+import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.common.kafka.event.InventoryChangeAction;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@UseCase
+@RequiredArgsConstructor
+@Slf4j
+public class ExpireInventoryReservationService implements ExpireInventoryReservationUseCase {
+    private final FindExpiredInventoryReservationPort findExpiredInventoryReservationPort;
+    private final FindInventoryReservationPort findInventoryReservationPort;
+    private final FindInventoryPort findInventoryPort;
+    private final UpdateInventoryPort updateInventoryPort;
+    private final DeleteInventoryReservationPort deleteInventoryReservationPort;
+    private final SaveInventoryRestorationHistoryPort saveInventoryRestorationHistoryPort;
+    private final SaveCacheStockPort saveCacheStockPort;
+    private final InventoryLockPort inventoryLockPort;
+    private final PublishInventoryEventPort publishInventoryEventPort;
+    private final PlatformTransactionManager transactionManager;
+
+    @Override
+    public void expireTimedOutReservations(LocalDateTime cutoff) {
+        List<InventoryReservation> expiredReservations =
+                findExpiredInventoryReservationPort.findExpiredBefore(cutoff);
+
+        if (expiredReservations.isEmpty()) {
+            return;
+        }
+
+        log.info("만료 예약 감지. count={}", expiredReservations.size());
+
+        Map<Long, List<InventoryReservation>> reservationsByOrderId = expiredReservations.stream()
+                .collect(Collectors.groupingBy(InventoryReservation::getOrderId));
+
+        reservationsByOrderId.forEach(this::expireByOrderIdSafely);
+    }
+
+    private void expireByOrderIdSafely(Long orderId, List<InventoryReservation> reservations) {
+        try {
+            log.info("만료 예약 해소 시작. orderId={}, reservationCount={}", orderId, reservations.size());
+            TransactionTemplate transactionTemplate = new TransactionTemplate(transactionManager);
+            transactionTemplate.setIsolationLevel(TransactionDefinition.ISOLATION_READ_COMMITTED);
+            transactionTemplate.executeWithoutResult(status ->
+                    expireByOrderId(orderId, extractPricePolicyIds(reservations))
+            );
+            log.info("만료 예약 해소 완료. orderId={}", orderId);
+        } catch (Exception e) {
+            log.error("만료 예약 해소 실패. orderId={}", orderId, e);
+        }
+    }
+
+    private void expireByOrderId(Long orderId, Set<Long> pricePolicyIds) {
+        inventoryLockPort.executeWithLock(pricePolicyIds, () -> {
+            List<InventoryReservation> currentReservations =
+                    findInventoryReservationPort.findByOrderIdAndPricePolicyIds(orderId, pricePolicyIds);
+
+            if (currentReservations.isEmpty()) {
+                log.info("예약이 이미 처리됨. orderId={}", orderId);
+                return;
+            }
+
+            Map<Long, Integer> quantityByPricePolicyId = currentReservations.stream()
+                    .collect(Collectors.toMap(
+                            InventoryReservation::getPricePolicyId,
+                            InventoryReservation::getQuantity
+                    ));
+
+            Set<Long> currentPricePolicyIds = quantityByPricePolicyId.keySet();
+            Set<Inventory> inventories = findInventoryPort.findByPricePolicyIds(currentPricePolicyIds);
+
+            inventories.forEach(inventory ->
+                    inventory.releaseReservation(quantityByPricePolicyId.get(inventory.getPricePolicyId()))
+            );
+
+            deleteInventoryReservationPort.deleteByOrderIdAndPricePolicyIds(orderId, currentPricePolicyIds);
+            updateInventoryPort.update(inventories);
+
+            Map<Long, Long> productIdsByPricePolicyId = inventories.stream()
+                    .collect(Collectors.toMap(Inventory::getPricePolicyId, Inventory::getProductId));
+            saveInventoryRestorationHistoryPort.save(
+                    InventoryRestorationHistories.from(quantityByPricePolicyId, productIdsByPricePolicyId, orderId, "예약 만료 - 스케줄러 자동 해소")
+            );
+
+            saveCacheStockPort.save(inventories);
+
+            inventories.forEach(inventory ->
+                    publishInventoryEventPort.publishInventoryChangedEvent(
+                            inventory.getPricePolicyId(), inventory.getProductId(),
+                            inventory.getStockValue(), InventoryChangeAction.UPDATED
+                    )
+            );
+        });
+    }
+
+    private Set<Long> extractPricePolicyIds(List<InventoryReservation> reservations) {
+        return reservations.stream()
+                .map(InventoryReservation::getPricePolicyId)
+                .collect(Collectors.toSet());
+    }
+}


### PR DESCRIPTION
## partially addresses #1575
## resolves #1580

## Task
- [x] ExpireInventoryReservationUseCase / ExpireInventoryReservationService 구현
- [x] FindExpiredInventoryReservationPort 인터페이스 정의 (reserved_at < cutoff 조건)
- [x] InventoryReservationTimeoutChecker 스케줄러 구현 (@scheduled, @ConditionalOnProperty)
- [x] Adapter에서 만료 예약 조회 + 배치 크기 500건 제한 (Pageable)
- [x] 개별 주문 해소 시 TransactionTemplate per-orderId 트랜잭션 격리
- [x] 개별 예약 해소 시 try-catch 격리 (하나 실패해도 나머지 처리)
- [x] TOCTOU Guard: 분산 락 획득 후 예약 레코드 재조회, 이미 처리된 경우 skip
- [x] 타임아웃 설정 외부화 (inventory.reservation.scheduler.timeout-minutes)
- [x] SchedulingConfig에서 @ConditionalOnProperty 제거 (개별 스케줄러 자체 조건 보유)