### PR TITLE
[#1653][#1772] feat: 관리자 기프티콘 노출 상품 관리 기능 추가

### DIFF
--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/gifticon/controller/AdminGifticonGoodsController.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/gifticon/controller/AdminGifticonGoodsController.java
@@ -2,11 +2,17 @@ package com.personal.marketnote.reward.adapter.in.web.gifticon.controller;
 
 import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
 import com.personal.marketnote.reward.adapter.in.web.gifticon.controller.apidocs.GetAdminGifticonGoodsApiDocs;
+import com.personal.marketnote.reward.adapter.in.web.gifticon.controller.apidocs.ManageGifticonGoodsExposureApiDocs;
+import com.personal.marketnote.reward.adapter.in.web.gifticon.request.ManageGifticonGoodsExposureRequest;
 import com.personal.marketnote.reward.adapter.in.web.gifticon.response.GetAdminGifticonGoodsResponse;
 import com.personal.marketnote.reward.port.in.command.gifticon.GetAdminGifticonGoodsCommand;
+import com.personal.marketnote.reward.port.in.command.gifticon.ManageGifticonGoodsExposureCommand;
+import com.personal.marketnote.reward.port.in.command.gifticon.ManageGifticonGoodsExposureCommand.ExposureItem;
 import com.personal.marketnote.reward.port.in.result.gifticon.GetAdminGifticonGoodsResult;
 import com.personal.marketnote.reward.port.in.usecase.gifticon.GetAdminGifticonGoodsUseCase;
+import com.personal.marketnote.reward.port.in.usecase.gifticon.ManageGifticonGoodsExposureUseCase;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -23,6 +29,7 @@ import static com.personal.marketnote.common.utility.ApiConstant.ADMIN_POINTCUT;
 public class AdminGifticonGoodsController {
 
     private final GetAdminGifticonGoodsUseCase getAdminGifticonGoodsUseCase;
+    private final ManageGifticonGoodsExposureUseCase manageGifticonGoodsExposureUseCase;
 
     /**
      * (관리자) 기프티콘 전체 상품 목록 조회
@@ -55,6 +62,37 @@ public class AdminGifticonGoodsController {
                         "관리자 기프티콘 상품 목록 조회 성공"
                 ),
                 HttpStatus.OK
+        );
+    }
+
+    /**
+     * (관리자) 기프티콘 노출 상품 관리
+     *
+     * @param request 노출 관리 요청
+     * @Author 성효빈
+     * @Date 2026-04-05
+     * @Description 관리자가 기프티콘 상품의 노출 여부를 변경합니다.
+     */
+    @PatchMapping("/exposure")
+    @PreAuthorize(ADMIN_POINTCUT)
+    @ManageGifticonGoodsExposureApiDocs
+    public ResponseEntity<BaseResponse<Void>> manageGifticonGoodsExposure(
+            @Valid @RequestBody ManageGifticonGoodsExposureRequest request
+    ) {
+        ManageGifticonGoodsExposureCommand command = new ManageGifticonGoodsExposureCommand(
+                request.items().stream()
+                        .map(item -> new ExposureItem(item.goodsCode(), item.exposed()))
+                        .toList()
+        );
+
+        manageGifticonGoodsExposureUseCase.manageExposure(command);
+
+        return ResponseEntity.ok(
+                BaseResponse.of(
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "기프티콘 상품 노출 관리 성공"
+                )
         );
     }
 }

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/gifticon/controller/apidocs/ManageGifticonGoodsExposureApiDocs.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/gifticon/controller/apidocs/ManageGifticonGoodsExposureApiDocs.java
@@ -1,0 +1,75 @@
+package com.personal.marketnote.reward.adapter.in.web.gifticon.controller.apidocs;
+
+import com.personal.marketnote.common.adapter.in.api.schema.StringResponseSchema;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Operation(
+        summary = "(관리자) 기프티콘 노출 상품 관리",
+        description = """
+                작성일자: 2026-04-05
+
+                작성자: 성효빈
+
+                ---
+
+                ## Description
+
+                - 관리자가 기프티콘 상품의 노출 여부를 변경합니다.
+
+                - exposed=true 설정은 SALE 상태인 상품만 가능합니다.
+
+                - exposed=false 설정은 상태와 무관하게 항상 가능합니다.
+
+                ---
+
+                ## Request Body
+
+                | **키** | **타입** | **설명** | **필수 여부** | **예시** |
+                | --- | --- | --- | --- | --- |
+                | items | array | 노출 관리 항목 목록 | Y | [ ... ] |
+                | items[].goodsCode | string | 상품 코드 | Y | "G00001" |
+                | items[].exposed | boolean | 노출 여부 | Y | true |
+
+                ---
+
+                ## Response
+
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | statusCode | number | 상태 코드 | 200 |
+                | code | string | 응답 코드 | "SUC01" |
+                | timestamp | string(datetime) | 응답 일시 | "2026-04-05T12:00:00.000" |
+                | content | null | 응답 본문 | null |
+                | message | string | 처리 결과 | "기프티콘 상품 노출 관리 성공" |
+                """,
+        security = {@SecurityRequirement(name = "bearer")},
+        responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "기프티콘 상품 노출 관리 성공",
+                        content = @Content(
+                                schema = @Schema(implementation = StringResponseSchema.class),
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 200,
+                                          "code": "SUC01",
+                                          "timestamp": "2026-04-05T12:00:00.000",
+                                          "content": null,
+                                          "message": "기프티콘 상품 노출 관리 성공"
+                                        }
+                                        """)
+                        )
+                )
+        })
+public @interface ManageGifticonGoodsExposureApiDocs {
+}

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/gifticon/request/ManageGifticonGoodsExposureRequest.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/gifticon/request/ManageGifticonGoodsExposureRequest.java
@@ -1,0 +1,22 @@
+package com.personal.marketnote.reward.adapter.in.web.gifticon.request;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
+
+public record ManageGifticonGoodsExposureRequest(
+        @NotEmpty(message = "노출 관리 항목은 필수입니다")
+        @Valid
+        List<ExposureItem> items
+) {
+    public record ExposureItem(
+            @NotNull(message = "상품 코드는 필수입니다")
+            String goodsCode,
+
+            @NotNull(message = "노출 여부는 필수입니다")
+            Boolean exposed
+    ) {
+    }
+}

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/command/gifticon/ManageGifticonGoodsExposureCommand.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/command/gifticon/ManageGifticonGoodsExposureCommand.java
@@ -1,0 +1,13 @@
+package com.personal.marketnote.reward.port.in.command.gifticon;
+
+import java.util.List;
+
+public record ManageGifticonGoodsExposureCommand(
+        List<ExposureItem> items
+) {
+    public record ExposureItem(
+            String goodsCode,
+            boolean exposed
+    ) {
+    }
+}

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/usecase/gifticon/ManageGifticonGoodsExposureUseCase.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/usecase/gifticon/ManageGifticonGoodsExposureUseCase.java
@@ -1,0 +1,21 @@
+package com.personal.marketnote.reward.port.in.usecase.gifticon;
+
+import com.personal.marketnote.reward.port.in.command.gifticon.ManageGifticonGoodsExposureCommand;
+
+/**
+ * 관리자 기프티콘 노출 상품 관리 유스케이스
+ *
+ * @Author 성효빈
+ * @Date 2026-04-05
+ * @Description 관리자가 기프티콘 상품의 노출 여부를 변경합니다.
+ */
+public interface ManageGifticonGoodsExposureUseCase {
+
+    /**
+     * @param command 노출 관리 요청 {@link ManageGifticonGoodsExposureCommand}
+     * @Date 2026-04-05
+     * @Author 성효빈
+     * @Description 기프티콘 상품의 노출 여부를 변경합니다.
+     */
+    void manageExposure(ManageGifticonGoodsExposureCommand command);
+}

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/service/gifticon/ManageGifticonGoodsExposureService.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/service/gifticon/ManageGifticonGoodsExposureService.java
@@ -1,0 +1,46 @@
+package com.personal.marketnote.reward.service.gifticon;
+
+import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.reward.domain.exception.GifticonGoodsNotFoundException;
+import com.personal.marketnote.reward.domain.exception.GifticonGoodsNotSaleException;
+import com.personal.marketnote.reward.domain.gifticon.GifticonGoods;
+import com.personal.marketnote.reward.port.in.command.gifticon.ManageGifticonGoodsExposureCommand;
+import com.personal.marketnote.reward.port.in.command.gifticon.ManageGifticonGoodsExposureCommand.ExposureItem;
+import com.personal.marketnote.reward.port.in.usecase.gifticon.ManageGifticonGoodsExposureUseCase;
+import com.personal.marketnote.reward.port.out.gifticon.FindGifticonGoodsPort;
+import com.personal.marketnote.reward.port.out.gifticon.UpdateGifticonGoodsPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional(isolation = READ_COMMITTED)
+public class ManageGifticonGoodsExposureService implements ManageGifticonGoodsExposureUseCase {
+
+    private final FindGifticonGoodsPort findGifticonGoodsPort;
+    private final UpdateGifticonGoodsPort updateGifticonGoodsPort;
+
+    @Override
+    public void manageExposure(ManageGifticonGoodsExposureCommand command) {
+        for (ExposureItem item : command.items()) {
+            GifticonGoods goods = findGifticonGoodsPort.findByGoodsCode(item.goodsCode())
+                    .orElseThrow(() -> new GifticonGoodsNotFoundException(item.goodsCode()));
+
+            applyExposure(goods, item);
+            updateGifticonGoodsPort.update(goods);
+        }
+    }
+
+    private void applyExposure(GifticonGoods goods, ExposureItem item) {
+        if (!item.exposed()) {
+            goods.unexpose();
+            return;
+        }
+        if (!goods.isSale()) {
+            throw new GifticonGoodsNotSaleException(item.goodsCode(), goods.getGoodsStatus());
+        }
+        goods.expose();
+    }
+}

--- a/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/exception/GifticonGoodsNotSaleException.java
+++ b/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/exception/GifticonGoodsNotSaleException.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.reward.domain.exception;
+
+public class GifticonGoodsNotSaleException extends IllegalStateException {
+    private static final String MESSAGE = "SALE 상태가 아닌 상품은 노출할 수 없습니다. goodsCode=%s, goodsStatus=%s";
+
+    public GifticonGoodsNotSaleException(String goodsCode, String goodsStatus) {
+        super(String.format(MESSAGE, goodsCode, goodsStatus));
+    }
+}


### PR DESCRIPTION
## partially addresses #1653
## resolves #1772

## Task
- [x] ManageGifticonGoodsExposureUseCase / Service 구현
- [x] SALE 상태 상품만 노출 전환 가능 (GifticonGoodsNotSaleException)
- [x] AdminGifticonGoodsController PATCH /api/v1/admin/gifticon/goods/exposure
- [x] 배치 요청 (List<ExposureItem>) 지원