### PR TITLE
[#1653][#1665] feat: 기프티콘 쿠폰 상태 동기화 배치 기능 추가

### DIFF
--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/scheduler/GifticonCouponSyncScheduler.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/scheduler/GifticonCouponSyncScheduler.java
@@ -1,0 +1,29 @@
+package com.personal.marketnote.reward.adapter.in.scheduler;
+
+import com.personal.marketnote.reward.port.in.usecase.gifticon.SyncGifticonCouponStatusUseCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(name = "gifticon.coupon-sync.scheduler.enabled", havingValue = "true", matchIfMissing = false)
+public class GifticonCouponSyncScheduler {
+
+    private final SyncGifticonCouponStatusUseCase syncGifticonCouponStatusUseCase;
+
+    @Scheduled(cron = "${gifticon.coupon-sync.scheduler.cron:0 0 4 * * *}", zone = "Asia/Seoul")
+    public void syncGifticonCouponStatuses() {
+        log.info("기프티콘 쿠폰 상태 동기화 스케줄러 실행 시작");
+
+        try {
+            syncGifticonCouponStatusUseCase.syncCouponStatuses();
+            log.info("기프티콘 쿠폰 상태 동기화 스케줄러 실행 완료");
+        } catch (Exception e) {
+            log.error("기프티콘 쿠폰 상태 동기화 스케줄러 실행 실패", e);
+        }
+    }
+}

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/gifticon/GifticonOrderPersistenceAdapter.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/gifticon/GifticonOrderPersistenceAdapter.java
@@ -85,6 +85,14 @@ public class GifticonOrderPersistenceAdapter
                 .toList();
     }
 
+    @Override
+    public List<GifticonOrder> findAllByOrderStatus(GifticonOrderStatus orderStatus) {
+        return gifticonOrderJpaRepository.findAllByOrderStatus(orderStatus)
+                .stream()
+                .map(GifticonOrderJpaEntity::toDomain)
+                .toList();
+    }
+
     private List<GifticonOrder> findByExpirySoonest(Long userId, List<GifticonOrderStatus> statuses,
                                                    Long cursor, int pageSize) {
         int offset = (cursor <= 0) ? 0 : (int) Math.min(cursor, 10_000);

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/gifticon/repository/GifticonOrderJpaRepository.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/gifticon/repository/GifticonOrderJpaRepository.java
@@ -45,4 +45,6 @@ public interface GifticonOrderJpaRepository extends JpaRepository<GifticonOrderJ
     long countByUserIdAndOrderStatusIn(Long userId, List<GifticonOrderStatus> statuses);
 
     Optional<GifticonOrderJpaEntity> findByIdAndUserId(Long id, Long userId);
+
+    List<GifticonOrderJpaEntity> findAllByOrderStatus(GifticonOrderStatus orderStatus);
 }

--- a/reward-service/reward-adapters/src/main/resources/application.yml
+++ b/reward-service/reward-adapters/src/main/resources/application.yml
@@ -116,6 +116,10 @@ gifticon:
     scheduler:
       enabled: ${GIFTICON_SYNC_SCHEDULER_ENABLED:false}
       cron: ${GIFTICON_SYNC_SCHEDULER_CRON:0 0 3 * * MON,WED,FRI}
