### PR TITLE
[#216][#2294] feat: 주문 취소 이벤트 정의 및 발행 인프라 추가

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/event/OrderEventKafkaProducer.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/event/OrderEventKafkaProducer.java
@@ -6,6 +6,7 @@ import com.personal.marketnote.commerce.port.out.event.PublishOrderEventPort;
 import com.personal.marketnote.common.adapter.out.ServiceAdapter;
 import com.personal.marketnote.common.kafka.KafkaTopicConstants;
 import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.OrderCancelledEvent;
 import com.personal.marketnote.common.kafka.event.OrderPaymentCompletedEvent;
 import com.personal.marketnote.common.kafka.event.OrderPaymentCompletedEvent.OrderProductItem;
 import com.personal.marketnote.common.kafka.event.OrderPurchaseConfirmedEvent;
@@ -57,6 +58,42 @@ public class OrderEventKafkaProducer implements PublishOrderEventPort {
         OrderPurchaseConfirmedEvent payload = new OrderPurchaseConfirmedEvent(orderId, buyerId, sharerKeys);
         String topic = KafkaTopicConstants.ORDER_PURCHASE_CONFIRMED;
         EventEnvelope<OrderPurchaseConfirmedEvent> envelope = EventEnvelope.of(
+                topic, SOURCE, payload, clock
+        );
+
+        saveToOutbox(envelope, topic, orderId.toString());
+    }
+
+    @Override
+    public void publishOrderCancelledEvent(Long orderId, String orderKey, Long buyerId,
+                                           Long cancelAmount, Long paymentAmount, Long pointAmount,
+                                           Long shippingFee, boolean isFullCancel, Long alreadyRefunded,
+                                           List<OrderProduct> orderProducts, List<OrderProduct> cancelProducts) {
+        List<OrderCancelledEvent.OrderProductItem> items = orderProducts.stream()
+                .map(op -> new OrderCancelledEvent.OrderProductItem(
+                        op.getPricePolicyId(),
+                        op.getSharerKey(),
+                        op.getQuantity(),
+                        op.getUnitAmount()
+                ))
+                .toList();
+
+        List<OrderCancelledEvent.OrderProductItem> cancelItems = cancelProducts.stream()
+                .map(op -> new OrderCancelledEvent.OrderProductItem(
+                        op.getPricePolicyId(),
+                        op.getSharerKey(),
+                        op.getQuantity(),
+                        op.getUnitAmount()
+                ))
+                .toList();
+
+        OrderCancelledEvent payload = new OrderCancelledEvent(
+                orderId, orderKey, buyerId, cancelAmount, paymentAmount,
+                pointAmount, shippingFee, isFullCancel, alreadyRefunded,
+                items, cancelItems
+        );
+        String topic = KafkaTopicConstants.ORDER_CANCELLED;
+        EventEnvelope<OrderCancelledEvent> envelope = EventEnvelope.of(
                 topic, SOURCE, payload, clock
         );
 

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/event/PublishOrderEventPort.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/event/PublishOrderEventPort.java
@@ -12,4 +12,9 @@ public interface PublishOrderEventPort {
                                            Long totalAccumulatedPoint);
 
     void publishOrderPurchaseConfirmedEvent(Long orderId, Long buyerId, List<UUID> sharerKeys);
+
+    void publishOrderCancelledEvent(Long orderId, String orderKey, Long buyerId,
+                                    Long cancelAmount, Long paymentAmount, Long pointAmount,
+                                    Long shippingFee, boolean isFullCancel, Long alreadyRefunded,
+                                    List<OrderProduct> orderProducts, List<OrderProduct> cancelProducts);
 }

--- a/common/src/main/java/com/personal/marketnote/common/kafka/KafkaTopicConstants.java
+++ b/common/src/main/java/com/personal/marketnote/common/kafka/KafkaTopicConstants.java
@@ -11,6 +11,7 @@ public final class KafkaTopicConstants {
     public static final String PAYMENT_FAILED = "commerce.payment.failed";
     public static final String PAYMENT_CANCELLED = "commerce.payment.cancelled";
     public static final String SETTLEMENT_EXECUTED = "commerce.settlement.executed";
+    public static final String ORDER_CANCELLED = "commerce.order.cancelled";
     public static final String ORDER_PURCHASE_CONFIRMED = "commerce.order.purchase-confirmed";
 
     // Product 이벤트

--- a/common/src/main/java/com/personal/marketnote/common/kafka/event/OrderCancelledEvent.java
+++ b/common/src/main/java/com/personal/marketnote/common/kafka/event/OrderCancelledEvent.java
@@ -1,0 +1,27 @@
+package com.personal.marketnote.common.kafka.event;
+
+import java.util.List;
+import java.util.UUID;
+
+public record OrderCancelledEvent(
+        Long orderId,
+        String orderKey,
+        Long buyerId,
+        Long cancelAmount,
+        Long paymentAmount,
+        Long pointAmount,
+        Long shippingFee,
+        boolean isFullCancel,
+        Long alreadyRefunded,
+        List<OrderProductItem> orderProducts,
+        List<OrderProductItem> cancelProducts
+) {
+
+    public record OrderProductItem(
+            Long pricePolicyId,
+            UUID sharerKey,
+            Integer quantity,
+            Long unitAmount
+    ) {
+    }
+}

--- a/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/out/persistence/post/PostPersistenceAdapter.java
+++ b/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/out/persistence/post/PostPersistenceAdapter.java
@@ -195,7 +195,7 @@ public class PostPersistenceAdapter implements SavePostPort, FindPostPort, Updat
             boolean isDesc,
             PostSortProperty sortProperty
     ) {
-        String sortField = sortProperty.getSortField();
+        String sortField = getSortField(sortProperty);
         Sort sort = isDesc ? Sort.by(Sort.Direction.DESC, sortField) : Sort.by(Sort.Direction.ASC, sortField);
         Pageable pageable = PageRequest.of(page - 1, pageSize, sort);
 
@@ -204,6 +204,13 @@ public class PostPersistenceAdapter implements SavePostPort, FindPostPort, Updat
                         userId, board, EntityStatus.ACTIVE, pageable
                 )
         );
