### PR TITLE
[#387][#1854] test: 출석 정책 삭제 기능 자동화 테스트 추가

### DIFF
--- a/reward-service/reward-application/src/test/java/com/personal/marketnote/reward/service/attendance/DeleteAttendancePolicyUseCaseTest.java
+++ b/reward-service/reward-application/src/test/java/com/personal/marketnote/reward/service/attendance/DeleteAttendancePolicyUseCaseTest.java
@@ -1,0 +1,72 @@
+package com.personal.marketnote.reward.service.attendance;
+
+import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.reward.domain.attendance.AttendancePolicy;
+import com.personal.marketnote.reward.domain.attendance.AttendancePolicySnapshotState;
+import com.personal.marketnote.reward.domain.attendance.AttendanceRewardType;
+import com.personal.marketnote.reward.port.out.attendance.FindAttendancePolicyPort;
+import com.personal.marketnote.reward.port.out.attendance.UpdateAttendancePolicyPort;
+import jakarta.persistence.EntityNotFoundException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("DeleteAttendancePolicyUseCase 테스트")
+class DeleteAttendancePolicyUseCaseTest {
+
+    @InjectMocks
+    private DeleteAttendancePolicyService deleteAttendancePolicyService;
+
+    @Mock
+    private FindAttendancePolicyPort findAttendancePolicyPort;
+
+    @Mock
+    private UpdateAttendancePolicyPort updateAttendancePolicyPort;
+
+    @Test
+    @DisplayName("출석 정책을 삭제하면 상태를 INACTIVE로 변경하고 업데이트한다")
+    void shouldDeletePolicyBySettingStatusToInactive() {
+        // given
+        Short policyId = (short) 1;
+        AttendancePolicy policy = AttendancePolicy.from(
+                AttendancePolicySnapshotState.builder()
+                        .id(policyId)
+                        .continuousPeriod((short) 3)
+                        .rewardType(AttendanceRewardType.POINT)
+                        .rewardQuantity(100L)
+                        .status(EntityStatus.ACTIVE)
+                        .build()
+        );
+
+        when(findAttendancePolicyPort.findByIdForUpdate(policyId)).thenReturn(Optional.of(policy));
+
+        // when
+        deleteAttendancePolicyService.delete(policyId);
+
+        // then
+        verify(findAttendancePolicyPort).findByIdForUpdate(policyId);
+        verify(updateAttendancePolicyPort).update(policy);
+    }
+
+    @Test
+    @DisplayName("출석 정책이 존재하지 않으면 EntityNotFoundException이 발생한다")
+    void shouldThrowWhenPolicyNotFound() {
+        // given
+        Short policyId = (short) 999;
+        when(findAttendancePolicyPort.findByIdForUpdate(policyId)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> deleteAttendancePolicyService.delete(policyId))
+                .isInstanceOf(EntityNotFoundException.class);
+    }
+}


### PR DESCRIPTION
## partially addresses #387
## resolves #1854

## Test Case
- [x] 재고가 부족하면 InsufficientQuantityException이 발생한다
- [x] 재고가 0이고 주문 수량이 1 이상이면 InsufficientQuantityException이 발생한다
- [x] 복수 상품 중 하나라도 재고가 부족하면 InsufficientQuantityException이 발생한다
- [x] DeleteAttendancePolicyUseCase 테스트
- [x] 출석 정책을 삭제하면 상태를 INACTIVE로 변경하고 업데이트한다
- [x] 출석 정책이 존재하지 않으면 EntityNotFoundException이 발생한다