### PR TITLE
[#1653][#1672] test: 기프티콘 구매 기능 자동화 테스트 추가

### DIFF
--- a/reward-service/reward-application/src/test/java/com/personal/marketnote/reward/service/gifticon/PurchaseGifticonServiceTest.java
+++ b/reward-service/reward-application/src/test/java/com/personal/marketnote/reward/service/gifticon/PurchaseGifticonServiceTest.java
@@ -1,0 +1,254 @@
+package com.personal.marketnote.reward.service.gifticon;
+
+import com.personal.marketnote.reward.domain.exception.GifticonCouponSendFailedException;
+import com.personal.marketnote.reward.domain.exception.GifticonGoodsNotFoundException;
+import com.personal.marketnote.reward.domain.gifticon.GifticonGoods;
+import com.personal.marketnote.reward.domain.gifticon.GifticonGoodsSnapshotState;
+import com.personal.marketnote.reward.port.in.command.gifticon.PurchaseGifticonCommand;
+import com.personal.marketnote.reward.port.in.result.gifticon.PurchaseGifticonResult;
+import com.personal.marketnote.reward.port.out.gifticon.CancelGifticonSendFailPort;
+import com.personal.marketnote.reward.port.out.gifticon.FindGifticonGoodsPort;
+import com.personal.marketnote.reward.port.out.gifticon.SendGifticonCouponPort;
+import com.personal.marketnote.reward.port.out.gifticon.SendGifticonCouponPort.SendCouponResult;
+import com.personal.marketnote.reward.service.gifticon.PurchaseGifticonTransactionHelper.DeductCashAndCreateOrderContext;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class PurchaseGifticonServiceTest {
+
+    @InjectMocks
+    private PurchaseGifticonService purchaseGifticonService;
+
+    @Mock
+    private FindGifticonGoodsPort findGifticonGoodsPort;
+
+    @Mock
+    private PurchaseGifticonTransactionHelper transactionHelper;
+
+    @Mock
+    private SendGifticonCouponPort sendGifticonCouponPort;
+
+    @Mock
+    private CancelGifticonSendFailPort cancelGifticonSendFailPort;
+
+    private static final Long USER_ID = 100L;
+    private static final String GOODS_CODE = "G00000280811";
+
+    @Test
+    @DisplayName("캐시가 충분하면 기프티콘 구매에 성공한다")
+    void shouldPurchaseGifticonSuccessfully() {
+        // given
+        GifticonGoods goods = createExposedSaleGoods();
+        when(findGifticonGoodsPort.findByGoodsCode(GOODS_CODE)).thenReturn(Optional.of(goods));
+
+        DeductCashAndCreateOrderContext context = new DeductCashAndCreateOrderContext(
+                1L, "NC100_260404210000", GOODS_CODE, "테스트 기프티콘", 5000L, USER_ID
+        );
+        when(transactionHelper.deductCashAndCreateOrder(
+                eq(USER_ID), eq(GOODS_CODE), any(), any(), any(), eq(5000L)
+        )).thenReturn(context);
+
+        SendCouponResult sendResult = SendCouponResult.builder()
+                .success(true)
+                .orderNo("20260404000001")
+                .pinNo("900343630367")
+                .couponImageUrl("http://t.giftishow.co.kr/coupon.jpg")
+                .validEndDate("20260504")
+                .build();
+        when(sendGifticonCouponPort.sendCoupon("NC100_260404210000", GOODS_CODE, String.valueOf(USER_ID)))
+                .thenReturn(sendResult);
+
+        PurchaseGifticonCommand command = new PurchaseGifticonCommand(USER_ID, GOODS_CODE);
+
+        // when
+        PurchaseGifticonResult result = purchaseGifticonService.purchase(command);
+
+        // then
+        assertThat(result.orderId()).isEqualTo(1L);
+        assertThat(result.orderNo()).isEqualTo("20260404000001");
+        assertThat(result.cashAmount()).isEqualTo(5000L);
+        assertThat(result.goodsName()).isEqualTo("테스트 기프티콘");
+        verify(transactionHelper).commitSuccess(context, sendResult);
+        verify(transactionHelper, never()).commitFailure(any());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 상품 코드로 구매 시 GifticonGoodsNotFoundException이 발생한다")
+    void shouldThrowExceptionWhenGoodsNotFound() {
+        // given
+        when(findGifticonGoodsPort.findByGoodsCode(GOODS_CODE)).thenReturn(Optional.empty());
+        PurchaseGifticonCommand command = new PurchaseGifticonCommand(USER_ID, GOODS_CODE);
+
+        // when & then
+        assertThatThrownBy(() -> purchaseGifticonService.purchase(command))
+                .isInstanceOf(GifticonGoodsNotFoundException.class);
+
+        verify(transactionHelper, never()).deductCashAndCreateOrder(any(), any(), any(), any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("노출되지 않은 상품으로 구매 시 GifticonGoodsNotFoundException이 발생한다")
+    void shouldThrowExceptionWhenGoodsNotExposed() {
+        // given
+        GifticonGoods goods = createUnexposedGoods();
+        when(findGifticonGoodsPort.findByGoodsCode(GOODS_CODE)).thenReturn(Optional.of(goods));
+        PurchaseGifticonCommand command = new PurchaseGifticonCommand(USER_ID, GOODS_CODE);
+
+        // when & then
+        assertThatThrownBy(() -> purchaseGifticonService.purchase(command))
+                .isInstanceOf(GifticonGoodsNotFoundException.class);
+
+        verify(transactionHelper, never()).deductCashAndCreateOrder(any(), any(), any(), any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("판매 중이 아닌 상품으로 구매 시 GifticonGoodsNotFoundException이 발생한다")
+    void shouldThrowExceptionWhenGoodsNotSale() {
+        // given
+        GifticonGoods goods = createSuspendedGoods();
+        when(findGifticonGoodsPort.findByGoodsCode(GOODS_CODE)).thenReturn(Optional.of(goods));
+        PurchaseGifticonCommand command = new PurchaseGifticonCommand(USER_ID, GOODS_CODE);
+
+        // when & then
+        assertThatThrownBy(() -> purchaseGifticonService.purchase(command))
+                .isInstanceOf(GifticonGoodsNotFoundException.class);
+
+        verify(transactionHelper, never()).deductCashAndCreateOrder(any(), any(), any(), any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("쿠폰 발송 실패 시 commitFailure가 호출되고 발송실패 취소 API가 호출된다")
+    void shouldCallCommitFailureAndCancelSendFailOnCouponSendFailure() {
+        // given
+        GifticonGoods goods = createExposedSaleGoods();
+        when(findGifticonGoodsPort.findByGoodsCode(GOODS_CODE)).thenReturn(Optional.of(goods));
+
+        DeductCashAndCreateOrderContext context = new DeductCashAndCreateOrderContext(
+                1L, "NC100_260404210000", GOODS_CODE, "테스트 기프티콘", 5000L, USER_ID
+        );
+        when(transactionHelper.deductCashAndCreateOrder(
+                eq(USER_ID), eq(GOODS_CODE), any(), any(), any(), eq(5000L)
+        )).thenReturn(context);
+
+        SendCouponResult failResult = SendCouponResult.builder()
+                .success(false)
+                .errorCode("ERR0999")
+                .errorMessage("쿠폰발송오류")
+                .build();
+        when(sendGifticonCouponPort.sendCoupon("NC100_260404210000", GOODS_CODE, String.valueOf(USER_ID)))
+                .thenReturn(failResult);
+
+        PurchaseGifticonCommand command = new PurchaseGifticonCommand(USER_ID, GOODS_CODE);
+
+        // when & then
+        assertThatThrownBy(() -> purchaseGifticonService.purchase(command))
+                .isInstanceOf(GifticonCouponSendFailedException.class);
+
+        verify(transactionHelper).commitFailure(context);
+        verify(cancelGifticonSendFailPort).cancelSendFailed("NC100_260404210000", String.valueOf(USER_ID));
+        verify(transactionHelper, never()).commitSuccess(any(), any());
+    }
+
+    @Test
+    @DisplayName("발송실패 취소 API 호출 실패 시에도 예외가 전파되지 않는다")
+    void shouldNotPropagateExceptionWhenCancelSendFailFails() {
+        // given
+        GifticonGoods goods = createExposedSaleGoods();
+        when(findGifticonGoodsPort.findByGoodsCode(GOODS_CODE)).thenReturn(Optional.of(goods));
+
+        DeductCashAndCreateOrderContext context = new DeductCashAndCreateOrderContext(
+                1L, "NC100_260404210000", GOODS_CODE, "테스트 기프티콘", 5000L, USER_ID
+        );
+        when(transactionHelper.deductCashAndCreateOrder(
+                eq(USER_ID), eq(GOODS_CODE), any(), any(), any(), eq(5000L)
+        )).thenReturn(context);
+
+        SendCouponResult failResult = SendCouponResult.builder()
+                .success(false)
+                .errorCode("ERR0999")
+                .errorMessage("쿠폰발송오류")
+                .build();
+        when(sendGifticonCouponPort.sendCoupon("NC100_260404210000", GOODS_CODE, String.valueOf(USER_ID)))
+                .thenReturn(failResult);
+
+        doThrow(new RuntimeException("발송실패 취소 API 호출 실패"))
+                .when(cancelGifticonSendFailPort).cancelSendFailed(any(), any());
+
+        PurchaseGifticonCommand command = new PurchaseGifticonCommand(USER_ID, GOODS_CODE);
+
+        // when & then
+        assertThatThrownBy(() -> purchaseGifticonService.purchase(command))
+                .isInstanceOf(GifticonCouponSendFailedException.class);
+
+        verify(transactionHelper).commitFailure(context);
+    }
+
+    private GifticonGoods createExposedSaleGoods() {
+        GifticonGoods goods = GifticonGoods.from(GifticonGoodsSnapshotState.builder()
+                .id(1L)
+                .goodsCode(GOODS_CODE)
+                .goodsName("테스트 기프티콘")
+                .brandCode("BR00046")
+                .brandName("세븐일레븐")
+                .brandImageUrl("https://example.com/brand.jpg")
+                .categoryCode("CAT001")
+                .realPrice(6000L)
+                .salePrice(5500L)
+                .cashPrice(5000L)
+                .imageUrl("https://example.com/goods.jpg")
+                .description("테스트 상품입니다")
+                .validDays(30)
+                .goodsStatus("SALE")
+                .exposed(true)
+                .popular(false)
+                .build());
+        return goods;
+    }
+
+    private GifticonGoods createUnexposedGoods() {
+        return GifticonGoods.from(GifticonGoodsSnapshotState.builder()
+                .id(1L)
+                .goodsCode(GOODS_CODE)
+                .goodsName("테스트 기프티콘")
+                .brandCode("BR00046")
+                .brandName("세븐일레븐")
+                .categoryCode("CAT001")
+                .realPrice(6000L)
+                .salePrice(5500L)
+                .cashPrice(5000L)
+                .goodsStatus("SALE")
+                .exposed(false)
+                .popular(false)
+                .build());
+    }
+
+    private GifticonGoods createSuspendedGoods() {
+        return GifticonGoods.from(GifticonGoodsSnapshotState.builder()
+                .id(1L)
+                .goodsCode(GOODS_CODE)
+                .goodsName("테스트 기프티콘")
+                .brandCode("BR00046")
+                .brandName("세븐일레븐")
+                .categoryCode("CAT001")
+                .realPrice(6000L)
+                .salePrice(5500L)
+                .cashPrice(5000L)
+                .goodsStatus("SUS")
+                .exposed(true)
+                .popular(false)
+                .build());
+    }
+}

--- a/reward-service/reward-application/src/test/java/com/personal/marketnote/reward/service/gifticon/PurchaseGifticonTransactionHelperTest.java
+++ b/reward-service/reward-application/src/test/java/com/personal/marketnote/reward/service/gifticon/PurchaseGifticonTransactionHelperTest.java
@@ -1,0 +1,331 @@
+package com.personal.marketnote.reward.service.gifticon;
+
+import com.personal.marketnote.reward.domain.exception.GifticonInsufficientCashException;
+import com.personal.marketnote.reward.domain.gifticon.GifticonOrder;
+import com.personal.marketnote.reward.domain.gifticon.GifticonOrderSnapshotState;
+import com.personal.marketnote.reward.domain.gifticon.GifticonOrderStatus;
+import com.personal.marketnote.reward.domain.point.PointAmount;
+import com.personal.marketnote.reward.domain.point.UserPoint;
+import com.personal.marketnote.reward.domain.point.UserPointChangeType;
+import com.personal.marketnote.reward.domain.point.UserPointSourceType;
+import com.personal.marketnote.reward.port.in.command.point.ModifyUserPointCommand;
+import com.personal.marketnote.reward.port.in.usecase.point.GetUserPointUseCase;
+import com.personal.marketnote.reward.port.in.usecase.point.ModifyUserPointUseCase;
+import com.personal.marketnote.reward.port.out.gifticon.*;
+import com.personal.marketnote.reward.port.out.gifticon.SendGifticonCouponPort.SendCouponResult;
+import com.personal.marketnote.reward.service.gifticon.PurchaseGifticonTransactionHelper.DeductCashAndCreateOrderContext;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class PurchaseGifticonTransactionHelperTest {
+
+    @InjectMocks
+    private PurchaseGifticonTransactionHelper helper;
+
+    @Mock
+    private GetUserPointUseCase getUserPointUseCase;
+
+    @Mock
+    private ModifyUserPointUseCase modifyUserPointUseCase;
+
+    @Mock
+    private SaveGifticonOrderPort saveGifticonOrderPort;
+
+    @Mock
+    private FindGifticonOrderPort findGifticonOrderPort;
+
+    @Mock
+    private UpdateGifticonOrderPort updateGifticonOrderPort;
+
+    @Mock
+    private EncryptGifticonPinPort encryptGifticonPinPort;
+
+    @Spy
+    private Clock clock = Clock.fixed(
+            Instant.parse("2026-04-06T12:00:00Z"),
+            ZoneId.of("Asia/Seoul")
+    );
+
+    private static final Long USER_ID = 100L;
+    private static final String GOODS_CODE = "G00000280811";
+    private static final String GOODS_NAME = "테스트 기프티콘";
+    private static final String BRAND_NAME = "세븐일레븐";
+    private static final String PRODUCT_IMAGE_URL = "https://example.com/image.jpg";
+    private static final Long CASH_PRICE = 5000L;
+
+    @Test
+    @DisplayName("캐시 차감 후 GifticonOrder가 PENDING 상태로 저장된다")
+    void shouldSaveOrderAsPendingAfterCashDeduction() {
+        // given
+        UserPoint userPoint = createUserPointWithAmount(10000L);
+        when(getUserPointUseCase.getUserPoint(USER_ID)).thenReturn(userPoint);
+        when(findGifticonOrderPort.existsByTrId(any())).thenReturn(false);
+        when(saveGifticonOrderPort.save(any())).thenAnswer(invocation -> {
+            GifticonOrder order = invocation.getArgument(0);
+            return GifticonOrder.from(GifticonOrderSnapshotState.builder()
+                    .id(1L)
+                    .userId(order.getUserId())
+                    .goodsCode(order.getGoodsCode())
+                    .goodsName(order.getGoodsName())
+                    .brandName(order.getBrandName())
+                    .productImageUrl(order.getProductImageUrl())
+                    .trId(order.getTrId())
+                    .cashPrice(order.getCashPrice())
+                    .orderStatus(order.getOrderStatus())
+                    .build());
+        });
+
+        // when
+        DeductCashAndCreateOrderContext context = helper.deductCashAndCreateOrder(
+                USER_ID, GOODS_CODE, GOODS_NAME, BRAND_NAME, PRODUCT_IMAGE_URL, CASH_PRICE
+        );
+
+        // then
+        ArgumentCaptor<GifticonOrder> orderCaptor = ArgumentCaptor.forClass(GifticonOrder.class);
+        verify(saveGifticonOrderPort).save(orderCaptor.capture());
+        GifticonOrder savedOrder = orderCaptor.getValue();
+        assertThat(savedOrder.getOrderStatus()).isEqualTo(GifticonOrderStatus.PENDING);
+        assertThat(savedOrder.getGoodsCode()).isEqualTo(GOODS_CODE);
+        assertThat(savedOrder.getCashPrice()).isEqualTo(CASH_PRICE);
+    }
+
+    @Test
+    @DisplayName("캐시 부족 시 GifticonInsufficientCashException이 발생한다")
+    void shouldThrowExceptionWhenInsufficientCash() {
+        // given
+        UserPoint userPoint = createUserPointWithAmount(3000L);
+        when(getUserPointUseCase.getUserPoint(USER_ID)).thenReturn(userPoint);
+
+        // when & then
+        assertThatThrownBy(() -> helper.deductCashAndCreateOrder(
+                USER_ID, GOODS_CODE, GOODS_NAME, BRAND_NAME, PRODUCT_IMAGE_URL, CASH_PRICE
+        ))
+                .isInstanceOf(GifticonInsufficientCashException.class)
+                .satisfies(ex -> {
+                    GifticonInsufficientCashException e = (GifticonInsufficientCashException) ex;
+                    assertThat(e.getShortfallAmount()).isEqualTo(2000L);
+                });
+
+        verify(saveGifticonOrderPort, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("TR_ID가 NC{userId}_{yyMMddHHmmss} 형식으로 생성된다")
+    void shouldGenerateTrIdInCorrectFormat() {
+        // given
+        UserPoint userPoint = createUserPointWithAmount(10000L);
+        when(getUserPointUseCase.getUserPoint(USER_ID)).thenReturn(userPoint);
+        when(findGifticonOrderPort.existsByTrId(any())).thenReturn(false);
+        when(saveGifticonOrderPort.save(any())).thenAnswer(invocation -> {
+            GifticonOrder order = invocation.getArgument(0);
+            return GifticonOrder.from(GifticonOrderSnapshotState.builder()
+                    .id(1L)
+                    .userId(order.getUserId())
+                    .goodsCode(order.getGoodsCode())
+                    .goodsName(order.getGoodsName())
+                    .brandName(order.getBrandName())
+                    .productImageUrl(order.getProductImageUrl())
+                    .trId(order.getTrId())
+                    .cashPrice(order.getCashPrice())
+                    .orderStatus(order.getOrderStatus())
+                    .build());
+        });
+
+        // when
+        DeductCashAndCreateOrderContext context = helper.deductCashAndCreateOrder(
+                USER_ID, GOODS_CODE, GOODS_NAME, BRAND_NAME, PRODUCT_IMAGE_URL, CASH_PRICE
+        );
+
+        // then
+        // NC{userId}_{yyMMddHHmmss} = "NC" + userId + "_" + 12자
+        assertThat(context.trId()).startsWith("NC" + USER_ID + "_");
+        assertThat(context.trId()).matches("NC\\d+_\\d{12}");
+        assertThat(context.trId().length()).isLessThanOrEqualTo(25);
+    }
+
+    @Test
+    @DisplayName("포인트 이력에 GIFTICON_PURCHASE sourceType으로 기록된다")
+    void shouldRecordGifticonPurchaseSourceType() {
+        // given
+        UserPoint userPoint = createUserPointWithAmount(10000L);
+        when(getUserPointUseCase.getUserPoint(USER_ID)).thenReturn(userPoint);
+        when(findGifticonOrderPort.existsByTrId(any())).thenReturn(false);
+        when(saveGifticonOrderPort.save(any())).thenAnswer(invocation -> {
+            GifticonOrder order = invocation.getArgument(0);
+            return GifticonOrder.from(GifticonOrderSnapshotState.builder()
+                    .id(1L)
+                    .userId(order.getUserId())
+                    .goodsCode(order.getGoodsCode())
+                    .goodsName(order.getGoodsName())
+                    .brandName(order.getBrandName())
+                    .productImageUrl(order.getProductImageUrl())
+                    .trId(order.getTrId())
+                    .cashPrice(order.getCashPrice())
+                    .orderStatus(order.getOrderStatus())
+                    .build());
+        });
+
+        // when
+        helper.deductCashAndCreateOrder(
+                USER_ID, GOODS_CODE, GOODS_NAME, BRAND_NAME, PRODUCT_IMAGE_URL, CASH_PRICE
+        );
+
+        // then
+        ArgumentCaptor<ModifyUserPointCommand> commandCaptor = ArgumentCaptor.forClass(ModifyUserPointCommand.class);
+        verify(modifyUserPointUseCase).modify(commandCaptor.capture());
+        ModifyUserPointCommand captured = commandCaptor.getValue();
+        assertThat(captured.sourceType()).isEqualTo(UserPointSourceType.GIFTICON_PURCHASE);
+        assertThat(captured.changeType()).isEqualTo(UserPointChangeType.DEDUCTION);
+        assertThat(captured.amount()).isEqualTo(CASH_PRICE);
+        assertThat(captured.userId()).isEqualTo(USER_ID);
+    }
+
+    @Test
+    @DisplayName("쿠폰 발송 성공 시 ISSUED 상태로 전이되고 orderNo/pinNo/couponImageUrl이 저장된다")
+    void shouldTransitionToIssuedOnSuccess() {
+        // given
+        GifticonOrder pendingOrder = createPendingOrder();
+        when(findGifticonOrderPort.findByTrId("NC100_260404210000")).thenReturn(Optional.of(pendingOrder));
+        when(encryptGifticonPinPort.encrypt("900343630367")).thenReturn("encryptedPin123");
+
+        DeductCashAndCreateOrderContext context = new DeductCashAndCreateOrderContext(
+                1L, "NC100_260404210000", GOODS_CODE, GOODS_NAME, CASH_PRICE, USER_ID
+        );
+        SendCouponResult sendResult = SendCouponResult.builder()
+                .success(true)
+                .orderNo("20260404000001")
+                .pinNo("900343630367")
+                .couponImageUrl("http://t.giftishow.co.kr/coupon_image.jpg")
+                .validEndDate("20260504")
+                .build();
+
+        // when
+        helper.commitSuccess(context, sendResult);
+
+        // then
+        ArgumentCaptor<GifticonOrder> orderCaptor = ArgumentCaptor.forClass(GifticonOrder.class);
+        verify(updateGifticonOrderPort).update(orderCaptor.capture());
+        GifticonOrder updatedOrder = orderCaptor.getValue();
+        assertThat(updatedOrder.getOrderStatus()).isEqualTo(GifticonOrderStatus.ISSUED);
+        assertThat(updatedOrder.getOrderNo()).isEqualTo("20260404000001");
+        assertThat(updatedOrder.getPinNo()).isEqualTo("encryptedPin123");
+        assertThat(updatedOrder.getCouponImageUrl()).isEqualTo("http://t.giftishow.co.kr/coupon_image.jpg");
+        assertThat(updatedOrder.getValidEndDate()).isEqualTo(LocalDate.of(2026, 5, 4));
+    }
+
+    @Test
+    @DisplayName("commitSuccess 시 pinNo가 암호화되어 저장된다")
+    void shouldEncryptPinNoOnCommitSuccess() {
+        // given
+        GifticonOrder pendingOrder = createPendingOrder();
+        when(findGifticonOrderPort.findByTrId("NC100_260404210000")).thenReturn(Optional.of(pendingOrder));
+        when(encryptGifticonPinPort.encrypt("plainPin")).thenReturn("encryptedPin");
+
+        DeductCashAndCreateOrderContext context = new DeductCashAndCreateOrderContext(
+                1L, "NC100_260404210000", GOODS_CODE, GOODS_NAME, CASH_PRICE, USER_ID
+        );
+        SendCouponResult sendResult = SendCouponResult.builder()
+                .success(true)
+                .orderNo("20260404000001")
+                .pinNo("plainPin")
+                .couponImageUrl("http://example.com/coupon.jpg")
+                .validEndDate("20260504")
+                .build();
+
+        // when
+        helper.commitSuccess(context, sendResult);
+
+        // then
+        verify(encryptGifticonPinPort).encrypt("plainPin");
+        ArgumentCaptor<GifticonOrder> orderCaptor = ArgumentCaptor.forClass(GifticonOrder.class);
+        verify(updateGifticonOrderPort).update(orderCaptor.capture());
+        assertThat(orderCaptor.getValue().getPinNo()).isEqualTo("encryptedPin");
+    }
+
+    @Test
+    @DisplayName("commitFailure 시 캐시가 환불된다")
+    void shouldRefundCashOnCommitFailure() {
+        // given
+        GifticonOrder pendingOrder = createPendingOrder();
+        when(findGifticonOrderPort.findByTrId("NC100_260404210000")).thenReturn(Optional.of(pendingOrder));
+
+        DeductCashAndCreateOrderContext context = new DeductCashAndCreateOrderContext(
+                1L, "NC100_260404210000", GOODS_CODE, GOODS_NAME, CASH_PRICE, USER_ID
+        );
+
+        // when
+        helper.commitFailure(context);
+
+        // then
+        ArgumentCaptor<ModifyUserPointCommand> commandCaptor = ArgumentCaptor.forClass(ModifyUserPointCommand.class);
+        verify(modifyUserPointUseCase).modify(commandCaptor.capture());
+        ModifyUserPointCommand captured = commandCaptor.getValue();
+        assertThat(captured.sourceType()).isEqualTo(UserPointSourceType.GIFTICON_REFUND);
+        assertThat(captured.changeType()).isEqualTo(UserPointChangeType.ACCRUAL);
+        assertThat(captured.amount()).isEqualTo(CASH_PRICE);
+        assertThat(captured.userId()).isEqualTo(USER_ID);
+    }
+
+    @Test
+    @DisplayName("commitFailure 시 SEND_FAILED 상태로 전이된다")
+    void shouldTransitionToSendFailedOnCommitFailure() {
+        // given
+        GifticonOrder pendingOrder = createPendingOrder();
+        when(findGifticonOrderPort.findByTrId("NC100_260404210000")).thenReturn(Optional.of(pendingOrder));
+
+        DeductCashAndCreateOrderContext context = new DeductCashAndCreateOrderContext(
+                1L, "NC100_260404210000", GOODS_CODE, GOODS_NAME, CASH_PRICE, USER_ID
+        );
+
+        // when
+        helper.commitFailure(context);
+
+        // then
+        ArgumentCaptor<GifticonOrder> orderCaptor = ArgumentCaptor.forClass(GifticonOrder.class);
+        verify(updateGifticonOrderPort).update(orderCaptor.capture());
+        assertThat(orderCaptor.getValue().getOrderStatus()).isEqualTo(GifticonOrderStatus.SEND_FAILED);
+    }
+
+    private UserPoint createUserPointWithAmount(Long amount) {
+        return UserPoint.from(
+                com.personal.marketnote.reward.domain.point.UserPointSnapshotState.builder()
+                        .userId(USER_ID)
+                        .amount(amount)
+                        .addExpectedAmount(0L)
+                        .expireExpectedAmount(0L)
+                        .build()
+        );
+    }
+
+    private GifticonOrder createPendingOrder() {
+        return GifticonOrder.from(GifticonOrderSnapshotState.builder()
+                .id(1L)
+                .userId(USER_ID)
+                .goodsCode(GOODS_CODE)
+                .goodsName(GOODS_NAME)
+                .brandName(BRAND_NAME)
+                .productImageUrl(PRODUCT_IMAGE_URL)
+                .trId("NC100_260404210000")
+                .cashPrice(CASH_PRICE)
+                .orderStatus(GifticonOrderStatus.PENDING)
+                .build());
+    }
+}


### PR DESCRIPTION
## partially addresses #1653
## resolves #1672

## Test Case
- [x] 캐시가 충분하면 기프티콘 구매에 성공한다
- [x] 캐시 차감 후 GifticonOrder가 PENDING 상태로 저장된다
- [x] 쿠폰 발송 성공 시 ISSUED 상태로 전이되고 orderNo/pinNo/couponImageUrl이 저장된다
- [x] 캐시 부족 시 GifticonInsufficientCashException이 발생한다
- [x] 존재하지 않는 상품 코드로 구매 시 GifticonGoodsNotFoundException이 발생한다
- [x] 노출되지 않은 상품으로 구매 시 GifticonGoodsNotFoundException이 발생한다
- [x] 판매 중이 아닌 상품으로 구매 시 GifticonGoodsNotFoundException이 발생한다
- [x] 쿠폰 발송 실패 시 commitFailure가 호출되고 발송실패 취소 API가 호출된다
- [x] 발송실패 취소 API 호출 실패 시에도 예외가 전파되지 않는다
- [x] TR_ID가 NC{userId}_{yyMMddHHmmss} 형식으로 생성된다
- [x] 포인트 이력에 GIFTICON_PURCHASE sourceType으로 기록된다
- [x] commitSuccess 시 pinNo가 암호화되어 저장된다
- [x] commitFailure 시 캐시가 환불된다
- [x] commitFailure 시 SEND_FAILED 상태로 전이된다