### PR TITLE
[#216][#1937] feat: 구매 자동 확정 스케줄러 추가

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/scheduler/AutoConfirmDeliveredOrdersScheduler.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/scheduler/AutoConfirmDeliveredOrdersScheduler.java
@@ -1,0 +1,29 @@
+package com.personal.marketnote.commerce.adapter.in.scheduler;
+
+import com.personal.marketnote.commerce.configuration.AutoConfirmSchedulerProperties;
+import com.personal.marketnote.commerce.port.in.usecase.order.AutoConfirmDeliveredOrdersUseCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(name = "order.auto-confirm.scheduler.enabled", havingValue = "true", matchIfMissing = false)
+public class AutoConfirmDeliveredOrdersScheduler {
+    private final AutoConfirmDeliveredOrdersUseCase autoConfirmDeliveredOrdersUseCase;
+    private final AutoConfirmSchedulerProperties properties;
+
+    @Scheduled(cron = "${order.auto-confirm.scheduler.cron}", zone = "Asia/Seoul")
+    public void autoConfirmDeliveredOrders() {
+        log.info("구매 자동 확정 스케줄러 실행 시작");
+        try {
+            autoConfirmDeliveredOrdersUseCase.autoConfirmDeliveredOrders(properties.getAutoConfirmDays());
+            log.info("구매 자동 확정 스케줄러 실행 완료");
+        } catch (Exception e) {
+            log.error("구매 자동 확정 스케줄러 실행 실패", e);
+        }
+    }
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/order/OrderPersistenceAdapter.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/order/OrderPersistenceAdapter.java
@@ -181,6 +181,11 @@ public class OrderPersistenceAdapter implements SaveOrderPort, FindOrderPort, Fi
                 .toList();
     }
 
+    @Override
+    public List<Long> findOrderIdsEligibleForAutoConfirm(LocalDateTime deliveredBefore) {
+        return orderJpaRepository.findOrderIdsEligibleForAutoConfirm(deliveredBefore);
+    }
+
     private OrderProductJpaEntity findEntityByOrderIdAndPricePolicyId(Long orderId, Long pricePolicyId) throws OrderProductNotFoundException {
         return orderProductJpaRepository.findByOrderIdAndPricePolicyId(orderId, pricePolicyId)
                 .orElseThrow(() -> new OrderProductNotFoundException(orderId, pricePolicyId));

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/order/repository/OrderJpaRepository.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/order/repository/OrderJpaRepository.java
@@ -52,4 +52,18 @@ public interface OrderJpaRepository extends JpaRepository<OrderJpaEntity, Long> 
             WHERE o.id IN :ids
             """)
     List<OrderJpaEntity> findWithProductsByIds(@Param("ids") List<Long> ids);
+
+    @Query(value = """
+            SELECT DISTINCT o.id
+            FROM orders o
+            INNER JOIN order_product op ON o.id = op.order_id
+            WHERE o.order_status = 'DELIVERED'
+              AND op.order_status = 'DELIVERED'
+              AND op.delivered_at IS NOT NULL
+              AND op.delivered_at <= CAST(:deliveredBefore AS timestamp)
+            ORDER BY o.id
+            """, nativeQuery = true)
+    List<Long> findOrderIdsEligibleForAutoConfirm(
+            @Param("deliveredBefore") java.time.LocalDateTime deliveredBefore
+    );
 }

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/configuration/AutoConfirmSchedulerProperties.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/configuration/AutoConfirmSchedulerProperties.java
@@ -1,0 +1,16 @@
+package com.personal.marketnote.commerce.configuration;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationProperties(prefix = "order.auto-confirm.scheduler")
+@Getter
+@Setter
+public class AutoConfirmSchedulerProperties {
+    private boolean enabled;
+    private String cron = "0 59 23 * * ?";
+    private long autoConfirmDays = 7;
+}

--- a/commerce-service/commerce-adapters/src/main/resources/application.yml
+++ b/commerce-service/commerce-adapters/src/main/resources/application.yml
@@ -136,6 +136,13 @@ inventory:
       timeout-minutes: ${INVENTORY_RESERVATION_TIMEOUT_MINUTES:10}
       check-interval-ms: ${INVENTORY_RESERVATION_CHECK_INTERVAL_MS:60000}
 
+order:
+  auto-confirm:
+    scheduler:
+      enabled: ${ORDER_AUTO_CONFIRM_SCHEDULER_ENABLED:false}
+      cron: ${ORDER_AUTO_CONFIRM_SCHEDULER_CRON:0 59 23 * * ?}
+      auto-confirm-days: ${ORDER_AUTO_CONFIRM_DAYS:7}
+
 management:
   endpoints:
     web:

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/order/AutoConfirmDeliveredOrdersUseCase.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/order/AutoConfirmDeliveredOrdersUseCase.java
@@ -1,0 +1,5 @@
+package com.personal.marketnote.commerce.port.in.usecase.order;
+
+public interface AutoConfirmDeliveredOrdersUseCase {
+    void autoConfirmDeliveredOrders(long autoConfirmDays);
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/order/FindOrderPort.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/order/FindOrderPort.java
@@ -57,4 +57,6 @@ public interface FindOrderPort {
             LocalDateTime endDate,
             OrderStatus orderStatus
     );
+
+    List<Long> findOrderIdsEligibleForAutoConfirm(LocalDateTime deliveredBefore);
 }

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/AutoConfirmDeliveredOrdersService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/AutoConfirmDeliveredOrdersService.java
@@ -1,0 +1,55 @@
+package com.personal.marketnote.commerce.service.order;
+
+import com.personal.marketnote.commerce.domain.order.OrderStatus;
+import com.personal.marketnote.commerce.port.in.command.order.ChangeOrderStatusCommand;
+import com.personal.marketnote.commerce.port.in.usecase.order.AutoConfirmDeliveredOrdersUseCase;
+import com.personal.marketnote.commerce.port.in.usecase.order.ChangeOrderStatusUseCase;
+import com.personal.marketnote.commerce.port.out.order.FindOrderPort;
+import com.personal.marketnote.common.application.UseCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@UseCase
+@RequiredArgsConstructor
+@Slf4j
+public class AutoConfirmDeliveredOrdersService implements AutoConfirmDeliveredOrdersUseCase {
+    private final FindOrderPort findOrderPort;
+    private final ChangeOrderStatusUseCase changeOrderStatusUseCase;
+    private final Clock clock;
+
+    @Override
+    public void autoConfirmDeliveredOrders(long autoConfirmDays) {
+        LocalDateTime deliveredBefore = LocalDateTime.now(clock).minusDays(autoConfirmDays);
+        List<Long> orderIds = findOrderPort.findOrderIdsEligibleForAutoConfirm(deliveredBefore);
+
+        if (orderIds.isEmpty()) {
+            log.info("자동 확정 대상 주문 없음");
+            return;
+        }
+
+        log.info("자동 확정 대상 주문 {}건 처리 시작", orderIds.size());
+
+        for (Long orderId : orderIds) {
+            confirmOrderSafely(orderId);
+        }
+
+        log.info("자동 확정 처리 완료");
+    }
+
+    private void confirmOrderSafely(Long orderId) {
+        try {
+            ChangeOrderStatusCommand command = ChangeOrderStatusCommand.builder()
+                    .id(orderId)
+                    .orderStatus(OrderStatus.CONFIRMED)
+                    .build();
+            changeOrderStatusUseCase.changeOrderStatus(command);
+            log.info("주문 자동 확정 완료 - orderId: {}", orderId);
+        } catch (Exception e) {
+            log.error("주문 자동 확정 실패 - orderId: {}, error: {}", orderId, e.getMessage(), e);
+        }
+    }
+}

--- a/reward-service/reward-adapters/src/main/resources/application.yml
+++ b/reward-service/reward-adapters/src/main/resources/application.yml
@@ -94,8 +94,8 @@ vendor:
     dev-yn: ${GIFTISHOW_DEV_YN:Y}
     callback-no: ${GIFTISHOW_CALLBACK_NO:0000000000}
     phone-no: ${GIFTISHOW_PHONE_NO:0000000000}
-    mms-msg: ${GIFTISHOW_MMS_MSG:뉴트리캐시 기프티콘}
-    mms-title: ${GIFTISHOW_MMS_TITLE:뉴트리캐시}
+    mms-msg: ${GIFTISHOW_MMS_MSG:마켓노트 기프티콘}
+    mms-title: ${GIFTISHOW_MMS_TITLE:마켓노트}
     gubun: I
     user-id: ${GIFTISHOW_USER_ID:0000}
     api:

--- a/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/adapter/out/vendor/giftishow/GiftishowApiClientTest.java
+++ b/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/adapter/out/vendor/giftishow/GiftishowApiClientTest.java
@@ -320,7 +320,7 @@ class GiftishowApiClientTest {
                             "01012345678",
                             "user1",
                             "기프티콘 발송",
-                            "뉴트리캐시"
+                            "마켓노트"
                     );
 
             // then

--- a/user-service/user-application/src/test/java/com/personal/marketnote/user/service/shippingaddress/UpdateShippingAddressUseCaseTest.java
+++ b/user-service/user-application/src/test/java/com/personal/marketnote/user/service/shippingaddress/UpdateShippingAddressUseCaseTest.java
@@ -238,7 +238,7 @@ class UpdateShippingAddressUseCaseTest {
         UpdateShippingAddressCommand command = UpdateShippingAddressCommand.builder()
                 .address("서울시 강남구 선릉로 100")
                 .addressDetail("10층")
-                .companyName("뉴트리캐시")
+                .companyName("마켓노트")
                 .addressAlias(null)
                 .recipientName("박민수")
                 .recipientPhoneNumber("010-7777-8888")


### PR DESCRIPTION
## partially addresses #216
## resolves #1937

## Task
- [x] AutoConfirmDeliveredOrdersUseCase 인터페이스 생성
- [x] AutoConfirmDeliveredOrdersService 구현 (주문별 try-catch 격리)
- [x] FindOrderPort에 findOrderIdsEligibleForAutoConfirm 메서드 추가
- [x] OrderJpaRepository에 자동 확정 대상 조회 네이티브 쿼리 추가
- [x] OrderPersistenceAdapter에 Port 구현 추가
- [x] AutoConfirmDeliveredOrdersScheduler 생성 (cron 기반)
- [x] AutoConfirmSchedulerProperties 설정 클래스 생성
- [x] application.yml에 스케줄러 설정 추가