### PR TITLE
[#300][#1586] refactor: Report 도메인 of() 팩토리 메서드를 from(State) 패턴으로 변경

### DIFF
--- a/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/out/mapper/ReportJpaEntityToDomainMapper.java
+++ b/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/out/mapper/ReportJpaEntityToDomainMapper.java
@@ -3,6 +3,7 @@ package com.personal.marketnote.community.adapter.out.mapper;
 import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.community.adapter.out.persistence.report.entity.ReportJpaEntity;
 import com.personal.marketnote.community.domain.report.Report;
+import com.personal.marketnote.community.domain.report.ReportSnapshotState;
 
 import java.util.Optional;
 
@@ -13,12 +14,14 @@ public class ReportJpaEntityToDomainMapper {
         }
 
         return Optional.of(
-                Report.of(
-                        entity.getId().getTargetType(),
-                        entity.getTargetId(),
-                        entity.getReporterId(),
-                        entity.getReason(),
-                        entity.getCreatedAt()
+                Report.from(
+                        ReportSnapshotState.builder()
+                                .targetType(entity.getId().getTargetType())
+                                .targetId(entity.getTargetId())
+                                .reporterId(entity.getReporterId())
+                                .reason(entity.getReason())
+                                .createdAt(entity.getCreatedAt())
+                                .build()
                 )
         );
     }

--- a/community-service/community-application/src/test/java/com/personal/marketnote/community/service/report/GetReportsUseCaseTest.java
+++ b/community-service/community-application/src/test/java/com/personal/marketnote/community/service/report/GetReportsUseCaseTest.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.community.service.report;
 
 import com.personal.marketnote.community.domain.report.Report;
+import com.personal.marketnote.community.domain.report.ReportSnapshotState;
 import com.personal.marketnote.community.domain.report.ReportTargetType;
 import com.personal.marketnote.community.port.out.report.FindReportPort;
 import org.junit.jupiter.api.DisplayName;
@@ -31,8 +32,20 @@ class GetReportsUseCaseTest {
         ReportTargetType targetType = ReportTargetType.REVIEW;
         Long targetId = 1L;
         List<Report> reports = List.of(
-                Report.of(targetType, targetId, 100L, "부적절한 콘텐츠", LocalDateTime.now()),
-                Report.of(targetType, targetId, 200L, "스팸 리뷰", LocalDateTime.now())
+                Report.from(ReportSnapshotState.builder()
+                        .targetType(targetType)
+                        .targetId(targetId)
+                        .reporterId(100L)
+                        .reason("부적절한 콘텐츠")
+                        .createdAt(LocalDateTime.now())
+                        .build()),
+                Report.from(ReportSnapshotState.builder()
+                        .targetType(targetType)
+                        .targetId(targetId)
+                        .reporterId(200L)
+                        .reason("스팸 리뷰")
+                        .createdAt(LocalDateTime.now())
+                        .build())
         );
         when(findReportPort.findByTargetTypeAndTargetId(targetType, targetId))
                 .thenReturn(reports);

--- a/community-service/community-domain/src/main/java/com/personal/marketnote/community/domain/report/Report.java
+++ b/community-service/community-domain/src/main/java/com/personal/marketnote/community/domain/report/Report.java
@@ -24,6 +24,7 @@ public class Report {
                 .build();
     }
 
+    @Deprecated
     public static Report of(
             ReportTargetType targetType, Long targetId, Long reporterId, String reason, LocalDateTime createdAt
     ) {
@@ -33,6 +34,16 @@ public class Report {
                 .reporterId(reporterId)
                 .reason(reason)
                 .createdAt(createdAt)
+                .build();
+    }
+
+    public static Report from(ReportSnapshotState state) {
+        return Report.builder()
+                .targetType(state.getTargetType())
+                .targetId(state.getTargetId())
+                .reporterId(state.getReporterId())
+                .reason(state.getReason())
+                .createdAt(state.getCreatedAt())
                 .build();
     }
 }

--- a/community-service/community-domain/src/main/java/com/personal/marketnote/community/domain/report/ReportSnapshotState.java
+++ b/community-service/community-domain/src/main/java/com/personal/marketnote/community/domain/report/ReportSnapshotState.java
@@ -1,0 +1,19 @@
+package com.personal.marketnote.community.domain.report;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ReportSnapshotState {
+    private final ReportTargetType targetType;
+    private final Long targetId;
+    private final Long reporterId;
+    private final String reason;
+    private final LocalDateTime createdAt;
+}


### PR DESCRIPTION
## partially addresses #300
## resolves #1586

## Task
- [x] ReportSnapshotState 생성 (targetType, targetId, reporterId, reason, createdAt)
- [x] Report에 from(SnapshotState) 추가
- [x] 기존 of() 5개 파라미터 오버로드 @Deprecated 처리 후 호출부 전환