### PR TITLE
[#475][#2181] test: delivery 영역 벤더 종속 제거 테스트 재작성

### DIFF
--- a/fulfillment-service/fulfillment-application/src/test/java/com/personal/marketnote/fulfillment/service/vendor/RegisterFulfillmentDeliveryCarUseCaseTest.java
+++ b/fulfillment-service/fulfillment-application/src/test/java/com/personal/marketnote/fulfillment/service/vendor/RegisterFulfillmentDeliveryCarUseCaseTest.java
@@ -33,11 +33,11 @@ class RegisterFulfillmentDeliveryCarUseCaseTest {
     void shouldReturnRegisterDeliveryCarResultFromPort() {
         // given
         RegisterFulfillmentDeliveryCarItemCommand itemCommand = RegisterFulfillmentDeliveryCarItemCommand.builder()
-                .ordDt("20260402")
-                .ordNo("ORD001")
-                .outWay("01")
-                .cstShopCd("SHOP001")
-                .godCds(List.of(RegisterFulfillmentDeliveryGoodsCommand.of("GOD001", "20260430", 1)))
+                .orderDate("20260402")
+                .orderNumber("ORD001")
+                .releaseMethod("01")
+                .shopCode("SHOP001")
+                .products(List.of(RegisterFulfillmentDeliveryGoodsCommand.of("GOD001", "20260430", 1)))
                 .build();
         RegisterFulfillmentDeliveryCarCommand command = RegisterFulfillmentDeliveryCarCommand.of(
                 "CUST001", "token", List.of(itemCommand)

--- a/fulfillment-service/fulfillment-application/src/test/java/com/personal/marketnote/fulfillment/service/vendor/RegisterFulfillmentDeliveryIcsUseCaseTest.java
+++ b/fulfillment-service/fulfillment-application/src/test/java/com/personal/marketnote/fulfillment/service/vendor/RegisterFulfillmentDeliveryIcsUseCaseTest.java
@@ -33,12 +33,12 @@ class RegisterFulfillmentDeliveryIcsUseCaseTest {
     void shouldReturnRegisterDeliveryIcsResultFromPort() {
         // given
         RegisterFulfillmentDeliveryIcsItemCommand itemCommand = RegisterFulfillmentDeliveryIcsItemCommand.builder()
-                .ordDt("20260402")
-                .ordNo("ORD001")
+                .orderDate("20260402")
+                .orderNumber("ORD001")
                 .platform("PLATFORM01")
-                .logiCenter("CENTER01")
-                .invoiceNo("INV001")
-                .godCds(List.of(RegisterFulfillmentDeliveryGoodsCommand.of("GOD001", "20260430", 1)))
+                .logisticsCenter("CENTER01")
+                .invoiceNumber("INV001")
+                .products(List.of(RegisterFulfillmentDeliveryGoodsCommand.of("GOD001", "20260430", 1)))
                 .build();
         RegisterFulfillmentDeliveryIcsCommand command = RegisterFulfillmentDeliveryIcsCommand.of(
                 "CUST001", "token", List.of(itemCommand)

--- a/fulfillment-service/fulfillment-application/src/test/java/com/personal/marketnote/fulfillment/service/vendor/RegisterFulfillmentDeliveryServiceTest.java
+++ b/fulfillment-service/fulfillment-application/src/test/java/com/personal/marketnote/fulfillment/service/vendor/RegisterFulfillmentDeliveryServiceTest.java
@@ -36,18 +36,18 @@ class RegisterFulfillmentDeliveryServiceTest {
     @Mock
     private SaveFulfillmentDeliveryRegistrationPort saveFulfillmentDeliveryRegistrationPort;
 
-    private RegisterFulfillmentDeliveryCommand buildCommand(String ordNo) {
+    private RegisterFulfillmentDeliveryCommand buildCommand(String orderNumber) {
         RegisterFulfillmentDeliveryGoodsCommand goodsCommand = RegisterFulfillmentDeliveryGoodsCommand.of(
                 "PROD001", "20260309", 1
         );
         RegisterFulfillmentDeliveryItemCommand itemCommand = RegisterFulfillmentDeliveryItemCommand.builder()
-                .ordNo(ordNo)
-                .ordDt("20260309")
-                .custNm("홍길동")
-                .custTelNo("01012345678")
-                .custAddr("서울시 강남구")
-                .outWay("01")
-                .godCds(List.of(goodsCommand))
+                .orderNumber(orderNumber)
+                .orderDate("20260309")
+                .recipientName("홍길동")
+                .recipientPhoneNumber("01012345678")
+                .recipientAddress("서울시 강남구")
+                .releaseMethod("01")
+                .products(List.of(goodsCommand))
                 .build();
         return RegisterFulfillmentDeliveryCommand.of("CUST001", "token", List.of(itemCommand));
     }

--- a/fulfillment-service/fulfillment-application/src/test/java/com/personal/marketnote/fulfillment/service/vendor/RegisterFulfillmentDirectReturnDeliveryUseCaseTest.java
+++ b/fulfillment-service/fulfillment-application/src/test/java/com/personal/marketnote/fulfillment/service/vendor/RegisterFulfillmentDirectReturnDeliveryUseCaseTest.java
@@ -32,13 +32,13 @@ class RegisterFulfillmentDirectReturnDeliveryUseCaseTest {
     void shouldReturnRegisterDirectReturnDeliveryResultFromPort() {
         // given
         RegisterFulfillmentDirectReturnDeliveryItemCommand itemCommand = RegisterFulfillmentDirectReturnDeliveryItemCommand.builder()
-                .ordDt("20260402")
-                .orgParcelCd("PARCEL001")
-                .orgInvoiceNo("INV001")
-                .inWay("01")
-                .custNm("테스트고객")
-                .rtnGubun("01")
-                .rtnReason("단순변심")
+                .orderDate("20260402")
+                .originalCourierCode("PARCEL001")
+                .originalInvoiceNumber("INV001")
+                .returnReceiveMethod("01")
+                .recipientName("테스트고객")
+                .returnType("01")
+                .returnReason("단순변심")
                 .build();
         RegisterFulfillmentDirectReturnDeliveryCommand command = RegisterFulfillmentDirectReturnDeliveryCommand.of(
                 "CUST001", "token", List.of(itemCommand)

--- a/fulfillment-service/fulfillment-application/src/test/java/com/personal/marketnote/fulfillment/service/vendor/RegisterFulfillmentReturnDeliveryUseCaseTest.java
+++ b/fulfillment-service/fulfillment-application/src/test/java/com/personal/marketnote/fulfillment/service/vendor/RegisterFulfillmentReturnDeliveryUseCaseTest.java
@@ -32,13 +32,13 @@ class RegisterFulfillmentReturnDeliveryUseCaseTest {
     void shouldReturnRegisterReturnDeliveryResultFromPort() {
         // given
         RegisterFulfillmentReturnDeliveryItemCommand itemCommand = RegisterFulfillmentReturnDeliveryItemCommand.builder()
-                .ordDt("20260402")
-                .ordNo("ORD001")
-                .parcelCd("PARCEL001")
-                .invoiceNo("INV001")
-                .custNm("테스트고객")
-                .custTelNo("01012345678")
-                .custAddr("서울시 강남구")
+                .orderDate("20260402")
+                .orderNumber("ORD001")
+                .courierCode("PARCEL001")
+                .invoiceNumber("INV001")
+                .recipientName("테스트고객")
+                .recipientPhoneNumber("01012345678")
+                .recipientAddress("서울시 강남구")
                 .build();
         RegisterFulfillmentReturnDeliveryCommand command = RegisterFulfillmentReturnDeliveryCommand.of(
                 "CUST001", "token", List.of(itemCommand)

--- a/fulfillment-service/fulfillment-application/src/test/java/com/personal/marketnote/fulfillment/service/vendor/UpdateFulfillmentDeliveryCarUseCaseTest.java
+++ b/fulfillment-service/fulfillment-application/src/test/java/com/personal/marketnote/fulfillment/service/vendor/UpdateFulfillmentDeliveryCarUseCaseTest.java
@@ -33,12 +33,12 @@ class UpdateFulfillmentDeliveryCarUseCaseTest {
     void shouldReturnUpdateDeliveryCarResultFromPort() {
         // given
         UpdateFulfillmentDeliveryCarItemCommand itemCommand = UpdateFulfillmentDeliveryCarItemCommand.builder()
-                .ordDt("20260402")
-                .ordNo("ORD001")
-                .slipNo("SLIP001")
-                .outWay("01")
-                .cstShopCd("SHOP001")
-                .godCds(List.of(RegisterFulfillmentDeliveryGoodsCommand.of("GOD001", "20260430", 1)))
+                .orderDate("20260402")
+                .orderNumber("ORD001")
+                .slipNumber("SLIP001")
+                .releaseMethod("01")
+                .shopCode("SHOP001")
+                .products(List.of(RegisterFulfillmentDeliveryGoodsCommand.of("GOD001", "20260430", 1)))
                 .build();
         UpdateFulfillmentDeliveryCarCommand command = UpdateFulfillmentDeliveryCarCommand.of(
                 "CUST001", "token", List.of(itemCommand)

--- a/fulfillment-service/fulfillment-application/src/test/java/com/personal/marketnote/fulfillment/service/vendor/UpdateFulfillmentDeliveryUseCaseTest.java
+++ b/fulfillment-service/fulfillment-application/src/test/java/com/personal/marketnote/fulfillment/service/vendor/UpdateFulfillmentDeliveryUseCaseTest.java
@@ -33,14 +33,14 @@ class UpdateFulfillmentDeliveryUseCaseTest {
     void shouldReturnUpdateDeliveryResultFromPort() {
         // given
         UpdateFulfillmentDeliveryItemCommand itemCommand = UpdateFulfillmentDeliveryItemCommand.builder()
-                .ordDt("20260402")
-                .ordNo("ORD001")
-                .slipNo("SLIP001")
-                .custNm("테스트고객")
-                .custTelNo("01012345678")
-                .custAddr("서울시 강남구")
-                .outWay("01")
-                .godCds(List.of(RegisterFulfillmentDeliveryGoodsCommand.of("GOD001", "20260430", 1)))
+                .orderDate("20260402")
+                .orderNumber("ORD001")
+                .slipNumber("SLIP001")
+                .recipientName("테스트고객")
+                .recipientPhoneNumber("01012345678")
+                .recipientAddress("서울시 강남구")
+                .releaseMethod("01")
+                .products(List.of(RegisterFulfillmentDeliveryGoodsCommand.of("GOD001", "20260430", 1)))
                 .build();
         UpdateFulfillmentDeliveryCommand command = UpdateFulfillmentDeliveryCommand.of(
                 "CUST001", "token", List.of(itemCommand)


### PR DESCRIPTION
## partially addresses #475
## resolves #2181

## Test Case
- [x] RegisterFulfillmentDeliveryServiceTest Command 필드명 변경 반영
- [x] UpdateFulfillmentDeliveryUseCaseTest Command 필드명 변경 반영
- [x] RegisterFulfillmentDeliveryCarUseCaseTest Command 필드명 변경 반영
- [x] UpdateFulfillmentDeliveryCarUseCaseTest Command 필드명 변경 반영
- [x] RegisterFulfillmentDeliveryIcsUseCaseTest Command 필드명 변경 반영
- [x] RegisterFulfillmentReturnDeliveryUseCaseTest Command 필드명 변경 반영
- [x] RegisterFulfillmentDirectReturnDeliveryUseCaseTest Command 필드명 변경 반영