+  coupon-sync:
+    scheduler:
+      enabled: ${GIFTICON_COUPON_SYNC_SCHEDULER_ENABLED:false}
+      cron: ${GIFTICON_COUPON_SYNC_SCHEDULER_CRON:0 0 4 * * *}
 
 logging:
   config: classpath:logback-spring.xml

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/usecase/gifticon/SyncGifticonCouponStatusUseCase.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/usecase/gifticon/SyncGifticonCouponStatusUseCase.java
@@ -1,0 +1,5 @@
+package com.personal.marketnote.reward.port.in.usecase.gifticon;
+
+public interface SyncGifticonCouponStatusUseCase {
+    void syncCouponStatuses();
+}

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/out/gifticon/FindGifticonOrderPort.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/out/gifticon/FindGifticonOrderPort.java
@@ -18,4 +18,6 @@ public interface FindGifticonOrderPort {
     long countByUserIdAndStatuses(Long userId, List<GifticonOrderStatus> statuses);
 
     Optional<GifticonOrder> findByIdAndUserId(Long id, Long userId);
+
+    List<GifticonOrder> findAllByOrderStatus(GifticonOrderStatus orderStatus);
 }

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/service/gifticon/SyncGifticonCouponStatusService.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/service/gifticon/SyncGifticonCouponStatusService.java
@@ -1,0 +1,89 @@
+package com.personal.marketnote.reward.service.gifticon;
+
+import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.reward.domain.gifticon.GifticonOrder;
+import com.personal.marketnote.reward.domain.gifticon.GifticonOrderStatus;
+import com.personal.marketnote.reward.port.in.usecase.gifticon.SyncGifticonCouponStatusUseCase;
+import com.personal.marketnote.reward.port.out.gifticon.FindGifticonOrderPort;
+import com.personal.marketnote.reward.port.out.gifticon.QueryGifticonCouponStatusPort;
+import com.personal.marketnote.reward.port.out.gifticon.QueryGifticonCouponStatusPort.CouponStatusResult;
+import com.personal.marketnote.reward.port.out.gifticon.UpdateGifticonOrderPort;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.util.List;
+
+@Slf4j
+@UseCase
+@RequiredArgsConstructor
+public class SyncGifticonCouponStatusService implements SyncGifticonCouponStatusUseCase {
+
+    private final FindGifticonOrderPort findGifticonOrderPort;
+    private final QueryGifticonCouponStatusPort queryGifticonCouponStatusPort;
+    private final UpdateGifticonOrderPort updateGifticonOrderPort;
+    private final TransactionTemplate transactionTemplate;
+
+    @Override
+    public void syncCouponStatuses() {
+        List<GifticonOrder> issuedOrders = findGifticonOrderPort.findAllByOrderStatus(GifticonOrderStatus.ISSUED);
+        log.info("쿠폰 상태 동기화 대상: {}건", issuedOrders.size());
+
+        int synced = 0;
+        int skipped = 0;
+        int failed = 0;
+
+        for (GifticonOrder order : issuedOrders) {
+            try {
+                SyncResult result = syncSingleCoupon(order);
+                if (result == SyncResult.SYNCED) {
+                    synced++;
+                    continue;
+                }
+                skipped++;
+            } catch (Exception e) {
+                log.error("쿠폰 상태 동기화 실패: trId={}", order.getTrId(), e);
+                failed++;
+            }
+        }
+
+        log.info("쿠폰 상태 동기화 완료: total={}, synced={}, skipped={}, failed={}",
+                issuedOrders.size(), synced, skipped, failed);
+    }
+
+    private SyncResult syncSingleCoupon(GifticonOrder order) {
+        CouponStatusResult statusResult = queryGifticonCouponStatusPort.queryStatus(order.getTrId());
+
+        if (!statusResult.success()) {
+            log.warn("쿠폰 상태 조회 실패: trId={}, errorCode={}, errorMessage={}",
+                    order.getTrId(), statusResult.errorCode(), statusResult.errorMessage());
+            return SyncResult.SKIPPED;
+        }
+
+        String pinStatusCd = statusResult.pinStatusCd();
+
+        if (!GifticonOrderStatus.hasPinStatusMapping(pinStatusCd)) {
+            log.info("매핑되지 않는 핀상태: trId={}, pinStatusCd={}", order.getTrId(), pinStatusCd);
+            return SyncResult.SKIPPED;
+        }
+
+        GifticonOrderStatus newStatus = GifticonOrderStatus.fromPinStatus(pinStatusCd);
+        boolean changed = order.syncStatus(newStatus);
+
+        if (!changed) {
+            return SyncResult.SKIPPED;
+        }
+
+        transactionTemplate.execute(status -> {
+            updateGifticonOrderPort.update(order);
+            return null;
+        });
+
+        log.info("쿠폰 상태 동기화 성공: trId={}, newStatus={}", order.getTrId(), newStatus);
+        return SyncResult.SYNCED;
+    }
+
+    private enum SyncResult {
+        SYNCED, SKIPPED
+    }
+}

--- a/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/gifticon/GifticonOrderStatus.java
+++ b/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/gifticon/GifticonOrderStatus.java
@@ -54,6 +54,10 @@ public enum GifticonOrderStatus {
         return this == USED || this == EXPIRED || this == CANCELLED;
     }
 
+    public static boolean hasPinStatusMapping(String pinStatusCd) {
+        return PIN_STATUS_MAP.containsKey(pinStatusCd);
+    }
+
     public static GifticonOrderStatus fromPinStatus(String pinStatus) {
         return PIN_STATUS_MAP.getOrDefault(pinStatus, CANCELLED);
     }


### PR DESCRIPTION
## partially addresses #1653
## resolves #1665

## Task
- [x] GifticonOrderStatus에 hasPinStatusMapping() 정적 메서드 추가
- [x] FindGifticonOrderPort에 findAllByOrderStatus() 메서드 추가
- [x] GifticonOrderJpaRepository에 findAllByOrderStatus() 쿼리 메서드 추가
- [x] GifticonOrderPersistenceAdapter에 findAllByOrderStatus() 구현 추가
- [x] SyncGifticonCouponStatusUseCase 인터페이스 생성
- [x] SyncGifticonCouponStatusService 구현 (핀상태 24종→4상태 매핑, 개별 try-catch 격리, TransactionTemplate 개별 TX)
- [x] GifticonCouponSyncScheduler 생성 (매일 새벽 4시, @ConditionalOnProperty)
- [x] application.yml에 gifticon.coupon-sync 스케줄러 설정 추가