### PR TITLE
[#1970][#1651] feat: 나의 리뷰 목록 조회 시 상품 가격을 구매 시점 주문 상품 가격으로 변경

### DIFF
--- a/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/in/web/review/mapper/ReviewRequestToCommandMapper.java
+++ b/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/in/web/review/mapper/ReviewRequestToCommandMapper.java
@@ -19,6 +19,7 @@ public class ReviewRequestToCommandMapper {
                 .rating(request.getRating())
                 .content(request.getContent())
                 .isPhoto(request.getIsPhoto())
+                .unitAmount(request.getUnitAmount())
                 .build();
     }
 

--- a/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/in/web/review/request/RegisterReviewRequest.java
+++ b/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/in/web/review/request/RegisterReviewRequest.java
@@ -12,7 +12,7 @@ public class RegisterReviewRequest {
             requiredMode = Schema.RequiredMode.REQUIRED
     )
     @NotNull(message = "주문 ID는 필수값입니다.")
-    @Positive(message = "가격 정책 ID는 자연수만 입력 가능합니다.")
+    @Positive(message = "주문 ID는 자연수만 입력 가능합니다.")
     @Min(value = 1, message = "주문 ID는 1 이상이어야 합니다.")
     @Max(value = Long.MAX_VALUE, message = "주문 ID는 정수형 최대값을 초과할 수 없습니다.")
     private Long orderId;
@@ -102,4 +102,12 @@ public class RegisterReviewRequest {
     )
     @NotNull(message = "포토 리뷰 여부는 필수값입니다.")
     private Boolean isPhoto;
+
+    @Schema(
+            name = "unitAmount",
+            description = "주문 상품 구매 시점 단가",
+            requiredMode = Schema.RequiredMode.NOT_REQUIRED
+    )
+    @Positive(message = "주문 상품 구매 시점 단가는 양수만 입력 가능합니다.")
+    private Long unitAmount;
 }

--- a/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/out/mapper/ReviewJpaEntityToDomainMapper.java
+++ b/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/out/mapper/ReviewJpaEntityToDomainMapper.java
@@ -35,6 +35,7 @@ public class ReviewJpaEntityToDomainMapper {
                                 .createdAt(entity.getCreatedAt())
                                 .modifiedAt(entity.getModifiedAt())
                                 .orderNum(entity.getOrderNum())
+                                .unitAmount(entity.getUnitAmount())
                                 .build()
                 )
         );

