### PR TITLE
[#216][#2217][#2219] feat: 회계 분개 배송비 계정 추가 / SettlementExecutedEvent 배송비 필드 추가

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/SettlementExecutedLedgerConsumer.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/SettlementExecutedLedgerConsumer.java
@@ -53,8 +53,11 @@ public class SettlementExecutedLedgerConsumer {
         }
 
         try {
+            long shippingFee = payload.shippingFee() != null ? payload.shippingFee() : 0L;
+            long feeBase = Math.addExact(payload.totalAllocatedAmount(), shippingFee);
+
             recordLedgerEntryUseCase.recordPgSettlement(
-                    payload.settlementId(), payload.totalAllocatedAmount(), payload.pgFeeAmount()
+                    payload.settlementId(), feeBase, payload.pgFeeAmount()
             );
 
             long sellerSettlementDebit = Math.addExact(payload.sellerPayoutAmount(), payload.platformFeeAmount());

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/event/SettlementEventKafkaProducer.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/event/SettlementEventKafkaProducer.java
@@ -25,10 +25,11 @@ public class SettlementEventKafkaProducer implements PublishSettlementEventPort 
 
     @Override
     public void publishSettlementExecutedEvent(Long settlementId, Long sellerId,
-                                               Long totalAllocatedAmount, Long pgFeeAmount,
-                                               Long platformFeeAmount, Long sellerPayoutAmount) {
+                                               Long totalAllocatedAmount, Long shippingFee,
+                                               Long pgFeeAmount, Long platformFeeAmount,
+                                               Long sellerPayoutAmount) {
         SettlementExecutedEvent payload = new SettlementExecutedEvent(
-                settlementId, sellerId, totalAllocatedAmount,
+                settlementId, sellerId, totalAllocatedAmount, shippingFee,
                 pgFeeAmount, platformFeeAmount, sellerPayoutAmount
         );
         String topic = KafkaTopicConstants.SETTLEMENT_EXECUTED;

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/event/PublishSettlementEventPort.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/event/PublishSettlementEventPort.java
@@ -3,6 +3,7 @@ package com.personal.marketnote.commerce.port.out.event;
 public interface PublishSettlementEventPort {
 
     void publishSettlementExecutedEvent(Long settlementId, Long sellerId,
-                                        Long totalAllocatedAmount, Long pgFeeAmount,
-                                        Long platformFeeAmount, Long sellerPayoutAmount);
+                                        Long totalAllocatedAmount, Long shippingFee,
+                                        Long pgFeeAmount, Long platformFeeAmount,
+                                        Long sellerPayoutAmount);
 }

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/settlement/ProcessSellerSettlementService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/settlement/ProcessSellerSettlementService.java
@@ -104,18 +104,19 @@ public class ProcessSellerSettlementService {
         updateSettlementPort.update(savedSettlement);
 
         publishSettlementExecutedEvent(settlementId, sellerId, totalAllocatedAmount,
-                pgFeeAmount, platformFeeAmount, sellerPayoutAmount);
+                totalShippingFee, pgFeeAmount, platformFeeAmount, sellerPayoutAmount);
 
         log.info("정산 완료 - settlementId: {}, sellerId: {}, year: {}, month: {}, total: {}, pgFee: {}, platformFee: {}, sellerPayout: {}",
                 settlementId, sellerId, year, month, totalAllocatedAmount, pgFeeAmount, platformFeeAmount, sellerPayoutAmount);
     }
 
     private void publishSettlementExecutedEvent(Long settlementId, Long sellerId,
-                                                Long totalAllocatedAmount, Long pgFeeAmount,
-                                                Long platformFeeAmount, Long sellerPayoutAmount) {
+                                                Long totalAllocatedAmount, Long shippingFee,
+                                                Long pgFeeAmount, Long platformFeeAmount,
+                                                Long sellerPayoutAmount) {
         try {
             publishSettlementEventPort.publishSettlementExecutedEvent(
-                    settlementId, sellerId, totalAllocatedAmount,
+                    settlementId, sellerId, totalAllocatedAmount, shippingFee,
                     pgFeeAmount, platformFeeAmount, sellerPayoutAmount);
         } catch (Exception e) {
             log.error("정산 실행 이벤트 발행 실패 - settlementId: {}, sellerId: {}, error: {}",

--- a/common/src/main/java/com/personal/marketnote/common/kafka/event/SettlementExecutedEvent.java
+++ b/common/src/main/java/com/personal/marketnote/common/kafka/event/SettlementExecutedEvent.java
@@ -4,6 +4,7 @@ public record SettlementExecutedEvent(
         Long settlementId,
         Long sellerId,
         Long totalAllocatedAmount,
+        Long shippingFee,
         Long pgFeeAmount,
         Long platformFeeAmount,
         Long sellerPayoutAmount


### PR DESCRIPTION
## partially addresses #216
## partially addresses #1197
## resolves #2217
## resolves #2219

## Task
- [x] SettlementExecutedEvent에 shippingFee 필드 추가
- [x] PublishSettlementEventPort/SettlementEventKafkaProducer에서 shippingFee 포함 이벤트 발행
- [x] Consumer 측 하위 호환 처리 (nullable)
- [x] RecordLedgerEntryService PG 정산 분개에 배송비 포함
- [x] RecordLedgerEntryService 판매자 정산 분개에 배송비 포함