### PR TITLE
[#216][#1595] refactor: 커머스 서비스 State 생성 로직 CommandToStateMapper 분리

### DIFF
--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/mapper/OrderCommandToStateMapper.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/mapper/OrderCommandToStateMapper.java
@@ -1,15 +1,87 @@
 package com.personal.marketnote.commerce.mapper;
 
+import com.personal.marketnote.commerce.domain.order.OrderAmount;
+import com.personal.marketnote.commerce.domain.order.OrderAmountCreateState;
+import com.personal.marketnote.commerce.domain.order.OrderCreateState;
+import com.personal.marketnote.commerce.domain.order.OrderProductCreateState;
 import com.personal.marketnote.commerce.domain.order.OrderStatusHistoryCreateState;
+import com.personal.marketnote.commerce.domain.order.ShippingAddress;
+import com.personal.marketnote.commerce.domain.payment.PaymentCreateState;
+import com.personal.marketnote.commerce.domain.settlement.PaymentAllocationCreateState;
+import com.personal.marketnote.commerce.domain.settlement.PaymentAllocationTargetType;
+import com.personal.marketnote.commerce.domain.settlement.PaymentAllocationTransactionType;
 import com.personal.marketnote.commerce.port.in.command.order.ChangeOrderStatusCommand;
+import com.personal.marketnote.commerce.port.in.command.order.OrderAmountCommand;
+import com.personal.marketnote.commerce.port.in.command.order.OrderProductItemCommand;
+
+import java.util.List;
+import java.util.UUID;
 
 public class OrderCommandToStateMapper {
+    private OrderCommandToStateMapper() {
+    }
+
     public static OrderStatusHistoryCreateState mapToState(ChangeOrderStatusCommand command) {
         return OrderStatusHistoryCreateState.builder()
                 .orderId(command.id())
                 .orderStatus(command.orderStatus())
                 .reasonCategory(command.reasonCategory())
                 .reason(command.reason())
+                .build();
+    }
+
+    public static List<OrderProductCreateState> mapToOrderProductStates(List<OrderProductItemCommand> orderProducts) {
+        return orderProducts.stream()
+                .map(item -> OrderProductCreateState.builder()
+                        .sellerId(item.sellerId())
+                        .pricePolicyId(item.pricePolicyId())
+                        .sharerKey(item.sharerKey())
+                        .quantity(item.quantity())
+                        .unitAmount(item.unitAmount())
+                        .imageUrl(item.imageUrl())
+                        .build())
+                .toList();
+    }
+
+    public static OrderAmountCreateState mapToOrderAmountState(OrderAmountCommand amountCommand) {
+        return OrderAmountCreateState.builder()
+                .totalAmount(amountCommand.totalAmount())
+                .couponAmount(amountCommand.couponAmount())
+                .pointAmount(amountCommand.pointAmount())
+                .shippingFee(amountCommand.shippingFee())
+                .build();
+    }
+
+    public static OrderCreateState mapToOrderState(Long buyerId,
+                                                    OrderAmount orderAmount,
+                                                    ShippingAddress shippingAddress,
+                                                    List<OrderProductCreateState> orderProductStates) {
+        return OrderCreateState.builder()
+                .buyerId(buyerId)
+                .amount(orderAmount)
+                .shippingAddress(shippingAddress)
+                .orderProductStates(orderProductStates)
+                .build();
+    }
+
+    public static PaymentCreateState mapToPaymentState(Long orderId, UUID orderKey, long paymentAmount) {
+        return PaymentCreateState.builder()
+                .orderId(orderId)
+                .orderKey(orderKey)
+                .paymentAmount(paymentAmount)
+                .build();
+    }
+
+    public static PaymentAllocationCreateState mapToPaymentAllocationState(Long orderId,
+                                                                            Long sellerId,
+                                                                            Long allocatedAmount) {
+        return PaymentAllocationCreateState.builder()
+                .orderId(orderId)
+                .sellerId(sellerId)
+                .allocatedAmount(allocatedAmount)
+                .transactionType(PaymentAllocationTransactionType.ORDER_REGISTRATION)
+                .targetType(PaymentAllocationTargetType.ORDER)
+                .idempotencyKey("ORDER_ALLOCATION:" + orderId + ":" + sellerId)
                 .build();
     }
 }

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/RegisterOrderService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/RegisterOrderService.java
@@ -3,12 +3,9 @@ package com.personal.marketnote.commerce.service.order;
 import com.personal.marketnote.commerce.domain.inventory.Inventory;
 import com.personal.marketnote.commerce.domain.order.*;
 import com.personal.marketnote.commerce.domain.payment.Payment;
-import com.personal.marketnote.commerce.domain.payment.PaymentCreateState;
 import com.personal.marketnote.commerce.domain.settlement.PaymentAllocation;
-import com.personal.marketnote.commerce.domain.settlement.PaymentAllocationCreateState;
-import com.personal.marketnote.commerce.domain.settlement.PaymentAllocationTargetType;
-import com.personal.marketnote.commerce.domain.settlement.PaymentAllocationTransactionType;
 import com.personal.marketnote.commerce.exception.*;
+import com.personal.marketnote.commerce.mapper.OrderCommandToStateMapper;
 import com.personal.marketnote.commerce.port.in.command.order.OrderProductItemCommand;
 import com.personal.marketnote.commerce.port.in.command.order.RegisterOrderCommand;
 import com.personal.marketnote.commerce.port.in.result.order.RegisterOrderResult;
@@ -102,36 +99,18 @@ public class RegisterOrderService implements RegisterOrderUseCase {
             inventory.validateIsSufficient(orderQuantity);
         });
 
