### PR TITLE
[#475][#1865] test: 풀필먼트 배송 차량 수정 기능 자동화 테스트 추가

### DIFF
--- a/fulfillment-service/fulfillment-application/src/test/java/com/personal/marketnote/fulfillment/service/vendor/UpdateFulfillmentDeliveryCarUseCaseTest.java
+++ b/fulfillment-service/fulfillment-application/src/test/java/com/personal/marketnote/fulfillment/service/vendor/UpdateFulfillmentDeliveryCarUseCaseTest.java
@@ -1,0 +1,56 @@
+package com.personal.marketnote.fulfillment.service.vendor;
+
+import com.personal.marketnote.fulfillment.port.in.command.vendor.RegisterFulfillmentDeliveryGoodsCommand;
+import com.personal.marketnote.fulfillment.port.in.command.vendor.UpdateFulfillmentDeliveryCarCommand;
+import com.personal.marketnote.fulfillment.port.in.command.vendor.UpdateFulfillmentDeliveryCarItemCommand;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.RegisterFulfillmentDeliveryResult;
+import com.personal.marketnote.fulfillment.port.out.vendor.UpdateFulfillmentDeliveryCarPort;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("UpdateFulfillmentDeliveryCarService 테스트")
+class UpdateFulfillmentDeliveryCarUseCaseTest {
+    @InjectMocks
+    private UpdateFulfillmentDeliveryCarService updateFulfillmentDeliveryCarService;
+
+    @Mock
+    private UpdateFulfillmentDeliveryCarPort updateFulfillmentDeliveryCarPort;
+
+    @Test
+    @DisplayName("출고 집차 수정 커맨드를 전달하면 포트를 통해 수정 결과를 반환한다")
+    void shouldReturnUpdateDeliveryCarResultFromPort() {
+        // given
+        UpdateFulfillmentDeliveryCarItemCommand itemCommand = UpdateFulfillmentDeliveryCarItemCommand.builder()
+                .ordDt("20260402")
+                .ordNo("ORD001")
+                .slipNo("SLIP001")
+                .outWay("01")
+                .cstShopCd("SHOP001")
+                .godCds(List.of(RegisterFulfillmentDeliveryGoodsCommand.of("GOD001", "20260430", 1)))
+                .build();
+        UpdateFulfillmentDeliveryCarCommand command = UpdateFulfillmentDeliveryCarCommand.of(
+                "CUST001", "token", List.of(itemCommand)
+        );
+        RegisterFulfillmentDeliveryResult expectedResult = RegisterFulfillmentDeliveryResult.of(0, List.of());
+        when(updateFulfillmentDeliveryCarPort.updateDeliveryCar(any())).thenReturn(expectedResult);
+
+        // when
+        RegisterFulfillmentDeliveryResult result = updateFulfillmentDeliveryCarService.updateDeliveryCar(command);
+
+        // then
+        assertThat(result).isEqualTo(expectedResult);
+        verify(updateFulfillmentDeliveryCarPort).updateDeliveryCar(any());
+    }
+}


### PR DESCRIPTION
## partially addresses #475
## resolves #1865

## Test Case
- [x] 재고가 부족하면 InsufficientQuantityException이 발생한다
- [x] 재고가 0이고 주문 수량이 1 이상이면 InsufficientQuantityException이 발생한다
- [x] 복수 상품 중 하나라도 재고가 부족하면 InsufficientQuantityException이 발생한다
- [x] UpdateFulfillmentDeliveryCarService 테스트
- [x] 출고 집차 수정 커맨드를 전달하면 포트를 통해 수정 결과를 반환한다