### PR TITLE
[#194][#1585] refactor: ResizedFile 도메인 of() 팩토리 메서드를 from(State) 패턴으로 변경

### DIFF
--- a/file-service/file-adapters/src/main/java/com/personal/marketnote/file/adapter/out/persistence/file/ResizedFilePersistenceAdapter.java
+++ b/file-service/file-adapters/src/main/java/com/personal/marketnote/file/adapter/out/persistence/file/ResizedFilePersistenceAdapter.java
@@ -7,6 +7,7 @@ import com.personal.marketnote.file.adapter.out.persistence.file.entity.ResizedF
 import com.personal.marketnote.file.adapter.out.persistence.file.repository.FileJpaRepository;
 import com.personal.marketnote.file.adapter.out.persistence.file.repository.ResizedFileJpaRepository;
 import com.personal.marketnote.file.domain.file.ResizedFile;
+import com.personal.marketnote.file.domain.file.ResizedFileSnapshotState;
 import com.personal.marketnote.file.port.out.resized.FindResizedFilesPort;
 import com.personal.marketnote.file.port.out.resized.SaveResizedFilesPort;
 import lombok.RequiredArgsConstructor;
@@ -39,13 +40,14 @@ public class ResizedFilePersistenceAdapter implements SaveResizedFilesPort, Find
     public List<ResizedFile> findByFileIds(List<Long> fileIds) {
         if (FormatValidator.hasValue(fileIds)) {
             return resizedFileJpaRepository.findAllByFile_IdIn(fileIds).stream()
-                    .map(e -> ResizedFile.of(
-                            e.getId(),
-                            e.getFile().getId(),
-                            e.getSize(),
-                            e.getStorageUrl(),
-                            e.getCreatedAt(),
-                            e.getStatus()
+                    .map(e -> ResizedFile.from(ResizedFileSnapshotState.builder()
+                            .id(e.getId())
+                            .fileId(e.getFile().getId())
+                            .size(e.getSize())
+                            .storageUrl(e.getStorageUrl())
+                            .createdAt(e.getCreatedAt())
+                            .status(e.getStatus())
+                            .build()
                     )).toList();
         }
 

--- a/file-service/file-application/src/main/java/com/personal/marketnote/file/service/file/UpdateFilesService.java
+++ b/file-service/file-application/src/main/java/com/personal/marketnote/file/service/file/UpdateFilesService.java
@@ -6,6 +6,7 @@ import com.personal.marketnote.common.domain.file.OwnerType;
 import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.file.domain.file.FileDomain;
 import com.personal.marketnote.file.domain.file.ResizedFile;
+import com.personal.marketnote.file.domain.file.ResizedFileCreateState;
 import com.personal.marketnote.file.exception.InvalidFileCountLimitException;
 import com.personal.marketnote.file.mapper.FileCommandToDomainMapper;
 import com.personal.marketnote.file.port.in.command.UpdateFileCommand;
@@ -104,7 +105,11 @@ public class UpdateFilesService implements UpdateFileUseCase {
                 List<ResizedFile> resizedWithUrls = new ArrayList<>(resizedToSave.size());
                 for (int i = 0; i < resizedToSave.size(); i++) {
                     ResizedFile base = resizedToSave.get(i);
-                    resizedWithUrls.add(ResizedFile.of(base.getFileId(), base.getSize(), resizedStorageUrls.get(i)));
+                    resizedWithUrls.add(ResizedFile.from(ResizedFileCreateState.builder()
+                            .fileId(base.getFileId())
+                            .size(base.getSize())
+                            .storageUrl(resizedStorageUrls.get(i))
+                            .build()));
                 }
                 saveResizedFilesPort.saveAll(resizedWithUrls);
             }
@@ -134,7 +139,10 @@ public class UpdateFilesService implements UpdateFileUseCase {
                         originalFile, size, appendSizeToFilename(originalFile.getOriginalFilename(), size + "x" + size)
                 );
                 resizedToUpload.add(resizedFile);
-                resizedToSave.add(ResizedFile.of(savedFile.getId(), size + "x" + size));
+                resizedToSave.add(ResizedFile.from(ResizedFileCreateState.builder()
+                        .fileId(savedFile.getId())
+                        .size(size + "x" + size)
+                        .build()));
             } catch (IOException ignored) {
             }
 
@@ -150,7 +158,10 @@ public class UpdateFilesService implements UpdateFileUseCase {
                             appendSizeToFilename(originalFile.getOriginalFilename(), String.valueOf(width))
                     );
                     resizedToUpload.add(resized);
-                    resizedToSave.add(ResizedFile.of(savedFile.getId(), String.valueOf(width)));
+                    resizedToSave.add(ResizedFile.from(ResizedFileCreateState.builder()
+                            .fileId(savedFile.getId())
+                            .size(String.valueOf(width))
+                            .build()));
                 } catch (IOException ignored) {
                 }
             }

--- a/file-service/file-application/src/test/java/com/personal/marketnote/file/service/file/GetFilesStringOwnerTypeUseCaseTest.java
+++ b/file-service/file-application/src/test/java/com/personal/marketnote/file/service/file/GetFilesStringOwnerTypeUseCaseTest.java
@@ -6,6 +6,7 @@ import com.personal.marketnote.common.domain.file.OwnerType;
 import com.personal.marketnote.file.domain.file.FileDomain;
 import com.personal.marketnote.file.domain.file.FileDomainSnapshotState;
 import com.personal.marketnote.file.domain.file.ResizedFile;
+import com.personal.marketnote.file.domain.file.ResizedFileSnapshotState;
 import com.personal.marketnote.file.port.in.result.GetFilesResult;
 import com.personal.marketnote.file.port.out.file.FindFilePort;
 import com.personal.marketnote.file.port.out.resized.FindResizedFilesPort;
@@ -41,7 +42,9 @@ class GetFilesStringOwnerTypeUseCaseTest {
         @DisplayName("파일이 존재하면 리사이즈 URL을 포함한 결과를 반환한다")
         void shouldReturnFilesWithResizedUrls() {
             FileDomain file = buildFile(1L);
-            ResizedFile resizedFile = ResizedFile.of(1L, "SMALL", "https://example.com/resized.jpg");
+            ResizedFile resizedFile = ResizedFile.from(ResizedFileSnapshotState.builder()
+                    .fileId(1L).size("SMALL").storageUrl("https://example.com/resized.jpg")
+                    .status(EntityStatus.ACTIVE).build());
             when(findFilePort.findByOwnerAndSort(OwnerType.PRODUCT, 100L, FileSort.PRODUCT_CATALOG_IMAGE)).thenReturn(List.of(file));
             when(findResizedFilesPort.findByFileIds(List.of(1L))).thenReturn(List.of(resizedFile));
             GetFilesResult result = getFileService.getFiles("PRODUCT", 100L, "PRODUCT_CATALOG_IMAGE");

--- a/file-service/file-application/src/test/java/com/personal/marketnote/file/service/file/GetResizedFilesUseCaseTest.java
+++ b/file-service/file-application/src/test/java/com/personal/marketnote/file/service/file/GetResizedFilesUseCaseTest.java
@@ -6,6 +6,7 @@ import com.personal.marketnote.common.domain.file.OwnerType;
 import com.personal.marketnote.file.domain.file.FileDomain;
 import com.personal.marketnote.file.domain.file.FileDomainSnapshotState;
 import com.personal.marketnote.file.domain.file.ResizedFile;
+import com.personal.marketnote.file.domain.file.ResizedFileSnapshotState;
 import com.personal.marketnote.file.port.out.file.FindFilePort;
 import com.personal.marketnote.file.port.out.resized.FindResizedFilesPort;
 import org.junit.jupiter.api.DisplayName;
@@ -41,8 +42,12 @@ class GetResizedFilesUseCaseTest {
         void shouldReturnResizedFilesForGivenFiles() {
             FileDomain file1 = buildFile(1L);
             FileDomain file2 = buildFile(2L);
-            ResizedFile resized1 = ResizedFile.of(1L, "SMALL", "https://example.com/resized-1.jpg");
-            ResizedFile resized2 = ResizedFile.of(2L, "SMALL", "https://example.com/resized-2.jpg");
+            ResizedFile resized1 = ResizedFile.from(ResizedFileSnapshotState.builder()
+                    .fileId(1L).size("SMALL").storageUrl("https://example.com/resized-1.jpg")
+                    .status(EntityStatus.ACTIVE).build());
+            ResizedFile resized2 = ResizedFile.from(ResizedFileSnapshotState.builder()
+                    .fileId(2L).size("SMALL").storageUrl("https://example.com/resized-2.jpg")
+                    .status(EntityStatus.ACTIVE).build());
             when(findResizedFilesPort.findByFileIds(List.of(1L, 2L))).thenReturn(List.of(resized1, resized2));
             List<ResizedFile> result = getFileService.getResizedFiles(List.of(file1, file2));
             assertThat(result).hasSize(2);

--- a/file-service/file-domain/src/main/java/com/personal/marketnote/file/domain/file/ResizedFile.java
+++ b/file-service/file-domain/src/main/java/com/personal/marketnote/file/domain/file/ResizedFile.java
@@ -5,9 +5,11 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder(access = AccessLevel.PRIVATE)
 @Getter
@@ -19,6 +21,26 @@ public class ResizedFile {
     private LocalDateTime createdAt;
     private EntityStatus status;
 
+    public static ResizedFile from(ResizedFileCreateState state) {
+        return ResizedFile.builder()
+                .fileId(state.getFileId())
+                .size(state.getSize())
+                .storageUrl(state.getStorageUrl())
+                .build();
+    }
+
+    public static ResizedFile from(ResizedFileSnapshotState state) {
+        return ResizedFile.builder()
+                .id(state.getId())
+                .fileId(state.getFileId())
+                .size(state.getSize())
+                .storageUrl(state.getStorageUrl())
+                .createdAt(state.getCreatedAt())
+                .status(state.getStatus())
+                .build();
+    }
+
+    @Deprecated
     public static ResizedFile of(Long fileId, String size) {
         return ResizedFile.builder()
                 .fileId(fileId)
@@ -26,6 +48,7 @@ public class ResizedFile {
                 .build();
     }
 
+    @Deprecated
     public static ResizedFile of(Long fileId, String size, String storageUrl) {
         return ResizedFile.builder()
                 .fileId(fileId)
@@ -34,6 +57,7 @@ public class ResizedFile {
                 .build();
     }
 
+    @Deprecated
     public static ResizedFile of(Long id, Long fileId, String size, LocalDateTime createdAt, EntityStatus status) {
         return ResizedFile.builder()
                 .id(id)
@@ -44,6 +68,7 @@ public class ResizedFile {
                 .build();
     }
 
+    @Deprecated
     public static ResizedFile of(Long id, Long fileId, String size, String storageUrl, LocalDateTime createdAt, EntityStatus status) {
         return ResizedFile.builder()
                 .id(id)
@@ -67,5 +92,3 @@ public class ResizedFile {
         status = EntityStatus.INACTIVE;
     }
 }
-
-

--- a/file-service/file-domain/src/main/java/com/personal/marketnote/file/domain/file/ResizedFileCreateState.java
+++ b/file-service/file-domain/src/main/java/com/personal/marketnote/file/domain/file/ResizedFileCreateState.java
@@ -1,0 +1,15 @@
+package com.personal.marketnote.file.domain.file;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ResizedFileCreateState {
+    private final Long fileId;
+    private final String size;
+    private final String storageUrl;
+}

--- a/file-service/file-domain/src/main/java/com/personal/marketnote/file/domain/file/ResizedFileSnapshotState.java
+++ b/file-service/file-domain/src/main/java/com/personal/marketnote/file/domain/file/ResizedFileSnapshotState.java
@@ -1,0 +1,21 @@
+package com.personal.marketnote.file.domain.file;
+
+import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ResizedFileSnapshotState {
+    private final Long id;
+    private final Long fileId;
+    private final String size;
+    private final String storageUrl;
+    private final LocalDateTime createdAt;
+    private final EntityStatus status;
+}


### PR DESCRIPTION
## partially addresses #194
## resolves #1585

## Task
- [x] ResizedFileCreateState 생성 (fileId, size)
- [x] ResizedFileSnapshotState 생성 (id, fileId, size, s3Url, createdAt, status)
- [x] ResizedFile에 from(CreateState), from(SnapshotState) 추가
- [x] 기존 of() 5~6개 파라미터 오버로드 @Deprecated 처리 후 호출부 전환