### PR TITLE
[#1653][#1658] feat: 기프티콘 상품 목록 조회 기능 추가

### DIFF
--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/gifticon/controller/GifticonGoodsController.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/gifticon/controller/GifticonGoodsController.java
@@ -1,0 +1,62 @@
+package com.personal.marketnote.reward.adapter.in.web.gifticon.controller;
+
+import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
+import com.personal.marketnote.reward.adapter.in.web.gifticon.controller.apidocs.GetGifticonGoodsApiDocs;
+import com.personal.marketnote.reward.adapter.in.web.gifticon.response.GetGifticonGoodsResponse;
+import com.personal.marketnote.reward.port.in.command.gifticon.GetGifticonGoodsCommand;
+import com.personal.marketnote.reward.port.in.result.gifticon.GetGifticonGoodsResult;
+import com.personal.marketnote.reward.port.in.usecase.gifticon.GetGifticonGoodsUseCase;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import static com.personal.marketnote.common.domain.exception.ExceptionCode.DEFAULT_SUCCESS_CODE;
+import static com.personal.marketnote.common.utility.ApiConstant.DEFAULT_PAGE_NUMBER;
+
+@RestController
+@RequestMapping("/api/v1/gifticon")
+@Tag(name = "기프티콘 상품 API", description = "기프티콘 상품 관련 API")
+@RequiredArgsConstructor
+public class GifticonGoodsController {
+
+    private final GetGifticonGoodsUseCase getGifticonGoodsUseCase;
+
+    /**
+     * 기프티콘 상품 목록 조회
+     *
+     * @param categoryCode 카테고리 코드 (선택)
+     * @param brandCode    브랜드 코드 (선택)
+     * @param page         페이지 번호 (기본: 1)
+     * @param pageSize     페이지 크기 (기본: 20)
+     * @return 상품 목록 응답 {@link GetGifticonGoodsResponse}
+     * @Author 성효빈
+     * @Date 2026-04-05
+     * @Description 노출 설정 및 판매 중인 기프티콘 상품 목록을 페이징으로 조회합니다.
+     */
+    @GetMapping("/goods")
+    @GetGifticonGoodsApiDocs
+    public ResponseEntity<BaseResponse<GetGifticonGoodsResponse>> getGoods(
+            @RequestParam(name = "category-code", required = false) String categoryCode,
+            @RequestParam(name = "brand-code", required = false) String brandCode,
+            @RequestParam(name = "page", required = false, defaultValue = DEFAULT_PAGE_NUMBER) int page,
+            @RequestParam(name = "page-size", required = false, defaultValue = "20") int pageSize
+    ) {
+        GetGifticonGoodsResult result = getGifticonGoodsUseCase.getGoods(
+                new GetGifticonGoodsCommand(categoryCode, brandCode, page, pageSize)
+        );
+
+        return ResponseEntity.ok(
+                BaseResponse.of(
+                        GetGifticonGoodsResponse.from(result),
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "기프티콘 상품 목록 조회 성공"
+                )
+        );
+    }
+}

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/gifticon/controller/apidocs/GetGifticonGoodsApiDocs.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/gifticon/controller/apidocs/GetGifticonGoodsApiDocs.java
@@ -1,0 +1,78 @@
+package com.personal.marketnote.reward.adapter.in.web.gifticon.controller.apidocs;
+
+import com.personal.marketnote.reward.adapter.in.web.gifticon.response.GetGifticonGoodsResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Operation(
+        summary = "기프티콘 상품 목록 조회",
+        description = """
+                작성일자: 2026-04-05
+
+                작성자: 성효빈
+
+                ---
+
+                ## Description
+
+                노출 설정 및 판매 중인 기프티콘 상품 목록을 페이징으로 조회합니다.
+                카테고리 코드, 브랜드 코드로 필터링할 수 있습니다.
+                """,
+        parameters = {
+                @Parameter(name = "category-code", description = "카테고리 코드", required = false, example = "1"),
+                @Parameter(name = "brand-code", description = "브랜드 코드", required = false, example = "BR001"),
+                @Parameter(name = "page", description = "페이지 번호 (기본: 1)", required = false, example = "1"),
+                @Parameter(name = "page-size", description = "페이지 크기 (기본: 20)", required = false, example = "20")
+        },
+        security = {@SecurityRequirement(name = "bearer")},
+        responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "기프티콘 상품 목록 조회 성공",
+                        content = @Content(
+                                schema = @Schema(implementation = GetGifticonGoodsResponse.class),
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 200,
+                                          "code": "SUC01",
+                                          "timestamp": "2026-04-05T10:00:00.000000",
+                                          "content": {
+                                            "goods": {
+                                              "page": 1,
+                                              "pageSize": 20,
+                                              "totalElements": 30,
+                                              "totalPages": 2,
+                                              "items": [
+                                                {
+                                                  "goodsCode": "GD001",
+                                                  "goodsName": "아메리카노",
+                                                  "brandCode": "BR001",
+                                                  "brandName": "스타벅스",
+                                                  "brandImageUrl": "https://img.com/sb.png",
+                                                  "salePrice": 4500,
+                                                  "cashPrice": 4000,
+                                                  "imageUrl": "https://img.com/americano.png",
+                                                  "orderNum": 1
+                                                }
+                                              ]
+                                            }
+                                          },
+                                          "message": "기프티콘 상품 목록 조회 성공"
+                                        }
+                                        """)
+                        )
+                )
+        }
+)
+public @interface GetGifticonGoodsApiDocs {
+}

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/gifticon/response/GetGifticonGoodsResponse.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/gifticon/response/GetGifticonGoodsResponse.java
@@ -1,0 +1,44 @@
+package com.personal.marketnote.reward.adapter.in.web.gifticon.response;
+
+import com.personal.marketnote.common.adapter.in.response.OffsetResponse;
+import com.personal.marketnote.reward.port.in.result.gifticon.GetGifticonGoodsResult;
+
+public record GetGifticonGoodsResponse(OffsetResponse<GifticonGoodsItemResponse> goods) {
+
+    public static GetGifticonGoodsResponse from(GetGifticonGoodsResult result) {
+        return new GetGifticonGoodsResponse(
+                new OffsetResponse<>(
+                        result.page(),
+                        result.pageSize(),
+                        result.totalElements(),
+                        result.totalPages(),
+                        result.items().stream()
+                                .map(item -> new GifticonGoodsItemResponse(
+                                        item.goodsCode(),
+                                        item.goodsName(),
+                                        item.brandCode(),
+                                        item.brandName(),
+                                        item.brandImageUrl(),
+                                        item.salePrice(),
+                                        item.cashPrice(),
+                                        item.imageUrl(),
+                                        item.orderNum()
+                                ))
+                                .toList()
+                )
+        );
+    }
+
+    public record GifticonGoodsItemResponse(
+            String goodsCode,
+            String goodsName,
+            String brandCode,
+            String brandName,
+            String brandImageUrl,
+            Long salePrice,
+            Long cashPrice,
+            String imageUrl,
+            Integer orderNum
+    ) {
+    }
+}

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/gifticon/GifticonGoodsPersistenceAdapter.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/gifticon/GifticonGoodsPersistenceAdapter.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.reward.adapter.out.persistence.gifticon;
 
 import com.personal.marketnote.common.adapter.out.PersistenceAdapter;
+import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.reward.adapter.out.persistence.gifticon.entity.GifticonGoodsJpaEntity;
 import com.personal.marketnote.reward.adapter.out.persistence.gifticon.repository.GifticonGoodsJpaRepository;
 import com.personal.marketnote.reward.domain.gifticon.GifticonGoods;
@@ -11,6 +12,7 @@ import com.personal.marketnote.reward.port.out.gifticon.UpdateGifticonGoodsPort;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 import java.util.Optional;
@@ -65,5 +67,25 @@ public class GifticonGoodsPersistenceAdapter implements FindGifticonGoodsPort, S
                 .map(GifticonGoodsJpaEntity::toDomain)
                 .toList();
         return new FindAllForAdminResult(items, pageResult.getTotalElements());
+    }
+
+    @Override
+    public List<GifticonGoods> findAllExposed(String categoryCode, String brandCode, int page, int pageSize) {
+        String categoryCodeParam = FormatValidator.hasValue(categoryCode) ? categoryCode : "";
+        String brandCodeParam = FormatValidator.hasValue(brandCode) ? brandCode : "";
+        Pageable pageable = PageRequest.of(page - 1, pageSize);
+        Page<GifticonGoodsJpaEntity> result = repository.findAllExposed(categoryCodeParam, brandCodeParam, pageable);
+        return result.getContent().stream()
+                .map(GifticonGoodsJpaEntity::toDomain)
+                .toList();
+    }
+
+    @Override
+    public long countAllExposed(String categoryCode, String brandCode) {
+        String categoryCodeParam = FormatValidator.hasValue(categoryCode) ? categoryCode : "";
+        String brandCodeParam = FormatValidator.hasValue(brandCode) ? brandCode : "";
+        Pageable pageable = PageRequest.of(0, 1);
+        Page<GifticonGoodsJpaEntity> result = repository.findAllExposed(categoryCodeParam, brandCodeParam, pageable);
+        return result.getTotalElements();
     }
 }

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/gifticon/repository/GifticonGoodsJpaRepository.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/gifticon/repository/GifticonGoodsJpaRepository.java
@@ -30,6 +30,30 @@ public interface GifticonGoodsJpaRepository extends JpaRepository<GifticonGoodsJ
 
     @Query(value = """
             SELECT g FROM GifticonGoodsJpaEntity g
+            WHERE g.exposed = true
+              AND g.goodsStatus = 'SALE'
+              AND (:categoryCode = '' OR g.categoryCode = :categoryCode)
+              AND (:brandCode = '' OR g.brandCode = :brandCode)
+            ORDER BY
+                CASE WHEN g.orderNum IS NULL THEN 1 ELSE 0 END,
+                g.orderNum ASC,
+                g.createdAt DESC
+            """,
+            countQuery = """
+            SELECT COUNT(g) FROM GifticonGoodsJpaEntity g
+            WHERE g.exposed = true
+              AND g.goodsStatus = 'SALE'
+              AND (:categoryCode = '' OR g.categoryCode = :categoryCode)
+              AND (:brandCode = '' OR g.brandCode = :brandCode)
+            """)
+    Page<GifticonGoodsJpaEntity> findAllExposed(
+            @Param("categoryCode") String categoryCode,
+            @Param("brandCode") String brandCode,
+            Pageable pageable
+    );
+
+    @Query(value = """
+            SELECT g FROM GifticonGoodsJpaEntity g
             WHERE (:goodsStatus = '' OR g.goodsStatus = :goodsStatus)
             AND (:exposed IS NULL OR g.exposed = :exposed)
             AND (:keyword = '' OR g.goodsName LIKE CONCAT('%', :keyword, '%'))

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/command/gifticon/GetGifticonGoodsCommand.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/command/gifticon/GetGifticonGoodsCommand.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.reward.port.in.command.gifticon;
+
+public record GetGifticonGoodsCommand(
+        String categoryCode,
+        String brandCode,
+        int page,
+        int pageSize
+) {
+}

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/result/gifticon/GetGifticonGoodsResult.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/result/gifticon/GetGifticonGoodsResult.java
@@ -1,0 +1,25 @@
+package com.personal.marketnote.reward.port.in.result.gifticon;
+
+import java.util.List;
+
+public record GetGifticonGoodsResult(
+        int page,
+        int pageSize,
+        long totalElements,
+        int totalPages,
+        List<GifticonGoodsItem> items
+) {
+
+    public record GifticonGoodsItem(
+            String goodsCode,
+            String goodsName,
+            String brandCode,
+            String brandName,
+            String brandImageUrl,
+            Long salePrice,
+            Long cashPrice,
+            String imageUrl,
+            Integer orderNum
+    ) {
+    }
+}

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/usecase/gifticon/GetGifticonGoodsUseCase.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/usecase/gifticon/GetGifticonGoodsUseCase.java
@@ -1,0 +1,22 @@
+package com.personal.marketnote.reward.port.in.usecase.gifticon;
+
+import com.personal.marketnote.reward.port.in.command.gifticon.GetGifticonGoodsCommand;
+import com.personal.marketnote.reward.port.in.result.gifticon.GetGifticonGoodsResult;
+
+/**
+ * 기프티콘 상품 목록 조회 유스케이스
+ *
+ * @Author 성효빈
+ * @Date 2026-04-05
+ * @Description 사용자가 노출된 기프티콘 상품 목록을 조회합니다.
+ */
+public interface GetGifticonGoodsUseCase {
+    /**
+     * @param command 상품 목록 조회 커맨드
+     * @return 상품 목록 (페이징) {@link GetGifticonGoodsResult}
+     * @Date 2026-04-05
+     * @Author 성효빈
+     * @Description 노출 설정 및 판매 중인 상품 목록을 페이징으로 조회합니다.
+     */
+    GetGifticonGoodsResult getGoods(GetGifticonGoodsCommand command);
+}

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/out/gifticon/FindGifticonGoodsPort.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/out/gifticon/FindGifticonGoodsPort.java
@@ -18,6 +18,10 @@ public interface FindGifticonGoodsPort {
 
     List<GifticonGoodsBrandProjection> findDistinctBrandsByCategoryCode(String categoryCode);
 
+    List<GifticonGoods> findAllExposed(String categoryCode, String brandCode, int page, int pageSize);
+
+    long countAllExposed(String categoryCode, String brandCode);
+
     record GifticonGoodsBrandProjection(
             String brandCode,
             String brandName,

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/service/gifticon/GetGifticonGoodsService.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/service/gifticon/GetGifticonGoodsService.java
@@ -1,0 +1,70 @@
+package com.personal.marketnote.reward.service.gifticon;
+
+import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.reward.domain.gifticon.GifticonGoods;
+import com.personal.marketnote.reward.port.in.command.gifticon.GetGifticonGoodsCommand;
+import com.personal.marketnote.reward.port.in.result.gifticon.GetGifticonGoodsResult;
+import com.personal.marketnote.reward.port.in.result.gifticon.GetGifticonGoodsResult.GifticonGoodsItem;
+import com.personal.marketnote.reward.port.in.usecase.gifticon.GetGifticonGoodsUseCase;
+import com.personal.marketnote.reward.port.out.gifticon.FindGifticonGoodsPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional(isolation = READ_COMMITTED, readOnly = true)
+public class GetGifticonGoodsService implements GetGifticonGoodsUseCase {
+
+    private final FindGifticonGoodsPort findGifticonGoodsPort;
+
+    @Override
+    public GetGifticonGoodsResult getGoods(GetGifticonGoodsCommand command) {
+        long totalElements = findGifticonGoodsPort.countAllExposed(
+                command.categoryCode(), command.brandCode()
+        );
+
+        List<GifticonGoods> goods = findGifticonGoodsPort.findAllExposed(
+                command.categoryCode(), command.brandCode(),
+                command.page(), command.pageSize()
+        );
+
+        int totalPages = calculateTotalPages(totalElements, command.pageSize());
+
+        List<GifticonGoodsItem> items = goods.stream()
+                .map(this::mapToItem)
+                .toList();
+
+        return new GetGifticonGoodsResult(
+                command.page(),
+                command.pageSize(),
+                totalElements,
+                totalPages,
+                items
+        );
+    }
+
+    private int calculateTotalPages(long totalElements, int pageSize) {
+        if (totalElements == 0) {
+            return 0;
+        }
+        return (int) Math.ceil((double) totalElements / pageSize);
+    }
+
+    private GifticonGoodsItem mapToItem(GifticonGoods goods) {
+        return new GifticonGoodsItem(
+                goods.getGoodsCode(),
+                goods.getGoodsName(),
+                goods.getBrandCode(),
+                goods.getBrandName(),
+                goods.getBrandImageUrl(),
+                goods.getSalePrice(),
+                goods.getCashPrice(),
+                goods.getImageUrl(),
+                goods.getOrderNum()
+        );
+    }
+}


### PR DESCRIPTION
## partially addresses #1653
## resolves #1658

## Task
- [x] GetGifticonGoodsUseCase / Service 구현
- [x] FindGifticonGoodsPort.findAllExposed / countAllExposed 추가
- [x] GifticonGoodsController GET /api/v1/gifticon/goods
- [x] exposed=true + SALE 필터, categoryCode + brandCode 복합 필터
- [x] orderNum ASC 정렬, totalCount 포함 (OffsetResponse)