--- a/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/out/persistence/review/entity/ReviewJpaEntity.java
+++ b/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/out/persistence/review/entity/ReviewJpaEntity.java
@@ -60,6 +60,9 @@ public class ReviewJpaEntity extends BaseOrderedGeneralEntity {
     @Column(name = "edited_yn", nullable = false, columnDefinition = BOOLEAN_DEFAULT_FALSE)
     private Boolean isEdited;
 
+    @Column(name = "unit_amount")
+    private Long unitAmount;
+
     @Formula("""
             (
                 SELECT count(l.user_id)
@@ -85,6 +88,7 @@ public class ReviewJpaEntity extends BaseOrderedGeneralEntity {
                 .rating(review.getRating())
                 .content(review.getContent())
                 .isPhoto(review.getIsPhoto())
+                .unitAmount(review.getUnitAmount())
                 .build();
     }
 

--- a/community-service/community-adapters/src/main/resources/db/migration/V20260403__add_unit_amount_to_review.sql
+++ b/community-service/community-adapters/src/main/resources/db/migration/V20260403__add_unit_amount_to_review.sql
@@ -1,0 +1,1 @@
+ALTER TABLE review ADD COLUMN unit_amount BIGINT;

--- a/community-service/community-application/src/main/java/com/personal/marketnote/community/mapper/ReviewCommandToStateMapper.java
+++ b/community-service/community-application/src/main/java/com/personal/marketnote/community/mapper/ReviewCommandToStateMapper.java
@@ -19,6 +19,7 @@ public class ReviewCommandToStateMapper {
                 .rating(command.rating())
                 .content(command.content())
                 .isPhoto(command.isPhoto())
+                .unitAmount(command.unitAmount())
                 .build();
     }
 

--- a/community-service/community-application/src/main/java/com/personal/marketnote/community/port/in/command/review/RegisterReviewCommand.java
+++ b/community-service/community-application/src/main/java/com/personal/marketnote/community/port/in/command/review/RegisterReviewCommand.java
@@ -14,6 +14,7 @@ public record RegisterReviewCommand(
         String reviewerName,
         Float rating,
         String content,
-        Boolean isPhoto
+        Boolean isPhoto,
+        Long unitAmount
 ) {
 }

--- a/community-service/community-application/src/main/java/com/personal/marketnote/community/port/in/result/review/GetMyReviewsResult.java
+++ b/community-service/community-application/src/main/java/com/personal/marketnote/community/port/in/result/review/GetMyReviewsResult.java
@@ -1,7 +1,6 @@
 package com.personal.marketnote.community.port.in.result.review;
 
 import com.personal.marketnote.common.application.file.port.in.result.GetFileResult;
-import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.community.domain.review.Review;
 
 import java.util.List;
@@ -27,10 +26,10 @@ public record GetMyReviewsResult(
                 hasNext,
                 reviews.stream()
                         .map(review -> {
-                            Long pricePolicyId = review.getPricePolicyId();
-                            ReviewProductInfoResult productInfo = FormatValidator.hasValue(pricePolicyId)
-                                    ? productInfoByPricePolicyId.get(pricePolicyId)
-                                    : null;
+                            ReviewProductInfoResult productInfo =
+                                    ReviewProductInfoResult.resolveForReview(
+                                            review, productInfoByPricePolicyId
+                                    );
 
                             return MyReviewItemResult.from(
                                     review,

--- a/community-service/community-application/src/main/java/com/personal/marketnote/community/port/in/result/review/ReviewProductInfoResult.java
+++ b/community-service/community-application/src/main/java/com/personal/marketnote/community/port/in/result/review/ReviewProductInfoResult.java
@@ -2,7 +2,10 @@ package com.personal.marketnote.community.port.in.result.review;
 
 import com.personal.marketnote.common.application.file.port.in.result.GetFileResult;
 import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.community.domain.review.Review;
 import com.personal.marketnote.community.port.out.result.product.ProductInfoResult;
+
+import java.util.Map;
 
 public record ReviewProductInfoResult(
         String name,
@@ -37,5 +40,26 @@ public record ReviewProductInfoResult(
                 productInfo.catalogImage(),
                 unitAmount
         );
+    }
+
+    public ReviewProductInfoResult withUnitAmount(Long unitAmount) {
+        return new ReviewProductInfoResult(name, brandName, pricePolicy, catalogImage, unitAmount);
+    }
+
+    public static ReviewProductInfoResult resolveForReview(
+            Review review, Map<Long, ReviewProductInfoResult> productInfoByPricePolicyId
+    ) {
+        Long pricePolicyId = review.getPricePolicyId();
+        if (FormatValidator.hasNoValue(pricePolicyId)) {
+            return null;
+        }
+        ReviewProductInfoResult productInfo = productInfoByPricePolicyId.get(pricePolicyId);
+        if (FormatValidator.hasNoValue(productInfo)) {
+            return null;
+        }
+        if (!review.hasUnitAmount()) {
+            return productInfo;
+        }
+        return productInfo.withUnitAmount(review.getUnitAmount());
     }
 }

--- a/community-service/community-application/src/main/java/com/personal/marketnote/community/service/review/GetReviewService.java
+++ b/community-service/community-application/src/main/java/com/personal/marketnote/community/service/review/GetReviewService.java
@@ -250,8 +250,8 @@ public class GetReviewService implements GetReviewUseCase {
             return null;
         }
 
-        Long unitAmount = null;
-        if (FormatValidator.hasValue(review.getOrderId())) {
+        Long unitAmount = review.getUnitAmount();
+        if (FormatValidator.hasNoValue(unitAmount) && FormatValidator.hasValue(review.getOrderId())) {
             unitAmount = findOrderProductPort
                     .findUnitAmountByOrderIdAndPricePolicyId(review.getOrderId(), pricePolicyId)
                     .orElse(null);

--- a/community-service/community-application/src/main/java/com/personal/marketnote/community/service/review/GetUserReviewsService.java
+++ b/community-service/community-application/src/main/java/com/personal/marketnote/community/service/review/GetUserReviewsService.java
@@ -59,10 +59,10 @@ public class GetUserReviewsService implements GetUserReviewsUseCase {
 
         List<UserReviewItemResult> reviewItems = reviewList.stream()
                 .map(review -> {
-                    Long pricePolicyId = review.getPricePolicyId();
-                    ReviewProductInfoResult productInfo = FormatValidator.hasValue(pricePolicyId)
-                            ? productInfoByPricePolicyId.get(pricePolicyId)
-                            : null;
+                    ReviewProductInfoResult productInfo =
+                            ReviewProductInfoResult.resolveForReview(
+                                    review, productInfoByPricePolicyId
+                            );
 
                     return UserReviewItemResult.from(
                             review,

--- a/community-service/community-domain/src/main/java/com/personal/marketnote/community/domain/review/Review.java
+++ b/community-service/community-domain/src/main/java/com/personal/marketnote/community/domain/review/Review.java
@@ -51,6 +51,7 @@ public class Review {
     private LocalDateTime modifiedAt;
 
     private Long orderNum;
+    private Long unitAmount;
 
     public static Review from(ReviewCreateState state) {
         return Review.builder()
@@ -66,6 +67,7 @@ public class Review {
                 .rating(round(state.getRating()))
                 .content(state.getContent())
                 .isPhoto(state.getIsPhoto())
+                .unitAmount(state.getUnitAmount())
                 .status(EntityStatus.ACTIVE)
                 .build();
     }
@@ -97,7 +99,12 @@ public class Review {
                 .createdAt(state.getCreatedAt())
                 .modifiedAt(state.getModifiedAt())
                 .orderNum(state.getOrderNum())
+                .unitAmount(state.getUnitAmount())
                 .build();
+    }
+
+    public boolean hasUnitAmount() {
+        return FormatValidator.hasValue(unitAmount);
     }
 
     public void updateIsUserLiked(boolean isUserLiked) {

--- a/community-service/community-domain/src/main/java/com/personal/marketnote/community/domain/review/ReviewCreateState.java
+++ b/community-service/community-domain/src/main/java/com/personal/marketnote/community/domain/review/ReviewCreateState.java
@@ -20,4 +20,5 @@ public class ReviewCreateState {
     private final Float rating;
     private final String content;
     private final Boolean isPhoto;
+    private final Long unitAmount;
 }

--- a/community-service/community-domain/src/main/java/com/personal/marketnote/community/domain/review/ReviewSnapshotState.java
+++ b/community-service/community-domain/src/main/java/com/personal/marketnote/community/domain/review/ReviewSnapshotState.java
@@ -31,4 +31,5 @@ public class ReviewSnapshotState {
     private final LocalDateTime createdAt;
     private final LocalDateTime modifiedAt;
     private final Long orderNum;
+    private final Long unitAmount;
 }


### PR DESCRIPTION
## partially addresses #1970
## resolves #1651

## Task
- [x] 리뷰 등록 API(`POST /api/v1/reviews`) 요청에 주문 상품 가격(unitAmount) 파라미터 추가
- [x] 리뷰 도메인/엔티티에 unitAmount 필드 추가
- [x] 리뷰 목록 조회 시 저장된 unitAmount를 응답 가격으로 사용
- [x] 리뷰 상세 조회 시 Review에 unitAmount가 저장되어 있으면 우선 사용, null이면 기존 findOrderProductPort fallback
- [x] RegisterReviewRequest orderId 필드 @Positive 검증 메시지 오류 수정