### PR TITLE
[#128][#2232] feat: 배송비 정책 도메인/API에 제주/도서산간 추가 배송비 필드 추가

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/ShippingPolicyChangedReadModelConsumer.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/ShippingPolicyChangedReadModelConsumer.java
@@ -3,6 +3,7 @@ package com.personal.marketnote.commerce.adapter.in.event;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.personal.marketnote.commerce.port.out.shipping.SaveShippingPolicyReadModelPort;
 import com.personal.marketnote.common.kafka.KafkaTopicConstants;
+import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.common.kafka.event.EventEnvelope;
 import com.personal.marketnote.common.kafka.event.EventPayloadValidator;
 import com.personal.marketnote.common.kafka.event.ShippingPolicyChangedEvent;
@@ -58,11 +59,15 @@ public class ShippingPolicyChangedReadModelConsumer {
         }
 
         if (payload.action().isCreated() || payload.action().isUpdated()) {
+            Long jejuSurcharge = FormatValidator.hasNoValue(payload.jejuSurcharge()) ? 0L : payload.jejuSurcharge();
+            Long islandSurcharge = FormatValidator.hasNoValue(payload.islandSurcharge()) ? 0L : payload.islandSurcharge();
             saveShippingPolicyReadModelPort.upsert(
-                    payload.sellerId(), payload.shippingFee(), payload.freeShippingThreshold()
+                    payload.sellerId(), payload.shippingFee(), payload.freeShippingThreshold(),
+                    jejuSurcharge, islandSurcharge
             );
-            log.info("배송비 정책 Read Model 저장 완료. sellerId={}, shippingFee={}, freeShippingThreshold={}",
-                    payload.sellerId(), payload.shippingFee(), payload.freeShippingThreshold());
+            log.info("배송비 정책 Read Model 저장 완료. sellerId={}, shippingFee={}, freeShippingThreshold={}, jejuSurcharge={}, islandSurcharge={}",
+                    payload.sellerId(), payload.shippingFee(), payload.freeShippingThreshold(),
+                    payload.jejuSurcharge(), payload.islandSurcharge());
         }
 
         acknowledgment.acknowledge();

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/shipping/ShippingPolicyReadModelPersistenceAdapter.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/shipping/ShippingPolicyReadModelPersistenceAdapter.java
@@ -42,7 +42,9 @@ public class ShippingPolicyReadModelPersistenceAdapter implements FindShippingPo
             result.put(entity.getSellerId(), new ShippingPolicyInfoResult(
                     entity.getSellerId(),
                     entity.getShippingFee(),
-                    entity.getFreeShippingThreshold()
+                    entity.getFreeShippingThreshold(),
+                    entity.getJejuSurcharge(),
+                    entity.getIslandSurcharge()
             ));
         }
 
@@ -51,23 +53,24 @@ public class ShippingPolicyReadModelPersistenceAdapter implements FindShippingPo
 
     @Override
     @Transactional(isolation = READ_COMMITTED)
