### PR TITLE
[#216][#1940] feat: 주문 취소 SAGA Definition 및 Context 추가

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/ShippingPolicyChangedReadModelConsumer.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/ShippingPolicyChangedReadModelConsumer.java
@@ -3,7 +3,6 @@ package com.personal.marketnote.commerce.adapter.in.event;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.personal.marketnote.commerce.port.out.shipping.SaveShippingPolicyReadModelPort;
 import com.personal.marketnote.common.kafka.KafkaTopicConstants;
-import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.common.kafka.event.EventEnvelope;
 import com.personal.marketnote.common.kafka.event.EventPayloadValidator;
 import com.personal.marketnote.common.kafka.event.ShippingPolicyChangedEvent;
@@ -59,15 +58,11 @@ public class ShippingPolicyChangedReadModelConsumer {
         }
 
         if (payload.action().isCreated() || payload.action().isUpdated()) {
-            Long jejuSurcharge = FormatValidator.hasNoValue(payload.jejuSurcharge()) ? 0L : payload.jejuSurcharge();
-            Long islandSurcharge = FormatValidator.hasNoValue(payload.islandSurcharge()) ? 0L : payload.islandSurcharge();
             saveShippingPolicyReadModelPort.upsert(
-                    payload.sellerId(), payload.shippingFee(), payload.freeShippingThreshold(),
-                    jejuSurcharge, islandSurcharge
+                    payload.sellerId(), payload.shippingFee(), payload.freeShippingThreshold()
             );
-            log.info("배송비 정책 Read Model 저장 완료. sellerId={}, shippingFee={}, freeShippingThreshold={}, jejuSurcharge={}, islandSurcharge={}",
-                    payload.sellerId(), payload.shippingFee(), payload.freeShippingThreshold(),
-                    payload.jejuSurcharge(), payload.islandSurcharge());
+            log.info("배송비 정책 Read Model 저장 완료. sellerId={}, shippingFee={}, freeShippingThreshold={}",
+                    payload.sellerId(), payload.shippingFee(), payload.freeShippingThreshold());
         }
 
         acknowledgment.acknowledge();

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/shipping/ShippingPolicyReadModelPersistenceAdapter.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/shipping/ShippingPolicyReadModelPersistenceAdapter.java
@@ -42,9 +42,7 @@ public class ShippingPolicyReadModelPersistenceAdapter implements FindShippingPo
             result.put(entity.getSellerId(), new ShippingPolicyInfoResult(
                     entity.getSellerId(),
                     entity.getShippingFee(),
-                    entity.getFreeShippingThreshold(),
-                    entity.getJejuSurcharge(),
-                    entity.getIslandSurcharge()
+                    entity.getFreeShippingThreshold()
             ));
         }
 
@@ -53,24 +51,23 @@ public class ShippingPolicyReadModelPersistenceAdapter implements FindShippingPo
 
     @Override
     @Transactional(isolation = READ_COMMITTED)
