### PR TITLE
[#215][#1584] feat: 반품 신청 API 회수지 전체 필드 전송 방식을 pickupAddressId 기반으로 변경

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/apidocs/ChangeOrderStatusApiDocs.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/apidocs/ChangeOrderStatusApiDocs.java
@@ -93,6 +93,9 @@ import java.lang.annotation.*;
                 | orderStatus | string | 주문 상태 | Y | "PAYMENT_PENDING" |
                 | reasonCategory | string | 변경 사유 카테고리 | N | "CANCEL_ORDER" |
                 | reason | string | 변경 사유 | N | default: 변경된 주문 상태의 디스크립션 |
+                | pickupAddressId | number | 회수지 배송지 ID (반품 신청 시, 미입력 시 배송지 기본값) | N | 5 |
+                | pickupRequestType | string | 회수 요청 타입 (NONE, CALL_BEFORE_VISIT, LEAVE_AT_DOOR, LEAVE_AT_SECURITY, CUSTOM) | N | "LEAVE_AT_DOOR" |
+                | pickupRequestMessage | string | 회수 요청사항 (CUSTOM 시 필수, 60자 제한) | N | "부재시 경비실에 맡겨주세요" |
                 
                 ---
                 
@@ -122,9 +125,12 @@ import java.lang.annotation.*;
                         examples = @ExampleObject("""
                                 {
                                   "pricePolicyIds": [1, 2, 3],
-                                  "orderStatus": "PAYMENT_PENDING",
+                                  "orderStatus": "REFUND_REQUESTED",
                                   "reasonCategory": "CANCEL_ORDER",
-                                  "reason": "주문 상태 변경 사유"
+                                  "reason": "주문 상태 변경 사유",
+                                  "pickupAddressId": 5,
+                                  "pickupRequestType": "LEAVE_AT_DOOR",
+                                  "pickupRequestMessage": null
                                 }
                                 """)
                 )

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/mapper/OrderRequestToCommandMapper.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/mapper/OrderRequestToCommandMapper.java
@@ -4,7 +4,6 @@ import com.personal.marketnote.commerce.adapter.in.web.order.request.CancelOrder
 import com.personal.marketnote.commerce.adapter.in.web.order.request.ChangeOrderStatusRequest;
 import com.personal.marketnote.commerce.adapter.in.web.order.request.RegisterOrderRequest;
 import com.personal.marketnote.commerce.adapter.in.web.order.request.RequestRefundRequest;
-import com.personal.marketnote.commerce.domain.order.ShippingAddress;
 import com.personal.marketnote.commerce.port.in.command.order.*;
 
 import java.util.List;
@@ -74,15 +73,9 @@ public class OrderRequestToCommandMapper {
                 .reason(request.getReason())
                 .role(role)
                 .buyerId(buyerId)
-                .pickupAddress(ShippingAddress.of(
-                        request.getPickupRecipientName(),
-                        request.getPickupRecipientPhoneNumber(),
-                        request.getPickupZipCode(),
-                        request.getPickupAddress(),
-                        request.getPickupAddressDetail(),
-                        null,
-                        request.getPickupRequestMessage()
-                ))
+                .pickupAddressId(request.getPickupAddressId())
+                .pickupRequestType(request.getPickupRequestType())
+                .pickupRequestMessage(request.getPickupRequestMessage())
                 .build();
     }
 }

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/request/ChangeOrderStatusRequest.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/request/ChangeOrderStatusRequest.java
@@ -2,6 +2,7 @@ package com.personal.marketnote.commerce.adapter.in.web.order.request;
 
 import com.personal.marketnote.commerce.domain.order.OrderStatus;
 import com.personal.marketnote.commerce.domain.order.OrderStatusReasonCategory;
+import com.personal.marketnote.common.domain.delivery.PickupRequestType;
 import com.personal.marketnote.common.utility.RegularExpressionConstant;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
