### PR TITLE
[#216][#2218] feat: 결제 취소 시 배송비 정산 역처리 기능 추가

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/OrderCancelledSettlementConsumer.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/OrderCancelledSettlementConsumer.java
@@ -1,0 +1,95 @@
+package com.personal.marketnote.commerce.adapter.in.event;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.commerce.domain.settlement.*;
+import com.personal.marketnote.commerce.port.out.settlement.FindPaymentAllocationPort;
+import com.personal.marketnote.commerce.port.out.settlement.SavePaymentAllocationPort;
+import com.personal.marketnote.common.kafka.KafkaTopicConstants;
+import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.EventPayloadValidator;
+import com.personal.marketnote.common.kafka.event.OrderCancelledEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OrderCancelledSettlementConsumer {
+    private static final String IDEMPOTENCY_KEY_PREFIX = "ORDER_CANCELLATION_ALLOCATION:";
+
+    private final ObjectMapper objectMapper;
+    private final FindPaymentAllocationPort findPaymentAllocationPort;
+    private final SavePaymentAllocationPort savePaymentAllocationPort;
+
+    @KafkaListener(
+            topics = KafkaTopicConstants.ORDER_CANCELLED,
+            groupId = "commerce-order-cancelled-settlement"
+    )
+    public void handleOrderCancelledEvent(
+            ConsumerRecord<String, EventEnvelope<?>> record,
+            Acknowledgment acknowledgment
+    ) {
+        EventEnvelope<?> envelope = record.value();
+
+        if (EventPayloadValidator.hasInvalidEnvelope(envelope, record)) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        if (EventPayloadValidator.hasEventTypeMismatch(envelope, KafkaTopicConstants.ORDER_CANCELLED)) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        OrderCancelledEvent payload = envelope.getPayloadAs(OrderCancelledEvent.class, objectMapper);
+
+        log.info("주문 취소 이벤트 수신 (정산 역배분). eventId={}, orderId={}, isFullCancel={}",
+                envelope.eventId(), payload.orderId(), payload.isFullCancel());
+
+        if (EventPayloadValidator.hasInvalidIds(envelope.eventId(),
+                EventPayloadValidator.id("orderId", payload.orderId()))) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        try {
+            createCancellationAllocations(payload.orderId());
+            log.info("주문 취소 역배분 생성 완료. orderId={}", payload.orderId());
+        } catch (DataIntegrityViolationException e) {
+            log.info("이미 처리된 주문 취소 역배분 이벤트 (멱등 처리). eventId={}, orderId={}",
+                    envelope.eventId(), payload.orderId());
+        }
+
+        acknowledgment.acknowledge();
+    }
+
+    private void createCancellationAllocations(Long orderId) {
+        List<PaymentAllocation> originalAllocations = findPaymentAllocationPort.findByOrderId(orderId);
+
+        List<PaymentAllocation> cancellationAllocations = originalAllocations.stream()
+                .filter(allocation -> allocation.getTransactionType().isPositiveContribution())
+                .map(allocation -> PaymentAllocation.from(
+                        PaymentAllocationCreateState.builder()
+                                .orderId(orderId)
+                                .sellerId(allocation.getSellerId())
+                                .allocatedAmount(allocation.getAllocatedAmount())
+                                .shippingFee(allocation.getShippingFee())
+                                .transactionType(PaymentAllocationTransactionType.CANCELLATION)
+                                .targetType(PaymentAllocationTargetType.ORDER)
+                                .idempotencyKey(IDEMPOTENCY_KEY_PREFIX + orderId + ":" + allocation.getSellerId())
+                                .build()
+                ))
+                .toList();
+
+        if (!cancellationAllocations.isEmpty()) {
+            savePaymentAllocationPort.saveAll(cancellationAllocations);
+        }
+    }
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/settlement/PaymentAllocationPersistenceAdapter.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/settlement/PaymentAllocationPersistenceAdapter.java
@@ -41,6 +41,13 @@ public class PaymentAllocationPersistenceAdapter
     }
 
     @Override
+    public List<PaymentAllocation> findByOrderId(Long orderId) {
+        return paymentAllocationJpaRepository.findAllByOrderId(orderId).stream()
+                .map(PaymentAllocationEntityToDomainMapper::toDomain)
+                .toList();
+    }
+
+    @Override
     public void assignSettlement(List<Long> allocationIds, Long settlementId) {
         paymentAllocationJpaRepository.bulkAssignSettlement(allocationIds, settlementId);
     }

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/settlement/repository/PaymentAllocationJpaRepository.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/settlement/repository/PaymentAllocationJpaRepository.java
@@ -20,4 +20,6 @@ public interface PaymentAllocationJpaRepository extends JpaRepository<PaymentAll
     int bulkAssignSettlement(@Param("ids") List<Long> ids, @Param("settlementId") Long settlementId);
 
     List<PaymentAllocationJpaEntity> findAllBySettlementId(Long settlementId);
+
+    List<PaymentAllocationJpaEntity> findAllByOrderId(Long orderId);
 }

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/settlement/FindPaymentAllocationPort.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/settlement/FindPaymentAllocationPort.java
@@ -8,4 +8,6 @@ public interface FindPaymentAllocationPort {
     List<PaymentAllocation> findUnsettledAllocations(Integer year, Integer month);
 
     List<PaymentAllocation> findBySettlementId(Long settlementId);
+
+    List<PaymentAllocation> findByOrderId(Long orderId);
 }

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/settlement/ProcessSellerSettlementService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/settlement/ProcessSellerSettlementService.java
@@ -67,13 +67,10 @@ public class ProcessSellerSettlementService {
             throw new SettlementAlreadyExistsException(sellerId, year, month);
         }
 
