### PR TITLE
[#1653][#1661] feat: 기프티콘 구매 기능 추가

### DIFF
--- a/common/src/main/java/com/personal/marketnote/common/configuration/security/SecurityPropertiesValidator.java
+++ b/common/src/main/java/com/personal/marketnote/common/configuration/security/SecurityPropertiesValidator.java
@@ -21,7 +21,8 @@ public class SecurityPropertiesValidator {
     private static final Set<String> WEAK_DEFAULTS = Set.of(
             "dev-secret-change-me", "dev-hmac-secret-change-me",
             "abc", "def", "ghi",
-            "change-me", "password", "root", "secret", "test"
+            "change-me", "password", "root", "secret", "test",
+            "0000", "1234567890123456"
     );
 
     @Value("${spring.jwt.secret:}")
@@ -48,6 +49,9 @@ public class SecurityPropertiesValidator {
     @Value("${spring.kafka.sasl.password:}")
     private String kafkaSaslPassword;
 
+    @Value("${gifticon.pin.encrypt-key:}")
+    private String gifticonPinEncryptKey;
+
     @PostConstruct
     public void validateSecurityProperties() {
         List<String> violations = new ArrayList<>();
@@ -61,6 +65,8 @@ public class SecurityPropertiesValidator {
             validateRequired(violations, "spring.kafka.sasl.username (KAFKA_SASL_USERNAME)", kafkaSaslUsername);
             validateRequired(violations, "spring.kafka.sasl.password (KAFKA_SASL_PASSWORD)", kafkaSaslPassword);
         }
+
+        validateRequired(violations, "gifticon.pin.encrypt-key (GIFTICON_PIN_ENCRYPT_KEY)", gifticonPinEncryptKey);
 
         if (!violations.isEmpty()) {
             String message = String.join("\n  - ", violations);

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/gifticon/controller/GifticonOrderController.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/gifticon/controller/GifticonOrderController.java
@@ -1,0 +1,52 @@
+package com.personal.marketnote.reward.adapter.in.web.gifticon.controller;
+
+import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
+import com.personal.marketnote.common.utility.ElementExtractor;
+import com.personal.marketnote.reward.adapter.in.web.gifticon.controller.apidocs.PurchaseGifticonApiDocs;
+import com.personal.marketnote.reward.adapter.in.web.gifticon.request.PurchaseGifticonRequest;
+import com.personal.marketnote.reward.adapter.in.web.gifticon.response.PurchaseGifticonResponse;
+import com.personal.marketnote.reward.port.in.command.gifticon.PurchaseGifticonCommand;
+import com.personal.marketnote.reward.port.in.result.gifticon.PurchaseGifticonResult;
+import com.personal.marketnote.reward.port.in.usecase.gifticon.PurchaseGifticonUseCase;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.core.OAuth2AuthenticatedPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static com.personal.marketnote.common.domain.exception.ExceptionCode.DEFAULT_SUCCESS_CODE;
+
+@RestController
+@RequestMapping("/api/v1/gifticons/orders")
+@RequiredArgsConstructor
+@Tag(name = "기프티콘 주문 API")
+public class GifticonOrderController {
+
+    private final PurchaseGifticonUseCase purchaseGifticonUseCase;
+
+    @PostMapping
+    @PurchaseGifticonApiDocs
+    public ResponseEntity<BaseResponse<PurchaseGifticonResponse>> purchaseGifticon(
+            @AuthenticationPrincipal OAuth2AuthenticatedPrincipal principal,
+            @Valid @RequestBody PurchaseGifticonRequest request
+    ) {
+        Long userId = ElementExtractor.extractUserId(principal);
+
+        PurchaseGifticonResult result = purchaseGifticonUseCase.purchase(
+                new PurchaseGifticonCommand(userId, request.goodsCode())
+        );
+
+        PurchaseGifticonResponse response = PurchaseGifticonResponse.from(result);
+
+        return new ResponseEntity<>(
+                BaseResponse.of(response, HttpStatus.OK, DEFAULT_SUCCESS_CODE, "기프티콘 구매 성공"),
+                HttpStatus.OK
+        );
+    }
+}

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/gifticon/controller/apidocs/PurchaseGifticonApiDocs.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/gifticon/controller/apidocs/PurchaseGifticonApiDocs.java
@@ -1,0 +1,57 @@
+package com.personal.marketnote.reward.adapter.in.web.gifticon.controller.apidocs;
+
+import com.personal.marketnote.reward.adapter.in.web.gifticon.response.PurchaseGifticonResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Operation(
+        summary = "기프티콘 구매",
+        description = """
+                작성일자: 2026-04-06
+
+                작성자: 성효빈
+
+                ---
+
+                ## Description
+
+                캐시를 차감하여 기프티콘을 구매합니다.
+                구매 성공 시 기프티쇼 쿠폰이 발행되며, 바코드 이미지 URL과 핀번호가 저장됩니다.
+                캐시 부족 시 부족 금액과 함께 에러가 반환됩니다.
+                """,
+        security = {@SecurityRequirement(name = "bearer")},
+        responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "기프티콘 구매 성공",
+                        content = @Content(
+                                schema = @Schema(implementation = PurchaseGifticonResponse.class),
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 200,
+                                          "code": "SUC01",
+                                          "timestamp": "2026-04-06T12:00:00.000000",
+                                          "content": {
+                                            "orderId": 1,
+                                            "orderNo": "20260404000001",
+                                            "cashAmount": 5000,
+                                            "goodsName": "아메리카노"
+                                          },
+                                          "message": "기프티콘 구매 성공"
+                                        }
+                                        """)
+                        )
+                )
+        }
+)
+public @interface PurchaseGifticonApiDocs {
+}

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/gifticon/request/PurchaseGifticonRequest.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/gifticon/request/PurchaseGifticonRequest.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.reward.adapter.in.web.gifticon.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record PurchaseGifticonRequest(
+        @NotBlank(message = "상품 코드는 필수입니다")
+        String goodsCode
+) {
+}

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/gifticon/response/PurchaseGifticonResponse.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/gifticon/response/PurchaseGifticonResponse.java
@@ -1,0 +1,19 @@
+package com.personal.marketnote.reward.adapter.in.web.gifticon.response;
+
+import com.personal.marketnote.reward.port.in.result.gifticon.PurchaseGifticonResult;
+
+public record PurchaseGifticonResponse(
+        Long orderId,
+        String orderNo,
+        Long cashAmount,
+        String goodsName
+) {
+    public static PurchaseGifticonResponse from(PurchaseGifticonResult result) {
+        return new PurchaseGifticonResponse(
+                result.orderId(),
+                result.orderNo(),
+                result.cashAmount(),
+                result.goodsName()
+        );
+    }
+}

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/gifticon/GifticonOrderPersistenceAdapter.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/gifticon/GifticonOrderPersistenceAdapter.java
@@ -1,0 +1,52 @@
+package com.personal.marketnote.reward.adapter.out.persistence.gifticon;
+
+import com.personal.marketnote.common.adapter.out.PersistenceAdapter;
+import com.personal.marketnote.reward.adapter.out.persistence.gifticon.entity.GifticonOrderJpaEntity;
+import com.personal.marketnote.reward.adapter.out.persistence.gifticon.repository.GifticonOrderJpaRepository;
+import com.personal.marketnote.reward.domain.exception.DuplicateGifticonOrderException;
+import com.personal.marketnote.reward.domain.exception.GifticonOrderNotFoundException;
+import com.personal.marketnote.reward.domain.gifticon.GifticonOrder;
+import com.personal.marketnote.reward.port.out.gifticon.FindGifticonOrderPort;
+import com.personal.marketnote.reward.port.out.gifticon.SaveGifticonOrderPort;
+import com.personal.marketnote.reward.port.out.gifticon.UpdateGifticonOrderPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+
+import java.util.Optional;
+
+@PersistenceAdapter
+@RequiredArgsConstructor
+public class GifticonOrderPersistenceAdapter
+        implements SaveGifticonOrderPort, UpdateGifticonOrderPort, FindGifticonOrderPort {
+
+    private final GifticonOrderJpaRepository gifticonOrderJpaRepository;
+
+    @Override
+    public GifticonOrder save(GifticonOrder order) {
+        try {
+            GifticonOrderJpaEntity entity = GifticonOrderJpaEntity.from(order);
+            GifticonOrderJpaEntity savedEntity = gifticonOrderJpaRepository.save(entity);
+            return savedEntity.toDomain();
+        } catch (DataIntegrityViolationException e) {
+            throw new DuplicateGifticonOrderException(order.getTrId());
+        }
+    }
+
+    @Override
+    public void update(GifticonOrder order) {
+        GifticonOrderJpaEntity entity = gifticonOrderJpaRepository.findByTrId(order.getTrId())
+                .orElseThrow(() -> new GifticonOrderNotFoundException(order.getTrId()));
+        entity.updateFrom(order);
+    }
+
+    @Override
+    public Optional<GifticonOrder> findByTrId(String trId) {
+        return gifticonOrderJpaRepository.findByTrId(trId)
+                .map(GifticonOrderJpaEntity::toDomain);
+    }
+
+    @Override
+    public boolean existsByTrId(String trId) {
+        return gifticonOrderJpaRepository.existsByTrId(trId);
+    }
+}

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/gifticon/GifticonPinEncryptAdapter.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/gifticon/GifticonPinEncryptAdapter.java
@@ -1,0 +1,50 @@
+package com.personal.marketnote.reward.adapter.out.persistence.gifticon;
+
+import com.personal.marketnote.reward.configuration.GifticonPinProperties;
+import com.personal.marketnote.reward.domain.exception.GifticonPinEncryptionFailedException;
+import com.personal.marketnote.reward.port.out.gifticon.EncryptGifticonPinPort;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.Cipher;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.security.SecureRandom;
+import java.util.Base64;
+
+@Component
+@Slf4j
+public class GifticonPinEncryptAdapter implements EncryptGifticonPinPort {
+
+    private final SecretKeySpec keySpec;
+    private final SecureRandom secureRandom = new SecureRandom();
+
+    public GifticonPinEncryptAdapter(GifticonPinProperties properties) {
+        this.keySpec = new SecretKeySpec(
+                properties.getEncryptKey().getBytes(StandardCharsets.UTF_8), "AES"
+        );
+    }
+
+    @Override
+    public String encrypt(String plainPin) {
+        try {
+            byte[] iv = new byte[16];
+            secureRandom.nextBytes(iv);
+            IvParameterSpec ivSpec = new IvParameterSpec(iv);
+
+            Cipher cipher = Cipher.getInstance("AES/CBC/PKCS5Padding");
+            cipher.init(Cipher.ENCRYPT_MODE, keySpec, ivSpec);
+            byte[] encrypted = cipher.doFinal(plainPin.getBytes(StandardCharsets.UTF_8));
+
+            byte[] combined = new byte[iv.length + encrypted.length];
+            System.arraycopy(iv, 0, combined, 0, iv.length);
+            System.arraycopy(encrypted, 0, combined, iv.length, encrypted.length);
+
+            return Base64.getEncoder().encodeToString(combined);
+        } catch (Exception e) {
+            log.error("PIN 암호화 실패: error={}", e.getMessage(), e);
+            throw new GifticonPinEncryptionFailedException(e);
+        }
+    }
+}

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/vendor/giftishow/GifticonCouponAdapter.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/vendor/giftishow/GifticonCouponAdapter.java
@@ -1,0 +1,66 @@
+package com.personal.marketnote.reward.adapter.out.vendor.giftishow;
+
+import com.personal.marketnote.reward.adapter.out.vendor.giftishow.dto.GiftishowApiResponse;
+import com.personal.marketnote.reward.adapter.out.vendor.giftishow.dto.GiftishowCouponSendResponse;
+import com.personal.marketnote.reward.configuration.GiftishowApiProperties;
+import com.personal.marketnote.reward.port.out.gifticon.CancelGifticonSendFailPort;
+import com.personal.marketnote.reward.port.out.gifticon.SendGifticonCouponPort;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class GifticonCouponAdapter implements SendGifticonCouponPort, CancelGifticonSendFailPort {
+
+    private final GiftishowApiClient giftishowApiClient;
+    private final GiftishowApiProperties properties;
+
+    @Override
+    public SendCouponResult sendCoupon(String trId, String goodsCode, String userId) {
+        try {
+            GiftishowApiResponse<GiftishowCouponSendResponse> response = giftishowApiClient.sendCoupon(
+                    trId, goodsCode, properties.getPhoneNo(), userId,
+                    properties.getMmsMsg(), properties.getMmsTitle()
+            );
+
+            if (!response.isSuccess()) {
+                log.error("기프티쇼 쿠폰 발송 실패: trId={}, code={}, message={}",
+                        trId, response.code(), response.message());
+                return SendCouponResult.builder()
+                        .success(false)
+                        .errorCode(response.code())
+                        .errorMessage(response.message())
+                        .build();
+            }
+
+            GiftishowCouponSendResponse result = response.result();
+            return SendCouponResult.builder()
+                    .success(true)
+                    .orderNo(result.orderNo())
+                    .pinNo(result.pinNo())
+                    .couponImageUrl(result.couponImgUrl())
+                    .validEndDate(result.validPrdEndDt())
+                    .build();
+
+        } catch (Exception e) {
+            log.error("기프티쇼 쿠폰 발송 통신 오류: trId={}, error={}", trId, e.getMessage(), e);
+            return SendCouponResult.builder()
+                    .success(false)
+                    .errorCode("COMM_ERROR")
+                    .errorMessage(e.getMessage())
+                    .build();
+        }
+    }
+
+    @Override
+    public void cancelSendFailed(String trId, String userId) {
+        try {
+            giftishowApiClient.cancelSendFailedCoupon(trId, userId);
+            log.info("기프티쇼 발송실패 취소 완료: trId={}", trId);
+        } catch (Exception e) {
+            log.error("기프티쇼 발송실패 취소 API 호출 실패: trId={}, error={}", trId, e.getMessage(), e);
+        }
+    }
+}

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/vendor/giftishow/GiftishowApiClient.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/vendor/giftishow/GiftishowApiClient.java
@@ -256,8 +256,13 @@ public class GiftishowApiClient {
             TypeReference<GiftishowApiResponse<T>> typeReference
     ) {
         String responseBody = rawResponse.getBody();
-        log.debug("기프티쇼 API 응답: path={}, status={}, body={}",
-                path, rawResponse.getStatusCode(), responseBody);
+        if (isSensitivePath(path)) {
+            log.debug("기프티쇼 API 응답: path={}, status={} (body 로깅 생략 — 민감 데이터 포함)",
+                    path, rawResponse.getStatusCode());
+        } else {
+            log.debug("기프티쇼 API 응답: path={}, status={}, body={}",
+                    path, rawResponse.getStatusCode(), responseBody);
+        }
 
         if (FormatValidator.hasNoValue(responseBody)) {
             throw new GiftishowCommunicationException(
@@ -273,5 +278,9 @@ public class GiftishowApiClient {
                     "기프티쇼 API 응답 파싱 실패. path=" + path, e
             );
         }
+    }
+
+    private boolean isSensitivePath(String path) {
+        return path.equals(properties.getApi().getCouponSendPath());
     }
 }

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/configuration/GifticonPinProperties.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/configuration/GifticonPinProperties.java
@@ -1,0 +1,14 @@
+package com.personal.marketnote.reward.configuration;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationProperties(prefix = "gifticon.pin")
+@Getter
+@Setter
+public class GifticonPinProperties {
+    private String encryptKey;
+}

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/configuration/GiftishowApiProperties.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/configuration/GiftishowApiProperties.java
@@ -16,6 +16,9 @@ public class GiftishowApiProperties {
     private String authToken;
     private String devYn;
     private String callbackNo;
+    private String phoneNo;
+    private String mmsMsg;
+    private String mmsTitle;
     private String gubun;
     private Api api = new Api();
 

--- a/reward-service/reward-adapters/src/main/resources/application.yml
+++ b/reward-service/reward-adapters/src/main/resources/application.yml
@@ -93,6 +93,9 @@ vendor:
     auth-token: ${GIFTISHOW_AUTH_TOKEN:0000}
     dev-yn: ${GIFTISHOW_DEV_YN:Y}
     callback-no: ${GIFTISHOW_CALLBACK_NO:0000000000}
+    phone-no: ${GIFTISHOW_PHONE_NO:0000000000}
+    mms-msg: ${GIFTISHOW_MMS_MSG:뉴트리캐시 기프티콘}
+    mms-title: ${GIFTISHOW_MMS_TITLE:뉴트리캐시}
     gubun: I
     api:
       product-list-path: /bizApi/goods
@@ -107,6 +110,8 @@ vendor:
       coupon-send-fail-cancel-path: /bizApi/coupon/sendFailCancel
 
 gifticon:
+  pin:
+    encrypt-key: ${GIFTICON_PIN_ENCRYPT_KEY:dev-pin-key-change-me}
   sync:
     scheduler:
       enabled: ${GIFTICON_SYNC_SCHEDULER_ENABLED:false}

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/command/gifticon/PurchaseGifticonCommand.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/command/gifticon/PurchaseGifticonCommand.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.reward.port.in.command.gifticon;
+
+public record PurchaseGifticonCommand(
+        Long userId,
+        String goodsCode
+) {
+}

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/result/gifticon/PurchaseGifticonResult.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/result/gifticon/PurchaseGifticonResult.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.reward.port.in.result.gifticon;
+
+public record PurchaseGifticonResult(
+        Long orderId,
+        String orderNo,
+        Long cashAmount,
+        String goodsName
+) {
+}

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/usecase/gifticon/PurchaseGifticonUseCase.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/usecase/gifticon/PurchaseGifticonUseCase.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.reward.port.in.usecase.gifticon;
+
+import com.personal.marketnote.reward.port.in.command.gifticon.PurchaseGifticonCommand;
+import com.personal.marketnote.reward.port.in.result.gifticon.PurchaseGifticonResult;
+
+public interface PurchaseGifticonUseCase {
+    PurchaseGifticonResult purchase(PurchaseGifticonCommand command);
+}

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/out/gifticon/CancelGifticonSendFailPort.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/out/gifticon/CancelGifticonSendFailPort.java
@@ -1,0 +1,5 @@
+package com.personal.marketnote.reward.port.out.gifticon;
+
+public interface CancelGifticonSendFailPort {
+    void cancelSendFailed(String trId, String userId);
+}

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/out/gifticon/EncryptGifticonPinPort.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/out/gifticon/EncryptGifticonPinPort.java
@@ -1,0 +1,5 @@
+package com.personal.marketnote.reward.port.out.gifticon;
+
+public interface EncryptGifticonPinPort {
+    String encrypt(String plainPin);
+}

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/out/gifticon/FindGifticonOrderPort.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/out/gifticon/FindGifticonOrderPort.java
@@ -1,0 +1,11 @@
+package com.personal.marketnote.reward.port.out.gifticon;
+
+import com.personal.marketnote.reward.domain.gifticon.GifticonOrder;
+
+import java.util.Optional;
+
+public interface FindGifticonOrderPort {
+    Optional<GifticonOrder> findByTrId(String trId);
+
+    boolean existsByTrId(String trId);
+}

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/out/gifticon/SaveGifticonOrderPort.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/out/gifticon/SaveGifticonOrderPort.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.reward.port.out.gifticon;
+
+import com.personal.marketnote.reward.domain.gifticon.GifticonOrder;
+
+public interface SaveGifticonOrderPort {
+    GifticonOrder save(GifticonOrder order);
+}

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/out/gifticon/SendGifticonCouponPort.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/out/gifticon/SendGifticonCouponPort.java
@@ -1,0 +1,19 @@
+package com.personal.marketnote.reward.port.out.gifticon;
+
+import lombok.Builder;
+
+public interface SendGifticonCouponPort {
+    SendCouponResult sendCoupon(String trId, String goodsCode, String userId);
+
+    @Builder
+    record SendCouponResult(
+            boolean success,
+            String orderNo,
+            String pinNo,
+            String couponImageUrl,
+            String validEndDate,
+            String errorCode,
+            String errorMessage
+    ) {
+    }
+}

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/out/gifticon/UpdateGifticonOrderPort.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/out/gifticon/UpdateGifticonOrderPort.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.reward.port.out.gifticon;
+
+import com.personal.marketnote.reward.domain.gifticon.GifticonOrder;
+
+public interface UpdateGifticonOrderPort {
+    void update(GifticonOrder order);
+}

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/service/gifticon/PurchaseGifticonService.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/service/gifticon/PurchaseGifticonService.java
@@ -1,0 +1,86 @@
+package com.personal.marketnote.reward.service.gifticon;
+
+import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.reward.domain.exception.GifticonCouponSendFailedException;
+import com.personal.marketnote.reward.domain.exception.GifticonGoodsNotFoundException;
+import com.personal.marketnote.reward.domain.gifticon.GifticonGoods;
+import com.personal.marketnote.reward.port.in.command.gifticon.PurchaseGifticonCommand;
+import com.personal.marketnote.reward.port.in.result.gifticon.PurchaseGifticonResult;
+import com.personal.marketnote.reward.port.in.usecase.gifticon.PurchaseGifticonUseCase;
+import com.personal.marketnote.reward.port.out.gifticon.CancelGifticonSendFailPort;
+import com.personal.marketnote.reward.port.out.gifticon.FindGifticonGoodsPort;
+import com.personal.marketnote.reward.port.out.gifticon.SendGifticonCouponPort;
+import com.personal.marketnote.reward.port.out.gifticon.SendGifticonCouponPort.SendCouponResult;
+import com.personal.marketnote.reward.service.gifticon.PurchaseGifticonTransactionHelper.DeductCashAndCreateOrderContext;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@UseCase
+@RequiredArgsConstructor
+@Slf4j
+public class PurchaseGifticonService implements PurchaseGifticonUseCase {
+
+    private final FindGifticonGoodsPort findGifticonGoodsPort;
+    private final PurchaseGifticonTransactionHelper transactionHelper;
+    private final SendGifticonCouponPort sendGifticonCouponPort;
+    private final CancelGifticonSendFailPort cancelGifticonSendFailPort;
+
+    @Override
+    public PurchaseGifticonResult purchase(PurchaseGifticonCommand command) {
+        GifticonGoods goods = findAndValidateGoods(command.goodsCode());
+
+        DeductCashAndCreateOrderContext context = transactionHelper.deductCashAndCreateOrder(
+                command.userId(),
+                goods.getGoodsCode(),
+                goods.getGoodsName(),
+                goods.getBrandName(),
+                goods.getImageUrl(),
+                goods.getCashPrice()
+        );
+
+        SendCouponResult sendResult = sendGifticonCouponPort.sendCoupon(
+                context.trId(), context.goodsCode(), String.valueOf(command.userId())
+        );
+
+        if (!sendResult.success()) {
+            handleSendFailure(context);
+            throw new GifticonCouponSendFailedException(sendResult.errorCode(), sendResult.errorMessage());
+        }
+
+        try {
+            transactionHelper.commitSuccess(context, sendResult);
+        } catch (Exception e) {
+            log.error("commitSuccess 실패 — 쿠폰은 발행되었으나 DB 저장 실패. 수동 복구 필요. trId={}, orderNo={}, error={}",
+                    context.trId(), sendResult.orderNo(), e.getMessage(), e);
+            throw e;
+        }
+
+        return new PurchaseGifticonResult(
+                context.orderId(),
+                sendResult.orderNo(),
+                context.cashPrice(),
+                context.goodsName()
+        );
+    }
+
+    private GifticonGoods findAndValidateGoods(String goodsCode) {
+        GifticonGoods goods = findGifticonGoodsPort.findByGoodsCode(goodsCode)
+                .orElseThrow(() -> new GifticonGoodsNotFoundException(goodsCode));
+
+        if (!goods.isExposed() || !goods.isSale()) {
+            throw new GifticonGoodsNotFoundException(goodsCode);
+        }
+
+        return goods;
+    }
+
+    private void handleSendFailure(DeductCashAndCreateOrderContext context) {
+        transactionHelper.commitFailure(context);
+
+        try {
+            cancelGifticonSendFailPort.cancelSendFailed(context.trId(), String.valueOf(context.userId()));
+        } catch (Exception e) {
+            log.error("발송실패 취소 API 호출 실패: trId={}, error={}", context.trId(), e.getMessage(), e);
+        }
+    }
+}

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/service/gifticon/PurchaseGifticonTransactionHelper.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/service/gifticon/PurchaseGifticonTransactionHelper.java
@@ -1,0 +1,134 @@
+package com.personal.marketnote.reward.service.gifticon;
+
+import com.personal.marketnote.reward.domain.exception.DuplicateGifticonOrderException;
+import com.personal.marketnote.reward.domain.exception.GifticonInsufficientCashException;
+import com.personal.marketnote.reward.domain.exception.GifticonOrderNotFoundException;
+import com.personal.marketnote.reward.domain.gifticon.GifticonOrder;
+import com.personal.marketnote.reward.domain.gifticon.GifticonOrderCreateState;
+import com.personal.marketnote.reward.domain.point.UserPoint;
+import com.personal.marketnote.reward.domain.point.UserPointChangeType;
+import com.personal.marketnote.reward.domain.point.UserPointSourceType;
+import com.personal.marketnote.reward.port.in.command.point.ModifyUserPointCommand;
+import com.personal.marketnote.reward.port.in.usecase.point.GetUserPointUseCase;
+import com.personal.marketnote.reward.port.in.usecase.point.ModifyUserPointUseCase;
+import com.personal.marketnote.reward.port.out.gifticon.*;
+import com.personal.marketnote.reward.port.out.gifticon.SendGifticonCouponPort.SendCouponResult;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+import static org.springframework.transaction.annotation.Propagation.REQUIRES_NEW;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class PurchaseGifticonTransactionHelper {
+
+    private final GetUserPointUseCase getUserPointUseCase;
+    private final ModifyUserPointUseCase modifyUserPointUseCase;
+    private final SaveGifticonOrderPort saveGifticonOrderPort;
+    private final FindGifticonOrderPort findGifticonOrderPort;
+    private final UpdateGifticonOrderPort updateGifticonOrderPort;
+    private final EncryptGifticonPinPort encryptGifticonPinPort;
+    private final Clock clock;
+
+    private static final DateTimeFormatter TR_ID_DATE_FORMAT = DateTimeFormatter.ofPattern("yyMMddHHmmss");
+    private static final DateTimeFormatter VALID_END_DATE_FORMAT = DateTimeFormatter.ofPattern("yyyyMMdd");
+
+    public record DeductCashAndCreateOrderContext(
+            Long orderId,
+            String trId,
+            String goodsCode,
+            String goodsName,
+            Long cashPrice,
+            Long userId
+    ) {
+    }
+
+    @Transactional(propagation = REQUIRES_NEW, isolation = READ_COMMITTED)
+    public DeductCashAndCreateOrderContext deductCashAndCreateOrder(
+            Long userId, String goodsCode, String goodsName, String brandName,
+            String productImageUrl, Long cashPrice
+    ) {
+        UserPoint userPoint = getUserPointUseCase.getUserPoint(userId);
+        Long currentBalance = userPoint.getAmountValue();
+
+        if (currentBalance < cashPrice) {
+            throw new GifticonInsufficientCashException(cashPrice - currentBalance);
+        }
+
+        String trId = generateTrId(userId);
+
+        modifyUserPointUseCase.modify(ModifyUserPointCommand.builder()
+                .userId(userId)
+                .changeType(UserPointChangeType.DEDUCTION)
+                .amount(cashPrice)
+                .sourceType(UserPointSourceType.GIFTICON_PURCHASE)
+                .reason("기프티콘 구매: " + goodsName)
+                .build());
+
+        GifticonOrder order = GifticonOrder.from(GifticonOrderCreateState.builder()
+                .userId(userId)
+                .goodsCode(goodsCode)
+                .goodsName(goodsName)
+                .brandName(brandName)
+                .productImageUrl(productImageUrl)
+                .trId(trId)
+                .cashPrice(cashPrice)
+                .build());
+
+        GifticonOrder savedOrder = saveGifticonOrderPort.save(order);
+
+        return new DeductCashAndCreateOrderContext(
+                savedOrder.getId(), trId, goodsCode, goodsName, cashPrice, userId
+        );
+    }
+
+    @Transactional(propagation = REQUIRES_NEW, isolation = READ_COMMITTED)
+    public void commitSuccess(DeductCashAndCreateOrderContext context, SendCouponResult sendResult) {
+        GifticonOrder order = findGifticonOrderPort.findByTrId(context.trId())
+                .orElseThrow(() -> new GifticonOrderNotFoundException(context.trId()));
+
+        String encryptedPin = encryptGifticonPinPort.encrypt(sendResult.pinNo());
+        LocalDate validEndDate = LocalDate.parse(sendResult.validEndDate(), VALID_END_DATE_FORMAT);
+
+        order.issue(sendResult.couponImageUrl(), encryptedPin, sendResult.orderNo(), validEndDate);
+        updateGifticonOrderPort.update(order);
+    }
+
+    @Transactional(propagation = REQUIRES_NEW, isolation = READ_COMMITTED)
+    public void commitFailure(DeductCashAndCreateOrderContext context) {
+        modifyUserPointUseCase.modify(ModifyUserPointCommand.builder()
+                .userId(context.userId())
+                .changeType(UserPointChangeType.ACCRUAL)
+                .amount(context.cashPrice())
+                .sourceType(UserPointSourceType.GIFTICON_REFUND)
+                .reason("기프티콘 구매 실패 환불: " + context.goodsName())
+                .build());
+
+        GifticonOrder order = findGifticonOrderPort.findByTrId(context.trId())
+                .orElseThrow(() -> new GifticonOrderNotFoundException(context.trId()));
+
+        order.markSendFailed();
+        updateGifticonOrderPort.update(order);
+    }
+
+    private String generateTrId(Long userId) {
+        LocalDateTime now = LocalDateTime.now(clock);
+        String trId = "NC" + userId + "_" + now.format(TR_ID_DATE_FORMAT);
+
+        if (findGifticonOrderPort.existsByTrId(trId)) {
+            log.warn("TR_ID 중복 발생, 재생성: trId={}", trId);
+            trId = "NC" + userId + "_" + LocalDateTime.now(clock).format(TR_ID_DATE_FORMAT);
+        }
+
+        return trId;
+    }
+}

--- a/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/exception/DuplicateGifticonOrderException.java
+++ b/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/exception/DuplicateGifticonOrderException.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.reward.domain.exception;
+
+public class DuplicateGifticonOrderException extends RuntimeException {
+    private static final String MESSAGE = "기프티콘 주문이 중복되었습니다. trId=%s";
+
+    public DuplicateGifticonOrderException(String trId) {
+        super(String.format(MESSAGE, trId));
+    }
+}

--- a/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/exception/GifticonCouponSendFailedException.java
+++ b/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/exception/GifticonCouponSendFailedException.java
@@ -1,0 +1,15 @@
+package com.personal.marketnote.reward.domain.exception;
+
+import lombok.Getter;
+
+@Getter
+public class GifticonCouponSendFailedException extends RuntimeException {
+    private static final String MESSAGE = "기프티콘 쿠폰 발송에 실패했습니다. errorCode=%s, errorMessage=%s";
+
+    private final String errorCode;
+
+    public GifticonCouponSendFailedException(String errorCode, String errorMessage) {
+        super(String.format(MESSAGE, errorCode, errorMessage));
+        this.errorCode = errorCode;
+    }
+}

--- a/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/exception/GifticonInsufficientCashException.java
+++ b/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/exception/GifticonInsufficientCashException.java
@@ -1,0 +1,15 @@
+package com.personal.marketnote.reward.domain.exception;
+
+import lombok.Getter;
+
+@Getter
+public class GifticonInsufficientCashException extends RuntimeException {
+    private static final String MESSAGE = "캐시가 부족합니다. 부족 금액=%d";
+
+    private final Long shortfallAmount;
+
+    public GifticonInsufficientCashException(Long shortfallAmount) {
+        super(String.format(MESSAGE, shortfallAmount));
+        this.shortfallAmount = shortfallAmount;
+    }
+}

--- a/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/exception/GifticonPinEncryptionFailedException.java
+++ b/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/exception/GifticonPinEncryptionFailedException.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.reward.domain.exception;
+
+public class GifticonPinEncryptionFailedException extends RuntimeException {
+    private static final String MESSAGE = "PIN 암호화에 실패했습니다.";
+
+    public GifticonPinEncryptionFailedException(Throwable cause) {
+        super(MESSAGE, cause);
+    }
+}

--- a/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/gifticon/GifticonOrder.java
+++ b/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/gifticon/GifticonOrder.java
@@ -27,6 +27,19 @@ public class GifticonOrder {
     private LocalDateTime createdAt;
     private LocalDateTime modifiedAt;
 
+    public static GifticonOrder from(GifticonOrderCreateState state) {
+        return GifticonOrder.builder()
+                .userId(state.getUserId())
+                .goodsCode(state.getGoodsCode())
+                .goodsName(state.getGoodsName())
+                .brandName(state.getBrandName())
+                .productImageUrl(state.getProductImageUrl())
+                .trId(state.getTrId())
+                .cashPrice(state.getCashPrice())
+                .orderStatus(GifticonOrderStatus.PENDING)
+                .build();
+    }
+
     public static GifticonOrder from(GifticonOrderSnapshotState state) {
         return GifticonOrder.builder()
                 .id(state.getId())

--- a/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/gifticon/GifticonOrderCreateState.java
+++ b/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/gifticon/GifticonOrderCreateState.java
@@ -1,0 +1,16 @@
+package com.personal.marketnote.reward.domain.gifticon;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class GifticonOrderCreateState {
+    private final Long userId;
+    private final String goodsCode;
+    private final String goodsName;
+    private final String brandName;
+    private final String productImageUrl;
+    private final String trId;
+    private final Long cashPrice;
+}

--- a/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/point/UserPointSourceType.java
+++ b/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/point/UserPointSourceType.java
@@ -9,7 +9,9 @@ public enum UserPointSourceType {
     OFFERWALL("OFFERWALL"),
     GAME("GAME"),
     PRODUCT("PRODUCT"),
-    ORDER("ORDER");
+    ORDER("ORDER"),
+    GIFTICON_PURCHASE("GIFTICON_PURCHASE"),
+    GIFTICON_REFUND("GIFTICON_REFUND");
 
     private final String description;
 }


### PR DESCRIPTION
## partially addresses #1653
## resolves #1661

## Task
- [x] PurchaseGifticonUseCase / PurchaseGifticonService 구현
- [x] REQUIRES_NEW 3단계 트랜잭션 분리 (캐시 차감 → 외부 API → 성공/실패 보상)
- [x] GifticonOrderController POST /api/v1/gifticons/orders
- [x] GifticonCouponAdapter (기프티쇼 0204 쿠폰 발송 / 0205 발송실패 취소)
- [x] GifticonPinEncryptAdapter (AES/CBC 랜덤 IV 암호화)
- [x] SecurityPropertiesValidator PIN 암호화 키 검증 추가