### PR TITLE
[#216][#2214] feat: PaymentAllocation 판매자별 배송비 필드 추가

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/settlement/response/GetSettlementDetailResponse.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/settlement/response/GetSettlementDetailResponse.java
@@ -15,6 +15,7 @@ public record GetSettlementDetailResponse(
         Long orderId,
         Long sellerId,
         Long allocatedAmount,
+        Long shippingFee,
         PaymentAllocationTransactionType transactionType,
         PaymentAllocationTargetType targetType,
         LocalDateTime createdAt
@@ -25,6 +26,7 @@ public record GetSettlementDetailResponse(
                 .orderId(result.orderId())
                 .sellerId(result.sellerId())
                 .allocatedAmount(result.allocatedAmount())
+                .shippingFee(result.shippingFee())
                 .transactionType(result.transactionType())
                 .targetType(result.targetType())
                 .createdAt(result.createdAt())

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/settlement/entity/PaymentAllocationJpaEntity.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/settlement/entity/PaymentAllocationJpaEntity.java
@@ -36,6 +36,9 @@ public class PaymentAllocationJpaEntity {
     @Column(name = "allocated_amount", nullable = false)
     private Long allocatedAmount;
 
+    @Column(name = "shipping_fee", nullable = false)
+    private Long shippingFee;
+
     @Column(name = "settlement_id")
     private Long settlementId;
 
@@ -59,6 +62,7 @@ public class PaymentAllocationJpaEntity {
                 .orderId(allocation.getOrderId())
                 .sellerId(allocation.getSellerId())
                 .allocatedAmount(allocation.getAllocatedAmount())
+                .shippingFee(allocation.getShippingFee())
                 .settlementId(allocation.getSettlementId())
                 .transactionType(allocation.getTransactionType())
                 .targetType(allocation.getTargetType())

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/settlement/mapper/PaymentAllocationEntityToDomainMapper.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/settlement/mapper/PaymentAllocationEntityToDomainMapper.java
@@ -15,6 +15,7 @@ public class PaymentAllocationEntityToDomainMapper {
                 .orderId(entity.getOrderId())
                 .sellerId(entity.getSellerId())
                 .allocatedAmount(entity.getAllocatedAmount())
+                .shippingFee(entity.getShippingFee())
                 .settlementId(entity.getSettlementId())
                 .transactionType(entity.getTransactionType())
                 .targetType(entity.getTargetType())

--- a/commerce-service/commerce-adapters/src/main/resources/db/migration/V912__add_shipping_fee_to_payment_allocation.sql
+++ b/commerce-service/commerce-adapters/src/main/resources/db/migration/V912__add_shipping_fee_to_payment_allocation.sql
@@ -1,0 +1,1 @@
+ALTER TABLE payment_allocation ADD COLUMN shipping_fee BIGINT NOT NULL DEFAULT 0;

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/mapper/OrderCommandToStateMapper.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/mapper/OrderCommandToStateMapper.java
@@ -90,11 +90,13 @@ public class OrderCommandToStateMapper {
 
     public static PaymentAllocationCreateState mapToPaymentAllocationState(Long orderId,
                                                                            Long sellerId,
-                                                                           Long allocatedAmount) {
+                                                                           Long allocatedAmount,
+                                                                           Long shippingFee) {
         return PaymentAllocationCreateState.builder()
                 .orderId(orderId)
                 .sellerId(sellerId)
                 .allocatedAmount(allocatedAmount)
+                .shippingFee(shippingFee)
                 .transactionType(PaymentAllocationTransactionType.ORDER_REGISTRATION)
                 .targetType(PaymentAllocationTargetType.ORDER)
                 .idempotencyKey("ORDER_ALLOCATION:" + orderId + ":" + sellerId)

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/result/settlement/GetSettlementDetailResult.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/result/settlement/GetSettlementDetailResult.java
@@ -14,6 +14,7 @@ public record GetSettlementDetailResult(
         Long orderId,
         Long sellerId,
         Long allocatedAmount,
+        Long shippingFee,
         PaymentAllocationTransactionType transactionType,
         PaymentAllocationTargetType targetType,
         LocalDateTime createdAt
@@ -24,6 +25,7 @@ public record GetSettlementDetailResult(
                 .orderId(allocation.getOrderId())
                 .sellerId(allocation.getSellerId())
                 .allocatedAmount(allocation.getAllocatedAmount())
+                .shippingFee(allocation.getShippingFee())
                 .transactionType(allocation.getTransactionType())
                 .targetType(allocation.getTargetType())
                 .createdAt(allocation.getCreatedAt())

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/RegisterOrderService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/RegisterOrderService.java
@@ -154,7 +154,7 @@ public class RegisterOrderService implements RegisterOrderUseCase {
                 .filter(entry -> entry.getValue() > 0)
                 .map(entry -> PaymentAllocation.from(
                         OrderCommandToStateMapper.mapToPaymentAllocationState(
-                                orderId, entry.getKey(), entry.getValue())
+                                orderId, entry.getKey(), entry.getValue(), 0L)
                 ))
                 .toList();
 

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/settlement/PaymentAllocation.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/settlement/PaymentAllocation.java
@@ -14,6 +14,7 @@ public class PaymentAllocation {
     private Long orderId;
     private Long sellerId;
     private Long allocatedAmount;
+    private Long shippingFee;
     private Long settlementId;
     private PaymentAllocationTransactionType transactionType;
     private PaymentAllocationTargetType targetType;
@@ -26,10 +27,17 @@ public class PaymentAllocation {
                     "배분 금액은 0보다 커야 합니다. allocatedAmount=" + state.getAllocatedAmount());
         }
 
+        Long shippingFee = FormatValidator.hasValue(state.getShippingFee()) ? state.getShippingFee() : 0L;
+        if (shippingFee < 0) {
+            throw new InvalidSettlementAmountException(
+                    "배송비는 음수일 수 없습니다. shippingFee=" + shippingFee);
+        }
+
         return PaymentAllocation.builder()
                 .orderId(state.getOrderId())
                 .sellerId(state.getSellerId())
                 .allocatedAmount(state.getAllocatedAmount())
+                .shippingFee(shippingFee)
                 .transactionType(state.getTransactionType())
                 .targetType(state.getTargetType())
                 .idempotencyKey(state.getIdempotencyKey())
@@ -42,6 +50,7 @@ public class PaymentAllocation {
                 .orderId(state.getOrderId())
                 .sellerId(state.getSellerId())
                 .allocatedAmount(state.getAllocatedAmount())
+                .shippingFee(state.getShippingFee())
                 .settlementId(state.getSettlementId())
                 .transactionType(state.getTransactionType())
                 .targetType(state.getTargetType())

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/settlement/PaymentAllocationCreateState.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/settlement/PaymentAllocationCreateState.java
@@ -10,6 +10,7 @@ public class PaymentAllocationCreateState {
     private Long orderId;
     private Long sellerId;
     private Long allocatedAmount;
+    private Long shippingFee;
     private PaymentAllocationTransactionType transactionType;
     private PaymentAllocationTargetType targetType;
     private String idempotencyKey;

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/settlement/PaymentAllocationSnapshotState.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/settlement/PaymentAllocationSnapshotState.java
@@ -13,6 +13,7 @@ public class PaymentAllocationSnapshotState {
     private Long orderId;
     private Long sellerId;
     private Long allocatedAmount;
+    private Long shippingFee;
     private Long settlementId;
     private PaymentAllocationTransactionType transactionType;
     private PaymentAllocationTargetType targetType;


### PR DESCRIPTION
## partially addresses #216
## resolves #2214

## Task
- [x] PaymentAllocation 도메인에 shippingFee 필드 추가
- [x] PaymentAllocationCreateState, PaymentAllocationSnapshotState에 shippingFee 필드 추가
- [x] PaymentAllocation JPA 엔티티에 shipping_fee 컬럼 추가
- [x] DB 마이그레이션 스크립트 작성 (V912)
- [x] 매퍼 업데이트 (EntityToDomainMapper, OrderCommandToStateMapper)
- [x] GetSettlementDetailResult/Response에 shippingFee 필드 추가