### PR TITLE
[#216][#1933] feat: CANCEL_REQUESTED 재추가 및 전이 맵 수정

### DIFF
--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/CancelOrderService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/CancelOrderService.java
@@ -41,21 +41,28 @@ public class CancelOrderService implements CancelOrderUseCase {
     private final PlatformTransactionManager transactionManager;
     private final Clock clock;
 
-    private static final OrderStatus TARGET_STATUS = OrderStatus.CANCELLED;
-
     @Override
     public void cancelOrder(CancelOrderCommand command) {
         Order order = getOrderUseCase.getOrder(command.id());
 
         validateBuyerOwnership(command, order);
         validateReasonCategory(command);
-        validateStatusTransition(order);
+
+        OrderStatus targetStatus = resolveTargetStatus(order);
+        validateStatusTransition(order, targetStatus);
 
         OrderStatus originalStatus = order.getOrderStatus();
 
         cancelFulfillmentIfRequired(order);
 
-        persistCancellation(command, order, originalStatus);
+        persistCancellation(command, order, originalStatus, targetStatus);
+    }
+
+    private OrderStatus resolveTargetStatus(Order order) {
+        if (order.getOrderStatus().isPending()) {
+            return OrderStatus.CANCELLED;
+        }
+        return OrderStatus.CANCEL_REQUESTED;
     }
 
     private void cancelFulfillmentIfRequired(Order order) {
@@ -75,17 +82,17 @@ public class CancelOrderService implements CancelOrderUseCase {
         }
     }
 
-    private void persistCancellation(CancelOrderCommand command, Order order, OrderStatus originalStatus) {
+    private void persistCancellation(CancelOrderCommand command, Order order, OrderStatus originalStatus, OrderStatus targetStatus) {
         TransactionTemplate transactionTemplate = new TransactionTemplate(transactionManager);
         transactionTemplate.setIsolationLevel(TransactionDefinition.ISOLATION_READ_COMMITTED);
         transactionTemplate.executeWithoutResult(status -> {
             LocalDateTime now = LocalDateTime.now(clock);
-            order.changeAllProductsStatus(TARGET_STATUS, now);
+            order.changeAllProductsStatus(targetStatus, now);
 
             OrderStatusHistory orderStatusHistory = OrderStatusHistory.from(
                     OrderStatusHistoryCreateState.builder()
                             .orderId(command.id())
-                            .orderStatus(TARGET_STATUS)
+                            .orderStatus(targetStatus)
                             .reasonCategory(command.reasonCategory())
                             .reason(command.reason())
                             .build()
@@ -135,13 +142,13 @@ public class CancelOrderService implements CancelOrderUseCase {
         }
     }
 
-    private void validateStatusTransition(Order order) {
-        if (TARGET_STATUS.isMe(order.getOrderStatus())) {
-            throw new OrderStatusAlreadyChangedException(TARGET_STATUS);
+    private void validateStatusTransition(Order order, OrderStatus targetStatus) {
+        if (targetStatus.isMe(order.getOrderStatus())) {
+            throw new OrderStatusAlreadyChangedException(targetStatus);
         }
 
-        if (!order.getOrderStatus().canTransitionTo(TARGET_STATUS)) {
-            throw new InvalidOrderStatusTransitionException(order.getOrderStatus(), TARGET_STATUS);
+        if (!order.getOrderStatus().canTransitionTo(targetStatus)) {
+            throw new InvalidOrderStatusTransitionException(order.getOrderStatus(), targetStatus);
         }
     }
 }

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/order/OrderStatus.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/order/OrderStatus.java
@@ -15,6 +15,7 @@ public enum OrderStatus {
     PAID("결제 완료"),
     FAILED("결제 실패"),
     PREPARING("상품 준비중"),
+    CANCEL_REQUESTED("취소 요청"),
     CANCELLED("주문 취소"),
     SHIPPING("배송중"),
     DELIVERED("배송 완료"),
@@ -29,14 +30,15 @@ public enum OrderStatus {
 
     private static final Map<OrderStatus, Set<OrderStatus>> ALLOWED_TRANSITIONS = new EnumMap<>(OrderStatus.class);
     private static final Set<OrderStatus> BUYER_ALLOWED_STATUSES = EnumSet.of(
-            CONFIRMED, CANCELLED, RETURN_REQUESTED
+            CONFIRMED, CANCEL_REQUESTED, CANCELLED, RETURN_REQUESTED
     );
 
     static {
         ALLOWED_TRANSITIONS.put(PAYMENT_PENDING, EnumSet.of(PAID, FAILED, CANCELLED));
-        ALLOWED_TRANSITIONS.put(PAID, EnumSet.of(PREPARING, CANCELLED));
+        ALLOWED_TRANSITIONS.put(PAID, EnumSet.of(PREPARING, CANCEL_REQUESTED));
         ALLOWED_TRANSITIONS.put(FAILED, EnumSet.noneOf(OrderStatus.class));
-        ALLOWED_TRANSITIONS.put(PREPARING, EnumSet.of(SHIPPING, CANCELLED));
+        ALLOWED_TRANSITIONS.put(PREPARING, EnumSet.of(SHIPPING, CANCEL_REQUESTED));
+        ALLOWED_TRANSITIONS.put(CANCEL_REQUESTED, EnumSet.of(CANCELLED));
         ALLOWED_TRANSITIONS.put(CANCELLED, EnumSet.noneOf(OrderStatus.class));
         ALLOWED_TRANSITIONS.put(SHIPPING, EnumSet.of(DELIVERED));
         ALLOWED_TRANSITIONS.put(DELIVERED, EnumSet.of(CONFIRMED, RETURN_REQUESTED));
@@ -96,6 +98,10 @@ public enum OrderStatus {
         return this == PREPARING;
     }
 
+    public boolean isCancelRequested() {
+        return this == CANCEL_REQUESTED;
+    }
+
     public boolean isCancelled() {
         return this == CANCELLED;
     }
@@ -119,7 +125,7 @@ public enum OrderStatus {
     /**
      * 구매자가 직접 변경할 수 있는 주문 상태인지 확인한다.
      * <p>
-     * 구매자 허용 상태: CONFIRMED, CANCELLED, RETURN_REQUESTED
+     * 구매자 허용 상태: CONFIRMED, CANCEL_REQUESTED, CANCELLED, RETURN_REQUESTED
      * </p>
      *
      * @return 구매자가 변경 가능한 상태이면 true


### PR DESCRIPTION
## partially addresses #216
## resolves #1933

## Task
- [x] OrderStatus에 CANCEL_REQUESTED("취소 요청") enum 값 추가
- [x] PAID → CANCEL_REQUESTED, PREPARING → CANCEL_REQUESTED 전이 맵 변경
- [x] CANCEL_REQUESTED → CANCELLED 전이 추가
- [x] PAYMENT_PENDING → CANCELLED 직접 전이 유지
- [x] BUYER_ALLOWED_STATUSES에 CANCEL_REQUESTED 추가
- [x] isCancelRequested() 술어 메서드 추가
- [x] CancelOrderService 타겟 상태 동적 해석 (PAID/PREPARING → CANCEL_REQUESTED, PAYMENT_PENDING → CANCELLED)
- [x] isBuyerAllowed() Javadoc 업데이트