### PR TITLE
[#475][#1866] test: 풀필먼트 배송 수정 기능 자동화 테스트 추가

### DIFF
--- a/fulfillment-service/fulfillment-application/src/test/java/com/personal/marketnote/fulfillment/service/vendor/UpdateFulfillmentDeliveryUseCaseTest.java
+++ b/fulfillment-service/fulfillment-application/src/test/java/com/personal/marketnote/fulfillment/service/vendor/UpdateFulfillmentDeliveryUseCaseTest.java
@@ -1,0 +1,58 @@
+package com.personal.marketnote.fulfillment.service.vendor;
+
+import com.personal.marketnote.fulfillment.port.in.command.vendor.RegisterFulfillmentDeliveryGoodsCommand;
+import com.personal.marketnote.fulfillment.port.in.command.vendor.UpdateFulfillmentDeliveryCommand;
+import com.personal.marketnote.fulfillment.port.in.command.vendor.UpdateFulfillmentDeliveryItemCommand;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.RegisterFulfillmentDeliveryResult;
+import com.personal.marketnote.fulfillment.port.out.vendor.UpdateFulfillmentDeliveryPort;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("UpdateFulfillmentDeliveryService 테스트")
+class UpdateFulfillmentDeliveryUseCaseTest {
+    @InjectMocks
+    private UpdateFulfillmentDeliveryService updateFulfillmentDeliveryService;
+
+    @Mock
+    private UpdateFulfillmentDeliveryPort updateFulfillmentDeliveryPort;
+
+    @Test
+    @DisplayName("출고 수정 커맨드를 전달하면 포트를 통해 수정 결과를 반환한다")
+    void shouldReturnUpdateDeliveryResultFromPort() {
+        // given
+        UpdateFulfillmentDeliveryItemCommand itemCommand = UpdateFulfillmentDeliveryItemCommand.builder()
+                .ordDt("20260402")
+                .ordNo("ORD001")
+                .slipNo("SLIP001")
+                .custNm("테스트고객")
+                .custTelNo("01012345678")
+                .custAddr("서울시 강남구")
+                .outWay("01")
+                .godCds(List.of(RegisterFulfillmentDeliveryGoodsCommand.of("GOD001", "20260430", 1)))
+                .build();
+        UpdateFulfillmentDeliveryCommand command = UpdateFulfillmentDeliveryCommand.of(
+                "CUST001", "token", List.of(itemCommand)
+        );
+        RegisterFulfillmentDeliveryResult expectedResult = RegisterFulfillmentDeliveryResult.of(0, List.of());
+        when(updateFulfillmentDeliveryPort.updateDelivery(any())).thenReturn(expectedResult);
+
+        // when
+        RegisterFulfillmentDeliveryResult result = updateFulfillmentDeliveryService.updateDelivery(command);
+
+        // then
+        assertThat(result).isEqualTo(expectedResult);
+        verify(updateFulfillmentDeliveryPort).updateDelivery(any());
+    }
+}


### PR DESCRIPTION
## partially addresses #475
## resolves #1866

## Test Case
- [x] 재고가 부족하면 InsufficientQuantityException이 발생한다
- [x] 재고가 0이고 주문 수량이 1 이상이면 InsufficientQuantityException이 발생한다
- [x] 복수 상품 중 하나라도 재고가 부족하면 InsufficientQuantityException이 발생한다
- [x] UpdateFulfillmentDeliveryService 테스트
- [x] 출고 수정 커맨드를 전달하면 포트를 통해 수정 결과를 반환한다