### PR TITLE
[#475][#1600] refactor: 풀필먼트 서비스 State 생성 로직 CommandToStateMapper 분리

### DIFF
--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/mapper/FasstoCommandToStateMapper.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/mapper/FasstoCommandToStateMapper.java
@@ -1,0 +1,31 @@
+package com.personal.marketnote.fulfillment.mapper;
+
+import com.personal.marketnote.fulfillment.domain.delivery.FulfillmentDeliveryRegistrationCreateState;
+import com.personal.marketnote.fulfillment.domain.goods.FulfillmentGoodsRegistrationCreateState;
+import com.personal.marketnote.fulfillment.port.in.command.vendor.RegisterFulfillmentDeliveryCommand;
+import com.personal.marketnote.fulfillment.port.in.command.vendor.RegisterFulfillmentGoodsCommand;
+
+public class FasstoCommandToStateMapper {
+    private FasstoCommandToStateMapper() {
+    }
+
+    public static FulfillmentDeliveryRegistrationCreateState mapToDeliveryRegistrationCreateState(
+            RegisterFulfillmentDeliveryCommand command
+    ) {
+        Long orderId = Long.parseLong(command.deliveryRequests().getFirst().ordNo());
+
+        return FulfillmentDeliveryRegistrationCreateState.builder()
+                .orderId(orderId)
+                .build();
+    }
+
+    public static FulfillmentGoodsRegistrationCreateState mapToGoodsRegistrationCreateState(
+            RegisterFulfillmentGoodsCommand command
+    ) {
+        Long productId = Long.parseLong(command.goods().getFirst().cstGodCd());
+
+        return FulfillmentGoodsRegistrationCreateState.builder()
+                .productId(productId)
+                .build();
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/vendor/RegisterFulfillmentDeliveryService.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/vendor/RegisterFulfillmentDeliveryService.java
@@ -2,7 +2,7 @@ package com.personal.marketnote.fulfillment.service.vendor;
 
 import com.personal.marketnote.common.application.UseCase;
 import com.personal.marketnote.fulfillment.domain.delivery.FulfillmentDeliveryRegistration;
-import com.personal.marketnote.fulfillment.domain.delivery.FulfillmentDeliveryRegistrationCreateState;
+import com.personal.marketnote.fulfillment.mapper.FasstoCommandToStateMapper;
 import com.personal.marketnote.fulfillment.mapper.FulfillmentDeliveryCommandToRequestMapper;
 import com.personal.marketnote.fulfillment.port.in.command.vendor.RegisterFulfillmentDeliveryCommand;
 import com.personal.marketnote.fulfillment.port.in.result.vendor.RegisterFulfillmentDeliveryResult;
@@ -31,12 +31,8 @@ public class RegisterFulfillmentDeliveryService implements RegisterFulfillmentDe
     @Override
     @Transactional(isolation = READ_COMMITTED)
     public RegisterFulfillmentDeliveryResult registerDeliveryIdempotent(RegisterFulfillmentDeliveryCommand command) {
-        Long orderId = Long.parseLong(command.deliveryRequests().getFirst().ordNo());
-
         FulfillmentDeliveryRegistration registration = FulfillmentDeliveryRegistration.from(
-                FulfillmentDeliveryRegistrationCreateState.builder()
-                        .orderId(orderId)
-                        .build()
+                FasstoCommandToStateMapper.mapToDeliveryRegistrationCreateState(command)
         );
         saveFulfillmentDeliveryRegistrationPort.save(registration);
 

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/vendor/RegisterFulfillmentGoodsService.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/vendor/RegisterFulfillmentGoodsService.java
@@ -2,7 +2,7 @@ package com.personal.marketnote.fulfillment.service.vendor;
 
 import com.personal.marketnote.common.application.UseCase;
 import com.personal.marketnote.fulfillment.domain.goods.FulfillmentGoodsRegistration;
-import com.personal.marketnote.fulfillment.domain.goods.FulfillmentGoodsRegistrationCreateState;
+import com.personal.marketnote.fulfillment.mapper.FasstoCommandToStateMapper;
 import com.personal.marketnote.fulfillment.mapper.FulfillmentGoodsCommandToRequestMapper;
 import com.personal.marketnote.fulfillment.port.in.command.vendor.RegisterFulfillmentGoodsCommand;
 import com.personal.marketnote.fulfillment.port.in.result.vendor.RegisterFulfillmentGoodsResult;
@@ -31,12 +31,8 @@ public class RegisterFulfillmentGoodsService implements RegisterFulfillmentGoods
     @Override
     @Transactional(isolation = READ_COMMITTED)
     public RegisterFulfillmentGoodsResult registerGoodsIdempotent(RegisterFulfillmentGoodsCommand command) {
-        Long productId = Long.parseLong(command.goods().getFirst().cstGodCd());
-
         FulfillmentGoodsRegistration registration = FulfillmentGoodsRegistration.from(
-                FulfillmentGoodsRegistrationCreateState.builder()
-                        .productId(productId)
-                        .build()
+                FasstoCommandToStateMapper.mapToGoodsRegistrationCreateState(command)
         );
         saveFulfillmentGoodsRegistrationPort.save(registration);
 


### PR DESCRIPTION
## partially addresses #475
## resolves #1600

## Task
- [x] RegisterFasstoDeliveryService → FasstoCommandToStateMapper 생성 (FasstoDeliveryRegistrationCreateState)
- [x] RegisterFasstoGoodsService → FasstoCommandToStateMapper에 FasstoGoodsRegistrationCreateState 매핑 메서드 추가