-    public void upsert(Long sellerId, Long shippingFee, Long freeShippingThreshold) {
+    public void upsert(Long sellerId, Long shippingFee, Long freeShippingThreshold,
+                       Long jejuSurcharge, Long islandSurcharge) {
         Optional<ShippingPolicyReadModelJpaEntity> existing = shippingPolicyReadModelJpaRepository.findBySellerId(sellerId);
 
         if (existing.isPresent()) {
-            existing.get().updateFrom(shippingFee, freeShippingThreshold);
+            existing.get().updateFrom(shippingFee, freeShippingThreshold, jejuSurcharge, islandSurcharge);
             return;
         }
 
         try {
             ShippingPolicyReadModelJpaEntity entity = ShippingPolicyReadModelJpaEntity.of(
-                    sellerId, shippingFee, freeShippingThreshold
+                    sellerId, shippingFee, freeShippingThreshold, jejuSurcharge, islandSurcharge
             );
             shippingPolicyReadModelJpaRepository.saveAndFlush(entity);
         } catch (DataIntegrityViolationException e) {
             log.info("배송비 정책 Read Model 중복 저장 (멱등 처리). sellerId={}", sellerId);
             shippingPolicyReadModelJpaRepository.findBySellerId(sellerId)
-                    .ifPresent(entity -> entity.updateFrom(shippingFee, freeShippingThreshold));
+                    .ifPresent(entity -> entity.updateFrom(shippingFee, freeShippingThreshold, jejuSurcharge, islandSurcharge));
         }
     }
 

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/shipping/entity/ShippingPolicyReadModelJpaEntity.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/shipping/entity/ShippingPolicyReadModelJpaEntity.java
@@ -30,17 +30,29 @@ public class ShippingPolicyReadModelJpaEntity extends BaseGeneralEntity {
     @Column(name = "free_shipping_threshold", nullable = false)
     private Long freeShippingThreshold;
 
-    public static ShippingPolicyReadModelJpaEntity of(Long sellerId, Long shippingFee, Long freeShippingThreshold) {
+    @Column(name = "jeju_surcharge")
+    private Long jejuSurcharge;
+
+    @Column(name = "island_surcharge")
+    private Long islandSurcharge;
+
+    public static ShippingPolicyReadModelJpaEntity of(Long sellerId, Long shippingFee, Long freeShippingThreshold,
+                                                      Long jejuSurcharge, Long islandSurcharge) {
         return ShippingPolicyReadModelJpaEntity.builder()
                 .sellerId(sellerId)
                 .shippingFee(shippingFee)
                 .freeShippingThreshold(freeShippingThreshold)
+                .jejuSurcharge(jejuSurcharge)
+                .islandSurcharge(islandSurcharge)
                 .build();
     }
 
-    public void updateFrom(Long shippingFee, Long freeShippingThreshold) {
+    public void updateFrom(Long shippingFee, Long freeShippingThreshold,
+                           Long jejuSurcharge, Long islandSurcharge) {
         this.shippingFee = shippingFee;
         this.freeShippingThreshold = freeShippingThreshold;
+        this.jejuSurcharge = jejuSurcharge;
+        this.islandSurcharge = islandSurcharge;
         activate();
     }
 

--- a/commerce-service/commerce-adapters/src/main/resources/db/migration/V914__add_surcharge_to_shipping_policy_read_models.sql
+++ b/commerce-service/commerce-adapters/src/main/resources/db/migration/V914__add_surcharge_to_shipping_policy_read_models.sql
@@ -1,0 +1,2 @@
+ALTER TABLE shipping_policy_read_models ADD COLUMN jeju_surcharge BIGINT DEFAULT 0;
+ALTER TABLE shipping_policy_read_models ADD COLUMN island_surcharge BIGINT DEFAULT 0;

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/result/shipping/ShippingPolicyInfoResult.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/result/shipping/ShippingPolicyInfoResult.java
@@ -3,6 +3,9 @@ package com.personal.marketnote.commerce.port.out.result.shipping;
 public record ShippingPolicyInfoResult(
         Long sellerId,
         Long shippingFee,
-        Long freeShippingThreshold
+        Long freeShippingThreshold,
+        Long jejuSurcharge,
+        Long islandSurcharge
 ) {
 }
+

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/shipping/SaveShippingPolicyReadModelPort.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/shipping/SaveShippingPolicyReadModelPort.java
@@ -2,7 +2,8 @@ package com.personal.marketnote.commerce.port.out.shipping;
 
 public interface SaveShippingPolicyReadModelPort {
 
-    void upsert(Long sellerId, Long shippingFee, Long freeShippingThreshold);
+    void upsert(Long sellerId, Long shippingFee, Long freeShippingThreshold,
+                Long jejuSurcharge, Long islandSurcharge);
 
     void deactivateBySellerId(Long sellerId);
 }

--- a/common/src/main/java/com/personal/marketnote/common/kafka/event/ShippingPolicyChangedEvent.java
+++ b/common/src/main/java/com/personal/marketnote/common/kafka/event/ShippingPolicyChangedEvent.java
@@ -4,6 +4,8 @@ public record ShippingPolicyChangedEvent(
         Long sellerId,
         Long shippingFee,
         Long freeShippingThreshold,
+        Long jejuSurcharge,
+        Long islandSurcharge,
         ShippingPolicyChangeAction action
 ) {
 }

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/shipping/controller/ShippingPolicyController.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/shipping/controller/ShippingPolicyController.java
@@ -139,7 +139,9 @@ public class ShippingPolicyController {
                 new RegisterShippingPolicyCommand(
                         request.deliveryCompany(),
                         request.shippingFee(),
-                        request.freeShippingThreshold()
+                        request.freeShippingThreshold(),
+                        request.jejuSurcharge(),
+                        request.islandSurcharge()
                 )
         );
 
@@ -178,7 +180,9 @@ public class ShippingPolicyController {
                 new UpdateShippingPolicyCommand(
                         request.deliveryCompany(),
                         request.shippingFee(),
-                        request.freeShippingThreshold()
+                        request.freeShippingThreshold(),
+                        request.jejuSurcharge(),
+                        request.islandSurcharge()
                 )
         );
 

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/shipping/controller/apidocs/GetShippingPoliciesBySellerIdsApiDocs.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/shipping/controller/apidocs/GetShippingPoliciesBySellerIdsApiDocs.java
@@ -56,6 +56,8 @@ import java.lang.annotation.*;
                 | sellerId | number | 판매자 ID | 10 |
                 | shippingFee | number | 배송비 | 3000 |
                 | freeShippingThreshold | number | 무료배송 기준금액 | 20000 |
+                | jejuSurcharge | number | 제주 추가 배송비 | 3000 |
+                | islandSurcharge | number | 도서산간 추가 배송비 | 5000 |
                 """,
         security = {@SecurityRequirement(name = "bearer")},
         parameters = {
@@ -82,12 +84,16 @@ import java.lang.annotation.*;
                                               {
                                                 "sellerId": 10,
                                                 "shippingFee": 3000,
-                                                "freeShippingThreshold": 20000
+                                                "freeShippingThreshold": 20000,
+                                                "jejuSurcharge": 3000,
+                                                "islandSurcharge": 5000
                                               },
                                               {
                                                 "sellerId": 20,
                                                 "shippingFee": 2500,
-                                                "freeShippingThreshold": 30000
+                                                "freeShippingThreshold": 30000,
+                                                "jejuSurcharge": 4000,
+                                                "islandSurcharge": 6000
                                               }
                                             ]
                                           },

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/shipping/controller/apidocs/GetShippingPolicyApiDocs.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/shipping/controller/apidocs/GetShippingPolicyApiDocs.java
@@ -48,6 +48,8 @@ import java.lang.annotation.*;
                 | deliveryCompany | string | 배송업체 | "한진택배" |
                 | shippingFee | number | 배송비 | 3000 |
                 | freeShippingThreshold | number | 무료배송 기준금액 | 20000 |
+                | jejuSurcharge | number | 제주 추가 배송비 | 3000 |
+                | islandSurcharge | number | 도서산간 추가 배송비 | 5000 |
                 """,
         security = {@SecurityRequirement(name = "bearer")},
         responses = {
@@ -65,7 +67,9 @@ import java.lang.annotation.*;
                                             "id": 1,
                                             "deliveryCompany": "한진택배",
                                             "shippingFee": 3000,
-                                            "freeShippingThreshold": 20000
+                                            "freeShippingThreshold": 20000,
+                                            "jejuSurcharge": 3000,
+                                            "islandSurcharge": 5000
                                           },
                                           "message": "판매자 배송비 정책 조회 성공"
                                         }

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/shipping/controller/apidocs/RegisterShippingPolicyApiDocs.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/shipping/controller/apidocs/RegisterShippingPolicyApiDocs.java
@@ -41,6 +41,8 @@ import java.lang.annotation.*;
                 | deliveryCompany | string | 배송업체 | Y | "한진택배" |
                 | shippingFee | number | 배송비 | Y | 3000 |
                 | freeShippingThreshold | number | 무료배송 기준금액 | Y | 20000 |
+                | jejuSurcharge | number | 제주 추가 배송비 | N | 3000 |
+                | islandSurcharge | number | 도서산간 추가 배송비 | N | 5000 |
                 
                 ---
                 
@@ -69,7 +71,9 @@ import java.lang.annotation.*;
                                 {
                                   "deliveryCompany": "한진택배",
                                   "shippingFee": 3000,
-                                  "freeShippingThreshold": 20000
+                                  "freeShippingThreshold": 20000,
+                                  "jejuSurcharge": 3000,
+                                  "islandSurcharge": 5000
                                 }
                                 """)
                 )

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/shipping/controller/apidocs/UpdateShippingPolicyApiDocs.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/shipping/controller/apidocs/UpdateShippingPolicyApiDocs.java
@@ -39,6 +39,8 @@ import java.lang.annotation.*;
                 | deliveryCompany | string | 배송업체 | Y | "CJ대한통운" |
                 | shippingFee | number | 배송비 | Y | 2500 |
                 | freeShippingThreshold | number | 무료배송 기준금액 | Y | 30000 |
+                | jejuSurcharge | number | 제주 추가 배송비 | N | 3000 |
+                | islandSurcharge | number | 도서산간 추가 배송비 | N | 5000 |
                 
                 ---
                 
@@ -60,6 +62,8 @@ import java.lang.annotation.*;
                 | deliveryCompany | string | 배송업체 | "CJ대한통운" |
                 | shippingFee | number | 배송비 | 2500 |
                 | freeShippingThreshold | number | 무료배송 기준금액 | 30000 |
+                | jejuSurcharge | number | 제주 추가 배송비 | 3000 |
+                | islandSurcharge | number | 도서산간 추가 배송비 | 5000 |
                 """,
         security = {@SecurityRequirement(name = "bearer")},
         requestBody = @RequestBody(
@@ -70,7 +74,9 @@ import java.lang.annotation.*;
                                 {
                                   "deliveryCompany": "CJ대한통운",
                                   "shippingFee": 2500,
-                                  "freeShippingThreshold": 30000
+                                  "freeShippingThreshold": 30000,
+                                  "jejuSurcharge": 3000,
+                                  "islandSurcharge": 5000
                                 }
                                 """)
                 )
@@ -90,7 +96,9 @@ import java.lang.annotation.*;
                                             "id": 1,
                                             "deliveryCompany": "CJ대한통운",
                                             "shippingFee": 2500,
-                                            "freeShippingThreshold": 30000
+                                            "freeShippingThreshold": 30000,
+                                            "jejuSurcharge": 3000,
+                                            "islandSurcharge": 5000
                                           },
                                           "message": "판매자 배송비 정책 수정 성공"
                                         }

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/shipping/request/RegisterShippingPolicyRequest.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/shipping/request/RegisterShippingPolicyRequest.java
@@ -20,6 +20,14 @@ public record RegisterShippingPolicyRequest(
         @NotNull(message = "무료배송 기준금액은 필수입니다")
         @Min(value = 0, message = "무료배송 기준금액은 0 이상이어야 합니다")
         @Schema(description = "무료배송 기준금액", example = "20000")
-        Long freeShippingThreshold
+        Long freeShippingThreshold,
+
+        @Min(value = 0, message = "제주 추가 배송비는 0 이상이어야 합니다")
+        @Schema(description = "제주 추가 배송비", example = "3000")
+        Long jejuSurcharge,
+
+        @Min(value = 0, message = "도서산간 추가 배송비는 0 이상이어야 합니다")
+        @Schema(description = "도서산간 추가 배송비", example = "5000")
+        Long islandSurcharge
 ) {
 }

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/shipping/request/UpdateShippingPolicyRequest.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/shipping/request/UpdateShippingPolicyRequest.java
@@ -20,6 +20,14 @@ public record UpdateShippingPolicyRequest(
         @NotNull(message = "무료배송 기준금액은 필수입니다")
         @Min(value = 0, message = "무료배송 기준금액은 0 이상이어야 합니다")
         @Schema(description = "무료배송 기준금액", example = "20000")
-        Long freeShippingThreshold
+        Long freeShippingThreshold,
+
+        @Min(value = 0, message = "제주 추가 배송비는 0 이상이어야 합니다")
+        @Schema(description = "제주 추가 배송비", example = "3000")
+        Long jejuSurcharge,
+
+        @Min(value = 0, message = "도서산간 추가 배송비는 0 이상이어야 합니다")
+        @Schema(description = "도서산간 추가 배송비", example = "5000")
+        Long islandSurcharge
 ) {
 }

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/shipping/response/GetShippingPoliciesBySellerIdsResponse.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/shipping/response/GetShippingPoliciesBySellerIdsResponse.java
@@ -18,14 +18,18 @@ public record GetShippingPoliciesBySellerIdsResponse(
     public record ShippingPolicyBySellerResponse(
             Long sellerId,
             Long shippingFee,
-            Long freeShippingThreshold
+            Long freeShippingThreshold,
+            Long jejuSurcharge,
+            Long islandSurcharge
     ) {
 
         public static ShippingPolicyBySellerResponse from(GetShippingPolicyBySellerResult result) {
             return new ShippingPolicyBySellerResponse(
                     result.sellerId(),
                     result.shippingFee(),
-                    result.freeShippingThreshold()
+                    result.freeShippingThreshold(),
+                    result.jejuSurcharge(),
+                    result.islandSurcharge()
             );
         }
     }

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/shipping/response/GetShippingPolicyResponse.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/shipping/response/GetShippingPolicyResponse.java
@@ -6,7 +6,9 @@ public record GetShippingPolicyResponse(
         Long id,
         String deliveryCompany,
         Long shippingFee,
-        Long freeShippingThreshold
+        Long freeShippingThreshold,
+        Long jejuSurcharge,
+        Long islandSurcharge
 ) {
 
     public static GetShippingPolicyResponse from(GetShippingPolicyResult result) {
@@ -14,7 +16,9 @@ public record GetShippingPolicyResponse(
                 result.id(),
                 result.deliveryCompany(),
                 result.shippingFee(),
-                result.freeShippingThreshold()
+                result.freeShippingThreshold(),
+                result.jejuSurcharge(),
+                result.islandSurcharge()
         );
     }
 }

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/shipping/response/UpdateShippingPolicyResponse.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/shipping/response/UpdateShippingPolicyResponse.java
@@ -6,7 +6,9 @@ public record UpdateShippingPolicyResponse(
         Long id,
         String deliveryCompany,
         Long shippingFee,
-        Long freeShippingThreshold
+        Long freeShippingThreshold,
+        Long jejuSurcharge,
+        Long islandSurcharge
 ) {
 
     public static UpdateShippingPolicyResponse from(UpdateShippingPolicyResult result) {
@@ -14,7 +16,9 @@ public record UpdateShippingPolicyResponse(
                 result.id(),
                 result.deliveryCompany(),
                 result.shippingFee(),
-                result.freeShippingThreshold()
+                result.freeShippingThreshold(),
+                result.jejuSurcharge(),
+                result.islandSurcharge()
         );
     }
 }

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/event/ShippingPolicyEventKafkaProducer.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/event/ShippingPolicyEventKafkaProducer.java
@@ -25,8 +25,10 @@ public class ShippingPolicyEventKafkaProducer implements PublishShippingPolicyEv
     private final Clock clock;
 
     @Override
-    public void publishShippingPolicyChangedEvent(Long sellerId, Long shippingFee, Long freeShippingThreshold, ShippingPolicyChangeAction action) {
-        ShippingPolicyChangedEvent payload = new ShippingPolicyChangedEvent(sellerId, shippingFee, freeShippingThreshold, action);
+    public void publishShippingPolicyChangedEvent(Long sellerId, Long shippingFee, Long freeShippingThreshold,
+                                                  Long jejuSurcharge, Long islandSurcharge, ShippingPolicyChangeAction action) {
+        ShippingPolicyChangedEvent payload = new ShippingPolicyChangedEvent(
+                sellerId, shippingFee, freeShippingThreshold, jejuSurcharge, islandSurcharge, action);
         String topic = KafkaTopicConstants.SHIPPING_POLICY_CHANGED;
         EventEnvelope<ShippingPolicyChangedEvent> envelope = EventEnvelope.of(topic, SOURCE, payload, clock);
 

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/mapper/ShippingPolicyJpaEntityToDomainMapper.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/mapper/ShippingPolicyJpaEntityToDomainMapper.java
@@ -20,6 +20,8 @@ public class ShippingPolicyJpaEntityToDomainMapper {
                                 .deliveryCompany(e.getDeliveryCompany())
                                 .shippingFee(e.getShippingFee())
                                 .freeShippingThreshold(e.getFreeShippingThreshold())
+                                .jejuSurcharge(e.getJejuSurcharge())
+                                .islandSurcharge(e.getIslandSurcharge())
                                 .status(e.getStatus())
                                 .createdAt(e.getCreatedAt())
                                 .modifiedAt(e.getModifiedAt())

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/shipping/entity/ShippingPolicyJpaEntity.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/shipping/entity/ShippingPolicyJpaEntity.java
@@ -32,12 +32,20 @@ public class ShippingPolicyJpaEntity extends BaseGeneralEntity {
     @Column(name = "free_shipping_threshold", nullable = false)
     private Long freeShippingThreshold;
 
+    @Column(name = "jeju_surcharge")
+    private Long jejuSurcharge;
+
+    @Column(name = "island_surcharge")
+    private Long islandSurcharge;
+
     public static ShippingPolicyJpaEntity from(ShippingPolicy policy) {
         return ShippingPolicyJpaEntity.builder()
                 .sellerId(policy.getSellerId())
                 .deliveryCompany(policy.getDeliveryCompany())
                 .shippingFee(policy.getShippingFee())
                 .freeShippingThreshold(policy.getFreeShippingThreshold())
+                .jejuSurcharge(policy.getJejuSurcharge())
+                .islandSurcharge(policy.getIslandSurcharge())
                 .build();
     }
 
@@ -45,5 +53,7 @@ public class ShippingPolicyJpaEntity extends BaseGeneralEntity {
         this.deliveryCompany = policy.getDeliveryCompany();
         this.shippingFee = policy.getShippingFee();
         this.freeShippingThreshold = policy.getFreeShippingThreshold();
+        this.jejuSurcharge = policy.getJejuSurcharge();
+        this.islandSurcharge = policy.getIslandSurcharge();
     }
 }

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/mapper/ShippingPolicyCommandToStateMapper.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/mapper/ShippingPolicyCommandToStateMapper.java
@@ -14,6 +14,8 @@ public class ShippingPolicyCommandToStateMapper {
                 .deliveryCompany(command.deliveryCompany())
                 .shippingFee(command.shippingFee())
                 .freeShippingThreshold(command.freeShippingThreshold())
+                .jejuSurcharge(command.jejuSurcharge())
+                .islandSurcharge(command.islandSurcharge())
                 .build();
     }
 }

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/command/RegisterShippingPolicyCommand.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/command/RegisterShippingPolicyCommand.java
@@ -3,6 +3,8 @@ package com.personal.marketnote.product.port.in.command;
 public record RegisterShippingPolicyCommand(
         String deliveryCompany,
         Long shippingFee,
-        Long freeShippingThreshold
+        Long freeShippingThreshold,
+        Long jejuSurcharge,
+        Long islandSurcharge
 ) {
 }

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/command/UpdateShippingPolicyCommand.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/command/UpdateShippingPolicyCommand.java
@@ -3,6 +3,8 @@ package com.personal.marketnote.product.port.in.command;
 public record UpdateShippingPolicyCommand(
         String deliveryCompany,
         Long shippingFee,
-        Long freeShippingThreshold
+        Long freeShippingThreshold,
+        Long jejuSurcharge,
+        Long islandSurcharge
 ) {
 }

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/result/shipping/GetShippingPolicyBySellerResult.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/result/shipping/GetShippingPolicyBySellerResult.java
@@ -5,14 +5,18 @@ import com.personal.marketnote.product.domain.shipping.ShippingPolicy;
 public record GetShippingPolicyBySellerResult(
         Long sellerId,
         Long shippingFee,
-        Long freeShippingThreshold
+        Long freeShippingThreshold,
+        Long jejuSurcharge,
+        Long islandSurcharge
 ) {
 
     public static GetShippingPolicyBySellerResult from(ShippingPolicy shippingPolicy) {
         return new GetShippingPolicyBySellerResult(
                 shippingPolicy.getSellerId(),
                 shippingPolicy.getShippingFee(),
-                shippingPolicy.getFreeShippingThreshold()
+                shippingPolicy.getFreeShippingThreshold(),
+                shippingPolicy.getJejuSurcharge(),
+                shippingPolicy.getIslandSurcharge()
         );
     }
 }

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/result/shipping/GetShippingPolicyResult.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/result/shipping/GetShippingPolicyResult.java
@@ -6,7 +6,9 @@ public record GetShippingPolicyResult(
         Long id,
         String deliveryCompany,
         Long shippingFee,
-        Long freeShippingThreshold
+        Long freeShippingThreshold,
+        Long jejuSurcharge,
+        Long islandSurcharge
 ) {
 
     public static GetShippingPolicyResult from(ShippingPolicy shippingPolicy) {
@@ -14,7 +16,9 @@ public record GetShippingPolicyResult(
                 shippingPolicy.getId(),
                 shippingPolicy.getDeliveryCompany(),
                 shippingPolicy.getShippingFee(),
-                shippingPolicy.getFreeShippingThreshold()
+                shippingPolicy.getFreeShippingThreshold(),
+                shippingPolicy.getJejuSurcharge(),
+                shippingPolicy.getIslandSurcharge()
         );
     }
 }

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/result/shipping/UpdateShippingPolicyResult.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/result/shipping/UpdateShippingPolicyResult.java
@@ -6,7 +6,9 @@ public record UpdateShippingPolicyResult(
         Long id,
         String deliveryCompany,
         Long shippingFee,
-        Long freeShippingThreshold
+        Long freeShippingThreshold,
+        Long jejuSurcharge,
+        Long islandSurcharge
 ) {
 
     public static UpdateShippingPolicyResult from(ShippingPolicy shippingPolicy) {
@@ -14,7 +16,9 @@ public record UpdateShippingPolicyResult(
                 shippingPolicy.getId(),
                 shippingPolicy.getDeliveryCompany(),
                 shippingPolicy.getShippingFee(),
-                shippingPolicy.getFreeShippingThreshold()
+                shippingPolicy.getFreeShippingThreshold(),
+                shippingPolicy.getJejuSurcharge(),
+                shippingPolicy.getIslandSurcharge()
         );
     }
 }

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/out/event/PublishShippingPolicyEventPort.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/out/event/PublishShippingPolicyEventPort.java
@@ -4,5 +4,6 @@ import com.personal.marketnote.common.kafka.event.ShippingPolicyChangeAction;
 
 public interface PublishShippingPolicyEventPort {
 
-    void publishShippingPolicyChangedEvent(Long sellerId, Long shippingFee, Long freeShippingThreshold, ShippingPolicyChangeAction action);
+    void publishShippingPolicyChangedEvent(Long sellerId, Long shippingFee, Long freeShippingThreshold,
+                                           Long jejuSurcharge, Long islandSurcharge, ShippingPolicyChangeAction action);
 }

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/service/shipping/RegisterShippingPolicyService.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/service/shipping/RegisterShippingPolicyService.java
@@ -35,7 +35,8 @@ public class RegisterShippingPolicyService implements RegisterShippingPolicyUseC
         Long savedId = saveShippingPolicyPort.save(shippingPolicy);
 
         publishShippingPolicyEventPort.publishShippingPolicyChangedEvent(
-                sellerId, command.shippingFee(), command.freeShippingThreshold(), ShippingPolicyChangeAction.CREATED
+                sellerId, shippingPolicy.getShippingFee(), shippingPolicy.getFreeShippingThreshold(),
+                shippingPolicy.getJejuSurcharge(), shippingPolicy.getIslandSurcharge(), ShippingPolicyChangeAction.CREATED
         );
 
         return RegisterShippingPolicyResult.of(savedId);

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/service/shipping/UpdateShippingPolicyService.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/service/shipping/UpdateShippingPolicyService.java
@@ -31,13 +31,16 @@ public class UpdateShippingPolicyService implements UpdateShippingPolicyUseCase 
         shippingPolicy.update(
                 command.deliveryCompany(),
                 command.shippingFee(),
-                command.freeShippingThreshold()
+                command.freeShippingThreshold(),
+                command.jejuSurcharge(),
+                command.islandSurcharge()
         );
 
         updateShippingPolicyPort.update(shippingPolicy);
 
         publishShippingPolicyEventPort.publishShippingPolicyChangedEvent(
-                sellerId, shippingPolicy.getShippingFee(), shippingPolicy.getFreeShippingThreshold(), ShippingPolicyChangeAction.UPDATED
+                sellerId, shippingPolicy.getShippingFee(), shippingPolicy.getFreeShippingThreshold(),
+                shippingPolicy.getJejuSurcharge(), shippingPolicy.getIslandSurcharge(), ShippingPolicyChangeAction.UPDATED
         );
 
         return UpdateShippingPolicyResult.from(shippingPolicy);

--- a/product-service/product-domain/src/main/java/com/personal/marketnote/product/domain/shipping/InvalidIslandSurchargeException.java
+++ b/product-service/product-domain/src/main/java/com/personal/marketnote/product/domain/shipping/InvalidIslandSurchargeException.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.product.domain.shipping;
+
+public class InvalidIslandSurchargeException extends IllegalArgumentException {
+    private static final String MESSAGE = "ERR_SHIPPING_POLICY_04::도서산간 추가 배송비가 유효하지 않습니다. %s";
+
+    public InvalidIslandSurchargeException(String detail) {
+        super(String.format(MESSAGE, detail));
+    }
+}

--- a/product-service/product-domain/src/main/java/com/personal/marketnote/product/domain/shipping/InvalidJejuSurchargeException.java
+++ b/product-service/product-domain/src/main/java/com/personal/marketnote/product/domain/shipping/InvalidJejuSurchargeException.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.product.domain.shipping;
+
+public class InvalidJejuSurchargeException extends IllegalArgumentException {
+    private static final String MESSAGE = "ERR_SHIPPING_POLICY_03::제주 추가 배송비가 유효하지 않습니다. %s";
+
+    public InvalidJejuSurchargeException(String detail) {
+        super(String.format(MESSAGE, detail));
+    }
+}

--- a/product-service/product-domain/src/main/java/com/personal/marketnote/product/domain/shipping/ShippingPolicy.java
+++ b/product-service/product-domain/src/main/java/com/personal/marketnote/product/domain/shipping/ShippingPolicy.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.product.domain.shipping;
 
 import com.personal.marketnote.common.domain.BaseDomain;
+import com.personal.marketnote.common.utility.FormatValidator;
 import lombok.*;
 
 import java.time.LocalDateTime;
@@ -15,6 +16,8 @@ public class ShippingPolicy extends BaseDomain {
     private String deliveryCompany;
     private Long shippingFee;
     private Long freeShippingThreshold;
+    private Long jejuSurcharge;
+    private Long islandSurcharge;
     private LocalDateTime createdAt;
     private LocalDateTime modifiedAt;
 
@@ -22,11 +25,18 @@ public class ShippingPolicy extends BaseDomain {
         validateShippingFee(state.getShippingFee());
         validateFreeShippingThreshold(state.getFreeShippingThreshold());
 
+        Long resolvedJejuSurcharge = resolveDefaultSurcharge(state.getJejuSurcharge());
+        Long resolvedIslandSurcharge = resolveDefaultSurcharge(state.getIslandSurcharge());
+        validateJejuSurcharge(resolvedJejuSurcharge);
+        validateIslandSurcharge(resolvedIslandSurcharge);
+
         ShippingPolicy policy = ShippingPolicy.builder()
                 .sellerId(state.getSellerId())
                 .deliveryCompany(state.getDeliveryCompany())
                 .shippingFee(state.getShippingFee())
                 .freeShippingThreshold(state.getFreeShippingThreshold())
+                .jejuSurcharge(resolvedJejuSurcharge)
+                .islandSurcharge(resolvedIslandSurcharge)
                 .build();
         policy.activate();
         return policy;
@@ -39,6 +49,8 @@ public class ShippingPolicy extends BaseDomain {
                 .deliveryCompany(state.getDeliveryCompany())
                 .shippingFee(state.getShippingFee())
                 .freeShippingThreshold(state.getFreeShippingThreshold())
+                .jejuSurcharge(state.getJejuSurcharge())
+                .islandSurcharge(state.getIslandSurcharge())
                 .createdAt(state.getCreatedAt())
                 .modifiedAt(state.getModifiedAt())
                 .build();
@@ -46,13 +58,21 @@ public class ShippingPolicy extends BaseDomain {
         return policy;
     }
 
-    public void update(String deliveryCompany, Long shippingFee, Long freeShippingThreshold) {
+    public void update(String deliveryCompany, Long shippingFee, Long freeShippingThreshold,
+                       Long jejuSurcharge, Long islandSurcharge) {
         validateShippingFee(shippingFee);
         validateFreeShippingThreshold(freeShippingThreshold);
+
+        Long resolvedJejuSurcharge = resolveDefaultSurcharge(jejuSurcharge);
+        Long resolvedIslandSurcharge = resolveDefaultSurcharge(islandSurcharge);
+        validateJejuSurcharge(resolvedJejuSurcharge);
+        validateIslandSurcharge(resolvedIslandSurcharge);
 
         this.deliveryCompany = deliveryCompany;
         this.shippingFee = shippingFee;
         this.freeShippingThreshold = freeShippingThreshold;
+        this.jejuSurcharge = resolvedJejuSurcharge;
+        this.islandSurcharge = resolvedIslandSurcharge;
     }
 
     @Override
@@ -81,5 +101,24 @@ public class ShippingPolicy extends BaseDomain {
         if (freeShippingThreshold < 0) {
             throw new InvalidFreeShippingThresholdException("무료배송 기준금액은 0 이상이어야 합니다. 입력값=" + freeShippingThreshold);
         }
+    }
+
+    private static void validateJejuSurcharge(Long jejuSurcharge) {
+        if (jejuSurcharge < 0) {
+            throw new InvalidJejuSurchargeException("제주 추가 배송비는 0 이상이어야 합니다. 입력값=" + jejuSurcharge);
+        }
+    }
+
+    private static void validateIslandSurcharge(Long islandSurcharge) {
+        if (islandSurcharge < 0) {
+            throw new InvalidIslandSurchargeException("도서산간 추가 배송비는 0 이상이어야 합니다. 입력값=" + islandSurcharge);
+        }
+    }
+
+    private static Long resolveDefaultSurcharge(Long surcharge) {
+        if (FormatValidator.hasNoValue(surcharge)) {
+            return 0L;
+        }
+        return surcharge;
     }
 }

--- a/product-service/product-domain/src/main/java/com/personal/marketnote/product/domain/shipping/ShippingPolicyCreateState.java
+++ b/product-service/product-domain/src/main/java/com/personal/marketnote/product/domain/shipping/ShippingPolicyCreateState.java
@@ -11,4 +11,6 @@ public class ShippingPolicyCreateState {
     private String deliveryCompany;
     private Long shippingFee;
     private Long freeShippingThreshold;
+    private Long jejuSurcharge;
+    private Long islandSurcharge;
 }

--- a/product-service/product-domain/src/main/java/com/personal/marketnote/product/domain/shipping/ShippingPolicySnapshotState.java
+++ b/product-service/product-domain/src/main/java/com/personal/marketnote/product/domain/shipping/ShippingPolicySnapshotState.java
@@ -15,6 +15,8 @@ public class ShippingPolicySnapshotState {
     private String deliveryCompany;
     private Long shippingFee;
     private Long freeShippingThreshold;
+    private Long jejuSurcharge;
+    private Long islandSurcharge;
     private EntityStatus status;
     private LocalDateTime createdAt;
     private LocalDateTime modifiedAt;


### PR DESCRIPTION
## partially addresses #128
## resolves #2232

## Task
- [x] ShippingPolicy 도메인에 jejuSurcharge, islandSurcharge 필드 추가
- [x] ShippingPolicyCreateState, SnapshotState에 필드 추가
- [x] ShippingPolicyJpaEntity에 컬럼 추가
- [x] RegisterShippingPolicyCommand, UpdateShippingPolicyCommand에 필드 추가
- [x] Request/Response DTO에 필드 추가
- [x] GetShippingPolicyResult, GetShippingPolicyBySellerResult에 필드 추가
- [x] GetProductInfoResult 상품 상세 조회 응답에 추가 배송비 노출
- [x] Mapper 업데이트
- [x] DB Migration 스크립트 추가 (V914)