### PR TITLE
[#216][#2304] test: 주문 취소 SAGA Definition 기능 자동화 테스트 추가

### DIFF
--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/saga/OrderCancelSagaDefinitionTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/saga/OrderCancelSagaDefinitionTest.java
@@ -1,0 +1,151 @@
+package com.personal.marketnote.commerce.service.saga;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.commerce.port.in.command.saga.OrderCancelSagaContext;
+import com.personal.marketnote.commerce.port.in.command.saga.OrderPaymentSagaContext.OrderProductItem;
+import com.personal.marketnote.common.kafka.KafkaTopicConstants;
+import com.personal.marketnote.common.saga.SagaStepDefinition;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("OrderCancelSagaDefinition 테스트")
+class OrderCancelSagaDefinitionTest {
+
+    private OrderCancelSagaDefinition definition;
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper();
+        definition = new OrderCancelSagaDefinition(objectMapper);
+    }
+
+    @Nested
+    @DisplayName("getSagaType")
+    class GetSagaType {
+
+        @Test
+        @DisplayName("SAGA 타입은 ORDER_CANCEL이다")
+        void shouldReturnOrderCancelSagaType() {
+            String sagaType = definition.getSagaType();
+
+            assertThat(sagaType).isEqualTo("ORDER_CANCEL");
+        }
+    }
+
+    @Nested
+    @DisplayName("getContextType")
+    class GetContextType {
+
+        @Test
+        @DisplayName("컨텍스트 타입은 OrderCancelSagaContext이다")
+        void shouldReturnContextType() {
+            Class<OrderCancelSagaContext> contextType = definition.getContextType();
+
+            assertThat(contextType).isEqualTo(OrderCancelSagaContext.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("getSteps")
+    class GetSteps {
+
+        @Test
+        @DisplayName("3개의 스텝이 정의되어 있다")
+        void shouldHaveThreeSteps() {
+            List<SagaStepDefinition<OrderCancelSagaContext>> steps = definition.getSteps();
+
+            assertThat(steps).hasSize(3);
+        }
+
+        @Test
+        @DisplayName("첫 번째 스텝은 CANCEL_FULFILLMENT_RELEASE이며 보상이 없다")
+        void shouldHaveCancelFulfillmentReleaseAsFirstStepWithoutCompensation() {
+            SagaStepDefinition<OrderCancelSagaContext> firstStep = definition.getSteps().get(0);
+
+            assertThat(firstStep.stepName()).isEqualTo("CANCEL_FULFILLMENT_RELEASE");
+            assertThat(firstStep.topic()).isEqualTo(KafkaTopicConstants.SAGA_ORDER_CANCEL_FULFILLMENT);
+            assertThat(firstStep.hasCompensation()).isFalse();
+        }
+
+        @Test
+        @DisplayName("두 번째 스텝은 REFUND_PAYMENT이며 보상이 없다")
+        void shouldHaveRefundPaymentAsSecondStepWithoutCompensation() {
+            SagaStepDefinition<OrderCancelSagaContext> secondStep = definition.getSteps().get(1);
+
+            assertThat(secondStep.stepName()).isEqualTo("REFUND_PAYMENT");
+            assertThat(secondStep.topic()).isEqualTo(KafkaTopicConstants.SAGA_ORDER_CANCEL_REFUND);
+            assertThat(secondStep.hasCompensation()).isFalse();
+        }
+
+        @Test
+        @DisplayName("세 번째 스텝은 COMPLETE_CANCELLATION이며 보상이 없다")
+        void shouldHaveCompleteCancellationAsLastStepWithoutCompensation() {
+            SagaStepDefinition<OrderCancelSagaContext> thirdStep = definition.getSteps().get(2);
+
+            assertThat(thirdStep.stepName()).isEqualTo("COMPLETE_CANCELLATION");
+            assertThat(thirdStep.topic()).isEqualTo(KafkaTopicConstants.SAGA_ORDER_CANCEL_COMPLETED);
+            assertThat(thirdStep.hasCompensation()).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("action 메시지 생성")
+    class ActionMessages {
+
+        private OrderCancelSagaContext context;
+
+        @BeforeEach
+        void setUp() {
+            context = new OrderCancelSagaContext(
+                    1L, "order-key-1", 100L,
+                    50000L, 50000L, 0L, 3000L,
+                    true, 0L,
+                    "PREPARING", "CANCEL_ORDER", "구매 의사 취소",
+                    List.of(
+                            new OrderProductItem(10L, UUID.fromString("550e8400-e29b-41d4-a716-446655440000"), 2, 25000L),
+                            new OrderProductItem(20L, null, 1, 10000L)
+                    )
+            );
+        }
+
+        @Test
+        @DisplayName("풀필먼트 취소 액션 메시지에 orderId와 originalStatus가 포함된다")
+        void shouldBuildFulfillmentCancelAction() {
+            String actionJson = definition.getSteps().get(0).action().apply(context);
+
+            assertThat(actionJson).contains("\"orderId\"");
+            assertThat(actionJson).contains("\"originalStatus\"");
+            assertThat(actionJson).contains("PREPARING");
+        }
+
+        @Test
+        @DisplayName("PG 환불 액션 메시지에 orderId, orderKey, cancelAmount가 포함된다")
+        void shouldBuildRefundPaymentAction() {
+            String actionJson = definition.getSteps().get(1).action().apply(context);
+
+            assertThat(actionJson).contains("\"orderId\"");
+            assertThat(actionJson).contains("\"orderKey\"");
+            assertThat(actionJson).contains("\"cancelAmount\"");
+            assertThat(actionJson).contains("50000");
+        }
+
+        @Test
+        @DisplayName("취소 완료 액션 메시지에 orderId, reasonCategory, orderProducts가 포함된다")
+        void shouldBuildCompleteCancellationAction() {
+            String actionJson = definition.getSteps().get(2).action().apply(context);
+
+            assertThat(actionJson).contains("\"orderId\"");
+            assertThat(actionJson).contains("\"reasonCategory\"");
+            assertThat(actionJson).contains("\"orderProducts\"");
+            assertThat(actionJson).contains("CANCEL_ORDER");
+        }
+    }
+}

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/saga/OrderCancelSagaStarterTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/saga/OrderCancelSagaStarterTest.java
@@ -1,0 +1,86 @@
+package com.personal.marketnote.commerce.service.saga;
+
+import com.personal.marketnote.commerce.port.in.command.saga.OrderCancelSagaContext;
+import com.personal.marketnote.commerce.port.in.command.saga.OrderPaymentSagaContext.OrderProductItem;
+import com.personal.marketnote.common.saga.SagaOrchestrator;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("OrderCancelSagaStarter 테스트")
+class OrderCancelSagaStarterTest {
+
+    @InjectMocks
+    private OrderCancelSagaStarter orderCancelSagaStarter;
+
+    @Mock
+    private SagaOrchestrator sagaOrchestrator;
+
+    @Mock
+    private OrderCancelSagaDefinition orderCancelSagaDefinition;
+
+    @Test
+    @DisplayName("SAGA를 시작하면 ORDER_CANCEL:{orderId} 형식의 sagaId로 SagaOrchestrator.start가 호출된다")
+    void shouldStartSagaWithCorrectSagaId() {
+        OrderCancelSagaContext context = new OrderCancelSagaContext(
+                1L, "order-key-1", 100L,
+                50000L, 50000L, 0L, 3000L,
+                true, 0L,
+                "PAID", "CANCEL_ORDER", "구매 의사 취소",
+                List.of(new OrderProductItem(10L, null, 2, 25000L))
+        );
+
+        orderCancelSagaStarter.start(context);
+
+        ArgumentCaptor<String> sagaIdCaptor = ArgumentCaptor.forClass(String.class);
+        verify(sagaOrchestrator).start(
+                eq(orderCancelSagaDefinition),
+                sagaIdCaptor.capture(),
+                eq(context)
+        );
+        assertThat(sagaIdCaptor.getValue()).isEqualTo("ORDER_CANCEL:1");
+    }
+
+    @Test
+    @DisplayName("SAGA를 시작하면 전달받은 컨텍스트가 그대로 전달된다")
+    void shouldPassContextToOrchestrator() {
+        OrderCancelSagaContext context = new OrderCancelSagaContext(
+                42L, "order-key-42", 200L,
+                100000L, 100000L, 5000L, 3000L,
+                true, 0L,
+                "PREPARING", "MISTAKE", "주문 실수",
+                List.of(
+                        new OrderProductItem(10L, null, 1, 50000L),
+                        new OrderProductItem(20L, null, 2, 25000L)
+                )
+        );
+
+        orderCancelSagaStarter.start(context);
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<OrderCancelSagaContext> contextCaptor =
+                ArgumentCaptor.forClass(OrderCancelSagaContext.class);
+        verify(sagaOrchestrator).start(
+                any(OrderCancelSagaDefinition.class),
+                eq("ORDER_CANCEL:42"),
+                contextCaptor.capture()
+        );
+        OrderCancelSagaContext captured = contextCaptor.getValue();
+        assertThat(captured.orderId()).isEqualTo(42L);
+        assertThat(captured.buyerId()).isEqualTo(200L);
+        assertThat(captured.originalStatus()).isEqualTo("PREPARING");
+        assertThat(captured.orderProducts()).hasSize(2);
+    }
+}


### PR DESCRIPTION
## partially addresses #216
## resolves #2304

## Test Case
- [x] SAGA 타입은 ORDER_CANCEL이다
- [x] 컨텍스트 타입은 OrderCancelSagaContext이다
- [x] 3개의 스텝이 정의되어 있다
- [x] 첫 번째 스텝은 CANCEL_FULFILLMENT_RELEASE이며 보상이 없다
- [x] 두 번째 스텝은 REFUND_PAYMENT이며 보상이 없다
- [x] 세 번째 스텝은 COMPLETE_CANCELLATION이며 보상이 없다
- [x] 풀필먼트 취소 액션 메시지에 orderId와 originalStatus가 포함된다
- [x] PG 환불 액션 메시지에 orderId, orderKey, cancelAmount가 포함된다
- [x] 취소 완료 액션 메시지에 orderId, reasonCategory, orderProducts가 포함된다
- [x] SAGA를 시작하면 ORDER_CANCEL:{orderId} 형식의 sagaId로 SagaOrchestrator.start가 호출된다
- [x] SAGA를 시작하면 전달받은 컨텍스트가 그대로 전달된다