### PR TITLE
[#475][#2159] refactor: auth + vendorcommunication 영역 벤더 종속 제거

### DIFF
--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/CancelFulfillmentDeliveryFailedException.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/CancelFulfillmentDeliveryFailedException.java
@@ -6,7 +6,7 @@ import com.personal.marketnote.common.utility.FormatValidator;
 import java.io.IOException;
 
 public class CancelFulfillmentDeliveryFailedException extends ExternalOperationFailedException {
-    private static final String DEFAULT_MESSAGE = "파스토 출고 취소 요청 중 오류가 발생했습니다.";
+    private static final String DEFAULT_MESSAGE = "풀필먼트 출고 취소 요청 중 오류가 발생했습니다.";
 
     public CancelFulfillmentDeliveryFailedException(IOException cause) {
         super(DEFAULT_MESSAGE, cause);
@@ -18,7 +18,7 @@ public class CancelFulfillmentDeliveryFailedException extends ExternalOperationF
 
     private static String resolveMessage(String vendorMessage) {
         if (FormatValidator.hasValue(vendorMessage)) {
-            return String.format("파스토 출고 취소 실패: %s", vendorMessage);
+            return String.format("풀필먼트 출고 취소 실패: %s", vendorMessage);
         }
         return DEFAULT_MESSAGE;
     }

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/CompleteFulfillmentDeliveryIcsFailedException.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/CompleteFulfillmentDeliveryIcsFailedException.java
@@ -6,7 +6,7 @@ import com.personal.marketnote.common.utility.FormatValidator;
 import java.io.IOException;
 
 public class CompleteFulfillmentDeliveryIcsFailedException extends ExternalOperationFailedException {
-    private static final String DEFAULT_MESSAGE = "파스토 배송완료 처리(해외) 중 오류가 발생했습니다.";
+    private static final String DEFAULT_MESSAGE = "풀필먼트 배송완료 처리(해외) 중 오류가 발생했습니다.";
 
     public CompleteFulfillmentDeliveryIcsFailedException(IOException cause) {
         super(DEFAULT_MESSAGE, cause);
@@ -18,7 +18,7 @@ public class CompleteFulfillmentDeliveryIcsFailedException extends ExternalOpera
 
     private static String resolveMessage(String vendorMessage) {
         if (FormatValidator.hasValue(vendorMessage)) {
-            return String.format("파스토 배송완료 처리(해외) 실패: %s", vendorMessage);
+            return String.format("풀필먼트 배송완료 처리(해외) 실패: %s", vendorMessage);
         }
         return DEFAULT_MESSAGE;
     }

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/FulfillmentAuthDisconnectFailedException.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/FulfillmentAuthDisconnectFailedException.java
@@ -6,11 +6,11 @@ import com.personal.marketnote.common.utility.FormatValidator;
 import java.io.IOException;
 
 public class FulfillmentAuthDisconnectFailedException extends ExternalOperationFailedException {
-    private static final String FASSTO_AUTH_DISCONNECT_FAILED_EXCEPTION_MESSAGE =
+    private static final String FULFILLMENT_AUTH_DISCONNECT_FAILED_EXCEPTION_MESSAGE =
             "Fulfillment authentication disconnect request failed.";
 
     public FulfillmentAuthDisconnectFailedException(IOException cause) {
-        super(FASSTO_AUTH_DISCONNECT_FAILED_EXCEPTION_MESSAGE, cause);
+        super(FULFILLMENT_AUTH_DISCONNECT_FAILED_EXCEPTION_MESSAGE, cause);
     }
 
     public FulfillmentAuthDisconnectFailedException(String vendorMessage, IOException cause) {
@@ -19,7 +19,7 @@ public class FulfillmentAuthDisconnectFailedException extends ExternalOperationF
 
     private static String resolveMessage(String vendorMessage) {
         if (FormatValidator.hasNoValue(vendorMessage)) {
-            return FASSTO_AUTH_DISCONNECT_FAILED_EXCEPTION_MESSAGE;
+            return FULFILLMENT_AUTH_DISCONNECT_FAILED_EXCEPTION_MESSAGE;
         }
         return vendorMessage;
     }

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/FulfillmentAuthRequestFailedException.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/FulfillmentAuthRequestFailedException.java
@@ -6,11 +6,11 @@ import com.personal.marketnote.common.utility.FormatValidator;
 import java.io.IOException;
 
 public class FulfillmentAuthRequestFailedException extends ExternalOperationFailedException {
-    private static final String FASSTO_AUTH_REQUEST_FAILED_EXCEPTION_MESSAGE =
+    private static final String FULFILLMENT_AUTH_REQUEST_FAILED_EXCEPTION_MESSAGE =
             "Fulfillment authentication request failed.";
 
     public FulfillmentAuthRequestFailedException(IOException cause) {
-        super(FASSTO_AUTH_REQUEST_FAILED_EXCEPTION_MESSAGE, cause);
+        super(FULFILLMENT_AUTH_REQUEST_FAILED_EXCEPTION_MESSAGE, cause);
     }
 
     public FulfillmentAuthRequestFailedException(String vendorMessage, IOException cause) {
@@ -19,7 +19,7 @@ public class FulfillmentAuthRequestFailedException extends ExternalOperationFail
 
     private static String resolveMessage(String vendorMessage) {
         if (FormatValidator.hasNoValue(vendorMessage)) {
-            return FASSTO_AUTH_REQUEST_FAILED_EXCEPTION_MESSAGE;
+            return FULFILLMENT_AUTH_REQUEST_FAILED_EXCEPTION_MESSAGE;
         }
         return vendorMessage;
     }

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/GetFulfillmentDeliveriesFailedException.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/GetFulfillmentDeliveriesFailedException.java
@@ -6,7 +6,7 @@ import com.personal.marketnote.common.utility.FormatValidator;
 import java.io.IOException;
 
 public class GetFulfillmentDeliveriesFailedException extends ExternalOperationFailedException {
-    private static final String DEFAULT_MESSAGE = "파스토 출고 목록 조회 중 오류가 발생했습니다.";
+    private static final String DEFAULT_MESSAGE = "풀필먼트 출고 목록 조회 중 오류가 발생했습니다.";
 
     public GetFulfillmentDeliveriesFailedException(IOException cause) {
         super(DEFAULT_MESSAGE, cause);
@@ -18,7 +18,7 @@ public class GetFulfillmentDeliveriesFailedException extends ExternalOperationFa
 
     private static String resolveMessage(String vendorMessage) {
         if (FormatValidator.hasValue(vendorMessage)) {
-            return String.format("파스토 출고 목록 조회 실패: %s", vendorMessage);
+            return String.format("풀필먼트 출고 목록 조회 실패: %s", vendorMessage);
         }
         return DEFAULT_MESSAGE;
     }

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/GetFulfillmentDeliveryDetailFailedException.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/GetFulfillmentDeliveryDetailFailedException.java
@@ -6,7 +6,7 @@ import com.personal.marketnote.common.utility.FormatValidator;
 import java.io.IOException;
 
 public class GetFulfillmentDeliveryDetailFailedException extends ExternalOperationFailedException {
-    private static final String DEFAULT_MESSAGE = "파스토 출고 상세 조회 중 오류가 발생했습니다.";
+    private static final String DEFAULT_MESSAGE = "풀필먼트 출고 상세 조회 중 오류가 발생했습니다.";
 
     public GetFulfillmentDeliveryDetailFailedException(IOException cause) {
         super(DEFAULT_MESSAGE, cause);
@@ -18,7 +18,7 @@ public class GetFulfillmentDeliveryDetailFailedException extends ExternalOperati
 
     private static String resolveMessage(String vendorMessage) {
         if (FormatValidator.hasValue(vendorMessage)) {
-            return String.format("파스토 출고 상세 조회 실패: %s", vendorMessage);
+            return String.format("풀필먼트 출고 상세 조회 실패: %s", vendorMessage);
         }
         return DEFAULT_MESSAGE;
     }

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/GetFulfillmentDeliveryGoodDetailFailedException.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/GetFulfillmentDeliveryGoodDetailFailedException.java
@@ -6,7 +6,7 @@ import com.personal.marketnote.common.utility.FormatValidator;
 import java.io.IOException;
 
 public class GetFulfillmentDeliveryGoodDetailFailedException extends ExternalOperationFailedException {
-    private static final String DEFAULT_MESSAGE = "파스토 출고 상품 상세 목록 조회 중 오류가 발생했습니다.";
+    private static final String DEFAULT_MESSAGE = "풀필먼트 출고 상품 상세 목록 조회 중 오류가 발생했습니다.";
 
     public GetFulfillmentDeliveryGoodDetailFailedException(IOException cause) {
         super(DEFAULT_MESSAGE, cause);
@@ -18,7 +18,7 @@ public class GetFulfillmentDeliveryGoodDetailFailedException extends ExternalOpe
 
     private static String resolveMessage(String vendorMessage) {
         if (FormatValidator.hasValue(vendorMessage)) {
-            return String.format("파스토 출고 상품 상세 목록 조회 실패: %s", vendorMessage);
+            return String.format("풀필먼트 출고 상품 상세 목록 조회 실패: %s", vendorMessage);
         }
         return DEFAULT_MESSAGE;
     }

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/GetFulfillmentDeliveryOutOrdGoodsByOrdNoFailedException.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/GetFulfillmentDeliveryOutOrdGoodsByOrdNoFailedException.java
@@ -6,7 +6,7 @@ import com.personal.marketnote.common.utility.FormatValidator;
 import java.io.IOException;
 
 public class GetFulfillmentDeliveryOutOrdGoodsByOrdNoFailedException extends ExternalOperationFailedException {
-    private static final String DEFAULT_MESSAGE = "파스토 주문번호 기반 출고중 상품 조회 중 오류가 발생했습니다.";
+    private static final String DEFAULT_MESSAGE = "풀필먼트 주문번호 기반 출고중 상품 조회 중 오류가 발생했습니다.";
 
     public GetFulfillmentDeliveryOutOrdGoodsByOrdNoFailedException(IOException cause) {
         super(DEFAULT_MESSAGE, cause);
@@ -18,7 +18,7 @@ public class GetFulfillmentDeliveryOutOrdGoodsByOrdNoFailedException extends Ext
 
     private static String resolveMessage(String vendorMessage) {
         if (FormatValidator.hasValue(vendorMessage)) {
-            return String.format("파스토 주문번호 기반 출고중 상품 조회 실패: %s", vendorMessage);
+            return String.format("풀필먼트 주문번호 기반 출고중 상품 조회 실패: %s", vendorMessage);
         }
         return DEFAULT_MESSAGE;
     }

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/GetFulfillmentDeliveryOutOrdGoodsDetailFailedException.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/GetFulfillmentDeliveryOutOrdGoodsDetailFailedException.java
@@ -6,7 +6,7 @@ import com.personal.marketnote.common.utility.FormatValidator;
 import java.io.IOException;
 
 public class GetFulfillmentDeliveryOutOrdGoodsDetailFailedException extends ExternalOperationFailedException {
-    private static final String DEFAULT_MESSAGE = "파스토 송장별 상품 정보 조회 중 오류가 발생했습니다.";
+    private static final String DEFAULT_MESSAGE = "풀필먼트 송장별 상품 정보 조회 중 오류가 발생했습니다.";
 
     public GetFulfillmentDeliveryOutOrdGoodsDetailFailedException(IOException cause) {
         super(DEFAULT_MESSAGE, cause);
@@ -18,7 +18,7 @@ public class GetFulfillmentDeliveryOutOrdGoodsDetailFailedException extends Exte
 
     private static String resolveMessage(String vendorMessage) {
         if (FormatValidator.hasValue(vendorMessage)) {
-            return String.format("파스토 송장별 상품 정보 조회 실패: %s", vendorMessage);
+            return String.format("풀필먼트 송장별 상품 정보 조회 실패: %s", vendorMessage);
         }
         return DEFAULT_MESSAGE;
     }

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/GetFulfillmentDeliveryStatusesFailedException.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/GetFulfillmentDeliveryStatusesFailedException.java
@@ -6,7 +6,7 @@ import com.personal.marketnote.common.utility.FormatValidator;
 import java.io.IOException;
 
 public class GetFulfillmentDeliveryStatusesFailedException extends ExternalOperationFailedException {
-    private static final String DEFAULT_MESSAGE = "파스토 출고 배송 조회 중 오류가 발생했습니다.";
+    private static final String DEFAULT_MESSAGE = "풀필먼트 출고 배송 조회 중 오류가 발생했습니다.";
 
     public GetFulfillmentDeliveryStatusesFailedException(IOException cause) {
         super(DEFAULT_MESSAGE, cause);
@@ -18,7 +18,7 @@ public class GetFulfillmentDeliveryStatusesFailedException extends ExternalOpera
 
     private static String resolveMessage(String vendorMessage) {
         if (FormatValidator.hasValue(vendorMessage)) {
-            return String.format("파스토 출고 배송 조회 실패: %s", vendorMessage);
+            return String.format("풀필먼트 출고 배송 조회 실패: %s", vendorMessage);
         }
         return DEFAULT_MESSAGE;
     }

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/GetFulfillmentGoodsDetailFailedException.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/GetFulfillmentGoodsDetailFailedException.java
@@ -6,7 +6,7 @@ import com.personal.marketnote.common.utility.FormatValidator;
 import java.io.IOException;
 
 public class GetFulfillmentGoodsDetailFailedException extends ExternalOperationFailedException {
-    private static final String DEFAULT_MESSAGE = "파스토 단일 상품 조회 중 오류가 발생했습니다.";
+    private static final String DEFAULT_MESSAGE = "풀필먼트 단일 상품 조회 중 오류가 발생했습니다.";
 
     public GetFulfillmentGoodsDetailFailedException(IOException cause) {
         super(DEFAULT_MESSAGE, cause);
@@ -18,7 +18,7 @@ public class GetFulfillmentGoodsDetailFailedException extends ExternalOperationF
 
     private static String resolveMessage(String vendorMessage) {
         if (FormatValidator.hasValue(vendorMessage)) {
-            return String.format("파스토 단일 상품 조회 실패: %s", vendorMessage);
+            return String.format("풀필먼트 단일 상품 조회 실패: %s", vendorMessage);
         }
         return DEFAULT_MESSAGE;
     }

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/GetFulfillmentGoodsElementsFailedException.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/GetFulfillmentGoodsElementsFailedException.java
@@ -6,7 +6,7 @@ import com.personal.marketnote.common.utility.FormatValidator;
 import java.io.IOException;
 
 public class GetFulfillmentGoodsElementsFailedException extends ExternalOperationFailedException {
-    private static final String DEFAULT_MESSAGE = "파스토 모음상품 상세 정보 조회 중 오류가 발생했습니다.";
+    private static final String DEFAULT_MESSAGE = "풀필먼트 모음상품 상세 정보 조회 중 오류가 발생했습니다.";
 
     public GetFulfillmentGoodsElementsFailedException(IOException cause) {
         super(DEFAULT_MESSAGE, cause);
@@ -18,7 +18,7 @@ public class GetFulfillmentGoodsElementsFailedException extends ExternalOperatio
 
     private static String resolveMessage(String vendorMessage) {
         if (FormatValidator.hasValue(vendorMessage)) {
-            return String.format("파스토 모음상품 상세 정보 조회 실패: %s", vendorMessage);
+            return String.format("풀필먼트 모음상품 상세 정보 조회 실패: %s", vendorMessage);
         }
         return DEFAULT_MESSAGE;
     }

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/GetFulfillmentGoodsFailedException.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/GetFulfillmentGoodsFailedException.java
@@ -6,7 +6,7 @@ import com.personal.marketnote.common.utility.FormatValidator;
 import java.io.IOException;
 
 public class GetFulfillmentGoodsFailedException extends ExternalOperationFailedException {
-    private static final String DEFAULT_MESSAGE = "파스토 상품 목록 조회 중 오류가 발생했습니다.";
+    private static final String DEFAULT_MESSAGE = "풀필먼트 상품 목록 조회 중 오류가 발생했습니다.";
 
     public GetFulfillmentGoodsFailedException(IOException cause) {
         super(DEFAULT_MESSAGE, cause);
@@ -18,7 +18,7 @@ public class GetFulfillmentGoodsFailedException extends ExternalOperationFailedE
 
     private static String resolveMessage(String vendorMessage) {
         if (FormatValidator.hasValue(vendorMessage)) {
-            return String.format("파스토 상품 목록 조회 실패: %s", vendorMessage);
+            return String.format("풀필먼트 상품 목록 조회 실패: %s", vendorMessage);
         }
         return DEFAULT_MESSAGE;
     }

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/GetFulfillmentReturnGodDetailFailedException.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/GetFulfillmentReturnGodDetailFailedException.java
@@ -6,7 +6,7 @@ import com.personal.marketnote.common.utility.FormatValidator;
 import java.io.IOException;
 
 public class GetFulfillmentReturnGodDetailFailedException extends ExternalOperationFailedException {
-    private static final String DEFAULT_MESSAGE = "파스토 반품 완료 상품 상세 목록 조회 중 오류가 발생했습니다.";
+    private static final String DEFAULT_MESSAGE = "풀필먼트 반품 완료 상품 상세 목록 조회 중 오류가 발생했습니다.";
 
     public GetFulfillmentReturnGodDetailFailedException(IOException cause) {
         super(DEFAULT_MESSAGE, cause);
@@ -18,7 +18,7 @@ public class GetFulfillmentReturnGodDetailFailedException extends ExternalOperat
 
     private static String resolveMessage(String vendorMessage) {
         if (FormatValidator.hasValue(vendorMessage)) {
-            return String.format("파스토 반품 완료 상품 상세 목록 조회 실패: %s", vendorMessage);
+            return String.format("풀필먼트 반품 완료 상품 상세 목록 조회 실패: %s", vendorMessage);
         }
         return DEFAULT_MESSAGE;
     }

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/GetFulfillmentSettlementDailyCostsFailedException.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/GetFulfillmentSettlementDailyCostsFailedException.java
@@ -6,7 +6,7 @@ import com.personal.marketnote.common.utility.FormatValidator;
 import java.io.IOException;
 
 public class GetFulfillmentSettlementDailyCostsFailedException extends ExternalOperationFailedException {
-    private static final String DEFAULT_MESSAGE = "파스토 물류비 일별 비용 조회 중 오류가 발생했습니다.";
+    private static final String DEFAULT_MESSAGE = "풀필먼트 물류비 일별 비용 조회 중 오류가 발생했습니다.";
 
     public GetFulfillmentSettlementDailyCostsFailedException(IOException cause) {
         super(DEFAULT_MESSAGE, cause);
@@ -18,7 +18,7 @@ public class GetFulfillmentSettlementDailyCostsFailedException extends ExternalO
 
     private static String resolveMessage(String vendorMessage) {
         if (FormatValidator.hasValue(vendorMessage)) {
-            return String.format("파스토 물류비 일별 비용 조회 실패: %s", vendorMessage);
+            return String.format("풀필먼트 물류비 일별 비용 조회 실패: %s", vendorMessage);
         }
         return DEFAULT_MESSAGE;
     }

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/GetFulfillmentShopsFailedException.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/GetFulfillmentShopsFailedException.java
@@ -6,11 +6,11 @@ import com.personal.marketnote.common.utility.FormatValidator;
 import java.io.IOException;
 
 public class GetFulfillmentShopsFailedException extends ExternalOperationFailedException {
-    private static final String GET_FASSTO_MARKETNOTE_LIST_FAILED_EXCEPTION_MESSAGE =
+    private static final String GET_FULFILLMENT_MARKETNOTE_LIST_FAILED_EXCEPTION_MESSAGE =
             "Fulfillment shop list request failed.";
 
     public GetFulfillmentShopsFailedException(IOException cause) {
-        super(GET_FASSTO_MARKETNOTE_LIST_FAILED_EXCEPTION_MESSAGE, cause);
+        super(GET_FULFILLMENT_MARKETNOTE_LIST_FAILED_EXCEPTION_MESSAGE, cause);
     }
 
     public GetFulfillmentShopsFailedException(String vendorMessage, IOException cause) {
@@ -19,7 +19,7 @@ public class GetFulfillmentShopsFailedException extends ExternalOperationFailedE
 
     private static String resolveMessage(String vendorMessage) {
         if (FormatValidator.hasNoValue(vendorMessage)) {
-            return GET_FASSTO_MARKETNOTE_LIST_FAILED_EXCEPTION_MESSAGE;
+            return GET_FULFILLMENT_MARKETNOTE_LIST_FAILED_EXCEPTION_MESSAGE;
         }
         return vendorMessage;
     }

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/GetFulfillmentStockDetailFailedException.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/GetFulfillmentStockDetailFailedException.java
@@ -6,7 +6,7 @@ import com.personal.marketnote.common.utility.FormatValidator;
 import java.io.IOException;
 
 public class GetFulfillmentStockDetailFailedException extends ExternalOperationFailedException {
-    private static final String DEFAULT_MESSAGE = "파스토 단일 상품 재고 정보 조회 중 오류가 발생했습니다.";
+    private static final String DEFAULT_MESSAGE = "풀필먼트 단일 상품 재고 정보 조회 중 오류가 발생했습니다.";
 
     public GetFulfillmentStockDetailFailedException(IOException cause) {
         super(DEFAULT_MESSAGE, cause);
@@ -18,7 +18,7 @@ public class GetFulfillmentStockDetailFailedException extends ExternalOperationF
 
     private static String resolveMessage(String vendorMessage) {
         if (FormatValidator.hasValue(vendorMessage)) {
-            return String.format("파스토 단일 상품 재고 정보 조회 실패: %s", vendorMessage);
+            return String.format("풀필먼트 단일 상품 재고 정보 조회 실패: %s", vendorMessage);
         }
         return DEFAULT_MESSAGE;
     }

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/GetFulfillmentStocksFailedException.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/GetFulfillmentStocksFailedException.java
@@ -6,7 +6,7 @@ import com.personal.marketnote.common.utility.FormatValidator;
 import java.io.IOException;
 
 public class GetFulfillmentStocksFailedException extends ExternalOperationFailedException {
-    private static final String DEFAULT_MESSAGE = "파스토 재고 목록 조회 중 오류가 발생했습니다.";
+    private static final String DEFAULT_MESSAGE = "풀필먼트 재고 목록 조회 중 오류가 발생했습니다.";
 
     public GetFulfillmentStocksFailedException(IOException cause) {
         super(DEFAULT_MESSAGE, cause);
@@ -18,7 +18,7 @@ public class GetFulfillmentStocksFailedException extends ExternalOperationFailed
 
     private static String resolveMessage(String vendorMessage) {
         if (FormatValidator.hasValue(vendorMessage)) {
-            return String.format("파스토 재고 목록 조회 실패: %s", vendorMessage);
+            return String.format("풀필먼트 재고 목록 조회 실패: %s", vendorMessage);
         }
         return DEFAULT_MESSAGE;
     }

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/GetFulfillmentSuppliersFailedException.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/GetFulfillmentSuppliersFailedException.java
@@ -6,11 +6,11 @@ import com.personal.marketnote.common.utility.FormatValidator;
 import java.io.IOException;
 
 public class GetFulfillmentSuppliersFailedException extends ExternalOperationFailedException {
-    private static final String GET_FASSTO_SUPPLIER_LIST_FAILED_EXCEPTION_MESSAGE =
+    private static final String GET_FULFILLMENT_SUPPLIER_LIST_FAILED_EXCEPTION_MESSAGE =
             "Fulfillment supplier list request failed.";
 
     public GetFulfillmentSuppliersFailedException(IOException cause) {
-        super(GET_FASSTO_SUPPLIER_LIST_FAILED_EXCEPTION_MESSAGE, cause);
+        super(GET_FULFILLMENT_SUPPLIER_LIST_FAILED_EXCEPTION_MESSAGE, cause);
     }
 
     public GetFulfillmentSuppliersFailedException(String vendorMessage, IOException cause) {
@@ -19,7 +19,7 @@ public class GetFulfillmentSuppliersFailedException extends ExternalOperationFai
 
     private static String resolveMessage(String vendorMessage) {
         if (FormatValidator.hasNoValue(vendorMessage)) {
-            return GET_FASSTO_SUPPLIER_LIST_FAILED_EXCEPTION_MESSAGE;
+            return GET_FULFILLMENT_SUPPLIER_LIST_FAILED_EXCEPTION_MESSAGE;
         }
         return vendorMessage;
     }

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/GetFulfillmentWarehousingAbnormalFailedException.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/GetFulfillmentWarehousingAbnormalFailedException.java
@@ -6,7 +6,7 @@ import com.personal.marketnote.common.utility.FormatValidator;
 import java.io.IOException;
 
 public class GetFulfillmentWarehousingAbnormalFailedException extends ExternalOperationFailedException {
-    private static final String DEFAULT_MESSAGE = "파스토 비정상 입고 조회 중 오류가 발생했습니다.";
+    private static final String DEFAULT_MESSAGE = "풀필먼트 비정상 입고 조회 중 오류가 발생했습니다.";
 
     public GetFulfillmentWarehousingAbnormalFailedException(IOException cause) {
         super(DEFAULT_MESSAGE, cause);
@@ -18,7 +18,7 @@ public class GetFulfillmentWarehousingAbnormalFailedException extends ExternalOp
 
     private static String resolveMessage(String vendorMessage) {
         if (FormatValidator.hasValue(vendorMessage)) {
-            return String.format("파스토 비정상 입고 조회 실패: %s", vendorMessage);
+            return String.format("풀필먼트 비정상 입고 조회 실패: %s", vendorMessage);
         }
         return DEFAULT_MESSAGE;
     }

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/GetFulfillmentWarehousingAbnormalImageFailedException.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/GetFulfillmentWarehousingAbnormalImageFailedException.java
@@ -6,7 +6,7 @@ import com.personal.marketnote.common.utility.FormatValidator;
 import java.io.IOException;
 
 public class GetFulfillmentWarehousingAbnormalImageFailedException extends ExternalOperationFailedException {
-    private static final String DEFAULT_MESSAGE = "파스토 비정상 입고 상품 이미지 조회 중 오류가 발생했습니다.";
+    private static final String DEFAULT_MESSAGE = "풀필먼트 비정상 입고 상품 이미지 조회 중 오류가 발생했습니다.";
 
     public GetFulfillmentWarehousingAbnormalImageFailedException(IOException cause) {
         super(DEFAULT_MESSAGE, cause);
@@ -18,7 +18,7 @@ public class GetFulfillmentWarehousingAbnormalImageFailedException extends Exter
 
     private static String resolveMessage(String vendorMessage) {
         if (FormatValidator.hasValue(vendorMessage)) {
-            return String.format("파스토 비정상 입고 상품 이미지 조회 실패: %s", vendorMessage);
+            return String.format("풀필먼트 비정상 입고 상품 이미지 조회 실패: %s", vendorMessage);
         }
         return DEFAULT_MESSAGE;
     }

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/GetFulfillmentWarehousingDetailFailedException.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/GetFulfillmentWarehousingDetailFailedException.java
@@ -6,7 +6,7 @@ import com.personal.marketnote.common.utility.FormatValidator;
 import java.io.IOException;
 
 public class GetFulfillmentWarehousingDetailFailedException extends ExternalOperationFailedException {
-    private static final String DEFAULT_MESSAGE = "파스토 입고 상세 조회 중 오류가 발생했습니다.";
+    private static final String DEFAULT_MESSAGE = "풀필먼트 입고 상세 조회 중 오류가 발생했습니다.";
 
     public GetFulfillmentWarehousingDetailFailedException(IOException cause) {
         super(DEFAULT_MESSAGE, cause);
@@ -18,7 +18,7 @@ public class GetFulfillmentWarehousingDetailFailedException extends ExternalOper
 
     private static String resolveMessage(String vendorMessage) {
         if (FormatValidator.hasValue(vendorMessage)) {
-            return String.format("파스토 입고 상세 조회 실패: %s", vendorMessage);
+            return String.format("풀필먼트 입고 상세 조회 실패: %s", vendorMessage);
         }
         return DEFAULT_MESSAGE;
     }

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/GetFulfillmentWarehousingFailedException.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/GetFulfillmentWarehousingFailedException.java
@@ -6,7 +6,7 @@ import com.personal.marketnote.common.utility.FormatValidator;
 import java.io.IOException;
 
 public class GetFulfillmentWarehousingFailedException extends ExternalOperationFailedException {
-    private static final String DEFAULT_MESSAGE = "파스토 상품 입고 목록 조회 중 오류가 발생했습니다.";
+    private static final String DEFAULT_MESSAGE = "풀필먼트 상품 입고 목록 조회 중 오류가 발생했습니다.";
 
     public GetFulfillmentWarehousingFailedException(IOException cause) {
         super(DEFAULT_MESSAGE, cause);
@@ -18,7 +18,7 @@ public class GetFulfillmentWarehousingFailedException extends ExternalOperationF
 
     private static String resolveMessage(String vendorMessage) {
         if (FormatValidator.hasValue(vendorMessage)) {
-            return String.format("파스토 상품 입고 목록 조회 실패: %s", vendorMessage);
+            return String.format("풀필먼트 상품 입고 목록 조회 실패: %s", vendorMessage);
         }
         return DEFAULT_MESSAGE;
     }

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/GetFulfillmentWarehousingInspecDetailFailedException.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/GetFulfillmentWarehousingInspecDetailFailedException.java
@@ -6,7 +6,7 @@ import com.personal.marketnote.common.utility.FormatValidator;
 import java.io.IOException;
 
 public class GetFulfillmentWarehousingInspecDetailFailedException extends ExternalOperationFailedException {
-    private static final String DEFAULT_MESSAGE = "파스토 입고 검수 상세 조회 중 오류가 발생했습니다.";
+    private static final String DEFAULT_MESSAGE = "풀필먼트 입고 검수 상세 조회 중 오류가 발생했습니다.";
 
     public GetFulfillmentWarehousingInspecDetailFailedException(IOException cause) {
         super(DEFAULT_MESSAGE, cause);
@@ -18,7 +18,7 @@ public class GetFulfillmentWarehousingInspecDetailFailedException extends Extern
 
     private static String resolveMessage(String vendorMessage) {
         if (FormatValidator.hasValue(vendorMessage)) {
-            return String.format("파스토 입고 검수 상세 조회 실패: %s", vendorMessage);
+            return String.format("풀필먼트 입고 검수 상세 조회 실패: %s", vendorMessage);
         }
         return DEFAULT_MESSAGE;
     }

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/RegisterFulfillmentDeliveryFailedException.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/RegisterFulfillmentDeliveryFailedException.java
@@ -6,11 +6,11 @@ import com.personal.marketnote.common.utility.FormatValidator;
 import java.io.IOException;
 
 public class RegisterFulfillmentDeliveryFailedException extends ExternalOperationFailedException {
-    private static final String REGISTER_FASSTO_DELIVERY_FAILED_EXCEPTION_MESSAGE =
+    private static final String REGISTER_FULFILLMENT_DELIVERY_FAILED_EXCEPTION_MESSAGE =
             "Fulfillment delivery registration request failed.";
 
     public RegisterFulfillmentDeliveryFailedException(IOException cause) {
-        super(REGISTER_FASSTO_DELIVERY_FAILED_EXCEPTION_MESSAGE, cause);
+        super(REGISTER_FULFILLMENT_DELIVERY_FAILED_EXCEPTION_MESSAGE, cause);
     }
 
     public RegisterFulfillmentDeliveryFailedException(String vendorMessage, IOException cause) {
@@ -19,7 +19,7 @@ public class RegisterFulfillmentDeliveryFailedException extends ExternalOperatio
 
     private static String resolveMessage(String vendorMessage) {
         if (FormatValidator.hasNoValue(vendorMessage)) {
-            return REGISTER_FASSTO_DELIVERY_FAILED_EXCEPTION_MESSAGE;
+            return REGISTER_FULFILLMENT_DELIVERY_FAILED_EXCEPTION_MESSAGE;
         }
         return vendorMessage;
     }

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/RegisterFulfillmentDirectReturnDeliveryFailedException.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/RegisterFulfillmentDirectReturnDeliveryFailedException.java
@@ -6,11 +6,11 @@ import com.personal.marketnote.common.utility.FormatValidator;
 import java.io.IOException;
 
 public class RegisterFulfillmentDirectReturnDeliveryFailedException extends ExternalOperationFailedException {
-    private static final String REGISTER_FASSTO_DIRECT_RETURN_DELIVERY_FAILED_EXCEPTION_MESSAGE =
+    private static final String REGISTER_FULFILLMENT_DIRECT_RETURN_DELIVERY_FAILED_EXCEPTION_MESSAGE =
             "Fulfillment direct return delivery registration request failed.";
 
     public RegisterFulfillmentDirectReturnDeliveryFailedException(IOException cause) {
-        super(REGISTER_FASSTO_DIRECT_RETURN_DELIVERY_FAILED_EXCEPTION_MESSAGE, cause);
+        super(REGISTER_FULFILLMENT_DIRECT_RETURN_DELIVERY_FAILED_EXCEPTION_MESSAGE, cause);
     }
 
     public RegisterFulfillmentDirectReturnDeliveryFailedException(String vendorMessage, IOException cause) {
@@ -19,7 +19,7 @@ public class RegisterFulfillmentDirectReturnDeliveryFailedException extends Exte
 
     private static String resolveMessage(String vendorMessage) {
         if (FormatValidator.hasNoValue(vendorMessage)) {
-            return REGISTER_FASSTO_DIRECT_RETURN_DELIVERY_FAILED_EXCEPTION_MESSAGE;
+            return REGISTER_FULFILLMENT_DIRECT_RETURN_DELIVERY_FAILED_EXCEPTION_MESSAGE;
         }
         return vendorMessage;
     }

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/RegisterFulfillmentGoodsFailedException.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/RegisterFulfillmentGoodsFailedException.java
@@ -6,11 +6,11 @@ import com.personal.marketnote.common.utility.FormatValidator;
 import java.io.IOException;
 
 public class RegisterFulfillmentGoodsFailedException extends ExternalOperationFailedException {
-    private static final String REGISTER_FASSTO_GOODS_FAILED_EXCEPTION_MESSAGE =
+    private static final String REGISTER_FULFILLMENT_GOODS_FAILED_EXCEPTION_MESSAGE =
             "Fulfillment goods registration request failed.";
 
     public RegisterFulfillmentGoodsFailedException(IOException cause) {
-        super(REGISTER_FASSTO_GOODS_FAILED_EXCEPTION_MESSAGE, cause);
+        super(REGISTER_FULFILLMENT_GOODS_FAILED_EXCEPTION_MESSAGE, cause);
     }
 
     public RegisterFulfillmentGoodsFailedException(String vendorMessage, IOException cause) {
@@ -19,7 +19,7 @@ public class RegisterFulfillmentGoodsFailedException extends ExternalOperationFa
 
     private static String resolveMessage(String vendorMessage) {
         if (FormatValidator.hasNoValue(vendorMessage)) {
-            return REGISTER_FASSTO_GOODS_FAILED_EXCEPTION_MESSAGE;
+            return REGISTER_FULFILLMENT_GOODS_FAILED_EXCEPTION_MESSAGE;
         }
         return vendorMessage;
     }

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/RegisterFulfillmentReturnDeliveryFailedException.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/RegisterFulfillmentReturnDeliveryFailedException.java
@@ -6,11 +6,11 @@ import com.personal.marketnote.common.utility.FormatValidator;
 import java.io.IOException;
 
 public class RegisterFulfillmentReturnDeliveryFailedException extends ExternalOperationFailedException {
-    private static final String REGISTER_FASSTO_RETURN_DELIVERY_FAILED_EXCEPTION_MESSAGE =
+    private static final String REGISTER_FULFILLMENT_RETURN_DELIVERY_FAILED_EXCEPTION_MESSAGE =
             "Fulfillment return delivery registration request failed.";
 
     public RegisterFulfillmentReturnDeliveryFailedException(IOException cause) {
-        super(REGISTER_FASSTO_RETURN_DELIVERY_FAILED_EXCEPTION_MESSAGE, cause);
+        super(REGISTER_FULFILLMENT_RETURN_DELIVERY_FAILED_EXCEPTION_MESSAGE, cause);
     }
 
     public RegisterFulfillmentReturnDeliveryFailedException(String vendorMessage, IOException cause) {
@@ -19,7 +19,7 @@ public class RegisterFulfillmentReturnDeliveryFailedException extends ExternalOp
 
     private static String resolveMessage(String vendorMessage) {
         if (FormatValidator.hasNoValue(vendorMessage)) {
-            return REGISTER_FASSTO_RETURN_DELIVERY_FAILED_EXCEPTION_MESSAGE;
+            return REGISTER_FULFILLMENT_RETURN_DELIVERY_FAILED_EXCEPTION_MESSAGE;
         }
         return vendorMessage;
     }

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/RegisterFulfillmentShopFailedException.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/RegisterFulfillmentShopFailedException.java
@@ -6,11 +6,11 @@ import com.personal.marketnote.common.utility.FormatValidator;
 import java.io.IOException;
 
 public class RegisterFulfillmentShopFailedException extends ExternalOperationFailedException {
-    private static final String REGISTER_FASSTO_MARKETNOTE_FAILED_EXCEPTION_MESSAGE =
+    private static final String REGISTER_FULFILLMENT_MARKETNOTE_FAILED_EXCEPTION_MESSAGE =
             "Fulfillment shop registration request failed.";
 
     public RegisterFulfillmentShopFailedException(IOException cause) {
-        super(REGISTER_FASSTO_MARKETNOTE_FAILED_EXCEPTION_MESSAGE, cause);
+        super(REGISTER_FULFILLMENT_MARKETNOTE_FAILED_EXCEPTION_MESSAGE, cause);
     }
 
     public RegisterFulfillmentShopFailedException(String vendorMessage, IOException cause) {
@@ -19,7 +19,7 @@ public class RegisterFulfillmentShopFailedException extends ExternalOperationFai
 
     private static String resolveMessage(String vendorMessage) {
         if (FormatValidator.hasNoValue(vendorMessage)) {
-            return REGISTER_FASSTO_MARKETNOTE_FAILED_EXCEPTION_MESSAGE;
+            return REGISTER_FULFILLMENT_MARKETNOTE_FAILED_EXCEPTION_MESSAGE;
         }
         return vendorMessage;
     }

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/RegisterFulfillmentSupplierFailedException.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/RegisterFulfillmentSupplierFailedException.java
@@ -6,11 +6,11 @@ import com.personal.marketnote.common.utility.FormatValidator;
 import java.io.IOException;
 
 public class RegisterFulfillmentSupplierFailedException extends ExternalOperationFailedException {
-    private static final String REGISTER_FASSTO_SUPPLIER_FAILED_EXCEPTION_MESSAGE =
+    private static final String REGISTER_FULFILLMENT_SUPPLIER_FAILED_EXCEPTION_MESSAGE =
             "Fulfillment supplier registration request failed.";
 
     public RegisterFulfillmentSupplierFailedException(IOException cause) {
-        super(REGISTER_FASSTO_SUPPLIER_FAILED_EXCEPTION_MESSAGE, cause);
+        super(REGISTER_FULFILLMENT_SUPPLIER_FAILED_EXCEPTION_MESSAGE, cause);
     }
 
     public RegisterFulfillmentSupplierFailedException(String vendorMessage, IOException cause) {
@@ -19,7 +19,7 @@ public class RegisterFulfillmentSupplierFailedException extends ExternalOperatio
 
     private static String resolveMessage(String vendorMessage) {
         if (FormatValidator.hasNoValue(vendorMessage)) {
-            return REGISTER_FASSTO_SUPPLIER_FAILED_EXCEPTION_MESSAGE;
+            return REGISTER_FULFILLMENT_SUPPLIER_FAILED_EXCEPTION_MESSAGE;
         }
         return vendorMessage;
     }

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/RegisterFulfillmentWarehousingFailedException.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/RegisterFulfillmentWarehousingFailedException.java
@@ -6,7 +6,7 @@ import com.personal.marketnote.common.utility.FormatValidator;
 import java.io.IOException;
 
 public class RegisterFulfillmentWarehousingFailedException extends ExternalOperationFailedException {
-    private static final String DEFAULT_MESSAGE = "파스토 상품 입고 요청 중 오류가 발생했습니다.";
+    private static final String DEFAULT_MESSAGE = "풀필먼트 상품 입고 요청 중 오류가 발생했습니다.";
 
     public RegisterFulfillmentWarehousingFailedException(IOException cause) {
         super(DEFAULT_MESSAGE, cause);
@@ -18,7 +18,7 @@ public class RegisterFulfillmentWarehousingFailedException extends ExternalOpera
 
     private static String resolveMessage(String vendorMessage) {
         if (FormatValidator.hasValue(vendorMessage)) {
-            return String.format("파스토 상품 입고 요청 실패: %s", vendorMessage);
+            return String.format("풀필먼트 상품 입고 요청 실패: %s", vendorMessage);
         }
         return DEFAULT_MESSAGE;
     }

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/UpdateFulfillmentDeliveryCarFailedException.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/UpdateFulfillmentDeliveryCarFailedException.java
@@ -6,7 +6,7 @@ import com.personal.marketnote.common.utility.FormatValidator;
 import java.io.IOException;
 
 public class UpdateFulfillmentDeliveryCarFailedException extends ExternalOperationFailedException {
-    private static final String DEFAULT_MESSAGE = "파스토 출고 수정(차량) 중 오류가 발생했습니다.";
+    private static final String DEFAULT_MESSAGE = "풀필먼트 출고 수정(차량) 중 오류가 발생했습니다.";
 
     public UpdateFulfillmentDeliveryCarFailedException(IOException cause) {
         super(DEFAULT_MESSAGE, cause);
@@ -18,7 +18,7 @@ public class UpdateFulfillmentDeliveryCarFailedException extends ExternalOperati
 
     private static String resolveMessage(String vendorMessage) {
         if (FormatValidator.hasValue(vendorMessage)) {
-            return String.format("파스토 출고 수정(차량) 실패: %s", vendorMessage);
+            return String.format("풀필먼트 출고 수정(차량) 실패: %s", vendorMessage);
         }
         return DEFAULT_MESSAGE;
     }

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/UpdateFulfillmentDeliveryFailedException.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/UpdateFulfillmentDeliveryFailedException.java
@@ -6,7 +6,7 @@ import com.personal.marketnote.common.utility.FormatValidator;
 import java.io.IOException;
 
 public class UpdateFulfillmentDeliveryFailedException extends ExternalOperationFailedException {
-    private static final String DEFAULT_MESSAGE = "파스토 출고 수정(택배) 중 오류가 발생했습니다.";
+    private static final String DEFAULT_MESSAGE = "풀필먼트 출고 수정(택배) 중 오류가 발생했습니다.";
 
     public UpdateFulfillmentDeliveryFailedException(IOException cause) {
         super(DEFAULT_MESSAGE, cause);
@@ -18,7 +18,7 @@ public class UpdateFulfillmentDeliveryFailedException extends ExternalOperationF
 
     private static String resolveMessage(String vendorMessage) {
         if (FormatValidator.hasValue(vendorMessage)) {
-            return String.format("파스토 출고 수정(택배) 실패: %s", vendorMessage);
+            return String.format("풀필먼트 출고 수정(택배) 실패: %s", vendorMessage);
         }
         return DEFAULT_MESSAGE;
     }

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/UpdateFulfillmentGoodsFailedException.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/UpdateFulfillmentGoodsFailedException.java
@@ -6,7 +6,7 @@ import com.personal.marketnote.common.utility.FormatValidator;
 import java.io.IOException;
 
 public class UpdateFulfillmentGoodsFailedException extends ExternalOperationFailedException {
-    private static final String DEFAULT_MESSAGE = "파스토 상품 수정 중 오류가 발생했습니다.";
+    private static final String DEFAULT_MESSAGE = "풀필먼트 상품 수정 중 오류가 발생했습니다.";
 
     public UpdateFulfillmentGoodsFailedException(IOException cause) {
         super(DEFAULT_MESSAGE, cause);
@@ -18,7 +18,7 @@ public class UpdateFulfillmentGoodsFailedException extends ExternalOperationFail
 
     private static String resolveMessage(String vendorMessage) {
         if (FormatValidator.hasValue(vendorMessage)) {
-            return String.format("파스토 상품 수정 실패: %s", vendorMessage);
+            return String.format("풀필먼트 상품 수정 실패: %s", vendorMessage);
         }
         return DEFAULT_MESSAGE;
     }

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/UpdateFulfillmentShopFailedException.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/UpdateFulfillmentShopFailedException.java
@@ -6,11 +6,11 @@ import com.personal.marketnote.common.utility.FormatValidator;
 import java.io.IOException;
 
 public class UpdateFulfillmentShopFailedException extends ExternalOperationFailedException {
-    private static final String UPDATE_FASSTO_MARKETNOTE_FAILED_EXCEPTION_MESSAGE =
+    private static final String UPDATE_FULFILLMENT_MARKETNOTE_FAILED_EXCEPTION_MESSAGE =
             "Fulfillment shop update request failed.";
 
     public UpdateFulfillmentShopFailedException(IOException cause) {
-        super(UPDATE_FASSTO_MARKETNOTE_FAILED_EXCEPTION_MESSAGE, cause);
+        super(UPDATE_FULFILLMENT_MARKETNOTE_FAILED_EXCEPTION_MESSAGE, cause);
     }
 
     public UpdateFulfillmentShopFailedException(String vendorMessage, IOException cause) {
@@ -19,7 +19,7 @@ public class UpdateFulfillmentShopFailedException extends ExternalOperationFaile
 
     private static String resolveMessage(String vendorMessage) {
         if (FormatValidator.hasNoValue(vendorMessage)) {
-            return UPDATE_FASSTO_MARKETNOTE_FAILED_EXCEPTION_MESSAGE;
+            return UPDATE_FULFILLMENT_MARKETNOTE_FAILED_EXCEPTION_MESSAGE;
         }
         return vendorMessage;
     }

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/UpdateFulfillmentSupplierFailedException.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/UpdateFulfillmentSupplierFailedException.java
@@ -6,11 +6,11 @@ import com.personal.marketnote.common.utility.FormatValidator;
 import java.io.IOException;
 
 public class UpdateFulfillmentSupplierFailedException extends ExternalOperationFailedException {
-    private static final String UPDATE_FASSTO_SUPPLIER_FAILED_EXCEPTION_MESSAGE =
+    private static final String UPDATE_FULFILLMENT_SUPPLIER_FAILED_EXCEPTION_MESSAGE =
             "Fulfillment supplier update request failed.";
 
     public UpdateFulfillmentSupplierFailedException(IOException cause) {
-        super(UPDATE_FASSTO_SUPPLIER_FAILED_EXCEPTION_MESSAGE, cause);
+        super(UPDATE_FULFILLMENT_SUPPLIER_FAILED_EXCEPTION_MESSAGE, cause);
     }
 
     public UpdateFulfillmentSupplierFailedException(String vendorMessage, IOException cause) {
@@ -19,7 +19,7 @@ public class UpdateFulfillmentSupplierFailedException extends ExternalOperationF
 
     private static String resolveMessage(String vendorMessage) {
         if (FormatValidator.hasNoValue(vendorMessage)) {
-            return UPDATE_FASSTO_SUPPLIER_FAILED_EXCEPTION_MESSAGE;
+            return UPDATE_FULFILLMENT_SUPPLIER_FAILED_EXCEPTION_MESSAGE;
         }
         return vendorMessage;
     }

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/UpdateFulfillmentWarehousingFailedException.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/UpdateFulfillmentWarehousingFailedException.java
@@ -6,7 +6,7 @@ import com.personal.marketnote.common.utility.FormatValidator;
 import java.io.IOException;
 
 public class UpdateFulfillmentWarehousingFailedException extends ExternalOperationFailedException {
-    private static final String DEFAULT_MESSAGE = "파스토 상품 입고 수정 중 오류가 발생했습니다.";
+    private static final String DEFAULT_MESSAGE = "풀필먼트 상품 입고 수정 중 오류가 발생했습니다.";
 
     public UpdateFulfillmentWarehousingFailedException(IOException cause) {
         super(DEFAULT_MESSAGE, cause);
@@ -18,7 +18,7 @@ public class UpdateFulfillmentWarehousingFailedException extends ExternalOperati
 
     private static String resolveMessage(String vendorMessage) {
         if (FormatValidator.hasValue(vendorMessage)) {
-            return String.format("파스토 상품 입고 수정 실패: %s", vendorMessage);
+            return String.format("풀필먼트 상품 입고 수정 실패: %s", vendorMessage);
         }
         return DEFAULT_MESSAGE;
     }

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/mapper/FulfillmentCommandToStateMapper.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/mapper/FulfillmentCommandToStateMapper.java
@@ -1,0 +1,31 @@
+package com.personal.marketnote.fulfillment.mapper;
+
+import com.personal.marketnote.fulfillment.domain.delivery.FulfillmentDeliveryRegistrationCreateState;
+import com.personal.marketnote.fulfillment.domain.goods.FulfillmentGoodsRegistrationCreateState;
+import com.personal.marketnote.fulfillment.port.in.command.vendor.RegisterFulfillmentDeliveryCommand;
+import com.personal.marketnote.fulfillment.port.in.command.vendor.RegisterFulfillmentGoodsCommand;
+
+public class FulfillmentCommandToStateMapper {
+    private FulfillmentCommandToStateMapper() {
+    }
+
+    public static FulfillmentDeliveryRegistrationCreateState mapToDeliveryRegistrationCreateState(
+            RegisterFulfillmentDeliveryCommand command
+    ) {
+        Long orderId = Long.parseLong(command.deliveryRequests().getFirst().orderNumber());
+
+        return FulfillmentDeliveryRegistrationCreateState.builder()
+                .orderId(orderId)
+                .build();
+    }
+
+    public static FulfillmentGoodsRegistrationCreateState mapToGoodsRegistrationCreateState(
+            RegisterFulfillmentGoodsCommand command
+    ) {
+        Long productId = Long.parseLong(command.goods().getFirst().productCode());
+
+        return FulfillmentGoodsRegistrationCreateState.builder()
+                .productId(productId)
+                .build();
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/usecase/vendor/DisconnectFulfillmentAuthUseCase.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/usecase/vendor/DisconnectFulfillmentAuthUseCase.java
@@ -1,11 +1,11 @@
 package com.personal.marketnote.fulfillment.port.in.usecase.vendor;
 
 /**
- * 파스토 인증 해제 유스케이스
+ * 풀필먼트 인증 해제 유스케이스
  *
  * @Author 성효빈
  * @Date 2026-01-25
- * @Description 파스토 인증 해제 기능을 제공합니다.
+ * @Description 풀필먼트 인증 해제 기능을 제공합니다.
  */
 public interface DisconnectFulfillmentAuthUseCase {
     /**

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/usecase/vendor/RequestFulfillmentAuthUseCase.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/usecase/vendor/RequestFulfillmentAuthUseCase.java
@@ -3,11 +3,11 @@ package com.personal.marketnote.fulfillment.port.in.usecase.vendor;
 import com.personal.marketnote.fulfillment.domain.FulfillmentAccessToken;
 
 /**
- * 파스토 인증 요청 유스케이스
+ * 풀필먼트 인증 요청 유스케이스
  *
  * @Author 성효빈
  * @Date 2026-01-24
- * @Description 파스토 인증 요청 기능을 제공합니다.
+ * @Description 풀필먼트 인증 요청 기능을 제공합니다.
  */
 public interface RequestFulfillmentAuthUseCase {
     /**

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/vendor/DisconnectFulfillmentAuthPort.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/vendor/DisconnectFulfillmentAuthPort.java
@@ -1,19 +1,19 @@
 package com.personal.marketnote.fulfillment.port.out.vendor;
 
 /**
- * 파스토 인증 해제 포트
+ * 풀필먼트 인증 해제 포트
  *
  * @Author 성효빈
  * @Date 2026-01-25
- * @Description 파스토 인증 해제 기능을 제공합니다.
+ * @Description 풀필먼트 인증 해제 기능을 제공합니다.
  */
 public interface DisconnectFulfillmentAuthPort {
 
     /**
-     * @param accessToken 해제할 파스토 액세스 토큰
+     * @param accessToken 해제할 풀필먼트 액세스 토큰
      * @Date 2026-01-25
      * @Author 성효빈
-     * @Description 파스토 액세스 토큰을 해제합니다.
+     * @Description 풀필먼트 액세스 토큰을 해제합니다.
      */
     void disconnectAccessToken(String accessToken);
 }

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/vendor/RequestFulfillmentAuthPort.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/vendor/RequestFulfillmentAuthPort.java
@@ -3,19 +3,19 @@ package com.personal.marketnote.fulfillment.port.out.vendor;
 import com.personal.marketnote.fulfillment.domain.FulfillmentAccessToken;
 
 /**
- * 파스토 인증 요청 포트
+ * 풀필먼트 인증 요청 포트
  *
  * @Author 성효빈
  * @Date 2026-01-24
- * @Description 파스토 인증 요청 기능을 제공합니다.
+ * @Description 풀필먼트 인증 요청 기능을 제공합니다.
  */
 public interface RequestFulfillmentAuthPort {
 
     /**
-     * @return 파스토 액세스 토큰 {@link FulfillmentAccessToken}
+     * @return 풀필먼트 액세스 토큰 {@link FulfillmentAccessToken}
      * @Date 2026-01-24
      * @Author 성효빈
-     * @Description 파스토 액세스 토큰을 요청합니다.
+     * @Description 풀필먼트 액세스 토큰을 요청합니다.
      */
     FulfillmentAccessToken requestAccessToken();
 }

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/vendor/RegisterFulfillmentDeliveryService.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/vendor/RegisterFulfillmentDeliveryService.java
@@ -2,7 +2,7 @@ package com.personal.marketnote.fulfillment.service.vendor;
 
 import com.personal.marketnote.common.application.UseCase;
 import com.personal.marketnote.fulfillment.domain.delivery.FulfillmentDeliveryRegistration;
-import com.personal.marketnote.fulfillment.mapper.FasstoCommandToStateMapper;
+import com.personal.marketnote.fulfillment.mapper.FulfillmentCommandToStateMapper;
 import com.personal.marketnote.fulfillment.port.in.command.vendor.RegisterFulfillmentDeliveryCommand;
 import com.personal.marketnote.fulfillment.port.in.result.vendor.RegisterFulfillmentDeliveryResult;
 import com.personal.marketnote.fulfillment.port.in.usecase.vendor.RegisterFulfillmentDeliveryUseCase;
@@ -29,7 +29,7 @@ public class RegisterFulfillmentDeliveryService implements RegisterFulfillmentDe
     @Transactional(isolation = READ_COMMITTED)
     public RegisterFulfillmentDeliveryResult registerDeliveryIdempotent(RegisterFulfillmentDeliveryCommand command) {
         FulfillmentDeliveryRegistration registration = FulfillmentDeliveryRegistration.from(
-                FasstoCommandToStateMapper.mapToDeliveryRegistrationCreateState(command)
+                FulfillmentCommandToStateMapper.mapToDeliveryRegistrationCreateState(command)
         );
         saveFulfillmentDeliveryRegistrationPort.save(registration);
 

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/vendor/RegisterFulfillmentGoodsService.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/vendor/RegisterFulfillmentGoodsService.java
@@ -2,7 +2,7 @@ package com.personal.marketnote.fulfillment.service.vendor;
 
 import com.personal.marketnote.common.application.UseCase;
 import com.personal.marketnote.fulfillment.domain.goods.FulfillmentGoodsRegistration;
-import com.personal.marketnote.fulfillment.mapper.FasstoCommandToStateMapper;
+import com.personal.marketnote.fulfillment.mapper.FulfillmentCommandToStateMapper;
 import com.personal.marketnote.fulfillment.port.in.command.vendor.RegisterFulfillmentGoodsCommand;
 import com.personal.marketnote.fulfillment.port.in.result.vendor.RegisterFulfillmentGoodsResult;
 import com.personal.marketnote.fulfillment.port.in.usecase.vendor.RegisterFulfillmentGoodsUseCase;
@@ -29,7 +29,7 @@ public class RegisterFulfillmentGoodsService implements RegisterFulfillmentGoods
     @Transactional(isolation = READ_COMMITTED)
     public RegisterFulfillmentGoodsResult registerGoodsIdempotent(RegisterFulfillmentGoodsCommand command) {
         FulfillmentGoodsRegistration registration = FulfillmentGoodsRegistration.from(
-                FasstoCommandToStateMapper.mapToGoodsRegistrationCreateState(command)
+                FulfillmentCommandToStateMapper.mapToGoodsRegistrationCreateState(command)
         );
         saveFulfillmentGoodsRegistrationPort.save(registration);
 


### PR DESCRIPTION
## partially addresses #475
## resolves #2159

## Task
- [x] FasstoCommandToStateMapper → FulfillmentCommandToStateMapper 이름 변경
- [x] exception 내부 FASSTO_ 상수명 → FULFILLMENT_ 일괄 변경 (37파일)
- [x] auth UseCase/Port Javadoc "파스토" → "풀필먼트" 변경
- [x] exception Javadoc "파스토" → "풀필먼트" 일괄 변경