### PR TITLE
[#300][#1626] feat: 리뷰 상세 조회 시 주문 상품 정보 추가

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/InternalOrderController.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/InternalOrderController.java
@@ -1,7 +1,10 @@
 package com.personal.marketnote.commerce.adapter.in.web.order.controller;
 
+import com.personal.marketnote.commerce.adapter.in.web.order.controller.apidocs.GetInternalOrderProductApiDocs;
 import com.personal.marketnote.commerce.adapter.in.web.order.controller.apidocs.VerifyOrderOwnershipApiDocs;
+import com.personal.marketnote.commerce.adapter.in.web.order.response.InternalOrderProductResponse;
 import com.personal.marketnote.commerce.domain.order.Order;
+import com.personal.marketnote.commerce.domain.order.OrderProduct;
 import com.personal.marketnote.commerce.exception.UnauthorizedOrderAccessException;
 import com.personal.marketnote.commerce.port.in.usecase.order.GetOrderUseCase;
 import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
@@ -56,6 +59,31 @@ public class InternalOrderController {
                         HttpStatus.OK,
                         DEFAULT_SUCCESS_CODE,
                         "주문 소유권 확인 성공"
+                ),
+                HttpStatus.OK
+        );
+    }
+
+    /**
+     * 주문 상품 조회 (서비스 간 통신용)
+     *
+     * @param orderId       주문 ID
+     * @param pricePolicyId 가격 정책 ID
+     */
+    @GetInternalOrderProductApiDocs
+    @GetMapping("/{orderId}/order-products/{pricePolicyId}")
+    public ResponseEntity<BaseResponse<InternalOrderProductResponse>> getOrderProduct(
+            @PathVariable Long orderId,
+            @PathVariable Long pricePolicyId
+    ) {
+        OrderProduct orderProduct = getOrderUseCase.getOrderProduct(orderId, pricePolicyId);
+
+        return new ResponseEntity<>(
+                BaseResponse.of(
+                        InternalOrderProductResponse.from(orderProduct),
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "주문 상품 조회 성공"
                 ),
                 HttpStatus.OK
         );

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/apidocs/GetInternalOrderProductApiDocs.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/apidocs/GetInternalOrderProductApiDocs.java
@@ -1,0 +1,102 @@
+package com.personal.marketnote.commerce.adapter.in.web.order.controller.apidocs;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Operation(
+        summary = "주문 상품 조회 (서비스 간 통신용)",
+        description = """
+                작성일자: 2026-04-05
+
+                작성자: 성효빈
+
+                ---
+
+                ## Description
+
+                - 주문 ID와 가격 정책 ID로 주문 상품의 구매 시점 단가를 조회합니다.
+                - HMAC 인증 기반 서비스 간 통신 전용 API입니다.
+
+                ---
+
+                ## Request
+
+                | **키** | **타입** | **설명** | **필수 여부** | **예시** |
+                | --- | --- | --- | --- | --- |
+                | orderId | number | 주문 ID | Y | 1 |
+                | pricePolicyId | number | 가격 정책 ID | Y | 100 |
+
+                ---
+
+                ## Response
+
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | statusCode | number | 상태 코드 | 200: 조회 성공 / 404: 주문 상품 미존재 |
+                | code | string | 응답 코드 | "SUC01" / "NOT_FOUND" |
+                | timestamp | string(datetime) | 응답 일시 | "2026-04-05T12:00:00.000" |
+                | content.unitAmount | number | 구매 시점 단가 | 15000 |
+                | message | string | 처리 결과 | "주문 상품 조회 성공" |
+                """,
+        parameters = {
+                @Parameter(
+                        name = "orderId",
+                        description = "주문 ID",
+                        in = ParameterIn.PATH,
+                        required = true,
+                        schema = @Schema(type = "number")
+                ),
+                @Parameter(
+                        name = "pricePolicyId",
+                        description = "가격 정책 ID",
+                        in = ParameterIn.PATH,
+                        required = true,
+                        schema = @Schema(type = "number")
+                )
+        },
+        responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "주문 상품 조회 성공",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 200,
+                                          "code": "SUC01",
+                                          "timestamp": "2026-04-05T12:00:00.000",
+                                          "content": {
+                                            "unitAmount": 15000
+                                          },
+                                          "message": "주문 상품 조회 성공"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "404",
+                        description = "주문 상품 미존재",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 404,
+                                          "code": "NOT_FOUND",
+                                          "timestamp": "2026-04-05T12:00:00.000",
+                                          "content": null,
+                                          "message": "주문 상품을 찾을 수 없습니다."
+                                        }
+                                        """)
+                        )
+                )
+        })
+public @interface GetInternalOrderProductApiDocs {
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/response/InternalOrderProductResponse.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/response/InternalOrderProductResponse.java
@@ -1,0 +1,13 @@
+package com.personal.marketnote.commerce.adapter.in.web.order.response;
+
+import com.personal.marketnote.commerce.domain.order.OrderProduct;
+
+public record InternalOrderProductResponse(
+        Long unitAmount
+) {
+    public static InternalOrderProductResponse from(OrderProduct orderProduct) {
+        return new InternalOrderProductResponse(
+                orderProduct.getUnitAmount()
+        );
+    }
+}

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/ChangeOrderStatusPickupAddressUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/ChangeOrderStatusPickupAddressUseCaseTest.java
@@ -47,7 +47,7 @@ class ChangeOrderStatusPickupAddressUseCaseTest {
     @Mock
     private FindUserShippingAddressPort findUserShippingAddressPort;
     @Spy
-    private Clock clock = Clock.fixed(Instant.parse("2026-04-03T00:00:00Z"), ZoneId.of("Asia/Seoul"));
+    private Clock clock = Clock.fixed(Instant.parse("2026-04-05T00:00:00Z"), ZoneId.of("Asia/Seoul"));
 
     @InjectMocks
     private ChangeOrderStatusService changeOrderStatusService;

--- a/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/in/web/review/controller/ReviewController.java
+++ b/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/in/web/review/controller/ReviewController.java
@@ -187,9 +187,11 @@ public class ReviewController {
             @PathVariable("id") Long id,
             @AuthenticationPrincipal OAuth2AuthenticatedPrincipal principal
     ) {
-        ReviewItemResult result = ReviewItemResult.from(
-                getReviewUseCase.getReview(id, ElementExtractor.extractUserId(principal))
-        );
+        Long userId = FormatValidator.hasValue(principal)
+                ? ElementExtractor.extractUserId(principal)
+                : null;
+
+        ReviewItemResult result = getReviewUseCase.getReviewDetail(id, userId);
 
         return new ResponseEntity<>(
                 BaseResponse.of(

--- a/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/in/web/review/response/ReviewProductInfoResponse.java
+++ b/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/in/web/review/response/ReviewProductInfoResponse.java
@@ -8,7 +8,8 @@ public record ReviewProductInfoResponse(
         String name,
         String brandName,
         ReviewProductPricePolicyResponse pricePolicy,
-        GetFileResult catalogImage
+        GetFileResult catalogImage,
+        Long unitAmount
 ) {
     public static ReviewProductInfoResponse from(ReviewProductInfoResult result) {
         if (FormatValidator.hasNoValue(result)) {
@@ -19,7 +20,8 @@ public record ReviewProductInfoResponse(
                 result.name(),
                 result.brandName(),
                 ReviewProductPricePolicyResponse.from(result.pricePolicy()),
-                result.catalogImage()
+                result.catalogImage(),
+                result.unitAmount()
         );
     }
 }

--- a/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/out/web/commerce/CommerceServiceClient.java
+++ b/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/out/web/commerce/CommerceServiceClient.java
@@ -7,6 +7,7 @@ import com.personal.marketnote.community.domain.servicecommunication.CommunitySe
 import com.personal.marketnote.community.domain.servicecommunication.CommunityServiceCommunicationTargetType;
 import com.personal.marketnote.community.domain.servicecommunication.CommunityServiceCommunicationType;
 import com.personal.marketnote.community.exception.UnauthorizedOrderAccessException;
+import com.personal.marketnote.community.port.out.order.FindOrderProductPort;
 import com.personal.marketnote.community.port.out.order.VerifyOrderOwnershipPort;
 import com.personal.marketnote.community.utility.ServiceCommunicationPayloadGenerator;
 import com.personal.marketnote.community.utility.ServiceCommunicationRecorder;
@@ -18,6 +19,7 @@ import org.springframework.web.client.RestClient;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.net.URI;
+import java.util.Optional;
 import java.util.concurrent.ThreadLocalRandom;
 
 import static com.personal.marketnote.common.utility.ApiConstant.*;
@@ -31,7 +33,7 @@ import static com.personal.marketnote.common.utility.ApiConstant.*;
  */
 @ServiceAdapter
 @Slf4j
-public class CommerceServiceClient implements VerifyOrderOwnershipPort {
+public class CommerceServiceClient implements VerifyOrderOwnershipPort, FindOrderProductPort {
     private static final CommunityServiceCommunicationTargetType TARGET_TYPE =
             CommunityServiceCommunicationTargetType.ORDER_OWNERSHIP;
     private static final CommunityServiceCommunicationSenderType REQUEST_SENDER =
@@ -130,6 +132,69 @@ public class CommerceServiceClient implements VerifyOrderOwnershipPort {
         );
         serviceCommunicationRecorder.record(
                 TARGET_TYPE,
+                CommunityServiceCommunicationType.RESPONSE,
+                RESPONSE_SENDER,
+                targetId,
+                responsePayloadJson.toString(),
+                responsePayloadJson,
+                exception
+        );
+    }
+
+    @Override
+    public Optional<Long> findUnitAmountByOrderIdAndPricePolicyId(Long orderId, Long pricePolicyId) {
+        URI uri = UriComponentsBuilder
+                .fromUriString(commerceServiceBaseUrl)
+                .path("/api/v1/internal/orders/{orderId}/order-products/{pricePolicyId}")
+                .buildAndExpand(orderId, pricePolicyId)
+                .toUri();
+
+        String targetId = orderId + ":" + pricePolicyId;
+
+        try {
+            JsonNode responseBody = restClient.get()
+                    .uri(uri)
+                    .headers(headers -> hmacServiceAuthHeaderBuilder.applyHeaders(headers, "GET", uri.getPath()))
+                    .retrieve()
+                    .body(JsonNode.class);
+
+            if (responseBody == null || !responseBody.has("content")) {
+                return Optional.empty();
+            }
+
+            JsonNode content = responseBody.get("content");
+            if (content.isNull() || !content.has("unitAmount")) {
+                return Optional.empty();
+            }
+
+            return Optional.of(content.get("unitAmount").asLong());
+        } catch (Exception e) {
+            recordOrderProductError(targetId, uri, e);
+            log.warn("커머스 서비스 주문 상품 조회 실패 - orderId: {}, pricePolicyId: {}", orderId, pricePolicyId, e);
+            return Optional.empty();
+        }
+    }
+
+    private void recordOrderProductError(String targetId, URI uri, Exception e) {
+        String exception = e.getClass().getSimpleName();
+        JsonNode requestPayloadJson = serviceCommunicationPayloadGenerator.buildRequestPayloadJson(
+                HttpMethod.GET, uri, null, 1
+        );
+        JsonNode responsePayloadJson = serviceCommunicationPayloadGenerator.buildErrorPayloadJson(
+                exception, e.getMessage(), 1
+        );
+
+        serviceCommunicationRecorder.record(
+                CommunityServiceCommunicationTargetType.ORDER_PRODUCT,
+                CommunityServiceCommunicationType.REQUEST,
+                REQUEST_SENDER,
+                targetId,
+                requestPayloadJson.toString(),
+                requestPayloadJson,
+                exception
+        );
+        serviceCommunicationRecorder.record(
+                CommunityServiceCommunicationTargetType.ORDER_PRODUCT,
                 CommunityServiceCommunicationType.RESPONSE,
                 RESPONSE_SENDER,
                 targetId,

--- a/community-service/community-application/src/main/java/com/personal/marketnote/community/port/in/result/review/ReviewProductInfoResult.java
+++ b/community-service/community-application/src/main/java/com/personal/marketnote/community/port/in/result/review/ReviewProductInfoResult.java
@@ -8,7 +8,8 @@ public record ReviewProductInfoResult(
         String name,
         String brandName,
         ReviewProductPricePolicyResult pricePolicy,
-        GetFileResult catalogImage
+        GetFileResult catalogImage,
+        Long unitAmount
 ) {
     public static ReviewProductInfoResult from(ProductInfoResult productInfo) {
         if (FormatValidator.hasNoValue(productInfo)) {
@@ -19,7 +20,22 @@ public record ReviewProductInfoResult(
                 productInfo.name(),
                 productInfo.brandName(),
                 ReviewProductPricePolicyResult.from(productInfo.pricePolicy()),
-                productInfo.catalogImage()
+                productInfo.catalogImage(),
+                null
+        );
+    }
+
+    public static ReviewProductInfoResult from(ProductInfoResult productInfo, Long unitAmount) {
+        if (FormatValidator.hasNoValue(productInfo)) {
+            return null;
+        }
+
+        return new ReviewProductInfoResult(
+                productInfo.name(),
+                productInfo.brandName(),
+                ReviewProductPricePolicyResult.from(productInfo.pricePolicy()),
+                productInfo.catalogImage(),
+                unitAmount
         );
     }
 }

--- a/community-service/community-application/src/main/java/com/personal/marketnote/community/port/in/usecase/review/GetReviewUseCase.java
+++ b/community-service/community-application/src/main/java/com/personal/marketnote/community/port/in/usecase/review/GetReviewUseCase.java
@@ -4,10 +4,7 @@ import com.personal.marketnote.community.domain.review.ProductReviewAggregate;
 import com.personal.marketnote.community.domain.review.Review;
 import com.personal.marketnote.community.domain.review.ReviewSortProperty;
 import com.personal.marketnote.community.port.in.command.review.RegisterReviewCommand;
-import com.personal.marketnote.community.port.in.result.review.GetMyReviewsResult;
-import com.personal.marketnote.community.port.in.result.review.GetProductReviewAggregatesResult;
-import com.personal.marketnote.community.port.in.result.review.GetReviewCountResult;
-import com.personal.marketnote.community.port.in.result.review.GetReviewsResult;
+import com.personal.marketnote.community.port.in.result.review.*;
 import org.springframework.data.domain.Sort;
 
 import java.util.List;
@@ -138,4 +135,14 @@ public interface GetReviewUseCase {
      * @Description 리뷰 존재 여부를 조회합니다.
      */
     boolean existsReview(Long id);
+
+    /**
+     * @param id     리뷰 ID
+     * @param userId 회원 ID
+     * @return 리뷰 상세 조회 결과 {@link ReviewItemResult}
+     * @Date 2026-04-05
+     * @Author 성효빈
+     * @Description 리뷰 상세 정보를 주문 상품 정보(상품명, 브랜드, 구매 시점 가격, 대표 이미지)와 함께 조회합니다.
+     */
+    ReviewItemResult getReviewDetail(Long id, Long userId);
 }

--- a/community-service/community-application/src/main/java/com/personal/marketnote/community/port/out/order/FindOrderProductPort.java
+++ b/community-service/community-application/src/main/java/com/personal/marketnote/community/port/out/order/FindOrderProductPort.java
@@ -1,0 +1,19 @@
+package com.personal.marketnote.community.port.out.order;
+
+import java.util.Optional;
+
+/**
+ * 주문 상품 조회 Out Port
+ *
+ * @Author 성효빈
+ * @Date 2026-04-05
+ * @Description 커머스 서비스에서 주문 상품의 구매 시점 단가를 조회합니다.
+ */
+public interface FindOrderProductPort {
+    /**
+     * @param orderId       주문 ID
+     * @param pricePolicyId 가격 정책 ID
+     * @return 구매 시점 단가 {@link Optional}
+     */
+    Optional<Long> findUnitAmountByOrderIdAndPricePolicyId(Long orderId, Long pricePolicyId);
+}

--- a/community-service/community-application/src/main/java/com/personal/marketnote/community/service/review/GetReviewService.java
+++ b/community-service/community-application/src/main/java/com/personal/marketnote/community/service/review/GetReviewService.java
@@ -17,6 +17,7 @@ import com.personal.marketnote.community.port.in.result.review.*;
 import com.personal.marketnote.community.port.in.usecase.like.GetLikeUseCase;
 import com.personal.marketnote.community.port.in.usecase.review.GetReviewUseCase;
 import com.personal.marketnote.community.port.out.file.FindReviewImagesPort;
+import com.personal.marketnote.community.port.out.order.FindOrderProductPort;
 import com.personal.marketnote.community.port.out.product.FindProductByPricePolicyPort;
 import com.personal.marketnote.community.port.out.result.product.ProductInfoResult;
 import com.personal.marketnote.community.port.out.review.FindReviewPort;
@@ -44,6 +45,7 @@ public class GetReviewService implements GetReviewUseCase {
     private final FindReviewPort findReviewPort;
     private final FindReviewImagesPort findReviewImagesPort;
     private final FindProductByPricePolicyPort findProductByPricePolicyPort;
+    private final FindOrderProductPort findOrderProductPort;
     private final GetLikeUseCase getLikeUseCase;
 
     @Override
@@ -206,6 +208,56 @@ public class GetReviewService implements GetReviewUseCase {
         long totalCount = findReviewPort.countActive(userId);
 
         return GetReviewCountResult.of(totalCount);
+    }
+
+    @Override
+    public ReviewItemResult getReviewDetail(Long id, Long userId) {
+        Review review = findReviewPort.findById(id)
+                .orElseThrow(() -> new ReviewNotFoundException(id));
+
+        if (FormatValidator.hasValue(userId)) {
+            review.updateIsUserLiked(
+                    getLikeUseCase.existsUserLike(LikeTargetType.REVIEW, review.getId(), userId)
+            );
+        }
+
+        List<GetFileResult> images = findReviewDetailImages(review);
+        ReviewProductInfoResult product = findReviewDetailProductInfo(review);
+
+        return ReviewItemResult.from(review, images, product);
+    }
+
+    private List<GetFileResult> findReviewDetailImages(Review review) {
+        if (!Boolean.TRUE.equals(review.getIsPhoto())) {
+            return null;
+        }
+
+        return findReviewImagesPort.findImagesByReviewIdAndSort(review.getId(), REVIEW_IMAGE)
+                .map(result -> result.images())
+                .orElse(null);
+    }
+
+    private ReviewProductInfoResult findReviewDetailProductInfo(Review review) {
+        Long pricePolicyId = review.getPricePolicyId();
+        if (FormatValidator.hasNoValue(pricePolicyId)) {
+            return null;
+        }
+
+        Map<Long, ProductInfoResult> productInfoMap
+                = findProductByPricePolicyPort.findByPricePolicyIds(List.of(pricePolicyId));
+        ProductInfoResult productInfo = productInfoMap.get(pricePolicyId);
+        if (FormatValidator.hasNoValue(productInfo)) {
+            return null;
+        }
+
+        Long unitAmount = null;
+        if (FormatValidator.hasValue(review.getOrderId())) {
+            unitAmount = findOrderProductPort
+                    .findUnitAmountByOrderIdAndPricePolicyId(review.getOrderId(), pricePolicyId)
+                    .orElse(null);
+        }
+
+        return ReviewProductInfoResult.from(productInfo, unitAmount);
     }
 
     @Override

--- a/community-service/community-domain/src/main/java/com/personal/marketnote/community/domain/servicecommunication/CommunityServiceCommunicationTargetType.java
+++ b/community-service/community-domain/src/main/java/com/personal/marketnote/community/domain/servicecommunication/CommunityServiceCommunicationTargetType.java
@@ -8,7 +8,8 @@ public enum CommunityServiceCommunicationTargetType {
     REVIEW_IMAGE("리뷰 이미지"),
     POST_IMAGE("게시글 이미지"),
     ORDER_PRODUCT_REVIEW_STATUS("주문 상품 리뷰 상태"),
-    ORDER_OWNERSHIP("주문 소유권");
+    ORDER_OWNERSHIP("주문 소유권"),
+    ORDER_PRODUCT("주문 상품");
 
     private final String description;
 }


### PR DESCRIPTION
## partially addresses #300
## resolves #1626

## Task
- [x] 리뷰 상세 조회 시 주문 상품 정보(상품명, 브랜드, 구매 시점 가격, 선택 옵션, 대표 이미지) 응답에 포함
- [x] 구매 시점 가격은 커머스 서비스 order_product의 unitAmount 기준으로 조회