### PR TITLE
[#475][#1928] feat: 풀필먼트 작업 상태 조회 내부 API 추가

### DIFF
--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/delivery/controller/InternalFulfillmentDeliveryController.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/delivery/controller/InternalFulfillmentDeliveryController.java
@@ -1,0 +1,57 @@
+package com.personal.marketnote.fulfillment.adapter.in.web.delivery.controller;
+
+import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
+import com.personal.marketnote.fulfillment.adapter.in.web.delivery.controller.apidocs.GetFulfillmentWorkStatusApiDocs;
+import com.personal.marketnote.fulfillment.adapter.in.web.delivery.response.GetFulfillmentWorkStatusResponse;
+import com.personal.marketnote.fulfillment.port.in.command.GetFulfillmentWorkStatusCommand;
+import com.personal.marketnote.fulfillment.port.in.result.GetFulfillmentWorkStatusResult;
+import com.personal.marketnote.fulfillment.port.in.usecase.GetFulfillmentWorkStatusUseCase;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import static com.personal.marketnote.common.domain.exception.ExceptionCode.DEFAULT_SUCCESS_CODE;
+
+/**
+ * 내부 풀필먼트 출고 컨트롤러 (서비스 간 통신용)
+ */
+@RestController
+@RequestMapping("/api/v1/internal/fulfillment/deliveries")
+@Tag(
+        name = "내부 풀필먼트 출고 API",
+        description = "서비스 간 통신용 풀필먼트 출고 API"
+)
+@RequiredArgsConstructor
+public class InternalFulfillmentDeliveryController {
+    private final GetFulfillmentWorkStatusUseCase getFulfillmentWorkStatusUseCase;
+
+    /**
+     * 풀필먼트 작업 상태 조회 (서비스 간 통신용)
+     *
+     * @param orderId 주문 ID
+     */
+    @GetMapping("/work-status")
+    @GetFulfillmentWorkStatusApiDocs
+    public ResponseEntity<BaseResponse<GetFulfillmentWorkStatusResponse>> getWorkStatus(
+            @RequestParam("order-id") Long orderId
+    ) {
+        GetFulfillmentWorkStatusResult result = getFulfillmentWorkStatusUseCase.getWorkStatus(
+                new GetFulfillmentWorkStatusCommand(orderId)
+        );
+
+        return new ResponseEntity<>(
+                BaseResponse.of(
+                        GetFulfillmentWorkStatusResponse.from(result),
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "풀필먼트 작업 상태 조회 성공"
+                ),
+                HttpStatus.OK
+        );
+    }
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/delivery/controller/apidocs/GetFulfillmentWorkStatusApiDocs.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/delivery/controller/apidocs/GetFulfillmentWorkStatusApiDocs.java
@@ -1,0 +1,33 @@
+package com.personal.marketnote.fulfillment.adapter.in.web.delivery.controller.apidocs;
+
+import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
+import com.personal.marketnote.fulfillment.adapter.in.web.delivery.response.GetFulfillmentWorkStatusResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Operation(
+        summary = "풀필먼트 작업 상태 조회",
+        description = "주문 ID로 풀필먼트 작업 상태를 조회합니다. 서비스 간 통신용 API입니다.",
+        parameters = {
+                @Parameter(name = "order-id", description = "주문 ID", required = true)
+        },
+        responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "풀필먼트 작업 상태 조회 성공",
+                        content = @Content(schema = @Schema(implementation = BaseResponse.class))
+                )
+        }
+)
+public @interface GetFulfillmentWorkStatusApiDocs {
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/delivery/response/GetFulfillmentWorkStatusResponse.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/delivery/response/GetFulfillmentWorkStatusResponse.java
@@ -1,0 +1,15 @@
+package com.personal.marketnote.fulfillment.adapter.in.web.delivery.response;
+
+import com.personal.marketnote.fulfillment.port.in.result.GetFulfillmentWorkStatusResult;
+
+public record GetFulfillmentWorkStatusResponse(
+        Long orderId,
+        String workStatus
+) {
+    public static GetFulfillmentWorkStatusResponse from(GetFulfillmentWorkStatusResult result) {
+        return new GetFulfillmentWorkStatusResponse(
+                result.orderId(),
+                result.workStatus()
+        );
+    }
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/persistence/delivery/FulfillmentDeliveryRegistrationPersistenceAdapter.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/persistence/delivery/FulfillmentDeliveryRegistrationPersistenceAdapter.java
@@ -5,13 +5,17 @@ import com.personal.marketnote.fulfillment.adapter.out.persistence.delivery.enti
 import com.personal.marketnote.fulfillment.adapter.out.persistence.delivery.repository.FulfillmentDeliveryRegistrationJpaRepository;
 import com.personal.marketnote.fulfillment.domain.delivery.FulfillmentDeliveryRegistration;
 import com.personal.marketnote.fulfillment.exception.FulfillmentDeliveryAlreadyRegisteredException;
+import com.personal.marketnote.fulfillment.port.out.delivery.FindFulfillmentDeliveryRegistrationPort;
 import com.personal.marketnote.fulfillment.port.out.delivery.SaveFulfillmentDeliveryRegistrationPort;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
 
+import java.util.Optional;
+
 @PersistenceAdapter
 @RequiredArgsConstructor
-public class FulfillmentDeliveryRegistrationPersistenceAdapter implements SaveFulfillmentDeliveryRegistrationPort {
+public class FulfillmentDeliveryRegistrationPersistenceAdapter
+        implements SaveFulfillmentDeliveryRegistrationPort, FindFulfillmentDeliveryRegistrationPort {
     private final FulfillmentDeliveryRegistrationJpaRepository repository;
 
     @Override
@@ -21,5 +25,11 @@ public class FulfillmentDeliveryRegistrationPersistenceAdapter implements SaveFu
         } catch (DataIntegrityViolationException e) {
             throw new FulfillmentDeliveryAlreadyRegisteredException(registration.getOrderId());
         }
+    }
+
+    @Override
+    public Optional<FulfillmentDeliveryRegistration> findByOrderId(Long orderId) {
+        return repository.findByOrderId(orderId)
+                .map(FulfillmentDeliveryRegistrationJpaEntity::toDomain);
     }
 }

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/persistence/delivery/entity/FulfillmentDeliveryRegistrationJpaEntity.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/persistence/delivery/entity/FulfillmentDeliveryRegistrationJpaEntity.java
@@ -2,6 +2,7 @@ package com.personal.marketnote.fulfillment.adapter.out.persistence.delivery.ent
 
 import com.personal.marketnote.fulfillment.domain.delivery.FulfillmentDeliveryRegistration;
 import com.personal.marketnote.fulfillment.domain.delivery.FulfillmentDeliveryRegistrationSnapshotState;
+import com.personal.marketnote.fulfillment.domain.delivery.FulfillmentWorkStatus;
 import jakarta.persistence.*;
 import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
@@ -24,6 +25,10 @@ public class FulfillmentDeliveryRegistrationJpaEntity {
     @Column(name = "order_id", nullable = false, unique = true)
     private Long orderId;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "work_status", nullable = false)
+    private FulfillmentWorkStatus workStatus;
+
     @CreatedDate
     @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt;
@@ -32,6 +37,7 @@ public class FulfillmentDeliveryRegistrationJpaEntity {
         return FulfillmentDeliveryRegistrationJpaEntity.builder()
                 .id(registration.getId())
                 .orderId(registration.getOrderId())
+                .workStatus(registration.getWorkStatus())
                 .createdAt(registration.getCreatedAt())
                 .build();
     }
@@ -41,6 +47,7 @@ public class FulfillmentDeliveryRegistrationJpaEntity {
                 FulfillmentDeliveryRegistrationSnapshotState.builder()
                         .id(id)
                         .orderId(orderId)
+                        .workStatus(workStatus)
                         .createdAt(createdAt)
                         .build()
         );

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/persistence/delivery/repository/FulfillmentDeliveryRegistrationJpaRepository.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/persistence/delivery/repository/FulfillmentDeliveryRegistrationJpaRepository.java
@@ -3,5 +3,8 @@ package com.personal.marketnote.fulfillment.adapter.out.persistence.delivery.rep
 import com.personal.marketnote.fulfillment.adapter.out.persistence.delivery.entity.FulfillmentDeliveryRegistrationJpaEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface FulfillmentDeliveryRegistrationJpaRepository extends JpaRepository<FulfillmentDeliveryRegistrationJpaEntity, Long> {
+    Optional<FulfillmentDeliveryRegistrationJpaEntity> findByOrderId(Long orderId);
 }

--- a/fulfillment-service/fulfillment-adapters/src/main/resources/db/migration/V20260406__add_work_status_to_fassto_delivery_registration.sql
+++ b/fulfillment-service/fulfillment-adapters/src/main/resources/db/migration/V20260406__add_work_status_to_fassto_delivery_registration.sql
@@ -1,0 +1,3 @@
+-- #1928: 풀필먼트 작업 상태 조회 API - work_status 컬럼 추가
+ALTER TABLE fassto_delivery_registration
+    ADD COLUMN work_status VARCHAR(20) NOT NULL DEFAULT 'REGISTERED';

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/GetFulfillmentWorkStatusCommand.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/GetFulfillmentWorkStatusCommand.java
@@ -1,0 +1,6 @@
+package com.personal.marketnote.fulfillment.port.in.command;
+
+public record GetFulfillmentWorkStatusCommand(
+        Long orderId
+) {
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/result/GetFulfillmentWorkStatusResult.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/result/GetFulfillmentWorkStatusResult.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.fulfillment.port.in.result;
+
+public record GetFulfillmentWorkStatusResult(
+        Long orderId,
+        String workStatus
+) {
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/usecase/GetFulfillmentWorkStatusUseCase.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/usecase/GetFulfillmentWorkStatusUseCase.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.fulfillment.port.in.usecase;
+
+import com.personal.marketnote.fulfillment.port.in.command.GetFulfillmentWorkStatusCommand;
+import com.personal.marketnote.fulfillment.port.in.result.GetFulfillmentWorkStatusResult;
+
+public interface GetFulfillmentWorkStatusUseCase {
+    GetFulfillmentWorkStatusResult getWorkStatus(GetFulfillmentWorkStatusCommand command);
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/delivery/FindFulfillmentDeliveryRegistrationPort.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/delivery/FindFulfillmentDeliveryRegistrationPort.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.fulfillment.port.out.delivery;
+
+import com.personal.marketnote.fulfillment.domain.delivery.FulfillmentDeliveryRegistration;
+
+import java.util.Optional;
+
+public interface FindFulfillmentDeliveryRegistrationPort {
+    Optional<FulfillmentDeliveryRegistration> findByOrderId(Long orderId);
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/GetFulfillmentWorkStatusService.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/GetFulfillmentWorkStatusService.java
@@ -1,0 +1,32 @@
+package com.personal.marketnote.fulfillment.service;
+
+import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.fulfillment.domain.delivery.FulfillmentWorkStatus;
+import com.personal.marketnote.fulfillment.port.in.command.GetFulfillmentWorkStatusCommand;
+import com.personal.marketnote.fulfillment.port.in.result.GetFulfillmentWorkStatusResult;
+import com.personal.marketnote.fulfillment.port.in.usecase.GetFulfillmentWorkStatusUseCase;
+import com.personal.marketnote.fulfillment.port.out.delivery.FindFulfillmentDeliveryRegistrationPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional(isolation = READ_COMMITTED, readOnly = true)
+public class GetFulfillmentWorkStatusService implements GetFulfillmentWorkStatusUseCase {
+    private final FindFulfillmentDeliveryRegistrationPort findFulfillmentDeliveryRegistrationPort;
+
+    @Override
+    public GetFulfillmentWorkStatusResult getWorkStatus(GetFulfillmentWorkStatusCommand command) {
+        return findFulfillmentDeliveryRegistrationPort.findByOrderId(command.orderId())
+                .map(registration -> new GetFulfillmentWorkStatusResult(
+                        command.orderId(),
+                        registration.getWorkStatus().name()
+                ))
+                .orElseGet(() -> new GetFulfillmentWorkStatusResult(
+                        command.orderId(),
+                        FulfillmentWorkStatus.NOT_REGISTERED.name()
+                ));
+    }
+}

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/delivery/FulfillmentDeliveryRegistration.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/delivery/FulfillmentDeliveryRegistration.java
@@ -13,6 +13,7 @@ import java.time.LocalDateTime;
 public class FulfillmentDeliveryRegistration {
     private Long id;
     private Long orderId;
+    private FulfillmentWorkStatus workStatus;
     private LocalDateTime createdAt;
 
     public static FulfillmentDeliveryRegistration from(FulfillmentDeliveryRegistrationCreateState state) {
@@ -21,6 +22,7 @@ public class FulfillmentDeliveryRegistration {
         }
         return FulfillmentDeliveryRegistration.builder()
                 .orderId(state.getOrderId())
+                .workStatus(FulfillmentWorkStatus.REGISTERED)
                 .build();
     }
 
@@ -28,6 +30,7 @@ public class FulfillmentDeliveryRegistration {
         return FulfillmentDeliveryRegistration.builder()
                 .id(state.getId())
                 .orderId(state.getOrderId())
+                .workStatus(state.getWorkStatus())
                 .createdAt(state.getCreatedAt())
                 .build();
     }

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/delivery/FulfillmentDeliveryRegistrationSnapshotState.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/delivery/FulfillmentDeliveryRegistrationSnapshotState.java
@@ -10,5 +10,6 @@ import java.time.LocalDateTime;
 public class FulfillmentDeliveryRegistrationSnapshotState {
     private final Long id;
     private final Long orderId;
+    private final FulfillmentWorkStatus workStatus;
     private final LocalDateTime createdAt;
 }

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/delivery/FulfillmentWorkStatus.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/delivery/FulfillmentWorkStatus.java
@@ -1,0 +1,41 @@
+package com.personal.marketnote.fulfillment.domain.delivery;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum FulfillmentWorkStatus {
+    NOT_REGISTERED("출고 미접수"),
+    REGISTERED("출고 접수"),
+    PICKING("피킹 진행 중"),
+    PICKED("피킹 완료"),
+    PACKING("포장 중"),
+    RELEASED("출고 완료");
+
+    private final String description;
+
+    public boolean isNotRegistered() {
+        return this == NOT_REGISTERED;
+    }
+
+    public boolean isRegistered() {
+        return this == REGISTERED;
+    }
+
+    public boolean isPicking() {
+        return this == PICKING;
+    }
+
+    public boolean isPicked() {
+        return this == PICKED;
+    }
+
+    public boolean isPacking() {
+        return this == PACKING;
+    }
+
+    public boolean isReleased() {
+        return this == RELEASED;
+    }
+}


### PR DESCRIPTION
## partially addresses #475
## resolves #1928

## Task
- [x] FulfillmentWorkStatus enum 생성 (NOT_REGISTERED, REGISTERED, PICKING, PICKED, PACKING, RELEASED)
- [x] FulfillmentDeliveryRegistration 도메인에 workStatus 필드 추가
- [x] GetFulfillmentWorkStatusUseCase / Service 구현
- [x] FindFulfillmentDeliveryRegistrationPort out port 추가
- [x] FulfillmentDeliveryRegistrationJpaEntity work_status 컬럼 추가
- [x] InternalFulfillmentDeliveryController 내부 API 컨트롤러 생성
- [x] DB 마이그레이션 SQL 추가