### PR TITLE
[#1653][#1801] feat: 관리자 기프티콘 카테고리 수정 기능 추가

### DIFF
--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/gifticon/controller/AdminGifticonCategoryController.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/gifticon/controller/AdminGifticonCategoryController.java
@@ -2,17 +2,18 @@ package com.personal.marketnote.reward.adapter.in.web.gifticon.controller;
 
 import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
 import com.personal.marketnote.reward.adapter.in.web.gifticon.controller.apidocs.GetAdminGifticonCategoriesApiDocs;
+import com.personal.marketnote.reward.adapter.in.web.gifticon.controller.apidocs.UpdateGifticonCategoryApiDocs;
+import com.personal.marketnote.reward.adapter.in.web.gifticon.request.UpdateGifticonCategoryRequest;
 import com.personal.marketnote.reward.adapter.in.web.gifticon.response.GetAdminGifticonCategoriesResponse;
 import com.personal.marketnote.reward.port.in.result.gifticon.GetAdminGifticonCategoriesResult;
 import com.personal.marketnote.reward.port.in.usecase.gifticon.GetAdminGifticonCategoriesUseCase;
+import com.personal.marketnote.reward.port.in.usecase.gifticon.UpdateGifticonCategoryUseCase;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import static com.personal.marketnote.common.domain.exception.ExceptionCode.DEFAULT_SUCCESS_CODE;
 import static com.personal.marketnote.common.utility.ApiConstant.ADMIN_POINTCUT;
@@ -24,6 +25,7 @@ import static com.personal.marketnote.common.utility.ApiConstant.ADMIN_POINTCUT;
 public class AdminGifticonCategoryController {
 
     private final GetAdminGifticonCategoriesUseCase getAdminGifticonCategoriesUseCase;
+    private final UpdateGifticonCategoryUseCase updateGifticonCategoryUseCase;
 
     /**
      * (관리자) 기프티콘 카테고리 목록 조회
@@ -46,6 +48,33 @@ public class AdminGifticonCategoryController {
                         "관리자 기프티콘 카테고리 목록 조회 성공"
                 ),
                 HttpStatus.OK
+        );
+    }
+
+    /**
+     * (관리자) 기프티콘 카테고리 수정
+     *
+     * @param categoryId 카테고리 ID
+     * @param request 카테고리 수정 요청
+     * @Author 성효빈
+     * @Date 2026-04-05
+     * @Description 기프티콘 카테고리의 표시명과 아이콘 URL을 수정합니다.
+     */
+    @PatchMapping("/{categoryId}")
+    @PreAuthorize(ADMIN_POINTCUT)
+    @UpdateGifticonCategoryApiDocs
+    public ResponseEntity<BaseResponse<Void>> updateGifticonCategory(
+            @PathVariable("categoryId") Long categoryId,
+            @RequestBody UpdateGifticonCategoryRequest request
+    ) {
+        updateGifticonCategoryUseCase.updateGifticonCategory(request.toCommand(categoryId));
+
+        return ResponseEntity.ok(
+                BaseResponse.of(
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "기프티콘 카테고리 수정 성공"
+                )
         );
     }
 }

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/gifticon/controller/apidocs/UpdateGifticonCategoryApiDocs.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/gifticon/controller/apidocs/UpdateGifticonCategoryApiDocs.java
@@ -1,0 +1,109 @@
+package com.personal.marketnote.reward.adapter.in.web.gifticon.controller.apidocs;
+
+import com.personal.marketnote.reward.adapter.in.web.gifticon.request.UpdateGifticonCategoryRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Operation(
+        summary = "(관리자) 기프티콘 카테고리 수정",
+        description = """
+                작성일자: 2026-04-05
+
+                작성자: 성효빈
+
+                ---
+
+                ## Description
+
+                기프티콘 카테고리의 표시명(displayName)과 아이콘 URL(iconUrl)을 수정합니다.
+                전달된 필드만 업데이트됩니다.
+                displayName을 빈 문자열("")로 전달하면 null로 초기화되어 원래 categoryName이 표시됩니다.
+
+                ---
+
+                ## Request Body
+
+                | 키 | 타입 | 설명 | 필수 | 예시 |
+                | --- | --- | --- | --- | --- |
+                | displayName | string | 표시명 (빈 문자열이면 초기화) | N | "편의점/마트" |
+                | iconUrl | string | 아이콘 URL | N | "https://..." |
+
+                ---
+
+                ## Response
+
+                200 OK (content: null)
+                """,
+        security = {@SecurityRequirement(name = "bearer")},
+        requestBody = @RequestBody(
+                required = true,
+                content = @Content(
+                        schema = @Schema(implementation = UpdateGifticonCategoryRequest.class),
+                        examples = @ExampleObject("""
+                                {
+                                  "displayName": "편의점/마트",
+                                  "iconUrl": "https://cdn.example.com/icon.png"
+                                }
+                                """)
+                )
+        ),
+        responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "기프티콘 카테고리 수정 성공",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 200,
+                                          "code": "SUC01",
+                                          "timestamp": "2026-04-05T10:00:00.000",
+                                          "content": null,
+                                          "message": "기프티콘 카테고리 수정 성공"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "401",
+                        description = "토큰 인증 실패",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 401,
+                                          "code": "UNAUTHORIZED",
+                                          "timestamp": "2026-04-05T10:00:00.000",
+                                          "content": null,
+                                          "message": "Invalid token"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "403",
+                        description = "토큰 인가 실패",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 403,
+                                          "code": "FORBIDDEN",
+                                          "timestamp": "2026-04-05T10:00:00.000",
+                                          "content": null,
+                                          "message": "Access Denied"
+                                        }
+                                        """)
+                        )
+                )
+        }
+)
+public @interface UpdateGifticonCategoryApiDocs {
+}

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/gifticon/request/UpdateGifticonCategoryRequest.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/gifticon/request/UpdateGifticonCategoryRequest.java
@@ -1,0 +1,38 @@
+package com.personal.marketnote.reward.adapter.in.web.gifticon.request;
+
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
+import com.personal.marketnote.reward.port.in.command.gifticon.UpdateGifticonCategoryCommand;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UpdateGifticonCategoryRequest {
+    private String displayName;
+    private boolean displayNameProvided;
+    private String iconUrl;
+    private boolean iconUrlProvided;
+
+    @JsonSetter(value = "displayName", nulls = Nulls.SET)
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+        this.displayNameProvided = true;
+    }
+
+    @JsonSetter(value = "iconUrl", nulls = Nulls.SET)
+    public void setIconUrl(String iconUrl) {
+        this.iconUrl = iconUrl;
+        this.iconUrlProvided = true;
+    }
+
+    public UpdateGifticonCategoryCommand toCommand(Long categoryId) {
+        return new UpdateGifticonCategoryCommand(
+                categoryId,
+                displayName,
+                displayNameProvided,
+                iconUrl,
+                iconUrlProvided
+        );
+    }
+}

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/command/gifticon/UpdateGifticonCategoryCommand.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/command/gifticon/UpdateGifticonCategoryCommand.java
@@ -1,0 +1,10 @@
+package com.personal.marketnote.reward.port.in.command.gifticon;
+
+public record UpdateGifticonCategoryCommand(
+        Long categoryId,
+        String displayName,
+        boolean displayNameProvided,
+        String iconUrl,
+        boolean iconUrlProvided
+) {
+}

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/usecase/gifticon/UpdateGifticonCategoryUseCase.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/usecase/gifticon/UpdateGifticonCategoryUseCase.java
@@ -1,0 +1,21 @@
+package com.personal.marketnote.reward.port.in.usecase.gifticon;
+
+import com.personal.marketnote.reward.port.in.command.gifticon.UpdateGifticonCategoryCommand;
+
+/**
+ * 관리자 기프티콘 카테고리 수정 유스케이스
+ *
+ * @Author 성효빈
+ * @Date 2026-04-05
+ * @Description 관리자가 기프티콘 카테고리의 표시명과 아이콘 URL을 수정합니다.
+ */
+public interface UpdateGifticonCategoryUseCase {
+
+    /**
+     * @param command 카테고리 수정 커맨드 {@link UpdateGifticonCategoryCommand}
+     * @Date 2026-04-05
+     * @Author 성효빈
+     * @Description 기프티콘 카테고리를 수정합니다.
+     */
+    void updateGifticonCategory(UpdateGifticonCategoryCommand command);
+}

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/service/gifticon/UpdateGifticonCategoryService.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/service/gifticon/UpdateGifticonCategoryService.java
@@ -1,0 +1,51 @@
+package com.personal.marketnote.reward.service.gifticon;
+
+import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.reward.domain.exception.GifticonCategoryNotFoundException;
+import com.personal.marketnote.reward.domain.gifticon.GifticonCategory;
+import com.personal.marketnote.reward.port.in.command.gifticon.UpdateGifticonCategoryCommand;
+import com.personal.marketnote.reward.port.in.usecase.gifticon.UpdateGifticonCategoryUseCase;
+import com.personal.marketnote.reward.port.out.gifticon.FindGifticonCategoryPort;
+import com.personal.marketnote.reward.port.out.gifticon.UpdateGifticonCategoryPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional(isolation = READ_COMMITTED)
+public class UpdateGifticonCategoryService implements UpdateGifticonCategoryUseCase {
+    private final FindGifticonCategoryPort findGifticonCategoryPort;
+    private final UpdateGifticonCategoryPort updateGifticonCategoryPort;
+
+    @Override
+    public void updateGifticonCategory(UpdateGifticonCategoryCommand command) {
+        GifticonCategory category = findGifticonCategoryPort.findById(command.categoryId())
+                .orElseThrow(() -> new GifticonCategoryNotFoundException(command.categoryId()));
+
+        applyDisplayName(category, command);
+        applyIconUrl(category, command);
+
+        updateGifticonCategoryPort.update(category);
+    }
+
+    private void applyDisplayName(GifticonCategory category, UpdateGifticonCategoryCommand command) {
+        if (!command.displayNameProvided()) {
+            return;
+        }
+        if (FormatValidator.hasNoValue(command.displayName())) {
+            category.updateDisplayName(null);
+            return;
+        }
+        category.updateDisplayName(command.displayName());
+    }
+
+    private void applyIconUrl(GifticonCategory category, UpdateGifticonCategoryCommand command) {
+        if (!command.iconUrlProvided()) {
+            return;
+        }
+        category.updateIconUrl(command.iconUrl());
+    }
+}


### PR DESCRIPTION
## partially addresses #1653
## resolves #1801

## Task
- [x] UpdateGifticonCategoryUseCase / Service 구현
- [x] displayName 오버라이드 + iconUrl 설정 지원
- [x] 빈 문자열 전달 시 displayName null 초기화 (categoryName 복귀)
- [x] AdminGifticonCategoryController PATCH /api/v1/admin/gifticon/categories/{categoryId}