### PR TITLE
[#1920][#1927] test: OrderStatus 술어 및 행위 메서드 자동화 테스트 추가

### DIFF
--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/ChangeOrderStatusRoleValidationUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/ChangeOrderStatusRoleValidationUseCaseTest.java
@@ -89,6 +89,23 @@ class ChangeOrderStatusRoleValidationUseCaseTest {
             assertThatCode(() -> changeOrderStatusService.changeOrderStatus(command))
                     .doesNotThrowAnyException();
         }
+
+        @Test
+        @DisplayName("구매자가 CANCELLED로 변경하면 정상 처리된다")
+        void buyer_cancelled_succeeds() {
+            Order order = createOrder(1L, OrderStatus.PAID);
+            when(getOrderUseCase.getOrder(1L)).thenReturn(order);
+
+            ChangeOrderStatusCommand command = ChangeOrderStatusCommand.builder()
+                    .id(1L)
+                    .orderStatus(OrderStatus.CANCELLED)
+                    .role("BUYER")
+                    .buyerId(1L)
+                    .build();
+
+            assertThatCode(() -> changeOrderStatusService.changeOrderStatus(command))
+                    .doesNotThrowAnyException();
+        }
     }
 
     // ==================================================================================
@@ -168,14 +185,14 @@ class ChangeOrderStatusRoleValidationUseCaseTest {
         }
 
         @Test
-        @DisplayName("구매자가 CANCELLED로 변경하면 UnauthorizedOrderStatusChangeException이 발생한다")
-        void buyer_cancelled_throwsException() {
-            Order order = createOrder(1L, OrderStatus.PAID);
+        @DisplayName("구매자가 RETURN_IN_PROGRESS로 변경하면 UnauthorizedOrderStatusChangeException이 발생한다")
+        void buyer_returnInProgress_throwsException() {
+            Order order = createOrder(1L, OrderStatus.RETURN_REQUESTED);
             when(getOrderUseCase.getOrder(1L)).thenReturn(order);
 
             ChangeOrderStatusCommand command = ChangeOrderStatusCommand.builder()
                     .id(1L)
-                    .orderStatus(OrderStatus.CANCELLED)
+                    .orderStatus(OrderStatus.RETURN_IN_PROGRESS)
                     .role("BUYER")
                     .buyerId(1L)
                     .build();

--- a/commerce-service/commerce-domain/src/test/java/com/personal/marketnote/commerce/domain/order/OrderStatusTest.java
+++ b/commerce-service/commerce-domain/src/test/java/com/personal/marketnote/commerce/domain/order/OrderStatusTest.java
@@ -49,9 +49,9 @@ class OrderStatusTest {
         }
 
         @Test
-        @DisplayName("CANCELLED는 구매자가 변경할 수 없는 상태이다")
-        void cancelled_isNotBuyerAllowed() {
-            assertThat(OrderStatus.CANCELLED.isBuyerAllowed()).isFalse();
+        @DisplayName("CANCELLED는 구매자가 변경 가능한 상태이다")
+        void cancelled_isBuyerAllowed() {
+            assertThat(OrderStatus.CANCELLED.isBuyerAllowed()).isTrue();
         }
 
         @Test
@@ -88,6 +88,29 @@ class OrderStatusTest {
         @DisplayName("RETURNED는 구매자가 변경할 수 없는 상태이다")
         void returned_isNotBuyerAllowed() {
             assertThat(OrderStatus.RETURNED.isBuyerAllowed()).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("배송 완료 상태 검증 (isDelivered)")
+    class IsDeliveredTest {
+
+        @Test
+        @DisplayName("DELIVERED는 배송 완료 상태이다")
+        void delivered_isDelivered() {
+            assertThat(OrderStatus.DELIVERED.isDelivered()).isTrue();
+        }
+
+        @Test
+        @DisplayName("SHIPPING는 배송 완료 상태가 아니다")
+        void shipping_isNotDelivered() {
+            assertThat(OrderStatus.SHIPPING.isDelivered()).isFalse();
+        }
+
+        @Test
+        @DisplayName("CONFIRMED는 배송 완료 상태가 아니다")
+        void confirmed_isNotDelivered() {
+            assertThat(OrderStatus.CONFIRMED.isDelivered()).isFalse();
         }
     }
 }


### PR DESCRIPTION
## partially addresses #1920
## resolves #1927

## Test Case
- [x] OrderStatusTest CANCELLED isBuyerAllowed true로 변경
- [x] OrderStatusTest isDelivered 검증 3개 테스트 추가
- [x] ChangeOrderStatusRoleValidationUseCaseTest 구매자 CANCELLED 허용 테스트 추가
- [x] ChangeOrderStatusRoleValidationUseCaseTest 구매자 CANCELLED 차단 테스트를 RETURN_IN_PROGRESS 차단으로 교체