### PR TITLE
[#216][#2215] feat: 주문 등록 시 PaymentAllocation 판매자별 배송비 반영 기능 추가

### DIFF
--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/RegisterOrderService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/RegisterOrderService.java
@@ -137,12 +137,13 @@ public class RegisterOrderService implements RegisterOrderUseCase {
                 )
         );
 
-        createPaymentAllocations(savedOrder.getId(), command.orderProducts());
+        createPaymentAllocations(savedOrder.getId(), command.orderProducts(), shippingPolicies);
 
         return RegisterOrderResult.from(savedOrder);
     }
 
-    private void createPaymentAllocations(Long orderId, List<OrderProductItemCommand> orderProducts) {
+    private void createPaymentAllocations(Long orderId, List<OrderProductItemCommand> orderProducts,
+                                          Map<Long, ShippingPolicyInfoResult> shippingPolicies) {
         Map<Long, Long> sellerGrossAmounts = orderProducts.stream()
                 .collect(Collectors.groupingBy(
                         OrderProductItemCommand::sellerId,
@@ -150,17 +151,47 @@ public class RegisterOrderService implements RegisterOrderUseCase {
                                 Math.multiplyExact(item.unitAmount(), (long) item.quantity()))
                 ));
 
+        Map<Long, Long> sellerShippingFees = calculateSellerShippingFees(sellerGrossAmounts, shippingPolicies);
+
         List<PaymentAllocation> allocations = sellerGrossAmounts.entrySet().stream()
                 .filter(entry -> entry.getValue() > 0)
-                .map(entry -> PaymentAllocation.from(
-                        OrderCommandToStateMapper.mapToPaymentAllocationState(
-                                orderId, entry.getKey(), entry.getValue(), 0L)
-                ))
+                .map(entry -> {
+                    Long sellerId = entry.getKey();
+                    Long sellerShippingFee = sellerShippingFees.getOrDefault(sellerId, 0L);
+                    return PaymentAllocation.from(
+                            OrderCommandToStateMapper.mapToPaymentAllocationState(
+                                    orderId, sellerId, entry.getValue(), sellerShippingFee)
+                    );
+                })
                 .toList();
 
         if (!allocations.isEmpty()) {
             savePaymentAllocationPort.saveAll(allocations);
         }
+    }
+
+    private Map<Long, Long> calculateSellerShippingFees(
+            Map<Long, Long> sellerAmounts,
+            Map<Long, ShippingPolicyInfoResult> shippingPolicies
+    ) {
+        Map<Long, Long> sellerShippingFees = new java.util.HashMap<>();
+        for (Map.Entry<Long, Long> entry : sellerAmounts.entrySet()) {
+            Long sellerId = entry.getKey();
+            Long sellerAmount = entry.getValue();
+
+            ShippingPolicyInfoResult policy = shippingPolicies.get(sellerId);
+            if (FormatValidator.hasNoValue(policy)) {
+                sellerShippingFees.put(sellerId, 0L);
+                continue;
+            }
+
+            if (sellerAmount < policy.freeShippingThreshold()) {
+                sellerShippingFees.put(sellerId, policy.shippingFee());
+                continue;
+            }
+            sellerShippingFees.put(sellerId, 0L);
+        }
+        return sellerShippingFees;
     }
 
     private void validateTotalAmountConsistency(RegisterOrderCommand command) {
@@ -309,21 +340,12 @@ public class RegisterOrderService implements RegisterOrderUseCase {
                                 Math.multiplyExact(item.unitAmount(), (long) item.quantity()))
                 ));
 
+        Map<Long, Long> sellerShippingFees = calculateSellerShippingFees(sellerAmounts, shippingPolicies);
+
         long totalShippingFee = 0L;
-        for (Map.Entry<Long, Long> entry : sellerAmounts.entrySet()) {
-            Long sellerId = entry.getKey();
-            Long sellerAmount = entry.getValue();
-
-            ShippingPolicyInfoResult policy = shippingPolicies.get(sellerId);
-            if (FormatValidator.hasNoValue(policy)) {
-                continue;
-            }
-
-            if (sellerAmount < policy.freeShippingThreshold()) {
-                totalShippingFee = Math.addExact(totalShippingFee, policy.shippingFee());
-            }
+        for (Long fee : sellerShippingFees.values()) {
+            totalShippingFee = Math.addExact(totalShippingFee, fee);
         }
-
         return totalShippingFee;
     }
 


### PR DESCRIPTION
## partially addresses #216
## resolves #2215

## Task
- [x] RegisterOrderService.createPaymentAllocations에서 판매자별 배송비 계산 후 PaymentAllocation에 포함
- [x] ShippingPolicy 조회 결과를 활용한 판매자별 배송비 매핑