-    public void upsert(Long sellerId, Long shippingFee, Long freeShippingThreshold,
-                       Long jejuSurcharge, Long islandSurcharge) {
+    public void upsert(Long sellerId, Long shippingFee, Long freeShippingThreshold) {
         Optional<ShippingPolicyReadModelJpaEntity> existing = shippingPolicyReadModelJpaRepository.findBySellerId(sellerId);
 
         if (existing.isPresent()) {
-            existing.get().updateFrom(shippingFee, freeShippingThreshold, jejuSurcharge, islandSurcharge);
+            existing.get().updateFrom(shippingFee, freeShippingThreshold);
             return;
         }
 
         try {
             ShippingPolicyReadModelJpaEntity entity = ShippingPolicyReadModelJpaEntity.of(
-                    sellerId, shippingFee, freeShippingThreshold, jejuSurcharge, islandSurcharge
+                    sellerId, shippingFee, freeShippingThreshold
             );
             shippingPolicyReadModelJpaRepository.saveAndFlush(entity);
         } catch (DataIntegrityViolationException e) {
             log.info("배송비 정책 Read Model 중복 저장 (멱등 처리). sellerId={}", sellerId);
             shippingPolicyReadModelJpaRepository.findBySellerId(sellerId)
-                    .ifPresent(entity -> entity.updateFrom(shippingFee, freeShippingThreshold, jejuSurcharge, islandSurcharge));
+                    .ifPresent(entity -> entity.updateFrom(shippingFee, freeShippingThreshold));
         }
     }
 

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/shipping/entity/ShippingPolicyReadModelJpaEntity.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/shipping/entity/ShippingPolicyReadModelJpaEntity.java
@@ -30,29 +30,17 @@ public class ShippingPolicyReadModelJpaEntity extends BaseGeneralEntity {
     @Column(name = "free_shipping_threshold", nullable = false)
     private Long freeShippingThreshold;
 
-    @Column(name = "jeju_surcharge")
-    private Long jejuSurcharge;
-
-    @Column(name = "island_surcharge")
-    private Long islandSurcharge;
-
-    public static ShippingPolicyReadModelJpaEntity of(Long sellerId, Long shippingFee, Long freeShippingThreshold,
-                                                      Long jejuSurcharge, Long islandSurcharge) {
+    public static ShippingPolicyReadModelJpaEntity of(Long sellerId, Long shippingFee, Long freeShippingThreshold) {
         return ShippingPolicyReadModelJpaEntity.builder()
                 .sellerId(sellerId)
                 .shippingFee(shippingFee)
                 .freeShippingThreshold(freeShippingThreshold)
-                .jejuSurcharge(jejuSurcharge)
-                .islandSurcharge(islandSurcharge)
                 .build();
     }
 
-    public void updateFrom(Long shippingFee, Long freeShippingThreshold,
-                           Long jejuSurcharge, Long islandSurcharge) {
+    public void updateFrom(Long shippingFee, Long freeShippingThreshold) {
         this.shippingFee = shippingFee;
         this.freeShippingThreshold = freeShippingThreshold;
-        this.jejuSurcharge = jejuSurcharge;
-        this.islandSurcharge = islandSurcharge;
         activate();
     }
 

--- a/commerce-service/commerce-adapters/src/main/resources/db/migration/V914__add_surcharge_to_shipping_policy_read_models.sql
+++ b/commerce-service/commerce-adapters/src/main/resources/db/migration/V914__add_surcharge_to_shipping_policy_read_models.sql
@@ -1,2 +1,0 @@
-ALTER TABLE shipping_policy_read_models ADD COLUMN jeju_surcharge BIGINT DEFAULT 0;
-ALTER TABLE shipping_policy_read_models ADD COLUMN island_surcharge BIGINT DEFAULT 0;

--- a/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/event/ShippingPolicyChangedReadModelConsumerTest.java
+++ b/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/event/ShippingPolicyChangedReadModelConsumerTest.java
@@ -58,7 +58,7 @@ class ShippingPolicyChangedReadModelConsumerTest {
     void handleShippingPolicyChangedEvent_created_upsertsReadModel() {
         // given
         ShippingPolicyChangedEvent payload = new ShippingPolicyChangedEvent(
-                10L, 3000L, 20000L, 3000L, 5000L, ShippingPolicyChangeAction.CREATED
+                10L, 3000L, 20000L, ShippingPolicyChangeAction.CREATED
         );
         EventEnvelope<ShippingPolicyChangedEvent> envelope = createEnvelope(payload);
         ConsumerRecord<String, EventEnvelope<?>> record = createRecord(envelope);
@@ -67,7 +67,7 @@ class ShippingPolicyChangedReadModelConsumerTest {
         consumer.handleShippingPolicyChangedEvent(record, acknowledgment);
 
         // then
-        verify(saveShippingPolicyReadModelPort).upsert(10L, 3000L, 20000L, 3000L, 5000L);
+        verify(saveShippingPolicyReadModelPort).upsert(10L, 3000L, 20000L);
         verify(acknowledgment).acknowledge();
     }
 
@@ -76,7 +76,7 @@ class ShippingPolicyChangedReadModelConsumerTest {
     void handleShippingPolicyChangedEvent_updated_upsertsReadModel() {
         // given
         ShippingPolicyChangedEvent payload = new ShippingPolicyChangedEvent(
-                20L, 2500L, 30000L, 4000L, 6000L, ShippingPolicyChangeAction.UPDATED
+                20L, 2500L, 30000L, ShippingPolicyChangeAction.UPDATED
         );
         EventEnvelope<ShippingPolicyChangedEvent> envelope = createEnvelope(payload);
         ConsumerRecord<String, EventEnvelope<?>> record = createRecord(envelope);
@@ -85,7 +85,7 @@ class ShippingPolicyChangedReadModelConsumerTest {
         consumer.handleShippingPolicyChangedEvent(record, acknowledgment);
 
         // then
-        verify(saveShippingPolicyReadModelPort).upsert(20L, 2500L, 30000L, 4000L, 6000L);
+        verify(saveShippingPolicyReadModelPort).upsert(20L, 2500L, 30000L);
         verify(acknowledgment).acknowledge();
     }
 
@@ -94,7 +94,7 @@ class ShippingPolicyChangedReadModelConsumerTest {
     void handleShippingPolicyChangedEvent_deleted_deactivatesReadModel() {
         // given
         ShippingPolicyChangedEvent payload = new ShippingPolicyChangedEvent(
-                10L, 3000L, 20000L, 3000L, 5000L, ShippingPolicyChangeAction.DELETED
+                10L, 3000L, 20000L, ShippingPolicyChangeAction.DELETED
         );
         EventEnvelope<ShippingPolicyChangedEvent> envelope = createEnvelope(payload);
         ConsumerRecord<String, EventEnvelope<?>> record = createRecord(envelope);
@@ -129,7 +129,7 @@ class ShippingPolicyChangedReadModelConsumerTest {
     void handleShippingPolicyChangedEvent_eventTypeMismatch_acknowledges() {
         // given
         ShippingPolicyChangedEvent payload = new ShippingPolicyChangedEvent(
-                10L, 3000L, 20000L, 3000L, 5000L, ShippingPolicyChangeAction.CREATED
+                10L, 3000L, 20000L, ShippingPolicyChangeAction.CREATED
         );
         EventEnvelope<ShippingPolicyChangedEvent> envelope = new EventEnvelope<>(
                 "test-event-id",
@@ -153,7 +153,7 @@ class ShippingPolicyChangedReadModelConsumerTest {
     void handleShippingPolicyChangedEvent_nullSellerId_acknowledges() {
         // given
         ShippingPolicyChangedEvent payload = new ShippingPolicyChangedEvent(
-                null, 3000L, 20000L, 3000L, 5000L, ShippingPolicyChangeAction.CREATED
+                null, 3000L, 20000L, ShippingPolicyChangeAction.CREATED
         );
         EventEnvelope<ShippingPolicyChangedEvent> envelope = createEnvelope(payload);
         ConsumerRecord<String, EventEnvelope<?>> record = createRecord(envelope);
@@ -171,7 +171,7 @@ class ShippingPolicyChangedReadModelConsumerTest {
     void handleShippingPolicyChangedEvent_zeroSellerId_acknowledges() {
         // given
         ShippingPolicyChangedEvent payload = new ShippingPolicyChangedEvent(
-                0L, 3000L, 20000L, 0L, 0L, ShippingPolicyChangeAction.CREATED
+                0L, 3000L, 20000L, ShippingPolicyChangeAction.CREATED
         );
         EventEnvelope<ShippingPolicyChangedEvent> envelope = createEnvelope(payload);
         ConsumerRecord<String, EventEnvelope<?>> record = createRecord(envelope);
@@ -189,7 +189,7 @@ class ShippingPolicyChangedReadModelConsumerTest {
     void handleShippingPolicyChangedEvent_negativeSellerId_acknowledges() {
         // given
         ShippingPolicyChangedEvent payload = new ShippingPolicyChangedEvent(
-                -1L, 3000L, 20000L, 0L, 0L, ShippingPolicyChangeAction.CREATED
+                -1L, 3000L, 20000L, ShippingPolicyChangeAction.CREATED
         );
         EventEnvelope<ShippingPolicyChangedEvent> envelope = createEnvelope(payload);
         ConsumerRecord<String, EventEnvelope<?>> record = createRecord(envelope);

--- a/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/out/persistence/shipping/ShippingPolicyReadModelPersistenceAdapterTest.java
+++ b/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/out/persistence/shipping/ShippingPolicyReadModelPersistenceAdapterTest.java
@@ -45,8 +45,8 @@ class ShippingPolicyReadModelPersistenceAdapterTest {
         @DisplayName("ACTIVE 상태의 배송비 정책을 판매자 ID별 맵으로 반환한다")
         void returnsActivePoliciesAsMap() {
             // given
-            adapter.upsert(10L, 3000L, 20000L, 3000L, 5000L);
-            adapter.upsert(20L, 2500L, 30000L, 4000L, 6000L);
+            adapter.upsert(10L, 3000L, 20000L);
+            adapter.upsert(20L, 2500L, 30000L);
 
             // when
             Map<Long, ShippingPolicyInfoResult> result = adapter.findBySellerIds(List.of(10L, 20L));
@@ -56,13 +56,9 @@ class ShippingPolicyReadModelPersistenceAdapterTest {
             assertThat(result.get(10L).sellerId()).isEqualTo(10L);
             assertThat(result.get(10L).shippingFee()).isEqualTo(3000L);
             assertThat(result.get(10L).freeShippingThreshold()).isEqualTo(20000L);
-            assertThat(result.get(10L).jejuSurcharge()).isEqualTo(3000L);
-            assertThat(result.get(10L).islandSurcharge()).isEqualTo(5000L);
             assertThat(result.get(20L).sellerId()).isEqualTo(20L);
             assertThat(result.get(20L).shippingFee()).isEqualTo(2500L);
             assertThat(result.get(20L).freeShippingThreshold()).isEqualTo(30000L);
-            assertThat(result.get(20L).jejuSurcharge()).isEqualTo(4000L);
-            assertThat(result.get(20L).islandSurcharge()).isEqualTo(6000L);
         }
 
         @Test
@@ -89,7 +85,7 @@ class ShippingPolicyReadModelPersistenceAdapterTest {
         @DisplayName("INACTIVE 상태의 배송비 정책은 조회하지 않는다")
         void excludesInactivePolicies() {
             // given
-            adapter.upsert(10L, 3000L, 20000L, 3000L, 5000L);
+            adapter.upsert(10L, 3000L, 20000L);
             adapter.deactivateBySellerId(10L);
 
             // when
@@ -103,7 +99,7 @@ class ShippingPolicyReadModelPersistenceAdapterTest {
         @DisplayName("존재하지 않는 sellerId는 결과에 포함하지 않는다")
         void excludesNonExistentSellerIds() {
             // given
-            adapter.upsert(10L, 3000L, 20000L, 3000L, 5000L);
+            adapter.upsert(10L, 3000L, 20000L);
 
             // when
             Map<Long, ShippingPolicyInfoResult> result = adapter.findBySellerIds(List.of(10L, 999L));
@@ -123,7 +119,7 @@ class ShippingPolicyReadModelPersistenceAdapterTest {
         @DisplayName("신규 배송비 정책을 저장한다")
         void insertsNewPolicy() {
             // when
-            adapter.upsert(10L, 3000L, 20000L, 3000L, 5000L);
+            adapter.upsert(10L, 3000L, 20000L);
 
             // then
             Optional<ShippingPolicyReadModelJpaEntity> entity = repository.findBySellerIdAndStatus(10L, EntityStatus.ACTIVE);
@@ -131,8 +127,6 @@ class ShippingPolicyReadModelPersistenceAdapterTest {
             assertThat(entity.get().getSellerId()).isEqualTo(10L);
             assertThat(entity.get().getShippingFee()).isEqualTo(3000L);
             assertThat(entity.get().getFreeShippingThreshold()).isEqualTo(20000L);
-            assertThat(entity.get().getJejuSurcharge()).isEqualTo(3000L);
-            assertThat(entity.get().getIslandSurcharge()).isEqualTo(5000L);
             assertThat(entity.get().getStatus()).isEqualTo(EntityStatus.ACTIVE);
         }
 
@@ -140,29 +134,27 @@ class ShippingPolicyReadModelPersistenceAdapterTest {
         @DisplayName("동일한 sellerId로 upsert 시 기존 데이터를 업데이트한다")
         void updatesExistingPolicy() {
             // given
-            adapter.upsert(10L, 3000L, 20000L, 3000L, 5000L);
+            adapter.upsert(10L, 3000L, 20000L);
 
             // when
-            adapter.upsert(10L, 5000L, 50000L, 7000L, 8000L);
+            adapter.upsert(10L, 5000L, 50000L);
 
             // then
             Optional<ShippingPolicyReadModelJpaEntity> entity = repository.findBySellerIdAndStatus(10L, EntityStatus.ACTIVE);
             assertThat(entity).isPresent();
             assertThat(entity.get().getShippingFee()).isEqualTo(5000L);
             assertThat(entity.get().getFreeShippingThreshold()).isEqualTo(50000L);
-            assertThat(entity.get().getJejuSurcharge()).isEqualTo(7000L);
-            assertThat(entity.get().getIslandSurcharge()).isEqualTo(8000L);
         }
 
         @Test
         @DisplayName("비활성화된 정책에 대해 upsert 시 다시 활성화된다")
         void reactivatesInactivePolicy() {
             // given
-            adapter.upsert(10L, 3000L, 20000L, 3000L, 5000L);
+            adapter.upsert(10L, 3000L, 20000L);
             adapter.deactivateBySellerId(10L);
 
             // when
-            adapter.upsert(10L, 5000L, 50000L, 7000L, 8000L);
+            adapter.upsert(10L, 5000L, 50000L);
 
             // then
             Optional<ShippingPolicyReadModelJpaEntity> entity = repository.findBySellerIdAndStatus(10L, EntityStatus.ACTIVE);
@@ -180,7 +172,7 @@ class ShippingPolicyReadModelPersistenceAdapterTest {
         @DisplayName("배송비 정책을 비활성화한다")
         void deactivatesPolicy() {
             // given
-            adapter.upsert(10L, 3000L, 20000L, 3000L, 5000L);
+            adapter.upsert(10L, 3000L, 20000L);
 
             // when
             adapter.deactivateBySellerId(10L);

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/command/saga/OrderCancelSagaContext.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/command/saga/OrderCancelSagaContext.java
@@ -1,0 +1,22 @@
+package com.personal.marketnote.commerce.port.in.command.saga;
+
+import com.personal.marketnote.commerce.port.in.command.saga.OrderPaymentSagaContext.OrderProductItem;
+
+import java.util.List;
+
+public record OrderCancelSagaContext(
+        Long orderId,
+        String orderKey,
+        Long buyerId,
+        Long cancelAmount,
+        Long paymentAmount,
+        Long pointAmount,
+        Long shippingFee,
+        boolean isFullCancel,
+        Long alreadyRefunded,
+        String originalStatus,
+        String reasonCategory,
+        String reason,
+        List<OrderProductItem> orderProducts
+) {
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/result/shipping/ShippingPolicyInfoResult.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/result/shipping/ShippingPolicyInfoResult.java
@@ -3,9 +3,6 @@ package com.personal.marketnote.commerce.port.out.result.shipping;
 public record ShippingPolicyInfoResult(
         Long sellerId,
         Long shippingFee,
-        Long freeShippingThreshold,
-        Long jejuSurcharge,
-        Long islandSurcharge
+        Long freeShippingThreshold
 ) {
 }
-

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/shipping/SaveShippingPolicyReadModelPort.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/shipping/SaveShippingPolicyReadModelPort.java
@@ -2,8 +2,7 @@ package com.personal.marketnote.commerce.port.out.shipping;
 
 public interface SaveShippingPolicyReadModelPort {
 
-    void upsert(Long sellerId, Long shippingFee, Long freeShippingThreshold,
-                Long jejuSurcharge, Long islandSurcharge);
+    void upsert(Long sellerId, Long shippingFee, Long freeShippingThreshold);
 
     void deactivateBySellerId(Long sellerId);
 }

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/saga/OrderCancelSagaDefinition.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/saga/OrderCancelSagaDefinition.java
@@ -1,0 +1,110 @@
+package com.personal.marketnote.commerce.service.saga;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.commerce.port.in.command.saga.OrderCancelSagaContext;
+import com.personal.marketnote.common.kafka.KafkaTopicConstants;
+import com.personal.marketnote.common.saga.SagaDefinition;
+import com.personal.marketnote.common.saga.SagaStepDefinition;
+import com.personal.marketnote.common.saga.exception.SagaSerializationException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Map.entry;
+
+@Component
+@ConditionalOnProperty(prefix = "saga", name = "enabled", havingValue = "true")
+@RequiredArgsConstructor
+public class OrderCancelSagaDefinition implements SagaDefinition<OrderCancelSagaContext> {
+
+    public static final String SAGA_TYPE = "ORDER_CANCEL";
+    public static final String STEP_CANCEL_FULFILLMENT_RELEASE = "CANCEL_FULFILLMENT_RELEASE";
+    public static final String STEP_REFUND_PAYMENT = "REFUND_PAYMENT";
+    public static final String STEP_COMPLETE_CANCELLATION = "COMPLETE_CANCELLATION";
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public String getSagaType() {
+        return SAGA_TYPE;
+    }
+
+    @Override
+    public Class<OrderCancelSagaContext> getContextType() {
+        return OrderCancelSagaContext.class;
+    }
+
+    @Override
+    public List<SagaStepDefinition<OrderCancelSagaContext>> getSteps() {
+        return List.of(
+                new SagaStepDefinition<>(
+                        STEP_CANCEL_FULFILLMENT_RELEASE,
+                        KafkaTopicConstants.SAGA_ORDER_CANCEL_FULFILLMENT,
+                        this::buildFulfillmentCancelAction,
+                        null
+                ),
+                new SagaStepDefinition<>(
+                        STEP_REFUND_PAYMENT,
+                        KafkaTopicConstants.SAGA_ORDER_CANCEL_REFUND,
+                        this::buildRefundPaymentAction,
+                        null
+                ),
+                new SagaStepDefinition<>(
+                        STEP_COMPLETE_CANCELLATION,
+                        KafkaTopicConstants.SAGA_ORDER_CANCEL_COMPLETED,
+                        this::buildCompleteCancellationAction,
+                        null
+                )
+        );
+    }
+
+    private String buildFulfillmentCancelAction(OrderCancelSagaContext context) {
+        return serialize(Map.of(
+                "orderId", context.orderId(),
+                "originalStatus", context.originalStatus()
+        ));
+    }
+
+    private String buildRefundPaymentAction(OrderCancelSagaContext context) {
+        return serialize(Map.of(
+                "orderId", context.orderId(),
+                "orderKey", context.orderKey(),
+                "buyerId", context.buyerId(),
+                "cancelAmount", context.cancelAmount(),
+                "paymentAmount", context.paymentAmount(),
+                "pointAmount", context.pointAmount(),
+                "shippingFee", context.shippingFee(),
+                "isFullCancel", context.isFullCancel(),
+                "alreadyRefunded", context.alreadyRefunded()
+        ));
+    }
+
+    private String buildCompleteCancellationAction(OrderCancelSagaContext context) {
+        return serialize(Map.ofEntries(
+                entry("orderId", context.orderId()),
+                entry("orderKey", context.orderKey()),
+                entry("buyerId", context.buyerId()),
+                entry("cancelAmount", context.cancelAmount()),
+                entry("paymentAmount", context.paymentAmount()),
+                entry("pointAmount", context.pointAmount()),
+                entry("shippingFee", context.shippingFee()),
+                entry("isFullCancel", context.isFullCancel()),
+                entry("alreadyRefunded", context.alreadyRefunded()),
+                entry("reasonCategory", context.reasonCategory()),
+                entry("reason", context.reason()),
+                entry("orderProducts", context.orderProducts())
+        ));
+    }
+
+    private String serialize(Object value) {
+        try {
+            return objectMapper.writeValueAsString(value);
+        } catch (JsonProcessingException e) {
+            throw new SagaSerializationException("OrderCancel SAGA 페이로드 직렬화에 실패했습니다.", e);
+        }
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/saga/OrderCancelSagaStarter.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/saga/OrderCancelSagaStarter.java
@@ -1,0 +1,29 @@
+package com.personal.marketnote.commerce.service.saga;
+
+import com.personal.marketnote.commerce.port.in.command.saga.OrderCancelSagaContext;
+import com.personal.marketnote.common.saga.SagaOrchestrator;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@ConditionalOnProperty(prefix = "saga", name = "enabled", havingValue = "true")
+@RequiredArgsConstructor
+public class OrderCancelSagaStarter {
+
+    private static final String SAGA_ID_PREFIX = "ORDER_CANCEL:";
+
+    private final SagaOrchestrator sagaOrchestrator;
+    private final OrderCancelSagaDefinition orderCancelSagaDefinition;
+
+    public void start(OrderCancelSagaContext context) {
+        String sagaId = SAGA_ID_PREFIX + context.orderId();
+
+        log.info("OrderCancel SAGA 시작. sagaId={}, orderId={}, originalStatus={}",
+                sagaId, context.orderId(), context.originalStatus());
+
+        sagaOrchestrator.start(orderCancelSagaDefinition, sagaId, context);
+    }
+}

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/RegisterOrderUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/RegisterOrderUseCaseTest.java
@@ -2193,8 +2193,8 @@ class RegisterOrderUseCaseTest {
                     pricePolicyId2, Map.entry(50000L, 20L)
             ));
             mockShippingPolicies(Map.of(
-                    10L, new ShippingPolicyInfoResult(10L, shippingFeeA, 100000L, 0L, 0L),
-                    20L, new ShippingPolicyInfoResult(20L, shippingFeeB, 100000L, 0L, 0L)
+                    10L, new ShippingPolicyInfoResult(10L, shippingFeeA, 100000L),
+                    20L, new ShippingPolicyInfoResult(20L, shippingFeeB, 100000L)
             ));
             Inventory inventory1 = Inventory.of(1L, pricePolicyId1, 100);
             Inventory inventory2 = Inventory.of(2L, pricePolicyId2, 50);
@@ -2484,8 +2484,8 @@ class RegisterOrderUseCaseTest {
                     pricePolicyIdB, Map.entry(unitAmountB, sellerIdB)
             ));
             mockShippingPolicies(Map.of(
-                    sellerIdA, new ShippingPolicyInfoResult(sellerIdA, shippingFeeA, 20000L, 0L, 0L),
-                    sellerIdB, new ShippingPolicyInfoResult(sellerIdB, shippingFeeB, 20000L, 0L, 0L)
+                    sellerIdA, new ShippingPolicyInfoResult(sellerIdA, shippingFeeA, 20000L),
+                    sellerIdB, new ShippingPolicyInfoResult(sellerIdB, shippingFeeB, 20000L)
             ));
             mockInventoryMultiple(Map.of(pricePolicyIdA, 100, pricePolicyIdB, 100));
             Order savedOrder = mockSavedOrder(1L);
@@ -2532,8 +2532,8 @@ class RegisterOrderUseCaseTest {
                     pricePolicyIdB, Map.entry(unitAmountB, sellerIdB)
             ));
             mockShippingPolicies(Map.of(
-                    sellerIdA, new ShippingPolicyInfoResult(sellerIdA, 3000L, 20000L, 0L, 0L),
-                    sellerIdB, new ShippingPolicyInfoResult(sellerIdB, shippingFeeB, 20000L, 0L, 0L)
+                    sellerIdA, new ShippingPolicyInfoResult(sellerIdA, 3000L, 20000L),
+                    sellerIdB, new ShippingPolicyInfoResult(sellerIdB, shippingFeeB, 20000L)
             ));
             mockInventoryMultiple(Map.of(pricePolicyIdA, 100, pricePolicyIdB, 100));
             Order savedOrder = mockSavedOrder(1L);
@@ -2580,7 +2580,7 @@ class RegisterOrderUseCaseTest {
                     pricePolicyIdB, Map.entry(unitAmountB, sellerIdB)
             ));
             mockShippingPolicies(Map.of(
-                    sellerIdA, new ShippingPolicyInfoResult(sellerIdA, shippingFeeA, 20000L, 0L, 0L)
+                    sellerIdA, new ShippingPolicyInfoResult(sellerIdA, shippingFeeA, 20000L)
             ));
             mockInventoryMultiple(Map.of(pricePolicyIdA, 100, pricePolicyIdB, 100));
             Order savedOrder = mockSavedOrder(1L);
@@ -2806,7 +2806,7 @@ class RegisterOrderUseCaseTest {
 
     private void mockShippingPolicy(Long sellerId, Long shippingFee, Long freeShippingThreshold) {
         when(findShippingPolicyBySellerIdsPort.findBySellerIds(anyList()))
-                .thenReturn(Map.of(sellerId, new ShippingPolicyInfoResult(sellerId, shippingFee, freeShippingThreshold, 0L, 0L)));
+                .thenReturn(Map.of(sellerId, new ShippingPolicyInfoResult(sellerId, shippingFee, freeShippingThreshold)));
     }
 
     private void mockShippingPolicies(Map<Long, ShippingPolicyInfoResult> policies) {

--- a/common/src/main/java/com/personal/marketnote/common/kafka/KafkaTopicConstants.java
+++ b/common/src/main/java/com/personal/marketnote/common/kafka/KafkaTopicConstants.java
@@ -40,6 +40,11 @@ public final class KafkaTopicConstants {
     public static final String SAGA_ORDER_PAYMENT_LEDGER = "saga.order-payment.ledger";
     public static final String SAGA_ORDER_PAYMENT_COMPLETED = "saga.order-payment.completed";
 
+    // OrderCancel SAGA 스텝
+    public static final String SAGA_ORDER_CANCEL_FULFILLMENT = "saga.order-cancel.fulfillment";
+    public static final String SAGA_ORDER_CANCEL_REFUND = "saga.order-cancel.refund";
+    public static final String SAGA_ORDER_CANCEL_COMPLETED = "saga.order-cancel.completed";
+
     // Inventory 이벤트
     public static final String INVENTORY_CHANGED = "commerce.inventory.changed";
 

--- a/common/src/main/java/com/personal/marketnote/common/kafka/event/ShippingPolicyChangedEvent.java
+++ b/common/src/main/java/com/personal/marketnote/common/kafka/event/ShippingPolicyChangedEvent.java
@@ -4,8 +4,6 @@ public record ShippingPolicyChangedEvent(
         Long sellerId,
         Long shippingFee,
         Long freeShippingThreshold,
-        Long jejuSurcharge,
-        Long islandSurcharge,
         ShippingPolicyChangeAction action
 ) {
 }

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/shipping/controller/ShippingPolicyController.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/shipping/controller/ShippingPolicyController.java
@@ -139,9 +139,7 @@ public class ShippingPolicyController {
                 new RegisterShippingPolicyCommand(
                         request.deliveryCompany(),
                         request.shippingFee(),
-                        request.freeShippingThreshold(),
-                        request.jejuSurcharge(),
-                        request.islandSurcharge()
+                        request.freeShippingThreshold()
                 )
         );
 
@@ -180,9 +178,7 @@ public class ShippingPolicyController {
                 new UpdateShippingPolicyCommand(
                         request.deliveryCompany(),
                         request.shippingFee(),
-                        request.freeShippingThreshold(),
-                        request.jejuSurcharge(),
-                        request.islandSurcharge()
+                        request.freeShippingThreshold()
                 )
         );
 

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/shipping/controller/apidocs/GetShippingPoliciesBySellerIdsApiDocs.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/shipping/controller/apidocs/GetShippingPoliciesBySellerIdsApiDocs.java
@@ -56,8 +56,6 @@ import java.lang.annotation.*;
                 | sellerId | number | 판매자 ID | 10 |
                 | shippingFee | number | 배송비 | 3000 |
                 | freeShippingThreshold | number | 무료배송 기준금액 | 20000 |
-                | jejuSurcharge | number | 제주 추가 배송비 | 3000 |
-                | islandSurcharge | number | 도서산간 추가 배송비 | 5000 |
                 """,
         security = {@SecurityRequirement(name = "bearer")},
         parameters = {
@@ -84,16 +82,12 @@ import java.lang.annotation.*;
                                               {
                                                 "sellerId": 10,
                                                 "shippingFee": 3000,
-                                                "freeShippingThreshold": 20000,
-                                                "jejuSurcharge": 3000,
-                                                "islandSurcharge": 5000
+                                                "freeShippingThreshold": 20000
                                               },
                                               {
                                                 "sellerId": 20,
                                                 "shippingFee": 2500,
-                                                "freeShippingThreshold": 30000,
-                                                "jejuSurcharge": 4000,
-                                                "islandSurcharge": 6000
+                                                "freeShippingThreshold": 30000
                                               }
                                             ]
                                           },

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/shipping/controller/apidocs/GetShippingPolicyApiDocs.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/shipping/controller/apidocs/GetShippingPolicyApiDocs.java
@@ -48,8 +48,6 @@ import java.lang.annotation.*;
                 | deliveryCompany | string | 배송업체 | "한진택배" |
                 | shippingFee | number | 배송비 | 3000 |
                 | freeShippingThreshold | number | 무료배송 기준금액 | 20000 |
-                | jejuSurcharge | number | 제주 추가 배송비 | 3000 |
-                | islandSurcharge | number | 도서산간 추가 배송비 | 5000 |
                 """,
         security = {@SecurityRequirement(name = "bearer")},
         responses = {
@@ -67,9 +65,7 @@ import java.lang.annotation.*;
                                             "id": 1,
                                             "deliveryCompany": "한진택배",
                                             "shippingFee": 3000,
-                                            "freeShippingThreshold": 20000,
-                                            "jejuSurcharge": 3000,
-                                            "islandSurcharge": 5000
+                                            "freeShippingThreshold": 20000
                                           },
                                           "message": "판매자 배송비 정책 조회 성공"
                                         }

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/shipping/controller/apidocs/RegisterShippingPolicyApiDocs.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/shipping/controller/apidocs/RegisterShippingPolicyApiDocs.java
@@ -41,8 +41,6 @@ import java.lang.annotation.*;
                 | deliveryCompany | string | 배송업체 | Y | "한진택배" |
                 | shippingFee | number | 배송비 | Y | 3000 |
                 | freeShippingThreshold | number | 무료배송 기준금액 | Y | 20000 |
-                | jejuSurcharge | number | 제주 추가 배송비 | N | 3000 |
-                | islandSurcharge | number | 도서산간 추가 배송비 | N | 5000 |
                 
                 ---
                 
@@ -71,9 +69,7 @@ import java.lang.annotation.*;
                                 {
                                   "deliveryCompany": "한진택배",
                                   "shippingFee": 3000,
-                                  "freeShippingThreshold": 20000,
-                                  "jejuSurcharge": 3000,
-                                  "islandSurcharge": 5000
+                                  "freeShippingThreshold": 20000
                                 }
                                 """)
                 )

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/shipping/controller/apidocs/UpdateShippingPolicyApiDocs.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/shipping/controller/apidocs/UpdateShippingPolicyApiDocs.java
@@ -39,8 +39,6 @@ import java.lang.annotation.*;
                 | deliveryCompany | string | 배송업체 | Y | "CJ대한통운" |
                 | shippingFee | number | 배송비 | Y | 2500 |
                 | freeShippingThreshold | number | 무료배송 기준금액 | Y | 30000 |
-                | jejuSurcharge | number | 제주 추가 배송비 | N | 3000 |
-                | islandSurcharge | number | 도서산간 추가 배송비 | N | 5000 |
                 
                 ---
                 
@@ -62,8 +60,6 @@ import java.lang.annotation.*;
                 | deliveryCompany | string | 배송업체 | "CJ대한통운" |
                 | shippingFee | number | 배송비 | 2500 |
                 | freeShippingThreshold | number | 무료배송 기준금액 | 30000 |
-                | jejuSurcharge | number | 제주 추가 배송비 | 3000 |
-                | islandSurcharge | number | 도서산간 추가 배송비 | 5000 |
                 """,
         security = {@SecurityRequirement(name = "bearer")},
         requestBody = @RequestBody(
@@ -74,9 +70,7 @@ import java.lang.annotation.*;
                                 {
                                   "deliveryCompany": "CJ대한통운",
                                   "shippingFee": 2500,
-                                  "freeShippingThreshold": 30000,
-                                  "jejuSurcharge": 3000,
-                                  "islandSurcharge": 5000
+                                  "freeShippingThreshold": 30000
                                 }
                                 """)
                 )
@@ -96,9 +90,7 @@ import java.lang.annotation.*;
                                             "id": 1,
                                             "deliveryCompany": "CJ대한통운",
                                             "shippingFee": 2500,
-                                            "freeShippingThreshold": 30000,
-                                            "jejuSurcharge": 3000,
-                                            "islandSurcharge": 5000
+                                            "freeShippingThreshold": 30000
                                           },
                                           "message": "판매자 배송비 정책 수정 성공"
                                         }

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/shipping/request/RegisterShippingPolicyRequest.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/shipping/request/RegisterShippingPolicyRequest.java
@@ -20,14 +20,6 @@ public record RegisterShippingPolicyRequest(
         @NotNull(message = "무료배송 기준금액은 필수입니다")
         @Min(value = 0, message = "무료배송 기준금액은 0 이상이어야 합니다")
         @Schema(description = "무료배송 기준금액", example = "20000")
-        Long freeShippingThreshold,
-
-        @Min(value = 0, message = "제주 추가 배송비는 0 이상이어야 합니다")
-        @Schema(description = "제주 추가 배송비", example = "3000")
-        Long jejuSurcharge,
-
-        @Min(value = 0, message = "도서산간 추가 배송비는 0 이상이어야 합니다")
-        @Schema(description = "도서산간 추가 배송비", example = "5000")
-        Long islandSurcharge
+        Long freeShippingThreshold
 ) {
 }

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/shipping/request/UpdateShippingPolicyRequest.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/shipping/request/UpdateShippingPolicyRequest.java
@@ -20,14 +20,6 @@ public record UpdateShippingPolicyRequest(
         @NotNull(message = "무료배송 기준금액은 필수입니다")
         @Min(value = 0, message = "무료배송 기준금액은 0 이상이어야 합니다")
         @Schema(description = "무료배송 기준금액", example = "20000")
-        Long freeShippingThreshold,
-
-        @Min(value = 0, message = "제주 추가 배송비는 0 이상이어야 합니다")
-        @Schema(description = "제주 추가 배송비", example = "3000")
-        Long jejuSurcharge,
-
-        @Min(value = 0, message = "도서산간 추가 배송비는 0 이상이어야 합니다")
-        @Schema(description = "도서산간 추가 배송비", example = "5000")
-        Long islandSurcharge
+        Long freeShippingThreshold
 ) {
 }

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/shipping/response/GetShippingPoliciesBySellerIdsResponse.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/shipping/response/GetShippingPoliciesBySellerIdsResponse.java
@@ -18,18 +18,14 @@ public record GetShippingPoliciesBySellerIdsResponse(
     public record ShippingPolicyBySellerResponse(
             Long sellerId,
             Long shippingFee,
-            Long freeShippingThreshold,
-            Long jejuSurcharge,
-            Long islandSurcharge
+            Long freeShippingThreshold
     ) {
 
         public static ShippingPolicyBySellerResponse from(GetShippingPolicyBySellerResult result) {
             return new ShippingPolicyBySellerResponse(
                     result.sellerId(),
                     result.shippingFee(),
-                    result.freeShippingThreshold(),
-                    result.jejuSurcharge(),
-                    result.islandSurcharge()
+                    result.freeShippingThreshold()
             );
         }
     }

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/shipping/response/GetShippingPolicyResponse.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/shipping/response/GetShippingPolicyResponse.java
@@ -6,9 +6,7 @@ public record GetShippingPolicyResponse(
         Long id,
         String deliveryCompany,
         Long shippingFee,
-        Long freeShippingThreshold,
-        Long jejuSurcharge,
-        Long islandSurcharge
+        Long freeShippingThreshold
 ) {
 
     public static GetShippingPolicyResponse from(GetShippingPolicyResult result) {
@@ -16,9 +14,7 @@ public record GetShippingPolicyResponse(
                 result.id(),
                 result.deliveryCompany(),
                 result.shippingFee(),
-                result.freeShippingThreshold(),
-                result.jejuSurcharge(),
-                result.islandSurcharge()
+                result.freeShippingThreshold()
         );
     }
 }

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/shipping/response/UpdateShippingPolicyResponse.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/shipping/response/UpdateShippingPolicyResponse.java
@@ -6,9 +6,7 @@ public record UpdateShippingPolicyResponse(
         Long id,
         String deliveryCompany,
         Long shippingFee,
-        Long freeShippingThreshold,
-        Long jejuSurcharge,
-        Long islandSurcharge
+        Long freeShippingThreshold
 ) {
 
     public static UpdateShippingPolicyResponse from(UpdateShippingPolicyResult result) {
@@ -16,9 +14,7 @@ public record UpdateShippingPolicyResponse(
                 result.id(),
                 result.deliveryCompany(),
                 result.shippingFee(),
-                result.freeShippingThreshold(),
-                result.jejuSurcharge(),
-                result.islandSurcharge()
+                result.freeShippingThreshold()
         );
     }
 }

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/event/ShippingPolicyEventKafkaProducer.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/event/ShippingPolicyEventKafkaProducer.java
@@ -25,10 +25,8 @@ public class ShippingPolicyEventKafkaProducer implements PublishShippingPolicyEv
     private final Clock clock;
 
     @Override
-    public void publishShippingPolicyChangedEvent(Long sellerId, Long shippingFee, Long freeShippingThreshold,
-                                                  Long jejuSurcharge, Long islandSurcharge, ShippingPolicyChangeAction action) {
-        ShippingPolicyChangedEvent payload = new ShippingPolicyChangedEvent(
-                sellerId, shippingFee, freeShippingThreshold, jejuSurcharge, islandSurcharge, action);
+    public void publishShippingPolicyChangedEvent(Long sellerId, Long shippingFee, Long freeShippingThreshold, ShippingPolicyChangeAction action) {
+        ShippingPolicyChangedEvent payload = new ShippingPolicyChangedEvent(sellerId, shippingFee, freeShippingThreshold, action);
         String topic = KafkaTopicConstants.SHIPPING_POLICY_CHANGED;
         EventEnvelope<ShippingPolicyChangedEvent> envelope = EventEnvelope.of(topic, SOURCE, payload, clock);
 

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/mapper/ShippingPolicyJpaEntityToDomainMapper.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/mapper/ShippingPolicyJpaEntityToDomainMapper.java
@@ -20,8 +20,6 @@ public class ShippingPolicyJpaEntityToDomainMapper {
                                 .deliveryCompany(e.getDeliveryCompany())
                                 .shippingFee(e.getShippingFee())
                                 .freeShippingThreshold(e.getFreeShippingThreshold())
-                                .jejuSurcharge(e.getJejuSurcharge())
-                                .islandSurcharge(e.getIslandSurcharge())
                                 .status(e.getStatus())
                                 .createdAt(e.getCreatedAt())
                                 .modifiedAt(e.getModifiedAt())

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/shipping/entity/ShippingPolicyJpaEntity.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/shipping/entity/ShippingPolicyJpaEntity.java
@@ -32,20 +32,12 @@ public class ShippingPolicyJpaEntity extends BaseGeneralEntity {
     @Column(name = "free_shipping_threshold", nullable = false)
     private Long freeShippingThreshold;
 
-    @Column(name = "jeju_surcharge")
-    private Long jejuSurcharge;
-
-    @Column(name = "island_surcharge")
-    private Long islandSurcharge;
-
     public static ShippingPolicyJpaEntity from(ShippingPolicy policy) {
         return ShippingPolicyJpaEntity.builder()
                 .sellerId(policy.getSellerId())
                 .deliveryCompany(policy.getDeliveryCompany())
                 .shippingFee(policy.getShippingFee())
                 .freeShippingThreshold(policy.getFreeShippingThreshold())
-                .jejuSurcharge(policy.getJejuSurcharge())
-                .islandSurcharge(policy.getIslandSurcharge())
                 .build();
     }
 
@@ -53,7 +45,5 @@ public class ShippingPolicyJpaEntity extends BaseGeneralEntity {
         this.deliveryCompany = policy.getDeliveryCompany();
         this.shippingFee = policy.getShippingFee();
         this.freeShippingThreshold = policy.getFreeShippingThreshold();
-        this.jejuSurcharge = policy.getJejuSurcharge();
-        this.islandSurcharge = policy.getIslandSurcharge();
     }
 }

--- a/product-service/product-adapters/src/test/java/com/personal/marketnote/product/adapter/in/web/shipping/controller/InternalShippingPolicyControllerTest.java
+++ b/product-service/product-adapters/src/test/java/com/personal/marketnote/product/adapter/in/web/shipping/controller/InternalShippingPolicyControllerTest.java
@@ -36,8 +36,8 @@ class InternalShippingPolicyControllerTest {
             // given
             List<Long> sellerIds = List.of(10L, 20L);
             List<GetShippingPolicyBySellerResult> results = List.of(
-                    new GetShippingPolicyBySellerResult(10L, 3000L, 20000L, 3000L, 5000L),
-                    new GetShippingPolicyBySellerResult(20L, 2500L, 30000L, 4000L, 6000L)
+                    new GetShippingPolicyBySellerResult(10L, 3000L, 20000L),
+                    new GetShippingPolicyBySellerResult(20L, 2500L, 30000L)
             );
             when(getShippingPolicyUseCase.getShippingPolicies(sellerIds)).thenReturn(results);
 

--- a/product-service/product-adapters/src/test/java/com/personal/marketnote/product/adapter/out/event/ShippingPolicyEventKafkaProducerTest.java
+++ b/product-service/product-adapters/src/test/java/com/personal/marketnote/product/adapter/out/event/ShippingPolicyEventKafkaProducerTest.java
@@ -55,7 +55,7 @@ class ShippingPolicyEventKafkaProducerTest {
 
         // when
         shippingPolicyEventKafkaProducer.publishShippingPolicyChangedEvent(
-                10L, 3000L, 20000L, 3000L, 5000L, ShippingPolicyChangeAction.CREATED
+                10L, 3000L, 20000L, ShippingPolicyChangeAction.CREATED
         );
 
         // then
@@ -79,7 +79,7 @@ class ShippingPolicyEventKafkaProducerTest {
 
         // when
         shippingPolicyEventKafkaProducer.publishShippingPolicyChangedEvent(
-                10L, 3000L, 20000L, 3000L, 5000L, ShippingPolicyChangeAction.CREATED
+                10L, 3000L, 20000L, ShippingPolicyChangeAction.CREATED
         );
 
         // then
@@ -96,8 +96,6 @@ class ShippingPolicyEventKafkaProducerTest {
         assertThat(payload.sellerId()).isEqualTo(10L);
         assertThat(payload.shippingFee()).isEqualTo(3000L);
         assertThat(payload.freeShippingThreshold()).isEqualTo(20000L);
-        assertThat(payload.jejuSurcharge()).isEqualTo(3000L);
-        assertThat(payload.islandSurcharge()).isEqualTo(5000L);
         assertThat(payload.action()).isEqualTo(ShippingPolicyChangeAction.CREATED);
     }
 
@@ -111,7 +109,7 @@ class ShippingPolicyEventKafkaProducerTest {
 
         // when
         shippingPolicyEventKafkaProducer.publishShippingPolicyChangedEvent(
-                20L, 2500L, 30000L, 4000L, 6000L, ShippingPolicyChangeAction.UPDATED
+                20L, 2500L, 30000L, ShippingPolicyChangeAction.UPDATED
         );
 
         // then
@@ -122,8 +120,6 @@ class ShippingPolicyEventKafkaProducerTest {
         assertThat(payload.sellerId()).isEqualTo(20L);
         assertThat(payload.shippingFee()).isEqualTo(2500L);
         assertThat(payload.freeShippingThreshold()).isEqualTo(30000L);
-        assertThat(payload.jejuSurcharge()).isEqualTo(4000L);
-        assertThat(payload.islandSurcharge()).isEqualTo(6000L);
         assertThat(payload.action()).isEqualTo(ShippingPolicyChangeAction.UPDATED);
     }
 }

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/mapper/ShippingPolicyCommandToStateMapper.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/mapper/ShippingPolicyCommandToStateMapper.java
@@ -14,8 +14,6 @@ public class ShippingPolicyCommandToStateMapper {
                 .deliveryCompany(command.deliveryCompany())
                 .shippingFee(command.shippingFee())
                 .freeShippingThreshold(command.freeShippingThreshold())
-                .jejuSurcharge(command.jejuSurcharge())
-                .islandSurcharge(command.islandSurcharge())
                 .build();
     }
 }

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/command/RegisterShippingPolicyCommand.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/command/RegisterShippingPolicyCommand.java
@@ -3,8 +3,6 @@ package com.personal.marketnote.product.port.in.command;
 public record RegisterShippingPolicyCommand(
         String deliveryCompany,
         Long shippingFee,
-        Long freeShippingThreshold,
-        Long jejuSurcharge,
-        Long islandSurcharge
+        Long freeShippingThreshold
 ) {
 }

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/command/UpdateShippingPolicyCommand.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/command/UpdateShippingPolicyCommand.java
@@ -3,8 +3,6 @@ package com.personal.marketnote.product.port.in.command;
 public record UpdateShippingPolicyCommand(
         String deliveryCompany,
         Long shippingFee,
-        Long freeShippingThreshold,
-        Long jejuSurcharge,
-        Long islandSurcharge
+        Long freeShippingThreshold
 ) {
 }

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/result/shipping/GetShippingPolicyBySellerResult.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/result/shipping/GetShippingPolicyBySellerResult.java
@@ -5,18 +5,14 @@ import com.personal.marketnote.product.domain.shipping.ShippingPolicy;
 public record GetShippingPolicyBySellerResult(
         Long sellerId,
         Long shippingFee,
-        Long freeShippingThreshold,
-        Long jejuSurcharge,
-        Long islandSurcharge
+        Long freeShippingThreshold
 ) {
 
     public static GetShippingPolicyBySellerResult from(ShippingPolicy shippingPolicy) {
         return new GetShippingPolicyBySellerResult(
                 shippingPolicy.getSellerId(),
                 shippingPolicy.getShippingFee(),
-                shippingPolicy.getFreeShippingThreshold(),
-                shippingPolicy.getJejuSurcharge(),
-                shippingPolicy.getIslandSurcharge()
+                shippingPolicy.getFreeShippingThreshold()
         );
     }
 }

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/result/shipping/GetShippingPolicyResult.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/result/shipping/GetShippingPolicyResult.java
@@ -6,9 +6,7 @@ public record GetShippingPolicyResult(
         Long id,
         String deliveryCompany,
         Long shippingFee,
-        Long freeShippingThreshold,
-        Long jejuSurcharge,
-        Long islandSurcharge
+        Long freeShippingThreshold
 ) {
 
     public static GetShippingPolicyResult from(ShippingPolicy shippingPolicy) {
@@ -16,9 +14,7 @@ public record GetShippingPolicyResult(
                 shippingPolicy.getId(),
                 shippingPolicy.getDeliveryCompany(),
                 shippingPolicy.getShippingFee(),
-                shippingPolicy.getFreeShippingThreshold(),
-                shippingPolicy.getJejuSurcharge(),
-                shippingPolicy.getIslandSurcharge()
+                shippingPolicy.getFreeShippingThreshold()
         );
     }
 }

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/result/shipping/UpdateShippingPolicyResult.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/result/shipping/UpdateShippingPolicyResult.java
@@ -6,9 +6,7 @@ public record UpdateShippingPolicyResult(
         Long id,
         String deliveryCompany,
         Long shippingFee,
-        Long freeShippingThreshold,
-        Long jejuSurcharge,
-        Long islandSurcharge
+        Long freeShippingThreshold
 ) {
 
     public static UpdateShippingPolicyResult from(ShippingPolicy shippingPolicy) {
@@ -16,9 +14,7 @@ public record UpdateShippingPolicyResult(
                 shippingPolicy.getId(),
                 shippingPolicy.getDeliveryCompany(),
                 shippingPolicy.getShippingFee(),
-                shippingPolicy.getFreeShippingThreshold(),
-                shippingPolicy.getJejuSurcharge(),
-                shippingPolicy.getIslandSurcharge()
+                shippingPolicy.getFreeShippingThreshold()
         );
     }
 }

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/out/event/PublishShippingPolicyEventPort.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/out/event/PublishShippingPolicyEventPort.java
@@ -4,6 +4,5 @@ import com.personal.marketnote.common.kafka.event.ShippingPolicyChangeAction;
 
 public interface PublishShippingPolicyEventPort {
 
-    void publishShippingPolicyChangedEvent(Long sellerId, Long shippingFee, Long freeShippingThreshold,
-                                           Long jejuSurcharge, Long islandSurcharge, ShippingPolicyChangeAction action);
+    void publishShippingPolicyChangedEvent(Long sellerId, Long shippingFee, Long freeShippingThreshold, ShippingPolicyChangeAction action);
 }

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/service/shipping/RegisterShippingPolicyService.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/service/shipping/RegisterShippingPolicyService.java
@@ -35,8 +35,7 @@ public class RegisterShippingPolicyService implements RegisterShippingPolicyUseC
         Long savedId = saveShippingPolicyPort.save(shippingPolicy);
 
         publishShippingPolicyEventPort.publishShippingPolicyChangedEvent(
-                sellerId, shippingPolicy.getShippingFee(), shippingPolicy.getFreeShippingThreshold(),
-                shippingPolicy.getJejuSurcharge(), shippingPolicy.getIslandSurcharge(), ShippingPolicyChangeAction.CREATED
+                sellerId, command.shippingFee(), command.freeShippingThreshold(), ShippingPolicyChangeAction.CREATED
         );
 
         return RegisterShippingPolicyResult.of(savedId);

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/service/shipping/UpdateShippingPolicyService.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/service/shipping/UpdateShippingPolicyService.java
@@ -31,16 +31,13 @@ public class UpdateShippingPolicyService implements UpdateShippingPolicyUseCase 
         shippingPolicy.update(
                 command.deliveryCompany(),
                 command.shippingFee(),
-                command.freeShippingThreshold(),
-                command.jejuSurcharge(),
-                command.islandSurcharge()
+                command.freeShippingThreshold()
         );
 
         updateShippingPolicyPort.update(shippingPolicy);
 
         publishShippingPolicyEventPort.publishShippingPolicyChangedEvent(
-                sellerId, shippingPolicy.getShippingFee(), shippingPolicy.getFreeShippingThreshold(),
-                shippingPolicy.getJejuSurcharge(), shippingPolicy.getIslandSurcharge(), ShippingPolicyChangeAction.UPDATED
+                sellerId, shippingPolicy.getShippingFee(), shippingPolicy.getFreeShippingThreshold(), ShippingPolicyChangeAction.UPDATED
         );
 
         return UpdateShippingPolicyResult.from(shippingPolicy);

--- a/product-service/product-application/src/test/java/com/personal/marketnote/product/service/shipping/RegisterShippingPolicyUseCaseTest.java
+++ b/product-service/product-application/src/test/java/com/personal/marketnote/product/service/shipping/RegisterShippingPolicyUseCaseTest.java
@@ -66,7 +66,7 @@ class RegisterShippingPolicyUseCaseTest {
         when(saveShippingPolicyPort.save(any(ShippingPolicy.class))).thenReturn(1L);
 
         RegisterShippingPolicyCommand command = new RegisterShippingPolicyCommand(
-                "한진택배", 3000L, 20000L, 3000L, 5000L
+                "한진택배", 3000L, 20000L
         );
 
         // when
@@ -83,8 +83,6 @@ class RegisterShippingPolicyUseCaseTest {
         assertThat(savedPolicy.getDeliveryCompany()).isEqualTo("한진택배");
         assertThat(savedPolicy.getShippingFee()).isEqualTo(3000L);
         assertThat(savedPolicy.getFreeShippingThreshold()).isEqualTo(20000L);
-        assertThat(savedPolicy.getJejuSurcharge()).isEqualTo(3000L);
-        assertThat(savedPolicy.getIslandSurcharge()).isEqualTo(5000L);
         assertThat(savedPolicy.isActive()).isTrue();
     }
 
@@ -97,7 +95,7 @@ class RegisterShippingPolicyUseCaseTest {
                 .thenReturn(Optional.of(createSavedPolicy(sellerId)));
 
         RegisterShippingPolicyCommand command = new RegisterShippingPolicyCommand(
-                "한진택배", 3000L, 20000L, 3000L, 5000L
+                "한진택배", 3000L, 20000L
         );
 
         // when & then
@@ -115,7 +113,7 @@ class RegisterShippingPolicyUseCaseTest {
         when(findShippingPolicyPort.findActiveBySellerId(sellerId)).thenReturn(Optional.empty());
 
         RegisterShippingPolicyCommand command = new RegisterShippingPolicyCommand(
-                "한진택배", -1L, 20000L, 0L, 0L
+                "한진택배", -1L, 20000L
         );
 
         // when & then
@@ -133,7 +131,7 @@ class RegisterShippingPolicyUseCaseTest {
         when(findShippingPolicyPort.findActiveBySellerId(sellerId)).thenReturn(Optional.empty());
 
         RegisterShippingPolicyCommand command = new RegisterShippingPolicyCommand(
-                "한진택배", 3000L, -1L, 0L, 0L
+                "한진택배", 3000L, -1L
         );
 
         // when & then
@@ -152,7 +150,7 @@ class RegisterShippingPolicyUseCaseTest {
         when(saveShippingPolicyPort.save(any(ShippingPolicy.class))).thenReturn(1L);
 
         RegisterShippingPolicyCommand command = new RegisterShippingPolicyCommand(
-                "한진택배", 3000L, 20000L, 3000L, 5000L
+                "한진택배", 3000L, 20000L
         );
 
         // when
@@ -160,7 +158,7 @@ class RegisterShippingPolicyUseCaseTest {
 
         // then
         verify(publishShippingPolicyEventPort).publishShippingPolicyChangedEvent(
-                sellerId, 3000L, 20000L, 3000L, 5000L, ShippingPolicyChangeAction.CREATED
+                sellerId, 3000L, 20000L, ShippingPolicyChangeAction.CREATED
         );
     }
 
@@ -173,7 +171,7 @@ class RegisterShippingPolicyUseCaseTest {
                 .thenReturn(Optional.of(createSavedPolicy(sellerId)));
 
         RegisterShippingPolicyCommand command = new RegisterShippingPolicyCommand(
-                "한진택배", 3000L, 20000L, 3000L, 5000L
+                "한진택배", 3000L, 20000L
         );
 
         // when & then

--- a/product-service/product-application/src/test/java/com/personal/marketnote/product/service/shipping/UpdateShippingPolicyUseCaseTest.java
+++ b/product-service/product-application/src/test/java/com/personal/marketnote/product/service/shipping/UpdateShippingPolicyUseCaseTest.java
@@ -66,7 +66,7 @@ class UpdateShippingPolicyUseCaseTest {
                 .thenReturn(Optional.of(existingPolicy));
 
         UpdateShippingPolicyCommand command = new UpdateShippingPolicyCommand(
-                "CJ대한통운", 2500L, 30000L, 4000L, 6000L
+                "CJ대한통운", 2500L, 30000L
         );
 
         // when
@@ -77,8 +77,6 @@ class UpdateShippingPolicyUseCaseTest {
         assertThat(result.deliveryCompany()).isEqualTo("CJ대한통운");
         assertThat(result.shippingFee()).isEqualTo(2500L);
         assertThat(result.freeShippingThreshold()).isEqualTo(30000L);
-        assertThat(result.jejuSurcharge()).isEqualTo(4000L);
-        assertThat(result.islandSurcharge()).isEqualTo(6000L);
 
         verify(updateShippingPolicyPort).update(existingPolicy);
     }
@@ -92,7 +90,7 @@ class UpdateShippingPolicyUseCaseTest {
                 .thenReturn(Optional.empty());
 
         UpdateShippingPolicyCommand command = new UpdateShippingPolicyCommand(
-                "CJ대한통운", 2500L, 30000L, 4000L, 6000L
+                "CJ대한통운", 2500L, 30000L
         );
 
         // when & then
@@ -112,7 +110,7 @@ class UpdateShippingPolicyUseCaseTest {
                 .thenReturn(Optional.of(existingPolicy));
 
         UpdateShippingPolicyCommand command = new UpdateShippingPolicyCommand(
-                "CJ대한통운", -1L, 30000L, 0L, 0L
+                "CJ대한통운", -1L, 30000L
         );
 
         // when & then
@@ -132,7 +130,7 @@ class UpdateShippingPolicyUseCaseTest {
                 .thenReturn(Optional.of(existingPolicy));
 
         UpdateShippingPolicyCommand command = new UpdateShippingPolicyCommand(
-                "CJ대한통운", 2500L, -1L, 0L, 0L
+                "CJ대한통운", 2500L, -1L
         );
 
         // when & then
@@ -152,7 +150,7 @@ class UpdateShippingPolicyUseCaseTest {
                 .thenReturn(Optional.of(existingPolicy));
 
         UpdateShippingPolicyCommand command = new UpdateShippingPolicyCommand(
-                "CJ대한통운", 2500L, 30000L, 4000L, 6000L
+                "CJ대한통운", 2500L, 30000L
         );
 
         // when
@@ -160,7 +158,7 @@ class UpdateShippingPolicyUseCaseTest {
 
         // then
         verify(publishShippingPolicyEventPort).publishShippingPolicyChangedEvent(
-                sellerId, 2500L, 30000L, 4000L, 6000L, ShippingPolicyChangeAction.UPDATED
+                sellerId, 2500L, 30000L, ShippingPolicyChangeAction.UPDATED
         );
     }
 
@@ -173,7 +171,7 @@ class UpdateShippingPolicyUseCaseTest {
                 .thenReturn(Optional.empty());
 
         UpdateShippingPolicyCommand command = new UpdateShippingPolicyCommand(
-                "CJ대한통운", 2500L, 30000L, 4000L, 6000L
+                "CJ대한통운", 2500L, 30000L
         );
 
         // when & then

--- a/product-service/product-domain/src/main/java/com/personal/marketnote/product/domain/shipping/InvalidIslandSurchargeException.java
+++ b/product-service/product-domain/src/main/java/com/personal/marketnote/product/domain/shipping/InvalidIslandSurchargeException.java
@@ -1,9 +1,0 @@
-package com.personal.marketnote.product.domain.shipping;
-
-public class InvalidIslandSurchargeException extends IllegalArgumentException {
-    private static final String MESSAGE = "ERR_SHIPPING_POLICY_04::도서산간 추가 배송비가 유효하지 않습니다. %s";
-
-    public InvalidIslandSurchargeException(String detail) {
-        super(String.format(MESSAGE, detail));
-    }
-}

--- a/product-service/product-domain/src/main/java/com/personal/marketnote/product/domain/shipping/InvalidJejuSurchargeException.java
+++ b/product-service/product-domain/src/main/java/com/personal/marketnote/product/domain/shipping/InvalidJejuSurchargeException.java
@@ -1,9 +1,0 @@
-package com.personal.marketnote.product.domain.shipping;
-
-public class InvalidJejuSurchargeException extends IllegalArgumentException {
-    private static final String MESSAGE = "ERR_SHIPPING_POLICY_03::제주 추가 배송비가 유효하지 않습니다. %s";
-
-    public InvalidJejuSurchargeException(String detail) {
-        super(String.format(MESSAGE, detail));
-    }
-}

--- a/product-service/product-domain/src/main/java/com/personal/marketnote/product/domain/shipping/ShippingPolicy.java
+++ b/product-service/product-domain/src/main/java/com/personal/marketnote/product/domain/shipping/ShippingPolicy.java
@@ -1,7 +1,6 @@
 package com.personal.marketnote.product.domain.shipping;
 
 import com.personal.marketnote.common.domain.BaseDomain;
-import com.personal.marketnote.common.utility.FormatValidator;
 import lombok.*;
 
 import java.time.LocalDateTime;
@@ -16,8 +15,6 @@ public class ShippingPolicy extends BaseDomain {
     private String deliveryCompany;
     private Long shippingFee;
     private Long freeShippingThreshold;
-    private Long jejuSurcharge;
-    private Long islandSurcharge;
     private LocalDateTime createdAt;
     private LocalDateTime modifiedAt;
 
@@ -25,18 +22,11 @@ public class ShippingPolicy extends BaseDomain {
         validateShippingFee(state.getShippingFee());
         validateFreeShippingThreshold(state.getFreeShippingThreshold());
 
-        Long resolvedJejuSurcharge = resolveDefaultSurcharge(state.getJejuSurcharge());
-        Long resolvedIslandSurcharge = resolveDefaultSurcharge(state.getIslandSurcharge());
-        validateJejuSurcharge(resolvedJejuSurcharge);
-        validateIslandSurcharge(resolvedIslandSurcharge);
-
         ShippingPolicy policy = ShippingPolicy.builder()
                 .sellerId(state.getSellerId())
                 .deliveryCompany(state.getDeliveryCompany())
                 .shippingFee(state.getShippingFee())
                 .freeShippingThreshold(state.getFreeShippingThreshold())
-                .jejuSurcharge(resolvedJejuSurcharge)
-                .islandSurcharge(resolvedIslandSurcharge)
                 .build();
         policy.activate();
         return policy;
@@ -49,8 +39,6 @@ public class ShippingPolicy extends BaseDomain {
                 .deliveryCompany(state.getDeliveryCompany())
                 .shippingFee(state.getShippingFee())
                 .freeShippingThreshold(state.getFreeShippingThreshold())
-                .jejuSurcharge(state.getJejuSurcharge())
-                .islandSurcharge(state.getIslandSurcharge())
                 .createdAt(state.getCreatedAt())
                 .modifiedAt(state.getModifiedAt())
                 .build();
@@ -58,21 +46,13 @@ public class ShippingPolicy extends BaseDomain {
         return policy;
     }
 
-    public void update(String deliveryCompany, Long shippingFee, Long freeShippingThreshold,
-                       Long jejuSurcharge, Long islandSurcharge) {
+    public void update(String deliveryCompany, Long shippingFee, Long freeShippingThreshold) {
         validateShippingFee(shippingFee);
         validateFreeShippingThreshold(freeShippingThreshold);
-
-        Long resolvedJejuSurcharge = resolveDefaultSurcharge(jejuSurcharge);
-        Long resolvedIslandSurcharge = resolveDefaultSurcharge(islandSurcharge);
-        validateJejuSurcharge(resolvedJejuSurcharge);
-        validateIslandSurcharge(resolvedIslandSurcharge);
 
         this.deliveryCompany = deliveryCompany;
         this.shippingFee = shippingFee;
         this.freeShippingThreshold = freeShippingThreshold;
-        this.jejuSurcharge = resolvedJejuSurcharge;
-        this.islandSurcharge = resolvedIslandSurcharge;
     }
 
     @Override
@@ -101,24 +81,5 @@ public class ShippingPolicy extends BaseDomain {
         if (freeShippingThreshold < 0) {
             throw new InvalidFreeShippingThresholdException("무료배송 기준금액은 0 이상이어야 합니다. 입력값=" + freeShippingThreshold);
         }
-    }
-
-    private static void validateJejuSurcharge(Long jejuSurcharge) {
-        if (jejuSurcharge < 0) {
-            throw new InvalidJejuSurchargeException("제주 추가 배송비는 0 이상이어야 합니다. 입력값=" + jejuSurcharge);
-        }
-    }
-
-    private static void validateIslandSurcharge(Long islandSurcharge) {
-        if (islandSurcharge < 0) {
-            throw new InvalidIslandSurchargeException("도서산간 추가 배송비는 0 이상이어야 합니다. 입력값=" + islandSurcharge);
-        }
-    }
-
-    private static Long resolveDefaultSurcharge(Long surcharge) {
-        if (FormatValidator.hasNoValue(surcharge)) {
-            return 0L;
-        }
-        return surcharge;
     }
 }

--- a/product-service/product-domain/src/main/java/com/personal/marketnote/product/domain/shipping/ShippingPolicyCreateState.java
+++ b/product-service/product-domain/src/main/java/com/personal/marketnote/product/domain/shipping/ShippingPolicyCreateState.java
@@ -11,6 +11,4 @@ public class ShippingPolicyCreateState {
     private String deliveryCompany;
     private Long shippingFee;
     private Long freeShippingThreshold;
-    private Long jejuSurcharge;
-    private Long islandSurcharge;
 }

--- a/product-service/product-domain/src/main/java/com/personal/marketnote/product/domain/shipping/ShippingPolicySnapshotState.java
+++ b/product-service/product-domain/src/main/java/com/personal/marketnote/product/domain/shipping/ShippingPolicySnapshotState.java
@@ -15,8 +15,6 @@ public class ShippingPolicySnapshotState {
     private String deliveryCompany;
     private Long shippingFee;
     private Long freeShippingThreshold;
-    private Long jejuSurcharge;
-    private Long islandSurcharge;
     private EntityStatus status;
     private LocalDateTime createdAt;
     private LocalDateTime modifiedAt;

--- a/product-service/product-domain/src/test/java/com/personal/marketnote/product/domain/shipping/ShippingPolicyTest.java
+++ b/product-service/product-domain/src/test/java/com/personal/marketnote/product/domain/shipping/ShippingPolicyTest.java
@@ -88,84 +88,6 @@ class ShippingPolicyTest {
             assertThat(policy.getShippingFee()).isZero();
             assertThat(policy.getFreeShippingThreshold()).isZero();
         }
-
-        @Test
-        @DisplayName("제주/도서산간 추가 배송비를 포함하여 정책을 생성한다")
-        void shouldCreateShippingPolicyWithSurcharges() {
-            // given
-            ShippingPolicyCreateState state = ShippingPolicyCreateState.builder()
-                    .sellerId(1L)
-                    .deliveryCompany("한진택배")
-                    .shippingFee(3000L)
-                    .freeShippingThreshold(20000L)
-                    .jejuSurcharge(3000L)
-                    .islandSurcharge(5000L)
-                    .build();
-
-            // when
-            ShippingPolicy policy = ShippingPolicy.from(state);
-
-            // then
-            assertThat(policy.getJejuSurcharge()).isEqualTo(3000L);
-            assertThat(policy.getIslandSurcharge()).isEqualTo(5000L);
-        }
-
-        @Test
-        @DisplayName("제주 추가 배송비가 null이면 0으로 기본값 설정된다")
-        void shouldDefaultJejuSurchargeToZeroWhenNull() {
-            // given
-            ShippingPolicyCreateState state = ShippingPolicyCreateState.builder()
-                    .sellerId(1L)
-                    .deliveryCompany("한진택배")
-                    .shippingFee(3000L)
-                    .freeShippingThreshold(20000L)
-                    .jejuSurcharge(null)
-                    .islandSurcharge(null)
-                    .build();
-
-            // when
-            ShippingPolicy policy = ShippingPolicy.from(state);
-
-            // then
-            assertThat(policy.getJejuSurcharge()).isZero();
-            assertThat(policy.getIslandSurcharge()).isZero();
-        }
-
-        @Test
-        @DisplayName("제주 추가 배송비가 음수이면 예외가 발생한다")
-        void shouldThrowExceptionWhenJejuSurchargeIsNegative() {
-            // given
-            ShippingPolicyCreateState state = ShippingPolicyCreateState.builder()
-                    .sellerId(1L)
-                    .deliveryCompany("한진택배")
-                    .shippingFee(3000L)
-                    .freeShippingThreshold(20000L)
-                    .jejuSurcharge(-1L)
-                    .islandSurcharge(0L)
-                    .build();
-
-            // when & then
-            assertThatThrownBy(() -> ShippingPolicy.from(state))
-                    .isInstanceOf(InvalidJejuSurchargeException.class);
-        }
-
-        @Test
-        @DisplayName("도서산간 추가 배송비가 음수이면 예외가 발생한다")
-        void shouldThrowExceptionWhenIslandSurchargeIsNegative() {
-            // given
-            ShippingPolicyCreateState state = ShippingPolicyCreateState.builder()
-                    .sellerId(1L)
-                    .deliveryCompany("한진택배")
-                    .shippingFee(3000L)
-                    .freeShippingThreshold(20000L)
-                    .jejuSurcharge(0L)
-                    .islandSurcharge(-1L)
-                    .build();
-
-            // when & then
-            assertThatThrownBy(() -> ShippingPolicy.from(state))
-                    .isInstanceOf(InvalidIslandSurchargeException.class);
-        }
     }
 
     @Nested
@@ -183,8 +105,6 @@ class ShippingPolicyTest {
                     .deliveryCompany("CJ대한통운")
                     .shippingFee(2500L)
                     .freeShippingThreshold(30000L)
-                    .jejuSurcharge(3000L)
-                    .islandSurcharge(5000L)
                     .status(EntityStatus.INACTIVE)
                     .createdAt(now)
                     .modifiedAt(now)
@@ -199,37 +119,9 @@ class ShippingPolicyTest {
             assertThat(policy.getDeliveryCompany()).isEqualTo("CJ대한통운");
             assertThat(policy.getShippingFee()).isEqualTo(2500L);
             assertThat(policy.getFreeShippingThreshold()).isEqualTo(30000L);
-            assertThat(policy.getJejuSurcharge()).isEqualTo(3000L);
-            assertThat(policy.getIslandSurcharge()).isEqualTo(5000L);
             assertThat(policy.isInactive()).isTrue();
             assertThat(policy.getCreatedAt()).isEqualTo(now);
             assertThat(policy.getModifiedAt()).isEqualTo(now);
-        }
-
-        @Test
-        @DisplayName("DB 스냅샷에 추가 배송비가 null이면 null로 복원한다")
-        void shouldRestoreNullSurchargesFromSnapshot() {
-            // given
-            LocalDateTime now = LocalDateTime.of(2026, 3, 10, 12, 0);
-            ShippingPolicySnapshotState state = ShippingPolicySnapshotState.builder()
-                    .id(10L)
-                    .sellerId(1L)
-                    .deliveryCompany("CJ대한통운")
-                    .shippingFee(2500L)
-                    .freeShippingThreshold(30000L)
-                    .jejuSurcharge(null)
-                    .islandSurcharge(null)
-                    .status(EntityStatus.ACTIVE)
-                    .createdAt(now)
-                    .modifiedAt(now)
-                    .build();
-
-            // when
-            ShippingPolicy policy = ShippingPolicy.from(state);
-
-            // then
-            assertThat(policy.getJejuSurcharge()).isNull();
-            assertThat(policy.getIslandSurcharge()).isNull();
         }
     }
 
@@ -244,14 +136,12 @@ class ShippingPolicyTest {
             ShippingPolicy policy = createDefaultPolicy();
 
             // when
-            policy.update("CJ대한통운", 2500L, 30000L, 4000L, 6000L);
+            policy.update("CJ대한통운", 2500L, 30000L);
 
             // then
             assertThat(policy.getDeliveryCompany()).isEqualTo("CJ대한통운");
             assertThat(policy.getShippingFee()).isEqualTo(2500L);
             assertThat(policy.getFreeShippingThreshold()).isEqualTo(30000L);
-            assertThat(policy.getJejuSurcharge()).isEqualTo(4000L);
-            assertThat(policy.getIslandSurcharge()).isEqualTo(6000L);
         }
 
         @Test
@@ -261,7 +151,7 @@ class ShippingPolicyTest {
             ShippingPolicy policy = createDefaultPolicy();
 
             // when & then
-            assertThatThrownBy(() -> policy.update("CJ대한통운", -1L, 30000L, 0L, 0L))
+            assertThatThrownBy(() -> policy.update("CJ대한통운", -1L, 30000L))
                     .isInstanceOf(InvalidShippingFeeException.class);
         }
 
@@ -272,44 +162,8 @@ class ShippingPolicyTest {
             ShippingPolicy policy = createDefaultPolicy();
 
             // when & then
-            assertThatThrownBy(() -> policy.update("CJ대한통운", 3000L, -1L, 0L, 0L))
+            assertThatThrownBy(() -> policy.update("CJ대한통운", 3000L, -1L))
                     .isInstanceOf(InvalidFreeShippingThresholdException.class);
-        }
-
-        @Test
-        @DisplayName("수정 시 제주 추가 배송비가 음수이면 예외가 발생한다")
-        void shouldThrowExceptionWhenUpdateWithNegativeJejuSurcharge() {
-            // given
-            ShippingPolicy policy = createDefaultPolicy();
-
-            // when & then
-            assertThatThrownBy(() -> policy.update("CJ대한통운", 3000L, 30000L, -1L, 0L))
-                    .isInstanceOf(InvalidJejuSurchargeException.class);
-        }
-
-        @Test
-        @DisplayName("수정 시 도서산간 추가 배송비가 음수이면 예외가 발생한다")
-        void shouldThrowExceptionWhenUpdateWithNegativeIslandSurcharge() {
-            // given
-            ShippingPolicy policy = createDefaultPolicy();
-
-            // when & then
-            assertThatThrownBy(() -> policy.update("CJ대한통운", 3000L, 30000L, 0L, -1L))
-                    .isInstanceOf(InvalidIslandSurchargeException.class);
-        }
-
-        @Test
-        @DisplayName("수정 시 제주/도서산간 추가 배송비가 null이면 0으로 기본값 설정된다")
-        void shouldDefaultSurchargesToZeroWhenNullOnUpdate() {
-            // given
-            ShippingPolicy policy = createDefaultPolicy();
-
-            // when
-            policy.update("CJ대한통운", 2500L, 30000L, null, null);
-
-            // then
-            assertThat(policy.getJejuSurcharge()).isZero();
-            assertThat(policy.getIslandSurcharge()).isZero();
         }
     }
 


### PR DESCRIPTION
## partially addresses #216
## resolves #1940

## Task
- [x] KafkaTopicConstants에 OrderCancel SAGA 토픽 상수 3개 추가
- [x] OrderCancelSagaContext record 추가 (orderId, orderKey, buyerId, cancelAmount, paymentAmount, pointAmount, shippingFee, isFullCancel, alreadyRefunded, originalStatus, reasonCategory, reason, orderProducts)
- [x] OrderCancelSagaDefinition 추가 (3 Steps: CANCEL_FULFILLMENT_RELEASE, REFUND_PAYMENT, COMPLETE_CANCELLATION)
- [x] OrderCancelSagaStarter 추가 (ORDER_CANCEL:{orderId} 형식 sagaId)
- [x] ShippingPolicyChangedReadModelConsumerTest 제주/도서산간 추가 배송비 필드 반영