### PR TITLE
[#1][#1799] fix: KafkaBrokerFailureScenarioTest 전체 빌드 시 간헐적으로 실패하는 이슈 대응

### DIFF
--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -81,6 +81,27 @@ tasks.withType<Test> {
     useJUnitPlatform()
 }
 
+tasks.named<Test>("test") {
+    useJUnitPlatform {
+        excludeTags("broker-failure")
+    }
+}
+
+tasks.register<Test>("brokerFailureTest") {
+    description = "KafkaBrokerFailureScenarioTest를 독립 JVM에서 실행한다"
+    group = "verification"
+    testClassesDirs = sourceSets["test"].output.classesDirs
+    classpath = sourceSets["test"].runtimeClasspath
+    shouldRunAfter("test")
+    useJUnitPlatform {
+        includeTags("broker-failure")
+    }
+}
+
+tasks.named("check") {
+    dependsOn("brokerFailureTest")
+}
+
 tasks.named("bootJar") {
     enabled = false
 }

--- a/common/src/test/java/com/personal/marketnote/common/configuration/kafka/KafkaBrokerFailureScenarioTest.java
+++ b/common/src/test/java/com/personal/marketnote/common/configuration/kafka/KafkaBrokerFailureScenarioTest.java
@@ -45,7 +45,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * <p>KRaft combined mode(각 노드가 controller+broker)에서 컨트롤러 쿼럼 유지를 위해
  * 최대 2브로커까지만 shutdown한다 (3/3 shutdown 시 쿼럼 소실로 복구 불안정).</p>
  */
-@Tag("slow")
+@Tag("broker-failure")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 @DisplayName("Kafka 브로커 장애 시나리오 검증")


### PR DESCRIPTION
## partially addresses #1
## resolves #1799

## Reason
common 모듈의 EmbeddedKafka 테스트 3개가 동일 JVM에서 실행되면서
KafkaBrokerFailureScenarioTest의 브로커 shutdown/restart가 다른 테스트의 브로커 상태에 간섭하여 간헐적 실패 발생

## Action
- [x] KafkaBrokerFailureScenarioTest @tag를 "slow"에서 "broker-failure"로 변경
- [x] 기존 test task에서 broker-failure 태그 제외 (excludeTags)
- [x] brokerFailureTest 별도 task 등록 (독립 JVM, testClassesDirs/classpath 설정)
- [x] check task에 brokerFailureTest 의존 추가 (build 시 자동 실행)