### PR TITLE
[#1653][#1662] feat: 내 기프티콘 목록 조회 기능 추가

### DIFF
--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/gifticon/controller/GifticonOrderController.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/gifticon/controller/GifticonOrderController.java
@@ -2,23 +2,27 @@ package com.personal.marketnote.reward.adapter.in.web.gifticon.controller;
 
 import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
 import com.personal.marketnote.common.utility.ElementExtractor;
+import com.personal.marketnote.reward.adapter.in.web.gifticon.controller.apidocs.GetMyGifticonOrdersApiDocs;
 import com.personal.marketnote.reward.adapter.in.web.gifticon.controller.apidocs.PurchaseGifticonApiDocs;
 import com.personal.marketnote.reward.adapter.in.web.gifticon.request.PurchaseGifticonRequest;
+import com.personal.marketnote.reward.adapter.in.web.gifticon.response.GetMyGifticonOrdersResponse;
 import com.personal.marketnote.reward.adapter.in.web.gifticon.response.PurchaseGifticonResponse;
+import com.personal.marketnote.reward.port.in.command.gifticon.GetMyGifticonOrdersCommand;
 import com.personal.marketnote.reward.port.in.command.gifticon.PurchaseGifticonCommand;
+import com.personal.marketnote.reward.port.in.result.gifticon.GetMyGifticonOrdersResult;
 import com.personal.marketnote.reward.port.in.result.gifticon.PurchaseGifticonResult;
+import com.personal.marketnote.reward.port.in.usecase.gifticon.GetMyGifticonOrdersUseCase;
 import com.personal.marketnote.reward.port.in.usecase.gifticon.PurchaseGifticonUseCase;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.core.OAuth2AuthenticatedPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import static com.personal.marketnote.common.domain.exception.ExceptionCode.DEFAULT_SUCCESS_CODE;
 
@@ -29,6 +33,7 @@ import static com.personal.marketnote.common.domain.exception.ExceptionCode.DEFA
 public class GifticonOrderController {
 
     private final PurchaseGifticonUseCase purchaseGifticonUseCase;
+    private final GetMyGifticonOrdersUseCase getMyGifticonOrdersUseCase;
 
     @PostMapping
     @PurchaseGifticonApiDocs
@@ -46,6 +51,29 @@ public class GifticonOrderController {
 
         return new ResponseEntity<>(
                 BaseResponse.of(response, HttpStatus.OK, DEFAULT_SUCCESS_CODE, "기프티콘 구매 성공"),
+                HttpStatus.OK
+        );
+    }
+
+    @GetMapping("/me")
+    @GetMyGifticonOrdersApiDocs
+    public ResponseEntity<BaseResponse<GetMyGifticonOrdersResponse>> getMyGifticonOrders(
+            @AuthenticationPrincipal OAuth2AuthenticatedPrincipal principal,
+            @RequestParam(name = "status", defaultValue = "AVAILABLE") String status,
+            @RequestParam(name = "sort", defaultValue = "PURCHASE_LATEST") String sort,
+            @RequestParam(name = "cursor", defaultValue = "-1") Long cursor,
+            @RequestParam(name = "page-size", defaultValue = "10") @Min(1) @Max(100) int pageSize
+    ) {
+        Long userId = ElementExtractor.extractUserId(principal);
+
+        GetMyGifticonOrdersResult result = getMyGifticonOrdersUseCase.getMyGifticonOrders(
+                new GetMyGifticonOrdersCommand(userId, status, sort, cursor, pageSize)
+        );
+
+        GetMyGifticonOrdersResponse response = GetMyGifticonOrdersResponse.from(result);
+
+        return new ResponseEntity<>(
+                BaseResponse.of(response, HttpStatus.OK, DEFAULT_SUCCESS_CODE, "내 기프티콘 목록 조회 성공"),
                 HttpStatus.OK
         );
     }

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/gifticon/controller/apidocs/GetMyGifticonOrdersApiDocs.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/gifticon/controller/apidocs/GetMyGifticonOrdersApiDocs.java
@@ -1,0 +1,84 @@
+package com.personal.marketnote.reward.adapter.in.web.gifticon.controller.apidocs;
+
+import com.personal.marketnote.reward.adapter.in.web.gifticon.response.GetMyGifticonOrdersResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Operation(
+        summary = "내 기프티콘 목록 조회",
+        description = """
+                작성일자: 2026-04-06
+
+                작성자: 성효빈
+
+                ---
+
+                ## Description
+
+                사용자가 구매한 기프티콘 목록을 조회합니다.
+                AVAILABLE(사용가능) / COMPLETED_OR_EXPIRED(완료/만료) 탭별 필터링과
+                PURCHASE_LATEST(구매 최신순) / EXPIRY_SOONEST(유효기간 임박순) 정렬을 지원합니다.
+
+                ### Parameters
+                - status: AVAILABLE(사용가능, ISSUED) / COMPLETED_OR_EXPIRED(사용완료/기간만료/취소)
+                - sort: PURCHASE_LATEST(구매 최신순) / EXPIRY_SOONEST(유효기간 임박순)
+                - cursor: 페이징 커서 (기본값 -1)
+                - page-size: 페이지 크기 (기본값 10)
+                """,
+        parameters = {
+                @Parameter(name = "status", description = "상태 필터 (AVAILABLE / COMPLETED_OR_EXPIRED)", example = "AVAILABLE"),
+                @Parameter(name = "sort", description = "정렬 (PURCHASE_LATEST / EXPIRY_SOONEST)", example = "PURCHASE_LATEST"),
+                @Parameter(name = "cursor", description = "페이징 커서", example = "-1"),
+                @Parameter(name = "page-size", description = "페이지 크기", example = "10")
+        },
+        security = {@SecurityRequirement(name = "bearer")},
+        responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "내 기프티콘 목록 조회 성공",
+                        content = @Content(
+                                schema = @Schema(implementation = GetMyGifticonOrdersResponse.class),
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 200,
+                                          "code": "SUC01",
+                                          "timestamp": "2026-04-06T12:00:00.000000",
+                                          "content": {
+                                            "availableCount": 3,
+                                            "completedOrExpiredCount": 5,
+                                            "hasNext": true,
+                                            "nextCursor": 8,
+                                            "items": [
+                                              {
+                                                "orderId": 10,
+                                                "goodsName": "아메리카노",
+                                                "brandName": "스타벅스",
+                                                "productImageUrl": "https://example.com/goods.jpg",
+                                                "cashPrice": 5000,
+                                                "expiryDate": "26.05.04까지 사용 가능",
+                                                "daysRemaining": 30,
+                                                "statusLabel": null,
+                                                "orderStatus": "ISSUED",
+                                                "createdAt": "2026-04-06T12:00:00"
+                                              }
+                                            ]
+                                          },
+                                          "message": "내 기프티콘 목록 조회 성공"
+                                        }
+                                        """)
+                        )
+                )
+        }
+)
+public @interface GetMyGifticonOrdersApiDocs {
+}

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/gifticon/response/GetMyGifticonOrdersResponse.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/gifticon/response/GetMyGifticonOrdersResponse.java
@@ -1,0 +1,54 @@
+package com.personal.marketnote.reward.adapter.in.web.gifticon.response;
+
+import com.personal.marketnote.reward.port.in.result.gifticon.GetMyGifticonOrdersResult;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record GetMyGifticonOrdersResponse(
+        long availableCount,
+        long completedOrExpiredCount,
+        boolean hasNext,
+        Long nextCursor,
+        List<MyGifticonOrderItemResponse> items
+) {
+
+    public record MyGifticonOrderItemResponse(
+            Long orderId,
+            String goodsName,
+            String brandName,
+            String productImageUrl,
+            Long cashPrice,
+            String expiryDate,
+            Integer daysRemaining,
+            String statusLabel,
+            String orderStatus,
+            LocalDateTime createdAt
+    ) {
+    }
+
+    public static GetMyGifticonOrdersResponse from(GetMyGifticonOrdersResult result) {
+        List<MyGifticonOrderItemResponse> items = result.items().stream()
+                .map(item -> new MyGifticonOrderItemResponse(
+                        item.orderId(),
+                        item.goodsName(),
+                        item.brandName(),
+                        item.productImageUrl(),
+                        item.cashPrice(),
+                        item.expiryDate(),
+                        item.daysRemaining(),
+                        item.statusLabel(),
+                        item.orderStatus(),
+                        item.createdAt()
+                ))
+                .toList();
+
+        return new GetMyGifticonOrdersResponse(
+                result.availableCount(),
+                result.completedOrExpiredCount(),
+                result.hasNext(),
+                result.nextCursor(),
+                items
+        );
+    }
+}

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/gifticon/GifticonOrderPersistenceAdapter.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/gifticon/GifticonOrderPersistenceAdapter.java
@@ -6,12 +6,17 @@ import com.personal.marketnote.reward.adapter.out.persistence.gifticon.repositor
 import com.personal.marketnote.reward.domain.exception.DuplicateGifticonOrderException;
 import com.personal.marketnote.reward.domain.exception.GifticonOrderNotFoundException;
 import com.personal.marketnote.reward.domain.gifticon.GifticonOrder;
+import com.personal.marketnote.reward.domain.gifticon.GifticonOrderSortType;
+import com.personal.marketnote.reward.domain.gifticon.GifticonOrderStatus;
 import com.personal.marketnote.reward.port.out.gifticon.FindGifticonOrderPort;
 import com.personal.marketnote.reward.port.out.gifticon.SaveGifticonOrderPort;
 import com.personal.marketnote.reward.port.out.gifticon.UpdateGifticonOrderPort;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
+import java.util.List;
 import java.util.Optional;
 
 @PersistenceAdapter
@@ -48,5 +53,42 @@ public class GifticonOrderPersistenceAdapter
     @Override
     public boolean existsByTrId(String trId) {
         return gifticonOrderJpaRepository.existsByTrId(trId);
+    }
+
+    @Override
+    public List<GifticonOrder> findByUserIdAndStatuses(Long userId, List<GifticonOrderStatus> statuses,
+                                                       GifticonOrderSortType sortType, Long cursor, int pageSize) {
+        if (sortType.isExpirySoonest()) {
+            return findByExpirySoonest(userId, statuses, cursor, pageSize);
+        }
+        return findByPurchaseLatest(userId, statuses, cursor, pageSize);
+    }
+
+    @Override
+    public long countByUserIdAndStatuses(Long userId, List<GifticonOrderStatus> statuses) {
+        return gifticonOrderJpaRepository.countByUserIdAndOrderStatusIn(userId, statuses);
+    }
+
+    private List<GifticonOrder> findByPurchaseLatest(Long userId, List<GifticonOrderStatus> statuses,
+                                                    Long cursor, int pageSize) {
+        Pageable pageable = PageRequest.of(0, pageSize);
+        return gifticonOrderJpaRepository.findByUserIdAndStatusesOrderByCreatedAtDesc(
+                        userId, statuses, cursor, pageable)
+                .stream()
+                .map(GifticonOrderJpaEntity::toDomain)
+                .toList();
+    }
+
+    private List<GifticonOrder> findByExpirySoonest(Long userId, List<GifticonOrderStatus> statuses,
+                                                   Long cursor, int pageSize) {
+        int offset = (cursor <= 0) ? 0 : (int) Math.min(cursor, 10_000);
+        int totalFetch = Math.addExact(offset, pageSize);
+        Pageable pageable = PageRequest.of(0, totalFetch);
+        return gifticonOrderJpaRepository.findByUserIdAndStatusesOrderByValidEndDateAsc(
+                        userId, statuses, pageable)
+                .stream()
+                .skip(offset)
+                .map(GifticonOrderJpaEntity::toDomain)
+                .toList();
     }
 }

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/gifticon/repository/GifticonOrderJpaRepository.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/gifticon/repository/GifticonOrderJpaRepository.java
@@ -1,8 +1,13 @@
 package com.personal.marketnote.reward.adapter.out.persistence.gifticon.repository;
 
 import com.personal.marketnote.reward.adapter.out.persistence.gifticon.entity.GifticonOrderJpaEntity;
+import com.personal.marketnote.reward.domain.gifticon.GifticonOrderStatus;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface GifticonOrderJpaRepository extends JpaRepository<GifticonOrderJpaEntity, Long> {
@@ -10,4 +15,32 @@ public interface GifticonOrderJpaRepository extends JpaRepository<GifticonOrderJ
     Optional<GifticonOrderJpaEntity> findByTrId(String trId);
 
     boolean existsByTrId(String trId);
+
+    @Query("""
+            SELECT o FROM GifticonOrderJpaEntity o
+            WHERE o.userId = :userId
+            AND o.orderStatus IN :statuses
+            AND (:cursor = -1L OR o.id < :cursor)
+            ORDER BY o.createdAt DESC, o.id DESC
+            """)
+    List<GifticonOrderJpaEntity> findByUserIdAndStatusesOrderByCreatedAtDesc(
+            @Param("userId") Long userId,
+            @Param("statuses") List<GifticonOrderStatus> statuses,
+            @Param("cursor") Long cursor,
+            Pageable pageable
+    );
+
+    @Query("""
+            SELECT o FROM GifticonOrderJpaEntity o
+            WHERE o.userId = :userId
+            AND o.orderStatus IN :statuses
+            ORDER BY o.validEndDate ASC, o.id ASC
+            """)
+    List<GifticonOrderJpaEntity> findByUserIdAndStatusesOrderByValidEndDateAsc(
+            @Param("userId") Long userId,
+            @Param("statuses") List<GifticonOrderStatus> statuses,
+            Pageable pageable
+    );
+
+    long countByUserIdAndOrderStatusIn(Long userId, List<GifticonOrderStatus> statuses);
 }

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/command/gifticon/GetMyGifticonOrdersCommand.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/command/gifticon/GetMyGifticonOrdersCommand.java
@@ -1,0 +1,10 @@
+package com.personal.marketnote.reward.port.in.command.gifticon;
+
+public record GetMyGifticonOrdersCommand(
+        Long userId,
+        String statusFilter,
+        String sortType,
+        Long cursor,
+        int pageSize
+) {
+}

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/result/gifticon/GetMyGifticonOrdersResult.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/result/gifticon/GetMyGifticonOrdersResult.java
@@ -1,0 +1,27 @@
+package com.personal.marketnote.reward.port.in.result.gifticon;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record GetMyGifticonOrdersResult(
+        long availableCount,
+        long completedOrExpiredCount,
+        boolean hasNext,
+        Long nextCursor,
+        List<MyGifticonOrderItem> items
+) {
+
+    public record MyGifticonOrderItem(
+            Long orderId,
+            String goodsName,
+            String brandName,
+            String productImageUrl,
+            Long cashPrice,
+            String expiryDate,
+            Integer daysRemaining,
+            String statusLabel,
+            String orderStatus,
+            LocalDateTime createdAt
+    ) {
+    }
+}

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/usecase/gifticon/GetMyGifticonOrdersUseCase.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/usecase/gifticon/GetMyGifticonOrdersUseCase.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.reward.port.in.usecase.gifticon;
+
+import com.personal.marketnote.reward.port.in.command.gifticon.GetMyGifticonOrdersCommand;
+import com.personal.marketnote.reward.port.in.result.gifticon.GetMyGifticonOrdersResult;
+
+public interface GetMyGifticonOrdersUseCase {
+    GetMyGifticonOrdersResult getMyGifticonOrders(GetMyGifticonOrdersCommand command);
+}

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/out/gifticon/FindGifticonOrderPort.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/out/gifticon/FindGifticonOrderPort.java
@@ -1,11 +1,19 @@
 package com.personal.marketnote.reward.port.out.gifticon;
 
 import com.personal.marketnote.reward.domain.gifticon.GifticonOrder;
+import com.personal.marketnote.reward.domain.gifticon.GifticonOrderSortType;
+import com.personal.marketnote.reward.domain.gifticon.GifticonOrderStatus;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface FindGifticonOrderPort {
     Optional<GifticonOrder> findByTrId(String trId);
 
     boolean existsByTrId(String trId);
+
+    List<GifticonOrder> findByUserIdAndStatuses(Long userId, List<GifticonOrderStatus> statuses,
+                                                GifticonOrderSortType sortType, Long cursor, int pageSize);
+
+    long countByUserIdAndStatuses(Long userId, List<GifticonOrderStatus> statuses);
 }

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/service/gifticon/GetMyGifticonOrdersService.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/service/gifticon/GetMyGifticonOrdersService.java
@@ -1,0 +1,85 @@
+package com.personal.marketnote.reward.service.gifticon;
+
+import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.reward.domain.gifticon.*;
+import com.personal.marketnote.reward.port.in.command.gifticon.GetMyGifticonOrdersCommand;
+import com.personal.marketnote.reward.port.in.result.gifticon.GetMyGifticonOrdersResult;
+import com.personal.marketnote.reward.port.in.result.gifticon.GetMyGifticonOrdersResult.MyGifticonOrderItem;
+import com.personal.marketnote.reward.port.in.usecase.gifticon.GetMyGifticonOrdersUseCase;
+import com.personal.marketnote.reward.port.out.gifticon.FindGifticonOrderPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@UseCase
+@RequiredArgsConstructor
+public class GetMyGifticonOrdersService implements GetMyGifticonOrdersUseCase {
+
+    private final FindGifticonOrderPort findGifticonOrderPort;
+    private final Clock clock;
+
+    @Override
+    @Transactional(isolation = READ_COMMITTED, readOnly = true)
+    public GetMyGifticonOrdersResult getMyGifticonOrders(GetMyGifticonOrdersCommand command) {
+        GifticonOrderStatusFilter statusFilter = GifticonOrderStatusFilter.from(command.statusFilter());
+        GifticonOrderSortType sortType = GifticonOrderSortType.from(command.sortType());
+        List<GifticonOrderStatus> statuses = statusFilter.toStatuses();
+        int fetchSize = command.pageSize() + 1;
+
+        List<GifticonOrder> fetched = findGifticonOrderPort.findByUserIdAndStatuses(
+                command.userId(), statuses, sortType, command.cursor(), fetchSize
+        );
+
+        boolean hasNext = fetched.size() > command.pageSize();
+        List<GifticonOrder> orders = hasNext ? fetched.subList(0, command.pageSize()) : fetched;
+        Long nextCursor = resolveNextCursor(sortType, hasNext, orders, command);
+
+        long availableCount = findGifticonOrderPort.countByUserIdAndStatuses(
+                command.userId(), GifticonOrderStatusFilter.AVAILABLE.toStatuses()
+        );
+        long completedOrExpiredCount = findGifticonOrderPort.countByUserIdAndStatuses(
+                command.userId(), GifticonOrderStatusFilter.COMPLETED_OR_EXPIRED.toStatuses()
+        );
+
+        LocalDate now = LocalDate.now(clock);
+        List<MyGifticonOrderItem> items = orders.stream()
+                .map(order -> toItem(order, now))
+                .toList();
+
+        return new GetMyGifticonOrdersResult(
+                availableCount, completedOrExpiredCount, hasNext, nextCursor, items
+        );
+    }
+
+    private Long resolveNextCursor(GifticonOrderSortType sortType, boolean hasNext,
+                                   List<GifticonOrder> orders, GetMyGifticonOrdersCommand command) {
+        if (!hasNext) {
+            return null;
+        }
+        if (sortType.isPurchaseLatest()) {
+            return orders.get(orders.size() - 1).getId();
+        }
+        long currentOffset = (command.cursor() <= 0) ? 0 : command.cursor();
+        return currentOffset + command.pageSize();
+    }
+
+    private MyGifticonOrderItem toItem(GifticonOrder order, LocalDate now) {
+        return new MyGifticonOrderItem(
+                order.getId(),
+                order.getGoodsName(),
+                order.getBrandName(),
+                order.getProductImageUrl(),
+                order.getCashPrice(),
+                order.formatExpiryDate(),
+                order.calculateDaysRemaining(now),
+                order.resolveStatusLabel(),
+                order.getOrderStatus().name(),
+                order.getCreatedAt()
+        );
+    }
+}

--- a/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/exception/InvalidGifticonOrderSortTypeException.java
+++ b/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/exception/InvalidGifticonOrderSortTypeException.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.reward.domain.exception;
+
+public class InvalidGifticonOrderSortTypeException extends IllegalArgumentException {
+    private static final String MESSAGE = "유효하지 않은 기프티콘 주문 정렬 타입입니다. value=%s";
+
+    public InvalidGifticonOrderSortTypeException(String value) {
+        super(String.format(MESSAGE, value));
+    }
+}

--- a/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/exception/InvalidGifticonOrderStatusFilterException.java
+++ b/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/exception/InvalidGifticonOrderStatusFilterException.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.reward.domain.exception;
+
+public class InvalidGifticonOrderStatusFilterException extends IllegalArgumentException {
+    private static final String MESSAGE = "유효하지 않은 기프티콘 주문 상태 필터입니다. value=%s";
+
+    public InvalidGifticonOrderStatusFilterException(String value) {
+        super(String.format(MESSAGE, value));
+    }
+}

--- a/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/gifticon/GifticonOrder.java
+++ b/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/gifticon/GifticonOrder.java
@@ -1,16 +1,20 @@
 package com.personal.marketnote.reward.domain.gifticon;
 
+import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.reward.domain.exception.InvalidGifticonOrderStatusTransitionException;
 import lombok.*;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder(access = AccessLevel.PRIVATE)
 public class GifticonOrder {
+    private static final DateTimeFormatter EXPIRY_DATE_FORMATTER = DateTimeFormatter.ofPattern("yy.MM.dd");
     private Long id;
     private Long userId;
     private String goodsCode;
@@ -108,5 +112,32 @@ public class GifticonOrder {
 
     public boolean isTerminal() {
         return this.orderStatus.isTerminal();
+    }
+
+    public Integer calculateDaysRemaining(LocalDate now) {
+        if (FormatValidator.hasNoValue(validEndDate)) {
+            return null;
+        }
+        return (int) ChronoUnit.DAYS.between(now, validEndDate);
+    }
+
+    public String resolveStatusLabel() {
+        if (orderStatus.isUsed()) {
+            return "사용완료";
+        }
+        if (orderStatus.isExpired()) {
+            return "기간만료";
+        }
+        if (orderStatus.isCancelled()) {
+            return "취소됨";
+        }
+        return null;
+    }
+
+    public String formatExpiryDate() {
+        if (FormatValidator.hasNoValue(validEndDate)) {
+            return null;
+        }
+        return validEndDate.format(EXPIRY_DATE_FORMATTER) + "까지 사용 가능";
     }
 }

--- a/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/gifticon/GifticonOrderSortType.java
+++ b/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/gifticon/GifticonOrderSortType.java
@@ -1,0 +1,24 @@
+package com.personal.marketnote.reward.domain.gifticon;
+
+import com.personal.marketnote.reward.domain.exception.InvalidGifticonOrderSortTypeException;
+
+public enum GifticonOrderSortType {
+    PURCHASE_LATEST,
+    EXPIRY_SOONEST;
+
+    public boolean isPurchaseLatest() {
+        return this == PURCHASE_LATEST;
+    }
+
+    public boolean isExpirySoonest() {
+        return this == EXPIRY_SOONEST;
+    }
+
+    public static GifticonOrderSortType from(String value) {
+        try {
+            return valueOf(value);
+        } catch (IllegalArgumentException e) {
+            throw new InvalidGifticonOrderSortTypeException(value);
+        }
+    }
+}

--- a/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/gifticon/GifticonOrderStatusFilter.java
+++ b/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/gifticon/GifticonOrderStatusFilter.java
@@ -1,0 +1,25 @@
+package com.personal.marketnote.reward.domain.gifticon;
+
+import com.personal.marketnote.reward.domain.exception.InvalidGifticonOrderStatusFilterException;
+
+import java.util.List;
+
+public enum GifticonOrderStatusFilter {
+    AVAILABLE,
+    COMPLETED_OR_EXPIRED;
+
+    public List<GifticonOrderStatus> toStatuses() {
+        if (this == AVAILABLE) {
+            return List.of(GifticonOrderStatus.ISSUED);
+        }
+        return List.of(GifticonOrderStatus.USED, GifticonOrderStatus.EXPIRED, GifticonOrderStatus.CANCELLED);
+    }
+
+    public static GifticonOrderStatusFilter from(String value) {
+        try {
+            return valueOf(value);
+        } catch (IllegalArgumentException e) {
+            throw new InvalidGifticonOrderStatusFilterException(value);
+        }
+    }
+}


### PR DESCRIPTION
## partially addresses #1653
## resolves #1662

## Task
- [x] GifticonOrderStatusFilter enum (AVAILABLE/COMPLETED_OR_EXPIRED 탭 필터)
- [x] GifticonOrderSortType enum (PURCHASE_LATEST/EXPIRY_SOONEST 정렬)
- [x] GifticonOrder 도메인 메서드 (daysRemaining, statusLabel, expiryDate)
- [x] GetMyGifticonOrdersService (커서/오프셋 하이브리드 페이지네이션)
- [x] GET /api/v1/gifticons/orders/me 엔드포인트
- [x] enum valueOf → from() 팩토리, pageSize 검증, 커서 오버플로 방지