### PR TITLE
[#1][#2179] refactor: domain/application 레이어 JPA 의존성 제거

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/payment/PaymentPersistenceAdapter.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/payment/PaymentPersistenceAdapter.java
@@ -8,7 +8,7 @@ import com.personal.marketnote.commerce.port.out.payment.FindPaymentPort;
 import com.personal.marketnote.commerce.port.out.payment.SavePaymentPort;
 import com.personal.marketnote.commerce.port.out.payment.UpdatePaymentPort;
 import com.personal.marketnote.common.adapter.out.PersistenceAdapter;
-import jakarta.persistence.EntityNotFoundException;
+import com.personal.marketnote.common.domain.exception.DomainNotFoundException;
 import lombok.RequiredArgsConstructor;
 
 import java.util.Optional;
@@ -41,7 +41,7 @@ public class PaymentPersistenceAdapter implements SavePaymentPort, FindPaymentPo
     @Override
     public void update(Payment payment) {
         PaymentJpaEntity entity = paymentJpaRepository.findByOrderKey(payment.getOrderKey())
-                .orElseThrow(() -> new EntityNotFoundException("결제 엔티티를 찾을 수 없습니다."));
+                .orElseThrow(() -> new DomainNotFoundException("결제 엔티티를 찾을 수 없습니다."));
         entity.updateFrom(payment);
     }
 }

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/payment/PspPaymentEventPersistenceAdapter.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/payment/PspPaymentEventPersistenceAdapter.java
@@ -9,7 +9,7 @@ import com.personal.marketnote.commerce.port.out.payment.FindPspPaymentEventPort
 import com.personal.marketnote.commerce.port.out.payment.SavePspPaymentEventPort;
 import com.personal.marketnote.commerce.port.out.payment.UpdatePspPaymentEventPort;
 import com.personal.marketnote.common.adapter.out.PersistenceAdapter;
-import jakarta.persistence.EntityNotFoundException;
+import com.personal.marketnote.common.domain.exception.DomainNotFoundException;
 import lombok.RequiredArgsConstructor;
 
 import java.util.List;
@@ -43,7 +43,7 @@ public class PspPaymentEventPersistenceAdapter implements SavePspPaymentEventPor
     @Override
     public void update(PspPaymentEvent event) {
         PspPaymentEventJpaEntity entity = pspPaymentEventJpaRepository.findByOrderKey(event.getOrderKey())
-                .orElseThrow(() -> new EntityNotFoundException("PspPaymentEvent 엔티티를 찾을 수 없습니다."));
+                .orElseThrow(() -> new DomainNotFoundException("PspPaymentEvent 엔티티를 찾을 수 없습니다."));
         entity.updateFrom(event);
     }
 }

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/vendor/kcp/KcpQuickPaymentAdapter.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/vendor/kcp/KcpQuickPaymentAdapter.java
@@ -63,8 +63,9 @@ public class KcpQuickPaymentAdapter implements RegisterQuickPaymentTransactionPo
                 .retUrl(kcpProperties.getRetUrl())
                 .build();
 
-        recordRequest(CommerceVendorCommunicationTargetType.QUICK_PAYMENT_TRADE_REGISTER,
-                command.transactionId(), request);
+        recordRequest(
+                CommerceVendorCommunicationTargetType.QUICK_PAYMENT_TRADE_REGISTER, command.transactionId(), request
+        );
 
         try {
             KcpTradeRegisterResponse response = kcpApiClient.registerTrade(request);
@@ -109,8 +110,7 @@ public class KcpQuickPaymentAdapter implements RegisterQuickPaymentTransactionPo
 
         try {
             KcpBatchKeyIssuanceResponse response = kcpApiClient.issueBatchKey(request);
-            recordResponse(CommerceVendorCommunicationTargetType.QUICK_PAYMENT_BATCH_KEY_ISSUANCE,
-                    null, response);
+            recordResponse(CommerceVendorCommunicationTargetType.QUICK_PAYMENT_BATCH_KEY_ISSUANCE, null, response);
 
             boolean isSuccess = response.isSuccess();
             if (!isSuccess) {
@@ -155,8 +155,7 @@ public class KcpQuickPaymentAdapter implements RegisterQuickPaymentTransactionPo
                 .mediaType(BATCH_PAYMENT_MEDIA_TYPE)
                 .build();
 
-        recordRequest(CommerceVendorCommunicationTargetType.QUICK_PAYMENT_BATCH_APPROVAL,
-                command.orderKey(), request);
+        recordRequest(CommerceVendorCommunicationTargetType.QUICK_PAYMENT_BATCH_APPROVAL, command.orderKey(), request);
 
         return executeBatchApprovalWithRetry(request, command.orderKey());
     }
@@ -211,8 +210,8 @@ public class KcpQuickPaymentAdapter implements RegisterQuickPaymentTransactionPo
         for (int attempt = 1; attempt <= maxAttempts; attempt++) {
             try {
                 KcpBatchPaymentApprovalResponse response = kcpApiClient.approveBatchPayment(request);
-                recordResponse(CommerceVendorCommunicationTargetType.QUICK_PAYMENT_BATCH_APPROVAL,
-                        orderKey, response);
+                recordResponse(CommerceVendorCommunicationTargetType.QUICK_PAYMENT_BATCH_APPROVAL, orderKey, response);
+
                 return buildBatchApprovalResult(response);
             } catch (Exception e) {
                 lastException = e;
@@ -226,6 +225,7 @@ public class KcpQuickPaymentAdapter implements RegisterQuickPaymentTransactionPo
                         sleepMillis *= retryConfig.getBackoffMultiplier();
                         continue;
                     }
+
                     throw new PaymentVendorConnectionFailedException(
                             "KCP 연결 실패: " + e.getMessage(), e
                     );
@@ -240,6 +240,7 @@ public class KcpQuickPaymentAdapter implements RegisterQuickPaymentTransactionPo
                         sleepMillis *= retryConfig.getBackoffMultiplier();
                         continue;
                     }
+
                     throw new KcpCommunicationException(
                             "빠른결제 배치 결제승인 읽기 타임아웃 초과: " + e.getMessage(), e
                     );
@@ -294,8 +295,10 @@ public class KcpQuickPaymentAdapter implements RegisterQuickPaymentTransactionPo
             if (causeType.isInstance(current)) {
                 return true;
             }
+
             current = current.getCause();
         }
+
         return false;
     }
 
