### PR TITLE
[#43][#2229] feat: 도서산간 지역 목록 조회 기능 추가

### DIFF
--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/AutoConfirmDeliveredOrdersUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/AutoConfirmDeliveredOrdersUseCaseTest.java
@@ -31,7 +31,7 @@ class AutoConfirmDeliveredOrdersUseCaseTest {
     @Mock
     private ChangeOrderStatusUseCase changeOrderStatusUseCase;
     @Spy
-    private Clock clock = Clock.fixed(Instant.parse("2026-04-08T14:59:00Z"), ZoneId.of("Asia/Seoul"));
+    private Clock clock = Clock.fixed(Instant.parse("2026-04-26T14:59:00Z"), ZoneId.of("Asia/Seoul"));
 
     @InjectMocks
     private AutoConfirmDeliveredOrdersService autoConfirmDeliveredOrdersService;
@@ -124,7 +124,7 @@ class AutoConfirmDeliveredOrdersUseCaseTest {
             autoConfirmDeliveredOrdersService.autoConfirmDeliveredOrders(AUTO_CONFIRM_DAYS);
 
             // then
-            // Clock이 2026-04-08T14:59:00Z = KST 2026-04-08 23:59:00
+            // Clock이 2026-04-26T14:59:00Z = KST 2026-04-26 23:59:00
             // deliveredBefore = 2026-04-01 23:59:00
             assertThat(expectedDeliveredBefore).isEqualTo(LocalDateTime.of(2026, 4, 1, 23, 59, 0));
             verify(findOrderPort).findOrderIdsEligibleForAutoConfirm(expectedDeliveredBefore);

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/remotearea/controller/RemoteAreaAdminController.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/remotearea/controller/RemoteAreaAdminController.java
@@ -1,9 +1,13 @@
 package com.personal.marketnote.user.adapter.in.web.remotearea.controller;
 
 import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
+import com.personal.marketnote.user.adapter.in.web.remotearea.controller.apidocs.GetRemoteAreaApiDocs;
 import com.personal.marketnote.user.adapter.in.web.remotearea.controller.apidocs.RegisterRemoteAreaApiDocs;
 import com.personal.marketnote.user.adapter.in.web.remotearea.request.RegisterRemoteAreaRequest;
+import com.personal.marketnote.user.adapter.in.web.remotearea.response.GetRemoteAreaResponse;
 import com.personal.marketnote.user.port.in.command.remotearea.RegisterRemoteAreaCommand;
+import com.personal.marketnote.user.port.in.result.remotearea.GetRemoteAreaResult;
+import com.personal.marketnote.user.port.in.usecase.remotearea.GetRemoteAreaUseCase;
 import com.personal.marketnote.user.port.in.usecase.remotearea.RegisterRemoteAreaUseCase;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -11,6 +15,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -29,6 +34,7 @@ import static com.personal.marketnote.common.utility.ApiConstant.ADMIN_POINTCUT;
 public class RemoteAreaAdminController {
 
     private final RegisterRemoteAreaUseCase registerRemoteAreaUseCase;
+    private final GetRemoteAreaUseCase getRemoteAreaUseCase;
 
     @PostMapping
     @PreAuthorize(ADMIN_POINTCUT)
@@ -48,6 +54,19 @@ public class RemoteAreaAdminController {
         return new ResponseEntity<>(
                 BaseResponse.of(null, HttpStatus.CREATED, DEFAULT_SUCCESS_CODE, "도서산간 지역 등록 성공"),
                 HttpStatus.CREATED
+        );
+    }
+
+    @GetMapping
+    @PreAuthorize(ADMIN_POINTCUT)
+    @GetRemoteAreaApiDocs
+    public ResponseEntity<BaseResponse<GetRemoteAreaResponse>> getRemoteAreas() {
+        GetRemoteAreaResult result = getRemoteAreaUseCase.getRemoteAreas();
+        GetRemoteAreaResponse response = GetRemoteAreaResponse.from(result);
+
+        return new ResponseEntity<>(
+                BaseResponse.of(response, HttpStatus.OK, DEFAULT_SUCCESS_CODE, "도서산간 지역 목록 조회 성공"),
+                HttpStatus.OK
         );
     }
 }

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/remotearea/controller/apidocs/GetRemoteAreaApiDocs.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/remotearea/controller/apidocs/GetRemoteAreaApiDocs.java
@@ -1,0 +1,84 @@
+package com.personal.marketnote.user.adapter.in.web.remotearea.controller.apidocs;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Operation(
+        summary = "도서산간 지역 목록 조회",
+        description = """
+                작성일자: 2026-04-26
+
+                작성자: 성효빈
+
+                ---
+
+                ## Description
+                - ACTIVE 상태의 도서산간 지역 전체 목록을 조회합니다.
+
+                ---
+
+                ## Response
+
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | statusCode | number | 상태 코드 | 200 |
+                | code | string | 응답 코드 | "SUC01" |
+                | timestamp | string(datetime) | 응답 일시 | "2026-04-26T12:00:00.000" |
+                | content.remoteAreas | array | 도서산간 지역 목록 | |
+                | content.remoteAreas[].id | number | 도서산간 지역 ID | 1 |
+                | content.remoteAreas[].province | string | 광역시도 | "충남" |
+                | content.remoteAreas[].district | string | 시군구 | "보령시" |
+                | content.remoteAreas[].village | string | 읍면동 | "오천면" |
+                | content.remoteAreas[].subarea | string | 세부지역 | "녹도리" |
+                | message | string | 처리 결과 | "도서산간 지역 목록 조회 성공" |
+                """,
+        security = {@SecurityRequirement(name = "bearer")},
+        responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "도서산간 지역 목록 조회 성공",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 200,
+                                          "code": "SUC01",
+                                          "timestamp": "2026-04-26T12:00:00.000000",
+                                          "content": {
+                                            "remoteAreas": [
+                                              {
+                                                "id": 1,
+                                                "province": "제주",
+                                                "district": "",
+                                                "village": "",
+                                                "subarea": ""
+                                              },
+                                              {
+                                                "id": 2,
+                                                "province": "충남",
+                                                "district": "보령시",
+                                                "village": "오천면",
+                                                "subarea": "녹도리"
+                                              }
+                                            ]
+                                          },
+                                          "message": "도서산간 지역 목록 조회 성공"
+                                        }
+                                        """)
+                        )
+                )
+        }
+)
+public @interface GetRemoteAreaApiDocs {
+}

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/remotearea/response/GetRemoteAreaItemResponse.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/remotearea/response/GetRemoteAreaItemResponse.java
@@ -1,0 +1,21 @@
+package com.personal.marketnote.user.adapter.in.web.remotearea.response;
+
+import com.personal.marketnote.user.port.in.result.remotearea.GetRemoteAreaItemResult;
+
+public record GetRemoteAreaItemResponse(
+        Long id,
+        String province,
+        String district,
+        String village,
+        String subarea
+) {
+    public static GetRemoteAreaItemResponse from(GetRemoteAreaItemResult result) {
+        return new GetRemoteAreaItemResponse(
+                result.id(),
+                result.province(),
+                result.district(),
+                result.village(),
+                result.subarea()
+        );
+    }
+}

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/remotearea/response/GetRemoteAreaResponse.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/remotearea/response/GetRemoteAreaResponse.java
@@ -1,0 +1,18 @@
+package com.personal.marketnote.user.adapter.in.web.remotearea.response;
+
+import com.personal.marketnote.user.port.in.result.remotearea.GetRemoteAreaResult;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public record GetRemoteAreaResponse(
+        List<GetRemoteAreaItemResponse> remoteAreas
+) {
+    public static GetRemoteAreaResponse from(GetRemoteAreaResult result) {
+        return new GetRemoteAreaResponse(
+                result.remoteAreas().stream()
+                        .map(GetRemoteAreaItemResponse::from)
+                        .collect(Collectors.toList())
+        );
+    }
+}

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/out/persistence/remotearea/RemoteAreaPersistenceAdapter.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/out/persistence/remotearea/RemoteAreaPersistenceAdapter.java
@@ -3,6 +3,7 @@ package com.personal.marketnote.user.adapter.out.persistence.remotearea;
 import com.personal.marketnote.common.adapter.out.PersistenceAdapter;
 import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.user.adapter.out.persistence.remotearea.entity.RemoteAreaJpaEntity;
+import com.personal.marketnote.user.adapter.out.persistence.remotearea.mapper.RemoteAreaJpaEntityToDomainMapper;
 import com.personal.marketnote.user.adapter.out.persistence.remotearea.repository.RemoteAreaJpaRepository;
 import com.personal.marketnote.user.domain.remotearea.RemoteArea;
 import com.personal.marketnote.user.exception.RemoteAreaAlreadyExistsException;
@@ -10,6 +11,8 @@ import com.personal.marketnote.user.port.out.remotearea.FindRemoteAreaPort;
 import com.personal.marketnote.user.port.out.remotearea.SaveRemoteAreaPort;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
+
+import java.util.List;
 
 @PersistenceAdapter
 @RequiredArgsConstructor
@@ -34,5 +37,12 @@ public class RemoteAreaPersistenceAdapter implements SaveRemoteAreaPort, FindRem
         return remoteAreaJpaRepository.existsByProvinceAndDistrictAndVillageAndSubareaAndStatus(
                 province, district, village, subarea, EntityStatus.ACTIVE
         );
+    }
+
+    @Override
+    public List<RemoteArea> findAllActive() {
+        return remoteAreaJpaRepository.findAllByStatus(EntityStatus.ACTIVE).stream()
+                .map(RemoteAreaJpaEntityToDomainMapper::mapToDomain)
+                .toList();
     }
 }

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/out/persistence/remotearea/mapper/RemoteAreaJpaEntityToDomainMapper.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/out/persistence/remotearea/mapper/RemoteAreaJpaEntityToDomainMapper.java
@@ -1,0 +1,20 @@
+package com.personal.marketnote.user.adapter.out.persistence.remotearea.mapper;
+
+import com.personal.marketnote.user.adapter.out.persistence.remotearea.entity.RemoteAreaJpaEntity;
+import com.personal.marketnote.user.domain.remotearea.RemoteArea;
+import com.personal.marketnote.user.domain.remotearea.RemoteAreaSnapshotState;
+
+public class RemoteAreaJpaEntityToDomainMapper {
+
+    public static RemoteArea mapToDomain(RemoteAreaJpaEntity entity) {
+        return RemoteArea.from(
+                RemoteAreaSnapshotState.builder()
+                        .id(entity.getId())
+                        .province(entity.getProvince())
+                        .district(entity.getDistrict())
+                        .village(entity.getVillage())
+                        .subarea(entity.getSubarea())
+                        .build()
+        );
+    }
+}

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/port/in/result/remotearea/GetRemoteAreaItemResult.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/port/in/result/remotearea/GetRemoteAreaItemResult.java
@@ -1,0 +1,21 @@
+package com.personal.marketnote.user.port.in.result.remotearea;
+
+import com.personal.marketnote.user.domain.remotearea.RemoteArea;
+
+public record GetRemoteAreaItemResult(
+        Long id,
+        String province,
+        String district,
+        String village,
+        String subarea
+) {
+    public static GetRemoteAreaItemResult from(RemoteArea remoteArea) {
+        return new GetRemoteAreaItemResult(
+                remoteArea.getId(),
+                remoteArea.getProvince(),
+                remoteArea.getDistrict(),
+                remoteArea.getVillage(),
+                remoteArea.getSubarea()
+        );
+    }
+}

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/port/in/result/remotearea/GetRemoteAreaResult.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/port/in/result/remotearea/GetRemoteAreaResult.java
@@ -1,0 +1,18 @@
+package com.personal.marketnote.user.port.in.result.remotearea;
+
+import com.personal.marketnote.user.domain.remotearea.RemoteArea;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public record GetRemoteAreaResult(
+        List<GetRemoteAreaItemResult> remoteAreas
+) {
+    public static GetRemoteAreaResult from(List<RemoteArea> remoteAreas) {
+        return new GetRemoteAreaResult(
+                remoteAreas.stream()
+                        .map(GetRemoteAreaItemResult::from)
+                        .collect(Collectors.toList())
+        );
+    }
+}

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/port/in/usecase/remotearea/GetRemoteAreaUseCase.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/port/in/usecase/remotearea/GetRemoteAreaUseCase.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.user.port.in.usecase.remotearea;
+
+import com.personal.marketnote.user.port.in.result.remotearea.GetRemoteAreaResult;
+
+public interface GetRemoteAreaUseCase {
+    GetRemoteAreaResult getRemoteAreas();
+}

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/port/out/remotearea/FindRemoteAreaPort.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/port/out/remotearea/FindRemoteAreaPort.java
@@ -1,5 +1,11 @@
 package com.personal.marketnote.user.port.out.remotearea;
 
+import com.personal.marketnote.user.domain.remotearea.RemoteArea;
+
+import java.util.List;
+
 public interface FindRemoteAreaPort {
     boolean existsByAddress(String province, String district, String village, String subarea);
+
+    List<RemoteArea> findAllActive();
 }

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/service/remotearea/GetRemoteAreaService.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/service/remotearea/GetRemoteAreaService.java
@@ -1,0 +1,27 @@
+package com.personal.marketnote.user.service.remotearea;
+
+import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.user.domain.remotearea.RemoteArea;
+import com.personal.marketnote.user.port.in.result.remotearea.GetRemoteAreaResult;
+import com.personal.marketnote.user.port.in.usecase.remotearea.GetRemoteAreaUseCase;
+import com.personal.marketnote.user.port.out.remotearea.FindRemoteAreaPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@UseCase
+@RequiredArgsConstructor
+public class GetRemoteAreaService implements GetRemoteAreaUseCase {
+
+    private final FindRemoteAreaPort findRemoteAreaPort;
+
+    @Override
+    @Transactional(isolation = READ_COMMITTED, readOnly = true)
+    public GetRemoteAreaResult getRemoteAreas() {
+        List<RemoteArea> remoteAreas = findRemoteAreaPort.findAllActive();
+        return GetRemoteAreaResult.from(remoteAreas);
+    }
+}


### PR DESCRIPTION
## partially addresses #43
## resolves #2229

## Task
- [x] GetRemoteAreaUseCase 인터페이스 정의
- [x] GetRemoteAreaResult, GetRemoteAreaItemResult 정의
- [x] GetRemoteAreaService 구현
- [x] FindRemoteAreaPort findAllActive() 정의 및 Adapter 구현
- [x] RemoteAreaJpaEntityToDomainMapper 생성
- [x] 관리자 REST Controller GET /api/v1/admin/remote-areas 추가
- [x] GetRemoteAreaResponse, GetRemoteAreaItemResponse 작성
- [x] GetRemoteAreaApiDocs 합성 애노테이션 추가