### PR TITLE
[#216][#1096] feat: 빠른결제 카드 배치키 발급 기능 추가

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/quickpayment/controller/QuickPaymentController.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/quickpayment/controller/QuickPaymentController.java
@@ -1,19 +1,28 @@
 package com.personal.marketnote.commerce.adapter.in.web.quickpayment.controller;
 
+import com.personal.marketnote.commerce.adapter.in.web.quickpayment.controller.apidocs.IssueBatchKeyApiDocs;
 import com.personal.marketnote.commerce.adapter.in.web.quickpayment.controller.apidocs.RegisterQuickPaymentTransactionApiDocs;
+import com.personal.marketnote.commerce.adapter.in.web.quickpayment.request.IssueBatchKeyRequest;
+import com.personal.marketnote.commerce.adapter.in.web.quickpayment.response.IssueBatchKeyResponse;
 import com.personal.marketnote.commerce.adapter.in.web.quickpayment.response.RegisterQuickPaymentTransactionResponse;
+import com.personal.marketnote.commerce.port.in.command.quickpayment.IssueBatchKeyCommand;
 import com.personal.marketnote.commerce.port.in.command.quickpayment.RegisterQuickPaymentTransactionCommand;
+import com.personal.marketnote.commerce.port.in.result.quickpayment.IssueBatchKeyResult;
 import com.personal.marketnote.commerce.port.in.result.quickpayment.RegisterQuickPaymentTransactionResult;
+import com.personal.marketnote.commerce.port.in.usecase.quickpayment.IssueBatchKeyUseCase;
 import com.personal.marketnote.commerce.port.in.usecase.quickpayment.RegisterQuickPaymentTransactionUseCase;
 import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
 import com.personal.marketnote.common.utility.ElementExtractor;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.core.OAuth2AuthenticatedPrincipal;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 import static com.personal.marketnote.common.domain.exception.ExceptionCode.DEFAULT_SUCCESS_CODE;
@@ -28,8 +37,10 @@ import static com.personal.marketnote.common.domain.exception.ExceptionCode.DEFA
 @RestController
 @Tag(name = "빠른결제 API", description = "빠른결제 관련 API")
 @RequiredArgsConstructor
+@Validated
 public class QuickPaymentController {
     private final RegisterQuickPaymentTransactionUseCase registerQuickPaymentTransactionUseCase;
+    private final IssueBatchKeyUseCase issueBatchKeyUseCase;
 
     /**
      * 빠른결제 거래 등록 (Mobile)
@@ -58,6 +69,42 @@ public class QuickPaymentController {
                         HttpStatus.OK,
                         DEFAULT_SUCCESS_CODE,
                         "빠른결제 거래 등록 성공"
+                ),
+                HttpStatus.OK
+        );
+    }
+
+    /**
+     * 빠른결제 카드 배치키 발급
+     *
+     * @param request 배치키 발급 요청
+     * @return 배치키 발급 응답 {@link IssueBatchKeyResponse}
+     * @Author 성효빈
+     * @Date 2026-04-16
+     * @Description 결제창 인증 완료 후 enc_data/enc_info로 KCP 배치키를 발급합니다.
+     */
+    @PostMapping("/api/v1/quick-payments/cards")
+    @IssueBatchKeyApiDocs
+    public ResponseEntity<BaseResponse<IssueBatchKeyResponse>> issueBatchKey(
+            @AuthenticationPrincipal OAuth2AuthenticatedPrincipal principal,
+            @Valid @RequestBody IssueBatchKeyRequest request
+    ) {
+        Long userId = ElementExtractor.extractUserId(principal);
+
+        IssueBatchKeyResult result = issueBatchKeyUseCase.issueBatchKey(
+                IssueBatchKeyCommand.builder()
+                        .userId(userId)
+                        .encData(request.getEncData())
+                        .encInfo(request.getEncInfo())
+                        .build()
+        );
+
+        return new ResponseEntity<>(
+                BaseResponse.of(
+                        IssueBatchKeyResponse.from(result),
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "빠른결제 카드 배치키 발급 성공"
                 ),
                 HttpStatus.OK
         );

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/quickpayment/controller/apidocs/IssueBatchKeyApiDocs.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/quickpayment/controller/apidocs/IssueBatchKeyApiDocs.java
@@ -1,0 +1,92 @@
+package com.personal.marketnote.commerce.adapter.in.web.quickpayment.controller.apidocs;
+
+import com.personal.marketnote.commerce.adapter.in.web.quickpayment.request.IssueBatchKeyRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Operation(
+        summary = "빠른결제 카드 배치키 발급",
+        description = """
+                작성일자: 2026-04-16
+
+                작성자: 성효빈
+
+                ---
+
+                ## Description
+
+                - 결제창 인증 완료 후 enc_data/enc_info로 KCP 배치키를 발급합니다.
+
+                - 발급된 배치키와 카드 정보를 DB에 저장하고 카드 정보를 반환합니다.
+
+                ---
+
+                ## Request
+
+                | **키** | **타입** | **설명** | **필수 여부** | **예시** |
+                | --- | --- | --- | --- | --- |
+                | encData | string | KCP 결제창 인증결과 암호화 데이터 | Y | "encrypted_data..." |
+                | encInfo | string | KCP 결제창 인증결과 암호화 정보 | Y | "encrypted_info..." |
+
+                ---
+
+                ## Response > content
+
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | quickPaymentCardId | number | 빠른결제 카드 ID | 1 |
+                | cardCode | string | 카드사 코드 | "CCDI" |
+                | cardName | string | 카드사명 | "현대카드" |
+                | maskedCardNumber | string | 마스킹 카드번호 | null |
+                | cardBinType01 | string | 개인(0)/법인(1) | "0" |
+                | cardBinType02 | string | 일반(0)/체크(1) | "0" |
+                """,
+        security = {@SecurityRequirement(name = "bearer")},
+        requestBody = @RequestBody(
+                required = true,
+                content = @Content(
+                        schema = @Schema(implementation = IssueBatchKeyRequest.class),
+                        examples = @ExampleObject("""
+                                {
+                                  "encData": "encrypted_data_from_payment_window",
+                                  "encInfo": "encrypted_info_from_payment_window"
+                                }
+                                """)
+                )
+        ),
+        responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "빠른결제 카드 배치키 발급 성공",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 200,
+                                          "code": "SUC01",
+                                          "timestamp": "2026-04-16T17:19:33.409686",
+                                          "content": {
+                                            "quickPaymentCardId": 1,
+                                            "cardCode": "CCDI",
+                                            "cardName": "현대카드",
+                                            "maskedCardNumber": null,
+                                            "cardBinType01": "0",
+                                            "cardBinType02": "0"
+                                          },
+                                          "message": "빠른결제 카드 배치키 발급 성공"
+                                        }
+                                        """)
+                        )
+                )
+        })
+public @interface IssueBatchKeyApiDocs {
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/quickpayment/request/IssueBatchKeyRequest.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/quickpayment/request/IssueBatchKeyRequest.java
@@ -1,0 +1,27 @@
+package com.personal.marketnote.commerce.adapter.in.web.quickpayment.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+@Getter
+public class IssueBatchKeyRequest {
+    @Schema(
+            name = "encData",
+            description = "KCP 결제창 인증결과 암호화 데이터",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    @NotBlank(message = "enc_data는 필수값입니다.")
+    @Size(max = 10000, message = "enc_data는 10000자를 초과할 수 없습니다.")
+    private String encData;
+
+    @Schema(
+            name = "encInfo",
+            description = "KCP 결제창 인증결과 암호화 정보",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    @NotBlank(message = "enc_info는 필수값입니다.")
+    @Size(max = 10000, message = "enc_info는 10000자를 초과할 수 없습니다.")
+    private String encInfo;
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/quickpayment/response/IssueBatchKeyResponse.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/quickpayment/response/IssueBatchKeyResponse.java
@@ -1,0 +1,26 @@
+package com.personal.marketnote.commerce.adapter.in.web.quickpayment.response;
+
+import com.personal.marketnote.commerce.port.in.result.quickpayment.IssueBatchKeyResult;
+import lombok.AccessLevel;
+import lombok.Builder;
+
+@Builder(access = AccessLevel.PRIVATE)
+public record IssueBatchKeyResponse(
+        Long quickPaymentCardId,
+        String cardCode,
+        String cardName,
+        String maskedCardNumber,
+        String cardBinType01,
+        String cardBinType02
+) {
+    public static IssueBatchKeyResponse from(IssueBatchKeyResult result) {
+        return IssueBatchKeyResponse.builder()
+                .quickPaymentCardId(result.quickPaymentCardId())
+                .cardCode(result.cardCode())
+                .cardName(result.cardName())
+                .maskedCardNumber(result.maskedCardNumber())
+                .cardBinType01(result.cardBinType01())
+                .cardBinType02(result.cardBinType02())
+                .build();
+    }
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/quickpayment/QuickPaymentCardPersistenceAdapter.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/quickpayment/QuickPaymentCardPersistenceAdapter.java
@@ -1,0 +1,22 @@
+package com.personal.marketnote.commerce.adapter.out.persistence.quickpayment;
+
+import com.personal.marketnote.commerce.adapter.out.persistence.quickpayment.entity.QuickPaymentCardJpaEntity;
+import com.personal.marketnote.commerce.adapter.out.persistence.quickpayment.mapper.QuickPaymentCardEntityToDomainMapper;
+import com.personal.marketnote.commerce.adapter.out.persistence.quickpayment.repository.QuickPaymentCardJpaRepository;
+import com.personal.marketnote.commerce.domain.quickpayment.QuickPaymentCard;
+import com.personal.marketnote.commerce.port.out.quickpayment.SaveQuickPaymentCardPort;
+import com.personal.marketnote.common.adapter.out.PersistenceAdapter;
+import lombok.RequiredArgsConstructor;
+
+@PersistenceAdapter
+@RequiredArgsConstructor
+public class QuickPaymentCardPersistenceAdapter implements SaveQuickPaymentCardPort {
+    private final QuickPaymentCardJpaRepository quickPaymentCardJpaRepository;
+
+    @Override
+    public QuickPaymentCard save(QuickPaymentCard quickPaymentCard) {
+        QuickPaymentCardJpaEntity entity = QuickPaymentCardJpaEntity.from(quickPaymentCard);
+        QuickPaymentCardJpaEntity savedEntity = quickPaymentCardJpaRepository.save(entity);
+        return QuickPaymentCardEntityToDomainMapper.mapToDomain(savedEntity);
+    }
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/quickpayment/entity/QuickPaymentCardJpaEntity.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/quickpayment/entity/QuickPaymentCardJpaEntity.java
@@ -1,0 +1,66 @@
+package com.personal.marketnote.commerce.adapter.out.persistence.quickpayment.entity;
+
+import com.personal.marketnote.commerce.domain.quickpayment.QuickPaymentCard;
+import com.personal.marketnote.common.adapter.out.persistence.audit.BaseEntity;
+import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.DynamicInsert;
+
+@Entity
+@Table(name = "quick_payment_card",
+        indexes = @Index(name = "idx_quick_payment_card_user_id", columnList = "user_id"),
+        uniqueConstraints = @UniqueConstraint(name = "uk_quick_payment_card_batch_key", columnNames = "batch_key"))
+@DynamicInsert
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+@Getter
+public class QuickPaymentCardJpaEntity extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "batch_key", nullable = false)
+    private String batchKey;
+
+    @Column(name = "group_id", length = 12)
+    private String groupId;
+
+    @Column(name = "card_code", nullable = false, length = 4)
+    private String cardCode;
+
+    @Column(name = "card_name", nullable = false, length = 20)
+    private String cardName;
+
+    @Column(name = "masked_card_number", length = 20)
+    private String maskedCardNumber;
+
+    @Column(name = "card_bin_type_01", nullable = false, length = 1)
+    private String cardBinType01;
+
+    @Column(name = "card_bin_type_02", nullable = false, length = 1)
+    private String cardBinType02;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 15)
+    private EntityStatus status;
+
+    public static QuickPaymentCardJpaEntity from(QuickPaymentCard domain) {
+        return QuickPaymentCardJpaEntity.builder()
+                .userId(domain.getUserId())
+                .batchKey(domain.getBatchKey())
+                .groupId(domain.getGroupId())
+                .cardCode(domain.getCardCode())
+                .cardName(domain.getCardName())
+                .maskedCardNumber(domain.getMaskedCardNumber())
+                .cardBinType01(domain.getCardBinType01())
+                .cardBinType02(domain.getCardBinType02())
+                .status(domain.getStatus())
+                .build();
+    }
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/quickpayment/mapper/QuickPaymentCardEntityToDomainMapper.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/quickpayment/mapper/QuickPaymentCardEntityToDomainMapper.java
@@ -1,0 +1,27 @@
+package com.personal.marketnote.commerce.adapter.out.persistence.quickpayment.mapper;
+
+import com.personal.marketnote.commerce.adapter.out.persistence.quickpayment.entity.QuickPaymentCardJpaEntity;
+import com.personal.marketnote.commerce.domain.quickpayment.QuickPaymentCard;
+import com.personal.marketnote.commerce.domain.quickpayment.QuickPaymentCardSnapshotState;
+
+public class QuickPaymentCardEntityToDomainMapper {
+
+    public static QuickPaymentCard mapToDomain(QuickPaymentCardJpaEntity entity) {
+        return QuickPaymentCard.from(
+                QuickPaymentCardSnapshotState.builder()
+                        .id(entity.getId())
+                        .userId(entity.getUserId())
+                        .batchKey(entity.getBatchKey())
+                        .groupId(entity.getGroupId())
+                        .cardCode(entity.getCardCode())
+                        .cardName(entity.getCardName())
+                        .maskedCardNumber(entity.getMaskedCardNumber())
+                        .cardBinType01(entity.getCardBinType01())
+                        .cardBinType02(entity.getCardBinType02())
+                        .status(entity.getStatus())
+                        .createdAt(entity.getCreatedAt())
+                        .modifiedAt(entity.getModifiedAt())
+                        .build()
+        );
+    }
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/quickpayment/repository/QuickPaymentCardJpaRepository.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/quickpayment/repository/QuickPaymentCardJpaRepository.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.commerce.adapter.out.persistence.quickpayment.repository;
+
+import com.personal.marketnote.commerce.adapter.out.persistence.quickpayment.entity.QuickPaymentCardJpaEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface QuickPaymentCardJpaRepository extends JpaRepository<QuickPaymentCardJpaEntity, Long> {
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/vendor/kcp/KcpApiClient.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/vendor/kcp/KcpApiClient.java
@@ -3,6 +3,8 @@ package com.personal.marketnote.commerce.adapter.out.vendor.kcp;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.personal.marketnote.commerce.adapter.out.vendor.kcp.dto.*;
+import com.personal.marketnote.commerce.adapter.out.vendor.kcp.dto.KcpBatchKeyIssuanceRequest;
+import com.personal.marketnote.commerce.adapter.out.vendor.kcp.dto.KcpBatchKeyIssuanceResponse;
 import com.personal.marketnote.commerce.adapter.out.vendor.kcp.exception.KcpCommunicationException;
 import com.personal.marketnote.commerce.configuration.KcpProperties;
 import com.personal.marketnote.common.utility.FormatValidator;
@@ -109,6 +111,33 @@ public class KcpApiClient {
         } catch (Exception e) {
             log.error("KCP 결제취소 응답 파싱 실패: {}", e.getMessage());
             throw new KcpCommunicationException("KCP 결제취소 응답 파싱 실패", e);
+        }
+    }
+
+    public KcpBatchKeyIssuanceResponse issueBatchKey(KcpBatchKeyIssuanceRequest request) {
+        String url = kcpProperties.getApi().getBatchKeyIssuanceUrl();
+
+        log.info("KCP 배치키 발급 요청: url={}, site_cd={}", url, request.siteCd());
+
+        ResponseEntity<String> rawResponse = restClient.post()
+                .uri(url)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(request)
+                .retrieve()
+                .toEntity(String.class);
+
+        String responseBody = rawResponse.getBody();
+        log.debug("KCP 배치키 발급 응답 Content-Type={}, body={}", rawResponse.getHeaders().getContentType(), responseBody);
+
+        if (FormatValidator.hasNoValue(responseBody)) {
+            throw new KcpCommunicationException("KCP 배치키 발급 응답 본문이 비어 있습니다.");
+        }
+
+        try {
+            return objectMapper.readValue(responseBody, KcpBatchKeyIssuanceResponse.class);
+        } catch (Exception e) {
+            log.error("KCP 배치키 발급 응답 파싱 실패: {}", e.getMessage());
+            throw new KcpCommunicationException("KCP 배치키 발급 응답 파싱 실패", e);
         }
     }
 

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/vendor/kcp/KcpQuickPaymentAdapter.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/vendor/kcp/KcpQuickPaymentAdapter.java
@@ -1,6 +1,9 @@
 package com.personal.marketnote.commerce.adapter.out.vendor.kcp;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.personal.marketnote.commerce.adapter.out.vendor.kcp.dto.KcpBatchKeyIssuanceRequest;
+import com.personal.marketnote.commerce.adapter.out.vendor.kcp.dto.KcpBatchKeyIssuanceResponse;
 import com.personal.marketnote.commerce.adapter.out.vendor.kcp.dto.KcpTradeRegisterRequest;
 import com.personal.marketnote.commerce.adapter.out.vendor.kcp.dto.KcpTradeRegisterResponse;
 import com.personal.marketnote.commerce.adapter.out.vendor.kcp.exception.KcpCommunicationException;
@@ -9,29 +12,32 @@ import com.personal.marketnote.commerce.domain.vendorcommunication.CommerceVendo
 import com.personal.marketnote.commerce.domain.vendorcommunication.CommerceVendorCommunicationTargetType;
 import com.personal.marketnote.commerce.domain.vendorcommunication.CommerceVendorCommunicationType;
 import com.personal.marketnote.commerce.domain.vendorcommunication.CommerceVendorName;
-import com.personal.marketnote.commerce.port.out.quickpayment.RegisterQuickPaymentTransactionPort;
-import com.personal.marketnote.commerce.port.out.quickpayment.RegisterQuickPaymentTransactionPortCommand;
-import com.personal.marketnote.commerce.port.out.quickpayment.RegisterQuickPaymentTransactionPortResult;
+import com.personal.marketnote.commerce.port.out.quickpayment.*;
 import com.personal.marketnote.commerce.utility.VendorCommunicationRecorder;
 import com.personal.marketnote.common.adapter.out.ServiceAdapter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.Map;
+import java.util.Set;
 
 @ServiceAdapter
 @RequiredArgsConstructor
 @Slf4j
-public class KcpQuickPaymentAdapter implements RegisterQuickPaymentTransactionPort {
+public class KcpQuickPaymentAdapter implements RegisterQuickPaymentTransactionPort, IssueBatchKeyPort {
     private static final CommerceVendorName VENDOR_NAME = CommerceVendorName.NHN_KCP;
-    private static final CommerceVendorCommunicationTargetType TARGET_TYPE =
-            CommerceVendorCommunicationTargetType.QUICK_PAYMENT_TRADE_REGISTER;
     private static final String GOOD_MNY = "0";
     private static final String PAY_METHOD = "AUTH";
     private static final String GOOD_NAME = "빠른결제 카드 등록";
+    private static final String BATCH_KEY_TRAN_CD = "00300001";
+    private static final String MASKED = "***MASKED***";
+    private static final Set<String> SENSITIVE_FIELDS = Set.of(
+            "kcp_cert_info", "enc_data", "enc_info", "batch_key"
+    );
 
     private final KcpProperties kcpProperties;
     private final KcpApiClient kcpApiClient;
+    private final KcpCertificateLoader kcpCertificateLoader;
     private final VendorCommunicationRecorder vendorCommunicationRecorder;
 
     @Override
@@ -47,11 +53,13 @@ public class KcpQuickPaymentAdapter implements RegisterQuickPaymentTransactionPo
                 .retUrl(kcpProperties.getRetUrl())
                 .build();
 
-        recordRequest(command.transactionId(), request);
+        recordRequest(CommerceVendorCommunicationTargetType.QUICK_PAYMENT_TRADE_REGISTER,
+                command.transactionId(), request);
 
         try {
             KcpTradeRegisterResponse response = kcpApiClient.registerTrade(request);
-            recordResponse(command.transactionId(), response);
+            recordResponse(CommerceVendorCommunicationTargetType.QUICK_PAYMENT_TRADE_REGISTER,
+                    command.transactionId(), response);
 
             boolean isSuccess = response.isSuccess();
             if (!isSuccess) {
@@ -68,15 +76,60 @@ public class KcpQuickPaymentAdapter implements RegisterQuickPaymentTransactionPo
                     .rawResponse(kcpApiClient.toJsonNode(response).toString())
                     .build();
         } catch (KcpCommunicationException e) {
-            recordError(command.transactionId(), e);
+            recordError(CommerceVendorCommunicationTargetType.QUICK_PAYMENT_TRADE_REGISTER,
+                    command.transactionId(), e);
             throw e;
         }
     }
 
-    private void recordRequest(String targetId, Object request) {
-        JsonNode payloadJson = kcpApiClient.toJsonNode(request);
+    @Override
+    public IssueBatchKeyPortResult issueBatchKey(IssueBatchKeyPortCommand command) {
+        String certInfo = kcpCertificateLoader.loadCertInfo();
+
+        KcpBatchKeyIssuanceRequest request = KcpBatchKeyIssuanceRequest.builder()
+                .siteCd(kcpProperties.getSiteCd())
+                .kcpCertInfo(certInfo)
+                .encData(command.encData())
+                .encInfo(command.encInfo())
+                .tranCd(BATCH_KEY_TRAN_CD)
+                .build();
+
+        recordRequest(CommerceVendorCommunicationTargetType.QUICK_PAYMENT_BATCH_KEY_ISSUANCE,
+                null, request);
+
+        try {
+            KcpBatchKeyIssuanceResponse response = kcpApiClient.issueBatchKey(request);
+            recordResponse(CommerceVendorCommunicationTargetType.QUICK_PAYMENT_BATCH_KEY_ISSUANCE,
+                    null, response);
+
+            boolean isSuccess = response.isSuccess();
+            if (!isSuccess) {
+                log.error("빠른결제 배치키 발급 실패: resCd={}, resMsg={}", response.resCd(), response.resMsg());
+            }
+
+            return IssueBatchKeyPortResult.builder()
+                    .success(isSuccess)
+                    .resultCode(response.resCd())
+                    .resultMessage(response.resMsg())
+                    .batchKey(response.batchKey())
+                    .cardCode(response.cardCd())
+                    .cardName(response.cardName())
+                    .cardBinType01(response.cardBinType01())
+                    .cardBinType02(response.cardBinType02())
+                    .rawResponse(kcpApiClient.toJsonNode(response).toString())
+                    .build();
+        } catch (KcpCommunicationException e) {
+            recordError(CommerceVendorCommunicationTargetType.QUICK_PAYMENT_BATCH_KEY_ISSUANCE,
+                    null, e);
+            throw e;
+        }
+    }
+
+    private void recordRequest(CommerceVendorCommunicationTargetType targetType,
+                               String targetId, Object request) {
+        JsonNode payloadJson = maskSensitiveFields(kcpApiClient.toJsonNode(request));
         vendorCommunicationRecorder.record(
-                TARGET_TYPE,
+                targetType,
                 CommerceVendorCommunicationType.REQUEST,
                 CommerceVendorCommunicationSenderType.SERVER,
                 targetId,
@@ -86,10 +139,22 @@ public class KcpQuickPaymentAdapter implements RegisterQuickPaymentTransactionPo
         );
     }
 
-    private void recordResponse(String targetId, Object response) {
-        JsonNode payloadJson = kcpApiClient.toJsonNode(response);
+    private JsonNode maskSensitiveFields(JsonNode node) {
+        if (node instanceof ObjectNode objectNode) {
+            SENSITIVE_FIELDS.forEach(field -> {
+                if (objectNode.has(field)) {
+                    objectNode.put(field, MASKED);
+                }
+            });
+        }
+        return node;
+    }
+
+    private void recordResponse(CommerceVendorCommunicationTargetType targetType,
+                                String targetId, Object response) {
+        JsonNode payloadJson = maskSensitiveFields(kcpApiClient.toJsonNode(response));
         vendorCommunicationRecorder.record(
-                TARGET_TYPE,
+                targetType,
                 CommerceVendorCommunicationType.RESPONSE,
                 CommerceVendorCommunicationSenderType.VENDOR,
                 targetId,
@@ -99,12 +164,13 @@ public class KcpQuickPaymentAdapter implements RegisterQuickPaymentTransactionPo
         );
     }
 
-    private void recordError(String targetId, Exception e) {
+    private void recordError(CommerceVendorCommunicationTargetType targetType,
+                             String targetId, Exception e) {
         JsonNode errorJson = kcpApiClient.toJsonNode(
                 Map.of("error", e.getClass().getSimpleName(), "message", e.getMessage())
         );
         vendorCommunicationRecorder.record(
-                TARGET_TYPE,
+                targetType,
                 CommerceVendorCommunicationType.RESPONSE,
                 CommerceVendorCommunicationSenderType.VENDOR,
                 targetId,

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/vendor/kcp/dto/KcpBatchKeyIssuanceRequest.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/vendor/kcp/dto/KcpBatchKeyIssuanceRequest.java
@@ -1,0 +1,14 @@
+package com.personal.marketnote.commerce.adapter.out.vendor.kcp.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+
+@Builder
+public record KcpBatchKeyIssuanceRequest(
+        @JsonProperty("site_cd") String siteCd,
+        @JsonProperty("kcp_cert_info") String kcpCertInfo,
+        @JsonProperty("enc_data") String encData,
+        @JsonProperty("enc_info") String encInfo,
+        @JsonProperty("tran_cd") String tranCd
+) {
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/vendor/kcp/dto/KcpBatchKeyIssuanceResponse.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/vendor/kcp/dto/KcpBatchKeyIssuanceResponse.java
@@ -1,0 +1,19 @@
+package com.personal.marketnote.commerce.adapter.out.vendor.kcp.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record KcpBatchKeyIssuanceResponse(
+        @JsonProperty("res_cd") String resCd,
+        @JsonProperty("res_msg") String resMsg,
+        @JsonProperty("batch_key") String batchKey,
+        @JsonProperty("card_cd") String cardCd,
+        @JsonProperty("card_name") String cardName,
+        @JsonProperty("card_bin_type_01") String cardBinType01,
+        @JsonProperty("card_bin_type_02") String cardBinType02
+) {
+    public boolean isSuccess() {
+        return "0000".equals(resCd);
+    }
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/configuration/KcpProperties.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/configuration/KcpProperties.java
@@ -23,6 +23,7 @@ public class KcpProperties {
         private String tradeRegisterUrl;
         private String paymentApprovalUrl;
         private String paymentCancelUrl;
+        private String batchKeyIssuanceUrl;
     }
 
     @Getter

--- a/commerce-service/commerce-adapters/src/main/resources/application.yml
+++ b/commerce-service/commerce-adapters/src/main/resources/application.yml
@@ -96,6 +96,7 @@ kcp:
     trade-register-url: ${KCP_TRADE_REGISTER_URL:https://testsmpay.kcp.co.kr/trade/register.do}
     payment-approval-url: ${KCP_PAYMENT_APPROVAL_URL:https://stg-spl.kcp.co.kr/gw/enc/v1/payment}
     payment-cancel-url: ${KCP_PAYMENT_CANCEL_URL:https://stg-spl.kcp.co.kr/gw/mod/v1/cancel}
+    batch-key-issuance-url: ${KCP_BATCH_KEY_ISSUANCE_URL:https://stg-spl.kcp.co.kr/gw/enc/v1/payment}
   retry:
     max-attempts: ${KCP_RETRY_MAX_ATTEMPTS:3}
     initial-delay-ms: ${KCP_RETRY_INITIAL_DELAY_MS:1000}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/exception/QuickPaymentBatchKeyIssuanceFailedException.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/exception/QuickPaymentBatchKeyIssuanceFailedException.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.commerce.exception;
+
+public class QuickPaymentBatchKeyIssuanceFailedException extends RuntimeException {
+    private static final String MESSAGE = "빠른결제 배치키 발급 실패 [%s]: %s";
+
+    public QuickPaymentBatchKeyIssuanceFailedException(String resultCode, String resultMessage) {
+        super(String.format(MESSAGE, resultCode, resultMessage));
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/command/quickpayment/IssueBatchKeyCommand.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/command/quickpayment/IssueBatchKeyCommand.java
@@ -1,0 +1,11 @@
+package com.personal.marketnote.commerce.port.in.command.quickpayment;
+
+import lombok.Builder;
+
+@Builder
+public record IssueBatchKeyCommand(
+        Long userId,
+        String encData,
+        String encInfo
+) {
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/result/quickpayment/IssueBatchKeyResult.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/result/quickpayment/IssueBatchKeyResult.java
@@ -1,0 +1,14 @@
+package com.personal.marketnote.commerce.port.in.result.quickpayment;
+
+import lombok.Builder;
+
+@Builder
+public record IssueBatchKeyResult(
+        Long quickPaymentCardId,
+        String cardCode,
+        String cardName,
+        String maskedCardNumber,
+        String cardBinType01,
+        String cardBinType02
+) {
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/quickpayment/IssueBatchKeyUseCase.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/quickpayment/IssueBatchKeyUseCase.java
@@ -1,0 +1,22 @@
+package com.personal.marketnote.commerce.port.in.usecase.quickpayment;
+
+import com.personal.marketnote.commerce.port.in.command.quickpayment.IssueBatchKeyCommand;
+import com.personal.marketnote.commerce.port.in.result.quickpayment.IssueBatchKeyResult;
+
+/**
+ * 빠른결제 배치키 발급 유스케이스
+ *
+ * @Author 성효빈
+ * @Date 2026-04-16
+ * @Description KCP 배치키를 발급하고 빠른결제 카드를 저장합니다.
+ */
+public interface IssueBatchKeyUseCase {
+    /**
+     * @param command 배치키 발급 커맨드
+     * @return 배치키 발급 결과 {@link IssueBatchKeyResult}
+     * @Date 2026-04-16
+     * @Author 성효빈
+     * @Description KCP에 배치키를 발급받고 빠른결제 카드를 DB에 저장합니다.
+     */
+    IssueBatchKeyResult issueBatchKey(IssueBatchKeyCommand command);
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/quickpayment/IssueBatchKeyPort.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/quickpayment/IssueBatchKeyPort.java
@@ -1,0 +1,19 @@
+package com.personal.marketnote.commerce.port.out.quickpayment;
+
+/**
+ * 빠른결제 배치키 발급 포트
+ *
+ * @Author 성효빈
+ * @Date 2026-04-16
+ * @Description KCP에 배치키 발급을 요청합니다.
+ */
+public interface IssueBatchKeyPort {
+    /**
+     * @param command 배치키 발급 요청 정보 {@link IssueBatchKeyPortCommand}
+     * @return 배치키 발급 결과 {@link IssueBatchKeyPortResult}
+     * @Date 2026-04-16
+     * @Author 성효빈
+     * @Description KCP에 배치키 발급을 요청합니다.
+     */
+    IssueBatchKeyPortResult issueBatchKey(IssueBatchKeyPortCommand command);
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/quickpayment/IssueBatchKeyPortCommand.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/quickpayment/IssueBatchKeyPortCommand.java
@@ -1,0 +1,10 @@
+package com.personal.marketnote.commerce.port.out.quickpayment;
+
+import lombok.Builder;
+
+@Builder
+public record IssueBatchKeyPortCommand(
+        String encData,
+        String encInfo
+) {
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/quickpayment/IssueBatchKeyPortResult.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/quickpayment/IssueBatchKeyPortResult.java
@@ -1,0 +1,17 @@
+package com.personal.marketnote.commerce.port.out.quickpayment;
+
+import lombok.Builder;
+
+@Builder
+public record IssueBatchKeyPortResult(
+        boolean success,
+        String resultCode,
+        String resultMessage,
+        String batchKey,
+        String cardCode,
+        String cardName,
+        String cardBinType01,
+        String cardBinType02,
+        String rawResponse
+) {
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/quickpayment/SaveQuickPaymentCardPort.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/quickpayment/SaveQuickPaymentCardPort.java
@@ -1,0 +1,21 @@
+package com.personal.marketnote.commerce.port.out.quickpayment;
+
+import com.personal.marketnote.commerce.domain.quickpayment.QuickPaymentCard;
+
+/**
+ * 빠른결제 카드 저장 포트
+ *
+ * @Author 성효빈
+ * @Date 2026-04-16
+ * @Description 빠른결제 카드를 DB에 저장합니다.
+ */
+public interface SaveQuickPaymentCardPort {
+    /**
+     * @param quickPaymentCard 저장할 빠른결제 카드 도메인
+     * @return 저장된 빠른결제 카드 {@link QuickPaymentCard}
+     * @Date 2026-04-16
+     * @Author 성효빈
+     * @Description 빠른결제 카드를 DB에 저장합니다.
+     */
+    QuickPaymentCard save(QuickPaymentCard quickPaymentCard);
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/quickpayment/IssueBatchKeyService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/quickpayment/IssueBatchKeyService.java
@@ -1,0 +1,59 @@
+package com.personal.marketnote.commerce.service.quickpayment;
+
+import com.personal.marketnote.commerce.domain.quickpayment.QuickPaymentCard;
+import com.personal.marketnote.commerce.domain.quickpayment.QuickPaymentCardCreateState;
+import com.personal.marketnote.commerce.exception.QuickPaymentBatchKeyIssuanceFailedException;
+import com.personal.marketnote.commerce.port.in.command.quickpayment.IssueBatchKeyCommand;
+import com.personal.marketnote.commerce.port.in.result.quickpayment.IssueBatchKeyResult;
+import com.personal.marketnote.commerce.port.in.usecase.quickpayment.IssueBatchKeyUseCase;
+import com.personal.marketnote.commerce.port.out.quickpayment.IssueBatchKeyPort;
+import com.personal.marketnote.commerce.port.out.quickpayment.IssueBatchKeyPortCommand;
+import com.personal.marketnote.commerce.port.out.quickpayment.IssueBatchKeyPortResult;
+import com.personal.marketnote.commerce.port.out.quickpayment.SaveQuickPaymentCardPort;
+import com.personal.marketnote.common.application.UseCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@UseCase
+@RequiredArgsConstructor
+@Slf4j
+public class IssueBatchKeyService implements IssueBatchKeyUseCase {
+    private final IssueBatchKeyPort issueBatchKeyPort;
+    private final SaveQuickPaymentCardPort saveQuickPaymentCardPort;
+
+    @Override
+    public IssueBatchKeyResult issueBatchKey(IssueBatchKeyCommand command) {
+        log.info("빠른결제 배치키 발급 요청 - userId: {}", command.userId());
+
+        IssueBatchKeyPortCommand portCommand = IssueBatchKeyPortCommand.builder()
+                .encData(command.encData())
+                .encInfo(command.encInfo())
+                .build();
+
+        IssueBatchKeyPortResult portResult = issueBatchKeyPort.issueBatchKey(portCommand);
+
+        if (!portResult.success()) {
+            throw new QuickPaymentBatchKeyIssuanceFailedException(portResult.resultCode(), portResult.resultMessage());
+        }
+
+        QuickPaymentCardCreateState createState = QuickPaymentCardCreateState.builder()
+                .userId(command.userId())
+                .batchKey(portResult.batchKey())
+                .cardCode(portResult.cardCode())
+                .cardName(portResult.cardName())
+                .cardBinType01(portResult.cardBinType01())
+                .cardBinType02(portResult.cardBinType02())
+                .build();
+
+        QuickPaymentCard savedCard = saveQuickPaymentCardPort.save(QuickPaymentCard.from(createState));
+
+        return IssueBatchKeyResult.builder()
+                .quickPaymentCardId(savedCard.getId())
+                .cardCode(savedCard.getCardCode())
+                .cardName(savedCard.getCardName())
+                .maskedCardNumber(savedCard.getMaskedCardNumber())
+                .cardBinType01(savedCard.getCardBinType01())
+                .cardBinType02(savedCard.getCardBinType02())
+                .build();
+    }
+}

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/quickpayment/QuickPaymentCard.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/quickpayment/QuickPaymentCard.java
@@ -1,0 +1,57 @@
+package com.personal.marketnote.commerce.domain.quickpayment;
+
+import com.personal.marketnote.common.domain.BaseDomain;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+@Getter
+public class QuickPaymentCard extends BaseDomain {
+    private Long id;
+    private Long userId;
+    private String batchKey;
+    private String groupId;
+    private String cardCode;
+    private String cardName;
+    private String maskedCardNumber;
+    private String cardBinType01;
+    private String cardBinType02;
+    private LocalDateTime createdAt;
+    private LocalDateTime modifiedAt;
+
+    public static QuickPaymentCard from(QuickPaymentCardCreateState state) {
+        QuickPaymentCard card = QuickPaymentCard.builder()
+                .userId(state.getUserId())
+                .batchKey(state.getBatchKey())
+                .groupId(state.getGroupId())
+                .cardCode(state.getCardCode())
+                .cardName(state.getCardName())
+                .maskedCardNumber(state.getMaskedCardNumber())
+                .cardBinType01(state.getCardBinType01())
+                .cardBinType02(state.getCardBinType02())
+                .build();
+        card.activate();
+        return card;
+    }
+
+    public static QuickPaymentCard from(QuickPaymentCardSnapshotState state) {
+        QuickPaymentCard card = QuickPaymentCard.builder()
+                .id(state.getId())
+                .userId(state.getUserId())
+                .batchKey(state.getBatchKey())
+                .groupId(state.getGroupId())
+                .cardCode(state.getCardCode())
+                .cardName(state.getCardName())
+                .maskedCardNumber(state.getMaskedCardNumber())
+                .cardBinType01(state.getCardBinType01())
+                .cardBinType02(state.getCardBinType02())
+                .createdAt(state.getCreatedAt())
+                .modifiedAt(state.getModifiedAt())
+                .build();
+        card.status = state.getStatus();
+        return card;
+    }
+}

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/quickpayment/QuickPaymentCardCreateState.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/quickpayment/QuickPaymentCardCreateState.java
@@ -1,0 +1,18 @@
+package com.personal.marketnote.commerce.domain.quickpayment;
+
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class QuickPaymentCardCreateState {
+    private Long userId;
+    private String batchKey;
+    private String groupId;
+    private String cardCode;
+    private String cardName;
+    private String maskedCardNumber;
+    private String cardBinType01;
+    private String cardBinType02;
+}

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/quickpayment/QuickPaymentCardSnapshotState.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/quickpayment/QuickPaymentCardSnapshotState.java
@@ -1,0 +1,25 @@
+package com.personal.marketnote.commerce.domain.quickpayment;
+
+import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class QuickPaymentCardSnapshotState {
+    private Long id;
+    private Long userId;
+    private String batchKey;
+    private String groupId;
+    private String cardCode;
+    private String cardName;
+    private String maskedCardNumber;
+    private String cardBinType01;
+    private String cardBinType02;
+    private EntityStatus status;
+    private LocalDateTime createdAt;
+    private LocalDateTime modifiedAt;
+}

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/vendorcommunication/CommerceVendorCommunicationTargetType.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/vendorcommunication/CommerceVendorCommunicationTargetType.java
@@ -7,7 +7,8 @@ public enum CommerceVendorCommunicationTargetType {
     TRADE_REGISTER("거래등록"),
     PAYMENT_APPROVAL("결제승인"),
     PAYMENT_CANCEL("결제취소"),
-    QUICK_PAYMENT_TRADE_REGISTER("빠른결제 거래등록");
+    QUICK_PAYMENT_TRADE_REGISTER("빠른결제 거래등록"),
+    QUICK_PAYMENT_BATCH_KEY_ISSUANCE("빠른결제 배치키 발급");
 
     private final String description;
 }


### PR DESCRIPTION
## partially addresses #216
## resolves #1096

## Task
- [x] QuickPaymentCard 도메인 모델 정의 (userId, batchKey, groupId, cardCode, cardName, maskedCardNumber, cardBinType01, cardBinType02)
- [x] QuickPaymentCardJpaEntity + JPA 리포지토리 정의
- [x] IssueBatchKeyUseCase UseCase 인터페이스 정의
- [x] IssueBatchKeyCommand / IssueBatchKeyResult 정의
- [x] IssueBatchKeyPort Out Port 정의 (KCP 배치키 발급 요청)
- [x] SaveQuickPaymentCardPort Out Port 정의 (DB 저장)
- [x] IssueBatchKeyService 서비스 구현 (KCP 발급 → DB 저장)
- [x] KCP 배치키 발급 HTTP 클라이언트 어댑터 구현 (kcp_cert_info, enc_data, enc_info, tran_cd=00300001)
- [x] 배치키 발급 REST API 컨트롤러 추가
- [x] ApiDocs 합성 애노테이션 추가