### PR TITLE
[#475][#1875] test: 풀필먼트 입고 이상 조회 기능 자동화 테스트 추가

### DIFF
--- a/fulfillment-service/fulfillment-application/src/test/java/com/personal/marketnote/fulfillment/service/vendor/GetFulfillmentWarehousingAbnormalUseCaseTest.java
+++ b/fulfillment-service/fulfillment-application/src/test/java/com/personal/marketnote/fulfillment/service/vendor/GetFulfillmentWarehousingAbnormalUseCaseTest.java
@@ -1,0 +1,41 @@
+package com.personal.marketnote.fulfillment.service.vendor;
+
+import com.personal.marketnote.fulfillment.port.in.command.vendor.GetFulfillmentWarehousingAbnormalCommand;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.GetFulfillmentWarehousingAbnormalResult;
+import com.personal.marketnote.fulfillment.port.out.vendor.GetFulfillmentWarehousingAbnormalPort;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("풀필먼트 입고 이상 조회 테스트")
+class GetFulfillmentWarehousingAbnormalUseCaseTest {
+    @InjectMocks
+    private GetFulfillmentWarehousingAbnormalService service;
+    @Mock
+    private GetFulfillmentWarehousingAbnormalPort getFulfillmentWarehousingAbnormalPort;
+
+    @Test
+    @DisplayName("Command를 Port에 위임하여 결과를 반환한다")
+    void shouldDelegateToPort() {
+        // given
+        GetFulfillmentWarehousingAbnormalCommand command = new GetFulfillmentWarehousingAbnormalCommand("CUST001", "token", "WH001", "SLIP001");
+        GetFulfillmentWarehousingAbnormalResult expectedResult = GetFulfillmentWarehousingAbnormalResult.of(0, List.of());
+        when(getFulfillmentWarehousingAbnormalPort.getWarehousingAbnormal(any())).thenReturn(expectedResult);
+        // when
+        GetFulfillmentWarehousingAbnormalResult result = service.getWarehousingAbnormal(command);
+        // then
+        assertThat(result).isEqualTo(expectedResult);
+        verify(getFulfillmentWarehousingAbnormalPort).getWarehousingAbnormal(any());
+    }
+}


### PR DESCRIPTION
## partially addresses #475
## resolves #1875

## Test Case
- [x] 재고가 부족하면 InsufficientQuantityException이 발생한다
- [x] 재고가 0이고 주문 수량이 1 이상이면 InsufficientQuantityException이 발생한다
- [x] 복수 상품 중 하나라도 재고가 부족하면 InsufficientQuantityException이 발생한다
- [x] 풀필먼트 입고 이상 조회 테스트