### PR TITLE
[#216][#1949] test: CancelOrderUseCaseTest 풀필먼트 연동 기반 재설계

### DIFF
--- a/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/out/event/OrderEventKafkaProducerTest.java
+++ b/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/out/event/OrderEventKafkaProducerTest.java
@@ -160,7 +160,7 @@ class OrderEventKafkaProducerTest {
     @DisplayName("주문 취소 이벤트 발행 시 올바른 토픽과 파티션 키로 Outbox에 저장된다")
     void publishOrderCancelledEvent_savesToOutboxWithCorrectTopicAndPartitionKey() throws Exception {
         // given
-        setUpClock("2026-04-07T10:00:00Z");
+        setUpClock("2026-04-24T10:00:00Z");
         when(objectMapper.writeValueAsString(any())).thenReturn("{}");
 
         List<OrderProduct> orderProducts = createOrderProducts();
@@ -190,7 +190,7 @@ class OrderEventKafkaProducerTest {
     @SuppressWarnings("unchecked")
     void publishOrderCancelledEvent_envelopeContainsCorrectPayload() throws Exception {
         // given
-        setUpClock("2026-04-07T10:00:00Z");
+        setUpClock("2026-04-24T10:00:00Z");
         when(objectMapper.writeValueAsString(any())).thenReturn("{}");
 
         List<OrderProduct> orderProducts = createOrderProducts();

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/CancelOrderUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/CancelOrderUseCaseTest.java
@@ -2,11 +2,17 @@ package com.personal.marketnote.commerce.service.order;
 
 import com.personal.marketnote.commerce.domain.order.*;
 import com.personal.marketnote.commerce.exception.InvalidOrderStatusTransitionException;
+import com.personal.marketnote.commerce.exception.OrderCancellationNotAllowedException;
 import com.personal.marketnote.commerce.exception.OrderStatusAlreadyChangedException;
 import com.personal.marketnote.commerce.exception.UnauthorizedOrderAccessException;
 import com.personal.marketnote.commerce.port.in.command.order.CancelOrderCommand;
 import com.personal.marketnote.commerce.port.in.usecase.order.GetOrderUseCase;
+import com.personal.marketnote.commerce.port.out.event.PublishOrderEventPort;
+import com.personal.marketnote.commerce.port.out.fulfillment.CancelFulfillmentReleasePort;
+import com.personal.marketnote.commerce.port.out.fulfillment.CancelFulfillmentReleaseResult;
 import com.personal.marketnote.commerce.port.out.order.UpdateOrderPort;
+import com.personal.marketnote.common.exception.FulfillmentServiceRequestFailedException;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -15,7 +21,11 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.TransactionStatus;
 
+import java.io.IOException;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDateTime;
@@ -26,6 +36,7 @@ import java.util.UUID;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -34,92 +45,158 @@ class CancelOrderUseCaseTest {
     private GetOrderUseCase getOrderUseCase;
     @Mock
     private UpdateOrderPort updateOrderPort;
+    @Mock
+    private CancelFulfillmentReleasePort cancelFulfillmentReleasePort;
+    @Mock
+    private PublishOrderEventPort publishOrderEventPort;
+    @Mock
+    private PlatformTransactionManager transactionManager;
     @Spy
     private Clock clock = Clock.fixed(Instant.parse("2026-04-05T00:00:00Z"), ZoneId.of("Asia/Seoul"));
 
     @InjectMocks
     private CancelOrderService cancelOrderService;
 
+    @BeforeEach
+    void setUp() {
+        lenient().when(transactionManager.getTransaction(any(TransactionDefinition.class)))
+                .thenReturn(mock(TransactionStatus.class));
+    }
+
     // ==================================================================================
-    // 정상 취소 요청
+    // 결제 대기 상태 취소
     // ==================================================================================
 
     @Nested
-    @DisplayName("정상 취소 요청")
-    class SuccessfulCancelRequestTest {
+    @DisplayName("결제 대기 상태 취소")
+    class PaymentPendingCancelTest {
 
         @Test
-        @DisplayName("결제 대기 상태의 주문을 취소 요청하면 정상 처리된다")
-        void cancelOrder_fromPaymentPending_succeeds() {
+        @DisplayName("결제 대기 상태의 주문을 취소하면 풀필먼트 취소 없이 즉시 CANCELLED 처리된다")
+        void cancelOrder_fromPaymentPending_cancelledWithoutFulfillmentAndEvent() {
             Long orderId = 1L;
             Long buyerId = 100L;
-            Order order = createOrderWithBuyerId(orderId, buyerId, OrderStatus.PAYMENT_PENDING);
+            Order order = createOrder(orderId, buyerId, OrderStatus.PAYMENT_PENDING);
             when(getOrderUseCase.getOrder(orderId)).thenReturn(order);
 
-            CancelOrderCommand command = CancelOrderCommand.builder()
-                    .id(orderId)
-                    .reasonCategory(OrderStatusReasonCategory.CANCEL_ORDER)
-                    .reason("구매 의사 취소")
-                    .buyerId(buyerId)
-                    .build();
-
-            assertThatCode(() -> cancelOrderService.cancelOrder(command))
-                    .doesNotThrowAnyException();
-        }
-
-        @Test
-        @DisplayName("결제 완료 상태의 주문을 취소 요청하면 정상 처리된다")
-        void cancelOrder_fromPaid_succeeds() {
-            Long orderId = 1L;
-            Long buyerId = 100L;
-            Order order = createOrderWithBuyerId(orderId, buyerId, OrderStatus.PAID);
-            when(getOrderUseCase.getOrder(orderId)).thenReturn(order);
-
-            CancelOrderCommand command = CancelOrderCommand.builder()
-                    .id(orderId)
-                    .reasonCategory(OrderStatusReasonCategory.MISTAKE)
-                    .buyerId(buyerId)
-                    .build();
-
-            assertThatCode(() -> cancelOrderService.cancelOrder(command))
-                    .doesNotThrowAnyException();
-        }
-
-        @Test
-        @DisplayName("상품 준비중 상태의 주문을 취소 요청하면 정상 처리된다")
-        void cancelOrder_fromPreparing_succeeds() {
-            Long orderId = 1L;
-            Long buyerId = 100L;
-            Order order = createOrderWithBuyerId(orderId, buyerId, OrderStatus.PREPARING);
-            when(getOrderUseCase.getOrder(orderId)).thenReturn(order);
-
-            CancelOrderCommand command = CancelOrderCommand.builder()
-                    .id(orderId)
-                    .buyerId(buyerId)
-                    .build();
-
-            assertThatCode(() -> cancelOrderService.cancelOrder(command))
-                    .doesNotThrowAnyException();
-        }
-
-        @Test
-        @DisplayName("취소 요청 성공 시 UpdateOrderPort를 호출한다")
-        void cancelOrder_callsUpdateOrderPort() {
-            Long orderId = 1L;
-            Long buyerId = 100L;
-            Order order = createOrderWithBuyerId(orderId, buyerId, OrderStatus.PAID);
-            when(getOrderUseCase.getOrder(orderId)).thenReturn(order);
-
-            CancelOrderCommand command = CancelOrderCommand.builder()
-                    .id(orderId)
-                    .reasonCategory(OrderStatusReasonCategory.CANCEL_ORDER)
-                    .reason("구매 의사 취소")
-                    .buyerId(buyerId)
-                    .build();
+            CancelOrderCommand command = createCommand(orderId, buyerId);
 
             cancelOrderService.cancelOrder(command);
 
             verify(updateOrderPort).update(any(Order.class), any(OrderStatusHistory.class));
+            verifyNoInteractions(cancelFulfillmentReleasePort);
+            verifyNoInteractions(publishOrderEventPort);
+        }
+    }
+
+    // ==================================================================================
+    // 결제 완료 상태 취소
+    // ==================================================================================
+
+    @Nested
+    @DisplayName("결제 완료 상태 취소")
+    class PaidCancelTest {
+
+        @Test
+        @DisplayName("결제 완료 상태의 주문을 취소하면 풀필먼트 취소 없이 이벤트를 발행한다")
+        void cancelOrder_fromPaid_publishesEventWithoutFulfillmentCancel() {
+            Long orderId = 1L;
+            Long buyerId = 100L;
+            Order order = createOrder(orderId, buyerId, OrderStatus.PAID);
+            when(getOrderUseCase.getOrder(orderId)).thenReturn(order);
+
+            CancelOrderCommand command = createCommand(orderId, buyerId);
+
+            cancelOrderService.cancelOrder(command);
+
+            verify(updateOrderPort).update(any(Order.class), any(OrderStatusHistory.class));
+            verifyNoInteractions(cancelFulfillmentReleasePort);
+            verify(publishOrderEventPort).publishOrderCancelledEvent(
+                    eq(orderId), any(String.class), eq(buyerId),
+                    eq(50000L), eq(50000L), eq(0L),
+                    eq(3000L), eq(true), eq(0L),
+                    any(), any()
+            );
+        }
+    }
+
+    // ==================================================================================
+    // 상품 준비중 상태 취소 — 풀필먼트 취소 성공
+    // ==================================================================================
+
+    @Nested
+    @DisplayName("상품 준비중 상태 취소 — 풀필먼트 취소 성공")
+    class PreparingCancelSuccessTest {
+
+        @Test
+        @DisplayName("상품 준비중 상태에서 풀필먼트 취소 성공 시 CANCELLED 처리되고 이벤트를 발행한다")
+        void cancelOrder_fromPreparing_fulfillmentApproved_cancelledAndPublishesEvent() {
+            Long orderId = 1L;
+            Long buyerId = 100L;
+            Order order = createOrder(orderId, buyerId, OrderStatus.PREPARING);
+            when(getOrderUseCase.getOrder(orderId)).thenReturn(order);
+            when(cancelFulfillmentReleasePort.cancelRelease(orderId))
+                    .thenReturn(new CancelFulfillmentReleaseResult(orderId, true, "취소 성공"));
+
+            CancelOrderCommand command = createCommand(orderId, buyerId);
+
+            cancelOrderService.cancelOrder(command);
+
+            verify(cancelFulfillmentReleasePort).cancelRelease(orderId);
+            verify(updateOrderPort).update(any(Order.class), any(OrderStatusHistory.class));
+            verify(publishOrderEventPort).publishOrderCancelledEvent(
+                    eq(orderId), any(String.class), eq(buyerId),
+                    eq(50000L), eq(50000L), eq(0L),
+                    eq(3000L), eq(true), eq(0L),
+                    any(), any()
+            );
+        }
+    }
+
+    // ==================================================================================
+    // 풀필먼트 취소 실패
+    // ==================================================================================
+
+    @Nested
+    @DisplayName("풀필먼트 취소 실패")
+    class FulfillmentCancelFailureTest {
+
+        @Test
+        @DisplayName("풀필먼트가 출고 취소를 거부하면 OrderCancellationNotAllowedException이 발생한다")
+        void cancelOrder_fulfillmentRejected_throwsException() {
+            Long orderId = 1L;
+            Long buyerId = 100L;
+            Order order = createOrder(orderId, buyerId, OrderStatus.PREPARING);
+            when(getOrderUseCase.getOrder(orderId)).thenReturn(order);
+            when(cancelFulfillmentReleasePort.cancelRelease(orderId))
+                    .thenReturn(new CancelFulfillmentReleaseResult(orderId, false, "피킹 완료"));
+
+            CancelOrderCommand command = createCommand(orderId, buyerId);
+
+            assertThatThrownBy(() -> cancelOrderService.cancelOrder(command))
+                    .isInstanceOf(OrderCancellationNotAllowedException.class);
+
+            verifyNoInteractions(updateOrderPort);
+            verifyNoInteractions(publishOrderEventPort);
+        }
+
+        @Test
+        @DisplayName("풀필먼트 서비스 통신 실패 시 OrderCancellationNotAllowedException이 발생한다")
+        void cancelOrder_fulfillmentCommunicationFailure_throwsException() {
+            Long orderId = 1L;
+            Long buyerId = 100L;
+            Order order = createOrder(orderId, buyerId, OrderStatus.PREPARING);
+            when(getOrderUseCase.getOrder(orderId)).thenReturn(order);
+            when(cancelFulfillmentReleasePort.cancelRelease(orderId))
+                    .thenThrow(new FulfillmentServiceRequestFailedException(new IOException("connection refused")));
+
+            CancelOrderCommand command = createCommand(orderId, buyerId);
+
+            assertThatThrownBy(() -> cancelOrderService.cancelOrder(command))
+                    .isInstanceOf(OrderCancellationNotAllowedException.class);
+
+            verifyNoInteractions(updateOrderPort);
+            verifyNoInteractions(publishOrderEventPort);
         }
     }
 
@@ -137,36 +214,17 @@ class CancelOrderUseCaseTest {
             Long orderId = 1L;
             Long ownerBuyerId = 100L;
             Long attackerBuyerId = 999L;
-            Order order = createOrderWithBuyerId(orderId, ownerBuyerId, OrderStatus.PAID);
+            Order order = createOrder(orderId, ownerBuyerId, OrderStatus.PAID);
             when(getOrderUseCase.getOrder(orderId)).thenReturn(order);
 
-            CancelOrderCommand command = CancelOrderCommand.builder()
-                    .id(orderId)
-                    .buyerId(attackerBuyerId)
-                    .build();
-
-            assertThatThrownBy(() -> cancelOrderService.cancelOrder(command))
-                    .isInstanceOf(UnauthorizedOrderAccessException.class);
-        }
-
-        @Test
-        @DisplayName("타인의 주문 취소 요청 시 UpdateOrderPort를 호출하지 않는다")
-        void cancelOrder_otherBuyerOrder_doesNotCallUpdatePort() {
-            Long orderId = 1L;
-            Long ownerBuyerId = 100L;
-            Long attackerBuyerId = 999L;
-            Order order = createOrderWithBuyerId(orderId, ownerBuyerId, OrderStatus.PAID);
-            when(getOrderUseCase.getOrder(orderId)).thenReturn(order);
-
-            CancelOrderCommand command = CancelOrderCommand.builder()
-                    .id(orderId)
-                    .buyerId(attackerBuyerId)
-                    .build();
+            CancelOrderCommand command = createCommand(orderId, attackerBuyerId);
 
             assertThatThrownBy(() -> cancelOrderService.cancelOrder(command))
                     .isInstanceOf(UnauthorizedOrderAccessException.class);
 
             verifyNoInteractions(updateOrderPort);
+            verifyNoInteractions(cancelFulfillmentReleasePort);
+            verifyNoInteractions(publishOrderEventPort);
         }
     }
 
@@ -183,16 +241,17 @@ class CancelOrderUseCaseTest {
         void cancelOrder_alreadyCancelled_throwsAlreadyChangedException() {
             Long orderId = 1L;
             Long buyerId = 100L;
-            Order order = createOrderWithBuyerId(orderId, buyerId, OrderStatus.CANCELLED);
+            Order order = createOrder(orderId, buyerId, OrderStatus.CANCELLED);
             when(getOrderUseCase.getOrder(orderId)).thenReturn(order);
 
-            CancelOrderCommand command = CancelOrderCommand.builder()
-                    .id(orderId)
-                    .buyerId(buyerId)
-                    .build();
+            CancelOrderCommand command = createCommand(orderId, buyerId);
 
             assertThatThrownBy(() -> cancelOrderService.cancelOrder(command))
                     .isInstanceOf(OrderStatusAlreadyChangedException.class);
+
+            verifyNoInteractions(updateOrderPort);
+            verifyNoInteractions(cancelFulfillmentReleasePort);
+            verifyNoInteractions(publishOrderEventPort);
         }
 
         @Test
@@ -200,69 +259,17 @@ class CancelOrderUseCaseTest {
         void cancelOrder_fromShipping_throwsException() {
             Long orderId = 1L;
             Long buyerId = 100L;
-            Order order = createOrderWithBuyerId(orderId, buyerId, OrderStatus.SHIPPING);
+            Order order = createOrder(orderId, buyerId, OrderStatus.SHIPPING);
             when(getOrderUseCase.getOrder(orderId)).thenReturn(order);
 
-            CancelOrderCommand command = CancelOrderCommand.builder()
-                    .id(orderId)
-                    .buyerId(buyerId)
-                    .build();
-
-            assertThatThrownBy(() -> cancelOrderService.cancelOrder(command))
-                    .isInstanceOf(InvalidOrderStatusTransitionException.class);
-        }
-
-        @Test
-        @DisplayName("배송 완료 상태의 주문을 취소 요청하면 InvalidOrderStatusTransitionException이 발생한다")
-        void cancelOrder_fromDelivered_throwsException() {
-            Long orderId = 1L;
-            Long buyerId = 100L;
-            Order order = createOrderWithBuyerId(orderId, buyerId, OrderStatus.DELIVERED);
-            when(getOrderUseCase.getOrder(orderId)).thenReturn(order);
-
-            CancelOrderCommand command = CancelOrderCommand.builder()
-                    .id(orderId)
-                    .buyerId(buyerId)
-                    .build();
-
-            assertThatThrownBy(() -> cancelOrderService.cancelOrder(command))
-                    .isInstanceOf(InvalidOrderStatusTransitionException.class);
-        }
-
-        @Test
-        @DisplayName("구매 확정 상태의 주문을 취소 요청하면 InvalidOrderStatusTransitionException이 발생한다")
-        void cancelOrder_fromConfirmed_throwsException() {
-            Long orderId = 1L;
-            Long buyerId = 100L;
-            Order order = createOrderWithBuyerId(orderId, buyerId, OrderStatus.CONFIRMED);
-            when(getOrderUseCase.getOrder(orderId)).thenReturn(order);
-
-            CancelOrderCommand command = CancelOrderCommand.builder()
-                    .id(orderId)
-                    .buyerId(buyerId)
-                    .build();
-
-            assertThatThrownBy(() -> cancelOrderService.cancelOrder(command))
-                    .isInstanceOf(InvalidOrderStatusTransitionException.class);
-        }
-
-        @Test
-        @DisplayName("상태 전이 실패 시 UpdateOrderPort를 호출하지 않는다")
-        void cancelOrder_invalidTransition_doesNotCallUpdatePort() {
-            Long orderId = 1L;
-            Long buyerId = 100L;
-            Order order = createOrderWithBuyerId(orderId, buyerId, OrderStatus.SHIPPING);
-            when(getOrderUseCase.getOrder(orderId)).thenReturn(order);
-
-            CancelOrderCommand command = CancelOrderCommand.builder()
-                    .id(orderId)
-                    .buyerId(buyerId)
-                    .build();
+            CancelOrderCommand command = createCommand(orderId, buyerId);
 
             assertThatThrownBy(() -> cancelOrderService.cancelOrder(command))
                     .isInstanceOf(InvalidOrderStatusTransitionException.class);
 
             verifyNoInteractions(updateOrderPort);
+            verifyNoInteractions(cancelFulfillmentReleasePort);
+            verifyNoInteractions(publishOrderEventPort);
         }
     }
 
@@ -270,12 +277,22 @@ class CancelOrderUseCaseTest {
     // 헬퍼 메서드
     // ==================================================================================
 
-    private Order createOrderWithBuyerId(Long orderId, Long buyerId, OrderStatus status) {
+    private CancelOrderCommand createCommand(Long orderId, Long buyerId) {
+        return CancelOrderCommand.builder()
+                .id(orderId)
+                .reasonCategory(OrderStatusReasonCategory.CANCEL_ORDER)
+                .reason("구매 의사 취소")
+                .buyerId(buyerId)
+                .build();
+    }
+
+    private Order createOrder(Long orderId, Long buyerId, OrderStatus status) {
         List<OrderProductSnapshotState> productStates = List.of(
                 OrderProductSnapshotState.builder()
                         .orderId(orderId)
                         .sellerId(10L)
                         .pricePolicyId(100L)
+                        .sharerKey(UUID.randomUUID())
                         .quantity(1)
                         .unitAmount(50000L)
                         .orderStatus(status)
@@ -288,7 +305,7 @@ class CancelOrderUseCaseTest {
                 .orderKey(UUID.randomUUID())
                 .orderNumber("ORD-" + orderId)
                 .orderStatus(status)
-                .amount(OrderAmount.of(50000L, null, 0L, 0L, null))
+                .amount(OrderAmount.of(50000L, 50000L, 0L, 0L, 3000L))
                 .shippingAddress(ShippingAddress.of("수령인", "01012345678", "12345", "서울시 강남구", "상세주소", null, null))
                 .orderProductStates(productStates)
                 .createdAt(LocalDateTime.now())

--- a/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/out/persistence/post/PostPersistenceAdapter.java
+++ b/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/out/persistence/post/PostPersistenceAdapter.java
@@ -195,7 +195,7 @@ public class PostPersistenceAdapter implements SavePostPort, FindPostPort, Updat
             boolean isDesc,
             PostSortProperty sortProperty
     ) {
-        String sortField = getSortField(sortProperty);
+        String sortField = sortProperty.getSortField();
         Sort sort = isDesc ? Sort.by(Sort.Direction.DESC, sortField) : Sort.by(Sort.Direction.ASC, sortField);
         Pageable pageable = PageRequest.of(page - 1, pageSize, sort);
 
@@ -204,13 +204,6 @@ public class PostPersistenceAdapter implements SavePostPort, FindPostPort, Updat
                         userId, board, EntityStatus.ACTIVE, pageable
                 )
         );
-    }
-
-    private String getSortField(PostSortProperty sortProperty) {
-        return switch (sortProperty) {
-            case ORDER_NUM -> "orderNum";
-            case IS_ANSWERED, ID -> "id";
-        };
     }
 
     @Override

--- a/community-service/community-application/src/main/java/com/personal/marketnote/community/service/post/GetPostService.java
+++ b/community-service/community-application/src/main/java/com/personal/marketnote/community/service/post/GetPostService.java
@@ -53,7 +53,7 @@ public class GetPostService implements GetPostUseCase {
                 ? query.sortDirection()
                 : Sort.Direction.DESC;
         PostSortProperty sortProperty = resolveSortProperty(query);
-        Pageable pageable = PageRequest.of(0, query.pageSize() + 1, Sort.by(sortDirection, getSortField(sortProperty)));
+        Pageable pageable = PageRequest.of(0, query.pageSize() + 1, Sort.by(sortDirection, sortProperty.getSortField()));
 
         Posts posts = getBoardPosts(query, pageable, sortProperty);
 
@@ -277,13 +277,6 @@ public class GetPostService implements GetPostUseCase {
         }
 
         return FormatValidator.hasValue(query.sortProperty()) ? query.sortProperty() : PostSortProperty.ID;
-    }
-
-    private String getSortField(PostSortProperty sortProperty) {
-        return switch (sortProperty) {
-            case ORDER_NUM -> "orderNum";
-            case IS_ANSWERED, ID -> "id";
-        };
     }
 
     private boolean matchesKeyword(Post post, PostSearchTarget searchTarget, String searchKeyword) {

--- a/community-service/community-domain/src/main/java/com/personal/marketnote/community/domain/post/PostSortProperty.java
+++ b/community-service/community-domain/src/main/java/com/personal/marketnote/community/domain/post/PostSortProperty.java
@@ -5,15 +5,17 @@ import lombok.Getter;
 
 @Getter
 public enum PostSortProperty {
-    ORDER_NUM("지정된 정렬 순서순"),
-    ID("기본키(최신순)"),
-    IS_ANSWERED("답변 여부");
+    ORDER_NUM("지정된 정렬 순서순", "orderNum"),
+    ID("기본키(최신순)", "id"),
+    IS_ANSWERED("답변 여부", "id");
 
     private final String description;
     private final String camelCaseValue;
+    private final String sortField;
 
-    PostSortProperty(String description) {
+    PostSortProperty(String description, String sortField) {
         this.description = description;
         this.camelCaseValue = FormatConverter.snakeToCamel(this.name());
+        this.sortField = sortField;
     }
 }

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/out/mapper/RemoteAreaJpaEntityToDomainMapper.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/out/mapper/RemoteAreaJpaEntityToDomainMapper.java
@@ -10,9 +10,10 @@ public class RemoteAreaJpaEntityToDomainMapper {
         return RemoteArea.from(
                 RemoteAreaSnapshotState.builder()
                         .id(entity.getId())
-                        .zipCode(entity.getZipCode())
-                        .remoteAreaType(entity.getRemoteAreaType())
-                        .regionName(entity.getRegionName())
+                        .province(entity.getProvince())
+                        .district(entity.getDistrict())
+                        .village(entity.getVillage())
+                        .subarea(entity.getSubarea())
                         .build()
         );
     }

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/out/persistence/remotearea/entity/RemoteAreaJpaEntity.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/out/persistence/remotearea/entity/RemoteAreaJpaEntity.java
@@ -2,14 +2,20 @@ package com.personal.marketnote.user.adapter.out.persistence.remotearea.entity;
 
 import com.personal.marketnote.common.adapter.out.persistence.audit.BaseGeneralEntity;
 import com.personal.marketnote.user.domain.remotearea.RemoteArea;
-import com.personal.marketnote.user.domain.remotearea.RemoteAreaType;
-import jakarta.persistence.*;
-import lombok.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Table(
         name = "remote_areas",
-        uniqueConstraints = @UniqueConstraint(columnNames = {"zip_code"})
+        uniqueConstraints = @UniqueConstraint(columnNames = {"province", "district", "village", "subarea"})
 )
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
@@ -17,21 +23,24 @@ import lombok.*;
 @Getter
 public class RemoteAreaJpaEntity extends BaseGeneralEntity {
 
-    @Column(name = "zip_code", nullable = false, length = 5)
-    private String zipCode;
+    @Column(name = "province", nullable = false, length = 50)
+    private String province;
 
-    @Enumerated(EnumType.STRING)
-    @Column(name = "remote_area_type", nullable = false, length = 30)
-    private RemoteAreaType remoteAreaType;
+    @Column(name = "district", nullable = false, length = 50)
+    private String district;
 
-    @Column(name = "region_name", nullable = false, length = 100)
-    private String regionName;
+    @Column(name = "village", nullable = false, length = 50)
+    private String village;
+
+    @Column(name = "subarea", nullable = false, length = 50)
+    private String subarea;
 
     public static RemoteAreaJpaEntity from(RemoteArea remoteArea) {
         return RemoteAreaJpaEntity.builder()
-                .zipCode(remoteArea.getZipCode())
-                .remoteAreaType(remoteArea.getRemoteAreaType())
-                .regionName(remoteArea.getRegionName())
+                .province(remoteArea.getProvince())
+                .district(remoteArea.getDistrict())
+                .village(remoteArea.getVillage())
+                .subarea(remoteArea.getSubarea())
                 .build();
     }
 }

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/out/persistence/remotearea/repository/RemoteAreaJpaRepository.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/out/persistence/remotearea/repository/RemoteAreaJpaRepository.java
@@ -5,13 +5,10 @@ import com.personal.marketnote.user.adapter.out.persistence.remotearea.entity.Re
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
-import java.util.Optional;
 
 public interface RemoteAreaJpaRepository extends JpaRepository<RemoteAreaJpaEntity, Long> {
 
-    Optional<RemoteAreaJpaEntity> findByZipCodeAndStatus(String zipCode, EntityStatus status);
+    boolean existsByProvinceAndDistrictAndVillageAndSubareaAndStatus(String province, String district, String village, String subarea, EntityStatus status);
 
     List<RemoteAreaJpaEntity> findAllByStatus(EntityStatus status);
-
-    boolean existsByZipCodeAndStatus(String zipCode, EntityStatus status);
 }

--- a/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/remotearea/RemoteArea.java
+++ b/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/remotearea/RemoteArea.java
@@ -2,17 +2,16 @@ package com.personal.marketnote.user.domain.remotearea;
 
 import com.personal.marketnote.common.domain.BaseDomain;
 import com.personal.marketnote.common.utility.FormatValidator;
-import com.personal.marketnote.user.domain.remotearea.exception.InvalidRemoteAreaRegionNameLengthException;
-import com.personal.marketnote.user.domain.remotearea.exception.InvalidRemoteAreaZipCodeException;
-import com.personal.marketnote.user.domain.remotearea.exception.RemoteAreaRegionNameNoValueException;
-import com.personal.marketnote.user.domain.remotearea.exception.RemoteAreaTypeNoValueException;
+import com.personal.marketnote.user.domain.remotearea.exception.InvalidRemoteAreaDistrictLengthException;
+import com.personal.marketnote.user.domain.remotearea.exception.InvalidRemoteAreaProvinceLengthException;
+import com.personal.marketnote.user.domain.remotearea.exception.InvalidRemoteAreaSubareaLengthException;
+import com.personal.marketnote.user.domain.remotearea.exception.InvalidRemoteAreaVillageLengthException;
+import com.personal.marketnote.user.domain.remotearea.exception.RemoteAreaProvinceNoValueException;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.util.regex.Pattern;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
@@ -20,60 +19,77 @@ import java.util.regex.Pattern;
 @Getter
 public class RemoteArea extends BaseDomain {
 
-    private static final Pattern ZIP_CODE_PATTERN = Pattern.compile("^\\d{5}$");
+    private static final int MAX_PROVINCE_LENGTH = 50;
+    private static final int MAX_DISTRICT_LENGTH = 50;
+    private static final int MAX_VILLAGE_LENGTH = 50;
+    private static final int MAX_SUBAREA_LENGTH = 50;
 
     private Long id;
-    private String zipCode;
-    private RemoteAreaType remoteAreaType;
-    private String regionName;
+    private String province;
+    private String district;
+    private String village;
+    private String subarea;
 
     public static RemoteArea from(RemoteAreaCreateState state) {
-        validateZipCode(state.getZipCode());
-        validateRemoteAreaType(state.getRemoteAreaType());
-        validateRegionName(state.getRegionName());
+        validateProvince(state.getProvince());
+
+        String district = normalizeOptionalField(state.getDistrict());
+        String village = normalizeOptionalField(state.getVillage());
+        String subarea = normalizeOptionalField(state.getSubarea());
+
+        validateDistrictLength(district);
+        validateVillageLength(village);
+        validateSubareaLength(subarea);
 
         return RemoteArea.builder()
-                .zipCode(state.getZipCode())
-                .remoteAreaType(state.getRemoteAreaType())
-                .regionName(state.getRegionName())
+                .province(state.getProvince())
+                .district(district)
+                .village(village)
+                .subarea(subarea)
                 .build();
     }
 
     public static RemoteArea from(RemoteAreaSnapshotState state) {
         return RemoteArea.builder()
                 .id(state.getId())
-                .zipCode(state.getZipCode())
-                .remoteAreaType(state.getRemoteAreaType())
-                .regionName(state.getRegionName())
+                .province(state.getProvince())
+                .district(state.getDistrict())
+                .village(state.getVillage())
+                .subarea(state.getSubarea())
                 .build();
     }
 
-    public boolean isJeju() {
-        return remoteAreaType.isJeju();
+    private static String normalizeOptionalField(String value) {
+        if (FormatValidator.hasNoValue(value)) {
+            return "";
+        }
+        return value;
     }
 
-    public boolean isIslandMountainous() {
-        return remoteAreaType.isIslandMountainous();
-    }
-
-    private static void validateZipCode(String zipCode) {
-        if (!FormatValidator.isValid(zipCode, ZIP_CODE_PATTERN)) {
-            throw new InvalidRemoteAreaZipCodeException();
+    private static void validateProvince(String province) {
+        if (FormatValidator.hasNoValue(province)) {
+            throw new RemoteAreaProvinceNoValueException();
+        }
+        if (province.length() > MAX_PROVINCE_LENGTH) {
+            throw new InvalidRemoteAreaProvinceLengthException();
         }
     }
 
-    private static void validateRemoteAreaType(RemoteAreaType remoteAreaType) {
-        if (FormatValidator.hasNoValue(remoteAreaType)) {
-            throw new RemoteAreaTypeNoValueException();
+    private static void validateDistrictLength(String district) {
+        if (district.length() > MAX_DISTRICT_LENGTH) {
+            throw new InvalidRemoteAreaDistrictLengthException();
         }
     }
 
-    private static void validateRegionName(String regionName) {
-        if (FormatValidator.hasNoValue(regionName)) {
-            throw new RemoteAreaRegionNameNoValueException();
+    private static void validateVillageLength(String village) {
+        if (village.length() > MAX_VILLAGE_LENGTH) {
+            throw new InvalidRemoteAreaVillageLengthException();
         }
-        if (regionName.length() > 100) {
-            throw new InvalidRemoteAreaRegionNameLengthException();
+    }
+
+    private static void validateSubareaLength(String subarea) {
+        if (subarea.length() > MAX_SUBAREA_LENGTH) {
+            throw new InvalidRemoteAreaSubareaLengthException();
         }
     }
 }

--- a/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/remotearea/RemoteAreaCreateState.java
+++ b/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/remotearea/RemoteAreaCreateState.java
@@ -9,7 +9,8 @@ import lombok.Getter;
 @Builder
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class RemoteAreaCreateState {
-    private final String zipCode;
-    private final RemoteAreaType remoteAreaType;
-    private final String regionName;
+    private final String province;
+    private final String district;
+    private final String village;
+    private final String subarea;
 }

--- a/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/remotearea/RemoteAreaSnapshotState.java
+++ b/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/remotearea/RemoteAreaSnapshotState.java
@@ -10,7 +10,8 @@ import lombok.Getter;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class RemoteAreaSnapshotState {
     private final Long id;
-    private final String zipCode;
-    private final RemoteAreaType remoteAreaType;
-    private final String regionName;
+    private final String province;
+    private final String district;
+    private final String village;
+    private final String subarea;
 }

--- a/user-service/user-domain/src/test/java/com/personal/marketnote/user/domain/remotearea/RemoteAreaTest.java
+++ b/user-service/user-domain/src/test/java/com/personal/marketnote/user/domain/remotearea/RemoteAreaTest.java
@@ -1,9 +1,10 @@
 package com.personal.marketnote.user.domain.remotearea;
 
-import com.personal.marketnote.user.domain.remotearea.exception.InvalidRemoteAreaRegionNameLengthException;
-import com.personal.marketnote.user.domain.remotearea.exception.InvalidRemoteAreaZipCodeException;
-import com.personal.marketnote.user.domain.remotearea.exception.RemoteAreaRegionNameNoValueException;
-import com.personal.marketnote.user.domain.remotearea.exception.RemoteAreaTypeNoValueException;
+import com.personal.marketnote.user.domain.remotearea.exception.InvalidRemoteAreaDistrictLengthException;
+import com.personal.marketnote.user.domain.remotearea.exception.InvalidRemoteAreaProvinceLengthException;
+import com.personal.marketnote.user.domain.remotearea.exception.InvalidRemoteAreaSubareaLengthException;
+import com.personal.marketnote.user.domain.remotearea.exception.InvalidRemoteAreaVillageLengthException;
+import com.personal.marketnote.user.domain.remotearea.exception.RemoteAreaProvinceNoValueException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -18,129 +19,152 @@ class RemoteAreaTest {
     class FromCreateState {
 
         @Test
-        @DisplayName("유효한 CreateState로 RemoteArea를 생성한다")
-        void shouldCreateRemoteAreaWithValidState() {
+        @DisplayName("광역시도만 지정하여 RemoteArea를 생성한다")
+        void shouldCreateRemoteAreaWithProvinceOnly() {
             // given
             RemoteAreaCreateState state = RemoteAreaCreateState.builder()
-                    .zipCode("63000")
-                    .remoteAreaType(RemoteAreaType.JEJU)
-                    .regionName("제주특별자치도 제주시")
+                    .province("인천")
                     .build();
 
             // when
             RemoteArea remoteArea = RemoteArea.from(state);
 
             // then
-            assertThat(remoteArea.getZipCode()).isEqualTo("63000");
-            assertThat(remoteArea.getRemoteAreaType()).isEqualTo(RemoteAreaType.JEJU);
-            assertThat(remoteArea.getRegionName()).isEqualTo("제주특별자치도 제주시");
+            assertThat(remoteArea.getProvince()).isEqualTo("인천");
+            assertThat(remoteArea.getDistrict()).isEmpty();
+            assertThat(remoteArea.getVillage()).isEmpty();
+            assertThat(remoteArea.getSubarea()).isEmpty();
             assertThat(remoteArea.isActive()).isTrue();
         }
 
         @Test
-        @DisplayName("우편번호가 null이면 InvalidRemoteAreaZipCodeException이 발생한다")
-        void shouldThrowWhenZipCodeIsNull() {
+        @DisplayName("광역시도, 시군구, 읍면동을 지정하여 RemoteArea를 생성한다")
+        void shouldCreateRemoteAreaWithProvinceDistrictVillage() {
             // given
             RemoteAreaCreateState state = RemoteAreaCreateState.builder()
-                    .zipCode(null)
-                    .remoteAreaType(RemoteAreaType.JEJU)
-                    .regionName("제주특별자치도 제주시")
+                    .province("경남")
+                    .district("통영시")
+                    .village("사량면")
                     .build();
 
-            // when & then
-            assertThatThrownBy(() -> RemoteArea.from(state))
-                    .isInstanceOf(InvalidRemoteAreaZipCodeException.class);
+            // when
+            RemoteArea remoteArea = RemoteArea.from(state);
+
+            // then
+            assertThat(remoteArea.getProvince()).isEqualTo("경남");
+            assertThat(remoteArea.getDistrict()).isEqualTo("통영시");
+            assertThat(remoteArea.getVillage()).isEqualTo("사량면");
+            assertThat(remoteArea.getSubarea()).isEmpty();
         }
 
         @Test
-        @DisplayName("우편번호가 5자리가 아니면 InvalidRemoteAreaZipCodeException이 발생한다")
-        void shouldThrowWhenZipCodeIsNot5Digits() {
+        @DisplayName("모든 필드를 지정하여 RemoteArea를 생성한다")
+        void shouldCreateRemoteAreaWithAllFields() {
             // given
             RemoteAreaCreateState state = RemoteAreaCreateState.builder()
-                    .zipCode("1234")
-                    .remoteAreaType(RemoteAreaType.ISLAND_MOUNTAINOUS)
-                    .regionName("경남 통영시 한산면")
+                    .province("충남")
+                    .district("보령시")
+                    .village("오천면")
+                    .subarea("녹도리")
                     .build();
 
-            // when & then
-            assertThatThrownBy(() -> RemoteArea.from(state))
-                    .isInstanceOf(InvalidRemoteAreaZipCodeException.class);
+            // when
+            RemoteArea remoteArea = RemoteArea.from(state);
+
+            // then
+            assertThat(remoteArea.getProvince()).isEqualTo("충남");
+            assertThat(remoteArea.getDistrict()).isEqualTo("보령시");
+            assertThat(remoteArea.getVillage()).isEqualTo("오천면");
+            assertThat(remoteArea.getSubarea()).isEqualTo("녹도리");
         }
 
         @Test
-        @DisplayName("우편번호에 숫자가 아닌 문자가 포함되면 InvalidRemoteAreaZipCodeException이 발생한다")
-        void shouldThrowWhenZipCodeContainsNonDigit() {
+        @DisplayName("광역시도가 null이면 RemoteAreaProvinceNoValueException이 발생한다")
+        void shouldThrowWhenProvinceIsNull() {
             // given
             RemoteAreaCreateState state = RemoteAreaCreateState.builder()
-                    .zipCode("6300a")
-                    .remoteAreaType(RemoteAreaType.JEJU)
-                    .regionName("제주특별자치도 제주시")
+                    .province(null)
+                    .district("옹진군")
                     .build();
 
             // when & then
             assertThatThrownBy(() -> RemoteArea.from(state))
-                    .isInstanceOf(InvalidRemoteAreaZipCodeException.class);
+                    .isInstanceOf(RemoteAreaProvinceNoValueException.class);
         }
 
         @Test
-        @DisplayName("지역 유형이 null이면 RemoteAreaTypeNoValueException이 발생한다")
-        void shouldThrowWhenRemoteAreaTypeIsNull() {
+        @DisplayName("광역시도가 빈 문자열이면 RemoteAreaProvinceNoValueException이 발생한다")
+        void shouldThrowWhenProvinceIsBlank() {
             // given
             RemoteAreaCreateState state = RemoteAreaCreateState.builder()
-                    .zipCode("63000")
-                    .remoteAreaType(null)
-                    .regionName("제주특별자치도 제주시")
+                    .province("   ")
                     .build();
 
             // when & then
             assertThatThrownBy(() -> RemoteArea.from(state))
-                    .isInstanceOf(RemoteAreaTypeNoValueException.class);
+                    .isInstanceOf(RemoteAreaProvinceNoValueException.class);
         }
 
         @Test
-        @DisplayName("지역명이 null이면 RemoteAreaRegionNameNoValueException이 발생한다")
-        void shouldThrowWhenRegionNameIsNull() {
+        @DisplayName("광역시도가 50자를 초과하면 InvalidRemoteAreaProvinceLengthException이 발생한다")
+        void shouldThrowWhenProvinceExceeds50Characters() {
             // given
+            String longProvince = "가".repeat(51);
             RemoteAreaCreateState state = RemoteAreaCreateState.builder()
-                    .zipCode("63000")
-                    .remoteAreaType(RemoteAreaType.JEJU)
-                    .regionName(null)
+                    .province(longProvince)
                     .build();
 
             // when & then
             assertThatThrownBy(() -> RemoteArea.from(state))
-                    .isInstanceOf(RemoteAreaRegionNameNoValueException.class);
+                    .isInstanceOf(InvalidRemoteAreaProvinceLengthException.class);
         }
 
         @Test
-        @DisplayName("지역명이 빈 문자열이면 RemoteAreaRegionNameNoValueException이 발생한다")
-        void shouldThrowWhenRegionNameIsBlank() {
+        @DisplayName("시군구가 50자를 초과하면 InvalidRemoteAreaDistrictLengthException이 발생한다")
+        void shouldThrowWhenDistrictExceeds50Characters() {
             // given
+            String longDistrict = "가".repeat(51);
             RemoteAreaCreateState state = RemoteAreaCreateState.builder()
-                    .zipCode("63000")
-                    .remoteAreaType(RemoteAreaType.JEJU)
-                    .regionName("   ")
+                    .province("충남")
+                    .district(longDistrict)
                     .build();
 
             // when & then
             assertThatThrownBy(() -> RemoteArea.from(state))
-                    .isInstanceOf(RemoteAreaRegionNameNoValueException.class);
+                    .isInstanceOf(InvalidRemoteAreaDistrictLengthException.class);
         }
 
         @Test
-        @DisplayName("지역명이 100자를 초과하면 InvalidRemoteAreaRegionNameLengthException이 발생한다")
-        void shouldThrowWhenRegionNameExceeds100Characters() {
+        @DisplayName("읍면동이 50자를 초과하면 InvalidRemoteAreaVillageLengthException이 발생한다")
+        void shouldThrowWhenVillageExceeds50Characters() {
             // given
-            String longRegionName = "가".repeat(101);
+            String longVillage = "가".repeat(51);
             RemoteAreaCreateState state = RemoteAreaCreateState.builder()
-                    .zipCode("63000")
-                    .remoteAreaType(RemoteAreaType.JEJU)
-                    .regionName(longRegionName)
+                    .province("충남")
+                    .district("보령시")
+                    .village(longVillage)
                     .build();
 
             // when & then
             assertThatThrownBy(() -> RemoteArea.from(state))
-                    .isInstanceOf(InvalidRemoteAreaRegionNameLengthException.class);
+                    .isInstanceOf(InvalidRemoteAreaVillageLengthException.class);
+        }
+
+        @Test
+        @DisplayName("세부지역이 50자를 초과하면 InvalidRemoteAreaSubareaLengthException이 발생한다")
+        void shouldThrowWhenSubareaExceeds50Characters() {
+            // given
+            String longSubarea = "가".repeat(51);
+            RemoteAreaCreateState state = RemoteAreaCreateState.builder()
+                    .province("충남")
+                    .district("보령시")
+                    .village("오천면")
+                    .subarea(longSubarea)
+                    .build();
+
+            // when & then
+            assertThatThrownBy(() -> RemoteArea.from(state))
+                    .isInstanceOf(InvalidRemoteAreaSubareaLengthException.class);
         }
     }
 
@@ -154,9 +178,10 @@ class RemoteAreaTest {
             // given
             RemoteAreaSnapshotState state = RemoteAreaSnapshotState.builder()
                     .id(1L)
-                    .zipCode("63000")
-                    .remoteAreaType(RemoteAreaType.JEJU)
-                    .regionName("제주특별자치도 제주시")
+                    .province("충남")
+                    .district("보령시")
+                    .village("오천면")
+                    .subarea("녹도리")
                     .build();
 
             // when
@@ -164,50 +189,10 @@ class RemoteAreaTest {
 
             // then
             assertThat(remoteArea.getId()).isEqualTo(1L);
-            assertThat(remoteArea.getZipCode()).isEqualTo("63000");
-            assertThat(remoteArea.getRemoteAreaType()).isEqualTo(RemoteAreaType.JEJU);
-            assertThat(remoteArea.getRegionName()).isEqualTo("제주특별자치도 제주시");
-        }
-    }
-
-    @Nested
-    @DisplayName("술어 메서드")
-    class PredicateMethods {
-
-        @Test
-        @DisplayName("제주 지역이면 isJeju()가 true를 반환한다")
-        void shouldReturnTrueForJeju() {
-            // given
-            RemoteArea remoteArea = RemoteArea.from(
-                    RemoteAreaSnapshotState.builder()
-                            .id(1L)
-                            .zipCode("63000")
-                            .remoteAreaType(RemoteAreaType.JEJU)
-                            .regionName("제주특별자치도 제주시")
-                            .build()
-            );
-
-            // when & then
-            assertThat(remoteArea.isJeju()).isTrue();
-            assertThat(remoteArea.isIslandMountainous()).isFalse();
-        }
-
-        @Test
-        @DisplayName("도서산간 지역이면 isIslandMountainous()가 true를 반환한다")
-        void shouldReturnTrueForIslandMountainous() {
-            // given
-            RemoteArea remoteArea = RemoteArea.from(
-                    RemoteAreaSnapshotState.builder()
-                            .id(2L)
-                            .zipCode("53000")
-                            .remoteAreaType(RemoteAreaType.ISLAND_MOUNTAINOUS)
-                            .regionName("경남 통영시 한산면")
-                            .build()
-            );
-
-            // when & then
-            assertThat(remoteArea.isIslandMountainous()).isTrue();
-            assertThat(remoteArea.isJeju()).isFalse();
+            assertThat(remoteArea.getProvince()).isEqualTo("충남");
+            assertThat(remoteArea.getDistrict()).isEqualTo("보령시");
+            assertThat(remoteArea.getVillage()).isEqualTo("오천면");
+            assertThat(remoteArea.getSubarea()).isEqualTo("녹도리");
         }
     }
 }


### PR DESCRIPTION
## partially addresses #216
## resolves #1949

## Test Case
- [x] CancelFulfillmentReleasePort Mock 추가
- [x] PublishOrderEventPort Mock 추가
- [x] PlatformTransactionManager Mock + TransactionTemplate 동작 설정
- [x] 결제 대기 상태의 주문을 취소하면 풀필먼트 취소 없이 즉시 CANCELLED 처리된다
- [x] 결제 완료 상태의 주문을 취소하면 풀필먼트 취소 없이 이벤트를 발행한다
- [x] 상품 준비중 상태에서 풀필먼트 취소 성공 시 CANCELLED 처리되고 이벤트를 발행한다
- [x] 풀필먼트가 출고 취소를 거부하면 OrderCancellationNotAllowedException이 발생한다
- [x] 풀필먼트 서비스 통신 실패 시 OrderCancellationNotAllowedException이 발생한다
- [x] 타인의 주문을 취소 요청하면 UnauthorizedOrderAccessException이 발생한다
- [x] 이미 취소된 주문을 다시 취소 요청하면 OrderStatusAlreadyChangedException이 발생한다
- [x] 배송중 상태의 주문을 취소 요청하면 InvalidOrderStatusTransitionException이 발생한다