### PR TITLE
[#216][#1934] test: CANCEL_REQUESTED 전이 규칙 자동화 테스트 추가

### DIFF
--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/CancelOrderUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/CancelOrderUseCaseTest.java
@@ -310,11 +310,29 @@ class CancelOrderUseCaseTest {
     class StatusTransitionValidationTest {
 
         @Test
-        @DisplayName("이미 취소된 주문을 다시 취소 요청하면 OrderStatusAlreadyChangedException이 발생한다")
-        void cancelOrder_alreadyCancelled_throwsAlreadyChangedException() {
+        @DisplayName("이미 취소된 주문을 다시 취소 요청하면 InvalidOrderStatusTransitionException이 발생한다")
+        void cancelOrder_alreadyCancelled_throwsInvalidTransitionException() {
             Long orderId = 1L;
             Long buyerId = 100L;
             Order order = createOrder(orderId, buyerId, OrderStatus.CANCELLED);
+            when(getOrderUseCase.getOrder(orderId)).thenReturn(order);
+
+            CancelOrderCommand command = createCommand(orderId, buyerId);
+
+            assertThatThrownBy(() -> cancelOrderService.cancelOrder(command))
+                    .isInstanceOf(InvalidOrderStatusTransitionException.class);
+
+            verifyNoInteractions(updateOrderPort);
+            verifyNoInteractions(cancelFulfillmentReleasePort);
+            verifyNoInteractions(publishOrderEventPort);
+        }
+
+        @Test
+        @DisplayName("이미 취소 요청된 주문을 다시 취소 요청하면 OrderStatusAlreadyChangedException이 발생한다")
+        void cancelOrder_alreadyCancelRequested_throwsAlreadyChangedException() {
+            Long orderId = 1L;
+            Long buyerId = 100L;
+            Order order = createOrder(orderId, buyerId, OrderStatus.CANCEL_REQUESTED);
             when(getOrderUseCase.getOrder(orderId)).thenReturn(order);
 
             CancelOrderCommand command = createCommand(orderId, buyerId);

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/ChangeOrderStatusRoleValidationUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/ChangeOrderStatusRoleValidationUseCaseTest.java
@@ -91,14 +91,14 @@ class ChangeOrderStatusRoleValidationUseCaseTest {
         }
 
         @Test
-        @DisplayName("구매자가 CANCELLED로 변경하면 정상 처리된다")
-        void buyer_cancelled_succeeds() {
+        @DisplayName("구매자가 CANCEL_REQUESTED로 변경하면 정상 처리된다")
+        void buyer_cancelRequested_succeeds() {
             Order order = createOrder(1L, OrderStatus.PAID);
             when(getOrderUseCase.getOrder(1L)).thenReturn(order);
 
             ChangeOrderStatusCommand command = ChangeOrderStatusCommand.builder()
                     .id(1L)
-                    .orderStatus(OrderStatus.CANCELLED)
+                    .orderStatus(OrderStatus.CANCEL_REQUESTED)
                     .role("BUYER")
                     .buyerId(1L)
                     .build();

--- a/commerce-service/commerce-domain/src/test/java/com/personal/marketnote/commerce/domain/order/OrderStatusTest.java
+++ b/commerce-service/commerce-domain/src/test/java/com/personal/marketnote/commerce/domain/order/OrderStatusTest.java
@@ -49,6 +49,12 @@ class OrderStatusTest {
         }
 
         @Test
+        @DisplayName("CANCEL_REQUESTED는 구매자가 변경 가능한 상태이다")
+        void cancelRequested_isBuyerAllowed() {
+            assertThat(OrderStatus.CANCEL_REQUESTED.isBuyerAllowed()).isTrue();
+        }
+
+        @Test
         @DisplayName("CANCELLED는 구매자가 변경 가능한 상태이다")
         void cancelled_isBuyerAllowed() {
             assertThat(OrderStatus.CANCELLED.isBuyerAllowed()).isTrue();
@@ -126,9 +132,15 @@ class OrderStatusTest {
         }
 
         @Test
-        @DisplayName("PAID에서 CANCELLED로 전이할 수 있다")
-        void paid_canTransitionTo_cancelled() {
-            assertThat(OrderStatus.PAID.canTransitionTo(OrderStatus.CANCELLED)).isTrue();
+        @DisplayName("PAID에서 CANCEL_REQUESTED로 전이할 수 있다")
+        void paid_canTransitionTo_cancelRequested() {
+            assertThat(OrderStatus.PAID.canTransitionTo(OrderStatus.CANCEL_REQUESTED)).isTrue();
+        }
+
+        @Test
+        @DisplayName("PAID에서 CANCELLED로 직접 전이할 수 없다")
+        void paid_cannotTransitionTo_cancelled() {
+            assertThat(OrderStatus.PAID.canTransitionTo(OrderStatus.CANCELLED)).isFalse();
         }
 
         @Test
@@ -144,9 +156,15 @@ class OrderStatusTest {
         }
 
         @Test
-        @DisplayName("PREPARING에서 CANCELLED로 전이할 수 있다")
-        void preparing_canTransitionTo_cancelled() {
-            assertThat(OrderStatus.PREPARING.canTransitionTo(OrderStatus.CANCELLED)).isTrue();
+        @DisplayName("PREPARING에서 CANCEL_REQUESTED로 전이할 수 있다")
+        void preparing_canTransitionTo_cancelRequested() {
+            assertThat(OrderStatus.PREPARING.canTransitionTo(OrderStatus.CANCEL_REQUESTED)).isTrue();
+        }
+
+        @Test
+        @DisplayName("PREPARING에서 CANCELLED로 직접 전이할 수 없다")
+        void preparing_cannotTransitionTo_cancelled() {
+            assertThat(OrderStatus.PREPARING.canTransitionTo(OrderStatus.CANCELLED)).isFalse();
         }
 
         @Test
@@ -207,6 +225,25 @@ class OrderStatusTest {
         @DisplayName("PARTIALLY_RETURNED에서 RETURNED로 전이할 수 있다")
         void partiallyReturned_canTransitionTo_returned() {
             assertThat(OrderStatus.PARTIALLY_RETURNED.canTransitionTo(OrderStatus.RETURNED)).isTrue();
+        }
+
+        @Test
+        @DisplayName("CANCEL_REQUESTED에서 CANCELLED로 전이할 수 있다")
+        void cancelRequested_canTransitionTo_cancelled() {
+            assertThat(OrderStatus.CANCEL_REQUESTED.canTransitionTo(OrderStatus.CANCELLED)).isTrue();
+        }
+
+        @Test
+        @DisplayName("CANCEL_REQUESTED에서 CANCELLED 외 다른 상태로 전이할 수 없다")
+        void cancelRequested_cannotTransitionTo_otherStatuses() {
+            for (OrderStatus target : OrderStatus.values()) {
+                if (target == OrderStatus.CANCELLED) {
+                    continue;
+                }
+                assertThat(OrderStatus.CANCEL_REQUESTED.canTransitionTo(target))
+                        .as("CANCEL_REQUESTED → %s는 불가해야 한다", target)
+                        .isFalse();
+            }
         }
 
         @Test
@@ -271,6 +308,12 @@ class OrderStatusTest {
         }
 
         @Test
+        @DisplayName("CANCEL_REQUESTED는 최종 상태가 아니다")
+        void cancelRequested_isNotTerminal() {
+            assertThat(OrderStatus.CANCEL_REQUESTED.isTerminal()).isFalse();
+        }
+
+        @Test
         @DisplayName("PAYMENT_PENDING는 최종 상태가 아니다")
         void paymentPending_isNotTerminal() {
             assertThat(OrderStatus.PAYMENT_PENDING.isTerminal()).isFalse();
@@ -322,6 +365,29 @@ class OrderStatusTest {
         @DisplayName("PARTIALLY_RETURNED는 최종 상태가 아니다")
         void partiallyReturned_isNotTerminal() {
             assertThat(OrderStatus.PARTIALLY_RETURNED.isTerminal()).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("취소 요청 상태 검증 (isCancelRequested)")
+    class IsCancelRequestedTest {
+
+        @Test
+        @DisplayName("CANCEL_REQUESTED는 취소 요청 상태이다")
+        void cancelRequested_isCancelRequested() {
+            assertThat(OrderStatus.CANCEL_REQUESTED.isCancelRequested()).isTrue();
+        }
+
+        @Test
+        @DisplayName("CANCELLED는 취소 요청 상태가 아니다")
+        void cancelled_isNotCancelRequested() {
+            assertThat(OrderStatus.CANCELLED.isCancelRequested()).isFalse();
+        }
+
+        @Test
+        @DisplayName("PAID는 취소 요청 상태가 아니다")
+        void paid_isNotCancelRequested() {
+            assertThat(OrderStatus.PAID.isCancelRequested()).isFalse();
         }
     }
 


### PR DESCRIPTION
## partially addresses #216
## resolves #1934

## Test Case
- [x] PAID → CANCEL_REQUESTED 전이 가능 테스트
- [x] PREPARING → CANCEL_REQUESTED 전이 가능 테스트
- [x] CANCEL_REQUESTED → CANCELLED 전이 가능 테스트
- [x] PAID → CANCELLED 직접 전이 불가 테스트
- [x] PREPARING → CANCELLED 직접 전이 불가 테스트
- [x] PAYMENT_PENDING → CANCELLED 직접 전이 가능 유지 테스트
- [x] CANCEL_REQUESTED → CANCELLED 외 다른 상태 전이 불가 테스트
- [x] CANCEL_REQUESTED 비터미널 상태 테스트
- [x] isCancelRequested() 술어 메서드 테스트
- [x] CANCEL_REQUESTED 구매자 허용 상태 테스트
- [x] CancelOrderUseCaseTest CANCEL_REQUESTED 상태 반영
- [x] ChangeOrderStatusRoleValidationUseCaseTest CANCEL_REQUESTED 반영