### PR TITLE
[#1653][#1657] feat: 기프티콘 브랜드 목록 조회 기능 추가

### DIFF
--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/gifticon/controller/GifticonBrandController.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/gifticon/controller/GifticonBrandController.java
@@ -1,0 +1,55 @@
+package com.personal.marketnote.reward.adapter.in.web.gifticon.controller;
+
+import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
+import com.personal.marketnote.reward.adapter.in.web.gifticon.controller.apidocs.GetGifticonBrandsApiDocs;
+import com.personal.marketnote.reward.adapter.in.web.gifticon.response.GetGifticonBrandsResponse;
+import com.personal.marketnote.reward.port.in.command.gifticon.GetGifticonBrandsCommand;
+import com.personal.marketnote.reward.port.in.result.gifticon.GetGifticonBrandsResult;
+import com.personal.marketnote.reward.port.in.usecase.gifticon.GetGifticonBrandsUseCase;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import static com.personal.marketnote.common.domain.exception.ExceptionCode.DEFAULT_SUCCESS_CODE;
+
+@RestController
+@RequestMapping("/api/v1/gifticon")
+@Tag(name = "기프티콘 브랜드 API", description = "기프티콘 브랜드 관련 API")
+@RequiredArgsConstructor
+public class GifticonBrandController {
+
+    private final GetGifticonBrandsUseCase getGifticonBrandsUseCase;
+
+    /**
+     * 기프티콘 브랜드 목록 조회
+     *
+     * @param categoryCode 카테고리 코드
+     * @return 해당 카테고리의 브랜드 목록 응답 {@link GetGifticonBrandsResponse}
+     * @Author 성효빈
+     * @Date 2026-04-05
+     * @Description 특정 카테고리에 노출된 판매 중 상품이 있는 브랜드 목록을 조회합니다.
+     */
+    @GetMapping("/brands")
+    @GetGifticonBrandsApiDocs
+    public ResponseEntity<BaseResponse<GetGifticonBrandsResponse>> getBrands(
+            @RequestParam(name = "category-code") String categoryCode
+    ) {
+        GetGifticonBrandsResult result = getGifticonBrandsUseCase.getBrands(
+                new GetGifticonBrandsCommand(categoryCode)
+        );
+
+        return ResponseEntity.ok(
+                BaseResponse.of(
+                        GetGifticonBrandsResponse.from(result),
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "기프티콘 브랜드 목록 조회 성공"
+                )
+        );
+    }
+}

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/gifticon/controller/apidocs/GetGifticonBrandsApiDocs.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/gifticon/controller/apidocs/GetGifticonBrandsApiDocs.java
@@ -1,0 +1,67 @@
+package com.personal.marketnote.reward.adapter.in.web.gifticon.controller.apidocs;
+
+import com.personal.marketnote.reward.adapter.in.web.gifticon.response.GetGifticonBrandsResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Operation(
+        summary = "기프티콘 브랜드 목록 조회",
+        description = """
+                작성일자: 2026-04-05
+
+                작성자: 성효빈
+
+                ---
+
+                ## Description
+
+                특정 카테고리에 노출된 판매 중 상품이 있는 브랜드 목록을 조회합니다.
+                """,
+        parameters = {
+                @Parameter(name = "category-code", description = "카테고리 코드", required = true, example = "1")
+        },
+        security = {@SecurityRequirement(name = "bearer")},
+        responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "기프티콘 브랜드 목록 조회 성공",
+                        content = @Content(
+                                schema = @Schema(implementation = GetGifticonBrandsResponse.class),
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 200,
+                                          "code": "SUC01",
+                                          "timestamp": "2026-04-05T10:00:00.000000",
+                                          "content": {
+                                            "brands": [
+                                              {
+                                                "brandCode": "BR001",
+                                                "brandName": "스타벅스",
+                                                "brandImageUrl": "https://img.com/starbucks.png"
+                                              },
+                                              {
+                                                "brandCode": "BR002",
+                                                "brandName": "이디야",
+                                                "brandImageUrl": "https://img.com/ediya.png"
+                                              }
+                                            ]
+                                          },
+                                          "message": "기프티콘 브랜드 목록 조회 성공"
+                                        }
+                                        """)
+                        )
+                )
+        }
+)
+public @interface GetGifticonBrandsApiDocs {
+}

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/gifticon/response/GetGifticonBrandsResponse.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/gifticon/response/GetGifticonBrandsResponse.java
@@ -1,0 +1,27 @@
+package com.personal.marketnote.reward.adapter.in.web.gifticon.response;
+
+import com.personal.marketnote.reward.port.in.result.gifticon.GetGifticonBrandsResult;
+
+import java.util.List;
+
+public record GetGifticonBrandsResponse(List<GifticonBrandItemResponse> brands) {
+
+    public static GetGifticonBrandsResponse from(GetGifticonBrandsResult result) {
+        List<GifticonBrandItemResponse> items = result.brands().stream()
+                .map(item -> new GifticonBrandItemResponse(
+                        item.brandCode(),
+                        item.brandName(),
+                        item.brandImageUrl()
+                ))
+                .toList();
+
+        return new GetGifticonBrandsResponse(items);
+    }
+
+    public record GifticonBrandItemResponse(
+            String brandCode,
+            String brandName,
+            String brandImageUrl
+    ) {
+    }
+}

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/gifticon/GifticonGoodsPersistenceAdapter.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/gifticon/GifticonGoodsPersistenceAdapter.java
@@ -47,6 +47,17 @@ public class GifticonGoodsPersistenceAdapter implements FindGifticonGoodsPort, S
     }
 
     @Override
+    public List<GifticonGoodsBrandProjection> findDistinctBrandsByCategoryCode(String categoryCode) {
+        return repository.findDistinctBrandsByCategoryCode(categoryCode).stream()
+                .map(row -> new GifticonGoodsBrandProjection(
+                        (String) row[0],
+                        (String) row[1],
+                        (String) row[2]
+                ))
+                .toList();
+    }
+
+    @Override
     public FindAllForAdminResult findAllForAdmin(int page, int pageSize, String goodsStatus, Boolean exposed, String keyword) {
         PageRequest pageRequest = PageRequest.of(page - 1, pageSize);
         Page<GifticonGoodsJpaEntity> pageResult = repository.findAllForAdmin(goodsStatus, exposed, keyword, pageRequest);

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/gifticon/repository/GifticonGoodsJpaRepository.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/gifticon/repository/GifticonGoodsJpaRepository.java
@@ -18,6 +18,16 @@ public interface GifticonGoodsJpaRepository extends JpaRepository<GifticonGoodsJ
 
     List<GifticonGoodsJpaEntity> findAllByGoodsStatus(String goodsStatus);
 
+    @Query("""
+            SELECT DISTINCT g.brandCode, g.brandName, g.brandImageUrl
+            FROM GifticonGoodsJpaEntity g
+            WHERE g.exposed = true
+              AND g.goodsStatus = 'SALE'
+              AND g.categoryCode = :categoryCode
+            ORDER BY g.brandName ASC
+            """)
+    List<Object[]> findDistinctBrandsByCategoryCode(@Param("categoryCode") String categoryCode);
+
     @Query(value = """
             SELECT g FROM GifticonGoodsJpaEntity g
             WHERE (:goodsStatus = '' OR g.goodsStatus = :goodsStatus)

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/command/gifticon/GetGifticonBrandsCommand.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/command/gifticon/GetGifticonBrandsCommand.java
@@ -1,0 +1,4 @@
+package com.personal.marketnote.reward.port.in.command.gifticon;
+
+public record GetGifticonBrandsCommand(String categoryCode) {
+}

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/result/gifticon/GetGifticonBrandsResult.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/result/gifticon/GetGifticonBrandsResult.java
@@ -1,0 +1,13 @@
+package com.personal.marketnote.reward.port.in.result.gifticon;
+
+import java.util.List;
+
+public record GetGifticonBrandsResult(List<GifticonBrandItem> brands) {
+
+    public record GifticonBrandItem(
+            String brandCode,
+            String brandName,
+            String brandImageUrl
+    ) {
+    }
+}

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/usecase/gifticon/GetGifticonBrandsUseCase.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/usecase/gifticon/GetGifticonBrandsUseCase.java
@@ -1,0 +1,22 @@
+package com.personal.marketnote.reward.port.in.usecase.gifticon;
+
+import com.personal.marketnote.reward.port.in.command.gifticon.GetGifticonBrandsCommand;
+import com.personal.marketnote.reward.port.in.result.gifticon.GetGifticonBrandsResult;
+
+/**
+ * 기프티콘 브랜드 목록 조회 유스케이스
+ *
+ * @Author 성효빈
+ * @Date 2026-04-05
+ * @Description 특정 카테고리 내 기프티콘 브랜드 목록을 조회합니다.
+ */
+public interface GetGifticonBrandsUseCase {
+    /**
+     * @param command 브랜드 조회 커맨드 (카테고리 코드)
+     * @return 브랜드 목록 {@link GetGifticonBrandsResult}
+     * @Date 2026-04-05
+     * @Author 성효빈
+     * @Description 해당 카테고리에 노출된 판매 중 상품이 있는 브랜드를 조회합니다.
+     */
+    GetGifticonBrandsResult getBrands(GetGifticonBrandsCommand command);
+}

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/out/gifticon/FindGifticonGoodsPort.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/out/gifticon/FindGifticonGoodsPort.java
@@ -15,4 +15,13 @@ public interface FindGifticonGoodsPort {
 
     record FindAllForAdminResult(List<GifticonGoods> items, long totalElements) {
     }
+
+    List<GifticonGoodsBrandProjection> findDistinctBrandsByCategoryCode(String categoryCode);
+
+    record GifticonGoodsBrandProjection(
+            String brandCode,
+            String brandName,
+            String brandImageUrl
+    ) {
+    }
 }

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/service/gifticon/GetGifticonBrandsService.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/service/gifticon/GetGifticonBrandsService.java
@@ -1,0 +1,39 @@
+package com.personal.marketnote.reward.service.gifticon;
+
+import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.reward.port.in.command.gifticon.GetGifticonBrandsCommand;
+import com.personal.marketnote.reward.port.in.result.gifticon.GetGifticonBrandsResult;
+import com.personal.marketnote.reward.port.in.result.gifticon.GetGifticonBrandsResult.GifticonBrandItem;
+import com.personal.marketnote.reward.port.in.usecase.gifticon.GetGifticonBrandsUseCase;
+import com.personal.marketnote.reward.port.out.gifticon.FindGifticonGoodsPort;
+import com.personal.marketnote.reward.port.out.gifticon.FindGifticonGoodsPort.GifticonGoodsBrandProjection;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional(isolation = READ_COMMITTED, readOnly = true)
+public class GetGifticonBrandsService implements GetGifticonBrandsUseCase {
+
+    private final FindGifticonGoodsPort findGifticonGoodsPort;
+
+    @Override
+    public GetGifticonBrandsResult getBrands(GetGifticonBrandsCommand command) {
+        List<GifticonGoodsBrandProjection> projections =
+                findGifticonGoodsPort.findDistinctBrandsByCategoryCode(command.categoryCode());
+
+        List<GifticonBrandItem> items = projections.stream()
+                .map(projection -> new GifticonBrandItem(
+                        projection.brandCode(),
+                        projection.brandName(),
+                        projection.brandImageUrl()
+                ))
+                .toList();
+
+        return new GetGifticonBrandsResult(items);
+    }
+}


### PR DESCRIPTION
## partially addresses #1653
## resolves #1657

## Task
- [x] GetGifticonBrandsUseCase / Service 구현
- [x] FindGifticonGoodsPort.findDistinctBrandsByCategoryCode 추가
- [x] GifticonBrandController GET /api/v1/gifticon/brands?category-code={code}
- [x] 해당 카테고리에 노출 상품이 존재하는 브랜드만 반환
- [x] brandImageUrl 포함