### PR TITLE
[#475][#1840] test: 풀필먼트 배송 목록 조회 기능 자동화 테스트 추가 (#2041)

### DIFF
--- a/fulfillment-service/fulfillment-application/src/test/java/com/personal/marketnote/fulfillment/service/vendor/GetFulfillmentDeliveriesUseCaseTest.java
+++ b/fulfillment-service/fulfillment-application/src/test/java/com/personal/marketnote/fulfillment/service/vendor/GetFulfillmentDeliveriesUseCaseTest.java
@@ -1,0 +1,46 @@
+package com.personal.marketnote.fulfillment.service.vendor;
+
+import com.personal.marketnote.fulfillment.port.in.command.vendor.GetFulfillmentDeliveriesCommand;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.GetFulfillmentDeliveriesResult;
+import com.personal.marketnote.fulfillment.port.out.vendor.GetFulfillmentDeliveriesPort;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GetFulfillmentDeliveriesService 테스트")
+class GetFulfillmentDeliveriesUseCaseTest {
+    @InjectMocks
+    private GetFulfillmentDeliveriesService getFulfillmentDeliveriesService;
+
+    @Mock
+    private GetFulfillmentDeliveriesPort getFulfillmentDeliveriesPort;
+
+    @Test
+    @DisplayName("출고 목록 조회 커맨드를 전달하면 포트를 통해 출고 목록을 반환한다")
+    void shouldReturnDeliveriesFromPort() {
+        // given
+        GetFulfillmentDeliveriesCommand command = GetFulfillmentDeliveriesCommand.of(
+                "CUST001", "token", "20260401", "20260402", "01", "01"
+        );
+        GetFulfillmentDeliveriesResult expectedResult = GetFulfillmentDeliveriesResult.of(0, List.of());
+        when(getFulfillmentDeliveriesPort.getDeliveries(any())).thenReturn(expectedResult);
+
+        // when
+        GetFulfillmentDeliveriesResult result = getFulfillmentDeliveriesService.getDeliveries(command);
+
+        // then
+        assertThat(result).isEqualTo(expectedResult);
+        verify(getFulfillmentDeliveriesPort).getDeliveries(any());
+    }
+}


### PR DESCRIPTION
## partially addresses #475
## resolves #1840

## Test Case
- [x] 재고가 부족하면 InsufficientQuantityException이 발생한다
- [x] 재고가 0이고 주문 수량이 1 이상이면 InsufficientQuantityException이 발생한다
- [x] 복수 상품 중 하나라도 재고가 부족하면 InsufficientQuantityException이 발생한다
- [x] GetFulfillmentDeliveriesService 테스트
- [x] 출고 목록 조회 커맨드를 전달하면 포트를 통해 출고 목록을 반환한다