### PR TITLE
[#1][#2178] refactor: EntityStatus 패키지 위치 수정

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/settlement/response/GetSettlementPolicyResponse.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/settlement/response/GetSettlementPolicyResponse.java
@@ -2,7 +2,7 @@ package com.personal.marketnote.commerce.adapter.in.web.settlement.response;
 
 import com.personal.marketnote.commerce.domain.settlement.SettlementCycle;
 import com.personal.marketnote.commerce.port.in.result.settlement.GetSettlementPolicyResult;
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import lombok.Builder;
 
 import java.time.LocalDateTime;

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/ledger/entity/AccountJpaEntity.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/ledger/entity/AccountJpaEntity.java
@@ -2,7 +2,7 @@ package com.personal.marketnote.commerce.adapter.out.persistence.ledger.entity;
 
 import com.personal.marketnote.commerce.domain.ledger.AccountType;
 import com.personal.marketnote.common.adapter.out.persistence.audit.BaseEntity;
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import jakarta.persistence.*;
 import lombok.*;
 

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/product/ProductReadModelPersistenceAdapter.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/product/ProductReadModelPersistenceAdapter.java
@@ -6,7 +6,7 @@ import com.personal.marketnote.commerce.port.out.product.FindProductByPricePolic
 import com.personal.marketnote.commerce.port.out.product.SaveProductReadModelPort;
 import com.personal.marketnote.commerce.port.out.result.product.ProductInfoResult;
 import com.personal.marketnote.common.adapter.out.PersistenceAdapter;
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.common.utility.FormatValidator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/product/repository/ProductReadModelJpaRepository.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/product/repository/ProductReadModelJpaRepository.java
@@ -1,7 +1,7 @@
 package com.personal.marketnote.commerce.adapter.out.persistence.product.repository;
 
 import com.personal.marketnote.commerce.adapter.out.persistence.product.entity.ProductReadModelJpaEntity;
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/quickpayment/QuickPaymentCardPersistenceAdapter.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/quickpayment/QuickPaymentCardPersistenceAdapter.java
@@ -9,7 +9,7 @@ import com.personal.marketnote.commerce.port.out.quickpayment.DeleteQuickPayment
 import com.personal.marketnote.commerce.port.out.quickpayment.FindQuickPaymentCardPort;
 import com.personal.marketnote.commerce.port.out.quickpayment.SaveQuickPaymentCardPort;
 import com.personal.marketnote.common.adapter.out.PersistenceAdapter;
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/quickpayment/entity/QuickPaymentCardJpaEntity.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/quickpayment/entity/QuickPaymentCardJpaEntity.java
@@ -2,7 +2,7 @@ package com.personal.marketnote.commerce.adapter.out.persistence.quickpayment.en
 
 import com.personal.marketnote.commerce.domain.quickpayment.QuickPaymentCard;
 import com.personal.marketnote.common.adapter.out.persistence.audit.BaseEntity;
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.DynamicInsert;

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/quickpayment/repository/QuickPaymentCardJpaRepository.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/quickpayment/repository/QuickPaymentCardJpaRepository.java
@@ -1,7 +1,7 @@
 package com.personal.marketnote.commerce.adapter.out.persistence.quickpayment.repository;
 
 import com.personal.marketnote.commerce.adapter.out.persistence.quickpayment.entity.QuickPaymentCardJpaEntity;
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/settlement/SettlementPolicyPersistenceAdapter.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/settlement/SettlementPolicyPersistenceAdapter.java
@@ -8,7 +8,7 @@ import com.personal.marketnote.commerce.port.out.settlement.FindSettlementPolicy
 import com.personal.marketnote.commerce.port.out.settlement.SaveSettlementPolicyPort;
 import com.personal.marketnote.commerce.port.out.settlement.UpdateSettlementPolicyPort;
 import com.personal.marketnote.common.adapter.out.PersistenceAdapter;
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import lombok.RequiredArgsConstructor;
 
 import java.util.List;

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/settlement/entity/SettlementPolicyJpaEntity.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/settlement/entity/SettlementPolicyJpaEntity.java
@@ -2,7 +2,7 @@ package com.personal.marketnote.commerce.adapter.out.persistence.settlement.enti
 
 import com.personal.marketnote.commerce.domain.settlement.SettlementCycle;
 import com.personal.marketnote.commerce.domain.settlement.SettlementPolicy;
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.DynamicInsert;

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/settlement/repository/SettlementPolicyJpaRepository.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/settlement/repository/SettlementPolicyJpaRepository.java
@@ -1,7 +1,7 @@
 package com.personal.marketnote.commerce.adapter.out.persistence.settlement.repository;
 
 import com.personal.marketnote.commerce.adapter.out.persistence.settlement.entity.SettlementPolicyJpaEntity;
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/shipping/ShippingAddressReadModelPersistenceAdapter.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/shipping/ShippingAddressReadModelPersistenceAdapter.java
@@ -7,7 +7,7 @@ import com.personal.marketnote.commerce.port.out.result.user.ShippingAddressInfo
 import com.personal.marketnote.commerce.port.out.user.FindUserShippingAddressPort;
 import com.personal.marketnote.commerce.port.out.user.SaveShippingAddressReadModelPort;
 import com.personal.marketnote.common.adapter.out.PersistenceAdapter;
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/shipping/ShippingPolicyReadModelPersistenceAdapter.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/shipping/ShippingPolicyReadModelPersistenceAdapter.java
@@ -6,7 +6,7 @@ import com.personal.marketnote.commerce.port.out.result.shipping.ShippingPolicyI
 import com.personal.marketnote.commerce.port.out.shipping.FindShippingPolicyBySellerIdsPort;
 import com.personal.marketnote.commerce.port.out.shipping.SaveShippingPolicyReadModelPort;
 import com.personal.marketnote.common.adapter.out.PersistenceAdapter;
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.common.utility.FormatValidator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/shipping/repository/ShippingAddressReadModelJpaRepository.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/shipping/repository/ShippingAddressReadModelJpaRepository.java
@@ -1,7 +1,7 @@
 package com.personal.marketnote.commerce.adapter.out.persistence.shipping.repository;
 
 import com.personal.marketnote.commerce.adapter.out.persistence.shipping.entity.ShippingAddressReadModelJpaEntity;
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/shipping/repository/ShippingPolicyReadModelJpaRepository.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/shipping/repository/ShippingPolicyReadModelJpaRepository.java
@@ -1,7 +1,7 @@
 package com.personal.marketnote.commerce.adapter.out.persistence.shipping.repository;
 
 import com.personal.marketnote.commerce.adapter.out.persistence.shipping.entity.ShippingPolicyReadModelJpaEntity;
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;

--- a/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/out/persistence/product/ProductReadModelPersistenceAdapterTest.java
+++ b/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/out/persistence/product/ProductReadModelPersistenceAdapterTest.java
@@ -3,7 +3,7 @@ package com.personal.marketnote.commerce.adapter.out.persistence.product;
 import com.personal.marketnote.commerce.adapter.out.persistence.product.entity.ProductReadModelJpaEntity;
 import com.personal.marketnote.commerce.adapter.out.persistence.product.repository.ProductReadModelJpaRepository;
 import com.personal.marketnote.commerce.port.out.result.product.ProductInfoResult;
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.common.configuration.AuditConfig;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;

--- a/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/out/persistence/shipping/ShippingAddressReadModelPersistenceAdapterTest.java
+++ b/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/out/persistence/shipping/ShippingAddressReadModelPersistenceAdapterTest.java
@@ -4,7 +4,7 @@ import com.personal.marketnote.commerce.adapter.out.persistence.shipping.entity.
 import com.personal.marketnote.commerce.adapter.out.persistence.shipping.repository.ShippingAddressReadModelJpaRepository;
 import com.personal.marketnote.commerce.exception.ShippingAddressNotFoundException;
 import com.personal.marketnote.commerce.port.out.result.user.ShippingAddressInfoResult;
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.common.configuration.AuditConfig;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;

--- a/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/out/persistence/shipping/ShippingPolicyReadModelPersistenceAdapterTest.java
+++ b/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/out/persistence/shipping/ShippingPolicyReadModelPersistenceAdapterTest.java
@@ -3,7 +3,7 @@ package com.personal.marketnote.commerce.adapter.out.persistence.shipping;
 import com.personal.marketnote.commerce.adapter.out.persistence.shipping.entity.ShippingPolicyReadModelJpaEntity;
 import com.personal.marketnote.commerce.adapter.out.persistence.shipping.repository.ShippingPolicyReadModelJpaRepository;
 import com.personal.marketnote.commerce.port.out.result.shipping.ShippingPolicyInfoResult;
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.common.configuration.AuditConfig;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/result/settlement/GetSettlementPolicyResult.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/result/settlement/GetSettlementPolicyResult.java
@@ -2,7 +2,7 @@ package com.personal.marketnote.commerce.port.in.result.settlement;
 
 import com.personal.marketnote.commerce.domain.settlement.SettlementCycle;
 import com.personal.marketnote.commerce.domain.settlement.SettlementPolicy;
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import lombok.Builder;
 
 import java.time.LocalDateTime;

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/ledger/GetAccountBalanceUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/ledger/GetAccountBalanceUseCaseTest.java
@@ -8,7 +8,7 @@ import com.personal.marketnote.commerce.port.in.result.ledger.GetAccountBalanceR
 import com.personal.marketnote.commerce.port.out.ledger.FindAccountPort;
 import com.personal.marketnote.commerce.port.out.ledger.FindLedgerEntryPort;
 import com.personal.marketnote.commerce.port.out.ledger.dto.AccountBalanceDto;
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/ledger/RecordLedgerEntryUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/ledger/RecordLedgerEntryUseCaseTest.java
@@ -8,7 +8,7 @@ import com.personal.marketnote.commerce.port.in.command.ledger.RecordLedgerEntry
 import com.personal.marketnote.commerce.port.out.ledger.FindAccountPort;
 import com.personal.marketnote.commerce.port.out.ledger.SaveLedgerEntryPort;
 import com.personal.marketnote.commerce.port.out.ledger.SaveLedgerTransactionPort;
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/quickpayment/ApproveQuickPaymentUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/quickpayment/ApproveQuickPaymentUseCaseTest.java
@@ -16,7 +16,7 @@ import com.personal.marketnote.commerce.port.out.quickpayment.ApproveQuickPaymen
 import com.personal.marketnote.commerce.port.out.quickpayment.FindQuickPaymentCardPort;
 import com.personal.marketnote.commerce.service.payment.PaymentApprovalContext;
 import com.personal.marketnote.commerce.service.payment.PaymentApprovalTransactionHelper;
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/quickpayment/DeleteQuickPaymentCardUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/quickpayment/DeleteQuickPaymentCardUseCaseTest.java
@@ -9,7 +9,7 @@ import com.personal.marketnote.commerce.port.out.quickpayment.DeleteBatchKeyPort
 import com.personal.marketnote.commerce.port.out.quickpayment.DeleteBatchKeyPortResult;
 import com.personal.marketnote.commerce.port.out.quickpayment.DeleteQuickPaymentCardPort;
 import com.personal.marketnote.commerce.port.out.quickpayment.FindQuickPaymentCardPort;
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/quickpayment/IssueBatchKeyUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/quickpayment/IssueBatchKeyUseCaseTest.java
@@ -215,7 +215,7 @@ class IssueBatchKeyUseCaseTest {
                         .cardName("현대카드")
                         .cardBinType01("0")
                         .cardBinType02("0")
-                        .status(com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus.ACTIVE)
+                        .status(com.personal.marketnote.common.domain.EntityStatus.ACTIVE)
                         .build()
         );
         return card;

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/settlement/CancelSettlementUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/settlement/CancelSettlementUseCaseTest.java
@@ -69,7 +69,7 @@ class CancelSettlementUseCaseTest {
                 .id(id)
                 .name(name)
                 .accountType(AccountType.ASSET)
-                .status(com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus.ACTIVE)
+                .status(com.personal.marketnote.common.domain.EntityStatus.ACTIVE)
                 .createdAt(LocalDateTime.now())
                 .modifiedAt(LocalDateTime.now())
                 .build());

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/settlement/DeleteSettlementPolicyUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/settlement/DeleteSettlementPolicyUseCaseTest.java
@@ -6,7 +6,7 @@ import com.personal.marketnote.commerce.domain.settlement.SettlementPolicySnapsh
 import com.personal.marketnote.commerce.exception.SettlementPolicyNotFoundException;
 import com.personal.marketnote.commerce.port.out.settlement.FindSettlementPolicyPort;
 import com.personal.marketnote.commerce.port.out.settlement.UpdateSettlementPolicyPort;
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/settlement/ExecuteSettlementUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/settlement/ExecuteSettlementUseCaseTest.java
@@ -6,7 +6,7 @@ import com.personal.marketnote.commerce.port.in.command.settlement.ExecuteSettle
 import com.personal.marketnote.commerce.port.out.settlement.DefaultSettlementPolicyProvider;
 import com.personal.marketnote.commerce.port.out.settlement.FindPaymentAllocationPort;
 import com.personal.marketnote.commerce.port.out.settlement.FindSettlementPolicyPort;
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/settlement/GetSettlementPolicyUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/settlement/GetSettlementPolicyUseCaseTest.java
@@ -6,7 +6,7 @@ import com.personal.marketnote.commerce.domain.settlement.SettlementPolicySnapsh
 import com.personal.marketnote.commerce.exception.SettlementPolicyNotFoundException;
 import com.personal.marketnote.commerce.port.in.result.settlement.GetSettlementPolicyResult;
 import com.personal.marketnote.commerce.port.out.settlement.FindSettlementPolicyPort;
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/settlement/ReExecuteSettlementUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/settlement/ReExecuteSettlementUseCaseTest.java
@@ -69,7 +69,7 @@ class ReExecuteSettlementUseCaseTest {
                 .id(id)
                 .name(name)
                 .accountType(AccountType.ASSET)
-                .status(com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus.ACTIVE)
+                .status(com.personal.marketnote.common.domain.EntityStatus.ACTIVE)
                 .createdAt(LocalDateTime.now())
                 .modifiedAt(LocalDateTime.now())
                 .build());

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/settlement/RegisterSettlementPolicyUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/settlement/RegisterSettlementPolicyUseCaseTest.java
@@ -8,7 +8,7 @@ import com.personal.marketnote.commerce.port.in.command.settlement.RegisterSettl
 import com.personal.marketnote.commerce.port.in.result.settlement.GetSettlementPolicyResult;
 import com.personal.marketnote.commerce.port.out.settlement.FindSettlementPolicyPort;
 import com.personal.marketnote.commerce.port.out.settlement.SaveSettlementPolicyPort;
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/settlement/UpdateSettlementPolicyUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/settlement/UpdateSettlementPolicyUseCaseTest.java
@@ -8,7 +8,7 @@ import com.personal.marketnote.commerce.port.in.command.settlement.UpdateSettlem
 import com.personal.marketnote.commerce.port.in.result.settlement.GetSettlementPolicyResult;
 import com.personal.marketnote.commerce.port.out.settlement.FindSettlementPolicyPort;
 import com.personal.marketnote.commerce.port.out.settlement.UpdateSettlementPolicyPort;
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/ledger/Account.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/ledger/Account.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.commerce.domain.ledger;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import lombok.*;
 
 import java.time.LocalDateTime;

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/ledger/AccountSnapshotState.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/ledger/AccountSnapshotState.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.commerce.domain.ledger;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import lombok.*;
 
 import java.time.LocalDateTime;

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/quickpayment/QuickPaymentCardSnapshotState.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/quickpayment/QuickPaymentCardSnapshotState.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.commerce.domain.quickpayment;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import lombok.*;
 
 import java.time.LocalDateTime;

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/settlement/SettlementPolicy.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/settlement/SettlementPolicy.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.commerce.domain.settlement;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.common.domain.BaseDomain;
 import com.personal.marketnote.common.utility.FormatValidator;
 import lombok.*;

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/settlement/SettlementPolicySnapshotState.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/settlement/SettlementPolicySnapshotState.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.commerce.domain.settlement;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import lombok.*;
 
 import java.time.LocalDateTime;

--- a/common/src/main/java/com/personal/marketnote/common/adapter/out/persistence/audit/BaseGeneralEntity.java
+++ b/common/src/main/java/com/personal/marketnote/common/adapter/out/persistence/audit/BaseGeneralEntity.java
@@ -1,5 +1,6 @@
 package com.personal.marketnote.common.adapter.out.persistence.audit;
 
+import com.personal.marketnote.common.domain.EntityStatus;
 import jakarta.persistence.*;
 import lombok.Getter;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;

--- a/common/src/main/java/com/personal/marketnote/common/domain/BaseDomain.java
+++ b/common/src/main/java/com/personal/marketnote/common/domain/BaseDomain.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.common.domain;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import lombok.Getter;
 
 @Getter

--- a/common/src/main/java/com/personal/marketnote/common/domain/EntityStatus.java
+++ b/common/src/main/java/com/personal/marketnote/common/domain/EntityStatus.java
@@ -1,0 +1,37 @@
+package com.personal.marketnote.common.domain;
+
+public enum EntityStatus {
+    ACTIVE("활성화"),
+    INACTIVE("비활성화"),
+    UNEXPOSED("비노출");
+
+    private final String description;
+
+    EntityStatus(String description) {
+        this.description = description;
+    }
+
+    public boolean isActive() {
+        return this == ACTIVE;
+    }
+
+    public boolean isInactive() {
+        return this == INACTIVE;
+    }
+
+    public static EntityStatus from(boolean isActive) {
+        if (isActive) {
+            return ACTIVE;
+        }
+
+        return INACTIVE;
+    }
+
+    public static EntityStatus changeVisibility(EntityStatus status) {
+        if (status.isActive()) {
+            return UNEXPOSED;
+        }
+
+        return ACTIVE;
+    }
+}

--- a/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/out/persistence/image/ImageReadModelPersistenceAdapter.java
+++ b/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/out/persistence/image/ImageReadModelPersistenceAdapter.java
@@ -1,7 +1,7 @@
 package com.personal.marketnote.community.adapter.out.persistence.image;
 
 import com.personal.marketnote.common.adapter.out.PersistenceAdapter;
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.common.application.file.port.in.result.GetFileResult;
 import com.personal.marketnote.common.application.file.port.in.result.GetFilesResult;
 import com.personal.marketnote.common.domain.file.FileSort;

--- a/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/out/persistence/image/repository/ImageReadModelJpaRepository.java
+++ b/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/out/persistence/image/repository/ImageReadModelJpaRepository.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.community.adapter.out.persistence.image.repository;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.community.adapter.out.persistence.image.entity.ImageReadModelJpaEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 

--- a/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/out/persistence/like/entity/LikeJpaEntity.java
+++ b/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/out/persistence/like/entity/LikeJpaEntity.java
@@ -1,7 +1,7 @@
 package com.personal.marketnote.community.adapter.out.persistence.like.entity;
 
 import com.personal.marketnote.common.adapter.out.persistence.audit.BaseEntity;
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.community.domain.like.Like;
 import jakarta.persistence.*;
 import lombok.*;

--- a/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/out/persistence/post/PostPersistenceAdapter.java
+++ b/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/out/persistence/post/PostPersistenceAdapter.java
@@ -1,7 +1,7 @@
 package com.personal.marketnote.community.adapter.out.persistence.post;
 
 import com.personal.marketnote.common.adapter.out.PersistenceAdapter;
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.community.adapter.out.mapper.PostJpaEntityToDomainMapper;
 import com.personal.marketnote.community.adapter.out.persistence.post.entity.PostJpaEntity;

--- a/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/out/persistence/post/repository/PostJpaRepository.java
+++ b/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/out/persistence/post/repository/PostJpaRepository.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.community.adapter.out.persistence.post.repository;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.community.adapter.out.persistence.post.entity.PostJpaEntity;
 import com.personal.marketnote.community.domain.post.Board;
 import com.personal.marketnote.community.domain.post.PostTargetGroupType;

--- a/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/out/persistence/product/ProductReadModelPersistenceAdapter.java
+++ b/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/out/persistence/product/ProductReadModelPersistenceAdapter.java
@@ -1,7 +1,7 @@
 package com.personal.marketnote.community.adapter.out.persistence.product;
 
 import com.personal.marketnote.common.adapter.out.PersistenceAdapter;
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.community.adapter.out.persistence.product.entity.ProductReadModelJpaEntity;
 import com.personal.marketnote.community.adapter.out.persistence.product.repository.ProductReadModelJpaRepository;

--- a/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/out/persistence/product/repository/ProductReadModelJpaRepository.java
+++ b/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/out/persistence/product/repository/ProductReadModelJpaRepository.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.community.adapter.out.persistence.product.repository;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.community.adapter.out.persistence.product.entity.ProductReadModelJpaEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 

--- a/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/out/persistence/profanity/ProfanityWordPersistenceAdapter.java
+++ b/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/out/persistence/profanity/ProfanityWordPersistenceAdapter.java
@@ -1,7 +1,7 @@
 package com.personal.marketnote.community.adapter.out.persistence.profanity;
 
 import com.personal.marketnote.common.adapter.out.PersistenceAdapter;
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.community.adapter.out.persistence.profanity.entity.ProfanityWordJpaEntity;
 import com.personal.marketnote.community.adapter.out.persistence.profanity.repository.ProfanityWordJpaRepository;
 import com.personal.marketnote.community.port.out.profanity.FindProfanityWordPort;

--- a/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/out/persistence/profanity/repository/ProfanityWordJpaRepository.java
+++ b/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/out/persistence/profanity/repository/ProfanityWordJpaRepository.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.community.adapter.out.persistence.profanity.repository;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.community.adapter.out.persistence.profanity.entity.ProfanityWordJpaEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 

--- a/community-service/community-adapters/src/test/java/com/personal/marketnote/community/adapter/out/persistence/image/ImageReadModelPersistenceAdapterTest.java
+++ b/community-service/community-adapters/src/test/java/com/personal/marketnote/community/adapter/out/persistence/image/ImageReadModelPersistenceAdapterTest.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.community.adapter.out.persistence.image;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.common.application.file.port.in.result.GetFileResult;
 import com.personal.marketnote.common.application.file.port.in.result.GetFilesResult;
 import com.personal.marketnote.common.configuration.AuditConfig;

--- a/community-service/community-adapters/src/test/java/com/personal/marketnote/community/adapter/out/persistence/product/ProductReadModelPersistenceAdapterTest.java
+++ b/community-service/community-adapters/src/test/java/com/personal/marketnote/community/adapter/out/persistence/product/ProductReadModelPersistenceAdapterTest.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.community.adapter.out.persistence.product;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.common.configuration.AuditConfig;
 import com.personal.marketnote.community.adapter.out.persistence.product.entity.ProductReadModelJpaEntity;
 import com.personal.marketnote.community.adapter.out.persistence.product.repository.ProductReadModelJpaRepository;

--- a/community-service/community-adapters/src/test/java/com/personal/marketnote/community/adapter/out/persistence/review/repository/ReviewLikeCountSortQueryTest.java
+++ b/community-service/community-adapters/src/test/java/com/personal/marketnote/community/adapter/out/persistence/review/repository/ReviewLikeCountSortQueryTest.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.community.adapter.out.persistence.review.repository;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.common.configuration.AuditConfig;
 import com.personal.marketnote.community.adapter.out.persistence.like.entity.LikeJpaEntity;
 import com.personal.marketnote.community.adapter.out.persistence.like.repository.LikeJpaRepository;

--- a/community-service/community-adapters/src/test/java/com/personal/marketnote/community/adapter/out/persistence/review/repository/ReviewRatingSortQueryTest.java
+++ b/community-service/community-adapters/src/test/java/com/personal/marketnote/community/adapter/out/persistence/review/repository/ReviewRatingSortQueryTest.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.community.adapter.out.persistence.review.repository;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.common.configuration.AuditConfig;
 import com.personal.marketnote.community.adapter.out.persistence.review.entity.ReviewJpaEntity;
 import com.personal.marketnote.community.domain.review.Review;

--- a/community-service/community-application/src/test/java/com/personal/marketnote/community/service/like/GetLikeUseCaseTest.java
+++ b/community-service/community-application/src/test/java/com/personal/marketnote/community/service/like/GetLikeUseCaseTest.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.community.service.like;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.community.domain.like.Like;
 import com.personal.marketnote.community.domain.like.LikeSnapshotState;
 import com.personal.marketnote.community.domain.like.LikeTargetType;

--- a/community-service/community-application/src/test/java/com/personal/marketnote/community/service/like/UpsertLikeUseCaseTest.java
+++ b/community-service/community-application/src/test/java/com/personal/marketnote/community/service/like/UpsertLikeUseCaseTest.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.community.service.like;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.community.domain.like.Like;
 import com.personal.marketnote.community.domain.like.LikeSnapshotState;
 import com.personal.marketnote.community.domain.like.LikeTargetType;

--- a/community-service/community-application/src/test/java/com/personal/marketnote/community/service/post/GetPostByIdUseCaseTest.java
+++ b/community-service/community-application/src/test/java/com/personal/marketnote/community/service/post/GetPostByIdUseCaseTest.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.community.service.post;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.community.domain.post.Board;
 import com.personal.marketnote.community.domain.post.Post;
 import com.personal.marketnote.community.domain.post.PostSnapshotState;

--- a/community-service/community-application/src/test/java/com/personal/marketnote/community/service/post/GetPostUseCaseTest.java
+++ b/community-service/community-application/src/test/java/com/personal/marketnote/community/service/post/GetPostUseCaseTest.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.community.service.post;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.common.application.file.port.in.result.GetFileResult;
 import com.personal.marketnote.common.application.file.port.in.result.GetFilesResult;
 import com.personal.marketnote.community.domain.post.Board;

--- a/community-service/community-application/src/test/java/com/personal/marketnote/community/service/post/GetPostsUseCaseTest.java
+++ b/community-service/community-application/src/test/java/com/personal/marketnote/community/service/post/GetPostsUseCaseTest.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.community.service.post;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.common.application.file.port.in.result.GetFileResult;
 import com.personal.marketnote.common.application.file.port.in.result.GetFilesResult;
 import com.personal.marketnote.community.domain.post.*;

--- a/community-service/community-application/src/test/java/com/personal/marketnote/community/service/post/GetUserOneOnOneInquiryPostsUseCaseTest.java
+++ b/community-service/community-application/src/test/java/com/personal/marketnote/community/service/post/GetUserOneOnOneInquiryPostsUseCaseTest.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.community.service.post;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.common.application.file.port.in.result.GetFileResult;
 import com.personal.marketnote.common.application.file.port.in.result.GetFilesResult;
 import com.personal.marketnote.community.domain.post.*;

--- a/community-service/community-application/src/test/java/com/personal/marketnote/community/service/post/GetUserProductInquiryPostsUseCaseTest.java
+++ b/community-service/community-application/src/test/java/com/personal/marketnote/community/service/post/GetUserProductInquiryPostsUseCaseTest.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.community.service.post;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.common.application.file.port.in.result.GetFileResult;
 import com.personal.marketnote.common.application.file.port.in.result.GetFilesResult;
 import com.personal.marketnote.community.domain.post.*;

--- a/community-service/community-application/src/test/java/com/personal/marketnote/community/service/post/RegisterPostUseCaseTest.java
+++ b/community-service/community-application/src/test/java/com/personal/marketnote/community/service/post/RegisterPostUseCaseTest.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.community.service.post;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.common.utility.ValueMasker;
 import com.personal.marketnote.community.domain.post.*;
 import com.personal.marketnote.community.exception.InvalidPostContentContainsProfanityException;

--- a/community-service/community-application/src/test/java/com/personal/marketnote/community/service/post/UpdatePostUseCaseTest.java
+++ b/community-service/community-application/src/test/java/com/personal/marketnote/community/service/post/UpdatePostUseCaseTest.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.community.service.post;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.community.domain.post.Board;
 import com.personal.marketnote.community.domain.post.Post;
 import com.personal.marketnote.community.domain.post.PostSnapshotState;

--- a/community-service/community-application/src/test/java/com/personal/marketnote/community/service/report/UpdateTargetStatusUseCaseTest.java
+++ b/community-service/community-application/src/test/java/com/personal/marketnote/community/service/report/UpdateTargetStatusUseCaseTest.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.community.service.report;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.community.domain.post.Board;
 import com.personal.marketnote.community.domain.post.Post;
 import com.personal.marketnote.community.domain.post.PostSnapshotState;

--- a/community-service/community-application/src/test/java/com/personal/marketnote/community/service/review/DeleteReviewUseCaseTest.java
+++ b/community-service/community-application/src/test/java/com/personal/marketnote/community/service/review/DeleteReviewUseCaseTest.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.community.service.review;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.community.domain.review.ProductReviewAggregate;
 import com.personal.marketnote.community.domain.review.ProductReviewAggregateSnapshotState;
 import com.personal.marketnote.community.domain.review.Review;

--- a/community-service/community-application/src/test/java/com/personal/marketnote/community/service/review/GetMyReviewsUseCaseTest.java
+++ b/community-service/community-application/src/test/java/com/personal/marketnote/community/service/review/GetMyReviewsUseCaseTest.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.community.service.review;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.common.application.file.port.in.result.GetFileResult;
 import com.personal.marketnote.community.domain.review.Review;
 import com.personal.marketnote.community.domain.review.ReviewSnapshotState;

--- a/community-service/community-application/src/test/java/com/personal/marketnote/community/service/review/GetReviewUseCaseTest.java
+++ b/community-service/community-application/src/test/java/com/personal/marketnote/community/service/review/GetReviewUseCaseTest.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.community.service.review;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.common.application.file.port.in.result.GetFileResult;
 import com.personal.marketnote.common.application.file.port.in.result.GetFilesResult;
 import com.personal.marketnote.common.domain.file.FileSort;

--- a/community-service/community-application/src/test/java/com/personal/marketnote/community/service/review/GetUserReviewsUseCaseTest.java
+++ b/community-service/community-application/src/test/java/com/personal/marketnote/community/service/review/GetUserReviewsUseCaseTest.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.community.service.review;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.common.application.file.port.in.result.GetFileResult;
 import com.personal.marketnote.common.application.file.port.in.result.GetFilesResult;
 import com.personal.marketnote.community.domain.review.Review;

--- a/community-service/community-application/src/test/java/com/personal/marketnote/community/service/review/RegisterReviewUseCaseTest.java
+++ b/community-service/community-application/src/test/java/com/personal/marketnote/community/service/review/RegisterReviewUseCaseTest.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.community.service.review;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.common.utility.ValueMasker;
 import com.personal.marketnote.community.domain.review.Review;
 import com.personal.marketnote.community.domain.review.ReviewSnapshotState;

--- a/community-service/community-application/src/test/java/com/personal/marketnote/community/service/review/UpdateReviewUseCaseTest.java
+++ b/community-service/community-application/src/test/java/com/personal/marketnote/community/service/review/UpdateReviewUseCaseTest.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.community.service.review;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.community.domain.review.Review;
 import com.personal.marketnote.community.domain.review.ReviewSnapshotState;
 import com.personal.marketnote.community.exception.InvalidReviewContentContainsProfanityException;

--- a/community-service/community-domain/src/main/java/com/personal/marketnote/community/domain/like/Like.java
+++ b/community-service/community-domain/src/main/java/com/personal/marketnote/community/domain/like/Like.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.community.domain.like;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.common.utility.FormatValidator;
 import lombok.*;
 

--- a/community-service/community-domain/src/main/java/com/personal/marketnote/community/domain/like/LikeSnapshotState.java
+++ b/community-service/community-domain/src/main/java/com/personal/marketnote/community/domain/like/LikeSnapshotState.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.community.domain.like;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/community-service/community-domain/src/main/java/com/personal/marketnote/community/domain/post/Post.java
+++ b/community-service/community-domain/src/main/java/com/personal/marketnote/community/domain/post/Post.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.common.utility.ValueMasker;
 import jakarta.persistence.Column;

--- a/community-service/community-domain/src/main/java/com/personal/marketnote/community/domain/post/PostSnapshotState.java
+++ b/community-service/community-domain/src/main/java/com/personal/marketnote/community/domain/post/PostSnapshotState.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.community.domain.post;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/community-service/community-domain/src/main/java/com/personal/marketnote/community/domain/review/Review.java
+++ b/community-service/community-domain/src/main/java/com/personal/marketnote/community/domain/review/Review.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.common.utility.ValueMasker;
 import jakarta.persistence.Column;

--- a/community-service/community-domain/src/main/java/com/personal/marketnote/community/domain/review/ReviewSnapshotState.java
+++ b/community-service/community-domain/src/main/java/com/personal/marketnote/community/domain/review/ReviewSnapshotState.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.community.domain.review;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/file-service/file-application/src/test/java/com/personal/marketnote/file/service/file/DeleteFileUseCaseTest.java
+++ b/file-service/file-application/src/test/java/com/personal/marketnote/file/service/file/DeleteFileUseCaseTest.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.file.service.file;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.common.domain.file.FileSort;
 import com.personal.marketnote.common.domain.file.OwnerType;
 import com.personal.marketnote.file.domain.file.FileDomain;

--- a/file-service/file-application/src/test/java/com/personal/marketnote/file/service/file/GetFileUseCaseTest.java
+++ b/file-service/file-application/src/test/java/com/personal/marketnote/file/service/file/GetFileUseCaseTest.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.file.service.file;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.common.domain.file.FileSort;
 import com.personal.marketnote.common.domain.file.OwnerType;
 import com.personal.marketnote.file.domain.file.FileDomain;

--- a/file-service/file-application/src/test/java/com/personal/marketnote/file/service/file/GetFilesOwnerTypeUseCaseTest.java
+++ b/file-service/file-application/src/test/java/com/personal/marketnote/file/service/file/GetFilesOwnerTypeUseCaseTest.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.file.service.file;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.common.domain.file.FileSort;
 import com.personal.marketnote.common.domain.file.OwnerType;
 import com.personal.marketnote.file.domain.file.FileDomain;

--- a/file-service/file-application/src/test/java/com/personal/marketnote/file/service/file/GetFilesStringOwnerTypeUseCaseTest.java
+++ b/file-service/file-application/src/test/java/com/personal/marketnote/file/service/file/GetFilesStringOwnerTypeUseCaseTest.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.file.service.file;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.common.domain.file.FileSort;
 import com.personal.marketnote.common.domain.file.OwnerType;
 import com.personal.marketnote.file.domain.file.FileDomain;

--- a/file-service/file-application/src/test/java/com/personal/marketnote/file/service/file/GetResizedFilesUseCaseTest.java
+++ b/file-service/file-application/src/test/java/com/personal/marketnote/file/service/file/GetResizedFilesUseCaseTest.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.file.service.file;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.common.domain.file.FileSort;
 import com.personal.marketnote.common.domain.file.OwnerType;
 import com.personal.marketnote.file.domain.file.FileDomain;

--- a/file-service/file-domain/src/main/java/com/personal/marketnote/file/domain/file/FileDomain.java
+++ b/file-service/file-domain/src/main/java/com/personal/marketnote/file/domain/file/FileDomain.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.file.domain.file;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.common.domain.file.FileSort;
 import com.personal.marketnote.common.domain.file.OwnerType;
 import lombok.AccessLevel;

--- a/file-service/file-domain/src/main/java/com/personal/marketnote/file/domain/file/FileDomainSnapshotState.java
+++ b/file-service/file-domain/src/main/java/com/personal/marketnote/file/domain/file/FileDomainSnapshotState.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.file.domain.file;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.common.domain.file.FileSort;
 import com.personal.marketnote.common.domain.file.OwnerType;
 import lombok.AccessLevel;

--- a/file-service/file-domain/src/main/java/com/personal/marketnote/file/domain/file/ResizedFile.java
+++ b/file-service/file-domain/src/main/java/com/personal/marketnote/file/domain/file/ResizedFile.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.file.domain.file;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import lombok.*;
 
 import java.time.LocalDateTime;

--- a/file-service/file-domain/src/main/java/com/personal/marketnote/file/domain/file/ResizedFileSnapshotState.java
+++ b/file-service/file-domain/src/main/java/com/personal/marketnote/file/domain/file/ResizedFileSnapshotState.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.file.domain.file;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/cart/entity/CartProductJpaEntity.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/cart/entity/CartProductJpaEntity.java
@@ -1,7 +1,7 @@
 package com.personal.marketnote.product.adapter.out.persistence.cart.entity;
 
 import com.personal.marketnote.common.adapter.out.persistence.audit.BaseEntity;
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.product.adapter.out.persistence.pricepolicy.entity.PricePolicyJpaEntity;
 import com.personal.marketnote.product.domain.cart.CartProduct;
 import jakarta.persistence.*;

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/category/CategoryPersistenceAdapter.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/category/CategoryPersistenceAdapter.java
@@ -1,7 +1,7 @@
 package com.personal.marketnote.product.adapter.out.persistence.category;
 
 import com.personal.marketnote.common.adapter.out.PersistenceAdapter;
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.product.adapter.out.mapper.CategoryJpaEntityToDomainMapper;
 import com.personal.marketnote.product.adapter.out.persistence.category.entity.CategoryJpaEntity;
 import com.personal.marketnote.product.adapter.out.persistence.category.repository.CategoryJpaRepository;

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/category/repository/CategoryJpaRepository.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/category/repository/CategoryJpaRepository.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.product.adapter.out.persistence.category.repository;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.product.adapter.out.persistence.category.entity.CategoryJpaEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -13,7 +13,7 @@ public interface CategoryJpaRepository extends JpaRepository<CategoryJpaEntity, 
             SELECT c
             FROM CategoryJpaEntity c
             WHERE 1 = 1
-              AND c.status = com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus.ACTIVE
+              AND c.status = com.personal.marketnote.common.domain.EntityStatus.ACTIVE
               AND (
                     (:parentId IS NULL AND c.parentCategoryId IS NULL)
                     OR (:parentId IS NOT NULL AND c.parentCategoryId = :parentId)

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/image/ImageReadModelPersistenceAdapter.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/image/ImageReadModelPersistenceAdapter.java
@@ -1,7 +1,7 @@
 package com.personal.marketnote.product.adapter.out.persistence.image;
 
 import com.personal.marketnote.common.adapter.out.PersistenceAdapter;
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.common.application.file.port.in.result.GetFileResult;
 import com.personal.marketnote.common.application.file.port.in.result.GetFilesResult;
 import com.personal.marketnote.common.domain.file.FileSort;

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/image/repository/ImageReadModelJpaRepository.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/image/repository/ImageReadModelJpaRepository.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.product.adapter.out.persistence.image.repository;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.product.adapter.out.persistence.image.entity.ImageReadModelJpaEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/inventory/InventoryReadModelPersistenceAdapter.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/inventory/InventoryReadModelPersistenceAdapter.java
@@ -1,7 +1,7 @@
 package com.personal.marketnote.product.adapter.out.persistence.inventory;
 
 import com.personal.marketnote.common.adapter.out.PersistenceAdapter;
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.product.adapter.out.persistence.inventory.entity.InventoryReadModelJpaEntity;
 import com.personal.marketnote.product.adapter.out.persistence.inventory.repository.InventoryReadModelJpaRepository;
 import com.personal.marketnote.product.port.out.inventory.FindStockPort;

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/inventory/repository/InventoryReadModelJpaRepository.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/inventory/repository/InventoryReadModelJpaRepository.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.product.adapter.out.persistence.inventory.repository;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.product.adapter.out.persistence.inventory.entity.InventoryReadModelJpaEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/pricepolicy/repository/PricePolicyJpaRepository.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/pricepolicy/repository/PricePolicyJpaRepository.java
@@ -50,8 +50,8 @@ public interface PricePolicyJpaRepository extends JpaRepository<PricePolicyJpaEn
             FROM PricePolicyJpaEntity pp
               JOIN pp.productJpaEntity p
             WHERE 1 = 1
-              AND p.status = com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus.ACTIVE
-              AND pp.status = com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus.ACTIVE
+              AND p.status = com.personal.marketnote.common.domain.EntityStatus.ACTIVE
+              AND pp.status = com.personal.marketnote.common.domain.EntityStatus.ACTIVE
               AND (
                     :pattern = ''
                  OR (:searchTarget = 'name' AND p.name LIKE :pattern)
@@ -127,8 +127,8 @@ public interface PricePolicyJpaRepository extends JpaRepository<PricePolicyJpaEn
             FROM PricePolicyJpaEntity pp
               JOIN pp.productJpaEntity p
             WHERE 1 = 1
-              AND p.status = com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus.ACTIVE
-              AND pp.status = com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus.ACTIVE
+              AND p.status = com.personal.marketnote.common.domain.EntityStatus.ACTIVE
+              AND pp.status = com.personal.marketnote.common.domain.EntityStatus.ACTIVE
               AND (
                     :pattern = ''
                  OR (:searchTarget = 'name' AND p.name LIKE :pattern)
@@ -244,8 +244,8 @@ public interface PricePolicyJpaRepository extends JpaRepository<PricePolicyJpaEn
             FROM PricePolicyJpaEntity pp
               JOIN pp.productJpaEntity p
             WHERE 1 = 1
-              AND p.status = com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus.ACTIVE
-              AND pp.status = com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus.ACTIVE
+              AND p.status = com.personal.marketnote.common.domain.EntityStatus.ACTIVE
+              AND pp.status = com.personal.marketnote.common.domain.EntityStatus.ACTIVE
               AND (
                     :pattern = ''
                  OR (:searchTarget = 'name' AND p.name LIKE :pattern)
@@ -289,8 +289,8 @@ public interface PricePolicyJpaRepository extends JpaRepository<PricePolicyJpaEn
             FROM PricePolicyJpaEntity pp
               JOIN pp.productJpaEntity p
             WHERE 1 = 1
-              AND p.status = com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus.ACTIVE
-              AND pp.status = com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus.ACTIVE
+              AND p.status = com.personal.marketnote.common.domain.EntityStatus.ACTIVE
+              AND pp.status = com.personal.marketnote.common.domain.EntityStatus.ACTIVE
               AND (
                     :pattern = ''
                  OR (:searchTarget = 'name' AND p.name LIKE :pattern)
@@ -334,8 +334,8 @@ public interface PricePolicyJpaRepository extends JpaRepository<PricePolicyJpaEn
             FROM PricePolicyJpaEntity pp
               JOIN pp.productJpaEntity p
             WHERE 1 = 1
-              AND p.status = com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus.ACTIVE
-              AND pp.status = com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus.ACTIVE
+              AND p.status = com.personal.marketnote.common.domain.EntityStatus.ACTIVE
+              AND pp.status = com.personal.marketnote.common.domain.EntityStatus.ACTIVE
               AND EXISTS (
                 SELECT 1
                 FROM ProductCategoryJpaEntity pc
@@ -361,8 +361,8 @@ public interface PricePolicyJpaRepository extends JpaRepository<PricePolicyJpaEn
             FROM PricePolicyJpaEntity pp
               JOIN pp.productJpaEntity p
             WHERE 1 = 1
-              AND p.status = com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus.ACTIVE
-              AND pp.status = com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus.ACTIVE
+              AND p.status = com.personal.marketnote.common.domain.EntityStatus.ACTIVE
+              AND pp.status = com.personal.marketnote.common.domain.EntityStatus.ACTIVE
               AND (
                     :pattern = ''
                  OR (:searchTarget = 'name' AND p.name LIKE :pattern)
@@ -386,7 +386,7 @@ public interface PricePolicyJpaRepository extends JpaRepository<PricePolicyJpaEn
 
     @Query("""
             UPDATE PricePolicyJpaEntity pp
-            SET pp.status = com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus.INACTIVE
+            SET pp.status = com.personal.marketnote.common.domain.EntityStatus.INACTIVE
             WHERE pp.productJpaEntity.id = :productId
             """)
     @Modifying(clearAutomatically = true, flushAutomatically = true)

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/product/repository/ProductJpaRepository.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/product/repository/ProductJpaRepository.java
@@ -29,7 +29,7 @@ public interface ProductJpaRepository extends JpaRepository<ProductJpaEntity, Lo
             SELECT p
             FROM ProductJpaEntity p
             WHERE 1 = 1
-              AND p.status = com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus.ACTIVE
+              AND p.status = com.personal.marketnote.common.domain.EntityStatus.ACTIVE
               AND EXISTS (
                 SELECT 1
                 FROM PricePolicyJpaEntity pp

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/productoption/repository/ProductOptionCategoryJpaRepository.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/productoption/repository/ProductOptionCategoryJpaRepository.java
@@ -15,8 +15,8 @@ public interface ProductOptionCategoryJpaRepository extends JpaRepository<Produc
               LEFT JOIN FETCH c.productOptionJpaEntities o
             WHERE 1 = 1
               AND p.id = :productId
-              AND c.status = com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus.ACTIVE
-              AND (o IS NULL OR o.status = com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus.ACTIVE)
+              AND c.status = com.personal.marketnote.common.domain.EntityStatus.ACTIVE
+              AND (o IS NULL OR o.status = com.personal.marketnote.common.domain.EntityStatus.ACTIVE)
             ORDER BY c.orderNum ASC, o.orderNum ASC
             """)
     List<ProductOptionCategoryJpaEntity> findActiveWithOptionsByProductId(

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/review/ReviewAggregateReadModelPersistenceAdapter.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/review/ReviewAggregateReadModelPersistenceAdapter.java
@@ -1,7 +1,7 @@
 package com.personal.marketnote.product.adapter.out.persistence.review;
 
 import com.personal.marketnote.common.adapter.out.PersistenceAdapter;
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.product.adapter.out.persistence.review.entity.ReviewAggregateReadModelJpaEntity;
 import com.personal.marketnote.product.adapter.out.persistence.review.repository.ReviewAggregateReadModelJpaRepository;

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/review/repository/ReviewAggregateReadModelJpaRepository.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/review/repository/ReviewAggregateReadModelJpaRepository.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.product.adapter.out.persistence.review.repository;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.product.adapter.out.persistence.review.entity.ReviewAggregateReadModelJpaEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/shipping/ShippingPolicyPersistenceAdapter.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/shipping/ShippingPolicyPersistenceAdapter.java
@@ -1,7 +1,7 @@
 package com.personal.marketnote.product.adapter.out.persistence.shipping;
 
 import com.personal.marketnote.common.adapter.out.PersistenceAdapter;
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.product.adapter.out.mapper.ShippingPolicyJpaEntityToDomainMapper;
 import com.personal.marketnote.product.adapter.out.persistence.shipping.entity.ShippingPolicyJpaEntity;
 import com.personal.marketnote.product.adapter.out.persistence.shipping.repository.ShippingPolicyJpaRepository;

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/shipping/repository/ShippingPolicyJpaRepository.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/shipping/repository/ShippingPolicyJpaRepository.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.product.adapter.out.persistence.shipping.repository;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.product.adapter.out.persistence.shipping.entity.ShippingPolicyJpaEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 

--- a/product-service/product-adapters/src/test/java/com/personal/marketnote/product/adapter/out/persistence/image/ImageReadModelPersistenceAdapterTest.java
+++ b/product-service/product-adapters/src/test/java/com/personal/marketnote/product/adapter/out/persistence/image/ImageReadModelPersistenceAdapterTest.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.product.adapter.out.persistence.image;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.common.application.file.port.in.result.GetFileResult;
 import com.personal.marketnote.common.application.file.port.in.result.GetFilesResult;
 import com.personal.marketnote.common.configuration.AuditConfig;

--- a/product-service/product-adapters/src/test/java/com/personal/marketnote/product/adapter/out/persistence/inventory/InventoryReadModelPersistenceAdapterTest.java
+++ b/product-service/product-adapters/src/test/java/com/personal/marketnote/product/adapter/out/persistence/inventory/InventoryReadModelPersistenceAdapterTest.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.product.adapter.out.persistence.inventory;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.common.configuration.AuditConfig;
 import com.personal.marketnote.product.adapter.out.persistence.inventory.entity.InventoryReadModelJpaEntity;
 import com.personal.marketnote.product.adapter.out.persistence.inventory.repository.InventoryReadModelJpaRepository;

--- a/product-service/product-adapters/src/test/java/com/personal/marketnote/product/adapter/out/persistence/pricepolicy/repository/PricePolicySearchQueryTest.java
+++ b/product-service/product-adapters/src/test/java/com/personal/marketnote/product/adapter/out/persistence/pricepolicy/repository/PricePolicySearchQueryTest.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.product.adapter.out.persistence.pricepolicy.repository;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.common.configuration.AuditConfig;
 import com.personal.marketnote.product.adapter.out.persistence.pricepolicy.entity.PricePolicyJpaEntity;
 import com.personal.marketnote.product.adapter.out.persistence.product.entity.ProductJpaEntity;

--- a/product-service/product-adapters/src/test/java/com/personal/marketnote/product/adapter/out/persistence/productoption/ProductOptionPersistenceAdapterTest.java
+++ b/product-service/product-adapters/src/test/java/com/personal/marketnote/product/adapter/out/persistence/productoption/ProductOptionPersistenceAdapterTest.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.product.adapter.out.persistence.productoption;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.product.adapter.out.persistence.pricepolicy.entity.PricePolicyJpaEntity;
 import com.personal.marketnote.product.adapter.out.persistence.pricepolicy.repository.PricePolicyJpaRepository;
 import com.personal.marketnote.product.adapter.out.persistence.product.entity.ProductJpaEntity;

--- a/product-service/product-adapters/src/test/java/com/personal/marketnote/product/adapter/out/persistence/review/ReviewAggregateReadModelPersistenceAdapterTest.java
+++ b/product-service/product-adapters/src/test/java/com/personal/marketnote/product/adapter/out/persistence/review/ReviewAggregateReadModelPersistenceAdapterTest.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.product.adapter.out.persistence.review;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.common.configuration.AuditConfig;
 import com.personal.marketnote.product.adapter.out.persistence.review.entity.ReviewAggregateReadModelJpaEntity;
 import com.personal.marketnote.product.adapter.out.persistence.review.repository.ReviewAggregateReadModelJpaRepository;

--- a/product-service/product-adapters/src/test/java/com/personal/marketnote/product/configuration/CacheConfigObjectMapperTest.java
+++ b/product-service/product-adapters/src/test/java/com/personal/marketnote/product/configuration/CacheConfigObjectMapperTest.java
@@ -10,7 +10,7 @@ import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
 import com.fasterxml.jackson.datatype.hibernate5.jakarta.Hibernate5JakartaModule;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.product.domain.pricepolicy.PricePolicy;
 import com.personal.marketnote.product.domain.pricepolicy.PricePolicySnapshotState;
 import com.personal.marketnote.product.domain.product.Product;

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/mapper/ProductCommandToStateMapper.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/mapper/ProductCommandToStateMapper.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.product.mapper;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.product.domain.option.ProductOptionCategoryCreateState;
 import com.personal.marketnote.product.domain.option.ProductOptionCreateState;
 import com.personal.marketnote.product.domain.pricepolicy.PricePolicyCreateState;

--- a/product-service/product-application/src/test/java/com/personal/marketnote/product/port/in/result/product/ProductItemResultTest.java
+++ b/product-service/product-application/src/test/java/com/personal/marketnote/product/port/in/result/product/ProductItemResultTest.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.product.port.in.result.product;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.product.domain.pricepolicy.PricePolicy;
 import com.personal.marketnote.product.domain.pricepolicy.PricePolicySnapshotState;
 import com.personal.marketnote.product.domain.product.Product;

--- a/product-service/product-application/src/test/java/com/personal/marketnote/product/service/cart/AddCartProductUseCaseTest.java
+++ b/product-service/product-application/src/test/java/com/personal/marketnote/product/service/cart/AddCartProductUseCaseTest.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.product.service.cart;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.product.domain.cart.CartProduct;
 import com.personal.marketnote.product.domain.cart.CartProductSnapshotState;
 import com.personal.marketnote.product.domain.cart.InvalidCartProductQuantityException;

--- a/product-service/product-application/src/test/java/com/personal/marketnote/product/service/cart/GetCartProductUseCaseTest.java
+++ b/product-service/product-application/src/test/java/com/personal/marketnote/product/service/cart/GetCartProductUseCaseTest.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.product.service.cart;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.product.domain.cart.CartProduct;
 import com.personal.marketnote.product.domain.cart.CartProductSnapshotState;
 import com.personal.marketnote.product.domain.pricepolicy.PricePolicy;

--- a/product-service/product-application/src/test/java/com/personal/marketnote/product/service/cart/UpdateCartProductOptionsUseCaseTest.java
+++ b/product-service/product-application/src/test/java/com/personal/marketnote/product/service/cart/UpdateCartProductOptionsUseCaseTest.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.product.service.cart;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.product.domain.cart.CartProduct;
 import com.personal.marketnote.product.domain.cart.CartProductSnapshotState;
 import com.personal.marketnote.product.domain.pricepolicy.PricePolicy;

--- a/product-service/product-application/src/test/java/com/personal/marketnote/product/service/cart/UpdateCartProductQuantityUseCaseTest.java
+++ b/product-service/product-application/src/test/java/com/personal/marketnote/product/service/cart/UpdateCartProductQuantityUseCaseTest.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.product.service.cart;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.product.domain.cart.CartProduct;
 import com.personal.marketnote.product.domain.cart.CartProductSnapshotState;
 import com.personal.marketnote.product.domain.pricepolicy.PricePolicy;

--- a/product-service/product-application/src/test/java/com/personal/marketnote/product/service/category/DeleteCategoryUseCaseTest.java
+++ b/product-service/product-application/src/test/java/com/personal/marketnote/product/service/category/DeleteCategoryUseCaseTest.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.product.service.category;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.product.domain.category.Category;
 import com.personal.marketnote.product.domain.category.CategorySnapshotState;
 import com.personal.marketnote.product.exception.CategoryHasChildrenException;

--- a/product-service/product-application/src/test/java/com/personal/marketnote/product/service/category/GetCategoriesByParentIdUseCaseTest.java
+++ b/product-service/product-application/src/test/java/com/personal/marketnote/product/service/category/GetCategoriesByParentIdUseCaseTest.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.product.service.category;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.product.domain.category.Category;
 import com.personal.marketnote.product.domain.category.CategorySnapshotState;
 import com.personal.marketnote.product.port.in.result.category.CategoryItemResult;

--- a/product-service/product-application/src/test/java/com/personal/marketnote/product/service/category/GetCategoryUseCaseTest.java
+++ b/product-service/product-application/src/test/java/com/personal/marketnote/product/service/category/GetCategoryUseCaseTest.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.product.service.category;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.product.domain.category.Category;
 import com.personal.marketnote.product.domain.category.CategorySnapshotState;
 import com.personal.marketnote.product.exception.CategoryNotFoundException;

--- a/product-service/product-application/src/test/java/com/personal/marketnote/product/service/category/RegisterCategoryUseCaseTest.java
+++ b/product-service/product-application/src/test/java/com/personal/marketnote/product/service/category/RegisterCategoryUseCaseTest.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.product.service.category;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.product.domain.category.Category;
 import com.personal.marketnote.product.domain.category.CategorySnapshotState;
 import com.personal.marketnote.product.exception.CategoryNotFoundException;

--- a/product-service/product-application/src/test/java/com/personal/marketnote/product/service/category/RegisterProductCategoriesUseCaseTest.java
+++ b/product-service/product-application/src/test/java/com/personal/marketnote/product/service/category/RegisterProductCategoriesUseCaseTest.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.product.service.category;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.product.domain.category.Category;
 import com.personal.marketnote.product.domain.category.CategorySnapshotState;
 import com.personal.marketnote.product.domain.product.Product;

--- a/product-service/product-application/src/test/java/com/personal/marketnote/product/service/option/GetProductOptionsUseCaseTest.java
+++ b/product-service/product-application/src/test/java/com/personal/marketnote/product/service/option/GetProductOptionsUseCaseTest.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.product.service.option;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.product.domain.option.ProductOption;
 import com.personal.marketnote.product.domain.option.ProductOptionCategory;
 import com.personal.marketnote.product.domain.option.ProductOptionCategorySnapshotState;

--- a/product-service/product-application/src/test/java/com/personal/marketnote/product/service/option/RegisterProductOptionsUseCaseTest.java
+++ b/product-service/product-application/src/test/java/com/personal/marketnote/product/service/option/RegisterProductOptionsUseCaseTest.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.product.service.option;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.product.domain.option.ProductOption;
 import com.personal.marketnote.product.domain.option.ProductOptionCategory;
 import com.personal.marketnote.product.domain.option.ProductOptionCategorySnapshotState;

--- a/product-service/product-application/src/test/java/com/personal/marketnote/product/service/option/UpdateProductOptionsUseCaseTest.java
+++ b/product-service/product-application/src/test/java/com/personal/marketnote/product/service/option/UpdateProductOptionsUseCaseTest.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.product.service.option;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.product.domain.option.ProductOption;
 import com.personal.marketnote.product.domain.option.ProductOptionCategory;
 import com.personal.marketnote.product.domain.option.ProductOptionCategorySnapshotState;

--- a/product-service/product-application/src/test/java/com/personal/marketnote/product/service/pricepolicy/GetPricePoliciesUseCaseTest.java
+++ b/product-service/product-application/src/test/java/com/personal/marketnote/product/service/pricepolicy/GetPricePoliciesUseCaseTest.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.product.service.pricepolicy;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.product.domain.pricepolicy.PricePolicy;
 import com.personal.marketnote.product.domain.pricepolicy.PricePolicySnapshotState;
 import com.personal.marketnote.product.port.in.result.pricepolicy.GetPricePoliciesResult;

--- a/product-service/product-application/src/test/java/com/personal/marketnote/product/service/pricepolicy/GetPricePolicyUseCaseTest.java
+++ b/product-service/product-application/src/test/java/com/personal/marketnote/product/service/pricepolicy/GetPricePolicyUseCaseTest.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.product.service.pricepolicy;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.product.domain.pricepolicy.PricePolicy;
 import com.personal.marketnote.product.domain.pricepolicy.PricePolicySnapshotState;
 import com.personal.marketnote.product.exception.PricePolicyNotFoundException;

--- a/product-service/product-application/src/test/java/com/personal/marketnote/product/service/pricepolicy/RegisterPricePolicyUseCaseTest.java
+++ b/product-service/product-application/src/test/java/com/personal/marketnote/product/service/pricepolicy/RegisterPricePolicyUseCaseTest.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.product.service.pricepolicy;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.product.domain.pricepolicy.PricePolicy;
 import com.personal.marketnote.product.domain.product.Product;
 import com.personal.marketnote.product.domain.product.ProductSnapshotState;

--- a/product-service/product-application/src/test/java/com/personal/marketnote/product/service/product/DeleteProductUseCaseTest.java
+++ b/product-service/product-application/src/test/java/com/personal/marketnote/product/service/product/DeleteProductUseCaseTest.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.product.service.product;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.product.domain.product.Product;
 import com.personal.marketnote.product.domain.product.ProductSnapshotState;
 import com.personal.marketnote.product.exception.NotProductOwnerException;

--- a/product-service/product-application/src/test/java/com/personal/marketnote/product/service/product/GetAdminProductsUseCaseTest.java
+++ b/product-service/product-application/src/test/java/com/personal/marketnote/product/service/product/GetAdminProductsUseCaseTest.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.product.service.product;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.product.domain.pricepolicy.PricePolicy;
 import com.personal.marketnote.product.domain.pricepolicy.PricePolicySnapshotState;
 import com.personal.marketnote.product.domain.product.Product;

--- a/product-service/product-application/src/test/java/com/personal/marketnote/product/service/product/GetMyOrderingProductsUseCaseTest.java
+++ b/product-service/product-application/src/test/java/com/personal/marketnote/product/service/product/GetMyOrderingProductsUseCaseTest.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.product.service.product;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.product.domain.pricepolicy.PricePolicy;
 import com.personal.marketnote.product.domain.pricepolicy.PricePolicySnapshotState;
 import com.personal.marketnote.product.domain.product.Product;

--- a/product-service/product-application/src/test/java/com/personal/marketnote/product/service/product/GetProductUseCaseTest.java
+++ b/product-service/product-application/src/test/java/com/personal/marketnote/product/service/product/GetProductUseCaseTest.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.product.service.product;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.common.application.file.port.in.result.GetFileResult;
 import com.personal.marketnote.common.application.file.port.in.result.GetFilesResult;
 import com.personal.marketnote.common.domain.file.FileSort;

--- a/product-service/product-application/src/test/java/com/personal/marketnote/product/service/product/RegisterProductUseCaseTest.java
+++ b/product-service/product-application/src/test/java/com/personal/marketnote/product/service/product/RegisterProductUseCaseTest.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.product.service.product;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.product.domain.product.Product;
 import com.personal.marketnote.product.domain.product.ProductSnapshotState;
 import com.personal.marketnote.product.domain.product.ProductTag;

--- a/product-service/product-application/src/test/java/com/personal/marketnote/product/service/product/ReorderProductTagsUseCaseTest.java
+++ b/product-service/product-application/src/test/java/com/personal/marketnote/product/service/product/ReorderProductTagsUseCaseTest.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.product.service.product;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.product.domain.product.Product;
 import com.personal.marketnote.product.domain.product.ProductSnapshotState;
 import com.personal.marketnote.product.domain.product.ProductTag;

--- a/product-service/product-application/src/test/java/com/personal/marketnote/product/service/product/UpdateProductUseCaseTest.java
+++ b/product-service/product-application/src/test/java/com/personal/marketnote/product/service/product/UpdateProductUseCaseTest.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.product.service.product;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.common.kafka.event.ProductUpdatedEvent;
 import com.personal.marketnote.product.domain.product.Product;
 import com.personal.marketnote.product.domain.product.ProductSnapshotState;

--- a/product-service/product-application/src/test/java/com/personal/marketnote/product/service/shipping/GetShippingPolicyUseCaseTest.java
+++ b/product-service/product-application/src/test/java/com/personal/marketnote/product/service/shipping/GetShippingPolicyUseCaseTest.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.product.service.shipping;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.product.domain.shipping.ShippingPolicy;
 import com.personal.marketnote.product.domain.shipping.ShippingPolicySnapshotState;
 import com.personal.marketnote.product.exception.ShippingPolicyNotFoundException;

--- a/product-service/product-application/src/test/java/com/personal/marketnote/product/service/shipping/RegisterShippingPolicyUseCaseTest.java
+++ b/product-service/product-application/src/test/java/com/personal/marketnote/product/service/shipping/RegisterShippingPolicyUseCaseTest.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.product.service.shipping;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.common.kafka.event.ShippingPolicyChangeAction;
 import com.personal.marketnote.product.domain.shipping.InvalidFreeShippingThresholdException;
 import com.personal.marketnote.product.domain.shipping.InvalidShippingFeeException;

--- a/product-service/product-application/src/test/java/com/personal/marketnote/product/service/shipping/UpdateShippingPolicyUseCaseTest.java
+++ b/product-service/product-application/src/test/java/com/personal/marketnote/product/service/shipping/UpdateShippingPolicyUseCaseTest.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.product.service.shipping;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.common.kafka.event.ShippingPolicyChangeAction;
 import com.personal.marketnote.product.domain.shipping.InvalidFreeShippingThresholdException;
 import com.personal.marketnote.product.domain.shipping.InvalidShippingFeeException;

--- a/product-service/product-domain/src/main/java/com/personal/marketnote/product/domain/cart/CartProductSnapshotState.java
+++ b/product-service/product-domain/src/main/java/com/personal/marketnote/product/domain/cart/CartProductSnapshotState.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.product.domain.cart;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.product.domain.pricepolicy.PricePolicy;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;

--- a/product-service/product-domain/src/main/java/com/personal/marketnote/product/domain/category/CategorySnapshotState.java
+++ b/product-service/product-domain/src/main/java/com/personal/marketnote/product/domain/category/CategorySnapshotState.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.product.domain.category;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/product-service/product-domain/src/main/java/com/personal/marketnote/product/domain/option/ProductOption.java
+++ b/product-service/product-domain/src/main/java/com/personal/marketnote/product/domain/option/ProductOption.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.product.domain.option;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/product-service/product-domain/src/main/java/com/personal/marketnote/product/domain/option/ProductOptionCategory.java
+++ b/product-service/product-domain/src/main/java/com/personal/marketnote/product/domain/option/ProductOptionCategory.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.product.domain.option;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.product.domain.product.Product;
 import lombok.AccessLevel;

--- a/product-service/product-domain/src/main/java/com/personal/marketnote/product/domain/option/ProductOptionCategorySnapshotState.java
+++ b/product-service/product-domain/src/main/java/com/personal/marketnote/product/domain/option/ProductOptionCategorySnapshotState.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.product.domain.option;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.product.domain.product.Product;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;

--- a/product-service/product-domain/src/main/java/com/personal/marketnote/product/domain/option/ProductOptionSnapshotState.java
+++ b/product-service/product-domain/src/main/java/com/personal/marketnote/product/domain/option/ProductOptionSnapshotState.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.product.domain.option;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/product-service/product-domain/src/main/java/com/personal/marketnote/product/domain/pricepolicy/PricePolicy.java
+++ b/product-service/product-domain/src/main/java/com/personal/marketnote/product/domain/pricepolicy/PricePolicy.java
@@ -3,7 +3,7 @@ package com.personal.marketnote.product.domain.pricepolicy;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.common.domain.BaseDomain;
 import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.product.domain.option.ProductOption;

--- a/product-service/product-domain/src/main/java/com/personal/marketnote/product/domain/pricepolicy/PricePolicyCreateState.java
+++ b/product-service/product-domain/src/main/java/com/personal/marketnote/product/domain/pricepolicy/PricePolicyCreateState.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.product.domain.pricepolicy;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.product.domain.product.Product;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;

--- a/product-service/product-domain/src/main/java/com/personal/marketnote/product/domain/pricepolicy/PricePolicySnapshotState.java
+++ b/product-service/product-domain/src/main/java/com/personal/marketnote/product/domain/pricepolicy/PricePolicySnapshotState.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.product.domain.pricepolicy;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.product.domain.option.ProductOption;
 import com.personal.marketnote.product.domain.product.Product;
 import lombok.AccessLevel;

--- a/product-service/product-domain/src/main/java/com/personal/marketnote/product/domain/product/Product.java
+++ b/product-service/product-domain/src/main/java/com/personal/marketnote/product/domain/product/Product.java
@@ -2,7 +2,7 @@ package com.personal.marketnote.product.domain.product;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.common.domain.BaseDomain;
 import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.product.domain.pricepolicy.PricePolicy;

--- a/product-service/product-domain/src/main/java/com/personal/marketnote/product/domain/product/ProductSnapshotState.java
+++ b/product-service/product-domain/src/main/java/com/personal/marketnote/product/domain/product/ProductSnapshotState.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.product.domain.product;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.product.domain.pricepolicy.PricePolicy;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;

--- a/product-service/product-domain/src/main/java/com/personal/marketnote/product/domain/product/ProductTag.java
+++ b/product-service/product-domain/src/main/java/com/personal/marketnote/product/domain/product/ProductTag.java
@@ -2,7 +2,7 @@ package com.personal.marketnote.product.domain.product;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import lombok.*;
 
 @AllArgsConstructor(access = AccessLevel.PRIVATE)

--- a/product-service/product-domain/src/main/java/com/personal/marketnote/product/domain/product/ProductTagSnapshotState.java
+++ b/product-service/product-domain/src/main/java/com/personal/marketnote/product/domain/product/ProductTagSnapshotState.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.product.domain.product;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/product-service/product-domain/src/main/java/com/personal/marketnote/product/domain/shipping/ShippingPolicySnapshotState.java
+++ b/product-service/product-domain/src/main/java/com/personal/marketnote/product/domain/shipping/ShippingPolicySnapshotState.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.product.domain.shipping;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import lombok.*;
 
 import java.time.LocalDateTime;

--- a/product-service/product-domain/src/test/java/com/personal/marketnote/product/domain/shipping/ShippingPolicyTest.java
+++ b/product-service/product-domain/src/test/java/com/personal/marketnote/product/domain/shipping/ShippingPolicyTest.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.product.domain.shipping;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/attendance/response/AttendancePolicyResponse.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/attendance/response/AttendancePolicyResponse.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.reward.adapter.in.web.attendance.response;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.reward.domain.attendance.AttendancePolicy;
 import com.personal.marketnote.reward.domain.attendance.AttendanceRewardType;
 import lombok.Builder;

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/attendance/entity/AttendancePolicyJpaEntity.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/attendance/entity/AttendancePolicyJpaEntity.java
@@ -1,7 +1,7 @@
 package com.personal.marketnote.reward.adapter.out.persistence.attendance.entity;
 
 import com.personal.marketnote.common.adapter.out.persistence.audit.BaseEntity;
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.reward.domain.attendance.AttendancePolicy;
 import com.personal.marketnote.reward.domain.attendance.AttendancePolicySnapshotState;
 import com.personal.marketnote.reward.domain.attendance.AttendanceRewardType;

--- a/reward-service/reward-application/src/test/java/com/personal/marketnote/reward/service/attendance/DeleteAttendancePolicyUseCaseTest.java
+++ b/reward-service/reward-application/src/test/java/com/personal/marketnote/reward/service/attendance/DeleteAttendancePolicyUseCaseTest.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.reward.service.attendance;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.reward.domain.attendance.AttendancePolicy;
 import com.personal.marketnote.reward.domain.attendance.AttendancePolicySnapshotState;
 import com.personal.marketnote.reward.domain.attendance.AttendanceRewardType;

--- a/reward-service/reward-application/src/test/java/com/personal/marketnote/reward/service/attendance/GetAttendancePoliciesUseCaseTest.java
+++ b/reward-service/reward-application/src/test/java/com/personal/marketnote/reward/service/attendance/GetAttendancePoliciesUseCaseTest.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.reward.service.attendance;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.reward.domain.attendance.AttendancePolicy;
 import com.personal.marketnote.reward.domain.attendance.AttendancePolicySnapshotState;
 import com.personal.marketnote.reward.domain.attendance.AttendanceRewardType;

--- a/reward-service/reward-application/src/test/java/com/personal/marketnote/reward/service/attendance/RegisterAttendanceUseCaseTest.java
+++ b/reward-service/reward-application/src/test/java/com/personal/marketnote/reward/service/attendance/RegisterAttendanceUseCaseTest.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.reward.service.attendance;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.common.domain.calendar.Month;
 import com.personal.marketnote.common.domain.calendar.Year;
 import com.personal.marketnote.reward.domain.attendance.*;

--- a/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/attendance/AttendancePolicy.java
+++ b/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/attendance/AttendancePolicy.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.reward.domain.attendance;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import lombok.*;
 
 import java.time.LocalDate;

--- a/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/attendance/AttendancePolicySnapshotState.java
+++ b/reward-service/reward-domain/src/main/java/com/personal/marketnote/reward/domain/attendance/AttendancePolicySnapshotState.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.reward.domain.attendance;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import lombok.Builder;
 import lombok.Getter;
 

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/out/persistence/profanity/ProfanityWordPersistenceAdapter.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/out/persistence/profanity/ProfanityWordPersistenceAdapter.java
@@ -1,7 +1,7 @@
 package com.personal.marketnote.user.adapter.out.persistence.profanity;
 
 import com.personal.marketnote.common.adapter.out.PersistenceAdapter;
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.user.adapter.out.persistence.profanity.entity.ProfanityWordJpaEntity;
 import com.personal.marketnote.user.adapter.out.persistence.profanity.repository.ProfanityWordJpaRepository;
 import com.personal.marketnote.user.port.out.profanity.FindProfanityWordPort;

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/out/persistence/profanity/repository/ProfanityWordJpaRepository.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/out/persistence/profanity/repository/ProfanityWordJpaRepository.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.user.adapter.out.persistence.profanity.repository;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.user.adapter.out.persistence.profanity.entity.ProfanityWordJpaEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/out/persistence/shippingaddress/ShippingAddressPersistenceAdapter.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/out/persistence/shippingaddress/ShippingAddressPersistenceAdapter.java
@@ -1,7 +1,7 @@
 package com.personal.marketnote.user.adapter.out.persistence.shippingaddress;
 
 import com.personal.marketnote.common.adapter.out.PersistenceAdapter;
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.user.adapter.out.mapper.ShippingAddressJpaEntityToDomainMapper;
 import com.personal.marketnote.user.adapter.out.persistence.shippingaddress.entity.ShippingAddressJpaEntity;
 import com.personal.marketnote.user.adapter.out.persistence.shippingaddress.repository.ShippingAddressJpaRepository;

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/out/persistence/shippingaddress/repository/ShippingAddressJpaRepository.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/out/persistence/shippingaddress/repository/ShippingAddressJpaRepository.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.user.adapter.out.persistence.shippingaddress.repository;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.user.adapter.out.persistence.shippingaddress.entity.ShippingAddressJpaEntity;
 import com.personal.marketnote.user.domain.shippingaddress.ShippingAddressType;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/out/persistence/user/repository/TermsJpaRepository.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/out/persistence/user/repository/TermsJpaRepository.java
@@ -11,7 +11,7 @@ public interface TermsJpaRepository extends JpaRepository<TermsJpaEntity, Long> 
             SELECT t
             FROM TermsJpaEntity t
             WHERE 1 = 1
-                AND t.status = com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus.ACTIVE
+                AND t.status = com.personal.marketnote.common.domain.EntityStatus.ACTIVE
             ORDER BY t.id ASC
             """)
     List<TermsJpaEntity> findAllByOrderByIdAsc();

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/out/persistence/user/repository/UserJpaRepository.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/out/persistence/user/repository/UserJpaRepository.java
@@ -16,7 +16,7 @@ public interface UserJpaRepository extends JpaRepository<UserJpaEntity, Long> {
             SELECT CASE WHEN COUNT(u) > 0 THEN true ELSE false END
             FROM UserJpaEntity u
             WHERE 1 = 1
-                AND u.status = com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus.ACTIVE
+                AND u.status = com.personal.marketnote.common.domain.EntityStatus.ACTIVE
                 AND EXISTS (
                 SELECT 1
                 FROM UserOauth2VendorJpaEntity uov
@@ -32,7 +32,7 @@ public interface UserJpaRepository extends JpaRepository<UserJpaEntity, Long> {
             SELECT CASE WHEN COUNT(u) > 0 THEN true ELSE false END
             FROM UserJpaEntity u
             WHERE 1 = 1
-                AND u.status = com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus.ACTIVE
+                AND u.status = com.personal.marketnote.common.domain.EntityStatus.ACTIVE
                 AND u.nickname = :nickname
             """)
     boolean existsByNickname(@Param("nickname") String nickname);
@@ -49,7 +49,7 @@ public interface UserJpaRepository extends JpaRepository<UserJpaEntity, Long> {
             SELECT CASE WHEN COUNT(u) > 0 THEN true ELSE false END
             FROM UserJpaEntity u
             WHERE 1 = 1
-                AND u.status = com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus.ACTIVE
+                AND u.status = com.personal.marketnote.common.domain.EntityStatus.ACTIVE
               AND u.phoneNumber = :phoneNumber
             """)
     boolean existsByPhoneNumber(@Param("phoneNumber") String phoneNumber);
@@ -57,7 +57,7 @@ public interface UserJpaRepository extends JpaRepository<UserJpaEntity, Long> {
     @Query("""
             SELECT CASE WHEN COUNT(u) > 0 THEN true ELSE false END
             FROM UserJpaEntity u
-            WHERE u.status = com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus.ACTIVE
+            WHERE u.status = com.personal.marketnote.common.domain.EntityStatus.ACTIVE
                 AND u.referenceCode = :referenceCode
             """)
     boolean existsByReferenceCode(@Param("referenceCode") String referenceCode);
@@ -65,7 +65,7 @@ public interface UserJpaRepository extends JpaRepository<UserJpaEntity, Long> {
     @Query("""
             SELECT u
             FROM UserJpaEntity u
-            WHERE u.status = com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus.ACTIVE
+            WHERE u.status = com.personal.marketnote.common.domain.EntityStatus.ACTIVE
                 AND u.id = :id
             ORDER BY u.orderNum ASC
             """)
@@ -74,7 +74,7 @@ public interface UserJpaRepository extends JpaRepository<UserJpaEntity, Long> {
     @Query("""
             SELECT u
             FROM UserJpaEntity u
-            WHERE u.status = com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus.ACTIVE
+            WHERE u.status = com.personal.marketnote.common.domain.EntityStatus.ACTIVE
                 AND u.referenceCode = :referredUserCode
             ORDER BY u.orderNum ASC
             """)
@@ -84,7 +84,7 @@ public interface UserJpaRepository extends JpaRepository<UserJpaEntity, Long> {
             SELECT u
             FROM UserJpaEntity u
             WHERE 1 = 1
-                AND u.status = com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus.ACTIVE
+                AND u.status = com.personal.marketnote.common.domain.EntityStatus.ACTIVE
               AND EXISTS (
               SELECT 1
               FROM UserOauth2VendorJpaEntity uov
@@ -102,7 +102,7 @@ public interface UserJpaRepository extends JpaRepository<UserJpaEntity, Long> {
             SELECT u
             FROM UserJpaEntity u
             WHERE 1 = 1
-                AND u.status = com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus.ACTIVE
+                AND u.status = com.personal.marketnote.common.domain.EntityStatus.ACTIVE
                 AND u.phoneNumber = :phoneNumber
             ORDER BY u.orderNum ASC
             """)
@@ -112,7 +112,7 @@ public interface UserJpaRepository extends JpaRepository<UserJpaEntity, Long> {
             SELECT u
             FROM UserJpaEntity u
             WHERE 1 = 1
-                AND u.status = com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus.ACTIVE
+                AND u.status = com.personal.marketnote.common.domain.EntityStatus.ACTIVE
                 AND u.email = :email
             ORDER BY u.orderNum ASC
             """)
@@ -145,7 +145,7 @@ public interface UserJpaRepository extends JpaRepository<UserJpaEntity, Long> {
     @Query("""
             SELECT u
             FROM UserJpaEntity u
-            WHERE u.status = com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus.ACTIVE
+            WHERE u.status = com.personal.marketnote.common.domain.EntityStatus.ACTIVE
               AND (
                     :searchKeyword IS NULL
                  OR :searchKeyword = ''

--- a/user-service/user-application/src/test/java/com/personal/marketnote/user/service/terms/GetTermsUseCaseTest.java
+++ b/user-service/user-application/src/test/java/com/personal/marketnote/user/service/terms/GetTermsUseCaseTest.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.user.service.terms;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.common.exception.UserNotFoundException;
 import com.personal.marketnote.user.domain.user.Terms;
 import com.personal.marketnote.user.domain.user.User;

--- a/user-service/user-application/src/test/java/com/personal/marketnote/user/service/terms/TermsTestObjectFactory.java
+++ b/user-service/user-application/src/test/java/com/personal/marketnote/user/service/terms/TermsTestObjectFactory.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.user.service.terms;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.user.domain.user.*;
 
 import java.time.LocalDateTime;

--- a/user-service/user-application/src/test/java/com/personal/marketnote/user/service/terms/UpdateTermsUseCaseTest.java
+++ b/user-service/user-application/src/test/java/com/personal/marketnote/user/service/terms/UpdateTermsUseCaseTest.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.user.service.terms;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.common.exception.UserNotFoundException;
 import com.personal.marketnote.user.domain.user.Terms;
 import com.personal.marketnote.user.domain.user.User;

--- a/user-service/user-application/src/test/java/com/personal/marketnote/user/service/user/GetLoginHistoryUseCaseTest.java
+++ b/user-service/user-application/src/test/java/com/personal/marketnote/user/service/user/GetLoginHistoryUseCaseTest.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.user.service.user;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.user.domain.user.LoginHistory;
 import com.personal.marketnote.user.domain.user.LoginHistorySnapshotState;
 import com.personal.marketnote.user.domain.user.LoginHistorySortProperty;

--- a/user-service/user-application/src/test/java/com/personal/marketnote/user/service/user/GetUserUseCaseTest.java
+++ b/user-service/user-application/src/test/java/com/personal/marketnote/user/service/user/GetUserUseCaseTest.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.user.service.user;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.common.exception.UserNotFoundException;
 import com.personal.marketnote.user.domain.authentication.Role;
 import com.personal.marketnote.user.domain.user.User;

--- a/user-service/user-application/src/test/java/com/personal/marketnote/user/service/user/RegisterReferredUserCodeUseCaseTest.java
+++ b/user-service/user-application/src/test/java/com/personal/marketnote/user/service/user/RegisterReferredUserCodeUseCaseTest.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.user.service.user;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.common.exception.UserNotFoundException;
 import com.personal.marketnote.user.domain.user.User;
 import com.personal.marketnote.user.exception.ReferredUserCodeAlreadyExistsException;

--- a/user-service/user-application/src/test/java/com/personal/marketnote/user/service/user/UserTestObjectFactory.java
+++ b/user-service/user-application/src/test/java/com/personal/marketnote/user/service/user/UserTestObjectFactory.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.user.service.user;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.user.domain.authentication.Role;
 import com.personal.marketnote.user.domain.user.User;
 import com.personal.marketnote.user.domain.user.UserAuthProvider;

--- a/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/user/Terms.java
+++ b/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/user/Terms.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.user.domain.user;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/user/TermsCreateState.java
+++ b/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/user/TermsCreateState.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.user.domain.user;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/user/TermsSnapshotState.java
+++ b/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/user/TermsSnapshotState.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.user.domain.user;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/user/User.java
+++ b/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/user/User.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.user.domain.user;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.common.domain.BaseDomain;
 import com.personal.marketnote.common.domain.exception.illegalstate.SameUpdateTargetException;
 import com.personal.marketnote.common.utility.FormatValidator;

--- a/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/user/UserSnapshotState.java
+++ b/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/user/UserSnapshotState.java
@@ -1,6 +1,6 @@
 package com.personal.marketnote.user.domain.user;
 
-import com.personal.marketnote.common.adapter.out.persistence.audit.EntityStatus;
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.user.domain.authentication.Role;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;


### PR DESCRIPTION
## partially addresses #1
## resolves #2178

## Task
- [x] EntityStatus를 common.adapter.out.persistence.audit → common.domain 패키지로 이동
- [x] 전 서비스 import 경로 일괄 변경 (169파일)