### PR TITLE
[#475][#2174] test: stock + settlement 영역 벤더 종속 제거 테스트 재작성

### DIFF
--- a/fulfillment-service/fulfillment-adapters/src/test/java/com/personal/marketnote/fulfillment/adapter/out/scheduler/FulfillmentWarehousingPollingSchedulerTest.java
+++ b/fulfillment-service/fulfillment-adapters/src/test/java/com/personal/marketnote/fulfillment/adapter/out/scheduler/FulfillmentWarehousingPollingSchedulerTest.java
@@ -103,7 +103,7 @@ class FulfillmentWarehousingPollingSchedulerTest {
                 ArgumentCaptor.forClass(SyncFulfillmentAllStockCommand.class);
         verify(syncFulfillmentAllStockUseCase).syncAll(syncCaptor.capture());
         assertThat(syncCaptor.getValue().customerCode()).isEqualTo("CUST");
-        assertThat(syncCaptor.getValue().whCd()).isEqualTo("WH1");
+        assertThat(syncCaptor.getValue().warehouseCode()).isEqualTo("WH1");
 
         ArgumentCaptor<GetFulfillmentWarehousingCommand> commandCaptor =
                 ArgumentCaptor.forClass(GetFulfillmentWarehousingCommand.class);
@@ -140,7 +140,7 @@ class FulfillmentWarehousingPollingSchedulerTest {
         ArgumentCaptor<SyncFulfillmentAllStockCommand> syncCaptor =
                 ArgumentCaptor.forClass(SyncFulfillmentAllStockCommand.class);
         verify(syncFulfillmentAllStockUseCase).syncAll(syncCaptor.capture());
-        assertThat(syncCaptor.getValue().whCd()).isEqualTo("WH2");
+        assertThat(syncCaptor.getValue().warehouseCode()).isEqualTo("WH2");
 
         ArgumentCaptor<GetFulfillmentWarehousingCommand> commandCaptor =
                 ArgumentCaptor.forClass(GetFulfillmentWarehousingCommand.class);

--- a/fulfillment-service/fulfillment-application/src/test/java/com/personal/marketnote/fulfillment/service/vendor/GetFulfillmentSettlementDailyCostsUseCaseTest.java
+++ b/fulfillment-service/fulfillment-application/src/test/java/com/personal/marketnote/fulfillment/service/vendor/GetFulfillmentSettlementDailyCostsUseCaseTest.java
@@ -13,12 +13,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-@DisplayName("GetFulfillmentSettlementDailyCostsService 테스트")
+@DisplayName("풀필먼트 정산 일별 비용 조회 테스트")
 class GetFulfillmentSettlementDailyCostsUseCaseTest {
     @InjectMocks
     private GetFulfillmentSettlementDailyCostsService getFulfillmentSettlementDailyCostsService;
@@ -27,20 +26,20 @@ class GetFulfillmentSettlementDailyCostsUseCaseTest {
     private GetFulfillmentSettlementDailyCostsPort getFulfillmentSettlementDailyCostsPort;
 
     @Test
-    @DisplayName("정산 일별 비용 조회 커맨드를 전달하면 포트를 통해 일별 비용을 반환한다")
-    void shouldReturnDailyCostsFromPort() {
+    @DisplayName("정산 일별 비용 조회 커맨드를 포트에 직접 전달하여 결과를 반환한다")
+    void shouldDelegateCommandDirectlyToPort() {
         // given
         GetFulfillmentSettlementDailyCostsCommand command = GetFulfillmentSettlementDailyCostsCommand.of(
                 "202604", "WH001", "CUST001", "token"
         );
         GetFulfillmentSettlementDailyCostsResult expectedResult = GetFulfillmentSettlementDailyCostsResult.of(0, List.of());
-        when(getFulfillmentSettlementDailyCostsPort.getDailyCosts(any())).thenReturn(expectedResult);
+        when(getFulfillmentSettlementDailyCostsPort.getDailyCosts(command)).thenReturn(expectedResult);
 
         // when
         GetFulfillmentSettlementDailyCostsResult result = getFulfillmentSettlementDailyCostsService.getDailyCosts(command);
 
         // then
         assertThat(result).isEqualTo(expectedResult);
-        verify(getFulfillmentSettlementDailyCostsPort).getDailyCosts(any());
+        verify(getFulfillmentSettlementDailyCostsPort).getDailyCosts(command);
     }
 }

--- a/fulfillment-service/fulfillment-application/src/test/java/com/personal/marketnote/fulfillment/service/vendor/GetFulfillmentStockDetailUseCaseTest.java
+++ b/fulfillment-service/fulfillment-application/src/test/java/com/personal/marketnote/fulfillment/service/vendor/GetFulfillmentStockDetailUseCaseTest.java
@@ -13,7 +13,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -22,20 +21,25 @@ import static org.mockito.Mockito.when;
 class GetFulfillmentStockDetailUseCaseTest {
     @InjectMocks
     private GetFulfillmentStockDetailService service;
+
     @Mock
     private GetFulfillmentStockDetailPort getFulfillmentStockDetailPort;
 
     @Test
-    @DisplayName("Command를 Port에 위임하여 결과를 반환한다")
-    void shouldDelegateToPort() {
+    @DisplayName("재고 상세 조회 커맨드를 포트에 직접 전달하여 결과를 반환한다")
+    void shouldDelegateCommandDirectlyToPort() {
         // given
-        GetFulfillmentStockDetailCommand command = new GetFulfillmentStockDetailCommand("CUST001", "token", "GOD001", "Y");
+        GetFulfillmentStockDetailCommand command = GetFulfillmentStockDetailCommand.of(
+                "CUST001", "token", "GOD001", "Y"
+        );
         GetFulfillmentStocksResult expectedResult = GetFulfillmentStocksResult.of(0, List.of());
-        when(getFulfillmentStockDetailPort.getStockDetail(any())).thenReturn(expectedResult);
+        when(getFulfillmentStockDetailPort.getStockDetail(command)).thenReturn(expectedResult);
+
         // when
         GetFulfillmentStocksResult result = service.getStockDetail(command);
+
         // then
         assertThat(result).isEqualTo(expectedResult);
-        verify(getFulfillmentStockDetailPort).getStockDetail(any());
+        verify(getFulfillmentStockDetailPort).getStockDetail(command);
     }
 }

--- a/fulfillment-service/fulfillment-application/src/test/java/com/personal/marketnote/fulfillment/service/vendor/GetFulfillmentStocksUseCaseTest.java
+++ b/fulfillment-service/fulfillment-application/src/test/java/com/personal/marketnote/fulfillment/service/vendor/GetFulfillmentStocksUseCaseTest.java
@@ -13,12 +13,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-@DisplayName("GetFulfillmentStocksService 테스트")
+@DisplayName("풀필먼트 재고 목록 조회 테스트")
 class GetFulfillmentStocksUseCaseTest {
     @InjectMocks
     private GetFulfillmentStocksService getFulfillmentStocksService;
@@ -27,18 +26,18 @@ class GetFulfillmentStocksUseCaseTest {
     private GetFulfillmentStocksPort getFulfillmentStocksPort;
 
     @Test
-    @DisplayName("재고 목록 조회 커맨드를 전달하면 포트를 통해 재고 목록을 반환한다")
-    void shouldReturnStocksFromPort() {
+    @DisplayName("재고 목록 조회 커맨드를 포트에 직접 전달하여 결과를 반환한다")
+    void shouldDelegateCommandDirectlyToPort() {
         // given
         GetFulfillmentStocksCommand command = GetFulfillmentStocksCommand.of("CUST001", "token");
         GetFulfillmentStocksResult expectedResult = GetFulfillmentStocksResult.of(0, List.of());
-        when(getFulfillmentStocksPort.getStocks(any())).thenReturn(expectedResult);
+        when(getFulfillmentStocksPort.getStocks(command)).thenReturn(expectedResult);
 
         // when
         GetFulfillmentStocksResult result = getFulfillmentStocksService.getStocks(command);
 
         // then
         assertThat(result).isEqualTo(expectedResult);
-        verify(getFulfillmentStocksPort).getStocks(any());
+        verify(getFulfillmentStocksPort).getStocks(command);
     }
 }

--- a/fulfillment-service/fulfillment-application/src/test/java/com/personal/marketnote/fulfillment/service/vendor/SyncFulfillmentStockUseCaseTest.java
+++ b/fulfillment-service/fulfillment-application/src/test/java/com/personal/marketnote/fulfillment/service/vendor/SyncFulfillmentStockUseCaseTest.java
@@ -2,7 +2,11 @@ package com.personal.marketnote.fulfillment.service.vendor;
 
 import com.personal.marketnote.fulfillment.domain.FulfillmentAccessToken;
 import com.personal.marketnote.fulfillment.domain.exception.FulfillmentQueryParameterNoValueException;
+import com.personal.marketnote.fulfillment.port.in.command.vendor.GetFulfillmentStockDetailCommand;
+import com.personal.marketnote.fulfillment.port.in.command.vendor.GetFulfillmentStocksCommand;
+import com.personal.marketnote.fulfillment.port.in.command.vendor.SyncFulfillmentAllStockCommand;
 import com.personal.marketnote.fulfillment.port.in.command.vendor.SyncFulfillmentStockCommand;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.FulfillmentStockInfoResult;
 import com.personal.marketnote.fulfillment.port.in.result.vendor.GetFulfillmentStocksResult;
 import com.personal.marketnote.fulfillment.port.in.usecase.vendor.GetFulfillmentStockDetailUseCase;
 import com.personal.marketnote.fulfillment.port.in.usecase.vendor.GetFulfillmentStocksUseCase;
@@ -20,14 +24,14 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("풀필먼트 재고 동기화 테스트")
 class SyncFulfillmentStockUseCaseTest {
     @InjectMocks
     private SyncFulfillmentStockService service;
+
     @Mock
     private RequestFulfillmentAuthUseCase requestFulfillmentAuthUseCase;
     @Mock
@@ -46,11 +50,13 @@ class SyncFulfillmentStockUseCaseTest {
             // given
             FulfillmentAccessToken accessToken = FulfillmentAccessToken.of("token", "20270101120000");
             when(requestFulfillmentAuthUseCase.requestAccessToken()).thenReturn(accessToken);
-            when(getFulfillmentStockDetailUseCase.getStockDetail(any()))
+            when(getFulfillmentStockDetailUseCase.getStockDetail(any(GetFulfillmentStockDetailCommand.class)))
                     .thenReturn(GetFulfillmentStocksResult.of(0, List.of()));
             SyncFulfillmentStockCommand command = SyncFulfillmentStockCommand.of("CUST001", List.of(1L));
+
             // when
             service.sync(command);
+
             // then
             verify(updateCommerceInventoryPort).updateInventories(any());
         }
@@ -79,6 +85,51 @@ class SyncFulfillmentStockUseCaseTest {
         void shouldThrowWhenProductIdsIsNull() {
             SyncFulfillmentStockCommand command = SyncFulfillmentStockCommand.of("CUST001", null);
             assertThatThrownBy(() -> service.sync(command))
+                    .isInstanceOf(FulfillmentQueryParameterNoValueException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("syncAll 성공")
+    class SyncAllSuccess {
+        @Test
+        @DisplayName("전체 재고 동기화를 수행하고 커머스 재고를 업데이트한다")
+        void shouldSyncAllAndUpdateInventory() {
+            // given
+            FulfillmentAccessToken accessToken = FulfillmentAccessToken.of("token", "20270101120000");
+            when(requestFulfillmentAuthUseCase.requestAccessToken()).thenReturn(accessToken);
+
+            FulfillmentStockInfoResult stockInfo = FulfillmentStockInfoResult.of(
+                    "WH001", "GOD001", "1", "상품명", null, null, null,
+                    10, 0, 10, null, null, null, List.of(), null
+            );
+            when(getFulfillmentStocksUseCase.getStocks(any(GetFulfillmentStocksCommand.class)))
+                    .thenReturn(GetFulfillmentStocksResult.of(1, List.of(stockInfo)));
+            SyncFulfillmentAllStockCommand command = SyncFulfillmentAllStockCommand.of("CUST001");
+
+            // when
+            service.syncAll(command);
+
+            // then
+            verify(updateCommerceInventoryPort).updateInventories(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("syncAll 실패")
+    class SyncAllFailure {
+        @Test
+        @DisplayName("command가 null이면 FulfillmentQueryParameterNoValueException이 발생한다")
+        void shouldThrowWhenCommandIsNull() {
+            assertThatThrownBy(() -> service.syncAll(null))
+                    .isInstanceOf(FulfillmentQueryParameterNoValueException.class);
+        }
+
+        @Test
+        @DisplayName("customerCode가 없으면 FulfillmentQueryParameterNoValueException이 발생한다")
+        void shouldThrowWhenCustomerCodeIsNull() {
+            SyncFulfillmentAllStockCommand command = SyncFulfillmentAllStockCommand.of(null);
+            assertThatThrownBy(() -> service.syncAll(command))
                     .isInstanceOf(FulfillmentQueryParameterNoValueException.class);
         }
     }


### PR DESCRIPTION
## partially addresses #475
## resolves #2174

## Test Case
- [x] 재고 목록 조회 커맨드를 포트에 직접 전달하여 결과를 반환한다
- [x] 재고 상세 조회 커맨드를 포트에 직접 전달하여 결과를 반환한다
- [x] 재고 동기화를 수행하고 커머스 재고를 업데이트한다
- [x] command가 null이면 FulfillmentQueryParameterNoValueException이 발생한다
- [x] customerCode가 없으면 FulfillmentQueryParameterNoValueException이 발생한다
- [x] productIds가 없으면 FulfillmentQueryParameterNoValueException이 발생한다
- [x] 전체 재고 동기화를 수행하고 커머스 재고를 업데이트한다
- [x] syncAll command가 null이면 FulfillmentQueryParameterNoValueException이 발생한다
- [x] syncAll customerCode가 없으면 FulfillmentQueryParameterNoValueException이 발생한다
- [x] 정산 일별 비용 조회 커맨드를 포트에 직접 전달하여 결과를 반환한다