### PR TITLE
[#387][#2203] fix: 포인트 사용(차감) API 동시 호출 시 잔액 초과 차감 레이스 컨디션 방어

### DIFF
--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/point/UserPointPersistenceAdapter.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/point/UserPointPersistenceAdapter.java
@@ -44,6 +44,11 @@ public class UserPointPersistenceAdapter implements SaveUserPointPort, FindUserP
     }
 
     @Override
+    public Optional<UserPoint> findByUserIdForUpdate(Long userId) {
+        return repository.findWithLockingByUserId(userId).map(UserPointJpaEntity::toDomain);
+    }
+
+    @Override
     public UserPoint update(UserPoint userPoint) throws UserPointNotFoundException {
         UserPointJpaEntity userPointJpaEntity = findEntityByUserId(userPoint.getUserId());
         userPointJpaEntity.updateFrom(userPoint);

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/point/repository/UserPointJpaRepository.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/point/repository/UserPointJpaRepository.java
@@ -1,7 +1,11 @@
 package com.personal.marketnote.reward.adapter.out.persistence.point.repository;
 
 import com.personal.marketnote.reward.adapter.out.persistence.point.entity.UserPointJpaEntity;
+import jakarta.persistence.LockModeType;
+import jakarta.persistence.QueryHint;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.QueryHints;
 
 import java.util.Optional;
 
@@ -13,4 +17,8 @@ public interface UserPointJpaRepository extends JpaRepository<UserPointJpaEntity
     Optional<UserPointJpaEntity> findByUserId(Long userId);
 
     Optional<UserPointJpaEntity> findByUserKey(String userKey);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @QueryHints({@QueryHint(name = "jakarta.persistence.lock.timeout", value = "3000")})
+    Optional<UserPointJpaEntity> findWithLockingByUserId(Long userId);
 }

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/out/point/FindUserPointPort.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/out/point/FindUserPointPort.java
@@ -47,4 +47,13 @@ public interface FindUserPointPort {
      * @Description 회원 키로 포인트를 조회합니다.
      */
     Optional<UserPoint> findByUserKey(String userKey);
+
+    /**
+     * @param userId 회원 식별자
+     * @return 회원 포인트 {@link UserPoint}
+     * @Date 2026-04-20
+     * @Author 성효빈
+     * @Description 회원 식별자로 포인트를 배타적 잠금으로 조회합니다. 동시 수정 방지용.
+     */
+    Optional<UserPoint> findByUserIdForUpdate(Long userId);
 }

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/service/gifticon/PurchaseGifticonTransactionHelper.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/service/gifticon/PurchaseGifticonTransactionHelper.java
@@ -2,19 +2,20 @@ package com.personal.marketnote.reward.service.gifticon;
 
 import com.personal.marketnote.reward.domain.exception.GifticonInsufficientCashException;
 import com.personal.marketnote.reward.domain.exception.GifticonOrderNotFoundException;
+import com.personal.marketnote.reward.exception.UserPointNotFoundException;
 import com.personal.marketnote.reward.domain.gifticon.GifticonOrder;
 import com.personal.marketnote.reward.domain.gifticon.GifticonOrderCreateState;
 import com.personal.marketnote.reward.domain.point.UserPoint;
 import com.personal.marketnote.reward.domain.point.UserPointChangeType;
 import com.personal.marketnote.reward.domain.point.UserPointSourceType;
 import com.personal.marketnote.reward.port.in.command.point.ModifyUserPointCommand;
-import com.personal.marketnote.reward.port.in.usecase.point.GetUserPointUseCase;
 import com.personal.marketnote.reward.port.in.usecase.point.ModifyUserPointUseCase;
 import com.personal.marketnote.reward.port.out.gifticon.EncryptGifticonPinPort;
 import com.personal.marketnote.reward.port.out.gifticon.FindGifticonOrderPort;
 import com.personal.marketnote.reward.port.out.gifticon.SaveGifticonOrderPort;
 import com.personal.marketnote.reward.port.out.gifticon.SendGifticonCouponPort.SendCouponResult;
 import com.personal.marketnote.reward.port.out.gifticon.UpdateGifticonOrderPort;
