### PR TITLE
[#475][#1847] test: 풀필먼트 쇼핑몰 목록 조회 기능 자동화 테스트 추가

### DIFF
--- a/fulfillment-service/fulfillment-application/src/test/java/com/personal/marketnote/fulfillment/service/vendor/GetFulfillmentShopsUseCaseTest.java
+++ b/fulfillment-service/fulfillment-application/src/test/java/com/personal/marketnote/fulfillment/service/vendor/GetFulfillmentShopsUseCaseTest.java
@@ -1,0 +1,44 @@
+package com.personal.marketnote.fulfillment.service.vendor;
+
+import com.personal.marketnote.fulfillment.port.in.command.vendor.GetFulfillmentShopsCommand;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.GetFulfillmentShopsResult;
+import com.personal.marketnote.fulfillment.port.out.vendor.GetFulfillmentShopsPort;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GetFulfillmentShopsService 테스트")
+class GetFulfillmentShopsUseCaseTest {
+    @InjectMocks
+    private GetFulfillmentShopsService getFulfillmentShopsService;
+
+    @Mock
+    private GetFulfillmentShopsPort getFulfillmentShopsPort;
+
+    @Test
+    @DisplayName("출고처 목록 조회 커맨드를 전달하면 포트를 통해 출고처 목록을 반환한다")
+    void shouldReturnShopsFromPort() {
+        // given
+        GetFulfillmentShopsCommand command = GetFulfillmentShopsCommand.of("CUST001", "token");
+        GetFulfillmentShopsResult expectedResult = GetFulfillmentShopsResult.of(0, List.of());
+        when(getFulfillmentShopsPort.getShops(any())).thenReturn(expectedResult);
+
+        // when
+        GetFulfillmentShopsResult result = getFulfillmentShopsService.getShops(command);
+
+        // then
+        assertThat(result).isEqualTo(expectedResult);
+        verify(getFulfillmentShopsPort).getShops(any());
+    }
+}


### PR DESCRIPTION
## partially addresses #475
## resolves #1847

## Test Case
- [x] 재고가 부족하면 InsufficientQuantityException이 발생한다
- [x] 재고가 0이고 주문 수량이 1 이상이면 InsufficientQuantityException이 발생한다
- [x] 복수 상품 중 하나라도 재고가 부족하면 InsufficientQuantityException이 발생한다
- [x] GetFulfillmentShopsService 테스트
- [x] 출고처 목록 조회 커맨드를 전달하면 포트를 통해 출고처 목록을 반환한다