### PR TITLE
[#475][#1870] test: 풀필먼트 상품 상세 조회 기능 자동화 테스트 추가

### DIFF
--- a/fulfillment-service/fulfillment-application/src/test/java/com/personal/marketnote/fulfillment/service/vendor/GetFulfillmentGoodsDetailUseCaseTest.java
+++ b/fulfillment-service/fulfillment-application/src/test/java/com/personal/marketnote/fulfillment/service/vendor/GetFulfillmentGoodsDetailUseCaseTest.java
@@ -1,0 +1,41 @@
+package com.personal.marketnote.fulfillment.service.vendor;
+
+import com.personal.marketnote.fulfillment.port.in.command.vendor.GetFulfillmentGoodsDetailCommand;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.GetFulfillmentGoodsResult;
+import com.personal.marketnote.fulfillment.port.out.vendor.GetFulfillmentGoodsDetailPort;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("풀필먼트 상품 상세 조회 테스트")
+class GetFulfillmentGoodsDetailUseCaseTest {
+    @InjectMocks
+    private GetFulfillmentGoodsDetailService service;
+    @Mock
+    private GetFulfillmentGoodsDetailPort getFulfillmentGoodsDetailPort;
+
+    @Test
+    @DisplayName("Command를 Port에 위임하여 결과를 반환한다")
+    void shouldDelegateToPort() {
+        // given
+        GetFulfillmentGoodsDetailCommand command = new GetFulfillmentGoodsDetailCommand("CUST001", "token", "GOODS001");
+        GetFulfillmentGoodsResult expectedResult = GetFulfillmentGoodsResult.of(0, List.of());
+        when(getFulfillmentGoodsDetailPort.getGoodsDetail(any())).thenReturn(expectedResult);
+        // when
+        GetFulfillmentGoodsResult result = service.getGoodsDetail(command);
+        // then
+        assertThat(result).isEqualTo(expectedResult);
+        verify(getFulfillmentGoodsDetailPort).getGoodsDetail(any());
+    }
+}


### PR DESCRIPTION
## partially addresses #475
## resolves #1870

## Test Case
- [x] 재고가 부족하면 InsufficientQuantityException이 발생한다
- [x] 재고가 0이고 주문 수량이 1 이상이면 InsufficientQuantityException이 발생한다
- [x] 복수 상품 중 하나라도 재고가 부족하면 InsufficientQuantityException이 발생한다
- [x] 풀필먼트 상품 상세 조회 테스트
- [x] Command를 Port에 위임하여 결과를 반환한다