### PR TITLE
[#1920][#1924] test: REFUND 상태 5개 RETURN으로 리네이밍 자동화 테스트 추가

### DIFF
--- a/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/event/PaymentCancelledOrderStatusConsumerTest.java
+++ b/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/event/PaymentCancelledOrderStatusConsumerTest.java
@@ -56,7 +56,7 @@ class PaymentCancelledOrderStatusConsumerTest {
 
     @Test
     @DisplayName("전체 취소 이벤트 수신 시 주문 상태를 CANCELLED로 변경하고 acknowledge한다")
-    void handlePaymentCancelledEvent_fullCancel_changesOrderStatusToCancelRequestedAndAcknowledges() {
+    void handlePaymentCancelledEvent_fullCancel_changesOrderStatusToCancelledAndAcknowledges() {
         // given
         ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, "order-key-1", true, 50000L);
 

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/ChangeOrderStatusPickupAddressUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/ChangeOrderStatusPickupAddressUseCaseTest.java
@@ -51,16 +51,16 @@ class ChangeOrderStatusPickupAddressUseCaseTest {
     private ChangeOrderStatusService changeOrderStatusService;
 
     // ==================================================================================
-    // 환불 요청 시 pickupAddressId 기반 회수지 조회 + 적용
+    // 반품 요청 시 pickupAddressId 기반 회수지 조회 + 적용
     // ==================================================================================
 
     @Nested
-    @DisplayName("환불 요청 시 pickupAddressId 기반 회수지 적용")
+    @DisplayName("반품 요청 시 pickupAddressId 기반 회수지 적용")
     class PickupAddressLookupTest {
 
         @Test
         @DisplayName("pickupAddressId가 있으면 회수지를 조회하여 적용한다")
-        void refundRequested_withPickupAddressId_appliesLookedUpAddress() {
+        void returnRequested_withPickupAddressId_appliesLookedUpAddress() {
             Long orderId = 1L;
             Long buyerId = 100L;
             Long pickupAddressId = 50L;
@@ -71,7 +71,7 @@ class ChangeOrderStatusPickupAddressUseCaseTest {
 
             ChangeOrderStatusCommand command = ChangeOrderStatusCommand.builder()
                     .id(orderId)
-                    .orderStatus(OrderStatus.REFUND_REQUESTED)
+                    .orderStatus(OrderStatus.RETURN_REQUESTED)
                     .role("BUYER")
                     .buyerId(buyerId)
                     .pickupAddressId(pickupAddressId)
@@ -92,7 +92,7 @@ class ChangeOrderStatusPickupAddressUseCaseTest {
 
         @Test
         @DisplayName("pickupAddressId가 없으면 배송지가 회수지 기본값으로 적용된다")
-        void refundRequested_withoutPickupAddressId_appliesShippingAddressAsDefault() {
+        void returnRequested_withoutPickupAddressId_appliesShippingAddressAsDefault() {
             Long orderId = 1L;
             Long buyerId = 100L;
             Order order = createOrderWithBuyerId(orderId, buyerId, OrderStatus.DELIVERED);
@@ -100,7 +100,7 @@ class ChangeOrderStatusPickupAddressUseCaseTest {
 
             ChangeOrderStatusCommand command = ChangeOrderStatusCommand.builder()
                     .id(orderId)
-                    .orderStatus(OrderStatus.REFUND_REQUESTED)
+                    .orderStatus(OrderStatus.RETURN_REQUESTED)
                     .role("BUYER")
                     .buyerId(buyerId)
                     .build();
@@ -117,7 +117,7 @@ class ChangeOrderStatusPickupAddressUseCaseTest {
 
         @Test
         @DisplayName("pickupAddressId가 있으면 FindUserShippingAddressPort를 호출한다")
-        void refundRequested_withPickupAddressId_callsFindPort() {
+        void returnRequested_withPickupAddressId_callsFindPort() {
             Long orderId = 1L;
             Long buyerId = 100L;
             Long pickupAddressId = 50L;
@@ -128,7 +128,7 @@ class ChangeOrderStatusPickupAddressUseCaseTest {
 
             ChangeOrderStatusCommand command = ChangeOrderStatusCommand.builder()
                     .id(orderId)
-                    .orderStatus(OrderStatus.REFUND_REQUESTED)
+                    .orderStatus(OrderStatus.RETURN_REQUESTED)
                     .role("BUYER")
                     .buyerId(buyerId)
                     .pickupAddressId(pickupAddressId)
@@ -162,7 +162,7 @@ class ChangeOrderStatusPickupAddressUseCaseTest {
 
             ChangeOrderStatusCommand command = ChangeOrderStatusCommand.builder()
                     .id(orderId)
-                    .orderStatus(OrderStatus.REFUND_REQUESTED)
+                    .orderStatus(OrderStatus.RETURN_REQUESTED)
                     .role("BUYER")
                     .buyerId(buyerId)
                     .pickupAddressId(pickupAddressId)
@@ -187,7 +187,7 @@ class ChangeOrderStatusPickupAddressUseCaseTest {
 
             ChangeOrderStatusCommand command = ChangeOrderStatusCommand.builder()
                     .id(orderId)
-                    .orderStatus(OrderStatus.REFUND_REQUESTED)
+                    .orderStatus(OrderStatus.RETURN_REQUESTED)
                     .role("BUYER")
                     .buyerId(buyerId)
                     .pickupAddressId(pickupAddressId)
@@ -210,7 +210,7 @@ class ChangeOrderStatusPickupAddressUseCaseTest {
 
             ChangeOrderStatusCommand command = ChangeOrderStatusCommand.builder()
                     .id(orderId)
-                    .orderStatus(OrderStatus.REFUND_REQUESTED)
+                    .orderStatus(OrderStatus.RETURN_REQUESTED)
                     .role("BUYER")
                     .buyerId(buyerId)
                     .pickupAddressId(pickupAddressId)
@@ -233,7 +233,7 @@ class ChangeOrderStatusPickupAddressUseCaseTest {
 
             ChangeOrderStatusCommand command = ChangeOrderStatusCommand.builder()
                     .id(orderId)
-                    .orderStatus(OrderStatus.REFUND_REQUESTED)
+                    .orderStatus(OrderStatus.RETURN_REQUESTED)
                     .role("BUYER")
                     .buyerId(buyerId)
                     .pickupAddressId(pickupAddressId)
@@ -249,16 +249,16 @@ class ChangeOrderStatusPickupAddressUseCaseTest {
     }
 
     // ==================================================================================
-    // 환불 요청이 아닌 경우 회수지 미조회
+    // 반품 요청이 아닌 경우 회수지 미조회
     // ==================================================================================
 
     @Nested
-    @DisplayName("환불 요청이 아닌 경우")
-    class NonRefundRequestTest {
+    @DisplayName("반품 요청이 아닌 경우")
+    class NonReturnRequestTest {
 
         @Test
-        @DisplayName("환불 요청이 아닌 상태 변경 시 FindUserShippingAddressPort를 호출하지 않는다")
-        void nonRefundRequest_doesNotCallFindPort() {
+        @DisplayName("반품 요청이 아닌 상태 변경 시 FindUserShippingAddressPort를 호출하지 않는다")
+        void nonReturnRequest_doesNotCallFindPort() {
             Long orderId = 1L;
             Long buyerId = 100L;
             Order order = createOrderWithBuyerId(orderId, buyerId, OrderStatus.DELIVERED);
@@ -277,8 +277,8 @@ class ChangeOrderStatusPickupAddressUseCaseTest {
         }
 
         @Test
-        @DisplayName("환불 요청이 아닌 상태 변경 시 회수지가 적용되지 않는다")
-        void nonRefundRequest_pickupAddressNotApplied() {
+        @DisplayName("반품 요청이 아닌 상태 변경 시 회수지가 적용되지 않는다")
+        void nonReturnRequest_pickupAddressNotApplied() {
             Long orderId = 1L;
             Long buyerId = 100L;
             Order order = createOrderWithBuyerId(orderId, buyerId, OrderStatus.DELIVERED);

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/ChangeOrderStatusRoleValidationUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/ChangeOrderStatusRoleValidationUseCaseTest.java
@@ -74,14 +74,14 @@ class ChangeOrderStatusRoleValidationUseCaseTest {
         }
 
         @Test
-        @DisplayName("구매자가 REFUND_REQUESTED로 변경하면 정상 처리된다")
-        void buyer_refundRequested_succeeds() {
+        @DisplayName("구매자가 RETURN_REQUESTED로 변경하면 정상 처리된다")
+        void buyer_returnRequested_succeeds() {
             Order order = createOrder(1L, OrderStatus.DELIVERED);
             when(getOrderUseCase.getOrder(1L)).thenReturn(order);
 
             ChangeOrderStatusCommand command = ChangeOrderStatusCommand.builder()
                     .id(1L)
-                    .orderStatus(OrderStatus.REFUND_REQUESTED)
+                    .orderStatus(OrderStatus.RETURN_REQUESTED)
                     .role("BUYER")
                     .buyerId(1L)
                     .build();

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/GetBuyerOrderCountUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/GetBuyerOrderCountUseCaseTest.java
@@ -528,7 +528,7 @@ class GetBuyerOrderCountUseCaseTest {
             assertThat(statusesCaptor.getValue()).containsExactlyInAnyOrder(
                     OrderStatus.PREPARING,
                     OrderStatus.SHIPPING,
-                    OrderStatus.REFUND_SHIPPING
+                    OrderStatus.RETURN_SHIPPING
             );
         }
 
@@ -567,10 +567,10 @@ class GetBuyerOrderCountUseCaseTest {
         }
 
         @Test
-        @DisplayName("status가 CANCEL_EXCHANGE_REFUND이면 취소/교환/환불 관련 상태들이 전달된다")
-        void passesCancelExchangeRefundStatusesWhenStatusIsCancelExchangeRefund() {
+        @DisplayName("status가 CANCEL_RETURN이면 취소/반품 관련 상태들이 전달된다")
+        void passesCancelReturnStatusesWhenStatusIsCancelReturn() {
             Long buyerId = 1L;
-            GetBuyerOrderHistoryQuery query = createQuery(buyerId, null, OrderStatusFilter.CANCEL_EXCHANGE_REFUND, null);
+            GetBuyerOrderHistoryQuery query = createQuery(buyerId, null, OrderStatusFilter.CANCEL_RETURN, null);
 
             when(findOrderPort.findByBuyerId(any(), any(), any(), anyList()))
                     .thenReturn(List.of());
@@ -582,11 +582,11 @@ class GetBuyerOrderCountUseCaseTest {
             );
             assertThat(statusesCaptor.getValue()).containsExactlyInAnyOrder(
                     OrderStatus.CANCELLED,
-                    OrderStatus.REFUND_REQUESTED,
-                    OrderStatus.REFUND_RECALLING,
-                    OrderStatus.REFUND_SHIPPING,
-                    OrderStatus.PARTIALLY_REFUNDED,
-                    OrderStatus.REFUNDED
+                    OrderStatus.RETURN_REQUESTED,
+                    OrderStatus.RETURN_RECALLING,
+                    OrderStatus.RETURN_SHIPPING,
+                    OrderStatus.PARTIALLY_RETURNED,
+                    OrderStatus.RETURNED
             );
         }
 

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/GetBuyerOrderHistoryUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/GetBuyerOrderHistoryUseCaseTest.java
@@ -628,7 +628,7 @@ class GetBuyerOrderHistoryUseCaseTest {
             assertThat(statusesCaptor.getValue()).containsExactlyInAnyOrder(
                     OrderStatus.PREPARING,
                     OrderStatus.SHIPPING,
-                    OrderStatus.REFUND_SHIPPING
+                    OrderStatus.RETURN_SHIPPING
             );
         }
 
@@ -667,10 +667,10 @@ class GetBuyerOrderHistoryUseCaseTest {
         }
 
         @Test
-        @DisplayName("status가 CANCEL_EXCHANGE_REFUND이면 취소/교환/환불 관련 상태들이 전달된다")
-        void passesCancelExchangeRefundStatusesWhenStatusIsCancelExchangeRefund() {
+        @DisplayName("status가 CANCEL_RETURN이면 취소/반품 관련 상태들이 전달된다")
+        void passesCancelReturnStatusesWhenStatusIsCancelReturn() {
             Long buyerId = 1L;
-            GetBuyerOrderHistoryQuery query = createQuery(buyerId, null, OrderStatusFilter.CANCEL_EXCHANGE_REFUND, null);
+            GetBuyerOrderHistoryQuery query = createQuery(buyerId, null, OrderStatusFilter.CANCEL_RETURN, null);
 
             when(findOrderPort.findByBuyerId(any(), any(), any(), anyList()))
                     .thenReturn(List.of());
@@ -682,11 +682,11 @@ class GetBuyerOrderHistoryUseCaseTest {
             );
             assertThat(statusesCaptor.getValue()).containsExactlyInAnyOrder(
                     OrderStatus.CANCELLED,
-                    OrderStatus.REFUND_REQUESTED,
-                    OrderStatus.REFUND_RECALLING,
-                    OrderStatus.REFUND_SHIPPING,
-                    OrderStatus.PARTIALLY_REFUNDED,
-                    OrderStatus.REFUNDED
+                    OrderStatus.RETURN_REQUESTED,
+                    OrderStatus.RETURN_RECALLING,
+                    OrderStatus.RETURN_SHIPPING,
+                    OrderStatus.PARTIALLY_RETURNED,
+                    OrderStatus.RETURNED
             );
         }
     }

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/GetBuyerOrderProductsUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/GetBuyerOrderProductsUseCaseTest.java
@@ -749,11 +749,11 @@ class GetBuyerOrderProductsUseCaseTest {
         }
 
         @Test
-        @DisplayName("주문 상품의 orderStatus가 REFUNDED이면 결과에서 제외된다")
-        void excludesRefundedOrderProduct() {
+        @DisplayName("주문 상품의 orderStatus가 RETURNED이면 결과에서 제외된다")
+        void excludesReturnedOrderProduct() {
             Long buyerId = 1L;
             Order order = createOrderWithReviewedProducts(1L, buyerId, List.of(
-                    productStateWithStatus(100L, null, OrderStatus.REFUNDED)
+                    productStateWithStatus(100L, null, OrderStatus.RETURNED)
             ));
             GetBuyerOrderProductsQuery query = createQuery(buyerId, null);
 

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/GetOrderAndOrderProductsUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/GetOrderAndOrderProductsUseCaseTest.java
@@ -983,10 +983,10 @@ class GetOrderAndOrderProductsUseCaseTest {
         }
 
         @Test
-        @DisplayName("주문 상태가 REFUNDED인 경우도 정상 조회된다")
-        void getOrderAndOrderProducts_refundedOrder_succeeds() {
+        @DisplayName("주문 상태가 RETURNED인 경우도 정상 조회된다")
+        void getOrderAndOrderProducts_returnedOrder_succeeds() {
             Long orderId = 1L;
-            Order order = createOrderWithStatus(orderId, OrderStatus.REFUNDED, List.of());
+            Order order = createOrderWithStatus(orderId, OrderStatus.RETURNED, List.of());
 
             when(findOrderPort.findById(orderId)).thenReturn(Optional.of(order));
             when(findProductByPricePolicyPort.findByPricePolicyIds(anyList()))
@@ -994,7 +994,7 @@ class GetOrderAndOrderProductsUseCaseTest {
 
             GetOrderResult result = getOrderService.getOrderAndOrderProducts(orderId);
 
-            assertThat(result.orderStatus()).isEqualTo(OrderStatus.REFUNDED);
+            assertThat(result.orderStatus()).isEqualTo(OrderStatus.RETURNED);
         }
     }
 
@@ -1148,7 +1148,7 @@ class GetOrderAndOrderProductsUseCaseTest {
                 .buyerId(1L)
                 .orderKey(UUID.randomUUID())
                 .orderNumber("ORD-" + orderId)
-                .orderStatus(OrderStatus.PARTIALLY_REFUNDED)
+                .orderStatus(OrderStatus.PARTIALLY_RETURNED)
                 .amount(OrderAmount.of(300000L, null, 0L, 0L, null))
                 .shippingAddress(ShippingAddress.of("수령인", "01012345678", "12345", "서울시 강남구", "상세주소", null, null))
                 .orderProductStates(List.of(
@@ -1166,7 +1166,7 @@ class GetOrderAndOrderProductsUseCaseTest {
                                 .pricePolicyId(200L)
                                 .quantity(1)
                                 .unitAmount(100000L)
-                                .orderStatus(OrderStatus.REFUNDED)
+                                .orderStatus(OrderStatus.RETURNED)
                                 .build(),
                         OrderProductSnapshotState.builder()
                                 .orderId(orderId)

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/GetOrderUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/GetOrderUseCaseTest.java
@@ -411,16 +411,16 @@ class GetOrderUseCaseTest {
         }
 
         @Test
-        @DisplayName("REFUNDED 상태의 주문을 정상 조회한다")
-        void getOrder_refunded_succeeds() {
+        @DisplayName("RETURNED 상태의 주문을 정상 조회한다")
+        void getOrder_returned_succeeds() {
             Long orderId = 1L;
-            Order order = createOrderWithStatus(orderId, OrderStatus.REFUNDED);
+            Order order = createOrderWithStatus(orderId, OrderStatus.RETURNED);
 
             when(findOrderPort.findById(orderId)).thenReturn(Optional.of(order));
 
             Order result = getOrderService.getOrder(orderId);
 
-            assertThat(result.getOrderStatus()).isEqualTo(OrderStatus.REFUNDED);
+            assertThat(result.getOrderStatus()).isEqualTo(OrderStatus.RETURNED);
         }
 
         @Test
@@ -437,16 +437,16 @@ class GetOrderUseCaseTest {
         }
 
         @Test
-        @DisplayName("PARTIALLY_REFUNDED 상태의 주문을 정상 조회한다")
-        void getOrder_partiallyRefunded_succeeds() {
+        @DisplayName("PARTIALLY_RETURNED 상태의 주문을 정상 조회한다")
+        void getOrder_partiallyReturned_succeeds() {
             Long orderId = 1L;
-            Order order = createOrderWithStatus(orderId, OrderStatus.PARTIALLY_REFUNDED);
+            Order order = createOrderWithStatus(orderId, OrderStatus.PARTIALLY_RETURNED);
 
             when(findOrderPort.findById(orderId)).thenReturn(Optional.of(order));
 
             Order result = getOrderService.getOrder(orderId);
 
-            assertThat(result.getOrderStatus()).isEqualTo(OrderStatus.PARTIALLY_REFUNDED);
+            assertThat(result.getOrderStatus()).isEqualTo(OrderStatus.PARTIALLY_RETURNED);
         }
     }
 

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/RequestReturnUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/RequestReturnUseCaseTest.java
@@ -4,7 +4,7 @@ import com.personal.marketnote.commerce.domain.order.*;
 import com.personal.marketnote.commerce.exception.InvalidOrderStatusTransitionException;
 import com.personal.marketnote.commerce.exception.OrderStatusAlreadyChangedException;
 import com.personal.marketnote.commerce.exception.UnauthorizedOrderAccessException;
-import com.personal.marketnote.commerce.port.in.command.order.RequestRefundCommand;
+import com.personal.marketnote.commerce.port.in.command.order.RequestReturnCommand;
 import com.personal.marketnote.commerce.port.in.usecase.order.GetOrderUseCase;
 import com.personal.marketnote.commerce.port.out.order.UpdateOrderPort;
 import org.junit.jupiter.api.DisplayName;
@@ -28,7 +28,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
-class RequestRefundUseCaseTest {
+class RequestReturnUseCaseTest {
     @Mock
     private GetOrderUseCase getOrderUseCase;
     @Mock
@@ -37,99 +37,99 @@ class RequestRefundUseCaseTest {
     private Clock clock = Clock.fixed(Instant.parse("2026-04-05T00:00:00Z"), ZoneId.of("Asia/Seoul"));
 
     @InjectMocks
-    private RequestRefundService requestRefundService;
+    private RequestReturnService requestReturnService;
 
     // ==================================================================================
-    // 정상 환불 요청
+    // 정상 반품 요청
     // ==================================================================================
 
     @Nested
-    @DisplayName("정상 환불 요청")
-    class SuccessfulRefundRequestTest {
+    @DisplayName("정상 반품 요청")
+    class SuccessfulReturnRequestTest {
 
         @Test
-        @DisplayName("배송 완료 상태의 주문을 환불 요청하면 정상 처리된다")
-        void requestRefund_fromDelivered_succeeds() {
+        @DisplayName("배송 완료 상태의 주문을 반품 요청하면 정상 처리된다")
+        void requestReturn_fromDelivered_succeeds() {
             Long orderId = 1L;
             Long buyerId = 100L;
             Order order = createOrderWithBuyerId(orderId, buyerId, OrderStatus.DELIVERED);
             when(getOrderUseCase.getOrder(orderId)).thenReturn(order);
 
-            RequestRefundCommand command = RequestRefundCommand.builder()
+            RequestReturnCommand command = RequestReturnCommand.builder()
                     .id(orderId)
                     .reasonCategory(OrderStatusReasonCategory.ETC)
                     .reason("상품 불량")
                     .buyerId(buyerId)
                     .build();
 
-            assertThatCode(() -> requestRefundService.requestRefund(command))
+            assertThatCode(() -> requestReturnService.requestReturn(command))
                     .doesNotThrowAnyException();
         }
 
         @Test
-        @DisplayName("부분 구매 확정 상태의 주문을 환불 요청하면 정상 처리된다")
-        void requestRefund_fromPartiallyConfirmed_succeeds() {
+        @DisplayName("부분 구매 확정 상태의 주문을 반품 요청하면 정상 처리된다")
+        void requestReturn_fromPartiallyConfirmed_succeeds() {
             Long orderId = 1L;
             Long buyerId = 100L;
             Order order = createOrderWithBuyerId(orderId, buyerId, OrderStatus.PARTIALLY_CONFIRMED);
             when(getOrderUseCase.getOrder(orderId)).thenReturn(order);
 
-            RequestRefundCommand command = RequestRefundCommand.builder()
+            RequestReturnCommand command = RequestReturnCommand.builder()
                     .id(orderId)
                     .reasonCategory(OrderStatusReasonCategory.ETC)
                     .buyerId(buyerId)
                     .build();
 
-            assertThatCode(() -> requestRefundService.requestRefund(command))
+            assertThatCode(() -> requestReturnService.requestReturn(command))
                     .doesNotThrowAnyException();
         }
 
         @Test
-        @DisplayName("부분 환불됨 상태의 주문을 환불 요청하면 정상 처리된다")
-        void requestRefund_fromPartiallyRefunded_succeeds() {
+        @DisplayName("부분 반품됨 상태의 주문을 반품 요청하면 정상 처리된다")
+        void requestReturn_fromPartiallyReturned_succeeds() {
             Long orderId = 1L;
             Long buyerId = 100L;
-            Order order = createOrderWithBuyerId(orderId, buyerId, OrderStatus.PARTIALLY_REFUNDED);
+            Order order = createOrderWithBuyerId(orderId, buyerId, OrderStatus.PARTIALLY_RETURNED);
             when(getOrderUseCase.getOrder(orderId)).thenReturn(order);
 
-            RequestRefundCommand command = RequestRefundCommand.builder()
+            RequestReturnCommand command = RequestReturnCommand.builder()
                     .id(orderId)
                     .buyerId(buyerId)
                     .build();
 
-            assertThatCode(() -> requestRefundService.requestRefund(command))
+            assertThatCode(() -> requestReturnService.requestReturn(command))
                     .doesNotThrowAnyException();
         }
 
         @Test
-        @DisplayName("환불 요청 성공 시 UpdateOrderPort를 호출한다")
-        void requestRefund_callsUpdateOrderPort() {
+        @DisplayName("반품 요청 성공 시 UpdateOrderPort를 호출한다")
+        void requestReturn_callsUpdateOrderPort() {
             Long orderId = 1L;
             Long buyerId = 100L;
             Order order = createOrderWithBuyerId(orderId, buyerId, OrderStatus.DELIVERED);
             when(getOrderUseCase.getOrder(orderId)).thenReturn(order);
 
-            RequestRefundCommand command = RequestRefundCommand.builder()
+            RequestReturnCommand command = RequestReturnCommand.builder()
                     .id(orderId)
                     .reasonCategory(OrderStatusReasonCategory.ETC)
                     .reason("상품 불량")
                     .buyerId(buyerId)
                     .build();
 
-            requestRefundService.requestRefund(command);
+            requestReturnService.requestReturn(command);
 
             verify(updateOrderPort).update(any(Order.class), any(OrderStatusHistory.class));
         }
 
         @Test
         @DisplayName("회수지 주소를 입력하면 입력된 회수지가 적용된다")
-        void requestRefund_withPickupAddress_appliesProvidedAddress() {
+        void requestReturn_withPickupAddress_appliesProvidedAddress() {
             Long orderId = 1L;
             Long buyerId = 100L;
             Order order = createOrderWithBuyerId(orderId, buyerId, OrderStatus.DELIVERED);
             when(getOrderUseCase.getOrder(orderId)).thenReturn(order);
 
-            RequestRefundCommand command = RequestRefundCommand.builder()
+            RequestReturnCommand command = RequestReturnCommand.builder()
                     .id(orderId)
                     .reasonCategory(OrderStatusReasonCategory.ETC)
                     .reason("상품 불량")
@@ -142,7 +142,7 @@ class RequestRefundUseCaseTest {
                     .pickupRequestMessage("부재시 경비실에 맡겨주세요")
                     .build();
 
-            requestRefundService.requestRefund(command);
+            requestReturnService.requestReturn(command);
 
             assertThat(order.getPickupAddress().getRecipientName()).isEqualTo("회수 수령인");
             assertThat(order.getPickupAddress().getRecipientPhoneNumber()).isEqualTo("01099998888");
@@ -154,19 +154,19 @@ class RequestRefundUseCaseTest {
 
         @Test
         @DisplayName("회수지 주소를 미입력하면 배송지가 회수지 기본값으로 적용된다")
-        void requestRefund_withoutPickupAddress_appliesShippingAddressAsDefault() {
+        void requestReturn_withoutPickupAddress_appliesShippingAddressAsDefault() {
             Long orderId = 1L;
             Long buyerId = 100L;
             Order order = createOrderWithBuyerId(orderId, buyerId, OrderStatus.DELIVERED);
             when(getOrderUseCase.getOrder(orderId)).thenReturn(order);
 
-            RequestRefundCommand command = RequestRefundCommand.builder()
+            RequestReturnCommand command = RequestReturnCommand.builder()
                     .id(orderId)
                     .reasonCategory(OrderStatusReasonCategory.ETC)
                     .buyerId(buyerId)
                     .build();
 
-            requestRefundService.requestRefund(command);
+            requestReturnService.requestReturn(command);
 
             assertThat(order.getPickupAddress().getRecipientName()).isEqualTo("수령인");
             assertThat(order.getPickupAddress().getRecipientPhoneNumber()).isEqualTo("01012345678");
@@ -185,38 +185,38 @@ class RequestRefundUseCaseTest {
     class BuyerOwnershipValidationTest {
 
         @Test
-        @DisplayName("타인의 주문을 환불 요청하면 UnauthorizedOrderAccessException이 발생한다")
-        void requestRefund_otherBuyerOrder_throwsException() {
+        @DisplayName("타인의 주문을 반품 요청하면 UnauthorizedOrderAccessException이 발생한다")
+        void requestReturn_otherBuyerOrder_throwsException() {
             Long orderId = 1L;
             Long ownerBuyerId = 100L;
             Long attackerBuyerId = 999L;
             Order order = createOrderWithBuyerId(orderId, ownerBuyerId, OrderStatus.DELIVERED);
             when(getOrderUseCase.getOrder(orderId)).thenReturn(order);
 
-            RequestRefundCommand command = RequestRefundCommand.builder()
+            RequestReturnCommand command = RequestReturnCommand.builder()
                     .id(orderId)
                     .buyerId(attackerBuyerId)
                     .build();
 
-            assertThatThrownBy(() -> requestRefundService.requestRefund(command))
+            assertThatThrownBy(() -> requestReturnService.requestReturn(command))
                     .isInstanceOf(UnauthorizedOrderAccessException.class);
         }
 
         @Test
-        @DisplayName("타인의 주문 환불 요청 시 UpdateOrderPort를 호출하지 않는다")
-        void requestRefund_otherBuyerOrder_doesNotCallUpdatePort() {
+        @DisplayName("타인의 주문 반품 요청 시 UpdateOrderPort를 호출하지 않는다")
+        void requestReturn_otherBuyerOrder_doesNotCallUpdatePort() {
             Long orderId = 1L;
             Long ownerBuyerId = 100L;
             Long attackerBuyerId = 999L;
             Order order = createOrderWithBuyerId(orderId, ownerBuyerId, OrderStatus.DELIVERED);
             when(getOrderUseCase.getOrder(orderId)).thenReturn(order);
 
-            RequestRefundCommand command = RequestRefundCommand.builder()
+            RequestReturnCommand command = RequestReturnCommand.builder()
                     .id(orderId)
                     .buyerId(attackerBuyerId)
                     .build();
 
-            assertThatThrownBy(() -> requestRefundService.requestRefund(command))
+            assertThatThrownBy(() -> requestReturnService.requestReturn(command))
                     .isInstanceOf(UnauthorizedOrderAccessException.class);
 
             verifyNoInteractions(updateOrderPort);
@@ -232,87 +232,87 @@ class RequestRefundUseCaseTest {
     class StatusTransitionValidationTest {
 
         @Test
-        @DisplayName("이미 환불 요청된 주문을 다시 환불 요청하면 OrderStatusAlreadyChangedException이 발생한다")
-        void requestRefund_alreadyRefundRequested_throwsException() {
+        @DisplayName("이미 반품 요청된 주문을 다시 반품 요청하면 OrderStatusAlreadyChangedException이 발생한다")
+        void requestReturn_alreadyReturnRequested_throwsException() {
             Long orderId = 1L;
             Long buyerId = 100L;
-            Order order = createOrderWithBuyerId(orderId, buyerId, OrderStatus.REFUND_REQUESTED);
+            Order order = createOrderWithBuyerId(orderId, buyerId, OrderStatus.RETURN_REQUESTED);
             when(getOrderUseCase.getOrder(orderId)).thenReturn(order);
 
-            RequestRefundCommand command = RequestRefundCommand.builder()
+            RequestReturnCommand command = RequestReturnCommand.builder()
                     .id(orderId)
                     .buyerId(buyerId)
                     .build();
 
-            assertThatThrownBy(() -> requestRefundService.requestRefund(command))
+            assertThatThrownBy(() -> requestReturnService.requestReturn(command))
                     .isInstanceOf(OrderStatusAlreadyChangedException.class);
         }
 
         @Test
-        @DisplayName("결제 대기 상태의 주문을 환불 요청하면 InvalidOrderStatusTransitionException이 발생한다")
-        void requestRefund_fromPaymentPending_throwsException() {
+        @DisplayName("결제 대기 상태의 주문을 반품 요청하면 InvalidOrderStatusTransitionException이 발생한다")
+        void requestReturn_fromPaymentPending_throwsException() {
             Long orderId = 1L;
             Long buyerId = 100L;
             Order order = createOrderWithBuyerId(orderId, buyerId, OrderStatus.PAYMENT_PENDING);
             when(getOrderUseCase.getOrder(orderId)).thenReturn(order);
 
-            RequestRefundCommand command = RequestRefundCommand.builder()
+            RequestReturnCommand command = RequestReturnCommand.builder()
                     .id(orderId)
                     .buyerId(buyerId)
                     .build();
 
-            assertThatThrownBy(() -> requestRefundService.requestRefund(command))
+            assertThatThrownBy(() -> requestReturnService.requestReturn(command))
                     .isInstanceOf(InvalidOrderStatusTransitionException.class);
         }
 
         @Test
-        @DisplayName("배송중 상태의 주문을 환불 요청하면 InvalidOrderStatusTransitionException이 발생한다")
-        void requestRefund_fromShipping_throwsException() {
+        @DisplayName("배송중 상태의 주문을 반품 요청하면 InvalidOrderStatusTransitionException이 발생한다")
+        void requestReturn_fromShipping_throwsException() {
             Long orderId = 1L;
             Long buyerId = 100L;
             Order order = createOrderWithBuyerId(orderId, buyerId, OrderStatus.SHIPPING);
             when(getOrderUseCase.getOrder(orderId)).thenReturn(order);
 
-            RequestRefundCommand command = RequestRefundCommand.builder()
+            RequestReturnCommand command = RequestReturnCommand.builder()
                     .id(orderId)
                     .buyerId(buyerId)
                     .build();
 
-            assertThatThrownBy(() -> requestRefundService.requestRefund(command))
+            assertThatThrownBy(() -> requestReturnService.requestReturn(command))
                     .isInstanceOf(InvalidOrderStatusTransitionException.class);
         }
 
         @Test
-        @DisplayName("구매 확정 상태의 주문을 환불 요청하면 InvalidOrderStatusTransitionException이 발생한다")
-        void requestRefund_fromConfirmed_throwsException() {
+        @DisplayName("구매 확정 상태의 주문을 반품 요청하면 InvalidOrderStatusTransitionException이 발생한다")
+        void requestReturn_fromConfirmed_throwsException() {
             Long orderId = 1L;
             Long buyerId = 100L;
             Order order = createOrderWithBuyerId(orderId, buyerId, OrderStatus.CONFIRMED);
             when(getOrderUseCase.getOrder(orderId)).thenReturn(order);
 
-            RequestRefundCommand command = RequestRefundCommand.builder()
+            RequestReturnCommand command = RequestReturnCommand.builder()
                     .id(orderId)
                     .buyerId(buyerId)
                     .build();
 
-            assertThatThrownBy(() -> requestRefundService.requestRefund(command))
+            assertThatThrownBy(() -> requestReturnService.requestReturn(command))
                     .isInstanceOf(InvalidOrderStatusTransitionException.class);
         }
 
         @Test
         @DisplayName("상태 전이 실패 시 UpdateOrderPort를 호출하지 않는다")
-        void requestRefund_invalidTransition_doesNotCallUpdatePort() {
+        void requestReturn_invalidTransition_doesNotCallUpdatePort() {
             Long orderId = 1L;
             Long buyerId = 100L;
             Order order = createOrderWithBuyerId(orderId, buyerId, OrderStatus.SHIPPING);
             when(getOrderUseCase.getOrder(orderId)).thenReturn(order);
 
-            RequestRefundCommand command = RequestRefundCommand.builder()
+            RequestReturnCommand command = RequestReturnCommand.builder()
                     .id(orderId)
                     .buyerId(buyerId)
                     .build();
 
-            assertThatThrownBy(() -> requestRefundService.requestRefund(command))
+            assertThatThrownBy(() -> requestReturnService.requestReturn(command))
                     .isInstanceOf(InvalidOrderStatusTransitionException.class);
 
             verifyNoInteractions(updateOrderPort);

--- a/commerce-service/commerce-domain/src/test/java/com/personal/marketnote/commerce/domain/order/OrderPickupAddressTest.java
+++ b/commerce-service/commerce-domain/src/test/java/com/personal/marketnote/commerce/domain/order/OrderPickupAddressTest.java
@@ -112,7 +112,7 @@ class OrderPickupAddressTest {
                     .buyerId(1L)
                     .orderKey(UUID.randomUUID())
                     .orderNumber("ORD-1")
-                    .orderStatus(OrderStatus.REFUND_REQUESTED)
+                    .orderStatus(OrderStatus.RETURN_REQUESTED)
                     .amount(OrderAmount.of(50000L, null, null, null, null))
                     .shippingAddress(ShippingAddress.of("배송 수령인", "01012345678", "12345", "서울시 강남구", "테헤란로 123", null, null))
                     .pickupAddress(ShippingAddress.of("회수 수령인", "01099998888", "54321", "회수지 주소", "회수지 상세주소", null, "회수 요청사항"))

--- a/commerce-service/commerce-domain/src/test/java/com/personal/marketnote/commerce/domain/order/OrderStatusTest.java
+++ b/commerce-service/commerce-domain/src/test/java/com/personal/marketnote/commerce/domain/order/OrderStatusTest.java
@@ -19,9 +19,9 @@ class OrderStatusTest {
         }
 
         @Test
-        @DisplayName("REFUND_REQUESTED는 구매자가 변경 가능한 상태이다")
-        void refundRequested_isBuyerAllowed() {
-            assertThat(OrderStatus.REFUND_REQUESTED.isBuyerAllowed()).isTrue();
+        @DisplayName("RETURN_REQUESTED는 구매자가 변경 가능한 상태이다")
+        void returnRequested_isBuyerAllowed() {
+            assertThat(OrderStatus.RETURN_REQUESTED.isBuyerAllowed()).isTrue();
         }
 
         @Test
@@ -73,27 +73,27 @@ class OrderStatusTest {
         }
 
         @Test
-        @DisplayName("REFUND_RECALLING는 구매자가 변경할 수 없는 상태이다")
-        void refundRecalling_isNotBuyerAllowed() {
-            assertThat(OrderStatus.REFUND_RECALLING.isBuyerAllowed()).isFalse();
+        @DisplayName("RETURN_RECALLING는 구매자가 변경할 수 없는 상태이다")
+        void returnRecalling_isNotBuyerAllowed() {
+            assertThat(OrderStatus.RETURN_RECALLING.isBuyerAllowed()).isFalse();
         }
 
         @Test
-        @DisplayName("REFUND_SHIPPING는 구매자가 변경할 수 없는 상태이다")
-        void refundShipping_isNotBuyerAllowed() {
-            assertThat(OrderStatus.REFUND_SHIPPING.isBuyerAllowed()).isFalse();
+        @DisplayName("RETURN_SHIPPING는 구매자가 변경할 수 없는 상태이다")
+        void returnShipping_isNotBuyerAllowed() {
+            assertThat(OrderStatus.RETURN_SHIPPING.isBuyerAllowed()).isFalse();
         }
 
         @Test
-        @DisplayName("PARTIALLY_REFUNDED는 구매자가 변경할 수 없는 상태이다")
-        void partiallyRefunded_isNotBuyerAllowed() {
-            assertThat(OrderStatus.PARTIALLY_REFUNDED.isBuyerAllowed()).isFalse();
+        @DisplayName("PARTIALLY_RETURNED는 구매자가 변경할 수 없는 상태이다")
+        void partiallyReturned_isNotBuyerAllowed() {
+            assertThat(OrderStatus.PARTIALLY_RETURNED.isBuyerAllowed()).isFalse();
         }
 
         @Test
-        @DisplayName("REFUNDED는 구매자가 변경할 수 없는 상태이다")
-        void refunded_isNotBuyerAllowed() {
-            assertThat(OrderStatus.REFUNDED.isBuyerAllowed()).isFalse();
+        @DisplayName("RETURNED는 구매자가 변경할 수 없는 상태이다")
+        void returned_isNotBuyerAllowed() {
+            assertThat(OrderStatus.RETURNED.isBuyerAllowed()).isFalse();
         }
     }
 }


### PR DESCRIPTION
## partially addresses #1920
## resolves #1924

## Test Case
- [x] OrderStatusTest REFUND → RETURN 참조 변경
- [x] OrderPickupAddressTest REFUND_REQUESTED → RETURN_REQUESTED
- [x] RequestRefundUseCaseTest → RequestReturnUseCaseTest 리네이밍
- [x] GetBuyerOrderHistoryUseCaseTest REFUND/CANCEL_EXCHANGE_REFUND → RETURN/CANCEL_RETURN
- [x] GetBuyerOrderCountUseCaseTest REFUND → RETURN 참조 변경
- [x] ChangeOrderStatusRoleValidationUseCaseTest REFUND_REQUESTED → RETURN_REQUESTED
- [x] ChangeOrderStatusPickupAddressUseCaseTest 환불 → 반품 리네이밍
- [x] GetOrderAndOrderProductsUseCaseTest REFUNDED → RETURNED
- [x] GetOrderUseCaseTest REFUNDED → RETURNED
- [x] GetBuyerOrderProductsUseCaseTest REFUNDED → RETURNED