### PR TITLE
[#43][#2226] feat: 도서산간 지역 도메인 및 엔티티 추가

### DIFF
--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/out/mapper/RemoteAreaJpaEntityToDomainMapper.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/out/mapper/RemoteAreaJpaEntityToDomainMapper.java
@@ -1,0 +1,19 @@
+package com.personal.marketnote.user.adapter.out.mapper;
+
+import com.personal.marketnote.user.adapter.out.persistence.remotearea.entity.RemoteAreaJpaEntity;
+import com.personal.marketnote.user.domain.remotearea.RemoteArea;
+import com.personal.marketnote.user.domain.remotearea.RemoteAreaSnapshotState;
+
+public class RemoteAreaJpaEntityToDomainMapper {
+
+    public static RemoteArea mapToDomain(RemoteAreaJpaEntity entity) {
+        return RemoteArea.from(
+                RemoteAreaSnapshotState.builder()
+                        .id(entity.getId())
+                        .zipCode(entity.getZipCode())
+                        .remoteAreaType(entity.getRemoteAreaType())
+                        .regionName(entity.getRegionName())
+                        .build()
+        );
+    }
+}

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/out/persistence/remotearea/entity/RemoteAreaJpaEntity.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/out/persistence/remotearea/entity/RemoteAreaJpaEntity.java
@@ -1,0 +1,37 @@
+package com.personal.marketnote.user.adapter.out.persistence.remotearea.entity;
+
+import com.personal.marketnote.common.adapter.out.persistence.audit.BaseGeneralEntity;
+import com.personal.marketnote.user.domain.remotearea.RemoteArea;
+import com.personal.marketnote.user.domain.remotearea.RemoteAreaType;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(
+        name = "remote_areas",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"zip_code"})
+)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+@Getter
+public class RemoteAreaJpaEntity extends BaseGeneralEntity {
+
+    @Column(name = "zip_code", nullable = false, length = 5)
+    private String zipCode;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "remote_area_type", nullable = false, length = 30)
+    private RemoteAreaType remoteAreaType;
+
+    @Column(name = "region_name", nullable = false, length = 100)
+    private String regionName;
+
+    public static RemoteAreaJpaEntity from(RemoteArea remoteArea) {
+        return RemoteAreaJpaEntity.builder()
+                .zipCode(remoteArea.getZipCode())
+                .remoteAreaType(remoteArea.getRemoteAreaType())
+                .regionName(remoteArea.getRegionName())
+                .build();
+    }
+}

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/out/persistence/remotearea/repository/RemoteAreaJpaRepository.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/out/persistence/remotearea/repository/RemoteAreaJpaRepository.java
@@ -1,0 +1,17 @@
+package com.personal.marketnote.user.adapter.out.persistence.remotearea.repository;
+
+import com.personal.marketnote.common.domain.EntityStatus;
+import com.personal.marketnote.user.adapter.out.persistence.remotearea.entity.RemoteAreaJpaEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface RemoteAreaJpaRepository extends JpaRepository<RemoteAreaJpaEntity, Long> {
+
+    Optional<RemoteAreaJpaEntity> findByZipCodeAndStatus(String zipCode, EntityStatus status);
+
+    List<RemoteAreaJpaEntity> findAllByStatus(EntityStatus status);
+
+    boolean existsByZipCodeAndStatus(String zipCode, EntityStatus status);
+}