+    }
+
+    private String getSortField(PostSortProperty sortProperty) {
+        return switch (sortProperty) {
+            case ORDER_NUM -> "orderNum";
+            case IS_ANSWERED, ID -> "id";
+        };
     }
 
     @Override

--- a/community-service/community-application/src/main/java/com/personal/marketnote/community/service/post/GetPostService.java
+++ b/community-service/community-application/src/main/java/com/personal/marketnote/community/service/post/GetPostService.java
@@ -53,7 +53,7 @@ public class GetPostService implements GetPostUseCase {
                 ? query.sortDirection()
                 : Sort.Direction.DESC;
         PostSortProperty sortProperty = resolveSortProperty(query);
-        Pageable pageable = PageRequest.of(0, query.pageSize() + 1, Sort.by(sortDirection, sortProperty.getSortField()));
+        Pageable pageable = PageRequest.of(0, query.pageSize() + 1, Sort.by(sortDirection, getSortField(sortProperty)));
 
         Posts posts = getBoardPosts(query, pageable, sortProperty);
 
@@ -277,6 +277,13 @@ public class GetPostService implements GetPostUseCase {
         }
 
         return FormatValidator.hasValue(query.sortProperty()) ? query.sortProperty() : PostSortProperty.ID;
+    }
+
+    private String getSortField(PostSortProperty sortProperty) {
+        return switch (sortProperty) {
+            case ORDER_NUM -> "orderNum";
+            case IS_ANSWERED, ID -> "id";
+        };
     }
 
     private boolean matchesKeyword(Post post, PostSearchTarget searchTarget, String searchKeyword) {

--- a/community-service/community-domain/src/main/java/com/personal/marketnote/community/domain/post/PostSortProperty.java
+++ b/community-service/community-domain/src/main/java/com/personal/marketnote/community/domain/post/PostSortProperty.java
@@ -5,17 +5,15 @@ import lombok.Getter;
 
 @Getter
 public enum PostSortProperty {
-    ORDER_NUM("지정된 정렬 순서순", "orderNum"),
-    ID("기본키(최신순)", "id"),
-    IS_ANSWERED("답변 여부", "id");
+    ORDER_NUM("지정된 정렬 순서순"),
+    ID("기본키(최신순)"),
+    IS_ANSWERED("답변 여부");
 
     private final String description;
     private final String camelCaseValue;
-    private final String sortField;
 
-    PostSortProperty(String description, String sortField) {
+    PostSortProperty(String description) {
         this.description = description;
         this.camelCaseValue = FormatConverter.snakeToCamel(this.name());
-        this.sortField = sortField;
     }
 }


### PR DESCRIPTION
## partially addresses #216
## resolves #2294

## Task
- [x] OrderCancelledEvent record 정의 (common 모듈)
- [x] KafkaTopicConstants에 ORDER_CANCELLED 토픽 추가
- [x] PublishOrderEventPort에 publishOrderCancelledEvent 메서드 추가
- [x] OrderEventKafkaProducer에 Outbox 기반 구현 추가