### PR TITLE
[#1653][#1800] feat: 관리자 기프티콘 카테고리 목록 조회 기능 추가

### DIFF
--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/gifticon/controller/AdminGifticonCategoryController.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/gifticon/controller/AdminGifticonCategoryController.java
@@ -1,0 +1,51 @@
+package com.personal.marketnote.reward.adapter.in.web.gifticon.controller;
+
+import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
+import com.personal.marketnote.reward.adapter.in.web.gifticon.controller.apidocs.GetAdminGifticonCategoriesApiDocs;
+import com.personal.marketnote.reward.adapter.in.web.gifticon.response.GetAdminGifticonCategoriesResponse;
+import com.personal.marketnote.reward.port.in.result.gifticon.GetAdminGifticonCategoriesResult;
+import com.personal.marketnote.reward.port.in.usecase.gifticon.GetAdminGifticonCategoriesUseCase;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static com.personal.marketnote.common.domain.exception.ExceptionCode.DEFAULT_SUCCESS_CODE;
+import static com.personal.marketnote.common.utility.ApiConstant.ADMIN_POINTCUT;
+
+@RestController
+@RequestMapping("/api/v1/admin/gifticon/categories")
+@Tag(name = "관리자 기프티콘 카테고리 API", description = "관리자 기프티콘 카테고리 관련 API")
+@RequiredArgsConstructor
+public class AdminGifticonCategoryController {
+
+    private final GetAdminGifticonCategoriesUseCase getAdminGifticonCategoriesUseCase;
+
+    /**
+     * (관리자) 기프티콘 카테고리 목록 조회
+     *
+     * @Author 성효빈
+     * @Date 2026-04-05
+     * @Description 관리자가 전체 기프티콘 카테고리를 조회합니다.
+     */
+    @GetMapping
+    @PreAuthorize(ADMIN_POINTCUT)
+    @GetAdminGifticonCategoriesApiDocs
+    public ResponseEntity<BaseResponse<GetAdminGifticonCategoriesResponse>> getAdminGifticonCategories() {
+        GetAdminGifticonCategoriesResult result = getAdminGifticonCategoriesUseCase.getAdminGifticonCategories();
+
+        return new ResponseEntity<>(
+                BaseResponse.of(
+                        GetAdminGifticonCategoriesResponse.from(result),
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "관리자 기프티콘 카테고리 목록 조회 성공"
+                ),
+                HttpStatus.OK
+        );
+    }
+}

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/gifticon/controller/apidocs/GetAdminGifticonCategoriesApiDocs.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/gifticon/controller/apidocs/GetAdminGifticonCategoriesApiDocs.java
@@ -1,0 +1,112 @@
+package com.personal.marketnote.reward.adapter.in.web.gifticon.controller.apidocs;
+
+import com.personal.marketnote.reward.adapter.in.web.gifticon.response.GetAdminGifticonCategoriesResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Operation(
+        summary = "(관리자) 기프티콘 카테고리 목록 조회",
+        description = """
+                작성일자: 2026-04-05
+
+                작성자: 성효빈
+
+                ---
+
+                ## Description
+
+                관리자가 전체 기프티콘 카테고리 목록을 조회합니다.
+
+                ---
+
+                ## Response
+
+                | 키 | 타입 | 설명 | 예시 |
+                | --- | --- | --- | --- |
+                | categories[].id | number | 카테고리 ID | 1 |
+                | categories[].categoryCode | string | 카테고리 코드 | "1" |
+                | categories[].categoryName | string | 카테고리 원본명 | "커피" |
+                | categories[].displayName | string | 관리자 설정 표시명 (null 가능) | "편의점/마트" |
+                | categories[].effectiveDisplayName | string | 실제 표시명 (displayName 우선, 없으면 categoryName) | "커피" |
+                | categories[].iconUrl | string | 아이콘 URL (null 가능) | "https://..." |
+                | categories[].exposed | boolean | 노출 여부 | true |
+                | categories[].orderNum | number | 노출 순서 (null 가능) | 1 |
+                | categories[].createdAt | string(datetime) | 생성일시 | "2026-04-05T10:00:00" |
+                | categories[].modifiedAt | string(datetime) | 수정일시 | "2026-04-05T10:00:00" |
+                """,
+        security = {@SecurityRequirement(name = "bearer")},
+        responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "기프티콘 카테고리 목록 조회 성공",
+                        content = @Content(
+                                schema = @Schema(implementation = GetAdminGifticonCategoriesResponse.class),
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 200,
+                                          "code": "SUC01",
+                                          "timestamp": "2026-04-05T10:00:00.000",
+                                          "content": {
+                                            "categories": [
+                                              {
+                                                "id": 1,
+                                                "categoryCode": "1",
+                                                "categoryName": "커피",
+                                                "displayName": null,
+                                                "effectiveDisplayName": "커피",
+                                                "iconUrl": null,
+                                                "exposed": true,
+                                                "orderNum": 1,
+                                                "createdAt": "2026-04-05T10:00:00",
+                                                "modifiedAt": "2026-04-05T10:00:00"
+                                              }
+                                            ]
+                                          },
+                                          "message": "기프티콘 카테고리 목록 조회 성공"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "401",
+                        description = "토큰 인증 실패",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 401,
+                                          "code": "UNAUTHORIZED",
+                                          "timestamp": "2026-04-05T10:00:00.000",
+                                          "content": null,
+                                          "message": "Invalid token"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "403",
+                        description = "토큰 인가 실패",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 403,
+                                          "code": "FORBIDDEN",
+                                          "timestamp": "2026-04-05T10:00:00.000",
+                                          "content": null,
+                                          "message": "Access Denied"
+                                        }
+                                        """)
+                        )
+                )
+        }
+)
+public @interface GetAdminGifticonCategoriesApiDocs {
+}

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/gifticon/response/GetAdminGifticonCategoriesResponse.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/gifticon/response/GetAdminGifticonCategoriesResponse.java
@@ -1,0 +1,53 @@
+package com.personal.marketnote.reward.adapter.in.web.gifticon.response;
+
+import com.personal.marketnote.reward.port.in.result.gifticon.GifticonCategoryItemResult;
+import com.personal.marketnote.reward.port.in.result.gifticon.GetAdminGifticonCategoriesResult;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+public class GetAdminGifticonCategoriesResponse {
+    private final List<GifticonCategoryItem> categories;
+
+    public static GetAdminGifticonCategoriesResponse from(GetAdminGifticonCategoriesResult result) {
+        return GetAdminGifticonCategoriesResponse.builder()
+                .categories(result.categories().stream()
+                        .map(GifticonCategoryItem::from)
+                        .toList())
+                .build();
+    }
+
+    @Getter
+    @Builder
+    public static class GifticonCategoryItem {
+        private final Long id;
+        private final String categoryCode;
+        private final String categoryName;
+        private final String displayName;
+        private final String effectiveDisplayName;
+        private final String iconUrl;
+        private final boolean exposed;
+        private final Integer orderNum;
+        private final LocalDateTime createdAt;
+        private final LocalDateTime modifiedAt;
+
+        public static GifticonCategoryItem from(GifticonCategoryItemResult item) {
+            return GifticonCategoryItem.builder()
+                    .id(item.id())
+                    .categoryCode(item.categoryCode())
+                    .categoryName(item.categoryName())
+                    .displayName(item.displayName())
+                    .effectiveDisplayName(item.effectiveDisplayName())
+                    .iconUrl(item.iconUrl())
+                    .exposed(item.exposed())
+                    .orderNum(item.orderNum())
+                    .createdAt(item.createdAt())
+                    .modifiedAt(item.modifiedAt())
+                    .build();
+        }
+    }
+}

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/gifticon/GifticonCategoryPersistenceAdapter.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/gifticon/GifticonCategoryPersistenceAdapter.java
@@ -10,6 +10,7 @@ import com.personal.marketnote.reward.domain.gifticon.GifticonCategory;
 import com.personal.marketnote.reward.port.out.gifticon.*;
 import lombok.RequiredArgsConstructor;
 
+import java.util.List;
 import java.util.Optional;
 
 @PersistenceAdapter
@@ -31,6 +32,13 @@ public class GifticonCategoryPersistenceAdapter implements
     public Optional<GifticonCategory> findById(Long id) {
         return categoryRepository.findById(id)
                 .map(GifticonCategoryJpaEntity::toDomain);
+    }
+
+    @Override
+    public List<GifticonCategory> findAllOrderByOrderNumAsc() {
+        return categoryRepository.findAllByOrderByOrderNumAsc().stream()
+                .map(GifticonCategoryJpaEntity::toDomain)
+                .toList();
     }
 
     @Override

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/gifticon/repository/GifticonCategoryJpaRepository.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/gifticon/repository/GifticonCategoryJpaRepository.java
@@ -3,9 +3,12 @@ package com.personal.marketnote.reward.adapter.out.persistence.gifticon.reposito
 import com.personal.marketnote.reward.adapter.out.persistence.gifticon.entity.GifticonCategoryJpaEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface GifticonCategoryJpaRepository extends JpaRepository<GifticonCategoryJpaEntity, Long> {
 
     Optional<GifticonCategoryJpaEntity> findByCategoryCode(String categoryCode);
+
+    List<GifticonCategoryJpaEntity> findAllByOrderByOrderNumAsc();
 }

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/result/gifticon/GetAdminGifticonCategoriesResult.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/result/gifticon/GetAdminGifticonCategoriesResult.java
@@ -1,0 +1,26 @@
+package com.personal.marketnote.reward.port.in.result.gifticon;
+
+import com.personal.marketnote.reward.domain.gifticon.GifticonCategory;
+
+import java.util.List;
+
+public record GetAdminGifticonCategoriesResult(List<GifticonCategoryItemResult> categories) {
+
+    public static GetAdminGifticonCategoriesResult from(List<GifticonCategory> categories) {
+        List<GifticonCategoryItemResult> items = categories.stream()
+                .map(category -> new GifticonCategoryItemResult(
+                        category.getId(),
+                        category.getCategoryCode(),
+                        category.getCategoryName(),
+                        category.getDisplayName(),
+                        category.getEffectiveDisplayName(),
+                        category.getIconUrl(),
+                        category.isExposed(),
+                        category.getOrderNum(),
+                        category.getCreatedAt(),
+                        category.getModifiedAt()
+                ))
+                .toList();
+        return new GetAdminGifticonCategoriesResult(items);
+    }
+}

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/result/gifticon/GifticonCategoryItemResult.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/result/gifticon/GifticonCategoryItemResult.java
@@ -1,0 +1,17 @@
+package com.personal.marketnote.reward.port.in.result.gifticon;
+
+import java.time.LocalDateTime;
+
+public record GifticonCategoryItemResult(
+        Long id,
+        String categoryCode,
+        String categoryName,
+        String displayName,
+        String effectiveDisplayName,
+        String iconUrl,
+        boolean exposed,
+        Integer orderNum,
+        LocalDateTime createdAt,
+        LocalDateTime modifiedAt
+) {
+}

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/usecase/gifticon/GetAdminGifticonCategoriesUseCase.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/usecase/gifticon/GetAdminGifticonCategoriesUseCase.java
@@ -1,0 +1,21 @@
+package com.personal.marketnote.reward.port.in.usecase.gifticon;
+
+import com.personal.marketnote.reward.port.in.result.gifticon.GetAdminGifticonCategoriesResult;
+
+/**
+ * 관리자 기프티콘 카테고리 목록 조회 유스케이스
+ *
+ * @Author 성효빈
+ * @Date 2026-04-05
+ * @Description 관리자가 전체 기프티콘 카테고리 목록을 조회합니다.
+ */
+public interface GetAdminGifticonCategoriesUseCase {
+
+    /**
+     * @return 기프티콘 카테고리 목록 {@link GetAdminGifticonCategoriesResult}
+     * @Date 2026-04-05
+     * @Author 성효빈
+     * @Description 전체 기프티콘 카테고리 목록을 조회합니다.
+     */
+    GetAdminGifticonCategoriesResult getAdminGifticonCategories();
+}

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/out/gifticon/FindGifticonCategoryPort.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/out/gifticon/FindGifticonCategoryPort.java
@@ -2,6 +2,7 @@ package com.personal.marketnote.reward.port.out.gifticon;
 
 import com.personal.marketnote.reward.domain.gifticon.GifticonCategory;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface FindGifticonCategoryPort {
@@ -9,4 +10,6 @@ public interface FindGifticonCategoryPort {
     Optional<GifticonCategory> findByCategoryCode(String categoryCode);
 
     Optional<GifticonCategory> findById(Long id);
+
+    List<GifticonCategory> findAllOrderByOrderNumAsc();
 }

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/service/gifticon/GetAdminGifticonCategoriesService.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/service/gifticon/GetAdminGifticonCategoriesService.java
@@ -1,0 +1,24 @@
+package com.personal.marketnote.reward.service.gifticon;
+
+import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.reward.port.in.result.gifticon.GetAdminGifticonCategoriesResult;
+import com.personal.marketnote.reward.port.in.usecase.gifticon.GetAdminGifticonCategoriesUseCase;
+import com.personal.marketnote.reward.port.out.gifticon.FindGifticonCategoryPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional(isolation = READ_COMMITTED, readOnly = true)
+public class GetAdminGifticonCategoriesService implements GetAdminGifticonCategoriesUseCase {
+    private final FindGifticonCategoryPort findGifticonCategoryPort;
+
+    @Override
+    public GetAdminGifticonCategoriesResult getAdminGifticonCategories() {
+        return GetAdminGifticonCategoriesResult.from(
+                findGifticonCategoryPort.findAllOrderByOrderNumAsc()
+        );
+    }
+}


### PR DESCRIPTION
## partially addresses #1653
## resolves #1800

## Task
- [x] ManageGifticonCategoryOrderUseCase / Service 구현
- [x] 노출 카테고리만 순서 설정 가능 (GifticonCategoryNotExposedException)
- [x] AdminGifticonCategoryController PATCH /api/v1/admin/gifticon/categories/order
- [x] 배치 요청 지원