### PR TITLE
[#216][#2216] feat: 판매자 정산 배송비 포함 계산 기능 추가

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/settlement/response/GetSettlementResponse.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/settlement/response/GetSettlementResponse.java
@@ -14,6 +14,7 @@ public record GetSettlementResponse(
         Integer year,
         Integer month,
         Long totalAllocatedAmount,
+        Long shippingFee,
         Long pgFeeAmount,
         Long platformFeeAmount,
         Long sellerPayoutAmount,
@@ -28,6 +29,7 @@ public record GetSettlementResponse(
                 .year(result.year())
                 .month(result.month())
                 .totalAllocatedAmount(result.totalAllocatedAmount())
+                .shippingFee(result.shippingFee())
                 .pgFeeAmount(result.pgFeeAmount())
                 .platformFeeAmount(result.platformFeeAmount())
                 .sellerPayoutAmount(result.sellerPayoutAmount())

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/settlement/entity/SettlementJpaEntity.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/settlement/entity/SettlementJpaEntity.java
@@ -39,6 +39,9 @@ public class SettlementJpaEntity {
     @Column(name = "total_allocated_amount", nullable = false)
     private Long totalAllocatedAmount;
 
+    @Column(name = "shipping_fee", nullable = false)
+    private Long shippingFee;
+
     @Column(name = "pg_fee_amount", nullable = false)
     private Long pgFeeAmount;
 
@@ -71,6 +74,7 @@ public class SettlementJpaEntity {
                 .year(settlement.getYear())
                 .month(settlement.getMonth())
                 .totalAllocatedAmount(settlement.getTotalAllocatedAmount())
+                .shippingFee(settlement.getShippingFee())
                 .pgFeeAmount(settlement.getPgFeeAmount())
                 .platformFeeAmount(settlement.getPlatformFeeAmount())
                 .sellerPayoutAmount(settlement.getSellerPayoutAmount())

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/settlement/mapper/SettlementEntityToDomainMapper.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/settlement/mapper/SettlementEntityToDomainMapper.java
@@ -17,6 +17,7 @@ public class SettlementEntityToDomainMapper {
                         .year(entity.getYear())
                         .month(entity.getMonth())
                         .totalAllocatedAmount(entity.getTotalAllocatedAmount())
+                        .shippingFee(entity.getShippingFee())
                         .pgFeeAmount(entity.getPgFeeAmount())
                         .platformFeeAmount(entity.getPlatformFeeAmount())
                         .sellerPayoutAmount(entity.getSellerPayoutAmount())

--- a/commerce-service/commerce-adapters/src/main/resources/db/migration/V913__add_shipping_fee_to_settlement.sql
+++ b/commerce-service/commerce-adapters/src/main/resources/db/migration/V913__add_shipping_fee_to_settlement.sql
@@ -1,0 +1,1 @@
+ALTER TABLE settlement ADD COLUMN shipping_fee BIGINT NOT NULL DEFAULT 0;

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/result/settlement/GetSettlementResult.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/result/settlement/GetSettlementResult.java
@@ -13,6 +13,7 @@ public record GetSettlementResult(
         Integer year,
         Integer month,
         Long totalAllocatedAmount,
+        Long shippingFee,
         Long pgFeeAmount,
         Long platformFeeAmount,
         Long sellerPayoutAmount,
@@ -27,6 +28,7 @@ public record GetSettlementResult(
                 .year(settlement.getYear())
                 .month(settlement.getMonth())
                 .totalAllocatedAmount(settlement.getTotalAllocatedAmount())
+                .shippingFee(settlement.getShippingFee())
                 .pgFeeAmount(settlement.getPgFeeAmount())
                 .platformFeeAmount(settlement.getPlatformFeeAmount())
                 .sellerPayoutAmount(settlement.getSellerPayoutAmount())

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/RegisterOrderService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/RegisterOrderService.java
@@ -137,12 +137,13 @@ public class RegisterOrderService implements RegisterOrderUseCase {
                 )
         );
 
-        createPaymentAllocations(savedOrder.getId(), command.orderProducts());
+        createPaymentAllocations(savedOrder.getId(), command.orderProducts(), shippingPolicies);
 
         return RegisterOrderResult.from(savedOrder);
     }
 
-    private void createPaymentAllocations(Long orderId, List<OrderProductItemCommand> orderProducts) {
+    private void createPaymentAllocations(Long orderId, List<OrderProductItemCommand> orderProducts,
+                                          Map<Long, ShippingPolicyInfoResult> shippingPolicies) {
         Map<Long, Long> sellerGrossAmounts = orderProducts.stream()
                 .collect(Collectors.groupingBy(
                         OrderProductItemCommand::sellerId,
@@ -150,17 +151,47 @@ public class RegisterOrderService implements RegisterOrderUseCase {
                                 Math.multiplyExact(item.unitAmount(), (long) item.quantity()))
                 ));
 
+        Map<Long, Long> sellerShippingFees = calculateSellerShippingFees(sellerGrossAmounts, shippingPolicies);
+
         List<PaymentAllocation> allocations = sellerGrossAmounts.entrySet().stream()
                 .filter(entry -> entry.getValue() > 0)
-                .map(entry -> PaymentAllocation.from(
-                        OrderCommandToStateMapper.mapToPaymentAllocationState(
-                                orderId, entry.getKey(), entry.getValue(), 0L)
-                ))
+                .map(entry -> {
+                    Long sellerId = entry.getKey();
+                    Long sellerShippingFee = sellerShippingFees.getOrDefault(sellerId, 0L);
+                    return PaymentAllocation.from(
+                            OrderCommandToStateMapper.mapToPaymentAllocationState(
+                                    orderId, sellerId, entry.getValue(), sellerShippingFee)
+                    );
+                })
                 .toList();
 
         if (!allocations.isEmpty()) {
             savePaymentAllocationPort.saveAll(allocations);
         }
+    }
+
+    private Map<Long, Long> calculateSellerShippingFees(
+            Map<Long, Long> sellerAmounts,
+            Map<Long, ShippingPolicyInfoResult> shippingPolicies
+    ) {
+        Map<Long, Long> sellerShippingFees = new java.util.HashMap<>();
+        for (Map.Entry<Long, Long> entry : sellerAmounts.entrySet()) {
+            Long sellerId = entry.getKey();
+            Long sellerAmount = entry.getValue();
+
+            ShippingPolicyInfoResult policy = shippingPolicies.get(sellerId);
+            if (FormatValidator.hasNoValue(policy)) {
+                sellerShippingFees.put(sellerId, 0L);
+                continue;
+            }
+
+            if (sellerAmount < policy.freeShippingThreshold()) {
+                sellerShippingFees.put(sellerId, policy.shippingFee());
+                continue;
+            }
+            sellerShippingFees.put(sellerId, 0L);
+        }
+        return sellerShippingFees;
     }
 
     private void validateTotalAmountConsistency(RegisterOrderCommand command) {
@@ -309,21 +340,12 @@ public class RegisterOrderService implements RegisterOrderUseCase {
                                 Math.multiplyExact(item.unitAmount(), (long) item.quantity()))
                 ));
 
+        Map<Long, Long> sellerShippingFees = calculateSellerShippingFees(sellerAmounts, shippingPolicies);
+
         long totalShippingFee = 0L;
-        for (Map.Entry<Long, Long> entry : sellerAmounts.entrySet()) {
-            Long sellerId = entry.getKey();
-            Long sellerAmount = entry.getValue();
-
-            ShippingPolicyInfoResult policy = shippingPolicies.get(sellerId);
-            if (FormatValidator.hasNoValue(policy)) {
-                continue;
-            }
-
-            if (sellerAmount < policy.freeShippingThreshold()) {
-                totalShippingFee = Math.addExact(totalShippingFee, policy.shippingFee());
-            }
+        for (Long fee : sellerShippingFees.values()) {
+            totalShippingFee = Math.addExact(totalShippingFee, fee);
         }
-
         return totalShippingFee;
     }
 

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/settlement/ProcessSellerSettlementService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/settlement/ProcessSellerSettlementService.java
@@ -71,15 +71,21 @@ public class ProcessSellerSettlementService {
                 .mapToLong(PaymentAllocation::getAllocatedAmount)
                 .sum();
 
-        long pgFeeAmount = Math.multiplyExact(totalAllocatedAmount, pgFeeRate) / BASIS_POINT_DENOMINATOR;
-        long platformFeeAmount = Math.multiplyExact(totalAllocatedAmount, platformFeeRate) / BASIS_POINT_DENOMINATOR;
-        long sellerPayoutAmount = totalAllocatedAmount - pgFeeAmount - platformFeeAmount;
+        long totalShippingFee = sellerAllocations.stream()
+                .mapToLong(allocation -> allocation.getShippingFee() != null ? allocation.getShippingFee() : 0L)
+                .sum();
+
+        long feeBase = Math.addExact(totalAllocatedAmount, totalShippingFee);
+        long pgFeeAmount = Math.multiplyExact(feeBase, pgFeeRate) / BASIS_POINT_DENOMINATOR;
+        long platformFeeAmount = Math.multiplyExact(feeBase, platformFeeRate) / BASIS_POINT_DENOMINATOR;
+        long sellerPayoutAmount = feeBase - pgFeeAmount - platformFeeAmount;
 
         Settlement settlement = Settlement.from(SettlementCreateState.builder()
                 .sellerId(sellerId)
                 .year(year)
                 .month(month)
                 .totalAllocatedAmount(totalAllocatedAmount)
+                .shippingFee(totalShippingFee)
                 .pgFeeAmount(pgFeeAmount)
                 .platformFeeAmount(platformFeeAmount)
                 .sellerPayoutAmount(sellerPayoutAmount)

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/RegisterOrderUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/RegisterOrderUseCaseTest.java
@@ -2160,14 +2160,16 @@ class RegisterOrderUseCaseTest {
     class PaymentAllocationTest {
 
         @Test
-        @DisplayName("주문 등록 시 판매자별 PaymentAllocation이 생성된다")
+        @DisplayName("주문 등록 시 판매자별 PaymentAllocation이 배송비 포함하여 생성된다")
         @SuppressWarnings("unchecked")
         void registerOrder_createsPaymentAllocationsPerSeller() {
             Long pricePolicyId1 = 100L;
             Long pricePolicyId2 = 200L;
+            Long shippingFeeA = 3000L;
+            Long shippingFeeB = 2500L;
             RegisterOrderCommand command = RegisterOrderCommand.builder()
                     .buyerId(1L)
-                    .amount(OrderAmountCommand.builder().totalAmount(100000L).couponAmount(0L).pointAmount(0L).shippingFee(null).build())
+                    .amount(OrderAmountCommand.builder().totalAmount(100000L).couponAmount(0L).pointAmount(0L).shippingFee(shippingFeeA + shippingFeeB).build())
                     .orderProducts(List.of(
                             OrderProductItemCommand.builder()
                                     .productId(100L)
@@ -2190,6 +2192,10 @@ class RegisterOrderUseCaseTest {
                     pricePolicyId1, Map.entry(25000L, 10L),
                     pricePolicyId2, Map.entry(50000L, 20L)
             ));
+            mockShippingPolicies(Map.of(
+                    10L, new ShippingPolicyInfoResult(10L, shippingFeeA, 100000L),
+                    20L, new ShippingPolicyInfoResult(20L, shippingFeeB, 100000L)
+            ));
             Inventory inventory1 = Inventory.of(1L, pricePolicyId1, 100);
             Inventory inventory2 = Inventory.of(2L, pricePolicyId2, 50);
             when(getInventoryUseCase.getOrCreateInventories(anyMap()))
@@ -2206,6 +2212,13 @@ class RegisterOrderUseCaseTest {
             assertThat(allocations)
                     .extracting(PaymentAllocation::getSellerId)
                     .containsExactlyInAnyOrder(10L, 20L);
+
+            PaymentAllocation allocationA = allocations.stream()
+                    .filter(a -> a.getSellerId().equals(10L)).findFirst().orElseThrow();
+            PaymentAllocation allocationB = allocations.stream()
+                    .filter(a -> a.getSellerId().equals(20L)).findFirst().orElseThrow();
+            assertThat(allocationA.getShippingFee()).isEqualTo(shippingFeeA);
+            assertThat(allocationB.getShippingFee()).isEqualTo(shippingFeeB);
         }
 
         @Test

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/settlement/Settlement.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/settlement/Settlement.java
@@ -15,6 +15,7 @@ public class Settlement {
     private Integer year;
     private Integer month;
     private Long totalAllocatedAmount;
+    private Long shippingFee;
     private Long pgFeeAmount;
     private Long platformFeeAmount;
     private Long sellerPayoutAmount;
@@ -32,9 +33,14 @@ public class Settlement {
             throw new InvalidSettlementAmountException(
                     "판매자 지급액은 0보다 커야 합니다. sellerPayoutAmount=" + state.getSellerPayoutAmount());
         }
+        long shippingFee = FormatValidator.hasValue(state.getShippingFee()) ? state.getShippingFee() : 0L;
         long pgFee = FormatValidator.hasValue(state.getPgFeeAmount()) ? state.getPgFeeAmount() : 0L;
         long platformFee = FormatValidator.hasValue(state.getPlatformFeeAmount()) ? state.getPlatformFeeAmount() : 0L;
 
+        if (shippingFee < 0) {
+            throw new InvalidSettlementAmountException(
+                    "배송비는 음수일 수 없습니다. shippingFee=" + shippingFee);
+        }
         if (pgFee < 0) {
             throw new InvalidSettlementAmountException(
                     "PG 수수료는 음수일 수 없습니다. pgFeeAmount=" + pgFee);
@@ -44,11 +50,13 @@ public class Settlement {
                     "플랫폼 수수료는 음수일 수 없습니다. platformFeeAmount=" + platformFee);
         }
 
-        long expectedPayout = state.getTotalAllocatedAmount() - pgFee - platformFee;
+        long feeBase = Math.addExact(state.getTotalAllocatedAmount(), shippingFee);
+        long expectedPayout = feeBase - pgFee - platformFee;
         if (expectedPayout != state.getSellerPayoutAmount()) {
             throw new InvalidSettlementAmountException(
-                    "정산 금액 정합성 불일치: totalAllocatedAmount(" + state.getTotalAllocatedAmount()
-                            + ") - pgFeeAmount(" + pgFee + ") - platformFeeAmount(" + platformFee
+                    "정산 금액 정합성 불일치: (totalAllocatedAmount(" + state.getTotalAllocatedAmount()
+                            + ") + shippingFee(" + shippingFee
+                            + ")) - pgFeeAmount(" + pgFee + ") - platformFeeAmount(" + platformFee
                             + ") != sellerPayoutAmount(" + state.getSellerPayoutAmount() + ")");
         }
 
@@ -57,6 +65,7 @@ public class Settlement {
                 .year(state.getYear())
                 .month(state.getMonth())
                 .totalAllocatedAmount(state.getTotalAllocatedAmount())
+                .shippingFee(shippingFee)
                 .pgFeeAmount(pgFee)
                 .platformFeeAmount(platformFee)
                 .sellerPayoutAmount(state.getSellerPayoutAmount())
@@ -71,6 +80,7 @@ public class Settlement {
                 .year(state.getYear())
                 .month(state.getMonth())
                 .totalAllocatedAmount(state.getTotalAllocatedAmount())
+                .shippingFee(state.getShippingFee())
                 .pgFeeAmount(state.getPgFeeAmount())
                 .platformFeeAmount(state.getPlatformFeeAmount())
                 .sellerPayoutAmount(state.getSellerPayoutAmount())

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/settlement/SettlementCreateState.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/settlement/SettlementCreateState.java
@@ -11,6 +11,7 @@ public class SettlementCreateState {
     private Integer year;
     private Integer month;
     private Long totalAllocatedAmount;
+    private Long shippingFee;
     private Long pgFeeAmount;
     private Long platformFeeAmount;
     private Long sellerPayoutAmount;

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/settlement/SettlementSnapshotState.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/settlement/SettlementSnapshotState.java
@@ -14,6 +14,7 @@ public class SettlementSnapshotState {
     private Integer year;
     private Integer month;
     private Long totalAllocatedAmount;
+    private Long shippingFee;
     private Long pgFeeAmount;
     private Long platformFeeAmount;
     private Long sellerPayoutAmount;


### PR DESCRIPTION
## partially addresses #216
## resolves #2216

## Task
- [x] ProcessSellerSettlementService에서 shippingFee 포함 정산 금액 계산
- [x] PG 수수료, 플랫폼 수수료 계산 기준에 배송비 포함
- [x] sellerPayoutAmount에 배송비 포함