### PR TITLE
[#216][#2302] test: 피킹 완료 이후 취소 불가 예외 추가 기능 자동화 테스트 추가

### DIFF
--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/CancelOrderUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/CancelOrderUseCaseTest.java
@@ -174,7 +174,8 @@ class CancelOrderUseCaseTest {
             CancelOrderCommand command = createCommand(orderId, buyerId);
 
             assertThatThrownBy(() -> cancelOrderService.cancelOrder(command))
-                    .isInstanceOf(OrderCancellationNotAllowedException.class);
+                    .isInstanceOf(OrderCancellationNotAllowedException.class)
+                    .hasMessageContaining("피킹완료 이후에는 주문 취소가 불가능합니다. 반품으로 처리해 주세요.");
 
             verifyNoInteractions(updateOrderPort);
             verifyNoInteractions(publishOrderEventPort);
@@ -193,7 +194,8 @@ class CancelOrderUseCaseTest {
             CancelOrderCommand command = createCommand(orderId, buyerId);
 
             assertThatThrownBy(() -> cancelOrderService.cancelOrder(command))
-                    .isInstanceOf(OrderCancellationNotAllowedException.class);
+                    .isInstanceOf(OrderCancellationNotAllowedException.class)
+                    .hasMessageContaining("피킹완료 이후에는 주문 취소가 불가능합니다. 반품으로 처리해 주세요.");
 
             verifyNoInteractions(updateOrderPort);
             verifyNoInteractions(publishOrderEventPort);


### PR DESCRIPTION
## partially addresses #216
## resolves #2302

## Test Case
- [x] 풀필먼트가 출고 취소를 거부하면 OrderCancellationNotAllowedException이 발생한다 — 메시지 검증 추가
- [x] 풀필먼트 서비스 통신 실패 시 OrderCancellationNotAllowedException이 발생한다 — 메시지 검증 추가