### PR TITLE
[#475][#2175] test: shop + supplier 영역 벤더 종속 제거 테스트 재작성

### DIFF
--- a/fulfillment-service/fulfillment-application/src/test/java/com/personal/marketnote/fulfillment/service/vendor/GetFulfillmentShopsUseCaseTest.java
+++ b/fulfillment-service/fulfillment-application/src/test/java/com/personal/marketnote/fulfillment/service/vendor/GetFulfillmentShopsUseCaseTest.java
@@ -13,12 +13,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-@DisplayName("GetFulfillmentShopsService 테스트")
+@DisplayName("풀필먼트 출고처 목록 조회 테스트")
 class GetFulfillmentShopsUseCaseTest {
     @InjectMocks
     private GetFulfillmentShopsService getFulfillmentShopsService;
@@ -27,18 +26,18 @@ class GetFulfillmentShopsUseCaseTest {
     private GetFulfillmentShopsPort getFulfillmentShopsPort;
 
     @Test
-    @DisplayName("출고처 목록 조회 커맨드를 전달하면 포트를 통해 출고처 목록을 반환한다")
-    void shouldReturnShopsFromPort() {
+    @DisplayName("출고처 목록 조회 커맨드를 포트에 직접 전달하여 결과를 반환한다")
+    void shouldDelegateCommandDirectlyToPort() {
         // given
         GetFulfillmentShopsCommand command = GetFulfillmentShopsCommand.of("CUST001", "token");
         GetFulfillmentShopsResult expectedResult = GetFulfillmentShopsResult.of(0, List.of());
-        when(getFulfillmentShopsPort.getShops(any())).thenReturn(expectedResult);
+        when(getFulfillmentShopsPort.getShops(command)).thenReturn(expectedResult);
 
         // when
         GetFulfillmentShopsResult result = getFulfillmentShopsService.getShops(command);
 
         // then
         assertThat(result).isEqualTo(expectedResult);
-        verify(getFulfillmentShopsPort).getShops(any());
+        verify(getFulfillmentShopsPort).getShops(command);
     }
 }

--- a/fulfillment-service/fulfillment-application/src/test/java/com/personal/marketnote/fulfillment/service/vendor/GetFulfillmentSuppliersUseCaseTest.java
+++ b/fulfillment-service/fulfillment-application/src/test/java/com/personal/marketnote/fulfillment/service/vendor/GetFulfillmentSuppliersUseCaseTest.java
@@ -13,29 +13,31 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-@DisplayName("풀필먼트 공급처 목록 조회 테스트")
+@DisplayName("풀필먼트 공급사 목록 조회 테스트")
 class GetFulfillmentSuppliersUseCaseTest {
     @InjectMocks
     private GetFulfillmentSuppliersService service;
+
     @Mock
     private GetFulfillmentSuppliersPort getFulfillmentSuppliersPort;
 
     @Test
-    @DisplayName("Command를 Port에 위임하여 결과를 반환한다")
-    void shouldDelegateToPort() {
+    @DisplayName("공급사 목록 조회 커맨드를 포트에 직접 전달하여 결과를 반환한다")
+    void shouldDelegateCommandDirectlyToPort() {
         // given
         GetFulfillmentSuppliersCommand command = GetFulfillmentSuppliersCommand.of("CUST001", "token");
         GetFulfillmentSuppliersResult expectedResult = GetFulfillmentSuppliersResult.of(0, List.of());
-        when(getFulfillmentSuppliersPort.getSuppliers(any())).thenReturn(expectedResult);
+        when(getFulfillmentSuppliersPort.getSuppliers(command)).thenReturn(expectedResult);
+
         // when
         GetFulfillmentSuppliersResult result = service.getSuppliers(command);
+
         // then
         assertThat(result).isEqualTo(expectedResult);
-        verify(getFulfillmentSuppliersPort).getSuppliers(any());
+        verify(getFulfillmentSuppliersPort).getSuppliers(command);
     }
 }

--- a/fulfillment-service/fulfillment-application/src/test/java/com/personal/marketnote/fulfillment/service/vendor/RegisterFulfillmentShopUseCaseTest.java
+++ b/fulfillment-service/fulfillment-application/src/test/java/com/personal/marketnote/fulfillment/service/vendor/RegisterFulfillmentShopUseCaseTest.java
@@ -11,7 +11,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -20,24 +19,27 @@ import static org.mockito.Mockito.when;
 class RegisterFulfillmentShopUseCaseTest {
     @InjectMocks
     private RegisterFulfillmentShopService service;
+
     @Mock
     private RegisterFulfillmentShopPort registerFulfillmentShopPort;
 
     @Test
-    @DisplayName("Command를 Port에 위임하여 결과를 반환한다")
-    void shouldDelegateToPort() {
+    @DisplayName("출고처 등록 커맨드를 포트에 직접 전달하여 결과를 반환한다")
+    void shouldDelegateCommandDirectlyToPort() {
         // given
-        RegisterFulfillmentShopCommand command = new RegisterFulfillmentShopCommand(
-                "CUST001", "token", "marketnote", "CST01", "20260401", "20270401",
-                "12345", "addr1", "addr2", "ceo", "123-45-67890", "01012345678",
-                "01", "01", "Y", "01", "emp", "manager", "01098765432", "Y"
+        RegisterFulfillmentShopCommand command = RegisterFulfillmentShopCommand.of(
+                "CUST001", "token", "출고처명", "CST01", "20260401", "20270401",
+                "12345", "서울시", "강남구", "대표자", "123-45-67890", "01012345678",
+                "01", "01", "Y", "01", "담당자", "매니저", "01098765432", "Y"
         );
         RegisterFulfillmentShopResult expectedResult = RegisterFulfillmentShopResult.of("등록 성공", "200", "SHOP001");
-        when(registerFulfillmentShopPort.registerShop(any())).thenReturn(expectedResult);
+        when(registerFulfillmentShopPort.registerShop(command)).thenReturn(expectedResult);
+
         // when
         RegisterFulfillmentShopResult result = service.registerShop(command);
+
         // then
         assertThat(result).isEqualTo(expectedResult);
-        verify(registerFulfillmentShopPort).registerShop(any());
+        verify(registerFulfillmentShopPort).registerShop(command);
     }
 }

--- a/fulfillment-service/fulfillment-application/src/test/java/com/personal/marketnote/fulfillment/service/vendor/RegisterFulfillmentSupplierUseCaseTest.java
+++ b/fulfillment-service/fulfillment-application/src/test/java/com/personal/marketnote/fulfillment/service/vendor/RegisterFulfillmentSupplierUseCaseTest.java
@@ -11,34 +11,36 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-@DisplayName("풀필먼트 공급처 등록 테스트")
+@DisplayName("풀필먼트 공급사 등록 테스트")
 class RegisterFulfillmentSupplierUseCaseTest {
     @InjectMocks
     private RegisterFulfillmentSupplierService service;
+
     @Mock
     private RegisterFulfillmentSupplierPort registerFulfillmentSupplierPort;
 
     @Test
-    @DisplayName("Command를 Port에 위임하여 결과를 반환한다")
-    void shouldDelegateToPort() {
+    @DisplayName("공급사 등록 커맨드를 포트에 직접 전달하여 결과를 반환한다")
+    void shouldDelegateCommandDirectlyToPort() {
         // given
-        RegisterFulfillmentSupplierCommand command = new RegisterFulfillmentSupplierCommand(
-                "CUST001", "token", "supplier", "CST01", "Y", "20260401", "20270401",
-                "12345", "addr1", "addr2", "ceo", "123-45-67890", "busSp", "busTp",
-                "01012345678", "0212345678", "emp1", "manager1", "01011111111", "emp1@test.com",
-                "emp2", "manager2", "01022222222", "emp2@test.com"
+        RegisterFulfillmentSupplierCommand command = RegisterFulfillmentSupplierCommand.of(
+                "CUST001", "token", "공급사명", "CST01", "Y", "20260401", "20270401",
+                "12345", "서울시", "강남구", "대표자", "123-45-67890", "도매", "식품",
+                "01012345678", "0212345678", "담당자1", "매니저", "01011111111", "emp1@test.com",
+                "담당자2", "부매니저", "01022222222", "emp2@test.com"
         );
         RegisterFulfillmentSupplierResult expectedResult = RegisterFulfillmentSupplierResult.of("등록 성공", "200", "SUP001");
-        when(registerFulfillmentSupplierPort.registerSupplier(any())).thenReturn(expectedResult);
+        when(registerFulfillmentSupplierPort.registerSupplier(command)).thenReturn(expectedResult);
+
         // when
         RegisterFulfillmentSupplierResult result = service.registerSupplier(command);
+
         // then
         assertThat(result).isEqualTo(expectedResult);
-        verify(registerFulfillmentSupplierPort).registerSupplier(any());
+        verify(registerFulfillmentSupplierPort).registerSupplier(command);
     }
 }

--- a/fulfillment-service/fulfillment-application/src/test/java/com/personal/marketnote/fulfillment/service/vendor/UpdateFulfillmentShopUseCaseTest.java
+++ b/fulfillment-service/fulfillment-application/src/test/java/com/personal/marketnote/fulfillment/service/vendor/UpdateFulfillmentShopUseCaseTest.java
@@ -11,7 +11,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -20,24 +19,27 @@ import static org.mockito.Mockito.when;
 class UpdateFulfillmentShopUseCaseTest {
     @InjectMocks
     private UpdateFulfillmentShopService service;
+
     @Mock
     private UpdateFulfillmentShopPort updateFulfillmentShopPort;
 
     @Test
-    @DisplayName("Command를 Port에 위임하여 결과를 반환한다")
-    void shouldDelegateToPort() {
+    @DisplayName("출고처 수정 커맨드를 포트에 직접 전달하여 결과를 반환한다")
+    void shouldDelegateCommandDirectlyToPort() {
         // given
-        UpdateFulfillmentShopCommand command = new UpdateFulfillmentShopCommand(
-                "CUST001", "token", "SHOP001", "marketnote", "CST01", "20260401", "20270401",
-                "12345", "addr1", "addr2", "ceo", "123-45-67890", "01012345678",
-                "01", "01", "Y", "01", "emp", "manager", "01098765432", "Y"
+        UpdateFulfillmentShopCommand command = UpdateFulfillmentShopCommand.of(
+                "CUST001", "token", "SHOP001", "출고처명", "CST01", "20260401", "20270401",
+                "12345", "서울시", "강남구", "대표자", "123-45-67890", "01012345678",
+                "01", "01", "Y", "01", "담당자", "매니저", "01098765432", "Y"
         );
         UpdateFulfillmentShopResult expectedResult = UpdateFulfillmentShopResult.of("수정 성공", "200", "SHOP001");
-        when(updateFulfillmentShopPort.updateShop(any())).thenReturn(expectedResult);
+        when(updateFulfillmentShopPort.updateShop(command)).thenReturn(expectedResult);
+
         // when
         UpdateFulfillmentShopResult result = service.updateShop(command);
+
         // then
         assertThat(result).isEqualTo(expectedResult);
-        verify(updateFulfillmentShopPort).updateShop(any());
+        verify(updateFulfillmentShopPort).updateShop(command);
     }
 }

--- a/fulfillment-service/fulfillment-application/src/test/java/com/personal/marketnote/fulfillment/service/vendor/UpdateFulfillmentSupplierUseCaseTest.java
+++ b/fulfillment-service/fulfillment-application/src/test/java/com/personal/marketnote/fulfillment/service/vendor/UpdateFulfillmentSupplierUseCaseTest.java
@@ -11,34 +11,36 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-@DisplayName("풀필먼트 공급처 수정 테스트")
+@DisplayName("풀필먼트 공급사 수정 테스트")
 class UpdateFulfillmentSupplierUseCaseTest {
     @InjectMocks
     private UpdateFulfillmentSupplierService service;
+
     @Mock
     private UpdateFulfillmentSupplierPort updateFulfillmentSupplierPort;
 
     @Test
-    @DisplayName("Command를 Port에 위임하여 결과를 반환한다")
-    void shouldDelegateToPort() {
+    @DisplayName("공급사 수정 커맨드를 포트에 직접 전달하여 결과를 반환한다")
+    void shouldDelegateCommandDirectlyToPort() {
         // given
-        UpdateFulfillmentSupplierCommand command = new UpdateFulfillmentSupplierCommand(
-                "CUST001", "token", "SUP001", "supplier", "CST01", "Y", "20260401", "20270401",
-                "12345", "addr1", "addr2", "ceo", "123-45-67890", "busSp", "busTp",
-                "01012345678", "0212345678", "emp1", "manager1", "01011111111", "emp1@test.com",
-                "emp2", "manager2", "01022222222", "emp2@test.com"
+        UpdateFulfillmentSupplierCommand command = UpdateFulfillmentSupplierCommand.of(
+                "CUST001", "token", "SUP001", "공급사명", "CST01", "Y", "20260401", "20270401",
+                "12345", "서울시", "강남구", "대표자", "123-45-67890", "도매", "식품",
+                "01012345678", "0212345678", "담당자1", "매니저", "01011111111", "emp1@test.com",
+                "담당자2", "부매니저", "01022222222", "emp2@test.com"
         );
         UpdateFulfillmentSupplierResult expectedResult = UpdateFulfillmentSupplierResult.of("수정 성공", "200", "SUP001");
-        when(updateFulfillmentSupplierPort.updateSupplier(any())).thenReturn(expectedResult);
+        when(updateFulfillmentSupplierPort.updateSupplier(command)).thenReturn(expectedResult);
+
         // when
         UpdateFulfillmentSupplierResult result = service.updateSupplier(command);
+
         // then
         assertThat(result).isEqualTo(expectedResult);
-        verify(updateFulfillmentSupplierPort).updateSupplier(any());
+        verify(updateFulfillmentSupplierPort).updateSupplier(command);
     }
 }


### PR DESCRIPTION
## partially addresses #475
## resolves #2175

## Test Case
- [x] 출고처 목록 조회 커맨드를 포트에 직접 전달하여 결과를 반환한다
- [x] 출고처 등록 커맨드를 포트에 직접 전달하여 결과를 반환한다
- [x] 출고처 수정 커맨드를 포트에 직접 전달하여 결과를 반환한다
- [x] 공급사 목록 조회 커맨드를 포트에 직접 전달하여 결과를 반환한다
- [x] 공급사 등록 커맨드를 포트에 직접 전달하여 결과를 반환한다
- [x] 공급사 수정 커맨드를 포트에 직접 전달하여 결과를 반환한다