@@ -309,8 +312,7 @@ public class KcpQuickPaymentAdapter implements RegisterQuickPaymentTransactionPo
         }
     }
 
-    private void recordRequest(CommerceVendorCommunicationTargetType targetType,
-                               String targetId, Object request) {
+    private void recordRequest(CommerceVendorCommunicationTargetType targetType, String targetId, Object request) {
         JsonNode payloadJson = maskSensitiveFields(kcpApiClient.toJsonNode(request));
         vendorCommunicationRecorder.record(
                 targetType,
@@ -334,8 +336,7 @@ public class KcpQuickPaymentAdapter implements RegisterQuickPaymentTransactionPo
         return node;
     }
 
-    private void recordResponse(CommerceVendorCommunicationTargetType targetType,
-                                String targetId, Object response) {
+    private void recordResponse(CommerceVendorCommunicationTargetType targetType, String targetId, Object response) {
         JsonNode payloadJson = maskSensitiveFields(kcpApiClient.toJsonNode(response));
         vendorCommunicationRecorder.record(
                 targetType,
@@ -348,8 +349,7 @@ public class KcpQuickPaymentAdapter implements RegisterQuickPaymentTransactionPo
         );
     }
 
-    private void recordError(CommerceVendorCommunicationTargetType targetType,
-                             String targetId, Exception e) {
+    private void recordError(CommerceVendorCommunicationTargetType targetType, String targetId, Exception e) {
         JsonNode errorJson = kcpApiClient.toJsonNode(
                 Map.of("error", e.getClass().getSimpleName(), "message", e.getMessage())
         );

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/exception/AccountNotFoundException.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/exception/AccountNotFoundException.java
@@ -1,8 +1,8 @@
 package com.personal.marketnote.commerce.exception;
 
-import jakarta.persistence.EntityNotFoundException;
+import com.personal.marketnote.common.domain.exception.DomainNotFoundException;
 
-public class AccountNotFoundException extends EntityNotFoundException {
+public class AccountNotFoundException extends DomainNotFoundException {
     public AccountNotFoundException(Long id) {
         super("계정과목을 찾을 수 없습니다. ID: " + id);
     }

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/exception/InventoryNotFoundException.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/exception/InventoryNotFoundException.java
@@ -1,10 +1,10 @@
 package com.personal.marketnote.commerce.exception;
 
-import jakarta.persistence.EntityNotFoundException;
+import com.personal.marketnote.common.domain.exception.DomainNotFoundException;
 import lombok.Getter;
 
 @Getter
-public class InventoryNotFoundException extends EntityNotFoundException {
+public class InventoryNotFoundException extends DomainNotFoundException {
     private static final String INVENTORY_NOT_FOUND_EXCEPTION_MESSAGE = "재고를 찾을 수 없습니다. 전송된 가격 정책 ID: %d";
 
     public InventoryNotFoundException(Long pricePolicyId) {

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/exception/InventoryProductNotFoundException.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/exception/InventoryProductNotFoundException.java
@@ -1,10 +1,10 @@
 package com.personal.marketnote.commerce.exception;
 
-import jakarta.persistence.EntityNotFoundException;
+import com.personal.marketnote.common.domain.exception.DomainNotFoundException;
 import lombok.Getter;
 
 @Getter
-public class InventoryProductNotFoundException extends EntityNotFoundException {
+public class InventoryProductNotFoundException extends DomainNotFoundException {
     private static final String INVENTORY_NOT_FOUND_EXCEPTION_MESSAGE = "재고를 찾을 수 없습니다. 전송된 상품 ID: %d";
 
     public InventoryProductNotFoundException(Long productId) {

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/exception/OrderNotFoundException.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/exception/OrderNotFoundException.java
@@ -1,10 +1,10 @@
 package com.personal.marketnote.commerce.exception;
 
-import jakarta.persistence.EntityNotFoundException;
+import com.personal.marketnote.common.domain.exception.DomainNotFoundException;
 import lombok.Getter;
 
 @Getter
-public class OrderNotFoundException extends EntityNotFoundException {
+public class OrderNotFoundException extends DomainNotFoundException {
     private static final String ORDER_NOT_FOUND_EXCEPTION_MESSAGE = "주문을 찾을 수 없습니다. 전송된 주문 ID: %d";
 
     public OrderNotFoundException(Long orderId) {

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/exception/OrderProductNotFoundException.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/exception/OrderProductNotFoundException.java
@@ -1,10 +1,10 @@
 package com.personal.marketnote.commerce.exception;
 
-import jakarta.persistence.EntityNotFoundException;
+import com.personal.marketnote.common.domain.exception.DomainNotFoundException;
 import lombok.Getter;
 
 @Getter
-public class OrderProductNotFoundException extends EntityNotFoundException {
+public class OrderProductNotFoundException extends DomainNotFoundException {
     private static final String ORDER_PRODUCT_NOT_FOUND_EXCEPTION_MESSAGE = "주문 상품을 찾을 수 없습니다. 전송된 주문 ID: %d, 가격 정책 ID: %d";
 
     public OrderProductNotFoundException(Long id, Long pricePolicyId) {

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/exception/PaymentEventNotFoundException.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/exception/PaymentEventNotFoundException.java
@@ -1,8 +1,8 @@
 package com.personal.marketnote.commerce.exception;
 
-import jakarta.persistence.EntityNotFoundException;
+import com.personal.marketnote.common.domain.exception.DomainNotFoundException;
 
-public class PaymentEventNotFoundException extends EntityNotFoundException {
+public class PaymentEventNotFoundException extends DomainNotFoundException {
     private static final String PAYMENT_EVENT_NOT_FOUND_BY_ORDER_KEY = "ERR_PAYMENT_EVENT_01::거래 등록 정보를 찾을 수 없습니다. 주문 키: %s";
 
     public PaymentEventNotFoundException(String orderKey) {

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/exception/PaymentNotFoundException.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/exception/PaymentNotFoundException.java
@@ -1,8 +1,8 @@
 package com.personal.marketnote.commerce.exception;
 
-import jakarta.persistence.EntityNotFoundException;
+import com.personal.marketnote.common.domain.exception.DomainNotFoundException;
 
-public class PaymentNotFoundException extends EntityNotFoundException {
+public class PaymentNotFoundException extends DomainNotFoundException {
     private static final String PAYMENT_NOT_FOUND_BY_ORDER_ID = "결제 정보를 찾을 수 없습니다. 주문 ID: %d";
     private static final String PAYMENT_NOT_FOUND_BY_ORDER_KEY = "결제 정보를 찾을 수 없습니다. 주문 키: %s";
 

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/exception/SettlementNotFoundException.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/exception/SettlementNotFoundException.java
@@ -1,8 +1,8 @@
 package com.personal.marketnote.commerce.exception;
 
-import jakarta.persistence.EntityNotFoundException;
+import com.personal.marketnote.common.domain.exception.DomainNotFoundException;
 
-public class SettlementNotFoundException extends EntityNotFoundException {
+public class SettlementNotFoundException extends DomainNotFoundException {
     public SettlementNotFoundException(Long id) {
         super("정산을 찾을 수 없습니다. ID: " + id);
     }

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/exception/SettlementPolicyNotFoundException.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/exception/SettlementPolicyNotFoundException.java
@@ -1,8 +1,8 @@
 package com.personal.marketnote.commerce.exception;
 
-import jakarta.persistence.EntityNotFoundException;
+import com.personal.marketnote.common.domain.exception.DomainNotFoundException;
 
-public class SettlementPolicyNotFoundException extends EntityNotFoundException {
+public class SettlementPolicyNotFoundException extends DomainNotFoundException {
     public SettlementPolicyNotFoundException(Long id) {
         super("정산 정책을 찾을 수 없습니다. ID: " + id);
     }

--- a/common/src/main/java/com/personal/marketnote/common/domain/exception/DomainAlreadyExistsException.java
+++ b/common/src/main/java/com/personal/marketnote/common/domain/exception/DomainAlreadyExistsException.java
@@ -1,0 +1,11 @@
+package com.personal.marketnote.common.domain.exception;
+
+public class DomainAlreadyExistsException extends RuntimeException {
+    public DomainAlreadyExistsException() {
+        super();
+    }
+
+    public DomainAlreadyExistsException(String message) {
+        super(message);
+    }
+}

--- a/common/src/main/java/com/personal/marketnote/common/domain/exception/DomainNotFoundException.java
+++ b/common/src/main/java/com/personal/marketnote/common/domain/exception/DomainNotFoundException.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.common.domain.exception;
+
+public class DomainNotFoundException extends RuntimeException {
+    public DomainNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/common/src/main/java/com/personal/marketnote/common/domain/exception/GlobalExceptionHandler.java
+++ b/common/src/main/java/com/personal/marketnote/common/domain/exception/GlobalExceptionHandler.java
@@ -3,8 +3,6 @@ package com.personal.marketnote.common.domain.exception;
 import com.personal.marketnote.common.utility.FormatValidator;
 import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.UnsupportedJwtException;
-import jakarta.persistence.EntityExistsException;
-import jakarta.persistence.EntityNotFoundException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -89,8 +87,8 @@ public class GlobalExceptionHandler {
         return buildErrorResponse(httpStatus, httpStatus.name(), "서버 내부 오류가 발생했습니다.");
     }
 
-    @ExceptionHandler(EntityNotFoundException.class)
-    ResponseEntity<ErrorResponse> handleEntityNotFoundException(EntityNotFoundException e) {
+    @ExceptionHandler(DomainNotFoundException.class)
+    ResponseEntity<ErrorResponse> handleDomainNotFoundException(DomainNotFoundException e) {
         HttpStatus httpStatus = HttpStatus.NOT_FOUND;
         log.warn(LOG_WARN_MESSAGE, e.getMessage(), e);
         return buildErrorResponse(httpStatus, e.getMessage());
@@ -191,8 +189,8 @@ public class GlobalExceptionHandler {
         return buildErrorResponse(httpStatus, httpStatus.name(), "지원하지 않는 토큰입니다.");
     }
 
-    @ExceptionHandler(EntityExistsException.class)
-    ResponseEntity<ErrorResponse> handleEntityExistsException(EntityExistsException e) {
+    @ExceptionHandler(DomainAlreadyExistsException.class)
+    ResponseEntity<ErrorResponse> handleDomainAlreadyExistsException(DomainAlreadyExistsException e) {
         HttpStatus httpStatus = HttpStatus.CONFLICT;
         log.info(LOG_INFO_MESSAGE, e.getMessage(), e);
         return buildErrorResponse(httpStatus, httpStatus.name(), "이미 존재하는 데이터입니다.");

--- a/common/src/main/java/com/personal/marketnote/common/exception/UserNotFoundException.java
+++ b/common/src/main/java/com/personal/marketnote/common/exception/UserNotFoundException.java
@@ -1,10 +1,10 @@
 package com.personal.marketnote.common.exception;
 
-import jakarta.persistence.EntityNotFoundException;
+import com.personal.marketnote.common.domain.exception.DomainNotFoundException;
 import lombok.Getter;
 
 @Getter
-public class UserNotFoundException extends EntityNotFoundException {
+public class UserNotFoundException extends DomainNotFoundException {
     public UserNotFoundException(String message) {
         super(message);
     }

--- a/common/src/test/java/com/personal/marketnote/common/domain/exception/GlobalExceptionHandlerTest.java
+++ b/common/src/test/java/com/personal/marketnote/common/domain/exception/GlobalExceptionHandlerTest.java
@@ -2,7 +2,7 @@ package com.personal.marketnote.common.domain.exception;
 
 import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.UnsupportedJwtException;
-import jakarta.persistence.EntityExistsException;
+import com.personal.marketnote.common.domain.exception.DomainAlreadyExistsException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -76,12 +76,12 @@ class GlobalExceptionHandlerTest {
         }
 
         @Test
-        @DisplayName("EntityNotFoundException 핸들러는 404를 반환한다")
-        void shouldReturn404ForEntityNotFoundException() {
-            jakarta.persistence.EntityNotFoundException exception =
-                    new jakarta.persistence.EntityNotFoundException("ERR_ENTITY_01::엔티티를 찾을 수 없습니다");
+        @DisplayName("DomainNotFoundException 핸들러는 404를 반환한다")
+        void shouldReturn404ForDomainNotFoundException() {
+            DomainNotFoundException exception =
+                    new DomainNotFoundException("ERR_ENTITY_01::엔티티를 찾을 수 없습니다");
 
-            ResponseEntity<ErrorResponse> response = handler.handleEntityNotFoundException(exception);
+            ResponseEntity<ErrorResponse> response = handler.handleDomainNotFoundException(exception);
 
             assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
             assertThat(response.getBody()).isNotNull();
@@ -328,12 +328,12 @@ class GlobalExceptionHandlerTest {
         }
 
         @Test
-        @DisplayName("EntityExistsException 핸들러는 고정 메시지를 반환한다")
-        void shouldReturnFixedMessageForEntityExistsException() {
-            EntityExistsException exception =
-                    new EntityExistsException("A different object with the same identifier value was already associated: [com.personal.marketnote.product.entity.ProductJpaEntity#123]");
+        @DisplayName("DomainAlreadyExistsException 핸들러는 고정 메시지를 반환한다")
+        void shouldReturnFixedMessageForDomainAlreadyExistsException() {
+            DomainAlreadyExistsException exception =
+                    new DomainAlreadyExistsException("A different object with the same identifier value was already associated: [com.personal.marketnote.product.entity.ProductJpaEntity#123]");
 
-            ResponseEntity<ErrorResponse> response = handler.handleEntityExistsException(exception);
+            ResponseEntity<ErrorResponse> response = handler.handleDomainAlreadyExistsException(exception);
 
             assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
             assertThat(response.getBody()).isNotNull();

--- a/community-service/community-application/src/main/java/com/personal/marketnote/community/exception/LikeNotFoundException.java
+++ b/community-service/community-application/src/main/java/com/personal/marketnote/community/exception/LikeNotFoundException.java
@@ -1,11 +1,11 @@
 package com.personal.marketnote.community.exception;
 
 import com.personal.marketnote.community.domain.like.LikeTargetType;
-import jakarta.persistence.EntityNotFoundException;
+import com.personal.marketnote.common.domain.exception.DomainNotFoundException;
 import lombok.Getter;
 
 @Getter
-public class LikeNotFoundException extends EntityNotFoundException {
+public class LikeNotFoundException extends DomainNotFoundException {
     private static final String LIKE_NOT_FOUND_EXCEPTION_MESSAGE = "좋아요를 찾을 수 없습니다. 전송된 대상 유형: %s, 대상 ID: %d, 회원 ID: %d";
 
     public LikeNotFoundException(LikeTargetType targetType, Long targetId, Long userId) {

--- a/community-service/community-application/src/main/java/com/personal/marketnote/community/exception/PostNotFoundException.java
+++ b/community-service/community-application/src/main/java/com/personal/marketnote/community/exception/PostNotFoundException.java
@@ -1,10 +1,10 @@
 package com.personal.marketnote.community.exception;
 
-import jakarta.persistence.EntityNotFoundException;
+import com.personal.marketnote.common.domain.exception.DomainNotFoundException;
 import lombok.Getter;
 
 @Getter
-public class PostNotFoundException extends EntityNotFoundException {
+public class PostNotFoundException extends DomainNotFoundException {
     private static final String POST_NOT_FOUND_EXCEPTION_MESSAGE = "게시글을 찾을 수 없습니다. 전송된 게시글 ID: %d";
 
     public PostNotFoundException(Long id) {

--- a/community-service/community-application/src/main/java/com/personal/marketnote/community/exception/ProductReviewAggregateNotFoundException.java
+++ b/community-service/community-application/src/main/java/com/personal/marketnote/community/exception/ProductReviewAggregateNotFoundException.java
@@ -1,10 +1,10 @@
 package com.personal.marketnote.community.exception;
 
-import jakarta.persistence.EntityNotFoundException;
+import com.personal.marketnote.common.domain.exception.DomainNotFoundException;
 import lombok.Getter;
 
 @Getter
-public class ProductReviewAggregateNotFoundException extends EntityNotFoundException {
+public class ProductReviewAggregateNotFoundException extends DomainNotFoundException {
     private static final String PRODUCT_REVIEW_AGGREGATE_NOT_FOUND_EXCEPTION_MESSAGE = "상품 리뷰 집계 정보를 찾을 수 없습니다. 전송된 상품 ID: %d";
 
     public ProductReviewAggregateNotFoundException(Long productId) {

--- a/community-service/community-application/src/main/java/com/personal/marketnote/community/exception/ReviewNotFoundException.java
+++ b/community-service/community-application/src/main/java/com/personal/marketnote/community/exception/ReviewNotFoundException.java
@@ -1,10 +1,10 @@
 package com.personal.marketnote.community.exception;
 
-import jakarta.persistence.EntityNotFoundException;
+import com.personal.marketnote.common.domain.exception.DomainNotFoundException;
 import lombok.Getter;
 
 @Getter
-public class ReviewNotFoundException extends EntityNotFoundException {
+public class ReviewNotFoundException extends DomainNotFoundException {
     private static final String REVIEW_NOT_FOUND_EXCEPTION_MESSAGE = "리뷰를 찾을 수 없습니다. 전송된 리뷰 ID: %d";
 
     public ReviewNotFoundException(Long id) {

--- a/community-service/community-domain/src/main/java/com/personal/marketnote/community/domain/post/Post.java
+++ b/community-service/community-domain/src/main/java/com/personal/marketnote/community/domain/post/Post.java
@@ -7,13 +7,10 @@ import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.common.utility.ValueMasker;
-import jakarta.persistence.Column;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
 
 import java.time.LocalDateTime;
 import java.util.Collections;
@@ -45,13 +42,10 @@ public class Post {
     @Builder.Default
     private List<Post> replies = Collections.emptyList();
 
-    @CreatedDate
-    @Column(nullable = false, updatable = false)
     @JsonSerialize(using = LocalDateTimeSerializer.class)
     @JsonDeserialize(using = LocalDateTimeDeserializer.class)
     private LocalDateTime createdAt;
 
-    @LastModifiedDate
     @JsonSerialize(using = LocalDateTimeSerializer.class)
     @JsonDeserialize(using = LocalDateTimeDeserializer.class)
     private LocalDateTime modifiedAt;

--- a/community-service/community-domain/src/main/java/com/personal/marketnote/community/domain/review/Review.java
+++ b/community-service/community-domain/src/main/java/com/personal/marketnote/community/domain/review/Review.java
@@ -7,10 +7,7 @@ import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.common.utility.ValueMasker;
-import jakarta.persistence.Column;
 import lombok.*;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
@@ -39,13 +36,10 @@ public class Review {
     private boolean isUserLiked;
     private EntityStatus status;
 
-    @CreatedDate
-    @Column(nullable = false, updatable = false)
     @JsonSerialize(using = LocalDateTimeSerializer.class)
     @JsonDeserialize(using = LocalDateTimeDeserializer.class)
     private LocalDateTime createdAt;
 
-    @LastModifiedDate
     @JsonSerialize(using = LocalDateTimeSerializer.class)
     @JsonDeserialize(using = LocalDateTimeDeserializer.class)
     private LocalDateTime modifiedAt;

--- a/file-service/file-application/src/main/java/com/personal/marketnote/file/exception/FileNotFoundException.java
+++ b/file-service/file-application/src/main/java/com/personal/marketnote/file/exception/FileNotFoundException.java
@@ -1,10 +1,10 @@
 package com.personal.marketnote.file.exception;
 
-import jakarta.persistence.EntityNotFoundException;
+import com.personal.marketnote.common.domain.exception.DomainNotFoundException;
 import lombok.Getter;
 
 @Getter
-public class FileNotFoundException extends EntityNotFoundException {
+public class FileNotFoundException extends DomainNotFoundException {
     private static final String FILE_NOT_FOUND_EXCEPTION_MESSAGE = "파일을 찾을 수 없습니다. 전송된 파일 ID: %d";
 
     public FileNotFoundException(Long id) {

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/exception/CartProductNotFoundException.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/exception/CartProductNotFoundException.java
@@ -1,10 +1,10 @@
 package com.personal.marketnote.product.exception;
 
-import jakarta.persistence.EntityNotFoundException;
+import com.personal.marketnote.common.domain.exception.DomainNotFoundException;
 import lombok.Getter;
 
 @Getter
-public class CartProductNotFoundException extends EntityNotFoundException {
+public class CartProductNotFoundException extends DomainNotFoundException {
     private static final String PRODUCT_NOT_FOUND_EXCEPTION_MESSAGE = "장바구니 상품을 찾을 수 없습니다. 전송된 가격 정책 ID: %d";
 
     public CartProductNotFoundException(Long pricePolicyId) {

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/exception/CategoryNotFoundException.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/exception/CategoryNotFoundException.java
@@ -1,10 +1,10 @@
 package com.personal.marketnote.product.exception;
 
-import jakarta.persistence.EntityNotFoundException;
+import com.personal.marketnote.common.domain.exception.DomainNotFoundException;
 import lombok.Getter;
 
 @Getter
-public class CategoryNotFoundException extends EntityNotFoundException {
+public class CategoryNotFoundException extends DomainNotFoundException {
     public CategoryNotFoundException(String message, Long parentCategoryId) {
         super(String.format(message, parentCategoryId));
     }

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/exception/PricePolicyNotFoundException.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/exception/PricePolicyNotFoundException.java
@@ -1,10 +1,10 @@
 package com.personal.marketnote.product.exception;
 
-import jakarta.persistence.EntityNotFoundException;
+import com.personal.marketnote.common.domain.exception.DomainNotFoundException;
 import lombok.Getter;
 
 @Getter
-public class PricePolicyNotFoundException extends EntityNotFoundException {
+public class PricePolicyNotFoundException extends DomainNotFoundException {
     private static final String PRICE_POLICY_NOT_FOUND_EXCEPTION_MESSAGE = "가격 정책을 찾을 수 없습니다. 전송된 가격 정책 ID: %d";
 
     public PricePolicyNotFoundException(Long id) {

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/exception/ProductNotFoundException.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/exception/ProductNotFoundException.java
@@ -1,10 +1,10 @@
 package com.personal.marketnote.product.exception;
 
-import jakarta.persistence.EntityNotFoundException;
+import com.personal.marketnote.common.domain.exception.DomainNotFoundException;
 import lombok.Getter;
 
 @Getter
-public class ProductNotFoundException extends EntityNotFoundException {
+public class ProductNotFoundException extends DomainNotFoundException {
     private static final String PRODUCT_NOT_FOUND_EXCEPTION_MESSAGE = "상품을 찾을 수 없습니다. 전송된 상품 ID: %d";
 
     public ProductNotFoundException(Long productId) {

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/exception/ShippingPolicyNotFoundException.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/exception/ShippingPolicyNotFoundException.java
@@ -1,8 +1,8 @@
 package com.personal.marketnote.product.exception;
 
-import jakarta.persistence.EntityNotFoundException;
+import com.personal.marketnote.common.domain.exception.DomainNotFoundException;
 
-public class ShippingPolicyNotFoundException extends EntityNotFoundException {
+public class ShippingPolicyNotFoundException extends DomainNotFoundException {
 
     public ShippingPolicyNotFoundException(Long sellerId) {
         super("해당 판매자의 배송비 정책을 찾을 수 없습니다. sellerId=" + sellerId);

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/exception/UserPointNotFoundException.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/exception/UserPointNotFoundException.java
@@ -1,8 +1,8 @@
 package com.personal.marketnote.reward.exception;
 
-import jakarta.persistence.EntityNotFoundException;
+import com.personal.marketnote.common.domain.exception.DomainNotFoundException;
 
-public class UserPointNotFoundException extends EntityNotFoundException {
+public class UserPointNotFoundException extends DomainNotFoundException {
     private static final String USER_POINT_NOT_FOUND_BY_ID_MESSAGE = "회원 포인트 정보를 찾을 수 없습니다. 전송된 회원 ID: %d";
     private static final String USER_POINT_NOT_FOUND_BY_KEY_MESSAGE = "회원 포인트 정보를 찾을 수 없습니다. 전송된 회원 키: %s";
 

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/service/attendance/DeleteAttendancePolicyService.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/service/attendance/DeleteAttendancePolicyService.java
@@ -5,7 +5,7 @@ import com.personal.marketnote.reward.domain.attendance.AttendancePolicy;
 import com.personal.marketnote.reward.port.in.usecase.attendance.DeleteAttendancePolicyUseCase;
 import com.personal.marketnote.reward.port.out.attendance.FindAttendancePolicyPort;
 import com.personal.marketnote.reward.port.out.attendance.UpdateAttendancePolicyPort;
-import jakarta.persistence.EntityNotFoundException;
+import com.personal.marketnote.common.domain.exception.DomainNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,7 +21,7 @@ public class DeleteAttendancePolicyService implements DeleteAttendancePolicyUseC
     @Override
     public void delete(Short id) {
         AttendancePolicy policy = findAttendancePolicyPort.findByIdForUpdate(id)
-                .orElseThrow(() -> new EntityNotFoundException("대상 출석 정책을 찾을 수 없습니다. 전송된 id: " + id));
+                .orElseThrow(() -> new DomainNotFoundException("대상 출석 정책을 찾을 수 없습니다. 전송된 id: " + id));
 
         policy.delete();
         updateAttendancePolicyPort.update(policy);

--- a/reward-service/reward-application/src/test/java/com/personal/marketnote/reward/service/attendance/DeleteAttendancePolicyUseCaseTest.java
+++ b/reward-service/reward-application/src/test/java/com/personal/marketnote/reward/service/attendance/DeleteAttendancePolicyUseCaseTest.java
@@ -6,7 +6,7 @@ import com.personal.marketnote.reward.domain.attendance.AttendancePolicySnapshot
 import com.personal.marketnote.reward.domain.attendance.AttendanceRewardType;
 import com.personal.marketnote.reward.port.out.attendance.FindAttendancePolicyPort;
 import com.personal.marketnote.reward.port.out.attendance.UpdateAttendancePolicyPort;
-import jakarta.persistence.EntityNotFoundException;
+import com.personal.marketnote.common.domain.exception.DomainNotFoundException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -59,7 +59,7 @@ class DeleteAttendancePolicyUseCaseTest {
     }
 
     @Test
-    @DisplayName("출석 정책이 존재하지 않으면 EntityNotFoundException이 발생한다")
+    @DisplayName("출석 정책이 존재하지 않으면 DomainNotFoundException이 발생한다")
     void shouldThrowWhenPolicyNotFound() {
         // given
         Short policyId = (short) 999;
@@ -67,6 +67,6 @@ class DeleteAttendancePolicyUseCaseTest {
 
         // when & then
         assertThatThrownBy(() -> deleteAttendancePolicyService.delete(policyId))
-                .isInstanceOf(EntityNotFoundException.class);
+                .isInstanceOf(DomainNotFoundException.class);
     }
 }

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/exception/ExceptionMessage.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/exception/ExceptionMessage.java
@@ -1,12 +1,12 @@
 package com.personal.marketnote.user.exception;
 
-import jakarta.persistence.EntityExistsException;
+import com.personal.marketnote.common.domain.exception.DomainAlreadyExistsException;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 @Getter
-public class ExceptionMessage extends EntityExistsException {
+public class ExceptionMessage extends DomainAlreadyExistsException {
     public static final String USER_ID_NOT_FOUND_EXCEPTION_MESSAGE = "존재하지 않는 회원입니다. 전송된 회원 ID: %d";
     public static final String USER_OIDC_ID_NOT_FOUND_EXCEPTION_MESSAGE = "존재하지 않는 회원입니다. 전송된 회원 OIDC ID: %s";
     public static final String USER_EMAIL_NOT_FOUND_EXCEPTION_MESSAGE = "존재하지 않는 회원입니다. 전송된 회원 이메일 주소: %s";

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/exception/ShippingAddressNotFoundException.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/exception/ShippingAddressNotFoundException.java
@@ -1,10 +1,10 @@
 package com.personal.marketnote.user.exception;
 
-import jakarta.persistence.EntityNotFoundException;
+import com.personal.marketnote.common.domain.exception.DomainNotFoundException;
 import lombok.Getter;
 
 @Getter
-public class ShippingAddressNotFoundException extends EntityNotFoundException {
+public class ShippingAddressNotFoundException extends DomainNotFoundException {
     private static final String SHIPPING_ADDRESS_NOT_FOUND_EXCEPTION_MESSAGE = "배송지를 찾을 수 없습니다. 전송된 배송지 ID: %d";
 
     public ShippingAddressNotFoundException(Long shippingAddressId) {

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/exception/UserExistsException.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/exception/UserExistsException.java
@@ -1,12 +1,12 @@
 package com.personal.marketnote.user.exception;
 
-import jakarta.persistence.EntityExistsException;
+import com.personal.marketnote.common.domain.exception.DomainAlreadyExistsException;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 @Getter
-public class UserExistsException extends EntityExistsException {
+public class UserExistsException extends DomainAlreadyExistsException {
     public UserExistsException(String message) {
         super(message);
     }

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/service/shippingaddress/RegisterShippingAddressService.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/service/shippingaddress/RegisterShippingAddressService.java
@@ -14,7 +14,7 @@ import com.personal.marketnote.user.port.out.event.PublishShippingAddressEventPo
 import com.personal.marketnote.user.port.out.shippingaddress.FindShippingAddressPort;
 import com.personal.marketnote.user.port.out.shippingaddress.SaveShippingAddressPort;
 import com.personal.marketnote.user.port.out.shippingaddress.UpdateShippingAddressPort;
-import jakarta.persistence.EntityExistsException;
+import com.personal.marketnote.common.domain.exception.DomainAlreadyExistsException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -70,14 +70,14 @@ public class RegisterShippingAddressService implements RegisterShippingAddressUs
         switch (addressType) {
             case HOME -> {
                 if (findShippingAddressPort.existsByUserIdAndAddressType(userId, ShippingAddressType.HOME)) {
-                    throw new EntityExistsException(
+                    throw new DomainAlreadyExistsException(
                             String.format("%s:: 이미 등록된 집 배송지가 존재합니다.", FIRST_ERROR_CODE)
                     );
                 }
             }
             case COMPANY -> {
                 if (findShippingAddressPort.existsByUserIdAndAddressType(userId, ShippingAddressType.COMPANY)) {
-                    throw new EntityExistsException(
+                    throw new DomainAlreadyExistsException(
                             String.format("%s:: 이미 등록된 회사 배송지가 존재합니다.", FIRST_ERROR_CODE)
                     );
                 }

--- a/user-service/user-application/src/test/java/com/personal/marketnote/user/service/shippingaddress/RegisterShippingAddressUseCaseTest.java
+++ b/user-service/user-application/src/test/java/com/personal/marketnote/user/service/shippingaddress/RegisterShippingAddressUseCaseTest.java
@@ -11,7 +11,7 @@ import com.personal.marketnote.user.port.out.event.PublishShippingAddressEventPo
 import com.personal.marketnote.user.port.out.shippingaddress.FindShippingAddressPort;
 import com.personal.marketnote.user.port.out.shippingaddress.SaveShippingAddressPort;
 import com.personal.marketnote.user.port.out.shippingaddress.UpdateShippingAddressPort;
-import jakarta.persistence.EntityExistsException;
+import com.personal.marketnote.common.domain.exception.DomainAlreadyExistsException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -135,8 +135,8 @@ class RegisterShippingAddressUseCaseTest {
     }
 
     @Test
-    @DisplayName("HOME 타입 배송지가 이미 존재하면 EntityExistsException이 발생한다")
-    void registerShippingAddress_duplicateHome_throwsEntityExistsException() {
+    @DisplayName("HOME 타입 배송지가 이미 존재하면 DomainAlreadyExistsException이 발생한다")
+    void registerShippingAddress_duplicateHome_throwsDomainAlreadyExistsException() {
         // given
         Long userId = 1L;
         RegisterShippingAddressCommand command = RegisterShippingAddressCommand.builder()
@@ -154,7 +154,7 @@ class RegisterShippingAddressUseCaseTest {
 
         // when & then
         assertThatThrownBy(() -> registerShippingAddressService.registerShippingAddress(command))
-                .isInstanceOf(EntityExistsException.class)
+                .isInstanceOf(DomainAlreadyExistsException.class)
                 .hasMessageContaining("이미 등록된 집 배송지가 존재합니다");
 
         verify(findShippingAddressPort).existsByUserIdAndAddressType(userId, ShippingAddressType.HOME);
@@ -163,8 +163,8 @@ class RegisterShippingAddressUseCaseTest {
     }
 
     @Test
-    @DisplayName("COMPANY 타입 배송지가 이미 존재하면 EntityExistsException이 발생한다")
-    void registerShippingAddress_duplicateCompany_throwsEntityExistsException() {
+    @DisplayName("COMPANY 타입 배송지가 이미 존재하면 DomainAlreadyExistsException이 발생한다")
+    void registerShippingAddress_duplicateCompany_throwsDomainAlreadyExistsException() {
         // given
         Long userId = 1L;
         RegisterShippingAddressCommand command = RegisterShippingAddressCommand.builder()
@@ -183,7 +183,7 @@ class RegisterShippingAddressUseCaseTest {
 
         // when & then
         assertThatThrownBy(() -> registerShippingAddressService.registerShippingAddress(command))
-                .isInstanceOf(EntityExistsException.class)
+                .isInstanceOf(DomainAlreadyExistsException.class)
                 .hasMessageContaining("이미 등록된 회사 배송지가 존재합니다");
 
         verify(findShippingAddressPort).existsByUserIdAndAddressType(userId, ShippingAddressType.COMPANY);

--- a/user-service/user-domain/src/main/java/com/personal/marketnote/user/exception/UserAuthProviderNotFoundException.java
+++ b/user-service/user-domain/src/main/java/com/personal/marketnote/user/exception/UserAuthProviderNotFoundException.java
@@ -1,11 +1,11 @@
 package com.personal.marketnote.user.exception;
 
 import com.personal.marketnote.user.security.token.vendor.AuthVendor;
-import jakarta.persistence.EntityNotFoundException;
+import com.personal.marketnote.common.domain.exception.DomainNotFoundException;
 import lombok.Getter;
 
 @Getter
-public class UserAuthProviderNotFoundException extends EntityNotFoundException {
+public class UserAuthProviderNotFoundException extends DomainNotFoundException {
     private static final String USER_AUTH_PROVIDER_NOT_FOUND_EXCEPTION_MESSAGE = "%s:: 존재하지 않는 회원 인증 제공자입니다. 전송된 회원 인증 제공자: %s";
 
     public UserAuthProviderNotFoundException(String code, AuthVendor authVendor) {


### PR DESCRIPTION
## partially addresses #1
## resolves #2179

## Task
- [x] community-service domain: Review.java, Post.java에서 @column, @CreatedDate, @LastModifiedDate 제거
- [x] EntityNotFoundException → DomainNotFoundException 전환 (전 서비스)
- [x] EntityExistsException → DomainAlreadyExistsException 전환 (전 서비스)
- [x] GlobalExceptionHandler JPA 예외 핸들러 → 도메인 예외 핸들러 전환