### PR TITLE
[#216][#2283] test: 커머스 서비스 풀필먼트 출고 취소 클라이언트 자동화 테스트 추가

### DIFF
--- a/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/out/web/fulfillment/FulfillmentServiceClientTest.java
+++ b/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/out/web/fulfillment/FulfillmentServiceClientTest.java
@@ -1,5 +1,6 @@
 package com.personal.marketnote.commerce.adapter.out.web.fulfillment;
 
+import com.personal.marketnote.commerce.port.out.fulfillment.CancelFulfillmentReleaseResult;
 import com.personal.marketnote.common.exception.FulfillmentServiceRequestFailedException;
 import com.personal.marketnote.common.security.hmac.HmacServiceAuthHeaderBuilder;
 import org.junit.jupiter.api.BeforeEach;
@@ -105,6 +106,78 @@ class FulfillmentServiceClientTest {
 
             // when & then
             assertThatThrownBy(() -> fulfillmentServiceClient.getWorkStatus(ORDER_ID))
+                    .isInstanceOf(FulfillmentServiceRequestFailedException.class);
+
+            mockServer.verify();
+        }
+    }
+
+    @Nested
+    @DisplayName("cancelRelease")
+    class CancelRelease {
+
+        @Test
+        @DisplayName("출고 취소에 성공하면 cancelled=true 결과를 반환한다")
+        void shouldReturnCancelledTrueWhenCancelSucceeds() {
+            // given
+            mockServer.expect(requestTo(BASE_URL + "/api/v1/internal/fulfillment/deliveries/cancel"))
+                    .andExpect(method(HttpMethod.POST))
+                    .andRespond(withSuccess("""
+                            {
+                                "content": {
+                                    "orderId": 100,
+                                    "cancelled": true,
+                                    "message": "출고 취소 처리 완료"
+                                }
+                            }
+                            """, MediaType.APPLICATION_JSON));
+
+            // when
+            CancelFulfillmentReleaseResult result = fulfillmentServiceClient.cancelRelease(ORDER_ID);
+
+            // then
+            assertThat(result.orderId()).isEqualTo(ORDER_ID);
+            assertThat(result.cancelled()).isTrue();
+            assertThat(result.message()).isEqualTo("출고 취소 처리 완료");
+            mockServer.verify();
+        }
+
+        @Test
+        @DisplayName("이미 출고된 주문이면 cancelled=false 결과를 반환한다")
+        void shouldReturnCancelledFalseWhenAlreadyShipped() {
+            // given
+            mockServer.expect(requestTo(BASE_URL + "/api/v1/internal/fulfillment/deliveries/cancel"))
+                    .andExpect(method(HttpMethod.POST))
+                    .andRespond(withSuccess("""
+                            {
+                                "content": {
+                                    "orderId": 100,
+                                    "cancelled": false,
+                                    "message": "이미 출고된 주문은 취소할 수 없습니다"
+                                }
+                            }
+                            """, MediaType.APPLICATION_JSON));
+
+            // when
+            CancelFulfillmentReleaseResult result = fulfillmentServiceClient.cancelRelease(ORDER_ID);
+
+            // then
+            assertThat(result.orderId()).isEqualTo(ORDER_ID);
+            assertThat(result.cancelled()).isFalse();
+            assertThat(result.message()).isEqualTo("이미 출고된 주문은 취소할 수 없습니다");
+            mockServer.verify();
+        }
+
+        @Test
+        @DisplayName("풀필먼트 서비스 요청이 실패하면 FulfillmentServiceRequestFailedException이 발생한다")
+        void shouldThrowExceptionWhenRequestFails() {
+            // given
+            mockServer.expect(requestTo(BASE_URL + "/api/v1/internal/fulfillment/deliveries/cancel"))
+                    .andExpect(method(HttpMethod.POST))
+                    .andRespond(withServerError());
+
+            // when & then
+            assertThatThrownBy(() -> fulfillmentServiceClient.cancelRelease(ORDER_ID))
                     .isInstanceOf(FulfillmentServiceRequestFailedException.class);
 
             mockServer.verify();


### PR DESCRIPTION
## partially addresses #216
## resolves #2283

## Test Case
- [x] 출고 취소에 성공하면 cancelled=true 결과를 반환한다
- [x] 이미 출고된 주문이면 cancelled=false 결과를 반환한다
- [x] 풀필먼트 서비스 요청이 실패하면 FulfillmentServiceRequestFailedException이 발생한다