### PR TITLE
[#1653][#1664] feat: 기프티콘 상품/브랜드 동기화 배치 기능 추가

### DIFF
--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/scheduler/GifticonSyncScheduler.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/scheduler/GifticonSyncScheduler.java
@@ -1,0 +1,29 @@
+package com.personal.marketnote.reward.adapter.in.scheduler;
+
+import com.personal.marketnote.reward.port.in.usecase.gifticon.SyncGifticonGoodsAndBrandsUseCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(name = "gifticon.sync.scheduler.enabled", havingValue = "true", matchIfMissing = false)
+public class GifticonSyncScheduler {
+
+    private final SyncGifticonGoodsAndBrandsUseCase syncGifticonGoodsAndBrandsUseCase;
+
+    @Scheduled(cron = "${gifticon.sync.scheduler.cron:0 0 3 * * MON,WED,FRI}", zone = "Asia/Seoul")
+    public void syncGifticonGoodsAndBrands() {
+        log.info("기프티콘 상품/브랜드 동기화 스케줄러 실행 시작");
+
+        try {
+            syncGifticonGoodsAndBrandsUseCase.syncAll();
+            log.info("기프티콘 상품/브랜드 동기화 스케줄러 실행 완료");
+        } catch (Exception e) {
+            log.error("기프티콘 상품/브랜드 동기화 스케줄러 실행 실패", e);
+        }
+    }
+}

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/gifticon/GifticonBrandPersistenceAdapter.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/gifticon/GifticonBrandPersistenceAdapter.java
@@ -1,0 +1,38 @@
+package com.personal.marketnote.reward.adapter.out.persistence.gifticon;
+
+import com.personal.marketnote.common.adapter.out.PersistenceAdapter;
+import com.personal.marketnote.reward.adapter.out.persistence.gifticon.entity.GifticonBrandJpaEntity;
+import com.personal.marketnote.reward.adapter.out.persistence.gifticon.repository.GifticonBrandJpaRepository;
+import com.personal.marketnote.reward.domain.exception.GifticonBrandNotFoundException;
+import com.personal.marketnote.reward.domain.gifticon.GifticonBrand;
+import com.personal.marketnote.reward.port.out.gifticon.FindGifticonBrandPort;
+import com.personal.marketnote.reward.port.out.gifticon.SaveGifticonBrandPort;
+import com.personal.marketnote.reward.port.out.gifticon.UpdateGifticonBrandPort;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Optional;
+
+@PersistenceAdapter
+@RequiredArgsConstructor
+public class GifticonBrandPersistenceAdapter implements FindGifticonBrandPort, SaveGifticonBrandPort, UpdateGifticonBrandPort {
+
+    private final GifticonBrandJpaRepository repository;
+
+    @Override
+    public Optional<GifticonBrand> findByBrandCode(String brandCode) {
+        return repository.findByBrandCode(brandCode)
+                .map(GifticonBrandJpaEntity::toDomain);
+    }
+
+    @Override
+    public void save(GifticonBrand brand) {
+        repository.save(GifticonBrandJpaEntity.from(brand));
+    }
+
+    @Override
+    public void update(GifticonBrand brand) {
+        GifticonBrandJpaEntity entity = repository.findById(brand.getId())
+                .orElseThrow(() -> new GifticonBrandNotFoundException(brand.getBrandCode()));
+        entity.updateFrom(brand);
+    }
+}

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/gifticon/GifticonCategoryPersistenceAdapter.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/gifticon/GifticonCategoryPersistenceAdapter.java
@@ -1,0 +1,59 @@
+package com.personal.marketnote.reward.adapter.out.persistence.gifticon;
+
+import com.personal.marketnote.common.adapter.out.PersistenceAdapter;
+import com.personal.marketnote.reward.adapter.out.persistence.gifticon.entity.GifticonCategoryJpaEntity;
+import com.personal.marketnote.reward.adapter.out.persistence.gifticon.entity.GifticonCategoryMappingJpaEntity;
+import com.personal.marketnote.reward.adapter.out.persistence.gifticon.repository.GifticonCategoryJpaRepository;
+import com.personal.marketnote.reward.adapter.out.persistence.gifticon.repository.GifticonCategoryMappingJpaRepository;
+import com.personal.marketnote.reward.domain.exception.GifticonCategoryNotFoundException;
+import com.personal.marketnote.reward.domain.gifticon.GifticonCategory;
+import com.personal.marketnote.reward.port.out.gifticon.*;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Optional;
+
+@PersistenceAdapter
+@RequiredArgsConstructor
+public class GifticonCategoryPersistenceAdapter implements
+        FindGifticonCategoryPort, SaveGifticonCategoryPort, UpdateGifticonCategoryPort,
+        FindGifticonCategoryMappingPort, SaveGifticonCategoryMappingPort {
+
+    private final GifticonCategoryJpaRepository categoryRepository;
+    private final GifticonCategoryMappingJpaRepository mappingRepository;
+
+    @Override
+    public Optional<GifticonCategory> findByCategoryCode(String categoryCode) {
+        return categoryRepository.findByCategoryCode(categoryCode)
+                .map(GifticonCategoryJpaEntity::toDomain);
+    }
+
+    @Override
+    public Optional<GifticonCategory> findById(Long id) {
+        return categoryRepository.findById(id)
+                .map(GifticonCategoryJpaEntity::toDomain);
+    }
+
+    @Override
+    public GifticonCategory save(GifticonCategory category) {
+        GifticonCategoryJpaEntity saved = categoryRepository.save(GifticonCategoryJpaEntity.from(category));
+        return saved.toDomain();
+    }
+
+    @Override
+    public void update(GifticonCategory category) {
+        GifticonCategoryJpaEntity entity = categoryRepository.findById(category.getId())
+                .orElseThrow(() -> new GifticonCategoryNotFoundException(category.getId()));
+        entity.updateFrom(category);
+    }
+
+    @Override
+    public Optional<Long> findCategoryIdByGiftishowCategorySeq(String giftishowCategorySeq) {
+        return mappingRepository.findByGiftishowCategorySeq(giftishowCategorySeq)
+                .map(GifticonCategoryMappingJpaEntity::getGifticonCategoryId);
+    }
+
+    @Override
+    public void save(String giftishowCategorySeq, Long gifticonCategoryId) {
+        mappingRepository.save(GifticonCategoryMappingJpaEntity.of(giftishowCategorySeq, gifticonCategoryId));
+    }
+}

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/gifticon/GifticonGoodsPersistenceAdapter.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/gifticon/GifticonGoodsPersistenceAdapter.java
@@ -1,0 +1,46 @@
+package com.personal.marketnote.reward.adapter.out.persistence.gifticon;
+
+import com.personal.marketnote.common.adapter.out.PersistenceAdapter;
+import com.personal.marketnote.reward.adapter.out.persistence.gifticon.entity.GifticonGoodsJpaEntity;
+import com.personal.marketnote.reward.adapter.out.persistence.gifticon.repository.GifticonGoodsJpaRepository;
+import com.personal.marketnote.reward.domain.gifticon.GifticonGoods;
+import com.personal.marketnote.reward.domain.exception.GifticonGoodsNotFoundException;
+import com.personal.marketnote.reward.port.out.gifticon.FindGifticonGoodsPort;
+import com.personal.marketnote.reward.port.out.gifticon.SaveGifticonGoodsPort;
+import com.personal.marketnote.reward.port.out.gifticon.UpdateGifticonGoodsPort;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+import java.util.Optional;
+
+@PersistenceAdapter
+@RequiredArgsConstructor
+public class GifticonGoodsPersistenceAdapter implements FindGifticonGoodsPort, SaveGifticonGoodsPort, UpdateGifticonGoodsPort {
+
+    private final GifticonGoodsJpaRepository repository;
+
+    @Override
+    public Optional<GifticonGoods> findByGoodsCode(String goodsCode) {
+        return repository.findByGoodsCode(goodsCode)
+                .map(GifticonGoodsJpaEntity::toDomain);
+    }
+
+    @Override
+    public List<GifticonGoods> findAllByGoodsStatus(String goodsStatus) {
+        return repository.findAllByGoodsStatus(goodsStatus).stream()
+                .map(GifticonGoodsJpaEntity::toDomain)
+                .toList();
+    }
+
+    @Override
+    public void save(GifticonGoods goods) {
+        repository.save(GifticonGoodsJpaEntity.from(goods));
+    }
+
+    @Override
+    public void update(GifticonGoods goods) {
+        GifticonGoodsJpaEntity entity = repository.findById(goods.getId())
+                .orElseThrow(() -> new GifticonGoodsNotFoundException(goods.getGoodsCode()));
+        entity.updateFrom(goods);
+    }
+}

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/gifticon/repository/GifticonGoodsJpaRepository.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/gifticon/repository/GifticonGoodsJpaRepository.java
@@ -3,6 +3,7 @@ package com.personal.marketnote.reward.adapter.out.persistence.gifticon.reposito
 import com.personal.marketnote.reward.adapter.out.persistence.gifticon.entity.GifticonGoodsJpaEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface GifticonGoodsJpaRepository extends JpaRepository<GifticonGoodsJpaEntity, Long> {
@@ -10,4 +11,6 @@ public interface GifticonGoodsJpaRepository extends JpaRepository<GifticonGoodsJ
     Optional<GifticonGoodsJpaEntity> findByGoodsCode(String goodsCode);
 
     boolean existsByGoodsCode(String goodsCode);
+
+    List<GifticonGoodsJpaEntity> findAllByGoodsStatus(String goodsStatus);
 }

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/vendor/giftishow/GifticonBrandFetchAdapter.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/vendor/giftishow/GifticonBrandFetchAdapter.java
@@ -1,0 +1,46 @@
+package com.personal.marketnote.reward.adapter.out.vendor.giftishow;
+
+import com.personal.marketnote.reward.adapter.out.vendor.giftishow.dto.GiftishowApiResponse;
+import com.personal.marketnote.reward.adapter.out.vendor.giftishow.dto.GiftishowBrandListResponse;
+import com.personal.marketnote.reward.adapter.out.vendor.giftishow.dto.GiftishowBrandListResponse.GiftishowBrandItem;
+import com.personal.marketnote.reward.port.out.gifticon.FetchGifticonBrandPort;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class GifticonBrandFetchAdapter implements FetchGifticonBrandPort {
+
+    private final GiftishowApiClient giftishowApiClient;
+
+    @Override
+    public FetchGifticonBrandResult fetchBrandList() {
+        GiftishowApiResponse<GiftishowBrandListResponse> response = giftishowApiClient.getBrandList();
+
+        if (!response.isSuccess()) {
+            log.warn("기프티쇼 브랜드 조회 실패: code={}, message={}", response.code(), response.message());
+            return new FetchGifticonBrandResult(0, List.of());
+        }
+
+        GiftishowBrandListResponse result = response.result();
+        List<FetchedGifticonBrandItem> items = result.brandList().stream()
+                .map(this::mapToFetchedItem)
+                .toList();
+
+        return new FetchGifticonBrandResult(result.listTotalCnt(), items);
+    }
+
+    private FetchedGifticonBrandItem mapToFetchedItem(GiftishowBrandItem item) {
+        return new FetchedGifticonBrandItem(
+                item.brandCode(),
+                item.brandName(),
+                item.brandIconImg(),
+                item.category1Seq(),
+                item.category1Name()
+        );
+    }
+}

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/vendor/giftishow/GifticonGoodsFetchAdapter.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/vendor/giftishow/GifticonGoodsFetchAdapter.java
@@ -1,0 +1,53 @@
+package com.personal.marketnote.reward.adapter.out.vendor.giftishow;
+
+import com.personal.marketnote.reward.adapter.out.vendor.giftishow.dto.GiftishowApiResponse;
+import com.personal.marketnote.reward.adapter.out.vendor.giftishow.dto.GiftishowProductListResponse;
+import com.personal.marketnote.reward.adapter.out.vendor.giftishow.dto.GiftishowProductListResponse.GiftishowProductItem;
+import com.personal.marketnote.reward.port.out.gifticon.FetchGifticonGoodsPort;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class GifticonGoodsFetchAdapter implements FetchGifticonGoodsPort {
+
+    private final GiftishowApiClient giftishowApiClient;
+
+    @Override
+    public FetchGifticonGoodsResult fetchProductList(int start, int size) {
+        GiftishowApiResponse<GiftishowProductListResponse> response = giftishowApiClient.getProductList(start, size);
+
+        if (!response.isSuccess()) {
+            log.warn("기프티쇼 상품 리스트 조회 실패: code={}, message={}", response.code(), response.message());
+            return new FetchGifticonGoodsResult(0, List.of());
+        }
+
+        GiftishowProductListResponse result = response.result();
+        List<FetchedGifticonGoodsItem> items = result.goodsList().stream()
+                .map(this::mapToFetchedItem)
+                .toList();
+
+        return new FetchGifticonGoodsResult(result.listTotalCnt(), items);
+    }
+
+    private FetchedGifticonGoodsItem mapToFetchedItem(GiftishowProductItem item) {
+        return new FetchedGifticonGoodsItem(
+                item.goodsCode(),
+                item.goodsName(),
+                item.goodsImgB(),
+                item.brandCode(),
+                item.brandName(),
+                item.brandIconImg(),
+                item.category1Seq(),
+                item.salePrice(),
+                item.realPrice(),
+                item.limitDay(),
+                item.content(),
+                item.goodsStatus()
+        );
+    }
+}

--- a/reward-service/reward-adapters/src/main/resources/application.yml
+++ b/reward-service/reward-adapters/src/main/resources/application.yml
@@ -106,6 +106,12 @@ vendor:
       biz-money-balance-path: /bizApi/bizMoney
       coupon-send-fail-cancel-path: /bizApi/coupon/sendFailCancel
 
+gifticon:
+  sync:
+    scheduler:
+      enabled: ${GIFTICON_SYNC_SCHEDULER_ENABLED:false}
+      cron: ${GIFTICON_SYNC_SCHEDULER_CRON:0 0 3 * * MON,WED,FRI}
+
 logging:
   config: classpath:logback-spring.xml
   level:

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/usecase/gifticon/SyncGifticonGoodsAndBrandsUseCase.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/usecase/gifticon/SyncGifticonGoodsAndBrandsUseCase.java
@@ -1,0 +1,6 @@
+package com.personal.marketnote.reward.port.in.usecase.gifticon;
+
+public interface SyncGifticonGoodsAndBrandsUseCase {
+
+    void syncAll();
+}

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/out/gifticon/FetchGifticonBrandPort.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/out/gifticon/FetchGifticonBrandPort.java
@@ -1,0 +1,23 @@
+package com.personal.marketnote.reward.port.out.gifticon;
+
+import java.util.List;
+
+public interface FetchGifticonBrandPort {
+
+    FetchGifticonBrandResult fetchBrandList();
+
+    record FetchGifticonBrandResult(
+            int totalCount,
+            List<FetchedGifticonBrandItem> items
+    ) {
+    }
+
+    record FetchedGifticonBrandItem(
+            String brandCode,
+            String brandName,
+            String brandIconImg,
+            String category1Seq,
+            String category1Name
+    ) {
+    }
+}

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/out/gifticon/FetchGifticonGoodsPort.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/out/gifticon/FetchGifticonGoodsPort.java
@@ -1,0 +1,30 @@
+package com.personal.marketnote.reward.port.out.gifticon;
+
+import java.util.List;
+
+public interface FetchGifticonGoodsPort {
+
+    FetchGifticonGoodsResult fetchProductList(int start, int size);
+
+    record FetchGifticonGoodsResult(
+            int totalCount,
+            List<FetchedGifticonGoodsItem> items
+    ) {
+    }
+
+    record FetchedGifticonGoodsItem(
+            String goodsCode,
+            String goodsName,
+            String goodsImgB,
+            String brandCode,
+            String brandName,
+            String brandIconImg,
+            String category1Seq,
+            long salePrice,
+            long realPrice,
+            int limitDay,
+            String content,
+            String goodsStatus
+    ) {
+    }
+}

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/out/gifticon/FindGifticonBrandPort.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/out/gifticon/FindGifticonBrandPort.java
@@ -1,0 +1,10 @@
+package com.personal.marketnote.reward.port.out.gifticon;
+
+import com.personal.marketnote.reward.domain.gifticon.GifticonBrand;
+
+import java.util.Optional;
+
+public interface FindGifticonBrandPort {
+
+    Optional<GifticonBrand> findByBrandCode(String brandCode);
+}

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/out/gifticon/FindGifticonCategoryMappingPort.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/out/gifticon/FindGifticonCategoryMappingPort.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.reward.port.out.gifticon;
+
+import java.util.Optional;
+
+public interface FindGifticonCategoryMappingPort {
+
+    Optional<Long> findCategoryIdByGiftishowCategorySeq(String giftishowCategorySeq);
+}

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/out/gifticon/FindGifticonCategoryPort.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/out/gifticon/FindGifticonCategoryPort.java
@@ -1,0 +1,12 @@
+package com.personal.marketnote.reward.port.out.gifticon;
+
+import com.personal.marketnote.reward.domain.gifticon.GifticonCategory;
+
+import java.util.Optional;
+
+public interface FindGifticonCategoryPort {
+
+    Optional<GifticonCategory> findByCategoryCode(String categoryCode);
+
+    Optional<GifticonCategory> findById(Long id);
+}

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/out/gifticon/FindGifticonGoodsPort.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/out/gifticon/FindGifticonGoodsPort.java
@@ -1,0 +1,13 @@
+package com.personal.marketnote.reward.port.out.gifticon;
+
+import com.personal.marketnote.reward.domain.gifticon.GifticonGoods;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface FindGifticonGoodsPort {
+
+    Optional<GifticonGoods> findByGoodsCode(String goodsCode);
+
+    List<GifticonGoods> findAllByGoodsStatus(String goodsStatus);
+}

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/out/gifticon/SaveGifticonBrandPort.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/out/gifticon/SaveGifticonBrandPort.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.reward.port.out.gifticon;
+
+import com.personal.marketnote.reward.domain.gifticon.GifticonBrand;
+
+public interface SaveGifticonBrandPort {
+
+    void save(GifticonBrand brand);
+}

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/out/gifticon/SaveGifticonCategoryMappingPort.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/out/gifticon/SaveGifticonCategoryMappingPort.java
@@ -1,0 +1,6 @@
+package com.personal.marketnote.reward.port.out.gifticon;
+
+public interface SaveGifticonCategoryMappingPort {
+
+    void save(String giftishowCategorySeq, Long gifticonCategoryId);
+}

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/out/gifticon/SaveGifticonCategoryPort.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/out/gifticon/SaveGifticonCategoryPort.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.reward.port.out.gifticon;
+
+import com.personal.marketnote.reward.domain.gifticon.GifticonCategory;
+
+public interface SaveGifticonCategoryPort {
+
+    GifticonCategory save(GifticonCategory category);
+}

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/out/gifticon/SaveGifticonGoodsPort.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/out/gifticon/SaveGifticonGoodsPort.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.reward.port.out.gifticon;
+
+import com.personal.marketnote.reward.domain.gifticon.GifticonGoods;
+
+public interface SaveGifticonGoodsPort {
+
+    void save(GifticonGoods goods);
+}

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/out/gifticon/UpdateGifticonBrandPort.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/out/gifticon/UpdateGifticonBrandPort.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.reward.port.out.gifticon;
+
+import com.personal.marketnote.reward.domain.gifticon.GifticonBrand;
+
+public interface UpdateGifticonBrandPort {
+
+    void update(GifticonBrand brand);
+}

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/out/gifticon/UpdateGifticonCategoryPort.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/out/gifticon/UpdateGifticonCategoryPort.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.reward.port.out.gifticon;
+
+import com.personal.marketnote.reward.domain.gifticon.GifticonCategory;
+
+public interface UpdateGifticonCategoryPort {
+
+    void update(GifticonCategory category);
+}

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/out/gifticon/UpdateGifticonGoodsPort.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/out/gifticon/UpdateGifticonGoodsPort.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.reward.port.out.gifticon;
+
+import com.personal.marketnote.reward.domain.gifticon.GifticonGoods;
+
+public interface UpdateGifticonGoodsPort {
+
+    void update(GifticonGoods goods);
+}

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/service/gifticon/SyncGifticonGoodsAndBrandsService.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/service/gifticon/SyncGifticonGoodsAndBrandsService.java
@@ -1,0 +1,199 @@
+package com.personal.marketnote.reward.service.gifticon;
+
+import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.reward.domain.gifticon.*;
+import com.personal.marketnote.reward.port.in.usecase.gifticon.SyncGifticonGoodsAndBrandsUseCase;
+import com.personal.marketnote.reward.port.out.gifticon.*;
+import com.personal.marketnote.reward.port.out.gifticon.FetchGifticonBrandPort.FetchGifticonBrandResult;
+import com.personal.marketnote.reward.port.out.gifticon.FetchGifticonBrandPort.FetchedGifticonBrandItem;
+import com.personal.marketnote.reward.port.out.gifticon.FetchGifticonGoodsPort.FetchGifticonGoodsResult;
+import com.personal.marketnote.reward.port.out.gifticon.FetchGifticonGoodsPort.FetchedGifticonGoodsItem;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.util.*;
+
+@Slf4j
+@UseCase
+@RequiredArgsConstructor
+public class SyncGifticonGoodsAndBrandsService implements SyncGifticonGoodsAndBrandsUseCase {
+
+    private static final int PAGE_SIZE = 20;
+    private static final int MAX_PAGES = 500;
+
+    private final TransactionTemplate transactionTemplate;
+    private final FetchGifticonBrandPort fetchGifticonBrandPort;
+    private final FetchGifticonGoodsPort fetchGifticonGoodsPort;
+    private final FindGifticonGoodsPort findGifticonGoodsPort;
+    private final SaveGifticonGoodsPort saveGifticonGoodsPort;
+    private final UpdateGifticonGoodsPort updateGifticonGoodsPort;
+    private final FindGifticonBrandPort findGifticonBrandPort;
+    private final SaveGifticonBrandPort saveGifticonBrandPort;
+    private final UpdateGifticonBrandPort updateGifticonBrandPort;
+    private final FindGifticonCategoryPort findGifticonCategoryPort;
+    private final SaveGifticonCategoryPort saveGifticonCategoryPort;
+    private final UpdateGifticonCategoryPort updateGifticonCategoryPort;
+    private final FindGifticonCategoryMappingPort findGifticonCategoryMappingPort;
+    private final SaveGifticonCategoryMappingPort saveGifticonCategoryMappingPort;
+
+    @Override
+    public void syncAll() {
+        FetchGifticonBrandResult brandResult = fetchGifticonBrandPort.fetchBrandList();
+        List<FetchedGifticonGoodsItem> allGoodsItems = fetchAllGoodsPages();
+
+        transactionTemplate.execute(status -> {
+            syncBrandsAndCategories(brandResult.items());
+            Set<String> syncedGoodsCodes = syncGoods(allGoodsItems);
+            suspendMissingGoods(syncedGoodsCodes);
+            return null;
+        });
+    }
+
+    private List<FetchedGifticonGoodsItem> fetchAllGoodsPages() {
+        List<FetchedGifticonGoodsItem> allItems = new ArrayList<>();
+        int start = 1;
+        int pageCount = 0;
+
+        while (pageCount < MAX_PAGES) {
+            FetchGifticonGoodsResult page = fetchGifticonGoodsPort.fetchProductList(start, PAGE_SIZE);
+            allItems.addAll(page.items());
+            pageCount++;
+
+            if (allItems.size() >= page.totalCount() || page.items().isEmpty()) {
+                break;
+            }
+            start += PAGE_SIZE;
+        }
+
+        return allItems;
+    }
+
+    private void syncBrandsAndCategories(List<FetchedGifticonBrandItem> brandItems) {
+        for (FetchedGifticonBrandItem item : brandItems) {
+            syncBrand(item);
+            syncCategoryFromBrand(item);
+        }
+    }
+
+    private void syncBrand(FetchedGifticonBrandItem item) {
+        Optional<GifticonBrand> existing = findGifticonBrandPort.findByBrandCode(item.brandCode());
+
+        if (existing.isPresent()) {
+            GifticonBrand brand = existing.get();
+            brand.syncFromApi(item.brandName(), item.brandIconImg());
+            updateGifticonBrandPort.update(brand);
+            return;
+        }
+
+        GifticonBrand brand = GifticonBrand.from(GifticonBrandCreateState.builder()
+                .brandCode(item.brandCode())
+                .brandName(item.brandName())
+                .brandImageUrl(item.brandIconImg())
+                .build());
+        saveGifticonBrandPort.save(brand);
+    }
+
+    private void syncCategoryFromBrand(FetchedGifticonBrandItem item) {
+        Optional<Long> existingCategoryId = findGifticonCategoryMappingPort
+                .findCategoryIdByGiftishowCategorySeq(item.category1Seq());
+
+        if (existingCategoryId.isPresent()) {
+            updateExistingCategory(existingCategoryId.get(), item.category1Name());
+            return;
+        }
+
+        createCategoryAndMapping(item.category1Seq(), item.category1Name());
+    }
+
+    private void updateExistingCategory(Long categoryId, String categoryName) {
+        Optional<GifticonCategory> category = findGifticonCategoryPort.findById(categoryId);
+
+        if (category.isEmpty()) {
+            return;
+        }
+
+        GifticonCategory existing = category.get();
+        existing.syncFromApi(categoryName);
+        updateGifticonCategoryPort.update(existing);
+    }
+
+    private void createCategoryAndMapping(String category1Seq, String category1Name) {
+        Optional<GifticonCategory> existing = findGifticonCategoryPort.findByCategoryCode(category1Seq);
+
+        if (existing.isPresent()) {
+            saveGifticonCategoryMappingPort.save(category1Seq, existing.get().getId());
+            return;
+        }
+
+        GifticonCategory category = GifticonCategory.from(GifticonCategoryCreateState.builder()
+                .categoryCode(category1Seq)
+                .categoryName(category1Name)
+                .build());
+        GifticonCategory savedCategory = saveGifticonCategoryPort.save(category);
+        saveGifticonCategoryMappingPort.save(category1Seq, savedCategory.getId());
+    }
+
+    private Set<String> syncGoods(List<FetchedGifticonGoodsItem> goodsItems) {
+        Set<String> syncedGoodsCodes = new HashSet<>();
+
+        for (FetchedGifticonGoodsItem item : goodsItems) {
+            syncSingleGoods(item);
+            syncedGoodsCodes.add(item.goodsCode());
+        }
+
+        return syncedGoodsCodes;
+    }
+
+    private void syncSingleGoods(FetchedGifticonGoodsItem item) {
+        Optional<GifticonGoods> existing = findGifticonGoodsPort.findByGoodsCode(item.goodsCode());
+
+        if (existing.isPresent()) {
+            GifticonGoods goods = existing.get();
+            goods.syncFromApi(GifticonGoodsSyncState.builder()
+                    .goodsName(item.goodsName())
+                    .brandCode(item.brandCode())
+                    .brandName(item.brandName())
+                    .brandImageUrl(item.brandIconImg())
+                    .categoryCode(item.category1Seq())
+                    .realPrice(item.realPrice())
+                    .salePrice(item.salePrice())
+                    .imageUrl(item.goodsImgB())
+                    .description(item.content())
+                    .validDays(item.limitDay())
+                    .goodsStatus(item.goodsStatus())
+                    .build());
+            updateGifticonGoodsPort.update(goods);
+            return;
+        }
+
+        GifticonGoods goods = GifticonGoods.from(GifticonGoodsCreateState.builder()
+                .goodsCode(item.goodsCode())
+                .goodsName(item.goodsName())
+                .brandCode(item.brandCode())
+                .brandName(item.brandName())
+                .brandImageUrl(item.brandIconImg())
+                .categoryCode(item.category1Seq())
+                .realPrice(item.realPrice())
+                .salePrice(item.salePrice())
+                .cashPrice(item.salePrice())
+                .imageUrl(item.goodsImgB())
+                .description(item.content())
+                .validDays(item.limitDay())
+                .goodsStatus(item.goodsStatus())
+                .build());
+        saveGifticonGoodsPort.save(goods);
+    }
+
+    private void suspendMissingGoods(Set<String> syncedGoodsCodes) {
+        List<GifticonGoods> saleGoods = findGifticonGoodsPort.findAllByGoodsStatus("SALE");
+
+        for (GifticonGoods goods : saleGoods) {
+            if (syncedGoodsCodes.contains(goods.getGoodsCode())) {
+                continue;
+            }
+            goods.suspend();
+            updateGifticonGoodsPort.update(goods);
+        }
+    }
+}

--- a/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/exception/GifticonBrandNotFoundException.java
+++ b/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/exception/GifticonBrandNotFoundException.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.reward.domain.exception;
+
+public class GifticonBrandNotFoundException extends RuntimeException {
+    private static final String MESSAGE = "기프티콘 브랜드를 찾을 수 없습니다. brandCode=%s";
+
+    public GifticonBrandNotFoundException(String brandCode) {
+        super(String.format(MESSAGE, brandCode));
+    }
+}

--- a/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/exception/GifticonCategoryNotFoundException.java
+++ b/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/exception/GifticonCategoryNotFoundException.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.reward.domain.exception;
+
+public class GifticonCategoryNotFoundException extends RuntimeException {
+    private static final String MESSAGE = "기프티콘 카테고리를 찾을 수 없습니다. id=%d";
+
+    public GifticonCategoryNotFoundException(Long id) {
+        super(String.format(MESSAGE, id));
+    }
+}

--- a/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/gifticon/GifticonCategory.java
+++ b/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/gifticon/GifticonCategory.java
@@ -20,6 +20,15 @@ public class GifticonCategory {
     private LocalDateTime createdAt;
     private LocalDateTime modifiedAt;
 
+    public static GifticonCategory from(GifticonCategoryCreateState state) {
+        return GifticonCategory.builder()
+                .categoryCode(state.getCategoryCode())
+                .categoryName(state.getCategoryName())
+                .exposed(false)
+                .orderNum(null)
+                .build();
+    }
+
     public static GifticonCategory from(GifticonCategorySnapshotState state) {
         return GifticonCategory.builder()
                 .id(state.getId())
@@ -59,5 +68,9 @@ public class GifticonCategory {
 
     public void changeOrderNum(Integer orderNum) {
         this.orderNum = orderNum;
+    }
+
+    public void syncFromApi(String categoryName) {
+        this.categoryName = categoryName;
     }
 }

--- a/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/gifticon/GifticonCategoryCreateState.java
+++ b/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/gifticon/GifticonCategoryCreateState.java
@@ -1,0 +1,11 @@
+package com.personal.marketnote.reward.domain.gifticon;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class GifticonCategoryCreateState {
+    private final String categoryCode;
+    private final String categoryName;
+}

--- a/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/gifticon/GifticonGoods.java
+++ b/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/gifticon/GifticonGoods.java
@@ -71,20 +71,18 @@ public class GifticonGoods {
                 .build();
     }
 
-    public void syncFromApi(String goodsName, String brandCode, String brandName, String brandImageUrl,
-                            String categoryCode, Long realPrice, Long salePrice, String imageUrl,
-                            String description, Integer validDays, String goodsStatus) {
-        this.goodsName = goodsName;
-        this.brandCode = brandCode;
-        this.brandName = brandName;
-        this.brandImageUrl = brandImageUrl;
-        this.categoryCode = categoryCode;
-        this.realPrice = realPrice;
-        this.salePrice = salePrice;
-        this.imageUrl = imageUrl;
-        this.description = description;
-        this.validDays = validDays;
-        this.goodsStatus = goodsStatus;
+    public void syncFromApi(GifticonGoodsSyncState state) {
+        this.goodsName = state.getGoodsName();
+        this.brandCode = state.getBrandCode();
+        this.brandName = state.getBrandName();
+        this.brandImageUrl = state.getBrandImageUrl();
+        this.categoryCode = state.getCategoryCode();
+        this.realPrice = state.getRealPrice();
+        this.salePrice = state.getSalePrice();
+        this.imageUrl = state.getImageUrl();
+        this.description = state.getDescription();
+        this.validDays = state.getValidDays();
+        this.goodsStatus = state.getGoodsStatus();
     }
 
     public void expose() {
@@ -101,5 +99,12 @@ public class GifticonGoods {
 
     public boolean isSale() {
         return "SALE".equals(this.goodsStatus);
+    }
+
+    public void suspend() {
+        if (!isSale()) {
+            return;
+        }
+        this.goodsStatus = "SUS";
     }
 }

--- a/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/gifticon/GifticonGoodsSyncState.java
+++ b/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/gifticon/GifticonGoodsSyncState.java
@@ -1,0 +1,20 @@
+package com.personal.marketnote.reward.domain.gifticon;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class GifticonGoodsSyncState {
+    private final String goodsName;
+    private final String brandCode;
+    private final String brandName;
+    private final String brandImageUrl;
+    private final String categoryCode;
+    private final Long realPrice;
+    private final Long salePrice;
+    private final String imageUrl;
+    private final String description;
+    private final Integer validDays;
+    private final String goodsStatus;
+}

--- a/reward-service/reward-domain/src/test/java/com/personal/marketnote/reward/domain/gifticon/GifticonGoodsTest.java
+++ b/reward-service/reward-domain/src/test/java/com/personal/marketnote/reward/domain/gifticon/GifticonGoodsTest.java
@@ -166,8 +166,19 @@ class GifticonGoodsTest {
                     .modifiedAt(LocalDateTime.of(2026, 4, 3, 12, 0, 0))
                     .build());
 
-            goods.syncFromApi("스타벅스 카페라떼", "B001", "스타벅스", "https://example.com/brand2.jpg",
-                    "3", 5500L, 5000L, "https://example.com/image2.jpg", "새 설명", 90, "SALE");
+            goods.syncFromApi(GifticonGoodsSyncState.builder()
+                    .goodsName("스타벅스 카페라떼")
+                    .brandCode("B001")
+                    .brandName("스타벅스")
+                    .brandImageUrl("https://example.com/brand2.jpg")
+                    .categoryCode("3")
+                    .realPrice(5500L)
+                    .salePrice(5000L)
+                    .imageUrl("https://example.com/image2.jpg")
+                    .description("새 설명")
+                    .validDays(90)
+                    .goodsStatus("SALE")
+                    .build());
 
             assertThat(goods.getGoodsName()).isEqualTo("스타벅스 카페라떼");
             assertThat(goods.getRealPrice()).isEqualTo(5500L);


### PR DESCRIPTION
## partially addresses #1653
## resolves #1664

## Task
- [x] GifticonGoods 도메인에 syncFromApi(GifticonGoodsSyncState) + suspend() 메서드 추가
- [x] GifticonCategory 도메인에 from(CreateState) 팩토리 메서드 + syncFromApi(String) 메서드 추가
- [x] GifticonCategoryCreateState, GifticonGoodsSyncState 도메인 State 클래스 추가
- [x] GifticonBrandNotFoundException, GifticonCategoryNotFoundException 예외 클래스 추가
- [x] SyncGifticonGoodsAndBrandsUseCase 인터페이스 + Service 구현 (TransactionTemplate 분리)
- [x] Port.out 인터페이스 13개 (Find/Save/Update Goods, Brand, Category + CategoryMapping + Fetch)
- [x] GifticonGoodsPersistenceAdapter, GifticonBrandPersistenceAdapter, GifticonCategoryPersistenceAdapter 구현
- [x] GifticonGoodsFetchAdapter (API 0101), GifticonBrandFetchAdapter (API 0102) 구현
- [x] GifticonSyncScheduler (@scheduled + @ConditionalOnProperty, 주 3회 새벽 3시)
- [x] GifticonGoodsJpaRepository.findAllByGoodsStatus 메서드 추가
- [x] application.yml 스케줄러 설정 추가
- [x] 기존 GifticonGoodsTest syncFromApi 시그니처 변경 반영