### PR TITLE
[#216][#1935] feat: 반품 사유 카테고리 추가

### DIFF
--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/exception/InvalidReasonCategoryException.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/exception/InvalidReasonCategoryException.java
@@ -1,0 +1,12 @@
+package com.personal.marketnote.commerce.exception;
+
+import com.personal.marketnote.commerce.domain.order.OrderStatusReasonCategory;
+
+public class InvalidReasonCategoryException extends IllegalArgumentException {
+    private static final String INVALID_REASON_CATEGORY_EXCEPTION_MESSAGE
+            = "주문 상태 변경에 적합하지 않은 사유 카테고리입니다. reasonCategory=%s";
+
+    public InvalidReasonCategoryException(OrderStatusReasonCategory reasonCategory) {
+        super(String.format(INVALID_REASON_CATEGORY_EXCEPTION_MESSAGE, reasonCategory.name()));
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/CancelOrderService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/CancelOrderService.java
@@ -5,7 +5,9 @@ import com.personal.marketnote.commerce.domain.order.OrderAmount;
 import com.personal.marketnote.commerce.domain.order.OrderStatus;
 import com.personal.marketnote.commerce.domain.order.OrderStatusHistory;
 import com.personal.marketnote.commerce.domain.order.OrderStatusHistoryCreateState;
+import com.personal.marketnote.commerce.domain.order.OrderStatusReasonCategory;
 import com.personal.marketnote.commerce.exception.InvalidOrderStatusTransitionException;
+import com.personal.marketnote.commerce.exception.InvalidReasonCategoryException;
 import com.personal.marketnote.commerce.exception.OrderCancellationNotAllowedException;
 import com.personal.marketnote.commerce.exception.OrderStatusAlreadyChangedException;
 import com.personal.marketnote.commerce.exception.UnauthorizedOrderAccessException;
@@ -18,6 +20,7 @@ import com.personal.marketnote.commerce.port.out.fulfillment.CancelFulfillmentRe
 import com.personal.marketnote.commerce.port.out.order.UpdateOrderPort;
 import com.personal.marketnote.common.application.UseCase;
 import com.personal.marketnote.common.exception.FulfillmentServiceRequestFailedException;
+import com.personal.marketnote.common.utility.FormatValidator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.transaction.PlatformTransactionManager;
@@ -45,6 +48,7 @@ public class CancelOrderService implements CancelOrderUseCase {
         Order order = getOrderUseCase.getOrder(command.id());
 
         validateBuyerOwnership(command, order);
+        validateReasonCategory(command);
         validateStatusTransition(order);
 
         OrderStatus originalStatus = order.getOrderStatus();
@@ -110,6 +114,17 @@ public class CancelOrderService implements CancelOrderUseCase {
                 order.getOrderProducts(),
                 order.getOrderProducts()
         );
+    }
+
+    private void validateReasonCategory(CancelOrderCommand command) {
+        OrderStatusReasonCategory reasonCategory = command.reasonCategory();
+        if (FormatValidator.hasNoValue(reasonCategory)) {
+            return;
+        }
+
+        if (!reasonCategory.isCancelReason()) {
+            throw new InvalidReasonCategoryException(reasonCategory);
+        }
     }
 
     private void validateBuyerOwnership(CancelOrderCommand command, Order order) {

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/RequestReturnService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/RequestReturnService.java
@@ -2,6 +2,7 @@ package com.personal.marketnote.commerce.service.order;
 
 import com.personal.marketnote.commerce.domain.order.*;
 import com.personal.marketnote.commerce.exception.InvalidOrderStatusTransitionException;
+import com.personal.marketnote.commerce.exception.InvalidReasonCategoryException;
 import com.personal.marketnote.commerce.exception.OrderStatusAlreadyChangedException;
 import com.personal.marketnote.commerce.exception.UnauthorizedOrderAccessException;
 import com.personal.marketnote.commerce.port.in.command.order.RequestReturnCommand;
@@ -9,6 +10,7 @@ import com.personal.marketnote.commerce.port.in.usecase.order.GetOrderUseCase;
 import com.personal.marketnote.commerce.port.in.usecase.order.RequestReturnUseCase;
 import com.personal.marketnote.commerce.port.out.order.UpdateOrderPort;
 import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.common.utility.FormatValidator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.transaction.annotation.Transactional;
@@ -34,6 +36,7 @@ public class RequestReturnService implements RequestReturnUseCase {
         Order order = getOrderUseCase.getOrder(command.id());
 
         validateBuyerOwnership(command, order);
+        validateReasonCategory(command);
         validateStatusTransition(order);
 
         LocalDateTime now = LocalDateTime.now(clock);
@@ -57,6 +60,17 @@ public class RequestReturnService implements RequestReturnUseCase {
             log.warn("주문 소유자 불일치 - orderId: {}, 주문소유자: {}, 요청자: {}",
                     command.id(), order.getBuyerId(), command.buyerId());
             throw new UnauthorizedOrderAccessException();
+        }
+    }
+
+    private void validateReasonCategory(RequestReturnCommand command) {
+        OrderStatusReasonCategory reasonCategory = command.reasonCategory();
+        if (FormatValidator.hasNoValue(reasonCategory)) {
+            return;
+        }
+
+        if (!reasonCategory.isReturnReason()) {
+            throw new InvalidReasonCategoryException(reasonCategory);
         }
     }
 

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/order/OrderStatusReasonCategory.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/order/OrderStatusReasonCategory.java
@@ -1,13 +1,33 @@
 package com.personal.marketnote.commerce.domain.order;
 
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
+@Getter
 public enum OrderStatusReasonCategory {
-    CANCEL_ORDER("구매 의사 취소"),
-    CHANGE_OPTION("색상, 사이즈 등 변경"),
-    MISTAKE("주문 실수"),
-    ETC("직접 입력");
+    CANCEL_ORDER("구매 의사 취소", ReasonType.CANCEL),
+    CHANGE_OPTION("색상, 사이즈 등 변경", ReasonType.CANCEL),
+    MISTAKE("주문 실수", ReasonType.BOTH),
+    ETC("직접 입력", ReasonType.BOTH),
+    SIMPLE_CHANGE_OF_MIND("단순 변심", ReasonType.RETURN),
+    PRODUCT_DAMAGE("상품 파손/변질", ReasonType.RETURN),
+    PRODUCT_MISMATCH("상품이 설명과 다름", ReasonType.RETURN),
+    WRONG_DELIVERY("다른 상품이 배송됨", ReasonType.RETURN),
+    MISSING_COMPONENTS("상품/구성품 누락", ReasonType.RETURN);
 
     private final String description;
+    private final ReasonType reasonType;
+
+    public boolean isCancelReason() {
+        return reasonType == ReasonType.CANCEL || reasonType == ReasonType.BOTH;
+    }
+
+    public boolean isReturnReason() {
+        return reasonType == ReasonType.RETURN || reasonType == ReasonType.BOTH;
+    }
+
+    public enum ReasonType {
+        CANCEL, RETURN, BOTH
+    }
 }


### PR DESCRIPTION
## partially addresses #216
## resolves #1935

## Task
- [x] OrderStatusReasonCategory에 반품 전용 사유 5개 추가 (SIMPLE_CHANGE_OF_MIND, PRODUCT_DAMAGE, PRODUCT_MISMATCH, WRONG_DELIVERY, MISSING_COMPONENTS)
- [x] ReasonType(CANCEL, RETURN, BOTH) 구분 + isCancelReason()/isReturnReason() 술어 메서드 추가
- [x] MISTAKE, ETC를 취소+반품 공용(BOTH)으로 변경
- [x] RequestReturnService에 반품 사유 카테고리 검증 추가
- [x] CancelOrderService에 취소 사유 카테고리 검증 추가
- [x] InvalidReasonCategoryException 커스텀 예외 추가