### PR TITLE
[#1653][#1803] feat: 관리자 기프티콘 카테고리 노출 순서 관리 기능 추가

### DIFF
--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/gifticon/controller/AdminGifticonCategoryController.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/gifticon/controller/AdminGifticonCategoryController.java
@@ -3,13 +3,16 @@ package com.personal.marketnote.reward.adapter.in.web.gifticon.controller;
 import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
 import com.personal.marketnote.reward.adapter.in.web.gifticon.controller.apidocs.GetAdminGifticonCategoriesApiDocs;
 import com.personal.marketnote.reward.adapter.in.web.gifticon.controller.apidocs.ManageGifticonCategoryExposureApiDocs;
+import com.personal.marketnote.reward.adapter.in.web.gifticon.controller.apidocs.ManageGifticonCategoryOrderApiDocs;
 import com.personal.marketnote.reward.adapter.in.web.gifticon.controller.apidocs.UpdateGifticonCategoryApiDocs;
 import com.personal.marketnote.reward.adapter.in.web.gifticon.request.ManageGifticonCategoryExposureRequest;
+import com.personal.marketnote.reward.adapter.in.web.gifticon.request.ManageGifticonCategoryOrderRequest;
 import com.personal.marketnote.reward.adapter.in.web.gifticon.request.UpdateGifticonCategoryRequest;
 import com.personal.marketnote.reward.adapter.in.web.gifticon.response.GetAdminGifticonCategoriesResponse;
 import com.personal.marketnote.reward.port.in.result.gifticon.GetAdminGifticonCategoriesResult;
 import com.personal.marketnote.reward.port.in.usecase.gifticon.GetAdminGifticonCategoriesUseCase;
 import com.personal.marketnote.reward.port.in.usecase.gifticon.ManageGifticonCategoryExposureUseCase;
+import com.personal.marketnote.reward.port.in.usecase.gifticon.ManageGifticonCategoryOrderUseCase;
 import com.personal.marketnote.reward.port.in.usecase.gifticon.UpdateGifticonCategoryUseCase;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -31,6 +34,7 @@ public class AdminGifticonCategoryController {
     private final GetAdminGifticonCategoriesUseCase getAdminGifticonCategoriesUseCase;
     private final UpdateGifticonCategoryUseCase updateGifticonCategoryUseCase;
     private final ManageGifticonCategoryExposureUseCase manageGifticonCategoryExposureUseCase;
+    private final ManageGifticonCategoryOrderUseCase manageGifticonCategoryOrderUseCase;
 
     /**
      * (관리자) 기프티콘 카테고리 목록 조회
@@ -104,6 +108,31 @@ public class AdminGifticonCategoryController {
                         HttpStatus.OK,
                         DEFAULT_SUCCESS_CODE,
                         "기프티콘 카테고리 노출 관리 성공"
+                )
+        );
+    }
+
+    /**
+     * (관리자) 기프티콘 카테고리 노출 순서 관리
+     *
+     * @param request 노출 순서 관리 요청
+     * @Author 성효빈
+     * @Date 2026-04-05
+     * @Description 기프티콘 카테고리의 노출 순서를 설정합니다.
+     */
+    @PatchMapping("/order")
+    @PreAuthorize(ADMIN_POINTCUT)
+    @ManageGifticonCategoryOrderApiDocs
+    public ResponseEntity<BaseResponse<Void>> manageGifticonCategoryOrder(
+            @Valid @RequestBody ManageGifticonCategoryOrderRequest request
+    ) {
+        manageGifticonCategoryOrderUseCase.manageOrder(request.toCommand());
+
+        return ResponseEntity.ok(
+                BaseResponse.of(
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "기프티콘 카테고리 노출 순서 관리 성공"
                 )
         );
     }

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/gifticon/controller/apidocs/ManageGifticonCategoryOrderApiDocs.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/gifticon/controller/apidocs/ManageGifticonCategoryOrderApiDocs.java
@@ -1,0 +1,110 @@
+package com.personal.marketnote.reward.adapter.in.web.gifticon.controller.apidocs;
+
+import com.personal.marketnote.reward.adapter.in.web.gifticon.request.ManageGifticonCategoryOrderRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Operation(
+        summary = "(관리자) 기프티콘 카테고리 노출 순서 관리",
+        description = """
+                작성일자: 2026-04-05
+
+                작성자: 성효빈
+
+                ---
+
+                ## Description
+
+                기프티콘 카테고리의 노출 순서(orderNum)를 설정합니다.
+                노출(exposed=true) 상태인 카테고리만 순서를 설정할 수 있습니다.
+
+                ---
+
+                ## Request Body
+
+                | 키 | 타입 | 설명 | 필수 | 예시 |
+                | --- | --- | --- | --- | --- |
+                | items[].categoryId | number | 카테고리 ID | Y | 1 |
+                | items[].orderNum | number | 노출 순서 | Y | 1 |
+
+                ---
+
+                ## Response
+
+                200 OK (content: null)
+                """,
+        security = {@SecurityRequirement(name = "bearer")},
+        requestBody = @RequestBody(
+                required = true,
+                content = @Content(
+                        schema = @Schema(implementation = ManageGifticonCategoryOrderRequest.class),
+                        examples = @ExampleObject("""
+                                {
+                                  "items": [
+                                    { "categoryId": 1, "orderNum": 1 },
+                                    { "categoryId": 2, "orderNum": 2 }
+                                  ]
+                                }
+                                """)
+                )
+        ),
+        responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "기프티콘 카테고리 노출 순서 관리 성공",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 200,
+                                          "code": "SUC01",
+                                          "timestamp": "2026-04-05T10:00:00.000",
+                                          "content": null,
+                                          "message": "기프티콘 카테고리 노출 순서 관리 성공"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "401",
+                        description = "토큰 인증 실패",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 401,
+                                          "code": "UNAUTHORIZED",
+                                          "timestamp": "2026-04-05T10:00:00.000",
+                                          "content": null,
+                                          "message": "Invalid token"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "403",
+                        description = "토큰 인가 실패",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 403,
+                                          "code": "FORBIDDEN",
+                                          "timestamp": "2026-04-05T10:00:00.000",
+                                          "content": null,
+                                          "message": "Access Denied"
+                                        }
+                                        """)
+                        )
+                )
+        }
+)
+public @interface ManageGifticonCategoryOrderApiDocs {
+}

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/gifticon/request/ManageGifticonCategoryOrderRequest.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/gifticon/request/ManageGifticonCategoryOrderRequest.java
@@ -1,0 +1,36 @@
+package com.personal.marketnote.reward.adapter.in.web.gifticon.request;
+
+import com.personal.marketnote.reward.port.in.command.gifticon.ManageGifticonCategoryOrderCommand;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class ManageGifticonCategoryOrderRequest {
+    @NotEmpty
+    @Valid
+    private List<OrderItem> items;
+
+    @Getter
+    @NoArgsConstructor
+    public static class OrderItem {
+        @NotNull
+        private Long categoryId;
+        @NotNull
+        private Integer orderNum;
+    }
+
+    public ManageGifticonCategoryOrderCommand toCommand() {
+        List<ManageGifticonCategoryOrderCommand.OrderItem> commandItems = items.stream()
+                .map(item -> new ManageGifticonCategoryOrderCommand.OrderItem(
+                        item.getCategoryId(), item.getOrderNum()
+                ))
+                .toList();
+        return new ManageGifticonCategoryOrderCommand(commandItems);
+    }
+}

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/command/gifticon/ManageGifticonCategoryOrderCommand.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/command/gifticon/ManageGifticonCategoryOrderCommand.java
@@ -1,0 +1,14 @@
+package com.personal.marketnote.reward.port.in.command.gifticon;
+
+import java.util.List;
+
+public record ManageGifticonCategoryOrderCommand(
+        List<OrderItem> items
+) {
+
+    public record OrderItem(
+            Long categoryId,
+            Integer orderNum
+    ) {
+    }
+}

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/usecase/gifticon/ManageGifticonCategoryOrderUseCase.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/usecase/gifticon/ManageGifticonCategoryOrderUseCase.java
@@ -1,0 +1,21 @@
+package com.personal.marketnote.reward.port.in.usecase.gifticon;
+
+import com.personal.marketnote.reward.port.in.command.gifticon.ManageGifticonCategoryOrderCommand;
+
+/**
+ * 관리자 기프티콘 카테고리 노출 순서 관리 유스케이스
+ *
+ * @Author 성효빈
+ * @Date 2026-04-05
+ * @Description 관리자가 기프티콘 카테고리의 노출 순서를 설정합니다.
+ */
+public interface ManageGifticonCategoryOrderUseCase {
+
+    /**
+     * @param command 노출 순서 관리 커맨드 {@link ManageGifticonCategoryOrderCommand}
+     * @Date 2026-04-05
+     * @Author 성효빈
+     * @Description 기프티콘 카테고리의 노출 순서를 설정합니다.
+     */
+    void manageOrder(ManageGifticonCategoryOrderCommand command);
+}

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/service/gifticon/ManageGifticonCategoryOrderService.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/service/gifticon/ManageGifticonCategoryOrderService.java
@@ -1,0 +1,38 @@
+package com.personal.marketnote.reward.service.gifticon;
+
+import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.reward.domain.exception.GifticonCategoryNotExposedException;
+import com.personal.marketnote.reward.domain.exception.GifticonCategoryNotFoundException;
+import com.personal.marketnote.reward.domain.gifticon.GifticonCategory;
+import com.personal.marketnote.reward.port.in.command.gifticon.ManageGifticonCategoryOrderCommand;
+import com.personal.marketnote.reward.port.in.command.gifticon.ManageGifticonCategoryOrderCommand.OrderItem;
+import com.personal.marketnote.reward.port.in.usecase.gifticon.ManageGifticonCategoryOrderUseCase;
+import com.personal.marketnote.reward.port.out.gifticon.FindGifticonCategoryPort;
+import com.personal.marketnote.reward.port.out.gifticon.UpdateGifticonCategoryPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional(isolation = READ_COMMITTED)
+public class ManageGifticonCategoryOrderService implements ManageGifticonCategoryOrderUseCase {
+    private final FindGifticonCategoryPort findGifticonCategoryPort;
+    private final UpdateGifticonCategoryPort updateGifticonCategoryPort;
+
+    @Override
+    public void manageOrder(ManageGifticonCategoryOrderCommand command) {
+        for (OrderItem item : command.items()) {
+            GifticonCategory category = findGifticonCategoryPort.findById(item.categoryId())
+                    .orElseThrow(() -> new GifticonCategoryNotFoundException(item.categoryId()));
+
+            if (!category.isExposed()) {
+                throw new GifticonCategoryNotExposedException(item.categoryId());
+            }
+
+            category.changeOrderNum(item.orderNum());
+            updateGifticonCategoryPort.update(category);
+        }
+    }
+}

--- a/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/exception/GifticonCategoryNotExposedException.java
+++ b/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/exception/GifticonCategoryNotExposedException.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.reward.domain.exception;
+
+public class GifticonCategoryNotExposedException extends IllegalStateException {
+    private static final String MESSAGE = "노출되지 않은 카테고리에는 노출 순서를 설정할 수 없습니다. id=%d";
+
+    public GifticonCategoryNotExposedException(Long id) {
+        super(String.format(MESSAGE, id));
+    }
+}


### PR DESCRIPTION
## partially addresses #1653
## resolves #1803

## Task
- [x] ManageGifticonCategoryOrderUseCase / Service 구현
- [x] 노출 카테고리만 순서 설정 가능 (GifticonCategoryNotExposedException)
- [x] AdminGifticonCategoryController PATCH /api/v1/admin/gifticon/categories/order
- [x] 배치 요청 지원