### PR TITLE
[#216][#2296] feat: 주문 취소 시 PG 환불 처리 컨슈머 추가

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/OrderCancelledPgRefundConsumer.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/OrderCancelledPgRefundConsumer.java
@@ -1,0 +1,77 @@
+package com.personal.marketnote.commerce.adapter.in.event;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.commerce.exception.PaymentAlreadyRefundedException;
+import com.personal.marketnote.commerce.port.in.command.payment.RefundPaymentCommand;
+import com.personal.marketnote.commerce.port.in.usecase.payment.RefundPaymentUseCase;
+import com.personal.marketnote.common.kafka.KafkaTopicConstants;
+import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.EventPayloadValidator;
+import com.personal.marketnote.common.kafka.event.OrderCancelledEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OrderCancelledPgRefundConsumer {
+    private final ObjectMapper objectMapper;
+    private final RefundPaymentUseCase refundPaymentUseCase;
+
+    @KafkaListener(
+            topics = KafkaTopicConstants.ORDER_CANCELLED,
+            groupId = "commerce-pg-refund"
+    )
+    public void handleOrderCancelledEvent(
+            ConsumerRecord<String, EventEnvelope<?>> record,
+            Acknowledgment acknowledgment
+    ) {
+        EventEnvelope<?> envelope = record.value();
+
+        if (EventPayloadValidator.hasInvalidEnvelope(envelope, record)) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        if (EventPayloadValidator.hasEventTypeMismatch(envelope, KafkaTopicConstants.ORDER_CANCELLED)) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        OrderCancelledEvent payload = envelope.getPayloadAs(OrderCancelledEvent.class, objectMapper);
+
+        log.info("주문 취소 이벤트 수신 (PG 환불). eventId={}, orderId={}, isFullCancel={}, cancelAmount={}",
+                envelope.eventId(), payload.orderId(), payload.isFullCancel(), payload.cancelAmount());
+
+        if (EventPayloadValidator.hasInvalidIds(envelope.eventId(),
+                EventPayloadValidator.id("orderId", payload.orderId()))) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        try {
+            RefundPaymentCommand command = RefundPaymentCommand.builder()
+                    .orderKey(payload.orderKey())
+                    .orderId(payload.orderId())
+                    .cancelAmount(payload.cancelAmount())
+                    .paymentAmount(payload.paymentAmount())
+                    .isFullCancel(payload.isFullCancel())
+                    .alreadyRefunded(payload.alreadyRefunded())
+                    .build();
+
+            refundPaymentUseCase.refund(command);
+
+            log.info("PG 환불 완료. orderId={}, isFullCancel={}, cancelAmount={}",
+                    payload.orderId(), payload.isFullCancel(), payload.cancelAmount());
+        } catch (PaymentAlreadyRefundedException e) {
+            log.info("이미 환불 처리된 결제 (멱등 처리). eventId={}, message={}",
+                    envelope.eventId(), e.getMessage());
+        }
+
+        acknowledgment.acknowledge();
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/exception/PaymentAlreadyRefundedException.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/exception/PaymentAlreadyRefundedException.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.commerce.exception;
+
+public class PaymentAlreadyRefundedException extends RuntimeException {
+    public PaymentAlreadyRefundedException(String orderKey) {
+        super("ERR_PAYMENT_REFUND_01::이미 환불 처리된 결제입니다. orderKey=" + orderKey);
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/command/payment/RefundPaymentCommand.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/command/payment/RefundPaymentCommand.java
@@ -1,0 +1,14 @@
+package com.personal.marketnote.commerce.port.in.command.payment;
+
+import lombok.Builder;
+
+@Builder
+public record RefundPaymentCommand(
+        String orderKey,
+        Long orderId,
+        Long cancelAmount,
+        Long paymentAmount,
+        boolean isFullCancel,
+        Long alreadyRefunded
+) {
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/payment/RefundPaymentUseCase.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/payment/RefundPaymentUseCase.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.commerce.port.in.usecase.payment;
+
+import com.personal.marketnote.commerce.port.in.command.payment.RefundPaymentCommand;
+
+public interface RefundPaymentUseCase {
+    void refund(RefundPaymentCommand command);
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/RefundPaymentService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/payment/RefundPaymentService.java
@@ -1,0 +1,166 @@
+package com.personal.marketnote.commerce.service.payment;
+
+import com.personal.marketnote.commerce.domain.payment.Payment;
+import com.personal.marketnote.commerce.domain.payment.PspPaymentEvent;
+import com.personal.marketnote.commerce.domain.refund.Refund;
+import com.personal.marketnote.commerce.domain.refund.RefundCreateState;
+import com.personal.marketnote.commerce.domain.refund.RefundType;
+import com.personal.marketnote.commerce.exception.PaymentAlreadyRefundedException;
+import com.personal.marketnote.commerce.exception.PaymentCancelException;
+import com.personal.marketnote.commerce.exception.PaymentNotFoundException;
+import com.personal.marketnote.commerce.port.in.command.payment.RefundPaymentCommand;
+import com.personal.marketnote.commerce.port.in.usecase.payment.RefundPaymentUseCase;
+import com.personal.marketnote.commerce.port.out.payment.*;
+import com.personal.marketnote.commerce.port.out.payment.vendor.PaymentCancelVendorCommand;
+import com.personal.marketnote.commerce.port.out.payment.vendor.PaymentCancelVendorResult;
+import com.personal.marketnote.commerce.port.out.refund.SaveRefundPort;
+import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.common.utility.FormatValidator;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.util.UUID;
+
+@UseCase
+@RequiredArgsConstructor
+@Slf4j
+public class RefundPaymentService implements RefundPaymentUseCase {
+    private static final String PSP_FULL_CANCEL_TYPE_CODE = "STSC";
+    private static final String PSP_PARTIAL_CANCEL_TYPE_CODE = "STPC";
+
+    private final FindPaymentPort findPaymentPort;
+    private final FindPspPaymentEventPort findPspPaymentEventPort;
+    private final UpdatePaymentPort updatePaymentPort;
+    private final UpdatePspPaymentEventPort updatePspPaymentEventPort;
+    private final PaymentVendorPort paymentVendorPort;
+    private final SaveRefundPort saveRefundPort;
+    private final PlatformTransactionManager transactionManager;
+
+    @Override
+    public void refund(RefundPaymentCommand command) {
+        Payment payment = findPayment(command.orderKey());
+        validateNotAlreadyRefunded(payment, command.orderKey());
+
+        PspPaymentEvent event = findPspPaymentEvent(command.orderKey());
+        validateRefundable(event, command.orderKey());
+
+        Long alreadyRefunded = FormatValidator.hasValue(command.alreadyRefunded()) ? command.alreadyRefunded() : 0L;
+        Long refundableAmount = command.paymentAmount() - alreadyRefunded;
+        Long cancelAmount = resolveCancelAmount(command.isFullCancel(), command.cancelAmount(), refundableAmount);
+        Long remainAmount = refundableAmount - cancelAmount;
+        String cancelType = command.isFullCancel() ? PSP_FULL_CANCEL_TYPE_CODE : PSP_PARTIAL_CANCEL_TYPE_CODE;
+
+        PaymentCancelVendorResult vendorResult = requestPgCancellation(
+                event.getPgPaymentKey(), cancelType, cancelAmount, remainAmount
+        );
+
+        persistRefundResult(command, payment, event, vendorResult, cancelAmount);
+    }
+
+    private Payment findPayment(String orderKey) {
+        UUID orderKeyUuid = UUID.fromString(orderKey);
+        return findPaymentPort.findByOrderKey(orderKeyUuid)
+                .orElseThrow(() -> new PaymentNotFoundException(orderKey));
+    }
+
+    private void validateNotAlreadyRefunded(Payment payment, String orderKey) {
+        if (payment.isAlreadyRefunded()) {
+            throw new PaymentAlreadyRefundedException(orderKey);
+        }
+    }
+
+    private PspPaymentEvent findPspPaymentEvent(String orderKey) {
+        return findPspPaymentEventPort.findByOrderKey(orderKey)
+                .orElseThrow(() -> new PaymentNotFoundException(orderKey));
+    }
+
+    private void validateRefundable(PspPaymentEvent event, String orderKey) {
+        if (!event.getPoStatus().isRefundable()) {
+            throw new PaymentAlreadyRefundedException(orderKey);
+        }
+    }
+
+    private Long resolveCancelAmount(boolean isFullCancel, Long cancelAmount, Long refundableAmount) {
+        if (isFullCancel) {
+            return refundableAmount;
+        }
+        return cancelAmount;
+    }
+
+    private PaymentCancelVendorResult requestPgCancellation(
+            String transactionNumber, String cancelType, Long cancelAmount, Long remainAmount
+    ) {
+        PaymentCancelVendorCommand vendorCommand = PaymentCancelVendorCommand.builder()
+                .transactionId(transactionNumber)
+                .cancelType(cancelType)
+                .cancelAmount(cancelAmount)
+                .remainAmount(remainAmount)
+                .cancelReason("주문 취소")
+                .build();
+
+        PaymentCancelVendorResult vendorResult = paymentVendorPort.cancelPayment(vendorCommand);
+
+        if (!vendorResult.success()) {
+            throw new PaymentCancelException(
+                    "결제 취소 실패 [" + vendorResult.resultCode() + "]: " + vendorResult.resultMessage()
+            );
+        }
+
+        return vendorResult;
+    }
+
+    private void persistRefundResult(
+            RefundPaymentCommand command, Payment payment, PspPaymentEvent event,
+            PaymentCancelVendorResult vendorResult, Long cancelAmount
+    ) {
+        TransactionTemplate transactionTemplate = new TransactionTemplate(transactionManager);
+        transactionTemplate.setIsolationLevel(TransactionDefinition.ISOLATION_READ_COMMITTED);
+        transactionTemplate.executeWithoutResult(status -> {
+            updateDomain(command.isFullCancel(), payment, event, vendorResult, cancelAmount);
+            updatePaymentPort.update(payment);
+            updatePspPaymentEventPort.update(event);
+            saveRefundRecord(payment, command.isFullCancel(), cancelAmount, vendorResult);
+        });
+    }
+
+    private void updateDomain(
+            boolean isFullCancel, Payment payment, PspPaymentEvent event,
+            PaymentCancelVendorResult vendorResult, Long cancelAmount
+    ) {
+        if (isFullCancel) {
+            payment.markAsRefunded();
+            event.cancel(vendorResult.rawResponse());
+            return;
+        }
+
+        payment.markAsPartiallyRefunded(cancelAmount);
+        event.partialRefund(vendorResult.rawResponse());
+    }
+
+    private void saveRefundRecord(
+            Payment payment, boolean isFullCancel, Long cancelAmount,
+            PaymentCancelVendorResult vendorResult
+    ) {
+        try {
+            RefundType refundType = isFullCancel ? RefundType.FULL_REFUND : RefundType.PARTIAL_REFUND;
+            RefundCreateState createState = RefundCreateState.builder()
+                    .paymentId(payment.getId())
+                    .orderId(payment.getOrderId())
+                    .refundType(refundType)
+                    .refundAmount(cancelAmount)
+                    .cancelReason("주문 취소")
+                    .processedBy("SYSTEM")
+                    .pgRefundKey(payment.getPgPaymentKey())
+                    .pgRawResponse(vendorResult.rawResponse())
+                    .build();
+            Refund refund = Refund.from(createState);
+            saveRefundPort.save(refund);
+        } catch (Exception e) {
+            log.error("환불 상세 기록 저장 실패 - orderId: {}, error: {}",
+                    payment.getOrderId(), e.getMessage(), e);
+        }
+    }
+}

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/payment/Payment.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/payment/Payment.java
@@ -62,6 +62,10 @@ public class Payment {
         refundAmount = paymentAmount;
     }
 
+    public boolean isAlreadyRefunded() {
+        return refundedYn;
+    }
+
     public void markAsPartiallyRefunded(Long amount) {
         long newRefundAmount = refundAmount + amount;
         if (newRefundAmount > paymentAmount) {


### PR DESCRIPTION
## partially addresses #216
## resolves #2296

## Task
- [x] RefundPaymentUseCase / RefundPaymentService 추가 (PG 환불 전담)
- [x] OrderCancelledPgRefundConsumer 추가 (commerce.order.cancelled, groupId: commerce-pg-refund)
- [x] Payment.isAlreadyRefunded() 술어 메서드 추가
- [x] PaymentAlreadyRefundedException 멱등 예외 추가
- [x] TX 분리: PG 호출(TX 밖) → TransactionTemplate(DB 업데이트)
- [x] 전체/부분 취소 모두 지원 (STSC/STPC)