### PR TITLE
[#475][#1862] test: 풀필먼트 배송 상태 목록 조회 기능 자동화 테스트 추가

### DIFF
--- a/fulfillment-service/fulfillment-application/src/test/java/com/personal/marketnote/fulfillment/service/vendor/GetFulfillmentDeliveryStatusesUseCaseTest.java
+++ b/fulfillment-service/fulfillment-application/src/test/java/com/personal/marketnote/fulfillment/service/vendor/GetFulfillmentDeliveryStatusesUseCaseTest.java
@@ -1,0 +1,46 @@
+package com.personal.marketnote.fulfillment.service.vendor;
+
+import com.personal.marketnote.fulfillment.port.in.command.vendor.GetFulfillmentDeliveryStatusesCommand;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.GetFulfillmentDeliveryStatusesResult;
+import com.personal.marketnote.fulfillment.port.out.vendor.GetFulfillmentDeliveryStatusesPort;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GetFulfillmentDeliveryStatusesService 테스트")
+class GetFulfillmentDeliveryStatusesUseCaseTest {
+    @InjectMocks
+    private GetFulfillmentDeliveryStatusesService getFulfillmentDeliveryStatusesService;
+
+    @Mock
+    private GetFulfillmentDeliveryStatusesPort getFulfillmentDeliveryStatusesPort;
+
+    @Test
+    @DisplayName("출고 상태 목록 조회 커맨드를 전달하면 포트를 통해 상태 목록을 반환한다")
+    void shouldReturnDeliveryStatusesResultFromPort() {
+        // given
+        GetFulfillmentDeliveryStatusesCommand command = GetFulfillmentDeliveryStatusesCommand.of(
+                "CUST001", "token", "2026-01-01", "2026-01-31", "OUT_DIV"
+        );
+        GetFulfillmentDeliveryStatusesResult expectedResult = GetFulfillmentDeliveryStatusesResult.of(0, List.of());
+        when(getFulfillmentDeliveryStatusesPort.getDeliveryStatuses(any())).thenReturn(expectedResult);
+
+        // when
+        GetFulfillmentDeliveryStatusesResult result = getFulfillmentDeliveryStatusesService.getDeliveryStatuses(command);
+
+        // then
+        assertThat(result).isEqualTo(expectedResult);
+        verify(getFulfillmentDeliveryStatusesPort).getDeliveryStatuses(any());
+    }
+}


### PR DESCRIPTION
## partially addresses #475
## resolves #1862

## Test Case
- [x] 재고가 부족하면 InsufficientQuantityException이 발생한다
- [x] 재고가 0이고 주문 수량이 1 이상이면 InsufficientQuantityException이 발생한다
- [x] 복수 상품 중 하나라도 재고가 부족하면 InsufficientQuantityException이 발생한다
- [x] GetFulfillmentDeliveryStatusesService 테스트
- [x] 출고 상태 목록 조회 커맨드를 전달하면 포트를 통해 상태 목록을 반환한다