### PR TITLE
[#1653][#1660] feat: 기프티콘 인기 상품 목록 조회 기능 추가

### DIFF
--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/gifticon/controller/GifticonGoodsController.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/gifticon/controller/GifticonGoodsController.java
@@ -4,13 +4,17 @@ import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
 import com.personal.marketnote.common.utility.ElementExtractor;
 import com.personal.marketnote.reward.adapter.in.web.gifticon.controller.apidocs.GetGifticonGoodsApiDocs;
 import com.personal.marketnote.reward.adapter.in.web.gifticon.controller.apidocs.GetGifticonGoodsDetailApiDocs;
+import com.personal.marketnote.reward.adapter.in.web.gifticon.controller.apidocs.GetPopularGifticonGoodsApiDocs;
 import com.personal.marketnote.reward.adapter.in.web.gifticon.response.GetGifticonGoodsDetailResponse;
+import com.personal.marketnote.reward.adapter.in.web.gifticon.response.GetPopularGifticonGoodsResponse;
 import com.personal.marketnote.reward.adapter.in.web.gifticon.response.GetGifticonGoodsResponse;
 import com.personal.marketnote.reward.port.in.command.gifticon.GetGifticonGoodsCommand;
 import com.personal.marketnote.reward.port.in.command.gifticon.GetGifticonGoodsDetailCommand;
 import com.personal.marketnote.reward.port.in.result.gifticon.GetGifticonGoodsDetailResult;
+import com.personal.marketnote.reward.port.in.result.gifticon.GetPopularGifticonGoodsResult;
 import com.personal.marketnote.reward.port.in.result.gifticon.GetGifticonGoodsResult;
 import com.personal.marketnote.reward.port.in.usecase.gifticon.GetGifticonGoodsDetailUseCase;
+import com.personal.marketnote.reward.port.in.usecase.gifticon.GetPopularGifticonGoodsUseCase;
 import com.personal.marketnote.reward.port.in.usecase.gifticon.GetGifticonGoodsUseCase;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -31,6 +35,7 @@ public class GifticonGoodsController {
 
     private final GetGifticonGoodsUseCase getGifticonGoodsUseCase;
     private final GetGifticonGoodsDetailUseCase getGifticonGoodsDetailUseCase;
+    private final GetPopularGifticonGoodsUseCase getPopularGifticonGoodsUseCase;
 
     /**
      * 기프티콘 상품 목록 조회
@@ -62,6 +67,29 @@ public class GifticonGoodsController {
                         HttpStatus.OK,
                         DEFAULT_SUCCESS_CODE,
                         "기프티콘 상품 목록 조회 성공"
+                )
+        );
+    }
+
+    /**
+     * 기프티콘 인기 상품 목록 조회
+     *
+     * @return 인기 상품 목록 응답 {@link GetPopularGifticonGoodsResponse}
+     * @Author 성효빈
+     * @Date 2026-04-05
+     * @Description 인기 설정된 기프티콘 상품 목록을 조회합니다. 최대 10개.
+     */
+    @GetMapping("/goods/popular")
+    @GetPopularGifticonGoodsApiDocs
+    public ResponseEntity<BaseResponse<GetPopularGifticonGoodsResponse>> getPopularGoods() {
+        GetPopularGifticonGoodsResult result = getPopularGifticonGoodsUseCase.getPopularGoods();
+
+        return ResponseEntity.ok(
+                BaseResponse.of(
+                        GetPopularGifticonGoodsResponse.from(result),
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "기프티콘 인기 상품 목록 조회 성공"
                 )
         );
     }

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/gifticon/controller/apidocs/GetPopularGifticonGoodsApiDocs.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/gifticon/controller/apidocs/GetPopularGifticonGoodsApiDocs.java
@@ -1,0 +1,63 @@
+package com.personal.marketnote.reward.adapter.in.web.gifticon.controller.apidocs;
+
+import com.personal.marketnote.reward.adapter.in.web.gifticon.response.GetPopularGifticonGoodsResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Operation(
+        summary = "기프티콘 인기 상품 목록 조회",
+        description = """
+                작성일자: 2026-04-05
+
+                작성자: 성효빈
+
+                ---
+
+                ## Description
+
+                인기 설정된 기프티콘 상품 목록을 조회합니다. 최대 10개까지 반환합니다.
+                """,
+        security = {@SecurityRequirement(name = "bearer")},
+        responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "기프티콘 인기 상품 목록 조회 성공",
+                        content = @Content(
+                                schema = @Schema(implementation = GetPopularGifticonGoodsResponse.class),
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 200,
+                                          "code": "SUC01",
+                                          "timestamp": "2026-04-05T10:00:00.000000",
+                                          "content": {
+                                            "items": [
+                                              {
+                                                "goodsCode": "GD001",
+                                                "goodsName": "아메리카노",
+                                                "brandCode": "BR001",
+                                                "brandName": "스타벅스",
+                                                "brandImageUrl": "https://img.com/sb.png",
+                                                "salePrice": 4500,
+                                                "cashPrice": 4000,
+                                                "imageUrl": "https://img.com/americano.png"
+                                              }
+                                            ]
+                                          },
+                                          "message": "기프티콘 인기 상품 목록 조회 성공"
+                                        }
+                                        """)
+                        )
+                )
+        }
+)
+public @interface GetPopularGifticonGoodsApiDocs {
+}

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/gifticon/response/GetPopularGifticonGoodsResponse.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/gifticon/response/GetPopularGifticonGoodsResponse.java
@@ -1,0 +1,37 @@
+package com.personal.marketnote.reward.adapter.in.web.gifticon.response;
+
+import com.personal.marketnote.reward.port.in.result.gifticon.GetPopularGifticonGoodsResult;
+
+import java.util.List;
+
+public record GetPopularGifticonGoodsResponse(List<PopularGifticonGoodsItemResponse> items) {
+
+    public static GetPopularGifticonGoodsResponse from(GetPopularGifticonGoodsResult result) {
+        List<PopularGifticonGoodsItemResponse> items = result.items().stream()
+                .map(item -> new PopularGifticonGoodsItemResponse(
+                        item.goodsCode(),
+                        item.goodsName(),
+                        item.brandCode(),
+                        item.brandName(),
+                        item.brandImageUrl(),
+                        item.salePrice(),
+                        item.cashPrice(),
+                        item.imageUrl()
+                ))
+                .toList();
+
+        return new GetPopularGifticonGoodsResponse(items);
+    }
+
+    public record PopularGifticonGoodsItemResponse(
+            String goodsCode,
+            String goodsName,
+            String brandCode,
+            String brandName,
+            String brandImageUrl,
+            Long salePrice,
+            Long cashPrice,
+            String imageUrl
+    ) {
+    }
+}

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/gifticon/GifticonGoodsPersistenceAdapter.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/gifticon/GifticonGoodsPersistenceAdapter.java
@@ -88,4 +88,12 @@ public class GifticonGoodsPersistenceAdapter implements FindGifticonGoodsPort, S
         Page<GifticonGoodsJpaEntity> result = repository.findAllExposed(categoryCodeParam, brandCodeParam, pageable);
         return result.getTotalElements();
     }
+
+    @Override
+    public List<GifticonGoods> findAllPopularAndExposed(int limit) {
+        Pageable pageable = PageRequest.of(0, limit);
+        return repository.findAllPopularAndExposed(pageable).stream()
+                .map(GifticonGoodsJpaEntity::toDomain)
+                .toList();
+    }
 }

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/gifticon/entity/GifticonGoodsJpaEntity.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/gifticon/entity/GifticonGoodsJpaEntity.java
@@ -59,6 +59,9 @@ public class GifticonGoodsJpaEntity extends BaseEntity {
     @Column(name = "exposed", nullable = false)
     private boolean exposed;
 
+    @Column(name = "popular", nullable = false)
+    private boolean popular;
+
     @Column(name = "order_num")
     private Integer orderNum;
 
@@ -79,6 +82,7 @@ public class GifticonGoodsJpaEntity extends BaseEntity {
                 .validDays(domain.getValidDays())
                 .goodsStatus(domain.getGoodsStatus())
                 .exposed(domain.isExposed())
+                .popular(domain.isPopular())
                 .orderNum(domain.getOrderNum())
                 .build();
     }
@@ -101,6 +105,7 @@ public class GifticonGoodsJpaEntity extends BaseEntity {
                         .validDays(validDays)
                         .goodsStatus(goodsStatus)
                         .exposed(exposed)
+                        .popular(popular)
                         .orderNum(orderNum)
                         .createdAt(getCreatedAt())
                         .modifiedAt(getModifiedAt())
@@ -122,6 +127,7 @@ public class GifticonGoodsJpaEntity extends BaseEntity {
         this.validDays = domain.getValidDays();
         this.goodsStatus = domain.getGoodsStatus();
         this.exposed = domain.isExposed();
+        this.popular = domain.isPopular();
         this.orderNum = domain.getOrderNum();
     }
 }

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/gifticon/repository/GifticonGoodsJpaRepository.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/gifticon/repository/GifticonGoodsJpaRepository.java
@@ -71,4 +71,15 @@ public interface GifticonGoodsJpaRepository extends JpaRepository<GifticonGoodsJ
             @Param("keyword") String keyword,
             Pageable pageable
     );
+
+    @Query("""
+            SELECT g FROM GifticonGoodsJpaEntity g
+            WHERE g.popular = true
+              AND g.exposed = true
+              AND g.goodsStatus = 'SALE'
+            ORDER BY
+                CASE WHEN g.orderNum IS NULL THEN 1 ELSE 0 END,
+                g.orderNum ASC
+            """)
+    List<GifticonGoodsJpaEntity> findAllPopularAndExposed(Pageable pageable);
 }

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/result/gifticon/GetPopularGifticonGoodsResult.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/result/gifticon/GetPopularGifticonGoodsResult.java
@@ -1,0 +1,18 @@
+package com.personal.marketnote.reward.port.in.result.gifticon;
+
+import java.util.List;
+
+public record GetPopularGifticonGoodsResult(List<PopularGifticonGoodsItem> items) {
+
+    public record PopularGifticonGoodsItem(
+            String goodsCode,
+            String goodsName,
+            String brandCode,
+            String brandName,
+            String brandImageUrl,
+            Long salePrice,
+            Long cashPrice,
+            String imageUrl
+    ) {
+    }
+}

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/usecase/gifticon/GetPopularGifticonGoodsUseCase.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/usecase/gifticon/GetPopularGifticonGoodsUseCase.java
@@ -1,0 +1,20 @@
+package com.personal.marketnote.reward.port.in.usecase.gifticon;
+
+import com.personal.marketnote.reward.port.in.result.gifticon.GetPopularGifticonGoodsResult;
+
+/**
+ * 기프티콘 인기 상품 목록 조회 유스케이스
+ *
+ * @Author 성효빈
+ * @Date 2026-04-05
+ * @Description 인기 설정된 기프티콘 상품 목록을 조회합니다.
+ */
+public interface GetPopularGifticonGoodsUseCase {
+    /**
+     * @return 인기 상품 목록 (최대 10개) {@link GetPopularGifticonGoodsResult}
+     * @Date 2026-04-05
+     * @Author 성효빈
+     * @Description 인기 설정 + 노출 + 판매 중인 상품을 orderNum 오름차순으로 조회합니다.
+     */
+    GetPopularGifticonGoodsResult getPopularGoods();
+}

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/out/gifticon/FindGifticonGoodsPort.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/out/gifticon/FindGifticonGoodsPort.java
@@ -22,6 +22,8 @@ public interface FindGifticonGoodsPort {
 
     long countAllExposed(String categoryCode, String brandCode);
 
+    List<GifticonGoods> findAllPopularAndExposed(int limit);
+
     record GifticonGoodsBrandProjection(
             String brandCode,
             String brandName,

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/service/gifticon/GetPopularGifticonGoodsService.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/service/gifticon/GetPopularGifticonGoodsService.java
@@ -1,0 +1,48 @@
+package com.personal.marketnote.reward.service.gifticon;
+
+import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.reward.domain.gifticon.GifticonGoods;
+import com.personal.marketnote.reward.port.in.result.gifticon.GetPopularGifticonGoodsResult;
+import com.personal.marketnote.reward.port.in.result.gifticon.GetPopularGifticonGoodsResult.PopularGifticonGoodsItem;
+import com.personal.marketnote.reward.port.in.usecase.gifticon.GetPopularGifticonGoodsUseCase;
+import com.personal.marketnote.reward.port.out.gifticon.FindGifticonGoodsPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional(isolation = READ_COMMITTED, readOnly = true)
+public class GetPopularGifticonGoodsService implements GetPopularGifticonGoodsUseCase {
+
+    private static final int POPULAR_GOODS_LIMIT = 10;
+
+    private final FindGifticonGoodsPort findGifticonGoodsPort;
+
+    @Override
+    public GetPopularGifticonGoodsResult getPopularGoods() {
+        List<GifticonGoods> goods = findGifticonGoodsPort.findAllPopularAndExposed(POPULAR_GOODS_LIMIT);
+
+        List<PopularGifticonGoodsItem> items = goods.stream()
+                .map(this::mapToItem)
+                .toList();
+
+        return new GetPopularGifticonGoodsResult(items);
+    }
+
+    private PopularGifticonGoodsItem mapToItem(GifticonGoods goods) {
+        return new PopularGifticonGoodsItem(
+                goods.getGoodsCode(),
+                goods.getGoodsName(),
+                goods.getBrandCode(),
+                goods.getBrandName(),
+                goods.getBrandImageUrl(),
+                goods.getSalePrice(),
+                goods.getCashPrice(),
+                goods.getImageUrl()
+        );
+    }
+}

--- a/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/gifticon/GifticonGoods.java
+++ b/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/gifticon/GifticonGoods.java
@@ -24,6 +24,7 @@ public class GifticonGoods {
     private Integer validDays;
     private String goodsStatus;
     private boolean exposed;
+    private boolean popular;
     private Integer orderNum;
     private LocalDateTime createdAt;
     private LocalDateTime modifiedAt;
@@ -44,6 +45,7 @@ public class GifticonGoods {
                 .validDays(state.getValidDays())
                 .goodsStatus(state.getGoodsStatus())
                 .exposed(false)
+                .popular(false)
                 .orderNum(null)
                 .build();
     }
@@ -65,6 +67,7 @@ public class GifticonGoods {
                 .validDays(state.getValidDays())
                 .goodsStatus(state.getGoodsStatus())
                 .exposed(state.isExposed())
+                .popular(state.isPopular())
                 .orderNum(state.getOrderNum())
                 .createdAt(state.getCreatedAt())
                 .modifiedAt(state.getModifiedAt())

--- a/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/gifticon/GifticonGoodsSnapshotState.java
+++ b/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/gifticon/GifticonGoodsSnapshotState.java
@@ -23,6 +23,7 @@ public class GifticonGoodsSnapshotState {
     private final Integer validDays;
     private final String goodsStatus;
     private final boolean exposed;
+    private final boolean popular;
     private final Integer orderNum;
     private final LocalDateTime createdAt;
     private final LocalDateTime modifiedAt;


### PR DESCRIPTION
## partially addresses #1653
## resolves #1660

## Task
- [x] GetPopularGifticonGoodsUseCase / Service 구현
- [x] GifticonGoods 도메인에 popular 필드 추가 (default false)
- [x] GifticonGoodsJpaEntity에 popular 컬럼 추가
- [x] FindGifticonGoodsPort.findAllPopularAndExposed 추가
- [x] GifticonGoodsController GET /api/v1/gifticon/goods/popular
- [x] popular=true + exposed=true + SALE 필터, 최대 10개, orderNum ASC 정렬