### PR TITLE
[#1653][#1655] feat: 기프티콘 도메인 모델 및 DB 스키마 구축

### DIFF
--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/gifticon/entity/GifticonBrandJpaEntity.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/gifticon/entity/GifticonBrandJpaEntity.java
@@ -1,0 +1,55 @@
+package com.personal.marketnote.reward.adapter.out.persistence.gifticon.entity;
+
+import com.personal.marketnote.common.adapter.out.persistence.audit.BaseEntity;
+import com.personal.marketnote.reward.domain.gifticon.GifticonBrand;
+import com.personal.marketnote.reward.domain.gifticon.GifticonBrandSnapshotState;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "gifticon_brand")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+@Getter
+public class GifticonBrandJpaEntity extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "brand_code", nullable = false, unique = true)
+    private String brandCode;
+
+    @Column(name = "brand_name", nullable = false)
+    private String brandName;
+
+    @Column(name = "brand_image_url")
+    private String brandImageUrl;
+
+    public static GifticonBrandJpaEntity from(GifticonBrand domain) {
+        return GifticonBrandJpaEntity.builder()
+                .id(domain.getId())
+                .brandCode(domain.getBrandCode())
+                .brandName(domain.getBrandName())
+                .brandImageUrl(domain.getBrandImageUrl())
+                .build();
+    }
+
+    public GifticonBrand toDomain() {
+        return GifticonBrand.from(
+                GifticonBrandSnapshotState.builder()
+                        .id(id)
+                        .brandCode(brandCode)
+                        .brandName(brandName)
+                        .brandImageUrl(brandImageUrl)
+                        .createdAt(getCreatedAt())
+                        .modifiedAt(getModifiedAt())
+                        .build()
+        );
+    }
+
+    public void updateFrom(GifticonBrand domain) {
+        this.brandName = domain.getBrandName();
+        this.brandImageUrl = domain.getBrandImageUrl();
+    }
+}

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/gifticon/entity/GifticonCategoryJpaEntity.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/gifticon/entity/GifticonCategoryJpaEntity.java
@@ -1,0 +1,73 @@
+package com.personal.marketnote.reward.adapter.out.persistence.gifticon.entity;
+
+import com.personal.marketnote.common.adapter.out.persistence.audit.BaseEntity;
+import com.personal.marketnote.reward.domain.gifticon.GifticonCategory;
+import com.personal.marketnote.reward.domain.gifticon.GifticonCategorySnapshotState;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "gifticon_category")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+@Getter
+public class GifticonCategoryJpaEntity extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "category_code", nullable = false, unique = true)
+    private String categoryCode;
+
+    @Column(name = "category_name", nullable = false)
+    private String categoryName;
+
+    @Column(name = "display_name")
+    private String displayName;
+
+    @Column(name = "icon_url")
+    private String iconUrl;
+
+    @Column(name = "exposed", nullable = false)
+    private boolean exposed;
+
+    @Column(name = "order_num")
+    private Integer orderNum;
+
+    public static GifticonCategoryJpaEntity from(GifticonCategory domain) {
+        return GifticonCategoryJpaEntity.builder()
+                .id(domain.getId())
+                .categoryCode(domain.getCategoryCode())
+                .categoryName(domain.getCategoryName())
+                .displayName(domain.getDisplayName())
+                .iconUrl(domain.getIconUrl())
+                .exposed(domain.isExposed())
+                .orderNum(domain.getOrderNum())
+                .build();
+    }
+
+    public GifticonCategory toDomain() {
+        return GifticonCategory.from(
+                GifticonCategorySnapshotState.builder()
+                        .id(id)
+                        .categoryCode(categoryCode)
+                        .categoryName(categoryName)
+                        .displayName(displayName)
+                        .iconUrl(iconUrl)
+                        .exposed(exposed)
+                        .orderNum(orderNum)
+                        .createdAt(getCreatedAt())
+                        .modifiedAt(getModifiedAt())
+                        .build()
+        );
+    }
+
+    public void updateFrom(GifticonCategory domain) {
+        this.categoryName = domain.getCategoryName();
+        this.displayName = domain.getDisplayName();
+        this.iconUrl = domain.getIconUrl();
+        this.exposed = domain.isExposed();
+        this.orderNum = domain.getOrderNum();
+    }
+}

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/gifticon/entity/GifticonCategoryMappingJpaEntity.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/gifticon/entity/GifticonCategoryMappingJpaEntity.java
@@ -1,0 +1,30 @@
+package com.personal.marketnote.reward.adapter.out.persistence.gifticon.entity;
+
+import com.personal.marketnote.common.adapter.out.persistence.audit.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "gifticon_category_mapping")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+@Getter
+public class GifticonCategoryMappingJpaEntity extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "giftishow_category_seq", nullable = false, unique = true)
+    private String giftishowCategorySeq;
+
+    @Column(name = "gifticon_category_id", nullable = false)
+    private Long gifticonCategoryId;
+
+    public static GifticonCategoryMappingJpaEntity of(String giftishowCategorySeq, Long gifticonCategoryId) {
+        return GifticonCategoryMappingJpaEntity.builder()
+                .giftishowCategorySeq(giftishowCategorySeq)
+                .gifticonCategoryId(gifticonCategoryId)
+                .build();
+    }
+}

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/gifticon/entity/GifticonGoodsJpaEntity.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/gifticon/entity/GifticonGoodsJpaEntity.java
@@ -1,0 +1,127 @@
+package com.personal.marketnote.reward.adapter.out.persistence.gifticon.entity;
+
+import com.personal.marketnote.common.adapter.out.persistence.audit.BaseEntity;
+import com.personal.marketnote.reward.domain.gifticon.GifticonGoods;
+import com.personal.marketnote.reward.domain.gifticon.GifticonGoodsSnapshotState;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "gifticon_goods")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+@Getter
+public class GifticonGoodsJpaEntity extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "goods_code", nullable = false, unique = true)
+    private String goodsCode;
+
+    @Column(name = "goods_name", nullable = false)
+    private String goodsName;
+
+    @Column(name = "brand_code", nullable = false)
+    private String brandCode;
+
+    @Column(name = "brand_name", nullable = false)
+    private String brandName;
+
+    @Column(name = "brand_image_url")
+    private String brandImageUrl;
+
+    @Column(name = "category_code")
+    private String categoryCode;
+
+    @Column(name = "real_price", nullable = false)
+    private Long realPrice;
+
+    @Column(name = "sale_price", nullable = false)
+    private Long salePrice;
+
+    @Column(name = "cash_price", nullable = false)
+    private Long cashPrice;
+
+    @Column(name = "image_url")
+    private String imageUrl;
+
+    @Column(name = "description", columnDefinition = "TEXT")
+    private String description;
+
+    @Column(name = "valid_days")
+    private Integer validDays;
+
+    @Column(name = "goods_status", nullable = false)
+    private String goodsStatus;
+
+    @Column(name = "exposed", nullable = false)
+    private boolean exposed;
+
+    @Column(name = "order_num")
+    private Integer orderNum;
+
+    public static GifticonGoodsJpaEntity from(GifticonGoods domain) {
+        return GifticonGoodsJpaEntity.builder()
+                .id(domain.getId())
+                .goodsCode(domain.getGoodsCode())
+                .goodsName(domain.getGoodsName())
+                .brandCode(domain.getBrandCode())
+                .brandName(domain.getBrandName())
+                .brandImageUrl(domain.getBrandImageUrl())
+                .categoryCode(domain.getCategoryCode())
+                .realPrice(domain.getRealPrice())
+                .salePrice(domain.getSalePrice())
+                .cashPrice(domain.getCashPrice())
+                .imageUrl(domain.getImageUrl())
+                .description(domain.getDescription())
+                .validDays(domain.getValidDays())
+                .goodsStatus(domain.getGoodsStatus())
+                .exposed(domain.isExposed())
+                .orderNum(domain.getOrderNum())
+                .build();
+    }
+
+    public GifticonGoods toDomain() {
+        return GifticonGoods.from(
+                GifticonGoodsSnapshotState.builder()
+                        .id(id)
+                        .goodsCode(goodsCode)
+                        .goodsName(goodsName)
+                        .brandCode(brandCode)
+                        .brandName(brandName)
+                        .brandImageUrl(brandImageUrl)
+                        .categoryCode(categoryCode)
+                        .realPrice(realPrice)
+                        .salePrice(salePrice)
+                        .cashPrice(cashPrice)
+                        .imageUrl(imageUrl)
+                        .description(description)
+                        .validDays(validDays)
+                        .goodsStatus(goodsStatus)
+                        .exposed(exposed)
+                        .orderNum(orderNum)
+                        .createdAt(getCreatedAt())
+                        .modifiedAt(getModifiedAt())
+                        .build()
+        );
+    }
+
+    public void updateFrom(GifticonGoods domain) {
+        this.goodsName = domain.getGoodsName();
+        this.brandCode = domain.getBrandCode();
+        this.brandName = domain.getBrandName();
+        this.brandImageUrl = domain.getBrandImageUrl();
+        this.categoryCode = domain.getCategoryCode();
+        this.realPrice = domain.getRealPrice();
+        this.salePrice = domain.getSalePrice();
+        this.cashPrice = domain.getCashPrice();
+        this.imageUrl = domain.getImageUrl();
+        this.description = domain.getDescription();
+        this.validDays = domain.getValidDays();
+        this.goodsStatus = domain.getGoodsStatus();
+        this.exposed = domain.isExposed();
+        this.orderNum = domain.getOrderNum();
+    }
+}

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/gifticon/entity/GifticonOrderJpaEntity.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/gifticon/entity/GifticonOrderJpaEntity.java
@@ -1,0 +1,107 @@
+package com.personal.marketnote.reward.adapter.out.persistence.gifticon.entity;
+
+import com.personal.marketnote.common.adapter.out.persistence.audit.BaseEntity;
+import com.personal.marketnote.reward.domain.gifticon.GifticonOrder;
+import com.personal.marketnote.reward.domain.gifticon.GifticonOrderSnapshotState;
+import com.personal.marketnote.reward.domain.gifticon.GifticonOrderStatus;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "gifticon_order")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+@Getter
+public class GifticonOrderJpaEntity extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "goods_code", nullable = false)
+    private String goodsCode;
+
+    @Column(name = "goods_name", nullable = false)
+    private String goodsName;
+
+    @Column(name = "brand_name")
+    private String brandName;
+
+    @Column(name = "product_image_url")
+    private String productImageUrl;
+
+    @Column(name = "tr_id", nullable = false, unique = true)
+    private String trId;
+
+    @Column(name = "order_no")
+    private String orderNo;
+
+    @Column(name = "cash_price", nullable = false)
+    private Long cashPrice;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "order_status", nullable = false)
+    private GifticonOrderStatus orderStatus;
+
+    @Column(name = "coupon_image_url")
+    private String couponImageUrl;
+
+    @Column(name = "pin_no")
+    private String pinNo;
+
+    @Column(name = "valid_end_date")
+    private LocalDate validEndDate;
+
+    public static GifticonOrderJpaEntity from(GifticonOrder domain) {
+        return GifticonOrderJpaEntity.builder()
+                .id(domain.getId())
+                .userId(domain.getUserId())
+                .goodsCode(domain.getGoodsCode())
+                .goodsName(domain.getGoodsName())
+                .brandName(domain.getBrandName())
+                .productImageUrl(domain.getProductImageUrl())
+                .trId(domain.getTrId())
+                .orderNo(domain.getOrderNo())
+                .cashPrice(domain.getCashPrice())
+                .orderStatus(domain.getOrderStatus())
+                .couponImageUrl(domain.getCouponImageUrl())
+                .pinNo(domain.getPinNo())
+                .validEndDate(domain.getValidEndDate())
+                .build();
+    }
+
+    public GifticonOrder toDomain() {
+        return GifticonOrder.from(
+                GifticonOrderSnapshotState.builder()
+                        .id(id)
+                        .userId(userId)
+                        .goodsCode(goodsCode)
+                        .goodsName(goodsName)
+                        .brandName(brandName)
+                        .productImageUrl(productImageUrl)
+                        .trId(trId)
+                        .orderNo(orderNo)
+                        .cashPrice(cashPrice)
+                        .orderStatus(orderStatus)
+                        .couponImageUrl(couponImageUrl)
+                        .pinNo(pinNo)
+                        .validEndDate(validEndDate)
+                        .createdAt(getCreatedAt())
+                        .modifiedAt(getModifiedAt())
+                        .build()
+        );
+    }
+
+    public void updateFrom(GifticonOrder domain) {
+        this.orderNo = domain.getOrderNo();
+        this.orderStatus = domain.getOrderStatus();
+        this.couponImageUrl = domain.getCouponImageUrl();
+        this.pinNo = domain.getPinNo();
+        this.validEndDate = domain.getValidEndDate();
+    }
+}

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/gifticon/repository/GifticonBrandJpaRepository.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/gifticon/repository/GifticonBrandJpaRepository.java
@@ -1,0 +1,13 @@
+package com.personal.marketnote.reward.adapter.out.persistence.gifticon.repository;
+
+import com.personal.marketnote.reward.adapter.out.persistence.gifticon.entity.GifticonBrandJpaEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface GifticonBrandJpaRepository extends JpaRepository<GifticonBrandJpaEntity, Long> {
+
+    Optional<GifticonBrandJpaEntity> findByBrandCode(String brandCode);
+
+    boolean existsByBrandCode(String brandCode);
+}

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/gifticon/repository/GifticonCategoryJpaRepository.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/gifticon/repository/GifticonCategoryJpaRepository.java
@@ -1,0 +1,11 @@
+package com.personal.marketnote.reward.adapter.out.persistence.gifticon.repository;
+
+import com.personal.marketnote.reward.adapter.out.persistence.gifticon.entity.GifticonCategoryJpaEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface GifticonCategoryJpaRepository extends JpaRepository<GifticonCategoryJpaEntity, Long> {
+
+    Optional<GifticonCategoryJpaEntity> findByCategoryCode(String categoryCode);
+}

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/gifticon/repository/GifticonCategoryMappingJpaRepository.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/gifticon/repository/GifticonCategoryMappingJpaRepository.java
@@ -1,0 +1,11 @@
+package com.personal.marketnote.reward.adapter.out.persistence.gifticon.repository;
+
+import com.personal.marketnote.reward.adapter.out.persistence.gifticon.entity.GifticonCategoryMappingJpaEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface GifticonCategoryMappingJpaRepository extends JpaRepository<GifticonCategoryMappingJpaEntity, Long> {
+
+    Optional<GifticonCategoryMappingJpaEntity> findByGiftishowCategorySeq(String giftishowCategorySeq);
+}

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/gifticon/repository/GifticonGoodsJpaRepository.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/gifticon/repository/GifticonGoodsJpaRepository.java
@@ -1,0 +1,13 @@
+package com.personal.marketnote.reward.adapter.out.persistence.gifticon.repository;
+
+import com.personal.marketnote.reward.adapter.out.persistence.gifticon.entity.GifticonGoodsJpaEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface GifticonGoodsJpaRepository extends JpaRepository<GifticonGoodsJpaEntity, Long> {
+
+    Optional<GifticonGoodsJpaEntity> findByGoodsCode(String goodsCode);
+
+    boolean existsByGoodsCode(String goodsCode);
+}

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/gifticon/repository/GifticonOrderJpaRepository.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/gifticon/repository/GifticonOrderJpaRepository.java
@@ -1,0 +1,13 @@
+package com.personal.marketnote.reward.adapter.out.persistence.gifticon.repository;
+
+import com.personal.marketnote.reward.adapter.out.persistence.gifticon.entity.GifticonOrderJpaEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface GifticonOrderJpaRepository extends JpaRepository<GifticonOrderJpaEntity, Long> {
+
+    Optional<GifticonOrderJpaEntity> findByTrId(String trId);
+
+    boolean existsByTrId(String trId);
+}

