### PR TITLE
[#43][#2150] refactor: 회원 서비스 OAuth2 벤더 네이밍 정리

### DIFF
--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/out/mapper/UserJpaEntityToDomainMapper.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/out/mapper/UserJpaEntityToDomainMapper.java
@@ -19,7 +19,7 @@ public class UserJpaEntityToDomainMapper {
                 .map(entity -> {
                     Role role = mapToRoleDomain(entity.getRoleJpaEntity()).orElse(null);
                     List<UserTerms> userTerms = mapToUserTermsDomain(entity.getUserTermsJpaEntities()).orElse(List.of());
-                    List<UserOauth2Vendor> vendors = mapToVendorDomainWithoutUser(entity.getUserOauth2VendorsJpaEntities()).orElse(List.of());
+                    List<UserAuthProvider> vendors = mapToAuthProviderDomainWithoutUser(entity.getUserOauth2VendorsJpaEntities()).orElse(List.of());
 
                     User user = User.from(
                             UserSnapshotState.builder()
@@ -33,7 +33,7 @@ public class UserJpaEntityToDomainMapper {
                                     .referenceCode(entity.getReferenceCode())
                                     .referredUserCode(entity.getReferredUserCode())
                                     .role(role)
-                                    .userOauth2Vendors(vendors)
+                                    .userAuthProviders(vendors)
                                     .userTerms(userTerms)
                                     .signedUpAt(entity.getSignedUpAt())
                                     .lastLoggedInAt(entity.getLastLoggedInAt())
@@ -55,11 +55,11 @@ public class UserJpaEntityToDomainMapper {
                 .map(entity -> Role.of(entity.getId(), entity.getName()));
     }
 
-    private static Optional<List<UserOauth2Vendor>> mapToVendorDomainWithoutUser(List<UserOauth2VendorJpaEntity> userOauth2VendorsJpaEntities) {
+    private static Optional<List<UserAuthProvider>> mapToAuthProviderDomainWithoutUser(List<UserOauth2VendorJpaEntity> userOauth2VendorsJpaEntities) {
         return Optional.ofNullable(userOauth2VendorsJpaEntities)
                 .filter(Objects::nonNull)
                 .map(entities -> entities.stream()
-                        .map(entity -> UserOauth2Vendor.of(entity.getAuthVendor(), entity.getOidcId()))
+                        .map(entity -> UserAuthProvider.of(entity.getAuthVendor(), entity.getOidcId()))
                         .collect(Collectors.toList()));
     }
 

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/out/persistence/user/entity/UserJpaEntity.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/out/persistence/user/entity/UserJpaEntity.java
@@ -8,7 +8,7 @@ import com.personal.marketnote.common.adapter.out.persistence.audit.BaseOrderedG
 import com.personal.marketnote.user.adapter.out.persistence.authentication.entity.RoleJpaEntity;
 import com.personal.marketnote.user.adapter.out.persistence.user.repository.TermsJpaRepository;
 import com.personal.marketnote.user.domain.user.User;
-import com.personal.marketnote.user.domain.user.UserOauth2Vendor;
+import com.personal.marketnote.user.domain.user.UserAuthProvider;
 import com.personal.marketnote.user.domain.user.UserTerms;
 import jakarta.persistence.*;
 import lombok.*;
@@ -96,7 +96,7 @@ public class UserJpaEntity extends BaseOrderedGeneralEntity {
                 .build();
 
         // set vendors after building to avoid recursive mapping
-        userJpaEntity.userOauth2VendorsJpaEntities = user.getUserOauth2Vendors().stream()
+        userJpaEntity.userOauth2VendorsJpaEntities = user.getUserAuthProviders().stream()
                 .map(v -> UserOauth2VendorJpaEntity.of(userJpaEntity, v.getAuthVendor(), v.getOidcId()))
                 .collect(Collectors.toList());
 
@@ -128,7 +128,7 @@ public class UserJpaEntity extends BaseOrderedGeneralEntity {
                 .withdrawalYn(user.isWithdrawn())
                 .build();
 
-        userJpaEntity.userOauth2VendorsJpaEntities = user.getUserOauth2Vendors().stream()
+        userJpaEntity.userOauth2VendorsJpaEntities = user.getUserAuthProviders().stream()
                 .map(v -> UserOauth2VendorJpaEntity.of(userJpaEntity, v.getAuthVendor(), v.getOidcId()))
                 .collect(Collectors.toList());
 
@@ -150,8 +150,8 @@ public class UserJpaEntity extends BaseOrderedGeneralEntity {
         // 회원 계정 정보 업데이트
         for (int i = 0; i < userOauth2VendorsJpaEntities.size(); i++) {
             UserOauth2VendorJpaEntity userOauth2VendorJpaEntity = userOauth2VendorsJpaEntities.get(i);
-            UserOauth2Vendor userOauth2Vendor = user.getUserOauth2Vendors().get(i);
-            userOauth2VendorJpaEntity.updateFrom(this, userOauth2Vendor);
+            UserAuthProvider userAuthProvider = user.getUserAuthProviders().get(i);
+            userOauth2VendorJpaEntity.updateFrom(this, userAuthProvider);
         }
 
         // 회원 약관 동의 정보 업데이트

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/out/persistence/user/entity/UserOauth2VendorJpaEntity.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/out/persistence/user/entity/UserOauth2VendorJpaEntity.java
@@ -1,7 +1,7 @@
 package com.personal.marketnote.user.adapter.out.persistence.user.entity;
 
 import com.personal.marketnote.common.adapter.out.persistence.audit.BaseGeneralEntity;
-import com.personal.marketnote.user.domain.user.UserOauth2Vendor;
+import com.personal.marketnote.user.domain.user.UserAuthProvider;
 import com.personal.marketnote.user.security.token.vendor.AuthVendor;
 import jakarta.persistence.*;
 import lombok.*;
@@ -24,11 +24,11 @@ public class UserOauth2VendorJpaEntity extends BaseGeneralEntity {
     @Column(name = "oidc_id", length = 255)
     private String oidcId;
 
-    public static UserOauth2VendorJpaEntity from(UserOauth2Vendor userOauth2Vendor) {
+    public static UserOauth2VendorJpaEntity from(UserAuthProvider userAuthProvider) {
         return UserOauth2VendorJpaEntity.builder()
-                .userJpaEntity(UserJpaEntity.from(userOauth2Vendor.getUser()))
-                .authVendor(userOauth2Vendor.getAuthVendor())
-                .oidcId(userOauth2Vendor.getOidcId())
+                .userJpaEntity(UserJpaEntity.from(userAuthProvider.getUser()))
+                .authVendor(userAuthProvider.getAuthVendor())
+                .oidcId(userAuthProvider.getOidcId())
                 .build();
     }
 
@@ -40,9 +40,9 @@ public class UserOauth2VendorJpaEntity extends BaseGeneralEntity {
                 .build();
     }
 
-    public void updateFrom(UserJpaEntity userJpaEntity, UserOauth2Vendor userOauth2Vendor) {
+    public void updateFrom(UserJpaEntity userJpaEntity, UserAuthProvider userAuthProvider) {
         this.userJpaEntity = userJpaEntity;
-        authVendor = userOauth2Vendor.getAuthVendor();
-        oidcId = userOauth2Vendor.getOidcId();
+        authVendor = userAuthProvider.getAuthVendor();
+        oidcId = userAuthProvider.getOidcId();
     }
 }

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/port/in/result/AccountInfoResult.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/port/in/result/AccountInfoResult.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.user.port.in.result;
 
-import com.personal.marketnote.user.domain.user.UserOauth2Vendor;
+import com.personal.marketnote.user.domain.user.UserAuthProvider;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -8,9 +8,9 @@ import java.util.stream.Collectors;
 public record AccountInfoResult(
         List<AccountResult> accounts
 ) {
-    public static AccountInfoResult from(List<UserOauth2Vendor> userOauth2Vendors) {
+    public static AccountInfoResult from(List<UserAuthProvider> userAuthProviders) {
         return new AccountInfoResult(
-                userOauth2Vendors.stream()
+                userAuthProviders.stream()
                         .map(AccountResult::from)
                         .collect(Collectors.toList())
         );

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/port/in/result/AccountResult.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/port/in/result/AccountResult.java
@@ -1,16 +1,16 @@
 package com.personal.marketnote.user.port.in.result;
 
-import com.personal.marketnote.user.domain.user.UserOauth2Vendor;
+import com.personal.marketnote.user.domain.user.UserAuthProvider;
 import com.personal.marketnote.user.security.token.vendor.AuthVendor;
 
 public record AccountResult(
         AuthVendor oauth2VendorId,
         String oidcId
 ) {
-    public static AccountResult from(UserOauth2Vendor userOauth2Vendor) {
+    public static AccountResult from(UserAuthProvider userAuthProvider) {
         return new AccountResult(
-                userOauth2Vendor.getAuthVendor(),
-                userOauth2Vendor.getOidcId()
+                userAuthProvider.getAuthVendor(),
+                userAuthProvider.getOidcId()
         );
     }
 }

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/port/in/result/GetUserInfoResult.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/port/in/result/GetUserInfoResult.java
@@ -25,7 +25,7 @@ public record GetUserInfoResult(
     public static GetUserInfoResult from(User user) {
         return GetUserInfoResult.builder()
                 .id(user.getId())
-                .accountInfo(AccountInfoResult.from(user.getUserOauth2Vendors()))
+                .accountInfo(AccountInfoResult.from(user.getUserAuthProviders()))
                 .nickname(user.getNickname())
                 .email(user.getEmail())
                 .fullName(user.getFullName())

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/port/in/result/GetUserResult.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/port/in/result/GetUserResult.java
@@ -25,7 +25,7 @@ public record GetUserResult(
     public static GetUserResult from(User user) {
         return GetUserResult.builder()
                 .id(user.getId())
-                .accountInfo(AccountInfoResult.from(user.getUserOauth2Vendors()))
+                .accountInfo(AccountInfoResult.from(user.getUserAuthProviders()))
                 .nickname(user.getNickname())
                 .email(user.getEmail())
                 .fullName(user.getFullName())

--- a/user-service/user-application/src/test/java/com/personal/marketnote/user/service/user/GetUserUseCaseTest.java
+++ b/user-service/user-application/src/test/java/com/personal/marketnote/user/service/user/GetUserUseCaseTest.java
@@ -4,7 +4,7 @@ import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus
 import com.personal.marketnote.common.exception.UserNotFoundException;
 import com.personal.marketnote.user.domain.authentication.Role;
 import com.personal.marketnote.user.domain.user.User;
-import com.personal.marketnote.user.domain.user.UserOauth2Vendor;
+import com.personal.marketnote.user.domain.user.UserAuthProvider;
 import com.personal.marketnote.user.domain.user.UserSearchTarget;
 import com.personal.marketnote.user.domain.user.UserSortProperty;
 import com.personal.marketnote.user.port.in.result.AccountResult;
@@ -51,9 +51,9 @@ class GetUserUseCaseTest {
         String phoneNumber = "010-1111-2222";
         String referenceCode = "ref-123";
         Role role = Role.getBuyer();
-        List<UserOauth2Vendor> userOauth2Vendors = List.of(
-                UserOauth2Vendor.of(AuthVendor.KAKAO, "kakao-oidc"),
-                UserOauth2Vendor.of(AuthVendor.GOOGLE, "google-oidc")
+        List<UserAuthProvider> userAuthProviders = List.of(
+                UserAuthProvider.of(AuthVendor.KAKAO, "kakao-oidc"),
+                UserAuthProvider.of(AuthVendor.GOOGLE, "google-oidc")
         );
         LocalDateTime signedUpAt = LocalDateTime.of(2024, 1, 1, 10, 0);
         LocalDateTime lastLoggedInAt = LocalDateTime.of(2024, 1, 2, 11, 0);
@@ -69,7 +69,7 @@ class GetUserUseCaseTest {
                 phoneNumber,
                 referenceCode,
                 role,
-                userOauth2Vendors,
+                userAuthProviders,
                 signedUpAt,
                 lastLoggedInAt,
                 status,
@@ -131,8 +131,8 @@ class GetUserUseCaseTest {
         String phoneNumber = "010-2222-3333";
         String referenceCode = "ref-456";
         Role role = Role.getBuyer();
-        List<UserOauth2Vendor> userOauth2Vendors = List.of(
-                UserOauth2Vendor.of(AuthVendor.KAKAO, "kakao-oidc-2")
+        List<UserAuthProvider> userAuthProviders = List.of(
+                UserAuthProvider.of(AuthVendor.KAKAO, "kakao-oidc-2")
         );
         LocalDateTime signedUpAt = LocalDateTime.of(2024, 2, 1, 9, 0);
         LocalDateTime lastLoggedInAt = LocalDateTime.of(2024, 2, 2, 10, 0);
@@ -148,7 +148,7 @@ class GetUserUseCaseTest {
                 phoneNumber,
                 referenceCode,
                 role,
-                userOauth2Vendors,
+                userAuthProviders,
                 signedUpAt,
                 lastLoggedInAt,
                 status,
@@ -491,7 +491,7 @@ class GetUserUseCaseTest {
                 "010-1000-0001",
                 "ref-1",
                 Role.getBuyer(),
-                List.of(UserOauth2Vendor.of(AuthVendor.KAKAO, "kakao-1")),
+                List.of(UserAuthProvider.of(AuthVendor.KAKAO, "kakao-1")),
                 LocalDateTime.of(2024, 3, 1, 9, 0),
                 LocalDateTime.of(2024, 3, 2, 10, 0),
                 EntityStatus.ACTIVE,
@@ -506,7 +506,7 @@ class GetUserUseCaseTest {
                 "010-1000-0002",
                 "ref-2",
                 Role.getBuyer(),
-                List.of(UserOauth2Vendor.of(AuthVendor.GOOGLE, "google-2")),
+                List.of(UserAuthProvider.of(AuthVendor.GOOGLE, "google-2")),
                 LocalDateTime.of(2024, 3, 3, 9, 0),
                 LocalDateTime.of(2024, 3, 4, 10, 0),
                 EntityStatus.INACTIVE,
@@ -662,10 +662,10 @@ class GetUserUseCaseTest {
     void getUserInfo_unexposedUser_mapsStatusAndAccounts() {
         // given
         Long id = 3L;
-        List<UserOauth2Vendor> userOauth2Vendors = List.of(
-                UserOauth2Vendor.of(AuthVendor.APPLE, "apple-oidc")
+        List<UserAuthProvider> userAuthProviders = List.of(
+                UserAuthProvider.of(AuthVendor.APPLE, "apple-oidc")
         );
-        User user = UserTestObjectFactory.createDefaultUser(id, EntityStatus.UNEXPOSED, false, userOauth2Vendors);
+        User user = UserTestObjectFactory.createDefaultUser(id, EntityStatus.UNEXPOSED, false, userAuthProviders);
 
         when(findUserPort.findById(id)).thenReturn(Optional.of(user));
 

--- a/user-service/user-application/src/test/java/com/personal/marketnote/user/service/user/UserTestObjectFactory.java
+++ b/user-service/user-application/src/test/java/com/personal/marketnote/user/service/user/UserTestObjectFactory.java
@@ -3,7 +3,7 @@ package com.personal.marketnote.user.service.user;
 import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
 import com.personal.marketnote.user.domain.authentication.Role;
 import com.personal.marketnote.user.domain.user.User;
-import com.personal.marketnote.user.domain.user.UserOauth2Vendor;
+import com.personal.marketnote.user.domain.user.UserAuthProvider;
 import com.personal.marketnote.user.domain.user.UserSnapshotState;
 
 import java.time.LocalDateTime;
@@ -20,7 +20,7 @@ final class UserTestObjectFactory {
             Long id,
             EntityStatus status,
             boolean withdrawalYn,
-            List<UserOauth2Vendor> userOauth2Vendors
+            List<UserAuthProvider> userAuthProviders
     ) {
         return createUser(
                 id,
@@ -30,7 +30,7 @@ final class UserTestObjectFactory {
                 "010-1111-2222",
                 "ref-123",
                 Role.getBuyer(),
-                userOauth2Vendors,
+                userAuthProviders,
                 LocalDateTime.of(2024, 1, 1, 10, 0),
                 LocalDateTime.of(2024, 1, 2, 11, 0),
                 status,
@@ -47,7 +47,7 @@ final class UserTestObjectFactory {
             String phoneNumber,
             String referenceCode,
             Role role,
-            List<UserOauth2Vendor> userOauth2Vendors,
+            List<UserAuthProvider> userAuthProviders,
             LocalDateTime signedUpAt,
             LocalDateTime lastLoggedInAt,
             EntityStatus status,
@@ -63,7 +63,7 @@ final class UserTestObjectFactory {
                 .phoneNumber(phoneNumber)
                 .referenceCode(referenceCode)
                 .role(role)
-                .userOauth2Vendors(userOauth2Vendors)
+                .userAuthProviders(userAuthProviders)
                 .userTerms(List.of())
                 .signedUpAt(signedUpAt)
                 .lastLoggedInAt(lastLoggedInAt)

--- a/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/user/User.java
+++ b/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/user/User.java
@@ -36,7 +36,7 @@ public class User extends BaseDomain {
     private String referenceCode;
     private String referredUserCode;
     private Role role;
-    private List<UserOauth2Vendor> userOauth2Vendors;
+    private List<UserAuthProvider> userAuthProviders;
     private List<UserTerms> userTerms;
     private LocalDateTime signedUpAt;
     private LocalDateTime lastLoggedInAt;
@@ -53,23 +53,23 @@ public class User extends BaseDomain {
                 ? state.getTerms()
                 : List.of();
 
-        List<UserOauth2Vendor> userOauth2Vendors = new ArrayList<>(AuthVendor.size());
+        List<UserAuthProvider> userAuthProviders = new ArrayList<>(AuthVendor.size());
         AuthVendor[] allAuthVendors = AuthVendor.values();
 
         // 최초 회원 가입 시 모든 공급업체 튜플 추가
         for (AuthVendor authVendor : allAuthVendors) {
-            UserOauth2Vendor userOauth2Vendor = UserOauth2Vendor.of(authVendor);
-            userOauth2Vendors.add(userOauth2Vendor);
+            UserAuthProvider userAuthProvider = UserAuthProvider.of(authVendor);
+            userAuthProviders.add(userAuthProvider);
 
             // 실제 가입한 공급업체만 OIDC ID 삽입
             if (authVendor.isMe(targetAuthVendor)) {
-                userOauth2Vendor.addOidcId(targetAuthVendor, state.getOidcId(), state.getEmail());
+                userAuthProvider.addOidcId(targetAuthVendor, state.getOidcId(), state.getEmail());
             }
         }
 
         User user = User.builder()
                 .userKey(RandomCodeGenerator.generateUserKey())
-                .userOauth2Vendors(userOauth2Vendors)
+                .userAuthProviders(userAuthProviders)
                 .nickname(state.getNickname())
                 .email(state.getEmail())
                 .fullName(state.getFullName())
@@ -109,7 +109,7 @@ public class User extends BaseDomain {
                 .referenceCode(state.getReferenceCode())
                 .referredUserCode(state.getReferredUserCode())
                 .role(state.getRole())
-                .userOauth2Vendors(state.getUserOauth2Vendors())
+                .userAuthProviders(state.getUserAuthProviders())
                 .userTerms(state.getUserTerms())
                 .signedUpAt(state.getSignedUpAt())
                 .lastLoggedInAt(state.getLastLoggedInAt())
@@ -136,14 +136,14 @@ public class User extends BaseDomain {
         return User.builder()
                 .id(id)
                 .role(Role.getGuest())
-                .userOauth2Vendors(new ArrayList<>())
+                .userAuthProviders(new ArrayList<>())
                 .userTerms(new ArrayList<>())
                 .build();
     }
 
     private static User createGuest(UserCreateState state) {
         return User.builder()
-                .userOauth2Vendors(List.of(UserOauth2Vendor.of(state.getAuthVendor(), state.getOidcId())))
+                .userAuthProviders(List.of(UserAuthProvider.of(state.getAuthVendor(), state.getOidcId())))
                 .role(Role.getGuest())
                 .build();
     }
@@ -195,8 +195,8 @@ public class User extends BaseDomain {
     }
 
     public void addLoginAccountInfo(AuthVendor authVendor, String oidcId, String password, PasswordEncoder passwordEncoder) {
-        userOauth2Vendors.forEach(
-                userOauth2Vendor -> userOauth2Vendor.update(authVendor, oidcId)
+        userAuthProviders.forEach(
+                userAuthProvider -> userAuthProvider.update(authVendor, oidcId)
         );
 
         if (FormatValidator.hasValue(password)) {
@@ -244,21 +244,21 @@ public class User extends BaseDomain {
     }
 
     public String getOidcIdByVendor(AuthVendor vendor) {
-        return userOauth2Vendors.stream()
+        return userAuthProviders.stream()
                 .filter(v -> v.isVendor(vendor))
                 .findFirst()
-                .map(UserOauth2Vendor::getOidcId)
+                .map(UserAuthProvider::getOidcId)
                 .orElse(null);
     }
 
     public boolean hasAccount(AuthVendor vendor) {
-        return userOauth2Vendors.stream()
+        return userAuthProviders.stream()
                 .anyMatch(v -> v.hasAccount(vendor));
     }
 
     public void removeOidcId(AuthVendor vendor) {
-        userOauth2Vendors.stream()
+        userAuthProviders.stream()
                 .filter(v -> v.isVendor(vendor))
-                .forEach(UserOauth2Vendor::removeOidcId);
+                .forEach(UserAuthProvider::removeOidcId);
     }
 }

--- a/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/user/UserAuthProvider.java
+++ b/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/user/UserAuthProvider.java
@@ -1,0 +1,73 @@
+package com.personal.marketnote.user.domain.user;
+
+import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.user.security.token.vendor.AuthVendor;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class UserAuthProvider {
+    private User user;
+    private final AuthVendor authVendor;
+    private String oidcId;
+
+    private UserAuthProvider(AuthVendor authVendor) {
+        this.authVendor = authVendor;
+    }
+
+    private UserAuthProvider(AuthVendor authVendor, String oidcId) {
+        this.authVendor = authVendor;
+        this.oidcId = oidcId;
+    }
+
+    static UserAuthProvider of(AuthVendor authVendor) {
+        return new UserAuthProvider(authVendor);
+    }
+
+    public static UserAuthProvider of(
+            AuthVendor authVendor,
+            String oidcId
+    ) {
+        return new UserAuthProvider(authVendor, oidcId);
+    }
+
+    public void addUser(User user) {
+        if (FormatValidator.hasNoValue(this.user)) {
+            this.user = user;
+        }
+    }
+
+    void update(AuthVendor authVendor, String oidcId) {
+        if (isMe(authVendor)) {
+            addOidcId(authVendor, oidcId, user.getEmail());
+        }
+    }
+
+    private boolean isMe(AuthVendor authVendor) {
+        return this.authVendor.isMe(authVendor);
+    }
+
+    void addOidcId(AuthVendor authVendor, String oidcId, String email) {
+        // 일반 회원인 경우 회원 이메일 주소를 oidcId로 사용
+        if (authVendor.isNative()) {
+            this.oidcId = email;
+            return;
+        }
+
+        this.oidcId = oidcId;
+    }
+
+    public boolean isVendor(AuthVendor vendor) {
+        return this.authVendor.isMe(vendor);
+    }
+
+    public boolean hasAccount(AuthVendor vendor) {
+        return isVendor(vendor) && FormatValidator.hasValue(oidcId);
+    }
+
+    public void removeOidcId() {
+        oidcId = null;
+    }
+}

--- a/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/user/UserSnapshotState.java
+++ b/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/user/UserSnapshotState.java
@@ -25,7 +25,7 @@ public class UserSnapshotState {
     private final String referenceCode;
     private final String referredUserCode;
     private final Role role;
-    private final List<UserOauth2Vendor> userOauth2Vendors;
+    private final List<UserAuthProvider> userAuthProviders;
     private final List<UserTerms> userTerms;
     private final LocalDateTime signedUpAt;
     private final LocalDateTime lastLoggedInAt;

--- a/user-service/user-domain/src/main/java/com/personal/marketnote/user/exception/UserAuthProviderNotFoundException.java
+++ b/user-service/user-domain/src/main/java/com/personal/marketnote/user/exception/UserAuthProviderNotFoundException.java
@@ -1,0 +1,14 @@
+package com.personal.marketnote.user.exception;
+
+import com.personal.marketnote.user.security.token.vendor.AuthVendor;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.Getter;
+
+@Getter
+public class UserAuthProviderNotFoundException extends EntityNotFoundException {
+    private static final String USER_AUTH_PROVIDER_NOT_FOUND_EXCEPTION_MESSAGE = "%s:: 존재하지 않는 회원 인증 제공자입니다. 전송된 회원 인증 제공자: %s";
+
+    public UserAuthProviderNotFoundException(String code, AuthVendor authVendor) {
+        super(String.format(USER_AUTH_PROVIDER_NOT_FOUND_EXCEPTION_MESSAGE, code, authVendor));
+    }
+}


### PR DESCRIPTION
## partially addresses #43
## resolves #2150

## Task
- [x] UserOauth2Vendor → UserAuthProvider 도메인 클래스 리네이밍
- [x] UserOauth2VendorNotFoundException → UserAuthProviderNotFoundException 예외 클래스 리네이밍
- [x] domain/application/adapters/test 전 계층 참조 변경 (14개 파일)
- [x] JPA 엔티티 클래스명(UserOauth2VendorJpaEntity) 및 API 응답 필드(oauth2VendorId) 유지