### PR TITLE
[#1920][#2265] fix: OrderStatusFilter enum 변경에 따른 클라이언트 하위 호환성 대응

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/converter/StringToOrderStatusFilterConverter.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/converter/StringToOrderStatusFilterConverter.java
@@ -1,0 +1,25 @@
+package com.personal.marketnote.commerce.adapter.in.web.order.converter;
+
+import com.personal.marketnote.commerce.domain.order.OrderStatusFilter;
+import com.personal.marketnote.common.utility.FormatValidator;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@Component
+public class StringToOrderStatusFilterConverter implements Converter<String, OrderStatusFilter> {
+
+    private static final Map<String, OrderStatusFilter> LEGACY_MAPPINGS = Map.of(
+            "CANCEL_EXCHANGE_REFUND", OrderStatusFilter.CANCEL_RETURN
+    );
+
+    @Override
+    public OrderStatusFilter convert(String source) {
+        OrderStatusFilter legacy = LEGACY_MAPPINGS.get(source);
+        if (FormatValidator.hasValue(legacy)) {
+            return legacy;
+        }
+        return OrderStatusFilter.valueOf(source);
+    }
+}


### PR DESCRIPTION
## partially addresses #1920
## resolves #2265

## Task
- [x] StringToOrderStatusFilterConverter 추가 — 레거시 값 CANCEL_EXCHANGE_REFUND를 CANCEL_RETURN으로 매핑