### PR TITLE
[#1920][#1923] test: CANCEL_REQUESTED 상태 삭제

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/PaymentCancelledOrderStatusConsumer.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/PaymentCancelledOrderStatusConsumer.java
@@ -64,17 +64,17 @@ public class PaymentCancelledOrderStatusConsumer {
 
             ChangeOrderStatusCommand command = ChangeOrderStatusCommand.builder()
                     .id(payload.orderId())
-                    .orderStatus(OrderStatus.CANCEL_REQUESTED)
+                    .orderStatus(OrderStatus.CANCELLED)
                     .build();
             changeOrderStatusUseCase.changeOrderStatus(command);
 
-            log.info("Kafka 이벤트로 주문 상태 CANCEL_REQUESTED 변경 완료. orderId={}",
+            log.info("Kafka 이벤트로 주문 상태 CANCELLED 변경 완료. orderId={}",
                     payload.orderId());
         } catch (OrderStatusAlreadyChangedException e) {
             log.warn("멱등 처리: 이미 주문 상태가 변경됨. eventId={}, key={}, message={}",
                     envelope.eventId(), record.key(), e.getMessage());
         } catch (Exception e) {
-            log.error("주문 상태 CANCEL_REQUESTED 변경 실패. eventId={}, key={}, error={}",
+            log.error("주문 상태 CANCELLED 변경 실패. eventId={}, key={}, error={}",
                     envelope.eventId(), record.key(), e.getMessage(), e);
             throw e;
         }

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/OrderController.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/OrderController.java
@@ -253,7 +253,7 @@ public class OrderController {
      * @param principal 인증된 사용자 정보
      * @Author 성효빈
      * @Date 2026-04-05
-     * @Description 구매자가 주문 취소를 요청합니다. 주문 상태를 CANCEL_REQUESTED로 변경합니다.
+     * @Description 구매자가 주문 취소를 요청합니다. 주문 상태를 CANCELLED로 변경합니다.
      */
     @PostMapping("/api/v1/orders/{id}/cancel")
     @CancelOrderApiDocs

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/apidocs/CancelOrderApiDocs.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/apidocs/CancelOrderApiDocs.java
@@ -29,7 +29,7 @@ import java.lang.annotation.*;
                 
                 - 구매자가 주문 취소를 요청합니다.
                 
-                - 주문 상태를 CANCEL_REQUESTED(주문 취소 요청됨)로 변경합니다.
+                - 주문 상태를 CANCELLED(주문 취소)로 변경합니다.
                 
                 - 결제 대기, 결제 완료, 상품 준비중 상태에서만 취소 요청이 가능합니다.
                 
@@ -118,7 +118,7 @@ import java.lang.annotation.*;
                 ),
                 @ApiResponse(
                         responseCode = "409",
-                        description = "이미 주문 취소 요청됨",
+                        description = "이미 주문 취소",
                         content = @Content(
                                 examples = @ExampleObject("""
                                         {
@@ -126,7 +126,7 @@ import java.lang.annotation.*;
                                           "code": "CONFLICT",
                                           "timestamp": "2026-04-05T12:00:00.000",
                                           "content": null,
-                                          "message": "이미 해당 주문 상태(주문 취소 요청됨)로 변경되었습니다."
+                                          "message": "이미 해당 주문 상태(주문 취소)로 변경되었습니다."
                                         }
                                         """)
                         )
@@ -141,7 +141,7 @@ import java.lang.annotation.*;
                                           "code": "BAD_REQUEST",
                                           "timestamp": "2026-04-05T12:00:00.000",
                                           "content": null,
-                                          "message": "주문 상태를 배송중에서 주문 취소 요청됨(으)로 변경할 수 없습니다."
+                                          "message": "주문 상태를 배송중에서 주문 취소(으)로 변경할 수 없습니다."
                                         }
                                         """)
                         )

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/apidocs/ChangeOrderStatusApiDocs.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/apidocs/ChangeOrderStatusApiDocs.java
@@ -43,8 +43,6 @@ import java.lang.annotation.*;
                 
                     - "PREPARING": 상품 준비중
                 
-                    - "CANCEL_REQUESTED": 주문 취소 요청됨
-                
                     - "CANCELLED": 주문 취소
                 
                     - "SHIPPING": 배송중

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/apidocs/GetOrderInfoApiDocs.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/apidocs/GetOrderInfoApiDocs.java
@@ -37,8 +37,6 @@ import java.lang.annotation.*;
                 
                     - "PREPARING": 상품 준비중
                 
-                    - "CANCEL_REQUESTED": 주문 취소 요청됨
-                
                     - "CANCELLED": 주문 취소
                 
                     - "SHIPPING": 배송중

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/apidocs/GetOrderStatusHistoryApiDocs.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/apidocs/GetOrderStatusHistoryApiDocs.java
@@ -83,8 +83,8 @@ import java.lang.annotation.*;
                                               },
                                               {
                                                 "id": 3,
-                                                "orderStatus": "CANCEL_REQUESTED",
-                                                "orderStatusDescription": "주문 취소 요청됨",
+                                                "orderStatus": "CANCELLED",
+                                                "orderStatusDescription": "주문 취소",
                                                 "reasonCategory": "CANCEL_ORDER",
                                                 "reason": "구매 의사 취소",
                                                 "createdAt": "2026-03-02T11:00:00"

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/apidocs/GetOrdersApiDocs.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/apidocs/GetOrdersApiDocs.java
@@ -34,8 +34,6 @@ import java.lang.annotation.*;
                 
                     - "PREPARING": 상품 준비중
                 
-                    - "CANCEL_REQUESTED": 주문 취소 요청됨
-                
                     - "CANCELLED": 주문 취소
                 
                     - "SHIPPING": 배송중

--- a/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/event/PaymentCancelledOrderStatusConsumerTest.java
+++ b/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/event/PaymentCancelledOrderStatusConsumerTest.java
@@ -20,7 +20,7 @@ import org.springframework.kafka.support.Acknowledgment;
 import java.time.LocalDateTime;
 import java.util.List;
 
-import static com.personal.marketnote.commerce.domain.order.OrderStatus.CANCEL_REQUESTED;
+import static com.personal.marketnote.commerce.domain.order.OrderStatus.CANCELLED;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -55,7 +55,7 @@ class PaymentCancelledOrderStatusConsumerTest {
     }
 
     @Test
-    @DisplayName("전체 취소 이벤트 수신 시 주문 상태를 CANCEL_REQUESTED로 변경하고 acknowledge한다")
+    @DisplayName("전체 취소 이벤트 수신 시 주문 상태를 CANCELLED로 변경하고 acknowledge한다")
     void handlePaymentCancelledEvent_fullCancel_changesOrderStatusToCancelRequestedAndAcknowledges() {
         // given
         ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, "order-key-1", true, 50000L);
@@ -69,7 +69,7 @@ class PaymentCancelledOrderStatusConsumerTest {
 
         ChangeOrderStatusCommand command = captor.getValue();
         assertThat(command.id()).isEqualTo(1L);
-        assertThat(command.orderStatus()).isEqualTo(CANCEL_REQUESTED);
+        assertThat(command.orderStatus()).isEqualTo(CANCELLED);
 
         verify(acknowledgment).acknowledge();
     }
@@ -107,7 +107,7 @@ class PaymentCancelledOrderStatusConsumerTest {
     void handlePaymentCancelledEvent_alreadyChanged_acknowledgesGracefully() {
         // given
         ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, "order-key-1", true, 50000L);
-        doThrow(new OrderStatusAlreadyChangedException(CANCEL_REQUESTED))
+        doThrow(new OrderStatusAlreadyChangedException(CANCELLED))
                 .when(changeOrderStatusUseCase).changeOrderStatus(any(ChangeOrderStatusCommand.class));
 
         // when

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/CancelOrderService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/CancelOrderService.java
@@ -30,7 +30,7 @@ public class CancelOrderService implements CancelOrderUseCase {
     private final UpdateOrderPort updateOrderPort;
     private final Clock clock;
 
-    private static final OrderStatus TARGET_STATUS = OrderStatus.CANCEL_REQUESTED;
+    private static final OrderStatus TARGET_STATUS = OrderStatus.CANCELLED;
 
     @Override
     public void cancelOrder(CancelOrderCommand command) {

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/port/in/command/order/ChangeOrderStatusCommandTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/port/in/command/order/ChangeOrderStatusCommandTest.java
@@ -20,7 +20,7 @@ class ChangeOrderStatusCommandTest {
         void isBuyerRole_buyer_returnsTrue() {
             ChangeOrderStatusCommand command = ChangeOrderStatusCommand.builder()
                     .id(1L)
-                    .orderStatus(OrderStatus.CANCEL_REQUESTED)
+                    .orderStatus(OrderStatus.CONFIRMED)
                     .role("BUYER")
                     .build();
 
@@ -78,7 +78,7 @@ class ChangeOrderStatusCommandTest {
         void isInternalCall_withRole_returnsFalse() {
             ChangeOrderStatusCommand command = ChangeOrderStatusCommand.builder()
                     .id(1L)
-                    .orderStatus(OrderStatus.CANCEL_REQUESTED)
+                    .orderStatus(OrderStatus.CONFIRMED)
                     .role("BUYER")
                     .build();
 
@@ -95,7 +95,7 @@ class ChangeOrderStatusCommandTest {
         void buildWithBuyerId_setsBuyerId() {
             ChangeOrderStatusCommand command = ChangeOrderStatusCommand.builder()
                     .id(1L)
-                    .orderStatus(OrderStatus.CANCEL_REQUESTED)
+                    .orderStatus(OrderStatus.CONFIRMED)
                     .role("BUYER")
                     .buyerId(100L)
                     .build();
@@ -151,7 +151,7 @@ class ChangeOrderStatusCommandTest {
         void isPartialProductChange_nullPricePolicyIds_returnsFalse() {
             ChangeOrderStatusCommand command = ChangeOrderStatusCommand.builder()
                     .id(1L)
-                    .orderStatus(OrderStatus.CANCEL_REQUESTED)
+                    .orderStatus(OrderStatus.CONFIRMED)
                     .role("BUYER")
                     .build();
 

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/CancelOrderUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/CancelOrderUseCaseTest.java
@@ -179,25 +179,8 @@ class CancelOrderUseCaseTest {
     class StatusTransitionValidationTest {
 
         @Test
-        @DisplayName("이미 취소 요청된 주문을 다시 취소 요청하면 OrderStatusAlreadyChangedException이 발생한다")
-        void cancelOrder_alreadyCancelRequested_throwsException() {
-            Long orderId = 1L;
-            Long buyerId = 100L;
-            Order order = createOrderWithBuyerId(orderId, buyerId, OrderStatus.CANCEL_REQUESTED);
-            when(getOrderUseCase.getOrder(orderId)).thenReturn(order);
-
-            CancelOrderCommand command = CancelOrderCommand.builder()
-                    .id(orderId)
-                    .buyerId(buyerId)
-                    .build();
-
-            assertThatThrownBy(() -> cancelOrderService.cancelOrder(command))
-                    .isInstanceOf(OrderStatusAlreadyChangedException.class);
-        }
-
-        @Test
-        @DisplayName("이미 취소된 주문을 취소 요청하면 InvalidOrderStatusTransitionException이 발생한다")
-        void cancelOrder_alreadyCancelled_throwsException() {
+        @DisplayName("이미 취소된 주문을 다시 취소 요청하면 OrderStatusAlreadyChangedException이 발생한다")
+        void cancelOrder_alreadyCancelled_throwsAlreadyChangedException() {
             Long orderId = 1L;
             Long buyerId = 100L;
             Order order = createOrderWithBuyerId(orderId, buyerId, OrderStatus.CANCELLED);
@@ -209,7 +192,7 @@ class CancelOrderUseCaseTest {
                     .build();
 
             assertThatThrownBy(() -> cancelOrderService.cancelOrder(command))
-                    .isInstanceOf(InvalidOrderStatusTransitionException.class);
+                    .isInstanceOf(OrderStatusAlreadyChangedException.class);
         }
 
         @Test

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/ChangeOrderStatusPickupAddressUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/ChangeOrderStatusPickupAddressUseCaseTest.java
@@ -261,12 +261,12 @@ class ChangeOrderStatusPickupAddressUseCaseTest {
         void nonRefundRequest_doesNotCallFindPort() {
             Long orderId = 1L;
             Long buyerId = 100L;
-            Order order = createOrderWithBuyerId(orderId, buyerId, OrderStatus.PAYMENT_PENDING);
+            Order order = createOrderWithBuyerId(orderId, buyerId, OrderStatus.DELIVERED);
             when(getOrderUseCase.getOrder(orderId)).thenReturn(order);
 
             ChangeOrderStatusCommand command = ChangeOrderStatusCommand.builder()
                     .id(orderId)
-                    .orderStatus(OrderStatus.CANCEL_REQUESTED)
+                    .orderStatus(OrderStatus.CONFIRMED)
                     .role("BUYER")
                     .buyerId(buyerId)
                     .build();
@@ -281,12 +281,12 @@ class ChangeOrderStatusPickupAddressUseCaseTest {
         void nonRefundRequest_pickupAddressNotApplied() {
             Long orderId = 1L;
             Long buyerId = 100L;
-            Order order = createOrderWithBuyerId(orderId, buyerId, OrderStatus.PAYMENT_PENDING);
+            Order order = createOrderWithBuyerId(orderId, buyerId, OrderStatus.DELIVERED);
             when(getOrderUseCase.getOrder(orderId)).thenReturn(order);
 
             ChangeOrderStatusCommand command = ChangeOrderStatusCommand.builder()
                     .id(orderId)
-                    .orderStatus(OrderStatus.CANCEL_REQUESTED)
+                    .orderStatus(OrderStatus.CONFIRMED)
                     .role("BUYER")
                     .buyerId(buyerId)
                     .pickupAddressId(50L)

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/ChangeOrderStatusRoleValidationUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/ChangeOrderStatusRoleValidationUseCaseTest.java
@@ -57,23 +57,6 @@ class ChangeOrderStatusRoleValidationUseCaseTest {
     class BuyerAllowedStatusChangeTest {
 
         @Test
-        @DisplayName("구매자가 CANCEL_REQUESTED로 변경하면 정상 처리된다")
-        void buyer_cancelRequested_succeeds() {
-            Order order = createOrder(1L, OrderStatus.PAYMENT_PENDING);
-            when(getOrderUseCase.getOrder(1L)).thenReturn(order);
-
-            ChangeOrderStatusCommand command = ChangeOrderStatusCommand.builder()
-                    .id(1L)
-                    .orderStatus(OrderStatus.CANCEL_REQUESTED)
-                    .role("BUYER")
-                    .buyerId(1L)
-                    .build();
-
-            assertThatCode(() -> changeOrderStatusService.changeOrderStatus(command))
-                    .doesNotThrowAnyException();
-        }
-
-        @Test
         @DisplayName("구매자가 CONFIRMED로 변경하면 정상 처리된다")
         void buyer_confirmed_succeeds() {
             Order order = createOrder(1L, OrderStatus.DELIVERED);
@@ -187,7 +170,7 @@ class ChangeOrderStatusRoleValidationUseCaseTest {
         @Test
         @DisplayName("구매자가 CANCELLED로 변경하면 UnauthorizedOrderStatusChangeException이 발생한다")
         void buyer_cancelled_throwsException() {
-            Order order = createOrder(1L, OrderStatus.CANCEL_REQUESTED);
+            Order order = createOrder(1L, OrderStatus.PAID);
             when(getOrderUseCase.getOrder(1L)).thenReturn(order);
 
             ChangeOrderStatusCommand command = ChangeOrderStatusCommand.builder()
@@ -329,12 +312,12 @@ class ChangeOrderStatusRoleValidationUseCaseTest {
         void buyer_ownOrder_succeeds() {
             Long orderId = 1L;
             Long buyerId = 100L;
-            Order order = createOrderWithBuyerId(orderId, buyerId, OrderStatus.PAYMENT_PENDING);
+            Order order = createOrderWithBuyerId(orderId, buyerId, OrderStatus.DELIVERED);
             when(getOrderUseCase.getOrder(orderId)).thenReturn(order);
 
             ChangeOrderStatusCommand command = ChangeOrderStatusCommand.builder()
                     .id(orderId)
-                    .orderStatus(OrderStatus.CANCEL_REQUESTED)
+                    .orderStatus(OrderStatus.CONFIRMED)
                     .role("BUYER")
                     .buyerId(buyerId)
                     .build();
@@ -349,12 +332,12 @@ class ChangeOrderStatusRoleValidationUseCaseTest {
             Long orderId = 1L;
             Long ownerBuyerId = 100L;
             Long attackerBuyerId = 999L;
-            Order order = createOrderWithBuyerId(orderId, ownerBuyerId, OrderStatus.PAYMENT_PENDING);
+            Order order = createOrderWithBuyerId(orderId, ownerBuyerId, OrderStatus.DELIVERED);
             when(getOrderUseCase.getOrder(orderId)).thenReturn(order);
 
             ChangeOrderStatusCommand command = ChangeOrderStatusCommand.builder()
                     .id(orderId)
-                    .orderStatus(OrderStatus.CANCEL_REQUESTED)
+                    .orderStatus(OrderStatus.CONFIRMED)
                     .role("BUYER")
                     .buyerId(attackerBuyerId)
                     .build();
@@ -369,12 +352,12 @@ class ChangeOrderStatusRoleValidationUseCaseTest {
             Long orderId = 1L;
             Long ownerBuyerId = 100L;
             Long attackerBuyerId = 999L;
-            Order order = createOrderWithBuyerId(orderId, ownerBuyerId, OrderStatus.PAYMENT_PENDING);
+            Order order = createOrderWithBuyerId(orderId, ownerBuyerId, OrderStatus.DELIVERED);
             when(getOrderUseCase.getOrder(orderId)).thenReturn(order);
 
             ChangeOrderStatusCommand command = ChangeOrderStatusCommand.builder()
                     .id(orderId)
-                    .orderStatus(OrderStatus.CANCEL_REQUESTED)
+                    .orderStatus(OrderStatus.CONFIRMED)
                     .role("BUYER")
                     .buyerId(attackerBuyerId)
                     .build();

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/ConfirmOrderUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/ConfirmOrderUseCaseTest.java
@@ -232,11 +232,11 @@ class ConfirmOrderUseCaseTest {
         }
 
         @Test
-        @DisplayName("취소 요청 상태의 주문을 구매 확정하면 InvalidOrderStatusTransitionException이 발생한다")
-        void confirmOrder_fromCancelRequested_throwsException() {
+        @DisplayName("취소 상태의 주문을 구매 확정하면 InvalidOrderStatusTransitionException이 발생한다")
+        void confirmOrder_fromCancelled_throwsException() {
             Long orderId = 1L;
             Long buyerId = 100L;
-            Order order = createOrderWithBuyerId(orderId, buyerId, OrderStatus.CANCEL_REQUESTED);
+            Order order = createOrderWithBuyerId(orderId, buyerId, OrderStatus.CANCELLED);
             when(getOrderUseCase.getOrder(orderId)).thenReturn(order);
 
             ConfirmOrderCommand command = ConfirmOrderCommand.builder()

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/GetBuyerOrderCountUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/GetBuyerOrderCountUseCaseTest.java
@@ -581,7 +581,6 @@ class GetBuyerOrderCountUseCaseTest {
                     any(), any(), any(), statusesCaptor.capture()
             );
             assertThat(statusesCaptor.getValue()).containsExactlyInAnyOrder(
-                    OrderStatus.CANCEL_REQUESTED,
                     OrderStatus.CANCELLED,
                     OrderStatus.REFUND_REQUESTED,
                     OrderStatus.REFUND_RECALLING,

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/GetBuyerOrderHistoryUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/GetBuyerOrderHistoryUseCaseTest.java
@@ -681,7 +681,6 @@ class GetBuyerOrderHistoryUseCaseTest {
                     any(), any(), any(), statusesCaptor.capture()
             );
             assertThat(statusesCaptor.getValue()).containsExactlyInAnyOrder(
-                    OrderStatus.CANCEL_REQUESTED,
                     OrderStatus.CANCELLED,
                     OrderStatus.REFUND_REQUESTED,
                     OrderStatus.REFUND_RECALLING,

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/GetOrderStatusHistoryUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/GetOrderStatusHistoryUseCaseTest.java
@@ -118,7 +118,7 @@ class GetOrderStatusHistoryUseCaseTest {
         when(findOrderPort.findById(orderId)).thenReturn(Optional.of(createOrder(orderId)));
 
         OrderStatusHistory history = createHistory(
-                3L, orderId, OrderStatus.CANCEL_REQUESTED, OrderStatusReasonCategory.CANCEL_ORDER,
+                3L, orderId, OrderStatus.CANCELLED, OrderStatusReasonCategory.CANCEL_ORDER,
                 "구매 의사 취소", LocalDateTime.of(2026, 2, 20, 11, 0));
         when(findOrderStatusHistoryPort.findAllByOrderId(orderId)).thenReturn(List.of(history));
 
@@ -128,7 +128,7 @@ class GetOrderStatusHistoryUseCaseTest {
         // then
         OrderStatusHistoryItem item = result.statusHistory().get(0);
         assertThat(item.id()).isEqualTo(3L);
-        assertThat(item.orderStatus()).isEqualTo(OrderStatus.CANCEL_REQUESTED);
+        assertThat(item.orderStatus()).isEqualTo(OrderStatus.CANCELLED);
         assertThat(item.reasonCategory()).isEqualTo(OrderStatusReasonCategory.CANCEL_ORDER);
         assertThat(item.reason()).isEqualTo("구매 의사 취소");
         assertThat(item.createdAt()).isEqualTo(LocalDateTime.of(2026, 2, 20, 11, 0));

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/order/OrderStatus.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/order/OrderStatus.java
@@ -15,7 +15,6 @@ public enum OrderStatus {
     PAID("결제 완료"),
     FAILED("결제 실패"),
     PREPARING("상품 준비중"),
-    CANCEL_REQUESTED("주문 취소 요청됨"),
     CANCELLED("주문 취소"),
     SHIPPING("배송중"),
     DELIVERED("배송 완료"),
@@ -31,15 +30,14 @@ public enum OrderStatus {
 
     private static final Map<OrderStatus, Set<OrderStatus>> ALLOWED_TRANSITIONS = new EnumMap<>(OrderStatus.class);
     private static final Set<OrderStatus> BUYER_ALLOWED_STATUSES = EnumSet.of(
-            CANCEL_REQUESTED, CONFIRMED, REFUND_REQUESTED
+            CONFIRMED, REFUND_REQUESTED
     );
 
     static {
-        ALLOWED_TRANSITIONS.put(PAYMENT_PENDING, EnumSet.of(PAID, FAILED, CANCEL_REQUESTED, CANCELLED));
-        ALLOWED_TRANSITIONS.put(PAID, EnumSet.of(PREPARING, CANCEL_REQUESTED, CANCELLED));
+        ALLOWED_TRANSITIONS.put(PAYMENT_PENDING, EnumSet.of(PAID, FAILED, CANCELLED));
+        ALLOWED_TRANSITIONS.put(PAID, EnumSet.of(PREPARING, CANCELLED));
         ALLOWED_TRANSITIONS.put(FAILED, EnumSet.noneOf(OrderStatus.class));
-        ALLOWED_TRANSITIONS.put(PREPARING, EnumSet.of(SHIPPING, CANCEL_REQUESTED, CANCELLED));
-        ALLOWED_TRANSITIONS.put(CANCEL_REQUESTED, EnumSet.of(CANCELLED));
+        ALLOWED_TRANSITIONS.put(PREPARING, EnumSet.of(SHIPPING, CANCELLED));
         ALLOWED_TRANSITIONS.put(CANCELLED, EnumSet.noneOf(OrderStatus.class));
         ALLOWED_TRANSITIONS.put(SHIPPING, EnumSet.of(DELIVERED));
         ALLOWED_TRANSITIONS.put(DELIVERED, EnumSet.of(CONFIRMED, PARTIALLY_CONFIRMED, REFUND_REQUESTED));
@@ -103,7 +101,7 @@ public enum OrderStatus {
     /**
      * 구매자가 직접 변경할 수 있는 주문 상태인지 확인한다.
      * <p>
-     * 구매자 허용 상태: CANCEL_REQUESTED, CONFIRMED, REFUND_REQUESTED
+     * 구매자 허용 상태: CONFIRMED, REFUND_REQUESTED
      * </p>
      *
      * @return 구매자가 변경 가능한 상태이면 true

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/order/OrderStatusFilter.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/order/OrderStatusFilter.java
@@ -18,7 +18,6 @@ public enum OrderStatusFilter {
     CONFIRMED(List.of(OrderStatus.CONFIRMED)),
     CANCEL_EXCHANGE_REFUND(
             List.of(
-                    OrderStatus.CANCEL_REQUESTED,
                     OrderStatus.CANCELLED,
                     OrderStatus.REFUND_REQUESTED,
                     OrderStatus.REFUND_RECALLING,

--- a/commerce-service/commerce-domain/src/test/java/com/personal/marketnote/commerce/domain/order/OrderStatusTest.java
+++ b/commerce-service/commerce-domain/src/test/java/com/personal/marketnote/commerce/domain/order/OrderStatusTest.java
@@ -13,12 +13,6 @@ class OrderStatusTest {
     class IsBuyerAllowedTest {
 
         @Test
-        @DisplayName("CANCEL_REQUESTED는 구매자가 변경 가능한 상태이다")
-        void cancelRequested_isBuyerAllowed() {
-            assertThat(OrderStatus.CANCEL_REQUESTED.isBuyerAllowed()).isTrue();
-        }
-
-        @Test
         @DisplayName("CONFIRMED는 구매자가 변경 가능한 상태이다")
         void confirmed_isBuyerAllowed() {
             assertThat(OrderStatus.CONFIRMED.isBuyerAllowed()).isTrue();


### PR DESCRIPTION
## partially addresses #1920
## resolves #1923

## Test Case
- [x] OrderStatusTest CANCEL_REQUESTED isBuyerAllowed 테스트 삭제
- [x] CancelOrderUseCaseTest 이미 취소 요청된 → 이미 취소된 테스트 수정
- [x] ChangeOrderStatusRoleValidationUseCaseTest CANCEL_REQUESTED 참조 제거, IDOR 테스트 초기 상태 DELIVERED로 변경
- [x] ChangeOrderStatusPickupAddressUseCaseTest 초기 상태 DELIVERED로 변경
- [x] ChangeOrderStatusCommandTest CANCEL_REQUESTED → CONFIRMED 대체
- [x] ConfirmOrderUseCaseTest CANCEL_REQUESTED → CANCELLED 변경
- [x] GetBuyerOrderHistoryUseCaseTest/GetBuyerOrderCountUseCaseTest 필터 assertion 수정
- [x] GetOrderStatusHistoryUseCaseTest CANCEL_REQUESTED → CANCELLED 변경
- [x] PaymentCancelledOrderStatusConsumerTest CANCEL_REQUESTED → CANCELLED 변경