### PR TITLE
[#216][#2305] test: 반품 사유 카테고리 추가 기능 자동화 테스트 추가

### DIFF
--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/CancelOrderUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/CancelOrderUseCaseTest.java
@@ -2,6 +2,7 @@ package com.personal.marketnote.commerce.service.order;
 
 import com.personal.marketnote.commerce.domain.order.*;
 import com.personal.marketnote.commerce.exception.InvalidOrderStatusTransitionException;
+import com.personal.marketnote.commerce.exception.InvalidReasonCategoryException;
 import com.personal.marketnote.commerce.exception.OrderCancellationNotAllowedException;
 import com.personal.marketnote.commerce.exception.OrderStatusAlreadyChangedException;
 import com.personal.marketnote.commerce.exception.UnauthorizedOrderAccessException;
@@ -199,6 +200,76 @@ class CancelOrderUseCaseTest {
 
             verifyNoInteractions(updateOrderPort);
             verifyNoInteractions(publishOrderEventPort);
+        }
+    }
+
+    // ==================================================================================
+    // 취소 사유 카테고리 검증
+    // ==================================================================================
+
+    @Nested
+    @DisplayName("취소 사유 카테고리 검증")
+    class CancelReasonCategoryValidationTest {
+
+        @Test
+        @DisplayName("반품 전용 사유로 취소 요청하면 InvalidReasonCategoryException이 발생한다")
+        void cancelOrder_withReturnOnlyReason_throwsException() {
+            Long orderId = 1L;
+            Long buyerId = 100L;
+            Order order = createOrder(orderId, buyerId, OrderStatus.PAID);
+            when(getOrderUseCase.getOrder(orderId)).thenReturn(order);
+
+            CancelOrderCommand command = CancelOrderCommand.builder()
+                    .id(orderId)
+                    .reasonCategory(OrderStatusReasonCategory.PRODUCT_DAMAGE)
+                    .reason("상품 파손")
+                    .buyerId(buyerId)
+                    .build();
+
+            assertThatThrownBy(() -> cancelOrderService.cancelOrder(command))
+                    .isInstanceOf(InvalidReasonCategoryException.class);
+
+            verifyNoInteractions(updateOrderPort);
+            verifyNoInteractions(cancelFulfillmentReleasePort);
+            verifyNoInteractions(publishOrderEventPort);
+        }
+
+        @Test
+        @DisplayName("취소 전용 사유로 취소 요청하면 정상 처리된다")
+        void cancelOrder_withCancelReason_succeeds() {
+            Long orderId = 1L;
+            Long buyerId = 100L;
+            Order order = createOrder(orderId, buyerId, OrderStatus.PAYMENT_PENDING);
+            when(getOrderUseCase.getOrder(orderId)).thenReturn(order);
+
+            CancelOrderCommand command = CancelOrderCommand.builder()
+                    .id(orderId)
+                    .reasonCategory(OrderStatusReasonCategory.CANCEL_ORDER)
+                    .reason("구매 의사 취소")
+                    .buyerId(buyerId)
+                    .build();
+
+            assertThatCode(() -> cancelOrderService.cancelOrder(command))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("공용 사유(MISTAKE)로 취소 요청하면 정상 처리된다")
+        void cancelOrder_withBothReason_succeeds() {
+            Long orderId = 1L;
+            Long buyerId = 100L;
+            Order order = createOrder(orderId, buyerId, OrderStatus.PAYMENT_PENDING);
+            when(getOrderUseCase.getOrder(orderId)).thenReturn(order);
+
+            CancelOrderCommand command = CancelOrderCommand.builder()
+                    .id(orderId)
+                    .reasonCategory(OrderStatusReasonCategory.MISTAKE)
+                    .reason("주문 실수")
+                    .buyerId(buyerId)
+                    .build();
+
+            assertThatCode(() -> cancelOrderService.cancelOrder(command))
+                    .doesNotThrowAnyException();
         }
     }
 

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/RequestReturnUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/RequestReturnUseCaseTest.java
@@ -2,6 +2,7 @@ package com.personal.marketnote.commerce.service.order;
 
 import com.personal.marketnote.commerce.domain.order.*;
 import com.personal.marketnote.commerce.exception.InvalidOrderStatusTransitionException;
+import com.personal.marketnote.commerce.exception.InvalidReasonCategoryException;
 import com.personal.marketnote.commerce.exception.OrderStatusAlreadyChangedException;
 import com.personal.marketnote.commerce.exception.UnauthorizedOrderAccessException;
 import com.personal.marketnote.commerce.port.in.command.order.RequestReturnCommand;
@@ -173,6 +174,89 @@ class RequestReturnUseCaseTest {
             assertThat(order.getPickupAddress().getZipCode()).isEqualTo("12345");
             assertThat(order.getPickupAddress().getAddress()).isEqualTo("서울시 강남구");
             assertThat(order.getPickupAddress().getAddressDetail()).isEqualTo("상세주소");
+        }
+    }
+
+    // ==================================================================================
+    // 반품 사유 카테고리 검증
+    // ==================================================================================
+
+    @Nested
+    @DisplayName("반품 사유 카테고리 검증")
+    class ReturnReasonCategoryValidationTest {
+
+        @Test
+        @DisplayName("반품 전용 사유로 반품 요청하면 정상 처리된다")
+        void requestReturn_withReturnReason_succeeds() {
+            Long orderId = 1L;
+            Long buyerId = 100L;
+            Order order = createOrderWithBuyerId(orderId, buyerId, OrderStatus.DELIVERED);
+            when(getOrderUseCase.getOrder(orderId)).thenReturn(order);
+
+            RequestReturnCommand command = RequestReturnCommand.builder()
+                    .id(orderId)
+                    .reasonCategory(OrderStatusReasonCategory.SIMPLE_CHANGE_OF_MIND)
+                    .buyerId(buyerId)
+                    .build();
+
+            assertThatCode(() -> requestReturnService.requestReturn(command))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("공용 사유(ETC)로 반품 요청하면 정상 처리된다")
+        void requestReturn_withBothReason_succeeds() {
+            Long orderId = 1L;
+            Long buyerId = 100L;
+            Order order = createOrderWithBuyerId(orderId, buyerId, OrderStatus.DELIVERED);
+            when(getOrderUseCase.getOrder(orderId)).thenReturn(order);
+
+            RequestReturnCommand command = RequestReturnCommand.builder()
+                    .id(orderId)
+                    .reasonCategory(OrderStatusReasonCategory.ETC)
+                    .reason("기타 사유")
+                    .buyerId(buyerId)
+                    .build();
+
+            assertThatCode(() -> requestReturnService.requestReturn(command))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("취소 전용 사유로 반품 요청하면 InvalidReasonCategoryException이 발생한다")
+        void requestReturn_withCancelOnlyReason_throwsException() {
+            Long orderId = 1L;
+            Long buyerId = 100L;
+            Order order = createOrderWithBuyerId(orderId, buyerId, OrderStatus.DELIVERED);
+            when(getOrderUseCase.getOrder(orderId)).thenReturn(order);
+
+            RequestReturnCommand command = RequestReturnCommand.builder()
+                    .id(orderId)
+                    .reasonCategory(OrderStatusReasonCategory.CANCEL_ORDER)
+                    .buyerId(buyerId)
+                    .build();
+
+            assertThatThrownBy(() -> requestReturnService.requestReturn(command))
+                    .isInstanceOf(InvalidReasonCategoryException.class);
+
+            verifyNoInteractions(updateOrderPort);
+        }
+
+        @Test
+        @DisplayName("사유 카테고리가 null이면 검증을 건너뛴다")
+        void requestReturn_withNullReasonCategory_succeeds() {
+            Long orderId = 1L;
+            Long buyerId = 100L;
+            Order order = createOrderWithBuyerId(orderId, buyerId, OrderStatus.DELIVERED);
+            when(getOrderUseCase.getOrder(orderId)).thenReturn(order);
+
+            RequestReturnCommand command = RequestReturnCommand.builder()
+                    .id(orderId)
+                    .buyerId(buyerId)
+                    .build();
+
+            assertThatCode(() -> requestReturnService.requestReturn(command))
+                    .doesNotThrowAnyException();
         }
     }
 

--- a/commerce-service/commerce-domain/src/test/java/com/personal/marketnote/commerce/domain/order/OrderStatusReasonCategoryTest.java
+++ b/commerce-service/commerce-domain/src/test/java/com/personal/marketnote/commerce/domain/order/OrderStatusReasonCategoryTest.java
@@ -1,0 +1,127 @@
+package com.personal.marketnote.commerce.domain.order;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OrderStatusReasonCategoryTest {
+
+    // ==================================================================================
+    // 취소 전용 사유
+    // ==================================================================================
+
+    @Nested
+    @DisplayName("취소 전용 사유")
+    class CancelOnlyReasonTest {
+
+        @Test
+        @DisplayName("CANCEL_ORDER는 취소 사유이다")
+        void cancelOrder_isCancelReason() {
+            assertThat(OrderStatusReasonCategory.CANCEL_ORDER.isCancelReason()).isTrue();
+        }
+
+        @Test
+        @DisplayName("CANCEL_ORDER는 반품 사유가 아니다")
+        void cancelOrder_isNotReturnReason() {
+            assertThat(OrderStatusReasonCategory.CANCEL_ORDER.isReturnReason()).isFalse();
+        }
+
+        @Test
+        @DisplayName("CHANGE_OPTION은 취소 사유이다")
+        void changeOption_isCancelReason() {
+            assertThat(OrderStatusReasonCategory.CHANGE_OPTION.isCancelReason()).isTrue();
+        }
+
+        @Test
+        @DisplayName("CHANGE_OPTION은 반품 사유가 아니다")
+        void changeOption_isNotReturnReason() {
+            assertThat(OrderStatusReasonCategory.CHANGE_OPTION.isReturnReason()).isFalse();
+        }
+    }
+
+    // ==================================================================================
+    // 반품 전용 사유
+    // ==================================================================================
+
+    @Nested
+    @DisplayName("반품 전용 사유")
+    class ReturnOnlyReasonTest {
+
+        @Test
+        @DisplayName("SIMPLE_CHANGE_OF_MIND는 반품 사유이다")
+        void simpleChangeOfMind_isReturnReason() {
+            assertThat(OrderStatusReasonCategory.SIMPLE_CHANGE_OF_MIND.isReturnReason()).isTrue();
+        }
+
+        @Test
+        @DisplayName("SIMPLE_CHANGE_OF_MIND는 취소 사유가 아니다")
+        void simpleChangeOfMind_isNotCancelReason() {
+            assertThat(OrderStatusReasonCategory.SIMPLE_CHANGE_OF_MIND.isCancelReason()).isFalse();
+        }
+
+        @Test
+        @DisplayName("PRODUCT_DAMAGE는 반품 사유이다")
+        void productDamage_isReturnReason() {
+            assertThat(OrderStatusReasonCategory.PRODUCT_DAMAGE.isReturnReason()).isTrue();
+        }
+
+        @Test
+        @DisplayName("PRODUCT_DAMAGE는 취소 사유가 아니다")
+        void productDamage_isNotCancelReason() {
+            assertThat(OrderStatusReasonCategory.PRODUCT_DAMAGE.isCancelReason()).isFalse();
+        }
+
+        @Test
+        @DisplayName("PRODUCT_MISMATCH는 반품 사유이다")
+        void productMismatch_isReturnReason() {
+            assertThat(OrderStatusReasonCategory.PRODUCT_MISMATCH.isReturnReason()).isTrue();
+        }
+
+        @Test
+        @DisplayName("WRONG_DELIVERY는 반품 사유이다")
+        void wrongDelivery_isReturnReason() {
+            assertThat(OrderStatusReasonCategory.WRONG_DELIVERY.isReturnReason()).isTrue();
+        }
+
+        @Test
+        @DisplayName("MISSING_COMPONENTS는 반품 사유이다")
+        void missingComponents_isReturnReason() {
+            assertThat(OrderStatusReasonCategory.MISSING_COMPONENTS.isReturnReason()).isTrue();
+        }
+    }
+
+    // ==================================================================================
+    // 취소+반품 공용 사유
+    // ==================================================================================
+
+    @Nested
+    @DisplayName("취소+반품 공용 사유")
+    class BothReasonTest {
+
+        @Test
+        @DisplayName("MISTAKE는 취소 사유이다")
+        void mistake_isCancelReason() {
+            assertThat(OrderStatusReasonCategory.MISTAKE.isCancelReason()).isTrue();
+        }
+
+        @Test
+        @DisplayName("MISTAKE는 반품 사유이다")
+        void mistake_isReturnReason() {
+            assertThat(OrderStatusReasonCategory.MISTAKE.isReturnReason()).isTrue();
+        }
+
+        @Test
+        @DisplayName("ETC는 취소 사유이다")
+        void etc_isCancelReason() {
+            assertThat(OrderStatusReasonCategory.ETC.isCancelReason()).isTrue();
+        }
+
+        @Test
+        @DisplayName("ETC는 반품 사유이다")
+        void etc_isReturnReason() {
+            assertThat(OrderStatusReasonCategory.ETC.isReturnReason()).isTrue();
+        }
+    }
+}


### PR DESCRIPTION
## partially addresses #216
## resolves #2305

## Test Case
- [x] CANCEL_ORDER는 취소 사유이다
- [x] CANCEL_ORDER는 반품 사유가 아니다
- [x] CHANGE_OPTION은 취소 사유이다
- [x] CHANGE_OPTION은 반품 사유가 아니다
- [x] SIMPLE_CHANGE_OF_MIND는 반품 사유이다
- [x] SIMPLE_CHANGE_OF_MIND는 취소 사유가 아니다
- [x] PRODUCT_DAMAGE는 반품 사유이다
- [x] PRODUCT_DAMAGE는 취소 사유가 아니다
- [x] PRODUCT_MISMATCH는 반품 사유이다
- [x] WRONG_DELIVERY는 반품 사유이다
- [x] MISSING_COMPONENTS는 반품 사유이다
- [x] MISTAKE는 취소 사유이다
- [x] MISTAKE는 반품 사유이다
- [x] ETC는 취소 사유이다
- [x] ETC는 반품 사유이다
- [x] 반품 전용 사유로 반품 요청하면 정상 처리된다
- [x] 공용 사유(ETC)로 반품 요청하면 정상 처리된다
- [x] 취소 전용 사유로 반품 요청하면 InvalidReasonCategoryException이 발생한다
- [x] 사유 카테고리가 null이면 검증을 건너뛴다
- [x] 반품 전용 사유로 취소 요청하면 InvalidReasonCategoryException이 발생한다
- [x] 취소 전용 사유로 취소 요청하면 정상 처리된다
- [x] 공용 사유(MISTAKE)로 취소 요청하면 정상 처리된다