--- a/reward-service/reward-adapters/src/main/resources/data-gifticon-category.sql
+++ b/reward-service/reward-adapters/src/main/resources/data-gifticon-category.sql
@@ -1,0 +1,62 @@
+-- 기프티콘 카테고리 초기 데이터 (기프티쇼 API 기준 7개 카테고리)
+-- 실행 방법: 최초 배포 시 수동 실행 또는 application.yml sql.init.data-locations에 추가
+
+INSERT INTO gifticon_category (category_code, category_name, display_name, icon_url, exposed, order_num, created_at, modified_at)
+VALUES ('1', '편의점', NULL, NULL, false, NULL, NOW(), NOW())
+ON CONFLICT (category_code) DO NOTHING;
+
+INSERT INTO gifticon_category (category_code, category_name, display_name, icon_url, exposed, order_num, created_at, modified_at)
+VALUES ('2', '외식/배달', NULL, NULL, false, NULL, NOW(), NOW())
+ON CONFLICT (category_code) DO NOTHING;
+
+INSERT INTO gifticon_category (category_code, category_name, display_name, icon_url, exposed, order_num, created_at, modified_at)
+VALUES ('3', '카페/베이커리', NULL, NULL, false, NULL, NOW(), NOW())
+ON CONFLICT (category_code) DO NOTHING;
+
+INSERT INTO gifticon_category (category_code, category_name, display_name, icon_url, exposed, order_num, created_at, modified_at)
+VALUES ('4', '아이스크림', NULL, NULL, false, NULL, NOW(), NOW())
+ON CONFLICT (category_code) DO NOTHING;
+
+INSERT INTO gifticon_category (category_code, category_name, display_name, icon_url, exposed, order_num, created_at, modified_at)
+VALUES ('5', '뷰티/패션', NULL, NULL, false, NULL, NOW(), NOW())
+ON CONFLICT (category_code) DO NOTHING;
+
+INSERT INTO gifticon_category (category_code, category_name, display_name, icon_url, exposed, order_num, created_at, modified_at)
+VALUES ('6', '생활/건강', NULL, NULL, false, NULL, NOW(), NOW())
+ON CONFLICT (category_code) DO NOTHING;
+
+INSERT INTO gifticon_category (category_code, category_name, display_name, icon_url, exposed, order_num, created_at, modified_at)
+VALUES ('7', '기타', NULL, NULL, false, NULL, NOW(), NOW())
+ON CONFLICT (category_code) DO NOTHING;
+
+-- 기프티콘 카테고리 매핑 초기 데이터 (기프티쇼 category1Seq → 자체 카테고리)
+-- giftishow_category_seq는 기프티쇼 API 브랜드 조회(0102) 응답의 category1Seq 값
+-- gifticon_category_id는 위 gifticon_category 테이블의 id (순서대로 1~7)
+
+INSERT INTO gifticon_category_mapping (giftishow_category_seq, gifticon_category_id, created_at, modified_at)
+VALUES ('1', 1, NOW(), NOW())
+ON CONFLICT DO NOTHING;
+
+INSERT INTO gifticon_category_mapping (giftishow_category_seq, gifticon_category_id, created_at, modified_at)
+VALUES ('2', 2, NOW(), NOW())
+ON CONFLICT DO NOTHING;
+
+INSERT INTO gifticon_category_mapping (giftishow_category_seq, gifticon_category_id, created_at, modified_at)
+VALUES ('3', 3, NOW(), NOW())
+ON CONFLICT DO NOTHING;
+
+INSERT INTO gifticon_category_mapping (giftishow_category_seq, gifticon_category_id, created_at, modified_at)
+VALUES ('4', 4, NOW(), NOW())
+ON CONFLICT DO NOTHING;
+
+INSERT INTO gifticon_category_mapping (giftishow_category_seq, gifticon_category_id, created_at, modified_at)
+VALUES ('5', 5, NOW(), NOW())
+ON CONFLICT DO NOTHING;
+
+INSERT INTO gifticon_category_mapping (giftishow_category_seq, gifticon_category_id, created_at, modified_at)
+VALUES ('6', 6, NOW(), NOW())
+ON CONFLICT DO NOTHING;
+
+INSERT INTO gifticon_category_mapping (giftishow_category_seq, gifticon_category_id, created_at, modified_at)
+VALUES ('7', 7, NOW(), NOW())
+ON CONFLICT DO NOTHING;