+import com.personal.marketnote.reward.port.out.point.FindUserPointPort;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -33,7 +34,7 @@ import static org.springframework.transaction.annotation.Propagation.REQUIRES_NE
 @Slf4j
 public class PurchaseGifticonTransactionHelper {
 
-    private final GetUserPointUseCase getUserPointUseCase;
+    private final FindUserPointPort findUserPointPort;
     private final ModifyUserPointUseCase modifyUserPointUseCase;
     private final SaveGifticonOrderPort saveGifticonOrderPort;
     private final FindGifticonOrderPort findGifticonOrderPort;
@@ -59,7 +60,8 @@ public class PurchaseGifticonTransactionHelper {
             Long userId, String goodsCode, String goodsName, String brandName,
             String productImageUrl, Long cashPrice
     ) {
-        UserPoint userPoint = getUserPointUseCase.getUserPoint(userId);
+        UserPoint userPoint = findUserPointPort.findByUserIdForUpdate(userId)
+                .orElseThrow(() -> new UserPointNotFoundException(userId));
         Long currentBalance = userPoint.getAmountValue();
 
         if (currentBalance < cashPrice) {

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/service/point/ModifyUserPointService.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/service/point/ModifyUserPointService.java
@@ -2,6 +2,7 @@ package com.personal.marketnote.reward.service.point;
 
 import com.personal.marketnote.common.application.UseCase;
 import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.reward.exception.UserPointNotFoundException;
 import com.personal.marketnote.reward.domain.point.UserPoint;
 import com.personal.marketnote.reward.domain.point.UserPointHistory;
 import com.personal.marketnote.reward.mapper.RewardCommandToStateMapper;
@@ -9,6 +10,7 @@ import com.personal.marketnote.reward.port.in.command.point.ModifyUserPointComma
 import com.personal.marketnote.reward.port.in.result.point.UpdateUserPointResult;
 import com.personal.marketnote.reward.port.in.usecase.point.GetUserPointUseCase;
 import com.personal.marketnote.reward.port.in.usecase.point.ModifyUserPointUseCase;
+import com.personal.marketnote.reward.port.out.point.FindUserPointPort;
 import com.personal.marketnote.reward.port.out.point.SaveUserPointHistoryPort;
 import com.personal.marketnote.reward.port.out.point.UpdateUserPointPort;
 import lombok.RequiredArgsConstructor;
@@ -21,6 +23,7 @@ import static org.springframework.transaction.annotation.Isolation.READ_COMMITTE
 @Transactional(isolation = READ_COMMITTED)
 public class ModifyUserPointService implements ModifyUserPointUseCase {
     private final GetUserPointUseCase getUserPointUseCase;
+    private final FindUserPointPort findUserPointPort;
     private final UpdateUserPointPort updateUserPointPort;
     private final SaveUserPointHistoryPort saveUserPointHistoryPort;
 
@@ -42,6 +45,11 @@ public class ModifyUserPointService implements ModifyUserPointUseCase {
     }
 
     private UserPoint getTargetUserPoint(ModifyUserPointCommand command) {
+        if (!command.isAccrual() && FormatValidator.hasValue(command.userId())) {
+            return findUserPointPort.findByUserIdForUpdate(command.userId())
+                    .orElseThrow(() -> new UserPointNotFoundException(command.userId()));
+        }
+
         Long userId = command.userId();
         if (FormatValidator.hasValue(userId)) {
             return getUserPointUseCase.getUserPoint(userId);


### PR DESCRIPTION
## partially addresses #387
## resolves #2203

## Task
- [x] UserPointJpaRepository에 @lock(PESSIMISTIC_WRITE) + @QueryHints(timeout=3000) findWithLockingByUserId 잠금 조회 메서드 추가
- [x] FindUserPointPort에 findByUserIdForUpdate 포트 메서드 추가
- [x] UserPointPersistenceAdapter에 findByUserIdForUpdate 구현 추가
- [x] ModifyUserPointService 차감 시 잠금 조회 사용, 적립은 기존 일반 조회 유지
- [x] PurchaseGifticonTransactionHelper 잔액 조회를 잠금 조회로 교체
- [x] 예외 타입 UserPointNotFoundException으로 통일