### PR TITLE
[#216][#1929] feat: 커머스 서비스 풀필먼트 상태 조회 클라이언트 추가

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/web/fulfillment/FulfillmentServiceClient.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/web/fulfillment/FulfillmentServiceClient.java
@@ -1,0 +1,73 @@
+package com.personal.marketnote.commerce.adapter.out.web.fulfillment;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.personal.marketnote.commerce.port.out.fulfillment.GetFulfillmentWorkStatusPort;
+import com.personal.marketnote.common.adapter.out.ServiceAdapter;
+import com.personal.marketnote.common.exception.FulfillmentServiceRequestFailedException;
+import com.personal.marketnote.common.security.hmac.HmacServiceAuthHeaderBuilder;
+import com.personal.marketnote.common.utility.FormatValidator;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.io.IOException;
+import java.net.URI;
+
+@ServiceAdapter
+@Slf4j
+public class FulfillmentServiceClient implements GetFulfillmentWorkStatusPort {
+    private final RestClient restClient;
+    private final String fulfillmentServiceBaseUrl;
+    private final HmacServiceAuthHeaderBuilder hmacServiceAuthHeaderBuilder;
+
+    public FulfillmentServiceClient(
+            RestClient.Builder restClientBuilder,
+            @Value("${fulfillment-service.base-url}") String fulfillmentServiceBaseUrl,
+            HmacServiceAuthHeaderBuilder hmacServiceAuthHeaderBuilder
+    ) {
+        this.restClient = restClientBuilder.build();
+        this.fulfillmentServiceBaseUrl = fulfillmentServiceBaseUrl;
+        this.hmacServiceAuthHeaderBuilder = hmacServiceAuthHeaderBuilder;
+    }
+
+    @Override
+    public String getWorkStatus(Long orderId) {
+        URI uri = buildWorkStatusUri(orderId);
+
+        try {
+            ResponseEntity<JsonNode> responseEntity = restClient.get()
+                    .uri(uri)
+                    .headers(headers -> hmacServiceAuthHeaderBuilder.applyHeaders(headers, "GET", uri.getPath()))
+                    .retrieve()
+                    .toEntity(JsonNode.class);
+
+            if (responseEntity.getStatusCode().isError()) {
+                throw new FulfillmentServiceRequestFailedException(
+                        new IOException("Fulfillment service returned error: " + responseEntity.getStatusCode()));
+            }
+
+            if (responseEntity.getStatusCode().is2xxSuccessful()
+                    && FormatValidator.hasValue(responseEntity.getBody())) {
+                return responseEntity.getBody().path("content").path("workStatus").asText();
+            }
+
+            throw new FulfillmentServiceRequestFailedException(
+                    new IOException("풀필먼트 작업 상태 조회 비정상 응답 - orderId: " + orderId));
+        } catch (FulfillmentServiceRequestFailedException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("풀필먼트 작업 상태 조회 실패 - orderId: {}", orderId, e);
+            throw new FulfillmentServiceRequestFailedException(new IOException(e));
+        }
+    }
+
+    private URI buildWorkStatusUri(Long orderId) {
+        return UriComponentsBuilder.fromHttpUrl(fulfillmentServiceBaseUrl)
+                .path("/api/v1/internal/fulfillment/deliveries/work-status")
+                .queryParam("order-id", orderId)
+                .build()
+                .toUri();
+    }
+}

--- a/commerce-service/commerce-adapters/src/main/resources/application.yml
+++ b/commerce-service/commerce-adapters/src/main/resources/application.yml
@@ -88,6 +88,9 @@ reward-service:
   base-url: ${REWARD_SERVICE_SERVER_ORIGIN:http://localhost:8084}
   share-point-rate: ${REWARD_SHARE_POINT_RATE:0.1}
 
+fulfillment-service:
+  base-url: ${FULFILLMENT_SERVICE_SERVER_ORIGIN:http://localhost:8083}
+
 kcp:
   site-cd: ${KCP_SITE_CD:T0000}
   cert-info-path: ${KCP_CERT_INFO_PATH:classpath:kcp/cert/kcp_test_cert.pem}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/fulfillment/GetFulfillmentWorkStatusPort.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/fulfillment/GetFulfillmentWorkStatusPort.java
@@ -1,0 +1,5 @@
+package com.personal.marketnote.commerce.port.out.fulfillment;
+
+public interface GetFulfillmentWorkStatusPort {
+    String getWorkStatus(Long orderId);
+}


### PR DESCRIPTION
## partially addresses #216
## resolves #1929

## Task
- [x] GetFulfillmentWorkStatusPort out port 생성
- [x] FulfillmentServiceClient 구현 (RestClient + HMAC 인증)
- [x] application.yml에 fulfillment-service.base-url 설정 추가