### PR TITLE
[#1653][#1654] feat: 기프티쇼 비즈 API 클라이언트 인프라 구축

### DIFF
--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/vendor/giftishow/GiftishowApiClient.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/vendor/giftishow/GiftishowApiClient.java
@@ -1,0 +1,277 @@
+package com.personal.marketnote.reward.adapter.out.vendor.giftishow;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.reward.adapter.out.vendor.giftishow.dto.*;
+import com.personal.marketnote.reward.adapter.out.vendor.giftishow.exception.GiftishowCommunicationException;
+import com.personal.marketnote.reward.configuration.GiftishowApiProperties;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClient;
+
+@Component
+@Slf4j
+public class GiftishowApiClient {
+
+    private final GiftishowApiProperties properties;
+    private final RestClient giftishowRestClient;
+    private final ObjectMapper objectMapper;
+
+    public GiftishowApiClient(
+            GiftishowApiProperties properties,
+            RestClient giftishowRestClient,
+            ObjectMapper objectMapper
+    ) {
+        this.properties = properties;
+        this.giftishowRestClient = giftishowRestClient;
+        this.objectMapper = objectMapper;
+    }
+
+    /**
+     * 0101 - 상품 리스트 조회 (POST)
+     */
+    public GiftishowApiResponse<GiftishowProductListResponse> getProductList(int start, int size) {
+        MultiValueMap<String, String> params = createAuthParams();
+        params.add("start", String.valueOf(start));
+        params.add("size", String.valueOf(size));
+
+        log.info("기프티쇼 상품 리스트 조회 요청: start={}, size={}", start, size);
+
+        return executePost(
+                properties.getApi().getProductListPath(),
+                params,
+                new TypeReference<>() {}
+        );
+    }
+
+    /**
+     * 0111 - 상품 상세 조회 (GET)
+     */
+    public GiftishowApiResponse<GiftishowProductDetailResponse> getProductDetail(String goodsCode) {
+        log.info("기프티쇼 상품 상세 조회 요청: goodsCode={}", goodsCode);
+
+        return executeGet(
+                properties.getApi().getProductDetailPath(),
+                goodsCode,
+                "goods_code",
+                new TypeReference<>() {}
+        );
+    }
+
+    /**
+     * 0102 - 브랜드 조회 (POST)
+     */
+    public GiftishowApiResponse<GiftishowBrandListResponse> getBrandList() {
+        MultiValueMap<String, String> params = createAuthParams();
+
+        log.info("기프티쇼 브랜드 조회 요청");
+
+        return executePost(
+                properties.getApi().getBrandListPath(),
+                params,
+                new TypeReference<>() {}
+        );
+    }
+
+    /**
+     * 0112 - 브랜드 상세 조회 (GET)
+     */
+    public GiftishowApiResponse<GiftishowBrandDetailResponse> getBrandDetail(String brandCode) {
+        log.info("기프티쇼 브랜드 상세 조회 요청: brandCode={}", brandCode);
+
+        return executeGet(
+                properties.getApi().getBrandDetailPath(),
+                brandCode,
+                "brand_code",
+                new TypeReference<>() {}
+        );
+    }
+
+    /**
+     * 0204 - 쿠폰 발송 (POST)
+     */
+    public GiftishowApiResponse<GiftishowCouponSendResponse> sendCoupon(
+            String trId,
+            String goodsCode,
+            String phoneNo,
+            String userId,
+            String mmsMsg,
+            String mmsTitle
+    ) {
+        MultiValueMap<String, String> params = createAuthParams();
+        params.add("tr_id", trId);
+        params.add("goods_code", goodsCode);
+        params.add("phone_no", phoneNo);
+        params.add("user_id", userId);
+        params.add("gubun", properties.getGubun());
+        params.add("callback_no", properties.getCallbackNo());
+        params.add("mms_msg", mmsMsg);
+        params.add("mms_title", mmsTitle);
+
+        log.info("기프티쇼 쿠폰 발송 요청: trId={}, goodsCode={}, userId={}", trId, goodsCode, userId);
+
+        return executePost(
+                properties.getApi().getCouponSendPath(),
+                params,
+                new TypeReference<>() {}
+        );
+    }
+
+    /**
+     * 0201 - 쿠폰 상세 조회 (POST)
+     */
+    public GiftishowApiResponse<GiftishowCouponDetailResponse> getCouponDetail(String trId) {
+        MultiValueMap<String, String> params = createAuthParams();
+        params.add("tr_id", trId);
+
+        log.info("기프티쇼 쿠폰 상세 조회 요청: trId={}", trId);
+
+        return executePost(
+                properties.getApi().getCouponDetailPath(),
+                params,
+                new TypeReference<>() {}
+        );
+    }
+
+    /**
+     * 0202 - 쿠폰 취소 (POST)
+     */
+    public GiftishowApiResponse<GiftishowCouponCancelResponse> cancelCoupon(String trId, String userId) {
+        MultiValueMap<String, String> params = createAuthParams();
+        params.add("tr_id", trId);
+        params.add("user_id", userId);
+
+        log.info("기프티쇼 쿠폰 취소 요청: trId={}, userId={}", trId, userId);
+
+        return executePost(
+                properties.getApi().getCouponCancelPath(),
+                params,
+                new TypeReference<>() {}
+        );
+    }
+
+    /**
+     * 0203 - 쿠폰 재전송 (POST)
+     */
+    public GiftishowApiResponse<GiftishowCouponResendResponse> resendCoupon(String trId, String phoneNo) {
+        MultiValueMap<String, String> params = createAuthParams();
+        params.add("tr_id", trId);
+        params.add("phone_no", phoneNo);
+
+        log.info("기프티쇼 쿠폰 재전송 요청: trId={}", trId);
+
+        return executePost(
+                properties.getApi().getCouponResendPath(),
+                params,
+                new TypeReference<>() {}
+        );
+    }
+
+    /**
+     * 0301 - 비즈머니 잔액 조회 (POST)
+     */
+    public GiftishowApiResponse<GiftishowBizMoneyResponse> getBizMoneyBalance(String userId) {
+        MultiValueMap<String, String> params = createAuthParams();
+        params.add("user_id", userId);
+
+        log.info("기프티쇼 비즈머니 잔액 조회 요청: userId={}", userId);
+
+        return executePost(
+                properties.getApi().getBizMoneyBalancePath(),
+                params,
+                new TypeReference<>() {}
+        );
+    }
+
+    /**
+     * 0205 - 발송실패 취소 (POST)
+     */
+    public GiftishowApiResponse<GiftishowCouponCancelResponse> cancelSendFailedCoupon(String trId, String userId) {
+        MultiValueMap<String, String> params = createAuthParams();
+        params.add("tr_id", trId);
+        params.add("user_id", userId);
+
+        log.info("기프티쇼 발송실패 취소 요청: trId={}, userId={}", trId, userId);
+
+        return executePost(
+                properties.getApi().getCouponSendFailCancelPath(),
+                params,
+                new TypeReference<>() {}
+        );
+    }
+
+    private MultiValueMap<String, String> createAuthParams() {
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("api_code", properties.getApiCode());
+        params.add("auth_code", properties.getAuthCode());
+        params.add("auth_token", properties.getAuthToken());
+        params.add("dev_yn", properties.getDevYn());
+        return params;
+    }
+
+    private <T> GiftishowApiResponse<T> executePost(
+            String path,
+            MultiValueMap<String, String> params,
+            TypeReference<GiftishowApiResponse<T>> typeReference
+    ) {
+        ResponseEntity<String> rawResponse = giftishowRestClient.post()
+                .uri(path)
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .body(params)
+                .retrieve()
+                .toEntity(String.class);
+
+        return parseResponse(rawResponse, path, typeReference);
+    }
+
+    private <T> GiftishowApiResponse<T> executeGet(
+            String path,
+            String paramValue,
+            String paramName,
+            TypeReference<GiftishowApiResponse<T>> typeReference
+    ) {
+        ResponseEntity<String> rawResponse = giftishowRestClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .path(path)
+                        .queryParam("api_code", properties.getApiCode())
+                        .queryParam("auth_code", properties.getAuthCode())
+                        .queryParam("auth_token", properties.getAuthToken())
+                        .queryParam("dev_yn", properties.getDevYn())
+                        .queryParam(paramName, paramValue)
+                        .build())
+                .retrieve()
+                .toEntity(String.class);
+
+        return parseResponse(rawResponse, path, typeReference);
+    }
+
+    private <T> GiftishowApiResponse<T> parseResponse(
+            ResponseEntity<String> rawResponse,
+            String path,
+            TypeReference<GiftishowApiResponse<T>> typeReference
+    ) {
+        String responseBody = rawResponse.getBody();
+        log.debug("기프티쇼 API 응답: path={}, status={}, body={}",
+                path, rawResponse.getStatusCode(), responseBody);
+
+        if (FormatValidator.hasNoValue(responseBody)) {
+            throw new GiftishowCommunicationException(
+                    "기프티쇼 API 응답 본문이 비어 있습니다. path=" + path
+            );
+        }
+
+        try {
+            return objectMapper.readValue(responseBody, typeReference);
+        } catch (Exception e) {
+            log.error("기프티쇼 API 응답 파싱 실패: path={}, error={}", path, e.getMessage());
+            throw new GiftishowCommunicationException(
+                    "기프티쇼 API 응답 파싱 실패. path=" + path, e
+            );
+        }
+    }
+}

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/vendor/giftishow/dto/GiftishowApiResponse.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/vendor/giftishow/dto/GiftishowApiResponse.java
@@ -1,0 +1,15 @@
+package com.personal.marketnote.reward.adapter.out.vendor.giftishow.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record GiftishowApiResponse<T>(
+        @JsonProperty("code") String code,
+        @JsonProperty("message") String message,
+        @JsonProperty("result") T result
+) {
+    public boolean isSuccess() {
+        return "0000".equals(code);
+    }
+}

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/vendor/giftishow/dto/GiftishowBizMoneyResponse.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/vendor/giftishow/dto/GiftishowBizMoneyResponse.java
@@ -1,0 +1,11 @@
+package com.personal.marketnote.reward.adapter.out.vendor.giftishow.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record GiftishowBizMoneyResponse(
+        @JsonProperty("user_id") String userId,
+        @JsonProperty("biz_money") long bizMoney
+) {
+}

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/vendor/giftishow/dto/GiftishowBrandDetailResponse.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/vendor/giftishow/dto/GiftishowBrandDetailResponse.java
@@ -1,0 +1,14 @@
+package com.personal.marketnote.reward.adapter.out.vendor.giftishow.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record GiftishowBrandDetailResponse(
+        @JsonProperty("brand_code") String brandCode,
+        @JsonProperty("brand_name") String brandName,
+        @JsonProperty("brand_icon_img") String brandIconImg,
+        @JsonProperty("category1Seq") String category1Seq,
+        @JsonProperty("category1Name") String category1Name
+) {
+}

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/vendor/giftishow/dto/GiftishowBrandListResponse.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/vendor/giftishow/dto/GiftishowBrandListResponse.java
@@ -1,0 +1,23 @@
+package com.personal.marketnote.reward.adapter.out.vendor.giftishow.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record GiftishowBrandListResponse(
+        @JsonProperty("list_total_cnt") int listTotalCnt,
+        @JsonProperty("brandList") List<GiftishowBrandItem> brandList
+) {
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record GiftishowBrandItem(
+            @JsonProperty("brand_code") String brandCode,
+            @JsonProperty("brand_name") String brandName,
+            @JsonProperty("brand_icon_img") String brandIconImg,
+            @JsonProperty("category1Seq") String category1Seq,
+            @JsonProperty("category1Name") String category1Name
+    ) {
+    }
+}

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/vendor/giftishow/dto/GiftishowCouponCancelResponse.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/vendor/giftishow/dto/GiftishowCouponCancelResponse.java
@@ -1,0 +1,11 @@
+package com.personal.marketnote.reward.adapter.out.vendor.giftishow.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record GiftishowCouponCancelResponse(
+        @JsonProperty("tr_id") String trId,
+        @JsonProperty("order_no") String orderNo
+) {
+}

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/vendor/giftishow/dto/GiftishowCouponDetailResponse.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/vendor/giftishow/dto/GiftishowCouponDetailResponse.java
@@ -1,0 +1,16 @@
+package com.personal.marketnote.reward.adapter.out.vendor.giftishow.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record GiftishowCouponDetailResponse(
+        @JsonProperty("tr_id") String trId,
+        @JsonProperty("order_no") String orderNo,
+        @JsonProperty("pin_status_cd") String pinStatusCd,
+        @JsonProperty("pin_status_nm") String pinStatusNm,
+        @JsonProperty("valid_prd_end_dt") String validPrdEndDt,
+        @JsonProperty("goods_code") String goodsCode,
+        @JsonProperty("goods_name") String goodsName
+) {
+}

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/vendor/giftishow/dto/GiftishowCouponResendResponse.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/vendor/giftishow/dto/GiftishowCouponResendResponse.java
@@ -1,0 +1,11 @@
+package com.personal.marketnote.reward.adapter.out.vendor.giftishow.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record GiftishowCouponResendResponse(
+        @JsonProperty("tr_id") String trId,
+        @JsonProperty("order_no") String orderNo
+) {
+}

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/vendor/giftishow/dto/GiftishowCouponSendResponse.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/vendor/giftishow/dto/GiftishowCouponSendResponse.java
@@ -1,0 +1,14 @@
+package com.personal.marketnote.reward.adapter.out.vendor.giftishow.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record GiftishowCouponSendResponse(
+        @JsonProperty("tr_id") String trId,
+        @JsonProperty("order_no") String orderNo,
+        @JsonProperty("pin_no") String pinNo,
+        @JsonProperty("coupon_img_url") String couponImgUrl,
+        @JsonProperty("valid_prd_end_dt") String validPrdEndDt
+) {
+}

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/vendor/giftishow/dto/GiftishowProductDetailResponse.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/vendor/giftishow/dto/GiftishowProductDetailResponse.java
@@ -1,0 +1,21 @@
+package com.personal.marketnote.reward.adapter.out.vendor.giftishow.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record GiftishowProductDetailResponse(
+        @JsonProperty("goods_code") String goodsCode,
+        @JsonProperty("goods_name") String goodsName,
+        @JsonProperty("goods_img_B") String goodsImgB,
+        @JsonProperty("brandCode") String brandCode,
+        @JsonProperty("brandName") String brandName,
+        @JsonProperty("brandIconImg") String brandIconImg,
+        @JsonProperty("category1Seq") String category1Seq,
+        @JsonProperty("sale_price") long salePrice,
+        @JsonProperty("real_price") long realPrice,
+        @JsonProperty("limitDay") int limitDay,
+        @JsonProperty("content") String content,
+        @JsonProperty("goods_status") String goodsStatus
+) {
+}

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/vendor/giftishow/dto/GiftishowProductListResponse.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/vendor/giftishow/dto/GiftishowProductListResponse.java
@@ -1,0 +1,30 @@
+package com.personal.marketnote.reward.adapter.out.vendor.giftishow.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record GiftishowProductListResponse(
+        @JsonProperty("list_total_cnt") int listTotalCnt,
+        @JsonProperty("goodsList") List<GiftishowProductItem> goodsList
+) {
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record GiftishowProductItem(
+            @JsonProperty("goods_code") String goodsCode,
+            @JsonProperty("goods_name") String goodsName,
+            @JsonProperty("goods_img_B") String goodsImgB,
+            @JsonProperty("brandCode") String brandCode,
+            @JsonProperty("brandName") String brandName,
+            @JsonProperty("brandIconImg") String brandIconImg,
+            @JsonProperty("category1Seq") String category1Seq,
+            @JsonProperty("sale_price") long salePrice,
+            @JsonProperty("real_price") long realPrice,
+            @JsonProperty("limitDay") int limitDay,
+            @JsonProperty("content") String content,
+            @JsonProperty("goods_status") String goodsStatus
+    ) {
+    }
+}

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/vendor/giftishow/exception/GiftishowCommunicationException.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/vendor/giftishow/exception/GiftishowCommunicationException.java
@@ -1,0 +1,12 @@
+package com.personal.marketnote.reward.adapter.out.vendor.giftishow.exception;
+
+public class GiftishowCommunicationException extends RuntimeException {
+
+    public GiftishowCommunicationException(String message) {
+        super(message);
+    }
+
+    public GiftishowCommunicationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/configuration/GiftishowApiProperties.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/configuration/GiftishowApiProperties.java
@@ -1,0 +1,36 @@
+package com.personal.marketnote.reward.configuration;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationProperties(prefix = "vendor.giftishow")
+@Getter
+@Setter
+public class GiftishowApiProperties {
+    private String baseUrl;
+    private String apiCode;
+    private String authCode;
+    private String authToken;
+    private String devYn;
+    private String callbackNo;
+    private String gubun;
+    private Api api = new Api();
+
+    @Getter
+    @Setter
+    public static class Api {
+        private String productListPath;
+        private String productDetailPath;
+        private String brandListPath;
+        private String brandDetailPath;
+        private String couponSendPath;
+        private String couponDetailPath;
+        private String couponCancelPath;
+        private String couponResendPath;
+        private String bizMoneyBalancePath;
+        private String couponSendFailCancelPath;
+    }
+}

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/configuration/GiftishowRestClientConfig.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/configuration/GiftishowRestClientConfig.java
@@ -1,0 +1,19 @@
+package com.personal.marketnote.reward.configuration;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+public class GiftishowRestClientConfig {
+
+    @Bean
+    public RestClient giftishowRestClient(
+            RestClient.Builder restClientBuilder,
+            GiftishowApiProperties giftishowApiProperties
+    ) {
+        return restClientBuilder.clone()
+                .baseUrl(giftishowApiProperties.getBaseUrl())
+                .build();
+    }
+}

--- a/reward-service/reward-adapters/src/main/resources/application.yml
+++ b/reward-service/reward-adapters/src/main/resources/application.yml
@@ -86,6 +86,25 @@ vendor:
       hash-key:
         android: ${ADISCOPE_ANDROID_HASH_KEY:abc}
         ios: ${ADISCOPE_IOS_HASH_KEY:def}
+  giftishow:
+    base-url: ${GIFTISHOW_BASE_URL:https://bizapi.giftishow.com}
+    api-code: ${GIFTISHOW_API_CODE:0000}
+    auth-code: ${GIFTISHOW_AUTH_CODE:0000}
+    auth-token: ${GIFTISHOW_AUTH_TOKEN:0000}
+    dev-yn: ${GIFTISHOW_DEV_YN:Y}
+    callback-no: ${GIFTISHOW_CALLBACK_NO:0000000000}
+    gubun: I
+    api:
+      product-list-path: /bizApi/goods
+      product-detail-path: /bizApi/goods
+      brand-list-path: /bizApi/brand
+      brand-detail-path: /bizApi/brand
+      coupon-send-path: /bizApi/coupon
+      coupon-detail-path: /bizApi/coupon/detail
+      coupon-cancel-path: /bizApi/coupon/cancel
+      coupon-resend-path: /bizApi/coupon/resend
+      biz-money-balance-path: /bizApi/bizMoney
+      coupon-send-fail-cancel-path: /bizApi/coupon/sendFailCancel
 
 logging:
   config: classpath:logback-spring.xml

--- a/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/adapter/out/vendor/giftishow/GiftishowApiClientTest.java
+++ b/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/adapter/out/vendor/giftishow/GiftishowApiClientTest.java
@@ -1,0 +1,544 @@
+package com.personal.marketnote.reward.adapter.out.vendor.giftishow;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.reward.adapter.out.vendor.giftishow.dto.*;
+import com.personal.marketnote.reward.adapter.out.vendor.giftishow.exception.GiftishowCommunicationException;
+import com.personal.marketnote.reward.configuration.GiftishowApiProperties;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.*;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GiftishowApiClient 테스트")
+class GiftishowApiClientTest {
+
+    private static final String BASE_URL = "http://localhost:9999";
+    private static final String API_CODE = "test-api-code";
+    private static final String AUTH_CODE = "test-auth-code";
+    private static final String AUTH_TOKEN = "test-auth-token";
+    private static final String DEV_YN = "Y";
+    private static final String CALLBACK_NO = "0000000000";
+    private static final String GUBUN = "I";
+
+    private MockRestServiceServer mockServer;
+    private GiftishowApiClient giftishowApiClient;
+    private GiftishowApiProperties properties;
+
+    @BeforeEach
+    void setUp() {
+        properties = new GiftishowApiProperties();
+        properties.setBaseUrl(BASE_URL);
+        properties.setApiCode(API_CODE);
+        properties.setAuthCode(AUTH_CODE);
+        properties.setAuthToken(AUTH_TOKEN);
+        properties.setDevYn(DEV_YN);
+        properties.setCallbackNo(CALLBACK_NO);
+        properties.setGubun(GUBUN);
+
+        GiftishowApiProperties.Api api = new GiftishowApiProperties.Api();
+        api.setProductListPath("/bizApi/goods");
+        api.setProductDetailPath("/bizApi/goods");
+        api.setBrandListPath("/bizApi/brand");
+        api.setBrandDetailPath("/bizApi/brand");
+        api.setCouponSendPath("/bizApi/coupon");
+        api.setCouponDetailPath("/bizApi/coupon/detail");
+        api.setCouponCancelPath("/bizApi/coupon/cancel");
+        api.setCouponResendPath("/bizApi/coupon/resend");
+        api.setBizMoneyBalancePath("/bizApi/bizMoney");
+        api.setCouponSendFailCancelPath("/bizApi/coupon/sendFailCancel");
+        properties.setApi(api);
+
+        RestClient.Builder builder = RestClient.builder().baseUrl(BASE_URL);
+        mockServer = MockRestServiceServer.bindTo(builder).build();
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        giftishowApiClient = new GiftishowApiClient(properties, builder.build(), objectMapper);
+    }
+
+    @Nested
+    @DisplayName("getProductList (0101)")
+    class GetProductListTest {
+
+        @Test
+        @DisplayName("상품 리스트 조회에 성공하면 응답을 반환한다")
+        void shouldReturnProductListWhenRequestSucceeds() {
+            // given
+            mockServer.expect(requestTo(BASE_URL + "/bizApi/goods"))
+                    .andExpect(method(HttpMethod.POST))
+                    .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_FORM_URLENCODED))
+                    .andRespond(withSuccess("""
+                            {
+                                "code": "0000",
+                                "message": "success",
+                                "result": {
+                                    "list_total_cnt": 1,
+                                    "goodsList": [
+                                        {
+                                            "goods_code": "G001",
+                                            "goods_name": "테스트 상품",
+                                            "goods_img_B": "http://img.test.com/goods.jpg",
+                                            "brandCode": "B001",
+                                            "brandName": "테스트 브랜드",
+                                            "brandIconImg": "http://img.test.com/brand.jpg",
+                                            "category1Seq": "1",
+                                            "sale_price": 10000,
+                                            "real_price": 12000,
+                                            "limitDay": 30,
+                                            "content": "테스트 상품 설명",
+                                            "goods_status": "SALE"
+                                        }
+                                    ]
+                                }
+                            }
+                            """, MediaType.APPLICATION_JSON));
+
+            // when
+            GiftishowApiResponse<GiftishowProductListResponse> response =
+                    giftishowApiClient.getProductList(0, 20);
+
+            // then
+            assertThat(response.isSuccess()).isTrue();
+            assertThat(response.code()).isEqualTo("0000");
+            assertThat(response.result().listTotalCnt()).isEqualTo(1);
+            assertThat(response.result().goodsList()).hasSize(1);
+
+            GiftishowProductListResponse.GiftishowProductItem item =
+                    response.result().goodsList().getFirst();
+            assertThat(item.goodsCode()).isEqualTo("G001");
+            assertThat(item.goodsName()).isEqualTo("테스트 상품");
+            assertThat(item.brandCode()).isEqualTo("B001");
+            assertThat(item.salePrice()).isEqualTo(10000L);
+            assertThat(item.limitDay()).isEqualTo(30);
+
+            mockServer.verify();
+        }
+
+        @Test
+        @DisplayName("응답 본문이 비어 있으면 GiftishowCommunicationException이 발생한다")
+        void shouldThrowExceptionWhenResponseBodyIsEmpty() {
+            // given
+            mockServer.expect(requestTo(BASE_URL + "/bizApi/goods"))
+                    .andExpect(method(HttpMethod.POST))
+                    .andRespond(withSuccess("", MediaType.APPLICATION_JSON));
+
+            // when & then
+            assertThatThrownBy(() -> giftishowApiClient.getProductList(0, 20))
+                    .isInstanceOf(GiftishowCommunicationException.class)
+                    .hasMessageContaining("응답 본문이 비어 있습니다");
+
+            mockServer.verify();
+        }
+
+        @Test
+        @DisplayName("응답 JSON이 잘못된 형식이면 GiftishowCommunicationException이 발생한다")
+        void shouldThrowExceptionWhenResponseJsonIsInvalid() {
+            // given
+            mockServer.expect(requestTo(BASE_URL + "/bizApi/goods"))
+                    .andExpect(method(HttpMethod.POST))
+                    .andRespond(withSuccess("invalid json", MediaType.APPLICATION_JSON));
+
+            // when & then
+            assertThatThrownBy(() -> giftishowApiClient.getProductList(0, 20))
+                    .isInstanceOf(GiftishowCommunicationException.class)
+                    .hasMessageContaining("응답 파싱 실패");
+
+            mockServer.verify();
+        }
+    }
+
+    @Nested
+    @DisplayName("getProductDetail (0111)")
+    class GetProductDetailTest {
+
+        @Test
+        @DisplayName("상품 상세 조회에 성공하면 응답을 반환한다")
+        void shouldReturnProductDetailWhenRequestSucceeds() {
+            // given
+            mockServer.expect(requestTo(BASE_URL + "/bizApi/goods?api_code=test-api-code&auth_code=test-auth-code&auth_token=test-auth-token&dev_yn=Y&goods_code=G001"))
+                    .andExpect(method(HttpMethod.GET))
+                    .andRespond(withSuccess("""
+                            {
+                                "code": "0000",
+                                "message": "success",
+                                "result": {
+                                    "goods_code": "G001",
+                                    "goods_name": "테스트 상품",
+                                    "goods_img_B": "http://img.test.com/goods.jpg",
+                                    "brandCode": "B001",
+                                    "brandName": "테스트 브랜드",
+                                    "brandIconImg": "http://img.test.com/brand.jpg",
+                                    "category1Seq": "1",
+                                    "sale_price": 10000,
+                                    "real_price": 12000,
+                                    "limitDay": 30,
+                                    "content": "테스트 상품 설명",
+                                    "goods_status": "SALE"
+                                }
+                            }
+                            """, MediaType.APPLICATION_JSON));
+
+            // when
+            GiftishowApiResponse<GiftishowProductDetailResponse> response =
+                    giftishowApiClient.getProductDetail("G001");
+
+            // then
+            assertThat(response.isSuccess()).isTrue();
+            assertThat(response.result().goodsCode()).isEqualTo("G001");
+            assertThat(response.result().goodsName()).isEqualTo("테스트 상품");
+            assertThat(response.result().salePrice()).isEqualTo(10000L);
+
+            mockServer.verify();
+        }
+    }
+
+    @Nested
+    @DisplayName("getBrandList (0102)")
+    class GetBrandListTest {
+
+        @Test
+        @DisplayName("브랜드 조회에 성공하면 응답을 반환한다")
+        void shouldReturnBrandListWhenRequestSucceeds() {
+            // given
+            mockServer.expect(requestTo(BASE_URL + "/bizApi/brand"))
+                    .andExpect(method(HttpMethod.POST))
+                    .andRespond(withSuccess("""
+                            {
+                                "code": "0000",
+                                "message": "success",
+                                "result": {
+                                    "list_total_cnt": 1,
+                                    "brandList": [
+                                        {
+                                            "brand_code": "B001",
+                                            "brand_name": "테스트 브랜드",
+                                            "brand_icon_img": "http://img.test.com/brand.jpg",
+                                            "category1Seq": "1",
+                                            "category1Name": "카페/음료"
+                                        }
+                                    ]
+                                }
+                            }
+                            """, MediaType.APPLICATION_JSON));
+
+            // when
+            GiftishowApiResponse<GiftishowBrandListResponse> response =
+                    giftishowApiClient.getBrandList();
+
+            // then
+            assertThat(response.isSuccess()).isTrue();
+            assertThat(response.result().brandList()).hasSize(1);
+
+            GiftishowBrandListResponse.GiftishowBrandItem item =
+                    response.result().brandList().getFirst();
+            assertThat(item.brandCode()).isEqualTo("B001");
+            assertThat(item.brandName()).isEqualTo("테스트 브랜드");
+            assertThat(item.category1Name()).isEqualTo("카페/음료");
+
+            mockServer.verify();
+        }
+    }
+
+    @Nested
+    @DisplayName("getBrandDetail (0112)")
+    class GetBrandDetailTest {
+
+        @Test
+        @DisplayName("브랜드 상세 조회에 성공하면 응답을 반환한다")
+        void shouldReturnBrandDetailWhenRequestSucceeds() {
+            // given
+            mockServer.expect(requestTo(BASE_URL + "/bizApi/brand?api_code=test-api-code&auth_code=test-auth-code&auth_token=test-auth-token&dev_yn=Y&brand_code=B001"))
+                    .andExpect(method(HttpMethod.GET))
+                    .andRespond(withSuccess("""
+                            {
+                                "code": "0000",
+                                "message": "success",
+                                "result": {
+                                    "brand_code": "B001",
+                                    "brand_name": "테스트 브랜드",
+                                    "brand_icon_img": "http://img.test.com/brand.jpg",
+                                    "category1Seq": "1",
+                                    "category1Name": "카페/음료"
+                                }
+                            }
+                            """, MediaType.APPLICATION_JSON));
+
+            // when
+            GiftishowApiResponse<GiftishowBrandDetailResponse> response =
+                    giftishowApiClient.getBrandDetail("B001");
+
+            // then
+            assertThat(response.isSuccess()).isTrue();
+            assertThat(response.result().brandCode()).isEqualTo("B001");
+            assertThat(response.result().category1Name()).isEqualTo("카페/음료");
+
+            mockServer.verify();
+        }
+    }
+
+    @Nested
+    @DisplayName("sendCoupon (0204)")
+    class SendCouponTest {
+
+        @Test
+        @DisplayName("쿠폰 발송에 성공하면 응답을 반환한다")
+        void shouldReturnCouponSendResponseWhenRequestSucceeds() {
+            // given
+            mockServer.expect(requestTo(BASE_URL + "/bizApi/coupon"))
+                    .andExpect(method(HttpMethod.POST))
+                    .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_FORM_URLENCODED))
+                    .andRespond(withSuccess("""
+                            {
+                                "code": "0000",
+                                "message": "success",
+                                "result": {
+                                    "tr_id": "NTCASH_1_20260403120000",
+                                    "order_no": "ORD001",
+                                    "pin_no": "1234-5678-9012",
+                                    "coupon_img_url": "http://img.test.com/coupon.jpg",
+                                    "valid_prd_end_dt": "20260503"
+                                }
+                            }
+                            """, MediaType.APPLICATION_JSON));
+
+            // when
+            GiftishowApiResponse<GiftishowCouponSendResponse> response =
+                    giftishowApiClient.sendCoupon(
+                            "NTCASH_1_20260403120000",
+                            "G001",
+                            "01012345678",
+                            "user1",
+                            "기프티콘 발송",
+                            "뉴트리캐시"
+                    );
+
+            // then
+            assertThat(response.isSuccess()).isTrue();
+            assertThat(response.result().trId()).isEqualTo("NTCASH_1_20260403120000");
+            assertThat(response.result().orderNo()).isEqualTo("ORD001");
+            assertThat(response.result().pinNo()).isEqualTo("1234-5678-9012");
+            assertThat(response.result().couponImgUrl()).isEqualTo("http://img.test.com/coupon.jpg");
+            assertThat(response.result().validPrdEndDt()).isEqualTo("20260503");
+
+            mockServer.verify();
+        }
+    }
+
+    @Nested
+    @DisplayName("getCouponDetail (0201)")
+    class GetCouponDetailTest {
+
+        @Test
+        @DisplayName("쿠폰 상세 조회에 성공하면 응답을 반환한다")
+        void shouldReturnCouponDetailWhenRequestSucceeds() {
+            // given
+            mockServer.expect(requestTo(BASE_URL + "/bizApi/coupon/detail"))
+                    .andExpect(method(HttpMethod.POST))
+                    .andRespond(withSuccess("""
+                            {
+                                "code": "0000",
+                                "message": "success",
+                                "result": {
+                                    "tr_id": "NTCASH_1_20260403120000",
+                                    "order_no": "ORD001",
+                                    "pin_status_cd": "01",
+                                    "pin_status_nm": "발행",
+                                    "valid_prd_end_dt": "20260503",
+                                    "goods_code": "G001",
+                                    "goods_name": "테스트 상품"
+                                }
+                            }
+                            """, MediaType.APPLICATION_JSON));
+
+            // when
+            GiftishowApiResponse<GiftishowCouponDetailResponse> response =
+                    giftishowApiClient.getCouponDetail("NTCASH_1_20260403120000");
+
+            // then
+            assertThat(response.isSuccess()).isTrue();
+            assertThat(response.result().pinStatusCd()).isEqualTo("01");
+            assertThat(response.result().pinStatusNm()).isEqualTo("발행");
+            assertThat(response.result().validPrdEndDt()).isEqualTo("20260503");
+
+            mockServer.verify();
+        }
+    }
+
+    @Nested
+    @DisplayName("cancelCoupon (0202)")
+    class CancelCouponTest {
+
+        @Test
+        @DisplayName("쿠폰 취소에 성공하면 응답을 반환한다")
+        void shouldReturnCancelResponseWhenRequestSucceeds() {
+            // given
+            mockServer.expect(requestTo(BASE_URL + "/bizApi/coupon/cancel"))
+                    .andExpect(method(HttpMethod.POST))
+                    .andRespond(withSuccess("""
+                            {
+                                "code": "0000",
+                                "message": "success",
+                                "result": {
+                                    "tr_id": "NTCASH_1_20260403120000",
+                                    "order_no": "ORD001"
+                                }
+                            }
+                            """, MediaType.APPLICATION_JSON));
+
+            // when
+            GiftishowApiResponse<GiftishowCouponCancelResponse> response =
+                    giftishowApiClient.cancelCoupon("NTCASH_1_20260403120000", "user1");
+
+            // then
+            assertThat(response.isSuccess()).isTrue();
+            assertThat(response.result().trId()).isEqualTo("NTCASH_1_20260403120000");
+
+            mockServer.verify();
+        }
+    }
+
+    @Nested
+    @DisplayName("resendCoupon (0203)")
+    class ResendCouponTest {
+
+        @Test
+        @DisplayName("쿠폰 재전송에 성공하면 응답을 반환한다")
+        void shouldReturnResendResponseWhenRequestSucceeds() {
+            // given
+            mockServer.expect(requestTo(BASE_URL + "/bizApi/coupon/resend"))
+                    .andExpect(method(HttpMethod.POST))
+                    .andRespond(withSuccess("""
+                            {
+                                "code": "0000",
+                                "message": "success",
+                                "result": {
+                                    "tr_id": "NTCASH_1_20260403120000",
+                                    "order_no": "ORD001"
+                                }
+                            }
+                            """, MediaType.APPLICATION_JSON));
+
+            // when
+            GiftishowApiResponse<GiftishowCouponResendResponse> response =
+                    giftishowApiClient.resendCoupon("NTCASH_1_20260403120000", "01012345678");
+
+            // then
+            assertThat(response.isSuccess()).isTrue();
+            assertThat(response.result().trId()).isEqualTo("NTCASH_1_20260403120000");
+
+            mockServer.verify();
+        }
+    }
+
+    @Nested
+    @DisplayName("getBizMoneyBalance (0301)")
+    class GetBizMoneyBalanceTest {
+
+        @Test
+        @DisplayName("비즈머니 잔액 조회에 성공하면 응답을 반환한다")
+        void shouldReturnBizMoneyBalanceWhenRequestSucceeds() {
+            // given
+            mockServer.expect(requestTo(BASE_URL + "/bizApi/bizMoney"))
+                    .andExpect(method(HttpMethod.POST))
+                    .andRespond(withSuccess("""
+                            {
+                                "code": "0000",
+                                "message": "success",
+                                "result": {
+                                    "user_id": "user1",
+                                    "biz_money": 500000
+                                }
+                            }
+                            """, MediaType.APPLICATION_JSON));
+
+            // when
+            GiftishowApiResponse<GiftishowBizMoneyResponse> response =
+                    giftishowApiClient.getBizMoneyBalance("user1");
+
+            // then
+            assertThat(response.isSuccess()).isTrue();
+            assertThat(response.result().userId()).isEqualTo("user1");
+            assertThat(response.result().bizMoney()).isEqualTo(500000L);
+
+            mockServer.verify();
+        }
+    }
+
+    @Nested
+    @DisplayName("cancelSendFailedCoupon (0205)")
+    class CancelSendFailedCouponTest {
+
+        @Test
+        @DisplayName("발송실패 취소에 성공하면 응답을 반환한다")
+        void shouldReturnCancelResponseWhenRequestSucceeds() {
+            // given
+            mockServer.expect(requestTo(BASE_URL + "/bizApi/coupon/sendFailCancel"))
+                    .andExpect(method(HttpMethod.POST))
+                    .andRespond(withSuccess("""
+                            {
+                                "code": "0000",
+                                "message": "success",
+                                "result": {
+                                    "tr_id": "NTCASH_1_20260403120000",
+                                    "order_no": "ORD001"
+                                }
+                            }
+                            """, MediaType.APPLICATION_JSON));
+
+            // when
+            GiftishowApiResponse<GiftishowCouponCancelResponse> response =
+                    giftishowApiClient.cancelSendFailedCoupon("NTCASH_1_20260403120000", "user1");
+
+            // then
+            assertThat(response.isSuccess()).isTrue();
+            assertThat(response.result().trId()).isEqualTo("NTCASH_1_20260403120000");
+
+            mockServer.verify();
+        }
+    }
+
+    @Nested
+    @DisplayName("GiftishowApiResponse 공통 검증")
+    class ApiResponseTest {
+
+        @Test
+        @DisplayName("응답 코드가 0000이 아니면 isSuccess는 false를 반환한다")
+        void shouldReturnFalseWhenCodeIsNotSuccess() {
+            // given
+            mockServer.expect(requestTo(BASE_URL + "/bizApi/bizMoney"))
+                    .andExpect(method(HttpMethod.POST))
+                    .andRespond(withSuccess("""
+                            {
+                                "code": "9999",
+                                "message": "인증 실패",
+                                "result": {
+                                    "user_id": "user1",
+                                    "biz_money": 0
+                                }
+                            }
+                            """, MediaType.APPLICATION_JSON));
+
+            // when
+            GiftishowApiResponse<GiftishowBizMoneyResponse> response =
+                    giftishowApiClient.getBizMoneyBalance("user1");
+
+            // then
+            assertThat(response.isSuccess()).isFalse();
+            assertThat(response.code()).isEqualTo("9999");
+            assertThat(response.message()).isEqualTo("인증 실패");
+
+            mockServer.verify();
+        }
+    }
+}


### PR DESCRIPTION
## partially addresses #1653
## resolves #1654

## Task
- [x] GiftishowApiProperties 설정 클래스 (baseUrl, apiCode, authCode, authToken, devYn, callbackNo, gubun)
- [x] GiftishowRestClientConfig Bean 설정 (RestClient.Builder.clone() 적용)
- [x] GiftishowApiClient 10개 API 메서드 구현 (0101, 0111, 0102, 0112, 0204, 0201, 0202, 0203, 0301, 0205)
- [x] 공통 요청/응답 DTO 10개 정의 (record 기반, @JsonIgnoreProperties)
- [x] GiftishowCommunicationException 예외 클래스 정의
- [x] application.yml vendor.giftishow 설정 추가
- [x] Content-Type: application/x-www-form-urlencoded 요청 설정