### PR TITLE
[#1653][#1771] feat: 관리자 기프티콘 전체 상품 목록 조회 기능 추가

### DIFF
--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/gifticon/controller/AdminGifticonGoodsController.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/gifticon/controller/AdminGifticonGoodsController.java
@@ -1,0 +1,60 @@
+package com.personal.marketnote.reward.adapter.in.web.gifticon.controller;
+
+import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
+import com.personal.marketnote.reward.adapter.in.web.gifticon.controller.apidocs.GetAdminGifticonGoodsApiDocs;
+import com.personal.marketnote.reward.adapter.in.web.gifticon.response.GetAdminGifticonGoodsResponse;
+import com.personal.marketnote.reward.port.in.command.gifticon.GetAdminGifticonGoodsCommand;
+import com.personal.marketnote.reward.port.in.result.gifticon.GetAdminGifticonGoodsResult;
+import com.personal.marketnote.reward.port.in.usecase.gifticon.GetAdminGifticonGoodsUseCase;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import static com.personal.marketnote.common.domain.exception.ExceptionCode.DEFAULT_SUCCESS_CODE;
+import static com.personal.marketnote.common.utility.ApiConstant.ADMIN_POINTCUT;
+
+@RestController
+@RequestMapping("/api/v1/admin/gifticon/goods")
+@Tag(name = "관리자 기프티콘 상품 API", description = "관리자 기프티콘 상품 관련 API")
+@RequiredArgsConstructor
+public class AdminGifticonGoodsController {
+
+    private final GetAdminGifticonGoodsUseCase getAdminGifticonGoodsUseCase;
+
+    /**
+     * (관리자) 기프티콘 전체 상품 목록 조회
+     *
+     * @Author 성효빈
+     * @Date 2026-04-05
+     * @Description 관리자가 기프티쇼에서 동기화된 전체 기프티콘 상품을 조회합니다.
+     */
+    @GetMapping
+    @PreAuthorize(ADMIN_POINTCUT)
+    @GetAdminGifticonGoodsApiDocs
+    public ResponseEntity<BaseResponse<GetAdminGifticonGoodsResponse>> getAdminGifticonGoods(
+            @RequestParam(value = "page", defaultValue = "1") int page,
+            @RequestParam(value = "page-size", defaultValue = "20") int pageSize,
+            @RequestParam(value = "goods-status", required = false) String goodsStatus,
+            @RequestParam(value = "exposed", required = false) Boolean exposed,
+            @RequestParam(value = "keyword", required = false) String keyword
+    ) {
+        GetAdminGifticonGoodsCommand command = new GetAdminGifticonGoodsCommand(
+                page, pageSize, goodsStatus, exposed, keyword
+        );
+
+        GetAdminGifticonGoodsResult result = getAdminGifticonGoodsUseCase.getAdminGifticonGoods(command);
+
+        return new ResponseEntity<>(
+                BaseResponse.of(
+                        GetAdminGifticonGoodsResponse.from(result),
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "관리자 기프티콘 상품 목록 조회 성공"
+                ),
+                HttpStatus.OK
+        );
+    }
+}

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/gifticon/controller/apidocs/GetAdminGifticonGoodsApiDocs.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/gifticon/controller/apidocs/GetAdminGifticonGoodsApiDocs.java
@@ -1,0 +1,167 @@
+package com.personal.marketnote.reward.adapter.in.web.gifticon.controller.apidocs;
+
+import com.personal.marketnote.common.adapter.in.api.schema.StringResponseSchema;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Operation(
+        summary = "(관리자) 기프티콘 전체 상품 목록 조회",
+        description = """
+                작성일자: 2026-04-05
+
+                작성자: 성효빈
+
+                ---
+
+                ## Description
+
+                - 관리자가 기프티쇼에서 동기화된 전체 기프티콘 상품 목록을 조회합니다.
+
+                - 오프셋 기반 페이지네이션을 사용합니다. (page: 1-based)
+
+                ---
+
+                ## Request
+
+                | **키** | **타입** | **설명** | **필수 여부** | **예시** |
+                | --- | --- | --- | --- | --- |
+                | page | number | 페이지 번호 (1-based) | N | 1 |
+                | page-size | number | 페이지 크기 | N | 20 |
+                | goods-status | string | 상품 상태 필터 (SALE/SUS) | N | SALE |
+                | exposed | boolean | 노출 여부 필터 | N | true |
+                | keyword | string | 상품명 검색 키워드 | N | "아메리카노" |
+
+                ---
+
+                ## Response
+
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | statusCode | number | 상태 코드 | 200 |
+                | code | string | 응답 코드 | "SUC01" |
+                | timestamp | string(datetime) | 응답 일시 | "2026-04-05T12:00:00.000" |
+                | content | object | 응답 본문 | { ... } |
+                | message | string | 처리 결과 | "관리자 기프티콘 상품 목록 조회 성공" |
+
+                ---
+
+                ### Response > content > goods
+
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | page | number | 현재 페이지 번호 (1-based) | 1 |
+                | pageSize | number | 페이지 크기 | 20 |
+                | totalElements | number | 총 아이템 수 | 50 |
+                | totalPages | number | 총 페이지 수 | 3 |
+                | items | array | 상품 목록 | [ ... ] |
+
+                ---
+
+                ### Response > content > goods > items
+
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | goodsCode | string | 상품 코드 | "G00001" |
+                | goodsName | string | 상품명 | "아메리카노" |
+                | brandCode | string | 브랜드 코드 | "BR001" |
+                | brandName | string | 브랜드명 | "스타벅스" |
+                | categoryCode | string | 카테고리 코드 | "1" |
+                | realPrice | number | 정상가 | 5000 |
+                | salePrice | number | 판매가 | 4500 |
+                | cashPrice | number | 현금가 | 3500 |
+                | goodsStatus | string | 상품 상태 | "SALE" |
+                | exposed | boolean | 노출 여부 | true |
+                | orderNum | number | 노출 순서 | 1 |
+                | imageUrl | string | 이미지 URL | "https://img.com/goods.png" |
+                | createdAt | string(datetime) | 생성일시 | "2026-04-01T10:00:00" |
+                | modifiedAt | string(datetime) | 수정일시 | "2026-04-01T10:00:00" |
+                """,
+        security = {@SecurityRequirement(name = "bearer")},
+        parameters = {
+                @Parameter(
+                        name = "page",
+                        in = ParameterIn.QUERY,
+                        description = "페이지 번호 (1-based, 기본값: 1)",
+                        schema = @Schema(type = "number", example = "1", defaultValue = "1")
+                ),
+                @Parameter(
+                        name = "page-size",
+                        in = ParameterIn.QUERY,
+                        description = "페이지 크기 (기본값: 20)",
+                        schema = @Schema(type = "number", example = "20", defaultValue = "20")
+                ),
+                @Parameter(
+                        name = "goods-status",
+                        in = ParameterIn.QUERY,
+                        description = "상품 상태 필터",
+                        schema = @Schema(type = "string", allowableValues = {"SALE", "SUS"})
+                ),
+                @Parameter(
+                        name = "exposed",
+                        in = ParameterIn.QUERY,
+                        description = "노출 여부 필터",
+                        schema = @Schema(type = "boolean")
+                ),
+                @Parameter(
+                        name = "keyword",
+                        in = ParameterIn.QUERY,
+                        description = "상품명 검색 키워드",
+                        schema = @Schema(type = "string")
+                )
+        },
+        responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "관리자 기프티콘 상품 목록 조회 성공",
+                        content = @Content(
+                                schema = @Schema(implementation = StringResponseSchema.class),
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 200,
+                                          "code": "SUC01",
+                                          "timestamp": "2026-04-05T12:00:00.000",
+                                          "content": {
+                                            "goods": {
+                                              "page": 1,
+                                              "pageSize": 20,
+                                              "totalElements": 50,
+                                              "totalPages": 3,
+                                              "items": [
+                                                {
+                                                  "goodsCode": "G00001",
+                                                  "goodsName": "아메리카노",
+                                                  "brandCode": "BR001",
+                                                  "brandName": "스타벅스",
+                                                  "categoryCode": "1",
+                                                  "realPrice": 5000,
+                                                  "salePrice": 4500,
+                                                  "cashPrice": 3500,
+                                                  "goodsStatus": "SALE",
+                                                  "exposed": true,
+                                                  "orderNum": 1,
+                                                  "imageUrl": "https://img.com/goods.png",
+                                                  "createdAt": "2026-04-01T10:00:00",
+                                                  "modifiedAt": "2026-04-01T10:00:00"
+                                                }
+                                              ]
+                                            }
+                                          },
+                                          "message": "관리자 기프티콘 상품 목록 조회 성공"
+                                        }
+                                        """)
+                        )
+                )
+        })
+public @interface GetAdminGifticonGoodsApiDocs {
+}

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/gifticon/response/GetAdminGifticonGoodsResponse.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/gifticon/response/GetAdminGifticonGoodsResponse.java
@@ -1,0 +1,60 @@
+package com.personal.marketnote.reward.adapter.in.web.gifticon.response;
+
+import com.personal.marketnote.common.adapter.in.response.OffsetResponse;
+import com.personal.marketnote.reward.port.in.result.gifticon.GetAdminGifticonGoodsResult;
+import com.personal.marketnote.reward.port.in.result.gifticon.GifticonGoodsItemResult;
+
+import java.time.LocalDateTime;
+
+public record GetAdminGifticonGoodsResponse(OffsetResponse<GifticonGoodsItem> goods) {
+
+    public static GetAdminGifticonGoodsResponse from(GetAdminGifticonGoodsResult result) {
+        return new GetAdminGifticonGoodsResponse(
+                new OffsetResponse<>(
+                        result.page(),
+                        result.pageSize(),
+                        result.totalElements(),
+                        result.totalPages(),
+                        result.items().stream()
+                                .map(GifticonGoodsItem::from)
+                                .toList()
+                )
+        );
+    }
+
+    public record GifticonGoodsItem(
+            String goodsCode,
+            String goodsName,
+            String brandCode,
+            String brandName,
+            String categoryCode,
+            Long realPrice,
+            Long salePrice,
+            Long cashPrice,
+            String goodsStatus,
+            boolean exposed,
+            Integer orderNum,
+            String imageUrl,
+            LocalDateTime createdAt,
+            LocalDateTime modifiedAt
+    ) {
+        public static GifticonGoodsItem from(GifticonGoodsItemResult item) {
+            return new GifticonGoodsItem(
+                    item.goodsCode(),
+                    item.goodsName(),
+                    item.brandCode(),
+                    item.brandName(),
+                    item.categoryCode(),
+                    item.realPrice(),
+                    item.salePrice(),
+                    item.cashPrice(),
+                    item.goodsStatus(),
+                    item.exposed(),
+                    item.orderNum(),
+                    item.imageUrl(),
+                    item.createdAt(),
+                    item.modifiedAt()
+            );
+        }
+    }
+}

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/gifticon/GifticonGoodsPersistenceAdapter.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/gifticon/GifticonGoodsPersistenceAdapter.java
@@ -9,6 +9,8 @@ import com.personal.marketnote.reward.port.out.gifticon.FindGifticonGoodsPort;
 import com.personal.marketnote.reward.port.out.gifticon.SaveGifticonGoodsPort;
 import com.personal.marketnote.reward.port.out.gifticon.UpdateGifticonGoodsPort;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 
 import java.util.List;
 import java.util.Optional;
@@ -42,5 +44,15 @@ public class GifticonGoodsPersistenceAdapter implements FindGifticonGoodsPort, S
         GifticonGoodsJpaEntity entity = repository.findById(goods.getId())
                 .orElseThrow(() -> new GifticonGoodsNotFoundException(goods.getGoodsCode()));
         entity.updateFrom(goods);
+    }
+
+    @Override
+    public FindAllForAdminResult findAllForAdmin(int page, int pageSize, String goodsStatus, Boolean exposed, String keyword) {
+        PageRequest pageRequest = PageRequest.of(page - 1, pageSize);
+        Page<GifticonGoodsJpaEntity> pageResult = repository.findAllForAdmin(goodsStatus, exposed, keyword, pageRequest);
+        List<GifticonGoods> items = pageResult.getContent().stream()
+                .map(GifticonGoodsJpaEntity::toDomain)
+                .toList();
+        return new FindAllForAdminResult(items, pageResult.getTotalElements());
     }
 }

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/gifticon/repository/GifticonGoodsJpaRepository.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/gifticon/repository/GifticonGoodsJpaRepository.java
@@ -1,7 +1,11 @@
 package com.personal.marketnote.reward.adapter.out.persistence.gifticon.repository;
 
 import com.personal.marketnote.reward.adapter.out.persistence.gifticon.entity.GifticonGoodsJpaEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -13,4 +17,24 @@ public interface GifticonGoodsJpaRepository extends JpaRepository<GifticonGoodsJ
     boolean existsByGoodsCode(String goodsCode);
 
     List<GifticonGoodsJpaEntity> findAllByGoodsStatus(String goodsStatus);
+
+    @Query(value = """
+            SELECT g FROM GifticonGoodsJpaEntity g
+            WHERE (:goodsStatus = '' OR g.goodsStatus = :goodsStatus)
+            AND (:exposed IS NULL OR g.exposed = :exposed)
+            AND (:keyword = '' OR g.goodsName LIKE CONCAT('%', :keyword, '%'))
+            ORDER BY g.id DESC
+            """,
+            countQuery = """
+            SELECT COUNT(g) FROM GifticonGoodsJpaEntity g
+            WHERE (:goodsStatus = '' OR g.goodsStatus = :goodsStatus)
+            AND (:exposed IS NULL OR g.exposed = :exposed)
+            AND (:keyword = '' OR g.goodsName LIKE CONCAT('%', :keyword, '%'))
+            """)
+    Page<GifticonGoodsJpaEntity> findAllForAdmin(
+            @Param("goodsStatus") String goodsStatus,
+            @Param("exposed") Boolean exposed,
+            @Param("keyword") String keyword,
+            Pageable pageable
+    );
 }

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/command/gifticon/GetAdminGifticonGoodsCommand.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/command/gifticon/GetAdminGifticonGoodsCommand.java
@@ -1,0 +1,10 @@
+package com.personal.marketnote.reward.port.in.command.gifticon;
+
+public record GetAdminGifticonGoodsCommand(
+        int page,
+        int pageSize,
+        String goodsStatus,
+        Boolean exposed,
+        String keyword
+) {
+}

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/result/gifticon/GetAdminGifticonGoodsResult.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/result/gifticon/GetAdminGifticonGoodsResult.java
@@ -1,0 +1,22 @@
+package com.personal.marketnote.reward.port.in.result.gifticon;
+
+import com.personal.marketnote.reward.domain.gifticon.GifticonGoods;
+import com.personal.marketnote.reward.port.out.gifticon.FindGifticonGoodsPort.FindAllForAdminResult;
+
+import java.util.List;
+
+public record GetAdminGifticonGoodsResult(
+        int page,
+        int pageSize,
+        long totalElements,
+        int totalPages,
+        List<GifticonGoodsItemResult> items
+) {
+    public static GetAdminGifticonGoodsResult from(int page, int pageSize, FindAllForAdminResult portResult) {
+        int totalPages = pageSize == 0 ? 0 : (int) Math.ceil((double) portResult.totalElements() / pageSize);
+        List<GifticonGoodsItemResult> items = portResult.items().stream()
+                .map(GifticonGoodsItemResult::from)
+                .toList();
+        return new GetAdminGifticonGoodsResult(page, pageSize, portResult.totalElements(), totalPages, items);
+    }
+}

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/result/gifticon/GifticonGoodsItemResult.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/result/gifticon/GifticonGoodsItemResult.java
@@ -1,0 +1,41 @@
+package com.personal.marketnote.reward.port.in.result.gifticon;
+
+import com.personal.marketnote.reward.domain.gifticon.GifticonGoods;
+
+import java.time.LocalDateTime;
+
+public record GifticonGoodsItemResult(
+        String goodsCode,
+        String goodsName,
+        String brandCode,
+        String brandName,
+        String categoryCode,
+        Long realPrice,
+        Long salePrice,
+        Long cashPrice,
+        String goodsStatus,
+        boolean exposed,
+        Integer orderNum,
+        String imageUrl,
+        LocalDateTime createdAt,
+        LocalDateTime modifiedAt
+) {
+    public static GifticonGoodsItemResult from(GifticonGoods goods) {
+        return new GifticonGoodsItemResult(
+                goods.getGoodsCode(),
+                goods.getGoodsName(),
+                goods.getBrandCode(),
+                goods.getBrandName(),
+                goods.getCategoryCode(),
+                goods.getRealPrice(),
+                goods.getSalePrice(),
+                goods.getCashPrice(),
+                goods.getGoodsStatus(),
+                goods.isExposed(),
+                goods.getOrderNum(),
+                goods.getImageUrl(),
+                goods.getCreatedAt(),
+                goods.getModifiedAt()
+        );
+    }
+}

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/usecase/gifticon/GetAdminGifticonGoodsUseCase.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/usecase/gifticon/GetAdminGifticonGoodsUseCase.java
@@ -1,0 +1,23 @@
+package com.personal.marketnote.reward.port.in.usecase.gifticon;
+
+import com.personal.marketnote.reward.port.in.command.gifticon.GetAdminGifticonGoodsCommand;
+import com.personal.marketnote.reward.port.in.result.gifticon.GetAdminGifticonGoodsResult;
+
+/**
+ * 관리자 기프티콘 전체 상품 목록 조회 유스케이스
+ *
+ * @Author 성효빈
+ * @Date 2026-04-05
+ * @Description 관리자가 기프티쇼에서 동기화된 전체 상품을 조회합니다.
+ */
+public interface GetAdminGifticonGoodsUseCase {
+
+    /**
+     * @param command 조회 조건 {@link GetAdminGifticonGoodsCommand}
+     * @return 페이징된 상품 목록 {@link GetAdminGifticonGoodsResult}
+     * @Date 2026-04-05
+     * @Author 성효빈
+     * @Description 관리자 기프티콘 전체 상품 목록을 조회합니다.
+     */
+    GetAdminGifticonGoodsResult getAdminGifticonGoods(GetAdminGifticonGoodsCommand command);
+}

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/out/gifticon/FindGifticonGoodsPort.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/out/gifticon/FindGifticonGoodsPort.java
@@ -10,4 +10,9 @@ public interface FindGifticonGoodsPort {
     Optional<GifticonGoods> findByGoodsCode(String goodsCode);
 
     List<GifticonGoods> findAllByGoodsStatus(String goodsStatus);
+
+    FindAllForAdminResult findAllForAdmin(int page, int pageSize, String goodsStatus, Boolean exposed, String keyword);
+
+    record FindAllForAdminResult(List<GifticonGoods> items, long totalElements) {
+    }
 }

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/service/gifticon/GetAdminGifticonGoodsService.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/service/gifticon/GetAdminGifticonGoodsService.java
@@ -1,0 +1,37 @@
+package com.personal.marketnote.reward.service.gifticon;
+
+import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.reward.port.in.command.gifticon.GetAdminGifticonGoodsCommand;
+import com.personal.marketnote.reward.port.in.result.gifticon.GetAdminGifticonGoodsResult;
+import com.personal.marketnote.reward.port.in.usecase.gifticon.GetAdminGifticonGoodsUseCase;
+import com.personal.marketnote.reward.port.out.gifticon.FindGifticonGoodsPort;
+import com.personal.marketnote.reward.port.out.gifticon.FindGifticonGoodsPort.FindAllForAdminResult;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional(isolation = READ_COMMITTED, readOnly = true)
+public class GetAdminGifticonGoodsService implements GetAdminGifticonGoodsUseCase {
+
+    private final FindGifticonGoodsPort findGifticonGoodsPort;
+
+    @Override
+    public GetAdminGifticonGoodsResult getAdminGifticonGoods(GetAdminGifticonGoodsCommand command) {
+        String goodsStatus = FormatValidator.hasValue(command.goodsStatus()) ? command.goodsStatus() : "";
+        String keyword = FormatValidator.hasValue(command.keyword()) ? command.keyword() : "";
+
+        FindAllForAdminResult portResult = findGifticonGoodsPort.findAllForAdmin(
+                command.page(),
+                command.pageSize(),
+                goodsStatus,
+                command.exposed(),
+                keyword
+        );
+
+        return GetAdminGifticonGoodsResult.from(command.page(), command.pageSize(), portResult);
+    }
+}


### PR DESCRIPTION
## partially addresses #1653
## resolves #1771

## Task
- [x] GetAdminGifticonGoodsUseCase / Service 구현
- [x] FindGifticonGoodsPort.findAllForAdmin 페이징 조회 추가
- [x] GifticonGoodsJpaRepository JPQL 동적 필터 쿼리 추가
- [x] AdminGifticonGoodsController GET /api/v1/admin/gifticon/goods
- [x] OffsetResponse 기반 페이징 응답 (goodsStatus/exposed/keyword 필터)