### PR TITLE
[#1653][#1802] feat: 관리자 기프티콘 카테고리 노출 관리 기능 추가

### DIFF
--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/gifticon/controller/AdminGifticonCategoryController.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/gifticon/controller/AdminGifticonCategoryController.java
@@ -2,13 +2,17 @@ package com.personal.marketnote.reward.adapter.in.web.gifticon.controller;
 
 import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
 import com.personal.marketnote.reward.adapter.in.web.gifticon.controller.apidocs.GetAdminGifticonCategoriesApiDocs;
+import com.personal.marketnote.reward.adapter.in.web.gifticon.controller.apidocs.ManageGifticonCategoryExposureApiDocs;
 import com.personal.marketnote.reward.adapter.in.web.gifticon.controller.apidocs.UpdateGifticonCategoryApiDocs;
+import com.personal.marketnote.reward.adapter.in.web.gifticon.request.ManageGifticonCategoryExposureRequest;
 import com.personal.marketnote.reward.adapter.in.web.gifticon.request.UpdateGifticonCategoryRequest;
 import com.personal.marketnote.reward.adapter.in.web.gifticon.response.GetAdminGifticonCategoriesResponse;
 import com.personal.marketnote.reward.port.in.result.gifticon.GetAdminGifticonCategoriesResult;
 import com.personal.marketnote.reward.port.in.usecase.gifticon.GetAdminGifticonCategoriesUseCase;
+import com.personal.marketnote.reward.port.in.usecase.gifticon.ManageGifticonCategoryExposureUseCase;
 import com.personal.marketnote.reward.port.in.usecase.gifticon.UpdateGifticonCategoryUseCase;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -26,6 +30,7 @@ public class AdminGifticonCategoryController {
 
     private final GetAdminGifticonCategoriesUseCase getAdminGifticonCategoriesUseCase;
     private final UpdateGifticonCategoryUseCase updateGifticonCategoryUseCase;
+    private final ManageGifticonCategoryExposureUseCase manageGifticonCategoryExposureUseCase;
 
     /**
      * (관리자) 기프티콘 카테고리 목록 조회
@@ -74,6 +79,31 @@ public class AdminGifticonCategoryController {
                         HttpStatus.OK,
                         DEFAULT_SUCCESS_CODE,
                         "기프티콘 카테고리 수정 성공"
+                )
+        );
+    }
+
+    /**
+     * (관리자) 기프티콘 카테고리 노출 관리
+     *
+     * @param request 노출 관리 요청
+     * @Author 성효빈
+     * @Date 2026-04-05
+     * @Description 기프티콘 카테고리의 노출 여부를 변경합니다.
+     */
+    @PatchMapping("/exposure")
+    @PreAuthorize(ADMIN_POINTCUT)
+    @ManageGifticonCategoryExposureApiDocs
+    public ResponseEntity<BaseResponse<Void>> manageGifticonCategoryExposure(
+            @Valid @RequestBody ManageGifticonCategoryExposureRequest request
+    ) {
+        manageGifticonCategoryExposureUseCase.manageExposure(request.toCommand());
+
+        return ResponseEntity.ok(
+                BaseResponse.of(
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "기프티콘 카테고리 노출 관리 성공"
                 )
         );
     }

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/gifticon/controller/apidocs/ManageGifticonCategoryExposureApiDocs.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/gifticon/controller/apidocs/ManageGifticonCategoryExposureApiDocs.java
@@ -1,0 +1,109 @@
+package com.personal.marketnote.reward.adapter.in.web.gifticon.controller.apidocs;
+
+import com.personal.marketnote.reward.adapter.in.web.gifticon.request.ManageGifticonCategoryExposureRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Operation(
+        summary = "(관리자) 기프티콘 카테고리 노출 관리",
+        description = """
+                작성일자: 2026-04-05
+
+                작성자: 성효빈
+
+                ---
+
+                ## Description
+
+                기프티콘 카테고리의 노출 여부(exposed)를 변경합니다.
+
+                ---
+
+                ## Request Body
+
+                | 키 | 타입 | 설명 | 필수 | 예시 |
+                | --- | --- | --- | --- | --- |
+                | items[].categoryId | number | 카테고리 ID | Y | 1 |
+                | items[].exposed | boolean | 노출 여부 | Y | true |
+
+                ---
+
+                ## Response
+
+                200 OK (content: null)
+                """,
+        security = {@SecurityRequirement(name = "bearer")},
+        requestBody = @RequestBody(
+                required = true,
+                content = @Content(
+                        schema = @Schema(implementation = ManageGifticonCategoryExposureRequest.class),
+                        examples = @ExampleObject("""
+                                {
+                                  "items": [
+                                    { "categoryId": 1, "exposed": true },
+                                    { "categoryId": 2, "exposed": false }
+                                  ]
+                                }
+                                """)
+                )
+        ),
+        responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "기프티콘 카테고리 노출 관리 성공",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 200,
+                                          "code": "SUC01",
+                                          "timestamp": "2026-04-05T10:00:00.000",
+                                          "content": null,
+                                          "message": "기프티콘 카테고리 노출 관리 성공"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "401",
+                        description = "토큰 인증 실패",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 401,
+                                          "code": "UNAUTHORIZED",
+                                          "timestamp": "2026-04-05T10:00:00.000",
+                                          "content": null,
+                                          "message": "Invalid token"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "403",
+                        description = "토큰 인가 실패",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 403,
+                                          "code": "FORBIDDEN",
+                                          "timestamp": "2026-04-05T10:00:00.000",
+                                          "content": null,
+                                          "message": "Access Denied"
+                                        }
+                                        """)
+                        )
+                )
+        }
+)
+public @interface ManageGifticonCategoryExposureApiDocs {
+}

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/gifticon/request/ManageGifticonCategoryExposureRequest.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/gifticon/request/ManageGifticonCategoryExposureRequest.java
@@ -1,0 +1,36 @@
+package com.personal.marketnote.reward.adapter.in.web.gifticon.request;
+
+import com.personal.marketnote.reward.port.in.command.gifticon.ManageGifticonCategoryExposureCommand;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class ManageGifticonCategoryExposureRequest {
+    @NotEmpty
+    @Valid
+    private List<ExposureItem> items;
+
+    @Getter
+    @NoArgsConstructor
+    public static class ExposureItem {
+        @NotNull
+        private Long categoryId;
+        @NotNull
+        private Boolean exposed;
+    }
+
+    public ManageGifticonCategoryExposureCommand toCommand() {
+        List<ManageGifticonCategoryExposureCommand.ExposureItem> commandItems = items.stream()
+                .map(item -> new ManageGifticonCategoryExposureCommand.ExposureItem(
+                        item.getCategoryId(), item.getExposed()
+                ))
+                .toList();
+        return new ManageGifticonCategoryExposureCommand(commandItems);
+    }
+}

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/command/gifticon/ManageGifticonCategoryExposureCommand.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/command/gifticon/ManageGifticonCategoryExposureCommand.java
@@ -1,0 +1,14 @@
+package com.personal.marketnote.reward.port.in.command.gifticon;
+
+import java.util.List;
+
+public record ManageGifticonCategoryExposureCommand(
+        List<ExposureItem> items
+) {
+
+    public record ExposureItem(
+            Long categoryId,
+            boolean exposed
+    ) {
+    }
+}

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/usecase/gifticon/ManageGifticonCategoryExposureUseCase.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/usecase/gifticon/ManageGifticonCategoryExposureUseCase.java
@@ -1,0 +1,21 @@
+package com.personal.marketnote.reward.port.in.usecase.gifticon;
+
+import com.personal.marketnote.reward.port.in.command.gifticon.ManageGifticonCategoryExposureCommand;
+
+/**
+ * 관리자 기프티콘 카테고리 노출 관리 유스케이스
+ *
+ * @Author 성효빈
+ * @Date 2026-04-05
+ * @Description 관리자가 기프티콘 카테고리의 노출 여부를 변경합니다.
+ */
+public interface ManageGifticonCategoryExposureUseCase {
+
+    /**
+     * @param command 노출 관리 커맨드 {@link ManageGifticonCategoryExposureCommand}
+     * @Date 2026-04-05
+     * @Author 성효빈
+     * @Description 기프티콘 카테고리의 노출 여부를 변경합니다.
+     */
+    void manageExposure(ManageGifticonCategoryExposureCommand command);
+}

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/service/gifticon/ManageGifticonCategoryExposureService.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/service/gifticon/ManageGifticonCategoryExposureService.java
@@ -1,0 +1,41 @@
+package com.personal.marketnote.reward.service.gifticon;
+
+import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.reward.domain.exception.GifticonCategoryNotFoundException;
+import com.personal.marketnote.reward.domain.gifticon.GifticonCategory;
+import com.personal.marketnote.reward.port.in.command.gifticon.ManageGifticonCategoryExposureCommand;
+import com.personal.marketnote.reward.port.in.command.gifticon.ManageGifticonCategoryExposureCommand.ExposureItem;
+import com.personal.marketnote.reward.port.in.usecase.gifticon.ManageGifticonCategoryExposureUseCase;
+import com.personal.marketnote.reward.port.out.gifticon.FindGifticonCategoryPort;
+import com.personal.marketnote.reward.port.out.gifticon.UpdateGifticonCategoryPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional(isolation = READ_COMMITTED)
+public class ManageGifticonCategoryExposureService implements ManageGifticonCategoryExposureUseCase {
+    private final FindGifticonCategoryPort findGifticonCategoryPort;
+    private final UpdateGifticonCategoryPort updateGifticonCategoryPort;
+
+    @Override
+    public void manageExposure(ManageGifticonCategoryExposureCommand command) {
+        for (ExposureItem item : command.items()) {
+            GifticonCategory category = findGifticonCategoryPort.findById(item.categoryId())
+                    .orElseThrow(() -> new GifticonCategoryNotFoundException(item.categoryId()));
+
+            applyExposure(category, item.exposed());
+            updateGifticonCategoryPort.update(category);
+        }
+    }
+
+    private void applyExposure(GifticonCategory category, boolean exposed) {
+        if (exposed) {
+            category.expose();
+            return;
+        }
+        category.unexpose();
+    }
+}


### PR DESCRIPTION
## partially addresses #1653
## resolves #1802

## Task
- [x] ManageGifticonCategoryExposureUseCase / Service 구현
- [x] expose()/unexpose() 도메인 메서드 활용
- [x] AdminGifticonCategoryController PATCH /api/v1/admin/gifticon/categories/exposure
- [x] 배치 요청 지원