@@ -44,52 +45,22 @@ public class ChangeOrderStatusRequest {
     private String reason;
 
     @Schema(
-            name = "pickupRecipientName",
-            description = "회수지 수령인명 (반품 신청 시 사용, 미입력 시 배송지 기본값)",
+            name = "pickupAddressId",
+            description = "회수지 배송지 ID (반품 신청 시 사용, 미입력 시 배송지 기본값)",
             requiredMode = Schema.RequiredMode.NOT_REQUIRED
     )
-    @Size(max = 50, message = "회수지 수령인명은 50자 이내여야 합니다.")
-    @Pattern(regexp = RegularExpressionConstant.RECIPIENT_NAME_PATTERN, message = "회수지 수령인명 형식이 올바르지 않습니다.")
-    private String pickupRecipientName;
+    private Long pickupAddressId;
 
     @Schema(
-            name = "pickupRecipientPhoneNumber",
-            description = "회수지 연락처 (반품 신청 시 사용, 미입력 시 배송지 기본값)",
+            name = "pickupRequestType",
+            description = "회수 요청 타입 (반품 신청 시 사용)",
             requiredMode = Schema.RequiredMode.NOT_REQUIRED
     )
-    @Size(max = 20, message = "회수지 연락처는 20자 이내여야 합니다.")
-    @Pattern(regexp = RegularExpressionConstant.PHONE_NUMBER_PATTERN, message = "회수지 연락처 형식이 올바르지 않습니다.")
-    private String pickupRecipientPhoneNumber;
-
-    @Schema(
-            name = "pickupZipCode",
-            description = "회수지 우편번호 (반품 신청 시 사용, 미입력 시 배송지 기본값)",
-            requiredMode = Schema.RequiredMode.NOT_REQUIRED
-    )
-    @Pattern(regexp = RegularExpressionConstant.ZIP_CODE_PATTERN, message = "회수지 우편번호는 5자리 숫자여야 합니다.")
-    private String pickupZipCode;
-
-    @Schema(
-            name = "pickupAddress",
-            description = "회수지 주소 (반품 신청 시 사용, 미입력 시 배송지 기본값)",
-            requiredMode = Schema.RequiredMode.NOT_REQUIRED
-    )
-    @Size(max = 255, message = "회수지 주소는 255자 이내여야 합니다.")
-    @Pattern(regexp = RegularExpressionConstant.NO_HTML_TAG_PATTERN, message = "회수지 주소에 허용되지 않는 문자가 포함되어 있습니다.")
-    private String pickupAddress;
-
-    @Schema(
-            name = "pickupAddressDetail",
-            description = "회수지 상세주소 (반품 신청 시 사용, 미입력 시 배송지 기본값)",
-            requiredMode = Schema.RequiredMode.NOT_REQUIRED
-    )
-    @Size(max = 255, message = "회수지 상세주소는 255자 이내여야 합니다.")
-    @Pattern(regexp = RegularExpressionConstant.NO_HTML_TAG_PATTERN, message = "회수지 상세주소에 허용되지 않는 문자가 포함되어 있습니다.")
-    private String pickupAddressDetail;
+    private PickupRequestType pickupRequestType;
 
     @Schema(
             name = "pickupRequestMessage",
-            description = "회수 요청사항 (반품 신청 시 사용, 60자 제한)",
+            description = "회수 요청사항 (반품 신청 시 사용, pickupRequestType이 CUSTOM인 경우 필수, 60자 제한)",
             requiredMode = Schema.RequiredMode.NOT_REQUIRED
     )
     @Size(max = 60, message = "회수 요청사항은 60자 이내여야 합니다.")

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/mapper/OrderJpaEntityToDomainMapper.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/mapper/OrderJpaEntityToDomainMapper.java
@@ -128,7 +128,7 @@ public class OrderJpaEntityToDomainMapper {
             return null;
         }
 
-        return ShippingAddress.of(
+        return ShippingAddress.ofPickup(
                 entity.getPickupRecipientName(),
                 entity.getPickupRecipientPhoneNumber(),
                 entity.getPickupZipCode(),

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/order/entity/OrderJpaEntity.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/order/entity/OrderJpaEntity.java
@@ -6,6 +6,7 @@ import com.personal.marketnote.commerce.domain.order.OrderStatus;
 import com.personal.marketnote.commerce.domain.order.ShippingAddress;
 import com.personal.marketnote.common.adapter.out.persistence.audit.BaseEntity;
 import com.personal.marketnote.common.domain.delivery.DeliveryRequestType;
+import com.personal.marketnote.common.domain.delivery.PickupRequestType;
 import com.personal.marketnote.common.utility.FormatValidator;
 import jakarta.persistence.*;
 import lombok.*;
@@ -104,7 +105,7 @@ public class OrderJpaEntity extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
     @Column(name = "pickup_delivery_request_type", length = 31)
-    private DeliveryRequestType pickupDeliveryRequestType;
+    private PickupRequestType pickupDeliveryRequestType;
 
     @Column(name = "pickup_request_message", length = 60)
     private String pickupDeliveryRequestMessage;
@@ -136,7 +137,7 @@ public class OrderJpaEntity extends BaseEntity {
                 .pickupZipCode(resolvePickupField(order, ShippingAddress::getZipCode))
                 .pickupAddress(resolvePickupField(order, ShippingAddress::getAddress))
                 .pickupAddressDetail(resolvePickupField(order, ShippingAddress::getAddressDetail))
-                .pickupDeliveryRequestType(resolvePickupField(order, ShippingAddress::getDeliveryRequestType))
+                .pickupDeliveryRequestType(resolvePickupField(order, ShippingAddress::getPickupRequestType))
                 .pickupDeliveryRequestMessage(resolvePickupField(order, ShippingAddress::getDeliveryRequestMessage))
                 .build();
     }
@@ -157,7 +158,7 @@ public class OrderJpaEntity extends BaseEntity {
         pickupZipCode = resolvePickupField(order, ShippingAddress::getZipCode);
         pickupAddress = resolvePickupField(order, ShippingAddress::getAddress);
         pickupAddressDetail = resolvePickupField(order, ShippingAddress::getAddressDetail);
-        pickupDeliveryRequestType = resolvePickupField(order, ShippingAddress::getDeliveryRequestType);
+        pickupDeliveryRequestType = resolvePickupField(order, ShippingAddress::getPickupRequestType);
         pickupDeliveryRequestMessage = resolvePickupField(order, ShippingAddress::getDeliveryRequestMessage);
 
         Map<Long, OrderProduct> orderProductsByPricePolicyId = order.getOrderProducts()

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/exception/InvalidPickupRequestMessageException.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/exception/InvalidPickupRequestMessageException.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.commerce.exception;
+
+public class InvalidPickupRequestMessageException extends IllegalArgumentException {
+    public InvalidPickupRequestMessageException() {
+        super("ERR_PICKUP_01::회수 요청 타입이 직접 입력인 경우 회수 요청사항은 필수입니다.");
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/command/order/ChangeOrderStatusCommand.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/command/order/ChangeOrderStatusCommand.java
@@ -2,7 +2,7 @@ package com.personal.marketnote.commerce.port.in.command.order;
 
 import com.personal.marketnote.commerce.domain.order.OrderStatus;
 import com.personal.marketnote.commerce.domain.order.OrderStatusReasonCategory;
-import com.personal.marketnote.commerce.domain.order.ShippingAddress;
+import com.personal.marketnote.common.domain.delivery.PickupRequestType;
 import com.personal.marketnote.common.utility.FormatValidator;
 import lombok.Builder;
 
@@ -17,7 +17,9 @@ public record ChangeOrderStatusCommand(
         String reason,
         String role,
         Long buyerId,
-        ShippingAddress pickupAddress,
+        Long pickupAddressId,
+        PickupRequestType pickupRequestType,
+        String pickupRequestMessage,
         Boolean skipSubsequentProcesses
 ) {
     private static final String BUYER_ROLE = "BUYER";
@@ -47,5 +49,9 @@ public record ChangeOrderStatusCommand(
 
     public boolean shouldSkipSubsequentProcesses() {
         return Boolean.TRUE.equals(skipSubsequentProcesses);
+    }
+
+    public boolean hasPickupAddressId() {
+        return FormatValidator.hasValue(pickupAddressId);
     }
 }

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/ChangeOrderStatusService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/ChangeOrderStatusService.java
@@ -4,7 +4,9 @@ import com.personal.marketnote.commerce.domain.order.Order;
 import com.personal.marketnote.commerce.domain.order.OrderProduct;
 import com.personal.marketnote.commerce.domain.order.OrderStatus;
 import com.personal.marketnote.commerce.domain.order.OrderStatusHistory;
+import com.personal.marketnote.commerce.domain.order.ShippingAddress;
 import com.personal.marketnote.commerce.exception.InvalidOrderStatusTransitionException;
+import com.personal.marketnote.commerce.exception.InvalidPickupRequestMessageException;
 import com.personal.marketnote.commerce.exception.OrderStatusAlreadyChangedException;
 import com.personal.marketnote.commerce.exception.UnauthorizedOrderAccessException;
 import com.personal.marketnote.commerce.exception.UnauthorizedOrderStatusChangeException;
@@ -16,8 +18,11 @@ import com.personal.marketnote.commerce.port.out.event.PublishOrderEventPort;
 import com.personal.marketnote.commerce.port.out.order.UpdateOrderPort;
 import com.personal.marketnote.commerce.port.out.product.FindProductByPricePolicyPort;
 import com.personal.marketnote.commerce.port.out.result.product.ProductInfoResult;
+import com.personal.marketnote.commerce.port.out.result.user.ShippingAddressInfoResult;
 import com.personal.marketnote.commerce.port.out.reward.ModifyUserPointPort;
+import com.personal.marketnote.commerce.port.out.user.FindUserShippingAddressPort;
 import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.common.domain.delivery.PickupRequestType;
 import com.personal.marketnote.common.utility.FormatValidator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -44,6 +49,7 @@ public class ChangeOrderStatusService implements ChangeOrderStatusUseCase {
     private final FindProductByPricePolicyPort findProductByPricePolicyPort;
     private final ModifyUserPointPort modifyUserPointPort;
     private final PublishOrderEventPort publishOrderEventPort;
+    private final FindUserShippingAddressPort findUserShippingAddressPort;
     private final Clock clock;
 
     @Override
@@ -62,8 +68,8 @@ public class ChangeOrderStatusService implements ChangeOrderStatusUseCase {
             throw new InvalidOrderStatusTransitionException(order.getOrderStatus(), status);
         }
 
-        changeOrderStatus(command, order);
         applyPickupAddressIfRefundRequested(command, order);
+        changeOrderStatus(command, order);
         OrderStatusHistory orderStatusHistory = OrderStatusHistory.from(OrderCommandToStateMapper.mapToState(command));
         updateOrderPort.update(order, orderStatusHistory);
 
@@ -100,6 +106,46 @@ public class ChangeOrderStatusService implements ChangeOrderStatusUseCase {
         }
     }
 
+    private void applyPickupAddressIfRefundRequested(ChangeOrderStatusCommand command, Order order) {
+        if (!command.orderStatus().isRefundRequested()) {
+            return;
+        }
+
+        validatePickupRequestType(command);
+
+        if (!command.hasPickupAddressId()) {
+            order.applyPickupAddress(null);
+            return;
+        }
+
+        ShippingAddressInfoResult addressInfo = findUserShippingAddressPort.findByIdAndUserId(
+                command.pickupAddressId(), command.buyerId()
+        );
+
+        ShippingAddress pickupAddress = ShippingAddress.ofPickup(
+                addressInfo.recipientName(),
+                addressInfo.recipientPhoneNumber(),
+                null,
+                addressInfo.address(),
+                addressInfo.addressDetail(),
+                command.pickupRequestType(),
+                command.pickupRequestMessage()
+        );
+
+        order.applyPickupAddress(pickupAddress);
+    }
+
+    private void validatePickupRequestType(ChangeOrderStatusCommand command) {
+        PickupRequestType pickupRequestType = command.pickupRequestType();
+        if (FormatValidator.hasNoValue(pickupRequestType)) {
+            return;
+        }
+
+        if (pickupRequestType.isCustom() && FormatValidator.hasNoValue(command.pickupRequestMessage())) {
+            throw new InvalidPickupRequestMessageException();
+        }
+    }
+
     private void changeOrderStatus(ChangeOrderStatusCommand command, Order order) {
         OrderStatus status = command.orderStatus();
         LocalDateTime now = LocalDateTime.now(clock);
@@ -110,14 +156,6 @@ public class ChangeOrderStatusService implements ChangeOrderStatusUseCase {
         }
 
         order.changeAllProductsStatus(status, now);
-    }
-
-    private void applyPickupAddressIfRefundRequested(ChangeOrderStatusCommand command, Order order) {
-        if (!command.orderStatus().isRefundRequested()) {
-            return;
-        }
-
-        order.applyPickupAddress(command.pickupAddress());
     }
 
     private void updatePaymentSubsequentProcesses(Order order) {

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/order/ShippingAddress.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/order/ShippingAddress.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.commerce.domain.order;
 
 import com.personal.marketnote.common.domain.delivery.DeliveryRequestType;
+import com.personal.marketnote.common.domain.delivery.PickupRequestType;
 import com.personal.marketnote.common.utility.FormatValidator;
 import lombok.*;
 
@@ -16,6 +17,7 @@ public class ShippingAddress {
     private String addressDetail;
     private DeliveryRequestType deliveryRequestType;
     private String deliveryRequestMessage;
+    private PickupRequestType pickupRequestType;
 
     public static ShippingAddress of(
             String recipientName,
@@ -34,6 +36,26 @@ public class ShippingAddress {
                 .addressDetail(addressDetail)
                 .deliveryRequestType(deliveryRequestType)
                 .deliveryRequestMessage(deliveryRequestMessage)
+                .build();
+    }
+
+    public static ShippingAddress ofPickup(
+            String recipientName,
+            String recipientPhoneNumber,
+            String zipCode,
+            String address,
+            String addressDetail,
+            PickupRequestType pickupRequestType,
+            String pickupRequestMessage
+    ) {
+        return ShippingAddress.builder()
+                .recipientName(recipientName)
+                .recipientPhoneNumber(recipientPhoneNumber)
+                .zipCode(zipCode)
+                .address(address)
+                .addressDetail(addressDetail)
+                .pickupRequestType(pickupRequestType)
+                .deliveryRequestMessage(pickupRequestMessage)
                 .build();
     }
 

--- a/common/src/main/java/com/personal/marketnote/common/domain/delivery/PickupRequestType.java
+++ b/common/src/main/java/com/personal/marketnote/common/domain/delivery/PickupRequestType.java
@@ -1,0 +1,20 @@
+package com.personal.marketnote.common.domain.delivery;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum PickupRequestType {
+    NONE("선택 안 함"),
+    CALL_BEFORE_VISIT("방문 전 연락 부탁드립니다"),
+    LEAVE_AT_DOOR("문 앞에 놓아주세요"),
+    LEAVE_AT_SECURITY("경비실에 맡겨주세요"),
+    CUSTOM("직접 입력");
+
+    private final String description;
+
+    public boolean isCustom() {
+        return this == CUSTOM;
+    }
+}


### PR DESCRIPTION
## partially addresses #216
## resolves #1584

## Task
- [x] PickupRequestType enum common 모듈 추가 (NONE, CALL_BEFORE_VISIT, LEAVE_AT_DOOR, LEAVE_AT_SECURITY, CUSTOM)
- [x] ChangeOrderStatusRequest 회수지 6개 필드 제거, pickupAddressId + pickupRequestType + pickupRequestMessage 추가
- [x] ChangeOrderStatusCommand ShippingAddress 도메인 객체 제거, 원시 타입 변경
- [x] ChangeOrderStatusService FindUserShippingAddressPort 회수지 조회 + CUSTOM 검증 추가
- [x] ShippingAddress 도메인 pickupRequestType 필드 + ofPickup() 팩토리 메서드 추가
- [x] OrderJpaEntity pickupDeliveryRequestType DeliveryRequestType → PickupRequestType 변경
- [x] OrderJpaEntityToDomainMapper mapToPickupAddress() ofPickup() 사용
- [x] ChangeOrderStatusApiDocs 업데이트