### PR TITLE
[#216][#1095] feat: 빠른결제 카드 거래 등록 기능 추가

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/quickpayment/controller/QuickPaymentController.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/quickpayment/controller/QuickPaymentController.java
@@ -1,0 +1,65 @@
+package com.personal.marketnote.commerce.adapter.in.web.quickpayment.controller;
+
+import com.personal.marketnote.commerce.adapter.in.web.quickpayment.controller.apidocs.RegisterQuickPaymentTransactionApiDocs;
+import com.personal.marketnote.commerce.adapter.in.web.quickpayment.response.RegisterQuickPaymentTransactionResponse;
+import com.personal.marketnote.commerce.port.in.command.quickpayment.RegisterQuickPaymentTransactionCommand;
+import com.personal.marketnote.commerce.port.in.result.quickpayment.RegisterQuickPaymentTransactionResult;
+import com.personal.marketnote.commerce.port.in.usecase.quickpayment.RegisterQuickPaymentTransactionUseCase;
+import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
+import com.personal.marketnote.common.utility.ElementExtractor;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.core.OAuth2AuthenticatedPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static com.personal.marketnote.common.domain.exception.ExceptionCode.DEFAULT_SUCCESS_CODE;
+
+/**
+ * 빠른결제 컨트롤러
+ *
+ * @Author 성효빈
+ * @Date 2026-04-16
+ * @Description 빠른결제 관련 API를 제공합니다.
+ */
+@RestController
+@Tag(name = "빠른결제 API", description = "빠른결제 관련 API")
+@RequiredArgsConstructor
+public class QuickPaymentController {
+    private final RegisterQuickPaymentTransactionUseCase registerQuickPaymentTransactionUseCase;
+
+    /**
+     * 빠른결제 거래 등록 (Mobile)
+     *
+     * @return 거래등록 응답 {@link RegisterQuickPaymentTransactionResponse}
+     * @Author 성효빈
+     * @Date 2026-04-16
+     * @Description 빠른결제 카드 등록을 위한 KCP 거래등록 API를 호출합니다.
+     */
+    @PostMapping("/api/v1/quick-payments/transactions")
+    @RegisterQuickPaymentTransactionApiDocs
+    public ResponseEntity<BaseResponse<RegisterQuickPaymentTransactionResponse>> registerTransaction(
+            @AuthenticationPrincipal OAuth2AuthenticatedPrincipal principal
+    ) {
+        Long userId = ElementExtractor.extractUserId(principal);
+
+        RegisterQuickPaymentTransactionResult result = registerQuickPaymentTransactionUseCase.register(
+                RegisterQuickPaymentTransactionCommand.builder()
+                        .userId(userId)
+                        .build()
+        );
+
+        return new ResponseEntity<>(
+                BaseResponse.of(
+                        RegisterQuickPaymentTransactionResponse.from(result),
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "빠른결제 거래 등록 성공"
+                ),
+                HttpStatus.OK
+        );
+    }
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/quickpayment/controller/apidocs/RegisterQuickPaymentTransactionApiDocs.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/quickpayment/controller/apidocs/RegisterQuickPaymentTransactionApiDocs.java
@@ -1,0 +1,66 @@
+package com.personal.marketnote.commerce.adapter.in.web.quickpayment.controller.apidocs;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Operation(
+        summary = "빠른결제 거래 등록 (Mobile)",
+        description = """
+                작성일자: 2026-04-16
+
+                작성자: 성효빈
+
+                ---
+
+                ## Description
+
+                - 빠른결제 카드 등록을 위한 KCP 거래등록 API를 호출합니다.
+
+                - approvalKey와 payUrl을 반환하여 클라이언트가 KCP 결제창을 호출할 수 있도록 합니다.
+
+                - 요청 본문은 필요하지 않으며, 인증 토큰만으로 처리됩니다.
+
+                ---
+
+                ## Response > content
+
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | transactionId | string | 거래 식별 ID (UUID) | "550e8400-e29b-41d4-a716-446655440000" |
+                | approvalKey | string | KCP 승인 키 | "5VRPBBPEo1cQnXV1SapUB8M20OrBegcHydQ/iE3gBBCT" |
+                | payUrl | string | Mobile 결제 URL | "https://testsmpay.kcp.co.kr/pay/mobileGW.kcp" |
+                | traceNo | string | 추적 번호 | "T0000MGABJUXLY81" |
+                """,
+        security = {@SecurityRequirement(name = "bearer")},
+        responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "빠른결제 거래 등록 성공",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 200,
+                                          "code": "SUC01",
+                                          "timestamp": "2026-04-16T17:19:33.409686",
+                                          "content": {
+                                            "transactionId": "550e8400-e29b-41d4-a716-446655440000",
+                                            "approvalKey": "5VRPBBPEo1cQnXV1SapUB8M20OrBegcHydQ/iE3gBBCT",
+                                            "payUrl": "https://testsmpay.kcp.co.kr/pay/mobileGW.kcp",
+                                            "traceNo": "T0000MGABJUXLY81"
+                                          },
+                                          "message": "빠른결제 거래 등록 성공"
+                                        }
+                                        """)
+                        )
+                )
+        })
+public @interface RegisterQuickPaymentTransactionApiDocs {
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/quickpayment/response/RegisterQuickPaymentTransactionResponse.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/quickpayment/response/RegisterQuickPaymentTransactionResponse.java
@@ -1,0 +1,22 @@
+package com.personal.marketnote.commerce.adapter.in.web.quickpayment.response;
+
+import com.personal.marketnote.commerce.port.in.result.quickpayment.RegisterQuickPaymentTransactionResult;
+import lombok.AccessLevel;
+import lombok.Builder;
+
+@Builder(access = AccessLevel.PRIVATE)
+public record RegisterQuickPaymentTransactionResponse(
+        String transactionId,
+        String approvalKey,
+        String payUrl,
+        String traceNo
+) {
+    public static RegisterQuickPaymentTransactionResponse from(RegisterQuickPaymentTransactionResult result) {
+        return RegisterQuickPaymentTransactionResponse.builder()
+                .transactionId(result.transactionId())
+                .approvalKey(result.approvalKey())
+                .payUrl(result.payUrl())
+                .traceNo(result.traceNo())
+                .build();
+    }
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/vendor/kcp/KcpQuickPaymentAdapter.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/vendor/kcp/KcpQuickPaymentAdapter.java
@@ -1,0 +1,117 @@
+package com.personal.marketnote.commerce.adapter.out.vendor.kcp;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.personal.marketnote.commerce.adapter.out.vendor.kcp.dto.KcpTradeRegisterRequest;
+import com.personal.marketnote.commerce.adapter.out.vendor.kcp.dto.KcpTradeRegisterResponse;
+import com.personal.marketnote.commerce.adapter.out.vendor.kcp.exception.KcpCommunicationException;
+import com.personal.marketnote.commerce.configuration.KcpProperties;
+import com.personal.marketnote.commerce.domain.vendorcommunication.CommerceVendorCommunicationSenderType;
+import com.personal.marketnote.commerce.domain.vendorcommunication.CommerceVendorCommunicationTargetType;
+import com.personal.marketnote.commerce.domain.vendorcommunication.CommerceVendorCommunicationType;
+import com.personal.marketnote.commerce.domain.vendorcommunication.CommerceVendorName;
+import com.personal.marketnote.commerce.port.out.quickpayment.RegisterQuickPaymentTransactionPort;
+import com.personal.marketnote.commerce.port.out.quickpayment.RegisterQuickPaymentTransactionPortCommand;
+import com.personal.marketnote.commerce.port.out.quickpayment.RegisterQuickPaymentTransactionPortResult;
+import com.personal.marketnote.commerce.utility.VendorCommunicationRecorder;
+import com.personal.marketnote.common.adapter.out.ServiceAdapter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Map;
+
+@ServiceAdapter
+@RequiredArgsConstructor
+@Slf4j
+public class KcpQuickPaymentAdapter implements RegisterQuickPaymentTransactionPort {
+    private static final CommerceVendorName VENDOR_NAME = CommerceVendorName.NHN_KCP;
+    private static final CommerceVendorCommunicationTargetType TARGET_TYPE =
+            CommerceVendorCommunicationTargetType.QUICK_PAYMENT_TRADE_REGISTER;
+    private static final String GOOD_MNY = "0";
+    private static final String PAY_METHOD = "AUTH";
+    private static final String GOOD_NAME = "빠른결제 카드 등록";
+
+    private final KcpProperties kcpProperties;
+    private final KcpApiClient kcpApiClient;
+    private final VendorCommunicationRecorder vendorCommunicationRecorder;
+
+    @Override
+    public RegisterQuickPaymentTransactionPortResult registerTransaction(
+            RegisterQuickPaymentTransactionPortCommand command
+    ) {
+        KcpTradeRegisterRequest request = KcpTradeRegisterRequest.builder()
+                .siteCd(kcpProperties.getSiteCd())
+                .ordrIdxx(command.transactionId())
+                .goodMny(GOOD_MNY)
+                .payMethod(PAY_METHOD)
+                .goodName(GOOD_NAME)
+                .retUrl(kcpProperties.getRetUrl())
+                .build();
+
+        recordRequest(command.transactionId(), request);
+
+        try {
+            KcpTradeRegisterResponse response = kcpApiClient.registerTrade(request);
+            recordResponse(command.transactionId(), response);
+
+            boolean isSuccess = response.isSuccess();
+            if (!isSuccess) {
+                log.error("빠른결제 거래등록 실패: resCd={}, resMsg={}", response.resCd(), response.resMsg());
+            }
+
+            return RegisterQuickPaymentTransactionPortResult.builder()
+                    .success(isSuccess)
+                    .resultCode(response.resCd())
+                    .resultMessage(response.resMsg())
+                    .approvalKey(response.approvalKey())
+                    .payUrl(response.payUrl())
+                    .traceNo(response.traceNo())
+                    .rawResponse(kcpApiClient.toJsonNode(response).toString())
+                    .build();
+        } catch (KcpCommunicationException e) {
+            recordError(command.transactionId(), e);
+            throw e;
+        }
+    }
+
+    private void recordRequest(String targetId, Object request) {
+        JsonNode payloadJson = kcpApiClient.toJsonNode(request);
+        vendorCommunicationRecorder.record(
+                TARGET_TYPE,
+                CommerceVendorCommunicationType.REQUEST,
+                CommerceVendorCommunicationSenderType.SERVER,
+                targetId,
+                VENDOR_NAME,
+                payloadJson.toString(),
+                payloadJson
+        );
+    }
+
+    private void recordResponse(String targetId, Object response) {
+        JsonNode payloadJson = kcpApiClient.toJsonNode(response);
+        vendorCommunicationRecorder.record(
+                TARGET_TYPE,
+                CommerceVendorCommunicationType.RESPONSE,
+                CommerceVendorCommunicationSenderType.VENDOR,
+                targetId,
+                VENDOR_NAME,
+                payloadJson.toString(),
+                payloadJson
+        );
+    }
+
+    private void recordError(String targetId, Exception e) {
+        JsonNode errorJson = kcpApiClient.toJsonNode(
+                Map.of("error", e.getClass().getSimpleName(), "message", e.getMessage())
+        );
+        vendorCommunicationRecorder.record(
+                TARGET_TYPE,
+                CommerceVendorCommunicationType.RESPONSE,
+                CommerceVendorCommunicationSenderType.VENDOR,
+                targetId,
+                VENDOR_NAME,
+                errorJson.toString(),
+                errorJson,
+                e.getClass().getSimpleName()
+        );
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/exception/QuickPaymentTransactionFailedException.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/exception/QuickPaymentTransactionFailedException.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.commerce.exception;
+
+public class QuickPaymentTransactionFailedException extends RuntimeException {
+    private static final String MESSAGE = "빠른결제 거래등록 실패 [%s]: %s";
+
+    public QuickPaymentTransactionFailedException(String resultCode, String resultMessage) {
+        super(String.format(MESSAGE, resultCode, resultMessage));
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/command/quickpayment/RegisterQuickPaymentTransactionCommand.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/command/quickpayment/RegisterQuickPaymentTransactionCommand.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.commerce.port.in.command.quickpayment;
+
+import lombok.Builder;
+
+@Builder
+public record RegisterQuickPaymentTransactionCommand(
+        Long userId
+) {
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/result/quickpayment/RegisterQuickPaymentTransactionResult.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/result/quickpayment/RegisterQuickPaymentTransactionResult.java
@@ -1,0 +1,12 @@
+package com.personal.marketnote.commerce.port.in.result.quickpayment;
+
+import lombok.Builder;
+
+@Builder
+public record RegisterQuickPaymentTransactionResult(
+        String transactionId,
+        String approvalKey,
+        String payUrl,
+        String traceNo
+) {
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/quickpayment/RegisterQuickPaymentTransactionUseCase.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/quickpayment/RegisterQuickPaymentTransactionUseCase.java
@@ -1,0 +1,22 @@
+package com.personal.marketnote.commerce.port.in.usecase.quickpayment;
+
+import com.personal.marketnote.commerce.port.in.command.quickpayment.RegisterQuickPaymentTransactionCommand;
+import com.personal.marketnote.commerce.port.in.result.quickpayment.RegisterQuickPaymentTransactionResult;
+
+/**
+ * 빠른결제 거래 등록 유스케이스
+ *
+ * @Author 성효빈
+ * @Date 2026-04-16
+ * @Description 빠른결제 카드 등록을 위한 KCP 거래 등록 기능을 제공합니다.
+ */
+public interface RegisterQuickPaymentTransactionUseCase {
+    /**
+     * @param command 빠른결제 거래 등록 커맨드
+     * @return 거래 등록 결과 {@link RegisterQuickPaymentTransactionResult}
+     * @Date 2026-04-16
+     * @Author 성효빈
+     * @Description KCP에 빠른결제 카드 등록용 거래를 등록합니다.
+     */
+    RegisterQuickPaymentTransactionResult register(RegisterQuickPaymentTransactionCommand command);
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/quickpayment/RegisterQuickPaymentTransactionPort.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/quickpayment/RegisterQuickPaymentTransactionPort.java
@@ -1,0 +1,19 @@
+package com.personal.marketnote.commerce.port.out.quickpayment;
+
+/**
+ * 빠른결제 거래 등록 포트
+ *
+ * @Author 성효빈
+ * @Date 2026-04-16
+ * @Description KCP에 빠른결제 카드 등록용 거래를 등록합니다.
+ */
+public interface RegisterQuickPaymentTransactionPort {
+    /**
+     * @param command 거래 등록 요청 정보 {@link RegisterQuickPaymentTransactionPortCommand}
+     * @return 거래 등록 결과 {@link RegisterQuickPaymentTransactionPortResult}
+     * @Date 2026-04-16
+     * @Author 성효빈
+     * @Description KCP에 빠른결제 거래를 등록합니다.
+     */
+    RegisterQuickPaymentTransactionPortResult registerTransaction(RegisterQuickPaymentTransactionPortCommand command);
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/quickpayment/RegisterQuickPaymentTransactionPortCommand.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/quickpayment/RegisterQuickPaymentTransactionPortCommand.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.commerce.port.out.quickpayment;
+
+import lombok.Builder;
+
+@Builder
+public record RegisterQuickPaymentTransactionPortCommand(
+        String transactionId
+) {
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/quickpayment/RegisterQuickPaymentTransactionPortResult.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/quickpayment/RegisterQuickPaymentTransactionPortResult.java
@@ -1,0 +1,15 @@
+package com.personal.marketnote.commerce.port.out.quickpayment;
+
+import lombok.Builder;
+
+@Builder
+public record RegisterQuickPaymentTransactionPortResult(
+        boolean success,
+        String resultCode,
+        String resultMessage,
+        String approvalKey,
+        String payUrl,
+        String traceNo,
+        String rawResponse
+) {
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/quickpayment/RegisterQuickPaymentTransactionService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/quickpayment/RegisterQuickPaymentTransactionService.java
@@ -1,0 +1,49 @@
+package com.personal.marketnote.commerce.service.quickpayment;
+
+import com.personal.marketnote.commerce.exception.QuickPaymentTransactionFailedException;
+import com.personal.marketnote.commerce.port.in.command.quickpayment.RegisterQuickPaymentTransactionCommand;
+import com.personal.marketnote.commerce.port.in.result.quickpayment.RegisterQuickPaymentTransactionResult;
+import com.personal.marketnote.commerce.port.in.usecase.quickpayment.RegisterQuickPaymentTransactionUseCase;
+import com.personal.marketnote.commerce.port.out.quickpayment.RegisterQuickPaymentTransactionPort;
+import com.personal.marketnote.commerce.port.out.quickpayment.RegisterQuickPaymentTransactionPortCommand;
+import com.personal.marketnote.commerce.port.out.quickpayment.RegisterQuickPaymentTransactionPortResult;
+import com.personal.marketnote.common.application.UseCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional(isolation = READ_COMMITTED)
+@Slf4j
+public class RegisterQuickPaymentTransactionService implements RegisterQuickPaymentTransactionUseCase {
+    private final RegisterQuickPaymentTransactionPort registerQuickPaymentTransactionPort;
+
+    @Override
+    public RegisterQuickPaymentTransactionResult register(RegisterQuickPaymentTransactionCommand command) {
+        String transactionId = UUID.randomUUID().toString();
+        log.info("빠른결제 거래등록 요청 - userId: {}, transactionId: {}", command.userId(), transactionId);
+
+        RegisterQuickPaymentTransactionPortCommand portCommand = RegisterQuickPaymentTransactionPortCommand.builder()
+                .transactionId(transactionId)
+                .build();
+
+        RegisterQuickPaymentTransactionPortResult portResult =
+                registerQuickPaymentTransactionPort.registerTransaction(portCommand);
+
+        if (!portResult.success()) {
+            throw new QuickPaymentTransactionFailedException(portResult.resultCode(), portResult.resultMessage());
+        }
+
+        return RegisterQuickPaymentTransactionResult.builder()
+                .transactionId(transactionId)
+                .approvalKey(portResult.approvalKey())
+                .payUrl(portResult.payUrl())
+                .traceNo(portResult.traceNo())
+                .build();
+    }
+}

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/vendorcommunication/CommerceVendorCommunicationTargetType.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/vendorcommunication/CommerceVendorCommunicationTargetType.java
@@ -6,7 +6,8 @@ import lombok.RequiredArgsConstructor;
 public enum CommerceVendorCommunicationTargetType {
     TRADE_REGISTER("거래등록"),
     PAYMENT_APPROVAL("결제승인"),
-    PAYMENT_CANCEL("결제취소");
+    PAYMENT_CANCEL("결제취소"),
+    QUICK_PAYMENT_TRADE_REGISTER("빠른결제 거래등록");
 
     private final String description;
 }


### PR DESCRIPTION
## partially addresses #216
## resolves #1095

## Task
- [x] RegisterQuickPaymentTransactionUseCase UseCase 인터페이스 정의
- [x] RegisterQuickPaymentTransactionCommand / RegisterQuickPaymentTransactionResult 정의
- [x] RegisterQuickPaymentTransactionPort Out Port 정의
- [x] RegisterQuickPaymentTransactionService 서비스 구현
- [x] KCP 거래 등록 HTTP 클라이언트 어댑터 구현
- [x] 빠른결제 거래 등록 REST API 컨트롤러 추가
- [x] ApiDocs 합성 애노테이션 추가