### PR TITLE
[#475][#1863] test: 풀필먼트 배송 ICS 등록 기능 자동화 테스트 추가

### DIFF
--- a/fulfillment-service/fulfillment-application/src/test/java/com/personal/marketnote/fulfillment/service/vendor/RegisterFulfillmentDeliveryIcsUseCaseTest.java
+++ b/fulfillment-service/fulfillment-application/src/test/java/com/personal/marketnote/fulfillment/service/vendor/RegisterFulfillmentDeliveryIcsUseCaseTest.java
@@ -1,0 +1,56 @@
+package com.personal.marketnote.fulfillment.service.vendor;
+
+import com.personal.marketnote.fulfillment.port.in.command.vendor.RegisterFulfillmentDeliveryGoodsCommand;
+import com.personal.marketnote.fulfillment.port.in.command.vendor.RegisterFulfillmentDeliveryIcsCommand;
+import com.personal.marketnote.fulfillment.port.in.command.vendor.RegisterFulfillmentDeliveryIcsItemCommand;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.RegisterFulfillmentDeliveryResult;
+import com.personal.marketnote.fulfillment.port.out.vendor.RegisterFulfillmentDeliveryIcsPort;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("RegisterFulfillmentDeliveryIcsService 테스트")
+class RegisterFulfillmentDeliveryIcsUseCaseTest {
+    @InjectMocks
+    private RegisterFulfillmentDeliveryIcsService registerFulfillmentDeliveryIcsService;
+
+    @Mock
+    private RegisterFulfillmentDeliveryIcsPort registerFulfillmentDeliveryIcsPort;
+
+    @Test
+    @DisplayName("출고 ICS 등록 커맨드를 전달하면 포트를 통해 등록 결과를 반환한다")
+    void shouldReturnRegisterDeliveryIcsResultFromPort() {
+        // given
+        RegisterFulfillmentDeliveryIcsItemCommand itemCommand = RegisterFulfillmentDeliveryIcsItemCommand.builder()
+                .ordDt("20260402")
+                .ordNo("ORD001")
+                .platform("PLATFORM01")
+                .logiCenter("CENTER01")
+                .invoiceNo("INV001")
+                .godCds(List.of(RegisterFulfillmentDeliveryGoodsCommand.of("GOD001", "20260430", 1)))
+                .build();
+        RegisterFulfillmentDeliveryIcsCommand command = RegisterFulfillmentDeliveryIcsCommand.of(
+                "CUST001", "token", List.of(itemCommand)
+        );
+        RegisterFulfillmentDeliveryResult expectedResult = RegisterFulfillmentDeliveryResult.of(0, List.of());
+        when(registerFulfillmentDeliveryIcsPort.registerDeliveryIcs(any())).thenReturn(expectedResult);
+
+        // when
+        RegisterFulfillmentDeliveryResult result = registerFulfillmentDeliveryIcsService.registerDeliveryIcs(command);
+
+        // then
+        assertThat(result).isEqualTo(expectedResult);
+        verify(registerFulfillmentDeliveryIcsPort).registerDeliveryIcs(any());
+    }
+}


### PR DESCRIPTION
## partially addresses #475
## resolves #1863

## Test Case
- [x] 재고가 부족하면 InsufficientQuantityException이 발생한다
- [x] 재고가 0이고 주문 수량이 1 이상이면 InsufficientQuantityException이 발생한다
- [x] 복수 상품 중 하나라도 재고가 부족하면 InsufficientQuantityException이 발생한다
- [x] RegisterFulfillmentDeliveryIcsService 테스트
- [x] 출고 ICS 등록 커맨드를 전달하면 포트를 통해 등록 결과를 반환한다