### PR TITLE
[#216][#1930] feat: 풀필먼트 취소 가능 상태 enum 정의

### DIFF
--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/fulfillment/CancellableFulfillmentWorkStatus.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/fulfillment/CancellableFulfillmentWorkStatus.java
@@ -1,0 +1,40 @@
+package com.personal.marketnote.commerce.domain.fulfillment;
+
+import com.personal.marketnote.common.utility.FormatValidator;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.EnumSet;
+import java.util.Set;
+
+@RequiredArgsConstructor
+@Getter
+public enum CancellableFulfillmentWorkStatus {
+    NOT_REGISTERED("출고 미접수"),
+    REGISTERED("출고 접수"),
+    PICKING("피킹 진행 중"),
+    PICKED("피킹 완료"),
+    PACKING("포장 중"),
+    RELEASED("출고 완료");
+
+    private final String description;
+
+    private static final Set<CancellableFulfillmentWorkStatus> CANCELLABLE_STATUSES = EnumSet.of(
+            NOT_REGISTERED, REGISTERED, PICKING
+    );
+
+    public boolean isCancellable() {
+        return CANCELLABLE_STATUSES.contains(this);
+    }
+
+    public static CancellableFulfillmentWorkStatus from(String workStatusCode) {
+        if (FormatValidator.hasNoValue(workStatusCode)) {
+            throw new InvalidFulfillmentWorkStatusException("null");
+        }
+        try {
+            return valueOf(workStatusCode);
+        } catch (IllegalArgumentException e) {
+            throw new InvalidFulfillmentWorkStatusException(workStatusCode);
+        }
+    }
+}

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/fulfillment/InvalidFulfillmentWorkStatusException.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/fulfillment/InvalidFulfillmentWorkStatusException.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.commerce.domain.fulfillment;
+
+public class InvalidFulfillmentWorkStatusException extends IllegalArgumentException {
+    public InvalidFulfillmentWorkStatusException(String workStatusCode) {
+        super("ERR_FULFILLMENT_01::유효하지 않은 풀필먼트 작업 상태입니다. workStatusCode=" + workStatusCode);
+    }
+}


### PR DESCRIPTION
## partially addresses #216
## resolves #1930

## Task
- [x] CancellableFulfillmentWorkStatus enum 정의 (commerce-domain)
- [x] 취소 가능 상태: NOT_REGISTERED, REGISTERED, PICKING
- [x] 취소 불가 상태: PICKED, PACKING, RELEASED
- [x] isCancellable() 술어 메서드 추가
- [x] from(String) 팩토리 메서드 추가 (풀필먼트 API 응답 String → enum 매핑)
- [x] InvalidFulfillmentWorkStatusException 커스텀 예외 추가
- [x] null 입력 방어 (FormatValidator.hasNoValue)