### PR TITLE
[#216][#1936] feat: deliveredAt 필드 추가 및 DB 마이그레이션

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/mapper/OrderJpaEntityToDomainMapper.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/mapper/OrderJpaEntityToDomainMapper.java
@@ -84,6 +84,7 @@ public class OrderJpaEntityToDomainMapper {
                         .orderStatus(entity.getOrderStatus())
                         .isReviewed(entity.getIsReviewed())
                         .confirmedAt(entity.getConfirmedAt())
+                        .deliveredAt(entity.getDeliveredAt())
                         .build());
     }
 
@@ -155,6 +156,7 @@ public class OrderJpaEntityToDomainMapper {
                                 .orderStatus(entity.getOrderStatus())
                                 .isReviewed(entity.getIsReviewed())
                                 .confirmedAt(entity.getConfirmedAt())
+                                .deliveredAt(entity.getDeliveredAt())
                                 .build()
                 ));
     }

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/order/entity/OrderProductJpaEntity.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/order/entity/OrderProductJpaEntity.java
@@ -58,6 +58,9 @@ public class OrderProductJpaEntity extends BaseEntity {
     @Column(name = "confirmed_at")
     private LocalDateTime confirmedAt;
 
+    @Column(name = "delivered_at")
+    private LocalDateTime deliveredAt;
+
     public static OrderProductJpaEntity from(OrderProduct orderProduct, OrderJpaEntity orderJpaEntity) {
         return OrderProductJpaEntity.builder()
                 .id(new OrderProductId(orderProduct.getPricePolicyId(), orderJpaEntity.getId()))
@@ -70,6 +73,7 @@ public class OrderProductJpaEntity extends BaseEntity {
                 .accumulatedPoint(orderProduct.getAccumulatedPoint())
                 .orderStatus(orderProduct.getOrderStatus())
                 .confirmedAt(orderProduct.getConfirmedAt())
+                .deliveredAt(orderProduct.getDeliveredAt())
                 .build();
     }
 
@@ -81,6 +85,7 @@ public class OrderProductJpaEntity extends BaseEntity {
         orderStatus = orderProduct.getOrderStatus();
         isReviewed = orderProduct.getIsReviewed();
         confirmedAt = orderProduct.getConfirmedAt();
+        deliveredAt = orderProduct.getDeliveredAt();
     }
 
     public Long getPricePolicyId() {

--- a/commerce-service/commerce-adapters/src/main/resources/db/migration/V907__add_delivered_at_to_order_product.sql
+++ b/commerce-service/commerce-adapters/src/main/resources/db/migration/V907__add_delivered_at_to_order_product.sql
@@ -1,0 +1,2 @@
+ALTER TABLE order_product
+    ADD COLUMN delivered_at TIMESTAMP;

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/order/OrderProduct.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/order/OrderProduct.java
@@ -24,6 +24,7 @@ public class OrderProduct {
     private OrderStatus orderStatus;
     private Boolean isReviewed;
     private LocalDateTime confirmedAt;
+    private LocalDateTime deliveredAt;
 
     public static OrderProduct from(OrderProductCreateState state) {
         return OrderProduct.builder()
@@ -51,6 +52,7 @@ public class OrderProduct {
                 .orderStatus(state.getOrderStatus())
                 .isReviewed(state.getIsReviewed())
                 .confirmedAt(state.getConfirmedAt())
+                .deliveredAt(state.getDeliveredAt())
                 .build();
     }
 
@@ -62,6 +64,9 @@ public class OrderProduct {
             throw new InvalidOrderProductStatusTransitionException(this.orderStatus, orderStatus);
         }
         this.orderStatus = orderStatus;
+        if (orderStatus.isDelivered()) {
+            this.deliveredAt = now;
+        }
         if (orderStatus.isConfirmed()) {
             this.confirmedAt = now;
         }

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/order/OrderProductSnapshotState.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/order/OrderProductSnapshotState.java
@@ -23,5 +23,6 @@ public class OrderProductSnapshotState {
     private final OrderStatus orderStatus;
     private final Boolean isReviewed;
     private final LocalDateTime confirmedAt;
+    private final LocalDateTime deliveredAt;
 }
 


### PR DESCRIPTION
## partially addresses #216
## resolves #1936

## Task
- [x] OrderProduct 도메인에 deliveredAt 필드 추가
- [x] changeOrderStatus에서 DELIVERED 전이 시 deliveredAt 설정
- [x] OrderProductSnapshotState에 deliveredAt 필드 추가
- [x] OrderProductJpaEntity에 delivered_at 컬럼 매핑
- [x] OrderJpaEntityToDomainMapper 매핑 반영 (2곳)
- [x] V907 마이그레이션 SQL 추가