--- a/user-service/user-adapters/src/main/resources/db/migration/V20260407__create_remote_areas_table.sql
+++ b/user-service/user-adapters/src/main/resources/db/migration/V20260407__create_remote_areas_table.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS remote_areas
+(
+    id               BIGSERIAL PRIMARY KEY,
+    zip_code         VARCHAR(5)   NOT NULL UNIQUE,
+    remote_area_type VARCHAR(30)  NOT NULL,
+    region_name      VARCHAR(100) NOT NULL,
+    status           VARCHAR(20)  NOT NULL DEFAULT 'ACTIVE',
+    created_at       TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    modified_at      TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX idx_remote_areas_zip_code_status ON remote_areas (zip_code, status);

--- a/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/remotearea/RemoteArea.java
+++ b/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/remotearea/RemoteArea.java
@@ -1,0 +1,79 @@
+package com.personal.marketnote.user.domain.remotearea;
+
+import com.personal.marketnote.common.domain.BaseDomain;
+import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.user.domain.remotearea.exception.InvalidRemoteAreaRegionNameLengthException;
+import com.personal.marketnote.user.domain.remotearea.exception.InvalidRemoteAreaZipCodeException;
+import com.personal.marketnote.user.domain.remotearea.exception.RemoteAreaRegionNameNoValueException;
+import com.personal.marketnote.user.domain.remotearea.exception.RemoteAreaTypeNoValueException;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.regex.Pattern;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+@Getter
+public class RemoteArea extends BaseDomain {
+
+    private static final Pattern ZIP_CODE_PATTERN = Pattern.compile("^\\d{5}$");
+
+    private Long id;
+    private String zipCode;
+    private RemoteAreaType remoteAreaType;
+    private String regionName;
+
+    public static RemoteArea from(RemoteAreaCreateState state) {
+        validateZipCode(state.getZipCode());
+        validateRemoteAreaType(state.getRemoteAreaType());
+        validateRegionName(state.getRegionName());
+
+        return RemoteArea.builder()
+                .zipCode(state.getZipCode())
+                .remoteAreaType(state.getRemoteAreaType())
+                .regionName(state.getRegionName())
+                .build();
+    }
+
+    public static RemoteArea from(RemoteAreaSnapshotState state) {
+        return RemoteArea.builder()
+                .id(state.getId())
+                .zipCode(state.getZipCode())
+                .remoteAreaType(state.getRemoteAreaType())
+                .regionName(state.getRegionName())
+                .build();
+    }
+
+    public boolean isJeju() {
+        return remoteAreaType.isJeju();
+    }
+
+    public boolean isIslandMountainous() {
+        return remoteAreaType.isIslandMountainous();
+    }
+
+    private static void validateZipCode(String zipCode) {
+        if (!FormatValidator.isValid(zipCode, ZIP_CODE_PATTERN)) {
+            throw new InvalidRemoteAreaZipCodeException();
+        }
+    }
+
+    private static void validateRemoteAreaType(RemoteAreaType remoteAreaType) {
+        if (FormatValidator.hasNoValue(remoteAreaType)) {
+            throw new RemoteAreaTypeNoValueException();
+        }
+    }
+
+    private static void validateRegionName(String regionName) {
+        if (FormatValidator.hasNoValue(regionName)) {
+            throw new RemoteAreaRegionNameNoValueException();
+        }
+        if (regionName.length() > 100) {
+            throw new InvalidRemoteAreaRegionNameLengthException();
+        }
+    }
+}

--- a/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/remotearea/RemoteAreaCreateState.java
+++ b/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/remotearea/RemoteAreaCreateState.java
@@ -1,0 +1,15 @@
+package com.personal.marketnote.user.domain.remotearea;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class RemoteAreaCreateState {
+    private final String zipCode;
+    private final RemoteAreaType remoteAreaType;
+    private final String regionName;
+}

--- a/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/remotearea/RemoteAreaSnapshotState.java
+++ b/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/remotearea/RemoteAreaSnapshotState.java
@@ -1,0 +1,16 @@
+package com.personal.marketnote.user.domain.remotearea;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class RemoteAreaSnapshotState {
+    private final Long id;
+    private final String zipCode;
+    private final RemoteAreaType remoteAreaType;
+    private final String regionName;
+}

--- a/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/remotearea/RemoteAreaType.java
+++ b/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/remotearea/RemoteAreaType.java
@@ -1,0 +1,20 @@
+package com.personal.marketnote.user.domain.remotearea;
+
+public enum RemoteAreaType {
+    JEJU("제주"),
+    ISLAND_MOUNTAINOUS("도서산간");
+
+    private final String description;
+
+    RemoteAreaType(String description) {
+        this.description = description;
+    }
+
+    public boolean isJeju() {
+        return this == JEJU;
+    }
+
+    public boolean isIslandMountainous() {
+        return this == ISLAND_MOUNTAINOUS;
+    }
+}

--- a/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/remotearea/exception/InvalidRemoteAreaRegionNameLengthException.java
+++ b/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/remotearea/exception/InvalidRemoteAreaRegionNameLengthException.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.user.domain.remotearea.exception;
+
+public class InvalidRemoteAreaRegionNameLengthException extends IllegalArgumentException {
+
+    public InvalidRemoteAreaRegionNameLengthException() {
+        super("ERR_REMOTE_AREA_04::도서산간 지역명은 최대 100자까지 입력할 수 있습니다.");
+    }
+}

--- a/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/remotearea/exception/InvalidRemoteAreaZipCodeException.java
+++ b/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/remotearea/exception/InvalidRemoteAreaZipCodeException.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.user.domain.remotearea.exception;
+
+public class InvalidRemoteAreaZipCodeException extends IllegalArgumentException {
+
+    public InvalidRemoteAreaZipCodeException() {
+        super("ERR_REMOTE_AREA_01::유효하지 않은 우편번호입니다. 우편번호는 5자리 숫자여야 합니다.");
+    }
+}

--- a/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/remotearea/exception/RemoteAreaRegionNameNoValueException.java
+++ b/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/remotearea/exception/RemoteAreaRegionNameNoValueException.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.user.domain.remotearea.exception;
+
+public class RemoteAreaRegionNameNoValueException extends RuntimeException {
+
+    public RemoteAreaRegionNameNoValueException() {
+        super("ERR_REMOTE_AREA_03::도서산간 지역명은 필수입니다.");
+    }
+}

--- a/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/remotearea/exception/RemoteAreaTypeNoValueException.java
+++ b/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/remotearea/exception/RemoteAreaTypeNoValueException.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.user.domain.remotearea.exception;
+
+public class RemoteAreaTypeNoValueException extends RuntimeException {
+
+    public RemoteAreaTypeNoValueException() {
+        super("ERR_REMOTE_AREA_02::도서산간 지역 유형은 필수입니다.");
+    }
+}


### PR DESCRIPTION
## partially addresses #43
## resolves #2226

## Task
- [x] RemoteArea 도메인 모델 추가 (user-domain)
- [x] RemoteAreaCreateState, RemoteAreaSnapshotState 추가
- [x] RemoteAreaType enum 추가 (JEJU, ISLAND_MOUNTAINOUS)
- [x] RemoteAreaJpaEntity 추가 (user-adapters)
- [x] RemoteAreaJpaRepository 추가
- [x] RemoteAreaJpaEntityToDomainMapper 추가
- [x] DB Migration 스크립트 추가