### PR TITLE
[#387][#2246] refactor: 리워드 서비스 ServiceTest → UseCaseTest 네이밍 통일

### DIFF
--- a/reward-service/reward-application/src/test/java/com/personal/marketnote/reward/service/gifticon/GetAdminGifticonCategoriesUseCaseTest.java
+++ b/reward-service/reward-application/src/test/java/com/personal/marketnote/reward/service/gifticon/GetAdminGifticonCategoriesUseCaseTest.java
@@ -1,0 +1,90 @@
+package com.personal.marketnote.reward.service.gifticon;
+
+import com.personal.marketnote.reward.domain.gifticon.GifticonCategory;
+import com.personal.marketnote.reward.domain.gifticon.GifticonCategorySnapshotState;
+import com.personal.marketnote.reward.port.in.result.gifticon.GetAdminGifticonCategoriesResult;
+import com.personal.marketnote.reward.port.in.result.gifticon.GifticonCategoryItemResult;
+import com.personal.marketnote.reward.port.out.gifticon.FindGifticonCategoryPort;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class GetAdminGifticonCategoriesUseCaseTest {
+
+    @InjectMocks
+    private GetAdminGifticonCategoriesService getAdminGifticonCategoriesService;
+
+    @Mock
+    private FindGifticonCategoryPort findGifticonCategoryPort;
+
+    @Test
+    @DisplayName("전체 카테고리 목록을 orderNum 오름차순으로 조회한다")
+    void shouldReturnAllCategoriesOrderedByOrderNumAsc() {
+        // given
+        GifticonCategory category1 = createCategory(1L, "1", "커피", null, true, 1);
+        GifticonCategory category2 = createCategory(2L, "2", "편의점", "편의점/마트", true, 2);
+        GifticonCategory category3 = createCategory(3L, "3", "외식", null, false, null);
+        when(findGifticonCategoryPort.findAllOrderByOrderNumAsc())
+                .thenReturn(List.of(category1, category2, category3));
+
+        // when
+        GetAdminGifticonCategoriesResult result = getAdminGifticonCategoriesService.getAdminGifticonCategories();
+
+        // then
+        assertThat(result.categories()).hasSize(3);
+        verify(findGifticonCategoryPort).findAllOrderByOrderNumAsc();
+
+        GifticonCategoryItemResult first = result.categories().get(0);
+        assertThat(first.id()).isEqualTo(1L);
+        assertThat(first.categoryCode()).isEqualTo("1");
+        assertThat(first.categoryName()).isEqualTo("커피");
+        assertThat(first.displayName()).isNull();
+        assertThat(first.effectiveDisplayName()).isEqualTo("커피");
+        assertThat(first.exposed()).isTrue();
+        assertThat(first.orderNum()).isEqualTo(1);
+
+        GifticonCategoryItemResult second = result.categories().get(1);
+        assertThat(second.displayName()).isEqualTo("편의점/마트");
+        assertThat(second.effectiveDisplayName()).isEqualTo("편의점/마트");
+    }
+
+    @Test
+    @DisplayName("카테고리가 없으면 빈 목록을 반환한다")
+    void shouldReturnEmptyListWhenNoCategoriesExist() {
+        // given
+        when(findGifticonCategoryPort.findAllOrderByOrderNumAsc())
+                .thenReturn(List.of());
+
+        // when
+        GetAdminGifticonCategoriesResult result = getAdminGifticonCategoriesService.getAdminGifticonCategories();
+
+        // then
+        assertThat(result.categories()).isEmpty();
+        verify(findGifticonCategoryPort).findAllOrderByOrderNumAsc();
+    }
+
+    private GifticonCategory createCategory(Long id, String categoryCode, String categoryName,
+                                            String displayName, boolean exposed, Integer orderNum) {
+        return GifticonCategory.from(GifticonCategorySnapshotState.builder()
+                .id(id)
+                .categoryCode(categoryCode)
+                .categoryName(categoryName)
+                .displayName(displayName)
+                .exposed(exposed)
+                .orderNum(orderNum)
+                .createdAt(LocalDateTime.of(2026, 4, 3, 10, 0))
+                .modifiedAt(LocalDateTime.of(2026, 4, 3, 10, 0))
+                .build());
+    }
+}

--- a/reward-service/reward-application/src/test/java/com/personal/marketnote/reward/service/gifticon/GetAdminGifticonGoodsUseCaseTest.java
+++ b/reward-service/reward-application/src/test/java/com/personal/marketnote/reward/service/gifticon/GetAdminGifticonGoodsUseCaseTest.java
@@ -1,0 +1,212 @@
+package com.personal.marketnote.reward.service.gifticon;
+
+import com.personal.marketnote.reward.domain.gifticon.GifticonGoods;
+import com.personal.marketnote.reward.domain.gifticon.GifticonGoodsSnapshotState;
+import com.personal.marketnote.reward.port.in.command.gifticon.GetAdminGifticonGoodsCommand;
+import com.personal.marketnote.reward.port.in.result.gifticon.GetAdminGifticonGoodsResult;
+import com.personal.marketnote.reward.port.out.gifticon.FindGifticonGoodsPort;
+import com.personal.marketnote.reward.port.out.gifticon.FindGifticonGoodsPort.FindAllForAdminResult;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class GetAdminGifticonGoodsUseCaseTest {
+
+    @InjectMocks
+    private GetAdminGifticonGoodsService getAdminGifticonGoodsService;
+
+    @Mock
+    private FindGifticonGoodsPort findGifticonGoodsPort;
+
+    @Test
+    @DisplayName("필터 없이 전체 상품 목록을 조회하면 페이징된 결과를 반환한다")
+    void shouldReturnPaginatedResultWhenNoFilter() {
+        // given
+        GetAdminGifticonGoodsCommand command = new GetAdminGifticonGoodsCommand(1, 20, null, null, null);
+        GifticonGoods goods = createGoods(1L, "G00001", "아메리카노", "BR001", "스타벅스", "SALE", true, 1);
+        FindAllForAdminResult portResult = new FindAllForAdminResult(List.of(goods), 1L);
+
+        when(findGifticonGoodsPort.findAllForAdmin(1, 20, "", null, ""))
+                .thenReturn(portResult);
+
+        // when
+        GetAdminGifticonGoodsResult result = getAdminGifticonGoodsService.getAdminGifticonGoods(command);
+
+        // then
+        assertThat(result.page()).isEqualTo(1);
+        assertThat(result.pageSize()).isEqualTo(20);
+        assertThat(result.totalElements()).isEqualTo(1L);
+        assertThat(result.totalPages()).isEqualTo(1);
+        assertThat(result.items()).hasSize(1);
+        assertThat(result.items().get(0).goodsCode()).isEqualTo("G00001");
+        assertThat(result.items().get(0).goodsName()).isEqualTo("아메리카노");
+        verify(findGifticonGoodsPort).findAllForAdmin(1, 20, "", null, "");
+    }
+
+    @Test
+    @DisplayName("goodsStatus 필터로 SALE 상품만 조회한다")
+    void shouldFilterByGoodsStatus() {
+        // given
+        GetAdminGifticonGoodsCommand command = new GetAdminGifticonGoodsCommand(1, 10, "SALE", null, null);
+        GifticonGoods goods = createGoods(1L, "G00001", "아메리카노", "BR001", "스타벅스", "SALE", false, null);
+        FindAllForAdminResult portResult = new FindAllForAdminResult(List.of(goods), 1L);
+
+        when(findGifticonGoodsPort.findAllForAdmin(1, 10, "SALE", null, ""))
+                .thenReturn(portResult);
+
+        // when
+        GetAdminGifticonGoodsResult result = getAdminGifticonGoodsService.getAdminGifticonGoods(command);
+
+        // then
+        assertThat(result.items()).hasSize(1);
+        assertThat(result.items().get(0).goodsStatus()).isEqualTo("SALE");
+        verify(findGifticonGoodsPort).findAllForAdmin(1, 10, "SALE", null, "");
+    }
+
+    @Test
+    @DisplayName("exposed 필터로 노출 상품만 조회한다")
+    void shouldFilterByExposed() {
+        // given
+        GetAdminGifticonGoodsCommand command = new GetAdminGifticonGoodsCommand(1, 10, null, true, null);
+        GifticonGoods goods = createGoods(1L, "G00001", "아메리카노", "BR001", "스타벅스", "SALE", true, 1);
+        FindAllForAdminResult portResult = new FindAllForAdminResult(List.of(goods), 1L);
+
+        when(findGifticonGoodsPort.findAllForAdmin(1, 10, "", true, ""))
+                .thenReturn(portResult);
+
+        // when
+        GetAdminGifticonGoodsResult result = getAdminGifticonGoodsService.getAdminGifticonGoods(command);
+
+        // then
+        assertThat(result.items()).hasSize(1);
+        assertThat(result.items().get(0).exposed()).isTrue();
+        verify(findGifticonGoodsPort).findAllForAdmin(1, 10, "", true, "");
+    }
+
+    @Test
+    @DisplayName("keyword 필터로 상품명 검색한다")
+    void shouldFilterByKeyword() {
+        // given
+        GetAdminGifticonGoodsCommand command = new GetAdminGifticonGoodsCommand(1, 10, null, null, "아메리카노");
+        GifticonGoods goods = createGoods(1L, "G00001", "아메리카노", "BR001", "스타벅스", "SALE", false, null);
+        FindAllForAdminResult portResult = new FindAllForAdminResult(List.of(goods), 1L);
+
+        when(findGifticonGoodsPort.findAllForAdmin(1, 10, "", null, "아메리카노"))
+                .thenReturn(portResult);
+
+        // when
+        GetAdminGifticonGoodsResult result = getAdminGifticonGoodsService.getAdminGifticonGoods(command);
+
+        // then
+        assertThat(result.items()).hasSize(1);
+        assertThat(result.items().get(0).goodsName()).isEqualTo("아메리카노");
+        verify(findGifticonGoodsPort).findAllForAdmin(1, 10, "", null, "아메리카노");
+    }
+
+    @Test
+    @DisplayName("결과가 없으면 빈 목록과 0건을 반환한다")
+    void shouldReturnEmptyResultWhenNoGoods() {
+        // given
+        GetAdminGifticonGoodsCommand command = new GetAdminGifticonGoodsCommand(1, 20, null, null, null);
+        FindAllForAdminResult portResult = new FindAllForAdminResult(List.of(), 0L);
+
+        when(findGifticonGoodsPort.findAllForAdmin(1, 20, "", null, ""))
+                .thenReturn(portResult);
+
+        // when
+        GetAdminGifticonGoodsResult result = getAdminGifticonGoodsService.getAdminGifticonGoods(command);
+
+        // then
+        assertThat(result.page()).isEqualTo(1);
+        assertThat(result.pageSize()).isEqualTo(20);
+        assertThat(result.totalElements()).isZero();
+        assertThat(result.totalPages()).isZero();
+        assertThat(result.items()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("totalPages는 totalElements와 pageSize로 올림 계산된다")
+    void shouldCalculateTotalPagesCorrectly() {
+        // given
+        GetAdminGifticonGoodsCommand command = new GetAdminGifticonGoodsCommand(1, 10, null, null, null);
+        GifticonGoods goods = createGoods(1L, "G00001", "아메리카노", "BR001", "스타벅스", "SALE", false, null);
+        FindAllForAdminResult portResult = new FindAllForAdminResult(List.of(goods), 25L);
+
+        when(findGifticonGoodsPort.findAllForAdmin(1, 10, "", null, ""))
+                .thenReturn(portResult);
+
+        // when
+        GetAdminGifticonGoodsResult result = getAdminGifticonGoodsService.getAdminGifticonGoods(command);
+
+        // then
+        assertThat(result.totalPages()).isEqualTo(3);
+        assertThat(result.totalElements()).isEqualTo(25L);
+    }
+
+    @Test
+    @DisplayName("Result의 각 항목에 모든 필드가 올바르게 매핑된다")
+    void shouldMapAllFieldsCorrectly() {
+        // given
+        GetAdminGifticonGoodsCommand command = new GetAdminGifticonGoodsCommand(1, 20, null, null, null);
+        GifticonGoods goods = createGoods(1L, "G00001", "아메리카노", "BR001", "스타벅스", "SALE", true, 3);
+        FindAllForAdminResult portResult = new FindAllForAdminResult(List.of(goods), 1L);
+
+        when(findGifticonGoodsPort.findAllForAdmin(1, 20, "", null, ""))
+                .thenReturn(portResult);
+
+        // when
+        GetAdminGifticonGoodsResult result = getAdminGifticonGoodsService.getAdminGifticonGoods(command);
+
+        // then
+        assertThat(result.items().get(0).goodsCode()).isEqualTo("G00001");
+        assertThat(result.items().get(0).goodsName()).isEqualTo("아메리카노");
+        assertThat(result.items().get(0).brandCode()).isEqualTo("BR001");
+        assertThat(result.items().get(0).brandName()).isEqualTo("스타벅스");
+        assertThat(result.items().get(0).categoryCode()).isEqualTo("1");
+        assertThat(result.items().get(0).realPrice()).isEqualTo(5000L);
+        assertThat(result.items().get(0).salePrice()).isEqualTo(4500L);
+        assertThat(result.items().get(0).cashPrice()).isEqualTo(3500L);
+        assertThat(result.items().get(0).goodsStatus()).isEqualTo("SALE");
+        assertThat(result.items().get(0).exposed()).isTrue();
+        assertThat(result.items().get(0).orderNum()).isEqualTo(3);
+        assertThat(result.items().get(0).imageUrl()).isEqualTo("https://img.com/goods.png");
+    }
+
+    // --- Helper Methods ---
+
+    private GifticonGoods createGoods(Long id, String goodsCode, String goodsName,
+                                      String brandCode, String brandName,
+                                      String goodsStatus, boolean exposed, Integer orderNum) {
+        return GifticonGoods.from(GifticonGoodsSnapshotState.builder()
+                .id(id)
+                .goodsCode(goodsCode)
+                .goodsName(goodsName)
+                .brandCode(brandCode)
+                .brandName(brandName)
+                .brandImageUrl("https://img.com/brand.png")
+                .categoryCode("1")
+                .realPrice(5000L)
+                .salePrice(4500L)
+                .cashPrice(3500L)
+                .imageUrl("https://img.com/goods.png")
+                .description("설명")
+                .validDays(30)
+                .goodsStatus(goodsStatus)
+                .exposed(exposed)
+                .orderNum(orderNum)
+                .createdAt(LocalDateTime.of(2026, 4, 1, 10, 0))
+                .modifiedAt(LocalDateTime.of(2026, 4, 1, 10, 0))
+                .build());
+    }
+}

--- a/reward-service/reward-application/src/test/java/com/personal/marketnote/reward/service/gifticon/GetGifticonBrandsUseCaseTest.java
+++ b/reward-service/reward-application/src/test/java/com/personal/marketnote/reward/service/gifticon/GetGifticonBrandsUseCaseTest.java
@@ -1,0 +1,70 @@
+package com.personal.marketnote.reward.service.gifticon;
+
+import com.personal.marketnote.reward.port.in.command.gifticon.GetGifticonBrandsCommand;
+import com.personal.marketnote.reward.port.in.result.gifticon.GetGifticonBrandsResult;
+import com.personal.marketnote.reward.port.out.gifticon.FindGifticonGoodsPort;
+import com.personal.marketnote.reward.port.out.gifticon.FindGifticonGoodsPort.GifticonGoodsBrandProjection;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class GetGifticonBrandsUseCaseTest {
+
+    @InjectMocks
+    private GetGifticonBrandsService getGifticonBrandsService;
+
+    @Mock
+    private FindGifticonGoodsPort findGifticonGoodsPort;
+
+    @Test
+    @DisplayName("카테고리 코드로 브랜드 목록을 조회하면 해당 카테고리의 브랜드를 반환한다")
+    void shouldReturnBrandsForGivenCategoryCode() {
+        // given
+        String categoryCode = "1";
+        GifticonGoodsBrandProjection brand1 = new GifticonGoodsBrandProjection("BR001", "스타벅스", "https://img.com/sb.png");
+        GifticonGoodsBrandProjection brand2 = new GifticonGoodsBrandProjection("BR002", "이디야", "https://img.com/ediya.png");
+        when(findGifticonGoodsPort.findDistinctBrandsByCategoryCode(categoryCode))
+                .thenReturn(List.of(brand1, brand2));
+
+        // when
+        GetGifticonBrandsResult result = getGifticonBrandsService.getBrands(
+                new GetGifticonBrandsCommand(categoryCode)
+        );
+
+        // then
+        assertThat(result.brands()).hasSize(2);
+        assertThat(result.brands().get(0).brandCode()).isEqualTo("BR001");
+        assertThat(result.brands().get(0).brandName()).isEqualTo("스타벅스");
+        assertThat(result.brands().get(0).brandImageUrl()).isEqualTo("https://img.com/sb.png");
+        assertThat(result.brands().get(1).brandCode()).isEqualTo("BR002");
+        verify(findGifticonGoodsPort).findDistinctBrandsByCategoryCode(categoryCode);
+    }
+
+    @Test
+    @DisplayName("해당 카테고리에 브랜드가 없으면 빈 목록을 반환한다")
+    void shouldReturnEmptyListWhenNoBrandsInCategory() {
+        // given
+        String categoryCode = "99";
+        when(findGifticonGoodsPort.findDistinctBrandsByCategoryCode(categoryCode))
+                .thenReturn(List.of());
+
+        // when
+        GetGifticonBrandsResult result = getGifticonBrandsService.getBrands(
+                new GetGifticonBrandsCommand(categoryCode)
+        );
+
+        // then
+        assertThat(result.brands()).isEmpty();
+        verify(findGifticonGoodsPort).findDistinctBrandsByCategoryCode(categoryCode);
+    }
+}

--- a/reward-service/reward-application/src/test/java/com/personal/marketnote/reward/service/gifticon/GetGifticonCategoriesUseCaseTest.java
+++ b/reward-service/reward-application/src/test/java/com/personal/marketnote/reward/service/gifticon/GetGifticonCategoriesUseCaseTest.java
@@ -1,0 +1,93 @@
+package com.personal.marketnote.reward.service.gifticon;
+
+import com.personal.marketnote.reward.domain.gifticon.GifticonCategory;
+import com.personal.marketnote.reward.domain.gifticon.GifticonCategorySnapshotState;
+import com.personal.marketnote.reward.port.in.result.gifticon.GetGifticonCategoriesResult;
+import com.personal.marketnote.reward.port.out.gifticon.FindGifticonCategoryPort;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class GetGifticonCategoriesUseCaseTest {
+
+    @InjectMocks
+    private GetGifticonCategoriesService getGifticonCategoriesService;
+
+    @Mock
+    private FindGifticonCategoryPort findGifticonCategoryPort;
+
+    @Test
+    @DisplayName("노출된 카테고리 목록을 조회하면 displayName과 iconUrl을 포함한 결과를 반환한다")
+    void shouldReturnExposedCategoriesWithDisplayNameAndIconUrl() {
+        // given
+        GifticonCategory category1 = createCategory(1L, "1", "커피", "카페", "https://img.com/coffee.png", 1);
+        GifticonCategory category2 = createCategory(2L, "2", "베이커리", null, "https://img.com/bakery.png", 2);
+        when(findGifticonCategoryPort.findAllExposed()).thenReturn(List.of(category1, category2));
+
+        // when
+        GetGifticonCategoriesResult result = getGifticonCategoriesService.getCategories();
+
+        // then
+        assertThat(result.categories()).hasSize(2);
+        assertThat(result.categories().get(0).categoryCode()).isEqualTo("1");
+        assertThat(result.categories().get(0).displayName()).isEqualTo("카페");
+        assertThat(result.categories().get(0).iconUrl()).isEqualTo("https://img.com/coffee.png");
+        assertThat(result.categories().get(0).orderNum()).isEqualTo(1);
+        assertThat(result.categories().get(1).displayName()).isEqualTo("베이커리");
+        verify(findGifticonCategoryPort).findAllExposed();
+    }
+
+    @Test
+    @DisplayName("노출된 카테고리가 없으면 빈 목록을 반환한다")
+    void shouldReturnEmptyListWhenNoCategoriesExposed() {
+        // given
+        when(findGifticonCategoryPort.findAllExposed()).thenReturn(List.of());
+
+        // when
+        GetGifticonCategoriesResult result = getGifticonCategoriesService.getCategories();
+
+        // then
+        assertThat(result.categories()).isEmpty();
+        verify(findGifticonCategoryPort).findAllExposed();
+    }
+
+    @Test
+    @DisplayName("displayName이 없으면 categoryName을 effectiveDisplayName으로 반환한다")
+    void shouldUseCategoryNameWhenDisplayNameIsNull() {
+        // given
+        GifticonCategory category = createCategory(1L, "3", "아이스크림", null, "https://img.com/ice.png", 3);
+        when(findGifticonCategoryPort.findAllExposed()).thenReturn(List.of(category));
+
+        // when
+        GetGifticonCategoriesResult result = getGifticonCategoriesService.getCategories();
+
+        // then
+        assertThat(result.categories().get(0).displayName()).isEqualTo("아이스크림");
+    }
+
+    private GifticonCategory createCategory(Long id, String categoryCode, String categoryName,
+                                            String displayName, String iconUrl, Integer orderNum) {
+        return GifticonCategory.from(GifticonCategorySnapshotState.builder()
+                .id(id)
+                .categoryCode(categoryCode)
+                .categoryName(categoryName)
+                .displayName(displayName)
+                .iconUrl(iconUrl)
+                .exposed(true)
+                .orderNum(orderNum)
+                .createdAt(LocalDateTime.now())
+                .modifiedAt(LocalDateTime.now())
+                .build());
+    }
+}

--- a/reward-service/reward-application/src/test/java/com/personal/marketnote/reward/service/gifticon/GetGifticonGoodsDetailUseCaseTest.java
+++ b/reward-service/reward-application/src/test/java/com/personal/marketnote/reward/service/gifticon/GetGifticonGoodsDetailUseCaseTest.java
@@ -1,0 +1,144 @@
+package com.personal.marketnote.reward.service.gifticon;
+
+import com.personal.marketnote.reward.domain.exception.GifticonGoodsNotFoundException;
+import com.personal.marketnote.reward.domain.gifticon.GifticonGoods;
+import com.personal.marketnote.reward.domain.gifticon.GifticonGoodsSnapshotState;
+import com.personal.marketnote.reward.domain.point.UserPoint;
+import com.personal.marketnote.reward.domain.point.UserPointSnapshotState;
+import com.personal.marketnote.reward.port.in.command.gifticon.GetGifticonGoodsDetailCommand;
+import com.personal.marketnote.reward.port.in.result.gifticon.GetGifticonGoodsDetailResult;
+import com.personal.marketnote.reward.port.in.usecase.point.GetUserPointUseCase;
+import com.personal.marketnote.reward.port.out.gifticon.FindGifticonGoodsPort;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class GetGifticonGoodsDetailUseCaseTest {
+
+    @InjectMocks
+    private GetGifticonGoodsDetailService getGifticonGoodsDetailService;
+
+    @Mock
+    private FindGifticonGoodsPort findGifticonGoodsPort;
+
+    @Mock
+    private GetUserPointUseCase getUserPointUseCase;
+
+    @Test
+    @DisplayName("노출된 판매 중 상품을 조회하면 상세 정보와 캐시 잔액을 반환한다")
+    void shouldReturnGoodsDetailWithCashBalance() {
+        // given
+        String goodsCode = "GD001";
+        Long userId = 1L;
+        GifticonGoods goods = createGoods(goodsCode, true, "SALE");
+        UserPoint userPoint = createUserPoint(userId, 10000L);
+        when(findGifticonGoodsPort.findByGoodsCode(goodsCode)).thenReturn(Optional.of(goods));
+        when(getUserPointUseCase.getUserPoint(userId)).thenReturn(userPoint);
+
+        // when
+        GetGifticonGoodsDetailResult result = getGifticonGoodsDetailService.getGoodsDetail(
+                new GetGifticonGoodsDetailCommand(goodsCode, userId)
+        );
+
+        // then
+        assertThat(result.goodsCode()).isEqualTo("GD001");
+        assertThat(result.goodsName()).isEqualTo("아메리카노");
+        assertThat(result.salePrice()).isEqualTo(4500L);
+        assertThat(result.cashPrice()).isEqualTo(4000L);
+        assertThat(result.description()).isEqualTo("맛있는 커피");
+        assertThat(result.validDays()).isEqualTo(30);
+        assertThat(result.userCashBalance()).isEqualTo(10000L);
+        verify(findGifticonGoodsPort).findByGoodsCode(goodsCode);
+        verify(getUserPointUseCase).getUserPoint(userId);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 상품 코드로 조회하면 GifticonGoodsNotFoundException이 발생한다")
+    void shouldThrowWhenGoodsNotFound() {
+        // given
+        String goodsCode = "INVALID";
+        Long userId = 1L;
+        when(findGifticonGoodsPort.findByGoodsCode(goodsCode)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> getGifticonGoodsDetailService.getGoodsDetail(
+                new GetGifticonGoodsDetailCommand(goodsCode, userId)
+        )).isInstanceOf(GifticonGoodsNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("노출되지 않은 상품을 조회하면 GifticonGoodsNotFoundException이 발생한다")
+    void shouldThrowWhenGoodsNotExposed() {
+        // given
+        String goodsCode = "GD002";
+        Long userId = 1L;
+        GifticonGoods goods = createGoods(goodsCode, false, "SALE");
+        when(findGifticonGoodsPort.findByGoodsCode(goodsCode)).thenReturn(Optional.of(goods));
+
+        // when & then
+        assertThatThrownBy(() -> getGifticonGoodsDetailService.getGoodsDetail(
+                new GetGifticonGoodsDetailCommand(goodsCode, userId)
+        )).isInstanceOf(GifticonGoodsNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("판매 중이 아닌 상품을 조회하면 GifticonGoodsNotFoundException이 발생한다")
+    void shouldThrowWhenGoodsNotOnSale() {
+        // given
+        String goodsCode = "GD003";
+        Long userId = 1L;
+        GifticonGoods goods = createGoods(goodsCode, true, "SUS");
+        when(findGifticonGoodsPort.findByGoodsCode(goodsCode)).thenReturn(Optional.of(goods));
+
+        // when & then
+        assertThatThrownBy(() -> getGifticonGoodsDetailService.getGoodsDetail(
+                new GetGifticonGoodsDetailCommand(goodsCode, userId)
+        )).isInstanceOf(GifticonGoodsNotFoundException.class);
+    }
+
+    private GifticonGoods createGoods(String goodsCode, boolean exposed, String goodsStatus) {
+        return GifticonGoods.from(GifticonGoodsSnapshotState.builder()
+                .id(1L)
+                .goodsCode(goodsCode)
+                .goodsName("아메리카노")
+                .brandCode("BR001")
+                .brandName("스타벅스")
+                .brandImageUrl("https://img.com/sb.png")
+                .categoryCode("1")
+                .realPrice(5000L)
+                .salePrice(4500L)
+                .cashPrice(4000L)
+                .imageUrl("https://img.com/goods.png")
+                .description("맛있는 커피")
+                .validDays(30)
+                .goodsStatus(goodsStatus)
+                .exposed(exposed)
+                .orderNum(1)
+                .createdAt(LocalDateTime.now())
+                .modifiedAt(LocalDateTime.now())
+                .build());
+    }
+
+    private UserPoint createUserPoint(Long userId, Long amount) {
+        return UserPoint.from(UserPointSnapshotState.builder()
+                .userId(userId)
+                .amount(amount)
+                .addExpectedAmount(0L)
+                .expireExpectedAmount(0L)
+                .createdAt(LocalDateTime.now())
+                .modifiedAt(LocalDateTime.now())
+                .build());
+    }
+}

--- a/reward-service/reward-application/src/test/java/com/personal/marketnote/reward/service/gifticon/GetGifticonGoodsUseCaseTest.java
+++ b/reward-service/reward-application/src/test/java/com/personal/marketnote/reward/service/gifticon/GetGifticonGoodsUseCaseTest.java
@@ -1,0 +1,117 @@
+package com.personal.marketnote.reward.service.gifticon;
+
+import com.personal.marketnote.reward.domain.gifticon.GifticonGoods;
+import com.personal.marketnote.reward.domain.gifticon.GifticonGoodsSnapshotState;
+import com.personal.marketnote.reward.port.in.command.gifticon.GetGifticonGoodsCommand;
+import com.personal.marketnote.reward.port.in.result.gifticon.GetGifticonGoodsResult;
+import com.personal.marketnote.reward.port.out.gifticon.FindGifticonGoodsPort;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class GetGifticonGoodsUseCaseTest {
+
+    @InjectMocks
+    private GetGifticonGoodsService getGifticonGoodsService;
+
+    @Mock
+    private FindGifticonGoodsPort findGifticonGoodsPort;
+
+    @Test
+    @DisplayName("카테고리와 브랜드로 상품 목록을 조회하면 페이징 결과를 반환한다")
+    void shouldReturnPaginatedGoodsForCategoryAndBrand() {
+        // given
+        String categoryCode = "1";
+        String brandCode = "BR001";
+        GifticonGoods goods = createGoods(1L, "GD001", "아메리카노", 4500L, 4000L, 1);
+        when(findGifticonGoodsPort.countAllExposed(categoryCode, brandCode)).thenReturn(1L);
+        when(findGifticonGoodsPort.findAllExposed(categoryCode, brandCode, 1, 20)).thenReturn(List.of(goods));
+
+        // when
+        GetGifticonGoodsResult result = getGifticonGoodsService.getGoods(
+                new GetGifticonGoodsCommand(categoryCode, brandCode, 1, 20)
+        );
+
+        // then
+        assertThat(result.page()).isEqualTo(1);
+        assertThat(result.pageSize()).isEqualTo(20);
+        assertThat(result.totalElements()).isEqualTo(1L);
+        assertThat(result.totalPages()).isEqualTo(1);
+        assertThat(result.items()).hasSize(1);
+        assertThat(result.items().get(0).goodsCode()).isEqualTo("GD001");
+        assertThat(result.items().get(0).goodsName()).isEqualTo("아메리카노");
+        assertThat(result.items().get(0).salePrice()).isEqualTo(4500L);
+        assertThat(result.items().get(0).cashPrice()).isEqualTo(4000L);
+        verify(findGifticonGoodsPort).countAllExposed(categoryCode, brandCode);
+        verify(findGifticonGoodsPort).findAllExposed(categoryCode, brandCode, 1, 20);
+    }
+
+    @Test
+    @DisplayName("상품이 없으면 빈 목록과 totalPages 0을 반환한다")
+    void shouldReturnEmptyListWhenNoGoods() {
+        // given
+        when(findGifticonGoodsPort.countAllExposed(null, null)).thenReturn(0L);
+        when(findGifticonGoodsPort.findAllExposed(null, null, 1, 20)).thenReturn(List.of());
+
+        // when
+        GetGifticonGoodsResult result = getGifticonGoodsService.getGoods(
+                new GetGifticonGoodsCommand(null, null, 1, 20)
+        );
+
+        // then
+        assertThat(result.totalElements()).isZero();
+        assertThat(result.totalPages()).isZero();
+        assertThat(result.items()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("총 상품 수가 pageSize보다 크면 totalPages가 올바르게 계산된다")
+    void shouldCalculateTotalPagesCorrectly() {
+        // given
+        when(findGifticonGoodsPort.countAllExposed(null, null)).thenReturn(45L);
+        when(findGifticonGoodsPort.findAllExposed(null, null, 1, 20)).thenReturn(List.of());
+
+        // when
+        GetGifticonGoodsResult result = getGifticonGoodsService.getGoods(
+                new GetGifticonGoodsCommand(null, null, 1, 20)
+        );
+
+        // then
+        assertThat(result.totalPages()).isEqualTo(3);
+    }
+
+    private GifticonGoods createGoods(Long id, String goodsCode, String goodsName,
+                                      Long salePrice, Long cashPrice, Integer orderNum) {
+        return GifticonGoods.from(GifticonGoodsSnapshotState.builder()
+                .id(id)
+                .goodsCode(goodsCode)
+                .goodsName(goodsName)
+                .brandCode("BR001")
+                .brandName("스타벅스")
+                .brandImageUrl("https://img.com/sb.png")
+                .categoryCode("1")
+                .realPrice(5000L)
+                .salePrice(salePrice)
+                .cashPrice(cashPrice)
+                .imageUrl("https://img.com/goods.png")
+                .description("설명")
+                .validDays(30)
+                .goodsStatus("SALE")
+                .exposed(true)
+                .orderNum(orderNum)
+                .createdAt(LocalDateTime.now())
+                .modifiedAt(LocalDateTime.now())
+                .build());
+    }
+}

--- a/reward-service/reward-application/src/test/java/com/personal/marketnote/reward/service/gifticon/GetMyGifticonOrderDetailUseCaseTest.java
+++ b/reward-service/reward-application/src/test/java/com/personal/marketnote/reward/service/gifticon/GetMyGifticonOrderDetailUseCaseTest.java
@@ -1,0 +1,360 @@
+package com.personal.marketnote.reward.service.gifticon;
+
+import com.personal.marketnote.reward.domain.exception.GifticonOrderNotFoundException;
+import com.personal.marketnote.reward.domain.gifticon.*;
+import com.personal.marketnote.reward.port.in.command.gifticon.GetMyGifticonOrderDetailCommand;
+import com.personal.marketnote.reward.port.in.result.gifticon.GetMyGifticonOrderDetailResult;
+import com.personal.marketnote.reward.port.out.gifticon.*;
+import com.personal.marketnote.reward.port.out.gifticon.QueryGifticonCouponStatusPort.CouponStatusResult;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.*;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class GetMyGifticonOrderDetailUseCaseTest {
+
+    @InjectMocks
+    private GetMyGifticonOrderDetailService getMyGifticonOrderDetailService;
+
+    @Mock
+    private FindGifticonOrderPort findGifticonOrderPort;
+
+    @Mock
+    private FindGifticonGoodsPort findGifticonGoodsPort;
+
+    @Mock
+    private QueryGifticonCouponStatusPort queryGifticonCouponStatusPort;
+
+    @Mock
+    private UpdateGifticonOrderPort updateGifticonOrderPort;
+
+    @Mock
+    private DecryptGifticonPinPort decryptGifticonPinPort;
+
+    @Spy
+    private Clock clock = Clock.fixed(
+            Instant.parse("2026-04-06T03:00:00Z"),
+            ZoneId.of("Asia/Seoul")
+    );
+
+    private static final Long USER_ID = 100L;
+    private static final Long ORDER_ID = 1L;
+    private static final String TR_ID = "NC100_260401100000";
+    private static final String GOODS_CODE = "G00000280811";
+
+    @Test
+    @DisplayName("ISSUED 상태 주문의 상세 정보를 정상적으로 반환한다")
+    void shouldReturnOrderDetailSuccessfully() {
+        // given
+        GifticonOrder order = createOrder(GifticonOrderStatus.ISSUED);
+        GifticonGoods goods = createGoods();
+
+        when(findGifticonOrderPort.findByIdAndUserId(ORDER_ID, USER_ID)).thenReturn(Optional.of(order));
+        when(queryGifticonCouponStatusPort.queryStatus(TR_ID)).thenReturn(
+                CouponStatusResult.builder().success(true).pinStatusCd("01").validPrdEndDt("20260504").build()
+        );
+        when(findGifticonGoodsPort.findByGoodsCode(GOODS_CODE)).thenReturn(Optional.of(goods));
+        when(decryptGifticonPinPort.decrypt("encryptedPin")).thenReturn("900343630367");
+
+        GetMyGifticonOrderDetailCommand command = new GetMyGifticonOrderDetailCommand(USER_ID, ORDER_ID);
+
+        // when
+        GetMyGifticonOrderDetailResult result = getMyGifticonOrderDetailService.getMyGifticonOrderDetail(command);
+
+        // then
+        assertThat(result.orderId()).isEqualTo(ORDER_ID);
+        assertThat(result.goodsName()).isEqualTo("테스트 기프티콘");
+        assertThat(result.brandName()).isEqualTo("세븐일레븐");
+        assertThat(result.brandImageUrl()).isEqualTo("https://example.com/brand.jpg");
+        assertThat(result.productImageUrl()).isEqualTo("https://example.com/goods.jpg");
+        assertThat(result.description()).isEqualTo("테스트 상품입니다");
+        assertThat(result.cashPrice()).isEqualTo(5000L);
+        assertThat(result.couponImageUrl()).isEqualTo("https://example.com/coupon.jpg");
+        assertThat(result.pinNo()).isEqualTo("900343630367");
+        assertThat(result.orderStatus()).isEqualTo("ISSUED");
+    }
+
+    @Test
+    @DisplayName("주문이 존재하지 않으면 GifticonOrderNotFoundException이 발생한다")
+    void shouldThrowExceptionWhenOrderNotFound() {
+        // given
+        when(findGifticonOrderPort.findByIdAndUserId(ORDER_ID, USER_ID)).thenReturn(Optional.empty());
+        GetMyGifticonOrderDetailCommand command = new GetMyGifticonOrderDetailCommand(USER_ID, ORDER_ID);
+
+        // when & then
+        assertThatThrownBy(() -> getMyGifticonOrderDetailService.getMyGifticonOrderDetail(command))
+                .isInstanceOf(GifticonOrderNotFoundException.class);
+
+        verifyNoInteractions(queryGifticonCouponStatusPort);
+        verifyNoInteractions(decryptGifticonPinPort);
+    }
+
+    @Test
+    @DisplayName("ISSUED 상태에서 기프티쇼 API 조회 결과 USED로 변경되면 상태가 동기화된다")
+    void shouldSyncStatusWhenPinStatusChangedToUsed() {
+        // given
+        GifticonOrder order = createOrder(GifticonOrderStatus.ISSUED);
+        GifticonGoods goods = createGoods();
+
+        when(findGifticonOrderPort.findByIdAndUserId(ORDER_ID, USER_ID)).thenReturn(Optional.of(order));
+        when(queryGifticonCouponStatusPort.queryStatus(TR_ID)).thenReturn(
+                CouponStatusResult.builder().success(true).pinStatusCd("02").validPrdEndDt("20260504").build()
+        );
+        when(findGifticonGoodsPort.findByGoodsCode(GOODS_CODE)).thenReturn(Optional.of(goods));
+        when(decryptGifticonPinPort.decrypt("encryptedPin")).thenReturn("900343630367");
+
+        GetMyGifticonOrderDetailCommand command = new GetMyGifticonOrderDetailCommand(USER_ID, ORDER_ID);
+
+        // when
+        GetMyGifticonOrderDetailResult result = getMyGifticonOrderDetailService.getMyGifticonOrderDetail(command);
+
+        // then
+        assertThat(result.orderStatus()).isEqualTo("USED");
+        assertThat(result.statusLabel()).isEqualTo("사용완료");
+        verify(updateGifticonOrderPort).update(order);
+    }
+
+    @Test
+    @DisplayName("ISSUED 상태에서 기프티쇼 API 조회 결과 EXPIRED로 변경되면 상태가 동기화된다")
+    void shouldSyncStatusWhenPinStatusChangedToExpired() {
+        // given
+        GifticonOrder order = createOrder(GifticonOrderStatus.ISSUED);
+        GifticonGoods goods = createGoods();
+
+        when(findGifticonOrderPort.findByIdAndUserId(ORDER_ID, USER_ID)).thenReturn(Optional.of(order));
+        when(queryGifticonCouponStatusPort.queryStatus(TR_ID)).thenReturn(
+                CouponStatusResult.builder().success(true).pinStatusCd("08").validPrdEndDt("20260504").build()
+        );
+        when(findGifticonGoodsPort.findByGoodsCode(GOODS_CODE)).thenReturn(Optional.of(goods));
+        when(decryptGifticonPinPort.decrypt("encryptedPin")).thenReturn("900343630367");
+
+        GetMyGifticonOrderDetailCommand command = new GetMyGifticonOrderDetailCommand(USER_ID, ORDER_ID);
+
+        // when
+        GetMyGifticonOrderDetailResult result = getMyGifticonOrderDetailService.getMyGifticonOrderDetail(command);
+
+        // then
+        assertThat(result.orderStatus()).isEqualTo("EXPIRED");
+        assertThat(result.statusLabel()).isEqualTo("기간만료");
+        verify(updateGifticonOrderPort).update(order);
+    }
+
+    @Test
+    @DisplayName("ISSUED 상태에서 기프티쇼 API 조회 결과 동일 상태이면 업데이트하지 않는다")
+    void shouldNotUpdateWhenStatusUnchanged() {
+        // given
+        GifticonOrder order = createOrder(GifticonOrderStatus.ISSUED);
+        GifticonGoods goods = createGoods();
+
+        when(findGifticonOrderPort.findByIdAndUserId(ORDER_ID, USER_ID)).thenReturn(Optional.of(order));
+        when(queryGifticonCouponStatusPort.queryStatus(TR_ID)).thenReturn(
+                CouponStatusResult.builder().success(true).pinStatusCd("01").validPrdEndDt("20260504").build()
+        );
+        when(findGifticonGoodsPort.findByGoodsCode(GOODS_CODE)).thenReturn(Optional.of(goods));
+        when(decryptGifticonPinPort.decrypt("encryptedPin")).thenReturn("900343630367");
+
+        GetMyGifticonOrderDetailCommand command = new GetMyGifticonOrderDetailCommand(USER_ID, ORDER_ID);
+
+        // when
+        getMyGifticonOrderDetailService.getMyGifticonOrderDetail(command);
+
+        // then
+        verify(updateGifticonOrderPort, never()).update(any());
+    }
+
+    @Test
+    @DisplayName("USED 등 terminal 상태에서는 기프티쇼 API를 호출하지 않는다")
+    void shouldNotCallApiForTerminalStatus() {
+        // given
+        GifticonOrder order = createOrder(GifticonOrderStatus.USED);
+        GifticonGoods goods = createGoods();
+
+        when(findGifticonOrderPort.findByIdAndUserId(ORDER_ID, USER_ID)).thenReturn(Optional.of(order));
+        when(findGifticonGoodsPort.findByGoodsCode(GOODS_CODE)).thenReturn(Optional.of(goods));
+        when(decryptGifticonPinPort.decrypt("encryptedPin")).thenReturn("900343630367");
+
+        GetMyGifticonOrderDetailCommand command = new GetMyGifticonOrderDetailCommand(USER_ID, ORDER_ID);
+
+        // when
+        GetMyGifticonOrderDetailResult result = getMyGifticonOrderDetailService.getMyGifticonOrderDetail(command);
+
+        // then
+        assertThat(result.orderStatus()).isEqualTo("USED");
+        verifyNoInteractions(queryGifticonCouponStatusPort);
+        verify(updateGifticonOrderPort, never()).update(any());
+    }
+
+    @Test
+    @DisplayName("기프티쇼 API 호출 실패 시 기존 상태를 유지한다 (fail-open)")
+    void shouldKeepCurrentStatusWhenApiCallFails() {
+        // given
+        GifticonOrder order = createOrder(GifticonOrderStatus.ISSUED);
+        GifticonGoods goods = createGoods();
+
+        when(findGifticonOrderPort.findByIdAndUserId(ORDER_ID, USER_ID)).thenReturn(Optional.of(order));
+        when(queryGifticonCouponStatusPort.queryStatus(TR_ID)).thenReturn(
+                CouponStatusResult.builder().success(false).errorCode("COMM_ERROR").errorMessage("통신 오류").build()
+        );
+        when(findGifticonGoodsPort.findByGoodsCode(GOODS_CODE)).thenReturn(Optional.of(goods));
+        when(decryptGifticonPinPort.decrypt("encryptedPin")).thenReturn("900343630367");
+
+        GetMyGifticonOrderDetailCommand command = new GetMyGifticonOrderDetailCommand(USER_ID, ORDER_ID);
+
+        // when
+        GetMyGifticonOrderDetailResult result = getMyGifticonOrderDetailService.getMyGifticonOrderDetail(command);
+
+        // then
+        assertThat(result.orderStatus()).isEqualTo("ISSUED");
+        verify(updateGifticonOrderPort, never()).update(any());
+    }
+
+    @Test
+    @DisplayName("상품이 DB에 없으면 description과 brandImageUrl이 null로 반환된다")
+    void shouldReturnNullFieldsWhenGoodsNotFound() {
+        // given
+        GifticonOrder order = createOrder(GifticonOrderStatus.USED);
+
+        when(findGifticonOrderPort.findByIdAndUserId(ORDER_ID, USER_ID)).thenReturn(Optional.of(order));
+        when(findGifticonGoodsPort.findByGoodsCode(GOODS_CODE)).thenReturn(Optional.empty());
+        when(decryptGifticonPinPort.decrypt("encryptedPin")).thenReturn("900343630367");
+
+        GetMyGifticonOrderDetailCommand command = new GetMyGifticonOrderDetailCommand(USER_ID, ORDER_ID);
+
+        // when
+        GetMyGifticonOrderDetailResult result = getMyGifticonOrderDetailService.getMyGifticonOrderDetail(command);
+
+        // then
+        assertThat(result.description()).isNull();
+        assertThat(result.brandImageUrl()).isNull();
+    }
+
+    @Test
+    @DisplayName("expiryDate가 'YY.MM.DD까지 사용 가능' 포맷으로 반환된다")
+    void shouldFormatExpiryDateCorrectly() {
+        // given
+        GifticonOrder order = createOrder(GifticonOrderStatus.USED);
+        GifticonGoods goods = createGoods();
+
+        when(findGifticonOrderPort.findByIdAndUserId(ORDER_ID, USER_ID)).thenReturn(Optional.of(order));
+        when(findGifticonGoodsPort.findByGoodsCode(GOODS_CODE)).thenReturn(Optional.of(goods));
+        when(decryptGifticonPinPort.decrypt("encryptedPin")).thenReturn("900343630367");
+
+        GetMyGifticonOrderDetailCommand command = new GetMyGifticonOrderDetailCommand(USER_ID, ORDER_ID);
+
+        // when
+        GetMyGifticonOrderDetailResult result = getMyGifticonOrderDetailService.getMyGifticonOrderDetail(command);
+
+        // then
+        assertThat(result.expiryDate()).isEqualTo("26.05.04까지 사용 가능");
+    }
+
+    @Test
+    @DisplayName("daysRemaining이 유효기간까지 남은 일수로 계산된다")
+    void shouldCalculateDaysRemainingCorrectly() {
+        // given — clock은 2026-04-06 KST
+        GifticonOrder order = createOrder(GifticonOrderStatus.USED);
+        GifticonGoods goods = createGoods();
+
+        when(findGifticonOrderPort.findByIdAndUserId(ORDER_ID, USER_ID)).thenReturn(Optional.of(order));
+        when(findGifticonGoodsPort.findByGoodsCode(GOODS_CODE)).thenReturn(Optional.of(goods));
+        when(decryptGifticonPinPort.decrypt("encryptedPin")).thenReturn("900343630367");
+
+        GetMyGifticonOrderDetailCommand command = new GetMyGifticonOrderDetailCommand(USER_ID, ORDER_ID);
+
+        // when
+        GetMyGifticonOrderDetailResult result = getMyGifticonOrderDetailService.getMyGifticonOrderDetail(command);
+
+        // then — 2026-04-06 → 2026-05-04 = 30일
+        assertThat(result.daysRemaining()).isEqualTo(30);
+    }
+
+    @Test
+    @DisplayName("pinNo가 null이면 복호화를 시도하지 않고 null을 반환한다")
+    void shouldReturnNullPinWhenPinNoIsNull() {
+        // given
+        GifticonOrder order = createOrderWithNullPin();
+        GifticonGoods goods = createGoods();
+
+        when(findGifticonOrderPort.findByIdAndUserId(ORDER_ID, USER_ID)).thenReturn(Optional.of(order));
+        when(findGifticonGoodsPort.findByGoodsCode(GOODS_CODE)).thenReturn(Optional.of(goods));
+
+        GetMyGifticonOrderDetailCommand command = new GetMyGifticonOrderDetailCommand(USER_ID, ORDER_ID);
+
+        // when
+        GetMyGifticonOrderDetailResult result = getMyGifticonOrderDetailService.getMyGifticonOrderDetail(command);
+
+        // then
+        assertThat(result.pinNo()).isNull();
+        verifyNoInteractions(decryptGifticonPinPort);
+    }
+
+    private GifticonOrder createOrder(GifticonOrderStatus status) {
+        return GifticonOrder.from(GifticonOrderSnapshotState.builder()
+                .id(ORDER_ID)
+                .userId(USER_ID)
+                .goodsCode(GOODS_CODE)
+                .goodsName("테스트 기프티콘")
+                .brandName("세븐일레븐")
+                .productImageUrl("https://example.com/goods.jpg")
+                .trId(TR_ID)
+                .orderNo("20260401000001")
+                .cashPrice(5000L)
+                .orderStatus(status)
+                .couponImageUrl("https://example.com/coupon.jpg")
+                .pinNo("encryptedPin")
+                .validEndDate(LocalDate.of(2026, 5, 4))
+                .createdAt(LocalDateTime.of(2026, 4, 1, 10, 0))
+                .modifiedAt(LocalDateTime.of(2026, 4, 1, 10, 0))
+                .build());
+    }
+
+    private GifticonOrder createOrderWithNullPin() {
+        return GifticonOrder.from(GifticonOrderSnapshotState.builder()
+                .id(ORDER_ID)
+                .userId(USER_ID)
+                .goodsCode(GOODS_CODE)
+                .goodsName("테스트 기프티콘")
+                .brandName("세븐일레븐")
+                .productImageUrl("https://example.com/goods.jpg")
+                .trId(TR_ID)
+                .orderNo("20260401000001")
+                .cashPrice(5000L)
+                .orderStatus(GifticonOrderStatus.PENDING)
+                .validEndDate(LocalDate.of(2026, 5, 4))
+                .createdAt(LocalDateTime.of(2026, 4, 1, 10, 0))
+                .modifiedAt(LocalDateTime.of(2026, 4, 1, 10, 0))
+                .build());
+    }
+
+    private GifticonGoods createGoods() {
+        return GifticonGoods.from(GifticonGoodsSnapshotState.builder()
+                .id(1L)
+                .goodsCode(GOODS_CODE)
+                .goodsName("테스트 기프티콘")
+                .brandCode("BR00046")
+                .brandName("세븐일레븐")
+                .brandImageUrl("https://example.com/brand.jpg")
+                .categoryCode("CAT001")
+                .realPrice(6000L)
+                .salePrice(5500L)
+                .cashPrice(5000L)
+                .imageUrl("https://example.com/goods.jpg")
+                .description("테스트 상품입니다")
+                .validDays(30)
+                .goodsStatus("SALE")
+                .exposed(true)
+                .popular(false)
+                .build());
+    }
+}

--- a/reward-service/reward-application/src/test/java/com/personal/marketnote/reward/service/gifticon/GetMyGifticonOrdersUseCaseTest.java
+++ b/reward-service/reward-application/src/test/java/com/personal/marketnote/reward/service/gifticon/GetMyGifticonOrdersUseCaseTest.java
@@ -1,0 +1,425 @@
+package com.personal.marketnote.reward.service.gifticon;
+
+import com.personal.marketnote.reward.domain.gifticon.GifticonOrder;
+import com.personal.marketnote.reward.domain.gifticon.GifticonOrderSnapshotState;
+import com.personal.marketnote.reward.domain.gifticon.GifticonOrderSortType;
+import com.personal.marketnote.reward.domain.gifticon.GifticonOrderStatus;
+import com.personal.marketnote.reward.port.in.command.gifticon.GetMyGifticonOrdersCommand;
+import com.personal.marketnote.reward.port.in.result.gifticon.GetMyGifticonOrdersResult;
+import com.personal.marketnote.reward.port.in.result.gifticon.GetMyGifticonOrdersResult.MyGifticonOrderItem;
+import com.personal.marketnote.reward.port.out.gifticon.FindGifticonOrderPort;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.*;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class GetMyGifticonOrdersUseCaseTest {
+
+    @InjectMocks
+    private GetMyGifticonOrdersService getMyGifticonOrdersService;
+
+    @Mock
+    private FindGifticonOrderPort findGifticonOrderPort;
+
+    @Spy
+    private Clock clock = Clock.fixed(
+            Instant.parse("2026-04-06T03:00:00Z"),
+            ZoneId.of("Asia/Seoul")
+    );
+
+    private static final Long USER_ID = 100L;
+
+    @Test
+    @DisplayName("AVAILABLE 필터로 조회하면 ISSUED 상태 주문만 반환한다")
+    void shouldReturnOnlyIssuedOrdersWhenFilterIsAvailable() {
+        // given
+        List<GifticonOrderStatus> availableStatuses = List.of(GifticonOrderStatus.ISSUED);
+        GifticonOrder issuedOrder = createOrder(1L, GifticonOrderStatus.ISSUED, LocalDate.of(2026, 5, 4));
+
+        when(findGifticonOrderPort.findByUserIdAndStatuses(
+                eq(USER_ID), eq(availableStatuses), eq(GifticonOrderSortType.PURCHASE_LATEST), eq(-1L), eq(11)
+        )).thenReturn(List.of(issuedOrder));
+
+        when(findGifticonOrderPort.countByUserIdAndStatuses(USER_ID, availableStatuses)).thenReturn(1L);
+        when(findGifticonOrderPort.countByUserIdAndStatuses(
+                USER_ID, List.of(GifticonOrderStatus.USED, GifticonOrderStatus.EXPIRED, GifticonOrderStatus.CANCELLED)
+        )).thenReturn(3L);
+
+        GetMyGifticonOrdersCommand command = new GetMyGifticonOrdersCommand(
+                USER_ID, "AVAILABLE", "PURCHASE_LATEST", -1L, 10
+        );
+
+        // when
+        GetMyGifticonOrdersResult result = getMyGifticonOrdersService.getMyGifticonOrders(command);
+
+        // then
+        assertThat(result.items()).hasSize(1);
+        assertThat(result.items().get(0).orderStatus()).isEqualTo("ISSUED");
+        assertThat(result.availableCount()).isEqualTo(1L);
+        assertThat(result.completedOrExpiredCount()).isEqualTo(3L);
+    }
+
+    @Test
+    @DisplayName("COMPLETED_OR_EXPIRED 필터로 조회하면 USED, EXPIRED, CANCELLED 상태 주문을 반환한다")
+    void shouldReturnTerminalOrdersWhenFilterIsCompletedOrExpired() {
+        // given
+        List<GifticonOrderStatus> terminalStatuses = List.of(
+                GifticonOrderStatus.USED, GifticonOrderStatus.EXPIRED, GifticonOrderStatus.CANCELLED
+        );
+        GifticonOrder usedOrder = createOrder(1L, GifticonOrderStatus.USED, LocalDate.of(2026, 3, 1));
+        GifticonOrder expiredOrder = createOrder(2L, GifticonOrderStatus.EXPIRED, LocalDate.of(2026, 3, 15));
+
+        when(findGifticonOrderPort.findByUserIdAndStatuses(
+                eq(USER_ID), eq(terminalStatuses), eq(GifticonOrderSortType.PURCHASE_LATEST), eq(-1L), eq(11)
+        )).thenReturn(List.of(usedOrder, expiredOrder));
+
+        when(findGifticonOrderPort.countByUserIdAndStatuses(
+                USER_ID, List.of(GifticonOrderStatus.ISSUED)
+        )).thenReturn(2L);
+        when(findGifticonOrderPort.countByUserIdAndStatuses(USER_ID, terminalStatuses)).thenReturn(5L);
+
+        GetMyGifticonOrdersCommand command = new GetMyGifticonOrdersCommand(
+                USER_ID, "COMPLETED_OR_EXPIRED", "PURCHASE_LATEST", -1L, 10
+        );
+
+        // when
+        GetMyGifticonOrdersResult result = getMyGifticonOrdersService.getMyGifticonOrders(command);
+
+        // then
+        assertThat(result.items()).hasSize(2);
+        assertThat(result.availableCount()).isEqualTo(2L);
+        assertThat(result.completedOrExpiredCount()).isEqualTo(5L);
+    }
+
+    @Test
+    @DisplayName("커서 기반 페이지네이션에서 다음 페이지가 존재하면 hasNext가 true이고 nextCursor가 반환된다")
+    void shouldReturnHasNextTrueWhenMoreItemsExist() {
+        // given
+        List<GifticonOrderStatus> availableStatuses = List.of(GifticonOrderStatus.ISSUED);
+        List<GifticonOrder> orders = List.of(
+                createOrder(10L, GifticonOrderStatus.ISSUED, LocalDate.of(2026, 5, 4)),
+                createOrder(9L, GifticonOrderStatus.ISSUED, LocalDate.of(2026, 5, 3)),
+                createOrder(8L, GifticonOrderStatus.ISSUED, LocalDate.of(2026, 5, 2))
+        );
+
+        when(findGifticonOrderPort.findByUserIdAndStatuses(
+                eq(USER_ID), eq(availableStatuses), eq(GifticonOrderSortType.PURCHASE_LATEST), eq(-1L), eq(3)
+        )).thenReturn(orders);
+
+        when(findGifticonOrderPort.countByUserIdAndStatuses(USER_ID, availableStatuses)).thenReturn(5L);
+        when(findGifticonOrderPort.countByUserIdAndStatuses(
+                USER_ID, List.of(GifticonOrderStatus.USED, GifticonOrderStatus.EXPIRED, GifticonOrderStatus.CANCELLED)
+        )).thenReturn(0L);
+
+        GetMyGifticonOrdersCommand command = new GetMyGifticonOrdersCommand(
+                USER_ID, "AVAILABLE", "PURCHASE_LATEST", -1L, 2
+        );
+
+        // when
+        GetMyGifticonOrdersResult result = getMyGifticonOrdersService.getMyGifticonOrders(command);
+
+        // then
+        assertThat(result.hasNext()).isTrue();
+        assertThat(result.nextCursor()).isEqualTo(9L);
+        assertThat(result.items()).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("마지막 페이지이면 hasNext가 false이고 nextCursor가 null이다")
+    void shouldReturnHasNextFalseWhenNoMoreItems() {
+        // given
+        List<GifticonOrderStatus> availableStatuses = List.of(GifticonOrderStatus.ISSUED);
+        GifticonOrder order = createOrder(1L, GifticonOrderStatus.ISSUED, LocalDate.of(2026, 5, 4));
+
+        when(findGifticonOrderPort.findByUserIdAndStatuses(
+                eq(USER_ID), eq(availableStatuses), eq(GifticonOrderSortType.PURCHASE_LATEST), eq(-1L), eq(11)
+        )).thenReturn(List.of(order));
+
+        when(findGifticonOrderPort.countByUserIdAndStatuses(USER_ID, availableStatuses)).thenReturn(1L);
+        when(findGifticonOrderPort.countByUserIdAndStatuses(
+                USER_ID, List.of(GifticonOrderStatus.USED, GifticonOrderStatus.EXPIRED, GifticonOrderStatus.CANCELLED)
+        )).thenReturn(0L);
+
+        GetMyGifticonOrdersCommand command = new GetMyGifticonOrdersCommand(
+                USER_ID, "AVAILABLE", "PURCHASE_LATEST", -1L, 10
+        );
+
+        // when
+        GetMyGifticonOrdersResult result = getMyGifticonOrdersService.getMyGifticonOrders(command);
+
+        // then
+        assertThat(result.hasNext()).isFalse();
+        assertThat(result.nextCursor()).isNull();
+    }
+
+    @Test
+    @DisplayName("daysRemaining이 유효기간까지 남은 일수로 정확히 계산된다")
+    void shouldCalculateDaysRemainingCorrectly() {
+        // given — clock은 2026-04-06 12:00 KST
+        List<GifticonOrderStatus> availableStatuses = List.of(GifticonOrderStatus.ISSUED);
+        GifticonOrder order = createOrder(1L, GifticonOrderStatus.ISSUED, LocalDate.of(2026, 5, 4));
+
+        when(findGifticonOrderPort.findByUserIdAndStatuses(
+                eq(USER_ID), eq(availableStatuses), eq(GifticonOrderSortType.PURCHASE_LATEST), eq(-1L), eq(11)
+        )).thenReturn(List.of(order));
+
+        when(findGifticonOrderPort.countByUserIdAndStatuses(USER_ID, availableStatuses)).thenReturn(1L);
+        when(findGifticonOrderPort.countByUserIdAndStatuses(
+                USER_ID, List.of(GifticonOrderStatus.USED, GifticonOrderStatus.EXPIRED, GifticonOrderStatus.CANCELLED)
+        )).thenReturn(0L);
+
+        GetMyGifticonOrdersCommand command = new GetMyGifticonOrdersCommand(
+                USER_ID, "AVAILABLE", "PURCHASE_LATEST", -1L, 10
+        );
+
+        // when
+        GetMyGifticonOrdersResult result = getMyGifticonOrdersService.getMyGifticonOrders(command);
+
+        // then — 2026-04-06 → 2026-05-04 = 30일
+        assertThat(result.items().get(0).daysRemaining()).isEqualTo(30);
+    }
+
+    @Test
+    @DisplayName("statusLabel이 USED이면 '사용완료', EXPIRED이면 '기간만료', CANCELLED이면 '취소됨'을 반환한다")
+    void shouldReturnCorrectStatusLabel() {
+        // given
+        List<GifticonOrderStatus> terminalStatuses = List.of(
+                GifticonOrderStatus.USED, GifticonOrderStatus.EXPIRED, GifticonOrderStatus.CANCELLED
+        );
+        GifticonOrder usedOrder = createOrder(1L, GifticonOrderStatus.USED, LocalDate.of(2026, 3, 1));
+        GifticonOrder expiredOrder = createOrder(2L, GifticonOrderStatus.EXPIRED, LocalDate.of(2026, 3, 15));
+        GifticonOrder cancelledOrder = createOrder(3L, GifticonOrderStatus.CANCELLED, LocalDate.of(2026, 4, 1));
+
+        when(findGifticonOrderPort.findByUserIdAndStatuses(
+                eq(USER_ID), eq(terminalStatuses), eq(GifticonOrderSortType.PURCHASE_LATEST), eq(-1L), eq(11)
+        )).thenReturn(List.of(usedOrder, expiredOrder, cancelledOrder));
+
+        when(findGifticonOrderPort.countByUserIdAndStatuses(
+                USER_ID, List.of(GifticonOrderStatus.ISSUED)
+        )).thenReturn(0L);
+        when(findGifticonOrderPort.countByUserIdAndStatuses(USER_ID, terminalStatuses)).thenReturn(3L);
+
+        GetMyGifticonOrdersCommand command = new GetMyGifticonOrdersCommand(
+                USER_ID, "COMPLETED_OR_EXPIRED", "PURCHASE_LATEST", -1L, 10
+        );
+
+        // when
+        GetMyGifticonOrdersResult result = getMyGifticonOrdersService.getMyGifticonOrders(command);
+
+        // then
+        assertThat(result.items().get(0).statusLabel()).isEqualTo("사용완료");
+        assertThat(result.items().get(1).statusLabel()).isEqualTo("기간만료");
+        assertThat(result.items().get(2).statusLabel()).isEqualTo("취소됨");
+    }
+
+    @Test
+    @DisplayName("expiryDate가 'YY.MM.DD까지 사용 가능' 포맷으로 반환된다")
+    void shouldFormatExpiryDateCorrectly() {
+        // given
+        List<GifticonOrderStatus> availableStatuses = List.of(GifticonOrderStatus.ISSUED);
+        GifticonOrder order = createOrder(1L, GifticonOrderStatus.ISSUED, LocalDate.of(2026, 5, 4));
+
+        when(findGifticonOrderPort.findByUserIdAndStatuses(
+                eq(USER_ID), eq(availableStatuses), eq(GifticonOrderSortType.PURCHASE_LATEST), eq(-1L), eq(11)
+        )).thenReturn(List.of(order));
+
+        when(findGifticonOrderPort.countByUserIdAndStatuses(USER_ID, availableStatuses)).thenReturn(1L);
+        when(findGifticonOrderPort.countByUserIdAndStatuses(
+                USER_ID, List.of(GifticonOrderStatus.USED, GifticonOrderStatus.EXPIRED, GifticonOrderStatus.CANCELLED)
+        )).thenReturn(0L);
+
+        GetMyGifticonOrdersCommand command = new GetMyGifticonOrdersCommand(
+                USER_ID, "AVAILABLE", "PURCHASE_LATEST", -1L, 10
+        );
+
+        // when
+        GetMyGifticonOrdersResult result = getMyGifticonOrdersService.getMyGifticonOrders(command);
+
+        // then
+        assertThat(result.items().get(0).expiryDate()).isEqualTo("26.05.04까지 사용 가능");
+    }
+
+    @Test
+    @DisplayName("주문이 없으면 빈 목록과 0건수를 반환한다")
+    void shouldReturnEmptyResultWhenNoOrders() {
+        // given
+        List<GifticonOrderStatus> availableStatuses = List.of(GifticonOrderStatus.ISSUED);
+
+        when(findGifticonOrderPort.findByUserIdAndStatuses(
+                eq(USER_ID), eq(availableStatuses), eq(GifticonOrderSortType.PURCHASE_LATEST), eq(-1L), eq(11)
+        )).thenReturn(Collections.emptyList());
+
+        when(findGifticonOrderPort.countByUserIdAndStatuses(USER_ID, availableStatuses)).thenReturn(0L);
+        when(findGifticonOrderPort.countByUserIdAndStatuses(
+                USER_ID, List.of(GifticonOrderStatus.USED, GifticonOrderStatus.EXPIRED, GifticonOrderStatus.CANCELLED)
+        )).thenReturn(0L);
+
+        GetMyGifticonOrdersCommand command = new GetMyGifticonOrdersCommand(
+                USER_ID, "AVAILABLE", "PURCHASE_LATEST", -1L, 10
+        );
+
+        // when
+        GetMyGifticonOrdersResult result = getMyGifticonOrdersService.getMyGifticonOrders(command);
+
+        // then
+        assertThat(result.items()).isEmpty();
+        assertThat(result.availableCount()).isZero();
+        assertThat(result.completedOrExpiredCount()).isZero();
+        assertThat(result.hasNext()).isFalse();
+        assertThat(result.nextCursor()).isNull();
+    }
+
+    @Test
+    @DisplayName("EXPIRY_SOONEST 정렬로 조회하면 Port에 해당 정렬 타입이 전달된다")
+    void shouldPassExpirySoonestSortTypeToPort() {
+        // given
+        List<GifticonOrderStatus> availableStatuses = List.of(GifticonOrderStatus.ISSUED);
+
+        when(findGifticonOrderPort.findByUserIdAndStatuses(
+                eq(USER_ID), eq(availableStatuses), eq(GifticonOrderSortType.EXPIRY_SOONEST), eq(-1L), eq(11)
+        )).thenReturn(Collections.emptyList());
+
+        when(findGifticonOrderPort.countByUserIdAndStatuses(USER_ID, availableStatuses)).thenReturn(0L);
+        when(findGifticonOrderPort.countByUserIdAndStatuses(
+                USER_ID, List.of(GifticonOrderStatus.USED, GifticonOrderStatus.EXPIRED, GifticonOrderStatus.CANCELLED)
+        )).thenReturn(0L);
+
+        GetMyGifticonOrdersCommand command = new GetMyGifticonOrdersCommand(
+                USER_ID, "AVAILABLE", "EXPIRY_SOONEST", -1L, 10
+        );
+
+        // when
+        getMyGifticonOrdersService.getMyGifticonOrders(command);
+
+        // then
+        verify(findGifticonOrderPort).findByUserIdAndStatuses(
+                USER_ID, availableStatuses, GifticonOrderSortType.EXPIRY_SOONEST, -1L, 11
+        );
+    }
+
+    @Test
+    @DisplayName("EXPIRY_SOONEST 정렬에서 다음 페이지가 존재하면 nextCursor가 offset 기반으로 반환된다")
+    void shouldReturnOffsetBasedNextCursorForExpirySoonest() {
+        // given
+        List<GifticonOrderStatus> availableStatuses = List.of(GifticonOrderStatus.ISSUED);
+        List<GifticonOrder> orders = List.of(
+                createOrder(5L, GifticonOrderStatus.ISSUED, LocalDate.of(2026, 5, 1)),
+                createOrder(3L, GifticonOrderStatus.ISSUED, LocalDate.of(2026, 5, 2)),
+                createOrder(7L, GifticonOrderStatus.ISSUED, LocalDate.of(2026, 5, 3))
+        );
+
+        when(findGifticonOrderPort.findByUserIdAndStatuses(
+                eq(USER_ID), eq(availableStatuses), eq(GifticonOrderSortType.EXPIRY_SOONEST), eq(-1L), eq(3)
+        )).thenReturn(orders);
+
+        when(findGifticonOrderPort.countByUserIdAndStatuses(USER_ID, availableStatuses)).thenReturn(5L);
+        when(findGifticonOrderPort.countByUserIdAndStatuses(
+                USER_ID, List.of(GifticonOrderStatus.USED, GifticonOrderStatus.EXPIRED, GifticonOrderStatus.CANCELLED)
+        )).thenReturn(0L);
+
+        GetMyGifticonOrdersCommand command = new GetMyGifticonOrdersCommand(
+                USER_ID, "AVAILABLE", "EXPIRY_SOONEST", -1L, 2
+        );
+
+        // when
+        GetMyGifticonOrdersResult result = getMyGifticonOrdersService.getMyGifticonOrders(command);
+
+        // then — EXPIRY_SOONEST: nextCursor = currentOffset(0) + pageSize(2) = 2
+        assertThat(result.hasNext()).isTrue();
+        assertThat(result.nextCursor()).isEqualTo(2L);
+        assertThat(result.items()).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("ISSUED 상태 주문의 statusLabel은 null이다")
+    void shouldReturnNullStatusLabelForIssuedOrder() {
+        // given
+        List<GifticonOrderStatus> availableStatuses = List.of(GifticonOrderStatus.ISSUED);
+        GifticonOrder order = createOrder(1L, GifticonOrderStatus.ISSUED, LocalDate.of(2026, 5, 4));
+
+        when(findGifticonOrderPort.findByUserIdAndStatuses(
+                eq(USER_ID), eq(availableStatuses), eq(GifticonOrderSortType.PURCHASE_LATEST), eq(-1L), eq(11)
+        )).thenReturn(List.of(order));
+
+        when(findGifticonOrderPort.countByUserIdAndStatuses(USER_ID, availableStatuses)).thenReturn(1L);
+        when(findGifticonOrderPort.countByUserIdAndStatuses(
+                USER_ID, List.of(GifticonOrderStatus.USED, GifticonOrderStatus.EXPIRED, GifticonOrderStatus.CANCELLED)
+        )).thenReturn(0L);
+
+        GetMyGifticonOrdersCommand command = new GetMyGifticonOrdersCommand(
+                USER_ID, "AVAILABLE", "PURCHASE_LATEST", -1L, 10
+        );
+
+        // when
+        GetMyGifticonOrdersResult result = getMyGifticonOrdersService.getMyGifticonOrders(command);
+
+        // then
+        assertThat(result.items().get(0).statusLabel()).isNull();
+    }
+
+    @Test
+    @DisplayName("각 주문 항목에 goodsName, brandName, productImageUrl, cashPrice, createdAt이 포함된다")
+    void shouldIncludeAllFieldsInOrderItem() {
+        // given
+        List<GifticonOrderStatus> availableStatuses = List.of(GifticonOrderStatus.ISSUED);
+        GifticonOrder order = createOrder(1L, GifticonOrderStatus.ISSUED, LocalDate.of(2026, 5, 4));
+
+        when(findGifticonOrderPort.findByUserIdAndStatuses(
+                eq(USER_ID), eq(availableStatuses), eq(GifticonOrderSortType.PURCHASE_LATEST), eq(-1L), eq(11)
+        )).thenReturn(List.of(order));
+
+        when(findGifticonOrderPort.countByUserIdAndStatuses(USER_ID, availableStatuses)).thenReturn(1L);
+        when(findGifticonOrderPort.countByUserIdAndStatuses(
+                USER_ID, List.of(GifticonOrderStatus.USED, GifticonOrderStatus.EXPIRED, GifticonOrderStatus.CANCELLED)
+        )).thenReturn(0L);
+
+        GetMyGifticonOrdersCommand command = new GetMyGifticonOrdersCommand(
+                USER_ID, "AVAILABLE", "PURCHASE_LATEST", -1L, 10
+        );
+
+        // when
+        GetMyGifticonOrdersResult result = getMyGifticonOrdersService.getMyGifticonOrders(command);
+
+        // then
+        MyGifticonOrderItem item = result.items().get(0);
+        assertThat(item.orderId()).isEqualTo(1L);
+        assertThat(item.goodsName()).isEqualTo("테스트 기프티콘");
+        assertThat(item.brandName()).isEqualTo("세븐일레븐");
+        assertThat(item.productImageUrl()).isEqualTo("https://example.com/goods.jpg");
+        assertThat(item.cashPrice()).isEqualTo(5000L);
+        assertThat(item.createdAt()).isEqualTo(LocalDateTime.of(2026, 4, 1, 10, 0));
+    }
+
+    private GifticonOrder createOrder(Long id, GifticonOrderStatus status, LocalDate validEndDate) {
+        return GifticonOrder.from(GifticonOrderSnapshotState.builder()
+                .id(id)
+                .userId(USER_ID)
+                .goodsCode("G00000280811")
+                .goodsName("테스트 기프티콘")
+                .brandName("세븐일레븐")
+                .productImageUrl("https://example.com/goods.jpg")
+                .trId("NC100_260401100000")
+                .orderNo("20260401000001")
+                .cashPrice(5000L)
+                .orderStatus(status)
+                .couponImageUrl("https://example.com/coupon.jpg")
+                .pinNo("encryptedPin")
+                .validEndDate(validEndDate)
+                .createdAt(LocalDateTime.of(2026, 4, 1, 10, 0))
+                .modifiedAt(LocalDateTime.of(2026, 4, 1, 10, 0))
+                .build());
+    }
+}

--- a/reward-service/reward-application/src/test/java/com/personal/marketnote/reward/service/gifticon/GetPopularGifticonGoodsUseCaseTest.java
+++ b/reward-service/reward-application/src/test/java/com/personal/marketnote/reward/service/gifticon/GetPopularGifticonGoodsUseCaseTest.java
@@ -1,0 +1,90 @@
+package com.personal.marketnote.reward.service.gifticon;
+
+import com.personal.marketnote.reward.domain.gifticon.GifticonGoods;
+import com.personal.marketnote.reward.domain.gifticon.GifticonGoodsSnapshotState;
+import com.personal.marketnote.reward.port.in.result.gifticon.GetPopularGifticonGoodsResult;
+import com.personal.marketnote.reward.port.out.gifticon.FindGifticonGoodsPort;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class GetPopularGifticonGoodsUseCaseTest {
+
+    @InjectMocks
+    private GetPopularGifticonGoodsService getPopularGifticonGoodsService;
+
+    @Mock
+    private FindGifticonGoodsPort findGifticonGoodsPort;
+
+    @Test
+    @DisplayName("인기 상품 목록을 조회하면 최대 10개의 상품 정보를 반환한다")
+    void shouldReturnPopularGoodsUpToLimit() {
+        // given
+        GifticonGoods goods1 = createGoods(1L, "GD001", "아메리카노", 4500L, 4000L);
+        GifticonGoods goods2 = createGoods(2L, "GD002", "카페라떼", 5500L, 5000L);
+        when(findGifticonGoodsPort.findAllPopularAndExposed(10)).thenReturn(List.of(goods1, goods2));
+
+        // when
+        GetPopularGifticonGoodsResult result = getPopularGifticonGoodsService.getPopularGoods();
+
+        // then
+        assertThat(result.items()).hasSize(2);
+        assertThat(result.items().get(0).goodsCode()).isEqualTo("GD001");
+        assertThat(result.items().get(0).goodsName()).isEqualTo("아메리카노");
+        assertThat(result.items().get(0).salePrice()).isEqualTo(4500L);
+        assertThat(result.items().get(0).cashPrice()).isEqualTo(4000L);
+        assertThat(result.items().get(0).imageUrl()).isEqualTo("https://img.com/goods.png");
+        assertThat(result.items().get(1).goodsCode()).isEqualTo("GD002");
+        verify(findGifticonGoodsPort).findAllPopularAndExposed(10);
+    }
+
+    @Test
+    @DisplayName("인기 상품이 없으면 빈 목록을 반환한다")
+    void shouldReturnEmptyListWhenNoPopularGoods() {
+        // given
+        when(findGifticonGoodsPort.findAllPopularAndExposed(10)).thenReturn(List.of());
+
+        // when
+        GetPopularGifticonGoodsResult result = getPopularGifticonGoodsService.getPopularGoods();
+
+        // then
+        assertThat(result.items()).isEmpty();
+        verify(findGifticonGoodsPort).findAllPopularAndExposed(10);
+    }
+
+    private GifticonGoods createGoods(Long id, String goodsCode, String goodsName,
+                                      Long salePrice, Long cashPrice) {
+        return GifticonGoods.from(GifticonGoodsSnapshotState.builder()
+                .id(id)
+                .goodsCode(goodsCode)
+                .goodsName(goodsName)
+                .brandCode("BR001")
+                .brandName("스타벅스")
+                .brandImageUrl("https://img.com/sb.png")
+                .categoryCode("1")
+                .realPrice(5000L)
+                .salePrice(salePrice)
+                .cashPrice(cashPrice)
+                .imageUrl("https://img.com/goods.png")
+                .description("설명")
+                .validDays(30)
+                .goodsStatus("SALE")
+                .exposed(true)
+                .popular(true)
+                .orderNum(1)
+                .createdAt(LocalDateTime.now())
+                .modifiedAt(LocalDateTime.now())
+                .build());
+    }
+}

--- a/reward-service/reward-application/src/test/java/com/personal/marketnote/reward/service/gifticon/ManageGifticonCategoryExposureUseCaseTest.java
+++ b/reward-service/reward-application/src/test/java/com/personal/marketnote/reward/service/gifticon/ManageGifticonCategoryExposureUseCaseTest.java
@@ -1,0 +1,120 @@
+package com.personal.marketnote.reward.service.gifticon;
+
+import com.personal.marketnote.reward.domain.exception.GifticonCategoryNotFoundException;
+import com.personal.marketnote.reward.domain.gifticon.GifticonCategory;
+import com.personal.marketnote.reward.domain.gifticon.GifticonCategorySnapshotState;
+import com.personal.marketnote.reward.port.in.command.gifticon.ManageGifticonCategoryExposureCommand;
+import com.personal.marketnote.reward.port.in.command.gifticon.ManageGifticonCategoryExposureCommand.ExposureItem;
+import com.personal.marketnote.reward.port.out.gifticon.FindGifticonCategoryPort;
+import com.personal.marketnote.reward.port.out.gifticon.UpdateGifticonCategoryPort;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ManageGifticonCategoryExposureUseCaseTest {
+
+    @InjectMocks
+    private ManageGifticonCategoryExposureService manageGifticonCategoryExposureService;
+
+    @Mock
+    private FindGifticonCategoryPort findGifticonCategoryPort;
+
+    @Mock
+    private UpdateGifticonCategoryPort updateGifticonCategoryPort;
+
+    @Test
+    @DisplayName("카테고리를 노출로 변경한다")
+    void shouldExposeCategory() {
+        // given
+        GifticonCategory category = createCategory(1L, false);
+        when(findGifticonCategoryPort.findById(1L)).thenReturn(Optional.of(category));
+        ManageGifticonCategoryExposureCommand command = new ManageGifticonCategoryExposureCommand(
+                List.of(new ExposureItem(1L, true))
+        );
+
+        // when
+        manageGifticonCategoryExposureService.manageExposure(command);
+
+        // then
+        assertThat(category.isExposed()).isTrue();
+        verify(updateGifticonCategoryPort).update(category);
+    }
+
+    @Test
+    @DisplayName("카테고리를 비노출로 변경한다")
+    void shouldUnexposeCategory() {
+        // given
+        GifticonCategory category = createCategory(1L, true);
+        when(findGifticonCategoryPort.findById(1L)).thenReturn(Optional.of(category));
+        ManageGifticonCategoryExposureCommand command = new ManageGifticonCategoryExposureCommand(
+                List.of(new ExposureItem(1L, false))
+        );
+
+        // when
+        manageGifticonCategoryExposureService.manageExposure(command);
+
+        // then
+        assertThat(category.isExposed()).isFalse();
+        verify(updateGifticonCategoryPort).update(category);
+    }
+
+    @Test
+    @DisplayName("여러 카테고리의 노출 여부를 한번에 변경한다")
+    void shouldManageMultipleCategoriesExposure() {
+        // given
+        GifticonCategory category1 = createCategory(1L, false);
+        GifticonCategory category2 = createCategory(2L, true);
+        when(findGifticonCategoryPort.findById(1L)).thenReturn(Optional.of(category1));
+        when(findGifticonCategoryPort.findById(2L)).thenReturn(Optional.of(category2));
+        ManageGifticonCategoryExposureCommand command = new ManageGifticonCategoryExposureCommand(
+                List.of(new ExposureItem(1L, true), new ExposureItem(2L, false))
+        );
+
+        // when
+        manageGifticonCategoryExposureService.manageExposure(command);
+
+        // then
+        assertThat(category1.isExposed()).isTrue();
+        assertThat(category2.isExposed()).isFalse();
+        verify(updateGifticonCategoryPort).update(category1);
+        verify(updateGifticonCategoryPort).update(category2);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 카테고리의 노출을 변경하면 GifticonCategoryNotFoundException이 발생한다")
+    void shouldThrowExceptionWhenCategoryNotFound() {
+        // given
+        when(findGifticonCategoryPort.findById(999L)).thenReturn(Optional.empty());
+        ManageGifticonCategoryExposureCommand command = new ManageGifticonCategoryExposureCommand(
+                List.of(new ExposureItem(999L, true))
+        );
+
+        // when & then
+        assertThatThrownBy(() -> manageGifticonCategoryExposureService.manageExposure(command))
+                .isInstanceOf(GifticonCategoryNotFoundException.class);
+        verify(updateGifticonCategoryPort, never()).update(any());
+    }
+
+    private GifticonCategory createCategory(Long id, boolean exposed) {
+        return GifticonCategory.from(GifticonCategorySnapshotState.builder()
+                .id(id)
+                .categoryCode(String.valueOf(id))
+                .categoryName("카테고리" + id)
+                .exposed(exposed)
+                .createdAt(LocalDateTime.of(2026, 4, 3, 10, 0))
+                .modifiedAt(LocalDateTime.of(2026, 4, 3, 10, 0))
+                .build());
+    }
+}

--- a/reward-service/reward-application/src/test/java/com/personal/marketnote/reward/service/gifticon/ManageGifticonCategoryOrderUseCaseTest.java
+++ b/reward-service/reward-application/src/test/java/com/personal/marketnote/reward/service/gifticon/ManageGifticonCategoryOrderUseCaseTest.java
@@ -1,0 +1,138 @@
+package com.personal.marketnote.reward.service.gifticon;
+
+import com.personal.marketnote.reward.domain.exception.GifticonCategoryNotExposedException;
+import com.personal.marketnote.reward.domain.exception.GifticonCategoryNotFoundException;
+import com.personal.marketnote.reward.domain.gifticon.GifticonCategory;
+import com.personal.marketnote.reward.domain.gifticon.GifticonCategorySnapshotState;
+import com.personal.marketnote.reward.port.in.command.gifticon.ManageGifticonCategoryOrderCommand;
+import com.personal.marketnote.reward.port.in.command.gifticon.ManageGifticonCategoryOrderCommand.OrderItem;
+import com.personal.marketnote.reward.port.out.gifticon.FindGifticonCategoryPort;
+import com.personal.marketnote.reward.port.out.gifticon.UpdateGifticonCategoryPort;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ManageGifticonCategoryOrderUseCaseTest {
+
+    @InjectMocks
+    private ManageGifticonCategoryOrderService manageGifticonCategoryOrderService;
+
+    @Mock
+    private FindGifticonCategoryPort findGifticonCategoryPort;
+
+    @Mock
+    private UpdateGifticonCategoryPort updateGifticonCategoryPort;
+
+    @Test
+    @DisplayName("노출된 카테고리의 노출 순서를 설정한다")
+    void shouldSetOrderNumForExposedCategory() {
+        // given
+        GifticonCategory category = createCategory(1L, true, null);
+        when(findGifticonCategoryPort.findById(1L)).thenReturn(Optional.of(category));
+        ManageGifticonCategoryOrderCommand command = new ManageGifticonCategoryOrderCommand(
+                List.of(new OrderItem(1L, 1))
+        );
+
+        // when
+        manageGifticonCategoryOrderService.manageOrder(command);
+
+        // then
+        assertThat(category.getOrderNum()).isEqualTo(1);
+        verify(updateGifticonCategoryPort).update(category);
+    }
+
+    @Test
+    @DisplayName("여러 카테고리의 노출 순서를 한번에 설정한다")
+    void shouldSetOrderNumForMultipleCategories() {
+        // given
+        GifticonCategory category1 = createCategory(1L, true, null);
+        GifticonCategory category2 = createCategory(2L, true, null);
+        when(findGifticonCategoryPort.findById(1L)).thenReturn(Optional.of(category1));
+        when(findGifticonCategoryPort.findById(2L)).thenReturn(Optional.of(category2));
+        ManageGifticonCategoryOrderCommand command = new ManageGifticonCategoryOrderCommand(
+                List.of(new OrderItem(1L, 1), new OrderItem(2L, 2))
+        );
+
+        // when
+        manageGifticonCategoryOrderService.manageOrder(command);
+
+        // then
+        assertThat(category1.getOrderNum()).isEqualTo(1);
+        assertThat(category2.getOrderNum()).isEqualTo(2);
+        verify(updateGifticonCategoryPort).update(category1);
+        verify(updateGifticonCategoryPort).update(category2);
+    }
+
+    @Test
+    @DisplayName("비노출 카테고리에 노출 순서를 설정하면 GifticonCategoryNotExposedException이 발생한다")
+    void shouldThrowExceptionWhenCategoryNotExposed() {
+        // given
+        GifticonCategory category = createCategory(1L, false, null);
+        when(findGifticonCategoryPort.findById(1L)).thenReturn(Optional.of(category));
+        ManageGifticonCategoryOrderCommand command = new ManageGifticonCategoryOrderCommand(
+                List.of(new OrderItem(1L, 1))
+        );
+
+        // when & then
+        assertThatThrownBy(() -> manageGifticonCategoryOrderService.manageOrder(command))
+                .isInstanceOf(GifticonCategoryNotExposedException.class);
+        verify(updateGifticonCategoryPort, never()).update(any());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 카테고리의 순서를 설정하면 GifticonCategoryNotFoundException이 발생한다")
+    void shouldThrowExceptionWhenCategoryNotFound() {
+        // given
+        when(findGifticonCategoryPort.findById(999L)).thenReturn(Optional.empty());
+        ManageGifticonCategoryOrderCommand command = new ManageGifticonCategoryOrderCommand(
+                List.of(new OrderItem(999L, 1))
+        );
+
+        // when & then
+        assertThatThrownBy(() -> manageGifticonCategoryOrderService.manageOrder(command))
+                .isInstanceOf(GifticonCategoryNotFoundException.class);
+        verify(updateGifticonCategoryPort, never()).update(any());
+    }
+
+    @Test
+    @DisplayName("기존 노출 순서를 새 값으로 변경한다")
+    void shouldChangeExistingOrderNum() {
+        // given
+        GifticonCategory category = createCategory(1L, true, 3);
+        when(findGifticonCategoryPort.findById(1L)).thenReturn(Optional.of(category));
+        ManageGifticonCategoryOrderCommand command = new ManageGifticonCategoryOrderCommand(
+                List.of(new OrderItem(1L, 5))
+        );
+
+        // when
+        manageGifticonCategoryOrderService.manageOrder(command);
+
+        // then
+        assertThat(category.getOrderNum()).isEqualTo(5);
+        verify(updateGifticonCategoryPort).update(category);
+    }
+
+    private GifticonCategory createCategory(Long id, boolean exposed, Integer orderNum) {
+        return GifticonCategory.from(GifticonCategorySnapshotState.builder()
+                .id(id)
+                .categoryCode(String.valueOf(id))
+                .categoryName("카테고리" + id)
+                .exposed(exposed)
+                .orderNum(orderNum)
+                .createdAt(LocalDateTime.of(2026, 4, 3, 10, 0))
+                .modifiedAt(LocalDateTime.of(2026, 4, 3, 10, 0))
+                .build());
+    }
+}

--- a/reward-service/reward-application/src/test/java/com/personal/marketnote/reward/service/gifticon/ManageGifticonGoodsExposureUseCaseTest.java
+++ b/reward-service/reward-application/src/test/java/com/personal/marketnote/reward/service/gifticon/ManageGifticonGoodsExposureUseCaseTest.java
@@ -1,0 +1,165 @@
+package com.personal.marketnote.reward.service.gifticon;
+
+import com.personal.marketnote.reward.domain.exception.GifticonGoodsNotFoundException;
+import com.personal.marketnote.reward.domain.exception.GifticonGoodsNotSaleException;
+import com.personal.marketnote.reward.domain.gifticon.GifticonGoods;
+import com.personal.marketnote.reward.domain.gifticon.GifticonGoodsSnapshotState;
+import com.personal.marketnote.reward.port.in.command.gifticon.ManageGifticonGoodsExposureCommand;
+import com.personal.marketnote.reward.port.in.command.gifticon.ManageGifticonGoodsExposureCommand.ExposureItem;
+import com.personal.marketnote.reward.port.out.gifticon.FindGifticonGoodsPort;
+import com.personal.marketnote.reward.port.out.gifticon.UpdateGifticonGoodsPort;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ManageGifticonGoodsExposureUseCaseTest {
+
+    @InjectMocks
+    private ManageGifticonGoodsExposureService manageGifticonGoodsExposureService;
+
+    @Mock
+    private FindGifticonGoodsPort findGifticonGoodsPort;
+
+    @Mock
+    private UpdateGifticonGoodsPort updateGifticonGoodsPort;
+
+    @Test
+    @DisplayName("SALE 상태 상품을 노출 설정하면 exposed가 true로 변경된다")
+    void shouldExposeGoodsWhenStatusIsSale() {
+        // given
+        GifticonGoods goods = createGoods("G00001", "SALE", false);
+        ManageGifticonGoodsExposureCommand command = new ManageGifticonGoodsExposureCommand(
+                List.of(new ExposureItem("G00001", true))
+        );
+
+        when(findGifticonGoodsPort.findByGoodsCode("G00001"))
+                .thenReturn(Optional.of(goods));
+
+        // when
+        manageGifticonGoodsExposureService.manageExposure(command);
+
+        // then
+        assertThat(goods.isExposed()).isTrue();
+        verify(updateGifticonGoodsPort).update(goods);
+    }
+
+    @Test
+    @DisplayName("SALE이 아닌 상품을 노출 설정하면 GifticonGoodsNotSaleException이 발생한다")
+    void shouldThrowExceptionWhenExposingNonSaleGoods() {
+        // given
+        GifticonGoods goods = createGoods("G00001", "SUS", false);
+        ManageGifticonGoodsExposureCommand command = new ManageGifticonGoodsExposureCommand(
+                List.of(new ExposureItem("G00001", true))
+        );
+
+        when(findGifticonGoodsPort.findByGoodsCode("G00001"))
+                .thenReturn(Optional.of(goods));
+
+        // when & then
+        assertThatThrownBy(() -> manageGifticonGoodsExposureService.manageExposure(command))
+                .isInstanceOf(GifticonGoodsNotSaleException.class);
+        verify(updateGifticonGoodsPort, never()).update(any());
+    }
+
+    @Test
+    @DisplayName("상품을 노출 해제하면 goodsStatus와 무관하게 exposed가 false로 변경된다")
+    void shouldUnexposeGoodsRegardlessOfStatus() {
+        // given
+        GifticonGoods goods = createGoods("G00001", "SUS", true);
+        ManageGifticonGoodsExposureCommand command = new ManageGifticonGoodsExposureCommand(
+                List.of(new ExposureItem("G00001", false))
+        );
+
+        when(findGifticonGoodsPort.findByGoodsCode("G00001"))
+                .thenReturn(Optional.of(goods));
+
+        // when
+        manageGifticonGoodsExposureService.manageExposure(command);
+
+        // then
+        assertThat(goods.isExposed()).isFalse();
+        verify(updateGifticonGoodsPort).update(goods);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 상품 코드로 요청하면 GifticonGoodsNotFoundException이 발생한다")
+    void shouldThrowExceptionWhenGoodsNotFound() {
+        // given
+        ManageGifticonGoodsExposureCommand command = new ManageGifticonGoodsExposureCommand(
+                List.of(new ExposureItem("G99999", true))
+        );
+
+        when(findGifticonGoodsPort.findByGoodsCode("G99999"))
+                .thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> manageGifticonGoodsExposureService.manageExposure(command))
+                .isInstanceOf(GifticonGoodsNotFoundException.class);
+        verify(updateGifticonGoodsPort, never()).update(any());
+    }
+
+    @Test
+    @DisplayName("여러 상품의 노출 상태를 한 번에 변경한다")
+    void shouldManageMultipleGoodsExposure() {
+        // given
+        GifticonGoods goods1 = createGoods("G00001", "SALE", false);
+        GifticonGoods goods2 = createGoods("G00002", "SALE", true);
+        ManageGifticonGoodsExposureCommand command = new ManageGifticonGoodsExposureCommand(
+                List.of(
+                        new ExposureItem("G00001", true),
+                        new ExposureItem("G00002", false)
+                )
+        );
+
+        when(findGifticonGoodsPort.findByGoodsCode("G00001"))
+                .thenReturn(Optional.of(goods1));
+        when(findGifticonGoodsPort.findByGoodsCode("G00002"))
+                .thenReturn(Optional.of(goods2));
+
+        // when
+        manageGifticonGoodsExposureService.manageExposure(command);
+
+        // then
+        assertThat(goods1.isExposed()).isTrue();
+        assertThat(goods2.isExposed()).isFalse();
+        verify(updateGifticonGoodsPort).update(goods1);
+        verify(updateGifticonGoodsPort).update(goods2);
+    }
+
+    // --- Helper Methods ---
+
+    private GifticonGoods createGoods(String goodsCode, String goodsStatus, boolean exposed) {
+        return GifticonGoods.from(GifticonGoodsSnapshotState.builder()
+                .id(1L)
+                .goodsCode(goodsCode)
+                .goodsName("테스트 상품")
+                .brandCode("BR001")
+                .brandName("스타벅스")
+                .brandImageUrl("https://img.com/brand.png")
+                .categoryCode("1")
+                .realPrice(5000L)
+                .salePrice(4500L)
+                .cashPrice(3500L)
+                .imageUrl("https://img.com/goods.png")
+                .description("설명")
+                .validDays(30)
+                .goodsStatus(goodsStatus)
+                .exposed(exposed)
+                .orderNum(null)
+                .createdAt(LocalDateTime.of(2026, 4, 1, 10, 0))
+                .modifiedAt(LocalDateTime.of(2026, 4, 1, 10, 0))
+                .build());
+    }
+}

--- a/reward-service/reward-application/src/test/java/com/personal/marketnote/reward/service/gifticon/ManageGifticonGoodsOrderUseCaseTest.java
+++ b/reward-service/reward-application/src/test/java/com/personal/marketnote/reward/service/gifticon/ManageGifticonGoodsOrderUseCaseTest.java
@@ -1,0 +1,165 @@
+package com.personal.marketnote.reward.service.gifticon;
+
+import com.personal.marketnote.reward.domain.exception.GifticonGoodsNotExposedException;
+import com.personal.marketnote.reward.domain.exception.GifticonGoodsNotFoundException;
+import com.personal.marketnote.reward.domain.gifticon.GifticonGoods;
+import com.personal.marketnote.reward.domain.gifticon.GifticonGoodsSnapshotState;
+import com.personal.marketnote.reward.port.in.command.gifticon.ManageGifticonGoodsOrderCommand;
+import com.personal.marketnote.reward.port.in.command.gifticon.ManageGifticonGoodsOrderCommand.OrderItem;
+import com.personal.marketnote.reward.port.out.gifticon.FindGifticonGoodsPort;
+import com.personal.marketnote.reward.port.out.gifticon.UpdateGifticonGoodsPort;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ManageGifticonGoodsOrderUseCaseTest {
+
+    @InjectMocks
+    private ManageGifticonGoodsOrderService manageGifticonGoodsOrderService;
+
+    @Mock
+    private FindGifticonGoodsPort findGifticonGoodsPort;
+
+    @Mock
+    private UpdateGifticonGoodsPort updateGifticonGoodsPort;
+
+    @Test
+    @DisplayName("노출된 상품의 정렬 순서를 변경하면 orderNum이 변경된다")
+    void shouldChangeOrderNumWhenGoodsIsExposed() {
+        // given
+        GifticonGoods goods = createGoods("G00001", true, null);
+        ManageGifticonGoodsOrderCommand command = new ManageGifticonGoodsOrderCommand(
+                List.of(new OrderItem("G00001", 1))
+        );
+
+        when(findGifticonGoodsPort.findByGoodsCode("G00001"))
+                .thenReturn(Optional.of(goods));
+
+        // when
+        manageGifticonGoodsOrderService.manageOrder(command);
+
+        // then
+        assertThat(goods.getOrderNum()).isEqualTo(1);
+        verify(updateGifticonGoodsPort).update(goods);
+    }
+
+    @Test
+    @DisplayName("미노출 상품에 정렬 순서를 설정하면 GifticonGoodsNotExposedException이 발생한다")
+    void shouldThrowExceptionWhenGoodsNotExposed() {
+        // given
+        GifticonGoods goods = createGoods("G00001", false, null);
+        ManageGifticonGoodsOrderCommand command = new ManageGifticonGoodsOrderCommand(
+                List.of(new OrderItem("G00001", 1))
+        );
+
+        when(findGifticonGoodsPort.findByGoodsCode("G00001"))
+                .thenReturn(Optional.of(goods));
+
+        // when & then
+        assertThatThrownBy(() -> manageGifticonGoodsOrderService.manageOrder(command))
+                .isInstanceOf(GifticonGoodsNotExposedException.class);
+        verify(updateGifticonGoodsPort, never()).update(any());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 상품 코드로 요청하면 GifticonGoodsNotFoundException이 발생한다")
+    void shouldThrowExceptionWhenGoodsNotFound() {
+        // given
+        ManageGifticonGoodsOrderCommand command = new ManageGifticonGoodsOrderCommand(
+                List.of(new OrderItem("G99999", 1))
+        );
+
+        when(findGifticonGoodsPort.findByGoodsCode("G99999"))
+                .thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> manageGifticonGoodsOrderService.manageOrder(command))
+                .isInstanceOf(GifticonGoodsNotFoundException.class);
+        verify(updateGifticonGoodsPort, never()).update(any());
+    }
+
+    @Test
+    @DisplayName("여러 상품의 정렬 순서를 한 번에 변경한다")
+    void shouldManageMultipleGoodsOrder() {
+        // given
+        GifticonGoods goods1 = createGoods("G00001", true, null);
+        GifticonGoods goods2 = createGoods("G00002", true, 5);
+        ManageGifticonGoodsOrderCommand command = new ManageGifticonGoodsOrderCommand(
+                List.of(
+                        new OrderItem("G00001", 1),
+                        new OrderItem("G00002", 2)
+                )
+        );
+
+        when(findGifticonGoodsPort.findByGoodsCode("G00001"))
+                .thenReturn(Optional.of(goods1));
+        when(findGifticonGoodsPort.findByGoodsCode("G00002"))
+                .thenReturn(Optional.of(goods2));
+
+        // when
+        manageGifticonGoodsOrderService.manageOrder(command);
+
+        // then
+        assertThat(goods1.getOrderNum()).isEqualTo(1);
+        assertThat(goods2.getOrderNum()).isEqualTo(2);
+        verify(updateGifticonGoodsPort).update(goods1);
+        verify(updateGifticonGoodsPort).update(goods2);
+    }
+
+    @Test
+    @DisplayName("orderNum을 null로 설정하면 정렬 순서가 해제된다")
+    void shouldClearOrderNumWhenSetToNull() {
+        // given
+        GifticonGoods goods = createGoods("G00001", true, 3);
+        ManageGifticonGoodsOrderCommand command = new ManageGifticonGoodsOrderCommand(
+                List.of(new OrderItem("G00001", null))
+        );
+
+        when(findGifticonGoodsPort.findByGoodsCode("G00001"))
+                .thenReturn(Optional.of(goods));
+
+        // when
+        manageGifticonGoodsOrderService.manageOrder(command);
+
+        // then
+        assertThat(goods.getOrderNum()).isNull();
+        verify(updateGifticonGoodsPort).update(goods);
+    }
+
+    // --- Helper Methods ---
+
+    private GifticonGoods createGoods(String goodsCode, boolean exposed, Integer orderNum) {
+        return GifticonGoods.from(GifticonGoodsSnapshotState.builder()
+                .id(1L)
+                .goodsCode(goodsCode)
+                .goodsName("테스트 상품")
+                .brandCode("BR001")
+                .brandName("스타벅스")
+                .brandImageUrl("https://img.com/brand.png")
+                .categoryCode("1")
+                .realPrice(5000L)
+                .salePrice(4500L)
+                .cashPrice(3500L)
+                .imageUrl("https://img.com/goods.png")
+                .description("설명")
+                .validDays(30)
+                .goodsStatus("SALE")
+                .exposed(exposed)
+                .orderNum(orderNum)
+                .createdAt(LocalDateTime.of(2026, 4, 1, 10, 0))
+                .modifiedAt(LocalDateTime.of(2026, 4, 1, 10, 0))
+                .build());
+    }
+}

--- a/reward-service/reward-application/src/test/java/com/personal/marketnote/reward/service/gifticon/PurchaseGifticonUseCaseTest.java
+++ b/reward-service/reward-application/src/test/java/com/personal/marketnote/reward/service/gifticon/PurchaseGifticonUseCaseTest.java
@@ -1,0 +1,254 @@
+package com.personal.marketnote.reward.service.gifticon;
+
+import com.personal.marketnote.reward.domain.exception.GifticonCouponSendFailedException;
+import com.personal.marketnote.reward.domain.exception.GifticonGoodsNotFoundException;
+import com.personal.marketnote.reward.domain.gifticon.GifticonGoods;
+import com.personal.marketnote.reward.domain.gifticon.GifticonGoodsSnapshotState;
+import com.personal.marketnote.reward.port.in.command.gifticon.PurchaseGifticonCommand;
+import com.personal.marketnote.reward.port.in.result.gifticon.PurchaseGifticonResult;
+import com.personal.marketnote.reward.port.out.gifticon.CancelGifticonSendFailPort;
+import com.personal.marketnote.reward.port.out.gifticon.FindGifticonGoodsPort;
+import com.personal.marketnote.reward.port.out.gifticon.SendGifticonCouponPort;
+import com.personal.marketnote.reward.port.out.gifticon.SendGifticonCouponPort.SendCouponResult;
+import com.personal.marketnote.reward.service.gifticon.PurchaseGifticonTransactionHelper.DeductCashAndCreateOrderContext;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class PurchaseGifticonUseCaseTest {
+
+    @InjectMocks
+    private PurchaseGifticonService purchaseGifticonService;
+
+    @Mock
+    private FindGifticonGoodsPort findGifticonGoodsPort;
+
+    @Mock
+    private PurchaseGifticonTransactionHelper transactionHelper;
+
+    @Mock
+    private SendGifticonCouponPort sendGifticonCouponPort;
+
+    @Mock
+    private CancelGifticonSendFailPort cancelGifticonSendFailPort;
+
+    private static final Long USER_ID = 100L;
+    private static final String GOODS_CODE = "G00000280811";
+
+    @Test
+    @DisplayName("캐시가 충분하면 기프티콘 구매에 성공한다")
+    void shouldPurchaseGifticonSuccessfully() {
+        // given
+        GifticonGoods goods = createExposedSaleGoods();
+        when(findGifticonGoodsPort.findByGoodsCode(GOODS_CODE)).thenReturn(Optional.of(goods));
+
+        DeductCashAndCreateOrderContext context = new DeductCashAndCreateOrderContext(
+                1L, "NC100_260404210000", GOODS_CODE, "테스트 기프티콘", 5000L, USER_ID
+        );
+        when(transactionHelper.deductCashAndCreateOrder(
+                eq(USER_ID), eq(GOODS_CODE), any(), any(), any(), eq(5000L)
+        )).thenReturn(context);
+
+        SendCouponResult sendResult = SendCouponResult.builder()
+                .success(true)
+                .orderNo("20260404000001")
+                .pinNo("900343630367")
+                .couponImageUrl("http://t.giftishow.co.kr/coupon.jpg")
+                .validEndDate("20260504")
+                .build();
+        when(sendGifticonCouponPort.sendCoupon("NC100_260404210000", GOODS_CODE, String.valueOf(USER_ID)))
+                .thenReturn(sendResult);
+
+        PurchaseGifticonCommand command = new PurchaseGifticonCommand(USER_ID, GOODS_CODE);
+
+        // when
+        PurchaseGifticonResult result = purchaseGifticonService.purchase(command);
+
+        // then
+        assertThat(result.orderId()).isEqualTo(1L);
+        assertThat(result.orderNo()).isEqualTo("20260404000001");
+        assertThat(result.cashAmount()).isEqualTo(5000L);
+        assertThat(result.goodsName()).isEqualTo("테스트 기프티콘");
+        verify(transactionHelper).commitSuccess(context, sendResult);
+        verify(transactionHelper, never()).commitFailure(any());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 상품 코드로 구매 시 GifticonGoodsNotFoundException이 발생한다")
+    void shouldThrowExceptionWhenGoodsNotFound() {
+        // given
+        when(findGifticonGoodsPort.findByGoodsCode(GOODS_CODE)).thenReturn(Optional.empty());
+        PurchaseGifticonCommand command = new PurchaseGifticonCommand(USER_ID, GOODS_CODE);
+
+        // when & then
+        assertThatThrownBy(() -> purchaseGifticonService.purchase(command))
+                .isInstanceOf(GifticonGoodsNotFoundException.class);
+
+        verify(transactionHelper, never()).deductCashAndCreateOrder(any(), any(), any(), any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("노출되지 않은 상품으로 구매 시 GifticonGoodsNotFoundException이 발생한다")
+    void shouldThrowExceptionWhenGoodsNotExposed() {
+        // given
+        GifticonGoods goods = createUnexposedGoods();
+        when(findGifticonGoodsPort.findByGoodsCode(GOODS_CODE)).thenReturn(Optional.of(goods));
+        PurchaseGifticonCommand command = new PurchaseGifticonCommand(USER_ID, GOODS_CODE);
+
+        // when & then
+        assertThatThrownBy(() -> purchaseGifticonService.purchase(command))
+                .isInstanceOf(GifticonGoodsNotFoundException.class);
+
+        verify(transactionHelper, never()).deductCashAndCreateOrder(any(), any(), any(), any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("판매 중이 아닌 상품으로 구매 시 GifticonGoodsNotFoundException이 발생한다")
+    void shouldThrowExceptionWhenGoodsNotSale() {
+        // given
+        GifticonGoods goods = createSuspendedGoods();
+        when(findGifticonGoodsPort.findByGoodsCode(GOODS_CODE)).thenReturn(Optional.of(goods));
+        PurchaseGifticonCommand command = new PurchaseGifticonCommand(USER_ID, GOODS_CODE);
+
+        // when & then
+        assertThatThrownBy(() -> purchaseGifticonService.purchase(command))
+                .isInstanceOf(GifticonGoodsNotFoundException.class);
+
+        verify(transactionHelper, never()).deductCashAndCreateOrder(any(), any(), any(), any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("쿠폰 발송 실패 시 commitFailure가 호출되고 발송실패 취소 API가 호출된다")
+    void shouldCallCommitFailureAndCancelSendFailOnCouponSendFailure() {
+        // given
+        GifticonGoods goods = createExposedSaleGoods();
+        when(findGifticonGoodsPort.findByGoodsCode(GOODS_CODE)).thenReturn(Optional.of(goods));
+
+        DeductCashAndCreateOrderContext context = new DeductCashAndCreateOrderContext(
+                1L, "NC100_260404210000", GOODS_CODE, "테스트 기프티콘", 5000L, USER_ID
+        );
+        when(transactionHelper.deductCashAndCreateOrder(
+                eq(USER_ID), eq(GOODS_CODE), any(), any(), any(), eq(5000L)
+        )).thenReturn(context);
+
+        SendCouponResult failResult = SendCouponResult.builder()
+                .success(false)
+                .errorCode("ERR0999")
+                .errorMessage("쿠폰발송오류")
+                .build();
+        when(sendGifticonCouponPort.sendCoupon("NC100_260404210000", GOODS_CODE, String.valueOf(USER_ID)))
+                .thenReturn(failResult);
+
+        PurchaseGifticonCommand command = new PurchaseGifticonCommand(USER_ID, GOODS_CODE);
+
+        // when & then
+        assertThatThrownBy(() -> purchaseGifticonService.purchase(command))
+                .isInstanceOf(GifticonCouponSendFailedException.class);
+
+        verify(transactionHelper).commitFailure(context);
+        verify(cancelGifticonSendFailPort).cancelSendFailed("NC100_260404210000", String.valueOf(USER_ID));
+        verify(transactionHelper, never()).commitSuccess(any(), any());
+    }
+
+    @Test
+    @DisplayName("발송실패 취소 API 호출 실패 시에도 예외가 전파되지 않는다")
+    void shouldNotPropagateExceptionWhenCancelSendFailFails() {
+        // given
+        GifticonGoods goods = createExposedSaleGoods();
+        when(findGifticonGoodsPort.findByGoodsCode(GOODS_CODE)).thenReturn(Optional.of(goods));
+
+        DeductCashAndCreateOrderContext context = new DeductCashAndCreateOrderContext(
+                1L, "NC100_260404210000", GOODS_CODE, "테스트 기프티콘", 5000L, USER_ID
+        );
+        when(transactionHelper.deductCashAndCreateOrder(
+                eq(USER_ID), eq(GOODS_CODE), any(), any(), any(), eq(5000L)
+        )).thenReturn(context);
+
+        SendCouponResult failResult = SendCouponResult.builder()
+                .success(false)
+                .errorCode("ERR0999")
+                .errorMessage("쿠폰발송오류")
+                .build();
+        when(sendGifticonCouponPort.sendCoupon("NC100_260404210000", GOODS_CODE, String.valueOf(USER_ID)))
+                .thenReturn(failResult);
+
+        doThrow(new RuntimeException("발송실패 취소 API 호출 실패"))
+                .when(cancelGifticonSendFailPort).cancelSendFailed(any(), any());
+
+        PurchaseGifticonCommand command = new PurchaseGifticonCommand(USER_ID, GOODS_CODE);
+
+        // when & then
+        assertThatThrownBy(() -> purchaseGifticonService.purchase(command))
+                .isInstanceOf(GifticonCouponSendFailedException.class);
+
+        verify(transactionHelper).commitFailure(context);
+    }
+
+    private GifticonGoods createExposedSaleGoods() {
+        GifticonGoods goods = GifticonGoods.from(GifticonGoodsSnapshotState.builder()
+                .id(1L)
+                .goodsCode(GOODS_CODE)
+                .goodsName("테스트 기프티콘")
+                .brandCode("BR00046")
+                .brandName("세븐일레븐")
+                .brandImageUrl("https://example.com/brand.jpg")
+                .categoryCode("CAT001")
+                .realPrice(6000L)
+                .salePrice(5500L)
+                .cashPrice(5000L)
+                .imageUrl("https://example.com/goods.jpg")
+                .description("테스트 상품입니다")
+                .validDays(30)
+                .goodsStatus("SALE")
+                .exposed(true)
+                .popular(false)
+                .build());
+        return goods;
+    }
+
+    private GifticonGoods createUnexposedGoods() {
+        return GifticonGoods.from(GifticonGoodsSnapshotState.builder()
+                .id(1L)
+                .goodsCode(GOODS_CODE)
+                .goodsName("테스트 기프티콘")
+                .brandCode("BR00046")
+                .brandName("세븐일레븐")
+                .categoryCode("CAT001")
+                .realPrice(6000L)
+                .salePrice(5500L)
+                .cashPrice(5000L)
+                .goodsStatus("SALE")
+                .exposed(false)
+                .popular(false)
+                .build());
+    }
+
+    private GifticonGoods createSuspendedGoods() {
+        return GifticonGoods.from(GifticonGoodsSnapshotState.builder()
+                .id(1L)
+                .goodsCode(GOODS_CODE)
+                .goodsName("테스트 기프티콘")
+                .brandCode("BR00046")
+                .brandName("세븐일레븐")
+                .categoryCode("CAT001")
+                .realPrice(6000L)
+                .salePrice(5500L)
+                .cashPrice(5000L)
+                .goodsStatus("SUS")
+                .exposed(true)
+                .popular(false)
+                .build());
+    }
+}

--- a/reward-service/reward-application/src/test/java/com/personal/marketnote/reward/service/gifticon/SyncGifticonGoodsAndBrandsUseCaseTest.java
+++ b/reward-service/reward-application/src/test/java/com/personal/marketnote/reward/service/gifticon/SyncGifticonGoodsAndBrandsUseCaseTest.java
@@ -1,0 +1,432 @@
+package com.personal.marketnote.reward.service.gifticon;
+
+import com.personal.marketnote.reward.domain.gifticon.*;
+import com.personal.marketnote.reward.port.out.gifticon.*;
+import com.personal.marketnote.reward.port.out.gifticon.FetchGifticonBrandPort.FetchGifticonBrandResult;
+import com.personal.marketnote.reward.port.out.gifticon.FetchGifticonBrandPort.FetchedGifticonBrandItem;
+import com.personal.marketnote.reward.port.out.gifticon.FetchGifticonGoodsPort.FetchGifticonGoodsResult;
+import com.personal.marketnote.reward.port.out.gifticon.FetchGifticonGoodsPort.FetchedGifticonGoodsItem;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class SyncGifticonGoodsAndBrandsUseCaseTest {
+
+    @InjectMocks
+    private SyncGifticonGoodsAndBrandsService syncGifticonGoodsAndBrandsService;
+
+    @Mock
+    private TransactionTemplate transactionTemplate;
+
+    @Mock
+    private FetchGifticonBrandPort fetchGifticonBrandPort;
+
+    @Mock
+    private FetchGifticonGoodsPort fetchGifticonGoodsPort;
+
+    @Mock
+    private FindGifticonGoodsPort findGifticonGoodsPort;
+
+    @Mock
+    private SaveGifticonGoodsPort saveGifticonGoodsPort;
+
+    @Mock
+    private UpdateGifticonGoodsPort updateGifticonGoodsPort;
+
+    @Mock
+    private FindGifticonBrandPort findGifticonBrandPort;
+
+    @Mock
+    private SaveGifticonBrandPort saveGifticonBrandPort;
+
+    @Mock
+    private UpdateGifticonBrandPort updateGifticonBrandPort;
+
+    @Mock
+    private FindGifticonCategoryPort findGifticonCategoryPort;
+
+    @Mock
+    private SaveGifticonCategoryPort saveGifticonCategoryPort;
+
+    @Mock
+    private UpdateGifticonCategoryPort updateGifticonCategoryPort;
+
+    @Mock
+    private FindGifticonCategoryMappingPort findGifticonCategoryMappingPort;
+
+    @Mock
+    private SaveGifticonCategoryMappingPort saveGifticonCategoryMappingPort;
+
+    @BeforeEach
+    void setUp() {
+        when(transactionTemplate.execute(any())).thenAnswer(invocation -> {
+            org.springframework.transaction.support.TransactionCallback<?> callback = invocation.getArgument(0);
+            return callback.doInTransaction(null);
+        });
+    }
+
+    @Test
+    @DisplayName("신규 브랜드를 동기화하면 브랜드가 저장된다")
+    void shouldSaveNewBrand() {
+        // given
+        FetchedGifticonBrandItem brandItem = new FetchedGifticonBrandItem(
+                "BR001", "스타벅스", "https://img.com/starbucks.png", "1", "커피"
+        );
+        when(fetchGifticonBrandPort.fetchBrandList())
+                .thenReturn(new FetchGifticonBrandResult(1, List.of(brandItem)));
+        when(findGifticonBrandPort.findByBrandCode("BR001"))
+                .thenReturn(Optional.empty());
+        when(fetchGifticonGoodsPort.fetchProductList(1, 20))
+                .thenReturn(new FetchGifticonGoodsResult(0, List.of()));
+        when(findGifticonGoodsPort.findAllByGoodsStatus("SALE"))
+                .thenReturn(List.of());
+        when(findGifticonCategoryMappingPort.findCategoryIdByGiftishowCategorySeq("1"))
+                .thenReturn(Optional.empty());
+        when(findGifticonCategoryPort.findByCategoryCode("1"))
+                .thenReturn(Optional.empty());
+        GifticonCategory savedCategory = createCategory(1L, "1", "커피");
+        when(saveGifticonCategoryPort.save(any(GifticonCategory.class)))
+                .thenReturn(savedCategory);
+
+        // when
+        syncGifticonGoodsAndBrandsService.syncAll();
+
+        // then
+        ArgumentCaptor<GifticonBrand> brandCaptor = ArgumentCaptor.forClass(GifticonBrand.class);
+        verify(saveGifticonBrandPort).save(brandCaptor.capture());
+        GifticonBrand savedBrand = brandCaptor.getValue();
+        assertThat(savedBrand.getBrandCode()).isEqualTo("BR001");
+        assertThat(savedBrand.getBrandName()).isEqualTo("스타벅스");
+        assertThat(savedBrand.getBrandImageUrl()).isEqualTo("https://img.com/starbucks.png");
+    }
+
+    @Test
+    @DisplayName("기존 브랜드가 존재하면 브랜드 정보를 갱신한다")
+    void shouldUpdateExistingBrand() {
+        // given
+        GifticonBrand existingBrand = createBrand(1L, "BR001", "스타벅스(구)", "https://img.com/old.png");
+        FetchedGifticonBrandItem brandItem = new FetchedGifticonBrandItem(
+                "BR001", "스타벅스", "https://img.com/new.png", "1", "커피"
+        );
+        when(fetchGifticonBrandPort.fetchBrandList())
+                .thenReturn(new FetchGifticonBrandResult(1, List.of(brandItem)));
+        when(findGifticonBrandPort.findByBrandCode("BR001"))
+                .thenReturn(Optional.of(existingBrand));
+        when(fetchGifticonGoodsPort.fetchProductList(1, 20))
+                .thenReturn(new FetchGifticonGoodsResult(0, List.of()));
+        when(findGifticonGoodsPort.findAllByGoodsStatus("SALE"))
+                .thenReturn(List.of());
+        when(findGifticonCategoryMappingPort.findCategoryIdByGiftishowCategorySeq("1"))
+                .thenReturn(Optional.of(1L));
+        when(findGifticonCategoryPort.findById(1L))
+                .thenReturn(Optional.of(createCategory(1L, "1", "커피")));
+
+        // when
+        syncGifticonGoodsAndBrandsService.syncAll();
+
+        // then
+        verify(updateGifticonBrandPort).update(existingBrand);
+        assertThat(existingBrand.getBrandName()).isEqualTo("스타벅스");
+        assertThat(existingBrand.getBrandImageUrl()).isEqualTo("https://img.com/new.png");
+        verify(saveGifticonBrandPort, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("신규 카테고리를 생성하고 매핑을 저장한다")
+    void shouldCreateNewCategoryAndMapping() {
+        // given
+        FetchedGifticonBrandItem brandItem = new FetchedGifticonBrandItem(
+                "BR001", "스타벅스", "https://img.com/sb.png", "1", "커피"
+        );
+        when(fetchGifticonBrandPort.fetchBrandList())
+                .thenReturn(new FetchGifticonBrandResult(1, List.of(brandItem)));
+        when(findGifticonBrandPort.findByBrandCode("BR001"))
+                .thenReturn(Optional.empty());
+        when(findGifticonCategoryMappingPort.findCategoryIdByGiftishowCategorySeq("1"))
+                .thenReturn(Optional.empty());
+        when(findGifticonCategoryPort.findByCategoryCode("1"))
+                .thenReturn(Optional.empty());
+        GifticonCategory savedCategory = createCategory(10L, "1", "커피");
+        when(saveGifticonCategoryPort.save(any(GifticonCategory.class)))
+                .thenReturn(savedCategory);
+        when(fetchGifticonGoodsPort.fetchProductList(1, 20))
+                .thenReturn(new FetchGifticonGoodsResult(0, List.of()));
+        when(findGifticonGoodsPort.findAllByGoodsStatus("SALE"))
+                .thenReturn(List.of());
+
+        // when
+        syncGifticonGoodsAndBrandsService.syncAll();
+
+        // then
+        ArgumentCaptor<GifticonCategory> categoryCaptor = ArgumentCaptor.forClass(GifticonCategory.class);
+        verify(saveGifticonCategoryPort).save(categoryCaptor.capture());
+        GifticonCategory created = categoryCaptor.getValue();
+        assertThat(created.getCategoryCode()).isEqualTo("1");
+        assertThat(created.getCategoryName()).isEqualTo("커피");
+        assertThat(created.isExposed()).isFalse();
+
+        verify(saveGifticonCategoryMappingPort).save("1", 10L);
+    }
+
+    @Test
+    @DisplayName("기존 카테고리 매핑이 존재하면 카테고리 이름을 갱신한다")
+    void shouldUpdateExistingCategoryName() {
+        // given
+        GifticonCategory existingCategory = createCategory(10L, "1", "커피(구)");
+        FetchedGifticonBrandItem brandItem = new FetchedGifticonBrandItem(
+                "BR001", "스타벅스", "https://img.com/sb.png", "1", "커피"
+        );
+        when(fetchGifticonBrandPort.fetchBrandList())
+                .thenReturn(new FetchGifticonBrandResult(1, List.of(brandItem)));
+        when(findGifticonBrandPort.findByBrandCode("BR001"))
+                .thenReturn(Optional.empty());
+        when(findGifticonCategoryMappingPort.findCategoryIdByGiftishowCategorySeq("1"))
+                .thenReturn(Optional.of(10L));
+        when(findGifticonCategoryPort.findById(10L))
+                .thenReturn(Optional.of(existingCategory));
+        when(fetchGifticonGoodsPort.fetchProductList(1, 20))
+                .thenReturn(new FetchGifticonGoodsResult(0, List.of()));
+        when(findGifticonGoodsPort.findAllByGoodsStatus("SALE"))
+                .thenReturn(List.of());
+
+        // when
+        syncGifticonGoodsAndBrandsService.syncAll();
+
+        // then
+        assertThat(existingCategory.getCategoryName()).isEqualTo("커피");
+        verify(updateGifticonCategoryPort).update(existingCategory);
+        verify(saveGifticonCategoryPort, never()).save(any());
+        verify(saveGifticonCategoryMappingPort, never()).save(anyString(), anyLong());
+    }
+
+    @Test
+    @DisplayName("신규 상품을 동기화하면 exposed=false, cashPrice=salePrice로 저장된다")
+    void shouldSaveNewGoodsWithDefaultValues() {
+        // given
+        stubEmptyBrandSync();
+        FetchedGifticonGoodsItem goodsItem = createGoodsItem(
+                "GD001", "아메리카노", "BR001", "스타벅스", "https://img.com/sb.png",
+                "1", 5000L, 4500L, 30, "맛있는 커피", "SALE"
+        );
+        when(fetchGifticonGoodsPort.fetchProductList(1, 20))
+                .thenReturn(new FetchGifticonGoodsResult(1, List.of(goodsItem)));
+        when(findGifticonGoodsPort.findByGoodsCode("GD001"))
+                .thenReturn(Optional.empty());
+        when(findGifticonGoodsPort.findAllByGoodsStatus("SALE"))
+                .thenReturn(List.of());
+
+        // when
+        syncGifticonGoodsAndBrandsService.syncAll();
+
+        // then
+        ArgumentCaptor<GifticonGoods> goodsCaptor = ArgumentCaptor.forClass(GifticonGoods.class);
+        verify(saveGifticonGoodsPort).save(goodsCaptor.capture());
+        GifticonGoods savedGoods = goodsCaptor.getValue();
+        assertThat(savedGoods.getGoodsCode()).isEqualTo("GD001");
+        assertThat(savedGoods.getGoodsName()).isEqualTo("아메리카노");
+        assertThat(savedGoods.getCashPrice()).isEqualTo(4500L);
+        assertThat(savedGoods.getSalePrice()).isEqualTo(4500L);
+        assertThat(savedGoods.isExposed()).isFalse();
+        assertThat(savedGoods.getOrderNum()).isNull();
+        assertThat(savedGoods.getGoodsStatus()).isEqualTo("SALE");
+    }
+
+    @Test
+    @DisplayName("기존 상품을 갱신할 때 cashPrice는 변경하지 않는다")
+    void shouldNotChangeCashPriceOnUpdate() {
+        // given
+        stubEmptyBrandSync();
+        GifticonGoods existingGoods = createGoods(1L, "GD001", "아메리카노(구)", 4500L, 3500L, "SALE");
+        FetchedGifticonGoodsItem goodsItem = createGoodsItem(
+                "GD001", "아메리카노", "BR001", "스타벅스", "https://img.com/sb.png",
+                "1", 5000L, 4800L, 30, "맛있는 커피", "SALE"
+        );
+        when(fetchGifticonGoodsPort.fetchProductList(1, 20))
+                .thenReturn(new FetchGifticonGoodsResult(1, List.of(goodsItem)));
+        when(findGifticonGoodsPort.findByGoodsCode("GD001"))
+                .thenReturn(Optional.of(existingGoods));
+        when(findGifticonGoodsPort.findAllByGoodsStatus("SALE"))
+                .thenReturn(List.of(existingGoods));
+
+        // when
+        syncGifticonGoodsAndBrandsService.syncAll();
+
+        // then
+        verify(updateGifticonGoodsPort).update(existingGoods);
+        assertThat(existingGoods.getGoodsName()).isEqualTo("아메리카노");
+        assertThat(existingGoods.getSalePrice()).isEqualTo(4800L);
+        assertThat(existingGoods.getCashPrice()).isEqualTo(3500L);
+        verify(saveGifticonGoodsPort, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("API에서 사라진 SALE 상품은 SUS 상태로 전환된다")
+    void shouldSuspendMissingGoods() {
+        // given
+        stubEmptyBrandSync();
+        GifticonGoods missingGoods = createGoods(2L, "GD002", "빙수", 4500L, 4500L, "SALE");
+        when(fetchGifticonGoodsPort.fetchProductList(1, 20))
+                .thenReturn(new FetchGifticonGoodsResult(0, List.of()));
+        when(findGifticonGoodsPort.findAllByGoodsStatus("SALE"))
+                .thenReturn(List.of(missingGoods));
+
+        // when
+        syncGifticonGoodsAndBrandsService.syncAll();
+
+        // then
+        verify(updateGifticonGoodsPort).update(missingGoods);
+        assertThat(missingGoods.getGoodsStatus()).isEqualTo("SUS");
+    }
+
+    @Test
+    @DisplayName("API에 여전히 존재하는 SALE 상품은 SUS 처리되지 않는다")
+    void shouldNotSuspendGoodsStillInApi() {
+        // given
+        stubEmptyBrandSync();
+        GifticonGoods existingGoods = createGoods(1L, "GD001", "아메리카노", 4500L, 4500L, "SALE");
+        FetchedGifticonGoodsItem goodsItem = createGoodsItem(
+                "GD001", "아메리카노", "BR001", "스타벅스", "https://img.com/sb.png",
+                "1", 5000L, 4500L, 30, "맛있는 커피", "SALE"
+        );
+        when(fetchGifticonGoodsPort.fetchProductList(1, 20))
+                .thenReturn(new FetchGifticonGoodsResult(1, List.of(goodsItem)));
+        when(findGifticonGoodsPort.findByGoodsCode("GD001"))
+                .thenReturn(Optional.of(existingGoods));
+        when(findGifticonGoodsPort.findAllByGoodsStatus("SALE"))
+                .thenReturn(List.of(existingGoods));
+
+        // when
+        syncGifticonGoodsAndBrandsService.syncAll();
+
+        // then
+        assertThat(existingGoods.getGoodsStatus()).isEqualTo("SALE");
+    }
+
+    @Test
+    @DisplayName("2페이지 이상의 상품을 순차적으로 수집한다")
+    void shouldFetchMultiplePagesSequentially() {
+        // given
+        stubEmptyBrandSync();
+        FetchedGifticonGoodsItem item1 = createGoodsItem(
+                "GD001", "아메리카노", "BR001", "스타벅스", "https://img.com/sb.png",
+                "1", 5000L, 4500L, 30, "커피", "SALE"
+        );
+        FetchedGifticonGoodsItem item2 = createGoodsItem(
+                "GD002", "라떼", "BR001", "스타벅스", "https://img.com/sb.png",
+                "1", 6000L, 5500L, 30, "라떼", "SALE"
+        );
+        when(fetchGifticonGoodsPort.fetchProductList(1, 20))
+                .thenReturn(new FetchGifticonGoodsResult(2, List.of(item1)));
+        when(fetchGifticonGoodsPort.fetchProductList(21, 20))
+                .thenReturn(new FetchGifticonGoodsResult(2, List.of(item2)));
+        when(findGifticonGoodsPort.findByGoodsCode("GD001")).thenReturn(Optional.empty());
+        when(findGifticonGoodsPort.findByGoodsCode("GD002")).thenReturn(Optional.empty());
+        when(findGifticonGoodsPort.findAllByGoodsStatus("SALE")).thenReturn(List.of());
+
+        // when
+        syncGifticonGoodsAndBrandsService.syncAll();
+
+        // then
+        verify(fetchGifticonGoodsPort).fetchProductList(1, 20);
+        verify(fetchGifticonGoodsPort).fetchProductList(21, 20);
+        verify(saveGifticonGoodsPort, times(2)).save(any(GifticonGoods.class));
+    }
+
+    @Test
+    @DisplayName("비SALE 상태 상품은 suspend 대상에서 제외된다")
+    void shouldNotSuspendNonSaleGoods() {
+        // given
+        stubEmptyBrandSync();
+        GifticonGoods susGoods = createGoods(3L, "GD003", "만료상품", 3000L, 3000L, "SUS");
+        when(fetchGifticonGoodsPort.fetchProductList(1, 20))
+                .thenReturn(new FetchGifticonGoodsResult(0, List.of()));
+        when(findGifticonGoodsPort.findAllByGoodsStatus("SALE"))
+                .thenReturn(List.of());
+
+        // when
+        syncGifticonGoodsAndBrandsService.syncAll();
+
+        // then
+        assertThat(susGoods.getGoodsStatus()).isEqualTo("SUS");
+        verify(updateGifticonGoodsPort, never()).update(susGoods);
+    }
+
+    // --- Helper Methods ---
+
+    private void stubEmptyBrandSync() {
+        when(fetchGifticonBrandPort.fetchBrandList())
+                .thenReturn(new FetchGifticonBrandResult(0, List.of()));
+    }
+
+    private GifticonBrand createBrand(Long id, String brandCode, String brandName, String brandImageUrl) {
+        return GifticonBrand.from(GifticonBrandSnapshotState.builder()
+                .id(id)
+                .brandCode(brandCode)
+                .brandName(brandName)
+                .brandImageUrl(brandImageUrl)
+                .createdAt(LocalDateTime.now())
+                .modifiedAt(LocalDateTime.now())
+                .build());
+    }
+
+    private GifticonCategory createCategory(Long id, String categoryCode, String categoryName) {
+        return GifticonCategory.from(GifticonCategorySnapshotState.builder()
+                .id(id)
+                .categoryCode(categoryCode)
+                .categoryName(categoryName)
+                .exposed(false)
+                .createdAt(LocalDateTime.now())
+                .modifiedAt(LocalDateTime.now())
+                .build());
+    }
+
+    private GifticonGoods createGoods(Long id, String goodsCode, String goodsName,
+                                      Long salePrice, Long cashPrice, String goodsStatus) {
+        return GifticonGoods.from(GifticonGoodsSnapshotState.builder()
+                .id(id)
+                .goodsCode(goodsCode)
+                .goodsName(goodsName)
+                .brandCode("BR001")
+                .brandName("스타벅스")
+                .brandImageUrl("https://img.com/sb.png")
+                .categoryCode("1")
+                .realPrice(5000L)
+                .salePrice(salePrice)
+                .cashPrice(cashPrice)
+                .imageUrl("https://img.com/goods.png")
+                .description("설명")
+                .validDays(30)
+                .goodsStatus(goodsStatus)
+                .exposed(false)
+                .createdAt(LocalDateTime.now())
+                .modifiedAt(LocalDateTime.now())
+                .build());
+    }
+
+    private FetchedGifticonGoodsItem createGoodsItem(String goodsCode, String goodsName,
+                                                     String brandCode, String brandName, String brandIconImg,
+                                                     String category1Seq, long realPrice, long salePrice,
+                                                     int limitDay, String content, String goodsStatus) {
+        return new FetchedGifticonGoodsItem(
+                goodsCode, goodsName, "https://img.com/" + goodsCode + ".png",
+                brandCode, brandName, brandIconImg,
+                category1Seq, salePrice, realPrice,
+                limitDay, content, goodsStatus
+        );
+    }
+}

--- a/reward-service/reward-application/src/test/java/com/personal/marketnote/reward/service/gifticon/UpdateGifticonCategoryUseCaseTest.java
+++ b/reward-service/reward-application/src/test/java/com/personal/marketnote/reward/service/gifticon/UpdateGifticonCategoryUseCaseTest.java
@@ -1,0 +1,137 @@
+package com.personal.marketnote.reward.service.gifticon;
+
+import com.personal.marketnote.reward.domain.exception.GifticonCategoryNotFoundException;
+import com.personal.marketnote.reward.domain.gifticon.GifticonCategory;
+import com.personal.marketnote.reward.domain.gifticon.GifticonCategorySnapshotState;
+import com.personal.marketnote.reward.port.in.command.gifticon.UpdateGifticonCategoryCommand;
+import com.personal.marketnote.reward.port.out.gifticon.FindGifticonCategoryPort;
+import com.personal.marketnote.reward.port.out.gifticon.UpdateGifticonCategoryPort;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class UpdateGifticonCategoryUseCaseTest {
+
+    @InjectMocks
+    private UpdateGifticonCategoryService updateGifticonCategoryService;
+
+    @Mock
+    private FindGifticonCategoryPort findGifticonCategoryPort;
+
+    @Mock
+    private UpdateGifticonCategoryPort updateGifticonCategoryPort;
+
+    @Test
+    @DisplayName("displayName과 iconUrl을 모두 수정한다")
+    void shouldUpdateBothDisplayNameAndIconUrl() {
+        // given
+        GifticonCategory category = createCategory(1L, "커피", null, null);
+        when(findGifticonCategoryPort.findById(1L)).thenReturn(Optional.of(category));
+        UpdateGifticonCategoryCommand command = new UpdateGifticonCategoryCommand(
+                1L, "편의점/마트", true, "https://cdn.example.com/icon.png", true
+        );
+
+        // when
+        updateGifticonCategoryService.updateGifticonCategory(command);
+
+        // then
+        assertThat(category.getDisplayName()).isEqualTo("편의점/마트");
+        assertThat(category.getIconUrl()).isEqualTo("https://cdn.example.com/icon.png");
+        verify(updateGifticonCategoryPort).update(category);
+    }
+
+    @Test
+    @DisplayName("displayName만 수정하고 iconUrl은 변경하지 않는다")
+    void shouldUpdateOnlyDisplayName() {
+        // given
+        GifticonCategory category = createCategory(1L, "커피", null, "https://old.com/icon.png");
+        when(findGifticonCategoryPort.findById(1L)).thenReturn(Optional.of(category));
+        UpdateGifticonCategoryCommand command = new UpdateGifticonCategoryCommand(
+                1L, "카페/음료", true, null, false
+        );
+
+        // when
+        updateGifticonCategoryService.updateGifticonCategory(command);
+
+        // then
+        assertThat(category.getDisplayName()).isEqualTo("카페/음료");
+        assertThat(category.getIconUrl()).isEqualTo("https://old.com/icon.png");
+        verify(updateGifticonCategoryPort).update(category);
+    }
+
+    @Test
+    @DisplayName("displayName을 빈 문자열로 전달하면 null로 초기화된다")
+    void shouldResetDisplayNameToNullWhenEmptyString() {
+        // given
+        GifticonCategory category = createCategory(1L, "커피", "카페/음료", null);
+        when(findGifticonCategoryPort.findById(1L)).thenReturn(Optional.of(category));
+        UpdateGifticonCategoryCommand command = new UpdateGifticonCategoryCommand(
+                1L, "", true, null, false
+        );
+
+        // when
+        updateGifticonCategoryService.updateGifticonCategory(command);
+
+        // then
+        assertThat(category.getDisplayName()).isNull();
+        verify(updateGifticonCategoryPort).update(category);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 카테고리를 수정하면 GifticonCategoryNotFoundException이 발생한다")
+    void shouldThrowExceptionWhenCategoryNotFound() {
+        // given
+        when(findGifticonCategoryPort.findById(999L)).thenReturn(Optional.empty());
+        UpdateGifticonCategoryCommand command = new UpdateGifticonCategoryCommand(
+                999L, "테스트", true, null, false
+        );
+
+        // when & then
+        assertThatThrownBy(() -> updateGifticonCategoryService.updateGifticonCategory(command))
+                .isInstanceOf(GifticonCategoryNotFoundException.class);
+        verify(updateGifticonCategoryPort, never()).update(any());
+    }
+
+    @Test
+    @DisplayName("displayName과 iconUrl 모두 미전달이면 기존 값을 유지한다")
+    void shouldKeepExistingValuesWhenNothingProvided() {
+        // given
+        GifticonCategory category = createCategory(1L, "커피", "카페/음료", "https://old.com/icon.png");
+        when(findGifticonCategoryPort.findById(1L)).thenReturn(Optional.of(category));
+        UpdateGifticonCategoryCommand command = new UpdateGifticonCategoryCommand(
+                1L, null, false, null, false
+        );
+
+        // when
+        updateGifticonCategoryService.updateGifticonCategory(command);
+
+        // then
+        assertThat(category.getDisplayName()).isEqualTo("카페/음료");
+        assertThat(category.getIconUrl()).isEqualTo("https://old.com/icon.png");
+        verify(updateGifticonCategoryPort).update(category);
+    }
+
+    private GifticonCategory createCategory(Long id, String categoryName, String displayName, String iconUrl) {
+        return GifticonCategory.from(GifticonCategorySnapshotState.builder()
+                .id(id)
+                .categoryCode("1")
+                .categoryName(categoryName)
+                .displayName(displayName)
+                .iconUrl(iconUrl)
+                .exposed(false)
+                .createdAt(LocalDateTime.of(2026, 4, 3, 10, 0))
+                .modifiedAt(LocalDateTime.of(2026, 4, 3, 10, 0))
+                .build());
+    }
+}

--- a/reward-service/reward-application/src/test/java/com/personal/marketnote/reward/service/point/CancelPendingPointUseCaseTest.java
+++ b/reward-service/reward-application/src/test/java/com/personal/marketnote/reward/service/point/CancelPendingPointUseCaseTest.java
@@ -1,0 +1,275 @@
+package com.personal.marketnote.reward.service.point;
+
+import com.personal.marketnote.reward.domain.exception.InsufficientPendingPointAmountException;
+import com.personal.marketnote.reward.domain.exception.PendingPointReflectionMismatchException;
+import com.personal.marketnote.reward.domain.point.*;
+import com.personal.marketnote.reward.exception.UserPointNotFoundException;
+import com.personal.marketnote.reward.port.in.command.point.CancelPendingPointCommand;
+import com.personal.marketnote.reward.port.in.result.point.UpdateUserPointResult;
+import com.personal.marketnote.reward.port.in.usecase.point.GetUserPointUseCase;
+import com.personal.marketnote.reward.port.out.point.FindUserPointHistoryPort;
+import com.personal.marketnote.reward.port.out.point.UpdateUserPointHistoryPort;
+import com.personal.marketnote.reward.port.out.point.UpdateUserPointPort;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class CancelPendingPointUseCaseTest {
+
+    @InjectMocks
+    private CancelPendingPointService cancelPendingPointService;
+
+    @Mock
+    private GetUserPointUseCase getUserPointUseCase;
+
+    @Mock
+    private FindUserPointHistoryPort findUserPointHistoryPort;
+
+    @Mock
+    private UpdateUserPointPort updateUserPointPort;
+
+    @Mock
+    private UpdateUserPointHistoryPort updateUserPointHistoryPort;
+
+    private static final Long USER_ID = 1L;
+    private static final Long ORDER_ID = 100L;
+    private static final LocalDateTime NOW = LocalDateTime.of(2026, 3, 4, 10, 0);
+
+    private UserPoint createUserPoint(Long amount, Long addExpectedAmount) {
+        return UserPoint.from(UserPointSnapshotState.builder()
+                .userId(USER_ID)
+                .amount(amount)
+                .addExpectedAmount(addExpectedAmount)
+                .expireExpectedAmount(0L)
+                .createdAt(NOW)
+                .modifiedAt(NOW)
+                .build());
+    }
+
+    private CancelPendingPointCommand createCommand() {
+        return CancelPendingPointCommand.builder()
+                .userId(USER_ID)
+                .sourceType(UserPointSourceType.ORDER)
+                .sourceId(ORDER_ID)
+                .reason("결제 취소 적립 예정 포인트 회수")
+                .build();
+    }
+
+    private UserPointHistory createPendingHistory(Long amount) {
+        return UserPointHistory.from(UserPointHistorySnapshotState.builder()
+                .id(1L)
+                .userId(USER_ID)
+                .amount(amount)
+                .isReflected(Boolean.FALSE)
+                .sourceType(UserPointSourceType.ORDER)
+                .sourceId(ORDER_ID)
+                .reason("상품 구매 적립")
+                .accumulatedAt(NOW)
+                .createdAt(NOW)
+                .build());
+    }
+
+    @Test
+    @DisplayName("적립 예정 포인트를 취소하면 pending에서 차감되고 실제 포인트는 변경되지 않는다")
+    void shouldCancelPendingPointSuccessfully() {
+        // given
+        UserPoint userPoint = createUserPoint(1000L, 500L);
+        UserPointHistory pendingHistory = createPendingHistory(500L);
+
+        when(findUserPointHistoryPort.findUnreflectedByUserIdAndSource(
+                USER_ID, UserPointSourceType.ORDER, ORDER_ID
+        )).thenReturn(List.of(pendingHistory));
+        when(getUserPointUseCase.getUserPoint(USER_ID)).thenReturn(userPoint);
+        when(updateUserPointPort.update(any(UserPoint.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(updateUserPointHistoryPort.markAsReflected(
+                USER_ID, UserPointSourceType.ORDER, ORDER_ID
+        )).thenReturn(1);
+
+        CancelPendingPointCommand command = createCommand();
+
+        // when
+        UpdateUserPointResult result = cancelPendingPointService.cancelPending(command);
+
+        // then
+        assertThat(result.addExpectedAmount()).isEqualTo(0L);
+        assertThat(result.amount()).isEqualTo(1000L);
+
+        ArgumentCaptor<UserPoint> captor = ArgumentCaptor.forClass(UserPoint.class);
+        verify(updateUserPointPort).update(captor.capture());
+        UserPoint capturedPoint = captor.getValue();
+        assertThat(capturedPoint.getAddExpectedAmount()).isEqualTo(0L);
+        assertThat(capturedPoint.getAmountValue()).isEqualTo(1000L);
+
+        verify(updateUserPointHistoryPort).markAsReflected(
+                USER_ID, UserPointSourceType.ORDER, ORDER_ID
+        );
+    }
+
+    @Test
+    @DisplayName("여러 건의 적립 예정 포인트 이력이 있으면 합산하여 취소한다")
+    void shouldCancelMultiplePendingHistories() {
+        // given
+        UserPoint userPoint = createUserPoint(1000L, 800L);
+        UserPointHistory history1 = createPendingHistory(500L);
+        UserPointHistory history2 = createPendingHistory(300L);
+
+        when(findUserPointHistoryPort.findUnreflectedByUserIdAndSource(
+                USER_ID, UserPointSourceType.ORDER, ORDER_ID
+        )).thenReturn(List.of(history1, history2));
+        when(getUserPointUseCase.getUserPoint(USER_ID)).thenReturn(userPoint);
+        when(updateUserPointPort.update(any(UserPoint.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(updateUserPointHistoryPort.markAsReflected(
+                USER_ID, UserPointSourceType.ORDER, ORDER_ID
+        )).thenReturn(2);
+
+        CancelPendingPointCommand command = createCommand();
+
+        // when
+        UpdateUserPointResult result = cancelPendingPointService.cancelPending(command);
+
+        // then
+        assertThat(result.addExpectedAmount()).isEqualTo(0L);
+        assertThat(result.amount()).isEqualTo(1000L);
+
+        ArgumentCaptor<UserPoint> captor = ArgumentCaptor.forClass(UserPoint.class);
+        verify(updateUserPointPort).update(captor.capture());
+        UserPoint capturedPoint = captor.getValue();
+        assertThat(capturedPoint.getAddExpectedAmount()).isEqualTo(0L);
+        assertThat(capturedPoint.getAmountValue()).isEqualTo(1000L);
+
+        verify(updateUserPointHistoryPort).markAsReflected(
+                USER_ID, UserPointSourceType.ORDER, ORDER_ID
+        );
+    }
+
+    @Test
+    @DisplayName("취소 대상 적립 예정 포인트 이력이 없으면 현재 포인트를 그대로 반환한다")
+    void shouldReturnCurrentPointWhenNoPendingHistoryFound() {
+        // given
+        UserPoint userPoint = createUserPoint(1000L, 0L);
+
+        when(findUserPointHistoryPort.findUnreflectedByUserIdAndSource(
+                USER_ID, UserPointSourceType.ORDER, ORDER_ID
+        )).thenReturn(Collections.emptyList());
+        when(getUserPointUseCase.getUserPoint(USER_ID)).thenReturn(userPoint);
+
+        CancelPendingPointCommand command = createCommand();
+
+        // when
+        UpdateUserPointResult result = cancelPendingPointService.cancelPending(command);
+
+        // then
+        assertThat(result.amount()).isEqualTo(1000L);
+        assertThat(result.addExpectedAmount()).isEqualTo(0L);
+
+        verify(updateUserPointPort, never()).update(any());
+        verify(updateUserPointHistoryPort, never()).markAsReflected(anyLong(), any(), anyLong());
+    }
+
+    @Test
+    @DisplayName("회원 포인트 정보가 존재하지 않으면 UserPointNotFoundException이 발생한다")
+    void shouldThrowWhenUserPointNotFound() {
+        // given
+        UserPointHistory pendingHistory = createPendingHistory(500L);
+
+        when(findUserPointHistoryPort.findUnreflectedByUserIdAndSource(
+                USER_ID, UserPointSourceType.ORDER, ORDER_ID
+        )).thenReturn(List.of(pendingHistory));
+        when(getUserPointUseCase.getUserPoint(USER_ID))
+                .thenThrow(new UserPointNotFoundException(USER_ID));
+
+        CancelPendingPointCommand command = createCommand();
+
+        // expect
+        assertThatThrownBy(() -> cancelPendingPointService.cancelPending(command))
+                .isInstanceOf(UserPointNotFoundException.class);
+
+        verify(updateUserPointPort, never()).update(any());
+    }
+
+    @Test
+    @DisplayName("적립 예정 포인트가 부족하면 InsufficientPendingPointAmountException이 발생한다")
+    void shouldThrowWhenInsufficientPendingAmount() {
+        // given
+        UserPoint userPoint = createUserPoint(1000L, 200L);
+        UserPointHistory pendingHistory = createPendingHistory(500L);
+
+        when(findUserPointHistoryPort.findUnreflectedByUserIdAndSource(
+                USER_ID, UserPointSourceType.ORDER, ORDER_ID
+        )).thenReturn(List.of(pendingHistory));
+        when(getUserPointUseCase.getUserPoint(USER_ID)).thenReturn(userPoint);
+
+        CancelPendingPointCommand command = createCommand();
+
+        // expect
+        assertThatThrownBy(() -> cancelPendingPointService.cancelPending(command))
+                .isInstanceOf(InsufficientPendingPointAmountException.class);
+
+        verify(updateUserPointPort, never()).update(any());
+    }
+
+    @Test
+    @DisplayName("이력 반영 건수가 조회 건수와 일치하지 않으면 PendingPointReflectionMismatchException이 발생한다")
+    void shouldThrowWhenReflectionCountMismatch() {
+        // given
+        UserPoint userPoint = createUserPoint(1000L, 500L);
+        UserPointHistory pendingHistory = createPendingHistory(500L);
+
+        when(findUserPointHistoryPort.findUnreflectedByUserIdAndSource(
+                USER_ID, UserPointSourceType.ORDER, ORDER_ID
+        )).thenReturn(List.of(pendingHistory));
+        when(getUserPointUseCase.getUserPoint(USER_ID)).thenReturn(userPoint);
+        when(updateUserPointPort.update(any(UserPoint.class))).thenReturn(userPoint);
+        when(updateUserPointHistoryPort.markAsReflected(
+                USER_ID, UserPointSourceType.ORDER, ORDER_ID
+        )).thenReturn(0);
+
+        CancelPendingPointCommand command = createCommand();
+
+        // expect
+        assertThatThrownBy(() -> cancelPendingPointService.cancelPending(command))
+                .isInstanceOf(PendingPointReflectionMismatchException.class);
+    }
+
+    @Test
+    @DisplayName("취소 시 기존 pending 이력의 isReflected를 true로 업데이트한다")
+    void shouldMarkExistingPendingHistoriesAsReflected() {
+        // given
+        UserPoint userPoint = createUserPoint(1000L, 500L);
+        UserPointHistory pendingHistory = createPendingHistory(500L);
+
+        when(findUserPointHistoryPort.findUnreflectedByUserIdAndSource(
+                USER_ID, UserPointSourceType.ORDER, ORDER_ID
+        )).thenReturn(List.of(pendingHistory));
+        when(getUserPointUseCase.getUserPoint(USER_ID)).thenReturn(userPoint);
+        when(updateUserPointPort.update(any(UserPoint.class))).thenReturn(userPoint);
+        when(updateUserPointHistoryPort.markAsReflected(
+                USER_ID, UserPointSourceType.ORDER, ORDER_ID
+        )).thenReturn(1);
+
+        CancelPendingPointCommand command = createCommand();
+
+        // when
+        cancelPendingPointService.cancelPending(command);
+
+        // then
+        verify(updateUserPointHistoryPort).markAsReflected(
+                USER_ID, UserPointSourceType.ORDER, ORDER_ID
+        );
+    }
+}

--- a/reward-service/reward-application/src/test/java/com/personal/marketnote/reward/service/point/ConfirmPendingPointUseCaseTest.java
+++ b/reward-service/reward-application/src/test/java/com/personal/marketnote/reward/service/point/ConfirmPendingPointUseCaseTest.java
@@ -1,0 +1,281 @@
+package com.personal.marketnote.reward.service.point;
+
+import com.personal.marketnote.reward.domain.exception.InsufficientPendingPointAmountException;
+import com.personal.marketnote.reward.domain.exception.PendingPointReflectionMismatchException;
+import com.personal.marketnote.reward.domain.point.*;
+import com.personal.marketnote.reward.exception.UserPointNotFoundException;
+import com.personal.marketnote.reward.port.in.command.point.ConfirmPendingPointCommand;
+import com.personal.marketnote.reward.port.in.result.point.UpdateUserPointResult;
+import com.personal.marketnote.reward.port.in.usecase.point.GetUserPointUseCase;
+import com.personal.marketnote.reward.port.out.point.FindUserPointHistoryPort;
+import com.personal.marketnote.reward.port.out.point.SaveUserPointHistoryPort;
+import com.personal.marketnote.reward.port.out.point.UpdateUserPointHistoryPort;
+import com.personal.marketnote.reward.port.out.point.UpdateUserPointPort;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ConfirmPendingPointUseCaseTest {
+
+    @InjectMocks
+    private ConfirmPendingPointService confirmPendingPointService;
+
+    @Mock
+    private GetUserPointUseCase getUserPointUseCase;
+
+    @Mock
+    private FindUserPointHistoryPort findUserPointHistoryPort;
+
+    @Mock
+    private UpdateUserPointPort updateUserPointPort;
+
+    @Mock
+    private UpdateUserPointHistoryPort updateUserPointHistoryPort;
+
+    @Mock
+    private SaveUserPointHistoryPort saveUserPointHistoryPort;
+
+    private static final Long USER_ID = 1L;
+    private static final Long ORDER_ID = 100L;
+    private static final LocalDateTime NOW = LocalDateTime.of(2026, 3, 4, 10, 0);
+
+    private UserPoint createUserPoint(Long amount, Long addExpectedAmount) {
+        return UserPoint.from(UserPointSnapshotState.builder()
+                .userId(USER_ID)
+                .amount(amount)
+                .addExpectedAmount(addExpectedAmount)
+                .expireExpectedAmount(0L)
+                .createdAt(NOW)
+                .modifiedAt(NOW)
+                .build());
+    }
+
+    private ConfirmPendingPointCommand createCommand() {
+        return ConfirmPendingPointCommand.builder()
+                .userId(USER_ID)
+                .sourceType(UserPointSourceType.ORDER)
+                .sourceId(ORDER_ID)
+                .reason("구매 확정 포인트 적립")
+                .build();
+    }
+
+    private UserPointHistory createPendingHistory(Long amount) {
+        return UserPointHistory.from(UserPointHistorySnapshotState.builder()
+                .id(1L)
+                .userId(USER_ID)
+                .amount(amount)
+                .isReflected(Boolean.FALSE)
+                .sourceType(UserPointSourceType.ORDER)
+                .sourceId(ORDER_ID)
+                .reason("주문 결제 적립 예정")
+                .accumulatedAt(NOW)
+                .createdAt(NOW)
+                .build());
+    }
+
+    @Test
+    @DisplayName("적립 예정 포인트를 확정하면 pending에서 차감되고 실제 포인트에 적립된다")
+    void shouldConfirmPendingPointSuccessfully() {
+        // given
+        UserPoint userPoint = createUserPoint(1000L, 500L);
+        UserPointHistory pendingHistory = createPendingHistory(500L);
+
+        when(findUserPointHistoryPort.findUnreflectedByUserIdAndSource(
+                USER_ID, UserPointSourceType.ORDER, ORDER_ID
+        )).thenReturn(List.of(pendingHistory));
+        when(getUserPointUseCase.getUserPoint(USER_ID)).thenReturn(userPoint);
+        when(updateUserPointPort.update(any(UserPoint.class))).thenReturn(userPoint);
+        when(updateUserPointHistoryPort.markAsReflected(
+                USER_ID, UserPointSourceType.ORDER, ORDER_ID
+        )).thenReturn(1);
+
+        ConfirmPendingPointCommand command = createCommand();
+
+        // when
+        UpdateUserPointResult result = confirmPendingPointService.confirmPending(command);
+
+        // then
+        assertThat(result.addExpectedAmount()).isEqualTo(0L);
+        assertThat(result.amount()).isEqualTo(1500L);
+
+        verify(updateUserPointPort).update(any(UserPoint.class));
+        verify(updateUserPointHistoryPort).markAsReflected(
+                USER_ID, UserPointSourceType.ORDER, ORDER_ID
+        );
+
+        ArgumentCaptor<UserPointHistory> historyCaptor = ArgumentCaptor.forClass(UserPointHistory.class);
+        verify(saveUserPointHistoryPort).save(historyCaptor.capture());
+        UserPointHistory savedHistory = historyCaptor.getValue();
+        assertThat(savedHistory.getIsReflected()).isTrue();
+        assertThat(savedHistory.getAmount()).isEqualTo(500L);
+        assertThat(savedHistory.getSourceType()).isEqualTo(UserPointSourceType.ORDER);
+        assertThat(savedHistory.getSourceId()).isEqualTo(ORDER_ID);
+    }
+
+    @Test
+    @DisplayName("여러 건의 적립 예정 포인트 이력이 있으면 합산하여 확정한다")
+    void shouldConfirmMultiplePendingHistories() {
+        // given
+        UserPoint userPoint = createUserPoint(1000L, 800L);
+        UserPointHistory history1 = createPendingHistory(500L);
+        UserPointHistory history2 = createPendingHistory(300L);
+
+        when(findUserPointHistoryPort.findUnreflectedByUserIdAndSource(
+                USER_ID, UserPointSourceType.ORDER, ORDER_ID
+        )).thenReturn(List.of(history1, history2));
+        when(getUserPointUseCase.getUserPoint(USER_ID)).thenReturn(userPoint);
+        when(updateUserPointPort.update(any(UserPoint.class))).thenReturn(userPoint);
+        when(updateUserPointHistoryPort.markAsReflected(
+                USER_ID, UserPointSourceType.ORDER, ORDER_ID
+        )).thenReturn(2);
+
+        ConfirmPendingPointCommand command = createCommand();
+
+        // when
+        UpdateUserPointResult result = confirmPendingPointService.confirmPending(command);
+
+        // then
+        assertThat(result.addExpectedAmount()).isEqualTo(0L);
+        assertThat(result.amount()).isEqualTo(1800L);
+
+        ArgumentCaptor<UserPointHistory> historyCaptor = ArgumentCaptor.forClass(UserPointHistory.class);
+        verify(saveUserPointHistoryPort).save(historyCaptor.capture());
+        assertThat(historyCaptor.getValue().getAmount()).isEqualTo(800L);
+    }
+
+    @Test
+    @DisplayName("확정 대상 적립 예정 포인트 이력이 없으면 현재 포인트를 그대로 반환한다")
+    void shouldReturnCurrentPointWhenNoPendingHistoryFound() {
+        // given
+        UserPoint userPoint = createUserPoint(1000L, 0L);
+
+        when(findUserPointHistoryPort.findUnreflectedByUserIdAndSource(
+                USER_ID, UserPointSourceType.ORDER, ORDER_ID
+        )).thenReturn(Collections.emptyList());
+        when(getUserPointUseCase.getUserPoint(USER_ID)).thenReturn(userPoint);
+
+        ConfirmPendingPointCommand command = createCommand();
+
+        // when
+        UpdateUserPointResult result = confirmPendingPointService.confirmPending(command);
+
+        // then
+        assertThat(result.amount()).isEqualTo(1000L);
+        assertThat(result.addExpectedAmount()).isEqualTo(0L);
+
+        verify(updateUserPointPort, never()).update(any());
+        verify(updateUserPointHistoryPort, never()).markAsReflected(anyLong(), any(), anyLong());
+        verify(saveUserPointHistoryPort, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("회원 포인트 정보가 존재하지 않으면 UserPointNotFoundException이 발생한다")
+    void shouldThrowWhenUserPointNotFound() {
+        // given
+        UserPointHistory pendingHistory = createPendingHistory(500L);
+
+        when(findUserPointHistoryPort.findUnreflectedByUserIdAndSource(
+                USER_ID, UserPointSourceType.ORDER, ORDER_ID
+        )).thenReturn(List.of(pendingHistory));
+        when(getUserPointUseCase.getUserPoint(USER_ID))
+                .thenThrow(new UserPointNotFoundException(USER_ID));
+
+        ConfirmPendingPointCommand command = createCommand();
+
+        // expect
+        assertThatThrownBy(() -> confirmPendingPointService.confirmPending(command))
+                .isInstanceOf(UserPointNotFoundException.class);
+
+        verify(updateUserPointPort, never()).update(any());
+        verify(saveUserPointHistoryPort, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("적립 예정 포인트가 부족하면 InsufficientPendingPointAmountException이 발생한다")
+    void shouldThrowWhenInsufficientPendingAmount() {
+        // given
+        UserPoint userPoint = createUserPoint(1000L, 200L);
+        UserPointHistory pendingHistory = createPendingHistory(500L);
+
+        when(findUserPointHistoryPort.findUnreflectedByUserIdAndSource(
+                USER_ID, UserPointSourceType.ORDER, ORDER_ID
+        )).thenReturn(List.of(pendingHistory));
+        when(getUserPointUseCase.getUserPoint(USER_ID)).thenReturn(userPoint);
+
+        ConfirmPendingPointCommand command = createCommand();
+
+        // expect
+        assertThatThrownBy(() -> confirmPendingPointService.confirmPending(command))
+                .isInstanceOf(InsufficientPendingPointAmountException.class);
+
+        verify(updateUserPointPort, never()).update(any());
+        verify(saveUserPointHistoryPort, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("이력 반영 건수가 조회 건수와 일치하지 않으면 PendingPointReflectionMismatchException이 발생한다")
+    void shouldThrowWhenReflectionCountMismatch() {
+        // given
+        UserPoint userPoint = createUserPoint(1000L, 500L);
+        UserPointHistory pendingHistory = createPendingHistory(500L);
+
+        when(findUserPointHistoryPort.findUnreflectedByUserIdAndSource(
+                USER_ID, UserPointSourceType.ORDER, ORDER_ID
+        )).thenReturn(List.of(pendingHistory));
+        when(getUserPointUseCase.getUserPoint(USER_ID)).thenReturn(userPoint);
+        when(updateUserPointPort.update(any(UserPoint.class))).thenReturn(userPoint);
+        when(updateUserPointHistoryPort.markAsReflected(
+                USER_ID, UserPointSourceType.ORDER, ORDER_ID
+        )).thenReturn(0);
+
+        ConfirmPendingPointCommand command = createCommand();
+
+        // expect
+        assertThatThrownBy(() -> confirmPendingPointService.confirmPending(command))
+                .isInstanceOf(PendingPointReflectionMismatchException.class);
+
+        verify(saveUserPointHistoryPort, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("확정 시 기존 pending 이력의 isReflected를 true로 업데이트한다")
+    void shouldMarkExistingPendingHistoriesAsReflected() {
+        // given
+        UserPoint userPoint = createUserPoint(1000L, 500L);
+        UserPointHistory pendingHistory = createPendingHistory(500L);
+
+        when(findUserPointHistoryPort.findUnreflectedByUserIdAndSource(
+                USER_ID, UserPointSourceType.ORDER, ORDER_ID
+        )).thenReturn(List.of(pendingHistory));
+        when(getUserPointUseCase.getUserPoint(USER_ID)).thenReturn(userPoint);
+        when(updateUserPointPort.update(any(UserPoint.class))).thenReturn(userPoint);
+        when(updateUserPointHistoryPort.markAsReflected(
+                USER_ID, UserPointSourceType.ORDER, ORDER_ID
+        )).thenReturn(1);
+
+        ConfirmPendingPointCommand command = createCommand();
+
+        // when
+        confirmPendingPointService.confirmPending(command);
+
+        // then
+        verify(updateUserPointHistoryPort).markAsReflected(
+                USER_ID, UserPointSourceType.ORDER, ORDER_ID
+        );
+    }
+}

--- a/reward-service/reward-application/src/test/java/com/personal/marketnote/reward/service/point/ModifyPendingPointUseCaseTest.java
+++ b/reward-service/reward-application/src/test/java/com/personal/marketnote/reward/service/point/ModifyPendingPointUseCaseTest.java
@@ -1,0 +1,154 @@
+package com.personal.marketnote.reward.service.point;
+
+import com.personal.marketnote.reward.domain.exception.InsufficientPendingPointAmountException;
+import com.personal.marketnote.reward.domain.point.*;
+import com.personal.marketnote.reward.exception.UserPointNotFoundException;
+import com.personal.marketnote.reward.port.in.command.point.ModifyPendingPointCommand;
+import com.personal.marketnote.reward.port.in.result.point.UpdateUserPointResult;
+import com.personal.marketnote.reward.port.in.usecase.point.GetUserPointUseCase;
+import com.personal.marketnote.reward.port.out.point.SaveUserPointHistoryPort;
+import com.personal.marketnote.reward.port.out.point.UpdateUserPointPort;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ModifyPendingPointUseCaseTest {
+
+    @InjectMocks
+    private ModifyPendingPointService modifyPendingPointService;
+
+    @Mock
+    private GetUserPointUseCase getUserPointUseCase;
+
+    @Mock
+    private UpdateUserPointPort updateUserPointPort;
+
+    @Mock
+    private SaveUserPointHistoryPort saveUserPointHistoryPort;
+
+    private UserPoint createUserPoint(Long amount, Long addExpectedAmount) {
+        return UserPoint.from(UserPointSnapshotState.builder()
+                .userId(1L)
+                .amount(amount)
+                .addExpectedAmount(addExpectedAmount)
+                .expireExpectedAmount(0L)
+                .createdAt(LocalDateTime.of(2026, 3, 4, 10, 0))
+                .modifiedAt(LocalDateTime.of(2026, 3, 4, 10, 0))
+                .build());
+    }
+
+    private ModifyPendingPointCommand createCommand(UserPointChangeType changeType, Long amount) {
+        return ModifyPendingPointCommand.builder()
+                .userId(1L)
+                .changeType(changeType)
+                .amount(amount)
+                .sourceType(UserPointSourceType.ORDER)
+                .sourceId(100L)
+                .reason("주문 결제 적립 예정")
+                .build();
+    }
+
+    @Test
+    @DisplayName("적립 예정 포인트를 추가하면 addExpectedAmount가 증가하고 이력이 저장된다")
+    void shouldAddPendingAmountAndSaveHistory() {
+        // given
+        UserPoint userPoint = createUserPoint(1000L, 0L);
+        when(getUserPointUseCase.getUserPoint(1L)).thenReturn(userPoint);
+        when(updateUserPointPort.update(any(UserPoint.class))).thenReturn(userPoint);
+        when(saveUserPointHistoryPort.save(any(UserPointHistory.class)))
+                .thenReturn(UserPointHistory.from(UserPointHistoryCreateState.builder()
+                        .userId(1L).amount(500L).isReflected(false)
+                        .sourceType(UserPointSourceType.ORDER).sourceId(100L)
+                        .reason("주문 결제 적립 예정").accumulatedAt(LocalDateTime.now())
+                        .build()));
+
+        ModifyPendingPointCommand command = createCommand(UserPointChangeType.ACCRUAL, 500L);
+
+        // when
+        UpdateUserPointResult result = modifyPendingPointService.modifyPending(command);
+
+        // then
+        assertThat(result.addExpectedAmount()).isEqualTo(500L);
+
+        verify(updateUserPointPort).update(any(UserPoint.class));
+
+        ArgumentCaptor<UserPointHistory> historyCaptor = ArgumentCaptor.forClass(UserPointHistory.class);
+        verify(saveUserPointHistoryPort).save(historyCaptor.capture());
+        UserPointHistory savedHistory = historyCaptor.getValue();
+        assertThat(savedHistory.getIsReflected()).isFalse();
+        assertThat(savedHistory.getAmount()).isEqualTo(500L);
+        assertThat(savedHistory.getSourceType()).isEqualTo(UserPointSourceType.ORDER);
+    }
+
+    @Test
+    @DisplayName("적립 예정 포인트를 차감하면 addExpectedAmount가 감소하고 이력이 저장된다")
+    void shouldDeductPendingAmountAndSaveHistory() {
+        // given
+        UserPoint userPoint = createUserPoint(1000L, 500L);
+        when(getUserPointUseCase.getUserPoint(1L)).thenReturn(userPoint);
+        when(updateUserPointPort.update(any(UserPoint.class))).thenReturn(userPoint);
+        when(saveUserPointHistoryPort.save(any(UserPointHistory.class)))
+                .thenReturn(UserPointHistory.from(UserPointHistoryCreateState.builder()
+                        .userId(1L).amount(-300L).isReflected(false)
+                        .sourceType(UserPointSourceType.ORDER).sourceId(100L)
+                        .reason("주문 취소 적립 예정 차감").accumulatedAt(LocalDateTime.now())
+                        .build()));
+
+        ModifyPendingPointCommand command = createCommand(UserPointChangeType.DEDUCTION, 300L);
+
+        // when
+        UpdateUserPointResult result = modifyPendingPointService.modifyPending(command);
+
+        // then
+        assertThat(result.addExpectedAmount()).isEqualTo(200L);
+
+        ArgumentCaptor<UserPointHistory> historyCaptor = ArgumentCaptor.forClass(UserPointHistory.class);
+        verify(saveUserPointHistoryPort).save(historyCaptor.capture());
+        UserPointHistory savedHistory = historyCaptor.getValue();
+        assertThat(savedHistory.getIsReflected()).isFalse();
+        assertThat(savedHistory.getAmount()).isEqualTo(-300L);
+    }
+
+    @Test
+    @DisplayName("적립 예정 포인트보다 큰 금액을 차감하면 InsufficientPendingPointAmountException이 발생한다")
+    void shouldThrowWhenInsufficientPendingAmount() {
+        // given
+        UserPoint userPoint = createUserPoint(1000L, 200L);
+        when(getUserPointUseCase.getUserPoint(1L)).thenReturn(userPoint);
+
+        ModifyPendingPointCommand command = createCommand(UserPointChangeType.DEDUCTION, 500L);
+
+        // expect
+        assertThatThrownBy(() -> modifyPendingPointService.modifyPending(command))
+                .isInstanceOf(InsufficientPendingPointAmountException.class);
+
+        verify(updateUserPointPort, never()).update(any());
+        verify(saveUserPointHistoryPort, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("회원 포인트 정보가 존재하지 않으면 UserPointNotFoundException이 발생한다")
+    void shouldThrowWhenUserPointNotFound() {
+        // given
+        when(getUserPointUseCase.getUserPoint(1L))
+                .thenThrow(new UserPointNotFoundException(1L));
+
+        ModifyPendingPointCommand command = createCommand(UserPointChangeType.ACCRUAL, 500L);
+
+        // expect
+        assertThatThrownBy(() -> modifyPendingPointService.modifyPending(command))
+                .isInstanceOf(UserPointNotFoundException.class);
+    }
+}

--- a/reward-service/reward-application/src/test/java/com/personal/marketnote/reward/service/point/ModifyPendingSharedPointUseCaseTest.java
+++ b/reward-service/reward-application/src/test/java/com/personal/marketnote/reward/service/point/ModifyPendingSharedPointUseCaseTest.java
@@ -1,0 +1,173 @@
+package com.personal.marketnote.reward.service.point;
+
+import com.personal.marketnote.reward.domain.point.UserPoint;
+import com.personal.marketnote.reward.domain.point.UserPointChangeType;
+import com.personal.marketnote.reward.domain.point.UserPointSnapshotState;
+import com.personal.marketnote.reward.domain.point.UserPointSourceType;
+import com.personal.marketnote.reward.exception.UserPointNotFoundException;
+import com.personal.marketnote.reward.port.in.command.point.ModifyPendingPointCommand;
+import com.personal.marketnote.reward.port.in.command.point.ModifyPendingSharedPointCommand;
+import com.personal.marketnote.reward.port.in.result.point.UpdateUserPointResult;
+import com.personal.marketnote.reward.port.in.usecase.point.ModifyPendingPointUseCase;
+import com.personal.marketnote.reward.port.out.point.FindUserPointPort;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ModifyPendingSharedPointUseCaseTest {
+
+    private static final UUID SHARER_KEY = UUID.fromString("550e8400-e29b-41d4-a716-446655440000");
+    private static final Long RESOLVED_USER_ID = 42L;
+
+    @InjectMocks
+    private ModifyPendingSharedPointService modifyPendingSharedPointService;
+
+    @Mock
+    private FindUserPointPort findUserPointPort;
+
+    @Mock
+    private ModifyPendingPointUseCase modifyPendingPointUseCase;
+
+    private UserPoint createUserPoint() {
+        return UserPoint.from(UserPointSnapshotState.builder()
+                .userId(RESOLVED_USER_ID)
+                .amount(1000L)
+                .addExpectedAmount(0L)
+                .expireExpectedAmount(0L)
+                .createdAt(LocalDateTime.of(2026, 4, 1, 10, 0))
+                .modifiedAt(LocalDateTime.of(2026, 4, 1, 10, 0))
+                .build());
+    }
+
+    private ModifyPendingSharedPointCommand createCommand(Long buyerId, UserPointChangeType changeType, Long amount) {
+        return ModifyPendingSharedPointCommand.builder()
+                .buyerId(buyerId)
+                .sharerKey(SHARER_KEY)
+                .changeType(changeType)
+                .amount(amount)
+                .sourceType(UserPointSourceType.ORDER)
+                .sourceId(100L)
+                .reason("링크 공유 회원 상품 구매")
+                .build();
+    }
+
+    @Test
+    @DisplayName("sharerKey로 UserPoint를 조회하여 userId를 해소한 후 적립 예정 포인트를 변경한다")
+    void shouldResolveUserIdFromSharerKeyAndDelegateToModifyPending() {
+        // given
+        UserPoint userPoint = createUserPoint();
+        when(findUserPointPort.findByUserKey(SHARER_KEY.toString())).thenReturn(Optional.of(userPoint));
+
+        UpdateUserPointResult expectedResult = UpdateUserPointResult.from(userPoint);
+        when(modifyPendingPointUseCase.modifyPending(any(ModifyPendingPointCommand.class))).thenReturn(expectedResult);
+
+        ModifyPendingSharedPointCommand command = createCommand(999L, UserPointChangeType.ACCRUAL, 500L);
+
+        // when
+        UpdateUserPointResult result = modifyPendingSharedPointService.modifyPending(command);
+
+        // then
+        assertThat(result.userId()).isEqualTo(RESOLVED_USER_ID);
+
+        ArgumentCaptor<ModifyPendingPointCommand> captor = ArgumentCaptor.forClass(ModifyPendingPointCommand.class);
+        verify(modifyPendingPointUseCase).modifyPending(captor.capture());
+
+        ModifyPendingPointCommand delegatedCommand = captor.getValue();
+        assertThat(delegatedCommand.userId()).isEqualTo(RESOLVED_USER_ID);
+        assertThat(delegatedCommand.changeType()).isEqualTo(UserPointChangeType.ACCRUAL);
+        assertThat(delegatedCommand.amount()).isEqualTo(500L);
+        assertThat(delegatedCommand.sourceType()).isEqualTo(UserPointSourceType.ORDER);
+        assertThat(delegatedCommand.sourceId()).isEqualTo(100L);
+        assertThat(delegatedCommand.reason()).isEqualTo("링크 공유 회원 상품 구매");
+    }
+
+    @Test
+    @DisplayName("sharerKey에 해당하는 UserPoint가 없으면 UserPointNotFoundException이 발생한다")
+    void shouldThrowWhenUserPointNotFoundBySharerKey() {
+        // given
+        when(findUserPointPort.findByUserKey(SHARER_KEY.toString())).thenReturn(Optional.empty());
+
+        ModifyPendingSharedPointCommand command = createCommand(999L, UserPointChangeType.ACCRUAL, 500L);
+
+        // expect
+        assertThatThrownBy(() -> modifyPendingSharedPointService.modifyPending(command))
+                .isInstanceOf(UserPointNotFoundException.class);
+
+        verify(modifyPendingPointUseCase, never()).modifyPending(any());
+    }
+
+    @Test
+    @DisplayName("구매자와 공유자가 동일인이면 적립 예정 포인트를 변경하지 않고 null을 반환한다")
+    void shouldReturnNullWhenBuyerAndSharerAreSamePerson() {
+        // given
+        UserPoint userPoint = createUserPoint();
+        when(findUserPointPort.findByUserKey(SHARER_KEY.toString())).thenReturn(Optional.of(userPoint));
+
+        ModifyPendingSharedPointCommand command = createCommand(RESOLVED_USER_ID, UserPointChangeType.ACCRUAL, 500L);
+
+        // when
+        UpdateUserPointResult result = modifyPendingSharedPointService.modifyPending(command);
+
+        // then
+        assertThat(result).isNull();
+        verify(modifyPendingPointUseCase, never()).modifyPending(any());
+    }
+
+    @Test
+    @DisplayName("buyerId가 null이면 동일인 검증을 건너뛰고 적립 예정 포인트를 변경한다")
+    void shouldProceedWhenBuyerIdIsNull() {
+        // given
+        UserPoint userPoint = createUserPoint();
+        when(findUserPointPort.findByUserKey(SHARER_KEY.toString())).thenReturn(Optional.of(userPoint));
+
+        UpdateUserPointResult expectedResult = UpdateUserPointResult.from(userPoint);
+        when(modifyPendingPointUseCase.modifyPending(any(ModifyPendingPointCommand.class))).thenReturn(expectedResult);
+
+        ModifyPendingSharedPointCommand command = createCommand(null, UserPointChangeType.ACCRUAL, 500L);
+
+        // when
+        UpdateUserPointResult result = modifyPendingSharedPointService.modifyPending(command);
+
+        // then
+        assertThat(result.userId()).isEqualTo(RESOLVED_USER_ID);
+        verify(modifyPendingPointUseCase).modifyPending(any(ModifyPendingPointCommand.class));
+    }
+
+    @Test
+    @DisplayName("차감 타입일 때 위임 커맨드의 changeType이 DEDUCTION이다")
+    void shouldDelegateDeductionChangeType() {
+        // given
+        UserPoint userPoint = createUserPoint();
+        when(findUserPointPort.findByUserKey(SHARER_KEY.toString())).thenReturn(Optional.of(userPoint));
+
+        UpdateUserPointResult expectedResult = UpdateUserPointResult.from(userPoint);
+        when(modifyPendingPointUseCase.modifyPending(any(ModifyPendingPointCommand.class))).thenReturn(expectedResult);
+
+        ModifyPendingSharedPointCommand command = createCommand(999L, UserPointChangeType.DEDUCTION, 300L);
+
+        // when
+        modifyPendingSharedPointService.modifyPending(command);
+
+        // then
+        ArgumentCaptor<ModifyPendingPointCommand> captor = ArgumentCaptor.forClass(ModifyPendingPointCommand.class);
+        verify(modifyPendingPointUseCase).modifyPending(captor.capture());
+
+        ModifyPendingPointCommand delegatedCommand = captor.getValue();
+        assertThat(delegatedCommand.changeType()).isEqualTo(UserPointChangeType.DEDUCTION);
+        assertThat(delegatedCommand.amount()).isEqualTo(300L);
+    }
+}


### PR DESCRIPTION
## partially addresses #387
## resolves #2246

## Task
- [x] point 4건: ModifyPendingSharedPoint, ConfirmPendingPoint, ModifyPendingPoint, CancelPendingPoint
- [x] gifticon 16건: GetGifticonGoods, GetGifticonGoodsDetail, ManageGifticonCategoryOrder, GetAdminGifticonCategories, GetGifticonCategories, GetMyGifticonOrderDetail, GetAdminGifticonGoods, PurchaseGifticon, GetPopularGifticonGoods, GetMyGifticonOrders, UpdateGifticonCategory, GetGifticonBrands, ManageGifticonGoodsExposure, ManageGifticonGoodsOrder, ManageGifticonCategoryExposure, SyncGifticonGoodsAndBrands