### PR TITLE
[#1653][#1659] feat: 기프티콘 상품 상세 조회 기능 추가

### DIFF
--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/gifticon/controller/GifticonGoodsController.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/gifticon/controller/GifticonGoodsController.java
@@ -1,19 +1,24 @@
 package com.personal.marketnote.reward.adapter.in.web.gifticon.controller;
 
 import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
+import com.personal.marketnote.common.utility.ElementExtractor;
 import com.personal.marketnote.reward.adapter.in.web.gifticon.controller.apidocs.GetGifticonGoodsApiDocs;
+import com.personal.marketnote.reward.adapter.in.web.gifticon.controller.apidocs.GetGifticonGoodsDetailApiDocs;
+import com.personal.marketnote.reward.adapter.in.web.gifticon.response.GetGifticonGoodsDetailResponse;
 import com.personal.marketnote.reward.adapter.in.web.gifticon.response.GetGifticonGoodsResponse;
 import com.personal.marketnote.reward.port.in.command.gifticon.GetGifticonGoodsCommand;
+import com.personal.marketnote.reward.port.in.command.gifticon.GetGifticonGoodsDetailCommand;
+import com.personal.marketnote.reward.port.in.result.gifticon.GetGifticonGoodsDetailResult;
 import com.personal.marketnote.reward.port.in.result.gifticon.GetGifticonGoodsResult;
+import com.personal.marketnote.reward.port.in.usecase.gifticon.GetGifticonGoodsDetailUseCase;
 import com.personal.marketnote.reward.port.in.usecase.gifticon.GetGifticonGoodsUseCase;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.core.OAuth2AuthenticatedPrincipal;
+import org.springframework.web.bind.annotation.*;
 
 import static com.personal.marketnote.common.domain.exception.ExceptionCode.DEFAULT_SUCCESS_CODE;
 import static com.personal.marketnote.common.utility.ApiConstant.DEFAULT_PAGE_NUMBER;
@@ -25,6 +30,7 @@ import static com.personal.marketnote.common.utility.ApiConstant.DEFAULT_PAGE_NU
 public class GifticonGoodsController {
 
     private final GetGifticonGoodsUseCase getGifticonGoodsUseCase;
+    private final GetGifticonGoodsDetailUseCase getGifticonGoodsDetailUseCase;
 
     /**
      * 기프티콘 상품 목록 조회
@@ -56,6 +62,37 @@ public class GifticonGoodsController {
                         HttpStatus.OK,
                         DEFAULT_SUCCESS_CODE,
                         "기프티콘 상품 목록 조회 성공"
+                )
+        );
+    }
+
+    /**
+     * 기프티콘 상품 상세 조회
+     *
+     * @param goodsCode 상품 코드
+     * @param principal 인증된 사용자 정보
+     * @return 상품 상세 응답 {@link GetGifticonGoodsDetailResponse}
+     * @Author 성효빈
+     * @Date 2026-04-05
+     * @Description 기프티콘 상품 상세 정보와 사용자 캐시 잔액을 조회합니다.
+     */
+    @GetMapping("/goods/{goodsCode}")
+    @GetGifticonGoodsDetailApiDocs
+    public ResponseEntity<BaseResponse<GetGifticonGoodsDetailResponse>> getGoodsDetail(
+            @PathVariable("goodsCode") String goodsCode,
+            @AuthenticationPrincipal OAuth2AuthenticatedPrincipal principal
+    ) {
+        Long userId = ElementExtractor.extractUserId(principal);
+        GetGifticonGoodsDetailResult result = getGifticonGoodsDetailUseCase.getGoodsDetail(
+                new GetGifticonGoodsDetailCommand(goodsCode, userId)
+        );
+
+        return ResponseEntity.ok(
+                BaseResponse.of(
+                        GetGifticonGoodsDetailResponse.from(result),
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "기프티콘 상품 상세 조회 성공"
                 )
         );
     }

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/gifticon/controller/apidocs/GetGifticonGoodsDetailApiDocs.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/gifticon/controller/apidocs/GetGifticonGoodsDetailApiDocs.java
@@ -1,0 +1,69 @@
+package com.personal.marketnote.reward.adapter.in.web.gifticon.controller.apidocs;
+
+import com.personal.marketnote.reward.adapter.in.web.gifticon.response.GetGifticonGoodsDetailResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Operation(
+        summary = "기프티콘 상품 상세 조회",
+        description = """
+                작성일자: 2026-04-05
+
+                작성자: 성효빈
+
+                ---
+
+                ## Description
+
+                기프티콘 상품 상세 정보와 사용자의 캐시 잔액을 조회합니다.
+                노출 설정 및 판매 중인 상품만 조회 가능합니다.
+                """,
+        parameters = {
+                @Parameter(name = "goodsCode", description = "상품 코드", required = true, example = "GD001")
+        },
+        security = {@SecurityRequirement(name = "bearer")},
+        responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "기프티콘 상품 상세 조회 성공",
+                        content = @Content(
+                                schema = @Schema(implementation = GetGifticonGoodsDetailResponse.class),
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 200,
+                                          "code": "SUC01",
+                                          "timestamp": "2026-04-05T10:00:00.000000",
+                                          "content": {
+                                            "goodsCode": "GD001",
+                                            "goodsName": "아메리카노",
+                                            "brandCode": "BR001",
+                                            "brandName": "스타벅스",
+                                            "brandImageUrl": "https://img.com/sb.png",
+                                            "categoryCode": "1",
+                                            "realPrice": 5000,
+                                            "salePrice": 4500,
+                                            "cashPrice": 4000,
+                                            "imageUrl": "https://img.com/americano.png",
+                                            "description": "맛있는 아메리카노",
+                                            "validDays": 30,
+                                            "userCashBalance": 10000
+                                          },
+                                          "message": "기프티콘 상품 상세 조회 성공"
+                                        }
+                                        """)
+                        )
+                )
+        }
+)
+public @interface GetGifticonGoodsDetailApiDocs {
+}

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/gifticon/response/GetGifticonGoodsDetailResponse.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/gifticon/response/GetGifticonGoodsDetailResponse.java
@@ -1,0 +1,38 @@
+package com.personal.marketnote.reward.adapter.in.web.gifticon.response;
+
+import com.personal.marketnote.reward.port.in.result.gifticon.GetGifticonGoodsDetailResult;
+
+public record GetGifticonGoodsDetailResponse(
+        String goodsCode,
+        String goodsName,
+        String brandCode,
+        String brandName,
+        String brandImageUrl,
+        String categoryCode,
+        Long realPrice,
+        Long salePrice,
+        Long cashPrice,
+        String imageUrl,
+        String description,
+        Integer validDays,
+        Long userCashBalance
+) {
+
+    public static GetGifticonGoodsDetailResponse from(GetGifticonGoodsDetailResult result) {
+        return new GetGifticonGoodsDetailResponse(
+                result.goodsCode(),
+                result.goodsName(),
+                result.brandCode(),
+                result.brandName(),
+                result.brandImageUrl(),
+                result.categoryCode(),
+                result.realPrice(),
+                result.salePrice(),
+                result.cashPrice(),
+                result.imageUrl(),
+                result.description(),
+                result.validDays(),
+                result.userCashBalance()
+        );
+    }
+}

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/command/gifticon/GetGifticonGoodsDetailCommand.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/command/gifticon/GetGifticonGoodsDetailCommand.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.reward.port.in.command.gifticon;
+
+public record GetGifticonGoodsDetailCommand(
+        String goodsCode,
+        Long userId
+) {
+}

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/result/gifticon/GetGifticonGoodsDetailResult.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/result/gifticon/GetGifticonGoodsDetailResult.java
@@ -1,0 +1,18 @@
+package com.personal.marketnote.reward.port.in.result.gifticon;
+
+public record GetGifticonGoodsDetailResult(
+        String goodsCode,
+        String goodsName,
+        String brandCode,
+        String brandName,
+        String brandImageUrl,
+        String categoryCode,
+        Long realPrice,
+        Long salePrice,
+        Long cashPrice,
+        String imageUrl,
+        String description,
+        Integer validDays,
+        Long userCashBalance
+) {
+}

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/usecase/gifticon/GetGifticonGoodsDetailUseCase.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/usecase/gifticon/GetGifticonGoodsDetailUseCase.java
@@ -1,0 +1,22 @@
+package com.personal.marketnote.reward.port.in.usecase.gifticon;
+
+import com.personal.marketnote.reward.port.in.command.gifticon.GetGifticonGoodsDetailCommand;
+import com.personal.marketnote.reward.port.in.result.gifticon.GetGifticonGoodsDetailResult;
+
+/**
+ * 기프티콘 상품 상세 조회 유스케이스
+ *
+ * @Author 성효빈
+ * @Date 2026-04-05
+ * @Description 사용자가 기프티콘 상품 상세 정보를 조회합니다.
+ */
+public interface GetGifticonGoodsDetailUseCase {
+    /**
+     * @param command 상품 상세 조회 커맨드 (상품 코드, 사용자 ID)
+     * @return 상품 상세 정보 + 사용자 캐시 잔액 {@link GetGifticonGoodsDetailResult}
+     * @Date 2026-04-05
+     * @Author 성효빈
+     * @Description 노출 및 판매 중인 상품의 상세 정보와 사용자 캐시 잔액을 조회합니다.
+     */
+    GetGifticonGoodsDetailResult getGoodsDetail(GetGifticonGoodsDetailCommand command);
+}

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/service/gifticon/GetGifticonGoodsDetailService.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/service/gifticon/GetGifticonGoodsDetailService.java
@@ -1,0 +1,62 @@
+package com.personal.marketnote.reward.service.gifticon;
+
+import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.reward.domain.exception.GifticonGoodsNotFoundException;
+import com.personal.marketnote.reward.domain.gifticon.GifticonGoods;
+import com.personal.marketnote.reward.domain.point.UserPoint;
+import com.personal.marketnote.reward.port.in.command.gifticon.GetGifticonGoodsDetailCommand;
+import com.personal.marketnote.reward.port.in.result.gifticon.GetGifticonGoodsDetailResult;
+import com.personal.marketnote.reward.port.in.usecase.gifticon.GetGifticonGoodsDetailUseCase;
+import com.personal.marketnote.reward.port.in.usecase.point.GetUserPointUseCase;
+import com.personal.marketnote.reward.port.out.gifticon.FindGifticonGoodsPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional(isolation = READ_COMMITTED, readOnly = true)
+public class GetGifticonGoodsDetailService implements GetGifticonGoodsDetailUseCase {
+
+    private final FindGifticonGoodsPort findGifticonGoodsPort;
+    private final GetUserPointUseCase getUserPointUseCase;
+
+    @Override
+    public GetGifticonGoodsDetailResult getGoodsDetail(GetGifticonGoodsDetailCommand command) {
+        GifticonGoods goods = findExposedSaleGoods(command.goodsCode());
+        Long userCashBalance = getUserCashBalance(command.userId());
+
+        return new GetGifticonGoodsDetailResult(
+                goods.getGoodsCode(),
+                goods.getGoodsName(),
+                goods.getBrandCode(),
+                goods.getBrandName(),
+                goods.getBrandImageUrl(),
+                goods.getCategoryCode(),
+                goods.getRealPrice(),
+                goods.getSalePrice(),
+                goods.getCashPrice(),
+                goods.getImageUrl(),
+                goods.getDescription(),
+                goods.getValidDays(),
+                userCashBalance
+        );
+    }
+
+    private GifticonGoods findExposedSaleGoods(String goodsCode) {
+        GifticonGoods goods = findGifticonGoodsPort.findByGoodsCode(goodsCode)
+                .orElseThrow(() -> new GifticonGoodsNotFoundException(goodsCode));
+
+        if (!goods.isExposed() || !goods.isSale()) {
+            throw new GifticonGoodsNotFoundException(goodsCode);
+        }
+
+        return goods;
+    }
+
+    private Long getUserCashBalance(Long userId) {
+        UserPoint userPoint = getUserPointUseCase.getUserPoint(userId);
+        return userPoint.getAmountValue();
+    }
+}


### PR DESCRIPTION
## partially addresses #1653
## resolves #1659

## Task
- [x] GetGifticonGoodsDetailUseCase / Service 구현
- [x] GifticonGoodsController GET /api/v1/gifticon/goods/{goodsCode}
- [x] exposed + SALE 상품만 조회, 아니면 GifticonGoodsNotFoundException
- [x] validDays, description, userCashBalance(캐시 잔액) 응답 포함
- [x] brandName, brandImageUrl 포함