--- a/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/exception/GifticonGoodsNotFoundException.java
+++ b/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/exception/GifticonGoodsNotFoundException.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.reward.domain.exception;
+
+public class GifticonGoodsNotFoundException extends RuntimeException {
+    private static final String MESSAGE = "기프티콘 상품을 찾을 수 없습니다. goodsCode=%s";
+
+    public GifticonGoodsNotFoundException(String goodsCode) {
+        super(String.format(MESSAGE, goodsCode));
+    }
+}

--- a/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/exception/GifticonOrderNotFoundException.java
+++ b/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/exception/GifticonOrderNotFoundException.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.reward.domain.exception;
+
+public class GifticonOrderNotFoundException extends RuntimeException {
+    private static final String MESSAGE = "기프티콘 주문을 찾을 수 없습니다. trId=%s";
+
+    public GifticonOrderNotFoundException(String trId) {
+        super(String.format(MESSAGE, trId));
+    }
+}

--- a/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/exception/InvalidGifticonOrderStatusTransitionException.java
+++ b/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/exception/InvalidGifticonOrderStatusTransitionException.java
@@ -1,0 +1,11 @@
+package com.personal.marketnote.reward.domain.exception;
+
+import com.personal.marketnote.reward.domain.gifticon.GifticonOrderStatus;
+
+public class InvalidGifticonOrderStatusTransitionException extends IllegalStateException {
+    private static final String MESSAGE = "기프티콘 주문 상태 전이가 유효하지 않습니다. 현재 상태=%s";
+
+    public InvalidGifticonOrderStatusTransitionException(GifticonOrderStatus currentStatus) {
+        super(String.format(MESSAGE, currentStatus));
+    }
+}

