### PR TITLE
[#723][#2207] fix: SecurityPropertiesValidator gifticon.pin.encrypt-key 전체 서비스 강제 검증으로 인한 배포 실패 픽스

### DIFF
--- a/common/src/main/java/com/personal/marketnote/common/configuration/security/SecurityPropertiesValidator.java
+++ b/common/src/main/java/com/personal/marketnote/common/configuration/security/SecurityPropertiesValidator.java
@@ -50,6 +50,9 @@ public class SecurityPropertiesValidator {
     @Value("${spring.kafka.sasl.password:}")
     private String kafkaSaslPassword;
 
+    @Value("${security.validation.gifticon-pin-enabled:false}")
+    private boolean gifticonPinValidationEnabled;
+
     @Value("${gifticon.pin.encrypt-key:}")
     private String gifticonPinEncryptKey;
 
@@ -67,7 +70,9 @@ public class SecurityPropertiesValidator {
             validateRequired(violations, "spring.kafka.sasl.password (KAFKA_SASL_PASSWORD)", kafkaSaslPassword);
         }
 
-        validateRequired(violations, "gifticon.pin.encrypt-key (GIFTICON_PIN_ENCRYPT_KEY)", gifticonPinEncryptKey);
+        if (gifticonPinValidationEnabled) {
+            validateRequired(violations, "gifticon.pin.encrypt-key (GIFTICON_PIN_ENCRYPT_KEY)", gifticonPinEncryptKey);
+        }
 
         if (!violations.isEmpty()) {
             String message = String.join("\n  - ", violations);

--- a/reward-service/reward-adapters/src/main/resources/application.yml
+++ b/reward-service/reward-adapters/src/main/resources/application.yml
@@ -110,6 +110,10 @@ vendor:
       biz-money-balance-path: /bizApi/bizMoney
       coupon-send-fail-cancel-path: /bizApi/coupon/sendFailCancel
 
+security:
+  validation:
+    gifticon-pin-enabled: true
+
 gifticon:
   pin:
     encrypt-key: ${GIFTICON_PIN_ENCRYPT_KEY:dev-pin-key-change-me}


### PR DESCRIPTION
## partially addresses #723
## resolves #2207

## Task
- [x] SecurityPropertiesValidator에 security.validation.gifticon-pin-enabled 플래그 추가 (기본값 false)
- [x] gifticon.pin.encrypt-key 검증을 플래그가 true일 때만 실행하도록 조건부 분기 적용
- [x] reward-service application.yml에 security.validation.gifticon-pin-enabled: true 설정 추가