-        long totalAllocatedAmount = sellerAllocations.stream()
-                .mapToLong(PaymentAllocation::getAllocatedAmount)
-                .sum();
+        long totalAllocatedAmount = calculateNetAmount(sellerAllocations, PaymentAllocation::getAllocatedAmount);
 
-        long totalShippingFee = sellerAllocations.stream()
-                .mapToLong(allocation -> allocation.getShippingFee() != null ? allocation.getShippingFee() : 0L)
-                .sum();
+        long totalShippingFee = calculateNetAmount(sellerAllocations,
+                allocation -> allocation.getShippingFee() != null ? allocation.getShippingFee() : 0L);
 
         long feeBase = Math.addExact(totalAllocatedAmount, totalShippingFee);
         long pgFeeAmount = Math.multiplyExact(feeBase, pgFeeRate) / BASIS_POINT_DENOMINATOR;
@@ -122,5 +119,20 @@ public class ProcessSellerSettlementService {
             log.error("정산 실행 이벤트 발행 실패 - settlementId: {}, sellerId: {}, error: {}",
                     settlementId, sellerId, e.getMessage(), e);
         }
+    }
+
+    private long calculateNetAmount(List<PaymentAllocation> allocations,
+                                    java.util.function.ToLongFunction<PaymentAllocation> amountExtractor) {
+        long positiveSum = 0L;
+        long negativeSum = 0L;
+        for (PaymentAllocation allocation : allocations) {
+            long amount = amountExtractor.applyAsLong(allocation);
+            if (allocation.getTransactionType().isPositiveContribution()) {
+                positiveSum = Math.addExact(positiveSum, amount);
+                continue;
+            }
+            negativeSum = Math.addExact(negativeSum, amount);
+        }
+        return positiveSum - negativeSum;
     }
 }

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/settlement/PaymentAllocationTransactionType.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/settlement/PaymentAllocationTransactionType.java
@@ -11,4 +11,12 @@ public enum PaymentAllocationTransactionType {
     PARTIAL_REFUND("부분 환불 역배분");
 
     private final String description;
+
+    public boolean isPositiveContribution() {
+        return this == ORDER_REGISTRATION;
+    }
+
+    public boolean isNegativeContribution() {
+        return this == CANCELLATION || this == PARTIAL_REFUND;
+    }
 }

--- a/user-service/user-adapters/src/main/resources/application.yml
+++ b/user-service/user-adapters/src/main/resources/application.yml
@@ -146,3 +146,7 @@ verification:
 profanity:
   init:
     enabled: ${PROFANITY_INIT_ENABLED:false}
+
+remote-area:
+  init:
+    enabled: ${REMOTE_AREA_INIT_ENABLED:false}


### PR DESCRIPTION
## partially addresses #216
## resolves #2218

## Task
- [x] 결제 취소 시 PaymentAllocation 배송비 포함 역처리 (OrderCancelledSettlementConsumer)
- [x] 배송비 포함 역분개 처리 (cancelAmount에 배송비 이미 포함)
- [x] 정산 취소 시 배송비 반영 (ProcessSellerSettlementService CANCELLATION 차감)