--- a/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/gifticon/GifticonBrand.java
+++ b/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/gifticon/GifticonBrand.java
@@ -1,0 +1,42 @@
+package com.personal.marketnote.reward.domain.gifticon;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+public class GifticonBrand {
+    private Long id;
+    private String brandCode;
+    private String brandName;
+    private String brandImageUrl;
+    private LocalDateTime createdAt;
+    private LocalDateTime modifiedAt;
+
+    public static GifticonBrand from(GifticonBrandCreateState state) {
+        return GifticonBrand.builder()
+                .brandCode(state.getBrandCode())
+                .brandName(state.getBrandName())
+                .brandImageUrl(state.getBrandImageUrl())
+                .build();
+    }
+
+    public static GifticonBrand from(GifticonBrandSnapshotState state) {
+        return GifticonBrand.builder()
+                .id(state.getId())
+                .brandCode(state.getBrandCode())
+                .brandName(state.getBrandName())
+                .brandImageUrl(state.getBrandImageUrl())
+                .createdAt(state.getCreatedAt())
+                .modifiedAt(state.getModifiedAt())
+                .build();
+    }
+
+    public void syncFromApi(String brandName, String brandImageUrl) {
+        this.brandName = brandName;
+        this.brandImageUrl = brandImageUrl;
+    }
+}

--- a/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/gifticon/GifticonBrandCreateState.java
+++ b/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/gifticon/GifticonBrandCreateState.java
@@ -1,0 +1,12 @@
+package com.personal.marketnote.reward.domain.gifticon;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class GifticonBrandCreateState {
+    private final String brandCode;
+    private final String brandName;
+    private final String brandImageUrl;
+}

--- a/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/gifticon/GifticonBrandSnapshotState.java
+++ b/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/gifticon/GifticonBrandSnapshotState.java
@@ -1,0 +1,17 @@
+package com.personal.marketnote.reward.domain.gifticon;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class GifticonBrandSnapshotState {
+    private final Long id;
+    private final String brandCode;
+    private final String brandName;
+    private final String brandImageUrl;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime modifiedAt;
+}

--- a/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/gifticon/GifticonCategory.java
+++ b/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/gifticon/GifticonCategory.java
@@ -1,0 +1,63 @@
+package com.personal.marketnote.reward.domain.gifticon;
+
+import com.personal.marketnote.common.utility.FormatValidator;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+public class GifticonCategory {
+    private Long id;
+    private String categoryCode;
+    private String categoryName;
+    private String displayName;
+    private String iconUrl;
+    private boolean exposed;
+    private Integer orderNum;
+    private LocalDateTime createdAt;
+    private LocalDateTime modifiedAt;
+
+    public static GifticonCategory from(GifticonCategorySnapshotState state) {
+        return GifticonCategory.builder()
+                .id(state.getId())
+                .categoryCode(state.getCategoryCode())
+                .categoryName(state.getCategoryName())
+                .displayName(state.getDisplayName())
+                .iconUrl(state.getIconUrl())
+                .exposed(state.isExposed())
+                .orderNum(state.getOrderNum())
+                .createdAt(state.getCreatedAt())
+                .modifiedAt(state.getModifiedAt())
+                .build();
+    }
+
+    public String getEffectiveDisplayName() {
+        if (FormatValidator.hasValue(displayName)) {
+            return displayName;
+        }
+        return categoryName;
+    }
+
+    public void updateDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public void updateIconUrl(String iconUrl) {
+        this.iconUrl = iconUrl;
+    }
+
+    public void expose() {
+        this.exposed = true;
+    }
+
+    public void unexpose() {
+        this.exposed = false;
+    }
+
+    public void changeOrderNum(Integer orderNum) {
+        this.orderNum = orderNum;
+    }
+}

--- a/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/gifticon/GifticonCategorySnapshotState.java
+++ b/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/gifticon/GifticonCategorySnapshotState.java
@@ -1,0 +1,20 @@
+package com.personal.marketnote.reward.domain.gifticon;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class GifticonCategorySnapshotState {
+    private final Long id;
+    private final String categoryCode;
+    private final String categoryName;
+    private final String displayName;
+    private final String iconUrl;
+    private final boolean exposed;
+    private final Integer orderNum;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime modifiedAt;
+}

--- a/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/gifticon/GifticonGoods.java
+++ b/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/gifticon/GifticonGoods.java
@@ -1,0 +1,105 @@
+package com.personal.marketnote.reward.domain.gifticon;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+public class GifticonGoods {
+    private Long id;
+    private String goodsCode;
+    private String goodsName;
+    private String brandCode;
+    private String brandName;
+    private String brandImageUrl;
+    private String categoryCode;
+    private Long realPrice;
+    private Long salePrice;
+    private Long cashPrice;
+    private String imageUrl;
+    private String description;
+    private Integer validDays;
+    private String goodsStatus;
+    private boolean exposed;
+    private Integer orderNum;
+    private LocalDateTime createdAt;
+    private LocalDateTime modifiedAt;
+
+    public static GifticonGoods from(GifticonGoodsCreateState state) {
+        return GifticonGoods.builder()
+                .goodsCode(state.getGoodsCode())
+                .goodsName(state.getGoodsName())
+                .brandCode(state.getBrandCode())
+                .brandName(state.getBrandName())
+                .brandImageUrl(state.getBrandImageUrl())
+                .categoryCode(state.getCategoryCode())
+                .realPrice(state.getRealPrice())
+                .salePrice(state.getSalePrice())
+                .cashPrice(state.getCashPrice())
+                .imageUrl(state.getImageUrl())
+                .description(state.getDescription())
+                .validDays(state.getValidDays())
+                .goodsStatus(state.getGoodsStatus())
+                .exposed(false)
+                .orderNum(null)
+                .build();
+    }
+
+    public static GifticonGoods from(GifticonGoodsSnapshotState state) {
+        return GifticonGoods.builder()
+                .id(state.getId())
+                .goodsCode(state.getGoodsCode())
+                .goodsName(state.getGoodsName())
+                .brandCode(state.getBrandCode())
+                .brandName(state.getBrandName())
+                .brandImageUrl(state.getBrandImageUrl())
+                .categoryCode(state.getCategoryCode())
+                .realPrice(state.getRealPrice())
+                .salePrice(state.getSalePrice())
+                .cashPrice(state.getCashPrice())
+                .imageUrl(state.getImageUrl())
+                .description(state.getDescription())
+                .validDays(state.getValidDays())
+                .goodsStatus(state.getGoodsStatus())
+                .exposed(state.isExposed())
+                .orderNum(state.getOrderNum())
+                .createdAt(state.getCreatedAt())
+                .modifiedAt(state.getModifiedAt())
+                .build();
+    }
+
+    public void syncFromApi(String goodsName, String brandCode, String brandName, String brandImageUrl,
+                            String categoryCode, Long realPrice, Long salePrice, String imageUrl,
+                            String description, Integer validDays, String goodsStatus) {
+        this.goodsName = goodsName;
+        this.brandCode = brandCode;
+        this.brandName = brandName;
+        this.brandImageUrl = brandImageUrl;
+        this.categoryCode = categoryCode;
+        this.realPrice = realPrice;
+        this.salePrice = salePrice;
+        this.imageUrl = imageUrl;
+        this.description = description;
+        this.validDays = validDays;
+        this.goodsStatus = goodsStatus;
+    }
+
+    public void expose() {
+        this.exposed = true;
+    }
+
+    public void unexpose() {
+        this.exposed = false;
+    }
+
+    public void changeOrderNum(Integer orderNum) {
+        this.orderNum = orderNum;
+    }
+
+    public boolean isSale() {
+        return "SALE".equals(this.goodsStatus);
+    }
+}

--- a/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/gifticon/GifticonGoodsCreateState.java
+++ b/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/gifticon/GifticonGoodsCreateState.java
@@ -1,0 +1,22 @@
+package com.personal.marketnote.reward.domain.gifticon;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class GifticonGoodsCreateState {
+    private final String goodsCode;
+    private final String goodsName;
+    private final String brandCode;
+    private final String brandName;
+    private final String brandImageUrl;
+    private final String categoryCode;
+    private final Long realPrice;
+    private final Long salePrice;
+    private final Long cashPrice;
+    private final String imageUrl;
+    private final String description;
+    private final Integer validDays;
+    private final String goodsStatus;
+}

