### PR TITLE
[#723][#2201] fix: KafkaBrokerFailureScenarioTest waitForLeaderElection 고정 대기로 인한 간헐적 테스트 실패 픽스

### DIFF
--- a/common/src/test/java/com/personal/marketnote/common/configuration/kafka/KafkaBrokerFailureScenarioTest.java
+++ b/common/src/test/java/com/personal/marketnote/common/configuration/kafka/KafkaBrokerFailureScenarioTest.java
@@ -6,6 +6,8 @@ import kafka.testkit.KafkaClusterTestKit;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.admin.TopicDescription;
+import org.apache.kafka.common.TopicPartitionInfo;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
@@ -294,8 +296,34 @@ class KafkaBrokerFailureScenarioTest {
         }
     }
 
-    private void waitForLeaderElection() throws InterruptedException {
-        Thread.sleep(15_000);
+    private void waitForLeaderElection() throws Exception {
+        Map<String, Object> adminProps = new HashMap<>();
+        adminProps.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        adminProps.put(AdminClientConfig.REQUEST_TIMEOUT_MS_CONFIG, 5000);
+
+        try (AdminClient adminClient = AdminClient.create(adminProps)) {
+            for (int attempt = 0; attempt < READY_CHECK_MAX_ATTEMPTS; attempt++) {
+                try {
+                    TopicDescription description = adminClient
+                            .describeTopics(Collections.singletonList(TEST_TOPIC))
+                            .allTopicNames()
+                            .get(10, TimeUnit.SECONDS)
+                            .get(TEST_TOPIC);
+
+                    boolean allPartitionsHaveLeader = description.partitions().stream()
+                            .map(TopicPartitionInfo::leader)
+                            .allMatch(leader -> FormatValidator.hasValue(leader) && leader.id() >= 0);
+
+                    if (allPartitionsHaveLeader) {
+                        Thread.sleep(2000);
+                        return;
+                    }
+                } catch (Exception e) {
+                    // 리더 선출 진행 중 — 재시도
+                }
+                Thread.sleep(1000);
+            }
+        }
     }
 
     private RecordMetadata publishWithRetry(String key, String value, int maxAttempts) throws Exception {


### PR DESCRIPTION
## partially addresses #723
## resolves #2201

## Reason
waitForLeaderElection()이 Thread.sleep(15_000) 고정 대기로 구현되어 CI 환경에서 간헐적 테스트 실패 발생

## Action
- [x] waitForLeaderElection()을 AdminClient.describeTopics() 기반 폴링 방식으로 변경하여 모든 파티션의 활성 리더 선출을 확인
- [x] 리더 선출 확인 후 ISR 동기화 여유 대기(2초) 추가
