### PR TITLE
[#387][#2204] test: 포인트 사용(차감) API 레이스 컨디션 방어 기능 자동화 테스트 추가

### DIFF
--- a/reward-service/reward-application/src/test/java/com/personal/marketnote/reward/service/gifticon/PurchaseGifticonTransactionHelperTest.java
+++ b/reward-service/reward-application/src/test/java/com/personal/marketnote/reward/service/gifticon/PurchaseGifticonTransactionHelperTest.java
@@ -8,13 +8,13 @@ import com.personal.marketnote.reward.domain.point.UserPoint;
 import com.personal.marketnote.reward.domain.point.UserPointChangeType;
 import com.personal.marketnote.reward.domain.point.UserPointSourceType;
 import com.personal.marketnote.reward.port.in.command.point.ModifyUserPointCommand;
-import com.personal.marketnote.reward.port.in.usecase.point.GetUserPointUseCase;
 import com.personal.marketnote.reward.port.in.usecase.point.ModifyUserPointUseCase;
 import com.personal.marketnote.reward.port.out.gifticon.EncryptGifticonPinPort;
 import com.personal.marketnote.reward.port.out.gifticon.FindGifticonOrderPort;
 import com.personal.marketnote.reward.port.out.gifticon.SaveGifticonOrderPort;
 import com.personal.marketnote.reward.port.out.gifticon.SendGifticonCouponPort.SendCouponResult;
 import com.personal.marketnote.reward.port.out.gifticon.UpdateGifticonOrderPort;
+import com.personal.marketnote.reward.port.out.point.FindUserPointPort;
 import com.personal.marketnote.reward.service.gifticon.PurchaseGifticonTransactionHelper.DeductCashAndCreateOrderContext;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -43,7 +43,7 @@ class PurchaseGifticonTransactionHelperTest {
     private PurchaseGifticonTransactionHelper helper;
 
     @Mock
-    private GetUserPointUseCase getUserPointUseCase;
+    private FindUserPointPort findUserPointPort;
 
     @Mock
     private ModifyUserPointUseCase modifyUserPointUseCase;
@@ -78,7 +78,7 @@ class PurchaseGifticonTransactionHelperTest {
     void shouldSaveOrderAsPendingAfterCashDeduction() {
         // given
         UserPoint userPoint = createUserPointWithAmount(10000L);
-        when(getUserPointUseCase.getUserPoint(USER_ID)).thenReturn(userPoint);
+        when(findUserPointPort.findByUserIdForUpdate(USER_ID)).thenReturn(Optional.of(userPoint));
         when(findGifticonOrderPort.existsByTrId(any())).thenReturn(false);
         when(saveGifticonOrderPort.save(any())).thenAnswer(invocation -> {
             GifticonOrder order = invocation.getArgument(0);
@@ -114,7 +114,7 @@ class PurchaseGifticonTransactionHelperTest {
     void shouldThrowExceptionWhenInsufficientCash() {
         // given
         UserPoint userPoint = createUserPointWithAmount(3000L);
-        when(getUserPointUseCase.getUserPoint(USER_ID)).thenReturn(userPoint);
+        when(findUserPointPort.findByUserIdForUpdate(USER_ID)).thenReturn(Optional.of(userPoint));
 
         // when & then
         assertThatThrownBy(() -> helper.deductCashAndCreateOrder(
@@ -130,11 +130,42 @@ class PurchaseGifticonTransactionHelperTest {
     }
 
     @Test
+    @DisplayName("잔액 조회 시 잠금 조회(findByUserIdForUpdate)를 사용한다")
+    void shouldUseFindByUserIdForUpdateForBalanceCheck() {
+        // given
+        UserPoint userPoint = createUserPointWithAmount(10000L);
+        when(findUserPointPort.findByUserIdForUpdate(USER_ID)).thenReturn(Optional.of(userPoint));
+        when(findGifticonOrderPort.existsByTrId(any())).thenReturn(false);
+        when(saveGifticonOrderPort.save(any())).thenAnswer(invocation -> {
+            GifticonOrder order = invocation.getArgument(0);
+            return GifticonOrder.from(GifticonOrderSnapshotState.builder()
+                    .id(1L)
+                    .userId(order.getUserId())
+                    .goodsCode(order.getGoodsCode())
+                    .goodsName(order.getGoodsName())
+                    .brandName(order.getBrandName())
+                    .productImageUrl(order.getProductImageUrl())
+                    .trId(order.getTrId())
+                    .cashPrice(order.getCashPrice())
+                    .orderStatus(order.getOrderStatus())
+                    .build());
+        });
+
+        // when
+        helper.deductCashAndCreateOrder(
+                USER_ID, GOODS_CODE, GOODS_NAME, BRAND_NAME, PRODUCT_IMAGE_URL, CASH_PRICE
+        );
+
+        // then
+        verify(findUserPointPort).findByUserIdForUpdate(USER_ID);
+    }
+
+    @Test
     @DisplayName("TR_ID가 NC{userId}_{yyMMddHHmmss} 형식으로 생성된다")
     void shouldGenerateTrIdInCorrectFormat() {
         // given
         UserPoint userPoint = createUserPointWithAmount(10000L);
-        when(getUserPointUseCase.getUserPoint(USER_ID)).thenReturn(userPoint);
+        when(findUserPointPort.findByUserIdForUpdate(USER_ID)).thenReturn(Optional.of(userPoint));
         when(findGifticonOrderPort.existsByTrId(any())).thenReturn(false);
         when(saveGifticonOrderPort.save(any())).thenAnswer(invocation -> {
             GifticonOrder order = invocation.getArgument(0);
@@ -168,7 +199,7 @@ class PurchaseGifticonTransactionHelperTest {
     void shouldRecordGifticonPurchaseSourceType() {
         // given
         UserPoint userPoint = createUserPointWithAmount(10000L);
-        when(getUserPointUseCase.getUserPoint(USER_ID)).thenReturn(userPoint);
+        when(findUserPointPort.findByUserIdForUpdate(USER_ID)).thenReturn(Optional.of(userPoint));
         when(findGifticonOrderPort.existsByTrId(any())).thenReturn(false);
         when(saveGifticonOrderPort.save(any())).thenAnswer(invocation -> {
             GifticonOrder order = invocation.getArgument(0);

--- a/reward-service/reward-application/src/test/java/com/personal/marketnote/reward/service/point/ModifyUserPointUseCaseTest.java
+++ b/reward-service/reward-application/src/test/java/com/personal/marketnote/reward/service/point/ModifyUserPointUseCaseTest.java
@@ -2,10 +2,12 @@ package com.personal.marketnote.reward.service.point;
 
 import com.personal.marketnote.common.exception.UserNotFoundException;
 import com.personal.marketnote.reward.domain.point.*;
+import com.personal.marketnote.reward.exception.UserPointNotFoundException;
 import com.personal.marketnote.reward.exception.DuplicateUserPointHistoryException;
 import com.personal.marketnote.reward.port.in.command.point.ModifyUserPointCommand;
 import com.personal.marketnote.reward.port.in.result.point.UpdateUserPointResult;
 import com.personal.marketnote.reward.port.in.usecase.point.GetUserPointUseCase;
+import com.personal.marketnote.reward.port.out.point.FindUserPointPort;
 import com.personal.marketnote.reward.port.out.point.SaveUserPointHistoryPort;
 import com.personal.marketnote.reward.port.out.point.UpdateUserPointPort;
 import org.junit.jupiter.api.DisplayName;
@@ -18,6 +20,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDateTime;
+
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -32,6 +36,9 @@ class ModifyUserPointUseCaseTest {
 
     @Mock
     private GetUserPointUseCase getUserPointUseCase;
+
+    @Mock
+    private FindUserPointPort findUserPointPort;
 
     @Mock
     private UpdateUserPointPort updateUserPointPort;
@@ -118,6 +125,27 @@ class ModifyUserPointUseCaseTest {
         }
 
         @Test
+        @DisplayName("적립 시 일반 조회를 사용하고 잠금 조회는 호출하지 않는다")
+        void shouldNotUseFindByUserIdForUpdateOnAccrual() {
+            // given
+            UserPoint userPoint = createUserPoint(1000L);
+            ModifyUserPointCommand command = createAccrualCommandWithUserId(500L);
+
+            when(getUserPointUseCase.getUserPoint(USER_ID)).thenReturn(userPoint);
+            when(updateUserPointPort.update(any(UserPoint.class)))
+                    .thenAnswer(invocation -> invocation.getArgument(0));
+            when(saveUserPointHistoryPort.save(any(UserPointHistory.class)))
+                    .thenAnswer(invocation -> invocation.getArgument(0));
+
+            // when
+            modifyUserPointService.modify(command);
+
+            // then
+            verify(getUserPointUseCase).getUserPoint(USER_ID);
+            verifyNoInteractions(findUserPointPort);
+        }
+
+        @Test
         @DisplayName("userKey로 포인트를 적립하면 기존 금액에 적립 금액이 더해진다")
         void shouldAccruePointByUserKey() {
             // given
@@ -152,7 +180,7 @@ class ModifyUserPointUseCaseTest {
             UserPoint userPoint = createUserPoint(1000L);
             ModifyUserPointCommand command = createDeductionCommandWithUserId(300L);
 
-            when(getUserPointUseCase.getUserPoint(USER_ID)).thenReturn(userPoint);
+            when(findUserPointPort.findByUserIdForUpdate(USER_ID)).thenReturn(Optional.of(userPoint));
             when(updateUserPointPort.update(any(UserPoint.class)))
                     .thenAnswer(invocation -> invocation.getArgument(0));
             when(saveUserPointHistoryPort.save(any(UserPointHistory.class)))
@@ -163,6 +191,45 @@ class ModifyUserPointUseCaseTest {
 
             // then
             assertThat(result.amount()).isEqualTo(700L);
+        }
+
+        @Test
+        @DisplayName("차감 시 잠금 조회(findByUserIdForUpdate)를 사용하고 일반 조회는 호출하지 않는다")
+        void shouldUseFindByUserIdForUpdateOnDeduction() {
+            // given
+            UserPoint userPoint = createUserPoint(1000L);
+            ModifyUserPointCommand command = createDeductionCommandWithUserId(300L);
+
+            when(findUserPointPort.findByUserIdForUpdate(USER_ID)).thenReturn(Optional.of(userPoint));
+            when(updateUserPointPort.update(any(UserPoint.class)))
+                    .thenAnswer(invocation -> invocation.getArgument(0));
+            when(saveUserPointHistoryPort.save(any(UserPointHistory.class)))
+                    .thenAnswer(invocation -> invocation.getArgument(0));
+
+            // when
+            modifyUserPointService.modify(command);
+
+            // then
+            verify(findUserPointPort).findByUserIdForUpdate(USER_ID);
+            verifyNoInteractions(getUserPointUseCase);
+        }
+
+        @Test
+        @DisplayName("차감 시 잠금 조회 결과가 없으면 UserPointNotFoundException이 발생한다")
+        void shouldThrowWhenUserPointNotFoundOnDeductionWithLock() {
+            // given
+            ModifyUserPointCommand command = createDeductionCommandWithUserId(300L);
+
+            when(findUserPointPort.findByUserIdForUpdate(USER_ID)).thenReturn(Optional.empty());
+
+            // expect
+            assertThatThrownBy(() -> modifyUserPointService.modify(command))
+                    .isInstanceOf(UserPointNotFoundException.class);
+
+            verify(findUserPointPort).findByUserIdForUpdate(USER_ID);
+            verifyNoInteractions(getUserPointUseCase);
+            verify(updateUserPointPort, never()).update(any());
+            verify(saveUserPointHistoryPort, never()).save(any());
         }
     }
 
@@ -203,7 +270,7 @@ class ModifyUserPointUseCaseTest {
             UserPoint userPoint = createUserPoint(1000L);
             ModifyUserPointCommand command = createDeductionCommandWithUserId(300L);
 
-            when(getUserPointUseCase.getUserPoint(USER_ID)).thenReturn(userPoint);
+            when(findUserPointPort.findByUserIdForUpdate(USER_ID)).thenReturn(Optional.of(userPoint));
             when(updateUserPointPort.update(any(UserPoint.class)))
                     .thenAnswer(invocation -> invocation.getArgument(0));
             when(saveUserPointHistoryPort.save(any(UserPointHistory.class)))


### PR DESCRIPTION
## partially addresses #387
## resolves #2204

## Test Case
- [x] 포인트를 차감하면 기존 금액에서 차감 금액이 빠진다
- [x] 차감 시 잠금 조회(findByUserIdForUpdate)를 사용하고 일반 조회는 호출하지 않는다
- [x] 차감 시 잠금 조회 결과가 없으면 UserPointNotFoundException이 발생한다
- [x] 적립 시 일반 조회를 사용하고 잠금 조회는 호출하지 않는다
- [x] 차감 시 이력의 금액은 음수로 저장된다
- [x] 잔액 조회 시 잠금 조회(findByUserIdForUpdate)를 사용한다