### PR TITLE
[#475][#1842] test: 풀필먼트 직접 반품 배송 등록 기능 자동화 테스트 추가

### DIFF
--- a/fulfillment-service/fulfillment-application/src/test/java/com/personal/marketnote/fulfillment/service/vendor/RegisterFulfillmentDirectReturnDeliveryUseCaseTest.java
+++ b/fulfillment-service/fulfillment-application/src/test/java/com/personal/marketnote/fulfillment/service/vendor/RegisterFulfillmentDirectReturnDeliveryUseCaseTest.java
@@ -1,0 +1,56 @@
+package com.personal.marketnote.fulfillment.service.vendor;
+
+import com.personal.marketnote.fulfillment.port.in.command.vendor.RegisterFulfillmentDirectReturnDeliveryCommand;
+import com.personal.marketnote.fulfillment.port.in.command.vendor.RegisterFulfillmentDirectReturnDeliveryItemCommand;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.RegisterFulfillmentDeliveryResult;
+import com.personal.marketnote.fulfillment.port.out.vendor.RegisterFulfillmentDirectReturnDeliveryPort;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("RegisterFulfillmentDirectReturnDeliveryService 테스트")
+class RegisterFulfillmentDirectReturnDeliveryUseCaseTest {
+    @InjectMocks
+    private RegisterFulfillmentDirectReturnDeliveryService registerFulfillmentDirectReturnDeliveryService;
+
+    @Mock
+    private RegisterFulfillmentDirectReturnDeliveryPort registerFulfillmentDirectReturnDeliveryPort;
+
+    @Test
+    @DisplayName("직접 반품 등록 커맨드를 전달하면 포트를 통해 등록 결과를 반환한다")
+    void shouldReturnRegisterDirectReturnDeliveryResultFromPort() {
+        // given
+        RegisterFulfillmentDirectReturnDeliveryItemCommand itemCommand = RegisterFulfillmentDirectReturnDeliveryItemCommand.builder()
+                .ordDt("20260402")
+                .orgParcelCd("PARCEL001")
+                .orgInvoiceNo("INV001")
+                .inWay("01")
+                .custNm("테스트고객")
+                .rtnGubun("01")
+                .rtnReason("단순변심")
+                .build();
+        RegisterFulfillmentDirectReturnDeliveryCommand command = RegisterFulfillmentDirectReturnDeliveryCommand.of(
+                "CUST001", "token", List.of(itemCommand)
+        );
+        RegisterFulfillmentDeliveryResult expectedResult = RegisterFulfillmentDeliveryResult.of(0, List.of());
+        when(registerFulfillmentDirectReturnDeliveryPort.registerDirectReturnDelivery(any())).thenReturn(expectedResult);
+
+        // when
+        RegisterFulfillmentDeliveryResult result = registerFulfillmentDirectReturnDeliveryService.registerDirectReturnDelivery(command);
+
+        // then
+        assertThat(result).isEqualTo(expectedResult);
+        verify(registerFulfillmentDirectReturnDeliveryPort).registerDirectReturnDelivery(any());
+    }
+}


### PR DESCRIPTION
## partially addresses #475
## resolves #1842

## Task
- [x] 재고가 부족하면 InsufficientQuantityException이 발생한다
- [x] 재고가 0이고 주문 수량이 1 이상이면 InsufficientQuantityException이 발생한다
- [x] 복수 상품 중 하나라도 재고가 부족하면 InsufficientQuantityException이 발생한다
- [x] RegisterFulfillmentDirectReturnDeliveryService 테스트
- [x] 직접 반품 등록 커맨드를 전달하면 포트를 통해 등록 결과를 반환한다