### PR TITLE
[#43][#2227] feat: 도서산간 지역 등록 기능 추가

### DIFF
--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/remotearea/controller/RemoteAreaAdminController.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/remotearea/controller/RemoteAreaAdminController.java
@@ -1,0 +1,53 @@
+package com.personal.marketnote.user.adapter.in.web.remotearea.controller;
+
+import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
+import com.personal.marketnote.user.adapter.in.web.remotearea.controller.apidocs.RegisterRemoteAreaApiDocs;
+import com.personal.marketnote.user.adapter.in.web.remotearea.request.RegisterRemoteAreaRequest;
+import com.personal.marketnote.user.port.in.command.remotearea.RegisterRemoteAreaCommand;
+import com.personal.marketnote.user.port.in.usecase.remotearea.RegisterRemoteAreaUseCase;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static com.personal.marketnote.common.domain.exception.ExceptionCode.DEFAULT_SUCCESS_CODE;
+import static com.personal.marketnote.common.utility.ApiConstant.ADMIN_POINTCUT;
+
+@RestController
+@RequestMapping("/api/v1/admin/remote-areas")
+@Tag(
+        name = "도서산간 지역 관리자 API",
+        description = "도서산간 지역 관련 관리자 API"
+)
+@RequiredArgsConstructor
+public class RemoteAreaAdminController {
+
+    private final RegisterRemoteAreaUseCase registerRemoteAreaUseCase;
+
+    @PostMapping
+    @PreAuthorize(ADMIN_POINTCUT)
+    @RegisterRemoteAreaApiDocs
+    public ResponseEntity<BaseResponse<Void>> registerRemoteArea(
+            @Valid @RequestBody RegisterRemoteAreaRequest request
+    ) {
+        RegisterRemoteAreaCommand command = new RegisterRemoteAreaCommand(
+                request.getProvince(),
+                request.getDistrict(),
+                request.getVillage(),
+                request.getSubarea()
+        );
+
+        registerRemoteAreaUseCase.registerRemoteArea(command);
+
+        return new ResponseEntity<>(
+                BaseResponse.of(null, HttpStatus.CREATED, DEFAULT_SUCCESS_CODE, "도서산간 지역 등록 성공"),
+                HttpStatus.CREATED
+        );
+    }
+}

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/remotearea/controller/apidocs/RegisterRemoteAreaApiDocs.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/remotearea/controller/apidocs/RegisterRemoteAreaApiDocs.java
@@ -1,0 +1,126 @@
+package com.personal.marketnote.user.adapter.in.web.remotearea.controller.apidocs;
+
+import com.personal.marketnote.user.adapter.in.web.remotearea.request.RegisterRemoteAreaRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Operation(
+        summary = "도서산간 지역 등록",
+        description = """
+                작성일자: 2026-04-24
+
+                작성자: 성효빈
+
+                ---
+
+                ## Description
+                - 도서산간 지역을 등록합니다.
+
+                - **광역시도(province)**는 필수이며, **시군구(district)**, **읍면동(village)**, **세부지역(subarea)**은 선택입니다.
+
+                - 광역시도만 등록하면 해당 광역시도 전체가 도서산간 지역으로 지정됩니다.
+
+                - 동일한 (광역시도, 시군구, 읍면동, 세부지역) 조합은 중복 등록할 수 없습니다.
+
+                ---
+
+                ## Request
+
+                | **키** | **타입** | **설명** | **필수 여부** | **예시** |
+                | --- | --- | --- | --- | --- |
+                | province | string | 광역시도 (최대 50자) | Y | "충남" |
+                | district | string | 시군구 (최대 50자) | N | "보령시" |
+                | village | string | 읍면동 (최대 50자) | N | "오천면" |
+                | subarea | string | 세부지역 (최대 50자) | N | "녹도리" |
+
+                ---
+
+                ## Response
+
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | statusCode | number | 상태 코드 | 201: 성공 / 400: 요청 검증 실패 / 409: 중복 등록 |
+                | code | string | 응답 코드 | "SUC01" / "ERR01" |
+                | timestamp | string(datetime) | 응답 일시 | "2026-04-24T12:00:00.000" |
+                | content | null | 응답 본문 (없음) | null |
+                | message | string | 처리 결과 | "도서산간 지역 등록 성공" |
+                """,
+        security = {@SecurityRequirement(name = "bearer")},
+        requestBody = @RequestBody(
+                required = true,
+                content = @Content(
+                        schema = @Schema(implementation = RegisterRemoteAreaRequest.class),
+                        examples = @ExampleObject("""
+                                {
+                                    "province": "충남",
+                                    "district": "보령시",
+                                    "village": "오천면",
+                                    "subarea": "녹도리"
+                                }
+                                """)
+                )
+        ),
+        responses = {
+                @ApiResponse(
+                        responseCode = "201",
+                        description = "도서산간 지역 등록 성공",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 201,
+                                          "code": "SUC01",
+                                          "timestamp": "2026-04-24T12:00:00.000000",
+                                          "content": null,
+                                          "message": "도서산간 지역 등록 성공"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "409",
+                        description = "이미 등록된 도서산간 지역",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 409,
+                                          "code": "ERR01",
+                                          "timestamp": "2026-04-24T12:00:00.000000",
+                                          "content": null,
+                                          "message": "ERR_REMOTE_AREA_06::이미 등록된 도서산간 지역입니다."
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "400",
+                        description = "요청 검증 실패",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 400,
+                                          "code": "ERR01",
+                                          "timestamp": "2026-04-24T12:00:00.000000",
+                                          "content": null,
+                                          "message": "광역시도는 필수값입니다."
+                                        }
+                                        """)
+                        )
+                )
+        }
+)
+public @interface RegisterRemoteAreaApiDocs {
+}

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/remotearea/request/RegisterRemoteAreaRequest.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/remotearea/request/RegisterRemoteAreaRequest.java
@@ -1,0 +1,27 @@
+package com.personal.marketnote.user.adapter.in.web.remotearea.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+@Getter
+public class RegisterRemoteAreaRequest {
+
+    @Schema(name = "province", description = "광역시도 (최대 50자)", requiredMode = Schema.RequiredMode.REQUIRED)
+    @NotBlank(message = "광역시도는 필수값입니다.")
+    @Size(max = 50, message = "광역시도는 최대 50자까지 입력할 수 있습니다.")
+    private String province;
+
+    @Schema(name = "district", description = "시군구 (최대 50자)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @Size(max = 50, message = "시군구는 최대 50자까지 입력할 수 있습니다.")
+    private String district;
+
+    @Schema(name = "village", description = "읍면동 (최대 50자)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @Size(max = 50, message = "읍면동은 최대 50자까지 입력할 수 있습니다.")
+    private String village;
+
+    @Schema(name = "subarea", description = "세부지역 (최대 50자)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+    @Size(max = 50, message = "세부지역은 최대 50자까지 입력할 수 있습니다.")
+    private String subarea;
+}

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/out/persistence/remotearea/RemoteAreaPersistenceAdapter.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/out/persistence/remotearea/RemoteAreaPersistenceAdapter.java
@@ -1,0 +1,38 @@
+package com.personal.marketnote.user.adapter.out.persistence.remotearea;
+
+import com.personal.marketnote.common.adapter.out.PersistenceAdapter;
+import com.personal.marketnote.common.domain.EntityStatus;
+import com.personal.marketnote.user.adapter.out.persistence.remotearea.entity.RemoteAreaJpaEntity;
+import com.personal.marketnote.user.adapter.out.persistence.remotearea.repository.RemoteAreaJpaRepository;
+import com.personal.marketnote.user.domain.remotearea.RemoteArea;
+import com.personal.marketnote.user.exception.RemoteAreaAlreadyExistsException;
+import com.personal.marketnote.user.port.out.remotearea.FindRemoteAreaPort;
+import com.personal.marketnote.user.port.out.remotearea.SaveRemoteAreaPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+
+@PersistenceAdapter
+@RequiredArgsConstructor
+public class RemoteAreaPersistenceAdapter implements SaveRemoteAreaPort, FindRemoteAreaPort {
+
+    private final RemoteAreaJpaRepository remoteAreaJpaRepository;
+
+    @Override
+    public void save(RemoteArea remoteArea) {
+        RemoteAreaJpaEntity entity = RemoteAreaJpaEntity.from(remoteArea);
+        try {
+            remoteAreaJpaRepository.save(entity);
+        } catch (DataIntegrityViolationException dive) {
+            throw new RemoteAreaAlreadyExistsException(
+                    remoteArea.getProvince(), remoteArea.getDistrict(), remoteArea.getVillage(), remoteArea.getSubarea()
+            );
+        }
+    }
+
+    @Override
+    public boolean existsByAddress(String province, String district, String village, String subarea) {
+        return remoteAreaJpaRepository.existsByProvinceAndDistrictAndVillageAndSubareaAndStatus(
+                province, district, village, subarea, EntityStatus.ACTIVE
+        );
+    }
+}

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/exception/RemoteAreaAlreadyExistsException.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/exception/RemoteAreaAlreadyExistsException.java
@@ -1,0 +1,10 @@
+package com.personal.marketnote.user.exception;
+
+import com.personal.marketnote.common.domain.exception.DomainAlreadyExistsException;
+
+public class RemoteAreaAlreadyExistsException extends DomainAlreadyExistsException {
+
+    public RemoteAreaAlreadyExistsException(String province, String district, String village, String subarea) {
+        super("ERR_REMOTE_AREA_06::이미 등록된 도서산간 지역입니다. province=" + province + ", district=" + district + ", village=" + village + ", subarea=" + subarea);
+    }
+}

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/port/in/command/remotearea/RegisterRemoteAreaCommand.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/port/in/command/remotearea/RegisterRemoteAreaCommand.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.user.port.in.command.remotearea;
+
+public record RegisterRemoteAreaCommand(
+        String province,
+        String district,
+        String village,
+        String subarea
+) {
+}

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/port/in/usecase/remotearea/RegisterRemoteAreaUseCase.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/port/in/usecase/remotearea/RegisterRemoteAreaUseCase.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.user.port.in.usecase.remotearea;
+
+import com.personal.marketnote.user.port.in.command.remotearea.RegisterRemoteAreaCommand;
+
+public interface RegisterRemoteAreaUseCase {
+    void registerRemoteArea(RegisterRemoteAreaCommand command);
+}

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/port/out/remotearea/FindRemoteAreaPort.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/port/out/remotearea/FindRemoteAreaPort.java
@@ -1,0 +1,5 @@
+package com.personal.marketnote.user.port.out.remotearea;
+
+public interface FindRemoteAreaPort {
+    boolean existsByAddress(String province, String district, String village, String subarea);
+}

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/port/out/remotearea/SaveRemoteAreaPort.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/port/out/remotearea/SaveRemoteAreaPort.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.user.port.out.remotearea;
+
+import com.personal.marketnote.user.domain.remotearea.RemoteArea;
+
+public interface SaveRemoteAreaPort {
+    void save(RemoteArea remoteArea);
+}

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/service/remotearea/RegisterRemoteAreaService.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/service/remotearea/RegisterRemoteAreaService.java
@@ -1,0 +1,45 @@
+package com.personal.marketnote.user.service.remotearea;
+
+import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.user.domain.remotearea.RemoteArea;
+import com.personal.marketnote.user.domain.remotearea.RemoteAreaCreateState;
+import com.personal.marketnote.user.exception.RemoteAreaAlreadyExistsException;
+import com.personal.marketnote.user.port.in.command.remotearea.RegisterRemoteAreaCommand;
+import com.personal.marketnote.user.port.in.usecase.remotearea.RegisterRemoteAreaUseCase;
+import com.personal.marketnote.user.port.out.remotearea.FindRemoteAreaPort;
+import com.personal.marketnote.user.port.out.remotearea.SaveRemoteAreaPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@UseCase
+@RequiredArgsConstructor
+public class RegisterRemoteAreaService implements RegisterRemoteAreaUseCase {
+
+    private final FindRemoteAreaPort findRemoteAreaPort;
+    private final SaveRemoteAreaPort saveRemoteAreaPort;
+
+    @Override
+    @Transactional(isolation = READ_COMMITTED)
+    public void registerRemoteArea(RegisterRemoteAreaCommand command) {
+        RemoteArea remoteArea = RemoteArea.from(
+                RemoteAreaCreateState.builder()
+                        .province(command.province())
+                        .district(command.district())
+                        .village(command.village())
+                        .subarea(command.subarea())
+                        .build()
+        );
+
+        validateNotDuplicate(remoteArea);
+
+        saveRemoteAreaPort.save(remoteArea);
+    }
+
+    private void validateNotDuplicate(RemoteArea remoteArea) {
+        if (findRemoteAreaPort.existsByAddress(remoteArea.getProvince(), remoteArea.getDistrict(), remoteArea.getVillage(), remoteArea.getSubarea())) {
+            throw new RemoteAreaAlreadyExistsException(remoteArea.getProvince(), remoteArea.getDistrict(), remoteArea.getVillage(), remoteArea.getSubarea());
+        }
+    }
+}

--- a/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/remotearea/exception/InvalidRemoteAreaDistrictLengthException.java
+++ b/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/remotearea/exception/InvalidRemoteAreaDistrictLengthException.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.user.domain.remotearea.exception;
+
+public class InvalidRemoteAreaDistrictLengthException extends IllegalArgumentException {
+
+    public InvalidRemoteAreaDistrictLengthException() {
+        super("ERR_REMOTE_AREA_03::도서산간 지역 읍면동은 최대 50자까지 입력할 수 있습니다.");
+    }
+}

--- a/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/remotearea/exception/InvalidRemoteAreaProvinceLengthException.java
+++ b/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/remotearea/exception/InvalidRemoteAreaProvinceLengthException.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.user.domain.remotearea.exception;
+
+public class InvalidRemoteAreaProvinceLengthException extends IllegalArgumentException {
+
+    public InvalidRemoteAreaProvinceLengthException() {
+        super("ERR_REMOTE_AREA_02::도서산간 지역 광역시도는 최대 50자까지 입력할 수 있습니다.");
+    }
+}

--- a/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/remotearea/exception/InvalidRemoteAreaSubareaLengthException.java
+++ b/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/remotearea/exception/InvalidRemoteAreaSubareaLengthException.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.user.domain.remotearea.exception;
+
+public class InvalidRemoteAreaSubareaLengthException extends IllegalArgumentException {
+
+    public InvalidRemoteAreaSubareaLengthException() {
+        super("ERR_REMOTE_AREA_05::도서산간 지역 세부지역은 최대 50자까지 입력할 수 있습니다.");
+    }
+}

--- a/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/remotearea/exception/InvalidRemoteAreaVillageLengthException.java
+++ b/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/remotearea/exception/InvalidRemoteAreaVillageLengthException.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.user.domain.remotearea.exception;
+
+public class InvalidRemoteAreaVillageLengthException extends IllegalArgumentException {
+
+    public InvalidRemoteAreaVillageLengthException() {
+        super("ERR_REMOTE_AREA_04::도서산간 지역 리는 최대 50자까지 입력할 수 있습니다.");
+    }
+}

--- a/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/remotearea/exception/RemoteAreaProvinceNoValueException.java
+++ b/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/remotearea/exception/RemoteAreaProvinceNoValueException.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.user.domain.remotearea.exception;
+
+public class RemoteAreaProvinceNoValueException extends RuntimeException {
+
+    public RemoteAreaProvinceNoValueException() {
+        super("ERR_REMOTE_AREA_01::도서산간 지역 광역시도는 필수입니다.");
+    }
+}


### PR DESCRIPTION
## partially addresses #43
## resolves #2227

## Task
- [x] RemoteArea 도메인 모델 변경 (zipCode 기반 → 주소 기반: province/district/village/subarea)
- [x] RemoteAreaType enum 삭제
- [x] RegisterRemoteAreaUseCase 인터페이스 정의
- [x] RegisterRemoteAreaCommand 정의
- [x] RegisterRemoteAreaService 구현
- [x] SaveRemoteAreaPort, FindRemoteAreaPort 정의 및 RemoteAreaPersistenceAdapter 구현
- [x] 관리자 REST Controller 추가 (POST /api/v1/admin/remote-areas)
- [x] RegisterRemoteAreaRequest DTO 작성
- [x] RegisterRemoteAreaApiDocs 합성 애노테이션 추가
- [x] 이중 방어 패턴 적용 (Application 선 검증 + DB UNIQUE + DataIntegrityViolationException 변환)