### PR TITLE
[#1653][#1656] feat: 기프티콘 카테고리 목록 조회 기능 추가

### DIFF
--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/gifticon/controller/GifticonCategoryController.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/gifticon/controller/GifticonCategoryController.java
@@ -1,0 +1,48 @@
+package com.personal.marketnote.reward.adapter.in.web.gifticon.controller;
+
+import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
+import com.personal.marketnote.reward.adapter.in.web.gifticon.controller.apidocs.GetGifticonCategoriesApiDocs;
+import com.personal.marketnote.reward.adapter.in.web.gifticon.response.GetGifticonCategoriesResponse;
+import com.personal.marketnote.reward.port.in.result.gifticon.GetGifticonCategoriesResult;
+import com.personal.marketnote.reward.port.in.usecase.gifticon.GetGifticonCategoriesUseCase;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static com.personal.marketnote.common.domain.exception.ExceptionCode.DEFAULT_SUCCESS_CODE;
+
+@RestController
+@RequestMapping("/api/v1/gifticon")
+@Tag(name = "기프티콘 카테고리 API", description = "기프티콘 카테고리 관련 API")
+@RequiredArgsConstructor
+public class GifticonCategoryController {
+
+    private final GetGifticonCategoriesUseCase getGifticonCategoriesUseCase;
+
+    /**
+     * 기프티콘 카테고리 목록 조회
+     *
+     * @return 노출된 카테고리 목록 응답 {@link GetGifticonCategoriesResponse}
+     * @Author 성효빈
+     * @Date 2026-04-05
+     * @Description 노출 설정된 기프티콘 카테고리 목록을 조회합니다.
+     */
+    @GetMapping("/categories")
+    @GetGifticonCategoriesApiDocs
+    public ResponseEntity<BaseResponse<GetGifticonCategoriesResponse>> getCategories() {
+        GetGifticonCategoriesResult result = getGifticonCategoriesUseCase.getCategories();
+
+        return ResponseEntity.ok(
+                BaseResponse.of(
+                        GetGifticonCategoriesResponse.from(result),
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "기프티콘 카테고리 목록 조회 성공"
+                )
+        );
+    }
+}

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/gifticon/controller/apidocs/GetGifticonCategoriesApiDocs.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/gifticon/controller/apidocs/GetGifticonCategoriesApiDocs.java
@@ -1,0 +1,65 @@
+package com.personal.marketnote.reward.adapter.in.web.gifticon.controller.apidocs;
+
+import com.personal.marketnote.reward.adapter.in.web.gifticon.response.GetGifticonCategoriesResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Operation(
+        summary = "기프티콘 카테고리 목록 조회",
+        description = """
+                작성일자: 2026-04-05
+
+                작성자: 성효빈
+
+                ---
+
+                ## Description
+
+                노출 설정된 기프티콘 카테고리 목록을 orderNum 오름차순으로 조회합니다.
+                """,
+        security = {@SecurityRequirement(name = "bearer")},
+        responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "기프티콘 카테고리 목록 조회 성공",
+                        content = @Content(
+                                schema = @Schema(implementation = GetGifticonCategoriesResponse.class),
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 200,
+                                          "code": "SUC01",
+                                          "timestamp": "2026-04-05T10:00:00.000000",
+                                          "content": {
+                                            "categories": [
+                                              {
+                                                "categoryCode": "1",
+                                                "displayName": "커피",
+                                                "iconUrl": "https://img.com/coffee.png",
+                                                "orderNum": 1
+                                              },
+                                              {
+                                                "categoryCode": "2",
+                                                "displayName": "베이커리",
+                                                "iconUrl": "https://img.com/bakery.png",
+                                                "orderNum": 2
+                                              }
+                                            ]
+                                          },
+                                          "message": "기프티콘 카테고리 목록 조회 성공"
+                                        }
+                                        """)
+                        )
+                )
+        }
+)
+public @interface GetGifticonCategoriesApiDocs {
+}

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/gifticon/response/GetGifticonCategoriesResponse.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/gifticon/response/GetGifticonCategoriesResponse.java
@@ -1,0 +1,29 @@
+package com.personal.marketnote.reward.adapter.in.web.gifticon.response;
+
+import com.personal.marketnote.reward.port.in.result.gifticon.GetGifticonCategoriesResult;
+
+import java.util.List;
+
+public record GetGifticonCategoriesResponse(List<GifticonCategoryItemResponse> categories) {
+
+    public static GetGifticonCategoriesResponse from(GetGifticonCategoriesResult result) {
+        List<GifticonCategoryItemResponse> items = result.categories().stream()
+                .map(item -> new GifticonCategoryItemResponse(
+                        item.categoryCode(),
+                        item.displayName(),
+                        item.iconUrl(),
+                        item.orderNum()
+                ))
+                .toList();
+
+        return new GetGifticonCategoriesResponse(items);
+    }
+
+    public record GifticonCategoryItemResponse(
+            String categoryCode,
+            String displayName,
+            String iconUrl,
+            Integer orderNum
+    ) {
+    }
+}

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/gifticon/GifticonCategoryPersistenceAdapter.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/gifticon/GifticonCategoryPersistenceAdapter.java
@@ -42,6 +42,13 @@ public class GifticonCategoryPersistenceAdapter implements
     }
 
     @Override
+    public List<GifticonCategory> findAllExposed() {
+        return categoryRepository.findAllExposed().stream()
+                .map(GifticonCategoryJpaEntity::toDomain)
+                .toList();
+    }
+
+    @Override
     public GifticonCategory save(GifticonCategory category) {
         GifticonCategoryJpaEntity saved = categoryRepository.save(GifticonCategoryJpaEntity.from(category));
         return saved.toDomain();

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/gifticon/repository/GifticonCategoryJpaRepository.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/gifticon/repository/GifticonCategoryJpaRepository.java
@@ -2,6 +2,7 @@ package com.personal.marketnote.reward.adapter.out.persistence.gifticon.reposito
 
 import com.personal.marketnote.reward.adapter.out.persistence.gifticon.entity.GifticonCategoryJpaEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 import java.util.Optional;
@@ -11,4 +12,13 @@ public interface GifticonCategoryJpaRepository extends JpaRepository<GifticonCat
     Optional<GifticonCategoryJpaEntity> findByCategoryCode(String categoryCode);
 
     List<GifticonCategoryJpaEntity> findAllByOrderByOrderNumAsc();
+
+    @Query("""
+            SELECT c FROM GifticonCategoryJpaEntity c
+            WHERE c.exposed = true
+            ORDER BY
+                CASE WHEN c.orderNum IS NULL THEN 1 ELSE 0 END,
+                c.orderNum ASC
+            """)
+    List<GifticonCategoryJpaEntity> findAllExposed();
 }

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/result/gifticon/GetGifticonCategoriesResult.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/result/gifticon/GetGifticonCategoriesResult.java
@@ -1,0 +1,14 @@
+package com.personal.marketnote.reward.port.in.result.gifticon;
+
+import java.util.List;
+
+public record GetGifticonCategoriesResult(List<GifticonCategoryItem> categories) {
+
+    public record GifticonCategoryItem(
+            String categoryCode,
+            String displayName,
+            String iconUrl,
+            Integer orderNum
+    ) {
+    }
+}

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/usecase/gifticon/GetGifticonCategoriesUseCase.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/usecase/gifticon/GetGifticonCategoriesUseCase.java
@@ -1,0 +1,20 @@
+package com.personal.marketnote.reward.port.in.usecase.gifticon;
+
+import com.personal.marketnote.reward.port.in.result.gifticon.GetGifticonCategoriesResult;
+
+/**
+ * 기프티콘 카테고리 목록 조회 유스케이스
+ *
+ * @Author 성효빈
+ * @Date 2026-04-05
+ * @Description 사용자가 노출된 기프티콘 카테고리 목록을 조회합니다.
+ */
+public interface GetGifticonCategoriesUseCase {
+    /**
+     * @return 노출된 기프티콘 카테고리 목록 {@link GetGifticonCategoriesResult}
+     * @Date 2026-04-05
+     * @Author 성효빈
+     * @Description 노출 설정된 카테고리 목록을 orderNum 오름차순으로 조회합니다.
+     */
+    GetGifticonCategoriesResult getCategories();
+}

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/out/gifticon/FindGifticonCategoryPort.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/out/gifticon/FindGifticonCategoryPort.java
@@ -12,4 +12,6 @@ public interface FindGifticonCategoryPort {
     Optional<GifticonCategory> findById(Long id);
 
     List<GifticonCategory> findAllOrderByOrderNumAsc();
+
+    List<GifticonCategory> findAllExposed();
 }

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/service/gifticon/GetGifticonCategoriesService.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/service/gifticon/GetGifticonCategoriesService.java
@@ -1,0 +1,38 @@
+package com.personal.marketnote.reward.service.gifticon;
+
+import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.reward.domain.gifticon.GifticonCategory;
+import com.personal.marketnote.reward.port.in.result.gifticon.GetGifticonCategoriesResult;
+import com.personal.marketnote.reward.port.in.result.gifticon.GetGifticonCategoriesResult.GifticonCategoryItem;
+import com.personal.marketnote.reward.port.in.usecase.gifticon.GetGifticonCategoriesUseCase;
+import com.personal.marketnote.reward.port.out.gifticon.FindGifticonCategoryPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional(isolation = READ_COMMITTED, readOnly = true)
+public class GetGifticonCategoriesService implements GetGifticonCategoriesUseCase {
+
+    private final FindGifticonCategoryPort findGifticonCategoryPort;
+
+    @Override
+    public GetGifticonCategoriesResult getCategories() {
+        List<GifticonCategory> categories = findGifticonCategoryPort.findAllExposed();
+
+        List<GifticonCategoryItem> items = categories.stream()
+                .map(category -> new GifticonCategoryItem(
+                        category.getCategoryCode(),
+                        category.getEffectiveDisplayName(),
+                        category.getIconUrl(),
+                        category.getOrderNum()
+                ))
+                .toList();
+
+        return new GetGifticonCategoriesResult(items);
+    }
+}


### PR DESCRIPTION
## partially addresses #1653
## resolves #1656

## Task
- [x] GetGifticonCategoriesUseCase / Service 구현
- [x] FindGifticonCategoryPort.findAllExposed 추가
- [x] GifticonCategoryController GET /api/v1/gifticon/categories
- [x] exposed=true 카테고리만 반환, orderNum ASC 정렬
- [x] effectiveDisplayName (displayName 우선) + iconUrl 포함