### PR TITLE
[#387][#1599] refactor: 리워드 서비스 State 생성 로직 CommandToStateMapper 분리

### DIFF
--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/mapper/RewardCommandToStateMapper.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/mapper/RewardCommandToStateMapper.java
@@ -1,7 +1,10 @@
 package com.personal.marketnote.reward.mapper;
 
+import com.personal.marketnote.common.domain.calendar.Month;
+import com.personal.marketnote.common.domain.calendar.Year;
 import com.personal.marketnote.reward.domain.attendance.AttendancePolicy;
 import com.personal.marketnote.reward.domain.attendance.AttendancePolicyCreateState;
+import com.personal.marketnote.reward.domain.attendance.UserAttendanceCreateState;
 import com.personal.marketnote.reward.domain.attendance.UserAttendanceHistoryCreateState;
 import com.personal.marketnote.reward.domain.offerwall.OfferwallMapperCreateState;
 import com.personal.marketnote.reward.domain.point.UserPointChangeType;
@@ -133,6 +136,19 @@ public class RewardCommandToStateMapper {
                 .continuousPeriod(continuousPeriod)
                 .rewardYn(Boolean.TRUE)
                 .attendedAt(command.attendedAt())
+                .build();
+    }
+
+    public static UserAttendanceCreateState mapToUserAttendanceCreateState(
+            Long userId,
+            Year year,
+            Month month
+    ) {
+        return UserAttendanceCreateState.builder()
+                .userId(userId)
+                .year(year)
+                .month(month)
+                .totalRewardQuantity(0L)
                 .build();
     }
 

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/service/attendance/RegisterAttendanceService.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/service/attendance/RegisterAttendanceService.java
@@ -6,7 +6,6 @@ import com.personal.marketnote.common.domain.calendar.Year;
 import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.reward.domain.attendance.AttendancePolicy;
 import com.personal.marketnote.reward.domain.attendance.UserAttendance;
-import com.personal.marketnote.reward.domain.attendance.UserAttendanceCreateState;
 import com.personal.marketnote.reward.domain.attendance.UserAttendanceHistory;
 import com.personal.marketnote.reward.exception.InvalidAttendanceTimeException;
 import com.personal.marketnote.reward.mapper.RewardCommandToStateMapper;
@@ -84,12 +83,7 @@ public class RegisterAttendanceService implements RegisterAttendanceUseCase {
         return findUserAttendancePort.findByUserIdAndYearAndMonth(userId, year, month)
                 .orElseGet(() -> saveUserAttendancePort.save(
                         UserAttendance.from(
-                                UserAttendanceCreateState.builder()
-                                        .userId(userId)
-                                        .year(year)
-                                        .month(month)
-                                        .totalRewardQuantity(0L)
-                                        .build()
+                                RewardCommandToStateMapper.mapToUserAttendanceCreateState(userId, year, month)
                         )
                 ));
     }


### PR DESCRIPTION
## partially addresses #387
## resolves #1599

## Task
- [x] RegisterAttendanceService → RewardCommandToStateMapper에 UserAttendanceCreateState 매핑 메서드 추가