### PR TITLE
[#475][#2154] refactor: warehousing 영역 벤더 종속 제거

### DIFF
--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/mapper/FulfillmentWarehousingRequestToCommandMapper.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/vendor/mapper/FulfillmentWarehousingRequestToCommandMapper.java
@@ -96,18 +96,18 @@ public class FulfillmentWarehousingRequestToCommandMapper {
                 .toList();
 
         return RegisterFulfillmentWarehousingItemCommand.builder()
-                .ordDt(item.getOrdDt())
-                .ordNo(item.getOrdNo())
-                .inWay(item.getInWay())
-                .slipNo(item.getSlipNo())
-                .parcelComp(item.getParcelComp())
-                .parcelInvoiceNo(item.getParcelInvoiceNo())
+                .orderDate(item.getOrdDt())
+                .orderNumber(item.getOrdNo())
+                .warehousingMethod(item.getInWay())
+                .slipNumber(item.getSlipNo())
+                .courierCompany(item.getParcelComp())
+                .trackingNumber(item.getParcelInvoiceNo())
                 .remark(item.getRemark())
-                .cstSupCd(item.getCstSupCd())
-                .distTermDt(item.getDistTermDt())
-                .makeDt(item.getMakeDt())
-                .preArv(item.getPreArv())
-                .godCds(goods)
+                .supplierCode(item.getCstSupCd())
+                .expirationDate(item.getDistTermDt())
+                .manufacturingDate(item.getMakeDt())
+                .preArrival(item.getPreArv())
+                .products(goods)
                 .build();
     }
 

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/scheduler/FulfillmentWarehousingPollingScheduler.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/scheduler/FulfillmentWarehousingPollingScheduler.java
@@ -46,7 +46,7 @@ public class FulfillmentWarehousingPollingScheduler implements ScheduleFulfillme
         Instant requestAt = clock.instant();
         if (FormatValidator.hasNoValue(command)
                 || FormatValidator.hasNoValue(command.customerCode())
-                || FormatValidator.hasNoValue(command.ordNo())) {
+                || FormatValidator.hasNoValue(command.orderNumber())) {
             return;
         }
 
@@ -210,7 +210,7 @@ public class FulfillmentWarehousingPollingScheduler implements ScheduleFulfillme
             Instant windowEnd = ZonedDateTime.of(requestDate, POLLING_END_TIME, DEFAULT_ZONE).toInstant();
             return new PollingContext(
                     command.customerCode(),
-                    command.ordNo(),
+                    command.orderNumber(),
                     normalizedDate,
                     normalizedDate,
                     requestDate,

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/client/FulfillmentWarehousingClient.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/client/FulfillmentWarehousingClient.java
@@ -5,14 +5,16 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.personal.marketnote.common.adapter.out.VendorAdapter;
 import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.common.utility.http.client.CommunicationFailureHandler;
+import com.personal.marketnote.fulfillment.adapter.out.vendor.fassto.mapper.FasstoWarehousingCommandToRequestMapper;
 import com.personal.marketnote.fulfillment.adapter.out.vendor.fassto.response.*;
+import com.personal.marketnote.fulfillment.adapter.out.vendor.fassto.warehousing.*;
 import com.personal.marketnote.fulfillment.configuration.FulfillmentAuthProperties;
-import com.personal.marketnote.fulfillment.domain.vendor.warehousing.*;
 import com.personal.marketnote.fulfillment.domain.vendorcommunication.FulfillmentVendorCommunicationSenderType;
 import com.personal.marketnote.fulfillment.domain.vendorcommunication.FulfillmentVendorCommunicationTargetType;
 import com.personal.marketnote.fulfillment.domain.vendorcommunication.FulfillmentVendorCommunicationType;
 import com.personal.marketnote.fulfillment.domain.vendorcommunication.FulfillmentVendorName;
 import com.personal.marketnote.fulfillment.exception.*;
+import com.personal.marketnote.fulfillment.port.in.command.vendor.*;
 import com.personal.marketnote.fulfillment.port.in.result.vendor.*;
 import com.personal.marketnote.fulfillment.port.out.vendor.*;
 import com.personal.marketnote.fulfillment.utility.VendorCommunicationFailureHandler;
@@ -66,7 +68,8 @@ public class FulfillmentWarehousingClient implements RegisterFulfillmentWarehous
     }
 
     @Override
-    public RegisterFulfillmentWarehousingResult registerWarehousing(FulfillmentWarehousingMapper request) {
+    public RegisterFulfillmentWarehousingResult registerWarehousing(RegisterFulfillmentWarehousingCommand command) {
+        FulfillmentWarehousingMapper request = FasstoWarehousingCommandToRequestMapper.mapToRegisterRequest(command);
         RegisterFulfillmentWarehousingResponse response = executeWarehousingMutation(
                 request,
                 "REGISTER",
@@ -77,7 +80,8 @@ public class FulfillmentWarehousingClient implements RegisterFulfillmentWarehous
     }
 
     @Override
-    public UpdateFulfillmentWarehousingResult updateWarehousing(FulfillmentWarehousingMapper request) {
+    public UpdateFulfillmentWarehousingResult updateWarehousing(UpdateFulfillmentWarehousingCommand command) {
+        FulfillmentWarehousingMapper request = FasstoWarehousingCommandToRequestMapper.mapToUpdateRequest(command);
         RegisterFulfillmentWarehousingResponse response = executeWarehousingMutation(
                 request,
                 "UPDATE",
@@ -88,7 +92,8 @@ public class FulfillmentWarehousingClient implements RegisterFulfillmentWarehous
     }
 
     @Override
-    public GetFulfillmentWarehousingResult getWarehousing(FulfillmentWarehousingQuery query) {
+    public GetFulfillmentWarehousingResult getWarehousing(GetFulfillmentWarehousingCommand command) {
+        FulfillmentWarehousingQuery query = FasstoWarehousingCommandToRequestMapper.mapToQuery(command);
         if (FormatValidator.hasNoValue(query)) {
             throw new IllegalArgumentException("Fulfillment warehousing query is required.");
         }
@@ -210,7 +215,8 @@ public class FulfillmentWarehousingClient implements RegisterFulfillmentWarehous
     }
 
     @Override
-    public GetFulfillmentWarehousingDetailResult getWarehousingDetail(FulfillmentWarehousingDetailQuery query) {
+    public GetFulfillmentWarehousingDetailResult getWarehousingDetail(GetFulfillmentWarehousingDetailCommand command) {
+        FulfillmentWarehousingDetailQuery query = FasstoWarehousingCommandToRequestMapper.mapToDetailQuery(command);
         if (FormatValidator.hasNoValue(query)) {
             throw new IllegalArgumentException("Fulfillment warehousing detail query is required.");
         }
@@ -326,7 +332,8 @@ public class FulfillmentWarehousingClient implements RegisterFulfillmentWarehous
     }
 
     @Override
-    public GetFulfillmentWarehousingInspecDetailResult getWarehousingInspecDetail(FulfillmentWarehousingInspecDetailQuery query) {
+    public GetFulfillmentWarehousingInspecDetailResult getWarehousingInspecDetail(GetFulfillmentWarehousingInspecDetailCommand command) {
+        FulfillmentWarehousingInspecDetailQuery query = FasstoWarehousingCommandToRequestMapper.mapToInspecDetailQuery(command);
         if (FormatValidator.hasNoValue(query)) {
             throw new IllegalArgumentException("Fulfillment warehousing inspection detail query is required.");
         }
@@ -440,7 +447,8 @@ public class FulfillmentWarehousingClient implements RegisterFulfillmentWarehous
     }
 
     @Override
-    public GetFulfillmentWarehousingAbnormalResult getWarehousingAbnormal(FulfillmentWarehousingAbnormalQuery query) {
+    public GetFulfillmentWarehousingAbnormalResult getWarehousingAbnormal(GetFulfillmentWarehousingAbnormalCommand command) {
+        FulfillmentWarehousingAbnormalQuery query = FasstoWarehousingCommandToRequestMapper.mapToAbnormalQuery(command);
         if (FormatValidator.hasNoValue(query)) {
             throw new IllegalArgumentException("Fulfillment warehousing abnormal query is required.");
         }
@@ -551,7 +559,8 @@ public class FulfillmentWarehousingClient implements RegisterFulfillmentWarehous
     }
 
     @Override
-    public GetFulfillmentWarehousingAbnormalImageResult getWarehousingAbnormalImage(FulfillmentWarehousingAbnormalImageQuery query) {
+    public GetFulfillmentWarehousingAbnormalImageResult getWarehousingAbnormalImage(GetFulfillmentWarehousingAbnormalImageCommand command) {
+        FulfillmentWarehousingAbnormalImageQuery query = FasstoWarehousingCommandToRequestMapper.mapToAbnormalImageQuery(command);
         if (FormatValidator.hasNoValue(query)) {
             throw new IllegalArgumentException("Fulfillment warehousing abnormal image query is required.");
         }

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/mapper/FasstoWarehousingCommandToRequestMapper.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/mapper/FasstoWarehousingCommandToRequestMapper.java
@@ -1,0 +1,144 @@
+package com.personal.marketnote.fulfillment.adapter.out.vendor.fassto.mapper;
+
+import com.personal.marketnote.fulfillment.adapter.out.vendor.fassto.warehousing.*;
+import com.personal.marketnote.fulfillment.port.in.command.vendor.*;
+
+import java.util.List;
+
+public class FasstoWarehousingCommandToRequestMapper {
+    public static FulfillmentWarehousingMapper mapToRegisterRequest(RegisterFulfillmentWarehousingCommand command) {
+        List<FulfillmentWarehousingItemMapper> requests = command.warehousingRequests().stream()
+                .map(FasstoWarehousingCommandToRequestMapper::mapItem)
+                .toList();
+
+        return FulfillmentWarehousingMapper.register(
+                command.customerCode(),
+                command.accessToken(),
+                requests
+        );
+    }
+
+    public static FulfillmentWarehousingQuery mapToQuery(GetFulfillmentWarehousingCommand command) {
+        return FulfillmentWarehousingQuery.of(
+                command.customerCode(),
+                command.accessToken(),
+                command.startDate(),
+                command.endDate(),
+                command.warehousingMethod(),
+                command.orderNumber(),
+                command.workStatus()
+        );
+    }
+
+    public static FulfillmentWarehousingDetailQuery mapToDetailQuery(GetFulfillmentWarehousingDetailCommand command) {
+        return FulfillmentWarehousingDetailQuery.of(
+                command.customerCode(),
+                command.accessToken(),
+                command.slipNumber(),
+                command.orderNumber()
+        );
+    }
+
+    public static FulfillmentWarehousingAbnormalQuery mapToAbnormalQuery(GetFulfillmentWarehousingAbnormalCommand command) {
+        return FulfillmentWarehousingAbnormalQuery.of(
+                command.customerCode(),
+                command.accessToken(),
+                command.warehouseCode(),
+                command.slipNumber()
+        );
+    }
+
+    public static FulfillmentWarehousingAbnormalImageQuery mapToAbnormalImageQuery(
+            GetFulfillmentWarehousingAbnormalImageCommand command
+    ) {
+        return FulfillmentWarehousingAbnormalImageQuery.of(
+                command.accessToken(),
+                command.slipNumber(),
+                command.productCode(),
+                command.goodsSerialNo(),
+                command.fileSeq(),
+                command.imageNumber()
+        );
+    }
+
+    public static FulfillmentWarehousingInspecDetailQuery mapToInspecDetailQuery(
+            GetFulfillmentWarehousingInspecDetailCommand command
+    ) {
+        return FulfillmentWarehousingInspecDetailQuery.of(
+                command.customerCode(),
+                command.accessToken(),
+                command.slipNumber(),
+                command.warehouseCode()
+        );
+    }
+
+    public static FulfillmentWarehousingMapper mapToUpdateRequest(UpdateFulfillmentWarehousingCommand command) {
+        List<FulfillmentWarehousingItemMapper> requests = command.warehousingRequests().stream()
+                .map(FasstoWarehousingCommandToRequestMapper::mapUpdateItem)
+                .toList();
+
+        return FulfillmentWarehousingMapper.update(
+                command.customerCode(),
+                command.accessToken(),
+                requests
+        );
+    }
+
+    private static FulfillmentWarehousingItemMapper mapItem(RegisterFulfillmentWarehousingItemCommand item) {
+        List<FulfillmentWarehousingGoodsMapper> goods = item.products().stream()
+                .map(FasstoWarehousingCommandToRequestMapper::mapGoods)
+                .toList();
+
+        return FulfillmentWarehousingItemMapper.of(
+                item.orderDate(),
+                item.orderNumber(),
+                item.warehousingMethod(),
+                item.slipNumber(),
+                item.courierCompany(),
+                item.trackingNumber(),
+                item.remark(),
+                item.supplierCode(),
+                item.expirationDate(),
+                item.manufacturingDate(),
+                item.preArrival(),
+                goods
+        );
+    }
+
+    private static FulfillmentWarehousingItemMapper mapUpdateItem(UpdateFulfillmentWarehousingItemCommand item) {
+        List<FulfillmentWarehousingGoodsMapper> goods = item.products().stream()
+                .map(FasstoWarehousingCommandToRequestMapper::mapUpdateGoods)
+                .toList();
+
+        return FulfillmentWarehousingItemMapper.update(
+                item.orderDate(),
+                item.orderNumber(),
+                item.warehousingMethod(),
+                item.slipNumber(),
+                item.courierCompany(),
+                item.trackingNumber(),
+                item.remark(),
+                item.supplierCode(),
+                item.expirationDate(),
+                item.manufacturingDate(),
+                item.preArrival(),
+                goods
+        );
+    }
+
+    private static FulfillmentWarehousingGoodsMapper mapGoods(RegisterFulfillmentWarehousingGoodsCommand item) {
+        return FulfillmentWarehousingGoodsMapper.of(
+                item.productCode(),
+                item.expirationDate(),
+                item.orderQuantity()
+        );
+    }
+
+    private static FulfillmentWarehousingGoodsMapper mapUpdateGoods(UpdateFulfillmentWarehousingGoodsCommand item) {
+        return FulfillmentWarehousingGoodsMapper.of(
+                item.productCode(),
+                item.expirationDate(),
+                item.orderQuantity()
+        );
+    }
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/warehousing/FulfillmentWarehousingAbnormalImageQuery.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/warehousing/FulfillmentWarehousingAbnormalImageQuery.java
@@ -1,0 +1,59 @@
+package com.personal.marketnote.fulfillment.adapter.out.vendor.fassto.warehousing;
+
+import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.fulfillment.domain.exception.FulfillmentQueryParameterNoValueException;
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+public class FulfillmentWarehousingAbnormalImageQuery {
+    private String accessToken;
+    private String slipNo;
+    private String godCd;
+    private String goodsSerialNo;
+    private String fileSeq;
+    private String imgNo;
+
+    public static FulfillmentWarehousingAbnormalImageQuery of(
+            String accessToken,
+            String slipNo,
+            String godCd,
+            String goodsSerialNo,
+            String fileSeq,
+            String imgNo
+    ) {
+        FulfillmentWarehousingAbnormalImageQuery query = FulfillmentWarehousingAbnormalImageQuery.builder()
+                .accessToken(accessToken)
+                .slipNo(slipNo)
+                .godCd(godCd)
+                .goodsSerialNo(goodsSerialNo)
+                .fileSeq(fileSeq)
+                .imgNo(imgNo)
+                .build();
+        query.validate();
+        return query;
+    }
+
+    private void validate() {
+        if (FormatValidator.hasNoValue(accessToken)) {
+            throw new FulfillmentQueryParameterNoValueException("accessToken");
+        }
+        if (FormatValidator.hasNoValue(slipNo)) {
+            throw new FulfillmentQueryParameterNoValueException("slipNo");
+        }
+        if (FormatValidator.hasNoValue(godCd)) {
+            throw new FulfillmentQueryParameterNoValueException("godCd");
+        }
+        if (FormatValidator.hasNoValue(goodsSerialNo)) {
+            throw new FulfillmentQueryParameterNoValueException("goodsSerialNo");
+        }
+        if (FormatValidator.hasNoValue(fileSeq)) {
+            throw new FulfillmentQueryParameterNoValueException("fileSeq");
+        }
+        if (FormatValidator.hasNoValue(imgNo)) {
+            throw new FulfillmentQueryParameterNoValueException("imgNo");
+        }
+    }
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/warehousing/FulfillmentWarehousingAbnormalQuery.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/warehousing/FulfillmentWarehousingAbnormalQuery.java
@@ -1,0 +1,47 @@
+package com.personal.marketnote.fulfillment.adapter.out.vendor.fassto.warehousing;
+
+import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.fulfillment.domain.exception.FulfillmentQueryParameterNoValueException;
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+public class FulfillmentWarehousingAbnormalQuery {
+    private String customerCode;
+    private String accessToken;
+    private String whCd;
+    private String slipNo;
+
+    public static FulfillmentWarehousingAbnormalQuery of(
+            String customerCode,
+            String accessToken,
+            String whCd,
+            String slipNo
+    ) {
+        FulfillmentWarehousingAbnormalQuery query = FulfillmentWarehousingAbnormalQuery.builder()
+                .customerCode(customerCode)
+                .accessToken(accessToken)
+                .whCd(whCd)
+                .slipNo(slipNo)
+                .build();
+        query.validate();
+        return query;
+    }
+
+    private void validate() {
+        if (FormatValidator.hasNoValue(customerCode)) {
+            throw new FulfillmentQueryParameterNoValueException("customerCode");
+        }
+        if (FormatValidator.hasNoValue(accessToken)) {
+            throw new FulfillmentQueryParameterNoValueException("accessToken");
+        }
+        if (FormatValidator.hasNoValue(whCd)) {
+            throw new FulfillmentQueryParameterNoValueException("whCd");
+        }
+        if (FormatValidator.hasNoValue(slipNo)) {
+            throw new FulfillmentQueryParameterNoValueException("slipNo");
+        }
+    }
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/warehousing/FulfillmentWarehousingDetailQuery.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/warehousing/FulfillmentWarehousingDetailQuery.java
@@ -1,0 +1,44 @@
+package com.personal.marketnote.fulfillment.adapter.out.vendor.fassto.warehousing;
+
+import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.fulfillment.domain.exception.FulfillmentQueryParameterNoValueException;
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+public class FulfillmentWarehousingDetailQuery {
+    private String customerCode;
+    private String accessToken;
+    private String slipNo;
+    private String ordNo;
+
+    public static FulfillmentWarehousingDetailQuery of(
+            String customerCode,
+            String accessToken,
+            String slipNo,
+            String ordNo
+    ) {
+        FulfillmentWarehousingDetailQuery query = FulfillmentWarehousingDetailQuery.builder()
+                .customerCode(customerCode)
+                .accessToken(accessToken)
+                .slipNo(slipNo)
+                .ordNo(ordNo)
+                .build();
+        query.validate();
+        return query;
+    }
+
+    private void validate() {
+        if (FormatValidator.hasNoValue(customerCode)) {
+            throw new FulfillmentQueryParameterNoValueException("customerCode");
+        }
+        if (FormatValidator.hasNoValue(accessToken)) {
+            throw new FulfillmentQueryParameterNoValueException("accessToken");
+        }
+        if (FormatValidator.hasNoValue(slipNo)) {
+            throw new FulfillmentQueryParameterNoValueException("slipNo");
+        }
+    }
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/warehousing/FulfillmentWarehousingGoodsMapper.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/warehousing/FulfillmentWarehousingGoodsMapper.java
@@ -1,0 +1,57 @@
+package com.personal.marketnote.fulfillment.adapter.out.vendor.fassto.warehousing;
+
+import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.fulfillment.domain.exception.FulfillmentQueryParameterNoValueException;
+import lombok.*;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+public class FulfillmentWarehousingGoodsMapper {
+    private String cstGodCd;
+    private String distTermDt;
+    private Integer ordQty;
+
+    public static FulfillmentWarehousingGoodsMapper of(
+            String cstGodCd,
+            String distTermDt,
+            Integer ordQty
+    ) {
+        FulfillmentWarehousingGoodsMapper mapper = FulfillmentWarehousingGoodsMapper.builder()
+                .cstGodCd(cstGodCd)
+                .distTermDt(distTermDt)
+                .ordQty(ordQty)
+                .build();
+        mapper.validate();
+        return mapper;
+    }
+
+    public Map<String, Object> toPayload() {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        putIfNotNull(payload, "cstGodCd", cstGodCd);
+        putIfNotNull(payload, "distTermDt", distTermDt);
+        if (FormatValidator.hasValue(ordQty)) {
+            payload.put("ordQty", ordQty);
+        }
+        return payload;
+    }
+
+    private void validate() {
+        if (FormatValidator.hasNoValue(cstGodCd)) {
+            throw new FulfillmentQueryParameterNoValueException("cstGodCd", "warehousing goods request");
+        }
+        if (FormatValidator.hasNoValue(ordQty)) {
+            throw new FulfillmentQueryParameterNoValueException("ordQty", "warehousing goods request");
+        }
+    }
+
+    private void putIfNotNull(Map<String, Object> payload, String key, String value) {
+        if (FormatValidator.hasValue(value)) {
+            payload.put(key, value);
+        }
+    }
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/warehousing/FulfillmentWarehousingInspecDetailQuery.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/warehousing/FulfillmentWarehousingInspecDetailQuery.java
@@ -1,0 +1,47 @@
+package com.personal.marketnote.fulfillment.adapter.out.vendor.fassto.warehousing;
+
+import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.fulfillment.domain.exception.FulfillmentQueryParameterNoValueException;
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+public class FulfillmentWarehousingInspecDetailQuery {
+    private String customerCode;
+    private String accessToken;
+    private String slipNo;
+    private String whCd;
+
+    public static FulfillmentWarehousingInspecDetailQuery of(
+            String customerCode,
+            String accessToken,
+            String slipNo,
+            String whCd
+    ) {
+        FulfillmentWarehousingInspecDetailQuery query = FulfillmentWarehousingInspecDetailQuery.builder()
+                .customerCode(customerCode)
+                .accessToken(accessToken)
+                .slipNo(slipNo)
+                .whCd(whCd)
+                .build();
+        query.validate();
+        return query;
+    }
+
+    private void validate() {
+        if (FormatValidator.hasNoValue(customerCode)) {
+            throw new FulfillmentQueryParameterNoValueException("customerCode");
+        }
+        if (FormatValidator.hasNoValue(accessToken)) {
+            throw new FulfillmentQueryParameterNoValueException("accessToken");
+        }
+        if (FormatValidator.hasNoValue(slipNo)) {
+            throw new FulfillmentQueryParameterNoValueException("slipNo");
+        }
+        if (FormatValidator.hasNoValue(whCd)) {
+            throw new FulfillmentQueryParameterNoValueException("whCd");
+        }
+    }
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/warehousing/FulfillmentWarehousingItemMapper.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/warehousing/FulfillmentWarehousingItemMapper.java
@@ -1,0 +1,138 @@
+package com.personal.marketnote.fulfillment.adapter.out.vendor.fassto.warehousing;
+
+import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.fulfillment.domain.exception.FulfillmentQueryParameterNoValueException;
+import lombok.*;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+public class FulfillmentWarehousingItemMapper {
+    private String ordDt;
+    private String ordNo;
+    private String inWay;
+    private String slipNo;
+    private String parcelComp;
+    private String parcelInvoiceNo;
+    private String remark;
+    private String cstSupCd;
+    private String distTermDt;
+    private String makeDt;
+    private String preArv;
+    private List<FulfillmentWarehousingGoodsMapper> godCds;
+
+    public static FulfillmentWarehousingItemMapper of(
+            String ordDt,
+            String ordNo,
+            String inWay,
+            String slipNo,
+            String parcelComp,
+            String parcelInvoiceNo,
+            String remark,
+            String cstSupCd,
+            String distTermDt,
+            String makeDt,
+            String preArv,
+            List<FulfillmentWarehousingGoodsMapper> godCds
+    ) {
+        FulfillmentWarehousingItemMapper mapper = FulfillmentWarehousingItemMapper.builder()
+                .ordDt(ordDt)
+                .ordNo(ordNo)
+                .inWay(inWay)
+                .slipNo(slipNo)
+                .parcelComp(parcelComp)
+                .parcelInvoiceNo(parcelInvoiceNo)
+                .remark(remark)
+                .cstSupCd(cstSupCd)
+                .distTermDt(distTermDt)
+                .makeDt(makeDt)
+                .preArv(preArv)
+                .godCds(godCds)
+                .build();
+        mapper.validate();
+        return mapper;
+    }
+
+    public static FulfillmentWarehousingItemMapper update(
+            String ordDt,
+            String ordNo,
+            String inWay,
+            String slipNo,
+            String parcelComp,
+            String parcelInvoiceNo,
+            String remark,
+            String cstSupCd,
+            String distTermDt,
+            String makeDt,
+            String preArv,
+            List<FulfillmentWarehousingGoodsMapper> godCds
+    ) {
+        FulfillmentWarehousingItemMapper mapper = FulfillmentWarehousingItemMapper.builder()
+                .ordDt(ordDt)
+                .ordNo(ordNo)
+                .inWay(inWay)
+                .slipNo(slipNo)
+                .parcelComp(parcelComp)
+                .parcelInvoiceNo(parcelInvoiceNo)
+                .remark(remark)
+                .cstSupCd(cstSupCd)
+                .distTermDt(distTermDt)
+                .makeDt(makeDt)
+                .preArv(preArv)
+                .godCds(godCds)
+                .build();
+        mapper.validateForUpdate();
+        return mapper;
+    }
+
+    public Map<String, Object> toPayload() {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        putIfNotNull(payload, "ordDt", ordDt);
+        putIfNotNull(payload, "ordNo", ordNo);
+        putIfNotNull(payload, "inWay", inWay);
+        putIfNotNull(payload, "slipNo", slipNo);
+        putIfNotNull(payload, "parcelComp", parcelComp);
+        putIfNotNull(payload, "parcelInvoiceNo", parcelInvoiceNo);
+        putIfNotNull(payload, "remark", remark);
+        putIfNotNull(payload, "cstSupCd", cstSupCd);
+        putIfNotNull(payload, "distTermDt", distTermDt);
+        putIfNotNull(payload, "makeDt", makeDt);
+        putIfNotNull(payload, "preArv", preArv);
+        if (FormatValidator.hasValue(godCds)) {
+            payload.put("godCds", godCds.stream()
+                    .map(FulfillmentWarehousingGoodsMapper::toPayload)
+                    .toList());
+        }
+        return payload;
+    }
+
+    private void validate() {
+        if (FormatValidator.hasNoValue(ordDt)) {
+            throw new FulfillmentQueryParameterNoValueException("ordDt", "warehousing request");
+        }
+        if (FormatValidator.hasNoValue(inWay)) {
+            throw new FulfillmentQueryParameterNoValueException("inWay", "warehousing request");
+        }
+        if (FormatValidator.hasNoValue(godCds)) {
+            throw new FulfillmentQueryParameterNoValueException("godCds", "warehousing request");
+        }
+    }
+
+    private void validateForUpdate() {
+        validate();
+        if (FormatValidator.hasNoValue(slipNo)) {
+            throw new FulfillmentQueryParameterNoValueException("slipNo", "warehousing update");
+        }
+    }
+
+    private void putIfNotNull(Map<String, Object> payload, String key, String value) {
+        if (FormatValidator.hasValue(value)) {
+            payload.put(key, value);
+        }
+    }
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/warehousing/FulfillmentWarehousingMapper.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/warehousing/FulfillmentWarehousingMapper.java
@@ -1,0 +1,66 @@
+package com.personal.marketnote.fulfillment.adapter.out.vendor.fassto.warehousing;
+
+import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.fulfillment.domain.exception.FulfillmentQueryParameterNoValueException;
+import lombok.*;
+
+import java.util.List;
+import java.util.Map;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+public class FulfillmentWarehousingMapper {
+    private String customerCode;
+    private String accessToken;
+    private List<FulfillmentWarehousingItemMapper> warehousingRequests;
+
+    public static FulfillmentWarehousingMapper register(
+            String customerCode,
+            String accessToken,
+            List<FulfillmentWarehousingItemMapper> warehousingRequests
+    ) {
+        return create(customerCode, accessToken, warehousingRequests);
+    }
+
+    public static FulfillmentWarehousingMapper update(
+            String customerCode,
+            String accessToken,
+            List<FulfillmentWarehousingItemMapper> warehousingRequests
+    ) {
+        return create(customerCode, accessToken, warehousingRequests);
+    }
+
+    public List<Map<String, Object>> toPayload() {
+        return warehousingRequests.stream()
+                .map(FulfillmentWarehousingItemMapper::toPayload)
+                .toList();
+    }
+
+    private void validate() {
+        if (FormatValidator.hasNoValue(customerCode)) {
+            throw new FulfillmentQueryParameterNoValueException("customerCode");
+        }
+        if (FormatValidator.hasNoValue(accessToken)) {
+            throw new FulfillmentQueryParameterNoValueException("accessToken");
+        }
+        if (FormatValidator.hasNoValue(warehousingRequests)) {
+            throw new FulfillmentQueryParameterNoValueException("warehousingRequests");
+        }
+    }
+
+    private static FulfillmentWarehousingMapper create(
+            String customerCode,
+            String accessToken,
+            List<FulfillmentWarehousingItemMapper> warehousingRequests
+    ) {
+        FulfillmentWarehousingMapper mapper = FulfillmentWarehousingMapper.builder()
+                .customerCode(customerCode)
+                .accessToken(accessToken)
+                .warehousingRequests(warehousingRequests)
+                .build();
+        mapper.validate();
+        return mapper;
+    }
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/warehousing/FulfillmentWarehousingQuery.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/warehousing/FulfillmentWarehousingQuery.java
@@ -1,0 +1,65 @@
+package com.personal.marketnote.fulfillment.adapter.out.vendor.fassto.warehousing;
+
+import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.fulfillment.domain.exception.FulfillmentQueryParameterNoValueException;
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+public class FulfillmentWarehousingQuery {
+    private String customerCode;
+    private String accessToken;
+    private String startDate;
+    private String endDate;
+    private String inWay;
+    private String ordNo;
+    private String wrkStat;
+
+    public static FulfillmentWarehousingQuery of(
+            String customerCode,
+            String accessToken,
+            String startDate,
+            String endDate
+    ) {
+        return FulfillmentWarehousingQuery.of(customerCode, accessToken, startDate, endDate, null, null, null);
+    }
+
+    public static FulfillmentWarehousingQuery of(
+            String customerCode,
+            String accessToken,
+            String startDate,
+            String endDate,
+            String inWay,
+            String ordNo,
+            String wrkStat
+    ) {
+        FulfillmentWarehousingQuery query = FulfillmentWarehousingQuery.builder()
+                .customerCode(customerCode)
+                .accessToken(accessToken)
+                .startDate(startDate)
+                .endDate(endDate)
+                .inWay(inWay)
+                .ordNo(ordNo)
+                .wrkStat(wrkStat)
+                .build();
+        query.validate();
+        return query;
+    }
+
+    private void validate() {
+        if (FormatValidator.hasNoValue(customerCode)) {
+            throw new FulfillmentQueryParameterNoValueException("customerCode");
+        }
+        if (FormatValidator.hasNoValue(accessToken)) {
+            throw new FulfillmentQueryParameterNoValueException("accessToken");
+        }
+        if (FormatValidator.hasNoValue(startDate)) {
+            throw new FulfillmentQueryParameterNoValueException("startDate");
+        }
+        if (FormatValidator.hasNoValue(endDate)) {
+            throw new FulfillmentQueryParameterNoValueException("endDate");
+        }
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/vendor/GetFulfillmentWarehousingAbnormalCommand.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/vendor/GetFulfillmentWarehousingAbnormalCommand.java
@@ -3,15 +3,15 @@ package com.personal.marketnote.fulfillment.port.in.command.vendor;
 public record GetFulfillmentWarehousingAbnormalCommand(
         String customerCode,
         String accessToken,
-        String whCd,
-        String slipNo
+        String warehouseCode,
+        String slipNumber
 ) {
     public static GetFulfillmentWarehousingAbnormalCommand of(
             String customerCode,
             String accessToken,
-            String whCd,
-            String slipNo
+            String warehouseCode,
+            String slipNumber
     ) {
-        return new GetFulfillmentWarehousingAbnormalCommand(customerCode, accessToken, whCd, slipNo);
+        return new GetFulfillmentWarehousingAbnormalCommand(customerCode, accessToken, warehouseCode, slipNumber);
     }
 }

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/vendor/GetFulfillmentWarehousingAbnormalImageCommand.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/vendor/GetFulfillmentWarehousingAbnormalImageCommand.java
@@ -2,20 +2,20 @@ package com.personal.marketnote.fulfillment.port.in.command.vendor;
 
 public record GetFulfillmentWarehousingAbnormalImageCommand(
         String accessToken,
-        String slipNo,
-        String godCd,
+        String slipNumber,
+        String productCode,
         String goodsSerialNo,
         String fileSeq,
-        String imgNo
+        String imageNumber
 ) {
     public static GetFulfillmentWarehousingAbnormalImageCommand of(
             String accessToken,
-            String slipNo,
-            String godCd,
+            String slipNumber,
+            String productCode,
             String goodsSerialNo,
             String fileSeq,
-            String imgNo
+            String imageNumber
     ) {
-        return new GetFulfillmentWarehousingAbnormalImageCommand(accessToken, slipNo, godCd, goodsSerialNo, fileSeq, imgNo);
+        return new GetFulfillmentWarehousingAbnormalImageCommand(accessToken, slipNumber, productCode, goodsSerialNo, fileSeq, imageNumber);
     }
 }

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/vendor/GetFulfillmentWarehousingCommand.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/vendor/GetFulfillmentWarehousingCommand.java
@@ -5,9 +5,9 @@ public record GetFulfillmentWarehousingCommand(
         String accessToken,
         String startDate,
         String endDate,
-        String inWay,
-        String ordNo,
-        String wrkStat
+        String warehousingMethod,
+        String orderNumber,
+        String workStatus
 ) {
     public static GetFulfillmentWarehousingCommand of(
             String customerCode,
@@ -23,10 +23,10 @@ public record GetFulfillmentWarehousingCommand(
             String accessToken,
             String startDate,
             String endDate,
-            String inWay,
-            String ordNo,
-            String wrkStat
+            String warehousingMethod,
+            String orderNumber,
+            String workStatus
     ) {
-        return new GetFulfillmentWarehousingCommand(customerCode, accessToken, startDate, endDate, inWay, ordNo, wrkStat);
+        return new GetFulfillmentWarehousingCommand(customerCode, accessToken, startDate, endDate, warehousingMethod, orderNumber, workStatus);
     }
 }

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/vendor/GetFulfillmentWarehousingDetailCommand.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/vendor/GetFulfillmentWarehousingDetailCommand.java
@@ -3,15 +3,15 @@ package com.personal.marketnote.fulfillment.port.in.command.vendor;
 public record GetFulfillmentWarehousingDetailCommand(
         String customerCode,
         String accessToken,
-        String slipNo,
-        String ordNo
+        String slipNumber,
+        String orderNumber
 ) {
     public static GetFulfillmentWarehousingDetailCommand of(
             String customerCode,
             String accessToken,
-            String slipNo,
-            String ordNo
+            String slipNumber,
+            String orderNumber
     ) {
-        return new GetFulfillmentWarehousingDetailCommand(customerCode, accessToken, slipNo, ordNo);
+        return new GetFulfillmentWarehousingDetailCommand(customerCode, accessToken, slipNumber, orderNumber);
     }
 }

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/vendor/GetFulfillmentWarehousingInspecDetailCommand.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/vendor/GetFulfillmentWarehousingInspecDetailCommand.java
@@ -3,15 +3,15 @@ package com.personal.marketnote.fulfillment.port.in.command.vendor;
 public record GetFulfillmentWarehousingInspecDetailCommand(
         String customerCode,
         String accessToken,
-        String slipNo,
-        String whCd
+        String slipNumber,
+        String warehouseCode
 ) {
     public static GetFulfillmentWarehousingInspecDetailCommand of(
             String customerCode,
             String accessToken,
-            String slipNo,
-            String whCd
+            String slipNumber,
+            String warehouseCode
     ) {
-        return new GetFulfillmentWarehousingInspecDetailCommand(customerCode, accessToken, slipNo, whCd);
+        return new GetFulfillmentWarehousingInspecDetailCommand(customerCode, accessToken, slipNumber, warehouseCode);
     }
 }

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/vendor/RegisterFulfillmentWarehousingGoodsCommand.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/vendor/RegisterFulfillmentWarehousingGoodsCommand.java
@@ -1,15 +1,15 @@
 package com.personal.marketnote.fulfillment.port.in.command.vendor;
 
 public record RegisterFulfillmentWarehousingGoodsCommand(
-        String cstGodCd,
-        String distTermDt,
-        Integer ordQty
+        String productCode,
+        String expirationDate,
+        Integer orderQuantity
 ) {
     public static RegisterFulfillmentWarehousingGoodsCommand of(
-            String cstGodCd,
-            String distTermDt,
-            Integer ordQty
+            String productCode,
+            String expirationDate,
+            Integer orderQuantity
     ) {
-        return new RegisterFulfillmentWarehousingGoodsCommand(cstGodCd, distTermDt, ordQty);
+        return new RegisterFulfillmentWarehousingGoodsCommand(productCode, expirationDate, orderQuantity);
     }
 }

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/vendor/RegisterFulfillmentWarehousingItemCommand.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/vendor/RegisterFulfillmentWarehousingItemCommand.java
@@ -6,17 +6,17 @@ import java.util.List;
 
 @Builder
 public record RegisterFulfillmentWarehousingItemCommand(
-        String ordDt,
-        String ordNo,
-        String inWay,
-        String slipNo,
-        String parcelComp,
-        String parcelInvoiceNo,
+        String orderDate,
+        String orderNumber,
+        String warehousingMethod,
+        String slipNumber,
+        String courierCompany,
+        String trackingNumber,
         String remark,
-        String cstSupCd,
-        String distTermDt,
-        String makeDt,
-        String preArv,
-        List<RegisterFulfillmentWarehousingGoodsCommand> godCds
+        String supplierCode,
+        String expirationDate,
+        String manufacturingDate,
+        String preArrival,
+        List<RegisterFulfillmentWarehousingGoodsCommand> products
 ) {
 }

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/vendor/UpdateFulfillmentWarehousingGoodsCommand.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/vendor/UpdateFulfillmentWarehousingGoodsCommand.java
@@ -1,15 +1,15 @@
 package com.personal.marketnote.fulfillment.port.in.command.vendor;
 
 public record UpdateFulfillmentWarehousingGoodsCommand(
-        String cstGodCd,
-        String distTermDt,
-        Integer ordQty
+        String productCode,
+        String expirationDate,
+        Integer orderQuantity
 ) {
     public static UpdateFulfillmentWarehousingGoodsCommand of(
-            String cstGodCd,
-            String distTermDt,
-            Integer ordQty
+            String productCode,
+            String expirationDate,
+            Integer orderQuantity
     ) {
-        return new UpdateFulfillmentWarehousingGoodsCommand(cstGodCd, distTermDt, ordQty);
+        return new UpdateFulfillmentWarehousingGoodsCommand(productCode, expirationDate, orderQuantity);
     }
 }

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/vendor/UpdateFulfillmentWarehousingItemCommand.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/vendor/UpdateFulfillmentWarehousingItemCommand.java
@@ -3,46 +3,46 @@ package com.personal.marketnote.fulfillment.port.in.command.vendor;
 import java.util.List;
 
 public record UpdateFulfillmentWarehousingItemCommand(
-        String ordDt,
-        String ordNo,
-        String inWay,
-        String slipNo,
-        String parcelComp,
-        String parcelInvoiceNo,
+        String orderDate,
+        String orderNumber,
+        String warehousingMethod,
+        String slipNumber,
+        String courierCompany,
+        String trackingNumber,
         String remark,
-        String cstSupCd,
-        String distTermDt,
-        String makeDt,
-        String preArv,
-        List<UpdateFulfillmentWarehousingGoodsCommand> godCds
+        String supplierCode,
+        String expirationDate,
+        String manufacturingDate,
+        String preArrival,
+        List<UpdateFulfillmentWarehousingGoodsCommand> products
 ) {
     public static UpdateFulfillmentWarehousingItemCommand of(
-            String ordDt,
-            String ordNo,
-            String inWay,
-            String slipNo,
-            String parcelComp,
-            String parcelInvoiceNo,
+            String orderDate,
+            String orderNumber,
+            String warehousingMethod,
+            String slipNumber,
+            String courierCompany,
+            String trackingNumber,
             String remark,
-            String cstSupCd,
-            String distTermDt,
-            String makeDt,
-            String preArv,
-            List<UpdateFulfillmentWarehousingGoodsCommand> godCds
+            String supplierCode,
+            String expirationDate,
+            String manufacturingDate,
+            String preArrival,
+            List<UpdateFulfillmentWarehousingGoodsCommand> products
     ) {
         return new UpdateFulfillmentWarehousingItemCommand(
-                ordDt,
-                ordNo,
-                inWay,
-                slipNo,
-                parcelComp,
-                parcelInvoiceNo,
+                orderDate,
+                orderNumber,
+                warehousingMethod,
+                slipNumber,
+                courierCompany,
+                trackingNumber,
                 remark,
-                cstSupCd,
-                distTermDt,
-                makeDt,
-                preArv,
-                godCds
+                supplierCode,
+                expirationDate,
+                manufacturingDate,
+                preArrival,
+                products
         );
     }
 }

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/scheduler/ScheduleFulfillmentWarehousingPollingCommand.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/scheduler/ScheduleFulfillmentWarehousingPollingCommand.java
@@ -2,14 +2,14 @@ package com.personal.marketnote.fulfillment.port.out.scheduler;
 
 public record ScheduleFulfillmentWarehousingPollingCommand(
         String customerCode,
-        String ordNo,
-        String ordDt
+        String orderNumber,
+        String orderDate
 ) {
     public static ScheduleFulfillmentWarehousingPollingCommand of(
             String customerCode,
-            String ordNo,
-            String ordDt
+            String orderNumber,
+            String orderDate
     ) {
-        return new ScheduleFulfillmentWarehousingPollingCommand(customerCode, ordNo, ordDt);
+        return new ScheduleFulfillmentWarehousingPollingCommand(customerCode, orderNumber, orderDate);
     }
 }

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/vendor/GetFulfillmentWarehousingAbnormalImagePort.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/vendor/GetFulfillmentWarehousingAbnormalImagePort.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.fulfillment.port.out.vendor;
 
-import com.personal.marketnote.fulfillment.domain.vendor.warehousing.FulfillmentWarehousingAbnormalImageQuery;
+import com.personal.marketnote.fulfillment.port.in.command.vendor.GetFulfillmentWarehousingAbnormalImageCommand;
 import com.personal.marketnote.fulfillment.port.in.result.vendor.GetFulfillmentWarehousingAbnormalImageResult;
 
 /**
@@ -13,11 +13,11 @@ import com.personal.marketnote.fulfillment.port.in.result.vendor.GetFulfillmentW
 public interface GetFulfillmentWarehousingAbnormalImagePort {
 
     /**
-     * @param query 파스토 입고 이상 이미지 조회 쿼리
+     * @param command 파스토 입고 이상 이미지 조회 커맨드
      * @return 파스토 입고 이상 이미지 조회 결과 {@link GetFulfillmentWarehousingAbnormalImageResult}
      * @Date 2026-02-17
      * @Author 성효빈
      * @Description 파스토 입고 이상 이미지를 조회합니다.
      */
-    GetFulfillmentWarehousingAbnormalImageResult getWarehousingAbnormalImage(FulfillmentWarehousingAbnormalImageQuery query);
+    GetFulfillmentWarehousingAbnormalImageResult getWarehousingAbnormalImage(GetFulfillmentWarehousingAbnormalImageCommand command);
 }

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/vendor/GetFulfillmentWarehousingAbnormalPort.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/vendor/GetFulfillmentWarehousingAbnormalPort.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.fulfillment.port.out.vendor;
 
-import com.personal.marketnote.fulfillment.domain.vendor.warehousing.FulfillmentWarehousingAbnormalQuery;
+import com.personal.marketnote.fulfillment.port.in.command.vendor.GetFulfillmentWarehousingAbnormalCommand;
 import com.personal.marketnote.fulfillment.port.in.result.vendor.GetFulfillmentWarehousingAbnormalResult;
 
 /**
@@ -13,11 +13,11 @@ import com.personal.marketnote.fulfillment.port.in.result.vendor.GetFulfillmentW
 public interface GetFulfillmentWarehousingAbnormalPort {
 
     /**
-     * @param query 파스토 입고 이상 조회 쿼리
+     * @param command 파스토 입고 이상 조회 커맨드
      * @return 파스토 입고 이상 조회 결과 {@link GetFulfillmentWarehousingAbnormalResult}
      * @Date 2026-02-14
      * @Author 성효빈
      * @Description 파스토 입고 이상 정보를 조회합니다.
      */
-    GetFulfillmentWarehousingAbnormalResult getWarehousingAbnormal(FulfillmentWarehousingAbnormalQuery query);
+    GetFulfillmentWarehousingAbnormalResult getWarehousingAbnormal(GetFulfillmentWarehousingAbnormalCommand command);
 }

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/vendor/GetFulfillmentWarehousingDetailPort.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/vendor/GetFulfillmentWarehousingDetailPort.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.fulfillment.port.out.vendor;
 
-import com.personal.marketnote.fulfillment.domain.vendor.warehousing.FulfillmentWarehousingDetailQuery;
+import com.personal.marketnote.fulfillment.port.in.command.vendor.GetFulfillmentWarehousingDetailCommand;
 import com.personal.marketnote.fulfillment.port.in.result.vendor.GetFulfillmentWarehousingDetailResult;
 
 /**
@@ -13,11 +13,11 @@ import com.personal.marketnote.fulfillment.port.in.result.vendor.GetFulfillmentW
 public interface GetFulfillmentWarehousingDetailPort {
 
     /**
-     * @param query 파스토 입고 상세 조회 쿼리
+     * @param command 파스토 입고 상세 조회 커맨드
      * @return 파스토 입고 상세 조회 결과 {@link GetFulfillmentWarehousingDetailResult}
      * @Date 2026-02-14
      * @Author 성효빈
      * @Description 파스토 입고 상세 정보를 조회합니다.
      */
-    GetFulfillmentWarehousingDetailResult getWarehousingDetail(FulfillmentWarehousingDetailQuery query);
+    GetFulfillmentWarehousingDetailResult getWarehousingDetail(GetFulfillmentWarehousingDetailCommand command);
 }

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/vendor/GetFulfillmentWarehousingInspecDetailPort.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/vendor/GetFulfillmentWarehousingInspecDetailPort.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.fulfillment.port.out.vendor;
 
-import com.personal.marketnote.fulfillment.domain.vendor.warehousing.FulfillmentWarehousingInspecDetailQuery;
+import com.personal.marketnote.fulfillment.port.in.command.vendor.GetFulfillmentWarehousingInspecDetailCommand;
 import com.personal.marketnote.fulfillment.port.in.result.vendor.GetFulfillmentWarehousingInspecDetailResult;
 
 /**
@@ -13,11 +13,11 @@ import com.personal.marketnote.fulfillment.port.in.result.vendor.GetFulfillmentW
 public interface GetFulfillmentWarehousingInspecDetailPort {
 
     /**
-     * @param query 파스토 입고 검수 상세 조회 쿼리
+     * @param command 파스토 입고 검수 상세 조회 커맨드
      * @return 파스토 입고 검수 상세 조회 결과 {@link GetFulfillmentWarehousingInspecDetailResult}
      * @Date 2026-02-17
      * @Author 성효빈
      * @Description 파스토 입고 검수 상세 정보를 조회합니다.
      */
-    GetFulfillmentWarehousingInspecDetailResult getWarehousingInspecDetail(FulfillmentWarehousingInspecDetailQuery query);
+    GetFulfillmentWarehousingInspecDetailResult getWarehousingInspecDetail(GetFulfillmentWarehousingInspecDetailCommand command);
 }

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/vendor/GetFulfillmentWarehousingPort.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/vendor/GetFulfillmentWarehousingPort.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.fulfillment.port.out.vendor;
 
-import com.personal.marketnote.fulfillment.domain.vendor.warehousing.FulfillmentWarehousingQuery;
+import com.personal.marketnote.fulfillment.port.in.command.vendor.GetFulfillmentWarehousingCommand;
 import com.personal.marketnote.fulfillment.port.in.result.vendor.GetFulfillmentWarehousingResult;
 
 /**
@@ -13,11 +13,11 @@ import com.personal.marketnote.fulfillment.port.in.result.vendor.GetFulfillmentW
 public interface GetFulfillmentWarehousingPort {
 
     /**
-     * @param query 파스토 입고 조회 쿼리
+     * @param command 파스토 입고 조회 커맨드
      * @return 파스토 입고 목록 조회 결과 {@link GetFulfillmentWarehousingResult}
      * @Date 2026-02-03
      * @Author 성효빈
      * @Description 파스토 입고 목록을 조회합니다.
      */
-    GetFulfillmentWarehousingResult getWarehousing(FulfillmentWarehousingQuery query);
+    GetFulfillmentWarehousingResult getWarehousing(GetFulfillmentWarehousingCommand command);
 }

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/vendor/RegisterFulfillmentWarehousingPort.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/vendor/RegisterFulfillmentWarehousingPort.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.fulfillment.port.out.vendor;
 
-import com.personal.marketnote.fulfillment.domain.vendor.warehousing.FulfillmentWarehousingMapper;
+import com.personal.marketnote.fulfillment.port.in.command.vendor.RegisterFulfillmentWarehousingCommand;
 import com.personal.marketnote.fulfillment.port.in.result.vendor.RegisterFulfillmentWarehousingResult;
 
 /**
@@ -13,11 +13,11 @@ import com.personal.marketnote.fulfillment.port.in.result.vendor.RegisterFulfill
 public interface RegisterFulfillmentWarehousingPort {
 
     /**
-     * @param request 파스토 입고 등록 요청 매퍼
+     * @param command 파스토 입고 등록 커맨드
      * @return 파스토 입고 등록 결과 {@link RegisterFulfillmentWarehousingResult}
      * @Date 2026-01-31
      * @Author 성효빈
      * @Description 파스토 입고를 등록합니다.
      */
-    RegisterFulfillmentWarehousingResult registerWarehousing(FulfillmentWarehousingMapper request);
+    RegisterFulfillmentWarehousingResult registerWarehousing(RegisterFulfillmentWarehousingCommand command);
 }

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/vendor/UpdateFulfillmentWarehousingPort.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/vendor/UpdateFulfillmentWarehousingPort.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.fulfillment.port.out.vendor;
 
-import com.personal.marketnote.fulfillment.domain.vendor.warehousing.FulfillmentWarehousingMapper;
+import com.personal.marketnote.fulfillment.port.in.command.vendor.UpdateFulfillmentWarehousingCommand;
 import com.personal.marketnote.fulfillment.port.in.result.vendor.UpdateFulfillmentWarehousingResult;
 
 /**
@@ -13,11 +13,11 @@ import com.personal.marketnote.fulfillment.port.in.result.vendor.UpdateFulfillme
 public interface UpdateFulfillmentWarehousingPort {
 
     /**
-     * @param request 파스토 입고 수정 요청 매퍼
+     * @param command 파스토 입고 수정 커맨드
      * @return 파스토 입고 수정 결과 {@link UpdateFulfillmentWarehousingResult}
      * @Date 2026-02-05
      * @Author 성효빈
      * @Description 파스토 입고를 수정합니다.
      */
-    UpdateFulfillmentWarehousingResult updateWarehousing(FulfillmentWarehousingMapper request);
+    UpdateFulfillmentWarehousingResult updateWarehousing(UpdateFulfillmentWarehousingCommand command);
 }

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/vendor/GetFulfillmentWarehousingAbnormalImageService.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/vendor/GetFulfillmentWarehousingAbnormalImageService.java
@@ -1,7 +1,6 @@
 package com.personal.marketnote.fulfillment.service.vendor;
 
 import com.personal.marketnote.common.application.UseCase;
-import com.personal.marketnote.fulfillment.mapper.FulfillmentWarehousingCommandToRequestMapper;
 import com.personal.marketnote.fulfillment.port.in.command.vendor.GetFulfillmentWarehousingAbnormalImageCommand;
 import com.personal.marketnote.fulfillment.port.in.result.vendor.GetFulfillmentWarehousingAbnormalImageResult;
 import com.personal.marketnote.fulfillment.port.in.usecase.vendor.GetFulfillmentWarehousingAbnormalImageUseCase;
@@ -21,8 +20,6 @@ public class GetFulfillmentWarehousingAbnormalImageService implements GetFulfill
     public GetFulfillmentWarehousingAbnormalImageResult getWarehousingAbnormalImage(
             GetFulfillmentWarehousingAbnormalImageCommand command
     ) {
-        return getFulfillmentWarehousingAbnormalImagePort.getWarehousingAbnormalImage(
-                FulfillmentWarehousingCommandToRequestMapper.mapToAbnormalImageQuery(command)
-        );
+        return getFulfillmentWarehousingAbnormalImagePort.getWarehousingAbnormalImage(command);
     }
 }

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/vendor/GetFulfillmentWarehousingAbnormalService.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/vendor/GetFulfillmentWarehousingAbnormalService.java
@@ -1,7 +1,6 @@
 package com.personal.marketnote.fulfillment.service.vendor;
 
 import com.personal.marketnote.common.application.UseCase;
-import com.personal.marketnote.fulfillment.mapper.FulfillmentWarehousingCommandToRequestMapper;
 import com.personal.marketnote.fulfillment.port.in.command.vendor.GetFulfillmentWarehousingAbnormalCommand;
 import com.personal.marketnote.fulfillment.port.in.result.vendor.GetFulfillmentWarehousingAbnormalResult;
 import com.personal.marketnote.fulfillment.port.in.usecase.vendor.GetFulfillmentWarehousingAbnormalUseCase;
@@ -19,8 +18,6 @@ public class GetFulfillmentWarehousingAbnormalService implements GetFulfillmentW
 
     @Override
     public GetFulfillmentWarehousingAbnormalResult getWarehousingAbnormal(GetFulfillmentWarehousingAbnormalCommand command) {
-        return getFulfillmentWarehousingAbnormalPort.getWarehousingAbnormal(
-                FulfillmentWarehousingCommandToRequestMapper.mapToAbnormalQuery(command)
-        );
+        return getFulfillmentWarehousingAbnormalPort.getWarehousingAbnormal(command);
     }
 }

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/vendor/GetFulfillmentWarehousingDetailService.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/vendor/GetFulfillmentWarehousingDetailService.java
@@ -1,7 +1,6 @@
 package com.personal.marketnote.fulfillment.service.vendor;
 
 import com.personal.marketnote.common.application.UseCase;
-import com.personal.marketnote.fulfillment.mapper.FulfillmentWarehousingCommandToRequestMapper;
 import com.personal.marketnote.fulfillment.port.in.command.vendor.GetFulfillmentWarehousingDetailCommand;
 import com.personal.marketnote.fulfillment.port.in.result.vendor.GetFulfillmentWarehousingDetailResult;
 import com.personal.marketnote.fulfillment.port.in.usecase.vendor.GetFulfillmentWarehousingDetailUseCase;
@@ -19,8 +18,6 @@ public class GetFulfillmentWarehousingDetailService implements GetFulfillmentWar
 
     @Override
     public GetFulfillmentWarehousingDetailResult getWarehousingDetail(GetFulfillmentWarehousingDetailCommand command) {
-        return getFulfillmentWarehousingDetailPort.getWarehousingDetail(
-                FulfillmentWarehousingCommandToRequestMapper.mapToDetailQuery(command)
-        );
+        return getFulfillmentWarehousingDetailPort.getWarehousingDetail(command);
     }
 }

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/vendor/GetFulfillmentWarehousingInspecDetailService.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/vendor/GetFulfillmentWarehousingInspecDetailService.java
@@ -1,7 +1,6 @@
 package com.personal.marketnote.fulfillment.service.vendor;
 
 import com.personal.marketnote.common.application.UseCase;
-import com.personal.marketnote.fulfillment.mapper.FulfillmentWarehousingCommandToRequestMapper;
 import com.personal.marketnote.fulfillment.port.in.command.vendor.GetFulfillmentWarehousingInspecDetailCommand;
 import com.personal.marketnote.fulfillment.port.in.result.vendor.GetFulfillmentWarehousingInspecDetailResult;
 import com.personal.marketnote.fulfillment.port.in.usecase.vendor.GetFulfillmentWarehousingInspecDetailUseCase;
@@ -19,8 +18,6 @@ public class GetFulfillmentWarehousingInspecDetailService implements GetFulfillm
 
     @Override
     public GetFulfillmentWarehousingInspecDetailResult getWarehousingInspecDetail(GetFulfillmentWarehousingInspecDetailCommand command) {
-        return getFulfillmentWarehousingInspecDetailPort.getWarehousingInspecDetail(
-                FulfillmentWarehousingCommandToRequestMapper.mapToInspecDetailQuery(command)
-        );
+        return getFulfillmentWarehousingInspecDetailPort.getWarehousingInspecDetail(command);
     }
 }

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/vendor/GetFulfillmentWarehousingService.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/vendor/GetFulfillmentWarehousingService.java
@@ -1,7 +1,6 @@
 package com.personal.marketnote.fulfillment.service.vendor;
 
 import com.personal.marketnote.common.application.UseCase;
-import com.personal.marketnote.fulfillment.mapper.FulfillmentWarehousingCommandToRequestMapper;
 import com.personal.marketnote.fulfillment.port.in.command.vendor.GetFulfillmentWarehousingCommand;
 import com.personal.marketnote.fulfillment.port.in.result.vendor.GetFulfillmentWarehousingResult;
 import com.personal.marketnote.fulfillment.port.in.usecase.vendor.GetFulfillmentWarehousingUseCase;
@@ -19,8 +18,6 @@ public class GetFulfillmentWarehousingService implements GetFulfillmentWarehousi
 
     @Override
     public GetFulfillmentWarehousingResult getWarehousing(GetFulfillmentWarehousingCommand command) {
-        return getFulfillmentWarehousingPort.getWarehousing(
-                FulfillmentWarehousingCommandToRequestMapper.mapToQuery(command)
-        );
+        return getFulfillmentWarehousingPort.getWarehousing(command);
     }
 }

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/vendor/RegisterFulfillmentWarehousingService.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/vendor/RegisterFulfillmentWarehousingService.java
@@ -2,7 +2,6 @@ package com.personal.marketnote.fulfillment.service.vendor;
 
 import com.personal.marketnote.common.application.UseCase;
 import com.personal.marketnote.common.utility.FormatValidator;
-import com.personal.marketnote.fulfillment.mapper.FulfillmentWarehousingCommandToRequestMapper;
 import com.personal.marketnote.fulfillment.port.in.command.vendor.RegisterFulfillmentWarehousingCommand;
 import com.personal.marketnote.fulfillment.port.in.command.vendor.RegisterFulfillmentWarehousingItemCommand;
 import com.personal.marketnote.fulfillment.port.in.result.vendor.RegisterFulfillmentWarehousingResult;
@@ -24,9 +23,7 @@ public class RegisterFulfillmentWarehousingService implements RegisterFulfillmen
 
     @Override
     public RegisterFulfillmentWarehousingResult registerWarehousing(RegisterFulfillmentWarehousingCommand command) {
-        RegisterFulfillmentWarehousingResult result = registerFulfillmentWarehousingPort.registerWarehousing(
-                FulfillmentWarehousingCommandToRequestMapper.mapToRegisterRequest(command)
-        );
+        RegisterFulfillmentWarehousingResult result = registerFulfillmentWarehousingPort.registerWarehousing(command);
         schedulePolling(command, result);
         return result;
     }
@@ -39,15 +36,15 @@ public class RegisterFulfillmentWarehousingService implements RegisterFulfillmen
         }
 
         for (RegisterFulfillmentWarehousingItemCommand item : command.warehousingRequests()) {
-            if (FormatValidator.hasNoValue(item) || FormatValidator.hasNoValue(item.ordNo())) {
+            if (FormatValidator.hasNoValue(item) || FormatValidator.hasNoValue(item.orderNumber())) {
                 continue;
             }
 
             scheduleFulfillmentWarehousingPollingPort.schedule(
                     ScheduleFulfillmentWarehousingPollingCommand.of(
                             command.customerCode(),
-                            item.ordNo(),
-                            item.ordDt()
+                            item.orderNumber(),
+                            item.orderDate()
                     )
             );
         }

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/vendor/UpdateFulfillmentWarehousingService.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/vendor/UpdateFulfillmentWarehousingService.java
@@ -1,7 +1,6 @@
 package com.personal.marketnote.fulfillment.service.vendor;
 
 import com.personal.marketnote.common.application.UseCase;
-import com.personal.marketnote.fulfillment.mapper.FulfillmentWarehousingCommandToRequestMapper;
 import com.personal.marketnote.fulfillment.port.in.command.vendor.UpdateFulfillmentWarehousingCommand;
 import com.personal.marketnote.fulfillment.port.in.result.vendor.UpdateFulfillmentWarehousingResult;
 import com.personal.marketnote.fulfillment.port.in.usecase.vendor.UpdateFulfillmentWarehousingUseCase;
@@ -19,8 +18,6 @@ public class UpdateFulfillmentWarehousingService implements UpdateFulfillmentWar
 
     @Override
     public UpdateFulfillmentWarehousingResult updateWarehousing(UpdateFulfillmentWarehousingCommand command) {
-        return updateFulfillmentWarehousingPort.updateWarehousing(
-                FulfillmentWarehousingCommandToRequestMapper.mapToUpdateRequest(command)
-        );
+        return updateFulfillmentWarehousingPort.updateWarehousing(command);
     }
 }


### PR DESCRIPTION
## partially addresses #475
## resolves #2154

## Task
- [x] domain vendor/warehousing/ 8파일 → adapters로 이동
- [x] application Command 파스토 전용 필드 제거, 도메인 개념 필드로 대체
- [x] application Port 인터페이스를 벤더 무관하게 재정의
- [x] application Service에서 Port에 Command 직접 전달
- [x] application 매퍼 1개 삭제
- [x] adapters에 Command → 파스토 요청 DTO 변환 매퍼 1개 작성