### PR TITLE
[#216][#2220] test: PaymentAllocation 판매자별 배송비 필드 추가 기능 자동화 테스트 추가

### DIFF
--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/settlement/ExecuteSettlementUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/settlement/ExecuteSettlementUseCaseTest.java
@@ -49,6 +49,7 @@ class ExecuteSettlementUseCaseTest {
                 .orderId(100L)
                 .sellerId(sellerId)
                 .allocatedAmount(allocatedAmount)
+                .shippingFee(0L)
                 .transactionType(PaymentAllocationTransactionType.ORDER_REGISTRATION)
                 .targetType(PaymentAllocationTargetType.ORDER)
                 .idempotencyKey("TEST:" + id)

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/settlement/GetSettlementDetailUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/settlement/GetSettlementDetailUseCaseTest.java
@@ -59,6 +59,7 @@ class GetSettlementDetailUseCaseTest {
                 .orderId(orderId)
                 .sellerId(sellerId)
                 .allocatedAmount(allocatedAmount)
+                .shippingFee(0L)
                 .settlementId(settlementId)
                 .transactionType(transactionType)
                 .targetType(targetType)

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/settlement/ProcessSellerSettlementUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/settlement/ProcessSellerSettlementUseCaseTest.java
@@ -60,6 +60,7 @@ class ProcessSellerSettlementUseCaseTest {
                 .orderId(100L)
                 .sellerId(sellerId)
                 .allocatedAmount(allocatedAmount)
+                .shippingFee(0L)
                 .transactionType(PaymentAllocationTransactionType.ORDER_REGISTRATION)
                 .targetType(PaymentAllocationTargetType.ORDER)
                 .idempotencyKey("TEST:" + id)

--- a/commerce-service/commerce-domain/src/test/java/com/personal/marketnote/commerce/domain/settlement/PaymentAllocationTest.java
+++ b/commerce-service/commerce-domain/src/test/java/com/personal/marketnote/commerce/domain/settlement/PaymentAllocationTest.java
@@ -24,6 +24,7 @@ class PaymentAllocationTest {
                     .orderId(100L)
                     .sellerId(10L)
                     .allocatedAmount(50000L)
+                    .shippingFee(3000L)
                     .transactionType(PaymentAllocationTransactionType.ORDER_REGISTRATION)
                     .targetType(PaymentAllocationTargetType.ORDER)
                     .idempotencyKey("ORDER_ALLOCATION:100:10")
@@ -36,10 +37,78 @@ class PaymentAllocationTest {
             assertThat(allocation.getOrderId()).isEqualTo(100L);
             assertThat(allocation.getSellerId()).isEqualTo(10L);
             assertThat(allocation.getAllocatedAmount()).isEqualTo(50000L);
+            assertThat(allocation.getShippingFee()).isEqualTo(3000L);
             assertThat(allocation.getTransactionType()).isEqualTo(PaymentAllocationTransactionType.ORDER_REGISTRATION);
             assertThat(allocation.getTargetType()).isEqualTo(PaymentAllocationTargetType.ORDER);
             assertThat(allocation.getIdempotencyKey()).isEqualTo("ORDER_ALLOCATION:100:10");
             assertThat(allocation.getSettlementId()).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("shippingFee 검증")
+    class ShippingFeeValidation {
+
+        @Test
+        @DisplayName("shippingFee가 null이면 0L로 기본값 처리된다")
+        void shouldDefaultToZeroWhenShippingFeeIsNull() {
+            // given
+            PaymentAllocationCreateState state = PaymentAllocationCreateState.builder()
+                    .orderId(100L)
+                    .sellerId(10L)
+                    .allocatedAmount(50000L)
+                    .shippingFee(null)
+                    .transactionType(PaymentAllocationTransactionType.ORDER_REGISTRATION)
+                    .targetType(PaymentAllocationTargetType.ORDER)
+                    .idempotencyKey("ORDER_ALLOCATION:100:10")
+                    .build();
+
+            // when
+            PaymentAllocation allocation = PaymentAllocation.from(state);
+
+            // then
+            assertThat(allocation.getShippingFee()).isEqualTo(0L);
+        }
+
+        @Test
+        @DisplayName("shippingFee가 0이면 허용된다")
+        void shouldAllowZeroShippingFee() {
+            // given
+            PaymentAllocationCreateState state = PaymentAllocationCreateState.builder()
+                    .orderId(100L)
+                    .sellerId(10L)
+                    .allocatedAmount(50000L)
+                    .shippingFee(0L)
+                    .transactionType(PaymentAllocationTransactionType.ORDER_REGISTRATION)
+                    .targetType(PaymentAllocationTargetType.ORDER)
+                    .idempotencyKey("ORDER_ALLOCATION:100:10")
+                    .build();
+
+            // when
+            PaymentAllocation allocation = PaymentAllocation.from(state);
+
+            // then
+            assertThat(allocation.getShippingFee()).isEqualTo(0L);
+        }
+
+        @Test
+        @DisplayName("shippingFee가 음수이면 InvalidSettlementAmountException을 던진다")
+        void shouldThrowWhenShippingFeeIsNegative() {
+            // given
+            PaymentAllocationCreateState state = PaymentAllocationCreateState.builder()
+                    .orderId(100L)
+                    .sellerId(10L)
+                    .allocatedAmount(50000L)
+                    .shippingFee(-1000L)
+                    .transactionType(PaymentAllocationTransactionType.ORDER_REGISTRATION)
+                    .targetType(PaymentAllocationTargetType.ORDER)
+                    .idempotencyKey("ORDER_ALLOCATION:100:10")
+                    .build();
+
+            // when & then
+            assertThatThrownBy(() -> PaymentAllocation.from(state))
+                    .isInstanceOf(InvalidSettlementAmountException.class)
+                    .hasMessageContaining("배송비는 음수일 수 없습니다");
         }
     }
 
@@ -119,6 +188,7 @@ class PaymentAllocationTest {
                     .orderId(100L)
                     .sellerId(10L)
                     .allocatedAmount(50000L)
+                    .shippingFee(3000L)
                     .settlementId(5L)
                     .transactionType(PaymentAllocationTransactionType.ORDER_REGISTRATION)
                     .targetType(PaymentAllocationTargetType.ORDER)
@@ -134,6 +204,7 @@ class PaymentAllocationTest {
             assertThat(allocation.getOrderId()).isEqualTo(100L);
             assertThat(allocation.getSellerId()).isEqualTo(10L);
             assertThat(allocation.getAllocatedAmount()).isEqualTo(50000L);
+            assertThat(allocation.getShippingFee()).isEqualTo(3000L);
             assertThat(allocation.getSettlementId()).isEqualTo(5L);
             assertThat(allocation.getCreatedAt()).isEqualTo(createdAt);
         }


### PR DESCRIPTION
## partially addresses #216
## resolves #2220

## Test Case
- [x] CreateState로부터 PaymentAllocation을 생성한다 / shippingFee 필드 검증 추가
- [x] shippingFee가 null이면 0L로 기본값 처리된다
- [x] shippingFee가 0이면 허용된다
- [x] shippingFee가 음수이면 InvalidSettlementAmountException을 던진다
- [x] SnapshotState로부터 PaymentAllocation을 복원한다 / shippingFee 매핑 검증 추가
- [x] 기존 정산 테스트 헬퍼 3개 파일에 shippingFee(0L) 반영