### PR TITLE
[#475][#1867] test: 풀필먼트 배송 취소 기능 자동화 테스트 추가

### DIFF
--- a/fulfillment-service/fulfillment-application/src/test/java/com/personal/marketnote/fulfillment/service/vendor/CancelFulfillmentDeliveryUseCaseTest.java
+++ b/fulfillment-service/fulfillment-application/src/test/java/com/personal/marketnote/fulfillment/service/vendor/CancelFulfillmentDeliveryUseCaseTest.java
@@ -1,0 +1,50 @@
+package com.personal.marketnote.fulfillment.service.vendor;
+
+import com.personal.marketnote.fulfillment.port.in.command.vendor.CancelFulfillmentDeliveryCommand;
+import com.personal.marketnote.fulfillment.port.in.command.vendor.CancelFulfillmentDeliveryItemCommand;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.CancelFulfillmentDeliveryResult;
+import com.personal.marketnote.fulfillment.port.out.vendor.CancelFulfillmentDeliveryPort;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("CancelFulfillmentDeliveryService 테스트")
+class CancelFulfillmentDeliveryUseCaseTest {
+    @InjectMocks
+    private CancelFulfillmentDeliveryService cancelFulfillmentDeliveryService;
+
+    @Mock
+    private CancelFulfillmentDeliveryPort cancelFulfillmentDeliveryPort;
+
+    @Test
+    @DisplayName("출고 취소 커맨드를 전달하면 포트를 통해 취소 결과를 반환한다")
+    void shouldReturnCancelDeliveryResultFromPort() {
+        // given
+        CancelFulfillmentDeliveryItemCommand itemCommand = CancelFulfillmentDeliveryItemCommand.of(
+                "SLIP001", "ORD001"
+        );
+        CancelFulfillmentDeliveryCommand command = CancelFulfillmentDeliveryCommand.of(
+                "CUST001", "token", List.of(itemCommand)
+        );
+        CancelFulfillmentDeliveryResult expectedResult = CancelFulfillmentDeliveryResult.of(0, List.of());
+        when(cancelFulfillmentDeliveryPort.cancelDelivery(any())).thenReturn(expectedResult);
+
+        // when
+        CancelFulfillmentDeliveryResult result = cancelFulfillmentDeliveryService.cancelDelivery(command);
+
+        // then
+        assertThat(result).isEqualTo(expectedResult);
+        verify(cancelFulfillmentDeliveryPort).cancelDelivery(any());
+    }
+}


### PR DESCRIPTION
## partially addresses #475
## resolves #1867

## Test Case
- [x] 재고가 부족하면 InsufficientQuantityException이 발생한다
- [x] 재고가 0이고 주문 수량이 1 이상이면 InsufficientQuantityException이 발생한다
- [x] 복수 상품 중 하나라도 재고가 부족하면 InsufficientQuantityException이 발생한다
- [x] CancelFulfillmentDeliveryService 테스트
- [x] 출고 취소 커맨드를 전달하면 포트를 통해 취소 결과를 반환한다