--- a/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/gifticon/GifticonGoodsSnapshotState.java
+++ b/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/gifticon/GifticonGoodsSnapshotState.java
@@ -1,0 +1,29 @@
+package com.personal.marketnote.reward.domain.gifticon;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class GifticonGoodsSnapshotState {
+    private final Long id;
+    private final String goodsCode;
+    private final String goodsName;
+    private final String brandCode;
+    private final String brandName;
+    private final String brandImageUrl;
+    private final String categoryCode;
+    private final Long realPrice;
+    private final Long salePrice;
+    private final Long cashPrice;
+    private final String imageUrl;
+    private final String description;
+    private final Integer validDays;
+    private final String goodsStatus;
+    private final boolean exposed;
+    private final Integer orderNum;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime modifiedAt;
+}

--- a/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/gifticon/GifticonOrder.java
+++ b/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/gifticon/GifticonOrder.java
@@ -1,0 +1,99 @@
+package com.personal.marketnote.reward.domain.gifticon;
+
+import com.personal.marketnote.reward.domain.exception.InvalidGifticonOrderStatusTransitionException;
+import lombok.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+public class GifticonOrder {
+    private Long id;
+    private Long userId;
+    private String goodsCode;
+    private String goodsName;
+    private String brandName;
+    private String productImageUrl;
+    private String trId;
+    private String orderNo;
+    private Long cashPrice;
+    private GifticonOrderStatus orderStatus;
+    private String couponImageUrl;
+    private String pinNo;
+    private LocalDate validEndDate;
+    private LocalDateTime createdAt;
+    private LocalDateTime modifiedAt;
+
+    public static GifticonOrder from(GifticonOrderSnapshotState state) {
+        return GifticonOrder.builder()
+                .id(state.getId())
+                .userId(state.getUserId())
+                .goodsCode(state.getGoodsCode())
+                .goodsName(state.getGoodsName())
+                .brandName(state.getBrandName())
+                .productImageUrl(state.getProductImageUrl())
+                .trId(state.getTrId())
+                .orderNo(state.getOrderNo())
+                .cashPrice(state.getCashPrice())
+                .orderStatus(state.getOrderStatus())
+                .couponImageUrl(state.getCouponImageUrl())
+                .pinNo(state.getPinNo())
+                .validEndDate(state.getValidEndDate())
+                .createdAt(state.getCreatedAt())
+                .modifiedAt(state.getModifiedAt())
+                .build();
+    }
+
+    public void issue(String couponImageUrl, String pinNo, String orderNo, LocalDate validEndDate) {
+        if (!isPending()) {
+            throw new InvalidGifticonOrderStatusTransitionException(this.orderStatus);
+        }
+        this.orderStatus = GifticonOrderStatus.ISSUED;
+        this.couponImageUrl = couponImageUrl;
+        this.pinNo = pinNo;
+        this.orderNo = orderNo;
+        this.validEndDate = validEndDate;
+    }
+
+    public void markSendFailed() {
+        if (!isPending()) {
+            throw new InvalidGifticonOrderStatusTransitionException(this.orderStatus);
+        }
+        this.orderStatus = GifticonOrderStatus.SEND_FAILED;
+    }
+
+    public void cancel() {
+        if (isPending() || isIssued() || isSendFailed()) {
+            this.orderStatus = GifticonOrderStatus.CANCELLED;
+            return;
+        }
+        throw new InvalidGifticonOrderStatusTransitionException(this.orderStatus);
+    }
+
+    public void syncStatus(GifticonOrderStatus newStatus) {
+        this.orderStatus = newStatus;
+    }
+
+    public boolean isPending() {
+        return this.orderStatus.isPending();
+    }
+
+    public boolean isIssued() {
+        return this.orderStatus.isIssued();
+    }
+
+    public boolean isAvailable() {
+        return this.orderStatus.isAvailable();
+    }
+
+    public boolean isSendFailed() {
+        return this.orderStatus.isSendFailed();
+    }
+
+    public boolean isTerminal() {
+        return this.orderStatus.isTerminal();
+    }
+}

--- a/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/gifticon/GifticonOrderSnapshotState.java
+++ b/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/gifticon/GifticonOrderSnapshotState.java
@@ -1,0 +1,27 @@
+package com.personal.marketnote.reward.domain.gifticon;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class GifticonOrderSnapshotState {
+    private final Long id;
+    private final Long userId;
+    private final String goodsCode;
+    private final String goodsName;
+    private final String brandName;
+    private final String productImageUrl;
+    private final String trId;
+    private final String orderNo;
+    private final Long cashPrice;
+    private final GifticonOrderStatus orderStatus;
+    private final String couponImageUrl;
+    private final String pinNo;
+    private final LocalDate validEndDate;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime modifiedAt;
+}

--- a/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/gifticon/GifticonOrderStatus.java
+++ b/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/gifticon/GifticonOrderStatus.java
@@ -1,0 +1,60 @@
+package com.personal.marketnote.reward.domain.gifticon;
+
+import java.util.Map;
+
+public enum GifticonOrderStatus {
+    PENDING,
+    ISSUED,
+    USED,
+    EXPIRED,
+    CANCELLED,
+    SEND_FAILED;
+
+    private static final Map<String, GifticonOrderStatus> PIN_STATUS_MAP = Map.ofEntries(
+            Map.entry("01", ISSUED),
+            Map.entry("06", ISSUED),
+            Map.entry("02", USED),
+            Map.entry("08", EXPIRED),
+            Map.entry("11", EXPIRED),
+            Map.entry("03", CANCELLED),
+            Map.entry("05", CANCELLED),
+            Map.entry("07", CANCELLED),
+            Map.entry("10", CANCELLED)
+    );
+
+    public boolean isPending() {
+        return this == PENDING;
+    }
+
+    public boolean isIssued() {
+        return this == ISSUED;
+    }
+
+    public boolean isUsed() {
+        return this == USED;
+    }
+
+    public boolean isExpired() {
+        return this == EXPIRED;
+    }
+
+    public boolean isCancelled() {
+        return this == CANCELLED;
+    }
+
+    public boolean isSendFailed() {
+        return this == SEND_FAILED;
+    }
+
+    public boolean isAvailable() {
+        return this == ISSUED;
+    }
+
+    public boolean isTerminal() {
+        return this == USED || this == EXPIRED || this == CANCELLED;
+    }
+
+    public static GifticonOrderStatus fromPinStatus(String pinStatus) {
+        return PIN_STATUS_MAP.getOrDefault(pinStatus, CANCELLED);
+    }
+}

