### PR TITLE
[#43][#2231] feat: 배송지 도메인에 지역 구분 필드 추가

### DIFF
--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/shippingaddress/response/GetMyShippingAddressResponse.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/shippingaddress/response/GetMyShippingAddressResponse.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.user.adapter.in.web.shippingaddress.response;
 
 import com.personal.marketnote.common.domain.delivery.DeliveryRequestType;
+import com.personal.marketnote.user.domain.shippingaddress.ShippingAddressRegionType;
 import com.personal.marketnote.user.domain.shippingaddress.ShippingAddressType;
 import com.personal.marketnote.user.port.in.result.shippingaddress.GetMyShippingAddressResult;
 
@@ -15,7 +16,8 @@ public record GetMyShippingAddressResponse(
         String recipientPhoneNumber,
         DeliveryRequestType deliveryRequestType,
         String deliveryRequestMessage,
-        boolean isDefault
+        boolean isDefault,
+        ShippingAddressRegionType regionType
 ) {
     public static GetMyShippingAddressResponse from(GetMyShippingAddressResult result) {
         return new GetMyShippingAddressResponse(
@@ -29,7 +31,8 @@ public record GetMyShippingAddressResponse(
                 result.recipientPhoneNumber(),
                 result.deliveryRequestType(),
                 result.deliveryRequestMessage(),
-                result.isDefault()
+                result.isDefault(),
+                result.regionType()
         );
     }
 }

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/shippingaddress/response/GetShippingAddressResponse.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/shippingaddress/response/GetShippingAddressResponse.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.user.adapter.in.web.shippingaddress.response;
 
 import com.personal.marketnote.common.domain.delivery.DeliveryRequestType;
+import com.personal.marketnote.user.domain.shippingaddress.ShippingAddressRegionType;
 import com.personal.marketnote.user.domain.shippingaddress.ShippingAddressType;
 import com.personal.marketnote.user.port.in.result.shippingaddress.GetShippingAddressResult;
 
@@ -15,7 +16,8 @@ public record GetShippingAddressResponse(
         String recipientPhoneNumber,
         DeliveryRequestType deliveryRequestType,
         String deliveryRequestMessage,
-        boolean isDefault
+        boolean isDefault,
+        ShippingAddressRegionType regionType
 ) {
     public static GetShippingAddressResponse from(GetShippingAddressResult result) {
         return new GetShippingAddressResponse(
@@ -29,7 +31,8 @@ public record GetShippingAddressResponse(
                 result.recipientPhoneNumber(),
                 result.deliveryRequestType(),
                 result.deliveryRequestMessage(),
-                result.isDefault()
+                result.isDefault(),
+                result.regionType()
         );
     }
 }

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/out/mapper/ShippingAddressJpaEntityToDomainMapper.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/out/mapper/ShippingAddressJpaEntityToDomainMapper.java
@@ -21,6 +21,7 @@ public class ShippingAddressJpaEntityToDomainMapper {
                         .deliveryRequestType(entity.getDeliveryRequestType())
                         .deliveryRequestMessage(entity.getDeliveryRequestMessage())
                         .isDefault(Boolean.TRUE.equals(entity.getIsDefault()))
+                        .regionType(entity.getRegionType())
                         .build()
         );
     }

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/out/persistence/remotearea/repository/RemoteAreaJpaRepository.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/out/persistence/remotearea/repository/RemoteAreaJpaRepository.java
@@ -11,6 +11,8 @@ public interface RemoteAreaJpaRepository extends JpaRepository<RemoteAreaJpaEnti
 
     boolean existsByProvinceAndDistrictAndVillageAndSubareaAndStatus(String province, String district, String village, String subarea, EntityStatus status);
 
+    boolean existsByProvinceAndDistrictAndStatus(String province, String district, EntityStatus status);
+
     List<RemoteAreaJpaEntity> findAllByStatus(EntityStatus status);
 
     Optional<RemoteAreaJpaEntity> findByIdAndStatus(Long id, EntityStatus status);

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/out/persistence/shippingaddress/ShippingAddressRegionClassifier.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/out/persistence/shippingaddress/ShippingAddressRegionClassifier.java
@@ -1,0 +1,81 @@
+package com.personal.marketnote.user.adapter.out.persistence.shippingaddress;
+
+import com.personal.marketnote.common.adapter.out.PersistenceAdapter;
+import com.personal.marketnote.common.domain.EntityStatus;
+import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.user.adapter.out.persistence.remotearea.repository.RemoteAreaJpaRepository;
+import com.personal.marketnote.user.domain.shippingaddress.ShippingAddressRegionType;
+import com.personal.marketnote.user.port.out.shippingaddress.ClassifyShippingAddressRegionPort;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Map;
+
+@PersistenceAdapter
+@RequiredArgsConstructor
+public class ShippingAddressRegionClassifier implements ClassifyShippingAddressRegionPort {
+
+    private static final Map<String, String> PROVINCE_ABBREVIATIONS = Map.ofEntries(
+            Map.entry("서울특별시", "서울"),
+            Map.entry("부산광역시", "부산"),
+            Map.entry("대구광역시", "대구"),
+            Map.entry("인천광역시", "인천"),
+            Map.entry("광주광역시", "광주"),
+            Map.entry("대전광역시", "대전"),
+            Map.entry("울산광역시", "울산"),
+            Map.entry("세종특별자치시", "세종"),
+            Map.entry("경기도", "경기"),
+            Map.entry("충청북도", "충북"),
+            Map.entry("충청남도", "충남"),
+            Map.entry("전라남도", "전남"),
+            Map.entry("전라북도", "전북"),
+            Map.entry("전북특별자치도", "전북"),
+            Map.entry("경상북도", "경북"),
+            Map.entry("경상남도", "경남"),
+            Map.entry("강원도", "강원"),
+            Map.entry("강원특별자치도", "강원"),
+            Map.entry("제주특별자치도", "제주")
+    );
+
+    private final RemoteAreaJpaRepository remoteAreaJpaRepository;
+
+    @Override
+    public ShippingAddressRegionType classify(String address) {
+        if (FormatValidator.hasNoValue(address)) {
+            return ShippingAddressRegionType.NORMAL;
+        }
+
+        if (isJejuAddress(address)) {
+            return ShippingAddressRegionType.JEJU;
+        }
+
+        if (isRemoteAreaAddress(address)) {
+            return ShippingAddressRegionType.ISLAND;
+        }
+
+        return ShippingAddressRegionType.NORMAL;
+    }
+
+    private boolean isJejuAddress(String address) {
+        return address.startsWith("제주");
+    }
+
+    private boolean isRemoteAreaAddress(String address) {
+        String[] tokens = address.split(" ");
+        if (tokens.length < 2) {
+            return false;
+        }
+
+        String province = normalizeProvince(tokens[0]);
+        String district = tokens[1];
+
+        return remoteAreaJpaRepository.existsByProvinceAndDistrictAndStatus(province, district, EntityStatus.ACTIVE);
+    }
+
+    private String normalizeProvince(String rawProvince) {
+        String abbreviation = PROVINCE_ABBREVIATIONS.get(rawProvince);
+        if (FormatValidator.hasValue(abbreviation)) {
+            return abbreviation;
+        }
+        return rawProvince;
+    }
+}

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/out/persistence/shippingaddress/entity/ShippingAddressJpaEntity.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/out/persistence/shippingaddress/entity/ShippingAddressJpaEntity.java
@@ -3,6 +3,7 @@ package com.personal.marketnote.user.adapter.out.persistence.shippingaddress.ent
 import com.personal.marketnote.common.adapter.out.persistence.audit.BaseGeneralEntity;
 import com.personal.marketnote.common.domain.delivery.DeliveryRequestType;
 import com.personal.marketnote.user.domain.shippingaddress.ShippingAddress;
+import com.personal.marketnote.user.domain.shippingaddress.ShippingAddressRegionType;
 import com.personal.marketnote.user.domain.shippingaddress.ShippingAddressType;
 import jakarta.persistence.*;
 import lombok.*;
@@ -50,6 +51,10 @@ public class ShippingAddressJpaEntity extends BaseGeneralEntity {
     @Column(name = "is_default", nullable = false, columnDefinition = "boolean default false")
     private Boolean isDefault;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "region_type", nullable = false, length = 15)
+    private ShippingAddressRegionType regionType;
+
     public void updateFrom(ShippingAddress shippingAddress) {
         if (shippingAddress.isInactive()) {
             deactivate();
@@ -63,6 +68,7 @@ public class ShippingAddressJpaEntity extends BaseGeneralEntity {
         this.deliveryRequestType = shippingAddress.getDeliveryRequestType();
         this.deliveryRequestMessage = shippingAddress.getDeliveryRequestMessage();
         this.isDefault = shippingAddress.isDefault();
+        this.regionType = shippingAddress.getRegionType();
     }
 
     public static ShippingAddressJpaEntity from(ShippingAddress shippingAddress) {
@@ -78,6 +84,7 @@ public class ShippingAddressJpaEntity extends BaseGeneralEntity {
                 .deliveryRequestType(shippingAddress.getDeliveryRequestType())
                 .deliveryRequestMessage(shippingAddress.getDeliveryRequestMessage())
                 .isDefault(shippingAddress.isDefault())
+                .regionType(shippingAddress.getRegionType())
                 .build();
     }
 }

--- a/user-service/user-adapters/src/main/resources/db/migration/V20260408__add_region_type_to_shipping_addresses.sql
+++ b/user-service/user-adapters/src/main/resources/db/migration/V20260408__add_region_type_to_shipping_addresses.sql
@@ -1,0 +1,1 @@
+ALTER TABLE shipping_addresses ADD COLUMN region_type VARCHAR(15) NOT NULL DEFAULT 'NORMAL';

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/mapper/ShippingAddressCommandToStateMapper.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/mapper/ShippingAddressCommandToStateMapper.java
@@ -3,6 +3,7 @@ package com.personal.marketnote.user.mapper;
 import com.personal.marketnote.common.domain.delivery.DeliveryRequestType;
 import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.user.domain.shippingaddress.ShippingAddressCreateState;
+import com.personal.marketnote.user.domain.shippingaddress.ShippingAddressRegionType;
 import com.personal.marketnote.user.port.in.command.shippingaddress.RegisterShippingAddressCommand;
 
 public class ShippingAddressCommandToStateMapper {
@@ -10,7 +11,7 @@ public class ShippingAddressCommandToStateMapper {
     }
 
     public static ShippingAddressCreateState mapToCreateState(
-            RegisterShippingAddressCommand command, boolean isDefault
+            RegisterShippingAddressCommand command, boolean isDefault, ShippingAddressRegionType regionType
     ) {
         return ShippingAddressCreateState.builder()
                 .userId(command.userId())
@@ -28,6 +29,7 @@ public class ShippingAddressCommandToStateMapper {
                 )
                 .deliveryRequestMessage(command.deliveryRequestMessage())
                 .isDefault(isDefault)
+                .regionType(regionType)
                 .build();
     }
 }

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/port/in/result/shippingaddress/GetMyShippingAddressResult.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/port/in/result/shippingaddress/GetMyShippingAddressResult.java
@@ -2,6 +2,7 @@ package com.personal.marketnote.user.port.in.result.shippingaddress;
 
 import com.personal.marketnote.common.domain.delivery.DeliveryRequestType;
 import com.personal.marketnote.user.domain.shippingaddress.ShippingAddress;
+import com.personal.marketnote.user.domain.shippingaddress.ShippingAddressRegionType;
 import com.personal.marketnote.user.domain.shippingaddress.ShippingAddressType;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -18,7 +19,8 @@ public record GetMyShippingAddressResult(
         String recipientPhoneNumber,
         DeliveryRequestType deliveryRequestType,
         String deliveryRequestMessage,
-        boolean isDefault
+        boolean isDefault,
+        ShippingAddressRegionType regionType
 ) {
     public static GetMyShippingAddressResult from(ShippingAddress shippingAddress) {
         return GetMyShippingAddressResult.builder()
@@ -33,6 +35,7 @@ public record GetMyShippingAddressResult(
                 .deliveryRequestType(shippingAddress.getDeliveryRequestType())
                 .deliveryRequestMessage(shippingAddress.getDeliveryRequestMessage())
                 .isDefault(shippingAddress.isDefault())
+                .regionType(shippingAddress.getRegionType())
                 .build();
     }
 }

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/port/in/result/shippingaddress/GetShippingAddressResult.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/port/in/result/shippingaddress/GetShippingAddressResult.java
@@ -2,6 +2,7 @@ package com.personal.marketnote.user.port.in.result.shippingaddress;
 
 import com.personal.marketnote.common.domain.delivery.DeliveryRequestType;
 import com.personal.marketnote.user.domain.shippingaddress.ShippingAddress;
+import com.personal.marketnote.user.domain.shippingaddress.ShippingAddressRegionType;
 import com.personal.marketnote.user.domain.shippingaddress.ShippingAddressType;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -18,7 +19,8 @@ public record GetShippingAddressResult(
         String recipientPhoneNumber,
         DeliveryRequestType deliveryRequestType,
         String deliveryRequestMessage,
-        boolean isDefault
+        boolean isDefault,
+        ShippingAddressRegionType regionType
 ) {
     public static GetShippingAddressResult from(ShippingAddress shippingAddress) {
         return GetShippingAddressResult.builder()
@@ -33,6 +35,7 @@ public record GetShippingAddressResult(
                 .deliveryRequestType(shippingAddress.getDeliveryRequestType())
                 .deliveryRequestMessage(shippingAddress.getDeliveryRequestMessage())
                 .isDefault(shippingAddress.isDefault())
+                .regionType(shippingAddress.getRegionType())
                 .build();
     }
 }

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/port/in/result/shippingaddress/RegisterShippingAddressResult.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/port/in/result/shippingaddress/RegisterShippingAddressResult.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.user.port.in.result.shippingaddress;
 
 import com.personal.marketnote.user.domain.shippingaddress.ShippingAddress;
+import com.personal.marketnote.user.domain.shippingaddress.ShippingAddressRegionType;
 import com.personal.marketnote.user.domain.shippingaddress.ShippingAddressType;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -9,13 +10,15 @@ import lombok.Builder;
 public record RegisterShippingAddressResult(
         Long id,
         ShippingAddressType addressType,
-        boolean isDefault
+        boolean isDefault,
+        ShippingAddressRegionType regionType
 ) {
     public static RegisterShippingAddressResult from(ShippingAddress shippingAddress) {
         return RegisterShippingAddressResult.builder()
                 .id(shippingAddress.getId())
                 .addressType(shippingAddress.getAddressType())
                 .isDefault(shippingAddress.isDefault())
+                .regionType(shippingAddress.getRegionType())
                 .build();
     }
 }

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/port/out/shippingaddress/ClassifyShippingAddressRegionPort.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/port/out/shippingaddress/ClassifyShippingAddressRegionPort.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.user.port.out.shippingaddress;
+
+import com.personal.marketnote.user.domain.shippingaddress.ShippingAddressRegionType;
+
+public interface ClassifyShippingAddressRegionPort {
+    ShippingAddressRegionType classify(String address);
+}

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/service/shippingaddress/RegisterShippingAddressService.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/service/shippingaddress/RegisterShippingAddressService.java
@@ -4,6 +4,7 @@ import com.personal.marketnote.common.application.UseCase;
 import com.personal.marketnote.common.kafka.event.ShippingAddressChangeAction;
 import com.personal.marketnote.user.domain.shippingaddress.ShippingAddress;
 import com.personal.marketnote.user.domain.shippingaddress.ShippingAddressCreateState;
+import com.personal.marketnote.user.domain.shippingaddress.ShippingAddressRegionType;
 import com.personal.marketnote.user.domain.shippingaddress.ShippingAddressType;
 import com.personal.marketnote.user.exception.TooManyOtherAddressesException;
 import com.personal.marketnote.user.mapper.ShippingAddressCommandToStateMapper;
@@ -11,6 +12,7 @@ import com.personal.marketnote.user.port.in.command.shippingaddress.RegisterShip
 import com.personal.marketnote.user.port.in.result.shippingaddress.RegisterShippingAddressResult;
 import com.personal.marketnote.user.port.in.usecase.shippingaddress.RegisterShippingAddressUseCase;
 import com.personal.marketnote.user.port.out.event.PublishShippingAddressEventPort;
+import com.personal.marketnote.user.port.out.shippingaddress.ClassifyShippingAddressRegionPort;
 import com.personal.marketnote.user.port.out.shippingaddress.FindShippingAddressPort;
 import com.personal.marketnote.user.port.out.shippingaddress.SaveShippingAddressPort;
 import com.personal.marketnote.user.port.out.shippingaddress.UpdateShippingAddressPort;
@@ -32,6 +34,7 @@ public class RegisterShippingAddressService implements RegisterShippingAddressUs
     private final SaveShippingAddressPort saveShippingAddressPort;
     private final UpdateShippingAddressPort updateShippingAddressPort;
     private final PublishShippingAddressEventPort publishShippingAddressEventPort;
+    private final ClassifyShippingAddressRegionPort classifyShippingAddressRegionPort;
 
     @Override
     public RegisterShippingAddressResult registerShippingAddress(RegisterShippingAddressCommand command) {
@@ -51,7 +54,8 @@ public class RegisterShippingAddressService implements RegisterShippingAddressUs
                     });
         }
 
-        ShippingAddressCreateState createState = ShippingAddressCommandToStateMapper.mapToCreateState(command, isDefault);
+        ShippingAddressRegionType regionType = classifyShippingAddressRegionPort.classify(command.address());
+        ShippingAddressCreateState createState = ShippingAddressCommandToStateMapper.mapToCreateState(command, isDefault, regionType);
         ShippingAddress shippingAddress = ShippingAddress.from(createState);
 
         ShippingAddress savedShippingAddress = saveShippingAddressPort.save(shippingAddress);

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/service/shippingaddress/UpdateShippingAddressService.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/service/shippingaddress/UpdateShippingAddressService.java
@@ -3,10 +3,12 @@ package com.personal.marketnote.user.service.shippingaddress;
 import com.personal.marketnote.common.application.UseCase;
 import com.personal.marketnote.common.kafka.event.ShippingAddressChangeAction;
 import com.personal.marketnote.user.domain.shippingaddress.ShippingAddress;
+import com.personal.marketnote.user.domain.shippingaddress.ShippingAddressRegionType;
 import com.personal.marketnote.user.exception.ShippingAddressNotFoundException;
 import com.personal.marketnote.user.port.in.command.shippingaddress.UpdateShippingAddressCommand;
 import com.personal.marketnote.user.port.in.usecase.shippingaddress.UpdateShippingAddressUseCase;
 import com.personal.marketnote.user.port.out.event.PublishShippingAddressEventPort;
+import com.personal.marketnote.user.port.out.shippingaddress.ClassifyShippingAddressRegionPort;
 import com.personal.marketnote.user.port.out.shippingaddress.FindShippingAddressPort;
 import com.personal.marketnote.user.port.out.shippingaddress.UpdateShippingAddressPort;
 import lombok.RequiredArgsConstructor;
@@ -21,6 +23,7 @@ public class UpdateShippingAddressService implements UpdateShippingAddressUseCas
     private final FindShippingAddressPort findShippingAddressPort;
     private final UpdateShippingAddressPort updateShippingAddressPort;
     private final PublishShippingAddressEventPort publishShippingAddressEventPort;
+    private final ClassifyShippingAddressRegionPort classifyShippingAddressRegionPort;
 
     @Override
     public void updateShippingAddress(Long shippingAddressId, Long userId, UpdateShippingAddressCommand command) {
@@ -37,6 +40,9 @@ public class UpdateShippingAddressService implements UpdateShippingAddressUseCas
                 command.deliveryRequestType(),
                 command.deliveryRequestMessage()
         );
+
+        ShippingAddressRegionType regionType = classifyShippingAddressRegionPort.classify(command.address());
+        shippingAddress.assignRegionType(regionType);
 
         updateShippingAddressPort.update(shippingAddress);
 

--- a/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/shippingaddress/ShippingAddress.java
+++ b/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/shippingaddress/ShippingAddress.java
@@ -28,6 +28,7 @@ public class ShippingAddress extends BaseDomain {
     private DeliveryRequestType deliveryRequestType;
     private String deliveryRequestMessage;
     private boolean isDefault;
+    private ShippingAddressRegionType regionType;
 
     public static ShippingAddress from(ShippingAddressCreateState state) {
         ShippingAddress shippingAddress = ShippingAddress.builder()
@@ -42,6 +43,7 @@ public class ShippingAddress extends BaseDomain {
                 .deliveryRequestType(state.getDeliveryRequestType())
                 .deliveryRequestMessage(state.getDeliveryRequestMessage())
                 .isDefault(state.isDefault())
+                .regionType(state.getRegionType())
                 .build();
 
         shippingAddress.validate();
@@ -62,6 +64,7 @@ public class ShippingAddress extends BaseDomain {
                 .deliveryRequestType(state.getDeliveryRequestType())
                 .deliveryRequestMessage(state.getDeliveryRequestMessage())
                 .isDefault(state.isDefault())
+                .regionType(state.getRegionType())
                 .build();
     }
 
@@ -77,6 +80,14 @@ public class ShippingAddress extends BaseDomain {
 
     public void unsetAsDefault() {
         this.isDefault = false;
+    }
+
+    public void assignRegionType(ShippingAddressRegionType regionType) {
+        if (FormatValidator.hasNoValue(regionType)) {
+            this.regionType = ShippingAddressRegionType.NORMAL;
+            return;
+        }
+        this.regionType = regionType;
     }
 
     public void delete() {

--- a/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/shippingaddress/ShippingAddressCreateState.java
+++ b/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/shippingaddress/ShippingAddressCreateState.java
@@ -21,4 +21,5 @@ public class ShippingAddressCreateState {
     private final DeliveryRequestType deliveryRequestType;
     private final String deliveryRequestMessage;
     private final boolean isDefault;
+    private final ShippingAddressRegionType regionType;
 }

--- a/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/shippingaddress/ShippingAddressRegionType.java
+++ b/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/shippingaddress/ShippingAddressRegionType.java
@@ -1,0 +1,26 @@
+package com.personal.marketnote.user.domain.shippingaddress;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum ShippingAddressRegionType {
+    NORMAL("일반"),
+    JEJU("제주"),
+    ISLAND("도서산간");
+
+    private final String description;
+
+    public boolean isNormal() {
+        return this == NORMAL;
+    }
+
+    public boolean isJeju() {
+        return this == JEJU;
+    }
+
+    public boolean isIsland() {
+        return this == ISLAND;
+    }
+}

--- a/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/shippingaddress/ShippingAddressSnapshotState.java
+++ b/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/shippingaddress/ShippingAddressSnapshotState.java
@@ -22,4 +22,5 @@ public class ShippingAddressSnapshotState {
     private final DeliveryRequestType deliveryRequestType;
     private final String deliveryRequestMessage;
     private final boolean isDefault;
+    private final ShippingAddressRegionType regionType;
 }


### PR DESCRIPTION
## partially addresses #43
## resolves #2231

## Task
- [x] ShippingAddressRegionType enum 추가 (NORMAL, JEJU, ISLAND)
- [x] ShippingAddress 도메인에 regionType 필드 추가
- [x] ShippingAddressJpaEntity에 region_type 컬럼 추가
- [x] 배송지 등록/수정 시 지역 자동 분류 로직 추가 (제주: 주소 판별, 도서산간: RemoteArea DB 조회)
- [x] DB Migration 스크립트 추가
- [x] 배송지 조회 응답에 regionType 노출