### PR TITLE
[#216][#2295] test: 주문 취소 이벤트 정의 및 발행 인프라 자동화 테스트 추가

### DIFF
--- a/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/out/event/OrderEventKafkaProducerTest.java
+++ b/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/out/event/OrderEventKafkaProducerTest.java
@@ -6,6 +6,7 @@ import com.personal.marketnote.commerce.domain.order.OrderProductSnapshotState;
 import com.personal.marketnote.commerce.domain.order.OrderStatus;
 import com.personal.marketnote.common.kafka.KafkaTopicConstants;
 import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.OrderCancelledEvent;
 import com.personal.marketnote.common.kafka.event.OrderPaymentCompletedEvent;
 import com.personal.marketnote.common.outbox.OutboxEvent;
 import com.personal.marketnote.common.outbox.SaveOutboxEventPort;
@@ -140,5 +141,108 @@ class OrderEventKafkaProducerTest {
         assertThat(secondItem.unitAmount()).isEqualTo(20000L);
 
         assertThat(payload.totalAccumulatedPoint()).isEqualTo(1500L);
+    }
+
+    private List<OrderProduct> createCancelProducts() {
+        OrderProduct cancelProduct = OrderProduct.from(OrderProductSnapshotState.builder()
+                .orderId(1L)
+                .sellerId(10L)
+                .pricePolicyId(100L)
+                .sharerKey(UUID.fromString("550e8400-e29b-41d4-a716-446655440000"))
+                .quantity(2)
+                .unitAmount(30000L)
+                .orderStatus(OrderStatus.CANCELLED)
+                .build());
+        return List.of(cancelProduct);
+    }
+
+    @Test
+    @DisplayName("주문 취소 이벤트 발행 시 올바른 토픽과 파티션 키로 Outbox에 저장된다")
+    void publishOrderCancelledEvent_savesToOutboxWithCorrectTopicAndPartitionKey() throws Exception {
+        // given
+        setUpClock("2026-04-07T10:00:00Z");
+        when(objectMapper.writeValueAsString(any())).thenReturn("{}");
+
+        List<OrderProduct> orderProducts = createOrderProducts();
+        List<OrderProduct> cancelProducts = createCancelProducts();
+
+        // when
+        orderEventKafkaProducer.publishOrderCancelledEvent(
+                1L, "order-key-001", 50L,
+                60000L, 80000L, 5000L, 3000L,
+                false, 0L,
+                orderProducts, cancelProducts
+        );
+
+        // then
+        ArgumentCaptor<OutboxEvent> outboxCaptor = ArgumentCaptor.forClass(OutboxEvent.class);
+        verify(saveOutboxEventPort).save(outboxCaptor.capture());
+
+        OutboxEvent captured = outboxCaptor.getValue();
+        assertThat(captured.getTopic()).isEqualTo(KafkaTopicConstants.ORDER_CANCELLED);
+        assertThat(captured.getPartitionKey()).isEqualTo("1");
+        assertThat(captured.getSource()).isEqualTo("commerce-service");
+        assertThat(captured.getEventId()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("주문 취소 이벤트 발행 시 EventEnvelope에 올바른 페이로드가 포함된다")
+    @SuppressWarnings("unchecked")
+    void publishOrderCancelledEvent_envelopeContainsCorrectPayload() throws Exception {
+        // given
+        setUpClock("2026-04-07T10:00:00Z");
+        when(objectMapper.writeValueAsString(any())).thenReturn("{}");
+
+        List<OrderProduct> orderProducts = createOrderProducts();
+        List<OrderProduct> cancelProducts = createCancelProducts();
+
+        // when
+        orderEventKafkaProducer.publishOrderCancelledEvent(
+                10L, "order-key-002", 50L,
+                60000L, 80000L, 5000L, 3000L,
+                true, 20000L,
+                orderProducts, cancelProducts
+        );
+
+        // then
+        ArgumentCaptor<EventEnvelope> envelopeCaptor = ArgumentCaptor.forClass(EventEnvelope.class);
+        verify(objectMapper).writeValueAsString(envelopeCaptor.capture());
+
+        EventEnvelope<?> capturedEnvelope = envelopeCaptor.getValue();
+        assertThat(capturedEnvelope.eventType()).isEqualTo(KafkaTopicConstants.ORDER_CANCELLED);
+        assertThat(capturedEnvelope.source()).isEqualTo("commerce-service");
+        assertThat(capturedEnvelope.eventId()).isNotNull();
+        assertThat(capturedEnvelope.timestamp()).isNotNull();
+
+        OrderCancelledEvent payload = (OrderCancelledEvent) capturedEnvelope.payload();
+        assertThat(payload.orderId()).isEqualTo(10L);
+        assertThat(payload.orderKey()).isEqualTo("order-key-002");
+        assertThat(payload.buyerId()).isEqualTo(50L);
+        assertThat(payload.cancelAmount()).isEqualTo(60000L);
+        assertThat(payload.paymentAmount()).isEqualTo(80000L);
+        assertThat(payload.pointAmount()).isEqualTo(5000L);
+        assertThat(payload.shippingFee()).isEqualTo(3000L);
+        assertThat(payload.isFullCancel()).isTrue();
+        assertThat(payload.alreadyRefunded()).isEqualTo(20000L);
+
+        assertThat(payload.orderProducts()).hasSize(2);
+        OrderCancelledEvent.OrderProductItem firstItem = payload.orderProducts().get(0);
+        assertThat(firstItem.pricePolicyId()).isEqualTo(100L);
+        assertThat(firstItem.sharerKey()).isEqualTo(UUID.fromString("550e8400-e29b-41d4-a716-446655440000"));
+        assertThat(firstItem.quantity()).isEqualTo(2);
+        assertThat(firstItem.unitAmount()).isEqualTo(30000L);
+
+        OrderCancelledEvent.OrderProductItem secondItem = payload.orderProducts().get(1);
+        assertThat(secondItem.pricePolicyId()).isEqualTo(101L);
+        assertThat(secondItem.sharerKey()).isNull();
+        assertThat(secondItem.quantity()).isEqualTo(1);
+        assertThat(secondItem.unitAmount()).isEqualTo(20000L);
+
+        assertThat(payload.cancelProducts()).hasSize(1);
+        OrderCancelledEvent.OrderProductItem cancelItem = payload.cancelProducts().get(0);
+        assertThat(cancelItem.pricePolicyId()).isEqualTo(100L);
+        assertThat(cancelItem.sharerKey()).isEqualTo(UUID.fromString("550e8400-e29b-41d4-a716-446655440000"));
+        assertThat(cancelItem.quantity()).isEqualTo(2);
+        assertThat(cancelItem.unitAmount()).isEqualTo(30000L);
     }
 }


### PR DESCRIPTION
## partially addresses #216
## resolves #2295

## Test Case
- [x] 주문 취소 이벤트 발행 시 올바른 토픽과 파티션 키로 Outbox에 저장된다
- [x] 주문 취소 이벤트 발행 시 EventEnvelope에 올바른 페이로드가 포함된다