### PR TITLE
[#43][#2239] test: 배송지 지역 구분 자동 분류 기능 자동화 테스트 추가

### DIFF
--- a/user-service/user-adapters/src/test/java/com/personal/marketnote/user/adapter/out/persistence/shippingaddress/ShippingAddressRegionClassifierTest.java
+++ b/user-service/user-adapters/src/test/java/com/personal/marketnote/user/adapter/out/persistence/shippingaddress/ShippingAddressRegionClassifierTest.java
@@ -1,0 +1,199 @@
+package com.personal.marketnote.user.adapter.out.persistence.shippingaddress;
+
+import com.personal.marketnote.common.domain.EntityStatus;
+import com.personal.marketnote.user.adapter.out.persistence.remotearea.repository.RemoteAreaJpaRepository;
+import com.personal.marketnote.user.domain.shippingaddress.ShippingAddressRegionType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ShippingAddressRegionClassifierTest {
+
+    @InjectMocks
+    private ShippingAddressRegionClassifier shippingAddressRegionClassifier;
+
+    @Mock
+    private RemoteAreaJpaRepository remoteAreaJpaRepository;
+
+    @Test
+    @DisplayName("제주특별자치도 주소는 JEJU로 분류된다")
+    void classify_jejuSpecialAutonomousProvince_returnsJeju() {
+        // given
+        String address = "제주특별자치도 제주시 한라산로 456";
+
+        // when
+        ShippingAddressRegionType result = shippingAddressRegionClassifier.classify(address);
+
+        // then
+        assertThat(result).isEqualTo(ShippingAddressRegionType.JEJU);
+        verifyNoInteractions(remoteAreaJpaRepository);
+    }
+
+    @Test
+    @DisplayName("제주시로 시작하는 주소는 JEJU로 분류된다")
+    void classify_jejuCity_returnsJeju() {
+        // given
+        String address = "제주시 한라산로 456";
+
+        // when
+        ShippingAddressRegionType result = shippingAddressRegionClassifier.classify(address);
+
+        // then
+        assertThat(result).isEqualTo(ShippingAddressRegionType.JEJU);
+        verifyNoInteractions(remoteAreaJpaRepository);
+    }
+
+    @Test
+    @DisplayName("도서산간 지역 주소는 ISLAND로 분류된다")
+    void classify_remoteAreaAddress_returnsIsland() {
+        // given
+        String address = "인천광역시 옹진군 영흥면 선재리 123";
+        when(remoteAreaJpaRepository.existsByProvinceAndDistrictAndStatus("인천", "옹진군", EntityStatus.ACTIVE))
+                .thenReturn(true);
+
+        // when
+        ShippingAddressRegionType result = shippingAddressRegionClassifier.classify(address);
+
+        // then
+        assertThat(result).isEqualTo(ShippingAddressRegionType.ISLAND);
+        verify(remoteAreaJpaRepository).existsByProvinceAndDistrictAndStatus("인천", "옹진군", EntityStatus.ACTIVE);
+    }
+
+    @Test
+    @DisplayName("일반 지역 주소는 NORMAL로 분류된다")
+    void classify_normalAddress_returnsNormal() {
+        // given
+        String address = "서울특별시 강남구 테헤란로 123";
+        when(remoteAreaJpaRepository.existsByProvinceAndDistrictAndStatus("서울", "강남구", EntityStatus.ACTIVE))
+                .thenReturn(false);
+
+        // when
+        ShippingAddressRegionType result = shippingAddressRegionClassifier.classify(address);
+
+        // then
+        assertThat(result).isEqualTo(ShippingAddressRegionType.NORMAL);
+        verify(remoteAreaJpaRepository).existsByProvinceAndDistrictAndStatus("서울", "강남구", EntityStatus.ACTIVE);
+    }
+
+    @Test
+    @DisplayName("경기도 주소에서 도서산간이 아닌 경우 NORMAL로 분류된다")
+    void classify_gyeonggiNonRemote_returnsNormal() {
+        // given
+        String address = "경기도 성남시 분당구 판교로 123";
+        when(remoteAreaJpaRepository.existsByProvinceAndDistrictAndStatus("경기", "성남시", EntityStatus.ACTIVE))
+                .thenReturn(false);
+
+        // when
+        ShippingAddressRegionType result = shippingAddressRegionClassifier.classify(address);
+
+        // then
+        assertThat(result).isEqualTo(ShippingAddressRegionType.NORMAL);
+        verify(remoteAreaJpaRepository).existsByProvinceAndDistrictAndStatus("경기", "성남시", EntityStatus.ACTIVE);
+    }
+
+    @Test
+    @DisplayName("경상남도 도서산간 지역은 ISLAND로 분류된다")
+    void classify_gyeongsangRemoteArea_returnsIsland() {
+        // given
+        String address = "경상남도 통영시 한산면 123";
+        when(remoteAreaJpaRepository.existsByProvinceAndDistrictAndStatus("경남", "통영시", EntityStatus.ACTIVE))
+                .thenReturn(true);
+
+        // when
+        ShippingAddressRegionType result = shippingAddressRegionClassifier.classify(address);
+
+        // then
+        assertThat(result).isEqualTo(ShippingAddressRegionType.ISLAND);
+        verify(remoteAreaJpaRepository).existsByProvinceAndDistrictAndStatus("경남", "통영시", EntityStatus.ACTIVE);
+    }
+
+    @Test
+    @DisplayName("세종특별자치시 주소는 NORMAL로 분류된다")
+    void classify_sejongAddress_returnsNormal() {
+        // given
+        String address = "세종특별자치시 한누리대로 123";
+        when(remoteAreaJpaRepository.existsByProvinceAndDistrictAndStatus("세종", "한누리대로", EntityStatus.ACTIVE))
+                .thenReturn(false);
+
+        // when
+        ShippingAddressRegionType result = shippingAddressRegionClassifier.classify(address);
+
+        // then
+        assertThat(result).isEqualTo(ShippingAddressRegionType.NORMAL);
+    }
+
+    @Test
+    @DisplayName("공백 구분 토큰이 1개뿐인 주소는 NORMAL로 분류된다")
+    void classify_singleTokenAddress_returnsNormal() {
+        // given
+        String address = "서울";
+
+        // when
+        ShippingAddressRegionType result = shippingAddressRegionClassifier.classify(address);
+
+        // then
+        assertThat(result).isEqualTo(ShippingAddressRegionType.NORMAL);
+        verifyNoInteractions(remoteAreaJpaRepository);
+    }
+
+    @Test
+    @DisplayName("null 주소 입력 시 NORMAL로 분류된다")
+    void classify_nullAddress_returnsNormal() {
+        // when
+        ShippingAddressRegionType result = shippingAddressRegionClassifier.classify(null);
+
+        // then
+        assertThat(result).isEqualTo(ShippingAddressRegionType.NORMAL);
+        verifyNoInteractions(remoteAreaJpaRepository);
+    }
+
+    @Test
+    @DisplayName("빈 문자열 주소 입력 시 NORMAL로 분류된다")
+    void classify_emptyAddress_returnsNormal() {
+        // when
+        ShippingAddressRegionType result = shippingAddressRegionClassifier.classify("");
+
+        // then
+        assertThat(result).isEqualTo(ShippingAddressRegionType.NORMAL);
+        verifyNoInteractions(remoteAreaJpaRepository);
+    }
+
+    @Test
+    @DisplayName("충청남도 주소에서 도서산간 지역은 ISLAND로 분류된다")
+    void classify_chungnamRemoteArea_returnsIsland() {
+        // given
+        String address = "충청남도 보령시 오천면 삽시도리 123";
+        when(remoteAreaJpaRepository.existsByProvinceAndDistrictAndStatus("충남", "보령시", EntityStatus.ACTIVE))
+                .thenReturn(true);
+
+        // when
+        ShippingAddressRegionType result = shippingAddressRegionClassifier.classify(address);
+
+        // then
+        assertThat(result).isEqualTo(ShippingAddressRegionType.ISLAND);
+        verify(remoteAreaJpaRepository).existsByProvinceAndDistrictAndStatus("충남", "보령시", EntityStatus.ACTIVE);
+    }
+
+    @Test
+    @DisplayName("전라남도 주소에서 도서산간 지역은 ISLAND로 분류된다")
+    void classify_jeonnamRemoteArea_returnsIsland() {
+        // given
+        String address = "전라남도 신안군 지도읍 선도리 123";
+        when(remoteAreaJpaRepository.existsByProvinceAndDistrictAndStatus("전남", "신안군", EntityStatus.ACTIVE))
+                .thenReturn(true);
+
+        // when
+        ShippingAddressRegionType result = shippingAddressRegionClassifier.classify(address);
+
+        // then
+        assertThat(result).isEqualTo(ShippingAddressRegionType.ISLAND);
+        verify(remoteAreaJpaRepository).existsByProvinceAndDistrictAndStatus("전남", "신안군", EntityStatus.ACTIVE);
+    }
+}

--- a/user-service/user-application/src/test/java/com/personal/marketnote/user/service/shippingaddress/DeleteShippingAddressUseCaseTest.java
+++ b/user-service/user-application/src/test/java/com/personal/marketnote/user/service/shippingaddress/DeleteShippingAddressUseCaseTest.java
@@ -4,6 +4,7 @@ import com.personal.marketnote.common.domain.delivery.DeliveryRequestType;
 import com.personal.marketnote.common.kafka.event.ShippingAddressChangeAction;
 import com.personal.marketnote.user.domain.shippingaddress.ShippingAddress;
 import com.personal.marketnote.user.domain.shippingaddress.ShippingAddressSnapshotState;
+import com.personal.marketnote.user.domain.shippingaddress.ShippingAddressRegionType;
 import com.personal.marketnote.user.domain.shippingaddress.ShippingAddressType;
 import com.personal.marketnote.user.exception.ShippingAddressNotFoundException;
 import com.personal.marketnote.user.port.out.event.PublishShippingAddressEventPort;
@@ -53,6 +54,7 @@ class DeleteShippingAddressUseCaseTest {
                 .recipientPhoneNumber("010-1234-5678")
                 .deliveryRequestType(DeliveryRequestType.NONE)
                 .isDefault(false)
+                .regionType(ShippingAddressRegionType.NORMAL)
                 .build());
 
         when(findShippingAddressPort.findByIdAndUserId(shippingAddressId, userId))
@@ -107,6 +109,7 @@ class DeleteShippingAddressUseCaseTest {
                 .recipientPhoneNumber("010-1234-5678")
                 .deliveryRequestType(DeliveryRequestType.NONE)
                 .isDefault(false)
+                .regionType(ShippingAddressRegionType.NORMAL)
                 .build());
 
         when(findShippingAddressPort.findByIdAndUserId(shippingAddressId, userId))
@@ -140,6 +143,7 @@ class DeleteShippingAddressUseCaseTest {
                 .recipientPhoneNumber("010-1234-5678")
                 .deliveryRequestType(DeliveryRequestType.NONE)
                 .isDefault(true)
+                .regionType(ShippingAddressRegionType.NORMAL)
                 .build());
 
         when(findShippingAddressPort.findByIdAndUserId(shippingAddressId, userId))

--- a/user-service/user-application/src/test/java/com/personal/marketnote/user/service/shippingaddress/GetMyShippingAddressesUseCaseTest.java
+++ b/user-service/user-application/src/test/java/com/personal/marketnote/user/service/shippingaddress/GetMyShippingAddressesUseCaseTest.java
@@ -3,6 +3,7 @@ package com.personal.marketnote.user.service.shippingaddress;
 import com.personal.marketnote.common.domain.delivery.DeliveryRequestType;
 import com.personal.marketnote.user.domain.shippingaddress.ShippingAddress;
 import com.personal.marketnote.user.domain.shippingaddress.ShippingAddressSnapshotState;
+import com.personal.marketnote.user.domain.shippingaddress.ShippingAddressRegionType;
 import com.personal.marketnote.user.domain.shippingaddress.ShippingAddressType;
 import com.personal.marketnote.user.port.in.result.shippingaddress.GetMyShippingAddressResult;
 import com.personal.marketnote.user.port.in.result.shippingaddress.GetMyShippingAddressesResult;
@@ -46,6 +47,7 @@ class GetMyShippingAddressesUseCaseTest {
                 .deliveryRequestType(DeliveryRequestType.NONE)
                 .deliveryRequestMessage(null)
                 .isDefault(false)
+                .regionType(ShippingAddressRegionType.NORMAL)
                 .build());
 
         ShippingAddress homeNonDefault = ShippingAddress.from(ShippingAddressSnapshotState.builder()
@@ -61,6 +63,7 @@ class GetMyShippingAddressesUseCaseTest {
                 .deliveryRequestType(DeliveryRequestType.LEAVE_AT_DOOR)
                 .deliveryRequestMessage(null)
                 .isDefault(false)
+                .regionType(ShippingAddressRegionType.NORMAL)
                 .build());
 
         ShippingAddress companyDefault = ShippingAddress.from(ShippingAddressSnapshotState.builder()
@@ -76,6 +79,7 @@ class GetMyShippingAddressesUseCaseTest {
                 .deliveryRequestType(DeliveryRequestType.LEAVE_AT_SECURITY)
                 .deliveryRequestMessage(null)
                 .isDefault(true)
+                .regionType(ShippingAddressRegionType.NORMAL)
                 .build());
 
         // 의도적으로 정렬되지 않은 순서로 제공: OTHER(비기본) → HOME(비기본) → COMPANY(기본)
@@ -146,6 +150,7 @@ class GetMyShippingAddressesUseCaseTest {
                 .deliveryRequestType(DeliveryRequestType.LEAVE_AT_SECURITY)
                 .deliveryRequestMessage(null)
                 .isDefault(true)
+                .regionType(ShippingAddressRegionType.NORMAL)
                 .build());
 
         ShippingAddress companyNonDefault = ShippingAddress.from(ShippingAddressSnapshotState.builder()
@@ -161,6 +166,7 @@ class GetMyShippingAddressesUseCaseTest {
                 .deliveryRequestType(DeliveryRequestType.NONE)
                 .deliveryRequestMessage(null)
                 .isDefault(false)
+                .regionType(ShippingAddressRegionType.NORMAL)
                 .build());
 
         ShippingAddress otherNonDefault = ShippingAddress.from(ShippingAddressSnapshotState.builder()
@@ -176,6 +182,7 @@ class GetMyShippingAddressesUseCaseTest {
                 .deliveryRequestType(DeliveryRequestType.LEAVE_AT_DELIVERY_BOX)
                 .deliveryRequestMessage(null)
                 .isDefault(false)
+                .regionType(ShippingAddressRegionType.NORMAL)
                 .build());
 
         // 의도적으로 기본 배송지를 마지막에 배치: COMPANY(비기본) → OTHER(비기본) → HOME(기본)

--- a/user-service/user-application/src/test/java/com/personal/marketnote/user/service/shippingaddress/GetShippingAddressUseCaseTest.java
+++ b/user-service/user-application/src/test/java/com/personal/marketnote/user/service/shippingaddress/GetShippingAddressUseCaseTest.java
@@ -3,6 +3,7 @@ package com.personal.marketnote.user.service.shippingaddress;
 import com.personal.marketnote.common.domain.delivery.DeliveryRequestType;
 import com.personal.marketnote.user.domain.shippingaddress.ShippingAddress;
 import com.personal.marketnote.user.domain.shippingaddress.ShippingAddressSnapshotState;
+import com.personal.marketnote.user.domain.shippingaddress.ShippingAddressRegionType;
 import com.personal.marketnote.user.domain.shippingaddress.ShippingAddressType;
 import com.personal.marketnote.user.exception.ShippingAddressNotFoundException;
 import com.personal.marketnote.user.port.in.result.shippingaddress.GetShippingAddressResult;
@@ -49,6 +50,7 @@ class GetShippingAddressUseCaseTest {
                         .deliveryRequestType(DeliveryRequestType.LEAVE_AT_DOOR)
                         .deliveryRequestMessage("문 앞에 놓아주세요")
                         .isDefault(true)
+                        .regionType(ShippingAddressRegionType.NORMAL)
                         .build()
         );
 

--- a/user-service/user-application/src/test/java/com/personal/marketnote/user/service/shippingaddress/RegisterShippingAddressUseCaseTest.java
+++ b/user-service/user-application/src/test/java/com/personal/marketnote/user/service/shippingaddress/RegisterShippingAddressUseCaseTest.java
@@ -3,11 +3,13 @@ package com.personal.marketnote.user.service.shippingaddress;
 import com.personal.marketnote.common.domain.delivery.DeliveryRequestType;
 import com.personal.marketnote.common.kafka.event.ShippingAddressChangeAction;
 import com.personal.marketnote.user.domain.shippingaddress.ShippingAddress;
+import com.personal.marketnote.user.domain.shippingaddress.ShippingAddressRegionType;
 import com.personal.marketnote.user.domain.shippingaddress.ShippingAddressSnapshotState;
 import com.personal.marketnote.user.domain.shippingaddress.ShippingAddressType;
 import com.personal.marketnote.user.port.in.command.shippingaddress.RegisterShippingAddressCommand;
 import com.personal.marketnote.user.port.in.result.shippingaddress.RegisterShippingAddressResult;
 import com.personal.marketnote.user.port.out.event.PublishShippingAddressEventPort;
+import com.personal.marketnote.user.port.out.shippingaddress.ClassifyShippingAddressRegionPort;
 import com.personal.marketnote.user.port.out.shippingaddress.FindShippingAddressPort;
 import com.personal.marketnote.user.port.out.shippingaddress.SaveShippingAddressPort;
 import com.personal.marketnote.user.port.out.shippingaddress.UpdateShippingAddressPort;
@@ -43,6 +45,9 @@ class RegisterShippingAddressUseCaseTest {
     @Mock
     private PublishShippingAddressEventPort publishShippingAddressEventPort;
 
+    @Mock
+    private ClassifyShippingAddressRegionPort classifyShippingAddressRegionPort;
+
     @Test
     @DisplayName("첫 번째 배송지 등록 시 기본 배송지로 설정된다")
     void registerShippingAddress_firstAddress_setsAsDefault() {
@@ -63,8 +68,10 @@ class RegisterShippingAddressUseCaseTest {
                 .thenReturn(false);
         when(findShippingAddressPort.existsByUserId(userId))
                 .thenReturn(false);
+        when(classifyShippingAddressRegionPort.classify("서울시 강남구 테헤란로 123"))
+                .thenReturn(ShippingAddressRegionType.NORMAL);
 
-        ShippingAddress savedShippingAddress = createShippingAddress(1L, userId, ShippingAddressType.HOME, true);
+        ShippingAddress savedShippingAddress = createShippingAddress(1L, userId, ShippingAddressType.HOME, true, ShippingAddressRegionType.NORMAL);
         when(saveShippingAddressPort.save(any(ShippingAddress.class)))
                 .thenReturn(savedShippingAddress);
 
@@ -79,6 +86,7 @@ class RegisterShippingAddressUseCaseTest {
         verify(findShippingAddressPort).existsByUserIdAndAddressType(userId, ShippingAddressType.HOME);
         verify(findShippingAddressPort).existsByUserId(userId);
         verify(findShippingAddressPort, never()).findDefaultsByUserId(userId);
+        verify(classifyShippingAddressRegionPort).classify("서울시 강남구 테헤란로 123");
         verify(saveShippingAddressPort).save(any(ShippingAddress.class));
         verify(publishShippingAddressEventPort).publishShippingAddressChangedEvent(
                 1L, 1L, "홍길동", "010-1234-5678", "서울시 강남구 테헤란로 123", "101동 1001호", ShippingAddressChangeAction.CREATED
@@ -107,12 +115,14 @@ class RegisterShippingAddressUseCaseTest {
                 .thenReturn(2L);
         when(findShippingAddressPort.existsByUserId(userId))
                 .thenReturn(true);
+        when(classifyShippingAddressRegionPort.classify("서울시 마포구 월드컵로 456"))
+                .thenReturn(ShippingAddressRegionType.NORMAL);
 
-        ShippingAddress existingDefault = createShippingAddress(10L, userId, ShippingAddressType.HOME, true);
+        ShippingAddress existingDefault = createShippingAddress(10L, userId, ShippingAddressType.HOME, true, ShippingAddressRegionType.NORMAL);
         when(findShippingAddressPort.findDefaultsByUserId(userId))
                 .thenReturn(List.of(existingDefault));
 
-        ShippingAddress savedShippingAddress = createShippingAddress(2L, userId, ShippingAddressType.OTHER, true);
+        ShippingAddress savedShippingAddress = createShippingAddress(2L, userId, ShippingAddressType.OTHER, true, ShippingAddressRegionType.NORMAL);
         when(saveShippingAddressPort.save(any(ShippingAddress.class)))
                 .thenReturn(savedShippingAddress);
 
@@ -128,6 +138,7 @@ class RegisterShippingAddressUseCaseTest {
         verify(findShippingAddressPort).existsByUserId(userId);
         verify(findShippingAddressPort).findDefaultsByUserId(userId);
         verify(updateShippingAddressPort).update(existingDefault);
+        verify(classifyShippingAddressRegionPort).classify("서울시 마포구 월드컵로 456");
         verify(saveShippingAddressPort).save(any(ShippingAddress.class));
         verify(publishShippingAddressEventPort).publishShippingAddressChangedEvent(
                 2L, 1L, "홍길동", "010-1234-5678", "서울시 강남구 테헤란로 123", "101동 1001호", ShippingAddressChangeAction.CREATED
@@ -159,7 +170,7 @@ class RegisterShippingAddressUseCaseTest {
 
         verify(findShippingAddressPort).existsByUserIdAndAddressType(userId, ShippingAddressType.HOME);
         verifyNoMoreInteractions(findShippingAddressPort);
-        verifyNoInteractions(saveShippingAddressPort, updateShippingAddressPort, publishShippingAddressEventPort);
+        verifyNoInteractions(saveShippingAddressPort, updateShippingAddressPort, publishShippingAddressEventPort, classifyShippingAddressRegionPort);
     }
 
     @Test
@@ -188,7 +199,7 @@ class RegisterShippingAddressUseCaseTest {
 
         verify(findShippingAddressPort).existsByUserIdAndAddressType(userId, ShippingAddressType.COMPANY);
         verifyNoMoreInteractions(findShippingAddressPort);
-        verifyNoInteractions(saveShippingAddressPort, updateShippingAddressPort, publishShippingAddressEventPort);
+        verifyNoInteractions(saveShippingAddressPort, updateShippingAddressPort, publishShippingAddressEventPort, classifyShippingAddressRegionPort);
     }
 
     @Test
@@ -217,7 +228,7 @@ class RegisterShippingAddressUseCaseTest {
 
         verify(findShippingAddressPort).countByUserIdAndAddressType(userId, ShippingAddressType.OTHER);
         verifyNoMoreInteractions(findShippingAddressPort);
-        verifyNoInteractions(saveShippingAddressPort, updateShippingAddressPort, publishShippingAddressEventPort);
+        verifyNoInteractions(saveShippingAddressPort, updateShippingAddressPort, publishShippingAddressEventPort, classifyShippingAddressRegionPort);
     }
 
     @Test
@@ -240,8 +251,10 @@ class RegisterShippingAddressUseCaseTest {
                 .thenReturn(false);
         when(findShippingAddressPort.existsByUserId(userId))
                 .thenReturn(false);
+        when(classifyShippingAddressRegionPort.classify("서울시 강남구 테헤란로 123"))
+                .thenReturn(ShippingAddressRegionType.NORMAL);
 
-        ShippingAddress savedShippingAddress = createShippingAddress(1L, userId, ShippingAddressType.HOME, true);
+        ShippingAddress savedShippingAddress = createShippingAddress(1L, userId, ShippingAddressType.HOME, true, ShippingAddressRegionType.NORMAL);
         when(saveShippingAddressPort.save(any(ShippingAddress.class)))
                 .thenReturn(savedShippingAddress);
 
@@ -253,6 +266,7 @@ class RegisterShippingAddressUseCaseTest {
 
         verify(findShippingAddressPort).existsByUserIdAndAddressType(userId, ShippingAddressType.HOME);
         verify(findShippingAddressPort).existsByUserId(userId);
+        verify(classifyShippingAddressRegionPort).classify("서울시 강남구 테헤란로 123");
         verify(saveShippingAddressPort).save(any(ShippingAddress.class));
         verify(publishShippingAddressEventPort).publishShippingAddressChangedEvent(
                 1L, 1L, "홍길동", "010-1234-5678", "서울시 강남구 테헤란로 123", "101동 1001호", ShippingAddressChangeAction.CREATED
@@ -281,8 +295,10 @@ class RegisterShippingAddressUseCaseTest {
                 .thenReturn(1L);
         when(findShippingAddressPort.existsByUserId(userId))
                 .thenReturn(true);
+        when(classifyShippingAddressRegionPort.classify("서울시 용산구 이태원로 200"))
+                .thenReturn(ShippingAddressRegionType.NORMAL);
 
-        ShippingAddress savedShippingAddress = createShippingAddress(3L, userId, ShippingAddressType.OTHER, false);
+        ShippingAddress savedShippingAddress = createShippingAddress(3L, userId, ShippingAddressType.OTHER, false, ShippingAddressRegionType.NORMAL);
         when(saveShippingAddressPort.save(any(ShippingAddress.class)))
                 .thenReturn(savedShippingAddress);
 
@@ -297,6 +313,7 @@ class RegisterShippingAddressUseCaseTest {
         verify(findShippingAddressPort).countByUserIdAndAddressType(userId, ShippingAddressType.OTHER);
         verify(findShippingAddressPort).existsByUserId(userId);
         verify(findShippingAddressPort, never()).findDefaultsByUserId(userId);
+        verify(classifyShippingAddressRegionPort).classify("서울시 용산구 이태원로 200");
         verify(saveShippingAddressPort).save(any(ShippingAddress.class));
         verify(publishShippingAddressEventPort).publishShippingAddressChangedEvent(
                 3L, 1L, "홍길동", "010-1234-5678", "서울시 강남구 테헤란로 123", "101동 1001호", ShippingAddressChangeAction.CREATED
@@ -326,8 +343,10 @@ class RegisterShippingAddressUseCaseTest {
                 .thenReturn(false);
         when(findShippingAddressPort.existsByUserId(userId))
                 .thenReturn(false);
+        when(classifyShippingAddressRegionPort.classify("서울시 강남구 테헤란로 123"))
+                .thenReturn(ShippingAddressRegionType.NORMAL);
 
-        ShippingAddress savedShippingAddress = createShippingAddress(1L, userId, ShippingAddressType.HOME, true);
+        ShippingAddress savedShippingAddress = createShippingAddress(1L, userId, ShippingAddressType.HOME, true, ShippingAddressRegionType.NORMAL);
         when(saveShippingAddressPort.save(any(ShippingAddress.class)))
                 .thenReturn(savedShippingAddress);
 
@@ -337,6 +356,7 @@ class RegisterShippingAddressUseCaseTest {
         // then
         assertThat(result.id()).isEqualTo(1L);
 
+        verify(classifyShippingAddressRegionPort).classify("서울시 강남구 테헤란로 123");
         verify(saveShippingAddressPort).save(argThat(sa ->
                 sa.getDeliveryRequestType() == DeliveryRequestType.CUSTOM
                         && message.equals(sa.getDeliveryRequestMessage())
@@ -368,12 +388,15 @@ class RegisterShippingAddressUseCaseTest {
                 .thenReturn(false);
         when(findShippingAddressPort.existsByUserId(userId))
                 .thenReturn(false);
+        when(classifyShippingAddressRegionPort.classify("서울시 강남구 테헤란로 123"))
+                .thenReturn(ShippingAddressRegionType.NORMAL);
 
         // when & then
         assertThatThrownBy(() -> registerShippingAddressService.registerShippingAddress(command))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("배송 요청사항 메시지는 최대 60자까지 입력할 수 있습니다");
 
+        verify(classifyShippingAddressRegionPort).classify("서울시 강남구 테헤란로 123");
         verifyNoInteractions(saveShippingAddressPort, publishShippingAddressEventPort);
     }
 
@@ -398,8 +421,10 @@ class RegisterShippingAddressUseCaseTest {
                 .thenReturn(false);
         when(findShippingAddressPort.existsByUserId(userId))
                 .thenReturn(false);
+        when(classifyShippingAddressRegionPort.classify("서울시 강남구 테헤란로 123"))
+                .thenReturn(ShippingAddressRegionType.NORMAL);
 
-        ShippingAddress savedShippingAddress = createShippingAddress(1L, userId, ShippingAddressType.HOME, true);
+        ShippingAddress savedShippingAddress = createShippingAddress(1L, userId, ShippingAddressType.HOME, true, ShippingAddressRegionType.NORMAL);
         when(saveShippingAddressPort.save(any(ShippingAddress.class)))
                 .thenReturn(savedShippingAddress);
 
@@ -407,6 +432,7 @@ class RegisterShippingAddressUseCaseTest {
         registerShippingAddressService.registerShippingAddress(command);
 
         // then
+        verify(classifyShippingAddressRegionPort).classify("서울시 강남구 테헤란로 123");
         verify(saveShippingAddressPort).save(argThat(sa ->
                 sa.getDeliveryRequestType() == DeliveryRequestType.LEAVE_AT_DOOR
                         && sa.getDeliveryRequestMessage() == null
@@ -437,8 +463,10 @@ class RegisterShippingAddressUseCaseTest {
                 .thenReturn(1L);
         when(findShippingAddressPort.existsByUserId(userId))
                 .thenReturn(true);
+        when(classifyShippingAddressRegionPort.classify("서울시 마포구 월드컵로 456"))
+                .thenReturn(ShippingAddressRegionType.NORMAL);
 
-        ShippingAddress savedShippingAddress = createShippingAddress(5L, userId, ShippingAddressType.OTHER, false);
+        ShippingAddress savedShippingAddress = createShippingAddress(5L, userId, ShippingAddressType.OTHER, false, ShippingAddressRegionType.NORMAL);
         when(saveShippingAddressPort.save(any(ShippingAddress.class)))
                 .thenReturn(savedShippingAddress);
 
@@ -449,17 +477,133 @@ class RegisterShippingAddressUseCaseTest {
         assertThat(result.id()).isEqualTo(5L);
         assertThat(result.addressType()).isEqualTo(ShippingAddressType.OTHER);
 
+        verify(classifyShippingAddressRegionPort).classify("서울시 마포구 월드컵로 456");
         verify(saveShippingAddressPort).save(any(ShippingAddress.class));
         verify(publishShippingAddressEventPort).publishShippingAddressChangedEvent(
                 5L, 1L, "홍길동", "010-1234-5678", "서울시 강남구 테헤란로 123", "101동 1001호", ShippingAddressChangeAction.CREATED
         );
     }
 
+    @Test
+    @DisplayName("제주 지역 주소 등록 시 regionType이 JEJU로 설정된다")
+    void registerShippingAddress_jejuAddress_setsRegionTypeToJeju() {
+        // given
+        Long userId = 1L;
+        String jejuAddress = "제주특별자치도 제주시 한라산로 456";
+        RegisterShippingAddressCommand command = RegisterShippingAddressCommand.builder()
+                .userId(userId)
+                .addressType(ShippingAddressType.HOME)
+                .address(jejuAddress)
+                .addressDetail("101동 201호")
+                .recipientName("홍길동")
+                .recipientPhoneNumber("010-1234-5678")
+                .deliveryRequestType(DeliveryRequestType.NONE)
+                .isDefault(false)
+                .build();
+
+        when(findShippingAddressPort.existsByUserIdAndAddressType(userId, ShippingAddressType.HOME))
+                .thenReturn(false);
+        when(findShippingAddressPort.existsByUserId(userId))
+                .thenReturn(false);
+        when(classifyShippingAddressRegionPort.classify(jejuAddress))
+                .thenReturn(ShippingAddressRegionType.JEJU);
+
+        ShippingAddress savedShippingAddress = createShippingAddress(1L, userId, ShippingAddressType.HOME, true, ShippingAddressRegionType.JEJU);
+        when(saveShippingAddressPort.save(any(ShippingAddress.class)))
+                .thenReturn(savedShippingAddress);
+
+        // when
+        registerShippingAddressService.registerShippingAddress(command);
+
+        // then
+        verify(classifyShippingAddressRegionPort).classify(jejuAddress);
+        verify(saveShippingAddressPort).save(argThat(sa ->
+                sa.getRegionType() == ShippingAddressRegionType.JEJU
+        ));
+    }
+
+    @Test
+    @DisplayName("도서산간 지역 주소 등록 시 regionType이 ISLAND로 설정된다")
+    void registerShippingAddress_islandAddress_setsRegionTypeToIsland() {
+        // given
+        Long userId = 1L;
+        String islandAddress = "인천광역시 옹진군 영흥면 선재리 123";
+        RegisterShippingAddressCommand command = RegisterShippingAddressCommand.builder()
+                .userId(userId)
+                .addressType(ShippingAddressType.HOME)
+                .address(islandAddress)
+                .addressDetail("101호")
+                .recipientName("홍길동")
+                .recipientPhoneNumber("010-1234-5678")
+                .deliveryRequestType(DeliveryRequestType.NONE)
+                .isDefault(false)
+                .build();
+
+        when(findShippingAddressPort.existsByUserIdAndAddressType(userId, ShippingAddressType.HOME))
+                .thenReturn(false);
+        when(findShippingAddressPort.existsByUserId(userId))
+                .thenReturn(false);
+        when(classifyShippingAddressRegionPort.classify(islandAddress))
+                .thenReturn(ShippingAddressRegionType.ISLAND);
+
+        ShippingAddress savedShippingAddress = createShippingAddress(1L, userId, ShippingAddressType.HOME, true, ShippingAddressRegionType.ISLAND);
+        when(saveShippingAddressPort.save(any(ShippingAddress.class)))
+                .thenReturn(savedShippingAddress);
+
+        // when
+        registerShippingAddressService.registerShippingAddress(command);
+
+        // then
+        verify(classifyShippingAddressRegionPort).classify(islandAddress);
+        verify(saveShippingAddressPort).save(argThat(sa ->
+                sa.getRegionType() == ShippingAddressRegionType.ISLAND
+        ));
+    }
+
+    @Test
+    @DisplayName("일반 지역 주소 등록 시 regionType이 NORMAL로 설정된다")
+    void registerShippingAddress_normalAddress_setsRegionTypeToNormal() {
+        // given
+        Long userId = 1L;
+        String normalAddress = "서울특별시 강남구 테헤란로 123";
+        RegisterShippingAddressCommand command = RegisterShippingAddressCommand.builder()
+                .userId(userId)
+                .addressType(ShippingAddressType.HOME)
+                .address(normalAddress)
+                .addressDetail("101동 1001호")
+                .recipientName("홍길동")
+                .recipientPhoneNumber("010-1234-5678")
+                .deliveryRequestType(DeliveryRequestType.NONE)
+                .isDefault(false)
+                .build();
+
+        when(findShippingAddressPort.existsByUserIdAndAddressType(userId, ShippingAddressType.HOME))
+                .thenReturn(false);
+        when(findShippingAddressPort.existsByUserId(userId))
+                .thenReturn(false);
+        when(classifyShippingAddressRegionPort.classify(normalAddress))
+                .thenReturn(ShippingAddressRegionType.NORMAL);
+
+        ShippingAddress savedShippingAddress = createShippingAddress(1L, userId, ShippingAddressType.HOME, true, ShippingAddressRegionType.NORMAL);
+        when(saveShippingAddressPort.save(any(ShippingAddress.class)))
+                .thenReturn(savedShippingAddress);
+
+        // when
+        registerShippingAddressService.registerShippingAddress(command);
+
+        // then
+        verify(classifyShippingAddressRegionPort).classify(normalAddress);
+        verify(saveShippingAddressPort).save(argThat(sa ->
+                sa.getRegionType() == ShippingAddressRegionType.NORMAL
+        ));
+    }
+
     private ShippingAddress createShippingAddress(
             Long id,
             Long userId,
             ShippingAddressType addressType,
-            boolean isDefault
+            boolean isDefault,
+            ShippingAddressRegionType regionType
     ) {
         return ShippingAddress.from(
                 ShippingAddressSnapshotState.builder()
@@ -472,6 +616,7 @@ class RegisterShippingAddressUseCaseTest {
                         .recipientPhoneNumber("010-1234-5678")
                         .deliveryRequestType(DeliveryRequestType.NONE)
                         .isDefault(isDefault)
+                        .regionType(regionType)
                         .build()
         );
     }

--- a/user-service/user-application/src/test/java/com/personal/marketnote/user/service/shippingaddress/SetDefaultShippingAddressUseCaseTest.java
+++ b/user-service/user-application/src/test/java/com/personal/marketnote/user/service/shippingaddress/SetDefaultShippingAddressUseCaseTest.java
@@ -3,6 +3,7 @@ package com.personal.marketnote.user.service.shippingaddress;
 import com.personal.marketnote.common.domain.delivery.DeliveryRequestType;
 import com.personal.marketnote.user.domain.shippingaddress.ShippingAddress;
 import com.personal.marketnote.user.domain.shippingaddress.ShippingAddressSnapshotState;
+import com.personal.marketnote.user.domain.shippingaddress.ShippingAddressRegionType;
 import com.personal.marketnote.user.domain.shippingaddress.ShippingAddressType;
 import com.personal.marketnote.user.exception.ShippingAddressNotFoundException;
 import com.personal.marketnote.user.port.out.shippingaddress.FindShippingAddressPort;
@@ -50,6 +51,7 @@ class SetDefaultShippingAddressUseCaseTest {
                 .recipientPhoneNumber("010-1234-5678")
                 .deliveryRequestType(DeliveryRequestType.NONE)
                 .isDefault(false)
+                .regionType(ShippingAddressRegionType.NORMAL)
                 .build());
 
         ShippingAddress currentDefault = ShippingAddress.from(ShippingAddressSnapshotState.builder()
@@ -63,6 +65,7 @@ class SetDefaultShippingAddressUseCaseTest {
                 .recipientPhoneNumber("010-9876-5432")
                 .deliveryRequestType(DeliveryRequestType.LEAVE_AT_DOOR)
                 .isDefault(true)
+                .regionType(ShippingAddressRegionType.NORMAL)
                 .build());
 
         when(findShippingAddressPort.findByIdAndUserId(shippingAddressId, userId))
@@ -102,6 +105,7 @@ class SetDefaultShippingAddressUseCaseTest {
                 .recipientPhoneNumber("010-1234-5678")
                 .deliveryRequestType(DeliveryRequestType.NONE)
                 .isDefault(true)
+                .regionType(ShippingAddressRegionType.NORMAL)
                 .build());
 
         when(findShippingAddressPort.findByIdAndUserId(shippingAddressId, userId))
@@ -155,6 +159,7 @@ class SetDefaultShippingAddressUseCaseTest {
                 .recipientPhoneNumber("010-1234-5678")
                 .deliveryRequestType(DeliveryRequestType.NONE)
                 .isDefault(false)
+                .regionType(ShippingAddressRegionType.NORMAL)
                 .build());
 
         ShippingAddress defaultAddress1 = ShippingAddress.from(ShippingAddressSnapshotState.builder()
@@ -168,6 +173,7 @@ class SetDefaultShippingAddressUseCaseTest {
                 .recipientPhoneNumber("010-9876-5432")
                 .deliveryRequestType(DeliveryRequestType.LEAVE_AT_DOOR)
                 .isDefault(true)
+                .regionType(ShippingAddressRegionType.NORMAL)
                 .build());
 
         ShippingAddress defaultAddress2 = ShippingAddress.from(ShippingAddressSnapshotState.builder()
@@ -181,6 +187,7 @@ class SetDefaultShippingAddressUseCaseTest {
                 .recipientPhoneNumber("010-5555-6666")
                 .deliveryRequestType(DeliveryRequestType.LEAVE_AT_SECURITY)
                 .isDefault(true)
+                .regionType(ShippingAddressRegionType.NORMAL)
                 .build());
 
         when(findShippingAddressPort.findByIdAndUserId(shippingAddressId, userId))

--- a/user-service/user-application/src/test/java/com/personal/marketnote/user/service/shippingaddress/UpdateDeliveryRequestUseCaseTest.java
+++ b/user-service/user-application/src/test/java/com/personal/marketnote/user/service/shippingaddress/UpdateDeliveryRequestUseCaseTest.java
@@ -3,6 +3,7 @@ package com.personal.marketnote.user.service.shippingaddress;
 import com.personal.marketnote.common.domain.delivery.DeliveryRequestType;
 import com.personal.marketnote.user.domain.shippingaddress.ShippingAddress;
 import com.personal.marketnote.user.domain.shippingaddress.ShippingAddressSnapshotState;
+import com.personal.marketnote.user.domain.shippingaddress.ShippingAddressRegionType;
 import com.personal.marketnote.user.domain.shippingaddress.ShippingAddressType;
 import com.personal.marketnote.user.domain.shippingaddress.exception.DeliveryRequestMessageNoValueException;
 import com.personal.marketnote.user.domain.shippingaddress.exception.InvalidDeliveryRequestMessageLengthException;
@@ -52,6 +53,7 @@ class UpdateDeliveryRequestUseCaseTest {
                 .deliveryRequestType(DeliveryRequestType.NONE)
                 .deliveryRequestMessage(null)
                 .isDefault(true)
+                .regionType(ShippingAddressRegionType.NORMAL)
                 .build());
 
         UpdateDeliveryRequestCommand command = UpdateDeliveryRequestCommand.builder()
@@ -93,6 +95,7 @@ class UpdateDeliveryRequestUseCaseTest {
                 .deliveryRequestType(DeliveryRequestType.NONE)
                 .deliveryRequestMessage(null)
                 .isDefault(true)
+                .regionType(ShippingAddressRegionType.NORMAL)
                 .build());
 
         UpdateDeliveryRequestCommand command = UpdateDeliveryRequestCommand.builder()
@@ -131,6 +134,7 @@ class UpdateDeliveryRequestUseCaseTest {
                 .deliveryRequestType(DeliveryRequestType.CUSTOM)
                 .deliveryRequestMessage("기존 요청사항")
                 .isDefault(true)
+                .regionType(ShippingAddressRegionType.NORMAL)
                 .build());
 
         UpdateDeliveryRequestCommand command = UpdateDeliveryRequestCommand.builder()
@@ -194,6 +198,7 @@ class UpdateDeliveryRequestUseCaseTest {
                 .deliveryRequestType(DeliveryRequestType.NONE)
                 .deliveryRequestMessage(null)
                 .isDefault(true)
+                .regionType(ShippingAddressRegionType.NORMAL)
                 .build());
 
         UpdateDeliveryRequestCommand command = UpdateDeliveryRequestCommand.builder()
@@ -231,6 +236,7 @@ class UpdateDeliveryRequestUseCaseTest {
                 .deliveryRequestType(DeliveryRequestType.NONE)
                 .deliveryRequestMessage(null)
                 .isDefault(true)
+                .regionType(ShippingAddressRegionType.NORMAL)
                 .build());
 
         UpdateDeliveryRequestCommand command = UpdateDeliveryRequestCommand.builder()

--- a/user-service/user-application/src/test/java/com/personal/marketnote/user/service/shippingaddress/UpdateShippingAddressUseCaseTest.java
+++ b/user-service/user-application/src/test/java/com/personal/marketnote/user/service/shippingaddress/UpdateShippingAddressUseCaseTest.java
@@ -3,11 +3,13 @@ package com.personal.marketnote.user.service.shippingaddress;
 import com.personal.marketnote.common.domain.delivery.DeliveryRequestType;
 import com.personal.marketnote.common.kafka.event.ShippingAddressChangeAction;
 import com.personal.marketnote.user.domain.shippingaddress.ShippingAddress;
+import com.personal.marketnote.user.domain.shippingaddress.ShippingAddressRegionType;
 import com.personal.marketnote.user.domain.shippingaddress.ShippingAddressSnapshotState;
 import com.personal.marketnote.user.domain.shippingaddress.ShippingAddressType;
 import com.personal.marketnote.user.exception.ShippingAddressNotFoundException;
 import com.personal.marketnote.user.port.in.command.shippingaddress.UpdateShippingAddressCommand;
 import com.personal.marketnote.user.port.out.event.PublishShippingAddressEventPort;
+import com.personal.marketnote.user.port.out.shippingaddress.ClassifyShippingAddressRegionPort;
 import com.personal.marketnote.user.port.out.shippingaddress.FindShippingAddressPort;
 import com.personal.marketnote.user.port.out.shippingaddress.UpdateShippingAddressPort;
 import org.junit.jupiter.api.DisplayName;
@@ -37,6 +39,9 @@ class UpdateShippingAddressUseCaseTest {
     @Mock
     private PublishShippingAddressEventPort publishShippingAddressEventPort;
 
+    @Mock
+    private ClassifyShippingAddressRegionPort classifyShippingAddressRegionPort;
+
     @Test
     @DisplayName("배송지가 존재하면 수정된 정보로 업데이트한다")
     void updateShippingAddress_existingAddress_updatesWithNewInfo() {
@@ -57,6 +62,7 @@ class UpdateShippingAddressUseCaseTest {
                 .deliveryRequestType(DeliveryRequestType.NONE)
                 .deliveryRequestMessage(null)
                 .isDefault(true)
+                .regionType(ShippingAddressRegionType.NORMAL)
                 .build());
 
         UpdateShippingAddressCommand command = UpdateShippingAddressCommand.builder()
@@ -72,6 +78,8 @@ class UpdateShippingAddressUseCaseTest {
 
         when(findShippingAddressPort.findByIdAndUserId(shippingAddressId, userId))
                 .thenReturn(Optional.of(shippingAddress));
+        when(classifyShippingAddressRegionPort.classify("서울시 서초구 서초대로 456"))
+                .thenReturn(ShippingAddressRegionType.NORMAL);
 
         // when
         updateShippingAddressService.updateShippingAddress(shippingAddressId, userId, command);
@@ -82,8 +90,10 @@ class UpdateShippingAddressUseCaseTest {
         assertThat(shippingAddress.getRecipientName()).isEqualTo("김철수");
         assertThat(shippingAddress.getRecipientPhoneNumber()).isEqualTo("010-9876-5432");
         assertThat(shippingAddress.getDeliveryRequestType()).isEqualTo(DeliveryRequestType.LEAVE_AT_DOOR);
+        assertThat(shippingAddress.getRegionType()).isEqualTo(ShippingAddressRegionType.NORMAL);
 
         verify(findShippingAddressPort).findByIdAndUserId(shippingAddressId, userId);
+        verify(classifyShippingAddressRegionPort).classify("서울시 서초구 서초대로 456");
         verify(updateShippingAddressPort).update(shippingAddress);
         verify(publishShippingAddressEventPort).publishShippingAddressChangedEvent(
                 1L, 100L, "김철수", "010-9876-5432", "서울시 서초구 서초대로 456", "202동 303호", ShippingAddressChangeAction.UPDATED
@@ -119,7 +129,7 @@ class UpdateShippingAddressUseCaseTest {
 
         verify(findShippingAddressPort).findByIdAndUserId(shippingAddressId, userId);
         verifyNoMoreInteractions(findShippingAddressPort);
-        verifyNoInteractions(updateShippingAddressPort, publishShippingAddressEventPort);
+        verifyNoInteractions(updateShippingAddressPort, publishShippingAddressEventPort, classifyShippingAddressRegionPort);
     }
 
     @Test
@@ -141,6 +151,7 @@ class UpdateShippingAddressUseCaseTest {
                 .deliveryRequestType(DeliveryRequestType.NONE)
                 .deliveryRequestMessage(null)
                 .isDefault(true)
+                .regionType(ShippingAddressRegionType.NORMAL)
                 .build());
 
         UpdateShippingAddressCommand command = UpdateShippingAddressCommand.builder()
@@ -154,6 +165,8 @@ class UpdateShippingAddressUseCaseTest {
 
         when(findShippingAddressPort.findByIdAndUserId(shippingAddressId, userId))
                 .thenReturn(Optional.of(shippingAddress));
+        when(classifyShippingAddressRegionPort.classify("서울시 강남구 테헤란로 123"))
+                .thenReturn(ShippingAddressRegionType.NORMAL);
 
         // when
         updateShippingAddressService.updateShippingAddress(shippingAddressId, userId, command);
@@ -162,6 +175,7 @@ class UpdateShippingAddressUseCaseTest {
         assertThat(shippingAddress.getDeliveryRequestType()).isEqualTo(DeliveryRequestType.CUSTOM);
         assertThat(shippingAddress.getDeliveryRequestMessage()).isEqualTo(message);
 
+        verify(classifyShippingAddressRegionPort).classify("서울시 강남구 테헤란로 123");
         verify(updateShippingAddressPort).update(shippingAddress);
         verify(publishShippingAddressEventPort).publishShippingAddressChangedEvent(
                 3L, 300L, "홍길동", "010-1234-5678", "서울시 강남구 테헤란로 123", "101동 201호", ShippingAddressChangeAction.UPDATED
@@ -186,6 +200,7 @@ class UpdateShippingAddressUseCaseTest {
                 .deliveryRequestType(DeliveryRequestType.CUSTOM)
                 .deliveryRequestMessage("기존 요청사항")
                 .isDefault(true)
+                .regionType(ShippingAddressRegionType.NORMAL)
                 .build());
 
         UpdateShippingAddressCommand command = UpdateShippingAddressCommand.builder()
@@ -199,6 +214,8 @@ class UpdateShippingAddressUseCaseTest {
 
         when(findShippingAddressPort.findByIdAndUserId(shippingAddressId, userId))
                 .thenReturn(Optional.of(shippingAddress));
+        when(classifyShippingAddressRegionPort.classify("서울시 강남구 테헤란로 123"))
+                .thenReturn(ShippingAddressRegionType.NORMAL);
 
         // when
         updateShippingAddressService.updateShippingAddress(shippingAddressId, userId, command);
@@ -207,6 +224,7 @@ class UpdateShippingAddressUseCaseTest {
         assertThat(shippingAddress.getDeliveryRequestType()).isEqualTo(DeliveryRequestType.LEAVE_AT_DOOR);
         assertThat(shippingAddress.getDeliveryRequestMessage()).isNull();
 
+        verify(classifyShippingAddressRegionPort).classify("서울시 강남구 테헤란로 123");
         verify(updateShippingAddressPort).update(shippingAddress);
         verify(publishShippingAddressEventPort).publishShippingAddressChangedEvent(
                 4L, 400L, "홍길동", "010-1234-5678", "서울시 강남구 테헤란로 123", "101동 201호", ShippingAddressChangeAction.UPDATED
@@ -233,6 +251,7 @@ class UpdateShippingAddressUseCaseTest {
                 .deliveryRequestType(DeliveryRequestType.LEAVE_AT_SECURITY)
                 .deliveryRequestMessage(null)
                 .isDefault(false)
+                .regionType(ShippingAddressRegionType.NORMAL)
                 .build());
 
         UpdateShippingAddressCommand command = UpdateShippingAddressCommand.builder()
@@ -248,16 +267,151 @@ class UpdateShippingAddressUseCaseTest {
 
         when(findShippingAddressPort.findByIdAndUserId(shippingAddressId, userId))
                 .thenReturn(Optional.of(shippingAddress));
+        when(classifyShippingAddressRegionPort.classify("서울시 강남구 선릉로 100"))
+                .thenReturn(ShippingAddressRegionType.NORMAL);
 
         // when
         updateShippingAddressService.updateShippingAddress(shippingAddressId, userId, command);
 
         // then
         verify(findShippingAddressPort).findByIdAndUserId(shippingAddressId, userId);
+        verify(classifyShippingAddressRegionPort).classify("서울시 강남구 선릉로 100");
         verify(updateShippingAddressPort).update(shippingAddress);
         verify(publishShippingAddressEventPort).publishShippingAddressChangedEvent(
                 2L, 200L, "박민수", "010-7777-8888", "서울시 강남구 선릉로 100", "10층", ShippingAddressChangeAction.UPDATED
         );
         verifyNoMoreInteractions(findShippingAddressPort, updateShippingAddressPort);
+    }
+
+    @Test
+    @DisplayName("일반 지역에서 제주 지역으로 주소 수정 시 regionType이 JEJU로 변경된다")
+    void updateShippingAddress_normalToJeju_changesRegionTypeToJeju() {
+        // given
+        Long shippingAddressId = 1L;
+        Long userId = 100L;
+
+        ShippingAddress shippingAddress = ShippingAddress.from(ShippingAddressSnapshotState.builder()
+                .id(shippingAddressId)
+                .userId(userId)
+                .addressType(ShippingAddressType.HOME)
+                .address("서울시 강남구 테헤란로 123")
+                .addressDetail("101동 201호")
+                .recipientName("홍길동")
+                .recipientPhoneNumber("010-1234-5678")
+                .deliveryRequestType(DeliveryRequestType.NONE)
+                .isDefault(true)
+                .regionType(ShippingAddressRegionType.NORMAL)
+                .build());
+
+        String jejuAddress = "제주특별자치도 제주시 한라산로 456";
+        UpdateShippingAddressCommand command = UpdateShippingAddressCommand.builder()
+                .address(jejuAddress)
+                .addressDetail("201호")
+                .recipientName("홍길동")
+                .recipientPhoneNumber("010-1234-5678")
+                .deliveryRequestType(DeliveryRequestType.NONE)
+                .build();
+
+        when(findShippingAddressPort.findByIdAndUserId(shippingAddressId, userId))
+                .thenReturn(Optional.of(shippingAddress));
+        when(classifyShippingAddressRegionPort.classify(jejuAddress))
+                .thenReturn(ShippingAddressRegionType.JEJU);
+
+        // when
+        updateShippingAddressService.updateShippingAddress(shippingAddressId, userId, command);
+
+        // then
+        assertThat(shippingAddress.getRegionType()).isEqualTo(ShippingAddressRegionType.JEJU);
+
+        verify(classifyShippingAddressRegionPort).classify(jejuAddress);
+        verify(updateShippingAddressPort).update(shippingAddress);
+    }
+
+    @Test
+    @DisplayName("제주 지역에서 일반 지역으로 주소 수정 시 regionType이 NORMAL로 변경된다")
+    void updateShippingAddress_jejuToNormal_changesRegionTypeToNormal() {
+        // given
+        Long shippingAddressId = 1L;
+        Long userId = 100L;
+
+        ShippingAddress shippingAddress = ShippingAddress.from(ShippingAddressSnapshotState.builder()
+                .id(shippingAddressId)
+                .userId(userId)
+                .addressType(ShippingAddressType.HOME)
+                .address("제주특별자치도 제주시 한라산로 456")
+                .addressDetail("201호")
+                .recipientName("홍길동")
+                .recipientPhoneNumber("010-1234-5678")
+                .deliveryRequestType(DeliveryRequestType.NONE)
+                .isDefault(true)
+                .regionType(ShippingAddressRegionType.JEJU)
+                .build());
+
+        String normalAddress = "서울시 강남구 테헤란로 123";
+        UpdateShippingAddressCommand command = UpdateShippingAddressCommand.builder()
+                .address(normalAddress)
+                .addressDetail("101동 201호")
+                .recipientName("홍길동")
+                .recipientPhoneNumber("010-1234-5678")
+                .deliveryRequestType(DeliveryRequestType.NONE)
+                .build();
+
+        when(findShippingAddressPort.findByIdAndUserId(shippingAddressId, userId))
+                .thenReturn(Optional.of(shippingAddress));
+        when(classifyShippingAddressRegionPort.classify(normalAddress))
+                .thenReturn(ShippingAddressRegionType.NORMAL);
+
+        // when
+        updateShippingAddressService.updateShippingAddress(shippingAddressId, userId, command);
+
+        // then
+        assertThat(shippingAddress.getRegionType()).isEqualTo(ShippingAddressRegionType.NORMAL);
+
+        verify(classifyShippingAddressRegionPort).classify(normalAddress);
+        verify(updateShippingAddressPort).update(shippingAddress);
+    }
+
+    @Test
+    @DisplayName("도서산간 지역에서 일반 지역으로 주소 수정 시 regionType이 NORMAL로 변경된다")
+    void updateShippingAddress_islandToNormal_changesRegionTypeToNormal() {
+        // given
+        Long shippingAddressId = 1L;
+        Long userId = 100L;
+
+        ShippingAddress shippingAddress = ShippingAddress.from(ShippingAddressSnapshotState.builder()
+                .id(shippingAddressId)
+                .userId(userId)
+                .addressType(ShippingAddressType.HOME)
+                .address("인천광역시 옹진군 영흥면 선재리 123")
+                .addressDetail("101호")
+                .recipientName("홍길동")
+                .recipientPhoneNumber("010-1234-5678")
+                .deliveryRequestType(DeliveryRequestType.NONE)
+                .isDefault(true)
+                .regionType(ShippingAddressRegionType.ISLAND)
+                .build());
+
+        String normalAddress = "서울시 강남구 테헤란로 123";
+        UpdateShippingAddressCommand command = UpdateShippingAddressCommand.builder()
+                .address(normalAddress)
+                .addressDetail("101동 201호")
+                .recipientName("홍길동")
+                .recipientPhoneNumber("010-1234-5678")
+                .deliveryRequestType(DeliveryRequestType.NONE)
+                .build();
+
+        when(findShippingAddressPort.findByIdAndUserId(shippingAddressId, userId))
+                .thenReturn(Optional.of(shippingAddress));
+        when(classifyShippingAddressRegionPort.classify(normalAddress))
+                .thenReturn(ShippingAddressRegionType.NORMAL);
+
+        // when
+        updateShippingAddressService.updateShippingAddress(shippingAddressId, userId, command);
+
+        // then
+        assertThat(shippingAddress.getRegionType()).isEqualTo(ShippingAddressRegionType.NORMAL);
+
+        verify(classifyShippingAddressRegionPort).classify(normalAddress);
+        verify(updateShippingAddressPort).update(shippingAddress);
     }
 }


### PR DESCRIPTION
## partially addresses #43
## resolves #2239

## Test Case
- [x] 제주특별자치도 주소는 JEJU로 분류된다
- [x] 제주시로 시작하는 주소는 JEJU로 분류된다
- [x] 도서산간 지역 주소는 ISLAND로 분류된다
- [x] 일반 지역 주소는 NORMAL로 분류된다
- [x] 경기도 주소에서 도서산간이 아닌 경우 NORMAL로 분류된다
- [x] 경상남도 도서산간 지역은 ISLAND로 분류된다
- [x] 세종특별자치시 주소는 NORMAL로 분류된다
- [x] 공백 구분 토큰이 1개뿐인 주소는 NORMAL로 분류된다
- [x] null 주소 입력 시 NORMAL로 분류된다
- [x] 빈 문자열 주소 입력 시 NORMAL로 분류된다
- [x] 충청남도 주소에서 도서산간 지역은 ISLAND로 분류된다
- [x] 전라남도 주소에서 도서산간 지역은 ISLAND로 분류된다
- [x] 제주 지역 주소 등록 시 regionType이 JEJU로 설정된다
- [x] 도서산간 지역 주소 등록 시 regionType이 ISLAND로 설정된다
- [x] 일반 지역 주소 등록 시 regionType이 NORMAL로 설정된다
- [x] 일반 지역에서 제주 지역으로 주소 수정 시 regionType이 JEJU로 변경된다
- [x] 제주 지역에서 일반 지역으로 주소 수정 시 regionType이 NORMAL로 변경된다
- [x] 도서산간 지역에서 일반 지역으로 주소 수정 시 regionType이 NORMAL로 변경된다