### PR TITLE
[#1920][#1921] feat: 교환 관련 상태 4개 삭제

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/apidocs/ChangeOrderStatusApiDocs.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/apidocs/ChangeOrderStatusApiDocs.java
@@ -55,14 +55,6 @@ import java.lang.annotation.*;
                 
                     - "CONFIRMED": 구매 확정
                 
-                    - "EXCHANGE_REQUESTED": 교환 요청됨
-                
-                    - "EXCHANGE_RECALLING": 교환 회수 중
-                
-                    - "EXCHANGE_SHIPPING": 교환 배송 중
-                
-                    - "EXCHANGED": 교환 완료
-                
                     - "REFUND_REQUESTED": 환불 요청됨
                 
                     - "REFUND_RECALLING": 환불 회수 중

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/apidocs/GetOrderInfoApiDocs.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/apidocs/GetOrderInfoApiDocs.java
@@ -49,14 +49,6 @@ import java.lang.annotation.*;
                 
                     - "CONFIRMED": 구매 확정
                 
-                    - "EXCHANGE_REQUESTED": 교환 요청됨
-                
-                    - "EXCHANGE_RECALLING": 교환 회수 중
-                
-                    - "EXCHANGE_SHIPPING": 교환 배송 중
-                
-                    - "EXCHANGED": 교환 완료
-                
                     - "REFUND_REQUESTED": 환불 요청됨
                 
                     - "REFUND_RECALLING": 환불 회수 중

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/apidocs/GetOrdersApiDocs.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/apidocs/GetOrdersApiDocs.java
@@ -46,14 +46,6 @@ import java.lang.annotation.*;
                 
                     - "CONFIRMED": 구매 확정
                 
-                    - "EXCHANGE_REQUESTED": 교환 요청됨
-                
-                    - "EXCHANGE_RECALLING": 교환 회수 중
-                
-                    - "EXCHANGE_SHIPPING": 교환 배송 중
-                
-                    - "EXCHANGED": 교환 완료
-                
                     - "REFUND_REQUESTED": 환불 요청됨
                 
                     - "REFUND_RECALLING": 환불 회수 중

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/order/OrderStatus.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/order/OrderStatus.java
@@ -22,10 +22,6 @@ public enum OrderStatus {
     DELIVERED("배송 완료"),
     PARTIALLY_CONFIRMED("부분 구매 확정"),
     CONFIRMED("구매 확정"),
-    EXCHANGE_REQUESTED("교환 요청됨"),
-    EXCHANGE_RECALLING("교환 회수 중"),
-    EXCHANGE_SHIPPING("교환 배송 중"),
-    EXCHANGED("교환 완료"),
     REFUND_REQUESTED("환불 요청됨"),
     REFUND_RECALLING("환불 회수 중"),
     REFUND_SHIPPING("환불 배송 중"),
@@ -36,7 +32,7 @@ public enum OrderStatus {
 
     private static final Map<OrderStatus, Set<OrderStatus>> ALLOWED_TRANSITIONS = new EnumMap<>(OrderStatus.class);
     private static final Set<OrderStatus> BUYER_ALLOWED_STATUSES = EnumSet.of(
-            CANCEL_REQUESTED, CONFIRMED, EXCHANGE_REQUESTED, REFUND_REQUESTED
+            CANCEL_REQUESTED, CONFIRMED, REFUND_REQUESTED
     );
 
     static {
@@ -48,13 +44,9 @@ public enum OrderStatus {
         ALLOWED_TRANSITIONS.put(CANCEL_REQUESTED, EnumSet.of(CANCELLED));
         ALLOWED_TRANSITIONS.put(CANCELLED, EnumSet.noneOf(OrderStatus.class));
         ALLOWED_TRANSITIONS.put(SHIPPING, EnumSet.of(DELIVERED));
-        ALLOWED_TRANSITIONS.put(DELIVERED, EnumSet.of(CONFIRMED, PARTIALLY_CONFIRMED, EXCHANGE_REQUESTED, REFUND_REQUESTED));
-        ALLOWED_TRANSITIONS.put(PARTIALLY_CONFIRMED, EnumSet.of(CONFIRMED, EXCHANGE_REQUESTED, REFUND_REQUESTED));
+        ALLOWED_TRANSITIONS.put(DELIVERED, EnumSet.of(CONFIRMED, PARTIALLY_CONFIRMED, REFUND_REQUESTED));
+        ALLOWED_TRANSITIONS.put(PARTIALLY_CONFIRMED, EnumSet.of(CONFIRMED, REFUND_REQUESTED));
         ALLOWED_TRANSITIONS.put(CONFIRMED, EnumSet.noneOf(OrderStatus.class));
-        ALLOWED_TRANSITIONS.put(EXCHANGE_REQUESTED, EnumSet.of(EXCHANGE_RECALLING));
-        ALLOWED_TRANSITIONS.put(EXCHANGE_RECALLING, EnumSet.of(EXCHANGE_SHIPPING));
-        ALLOWED_TRANSITIONS.put(EXCHANGE_SHIPPING, EnumSet.of(EXCHANGED));
-        ALLOWED_TRANSITIONS.put(EXCHANGED, EnumSet.noneOf(OrderStatus.class));
         ALLOWED_TRANSITIONS.put(REFUND_REQUESTED, EnumSet.of(REFUND_RECALLING));
         ALLOWED_TRANSITIONS.put(REFUND_RECALLING, EnumSet.of(REFUND_SHIPPING));
         ALLOWED_TRANSITIONS.put(REFUND_SHIPPING, EnumSet.of(REFUNDED, PARTIALLY_REFUNDED));
@@ -113,7 +105,7 @@ public enum OrderStatus {
     /**
      * 구매자가 직접 변경할 수 있는 주문 상태인지 확인한다.
      * <p>
-     * 구매자 허용 상태: CANCEL_REQUESTED, CONFIRMED, EXCHANGE_REQUESTED, REFUND_REQUESTED
+     * 구매자 허용 상태: CANCEL_REQUESTED, CONFIRMED, REFUND_REQUESTED
      * </p>
      *
      * @return 구매자가 변경 가능한 상태이면 true

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/order/OrderStatusFilter.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/order/OrderStatusFilter.java
@@ -12,7 +12,6 @@ public enum OrderStatusFilter {
                     OrderStatus.PREPARING,
                     OrderStatus.PREPARED,
                     OrderStatus.SHIPPING,
-                    OrderStatus.EXCHANGE_SHIPPING,
                     OrderStatus.REFUND_SHIPPING
             )
     ),
@@ -22,10 +21,6 @@ public enum OrderStatusFilter {
             List.of(
                     OrderStatus.CANCEL_REQUESTED,
                     OrderStatus.CANCELLED,
-                    OrderStatus.EXCHANGE_REQUESTED,
-                    OrderStatus.EXCHANGE_RECALLING,
-                    OrderStatus.EXCHANGE_SHIPPING,
-                    OrderStatus.EXCHANGED,
                     OrderStatus.REFUND_REQUESTED,
                     OrderStatus.REFUND_RECALLING,
                     OrderStatus.REFUND_SHIPPING,


### PR DESCRIPTION
## partially addresses #1920
## resolves #1921

## Task
- [x] OrderStatus enum에서 EXCHANGE_REQUESTED, EXCHANGE_RECALLING, EXCHANGE_SHIPPING, EXCHANGED 삭제
- [x] ALLOWED_TRANSITIONS에서 교환 관련 전이 규칙 삭제
- [x] BUYER_ALLOWED_STATUSES에서 EXCHANGE_REQUESTED 삭제
- [x] DELIVERED, PARTIALLY_CONFIRMED 전이 대상에서 EXCHANGE_REQUESTED 제거
- [x] OrderStatusFilter SHIPPING/CANCEL_EXCHANGE_REFUND 내부 상태 수정
- [x] API 문서 3개에서 교환 상태 설명 삭제