### PR TITLE
[#216][#2224] test: 결제 취소 시 배송비 정산 역처리 기능 자동화 테스트 추가

### DIFF
--- a/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/event/OrderCancelledSettlementConsumerTest.java
+++ b/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/event/OrderCancelledSettlementConsumerTest.java
@@ -1,0 +1,132 @@
+package com.personal.marketnote.commerce.adapter.in.event;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.commerce.domain.settlement.*;
+import com.personal.marketnote.commerce.port.out.settlement.FindPaymentAllocationPort;
+import com.personal.marketnote.commerce.port.out.settlement.SavePaymentAllocationPort;
+import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.OrderCancelledEvent;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.support.Acknowledgment;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("OrderCancelledSettlementConsumer 테스트")
+class OrderCancelledSettlementConsumerTest {
+    @InjectMocks
+    private OrderCancelledSettlementConsumer consumer;
+
+    @Mock
+    private FindPaymentAllocationPort findPaymentAllocationPort;
+
+    @Mock
+    private SavePaymentAllocationPort savePaymentAllocationPort;
+
+    @Spy
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @Mock
+    private Acknowledgment acknowledgment;
+
+    private ConsumerRecord<String, EventEnvelope<?>> buildRecord(Long orderId) {
+        OrderCancelledEvent event = new OrderCancelledEvent(
+                orderId, "order-key-1", 1L, 50000L, 50000L, 0L, 3000L,
+                true, 0L, List.of(), List.of()
+        );
+        EventEnvelope<OrderCancelledEvent> envelope = new EventEnvelope<>(
+                "test-event-id", "commerce.order.cancelled", "commerce-service",
+                LocalDateTime.of(2026, 4, 8, 10, 0), event
+        );
+        return new ConsumerRecord<>("commerce.order.cancelled", 0, 0L, String.valueOf(orderId), envelope);
+    }
+
+    private PaymentAllocation createOriginalAllocation(Long id, Long orderId, Long sellerId,
+                                                       Long allocatedAmount, Long shippingFee) {
+        return PaymentAllocation.from(PaymentAllocationSnapshotState.builder()
+                .id(id)
+                .orderId(orderId)
+                .sellerId(sellerId)
+                .allocatedAmount(allocatedAmount)
+                .shippingFee(shippingFee)
+                .transactionType(PaymentAllocationTransactionType.ORDER_REGISTRATION)
+                .targetType(PaymentAllocationTargetType.ORDER)
+                .idempotencyKey("ORDER_ALLOCATION:" + orderId + ":" + sellerId)
+                .createdAt(LocalDateTime.of(2026, 4, 7, 10, 0))
+                .build());
+    }
+
+    @Test
+    @DisplayName("주문 취소 시 원래 배분에 대응하는 CANCELLATION PaymentAllocation을 생성한다")
+    @SuppressWarnings("unchecked")
+    void handleOrderCancelledEvent_createsCancellationAllocations() {
+        // given
+        Long orderId = 100L;
+        PaymentAllocation original = createOriginalAllocation(1L, orderId, 10L, 50000L, 3000L);
+        when(findPaymentAllocationPort.findByOrderId(orderId)).thenReturn(List.of(original));
+
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(orderId);
+
+        // when
+        consumer.handleOrderCancelledEvent(record, acknowledgment);
+
+        // then
+        ArgumentCaptor<List<PaymentAllocation>> captor = ArgumentCaptor.forClass(List.class);
+        verify(savePaymentAllocationPort).saveAll(captor.capture());
+        List<PaymentAllocation> cancellations = captor.getValue();
+
+        assertThat(cancellations).hasSize(1);
+        PaymentAllocation cancellation = cancellations.get(0);
+        assertThat(cancellation.getOrderId()).isEqualTo(orderId);
+        assertThat(cancellation.getSellerId()).isEqualTo(10L);
+        assertThat(cancellation.getAllocatedAmount()).isEqualTo(50000L);
+        assertThat(cancellation.getShippingFee()).isEqualTo(3000L);
+        assertThat(cancellation.getTransactionType()).isEqualTo(PaymentAllocationTransactionType.CANCELLATION);
+        assertThat(cancellation.getIdempotencyKey()).isEqualTo("ORDER_CANCELLATION_ALLOCATION:100:10");
+
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("원래 배분이 없으면 CANCELLATION을 생성하지 않는다")
+    void handleOrderCancelledEvent_noOriginalAllocations_skips() {
+        // given
+        Long orderId = 100L;
+        when(findPaymentAllocationPort.findByOrderId(orderId)).thenReturn(List.of());
+
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(orderId);
+
+        // when
+        consumer.handleOrderCancelledEvent(record, acknowledgment);
+
+        // then
+        verify(savePaymentAllocationPort, never()).saveAll(anyList());
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("orderId가 null이면 이벤트를 무시하고 acknowledge한다")
+    void handleOrderCancelledEvent_nullOrderId_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(null);
+
+        // when
+        consumer.handleOrderCancelledEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(findPaymentAllocationPort, savePaymentAllocationPort);
+        verify(acknowledgment).acknowledge();
+    }
+}

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/settlement/ProcessSellerSettlementUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/settlement/ProcessSellerSettlementUseCaseTest.java
@@ -208,6 +208,59 @@ class ProcessSellerSettlementUseCaseTest {
         }
 
         @Test
+        @DisplayName("CANCELLATION 배분이 포함되면 정산 금액에서 차감된다")
+        void shouldSubtractCancellationAllocations() {
+            // given
+            // ORDER_REGISTRATION: 10000 + shipping 2000 = 12000
+            // CANCELLATION: 3000 + shipping 0 = 3000 (부분 취소 역배분)
+            // net: allocated=7000, shipping=2000, feeBase=9000
+            PaymentAllocation orderAllocation = createAllocation(1L, 10L, 10000L, 2000L);
+            PaymentAllocation cancelAllocation = PaymentAllocation.from(PaymentAllocationSnapshotState.builder()
+                    .id(2L)
+                    .orderId(100L)
+                    .sellerId(10L)
+                    .allocatedAmount(3000L)
+                    .shippingFee(0L)
+                    .transactionType(PaymentAllocationTransactionType.CANCELLATION)
+                    .targetType(PaymentAllocationTargetType.ORDER)
+                    .idempotencyKey("CANCEL:2")
+                    .createdAt(LocalDateTime.of(2026, 2, 15, 10, 0))
+                    .build());
+
+            when(findSettlementPort.existsBySellerIdAndYearAndMonth(10L, 2026, 2))
+                    .thenReturn(false);
+            when(saveSettlementPort.save(any(Settlement.class)))
+                    .thenAnswer(invocation -> {
+                        Settlement s = invocation.getArgument(0);
+                        return createSavedSettlement(1L, s.getSellerId(), s.getYear(), s.getMonth(),
+                                s.getTotalAllocatedAmount(), s.getPgFeeAmount(),
+                                s.getPlatformFeeAmount(), s.getSellerPayoutAmount());
+                    });
+            when(updateSettlementPort.update(any(Settlement.class)))
+                    .thenAnswer(invocation -> invocation.getArgument(0));
+
+            ExecuteSettlementCommand command = ExecuteSettlementCommand.builder()
+                    .year(2026).month(2).build();
+
+            // when
+            // feeBase = 7000 + 2000 = 9000
+            // pgFee = 9000 * 300 / 10000 = 270
+            // platformFee = 9000 * 500 / 10000 = 450
+            // sellerPayout = 9000 - 270 - 450 = 8280
+            processSellerSettlementService.process(
+                    command, 10L, List.of(orderAllocation, cancelAllocation), 300, 500);
+
+            // then
+            verify(saveSettlementPort).save(settlementCaptor.capture());
+            Settlement saved = settlementCaptor.getValue();
+            assertThat(saved.getTotalAllocatedAmount()).isEqualTo(7000L);
+            assertThat(saved.getShippingFee()).isEqualTo(2000L);
+            assertThat(saved.getPgFeeAmount()).isEqualTo(270L);
+            assertThat(saved.getPlatformFeeAmount()).isEqualTo(450L);
+            assertThat(saved.getSellerPayoutAmount()).isEqualTo(8280L);
+        }
+
+        @Test
         @DisplayName("수수료 역산 정합성이 유지된다")
         void shouldMaintainFeeIntegrity() {
             // given


### PR DESCRIPTION
## partially addresses #216
## resolves #2224

## Test Case
- [x] 주문 취소 시 원래 배분에 대응하는 CANCELLATION PaymentAllocation을 생성한다
- [x] 원래 배분이 없으면 CANCELLATION을 생성하지 않는다
- [x] orderId가 null이면 이벤트를 무시하고 acknowledge한다
- [x] CANCELLATION 배분이 포함되면 정산 금액에서 차감된다