### PR TITLE
[#475][#2280] feat: 풀필먼트 출고 취소 내부 API 추가

### DIFF
--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/delivery/controller/InternalFulfillmentDeliveryController.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/delivery/controller/InternalFulfillmentDeliveryController.java
@@ -1,19 +1,23 @@
 package com.personal.marketnote.fulfillment.adapter.in.web.delivery.controller;
 
 import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
+import com.personal.marketnote.fulfillment.adapter.in.web.delivery.controller.apidocs.CancelInternalFulfillmentDeliveryApiDocs;
 import com.personal.marketnote.fulfillment.adapter.in.web.delivery.controller.apidocs.GetFulfillmentWorkStatusApiDocs;
+import com.personal.marketnote.fulfillment.adapter.in.web.delivery.request.CancelInternalFulfillmentDeliveryRequest;
+import com.personal.marketnote.fulfillment.adapter.in.web.delivery.response.CancelInternalFulfillmentDeliveryResponse;
 import com.personal.marketnote.fulfillment.adapter.in.web.delivery.response.GetFulfillmentWorkStatusResponse;
+import com.personal.marketnote.fulfillment.port.in.command.CancelInternalFulfillmentDeliveryCommand;
 import com.personal.marketnote.fulfillment.port.in.command.GetFulfillmentWorkStatusCommand;
+import com.personal.marketnote.fulfillment.port.in.result.CancelInternalFulfillmentDeliveryResult;
 import com.personal.marketnote.fulfillment.port.in.result.GetFulfillmentWorkStatusResult;
+import com.personal.marketnote.fulfillment.port.in.usecase.CancelInternalFulfillmentDeliveryUseCase;
 import com.personal.marketnote.fulfillment.port.in.usecase.GetFulfillmentWorkStatusUseCase;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import static com.personal.marketnote.common.domain.exception.ExceptionCode.DEFAULT_SUCCESS_CODE;
 
@@ -29,6 +33,7 @@ import static com.personal.marketnote.common.domain.exception.ExceptionCode.DEFA
 @RequiredArgsConstructor
 public class InternalFulfillmentDeliveryController {
     private final GetFulfillmentWorkStatusUseCase getFulfillmentWorkStatusUseCase;
+    private final CancelInternalFulfillmentDeliveryUseCase cancelInternalFulfillmentDeliveryUseCase;
 
     /**
      * 풀필먼트 작업 상태 조회 (서비스 간 통신용)
@@ -50,6 +55,31 @@ public class InternalFulfillmentDeliveryController {
                         HttpStatus.OK,
                         DEFAULT_SUCCESS_CODE,
                         "풀필먼트 작업 상태 조회 성공"
+                ),
+                HttpStatus.OK
+        );
+    }
+
+    /**
+     * 풀필먼트 출고 취소 (서비스 간 통신용)
+     *
+     * @param request 출고 취소 요청 (orderId)
+     */
+    @PostMapping("/cancel")
+    @CancelInternalFulfillmentDeliveryApiDocs
+    public ResponseEntity<BaseResponse<CancelInternalFulfillmentDeliveryResponse>> cancelDelivery(
+            @Valid @RequestBody CancelInternalFulfillmentDeliveryRequest request
+    ) {
+        CancelInternalFulfillmentDeliveryResult result = cancelInternalFulfillmentDeliveryUseCase.cancelDelivery(
+                new CancelInternalFulfillmentDeliveryCommand(request.orderId())
+        );
+
+        return new ResponseEntity<>(
+                BaseResponse.of(
+                        CancelInternalFulfillmentDeliveryResponse.from(result),
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "풀필먼트 출고 취소 처리 완료"
                 ),
                 HttpStatus.OK
         );

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/delivery/controller/apidocs/CancelInternalFulfillmentDeliveryApiDocs.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/delivery/controller/apidocs/CancelInternalFulfillmentDeliveryApiDocs.java
@@ -1,0 +1,28 @@
+package com.personal.marketnote.fulfillment.adapter.in.web.delivery.controller.apidocs;
+
+import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Operation(
+        summary = "풀필먼트 출고 취소",
+        description = "주문 ID로 풀필먼트 출고를 취소합니다. 서비스 간 통신용 내부 API입니다.",
+        responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "풀필먼트 출고 취소 처리 완료",
+                        content = @Content(schema = @Schema(implementation = BaseResponse.class))
+                )
+        }
+)
+public @interface CancelInternalFulfillmentDeliveryApiDocs {
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/delivery/request/CancelInternalFulfillmentDeliveryRequest.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/delivery/request/CancelInternalFulfillmentDeliveryRequest.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.fulfillment.adapter.in.web.delivery.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record CancelInternalFulfillmentDeliveryRequest(
+        @NotNull(message = "주문 ID는 필수입니다")
+        Long orderId
+) {
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/delivery/response/CancelInternalFulfillmentDeliveryResponse.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/delivery/response/CancelInternalFulfillmentDeliveryResponse.java
@@ -1,0 +1,17 @@
+package com.personal.marketnote.fulfillment.adapter.in.web.delivery.response;
+
+import com.personal.marketnote.fulfillment.port.in.result.CancelInternalFulfillmentDeliveryResult;
+
+public record CancelInternalFulfillmentDeliveryResponse(
+        Long orderId,
+        boolean cancelled,
+        String message
+) {
+    public static CancelInternalFulfillmentDeliveryResponse from(CancelInternalFulfillmentDeliveryResult result) {
+        return new CancelInternalFulfillmentDeliveryResponse(
+                result.orderId(),
+                result.cancelled(),
+                result.message()
+        );
+    }
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/client/FulfillmentCustomerCodeAdapter.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/vendor/fassto/client/FulfillmentCustomerCodeAdapter.java
@@ -1,0 +1,17 @@
+package com.personal.marketnote.fulfillment.adapter.out.vendor.fassto.client;
+
+import com.personal.marketnote.common.adapter.out.VendorAdapter;
+import com.personal.marketnote.fulfillment.configuration.FulfillmentAuthProperties;
+import com.personal.marketnote.fulfillment.port.out.vendor.GetFulfillmentCustomerCodePort;
+import lombok.RequiredArgsConstructor;
+
+@VendorAdapter
+@RequiredArgsConstructor
+public class FulfillmentCustomerCodeAdapter implements GetFulfillmentCustomerCodePort {
+    private final FulfillmentAuthProperties fulfillmentAuthProperties;
+
+    @Override
+    public String getCustomerCode() {
+        return fulfillmentAuthProperties.getCustomerCode();
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/FulfillmentDeliveryCancellationNotAllowedException.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/FulfillmentDeliveryCancellationNotAllowedException.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.fulfillment.exception;
+
+import com.personal.marketnote.fulfillment.domain.delivery.FulfillmentWorkStatus;
+
+public class FulfillmentDeliveryCancellationNotAllowedException extends RuntimeException {
+    public FulfillmentDeliveryCancellationNotAllowedException(FulfillmentWorkStatus currentStatus) {
+        super("현재 작업 상태에서는 출고 취소가 불가합니다. workStatus=" + currentStatus.name());
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/FulfillmentDeliveryRegistrationNotFoundException.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/FulfillmentDeliveryRegistrationNotFoundException.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.fulfillment.exception;
+
+public class FulfillmentDeliveryRegistrationNotFoundException extends RuntimeException {
+    public FulfillmentDeliveryRegistrationNotFoundException(Long orderId) {
+        super("orderId에 해당하는 출고 등록을 찾을 수 없습니다. orderId=" + orderId);
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/CancelInternalFulfillmentDeliveryCommand.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/CancelInternalFulfillmentDeliveryCommand.java
@@ -1,0 +1,4 @@
+package com.personal.marketnote.fulfillment.port.in.command;
+
+public record CancelInternalFulfillmentDeliveryCommand(Long orderId) {
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/result/CancelInternalFulfillmentDeliveryResult.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/result/CancelInternalFulfillmentDeliveryResult.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.fulfillment.port.in.result;
+
+public record CancelInternalFulfillmentDeliveryResult(
+        Long orderId,
+        boolean cancelled,
+        String message
+) {
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/usecase/CancelInternalFulfillmentDeliveryUseCase.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/usecase/CancelInternalFulfillmentDeliveryUseCase.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.fulfillment.port.in.usecase;
+
+import com.personal.marketnote.fulfillment.port.in.command.CancelInternalFulfillmentDeliveryCommand;
+import com.personal.marketnote.fulfillment.port.in.result.CancelInternalFulfillmentDeliveryResult;
+
+public interface CancelInternalFulfillmentDeliveryUseCase {
+    CancelInternalFulfillmentDeliveryResult cancelDelivery(CancelInternalFulfillmentDeliveryCommand command);
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/vendor/GetFulfillmentCustomerCodePort.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/vendor/GetFulfillmentCustomerCodePort.java
@@ -1,0 +1,5 @@
+package com.personal.marketnote.fulfillment.port.out.vendor;
+
+public interface GetFulfillmentCustomerCodePort {
+    String getCustomerCode();
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/CancelInternalFulfillmentDeliveryService.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/CancelInternalFulfillmentDeliveryService.java
@@ -1,0 +1,70 @@
+package com.personal.marketnote.fulfillment.service;
+
+import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.fulfillment.domain.FulfillmentAccessToken;
+import com.personal.marketnote.fulfillment.domain.delivery.FulfillmentDeliveryRegistration;
+import com.personal.marketnote.fulfillment.exception.FulfillmentDeliveryCancellationNotAllowedException;
+import com.personal.marketnote.fulfillment.exception.FulfillmentDeliveryRegistrationNotFoundException;
+import com.personal.marketnote.fulfillment.port.in.command.CancelInternalFulfillmentDeliveryCommand;
+import com.personal.marketnote.fulfillment.port.in.command.vendor.CancelFulfillmentDeliveryCommand;
+import com.personal.marketnote.fulfillment.port.in.command.vendor.CancelFulfillmentDeliveryItemCommand;
+import com.personal.marketnote.fulfillment.port.in.result.CancelInternalFulfillmentDeliveryResult;
+import com.personal.marketnote.fulfillment.port.in.usecase.CancelInternalFulfillmentDeliveryUseCase;
+import com.personal.marketnote.fulfillment.port.out.delivery.FindFulfillmentDeliveryRegistrationPort;
+import com.personal.marketnote.fulfillment.port.out.vendor.CancelFulfillmentDeliveryPort;
+import com.personal.marketnote.fulfillment.port.out.vendor.DisconnectFulfillmentAuthPort;
+import com.personal.marketnote.fulfillment.port.out.vendor.GetFulfillmentCustomerCodePort;
+import com.personal.marketnote.fulfillment.port.out.vendor.RequestFulfillmentAuthPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional(isolation = READ_COMMITTED, readOnly = true)
+public class CancelInternalFulfillmentDeliveryService implements CancelInternalFulfillmentDeliveryUseCase {
+    private final FindFulfillmentDeliveryRegistrationPort findFulfillmentDeliveryRegistrationPort;
+    private final GetFulfillmentCustomerCodePort getFulfillmentCustomerCodePort;
+    private final RequestFulfillmentAuthPort requestFulfillmentAuthPort;
+    private final DisconnectFulfillmentAuthPort disconnectFulfillmentAuthPort;
+    private final CancelFulfillmentDeliveryPort cancelFulfillmentDeliveryPort;
+
+    @Override
+    public CancelInternalFulfillmentDeliveryResult cancelDelivery(CancelInternalFulfillmentDeliveryCommand command) {
+        FulfillmentDeliveryRegistration registration = findRegistration(command.orderId());
+        validateCancellable(registration);
+
+        FulfillmentAccessToken accessToken = requestFulfillmentAuthPort.requestAccessToken();
+        try {
+            String customerCode = getFulfillmentCustomerCodePort.getCustomerCode();
+            CancelFulfillmentDeliveryCommand cancelCommand = buildCancelCommand(
+                    customerCode, accessToken.getValue(), command.orderId()
+            );
+            cancelFulfillmentDeliveryPort.cancelDelivery(cancelCommand);
+
+            return new CancelInternalFulfillmentDeliveryResult(command.orderId(), true, "출고 취소 성공");
+        } finally {
+            disconnectFulfillmentAuthPort.disconnectAccessToken(accessToken.getValue());
+        }
+    }
+
+    private FulfillmentDeliveryRegistration findRegistration(Long orderId) {
+        return findFulfillmentDeliveryRegistrationPort.findByOrderId(orderId)
+                .orElseThrow(() -> new FulfillmentDeliveryRegistrationNotFoundException(orderId));
+    }
+
+    private void validateCancellable(FulfillmentDeliveryRegistration registration) {
+        if (!registration.isCancellable()) {
+            throw new FulfillmentDeliveryCancellationNotAllowedException(registration.getWorkStatus());
+        }
+    }
+
+    private CancelFulfillmentDeliveryCommand buildCancelCommand(String customerCode, String accessToken, Long orderId) {
+        String orderNumber = String.valueOf(orderId);
+        CancelFulfillmentDeliveryItemCommand itemCommand = CancelFulfillmentDeliveryItemCommand.of(orderNumber, orderNumber);
+        return CancelFulfillmentDeliveryCommand.of(customerCode, accessToken, List.of(itemCommand));
+    }
+}

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/delivery/FulfillmentDeliveryRegistration.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/delivery/FulfillmentDeliveryRegistration.java
@@ -34,4 +34,8 @@ public class FulfillmentDeliveryRegistration {
                 .createdAt(state.getCreatedAt())
                 .build();
     }
+
+    public boolean isCancellable() {
+        return workStatus.isCancellable();
+    }
 }

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/delivery/FulfillmentWorkStatus.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/delivery/FulfillmentWorkStatus.java
@@ -3,6 +3,9 @@ package com.personal.marketnote.fulfillment.domain.delivery;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+import java.util.EnumSet;
+import java.util.Set;
+
 @RequiredArgsConstructor
 @Getter
 public enum FulfillmentWorkStatus {
@@ -14,6 +17,14 @@ public enum FulfillmentWorkStatus {
     RELEASED("출고 완료");
 
     private final String description;
+
+    private static final Set<FulfillmentWorkStatus> CANCELLABLE_STATUSES = EnumSet.of(
+            NOT_REGISTERED, REGISTERED, PICKING
+    );
+
+    public boolean isCancellable() {
+        return CANCELLABLE_STATUSES.contains(this);
+    }
 
     public boolean isNotRegistered() {
         return this == NOT_REGISTERED;


### PR DESCRIPTION
## partially addresses #475
## resolves #2280

## Task
- [x] 내부 출고 취소 엔드포인트 추가 (POST /api/v1/internal/fulfillment/deliveries/cancel)
- [x] orderId만 받아 Fassto 세부사항(customerCode, accessToken, slipNumber)은 내부에서 해소
- [x] 기존 CancelFulfillmentDeliveryPort를 활용하여 Fassto 출고 취소 호출
- [x] 취소 성공/실패 응답 반환 (피킹완료 이후 취소 불가 시 실패 응답)