### PR TITLE
[#300][#2306] refactor: PostSortProperty switch 중복 제거 리팩토링

### DIFF
--- a/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/out/persistence/post/PostPersistenceAdapter.java
+++ b/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/out/persistence/post/PostPersistenceAdapter.java
@@ -195,7 +195,7 @@ public class PostPersistenceAdapter implements SavePostPort, FindPostPort, Updat
             boolean isDesc,
             PostSortProperty sortProperty
     ) {
-        String sortField = getSortField(sortProperty);
+        String sortField = sortProperty.getSortField();
         Sort sort = isDesc ? Sort.by(Sort.Direction.DESC, sortField) : Sort.by(Sort.Direction.ASC, sortField);
         Pageable pageable = PageRequest.of(page - 1, pageSize, sort);
 
@@ -204,13 +204,6 @@ public class PostPersistenceAdapter implements SavePostPort, FindPostPort, Updat
                         userId, board, EntityStatus.ACTIVE, pageable
                 )
         );
-    }
-
-    private String getSortField(PostSortProperty sortProperty) {
-        return switch (sortProperty) {
-            case ORDER_NUM -> "orderNum";
-            case IS_ANSWERED, ID -> "id";
-        };
     }
 
     @Override

--- a/community-service/community-application/src/main/java/com/personal/marketnote/community/service/post/GetPostService.java
+++ b/community-service/community-application/src/main/java/com/personal/marketnote/community/service/post/GetPostService.java
@@ -53,7 +53,7 @@ public class GetPostService implements GetPostUseCase {
                 ? query.sortDirection()
                 : Sort.Direction.DESC;
         PostSortProperty sortProperty = resolveSortProperty(query);
-        Pageable pageable = PageRequest.of(0, query.pageSize() + 1, Sort.by(sortDirection, getSortField(sortProperty)));
+        Pageable pageable = PageRequest.of(0, query.pageSize() + 1, Sort.by(sortDirection, sortProperty.getSortField()));
 
         Posts posts = getBoardPosts(query, pageable, sortProperty);
 
@@ -277,13 +277,6 @@ public class GetPostService implements GetPostUseCase {
         }
 
         return FormatValidator.hasValue(query.sortProperty()) ? query.sortProperty() : PostSortProperty.ID;
-    }
-
-    private String getSortField(PostSortProperty sortProperty) {
-        return switch (sortProperty) {
-            case ORDER_NUM -> "orderNum";
-            case IS_ANSWERED, ID -> "id";
-        };
     }
 
     private boolean matchesKeyword(Post post, PostSearchTarget searchTarget, String searchKeyword) {

--- a/community-service/community-domain/src/main/java/com/personal/marketnote/community/domain/post/PostSortProperty.java
+++ b/community-service/community-domain/src/main/java/com/personal/marketnote/community/domain/post/PostSortProperty.java
@@ -5,15 +5,17 @@ import lombok.Getter;
 
 @Getter
 public enum PostSortProperty {
-    ORDER_NUM("지정된 정렬 순서순"),
-    ID("기본키(최신순)"),
-    IS_ANSWERED("답변 여부");
+    ORDER_NUM("지정된 정렬 순서순", "orderNum"),
+    ID("기본키(최신순)", "id"),
+    IS_ANSWERED("답변 여부", "id");
 
     private final String description;
     private final String camelCaseValue;
+    private final String sortField;
 
-    PostSortProperty(String description) {
+    PostSortProperty(String description, String sortField) {
         this.description = description;
         this.camelCaseValue = FormatConverter.snakeToCamel(this.name());
+        this.sortField = sortField;
     }
 }


### PR DESCRIPTION
## partially addresses #300
## resolves #2306

## Task
- [x] PostSortProperty enum에 sortField 필드 추가
- [x] GetPostService.getSortField() 메서드 제거 및 sortProperty.getSortField() 대체
- [x] PostPersistenceAdapter.getSortField() 메서드 제거 및 sortProperty.getSortField() 대체