-        List<OrderProductCreateState> orderProductStates = command.orderProducts().stream()
-                .map(item -> OrderProductCreateState.builder()
-                        .sellerId(item.sellerId())
-                        .pricePolicyId(item.pricePolicyId())
-                        .sharerKey(item.sharerKey())
-                        .quantity(item.quantity())
-                        .unitAmount(item.unitAmount())
-                        .imageUrl(item.imageUrl())
-                        .build())
-                .toList();
+        List<OrderProductCreateState> orderProductStates = OrderCommandToStateMapper.mapToOrderProductStates(command.orderProducts());
 
         OrderAmount orderAmount = OrderAmount.from(
-                OrderAmountCreateState.builder()
-                        .totalAmount(command.amount().totalAmount())
-                        .couponAmount(command.amount().couponAmount())
-                        .pointAmount(command.amount().pointAmount())
-                        .shippingFee(command.amount().shippingFee())
-                        .build()
+                OrderCommandToStateMapper.mapToOrderAmountState(command.amount())
         );
 
         ShippingAddress shippingAddress = resolveShippingAddress(command);
 
         Order savedOrder = saveOrderPort.save(
                 Order.from(
-                        OrderCreateState.builder()
-                                .buyerId(command.buyerId())
-                                .amount(orderAmount)
-                                .shippingAddress(shippingAddress)
-                                .orderProductStates(orderProductStates)
-                                .build()
+                        OrderCommandToStateMapper.mapToOrderState(
+                                command.buyerId(), orderAmount, shippingAddress, orderProductStates)
                 )
         );
 
@@ -150,11 +129,8 @@ public class RegisterOrderService implements RegisterOrderUseCase {
 
         savePaymentPort.save(
                 Payment.from(
-                        PaymentCreateState.builder()
-                                .orderId(savedOrder.getId())
-                                .orderKey(savedOrder.getOrderKey())
-                                .paymentAmount(paymentAmount)
-                                .build()
+                        OrderCommandToStateMapper.mapToPaymentState(
+                                savedOrder.getId(), savedOrder.getOrderKey(), paymentAmount)
                 )
         );
 
@@ -174,14 +150,8 @@ public class RegisterOrderService implements RegisterOrderUseCase {
         List<PaymentAllocation> allocations = sellerGrossAmounts.entrySet().stream()
                 .filter(entry -> entry.getValue() > 0)
                 .map(entry -> PaymentAllocation.from(
-                        PaymentAllocationCreateState.builder()
-                                .orderId(orderId)
-                                .sellerId(entry.getKey())
-                                .allocatedAmount(entry.getValue())
-                                .transactionType(PaymentAllocationTransactionType.ORDER_REGISTRATION)
-                                .targetType(PaymentAllocationTargetType.ORDER)
-                                .idempotencyKey("ORDER_ALLOCATION:" + orderId + ":" + entry.getKey())
-                                .build()
+                        OrderCommandToStateMapper.mapToPaymentAllocationState(
+                                orderId, entry.getKey(), entry.getValue())
                 ))
                 .toList();
 


### PR DESCRIPTION
## partially addresses #216
## resolves #1595

## Task
- [x] RegisterOrderService → OrderCommandToStateMapper에 OrderProductCreateState 매핑 메서드 추가
- [x] RegisterOrderService → OrderCommandToStateMapper에 OrderAmountCreateState 매핑 메서드 추가
- [x] RegisterOrderService → OrderCommandToStateMapper에 OrderCreateState 매핑 메서드 추가
- [x] RegisterOrderService → OrderCommandToStateMapper에 PaymentCreateState 매핑 메서드 추가
- [x] RegisterOrderService → OrderCommandToStateMapper에 PaymentAllocationCreateState 매핑 메서드 추가