### PR TITLE
[#1653][#1663] feat: 내 기프티콘 상세 조회 기능 추가

### DIFF
--- a/common/src/main/java/com/personal/marketnote/common/configuration/security/SecurityPropertiesValidator.java
+++ b/common/src/main/java/com/personal/marketnote/common/configuration/security/SecurityPropertiesValidator.java
@@ -20,6 +20,7 @@ public class SecurityPropertiesValidator {
 
     private static final Set<String> WEAK_DEFAULTS = Set.of(
             "dev-secret-change-me", "dev-hmac-secret-change-me",
+            "dev-pin-key-change-me",
             "abc", "def", "ghi",
             "change-me", "password", "root", "secret", "test",
             "0000", "1234567890123456"

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/gifticon/controller/GifticonOrderController.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/gifticon/controller/GifticonOrderController.java
@@ -2,15 +2,20 @@ package com.personal.marketnote.reward.adapter.in.web.gifticon.controller;
 
 import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
 import com.personal.marketnote.common.utility.ElementExtractor;
+import com.personal.marketnote.reward.adapter.in.web.gifticon.controller.apidocs.GetMyGifticonOrderDetailApiDocs;
 import com.personal.marketnote.reward.adapter.in.web.gifticon.controller.apidocs.GetMyGifticonOrdersApiDocs;
 import com.personal.marketnote.reward.adapter.in.web.gifticon.controller.apidocs.PurchaseGifticonApiDocs;
 import com.personal.marketnote.reward.adapter.in.web.gifticon.request.PurchaseGifticonRequest;
+import com.personal.marketnote.reward.adapter.in.web.gifticon.response.GetMyGifticonOrderDetailResponse;
 import com.personal.marketnote.reward.adapter.in.web.gifticon.response.GetMyGifticonOrdersResponse;
 import com.personal.marketnote.reward.adapter.in.web.gifticon.response.PurchaseGifticonResponse;
+import com.personal.marketnote.reward.port.in.command.gifticon.GetMyGifticonOrderDetailCommand;
 import com.personal.marketnote.reward.port.in.command.gifticon.GetMyGifticonOrdersCommand;
 import com.personal.marketnote.reward.port.in.command.gifticon.PurchaseGifticonCommand;
+import com.personal.marketnote.reward.port.in.result.gifticon.GetMyGifticonOrderDetailResult;
 import com.personal.marketnote.reward.port.in.result.gifticon.GetMyGifticonOrdersResult;
 import com.personal.marketnote.reward.port.in.result.gifticon.PurchaseGifticonResult;
+import com.personal.marketnote.reward.port.in.usecase.gifticon.GetMyGifticonOrderDetailUseCase;
 import com.personal.marketnote.reward.port.in.usecase.gifticon.GetMyGifticonOrdersUseCase;
 import com.personal.marketnote.reward.port.in.usecase.gifticon.PurchaseGifticonUseCase;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -34,6 +39,7 @@ public class GifticonOrderController {
 
     private final PurchaseGifticonUseCase purchaseGifticonUseCase;
     private final GetMyGifticonOrdersUseCase getMyGifticonOrdersUseCase;
+    private final GetMyGifticonOrderDetailUseCase getMyGifticonOrderDetailUseCase;
 
     @PostMapping
     @PurchaseGifticonApiDocs
@@ -74,6 +80,26 @@ public class GifticonOrderController {
 
         return new ResponseEntity<>(
                 BaseResponse.of(response, HttpStatus.OK, DEFAULT_SUCCESS_CODE, "내 기프티콘 목록 조회 성공"),
+                HttpStatus.OK
+        );
+    }
+
+    @GetMapping("/me/{orderId}")
+    @GetMyGifticonOrderDetailApiDocs
+    public ResponseEntity<BaseResponse<GetMyGifticonOrderDetailResponse>> getMyGifticonOrderDetail(
+            @AuthenticationPrincipal OAuth2AuthenticatedPrincipal principal,
+            @PathVariable Long orderId
+    ) {
+        Long userId = ElementExtractor.extractUserId(principal);
+
+        GetMyGifticonOrderDetailResult result = getMyGifticonOrderDetailUseCase.getMyGifticonOrderDetail(
+                new GetMyGifticonOrderDetailCommand(userId, orderId)
+        );
+
+        GetMyGifticonOrderDetailResponse response = GetMyGifticonOrderDetailResponse.from(result);
+
+        return new ResponseEntity<>(
+                BaseResponse.of(response, HttpStatus.OK, DEFAULT_SUCCESS_CODE, "내 기프티콘 상세 조회 성공"),
                 HttpStatus.OK
         );
     }

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/gifticon/controller/apidocs/GetMyGifticonOrderDetailApiDocs.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/gifticon/controller/apidocs/GetMyGifticonOrderDetailApiDocs.java
@@ -1,0 +1,71 @@
+package com.personal.marketnote.reward.adapter.in.web.gifticon.controller.apidocs;
+
+import com.personal.marketnote.reward.adapter.in.web.gifticon.response.GetMyGifticonOrderDetailResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Operation(
+        summary = "내 기프티콘 상세 조회",
+        description = """
+                작성일자: 2026-04-06
+
+                작성자: 성효빈
+
+                ---
+
+                ## Description
+
+                사용자가 구매한 기프티콘의 상세 정보를 조회합니다.
+                ISSUED 상태인 경우 기프티쇼 API를 호출하여 최신 상태를 동기화합니다.
+                PIN 번호는 복호화되어 응답됩니다.
+                """,
+        parameters = {
+                @Parameter(name = "orderId", description = "주문 ID", example = "1", required = true)
+        },
+        security = {@SecurityRequirement(name = "bearer")},
+        responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "내 기프티콘 상세 조회 성공",
+                        content = @Content(
+                                schema = @Schema(implementation = GetMyGifticonOrderDetailResponse.class),
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 200,
+                                          "code": "SUC01",
+                                          "timestamp": "2026-04-06T12:00:00.000000",
+                                          "content": {
+                                            "orderId": 1,
+                                            "goodsName": "아메리카노",
+                                            "brandName": "스타벅스",
+                                            "brandImageUrl": "https://example.com/brand.jpg",
+                                            "productImageUrl": "https://example.com/goods.jpg",
+                                            "description": "스타벅스 아메리카노 Tall",
+                                            "cashPrice": 5000,
+                                            "couponImageUrl": "https://example.com/coupon.jpg",
+                                            "pinNo": "900343630367",
+                                            "expiryDate": "26.05.04까지 사용 가능",
+                                            "daysRemaining": 30,
+                                            "statusLabel": null,
+                                            "orderStatus": "ISSUED",
+                                            "createdAt": "2026-04-06T12:00:00"
+                                          },
+                                          "message": "내 기프티콘 상세 조회 성공"
+                                        }
+                                        """)
+                        )
+                )
+        }
+)
+public @interface GetMyGifticonOrderDetailApiDocs {
+}

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/gifticon/response/GetMyGifticonOrderDetailResponse.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/gifticon/response/GetMyGifticonOrderDetailResponse.java
@@ -1,0 +1,41 @@
+package com.personal.marketnote.reward.adapter.in.web.gifticon.response;
+
+import com.personal.marketnote.reward.port.in.result.gifticon.GetMyGifticonOrderDetailResult;
+
+import java.time.LocalDateTime;
+
+public record GetMyGifticonOrderDetailResponse(
+        Long orderId,
+        String goodsName,
+        String brandName,
+        String brandImageUrl,
+        String productImageUrl,
+        String description,
+        Long cashPrice,
+        String couponImageUrl,
+        String pinNo,
+        String expiryDate,
+        Integer daysRemaining,
+        String statusLabel,
+        String orderStatus,
+        LocalDateTime createdAt
+) {
+    public static GetMyGifticonOrderDetailResponse from(GetMyGifticonOrderDetailResult result) {
+        return new GetMyGifticonOrderDetailResponse(
+                result.orderId(),
+                result.goodsName(),
+                result.brandName(),
+                result.brandImageUrl(),
+                result.productImageUrl(),
+                result.description(),
+                result.cashPrice(),
+                result.couponImageUrl(),
+                result.pinNo(),
+                result.expiryDate(),
+                result.daysRemaining(),
+                result.statusLabel(),
+                result.orderStatus(),
+                result.createdAt()
+        );
+    }
+}

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/gifticon/GifticonOrderPersistenceAdapter.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/gifticon/GifticonOrderPersistenceAdapter.java
@@ -65,6 +65,12 @@ public class GifticonOrderPersistenceAdapter
     }
 
     @Override
+    public Optional<GifticonOrder> findByIdAndUserId(Long id, Long userId) {
+        return gifticonOrderJpaRepository.findByIdAndUserId(id, userId)
+                .map(GifticonOrderJpaEntity::toDomain);
+    }
+
+    @Override
     public long countByUserIdAndStatuses(Long userId, List<GifticonOrderStatus> statuses) {
         return gifticonOrderJpaRepository.countByUserIdAndOrderStatusIn(userId, statuses);
     }

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/gifticon/GifticonPinEncryptAdapter.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/gifticon/GifticonPinEncryptAdapter.java
@@ -1,7 +1,9 @@
 package com.personal.marketnote.reward.adapter.out.persistence.gifticon;
 
 import com.personal.marketnote.reward.configuration.GifticonPinProperties;
+import com.personal.marketnote.reward.domain.exception.GifticonPinDecryptionFailedException;
 import com.personal.marketnote.reward.domain.exception.GifticonPinEncryptionFailedException;
+import com.personal.marketnote.reward.port.out.gifticon.DecryptGifticonPinPort;
 import com.personal.marketnote.reward.port.out.gifticon.EncryptGifticonPinPort;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -11,11 +13,12 @@ import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
+import java.util.Arrays;
 import java.util.Base64;
 
 @Component
 @Slf4j
-public class GifticonPinEncryptAdapter implements EncryptGifticonPinPort {
+public class GifticonPinEncryptAdapter implements EncryptGifticonPinPort, DecryptGifticonPinPort {
 
     private final SecretKeySpec keySpec;
     private final SecureRandom secureRandom = new SecureRandom();
@@ -45,6 +48,25 @@ public class GifticonPinEncryptAdapter implements EncryptGifticonPinPort {
         } catch (Exception e) {
             log.error("PIN 암호화 실패: error={}", e.getMessage(), e);
             throw new GifticonPinEncryptionFailedException(e);
+        }
+    }
+
+    @Override
+    public String decrypt(String encryptedPin) {
+        try {
+            byte[] combined = Base64.getDecoder().decode(encryptedPin);
+            byte[] iv = Arrays.copyOfRange(combined, 0, 16);
+            byte[] encrypted = Arrays.copyOfRange(combined, 16, combined.length);
+
+            IvParameterSpec ivSpec = new IvParameterSpec(iv);
+            Cipher cipher = Cipher.getInstance("AES/CBC/PKCS5Padding");
+            cipher.init(Cipher.DECRYPT_MODE, keySpec, ivSpec);
+            byte[] decrypted = cipher.doFinal(encrypted);
+
+            return new String(decrypted, StandardCharsets.UTF_8);
+        } catch (Exception e) {
+            log.error("PIN 복호화 실패: error={}", e.getMessage(), e);
+            throw new GifticonPinDecryptionFailedException(e);
         }
     }
 }

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/gifticon/repository/GifticonOrderJpaRepository.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/gifticon/repository/GifticonOrderJpaRepository.java
@@ -43,4 +43,6 @@ public interface GifticonOrderJpaRepository extends JpaRepository<GifticonOrderJ
     );
 
     long countByUserIdAndOrderStatusIn(Long userId, List<GifticonOrderStatus> statuses);
+
+    Optional<GifticonOrderJpaEntity> findByIdAndUserId(Long id, Long userId);
 }

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/vendor/giftishow/GifticonCouponAdapter.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/vendor/giftishow/GifticonCouponAdapter.java
@@ -1,9 +1,11 @@
 package com.personal.marketnote.reward.adapter.out.vendor.giftishow;
 
 import com.personal.marketnote.reward.adapter.out.vendor.giftishow.dto.GiftishowApiResponse;
+import com.personal.marketnote.reward.adapter.out.vendor.giftishow.dto.GiftishowCouponDetailResponse;
 import com.personal.marketnote.reward.adapter.out.vendor.giftishow.dto.GiftishowCouponSendResponse;
 import com.personal.marketnote.reward.configuration.GiftishowApiProperties;
 import com.personal.marketnote.reward.port.out.gifticon.CancelGifticonSendFailPort;
+import com.personal.marketnote.reward.port.out.gifticon.QueryGifticonCouponStatusPort;
 import com.personal.marketnote.reward.port.out.gifticon.SendGifticonCouponPort;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -12,7 +14,7 @@ import org.springframework.stereotype.Component;
 @Component
 @RequiredArgsConstructor
 @Slf4j
-public class GifticonCouponAdapter implements SendGifticonCouponPort, CancelGifticonSendFailPort {
+public class GifticonCouponAdapter implements SendGifticonCouponPort, CancelGifticonSendFailPort, QueryGifticonCouponStatusPort {
 
     private final GiftishowApiClient giftishowApiClient;
     private final GiftishowApiProperties properties;
@@ -47,6 +49,38 @@ public class GifticonCouponAdapter implements SendGifticonCouponPort, CancelGift
         } catch (Exception e) {
             log.error("기프티쇼 쿠폰 발송 통신 오류: trId={}, error={}", trId, e.getMessage(), e);
             return SendCouponResult.builder()
+                    .success(false)
+                    .errorCode("COMM_ERROR")
+                    .errorMessage(e.getMessage())
+                    .build();
+        }
+    }
+
+    @Override
+    public CouponStatusResult queryStatus(String trId) {
+        try {
+            GiftishowApiResponse<GiftishowCouponDetailResponse> response = giftishowApiClient.getCouponDetail(trId);
+
+            if (!response.isSuccess()) {
+                log.error("기프티쇼 쿠폰 상세 조회 실패: trId={}, code={}, message={}",
+                        trId, response.code(), response.message());
+                return CouponStatusResult.builder()
+                        .success(false)
+                        .errorCode(response.code())
+                        .errorMessage(response.message())
+                        .build();
+            }
+
+            GiftishowCouponDetailResponse result = response.result();
+            return CouponStatusResult.builder()
+                    .success(true)
+                    .pinStatusCd(result.pinStatusCd())
+                    .validPrdEndDt(result.validPrdEndDt())
+                    .build();
+
+        } catch (Exception e) {
+            log.error("기프티쇼 쿠폰 상세 조회 통신 오류: trId={}, error={}", trId, e.getMessage(), e);
+            return CouponStatusResult.builder()
                     .success(false)
                     .errorCode("COMM_ERROR")
                     .errorMessage(e.getMessage())

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/command/gifticon/GetMyGifticonOrderDetailCommand.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/command/gifticon/GetMyGifticonOrderDetailCommand.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.reward.port.in.command.gifticon;
+
+public record GetMyGifticonOrderDetailCommand(
+        Long userId,
+        Long orderId
+) {
+}

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/result/gifticon/GetMyGifticonOrderDetailResult.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/result/gifticon/GetMyGifticonOrderDetailResult.java
@@ -1,0 +1,21 @@
+package com.personal.marketnote.reward.port.in.result.gifticon;
+
+import java.time.LocalDateTime;
+
+public record GetMyGifticonOrderDetailResult(
+        Long orderId,
+        String goodsName,
+        String brandName,
+        String brandImageUrl,
+        String productImageUrl,
+        String description,
+        Long cashPrice,
+        String couponImageUrl,
+        String pinNo,
+        String expiryDate,
+        Integer daysRemaining,
+        String statusLabel,
+        String orderStatus,
+        LocalDateTime createdAt
+) {
+}

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/usecase/gifticon/GetMyGifticonOrderDetailUseCase.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/usecase/gifticon/GetMyGifticonOrderDetailUseCase.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.reward.port.in.usecase.gifticon;
+
+import com.personal.marketnote.reward.port.in.command.gifticon.GetMyGifticonOrderDetailCommand;
+import com.personal.marketnote.reward.port.in.result.gifticon.GetMyGifticonOrderDetailResult;
+
+public interface GetMyGifticonOrderDetailUseCase {
+    GetMyGifticonOrderDetailResult getMyGifticonOrderDetail(GetMyGifticonOrderDetailCommand command);
+}

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/out/gifticon/DecryptGifticonPinPort.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/out/gifticon/DecryptGifticonPinPort.java
@@ -1,0 +1,5 @@
+package com.personal.marketnote.reward.port.out.gifticon;
+
+public interface DecryptGifticonPinPort {
+    String decrypt(String encryptedPin);
+}

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/out/gifticon/FindGifticonOrderPort.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/out/gifticon/FindGifticonOrderPort.java
@@ -16,4 +16,6 @@ public interface FindGifticonOrderPort {
                                                 GifticonOrderSortType sortType, Long cursor, int pageSize);
 
     long countByUserIdAndStatuses(Long userId, List<GifticonOrderStatus> statuses);
+
+    Optional<GifticonOrder> findByIdAndUserId(Long id, Long userId);
 }

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/out/gifticon/QueryGifticonCouponStatusPort.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/out/gifticon/QueryGifticonCouponStatusPort.java
@@ -1,0 +1,17 @@
+package com.personal.marketnote.reward.port.out.gifticon;
+
+import lombok.Builder;
+
+public interface QueryGifticonCouponStatusPort {
+    CouponStatusResult queryStatus(String trId);
+
+    @Builder
+    record CouponStatusResult(
+            boolean success,
+            String pinStatusCd,
+            String validPrdEndDt,
+            String errorCode,
+            String errorMessage
+    ) {
+    }
+}

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/service/gifticon/GetMyGifticonOrderDetailService.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/service/gifticon/GetMyGifticonOrderDetailService.java
@@ -1,0 +1,119 @@
+package com.personal.marketnote.reward.service.gifticon;
+
+import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.reward.domain.exception.GifticonOrderNotFoundException;
+import com.personal.marketnote.reward.domain.gifticon.GifticonGoods;
+import com.personal.marketnote.reward.domain.gifticon.GifticonOrder;
+import com.personal.marketnote.reward.domain.gifticon.GifticonOrderStatus;
+import com.personal.marketnote.reward.port.in.command.gifticon.GetMyGifticonOrderDetailCommand;
+import com.personal.marketnote.reward.port.in.result.gifticon.GetMyGifticonOrderDetailResult;
+import com.personal.marketnote.reward.port.in.usecase.gifticon.GetMyGifticonOrderDetailUseCase;
+import com.personal.marketnote.reward.port.out.gifticon.*;
+import com.personal.marketnote.reward.port.out.gifticon.QueryGifticonCouponStatusPort.CouponStatusResult;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.time.LocalDate;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@UseCase
+@RequiredArgsConstructor
+@Slf4j
+public class GetMyGifticonOrderDetailService implements GetMyGifticonOrderDetailUseCase {
+
+    private final FindGifticonOrderPort findGifticonOrderPort;
+    private final FindGifticonGoodsPort findGifticonGoodsPort;
+    private final QueryGifticonCouponStatusPort queryGifticonCouponStatusPort;
+    private final UpdateGifticonOrderPort updateGifticonOrderPort;
+    private final DecryptGifticonPinPort decryptGifticonPinPort;
+    private final Clock clock;
+
+    @Override
+    public GetMyGifticonOrderDetailResult getMyGifticonOrderDetail(GetMyGifticonOrderDetailCommand command) {
+        GifticonOrder order = findOrder(command.orderId(), command.userId());
+
+        syncStatusIfIssued(order);
+
+        return buildDetailResult(order);
+    }
+
+    @Transactional(isolation = READ_COMMITTED, readOnly = true)
+    public GifticonOrder findOrder(Long orderId, Long userId) {
+        return findGifticonOrderPort.findByIdAndUserId(orderId, userId)
+                .orElseThrow(() -> new GifticonOrderNotFoundException(orderId));
+    }
+
+    private void syncStatusIfIssued(GifticonOrder order) {
+        if (!order.isIssued()) {
+            return;
+        }
+        CouponStatusResult statusResult = queryCouponStatus(order.getTrId());
+        if (FormatValidator.hasNoValue(statusResult)) {
+            return;
+        }
+        GifticonOrderStatus newStatus = GifticonOrderStatus.fromPinStatus(statusResult.pinStatusCd());
+        boolean changed = order.syncStatus(newStatus);
+        if (!changed) {
+            return;
+        }
+        persistStatusChange(order, newStatus);
+    }
+
+    private CouponStatusResult queryCouponStatus(String trId) {
+        try {
+            CouponStatusResult statusResult = queryGifticonCouponStatusPort.queryStatus(trId);
+            if (!statusResult.success()) {
+                log.warn("기프티쇼 쿠폰 상태 조회 실패: trId={}, errorCode={}", trId, statusResult.errorCode());
+                return null;
+            }
+            return statusResult;
+        } catch (Exception e) {
+            log.warn("기프티쇼 쿠폰 상태 동기화 실패 (fail-open): trId={}, error={}", trId, e.getMessage());
+            return null;
+        }
+    }
+
+    @Transactional(isolation = READ_COMMITTED)
+    public void persistStatusChange(GifticonOrder order, GifticonOrderStatus newStatus) {
+        updateGifticonOrderPort.update(order);
+        log.info("기프티콘 주문 상태 동기화: orderId={}, newStatus={}", order.getId(), newStatus);
+    }
+
+    @Transactional(isolation = READ_COMMITTED, readOnly = true)
+    public GetMyGifticonOrderDetailResult buildDetailResult(GifticonOrder order) {
+        GifticonGoods goods = findGifticonGoodsPort.findByGoodsCode(order.getGoodsCode()).orElse(null);
+        String decryptedPin = decryptPin(order.getPinNo());
+        LocalDate now = LocalDate.now(clock);
+
+        String description = FormatValidator.hasValue(goods) ? goods.getDescription() : null;
+        String brandImageUrl = FormatValidator.hasValue(goods) ? goods.getBrandImageUrl() : null;
+
+        return new GetMyGifticonOrderDetailResult(
+                order.getId(),
+                order.getGoodsName(),
+                order.getBrandName(),
+                brandImageUrl,
+                order.getProductImageUrl(),
+                description,
+                order.getCashPrice(),
+                order.getCouponImageUrl(),
+                decryptedPin,
+                order.formatExpiryDate(),
+                order.calculateDaysRemaining(now),
+                order.resolveStatusLabel(),
+                order.getOrderStatus().name(),
+                order.getCreatedAt()
+        );
+    }
+
+    private String decryptPin(String encryptedPin) {
+        if (FormatValidator.hasNoValue(encryptedPin)) {
+            return null;
+        }
+        return decryptGifticonPinPort.decrypt(encryptedPin);
+    }
+}

--- a/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/exception/GifticonOrderNotFoundException.java
+++ b/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/exception/GifticonOrderNotFoundException.java
@@ -1,9 +1,14 @@
 package com.personal.marketnote.reward.domain.exception;
 
 public class GifticonOrderNotFoundException extends RuntimeException {
-    private static final String MESSAGE = "기프티콘 주문을 찾을 수 없습니다. trId=%s";
+    private static final String MESSAGE_BY_TR_ID = "기프티콘 주문을 찾을 수 없습니다. trId=%s";
+    private static final String MESSAGE_BY_ORDER_ID = "기프티콘 주문을 찾을 수 없습니다. orderId=%d";
 
     public GifticonOrderNotFoundException(String trId) {
-        super(String.format(MESSAGE, trId));
+        super(String.format(MESSAGE_BY_TR_ID, trId));
+    }
+
+    public GifticonOrderNotFoundException(Long orderId) {
+        super(String.format(MESSAGE_BY_ORDER_ID, orderId));
     }
 }

--- a/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/exception/GifticonPinDecryptionFailedException.java
+++ b/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/exception/GifticonPinDecryptionFailedException.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.reward.domain.exception;
+
+public class GifticonPinDecryptionFailedException extends RuntimeException {
+    private static final String MESSAGE = "기프티콘 PIN 복호화에 실패했습니다.";
+
+    public GifticonPinDecryptionFailedException(Throwable cause) {
+        super(MESSAGE, cause);
+    }
+}

--- a/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/gifticon/GifticonOrder.java
+++ b/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/gifticon/GifticonOrder.java
@@ -90,8 +90,12 @@ public class GifticonOrder {
         throw new InvalidGifticonOrderStatusTransitionException(this.orderStatus);
     }
 
-    public void syncStatus(GifticonOrderStatus newStatus) {
+    public boolean syncStatus(GifticonOrderStatus newStatus) {
+        if (this.orderStatus == newStatus) {
+            return false;
+        }
         this.orderStatus = newStatus;
+        return true;
     }
 
     public boolean isPending() {
@@ -112,6 +116,10 @@ public class GifticonOrder {
 
     public boolean isTerminal() {
         return this.orderStatus.isTerminal();
+    }
+
+    public boolean hasStatus(GifticonOrderStatus status) {
+        return this.orderStatus == status;
     }
 
     public Integer calculateDaysRemaining(LocalDate now) {


### PR DESCRIPTION
## partially addresses #1653
## resolves #1663

## Task
- [x] DecryptGifticonPinPort/Adapter 추가 (AES-256 CBC 복호화)
- [x] QueryGifticonCouponStatusPort/Adapter 추가 (기프티쇼 0201 쿠폰 상세 API)
- [x] GetMyGifticonOrderDetailService 구현 (on-demand 상태 동기화, fail-open)
- [x] 트랜잭션 외부 API 분리 (findOrder/persistStatusChange/buildDetailResult 개별 TX)
- [x] GifticonOrder.syncStatus() 동일 상태 스킵 guard 추가 (boolean 반환)
- [x] GifticonOrder.hasStatus() 술어 메서드 추가
- [x] GifticonOrderNotFoundException orderId 생성자 오버로딩
- [x] GET /api/v1/gifticons/orders/me/{orderId} 엔드포인트 추가