### PR TITLE
[#128][#1597] refactor: 상품 서비스 State 생성 로직 CommandToStateMapper 분리

### DIFF
--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/mapper/ShippingPolicyCommandToStateMapper.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/mapper/ShippingPolicyCommandToStateMapper.java
@@ -1,0 +1,19 @@
+package com.personal.marketnote.product.mapper;
+
+import com.personal.marketnote.product.domain.shipping.ShippingPolicyCreateState;
+import com.personal.marketnote.product.port.in.command.RegisterShippingPolicyCommand;
+
+public class ShippingPolicyCommandToStateMapper {
+
+    private ShippingPolicyCommandToStateMapper() {
+    }
+
+    public static ShippingPolicyCreateState mapToState(Long sellerId, RegisterShippingPolicyCommand command) {
+        return ShippingPolicyCreateState.builder()
+                .sellerId(sellerId)
+                .deliveryCompany(command.deliveryCompany())
+                .shippingFee(command.shippingFee())
+                .freeShippingThreshold(command.freeShippingThreshold())
+                .build();
+    }
+}

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/service/shipping/RegisterShippingPolicyService.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/service/shipping/RegisterShippingPolicyService.java
@@ -3,8 +3,8 @@ package com.personal.marketnote.product.service.shipping;
 import com.personal.marketnote.common.application.UseCase;
 import com.personal.marketnote.common.kafka.event.ShippingPolicyChangeAction;
 import com.personal.marketnote.product.domain.shipping.ShippingPolicy;
-import com.personal.marketnote.product.domain.shipping.ShippingPolicyCreateState;
 import com.personal.marketnote.product.exception.ShippingPolicyAlreadyExistsException;
+import com.personal.marketnote.product.mapper.ShippingPolicyCommandToStateMapper;
 import com.personal.marketnote.product.port.in.command.RegisterShippingPolicyCommand;
 import com.personal.marketnote.product.port.in.result.shipping.RegisterShippingPolicyResult;
 import com.personal.marketnote.product.port.in.usecase.shipping.RegisterShippingPolicyUseCase;
@@ -29,12 +29,8 @@ public class RegisterShippingPolicyService implements RegisterShippingPolicyUseC
     public RegisterShippingPolicyResult registerShippingPolicy(Long sellerId, RegisterShippingPolicyCommand command) {
         validateNoDuplicatePolicy(sellerId);
 
-        ShippingPolicy shippingPolicy = ShippingPolicy.from(ShippingPolicyCreateState.builder()
-                .sellerId(sellerId)
-                .deliveryCompany(command.deliveryCompany())
-                .shippingFee(command.shippingFee())
-                .freeShippingThreshold(command.freeShippingThreshold())
-                .build());
+        ShippingPolicy shippingPolicy = ShippingPolicy.from(
+                ShippingPolicyCommandToStateMapper.mapToState(sellerId, command));
 
         Long savedId = saveShippingPolicyPort.save(shippingPolicy);
 


### PR DESCRIPTION
## partially addresses #128
## resolves #1597

## Task
- [x] RegisterShippingPolicyService → ShippingPolicyCommandToStateMapper 생성 (ShippingPolicyCreateState)