### PR TITLE
[#128][#2240] test: 배송비 정책 제주/도서산간 추가 배송비 기능 자동화 테스트 추가

### DIFF
--- a/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/event/ShippingPolicyChangedReadModelConsumerTest.java
+++ b/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/event/ShippingPolicyChangedReadModelConsumerTest.java
@@ -58,7 +58,7 @@ class ShippingPolicyChangedReadModelConsumerTest {
     void handleShippingPolicyChangedEvent_created_upsertsReadModel() {
         // given
         ShippingPolicyChangedEvent payload = new ShippingPolicyChangedEvent(
-                10L, 3000L, 20000L, ShippingPolicyChangeAction.CREATED
+                10L, 3000L, 20000L, 3000L, 5000L, ShippingPolicyChangeAction.CREATED
         );
         EventEnvelope<ShippingPolicyChangedEvent> envelope = createEnvelope(payload);
         ConsumerRecord<String, EventEnvelope<?>> record = createRecord(envelope);
@@ -67,7 +67,7 @@ class ShippingPolicyChangedReadModelConsumerTest {
         consumer.handleShippingPolicyChangedEvent(record, acknowledgment);
 
         // then
-        verify(saveShippingPolicyReadModelPort).upsert(10L, 3000L, 20000L);
+        verify(saveShippingPolicyReadModelPort).upsert(10L, 3000L, 20000L, 3000L, 5000L);
         verify(acknowledgment).acknowledge();
     }
 
@@ -76,7 +76,7 @@ class ShippingPolicyChangedReadModelConsumerTest {
     void handleShippingPolicyChangedEvent_updated_upsertsReadModel() {
         // given
         ShippingPolicyChangedEvent payload = new ShippingPolicyChangedEvent(
-                20L, 2500L, 30000L, ShippingPolicyChangeAction.UPDATED
+                20L, 2500L, 30000L, 4000L, 6000L, ShippingPolicyChangeAction.UPDATED
         );
         EventEnvelope<ShippingPolicyChangedEvent> envelope = createEnvelope(payload);
         ConsumerRecord<String, EventEnvelope<?>> record = createRecord(envelope);
@@ -85,7 +85,7 @@ class ShippingPolicyChangedReadModelConsumerTest {
         consumer.handleShippingPolicyChangedEvent(record, acknowledgment);
 
         // then
-        verify(saveShippingPolicyReadModelPort).upsert(20L, 2500L, 30000L);
+        verify(saveShippingPolicyReadModelPort).upsert(20L, 2500L, 30000L, 4000L, 6000L);
         verify(acknowledgment).acknowledge();
     }
 
@@ -94,7 +94,7 @@ class ShippingPolicyChangedReadModelConsumerTest {
     void handleShippingPolicyChangedEvent_deleted_deactivatesReadModel() {
         // given
         ShippingPolicyChangedEvent payload = new ShippingPolicyChangedEvent(
-                10L, 3000L, 20000L, ShippingPolicyChangeAction.DELETED
+                10L, 3000L, 20000L, 3000L, 5000L, ShippingPolicyChangeAction.DELETED
         );
         EventEnvelope<ShippingPolicyChangedEvent> envelope = createEnvelope(payload);
         ConsumerRecord<String, EventEnvelope<?>> record = createRecord(envelope);
@@ -129,7 +129,7 @@ class ShippingPolicyChangedReadModelConsumerTest {
     void handleShippingPolicyChangedEvent_eventTypeMismatch_acknowledges() {
         // given
         ShippingPolicyChangedEvent payload = new ShippingPolicyChangedEvent(
-                10L, 3000L, 20000L, ShippingPolicyChangeAction.CREATED
+                10L, 3000L, 20000L, 3000L, 5000L, ShippingPolicyChangeAction.CREATED
         );
         EventEnvelope<ShippingPolicyChangedEvent> envelope = new EventEnvelope<>(
                 "test-event-id",
@@ -153,7 +153,7 @@ class ShippingPolicyChangedReadModelConsumerTest {
     void handleShippingPolicyChangedEvent_nullSellerId_acknowledges() {
         // given
         ShippingPolicyChangedEvent payload = new ShippingPolicyChangedEvent(
-                null, 3000L, 20000L, ShippingPolicyChangeAction.CREATED
+                null, 3000L, 20000L, 3000L, 5000L, ShippingPolicyChangeAction.CREATED
         );
         EventEnvelope<ShippingPolicyChangedEvent> envelope = createEnvelope(payload);
         ConsumerRecord<String, EventEnvelope<?>> record = createRecord(envelope);
@@ -171,7 +171,7 @@ class ShippingPolicyChangedReadModelConsumerTest {
     void handleShippingPolicyChangedEvent_zeroSellerId_acknowledges() {
         // given
         ShippingPolicyChangedEvent payload = new ShippingPolicyChangedEvent(
-                0L, 3000L, 20000L, ShippingPolicyChangeAction.CREATED
+                0L, 3000L, 20000L, 0L, 0L, ShippingPolicyChangeAction.CREATED
         );
         EventEnvelope<ShippingPolicyChangedEvent> envelope = createEnvelope(payload);
         ConsumerRecord<String, EventEnvelope<?>> record = createRecord(envelope);
@@ -189,7 +189,7 @@ class ShippingPolicyChangedReadModelConsumerTest {
     void handleShippingPolicyChangedEvent_negativeSellerId_acknowledges() {
         // given
         ShippingPolicyChangedEvent payload = new ShippingPolicyChangedEvent(
-                -1L, 3000L, 20000L, ShippingPolicyChangeAction.CREATED
+                -1L, 3000L, 20000L, 0L, 0L, ShippingPolicyChangeAction.CREATED
         );
         EventEnvelope<ShippingPolicyChangedEvent> envelope = createEnvelope(payload);
         ConsumerRecord<String, EventEnvelope<?>> record = createRecord(envelope);

--- a/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/out/persistence/shipping/ShippingPolicyReadModelPersistenceAdapterTest.java
+++ b/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/out/persistence/shipping/ShippingPolicyReadModelPersistenceAdapterTest.java
@@ -45,8 +45,8 @@ class ShippingPolicyReadModelPersistenceAdapterTest {
         @DisplayName("ACTIVE 상태의 배송비 정책을 판매자 ID별 맵으로 반환한다")
         void returnsActivePoliciesAsMap() {
             // given
-            adapter.upsert(10L, 3000L, 20000L);
-            adapter.upsert(20L, 2500L, 30000L);
+            adapter.upsert(10L, 3000L, 20000L, 3000L, 5000L);
+            adapter.upsert(20L, 2500L, 30000L, 4000L, 6000L);
 
             // when
             Map<Long, ShippingPolicyInfoResult> result = adapter.findBySellerIds(List.of(10L, 20L));
@@ -56,9 +56,13 @@ class ShippingPolicyReadModelPersistenceAdapterTest {
             assertThat(result.get(10L).sellerId()).isEqualTo(10L);
             assertThat(result.get(10L).shippingFee()).isEqualTo(3000L);
             assertThat(result.get(10L).freeShippingThreshold()).isEqualTo(20000L);
+            assertThat(result.get(10L).jejuSurcharge()).isEqualTo(3000L);
+            assertThat(result.get(10L).islandSurcharge()).isEqualTo(5000L);
             assertThat(result.get(20L).sellerId()).isEqualTo(20L);
             assertThat(result.get(20L).shippingFee()).isEqualTo(2500L);
             assertThat(result.get(20L).freeShippingThreshold()).isEqualTo(30000L);
+            assertThat(result.get(20L).jejuSurcharge()).isEqualTo(4000L);
+            assertThat(result.get(20L).islandSurcharge()).isEqualTo(6000L);
         }
 
         @Test
@@ -85,7 +89,7 @@ class ShippingPolicyReadModelPersistenceAdapterTest {
         @DisplayName("INACTIVE 상태의 배송비 정책은 조회하지 않는다")
         void excludesInactivePolicies() {
             // given
-            adapter.upsert(10L, 3000L, 20000L);
+            adapter.upsert(10L, 3000L, 20000L, 3000L, 5000L);
             adapter.deactivateBySellerId(10L);
 
             // when
@@ -99,7 +103,7 @@ class ShippingPolicyReadModelPersistenceAdapterTest {
         @DisplayName("존재하지 않는 sellerId는 결과에 포함하지 않는다")
         void excludesNonExistentSellerIds() {
             // given
-            adapter.upsert(10L, 3000L, 20000L);
+            adapter.upsert(10L, 3000L, 20000L, 3000L, 5000L);
 
             // when
             Map<Long, ShippingPolicyInfoResult> result = adapter.findBySellerIds(List.of(10L, 999L));
@@ -119,7 +123,7 @@ class ShippingPolicyReadModelPersistenceAdapterTest {
         @DisplayName("신규 배송비 정책을 저장한다")
         void insertsNewPolicy() {
             // when
-            adapter.upsert(10L, 3000L, 20000L);
+            adapter.upsert(10L, 3000L, 20000L, 3000L, 5000L);
 
             // then
             Optional<ShippingPolicyReadModelJpaEntity> entity = repository.findBySellerIdAndStatus(10L, EntityStatus.ACTIVE);
@@ -127,6 +131,8 @@ class ShippingPolicyReadModelPersistenceAdapterTest {
             assertThat(entity.get().getSellerId()).isEqualTo(10L);
             assertThat(entity.get().getShippingFee()).isEqualTo(3000L);
             assertThat(entity.get().getFreeShippingThreshold()).isEqualTo(20000L);
+            assertThat(entity.get().getJejuSurcharge()).isEqualTo(3000L);
+            assertThat(entity.get().getIslandSurcharge()).isEqualTo(5000L);
             assertThat(entity.get().getStatus()).isEqualTo(EntityStatus.ACTIVE);
         }
 
@@ -134,27 +140,29 @@ class ShippingPolicyReadModelPersistenceAdapterTest {
         @DisplayName("동일한 sellerId로 upsert 시 기존 데이터를 업데이트한다")
         void updatesExistingPolicy() {
             // given
-            adapter.upsert(10L, 3000L, 20000L);
+            adapter.upsert(10L, 3000L, 20000L, 3000L, 5000L);
 
             // when
-            adapter.upsert(10L, 5000L, 50000L);
+            adapter.upsert(10L, 5000L, 50000L, 7000L, 8000L);
 
             // then
             Optional<ShippingPolicyReadModelJpaEntity> entity = repository.findBySellerIdAndStatus(10L, EntityStatus.ACTIVE);
             assertThat(entity).isPresent();
             assertThat(entity.get().getShippingFee()).isEqualTo(5000L);
             assertThat(entity.get().getFreeShippingThreshold()).isEqualTo(50000L);
+            assertThat(entity.get().getJejuSurcharge()).isEqualTo(7000L);
+            assertThat(entity.get().getIslandSurcharge()).isEqualTo(8000L);
         }
 
         @Test
         @DisplayName("비활성화된 정책에 대해 upsert 시 다시 활성화된다")
         void reactivatesInactivePolicy() {
             // given
-            adapter.upsert(10L, 3000L, 20000L);
+            adapter.upsert(10L, 3000L, 20000L, 3000L, 5000L);
             adapter.deactivateBySellerId(10L);
 
             // when
-            adapter.upsert(10L, 5000L, 50000L);
+            adapter.upsert(10L, 5000L, 50000L, 7000L, 8000L);
 
             // then
             Optional<ShippingPolicyReadModelJpaEntity> entity = repository.findBySellerIdAndStatus(10L, EntityStatus.ACTIVE);
@@ -172,7 +180,7 @@ class ShippingPolicyReadModelPersistenceAdapterTest {
         @DisplayName("배송비 정책을 비활성화한다")
         void deactivatesPolicy() {
             // given
-            adapter.upsert(10L, 3000L, 20000L);
+            adapter.upsert(10L, 3000L, 20000L, 3000L, 5000L);
 
             // when
             adapter.deactivateBySellerId(10L);

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/RegisterOrderUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/RegisterOrderUseCaseTest.java
@@ -2193,8 +2193,8 @@ class RegisterOrderUseCaseTest {
                     pricePolicyId2, Map.entry(50000L, 20L)
             ));
             mockShippingPolicies(Map.of(
-                    10L, new ShippingPolicyInfoResult(10L, shippingFeeA, 100000L),
-                    20L, new ShippingPolicyInfoResult(20L, shippingFeeB, 100000L)
+                    10L, new ShippingPolicyInfoResult(10L, shippingFeeA, 100000L, 0L, 0L),
+                    20L, new ShippingPolicyInfoResult(20L, shippingFeeB, 100000L, 0L, 0L)
             ));
             Inventory inventory1 = Inventory.of(1L, pricePolicyId1, 100);
             Inventory inventory2 = Inventory.of(2L, pricePolicyId2, 50);
@@ -2484,8 +2484,8 @@ class RegisterOrderUseCaseTest {
                     pricePolicyIdB, Map.entry(unitAmountB, sellerIdB)
             ));
             mockShippingPolicies(Map.of(
-                    sellerIdA, new ShippingPolicyInfoResult(sellerIdA, shippingFeeA, 20000L),
-                    sellerIdB, new ShippingPolicyInfoResult(sellerIdB, shippingFeeB, 20000L)
+                    sellerIdA, new ShippingPolicyInfoResult(sellerIdA, shippingFeeA, 20000L, 0L, 0L),
+                    sellerIdB, new ShippingPolicyInfoResult(sellerIdB, shippingFeeB, 20000L, 0L, 0L)
             ));
             mockInventoryMultiple(Map.of(pricePolicyIdA, 100, pricePolicyIdB, 100));
             Order savedOrder = mockSavedOrder(1L);
@@ -2532,8 +2532,8 @@ class RegisterOrderUseCaseTest {
                     pricePolicyIdB, Map.entry(unitAmountB, sellerIdB)
             ));
             mockShippingPolicies(Map.of(
-                    sellerIdA, new ShippingPolicyInfoResult(sellerIdA, 3000L, 20000L),
-                    sellerIdB, new ShippingPolicyInfoResult(sellerIdB, shippingFeeB, 20000L)
+                    sellerIdA, new ShippingPolicyInfoResult(sellerIdA, 3000L, 20000L, 0L, 0L),
+                    sellerIdB, new ShippingPolicyInfoResult(sellerIdB, shippingFeeB, 20000L, 0L, 0L)
             ));
             mockInventoryMultiple(Map.of(pricePolicyIdA, 100, pricePolicyIdB, 100));
             Order savedOrder = mockSavedOrder(1L);
@@ -2580,7 +2580,7 @@ class RegisterOrderUseCaseTest {
                     pricePolicyIdB, Map.entry(unitAmountB, sellerIdB)
             ));
             mockShippingPolicies(Map.of(
-                    sellerIdA, new ShippingPolicyInfoResult(sellerIdA, shippingFeeA, 20000L)
+                    sellerIdA, new ShippingPolicyInfoResult(sellerIdA, shippingFeeA, 20000L, 0L, 0L)
             ));
             mockInventoryMultiple(Map.of(pricePolicyIdA, 100, pricePolicyIdB, 100));
             Order savedOrder = mockSavedOrder(1L);
@@ -2806,7 +2806,7 @@ class RegisterOrderUseCaseTest {
 
     private void mockShippingPolicy(Long sellerId, Long shippingFee, Long freeShippingThreshold) {
         when(findShippingPolicyBySellerIdsPort.findBySellerIds(anyList()))
-                .thenReturn(Map.of(sellerId, new ShippingPolicyInfoResult(sellerId, shippingFee, freeShippingThreshold)));
+                .thenReturn(Map.of(sellerId, new ShippingPolicyInfoResult(sellerId, shippingFee, freeShippingThreshold, 0L, 0L)));
     }
 
     private void mockShippingPolicies(Map<Long, ShippingPolicyInfoResult> policies) {

--- a/product-service/product-adapters/src/test/java/com/personal/marketnote/product/adapter/in/web/shipping/controller/InternalShippingPolicyControllerTest.java
+++ b/product-service/product-adapters/src/test/java/com/personal/marketnote/product/adapter/in/web/shipping/controller/InternalShippingPolicyControllerTest.java
@@ -36,8 +36,8 @@ class InternalShippingPolicyControllerTest {
             // given
             List<Long> sellerIds = List.of(10L, 20L);
             List<GetShippingPolicyBySellerResult> results = List.of(
-                    new GetShippingPolicyBySellerResult(10L, 3000L, 20000L),
-                    new GetShippingPolicyBySellerResult(20L, 2500L, 30000L)
+                    new GetShippingPolicyBySellerResult(10L, 3000L, 20000L, 3000L, 5000L),
+                    new GetShippingPolicyBySellerResult(20L, 2500L, 30000L, 4000L, 6000L)
             );
             when(getShippingPolicyUseCase.getShippingPolicies(sellerIds)).thenReturn(results);
 

--- a/product-service/product-adapters/src/test/java/com/personal/marketnote/product/adapter/out/event/ShippingPolicyEventKafkaProducerTest.java
+++ b/product-service/product-adapters/src/test/java/com/personal/marketnote/product/adapter/out/event/ShippingPolicyEventKafkaProducerTest.java
@@ -55,7 +55,7 @@ class ShippingPolicyEventKafkaProducerTest {
 
         // when
         shippingPolicyEventKafkaProducer.publishShippingPolicyChangedEvent(
-                10L, 3000L, 20000L, ShippingPolicyChangeAction.CREATED
+                10L, 3000L, 20000L, 3000L, 5000L, ShippingPolicyChangeAction.CREATED
         );
 
         // then
@@ -79,7 +79,7 @@ class ShippingPolicyEventKafkaProducerTest {
 
         // when
         shippingPolicyEventKafkaProducer.publishShippingPolicyChangedEvent(
-                10L, 3000L, 20000L, ShippingPolicyChangeAction.CREATED
+                10L, 3000L, 20000L, 3000L, 5000L, ShippingPolicyChangeAction.CREATED
         );
 
         // then
@@ -96,6 +96,8 @@ class ShippingPolicyEventKafkaProducerTest {
         assertThat(payload.sellerId()).isEqualTo(10L);
         assertThat(payload.shippingFee()).isEqualTo(3000L);
         assertThat(payload.freeShippingThreshold()).isEqualTo(20000L);
+        assertThat(payload.jejuSurcharge()).isEqualTo(3000L);
+        assertThat(payload.islandSurcharge()).isEqualTo(5000L);
         assertThat(payload.action()).isEqualTo(ShippingPolicyChangeAction.CREATED);
     }
 
@@ -109,7 +111,7 @@ class ShippingPolicyEventKafkaProducerTest {
 
         // when
         shippingPolicyEventKafkaProducer.publishShippingPolicyChangedEvent(
-                20L, 2500L, 30000L, ShippingPolicyChangeAction.UPDATED
+                20L, 2500L, 30000L, 4000L, 6000L, ShippingPolicyChangeAction.UPDATED
         );
 
         // then
@@ -120,6 +122,8 @@ class ShippingPolicyEventKafkaProducerTest {
         assertThat(payload.sellerId()).isEqualTo(20L);
         assertThat(payload.shippingFee()).isEqualTo(2500L);
         assertThat(payload.freeShippingThreshold()).isEqualTo(30000L);
+        assertThat(payload.jejuSurcharge()).isEqualTo(4000L);
+        assertThat(payload.islandSurcharge()).isEqualTo(6000L);
         assertThat(payload.action()).isEqualTo(ShippingPolicyChangeAction.UPDATED);
     }
 }

--- a/product-service/product-application/src/test/java/com/personal/marketnote/product/service/shipping/RegisterShippingPolicyUseCaseTest.java
+++ b/product-service/product-application/src/test/java/com/personal/marketnote/product/service/shipping/RegisterShippingPolicyUseCaseTest.java
@@ -66,7 +66,7 @@ class RegisterShippingPolicyUseCaseTest {
         when(saveShippingPolicyPort.save(any(ShippingPolicy.class))).thenReturn(1L);
 
         RegisterShippingPolicyCommand command = new RegisterShippingPolicyCommand(
-                "한진택배", 3000L, 20000L
+                "한진택배", 3000L, 20000L, 3000L, 5000L
         );
 
         // when
@@ -83,6 +83,8 @@ class RegisterShippingPolicyUseCaseTest {
         assertThat(savedPolicy.getDeliveryCompany()).isEqualTo("한진택배");
         assertThat(savedPolicy.getShippingFee()).isEqualTo(3000L);
         assertThat(savedPolicy.getFreeShippingThreshold()).isEqualTo(20000L);
+        assertThat(savedPolicy.getJejuSurcharge()).isEqualTo(3000L);
+        assertThat(savedPolicy.getIslandSurcharge()).isEqualTo(5000L);
         assertThat(savedPolicy.isActive()).isTrue();
     }
 
@@ -95,7 +97,7 @@ class RegisterShippingPolicyUseCaseTest {
                 .thenReturn(Optional.of(createSavedPolicy(sellerId)));
 
         RegisterShippingPolicyCommand command = new RegisterShippingPolicyCommand(
-                "한진택배", 3000L, 20000L
+                "한진택배", 3000L, 20000L, 3000L, 5000L
         );
 
         // when & then
@@ -113,7 +115,7 @@ class RegisterShippingPolicyUseCaseTest {
         when(findShippingPolicyPort.findActiveBySellerId(sellerId)).thenReturn(Optional.empty());
 
         RegisterShippingPolicyCommand command = new RegisterShippingPolicyCommand(
-                "한진택배", -1L, 20000L
+                "한진택배", -1L, 20000L, 0L, 0L
         );
 
         // when & then
@@ -131,7 +133,7 @@ class RegisterShippingPolicyUseCaseTest {
         when(findShippingPolicyPort.findActiveBySellerId(sellerId)).thenReturn(Optional.empty());
 
         RegisterShippingPolicyCommand command = new RegisterShippingPolicyCommand(
-                "한진택배", 3000L, -1L
+                "한진택배", 3000L, -1L, 0L, 0L
         );
 
         // when & then
@@ -150,7 +152,7 @@ class RegisterShippingPolicyUseCaseTest {
         when(saveShippingPolicyPort.save(any(ShippingPolicy.class))).thenReturn(1L);
 
         RegisterShippingPolicyCommand command = new RegisterShippingPolicyCommand(
-                "한진택배", 3000L, 20000L
+                "한진택배", 3000L, 20000L, 3000L, 5000L
         );
 
         // when
@@ -158,7 +160,7 @@ class RegisterShippingPolicyUseCaseTest {
 
         // then
         verify(publishShippingPolicyEventPort).publishShippingPolicyChangedEvent(
-                sellerId, 3000L, 20000L, ShippingPolicyChangeAction.CREATED
+                sellerId, 3000L, 20000L, 3000L, 5000L, ShippingPolicyChangeAction.CREATED
         );
     }
 
@@ -171,7 +173,7 @@ class RegisterShippingPolicyUseCaseTest {
                 .thenReturn(Optional.of(createSavedPolicy(sellerId)));
 
         RegisterShippingPolicyCommand command = new RegisterShippingPolicyCommand(
-                "한진택배", 3000L, 20000L
+                "한진택배", 3000L, 20000L, 3000L, 5000L
         );
 
         // when & then

--- a/product-service/product-application/src/test/java/com/personal/marketnote/product/service/shipping/UpdateShippingPolicyUseCaseTest.java
+++ b/product-service/product-application/src/test/java/com/personal/marketnote/product/service/shipping/UpdateShippingPolicyUseCaseTest.java
@@ -66,7 +66,7 @@ class UpdateShippingPolicyUseCaseTest {
                 .thenReturn(Optional.of(existingPolicy));
 
         UpdateShippingPolicyCommand command = new UpdateShippingPolicyCommand(
-                "CJ대한통운", 2500L, 30000L
+                "CJ대한통운", 2500L, 30000L, 4000L, 6000L
         );
 
         // when
@@ -77,6 +77,8 @@ class UpdateShippingPolicyUseCaseTest {
         assertThat(result.deliveryCompany()).isEqualTo("CJ대한통운");
         assertThat(result.shippingFee()).isEqualTo(2500L);
         assertThat(result.freeShippingThreshold()).isEqualTo(30000L);
+        assertThat(result.jejuSurcharge()).isEqualTo(4000L);
+        assertThat(result.islandSurcharge()).isEqualTo(6000L);
 
         verify(updateShippingPolicyPort).update(existingPolicy);
     }
@@ -90,7 +92,7 @@ class UpdateShippingPolicyUseCaseTest {
                 .thenReturn(Optional.empty());
 
         UpdateShippingPolicyCommand command = new UpdateShippingPolicyCommand(
-                "CJ대한통운", 2500L, 30000L
+                "CJ대한통운", 2500L, 30000L, 4000L, 6000L
         );
 
         // when & then
@@ -110,7 +112,7 @@ class UpdateShippingPolicyUseCaseTest {
                 .thenReturn(Optional.of(existingPolicy));
 
         UpdateShippingPolicyCommand command = new UpdateShippingPolicyCommand(
-                "CJ대한통운", -1L, 30000L
+                "CJ대한통운", -1L, 30000L, 0L, 0L
         );
 
         // when & then
@@ -130,7 +132,7 @@ class UpdateShippingPolicyUseCaseTest {
                 .thenReturn(Optional.of(existingPolicy));
 
         UpdateShippingPolicyCommand command = new UpdateShippingPolicyCommand(
-                "CJ대한통운", 2500L, -1L
+                "CJ대한통운", 2500L, -1L, 0L, 0L
         );
 
         // when & then
@@ -150,7 +152,7 @@ class UpdateShippingPolicyUseCaseTest {
                 .thenReturn(Optional.of(existingPolicy));
 
         UpdateShippingPolicyCommand command = new UpdateShippingPolicyCommand(
-                "CJ대한통운", 2500L, 30000L
+                "CJ대한통운", 2500L, 30000L, 4000L, 6000L
         );
 
         // when
@@ -158,7 +160,7 @@ class UpdateShippingPolicyUseCaseTest {
 
         // then
         verify(publishShippingPolicyEventPort).publishShippingPolicyChangedEvent(
-                sellerId, 2500L, 30000L, ShippingPolicyChangeAction.UPDATED
+                sellerId, 2500L, 30000L, 4000L, 6000L, ShippingPolicyChangeAction.UPDATED
         );
     }
 
@@ -171,7 +173,7 @@ class UpdateShippingPolicyUseCaseTest {
                 .thenReturn(Optional.empty());
 
         UpdateShippingPolicyCommand command = new UpdateShippingPolicyCommand(
-                "CJ대한통운", 2500L, 30000L
+                "CJ대한통운", 2500L, 30000L, 4000L, 6000L
         );
 
         // when & then

--- a/product-service/product-domain/src/test/java/com/personal/marketnote/product/domain/shipping/ShippingPolicyTest.java
+++ b/product-service/product-domain/src/test/java/com/personal/marketnote/product/domain/shipping/ShippingPolicyTest.java
@@ -88,6 +88,84 @@ class ShippingPolicyTest {
             assertThat(policy.getShippingFee()).isZero();
             assertThat(policy.getFreeShippingThreshold()).isZero();
         }
+
+        @Test
+        @DisplayName("제주/도서산간 추가 배송비를 포함하여 정책을 생성한다")
+        void shouldCreateShippingPolicyWithSurcharges() {
+            // given
+            ShippingPolicyCreateState state = ShippingPolicyCreateState.builder()
+                    .sellerId(1L)
+                    .deliveryCompany("한진택배")
+                    .shippingFee(3000L)
+                    .freeShippingThreshold(20000L)
+                    .jejuSurcharge(3000L)
+                    .islandSurcharge(5000L)
+                    .build();
+
+            // when
+            ShippingPolicy policy = ShippingPolicy.from(state);
+
+            // then
+            assertThat(policy.getJejuSurcharge()).isEqualTo(3000L);
+            assertThat(policy.getIslandSurcharge()).isEqualTo(5000L);
+        }
+
+        @Test
+        @DisplayName("제주 추가 배송비가 null이면 0으로 기본값 설정된다")
+        void shouldDefaultJejuSurchargeToZeroWhenNull() {
+            // given
+            ShippingPolicyCreateState state = ShippingPolicyCreateState.builder()
+                    .sellerId(1L)
+                    .deliveryCompany("한진택배")
+                    .shippingFee(3000L)
+                    .freeShippingThreshold(20000L)
+                    .jejuSurcharge(null)
+                    .islandSurcharge(null)
+                    .build();
+
+            // when
+            ShippingPolicy policy = ShippingPolicy.from(state);
+
+            // then
+            assertThat(policy.getJejuSurcharge()).isZero();
+            assertThat(policy.getIslandSurcharge()).isZero();
+        }
+
+        @Test
+        @DisplayName("제주 추가 배송비가 음수이면 예외가 발생한다")
+        void shouldThrowExceptionWhenJejuSurchargeIsNegative() {
+            // given
+            ShippingPolicyCreateState state = ShippingPolicyCreateState.builder()
+                    .sellerId(1L)
+                    .deliveryCompany("한진택배")
+                    .shippingFee(3000L)
+                    .freeShippingThreshold(20000L)
+                    .jejuSurcharge(-1L)
+                    .islandSurcharge(0L)
+                    .build();
+
+            // when & then
+            assertThatThrownBy(() -> ShippingPolicy.from(state))
+                    .isInstanceOf(InvalidJejuSurchargeException.class);
+        }
+
+        @Test
+        @DisplayName("도서산간 추가 배송비가 음수이면 예외가 발생한다")
+        void shouldThrowExceptionWhenIslandSurchargeIsNegative() {
+            // given
+            ShippingPolicyCreateState state = ShippingPolicyCreateState.builder()
+                    .sellerId(1L)
+                    .deliveryCompany("한진택배")
+                    .shippingFee(3000L)
+                    .freeShippingThreshold(20000L)
+                    .jejuSurcharge(0L)
+                    .islandSurcharge(-1L)
+                    .build();
+
+            // when & then
+            assertThatThrownBy(() -> ShippingPolicy.from(state))
+                    .isInstanceOf(InvalidIslandSurchargeException.class);
+        }
     }
 
     @Nested
@@ -105,6 +183,8 @@ class ShippingPolicyTest {
                     .deliveryCompany("CJ대한통운")
                     .shippingFee(2500L)
                     .freeShippingThreshold(30000L)
+                    .jejuSurcharge(3000L)
+                    .islandSurcharge(5000L)
                     .status(EntityStatus.INACTIVE)
                     .createdAt(now)
                     .modifiedAt(now)
@@ -119,9 +199,37 @@ class ShippingPolicyTest {
             assertThat(policy.getDeliveryCompany()).isEqualTo("CJ대한통운");
             assertThat(policy.getShippingFee()).isEqualTo(2500L);
             assertThat(policy.getFreeShippingThreshold()).isEqualTo(30000L);
+            assertThat(policy.getJejuSurcharge()).isEqualTo(3000L);
+            assertThat(policy.getIslandSurcharge()).isEqualTo(5000L);
             assertThat(policy.isInactive()).isTrue();
             assertThat(policy.getCreatedAt()).isEqualTo(now);
             assertThat(policy.getModifiedAt()).isEqualTo(now);
+        }
+
+        @Test
+        @DisplayName("DB 스냅샷에 추가 배송비가 null이면 null로 복원한다")
+        void shouldRestoreNullSurchargesFromSnapshot() {
+            // given
+            LocalDateTime now = LocalDateTime.of(2026, 3, 10, 12, 0);
+            ShippingPolicySnapshotState state = ShippingPolicySnapshotState.builder()
+                    .id(10L)
+                    .sellerId(1L)
+                    .deliveryCompany("CJ대한통운")
+                    .shippingFee(2500L)
+                    .freeShippingThreshold(30000L)
+                    .jejuSurcharge(null)
+                    .islandSurcharge(null)
+                    .status(EntityStatus.ACTIVE)
+                    .createdAt(now)
+                    .modifiedAt(now)
+                    .build();
+
+            // when
+            ShippingPolicy policy = ShippingPolicy.from(state);
+
+            // then
+            assertThat(policy.getJejuSurcharge()).isNull();
+            assertThat(policy.getIslandSurcharge()).isNull();
         }
     }
 
@@ -136,12 +244,14 @@ class ShippingPolicyTest {
             ShippingPolicy policy = createDefaultPolicy();
 
             // when
-            policy.update("CJ대한통운", 2500L, 30000L);
+            policy.update("CJ대한통운", 2500L, 30000L, 4000L, 6000L);
 
             // then
             assertThat(policy.getDeliveryCompany()).isEqualTo("CJ대한통운");
             assertThat(policy.getShippingFee()).isEqualTo(2500L);
             assertThat(policy.getFreeShippingThreshold()).isEqualTo(30000L);
+            assertThat(policy.getJejuSurcharge()).isEqualTo(4000L);
+            assertThat(policy.getIslandSurcharge()).isEqualTo(6000L);
         }
 
         @Test
@@ -151,7 +261,7 @@ class ShippingPolicyTest {
             ShippingPolicy policy = createDefaultPolicy();
 
             // when & then
-            assertThatThrownBy(() -> policy.update("CJ대한통운", -1L, 30000L))
+            assertThatThrownBy(() -> policy.update("CJ대한통운", -1L, 30000L, 0L, 0L))
                     .isInstanceOf(InvalidShippingFeeException.class);
         }
 
@@ -162,8 +272,44 @@ class ShippingPolicyTest {
             ShippingPolicy policy = createDefaultPolicy();
 
             // when & then
-            assertThatThrownBy(() -> policy.update("CJ대한통운", 3000L, -1L))
+            assertThatThrownBy(() -> policy.update("CJ대한통운", 3000L, -1L, 0L, 0L))
                     .isInstanceOf(InvalidFreeShippingThresholdException.class);
+        }
+
+        @Test
+        @DisplayName("수정 시 제주 추가 배송비가 음수이면 예외가 발생한다")
+        void shouldThrowExceptionWhenUpdateWithNegativeJejuSurcharge() {
+            // given
+            ShippingPolicy policy = createDefaultPolicy();
+
+            // when & then
+            assertThatThrownBy(() -> policy.update("CJ대한통운", 3000L, 30000L, -1L, 0L))
+                    .isInstanceOf(InvalidJejuSurchargeException.class);
+        }
+
+        @Test
+        @DisplayName("수정 시 도서산간 추가 배송비가 음수이면 예외가 발생한다")
+        void shouldThrowExceptionWhenUpdateWithNegativeIslandSurcharge() {
+            // given
+            ShippingPolicy policy = createDefaultPolicy();
+
+            // when & then
+            assertThatThrownBy(() -> policy.update("CJ대한통운", 3000L, 30000L, 0L, -1L))
+                    .isInstanceOf(InvalidIslandSurchargeException.class);
+        }
+
+        @Test
+        @DisplayName("수정 시 제주/도서산간 추가 배송비가 null이면 0으로 기본값 설정된다")
+        void shouldDefaultSurchargesToZeroWhenNullOnUpdate() {
+            // given
+            ShippingPolicy policy = createDefaultPolicy();
+
+            // when
+            policy.update("CJ대한통운", 2500L, 30000L, null, null);
+
+            // then
+            assertThat(policy.getJejuSurcharge()).isZero();
+            assertThat(policy.getIslandSurcharge()).isZero();
         }
     }
 


### PR DESCRIPTION
## partially addresses #128
## resolves #2240

## Test Case
- [x] 유효한 값으로 제주/도서산간 추가 배송비 포함 정책 생성
- [x] 제주/도서산간 추가 배송비 null 시 기본값 0 설정
- [x] 제주 추가 배송비 음수 시 InvalidJejuSurchargeException
- [x] 도서산간 추가 배송비 음수 시 InvalidIslandSurchargeException
- [x] DB 스냅샷 복원 시 제주/도서산간 추가 배송비 매핑
- [x] DB 스냅샷에 추가 배송비 null 시 null 보존
- [x] 수정 시 제주/도서산간 추가 배송비 반영
- [x] 수정 시 제주 추가 배송비 음수 예외
- [x] 수정 시 도서산간 추가 배송비 음수 예외
- [x] 수정 시 null 기본값 0 설정
- [x] 등록/수정/조회 UseCase 테스트 surcharge 필드 반영
- [x] Kafka Producer 테스트 surcharge 필드 검증
- [x] Commerce Consumer/PersistenceAdapter 테스트 surcharge 필드 반영