--- a/reward-service/reward-domain/src/test/java/com/personal/marketnote/reward/domain/gifticon/GifticonGoodsTest.java
+++ b/reward-service/reward-domain/src/test/java/com/personal/marketnote/reward/domain/gifticon/GifticonGoodsTest.java
@@ -1,0 +1,214 @@
+package com.personal.marketnote.reward.domain.gifticon;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GifticonGoodsTest {
+
+    @Nested
+    @DisplayName("CreateState로 생성")
+    class FromCreateState {
+
+        @Test
+        @DisplayName("CreateState로 GifticonGoods를 생성하면 exposed=false, orderNum=null이다")
+        void createWithDefaults() {
+            GifticonGoods goods = GifticonGoods.from(GifticonGoodsCreateState.builder()
+                    .goodsCode("G001")
+                    .goodsName("스타벅스 아메리카노")
+                    .brandCode("B001")
+                    .brandName("스타벅스")
+                    .brandImageUrl("https://example.com/brand.jpg")
+                    .categoryCode("3")
+                    .realPrice(5000L)
+                    .salePrice(4500L)
+                    .cashPrice(4500L)
+                    .imageUrl("https://example.com/image.jpg")
+                    .description("상품 설명")
+                    .validDays(90)
+                    .goodsStatus("SALE")
+                    .build());
+
+            assertThat(goods.getGoodsCode()).isEqualTo("G001");
+            assertThat(goods.getGoodsName()).isEqualTo("스타벅스 아메리카노");
+            assertThat(goods.getBrandCode()).isEqualTo("B001");
+            assertThat(goods.getBrandName()).isEqualTo("스타벅스");
+            assertThat(goods.getRealPrice()).isEqualTo(5000L);
+            assertThat(goods.getSalePrice()).isEqualTo(4500L);
+            assertThat(goods.getCashPrice()).isEqualTo(4500L);
+            assertThat(goods.getGoodsStatus()).isEqualTo("SALE");
+            assertThat(goods.isExposed()).isFalse();
+            assertThat(goods.getOrderNum()).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("SnapshotState로 복원")
+    class FromSnapshotState {
+
+        @Test
+        @DisplayName("SnapshotState로 GifticonGoods를 복원한다")
+        void restoreFromSnapshotState() {
+            GifticonGoods goods = GifticonGoods.from(GifticonGoodsSnapshotState.builder()
+                    .id(1L)
+                    .goodsCode("G001")
+                    .goodsName("스타벅스 아메리카노")
+                    .brandCode("B001")
+                    .brandName("스타벅스")
+                    .brandImageUrl("https://example.com/brand.jpg")
+                    .categoryCode("3")
+                    .realPrice(5000L)
+                    .salePrice(4500L)
+                    .cashPrice(4000L)
+                    .imageUrl("https://example.com/image.jpg")
+                    .description("상품 설명")
+                    .validDays(90)
+                    .goodsStatus("SALE")
+                    .exposed(true)
+                    .orderNum(1)
+                    .createdAt(LocalDateTime.of(2026, 4, 3, 12, 0, 0))
+                    .modifiedAt(LocalDateTime.of(2026, 4, 3, 12, 0, 0))
+                    .build());
+
+            assertThat(goods.getId()).isEqualTo(1L);
+            assertThat(goods.isExposed()).isTrue();
+            assertThat(goods.getOrderNum()).isEqualTo(1);
+            assertThat(goods.getCashPrice()).isEqualTo(4000L);
+        }
+    }
+
+    @Nested
+    @DisplayName("상태 변경 메서드")
+    class StateMutation {
+
+        @Test
+        @DisplayName("expose 호출 시 exposed가 true로 변경된다")
+        void exposeChangesExposedToTrue() {
+            GifticonGoods goods = GifticonGoods.from(GifticonGoodsCreateState.builder()
+                    .goodsCode("G001")
+                    .goodsName("스타벅스 아메리카노")
+                    .brandCode("B001")
+                    .brandName("스타벅스")
+                    .realPrice(5000L)
+                    .salePrice(4500L)
+                    .cashPrice(4500L)
+                    .goodsStatus("SALE")
+                    .build());
+
+            goods.expose();
+
+            assertThat(goods.isExposed()).isTrue();
+        }
+
+        @Test
+        @DisplayName("unexpose 호출 시 exposed가 false로 변경된다")
+        void unexposeChangesExposedToFalse() {
+            GifticonGoods goods = GifticonGoods.from(GifticonGoodsSnapshotState.builder()
+                    .id(1L)
+                    .goodsCode("G001")
+                    .goodsName("스타벅스 아메리카노")
+                    .brandCode("B001")
+                    .brandName("스타벅스")
+                    .realPrice(5000L)
+                    .salePrice(4500L)
+                    .cashPrice(4500L)
+                    .goodsStatus("SALE")
+                    .exposed(true)
+                    .orderNum(1)
+                    .createdAt(LocalDateTime.of(2026, 4, 3, 12, 0, 0))
+                    .modifiedAt(LocalDateTime.of(2026, 4, 3, 12, 0, 0))
+                    .build());
+
+            goods.unexpose();
+
+            assertThat(goods.isExposed()).isFalse();
+        }
+
+        @Test
+        @DisplayName("changeOrderNum 호출 시 orderNum이 변경된다")
+        void changeOrderNumUpdatesOrderNum() {
+            GifticonGoods goods = GifticonGoods.from(GifticonGoodsCreateState.builder()
+                    .goodsCode("G001")
+                    .goodsName("스타벅스 아메리카노")
+                    .brandCode("B001")
+                    .brandName("스타벅스")
+                    .realPrice(5000L)
+                    .salePrice(4500L)
+                    .cashPrice(4500L)
+                    .goodsStatus("SALE")
+                    .build());
+
+            goods.changeOrderNum(5);
+
+            assertThat(goods.getOrderNum()).isEqualTo(5);
+        }
+
+        @Test
+        @DisplayName("동기화 시 상품 정보가 업데이트된다")
+        void syncUpdatesGoodsInfo() {
+            GifticonGoods goods = GifticonGoods.from(GifticonGoodsSnapshotState.builder()
+                    .id(1L)
+                    .goodsCode("G001")
+                    .goodsName("스타벅스 아메리카노")
+                    .brandCode("B001")
+                    .brandName("스타벅스")
+                    .realPrice(5000L)
+                    .salePrice(4500L)
+                    .cashPrice(4000L)
+                    .goodsStatus("SALE")
+                    .exposed(true)
+                    .orderNum(1)
+                    .createdAt(LocalDateTime.of(2026, 4, 3, 12, 0, 0))
+                    .modifiedAt(LocalDateTime.of(2026, 4, 3, 12, 0, 0))
+                    .build());
+
+            goods.syncFromApi("스타벅스 카페라떼", "B001", "스타벅스", "https://example.com/brand2.jpg",
+                    "3", 5500L, 5000L, "https://example.com/image2.jpg", "새 설명", 90, "SALE");
+
+            assertThat(goods.getGoodsName()).isEqualTo("스타벅스 카페라떼");
+            assertThat(goods.getRealPrice()).isEqualTo(5500L);
+            assertThat(goods.getSalePrice()).isEqualTo(5000L);
+            assertThat(goods.getCashPrice()).isEqualTo(4000L);
+            assertThat(goods.isExposed()).isTrue();
+            assertThat(goods.getOrderNum()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("isSale은 goodsStatus가 SALE일 때 true이다")
+        void isSaleReturnsTrueWhenSale() {
+            GifticonGoods goods = GifticonGoods.from(GifticonGoodsCreateState.builder()
+                    .goodsCode("G001")
+                    .goodsName("스타벅스 아메리카노")
+                    .brandCode("B001")
+                    .brandName("스타벅스")
+                    .realPrice(5000L)
+                    .salePrice(4500L)
+                    .cashPrice(4500L)
+                    .goodsStatus("SALE")
+                    .build());
+
+            assertThat(goods.isSale()).isTrue();
+        }
+
+        @Test
+        @DisplayName("isSale은 goodsStatus가 SUS일 때 false이다")
+        void isSaleReturnsFalseWhenSuspended() {
+            GifticonGoods goods = GifticonGoods.from(GifticonGoodsCreateState.builder()
+                    .goodsCode("G001")
+                    .goodsName("스타벅스 아메리카노")
+                    .brandCode("B001")
+                    .brandName("스타벅스")
+                    .realPrice(5000L)
+                    .salePrice(4500L)
+                    .cashPrice(4500L)
+                    .goodsStatus("SUS")
+                    .build());
+
+            assertThat(goods.isSale()).isFalse();
+        }
+    }
+}

--- a/reward-service/reward-domain/src/test/java/com/personal/marketnote/reward/domain/gifticon/GifticonOrderStatusTest.java
+++ b/reward-service/reward-domain/src/test/java/com/personal/marketnote/reward/domain/gifticon/GifticonOrderStatusTest.java
@@ -1,0 +1,122 @@
+package com.personal.marketnote.reward.domain.gifticon;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class GifticonOrderStatusTest {
+
+    @Nested
+    @DisplayName("술어 메서드")
+    class PredicateMethods {
+
+        @Test
+        @DisplayName("PENDING 상태는 isPending이 true이다")
+        void pendingIsPending() {
+            assertThat(GifticonOrderStatus.PENDING.isPending()).isTrue();
+            assertThat(GifticonOrderStatus.ISSUED.isPending()).isFalse();
+        }
+
+        @Test
+        @DisplayName("ISSUED 상태는 isIssued이 true이다")
+        void issuedIsIssued() {
+            assertThat(GifticonOrderStatus.ISSUED.isIssued()).isTrue();
+            assertThat(GifticonOrderStatus.PENDING.isIssued()).isFalse();
+        }
+
+        @Test
+        @DisplayName("USED 상태는 isUsed이 true이다")
+        void usedIsUsed() {
+            assertThat(GifticonOrderStatus.USED.isUsed()).isTrue();
+            assertThat(GifticonOrderStatus.ISSUED.isUsed()).isFalse();
+        }
+
+        @Test
+        @DisplayName("EXPIRED 상태는 isExpired이 true이다")
+        void expiredIsExpired() {
+            assertThat(GifticonOrderStatus.EXPIRED.isExpired()).isTrue();
+            assertThat(GifticonOrderStatus.ISSUED.isExpired()).isFalse();
+        }
+
+        @Test
+        @DisplayName("CANCELLED 상태는 isCancelled이 true이다")
+        void cancelledIsCancelled() {
+            assertThat(GifticonOrderStatus.CANCELLED.isCancelled()).isTrue();
+            assertThat(GifticonOrderStatus.ISSUED.isCancelled()).isFalse();
+        }
+
+        @Test
+        @DisplayName("SEND_FAILED 상태는 isSendFailed이 true이다")
+        void sendFailedIsSendFailed() {
+            assertThat(GifticonOrderStatus.SEND_FAILED.isSendFailed()).isTrue();
+            assertThat(GifticonOrderStatus.ISSUED.isSendFailed()).isFalse();
+        }
+
+        @Test
+        @DisplayName("ISSUED 상태만 isAvailable이 true이다")
+        void onlyIssuedIsAvailable() {
+            assertThat(GifticonOrderStatus.ISSUED.isAvailable()).isTrue();
+            assertThat(GifticonOrderStatus.PENDING.isAvailable()).isFalse();
+            assertThat(GifticonOrderStatus.USED.isAvailable()).isFalse();
+            assertThat(GifticonOrderStatus.EXPIRED.isAvailable()).isFalse();
+            assertThat(GifticonOrderStatus.CANCELLED.isAvailable()).isFalse();
+            assertThat(GifticonOrderStatus.SEND_FAILED.isAvailable()).isFalse();
+        }
+
+        @Test
+        @DisplayName("USED, EXPIRED, CANCELLED 상태는 isTerminal이 true이다")
+        void terminalStatuses() {
+            assertThat(GifticonOrderStatus.USED.isTerminal()).isTrue();
+            assertThat(GifticonOrderStatus.EXPIRED.isTerminal()).isTrue();
+            assertThat(GifticonOrderStatus.CANCELLED.isTerminal()).isTrue();
+            assertThat(GifticonOrderStatus.PENDING.isTerminal()).isFalse();
+            assertThat(GifticonOrderStatus.ISSUED.isTerminal()).isFalse();
+            assertThat(GifticonOrderStatus.SEND_FAILED.isTerminal()).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("핀상태 코드 매핑 (fromPinStatus)")
+    class FromPinStatus {
+
+        @ParameterizedTest
+        @ValueSource(strings = {"01", "06"})
+        @DisplayName("핀상태 01(발행), 06(재발행)은 ISSUED로 매핑된다")
+        void issuedPinStatuses(String pinStatus) {
+            assertThat(GifticonOrderStatus.fromPinStatus(pinStatus)).isEqualTo(GifticonOrderStatus.ISSUED);
+        }
+
+        @Test
+        @DisplayName("핀상태 02(교환)는 USED로 매핑된다")
+        void usedPinStatus() {
+            assertThat(GifticonOrderStatus.fromPinStatus("02")).isEqualTo(GifticonOrderStatus.USED);
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"08", "11"})
+        @DisplayName("핀상태 08(기간만료), 11(잔액기간만료)은 EXPIRED로 매핑된다")
+        void expiredPinStatuses(String pinStatus) {
+            assertThat(GifticonOrderStatus.fromPinStatus(pinStatus)).isEqualTo(GifticonOrderStatus.EXPIRED);
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"03", "05", "07", "10"})
+        @DisplayName("핀상태 03(반품), 05(환불), 07(구매취소), 10(잔액환불)은 CANCELLED로 매핑된다")
+        void cancelledPinStatuses(String pinStatus) {
+            assertThat(GifticonOrderStatus.fromPinStatus(pinStatus)).isEqualTo(GifticonOrderStatus.CANCELLED);
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"04", "09", "12", "99"})
+        @DisplayName("매핑되지 않는 핀상태 코드는 CANCELLED로 매핑된다")
+        void unmappedPinStatusesFallbackToCancelled(String pinStatus) {
+            assertThat(GifticonOrderStatus.fromPinStatus(pinStatus)).isEqualTo(GifticonOrderStatus.CANCELLED);
+        }
+    }
+}

--- a/reward-service/reward-domain/src/test/java/com/personal/marketnote/reward/domain/gifticon/GifticonOrderTest.java
+++ b/reward-service/reward-domain/src/test/java/com/personal/marketnote/reward/domain/gifticon/GifticonOrderTest.java
@@ -1,0 +1,204 @@
+package com.personal.marketnote.reward.domain.gifticon;
+
+import com.personal.marketnote.reward.domain.exception.InvalidGifticonOrderStatusTransitionException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class GifticonOrderTest {
+
+    private GifticonOrder createPendingOrder() {
+        return GifticonOrder.from(GifticonOrderSnapshotState.builder()
+                .id(1L)
+                .userId(100L)
+                .goodsCode("G001")
+                .goodsName("스타벅스 아메리카노")
+                .brandName("스타벅스")
+                .productImageUrl("https://example.com/image.jpg")
+                .trId("NTCASH_100_20260403120000")
+                .orderNo("ORD001")
+                .cashPrice(4500L)
+                .orderStatus(GifticonOrderStatus.PENDING)
+                .couponImageUrl(null)
+                .pinNo(null)
+                .validEndDate(LocalDate.of(2026, 7, 3))
+                .createdAt(LocalDateTime.of(2026, 4, 3, 12, 0, 0))
+                .modifiedAt(LocalDateTime.of(2026, 4, 3, 12, 0, 0))
+                .build());
+    }
+
+    private GifticonOrder createIssuedOrder() {
+        return GifticonOrder.from(GifticonOrderSnapshotState.builder()
+                .id(1L)
+                .userId(100L)
+                .goodsCode("G001")
+                .goodsName("스타벅스 아메리카노")
+                .brandName("스타벅스")
+                .productImageUrl("https://example.com/image.jpg")
+                .trId("NTCASH_100_20260403120000")
+                .orderNo("ORD001")
+                .cashPrice(4500L)
+                .orderStatus(GifticonOrderStatus.ISSUED)
+                .couponImageUrl("https://example.com/coupon.jpg")
+                .pinNo("encrypted_pin")
+                .validEndDate(LocalDate.of(2026, 7, 3))
+                .createdAt(LocalDateTime.of(2026, 4, 3, 12, 0, 0))
+                .modifiedAt(LocalDateTime.of(2026, 4, 3, 12, 0, 0))
+                .build());
+    }
+
+    @Nested
+    @DisplayName("SnapshotState로 복원")
+    class FromSnapshotState {
+
+        @Test
+        @DisplayName("SnapshotState로 GifticonOrder를 복원한다")
+        void restoreFromSnapshotState() {
+            GifticonOrder order = createPendingOrder();
+
+            assertThat(order.getId()).isEqualTo(1L);
+            assertThat(order.getUserId()).isEqualTo(100L);
+            assertThat(order.getGoodsCode()).isEqualTo("G001");
+            assertThat(order.getGoodsName()).isEqualTo("스타벅스 아메리카노");
+            assertThat(order.getBrandName()).isEqualTo("스타벅스");
+            assertThat(order.getTrId()).isEqualTo("NTCASH_100_20260403120000");
+            assertThat(order.getCashPrice()).isEqualTo(4500L);
+            assertThat(order.getOrderStatus()).isEqualTo(GifticonOrderStatus.PENDING);
+        }
+    }
+
+    @Nested
+    @DisplayName("상태 전이")
+    class StatusTransition {
+
+        @Test
+        @DisplayName("PENDING → ISSUED 전이에 성공한다")
+        void pendingToIssued() {
+            GifticonOrder order = createPendingOrder();
+
+            order.issue("https://example.com/coupon.jpg", "encrypted_pin", "ORD001", LocalDate.of(2026, 7, 3));
+
+            assertThat(order.getOrderStatus()).isEqualTo(GifticonOrderStatus.ISSUED);
+            assertThat(order.getCouponImageUrl()).isEqualTo("https://example.com/coupon.jpg");
+            assertThat(order.getPinNo()).isEqualTo("encrypted_pin");
+            assertThat(order.getOrderNo()).isEqualTo("ORD001");
+            assertThat(order.getValidEndDate()).isEqualTo(LocalDate.of(2026, 7, 3));
+        }
+
+        @Test
+        @DisplayName("ISSUED 상태에서 issue 호출 시 예외가 발생한다")
+        void issuedToIssuedThrowsException() {
+            GifticonOrder order = createIssuedOrder();
+
+            assertThatThrownBy(() -> order.issue("url", "pin", "ORD002", LocalDate.of(2026, 7, 3)))
+                    .isInstanceOf(InvalidGifticonOrderStatusTransitionException.class);
+        }
+
+        @Test
+        @DisplayName("PENDING → SEND_FAILED 전이에 성공한다")
+        void pendingToSendFailed() {
+            GifticonOrder order = createPendingOrder();
+
+            order.markSendFailed();
+
+            assertThat(order.getOrderStatus()).isEqualTo(GifticonOrderStatus.SEND_FAILED);
+        }
+
+        @Test
+        @DisplayName("ISSUED 상태에서 markSendFailed 호출 시 예외가 발생한다")
+        void issuedToSendFailedThrowsException() {
+            GifticonOrder order = createIssuedOrder();
+
+            assertThatThrownBy(() -> order.markSendFailed())
+                    .isInstanceOf(InvalidGifticonOrderStatusTransitionException.class);
+        }
+
+        @Test
+        @DisplayName("PENDING → CANCELLED 전이에 성공한다")
+        void pendingToCancelled() {
+            GifticonOrder order = createPendingOrder();
+
+            order.cancel();
+
+            assertThat(order.getOrderStatus()).isEqualTo(GifticonOrderStatus.CANCELLED);
+        }
+
+        @Test
+        @DisplayName("ISSUED → CANCELLED 전이에 성공한다")
+        void issuedToCancelled() {
+            GifticonOrder order = createIssuedOrder();
+
+            order.cancel();
+
+            assertThat(order.getOrderStatus()).isEqualTo(GifticonOrderStatus.CANCELLED);
+        }
+
+        @Test
+        @DisplayName("SEND_FAILED → CANCELLED 전이에 성공한다")
+        void sendFailedToCancelled() {
+            GifticonOrder order = createPendingOrder();
+            order.markSendFailed();
+
+            order.cancel();
+
+            assertThat(order.getOrderStatus()).isEqualTo(GifticonOrderStatus.CANCELLED);
+        }
+
+        @Test
+        @DisplayName("USED 상태에서 cancel 호출 시 예외가 발생한다")
+        void usedToCancelledThrowsException() {
+            GifticonOrder order = createIssuedOrder();
+            order.syncStatus(GifticonOrderStatus.USED);
+
+            assertThatThrownBy(() -> order.cancel())
+                    .isInstanceOf(InvalidGifticonOrderStatusTransitionException.class);
+        }
+
+        @Test
+        @DisplayName("syncStatus로 외부 동기화 상태를 반영한다")
+        void syncStatusUpdates() {
+            GifticonOrder order = createIssuedOrder();
+
+            order.syncStatus(GifticonOrderStatus.USED);
+
+            assertThat(order.getOrderStatus()).isEqualTo(GifticonOrderStatus.USED);
+        }
+
+        @Test
+        @DisplayName("syncStatus로 동일 상태 반영 시 상태가 유지된다")
+        void syncStatusSameStatusIsIdempotent() {
+            GifticonOrder order = createIssuedOrder();
+
+            order.syncStatus(GifticonOrderStatus.ISSUED);
+
+            assertThat(order.getOrderStatus()).isEqualTo(GifticonOrderStatus.ISSUED);
+        }
+    }
+
+    @Nested
+    @DisplayName("술어 메서드")
+    class PredicateMethods {
+
+        @Test
+        @DisplayName("PENDING 상태 주문은 isPending이 true이다")
+        void pendingOrderIsPending() {
+            GifticonOrder order = createPendingOrder();
+            assertThat(order.isPending()).isTrue();
+            assertThat(order.isIssued()).isFalse();
+        }
+
+        @Test
+        @DisplayName("ISSUED 상태 주문은 isIssued이 true이다")
+        void issuedOrderIsIssued() {
+            GifticonOrder order = createIssuedOrder();
+            assertThat(order.isIssued()).isTrue();
+            assertThat(order.isPending()).isFalse();
+        }
+    }
+}


### PR DESCRIPTION
## partially addresses #1653
## resolves #1655

## Task
- [x] GifticonGoods 도메인 + JPA Entity + Repository
- [x] GifticonBrand 도메인 + JPA Entity + Repository
- [x] GifticonCategory 도메인 + JPA Entity + Repository + 초기 데이터(7개)
- [x] GifticonCategoryMapping JPA Entity + Repository + 초기 데이터
- [x] GifticonOrder 도메인 + JPA Entity + Repository
- [x] GifticonOrderStatus Enum (PENDING, ISSUED, USED, EXPIRED, CANCELLED, SEND_FAILED) + 핀상태 24종 매핑
- [x] 도메인 예외 클래스 3개 정의
- [x] CreateState/SnapshotState 6개 정의
- [x] JPA Entity ↔ Domain 변환 (toDomain, from, updateFrom)