### PR TITLE
[#216][#1097] feat: 빠른결제 카드 결제 승인 기능 추가

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/quickpayment/controller/QuickPaymentController.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/quickpayment/controller/QuickPaymentController.java
@@ -1,14 +1,20 @@
 package com.personal.marketnote.commerce.adapter.in.web.quickpayment.controller;
 
+import com.personal.marketnote.commerce.adapter.in.web.quickpayment.controller.apidocs.ApproveQuickPaymentApiDocs;
 import com.personal.marketnote.commerce.adapter.in.web.quickpayment.controller.apidocs.IssueBatchKeyApiDocs;
 import com.personal.marketnote.commerce.adapter.in.web.quickpayment.controller.apidocs.RegisterQuickPaymentTransactionApiDocs;
+import com.personal.marketnote.commerce.adapter.in.web.quickpayment.request.ApproveQuickPaymentRequest;
 import com.personal.marketnote.commerce.adapter.in.web.quickpayment.request.IssueBatchKeyRequest;
+import com.personal.marketnote.commerce.adapter.in.web.quickpayment.response.ApproveQuickPaymentResponse;
 import com.personal.marketnote.commerce.adapter.in.web.quickpayment.response.IssueBatchKeyResponse;
 import com.personal.marketnote.commerce.adapter.in.web.quickpayment.response.RegisterQuickPaymentTransactionResponse;
+import com.personal.marketnote.commerce.port.in.command.quickpayment.ApproveQuickPaymentCommand;
 import com.personal.marketnote.commerce.port.in.command.quickpayment.IssueBatchKeyCommand;
 import com.personal.marketnote.commerce.port.in.command.quickpayment.RegisterQuickPaymentTransactionCommand;
+import com.personal.marketnote.commerce.port.in.result.quickpayment.ApproveQuickPaymentResult;
 import com.personal.marketnote.commerce.port.in.result.quickpayment.IssueBatchKeyResult;
 import com.personal.marketnote.commerce.port.in.result.quickpayment.RegisterQuickPaymentTransactionResult;
+import com.personal.marketnote.commerce.port.in.usecase.quickpayment.ApproveQuickPaymentUseCase;
 import com.personal.marketnote.commerce.port.in.usecase.quickpayment.IssueBatchKeyUseCase;
 import com.personal.marketnote.commerce.port.in.usecase.quickpayment.RegisterQuickPaymentTransactionUseCase;
 import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
@@ -41,6 +47,7 @@ import static com.personal.marketnote.common.domain.exception.ExceptionCode.DEFA
 public class QuickPaymentController {
     private final RegisterQuickPaymentTransactionUseCase registerQuickPaymentTransactionUseCase;
     private final IssueBatchKeyUseCase issueBatchKeyUseCase;
+    private final ApproveQuickPaymentUseCase approveQuickPaymentUseCase;
 
     /**
      * 빠른결제 거래 등록 (Mobile)
@@ -105,6 +112,43 @@ public class QuickPaymentController {
                         HttpStatus.OK,
                         DEFAULT_SUCCESS_CODE,
                         "빠른결제 카드 배치키 발급 성공"
+                ),
+                HttpStatus.OK
+        );
+    }
+
+    /**
+     * 빠른결제 결제 승인
+     *
+     * @param request 빠른결제 승인 요청
+     * @return 승인 응답 {@link ApproveQuickPaymentResponse}
+     * @Author 성효빈
+     * @Date 2026-04-16
+     * @Description 저장된 배치키로 KCP 서버 투 서버 결제 승인을 수행합니다.
+     */
+    @PostMapping("/api/v1/quick-payments/approve")
+    @ApproveQuickPaymentApiDocs
+    public ResponseEntity<BaseResponse<ApproveQuickPaymentResponse>> approveQuickPayment(
+            @AuthenticationPrincipal OAuth2AuthenticatedPrincipal principal,
+            @Valid @RequestBody ApproveQuickPaymentRequest request
+    ) {
+        Long userId = ElementExtractor.extractUserId(principal);
+
+        ApproveQuickPaymentResult result = approveQuickPaymentUseCase.approve(
+                ApproveQuickPaymentCommand.builder()
+                        .buyerId(userId)
+                        .orderKey(request.getOrderKey())
+                        .quickPaymentCardId(request.getQuickPaymentCardId())
+                        .goodName(request.getGoodName())
+                        .build()
+        );
+
+        return new ResponseEntity<>(
+                BaseResponse.of(
+                        ApproveQuickPaymentResponse.from(result),
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "빠른결제 승인 성공"
                 ),
                 HttpStatus.OK
         );

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/quickpayment/controller/apidocs/ApproveQuickPaymentApiDocs.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/quickpayment/controller/apidocs/ApproveQuickPaymentApiDocs.java
@@ -1,0 +1,96 @@
+package com.personal.marketnote.commerce.adapter.in.web.quickpayment.controller.apidocs;
+
+import com.personal.marketnote.commerce.adapter.in.web.quickpayment.request.ApproveQuickPaymentRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Operation(
+        summary = "빠른결제 결제 승인",
+        description = """
+                작성일자: 2026-04-16
+
+                작성자: 성효빈
+
+                ---
+
+                ## Description
+
+                - 저장된 배치키를 사용하여 서버 투 서버로 KCP 결제 승인을 수행합니다.
+
+                - 클라이언트 결제창 경유 없이 배치키 기반으로 즉시 승인합니다.
+
+                ---
+
+                ## Request
+
+                | **키** | **타입** | **설명** | **필수 여부** | **예시** |
+                | --- | --- | --- | --- | --- |
+                | orderKey | string | 주문 키 (UUID) | Y | "550e8400-e29b-41d4-a716-446655440000" |
+                | quickPaymentCardId | number | 빠른결제 카드 ID | Y | 1 |
+                | goodName | string | 상품명 | Y | "건강식품 외 2건" |
+
+                ---
+
+                ## Response > content
+
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | orderId | number | 주문 ID | 1 |
+                | orderKey | string | 주문 키 (UUID) | "550e8400-e29b-41d4-a716-446655440000" |
+                | pgPaymentKey | string | PG 결제 키 (KCP tno) | "T0000..." |
+                | amount | number | 결제 금액 | 50000 |
+                | resultCode | string | 결과 코드 | "0000" |
+                | resultMessage | string | 결과 메시지 | "승인 성공" |
+                | payMethod | string | 결제 수단 | "PACA" |
+                """,
+        security = {@SecurityRequirement(name = "bearer")},
+        requestBody = @RequestBody(
+                required = true,
+                content = @Content(
+                        schema = @Schema(implementation = ApproveQuickPaymentRequest.class),
+                        examples = @ExampleObject("""
+                                {
+                                  "orderKey": "550e8400-e29b-41d4-a716-446655440000",
+                                  "quickPaymentCardId": 1,
+                                  "goodName": "건강식품 외 2건"
+                                }
+                                """)
+                )
+        ),
+        responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "빠른결제 승인 성공",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 200,
+                                          "code": "SUC01",
+                                          "timestamp": "2026-04-16T17:19:33.409686",
+                                          "content": {
+                                            "orderId": 1,
+                                            "orderKey": "550e8400-e29b-41d4-a716-446655440000",
+                                            "pgPaymentKey": "T0000MGABJUXLY81",
+                                            "amount": 50000,
+                                            "resultCode": "0000",
+                                            "resultMessage": "승인 성공",
+                                            "payMethod": "PACA"
+                                          },
+                                          "message": "빠른결제 승인 성공"
+                                        }
+                                        """)
+                        )
+                )
+        })
+public @interface ApproveQuickPaymentApiDocs {
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/quickpayment/request/ApproveQuickPaymentRequest.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/quickpayment/request/ApproveQuickPaymentRequest.java
@@ -1,0 +1,37 @@
+package com.personal.marketnote.commerce.adapter.in.web.quickpayment.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+@Getter
+public class ApproveQuickPaymentRequest {
+    @Schema(
+            name = "orderKey",
+            description = "주문 키 (UUID)",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    @NotBlank(message = "주문 키는 필수값입니다.")
+    private String orderKey;
+
+    @Schema(
+            name = "quickPaymentCardId",
+            description = "빠른결제 카드 ID",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    @NotNull(message = "빠른결제 카드 ID는 필수값입니다.")
+    @Min(value = 1, message = "빠른결제 카드 ID는 1 이상이어야 합니다.")
+    private Long quickPaymentCardId;
+
+    @Schema(
+            name = "goodName",
+            description = "상품명",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    @NotBlank(message = "상품명은 필수값입니다.")
+    @Size(max = 100, message = "상품명은 100자를 초과할 수 없습니다.")
+    private String goodName;
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/quickpayment/response/ApproveQuickPaymentResponse.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/quickpayment/response/ApproveQuickPaymentResponse.java
@@ -1,0 +1,28 @@
+package com.personal.marketnote.commerce.adapter.in.web.quickpayment.response;
+
+import com.personal.marketnote.commerce.port.in.result.quickpayment.ApproveQuickPaymentResult;
+import lombok.AccessLevel;
+import lombok.Builder;
+
+@Builder(access = AccessLevel.PRIVATE)
+public record ApproveQuickPaymentResponse(
+        Long orderId,
+        String orderKey,
+        String pgPaymentKey,
+        Long amount,
+        String resultCode,
+        String resultMessage,
+        String payMethod
+) {
+    public static ApproveQuickPaymentResponse from(ApproveQuickPaymentResult result) {
+        return ApproveQuickPaymentResponse.builder()
+                .orderId(result.orderId())
+                .orderKey(result.orderKey())
+                .pgPaymentKey(result.pgPaymentKey())
+                .amount(result.amount())
+                .resultCode(result.resultCode())
+                .resultMessage(result.resultMessage())
+                .payMethod(result.payMethod())
+                .build();
+    }
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/quickpayment/QuickPaymentCardPersistenceAdapter.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/quickpayment/QuickPaymentCardPersistenceAdapter.java
@@ -4,13 +4,17 @@ import com.personal.marketnote.commerce.adapter.out.persistence.quickpayment.ent
 import com.personal.marketnote.commerce.adapter.out.persistence.quickpayment.mapper.QuickPaymentCardEntityToDomainMapper;
 import com.personal.marketnote.commerce.adapter.out.persistence.quickpayment.repository.QuickPaymentCardJpaRepository;
 import com.personal.marketnote.commerce.domain.quickpayment.QuickPaymentCard;
+import com.personal.marketnote.commerce.port.out.quickpayment.FindQuickPaymentCardPort;
 import com.personal.marketnote.commerce.port.out.quickpayment.SaveQuickPaymentCardPort;
 import com.personal.marketnote.common.adapter.out.PersistenceAdapter;
+import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
 import lombok.RequiredArgsConstructor;
+
+import java.util.Optional;
 
 @PersistenceAdapter
 @RequiredArgsConstructor
-public class QuickPaymentCardPersistenceAdapter implements SaveQuickPaymentCardPort {
+public class QuickPaymentCardPersistenceAdapter implements SaveQuickPaymentCardPort, FindQuickPaymentCardPort {
     private final QuickPaymentCardJpaRepository quickPaymentCardJpaRepository;
 
     @Override
@@ -18,5 +22,11 @@ public class QuickPaymentCardPersistenceAdapter implements SaveQuickPaymentCardP
         QuickPaymentCardJpaEntity entity = QuickPaymentCardJpaEntity.from(quickPaymentCard);
         QuickPaymentCardJpaEntity savedEntity = quickPaymentCardJpaRepository.save(entity);
         return QuickPaymentCardEntityToDomainMapper.mapToDomain(savedEntity);
+    }
+
+    @Override
+    public Optional<QuickPaymentCard> findActiveByIdAndUserId(Long id, Long userId) {
+        return quickPaymentCardJpaRepository.findByIdAndUserIdAndStatus(id, userId, EntityStatus.ACTIVE)
+                .map(QuickPaymentCardEntityToDomainMapper::mapToDomain);
     }
 }

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/quickpayment/repository/QuickPaymentCardJpaRepository.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/quickpayment/repository/QuickPaymentCardJpaRepository.java
@@ -1,7 +1,11 @@
 package com.personal.marketnote.commerce.adapter.out.persistence.quickpayment.repository;
 
 import com.personal.marketnote.commerce.adapter.out.persistence.quickpayment.entity.QuickPaymentCardJpaEntity;
+import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface QuickPaymentCardJpaRepository extends JpaRepository<QuickPaymentCardJpaEntity, Long> {
+    Optional<QuickPaymentCardJpaEntity> findByIdAndUserIdAndStatus(Long id, Long userId, EntityStatus status);
 }

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/vendor/kcp/KcpApiClient.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/vendor/kcp/KcpApiClient.java
@@ -141,6 +141,33 @@ public class KcpApiClient {
         }
     }
 
+    public KcpBatchPaymentApprovalResponse approveBatchPayment(KcpBatchPaymentApprovalRequest request) {
+        String url = kcpProperties.getApi().getBatchPaymentApprovalUrl();
+
+        log.info("KCP 배치 결제승인 요청: url={}, site_cd={}, ordr_idxx={}", url, request.siteCd(), request.ordrIdxx());
+
+        ResponseEntity<String> rawResponse = restClient.post()
+                .uri(url)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(request)
+                .retrieve()
+                .toEntity(String.class);
+
+        String responseBody = rawResponse.getBody();
+        log.debug("KCP 배치 결제승인 응답 Content-Type={}, body={}", rawResponse.getHeaders().getContentType(), responseBody);
+
+        if (FormatValidator.hasNoValue(responseBody)) {
+            throw new KcpCommunicationException("KCP 배치 결제승인 응답 본문이 비어 있습니다.");
+        }
+
+        try {
+            return objectMapper.readValue(responseBody, KcpBatchPaymentApprovalResponse.class);
+        } catch (Exception e) {
+            log.error("KCP 배치 결제승인 응답 파싱 실패: {}", e.getMessage());
+            throw new KcpCommunicationException("KCP 배치 결제승인 응답 파싱 실패", e);
+        }
+    }
+
     public JsonNode toJsonNode(Object object) {
         return objectMapper.valueToTree(object);
     }

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/vendor/kcp/KcpQuickPaymentAdapter.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/vendor/kcp/KcpQuickPaymentAdapter.java
@@ -2,10 +2,7 @@ package com.personal.marketnote.commerce.adapter.out.vendor.kcp;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.personal.marketnote.commerce.adapter.out.vendor.kcp.dto.KcpBatchKeyIssuanceRequest;
-import com.personal.marketnote.commerce.adapter.out.vendor.kcp.dto.KcpBatchKeyIssuanceResponse;
-import com.personal.marketnote.commerce.adapter.out.vendor.kcp.dto.KcpTradeRegisterRequest;
-import com.personal.marketnote.commerce.adapter.out.vendor.kcp.dto.KcpTradeRegisterResponse;
+import com.personal.marketnote.commerce.adapter.out.vendor.kcp.dto.*;
 import com.personal.marketnote.commerce.adapter.out.vendor.kcp.exception.KcpCommunicationException;
 import com.personal.marketnote.commerce.configuration.KcpProperties;
 import com.personal.marketnote.commerce.domain.vendorcommunication.CommerceVendorCommunicationSenderType;
@@ -24,15 +21,20 @@ import java.util.Set;
 @ServiceAdapter
 @RequiredArgsConstructor
 @Slf4j
-public class KcpQuickPaymentAdapter implements RegisterQuickPaymentTransactionPort, IssueBatchKeyPort {
+public class KcpQuickPaymentAdapter implements RegisterQuickPaymentTransactionPort, IssueBatchKeyPort, ApproveQuickPaymentPort {
     private static final CommerceVendorName VENDOR_NAME = CommerceVendorName.NHN_KCP;
     private static final String GOOD_MNY = "0";
     private static final String PAY_METHOD = "AUTH";
     private static final String GOOD_NAME = "빠른결제 카드 등록";
     private static final String BATCH_KEY_TRAN_CD = "00300001";
     private static final String MASKED = "***MASKED***";
+    private static final String BATCH_PAYMENT_PAY_METHOD = "CARD";
+    private static final String BATCH_PAYMENT_QUOTA = "00";
+    private static final String BATCH_PAYMENT_CURRENCY = "410";
+    private static final String BATCH_PAYMENT_CARD_TX_TYPE = "11511000";
+    private static final String BATCH_PAYMENT_MEDIA_TYPE = "MC02";
     private static final Set<String> SENSITIVE_FIELDS = Set.of(
-            "kcp_cert_info", "enc_data", "enc_info", "batch_key"
+            "kcp_cert_info", "enc_data", "enc_info", "batch_key", "bt_batch_key"
     );
 
     private final KcpProperties kcpProperties;
@@ -121,6 +123,65 @@ public class KcpQuickPaymentAdapter implements RegisterQuickPaymentTransactionPo
         } catch (KcpCommunicationException e) {
             recordError(CommerceVendorCommunicationTargetType.QUICK_PAYMENT_BATCH_KEY_ISSUANCE,
                     null, e);
+            throw e;
+        }
+    }
+
+    @Override
+    public ApproveQuickPaymentPortResult approvePayment(ApproveQuickPaymentPortCommand command) {
+        String certInfo = kcpCertificateLoader.loadCertInfo();
+
+        KcpBatchPaymentApprovalRequest request = KcpBatchPaymentApprovalRequest.builder()
+                .kcpCertInfo(certInfo)
+                .siteCd(kcpProperties.getSiteCd())
+                .payMethod(BATCH_PAYMENT_PAY_METHOD)
+                .amount(command.amount())
+                .cardMny(command.amount())
+                .quota(BATCH_PAYMENT_QUOTA)
+                .currency(BATCH_PAYMENT_CURRENCY)
+                .ordrIdxx(command.orderKey())
+                .goodName(command.goodName())
+                .cardTxType(BATCH_PAYMENT_CARD_TX_TYPE)
+                .btBatchKey(command.batchKey())
+                .btGroupId(command.groupId())
+                .mediaType(BATCH_PAYMENT_MEDIA_TYPE)
+                .build();
+
+        recordRequest(CommerceVendorCommunicationTargetType.QUICK_PAYMENT_BATCH_APPROVAL,
+                command.orderKey(), request);
+
+        try {
+            KcpBatchPaymentApprovalResponse response = kcpApiClient.approveBatchPayment(request);
+            recordResponse(CommerceVendorCommunicationTargetType.QUICK_PAYMENT_BATCH_APPROVAL,
+                    command.orderKey(), response);
+
+            boolean isSuccess = response.isSuccess();
+            if (!isSuccess) {
+                log.error("빠른결제 배치 결제승인 실패: resCd={}, resMsg={}", response.resCd(), response.resMsg());
+            }
+
+            return ApproveQuickPaymentPortResult.builder()
+                    .success(isSuccess)
+                    .resultCode(response.resCd())
+                    .resultMessage(response.resMsg())
+                    .transactionId(response.tno())
+                    .amount(response.amount())
+                    .payMethod(response.payMethod())
+                    .cardCode(response.cardCd())
+                    .cardName(response.cardName())
+                    .cardNumber(response.cardNo())
+                    .approvalNumber(response.appNo())
+                    .approvalTime(response.appTime())
+                    .installmentMonths(response.quota())
+                    .cardAmount(response.cardMny())
+                    .partialCancelYn(response.partcancYn())
+                    .cardBinType01(response.cardBinType01())
+                    .cardBinType02(response.cardBinType02())
+                    .rawResponse(kcpApiClient.toJsonNode(response).toString())
+                    .build();
+        } catch (KcpCommunicationException e) {
+            recordError(CommerceVendorCommunicationTargetType.QUICK_PAYMENT_BATCH_APPROVAL,
+                    command.orderKey(), e);
             throw e;
         }
     }

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/vendor/kcp/dto/KcpBatchPaymentApprovalRequest.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/vendor/kcp/dto/KcpBatchPaymentApprovalRequest.java
@@ -1,0 +1,22 @@
+package com.personal.marketnote.commerce.adapter.out.vendor.kcp.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+
+@Builder
+public record KcpBatchPaymentApprovalRequest(
+        @JsonProperty("kcp_cert_info") String kcpCertInfo,
+        @JsonProperty("site_cd") String siteCd,
+        @JsonProperty("pay_method") String payMethod,
+        @JsonProperty("amount") String amount,
+        @JsonProperty("card_mny") String cardMny,
+        @JsonProperty("quota") String quota,
+        @JsonProperty("currency") String currency,
+        @JsonProperty("ordr_idxx") String ordrIdxx,
+        @JsonProperty("good_name") String goodName,
+        @JsonProperty("card_tx_type") String cardTxType,
+        @JsonProperty("bt_batch_key") String btBatchKey,
+        @JsonProperty("bt_group_id") String btGroupId,
+        @JsonProperty("media_type") String mediaType
+) {
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/vendor/kcp/dto/KcpBatchPaymentApprovalResponse.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/vendor/kcp/dto/KcpBatchPaymentApprovalResponse.java
@@ -1,0 +1,29 @@
+package com.personal.marketnote.commerce.adapter.out.vendor.kcp.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record KcpBatchPaymentApprovalResponse(
+        @JsonProperty("res_cd") String resCd,
+        @JsonProperty("res_msg") String resMsg,
+        @JsonProperty("pay_method") String payMethod,
+        @JsonProperty("tno") String tno,
+        @JsonProperty("amount") String amount,
+        @JsonProperty("card_cd") String cardCd,
+        @JsonProperty("card_mny") String cardMny,
+        @JsonProperty("card_name") String cardName,
+        @JsonProperty("card_no") String cardNo,
+        @JsonProperty("app_no") String appNo,
+        @JsonProperty("app_time") String appTime,
+        @JsonProperty("quota") String quota,
+        @JsonProperty("acqu_cd") String acquCd,
+        @JsonProperty("acqu_name") String acquName,
+        @JsonProperty("partcanc_yn") String partcancYn,
+        @JsonProperty("card_bin_type_01") String cardBinType01,
+        @JsonProperty("card_bin_type_02") String cardBinType02
+) {
+    public boolean isSuccess() {
+        return "0000".equals(resCd);
+    }
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/configuration/KcpProperties.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/configuration/KcpProperties.java
@@ -24,6 +24,7 @@ public class KcpProperties {
         private String paymentApprovalUrl;
         private String paymentCancelUrl;
         private String batchKeyIssuanceUrl;
+        private String batchPaymentApprovalUrl;
     }
 
     @Getter

--- a/commerce-service/commerce-adapters/src/main/resources/application.yml
+++ b/commerce-service/commerce-adapters/src/main/resources/application.yml
@@ -97,6 +97,7 @@ kcp:
     payment-approval-url: ${KCP_PAYMENT_APPROVAL_URL:https://stg-spl.kcp.co.kr/gw/enc/v1/payment}
     payment-cancel-url: ${KCP_PAYMENT_CANCEL_URL:https://stg-spl.kcp.co.kr/gw/mod/v1/cancel}
     batch-key-issuance-url: ${KCP_BATCH_KEY_ISSUANCE_URL:https://stg-spl.kcp.co.kr/gw/enc/v1/payment}
+    batch-payment-approval-url: ${KCP_BATCH_PAYMENT_APPROVAL_URL:https://stg-spl.kcp.co.kr/gw/hub/v1/payment}
   retry:
     max-attempts: ${KCP_RETRY_MAX_ATTEMPTS:3}
     initial-delay-ms: ${KCP_RETRY_INITIAL_DELAY_MS:1000}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/exception/QuickPaymentApprovalFailedException.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/exception/QuickPaymentApprovalFailedException.java
@@ -1,0 +1,22 @@
+package com.personal.marketnote.commerce.exception;
+
+public class QuickPaymentApprovalFailedException extends RuntimeException {
+    private static final String APPROVAL_FAILED = "빠른결제 승인 실패 [%s]: %s";
+    private static final String APPROVAL_REQUEST_FAILED = "빠른결제 승인 요청 실패";
+
+    private QuickPaymentApprovalFailedException(String message) {
+        super(message);
+    }
+
+    private QuickPaymentApprovalFailedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public static QuickPaymentApprovalFailedException approvalFailed(String resultCode, String resultMessage) {
+        return new QuickPaymentApprovalFailedException(String.format(APPROVAL_FAILED, resultCode, resultMessage));
+    }
+
+    public static QuickPaymentApprovalFailedException approvalRequestFailed(Throwable cause) {
+        return new QuickPaymentApprovalFailedException(APPROVAL_REQUEST_FAILED, cause);
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/exception/QuickPaymentCardNotFoundException.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/exception/QuickPaymentCardNotFoundException.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.commerce.exception;
+
+public class QuickPaymentCardNotFoundException extends RuntimeException {
+    private static final String MESSAGE = "빠른결제 카드를 찾을 수 없습니다. id=%d, userId=%d";
+
+    public QuickPaymentCardNotFoundException(Long id, Long userId) {
+        super(String.format(MESSAGE, id, userId));
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/command/quickpayment/ApproveQuickPaymentCommand.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/command/quickpayment/ApproveQuickPaymentCommand.java
@@ -1,0 +1,12 @@
+package com.personal.marketnote.commerce.port.in.command.quickpayment;
+
+import lombok.Builder;
+
+@Builder
+public record ApproveQuickPaymentCommand(
+        Long buyerId,
+        String orderKey,
+        Long quickPaymentCardId,
+        String goodName
+) {
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/result/quickpayment/ApproveQuickPaymentResult.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/result/quickpayment/ApproveQuickPaymentResult.java
@@ -1,0 +1,15 @@
+package com.personal.marketnote.commerce.port.in.result.quickpayment;
+
+import lombok.Builder;
+
+@Builder
+public record ApproveQuickPaymentResult(
+        Long orderId,
+        String orderKey,
+        String pgPaymentKey,
+        Long amount,
+        String resultCode,
+        String resultMessage,
+        String payMethod
+) {
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/quickpayment/ApproveQuickPaymentUseCase.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/quickpayment/ApproveQuickPaymentUseCase.java
@@ -1,0 +1,22 @@
+package com.personal.marketnote.commerce.port.in.usecase.quickpayment;
+
+import com.personal.marketnote.commerce.port.in.command.quickpayment.ApproveQuickPaymentCommand;
+import com.personal.marketnote.commerce.port.in.result.quickpayment.ApproveQuickPaymentResult;
+
+/**
+ * 빠른결제 결제 승인 유스케이스
+ *
+ * @Author 성효빈
+ * @Date 2026-04-16
+ * @Description 저장된 배치키로 KCP 서버 투 서버 결제 승인을 수행합니다.
+ */
+public interface ApproveQuickPaymentUseCase {
+    /**
+     * @param command 빠른결제 승인 커맨드
+     * @return 승인 결과 {@link ApproveQuickPaymentResult}
+     * @Date 2026-04-16
+     * @Author 성효빈
+     * @Description 배치키 기반 KCP 결제 승인을 수행합니다.
+     */
+    ApproveQuickPaymentResult approve(ApproveQuickPaymentCommand command);
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/quickpayment/ApproveQuickPaymentPort.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/quickpayment/ApproveQuickPaymentPort.java
@@ -1,0 +1,19 @@
+package com.personal.marketnote.commerce.port.out.quickpayment;
+
+/**
+ * 빠른결제 결제 승인 포트
+ *
+ * @Author 성효빈
+ * @Date 2026-04-16
+ * @Description KCP 배치키 기반 결제 승인을 요청합니다.
+ */
+public interface ApproveQuickPaymentPort {
+    /**
+     * @param command 배치 결제 승인 요청 정보 {@link ApproveQuickPaymentPortCommand}
+     * @return 배치 결제 승인 결과 {@link ApproveQuickPaymentPortResult}
+     * @Date 2026-04-16
+     * @Author 성효빈
+     * @Description KCP 배치키 기반 결제 승인을 요청합니다.
+     */
+    ApproveQuickPaymentPortResult approvePayment(ApproveQuickPaymentPortCommand command);
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/quickpayment/ApproveQuickPaymentPortCommand.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/quickpayment/ApproveQuickPaymentPortCommand.java
@@ -1,0 +1,13 @@
+package com.personal.marketnote.commerce.port.out.quickpayment;
+
+import lombok.Builder;
+
+@Builder
+public record ApproveQuickPaymentPortCommand(
+        String batchKey,
+        String groupId,
+        String orderKey,
+        String amount,
+        String goodName
+) {
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/quickpayment/ApproveQuickPaymentPortResult.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/quickpayment/ApproveQuickPaymentPortResult.java
@@ -1,0 +1,25 @@
+package com.personal.marketnote.commerce.port.out.quickpayment;
+
+import lombok.Builder;
+
+@Builder
+public record ApproveQuickPaymentPortResult(
+        boolean success,
+        String resultCode,
+        String resultMessage,
+        String transactionId,
+        String amount,
+        String payMethod,
+        String cardCode,
+        String cardName,
+        String cardNumber,
+        String approvalNumber,
+        String approvalTime,
+        String installmentMonths,
+        String cardAmount,
+        String partialCancelYn,
+        String cardBinType01,
+        String cardBinType02,
+        String rawResponse
+) {
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/quickpayment/FindQuickPaymentCardPort.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/quickpayment/FindQuickPaymentCardPort.java
@@ -1,0 +1,24 @@
+package com.personal.marketnote.commerce.port.out.quickpayment;
+
+import com.personal.marketnote.commerce.domain.quickpayment.QuickPaymentCard;
+
+import java.util.Optional;
+
+/**
+ * 빠른결제 카드 조회 포트
+ *
+ * @Author 성효빈
+ * @Date 2026-04-16
+ * @Description 저장된 빠른결제 카드를 조회합니다.
+ */
+public interface FindQuickPaymentCardPort {
+    /**
+     * @param id     빠른결제 카드 ID
+     * @param userId 사용자 ID
+     * @return 활성 상태의 빠른결제 카드 {@link QuickPaymentCard}
+     * @Date 2026-04-16
+     * @Author 성효빈
+     * @Description 사용자 소유의 활성 빠른결제 카드를 조회합니다.
+     */
+    Optional<QuickPaymentCard> findActiveByIdAndUserId(Long id, Long userId);
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/PaymentApprovalTransactionHelper.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/PaymentApprovalTransactionHelper.java
@@ -18,6 +18,7 @@ import com.personal.marketnote.commerce.port.out.event.PublishPaymentEventPort;
 import com.personal.marketnote.commerce.port.out.order.FindOrderPort;
 import com.personal.marketnote.commerce.port.out.payment.FindPaymentPort;
 import com.personal.marketnote.commerce.port.out.payment.FindPspPaymentEventPort;
+import com.personal.marketnote.commerce.port.out.payment.SavePspPaymentEventPort;
 import com.personal.marketnote.commerce.port.out.payment.UpdatePaymentPort;
 import com.personal.marketnote.commerce.port.out.payment.UpdatePspPaymentEventPort;
 import com.personal.marketnote.commerce.port.out.payment.vendor.PaymentApprovalVendorResult;
@@ -52,6 +53,7 @@ public class PaymentApprovalTransactionHelper {
     private final FindPaymentPort findPaymentPort;
     private final UpdatePaymentPort updatePaymentPort;
     private final FindPspPaymentEventPort findPspPaymentEventPort;
+    private final SavePspPaymentEventPort savePspPaymentEventPort;
     private final UpdatePspPaymentEventPort updatePspPaymentEventPort;
     private final ChangeOrderStatusUseCase changeOrderStatusUseCase;
     private final ReserveInventoryUseCase reserveInventoryUseCase;
@@ -79,6 +81,40 @@ public class PaymentApprovalTransactionHelper {
         updatePspPaymentEventPort.update(event);
 
         return PaymentApprovalContext.of(payment, event);
+    }
+
+    /**
+     * TX-1: 빠른결제용 검증 + PspPaymentEvent 생성 + EXECUTING 상태 커밋
+     *
+     * <p>빠른결제에는 거래등록(ReadyPayment) 단계가 없어 PspPaymentEvent가 사전에 존재하지 않으므로,
+     * 이 메서드에서 직접 생성한다.</p>
+     */
+    @Transactional(propagation = REQUIRES_NEW, isolation = READ_COMMITTED)
+    public PaymentApprovalContext prepareExecutionForQuickPayment(
+            Long buyerId, String orderKey, String pgCompanyKey, String pgShopKey
+    ) {
+        UUID orderKeyUuid = UUID.fromString(orderKey);
+        Payment payment = findPaymentPort.findByOrderKey(orderKeyUuid)
+                .orElseThrow(() -> new PaymentNotFoundException(orderKey));
+
+        Order order = findVerifiedOrder(payment.getOrderId(), buyerId);
+        verifyPaymentAmount(order, payment);
+
+        findPspPaymentEventPort.findByOrderKey(orderKey)
+                .filter(PspPaymentEvent::isUnresolved)
+                .ifPresent(event -> {
+                    log.warn("빠른결제 중복 결제 시도 - orderKey: {}, 기존 이벤트 상태: {}", orderKey, event.getPoStatus());
+                    throw new DuplicatePaymentReadyException(orderKey);
+                });
+
+        reserveInventory(order);
+
+        PspPaymentEvent event = PspPaymentEvent.createReady(payment, pgCompanyKey, pgShopKey, "PACA");
+        PspPaymentEvent savedEvent = savePspPaymentEventPort.save(event);
+        savedEvent.startExecution();
+        updatePspPaymentEventPort.update(savedEvent);
+
+        return PaymentApprovalContext.of(payment, savedEvent);
     }
 
     /**

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/quickpayment/ApproveQuickPaymentService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/quickpayment/ApproveQuickPaymentService.java
@@ -1,0 +1,127 @@
+package com.personal.marketnote.commerce.service.quickpayment;
+
+import com.personal.marketnote.commerce.domain.quickpayment.QuickPaymentCard;
+import com.personal.marketnote.commerce.exception.QuickPaymentApprovalFailedException;
+import com.personal.marketnote.commerce.exception.QuickPaymentCardNotFoundException;
+import com.personal.marketnote.commerce.exception.PaymentVendorConnectionFailedException;
+import com.personal.marketnote.commerce.port.in.command.quickpayment.ApproveQuickPaymentCommand;
+import com.personal.marketnote.commerce.port.in.result.payment.ApprovePaymentResult;
+import com.personal.marketnote.commerce.port.in.result.quickpayment.ApproveQuickPaymentResult;
+import com.personal.marketnote.commerce.port.in.usecase.quickpayment.ApproveQuickPaymentUseCase;
+import com.personal.marketnote.commerce.port.out.payment.PaymentVendorPort;
+import com.personal.marketnote.commerce.port.out.payment.vendor.PaymentApprovalVendorResult;
+import com.personal.marketnote.commerce.port.out.quickpayment.ApproveQuickPaymentPort;
+import com.personal.marketnote.commerce.port.out.quickpayment.ApproveQuickPaymentPortCommand;
+import com.personal.marketnote.commerce.port.out.quickpayment.ApproveQuickPaymentPortResult;
+import com.personal.marketnote.commerce.port.out.quickpayment.FindQuickPaymentCardPort;
+import com.personal.marketnote.commerce.service.payment.PaymentApprovalContext;
+import com.personal.marketnote.commerce.service.payment.PaymentApprovalTransactionHelper;
+import com.personal.marketnote.common.application.UseCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@UseCase
+@RequiredArgsConstructor
+@Slf4j
+public class ApproveQuickPaymentService implements ApproveQuickPaymentUseCase {
+    private final PaymentApprovalTransactionHelper txHelper;
+    private final FindQuickPaymentCardPort findQuickPaymentCardPort;
+    private final ApproveQuickPaymentPort approveQuickPaymentPort;
+    private final PaymentVendorPort paymentVendorPort;
+
+    @Override
+    public ApproveQuickPaymentResult approve(ApproveQuickPaymentCommand command) {
+        log.info("빠른결제 승인 요청 - buyerId: {}, orderKey: {}, cardId: {}",
+                command.buyerId(), command.orderKey(), command.quickPaymentCardId());
+
+        QuickPaymentCard card = findQuickPaymentCardPort
+                .findActiveByIdAndUserId(command.quickPaymentCardId(), command.buyerId())
+                .orElseThrow(() -> new QuickPaymentCardNotFoundException(
+                        command.quickPaymentCardId(), command.buyerId()));
+
+        // TX-1: 검증 + PspPaymentEvent 생성 + EXECUTING
+        PaymentApprovalContext context = txHelper.prepareExecutionForQuickPayment(
+                command.buyerId(),
+                command.orderKey(),
+                paymentVendorPort.getVendorKey(),
+                paymentVendorPort.getShopCode()
+        );
+
+        // PG사 호출 (트랜잭션 외부)
+        ApproveQuickPaymentPortResult portResult = requestBatchPaymentApproval(command, card, context);
+
+        // TX-2: 성공 또는 실패
+        if (portResult.success()) {
+            Short installment = parseInstallment(portResult.installmentMonths());
+            PaymentApprovalVendorResult vendorResult = toVendorResult(portResult);
+            ApprovePaymentResult paymentResult = txHelper.commitSuccess(context, vendorResult, installment);
+            return toQuickPaymentResult(paymentResult);
+        }
+
+        txHelper.commitFailure(context, portResult.resultCode(), portResult.resultMessage());
+        throw QuickPaymentApprovalFailedException.approvalFailed(portResult.resultCode(), portResult.resultMessage());
+    }
+
+    private ApproveQuickPaymentPortResult requestBatchPaymentApproval(
+            ApproveQuickPaymentCommand command, QuickPaymentCard card, PaymentApprovalContext context
+    ) {
+        try {
+            ApproveQuickPaymentPortCommand portCommand = ApproveQuickPaymentPortCommand.builder()
+                    .batchKey(card.getBatchKey())
+                    .groupId(card.getGroupId())
+                    .orderKey(command.orderKey())
+                    .amount(String.valueOf(context.paymentAmount()))
+                    .goodName(command.goodName())
+                    .build();
+            return approveQuickPaymentPort.approvePayment(portCommand);
+        } catch (PaymentVendorConnectionFailedException e) {
+            txHelper.commitFailure(context, "CONN_FAIL", e.getMessage());
+            throw QuickPaymentApprovalFailedException.approvalRequestFailed(e);
+        } catch (Exception e) {
+            txHelper.commitUnknown(context, "UNKNOWN", "PG사 통신 오류: " + e.getMessage());
+            throw QuickPaymentApprovalFailedException.approvalRequestFailed(e);
+        }
+    }
+
+    private PaymentApprovalVendorResult toVendorResult(ApproveQuickPaymentPortResult portResult) {
+        return PaymentApprovalVendorResult.builder()
+                .success(portResult.success())
+                .resultCode(portResult.resultCode())
+                .resultMessage(portResult.resultMessage())
+                .transactionId(portResult.transactionId())
+                .amount(portResult.amount())
+                .payMethod(portResult.payMethod())
+                .cardCode(portResult.cardCode())
+                .cardName(portResult.cardName())
+                .cardNumber(portResult.cardNumber())
+                .approvalNumber(portResult.approvalNumber())
+                .approvalTime(portResult.approvalTime())
+                .installmentMonths(portResult.installmentMonths())
+                .cardAmount(portResult.cardAmount())
+                .partialCancelYn(portResult.partialCancelYn())
+                .cardBinType01(portResult.cardBinType01())
+                .cardBinType02(portResult.cardBinType02())
+                .rawResponse(portResult.rawResponse())
+                .build();
+    }
+
+    private ApproveQuickPaymentResult toQuickPaymentResult(ApprovePaymentResult paymentResult) {
+        return ApproveQuickPaymentResult.builder()
+                .orderId(paymentResult.orderId())
+                .orderKey(paymentResult.orderKey())
+                .pgPaymentKey(paymentResult.pgPaymentKey())
+                .amount(paymentResult.amount())
+                .resultCode(paymentResult.resultCode())
+                .resultMessage(paymentResult.resultMessage())
+                .payMethod(paymentResult.payMethod())
+                .build();
+    }
+
+    private Short parseInstallment(String quota) {
+        try {
+            return Short.parseShort(quota);
+        } catch (NumberFormatException e) {
+            return (short) 0;
+        }
+    }
+}

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/vendorcommunication/CommerceVendorCommunicationTargetType.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/vendorcommunication/CommerceVendorCommunicationTargetType.java
@@ -8,7 +8,8 @@ public enum CommerceVendorCommunicationTargetType {
     PAYMENT_APPROVAL("결제승인"),
     PAYMENT_CANCEL("결제취소"),
     QUICK_PAYMENT_TRADE_REGISTER("빠른결제 거래등록"),
-    QUICK_PAYMENT_BATCH_KEY_ISSUANCE("빠른결제 배치키 발급");
+    QUICK_PAYMENT_BATCH_KEY_ISSUANCE("빠른결제 배치키 발급"),
+    QUICK_PAYMENT_BATCH_APPROVAL("빠른결제 배치 결제승인");
 
     private final String description;
 }


### PR DESCRIPTION
## partially addresses #216
## resolves #1097

## Task
- [x] ApproveQuickPaymentUseCase UseCase 인터페이스 정의
- [x] ApproveQuickPaymentCommand / ApproveQuickPaymentResult 정의
- [x] ApproveQuickPaymentPort Out Port 정의
- [x] FindQuickPaymentCardPort Out Port 정의 (저장된 배치키 조회)
- [x] ApproveQuickPaymentService 서비스 구현 (배치키 조회 → KCP 승인 요청 → 기존 결제/주문 플로우 연동)
- [x] KCP 배치 결제 승인 HTTP 클라이언트 어댑터 구현 (bt_batch_key, bt_group_id, card_tx_type=11511000)
- [x] 기존 주문/분개/정산 플로우와 연동
- [x] 빠른결제 승인 REST API 컨트롤러 추가
- [x] ApiDocs 합성 애노테이션 추가