### PR TITLE
[#1653][#1774] feat: 관리자 기프티콘 상품 노출 순서 관리 기능 추가

### DIFF
--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/gifticon/controller/AdminGifticonGoodsController.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/gifticon/controller/AdminGifticonGoodsController.java
@@ -3,14 +3,19 @@ package com.personal.marketnote.reward.adapter.in.web.gifticon.controller;
 import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
 import com.personal.marketnote.reward.adapter.in.web.gifticon.controller.apidocs.GetAdminGifticonGoodsApiDocs;
 import com.personal.marketnote.reward.adapter.in.web.gifticon.controller.apidocs.ManageGifticonGoodsExposureApiDocs;
+import com.personal.marketnote.reward.adapter.in.web.gifticon.controller.apidocs.ManageGifticonGoodsOrderApiDocs;
 import com.personal.marketnote.reward.adapter.in.web.gifticon.request.ManageGifticonGoodsExposureRequest;
+import com.personal.marketnote.reward.adapter.in.web.gifticon.request.ManageGifticonGoodsOrderRequest;
 import com.personal.marketnote.reward.adapter.in.web.gifticon.response.GetAdminGifticonGoodsResponse;
 import com.personal.marketnote.reward.port.in.command.gifticon.GetAdminGifticonGoodsCommand;
 import com.personal.marketnote.reward.port.in.command.gifticon.ManageGifticonGoodsExposureCommand;
 import com.personal.marketnote.reward.port.in.command.gifticon.ManageGifticonGoodsExposureCommand.ExposureItem;
+import com.personal.marketnote.reward.port.in.command.gifticon.ManageGifticonGoodsOrderCommand;
+import com.personal.marketnote.reward.port.in.command.gifticon.ManageGifticonGoodsOrderCommand.OrderItem;
 import com.personal.marketnote.reward.port.in.result.gifticon.GetAdminGifticonGoodsResult;
 import com.personal.marketnote.reward.port.in.usecase.gifticon.GetAdminGifticonGoodsUseCase;
 import com.personal.marketnote.reward.port.in.usecase.gifticon.ManageGifticonGoodsExposureUseCase;
+import com.personal.marketnote.reward.port.in.usecase.gifticon.ManageGifticonGoodsOrderUseCase;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -30,6 +35,7 @@ public class AdminGifticonGoodsController {
 
     private final GetAdminGifticonGoodsUseCase getAdminGifticonGoodsUseCase;
     private final ManageGifticonGoodsExposureUseCase manageGifticonGoodsExposureUseCase;
+    private final ManageGifticonGoodsOrderUseCase manageGifticonGoodsOrderUseCase;
 
     /**
      * (관리자) 기프티콘 전체 상품 목록 조회
@@ -92,6 +98,37 @@ public class AdminGifticonGoodsController {
                         HttpStatus.OK,
                         DEFAULT_SUCCESS_CODE,
                         "기프티콘 상품 노출 관리 성공"
+                )
+        );
+    }
+
+    /**
+     * (관리자) 기프티콘 상품 노출 순서 관리
+     *
+     * @param request 순서 관리 요청
+     * @Author 성효빈
+     * @Date 2026-04-05
+     * @Description 관리자가 노출 상품의 정렬 순서를 설정합니다.
+     */
+    @PatchMapping("/order")
+    @PreAuthorize(ADMIN_POINTCUT)
+    @ManageGifticonGoodsOrderApiDocs
+    public ResponseEntity<BaseResponse<Void>> manageGifticonGoodsOrder(
+            @Valid @RequestBody ManageGifticonGoodsOrderRequest request
+    ) {
+        ManageGifticonGoodsOrderCommand command = new ManageGifticonGoodsOrderCommand(
+                request.items().stream()
+                        .map(item -> new OrderItem(item.goodsCode(), item.orderNum()))
+                        .toList()
+        );
+
+        manageGifticonGoodsOrderUseCase.manageOrder(command);
+
+        return ResponseEntity.ok(
+                BaseResponse.of(
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "기프티콘 상품 노출 순서 관리 성공"
                 )
         );
     }

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/gifticon/controller/apidocs/ManageGifticonGoodsOrderApiDocs.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/gifticon/controller/apidocs/ManageGifticonGoodsOrderApiDocs.java
@@ -1,0 +1,73 @@
+package com.personal.marketnote.reward.adapter.in.web.gifticon.controller.apidocs;
+
+import com.personal.marketnote.common.adapter.in.api.schema.StringResponseSchema;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Operation(
+        summary = "(관리자) 기프티콘 상품 노출 순서 관리",
+        description = """
+                작성일자: 2026-04-05
+
+                작성자: 성효빈
+
+                ---
+
+                ## Description
+
+                - 관리자가 노출 상품의 정렬 순서(orderNum)를 설정합니다.
+
+                - exposed=true인 상품만 정렬 순서 설정이 가능합니다.
+
+                ---
+
+                ## Request Body
+
+                | **키** | **타입** | **설명** | **필수 여부** | **예시** |
+                | --- | --- | --- | --- | --- |
+                | items | array | 순서 관리 항목 목록 | Y | [ ... ] |
+                | items[].goodsCode | string | 상품 코드 | Y | "G00001" |
+                | items[].orderNum | number | 정렬 순서 (null이면 순서 해제) | N | 1 |
+
+                ---
+
+                ## Response
+
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | statusCode | number | 상태 코드 | 200 |
+                | code | string | 응답 코드 | "SUC01" |
+                | timestamp | string(datetime) | 응답 일시 | "2026-04-05T12:00:00.000" |
+                | content | null | 응답 본문 | null |
+                | message | string | 처리 결과 | "기프티콘 상품 노출 순서 관리 성공" |
+                """,
+        security = {@SecurityRequirement(name = "bearer")},
+        responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "기프티콘 상품 노출 순서 관리 성공",
+                        content = @Content(
+                                schema = @Schema(implementation = StringResponseSchema.class),
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 200,
+                                          "code": "SUC01",
+                                          "timestamp": "2026-04-05T12:00:00.000",
+                                          "content": null,
+                                          "message": "기프티콘 상품 노출 순서 관리 성공"
+                                        }
+                                        """)
+                        )
+                )
+        })
+public @interface ManageGifticonGoodsOrderApiDocs {
+}

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/gifticon/request/ManageGifticonGoodsOrderRequest.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/gifticon/request/ManageGifticonGoodsOrderRequest.java
@@ -1,0 +1,21 @@
+package com.personal.marketnote.reward.adapter.in.web.gifticon.request;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
+
+public record ManageGifticonGoodsOrderRequest(
+        @NotEmpty(message = "순서 관리 항목은 필수입니다")
+        @Valid
+        List<OrderItem> items
+) {
+    public record OrderItem(
+            @NotNull(message = "상품 코드는 필수입니다")
+            String goodsCode,
+
+            Integer orderNum
+    ) {
+    }
+}

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/command/gifticon/ManageGifticonGoodsOrderCommand.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/command/gifticon/ManageGifticonGoodsOrderCommand.java
@@ -1,0 +1,13 @@
+package com.personal.marketnote.reward.port.in.command.gifticon;
+
+import java.util.List;
+
+public record ManageGifticonGoodsOrderCommand(
+        List<OrderItem> items
+) {
+    public record OrderItem(
+            String goodsCode,
+            Integer orderNum
+    ) {
+    }
+}

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/usecase/gifticon/ManageGifticonGoodsOrderUseCase.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/usecase/gifticon/ManageGifticonGoodsOrderUseCase.java
@@ -1,0 +1,21 @@
+package com.personal.marketnote.reward.port.in.usecase.gifticon;
+
+import com.personal.marketnote.reward.port.in.command.gifticon.ManageGifticonGoodsOrderCommand;
+
+/**
+ * 관리자 기프티콘 상품 노출 순서 관리 유스케이스
+ *
+ * @Author 성효빈
+ * @Date 2026-04-05
+ * @Description 관리자가 노출 상품의 정렬 순서를 설정합니다.
+ */
+public interface ManageGifticonGoodsOrderUseCase {
+
+    /**
+     * @param command 순서 관리 요청 {@link ManageGifticonGoodsOrderCommand}
+     * @Date 2026-04-05
+     * @Author 성효빈
+     * @Description 기프티콘 상품의 노출 순서를 변경합니다.
+     */
+    void manageOrder(ManageGifticonGoodsOrderCommand command);
+}

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/service/gifticon/ManageGifticonGoodsOrderService.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/service/gifticon/ManageGifticonGoodsOrderService.java
@@ -1,0 +1,39 @@
+package com.personal.marketnote.reward.service.gifticon;
+
+import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.reward.domain.exception.GifticonGoodsNotExposedException;
+import com.personal.marketnote.reward.domain.exception.GifticonGoodsNotFoundException;
+import com.personal.marketnote.reward.domain.gifticon.GifticonGoods;
+import com.personal.marketnote.reward.port.in.command.gifticon.ManageGifticonGoodsOrderCommand;
+import com.personal.marketnote.reward.port.in.command.gifticon.ManageGifticonGoodsOrderCommand.OrderItem;
+import com.personal.marketnote.reward.port.in.usecase.gifticon.ManageGifticonGoodsOrderUseCase;
+import com.personal.marketnote.reward.port.out.gifticon.FindGifticonGoodsPort;
+import com.personal.marketnote.reward.port.out.gifticon.UpdateGifticonGoodsPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional(isolation = READ_COMMITTED)
+public class ManageGifticonGoodsOrderService implements ManageGifticonGoodsOrderUseCase {
+
+    private final FindGifticonGoodsPort findGifticonGoodsPort;
+    private final UpdateGifticonGoodsPort updateGifticonGoodsPort;
+
+    @Override
+    public void manageOrder(ManageGifticonGoodsOrderCommand command) {
+        for (OrderItem item : command.items()) {
+            GifticonGoods goods = findGifticonGoodsPort.findByGoodsCode(item.goodsCode())
+                    .orElseThrow(() -> new GifticonGoodsNotFoundException(item.goodsCode()));
+
+            if (!goods.isExposed()) {
+                throw new GifticonGoodsNotExposedException(item.goodsCode());
+            }
+
+            goods.changeOrderNum(item.orderNum());
+            updateGifticonGoodsPort.update(goods);
+        }
+    }
+}

--- a/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/exception/GifticonGoodsNotExposedException.java
+++ b/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/exception/GifticonGoodsNotExposedException.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.reward.domain.exception;
+
+public class GifticonGoodsNotExposedException extends IllegalStateException {
+    private static final String MESSAGE = "노출되지 않은 상품에는 정렬 순서를 설정할 수 없습니다. goodsCode=%s";
+
+    public GifticonGoodsNotExposedException(String goodsCode) {
+        super(String.format(MESSAGE, goodsCode));
+    }
+}


### PR DESCRIPTION
## partially addresses #1653
## resolves #1774

## Task
- [x] ManageGifticonGoodsOrderUseCase / Service 구현
- [x] 노출 상품만 순서 설정 가능 (GifticonGoodsNotExposedException)
- [x] AdminGifticonGoodsController PATCH /api/v1/admin/gifticon/goods/order
- [x] 배치 요청 (List<OrderItem>) 지원