### PR TITLE
[#1920][#1925] test: REFUND_RECALLING과 REFUND_SHIPPING을 RETURN_IN_PROGRESS로 통합 자동화 테스트 추가

### DIFF
--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/GetBuyerOrderCountUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/GetBuyerOrderCountUseCaseTest.java
@@ -528,7 +528,7 @@ class GetBuyerOrderCountUseCaseTest {
             assertThat(statusesCaptor.getValue()).containsExactlyInAnyOrder(
                     OrderStatus.PREPARING,
                     OrderStatus.SHIPPING,
-                    OrderStatus.RETURN_SHIPPING
+                    OrderStatus.RETURN_IN_PROGRESS
             );
         }
 
@@ -583,8 +583,7 @@ class GetBuyerOrderCountUseCaseTest {
             assertThat(statusesCaptor.getValue()).containsExactlyInAnyOrder(
                     OrderStatus.CANCELLED,
                     OrderStatus.RETURN_REQUESTED,
-                    OrderStatus.RETURN_RECALLING,
-                    OrderStatus.RETURN_SHIPPING,
+                    OrderStatus.RETURN_IN_PROGRESS,
                     OrderStatus.PARTIALLY_RETURNED,
                     OrderStatus.RETURNED
             );

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/GetBuyerOrderHistoryUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/GetBuyerOrderHistoryUseCaseTest.java
@@ -628,7 +628,7 @@ class GetBuyerOrderHistoryUseCaseTest {
             assertThat(statusesCaptor.getValue()).containsExactlyInAnyOrder(
                     OrderStatus.PREPARING,
                     OrderStatus.SHIPPING,
-                    OrderStatus.RETURN_SHIPPING
+                    OrderStatus.RETURN_IN_PROGRESS
             );
         }
 
@@ -683,8 +683,7 @@ class GetBuyerOrderHistoryUseCaseTest {
             assertThat(statusesCaptor.getValue()).containsExactlyInAnyOrder(
                     OrderStatus.CANCELLED,
                     OrderStatus.RETURN_REQUESTED,
-                    OrderStatus.RETURN_RECALLING,
-                    OrderStatus.RETURN_SHIPPING,
+                    OrderStatus.RETURN_IN_PROGRESS,
                     OrderStatus.PARTIALLY_RETURNED,
                     OrderStatus.RETURNED
             );

--- a/commerce-service/commerce-domain/src/test/java/com/personal/marketnote/commerce/domain/order/OrderStatusTest.java
+++ b/commerce-service/commerce-domain/src/test/java/com/personal/marketnote/commerce/domain/order/OrderStatusTest.java
@@ -73,15 +73,9 @@ class OrderStatusTest {
         }
 
         @Test
-        @DisplayName("RETURN_RECALLING는 구매자가 변경할 수 없는 상태이다")
-        void returnRecalling_isNotBuyerAllowed() {
-            assertThat(OrderStatus.RETURN_RECALLING.isBuyerAllowed()).isFalse();
-        }
-
-        @Test
-        @DisplayName("RETURN_SHIPPING는 구매자가 변경할 수 없는 상태이다")
-        void returnShipping_isNotBuyerAllowed() {
-            assertThat(OrderStatus.RETURN_SHIPPING.isBuyerAllowed()).isFalse();
+        @DisplayName("RETURN_IN_PROGRESS는 구매자가 변경할 수 없는 상태이다")
+        void returnInProgress_isNotBuyerAllowed() {
+            assertThat(OrderStatus.RETURN_IN_PROGRESS.isBuyerAllowed()).isFalse();
         }
 
         @Test


### PR DESCRIPTION
## partially addresses #1920
## resolves #1925

## Test Case
- [x] OrderStatusTest RETURN_RECALLING, RETURN_SHIPPING 테스트 2개를 RETURN_IN_PROGRESS 1개로 교체
- [x] GetBuyerOrderHistoryUseCaseTest SHIPPING, CANCEL_RETURN 필터 검증 업데이트
- [x] GetBuyerOrderCountUseCaseTest SHIPPING, CANCEL_RETURN 필터 검증 업데이트