### PR TITLE
[#216][#2342] feat: 풀필먼트 출고 취소 SAGA Step Consumer 추가

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/ShippingPolicyChangedReadModelConsumer.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/ShippingPolicyChangedReadModelConsumer.java
@@ -3,6 +3,7 @@ package com.personal.marketnote.commerce.adapter.in.event;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.personal.marketnote.commerce.port.out.shipping.SaveShippingPolicyReadModelPort;
 import com.personal.marketnote.common.kafka.KafkaTopicConstants;
+import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.common.kafka.event.EventEnvelope;
 import com.personal.marketnote.common.kafka.event.EventPayloadValidator;
 import com.personal.marketnote.common.kafka.event.ShippingPolicyChangedEvent;
@@ -58,11 +59,15 @@ public class ShippingPolicyChangedReadModelConsumer {
         }
 
         if (payload.action().isCreated() || payload.action().isUpdated()) {
+            Long jejuSurcharge = FormatValidator.hasNoValue(payload.jejuSurcharge()) ? 0L : payload.jejuSurcharge();
+            Long islandSurcharge = FormatValidator.hasNoValue(payload.islandSurcharge()) ? 0L : payload.islandSurcharge();
             saveShippingPolicyReadModelPort.upsert(
-                    payload.sellerId(), payload.shippingFee(), payload.freeShippingThreshold()
+                    payload.sellerId(), payload.shippingFee(), payload.freeShippingThreshold(),
+                    jejuSurcharge, islandSurcharge
             );
-            log.info("배송비 정책 Read Model 저장 완료. sellerId={}, shippingFee={}, freeShippingThreshold={}",
-                    payload.sellerId(), payload.shippingFee(), payload.freeShippingThreshold());
+            log.info("배송비 정책 Read Model 저장 완료. sellerId={}, shippingFee={}, freeShippingThreshold={}, jejuSurcharge={}, islandSurcharge={}",
+                    payload.sellerId(), payload.shippingFee(), payload.freeShippingThreshold(),
+                    payload.jejuSurcharge(), payload.islandSurcharge());
         }
 
         acknowledgment.acknowledge();

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/saga/OrderCancelFulfillmentSagaConsumer.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/saga/OrderCancelFulfillmentSagaConsumer.java
@@ -1,0 +1,116 @@
+package com.personal.marketnote.commerce.adapter.in.event.saga;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.commerce.adapter.in.event.saga.payload.FulfillmentCancelSagaPayload;
+import com.personal.marketnote.commerce.port.out.fulfillment.CancelFulfillmentReleasePort;
+import com.personal.marketnote.commerce.port.out.fulfillment.CancelFulfillmentReleaseResult;
+import com.personal.marketnote.common.kafka.KafkaTopicConstants;
+import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.EventPayloadValidator;
+import com.personal.marketnote.common.saga.SagaResponsePublisher;
+import com.personal.marketnote.common.saga.SagaStepMessage;
+import com.personal.marketnote.common.utility.FormatValidator;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@ConditionalOnProperty(prefix = "saga", name = "enabled", havingValue = "true")
+@RequiredArgsConstructor
+public class OrderCancelFulfillmentSagaConsumer {
+
+    private static final String REQUIRES_FULFILLMENT_CANCEL = "PREPARING";
+
+    private final ObjectMapper objectMapper;
+    private final CancelFulfillmentReleasePort cancelFulfillmentReleasePort;
+    private final SagaResponsePublisher sagaResponsePublisher;
+
+    @KafkaListener(
+            topics = KafkaTopicConstants.SAGA_ORDER_CANCEL_FULFILLMENT,
+            groupId = "saga-order-cancel-fulfillment"
+    )
+    public void handleFulfillmentCancelStep(
+            ConsumerRecord<String, EventEnvelope<?>> record,
+            Acknowledgment acknowledgment
+    ) {
+        EventEnvelope<?> envelope = record.value();
+
+        if (EventPayloadValidator.hasInvalidEnvelope(envelope, record)) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        SagaStepMessage stepMessage = envelope.getPayloadAs(SagaStepMessage.class, objectMapper);
+
+        log.info("SAGA 풀필먼트 취소 스텝 수신. sagaId={}, messageType={}",
+                stepMessage.sagaId(), stepMessage.messageType());
+
+        if (SagaStepMessage.ACTION.equals(stepMessage.messageType())) {
+            handleAction(stepMessage);
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        log.warn("풀필먼트 취소 스텝은 보상이 없음. 알 수 없는 messageType. sagaId={}, messageType={}",
+                stepMessage.sagaId(), stepMessage.messageType());
+        acknowledgment.acknowledge();
+    }
+
+    private void handleAction(SagaStepMessage stepMessage) {
+        try {
+            FulfillmentCancelSagaPayload payload = objectMapper.readValue(
+                    stepMessage.payload(), FulfillmentCancelSagaPayload.class);
+
+            if (FormatValidator.hasNoValue(payload.orderId())) {
+                publishValidationFailure(stepMessage, "orderId 누락");
+                return;
+            }
+
+            if (!REQUIRES_FULFILLMENT_CANCEL.equals(payload.originalStatus())) {
+                log.info("풀필먼트 취소 불필요 (originalStatus={}). sagaId={}, orderId={}",
+                        payload.originalStatus(), stepMessage.sagaId(), payload.orderId());
+                sagaResponsePublisher.publishSuccess(
+                        stepMessage.sagaId(), stepMessage.sagaType(), stepMessage.stepName(),
+                        stepMessage.messageType(), "{\"success\":true,\"skipped\":true}");
+                return;
+            }
+
+            CancelFulfillmentReleaseResult result = cancelFulfillmentReleasePort.cancelRelease(payload.orderId());
+
+            if (!result.cancelled()) {
+                log.warn("풀필먼트 출고 취소 거부. sagaId={}, orderId={}, message={}",
+                        stepMessage.sagaId(), payload.orderId(), result.message());
+                sagaResponsePublisher.publishFailure(
+                        stepMessage.sagaId(), stepMessage.sagaType(), stepMessage.stepName(),
+                        stepMessage.messageType(), "풀필먼트 출고 취소 거부: " + result.message());
+                return;
+            }
+
+            sagaResponsePublisher.publishSuccess(
+                    stepMessage.sagaId(), stepMessage.sagaType(), stepMessage.stepName(),
+                    stepMessage.messageType(), "{\"success\":true}");
+
+            log.info("SAGA 풀필먼트 출고 취소 성공. sagaId={}, orderId={}",
+                    stepMessage.sagaId(), payload.orderId());
+        } catch (Exception e) {
+            log.error("SAGA 풀필먼트 출고 취소 처리 실패. sagaId={}, error={}",
+                    stepMessage.sagaId(), e.getMessage(), e);
+            sagaResponsePublisher.publishFailure(
+                    stepMessage.sagaId(), stepMessage.sagaType(), stepMessage.stepName(),
+                    stepMessage.messageType(), "풀필먼트 출고 취소 처리 실패");
+        }
+    }
+
+    private void publishValidationFailure(SagaStepMessage stepMessage, String reason) {
+        log.warn("SAGA 풀필먼트 취소 스텝 페이로드 검증 실패. sagaId={}, reason={}",
+                stepMessage.sagaId(), reason);
+        sagaResponsePublisher.publishFailure(
+                stepMessage.sagaId(), stepMessage.sagaType(), stepMessage.stepName(),
+                stepMessage.messageType(), "페이로드 검증 실패: " + reason);
+    }
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/saga/payload/FulfillmentCancelSagaPayload.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/saga/payload/FulfillmentCancelSagaPayload.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.commerce.adapter.in.event.saga.payload;
+
+public record FulfillmentCancelSagaPayload(
+        Long orderId,
+        String originalStatus
+) {
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/shipping/ShippingPolicyReadModelPersistenceAdapter.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/shipping/ShippingPolicyReadModelPersistenceAdapter.java
@@ -42,7 +42,9 @@ public class ShippingPolicyReadModelPersistenceAdapter implements FindShippingPo
             result.put(entity.getSellerId(), new ShippingPolicyInfoResult(
                     entity.getSellerId(),
                     entity.getShippingFee(),
-                    entity.getFreeShippingThreshold()
+                    entity.getFreeShippingThreshold(),
+                    entity.getJejuSurcharge(),
+                    entity.getIslandSurcharge()
             ));
         }
 
@@ -51,23 +53,24 @@ public class ShippingPolicyReadModelPersistenceAdapter implements FindShippingPo
 
     @Override
     @Transactional(isolation = READ_COMMITTED)
-    public void upsert(Long sellerId, Long shippingFee, Long freeShippingThreshold) {
+    public void upsert(Long sellerId, Long shippingFee, Long freeShippingThreshold,
+                       Long jejuSurcharge, Long islandSurcharge) {
         Optional<ShippingPolicyReadModelJpaEntity> existing = shippingPolicyReadModelJpaRepository.findBySellerId(sellerId);
 
         if (existing.isPresent()) {
-            existing.get().updateFrom(shippingFee, freeShippingThreshold);
+            existing.get().updateFrom(shippingFee, freeShippingThreshold, jejuSurcharge, islandSurcharge);
             return;
         }
 
         try {
             ShippingPolicyReadModelJpaEntity entity = ShippingPolicyReadModelJpaEntity.of(
-                    sellerId, shippingFee, freeShippingThreshold
+                    sellerId, shippingFee, freeShippingThreshold, jejuSurcharge, islandSurcharge
             );
             shippingPolicyReadModelJpaRepository.saveAndFlush(entity);
         } catch (DataIntegrityViolationException e) {
             log.info("배송비 정책 Read Model 중복 저장 (멱등 처리). sellerId={}", sellerId);
             shippingPolicyReadModelJpaRepository.findBySellerId(sellerId)
-                    .ifPresent(entity -> entity.updateFrom(shippingFee, freeShippingThreshold));
+                    .ifPresent(entity -> entity.updateFrom(shippingFee, freeShippingThreshold, jejuSurcharge, islandSurcharge));
         }
     }
 

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/shipping/entity/ShippingPolicyReadModelJpaEntity.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/shipping/entity/ShippingPolicyReadModelJpaEntity.java
@@ -30,17 +30,29 @@ public class ShippingPolicyReadModelJpaEntity extends BaseGeneralEntity {
     @Column(name = "free_shipping_threshold", nullable = false)
     private Long freeShippingThreshold;
 
-    public static ShippingPolicyReadModelJpaEntity of(Long sellerId, Long shippingFee, Long freeShippingThreshold) {
+    @Column(name = "jeju_surcharge")
+    private Long jejuSurcharge;
+
+    @Column(name = "island_surcharge")
+    private Long islandSurcharge;
+
+    public static ShippingPolicyReadModelJpaEntity of(Long sellerId, Long shippingFee, Long freeShippingThreshold,
+                                                      Long jejuSurcharge, Long islandSurcharge) {
         return ShippingPolicyReadModelJpaEntity.builder()
                 .sellerId(sellerId)
                 .shippingFee(shippingFee)
                 .freeShippingThreshold(freeShippingThreshold)
+                .jejuSurcharge(jejuSurcharge)
+                .islandSurcharge(islandSurcharge)
                 .build();
     }
 
-    public void updateFrom(Long shippingFee, Long freeShippingThreshold) {
+    public void updateFrom(Long shippingFee, Long freeShippingThreshold,
+                           Long jejuSurcharge, Long islandSurcharge) {
         this.shippingFee = shippingFee;
         this.freeShippingThreshold = freeShippingThreshold;
+        this.jejuSurcharge = jejuSurcharge;
+        this.islandSurcharge = islandSurcharge;
         activate();
     }
 

--- a/commerce-service/commerce-adapters/src/main/resources/db/migration/V914__add_surcharge_to_shipping_policy_read_models.sql
+++ b/commerce-service/commerce-adapters/src/main/resources/db/migration/V914__add_surcharge_to_shipping_policy_read_models.sql
@@ -1,0 +1,2 @@
+ALTER TABLE shipping_policy_read_models ADD COLUMN jeju_surcharge BIGINT DEFAULT 0;
+ALTER TABLE shipping_policy_read_models ADD COLUMN island_surcharge BIGINT DEFAULT 0;

--- a/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/event/ShippingPolicyChangedReadModelConsumerTest.java
+++ b/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/event/ShippingPolicyChangedReadModelConsumerTest.java
@@ -58,7 +58,7 @@ class ShippingPolicyChangedReadModelConsumerTest {
     void handleShippingPolicyChangedEvent_created_upsertsReadModel() {
         // given
         ShippingPolicyChangedEvent payload = new ShippingPolicyChangedEvent(
-                10L, 3000L, 20000L, ShippingPolicyChangeAction.CREATED
+                10L, 3000L, 20000L, 3000L, 5000L, ShippingPolicyChangeAction.CREATED
         );
         EventEnvelope<ShippingPolicyChangedEvent> envelope = createEnvelope(payload);
         ConsumerRecord<String, EventEnvelope<?>> record = createRecord(envelope);
@@ -67,7 +67,7 @@ class ShippingPolicyChangedReadModelConsumerTest {
         consumer.handleShippingPolicyChangedEvent(record, acknowledgment);
 
         // then
-        verify(saveShippingPolicyReadModelPort).upsert(10L, 3000L, 20000L);
+        verify(saveShippingPolicyReadModelPort).upsert(10L, 3000L, 20000L, 3000L, 5000L);
         verify(acknowledgment).acknowledge();
     }
 
@@ -76,7 +76,7 @@ class ShippingPolicyChangedReadModelConsumerTest {
     void handleShippingPolicyChangedEvent_updated_upsertsReadModel() {
         // given
         ShippingPolicyChangedEvent payload = new ShippingPolicyChangedEvent(
-                20L, 2500L, 30000L, ShippingPolicyChangeAction.UPDATED
+                20L, 2500L, 30000L, 4000L, 6000L, ShippingPolicyChangeAction.UPDATED
         );
         EventEnvelope<ShippingPolicyChangedEvent> envelope = createEnvelope(payload);
         ConsumerRecord<String, EventEnvelope<?>> record = createRecord(envelope);
@@ -85,7 +85,7 @@ class ShippingPolicyChangedReadModelConsumerTest {
         consumer.handleShippingPolicyChangedEvent(record, acknowledgment);
 
         // then
-        verify(saveShippingPolicyReadModelPort).upsert(20L, 2500L, 30000L);
+        verify(saveShippingPolicyReadModelPort).upsert(20L, 2500L, 30000L, 4000L, 6000L);
         verify(acknowledgment).acknowledge();
     }
 
@@ -94,7 +94,7 @@ class ShippingPolicyChangedReadModelConsumerTest {
     void handleShippingPolicyChangedEvent_deleted_deactivatesReadModel() {
         // given
         ShippingPolicyChangedEvent payload = new ShippingPolicyChangedEvent(
-                10L, 3000L, 20000L, ShippingPolicyChangeAction.DELETED
+                10L, 3000L, 20000L, 3000L, 5000L, ShippingPolicyChangeAction.DELETED
         );
         EventEnvelope<ShippingPolicyChangedEvent> envelope = createEnvelope(payload);
         ConsumerRecord<String, EventEnvelope<?>> record = createRecord(envelope);
@@ -129,7 +129,7 @@ class ShippingPolicyChangedReadModelConsumerTest {
     void handleShippingPolicyChangedEvent_eventTypeMismatch_acknowledges() {
         // given
         ShippingPolicyChangedEvent payload = new ShippingPolicyChangedEvent(
-                10L, 3000L, 20000L, ShippingPolicyChangeAction.CREATED
+                10L, 3000L, 20000L, 3000L, 5000L, ShippingPolicyChangeAction.CREATED
         );
         EventEnvelope<ShippingPolicyChangedEvent> envelope = new EventEnvelope<>(
                 "test-event-id",
@@ -153,7 +153,7 @@ class ShippingPolicyChangedReadModelConsumerTest {
     void handleShippingPolicyChangedEvent_nullSellerId_acknowledges() {
         // given
         ShippingPolicyChangedEvent payload = new ShippingPolicyChangedEvent(
-                null, 3000L, 20000L, ShippingPolicyChangeAction.CREATED
+                null, 3000L, 20000L, 3000L, 5000L, ShippingPolicyChangeAction.CREATED
         );
         EventEnvelope<ShippingPolicyChangedEvent> envelope = createEnvelope(payload);
         ConsumerRecord<String, EventEnvelope<?>> record = createRecord(envelope);
@@ -171,7 +171,7 @@ class ShippingPolicyChangedReadModelConsumerTest {
     void handleShippingPolicyChangedEvent_zeroSellerId_acknowledges() {
         // given
         ShippingPolicyChangedEvent payload = new ShippingPolicyChangedEvent(
-                0L, 3000L, 20000L, ShippingPolicyChangeAction.CREATED
+                0L, 3000L, 20000L, 0L, 0L, ShippingPolicyChangeAction.CREATED
         );
         EventEnvelope<ShippingPolicyChangedEvent> envelope = createEnvelope(payload);
         ConsumerRecord<String, EventEnvelope<?>> record = createRecord(envelope);
@@ -189,7 +189,7 @@ class ShippingPolicyChangedReadModelConsumerTest {
     void handleShippingPolicyChangedEvent_negativeSellerId_acknowledges() {
         // given
         ShippingPolicyChangedEvent payload = new ShippingPolicyChangedEvent(
-                -1L, 3000L, 20000L, ShippingPolicyChangeAction.CREATED
+                -1L, 3000L, 20000L, 0L, 0L, ShippingPolicyChangeAction.CREATED
         );
         EventEnvelope<ShippingPolicyChangedEvent> envelope = createEnvelope(payload);
         ConsumerRecord<String, EventEnvelope<?>> record = createRecord(envelope);

--- a/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/out/persistence/shipping/ShippingPolicyReadModelPersistenceAdapterTest.java
+++ b/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/out/persistence/shipping/ShippingPolicyReadModelPersistenceAdapterTest.java
@@ -45,8 +45,8 @@ class ShippingPolicyReadModelPersistenceAdapterTest {
         @DisplayName("ACTIVE 상태의 배송비 정책을 판매자 ID별 맵으로 반환한다")
         void returnsActivePoliciesAsMap() {
             // given
-            adapter.upsert(10L, 3000L, 20000L);
-            adapter.upsert(20L, 2500L, 30000L);
+            adapter.upsert(10L, 3000L, 20000L, 3000L, 5000L);
+            adapter.upsert(20L, 2500L, 30000L, 4000L, 6000L);
 
             // when
             Map<Long, ShippingPolicyInfoResult> result = adapter.findBySellerIds(List.of(10L, 20L));
@@ -56,9 +56,13 @@ class ShippingPolicyReadModelPersistenceAdapterTest {
             assertThat(result.get(10L).sellerId()).isEqualTo(10L);
             assertThat(result.get(10L).shippingFee()).isEqualTo(3000L);
             assertThat(result.get(10L).freeShippingThreshold()).isEqualTo(20000L);
+            assertThat(result.get(10L).jejuSurcharge()).isEqualTo(3000L);
+            assertThat(result.get(10L).islandSurcharge()).isEqualTo(5000L);
             assertThat(result.get(20L).sellerId()).isEqualTo(20L);
             assertThat(result.get(20L).shippingFee()).isEqualTo(2500L);
             assertThat(result.get(20L).freeShippingThreshold()).isEqualTo(30000L);
+            assertThat(result.get(20L).jejuSurcharge()).isEqualTo(4000L);
+            assertThat(result.get(20L).islandSurcharge()).isEqualTo(6000L);
         }
 
         @Test
@@ -85,7 +89,7 @@ class ShippingPolicyReadModelPersistenceAdapterTest {
         @DisplayName("INACTIVE 상태의 배송비 정책은 조회하지 않는다")
         void excludesInactivePolicies() {
             // given
-            adapter.upsert(10L, 3000L, 20000L);
+            adapter.upsert(10L, 3000L, 20000L, 3000L, 5000L);
             adapter.deactivateBySellerId(10L);
 
             // when
@@ -99,7 +103,7 @@ class ShippingPolicyReadModelPersistenceAdapterTest {
         @DisplayName("존재하지 않는 sellerId는 결과에 포함하지 않는다")
         void excludesNonExistentSellerIds() {
             // given
-            adapter.upsert(10L, 3000L, 20000L);
+            adapter.upsert(10L, 3000L, 20000L, 3000L, 5000L);
 
             // when
             Map<Long, ShippingPolicyInfoResult> result = adapter.findBySellerIds(List.of(10L, 999L));
@@ -119,7 +123,7 @@ class ShippingPolicyReadModelPersistenceAdapterTest {
         @DisplayName("신규 배송비 정책을 저장한다")
         void insertsNewPolicy() {
             // when
-            adapter.upsert(10L, 3000L, 20000L);
+            adapter.upsert(10L, 3000L, 20000L, 3000L, 5000L);
 
             // then
             Optional<ShippingPolicyReadModelJpaEntity> entity = repository.findBySellerIdAndStatus(10L, EntityStatus.ACTIVE);
@@ -127,6 +131,8 @@ class ShippingPolicyReadModelPersistenceAdapterTest {
             assertThat(entity.get().getSellerId()).isEqualTo(10L);
             assertThat(entity.get().getShippingFee()).isEqualTo(3000L);
             assertThat(entity.get().getFreeShippingThreshold()).isEqualTo(20000L);
+            assertThat(entity.get().getJejuSurcharge()).isEqualTo(3000L);
+            assertThat(entity.get().getIslandSurcharge()).isEqualTo(5000L);
             assertThat(entity.get().getStatus()).isEqualTo(EntityStatus.ACTIVE);
         }
 
@@ -134,27 +140,29 @@ class ShippingPolicyReadModelPersistenceAdapterTest {
         @DisplayName("동일한 sellerId로 upsert 시 기존 데이터를 업데이트한다")
         void updatesExistingPolicy() {
             // given
-            adapter.upsert(10L, 3000L, 20000L);
+            adapter.upsert(10L, 3000L, 20000L, 3000L, 5000L);
 
             // when
-            adapter.upsert(10L, 5000L, 50000L);
+            adapter.upsert(10L, 5000L, 50000L, 7000L, 8000L);
 
             // then
             Optional<ShippingPolicyReadModelJpaEntity> entity = repository.findBySellerIdAndStatus(10L, EntityStatus.ACTIVE);
             assertThat(entity).isPresent();
             assertThat(entity.get().getShippingFee()).isEqualTo(5000L);
             assertThat(entity.get().getFreeShippingThreshold()).isEqualTo(50000L);
+            assertThat(entity.get().getJejuSurcharge()).isEqualTo(7000L);
+            assertThat(entity.get().getIslandSurcharge()).isEqualTo(8000L);
         }
 
         @Test
         @DisplayName("비활성화된 정책에 대해 upsert 시 다시 활성화된다")
         void reactivatesInactivePolicy() {
             // given
-            adapter.upsert(10L, 3000L, 20000L);
+            adapter.upsert(10L, 3000L, 20000L, 3000L, 5000L);
             adapter.deactivateBySellerId(10L);
 
             // when
-            adapter.upsert(10L, 5000L, 50000L);
+            adapter.upsert(10L, 5000L, 50000L, 7000L, 8000L);
 
             // then
             Optional<ShippingPolicyReadModelJpaEntity> entity = repository.findBySellerIdAndStatus(10L, EntityStatus.ACTIVE);
@@ -172,7 +180,7 @@ class ShippingPolicyReadModelPersistenceAdapterTest {
         @DisplayName("배송비 정책을 비활성화한다")
         void deactivatesPolicy() {
             // given
-            adapter.upsert(10L, 3000L, 20000L);
+            adapter.upsert(10L, 3000L, 20000L, 3000L, 5000L);
 
             // when
             adapter.deactivateBySellerId(10L);

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/result/shipping/ShippingPolicyInfoResult.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/result/shipping/ShippingPolicyInfoResult.java
@@ -3,6 +3,9 @@ package com.personal.marketnote.commerce.port.out.result.shipping;
 public record ShippingPolicyInfoResult(
         Long sellerId,
         Long shippingFee,
-        Long freeShippingThreshold
+        Long freeShippingThreshold,
+        Long jejuSurcharge,
+        Long islandSurcharge
 ) {
 }
+

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/shipping/SaveShippingPolicyReadModelPort.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/shipping/SaveShippingPolicyReadModelPort.java
@@ -2,7 +2,8 @@ package com.personal.marketnote.commerce.port.out.shipping;
 
 public interface SaveShippingPolicyReadModelPort {
 
-    void upsert(Long sellerId, Long shippingFee, Long freeShippingThreshold);
+    void upsert(Long sellerId, Long shippingFee, Long freeShippingThreshold,
+                Long jejuSurcharge, Long islandSurcharge);
 
     void deactivateBySellerId(Long sellerId);
 }

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/RegisterOrderUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/RegisterOrderUseCaseTest.java
@@ -2193,8 +2193,8 @@ class RegisterOrderUseCaseTest {
                     pricePolicyId2, Map.entry(50000L, 20L)
             ));
             mockShippingPolicies(Map.of(
-                    10L, new ShippingPolicyInfoResult(10L, shippingFeeA, 100000L),
-                    20L, new ShippingPolicyInfoResult(20L, shippingFeeB, 100000L)
+                    10L, new ShippingPolicyInfoResult(10L, shippingFeeA, 100000L, 0L, 0L),
+                    20L, new ShippingPolicyInfoResult(20L, shippingFeeB, 100000L, 0L, 0L)
             ));
             Inventory inventory1 = Inventory.of(1L, pricePolicyId1, 100);
             Inventory inventory2 = Inventory.of(2L, pricePolicyId2, 50);
@@ -2484,8 +2484,8 @@ class RegisterOrderUseCaseTest {
                     pricePolicyIdB, Map.entry(unitAmountB, sellerIdB)
             ));
             mockShippingPolicies(Map.of(
-                    sellerIdA, new ShippingPolicyInfoResult(sellerIdA, shippingFeeA, 20000L),
-                    sellerIdB, new ShippingPolicyInfoResult(sellerIdB, shippingFeeB, 20000L)
+                    sellerIdA, new ShippingPolicyInfoResult(sellerIdA, shippingFeeA, 20000L, 0L, 0L),
+                    sellerIdB, new ShippingPolicyInfoResult(sellerIdB, shippingFeeB, 20000L, 0L, 0L)
             ));
             mockInventoryMultiple(Map.of(pricePolicyIdA, 100, pricePolicyIdB, 100));
             Order savedOrder = mockSavedOrder(1L);
@@ -2532,8 +2532,8 @@ class RegisterOrderUseCaseTest {
                     pricePolicyIdB, Map.entry(unitAmountB, sellerIdB)
             ));
             mockShippingPolicies(Map.of(
-                    sellerIdA, new ShippingPolicyInfoResult(sellerIdA, 3000L, 20000L),
-                    sellerIdB, new ShippingPolicyInfoResult(sellerIdB, shippingFeeB, 20000L)
+                    sellerIdA, new ShippingPolicyInfoResult(sellerIdA, 3000L, 20000L, 0L, 0L),
+                    sellerIdB, new ShippingPolicyInfoResult(sellerIdB, shippingFeeB, 20000L, 0L, 0L)
             ));
             mockInventoryMultiple(Map.of(pricePolicyIdA, 100, pricePolicyIdB, 100));
             Order savedOrder = mockSavedOrder(1L);
@@ -2580,7 +2580,7 @@ class RegisterOrderUseCaseTest {
                     pricePolicyIdB, Map.entry(unitAmountB, sellerIdB)
             ));
             mockShippingPolicies(Map.of(
-                    sellerIdA, new ShippingPolicyInfoResult(sellerIdA, shippingFeeA, 20000L)
+                    sellerIdA, new ShippingPolicyInfoResult(sellerIdA, shippingFeeA, 20000L, 0L, 0L)
             ));
             mockInventoryMultiple(Map.of(pricePolicyIdA, 100, pricePolicyIdB, 100));
             Order savedOrder = mockSavedOrder(1L);
@@ -2806,7 +2806,7 @@ class RegisterOrderUseCaseTest {
 
     private void mockShippingPolicy(Long sellerId, Long shippingFee, Long freeShippingThreshold) {
         when(findShippingPolicyBySellerIdsPort.findBySellerIds(anyList()))
-                .thenReturn(Map.of(sellerId, new ShippingPolicyInfoResult(sellerId, shippingFee, freeShippingThreshold)));
+                .thenReturn(Map.of(sellerId, new ShippingPolicyInfoResult(sellerId, shippingFee, freeShippingThreshold, 0L, 0L)));
     }
 
     private void mockShippingPolicies(Map<Long, ShippingPolicyInfoResult> policies) {

--- a/common/src/main/java/com/personal/marketnote/common/kafka/event/ShippingPolicyChangedEvent.java
+++ b/common/src/main/java/com/personal/marketnote/common/kafka/event/ShippingPolicyChangedEvent.java
@@ -4,6 +4,8 @@ public record ShippingPolicyChangedEvent(
         Long sellerId,
         Long shippingFee,
         Long freeShippingThreshold,
+        Long jejuSurcharge,
+        Long islandSurcharge,
         ShippingPolicyChangeAction action
 ) {
 }

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/shipping/controller/ShippingPolicyController.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/shipping/controller/ShippingPolicyController.java
@@ -139,7 +139,9 @@ public class ShippingPolicyController {
                 new RegisterShippingPolicyCommand(
                         request.deliveryCompany(),
                         request.shippingFee(),
-                        request.freeShippingThreshold()
+                        request.freeShippingThreshold(),
+                        request.jejuSurcharge(),
+                        request.islandSurcharge()
                 )
         );
 
@@ -178,7 +180,9 @@ public class ShippingPolicyController {
                 new UpdateShippingPolicyCommand(
                         request.deliveryCompany(),
                         request.shippingFee(),
-                        request.freeShippingThreshold()
+                        request.freeShippingThreshold(),
+                        request.jejuSurcharge(),
+                        request.islandSurcharge()
                 )
         );
 

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/shipping/controller/apidocs/GetShippingPoliciesBySellerIdsApiDocs.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/shipping/controller/apidocs/GetShippingPoliciesBySellerIdsApiDocs.java
@@ -56,6 +56,8 @@ import java.lang.annotation.*;
                 | sellerId | number | 판매자 ID | 10 |
                 | shippingFee | number | 배송비 | 3000 |
                 | freeShippingThreshold | number | 무료배송 기준금액 | 20000 |
+                | jejuSurcharge | number | 제주 추가 배송비 | 3000 |
+                | islandSurcharge | number | 도서산간 추가 배송비 | 5000 |
                 """,
         security = {@SecurityRequirement(name = "bearer")},
         parameters = {
@@ -82,12 +84,16 @@ import java.lang.annotation.*;
                                               {
                                                 "sellerId": 10,
                                                 "shippingFee": 3000,
-                                                "freeShippingThreshold": 20000
+                                                "freeShippingThreshold": 20000,
+                                                "jejuSurcharge": 3000,
+                                                "islandSurcharge": 5000
                                               },
                                               {
                                                 "sellerId": 20,
                                                 "shippingFee": 2500,
-                                                "freeShippingThreshold": 30000
+                                                "freeShippingThreshold": 30000,
+                                                "jejuSurcharge": 4000,
+                                                "islandSurcharge": 6000
                                               }
                                             ]
                                           },

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/shipping/controller/apidocs/GetShippingPolicyApiDocs.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/shipping/controller/apidocs/GetShippingPolicyApiDocs.java
@@ -48,6 +48,8 @@ import java.lang.annotation.*;
                 | deliveryCompany | string | 배송업체 | "한진택배" |
                 | shippingFee | number | 배송비 | 3000 |
                 | freeShippingThreshold | number | 무료배송 기준금액 | 20000 |
+                | jejuSurcharge | number | 제주 추가 배송비 | 3000 |
+                | islandSurcharge | number | 도서산간 추가 배송비 | 5000 |
                 """,
         security = {@SecurityRequirement(name = "bearer")},
         responses = {
@@ -65,7 +67,9 @@ import java.lang.annotation.*;
                                             "id": 1,
                                             "deliveryCompany": "한진택배",
                                             "shippingFee": 3000,
-                                            "freeShippingThreshold": 20000
+                                            "freeShippingThreshold": 20000,
+                                            "jejuSurcharge": 3000,
+                                            "islandSurcharge": 5000
                                           },
                                           "message": "판매자 배송비 정책 조회 성공"
                                         }

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/shipping/controller/apidocs/RegisterShippingPolicyApiDocs.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/shipping/controller/apidocs/RegisterShippingPolicyApiDocs.java
@@ -41,6 +41,8 @@ import java.lang.annotation.*;
                 | deliveryCompany | string | 배송업체 | Y | "한진택배" |
                 | shippingFee | number | 배송비 | Y | 3000 |
                 | freeShippingThreshold | number | 무료배송 기준금액 | Y | 20000 |
+                | jejuSurcharge | number | 제주 추가 배송비 | N | 3000 |
+                | islandSurcharge | number | 도서산간 추가 배송비 | N | 5000 |
                 
                 ---
                 
@@ -69,7 +71,9 @@ import java.lang.annotation.*;
                                 {
                                   "deliveryCompany": "한진택배",
                                   "shippingFee": 3000,
-                                  "freeShippingThreshold": 20000
+                                  "freeShippingThreshold": 20000,
+                                  "jejuSurcharge": 3000,
+                                  "islandSurcharge": 5000
                                 }
                                 """)
                 )

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/shipping/controller/apidocs/UpdateShippingPolicyApiDocs.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/shipping/controller/apidocs/UpdateShippingPolicyApiDocs.java
@@ -39,6 +39,8 @@ import java.lang.annotation.*;
                 | deliveryCompany | string | 배송업체 | Y | "CJ대한통운" |
                 | shippingFee | number | 배송비 | Y | 2500 |
                 | freeShippingThreshold | number | 무료배송 기준금액 | Y | 30000 |
+                | jejuSurcharge | number | 제주 추가 배송비 | N | 3000 |
+                | islandSurcharge | number | 도서산간 추가 배송비 | N | 5000 |
                 
                 ---
                 
@@ -60,6 +62,8 @@ import java.lang.annotation.*;
                 | deliveryCompany | string | 배송업체 | "CJ대한통운" |
                 | shippingFee | number | 배송비 | 2500 |
                 | freeShippingThreshold | number | 무료배송 기준금액 | 30000 |
+                | jejuSurcharge | number | 제주 추가 배송비 | 3000 |
+                | islandSurcharge | number | 도서산간 추가 배송비 | 5000 |
                 """,
         security = {@SecurityRequirement(name = "bearer")},
         requestBody = @RequestBody(
@@ -70,7 +74,9 @@ import java.lang.annotation.*;
                                 {
                                   "deliveryCompany": "CJ대한통운",
                                   "shippingFee": 2500,
-                                  "freeShippingThreshold": 30000
+                                  "freeShippingThreshold": 30000,
+                                  "jejuSurcharge": 3000,
+                                  "islandSurcharge": 5000
                                 }
                                 """)
                 )
@@ -90,7 +96,9 @@ import java.lang.annotation.*;
                                             "id": 1,
                                             "deliveryCompany": "CJ대한통운",
                                             "shippingFee": 2500,
-                                            "freeShippingThreshold": 30000
+                                            "freeShippingThreshold": 30000,
+                                            "jejuSurcharge": 3000,
+                                            "islandSurcharge": 5000
                                           },
                                           "message": "판매자 배송비 정책 수정 성공"
                                         }

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/shipping/request/RegisterShippingPolicyRequest.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/shipping/request/RegisterShippingPolicyRequest.java
@@ -20,6 +20,14 @@ public record RegisterShippingPolicyRequest(
         @NotNull(message = "무료배송 기준금액은 필수입니다")
         @Min(value = 0, message = "무료배송 기준금액은 0 이상이어야 합니다")
         @Schema(description = "무료배송 기준금액", example = "20000")
-        Long freeShippingThreshold
+        Long freeShippingThreshold,
+
+        @Min(value = 0, message = "제주 추가 배송비는 0 이상이어야 합니다")
+        @Schema(description = "제주 추가 배송비", example = "3000")
+        Long jejuSurcharge,
+
+        @Min(value = 0, message = "도서산간 추가 배송비는 0 이상이어야 합니다")
+        @Schema(description = "도서산간 추가 배송비", example = "5000")
+        Long islandSurcharge
 ) {
 }

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/shipping/request/UpdateShippingPolicyRequest.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/shipping/request/UpdateShippingPolicyRequest.java
@@ -20,6 +20,14 @@ public record UpdateShippingPolicyRequest(
         @NotNull(message = "무료배송 기준금액은 필수입니다")
         @Min(value = 0, message = "무료배송 기준금액은 0 이상이어야 합니다")
         @Schema(description = "무료배송 기준금액", example = "20000")
-        Long freeShippingThreshold
+        Long freeShippingThreshold,
+
+        @Min(value = 0, message = "제주 추가 배송비는 0 이상이어야 합니다")
+        @Schema(description = "제주 추가 배송비", example = "3000")
+        Long jejuSurcharge,
+
+        @Min(value = 0, message = "도서산간 추가 배송비는 0 이상이어야 합니다")
+        @Schema(description = "도서산간 추가 배송비", example = "5000")
+        Long islandSurcharge
 ) {
 }

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/shipping/response/GetShippingPoliciesBySellerIdsResponse.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/shipping/response/GetShippingPoliciesBySellerIdsResponse.java
@@ -18,14 +18,18 @@ public record GetShippingPoliciesBySellerIdsResponse(
     public record ShippingPolicyBySellerResponse(
             Long sellerId,
             Long shippingFee,
-            Long freeShippingThreshold
+            Long freeShippingThreshold,
+            Long jejuSurcharge,
+            Long islandSurcharge
     ) {
 
         public static ShippingPolicyBySellerResponse from(GetShippingPolicyBySellerResult result) {
             return new ShippingPolicyBySellerResponse(
                     result.sellerId(),
                     result.shippingFee(),
-                    result.freeShippingThreshold()
+                    result.freeShippingThreshold(),
+                    result.jejuSurcharge(),
+                    result.islandSurcharge()
             );
         }
     }

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/shipping/response/GetShippingPolicyResponse.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/shipping/response/GetShippingPolicyResponse.java
@@ -6,7 +6,9 @@ public record GetShippingPolicyResponse(
         Long id,
         String deliveryCompany,
         Long shippingFee,
-        Long freeShippingThreshold
+        Long freeShippingThreshold,
+        Long jejuSurcharge,
+        Long islandSurcharge
 ) {
 
     public static GetShippingPolicyResponse from(GetShippingPolicyResult result) {
@@ -14,7 +16,9 @@ public record GetShippingPolicyResponse(
                 result.id(),
                 result.deliveryCompany(),
                 result.shippingFee(),
-                result.freeShippingThreshold()
+                result.freeShippingThreshold(),
+                result.jejuSurcharge(),
+                result.islandSurcharge()
         );
     }
 }

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/shipping/response/UpdateShippingPolicyResponse.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/shipping/response/UpdateShippingPolicyResponse.java
@@ -6,7 +6,9 @@ public record UpdateShippingPolicyResponse(
         Long id,
         String deliveryCompany,
         Long shippingFee,
-        Long freeShippingThreshold
+        Long freeShippingThreshold,
+        Long jejuSurcharge,
+        Long islandSurcharge
 ) {
 
     public static UpdateShippingPolicyResponse from(UpdateShippingPolicyResult result) {
@@ -14,7 +16,9 @@ public record UpdateShippingPolicyResponse(
                 result.id(),
                 result.deliveryCompany(),
                 result.shippingFee(),
-                result.freeShippingThreshold()
+                result.freeShippingThreshold(),
+                result.jejuSurcharge(),
+                result.islandSurcharge()
         );
     }
 }

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/event/ShippingPolicyEventKafkaProducer.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/event/ShippingPolicyEventKafkaProducer.java
@@ -25,8 +25,10 @@ public class ShippingPolicyEventKafkaProducer implements PublishShippingPolicyEv
     private final Clock clock;
 
     @Override
-    public void publishShippingPolicyChangedEvent(Long sellerId, Long shippingFee, Long freeShippingThreshold, ShippingPolicyChangeAction action) {
-        ShippingPolicyChangedEvent payload = new ShippingPolicyChangedEvent(sellerId, shippingFee, freeShippingThreshold, action);
+    public void publishShippingPolicyChangedEvent(Long sellerId, Long shippingFee, Long freeShippingThreshold,
+                                                  Long jejuSurcharge, Long islandSurcharge, ShippingPolicyChangeAction action) {
+        ShippingPolicyChangedEvent payload = new ShippingPolicyChangedEvent(
+                sellerId, shippingFee, freeShippingThreshold, jejuSurcharge, islandSurcharge, action);
         String topic = KafkaTopicConstants.SHIPPING_POLICY_CHANGED;
         EventEnvelope<ShippingPolicyChangedEvent> envelope = EventEnvelope.of(topic, SOURCE, payload, clock);
 

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/mapper/ShippingPolicyJpaEntityToDomainMapper.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/mapper/ShippingPolicyJpaEntityToDomainMapper.java
@@ -20,6 +20,8 @@ public class ShippingPolicyJpaEntityToDomainMapper {
                                 .deliveryCompany(e.getDeliveryCompany())
                                 .shippingFee(e.getShippingFee())
                                 .freeShippingThreshold(e.getFreeShippingThreshold())
+                                .jejuSurcharge(e.getJejuSurcharge())
+                                .islandSurcharge(e.getIslandSurcharge())
                                 .status(e.getStatus())
                                 .createdAt(e.getCreatedAt())
                                 .modifiedAt(e.getModifiedAt())

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/shipping/entity/ShippingPolicyJpaEntity.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/out/persistence/shipping/entity/ShippingPolicyJpaEntity.java
@@ -32,12 +32,20 @@ public class ShippingPolicyJpaEntity extends BaseGeneralEntity {
     @Column(name = "free_shipping_threshold", nullable = false)
     private Long freeShippingThreshold;
 
+    @Column(name = "jeju_surcharge")
+    private Long jejuSurcharge;
+
+    @Column(name = "island_surcharge")
+    private Long islandSurcharge;
+
     public static ShippingPolicyJpaEntity from(ShippingPolicy policy) {
         return ShippingPolicyJpaEntity.builder()
                 .sellerId(policy.getSellerId())
                 .deliveryCompany(policy.getDeliveryCompany())
                 .shippingFee(policy.getShippingFee())
                 .freeShippingThreshold(policy.getFreeShippingThreshold())
+                .jejuSurcharge(policy.getJejuSurcharge())
+                .islandSurcharge(policy.getIslandSurcharge())
                 .build();
     }
 
@@ -45,5 +53,7 @@ public class ShippingPolicyJpaEntity extends BaseGeneralEntity {
         this.deliveryCompany = policy.getDeliveryCompany();
         this.shippingFee = policy.getShippingFee();
         this.freeShippingThreshold = policy.getFreeShippingThreshold();
+        this.jejuSurcharge = policy.getJejuSurcharge();
+        this.islandSurcharge = policy.getIslandSurcharge();
     }
 }

--- a/product-service/product-adapters/src/test/java/com/personal/marketnote/product/adapter/in/web/shipping/controller/InternalShippingPolicyControllerTest.java
+++ b/product-service/product-adapters/src/test/java/com/personal/marketnote/product/adapter/in/web/shipping/controller/InternalShippingPolicyControllerTest.java
@@ -36,8 +36,8 @@ class InternalShippingPolicyControllerTest {
             // given
             List<Long> sellerIds = List.of(10L, 20L);
             List<GetShippingPolicyBySellerResult> results = List.of(
-                    new GetShippingPolicyBySellerResult(10L, 3000L, 20000L),
-                    new GetShippingPolicyBySellerResult(20L, 2500L, 30000L)
+                    new GetShippingPolicyBySellerResult(10L, 3000L, 20000L, 3000L, 5000L),
+                    new GetShippingPolicyBySellerResult(20L, 2500L, 30000L, 4000L, 6000L)
             );
             when(getShippingPolicyUseCase.getShippingPolicies(sellerIds)).thenReturn(results);
 

--- a/product-service/product-adapters/src/test/java/com/personal/marketnote/product/adapter/out/event/ShippingPolicyEventKafkaProducerTest.java
+++ b/product-service/product-adapters/src/test/java/com/personal/marketnote/product/adapter/out/event/ShippingPolicyEventKafkaProducerTest.java
@@ -55,7 +55,7 @@ class ShippingPolicyEventKafkaProducerTest {
 
         // when
         shippingPolicyEventKafkaProducer.publishShippingPolicyChangedEvent(
-                10L, 3000L, 20000L, ShippingPolicyChangeAction.CREATED
+                10L, 3000L, 20000L, 3000L, 5000L, ShippingPolicyChangeAction.CREATED
         );
 
         // then
@@ -79,7 +79,7 @@ class ShippingPolicyEventKafkaProducerTest {
 
         // when
         shippingPolicyEventKafkaProducer.publishShippingPolicyChangedEvent(
-                10L, 3000L, 20000L, ShippingPolicyChangeAction.CREATED
+                10L, 3000L, 20000L, 3000L, 5000L, ShippingPolicyChangeAction.CREATED
         );
 
         // then
@@ -96,6 +96,8 @@ class ShippingPolicyEventKafkaProducerTest {
         assertThat(payload.sellerId()).isEqualTo(10L);
         assertThat(payload.shippingFee()).isEqualTo(3000L);
         assertThat(payload.freeShippingThreshold()).isEqualTo(20000L);
+        assertThat(payload.jejuSurcharge()).isEqualTo(3000L);
+        assertThat(payload.islandSurcharge()).isEqualTo(5000L);
         assertThat(payload.action()).isEqualTo(ShippingPolicyChangeAction.CREATED);
     }
 
@@ -109,7 +111,7 @@ class ShippingPolicyEventKafkaProducerTest {
 
         // when
         shippingPolicyEventKafkaProducer.publishShippingPolicyChangedEvent(
-                20L, 2500L, 30000L, ShippingPolicyChangeAction.UPDATED
+                20L, 2500L, 30000L, 4000L, 6000L, ShippingPolicyChangeAction.UPDATED
         );
 
         // then
@@ -120,6 +122,8 @@ class ShippingPolicyEventKafkaProducerTest {
         assertThat(payload.sellerId()).isEqualTo(20L);
         assertThat(payload.shippingFee()).isEqualTo(2500L);
         assertThat(payload.freeShippingThreshold()).isEqualTo(30000L);
+        assertThat(payload.jejuSurcharge()).isEqualTo(4000L);
+        assertThat(payload.islandSurcharge()).isEqualTo(6000L);
         assertThat(payload.action()).isEqualTo(ShippingPolicyChangeAction.UPDATED);
     }
 }

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/mapper/ShippingPolicyCommandToStateMapper.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/mapper/ShippingPolicyCommandToStateMapper.java
@@ -14,6 +14,8 @@ public class ShippingPolicyCommandToStateMapper {
                 .deliveryCompany(command.deliveryCompany())
                 .shippingFee(command.shippingFee())
                 .freeShippingThreshold(command.freeShippingThreshold())
+                .jejuSurcharge(command.jejuSurcharge())
+                .islandSurcharge(command.islandSurcharge())
                 .build();
     }
 }

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/command/RegisterShippingPolicyCommand.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/command/RegisterShippingPolicyCommand.java
@@ -3,6 +3,8 @@ package com.personal.marketnote.product.port.in.command;
 public record RegisterShippingPolicyCommand(
         String deliveryCompany,
         Long shippingFee,
-        Long freeShippingThreshold
+        Long freeShippingThreshold,
+        Long jejuSurcharge,
+        Long islandSurcharge
 ) {
 }

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/command/UpdateShippingPolicyCommand.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/command/UpdateShippingPolicyCommand.java
@@ -3,6 +3,8 @@ package com.personal.marketnote.product.port.in.command;
 public record UpdateShippingPolicyCommand(
         String deliveryCompany,
         Long shippingFee,
-        Long freeShippingThreshold
+        Long freeShippingThreshold,
+        Long jejuSurcharge,
+        Long islandSurcharge
 ) {
 }

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/result/shipping/GetShippingPolicyBySellerResult.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/result/shipping/GetShippingPolicyBySellerResult.java
@@ -5,14 +5,18 @@ import com.personal.marketnote.product.domain.shipping.ShippingPolicy;
 public record GetShippingPolicyBySellerResult(
         Long sellerId,
         Long shippingFee,
-        Long freeShippingThreshold
+        Long freeShippingThreshold,
+        Long jejuSurcharge,
+        Long islandSurcharge
 ) {
 
     public static GetShippingPolicyBySellerResult from(ShippingPolicy shippingPolicy) {
         return new GetShippingPolicyBySellerResult(
                 shippingPolicy.getSellerId(),
                 shippingPolicy.getShippingFee(),
-                shippingPolicy.getFreeShippingThreshold()
+                shippingPolicy.getFreeShippingThreshold(),
+                shippingPolicy.getJejuSurcharge(),
+                shippingPolicy.getIslandSurcharge()
         );
     }
 }

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/result/shipping/GetShippingPolicyResult.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/result/shipping/GetShippingPolicyResult.java
@@ -6,7 +6,9 @@ public record GetShippingPolicyResult(
         Long id,
         String deliveryCompany,
         Long shippingFee,
-        Long freeShippingThreshold
+        Long freeShippingThreshold,
+        Long jejuSurcharge,
+        Long islandSurcharge
 ) {
 
     public static GetShippingPolicyResult from(ShippingPolicy shippingPolicy) {
@@ -14,7 +16,9 @@ public record GetShippingPolicyResult(
                 shippingPolicy.getId(),
                 shippingPolicy.getDeliveryCompany(),
                 shippingPolicy.getShippingFee(),
-                shippingPolicy.getFreeShippingThreshold()
+                shippingPolicy.getFreeShippingThreshold(),
+                shippingPolicy.getJejuSurcharge(),
+                shippingPolicy.getIslandSurcharge()
         );
     }
 }

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/result/shipping/UpdateShippingPolicyResult.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/in/result/shipping/UpdateShippingPolicyResult.java
@@ -6,7 +6,9 @@ public record UpdateShippingPolicyResult(
         Long id,
         String deliveryCompany,
         Long shippingFee,
-        Long freeShippingThreshold
+        Long freeShippingThreshold,
+        Long jejuSurcharge,
+        Long islandSurcharge
 ) {
 
     public static UpdateShippingPolicyResult from(ShippingPolicy shippingPolicy) {
@@ -14,7 +16,9 @@ public record UpdateShippingPolicyResult(
                 shippingPolicy.getId(),
                 shippingPolicy.getDeliveryCompany(),
                 shippingPolicy.getShippingFee(),
-                shippingPolicy.getFreeShippingThreshold()
+                shippingPolicy.getFreeShippingThreshold(),
+                shippingPolicy.getJejuSurcharge(),
+                shippingPolicy.getIslandSurcharge()
         );
     }
 }

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/port/out/event/PublishShippingPolicyEventPort.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/port/out/event/PublishShippingPolicyEventPort.java
@@ -4,5 +4,6 @@ import com.personal.marketnote.common.kafka.event.ShippingPolicyChangeAction;
 
 public interface PublishShippingPolicyEventPort {
 
-    void publishShippingPolicyChangedEvent(Long sellerId, Long shippingFee, Long freeShippingThreshold, ShippingPolicyChangeAction action);
+    void publishShippingPolicyChangedEvent(Long sellerId, Long shippingFee, Long freeShippingThreshold,
+                                           Long jejuSurcharge, Long islandSurcharge, ShippingPolicyChangeAction action);
 }

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/service/shipping/RegisterShippingPolicyService.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/service/shipping/RegisterShippingPolicyService.java
@@ -35,7 +35,8 @@ public class RegisterShippingPolicyService implements RegisterShippingPolicyUseC
         Long savedId = saveShippingPolicyPort.save(shippingPolicy);
 
         publishShippingPolicyEventPort.publishShippingPolicyChangedEvent(
-                sellerId, command.shippingFee(), command.freeShippingThreshold(), ShippingPolicyChangeAction.CREATED
+                sellerId, shippingPolicy.getShippingFee(), shippingPolicy.getFreeShippingThreshold(),
+                shippingPolicy.getJejuSurcharge(), shippingPolicy.getIslandSurcharge(), ShippingPolicyChangeAction.CREATED
         );
 
         return RegisterShippingPolicyResult.of(savedId);

--- a/product-service/product-application/src/main/java/com/personal/marketnote/product/service/shipping/UpdateShippingPolicyService.java
+++ b/product-service/product-application/src/main/java/com/personal/marketnote/product/service/shipping/UpdateShippingPolicyService.java
@@ -31,13 +31,16 @@ public class UpdateShippingPolicyService implements UpdateShippingPolicyUseCase 
         shippingPolicy.update(
                 command.deliveryCompany(),
                 command.shippingFee(),
-                command.freeShippingThreshold()
+                command.freeShippingThreshold(),
+                command.jejuSurcharge(),
+                command.islandSurcharge()
         );
 
         updateShippingPolicyPort.update(shippingPolicy);
 
         publishShippingPolicyEventPort.publishShippingPolicyChangedEvent(
-                sellerId, shippingPolicy.getShippingFee(), shippingPolicy.getFreeShippingThreshold(), ShippingPolicyChangeAction.UPDATED
+                sellerId, shippingPolicy.getShippingFee(), shippingPolicy.getFreeShippingThreshold(),
+                shippingPolicy.getJejuSurcharge(), shippingPolicy.getIslandSurcharge(), ShippingPolicyChangeAction.UPDATED
         );
 
         return UpdateShippingPolicyResult.from(shippingPolicy);

--- a/product-service/product-application/src/test/java/com/personal/marketnote/product/service/shipping/RegisterShippingPolicyUseCaseTest.java
+++ b/product-service/product-application/src/test/java/com/personal/marketnote/product/service/shipping/RegisterShippingPolicyUseCaseTest.java
@@ -66,7 +66,7 @@ class RegisterShippingPolicyUseCaseTest {
         when(saveShippingPolicyPort.save(any(ShippingPolicy.class))).thenReturn(1L);
 
         RegisterShippingPolicyCommand command = new RegisterShippingPolicyCommand(
-                "한진택배", 3000L, 20000L
+                "한진택배", 3000L, 20000L, 3000L, 5000L
         );
 
         // when
@@ -83,6 +83,8 @@ class RegisterShippingPolicyUseCaseTest {
         assertThat(savedPolicy.getDeliveryCompany()).isEqualTo("한진택배");
         assertThat(savedPolicy.getShippingFee()).isEqualTo(3000L);
         assertThat(savedPolicy.getFreeShippingThreshold()).isEqualTo(20000L);
+        assertThat(savedPolicy.getJejuSurcharge()).isEqualTo(3000L);
+        assertThat(savedPolicy.getIslandSurcharge()).isEqualTo(5000L);
         assertThat(savedPolicy.isActive()).isTrue();
     }
 
@@ -95,7 +97,7 @@ class RegisterShippingPolicyUseCaseTest {
                 .thenReturn(Optional.of(createSavedPolicy(sellerId)));
 
         RegisterShippingPolicyCommand command = new RegisterShippingPolicyCommand(
-                "한진택배", 3000L, 20000L
+                "한진택배", 3000L, 20000L, 3000L, 5000L
         );
 
         // when & then
@@ -113,7 +115,7 @@ class RegisterShippingPolicyUseCaseTest {
         when(findShippingPolicyPort.findActiveBySellerId(sellerId)).thenReturn(Optional.empty());
 
         RegisterShippingPolicyCommand command = new RegisterShippingPolicyCommand(
-                "한진택배", -1L, 20000L
+                "한진택배", -1L, 20000L, 0L, 0L
         );
 
         // when & then
@@ -131,7 +133,7 @@ class RegisterShippingPolicyUseCaseTest {
         when(findShippingPolicyPort.findActiveBySellerId(sellerId)).thenReturn(Optional.empty());
 
         RegisterShippingPolicyCommand command = new RegisterShippingPolicyCommand(
-                "한진택배", 3000L, -1L
+                "한진택배", 3000L, -1L, 0L, 0L
         );
 
         // when & then
@@ -150,7 +152,7 @@ class RegisterShippingPolicyUseCaseTest {
         when(saveShippingPolicyPort.save(any(ShippingPolicy.class))).thenReturn(1L);
 
         RegisterShippingPolicyCommand command = new RegisterShippingPolicyCommand(
-                "한진택배", 3000L, 20000L
+                "한진택배", 3000L, 20000L, 3000L, 5000L
         );
 
         // when
@@ -158,7 +160,7 @@ class RegisterShippingPolicyUseCaseTest {
 
         // then
         verify(publishShippingPolicyEventPort).publishShippingPolicyChangedEvent(
-                sellerId, 3000L, 20000L, ShippingPolicyChangeAction.CREATED
+                sellerId, 3000L, 20000L, 3000L, 5000L, ShippingPolicyChangeAction.CREATED
         );
     }
 
@@ -171,7 +173,7 @@ class RegisterShippingPolicyUseCaseTest {
                 .thenReturn(Optional.of(createSavedPolicy(sellerId)));
 
         RegisterShippingPolicyCommand command = new RegisterShippingPolicyCommand(
-                "한진택배", 3000L, 20000L
+                "한진택배", 3000L, 20000L, 3000L, 5000L
         );
 
         // when & then

--- a/product-service/product-application/src/test/java/com/personal/marketnote/product/service/shipping/UpdateShippingPolicyUseCaseTest.java
+++ b/product-service/product-application/src/test/java/com/personal/marketnote/product/service/shipping/UpdateShippingPolicyUseCaseTest.java
@@ -66,7 +66,7 @@ class UpdateShippingPolicyUseCaseTest {
                 .thenReturn(Optional.of(existingPolicy));
 
         UpdateShippingPolicyCommand command = new UpdateShippingPolicyCommand(
-                "CJ대한통운", 2500L, 30000L
+                "CJ대한통운", 2500L, 30000L, 4000L, 6000L
         );
 
         // when
@@ -77,6 +77,8 @@ class UpdateShippingPolicyUseCaseTest {
         assertThat(result.deliveryCompany()).isEqualTo("CJ대한통운");
         assertThat(result.shippingFee()).isEqualTo(2500L);
         assertThat(result.freeShippingThreshold()).isEqualTo(30000L);
+        assertThat(result.jejuSurcharge()).isEqualTo(4000L);
+        assertThat(result.islandSurcharge()).isEqualTo(6000L);
 
         verify(updateShippingPolicyPort).update(existingPolicy);
     }
@@ -90,7 +92,7 @@ class UpdateShippingPolicyUseCaseTest {
                 .thenReturn(Optional.empty());
 
         UpdateShippingPolicyCommand command = new UpdateShippingPolicyCommand(
-                "CJ대한통운", 2500L, 30000L
+                "CJ대한통운", 2500L, 30000L, 4000L, 6000L
         );
 
         // when & then
@@ -110,7 +112,7 @@ class UpdateShippingPolicyUseCaseTest {
                 .thenReturn(Optional.of(existingPolicy));
 
         UpdateShippingPolicyCommand command = new UpdateShippingPolicyCommand(
-                "CJ대한통운", -1L, 30000L
+                "CJ대한통운", -1L, 30000L, 0L, 0L
         );
 
         // when & then
@@ -130,7 +132,7 @@ class UpdateShippingPolicyUseCaseTest {
                 .thenReturn(Optional.of(existingPolicy));
 
         UpdateShippingPolicyCommand command = new UpdateShippingPolicyCommand(
-                "CJ대한통운", 2500L, -1L
+                "CJ대한통운", 2500L, -1L, 0L, 0L
         );
 
         // when & then
@@ -150,7 +152,7 @@ class UpdateShippingPolicyUseCaseTest {
                 .thenReturn(Optional.of(existingPolicy));
 
         UpdateShippingPolicyCommand command = new UpdateShippingPolicyCommand(
-                "CJ대한통운", 2500L, 30000L
+                "CJ대한통운", 2500L, 30000L, 4000L, 6000L
         );
 
         // when
@@ -158,7 +160,7 @@ class UpdateShippingPolicyUseCaseTest {
 
         // then
         verify(publishShippingPolicyEventPort).publishShippingPolicyChangedEvent(
-                sellerId, 2500L, 30000L, ShippingPolicyChangeAction.UPDATED
+                sellerId, 2500L, 30000L, 4000L, 6000L, ShippingPolicyChangeAction.UPDATED
         );
     }
 
@@ -171,7 +173,7 @@ class UpdateShippingPolicyUseCaseTest {
                 .thenReturn(Optional.empty());
 
         UpdateShippingPolicyCommand command = new UpdateShippingPolicyCommand(
-                "CJ대한통운", 2500L, 30000L
+                "CJ대한통운", 2500L, 30000L, 4000L, 6000L
         );
 
         // when & then

--- a/product-service/product-domain/src/main/java/com/personal/marketnote/product/domain/shipping/InvalidIslandSurchargeException.java
+++ b/product-service/product-domain/src/main/java/com/personal/marketnote/product/domain/shipping/InvalidIslandSurchargeException.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.product.domain.shipping;
+
+public class InvalidIslandSurchargeException extends IllegalArgumentException {
+    private static final String MESSAGE = "ERR_SHIPPING_POLICY_04::도서산간 추가 배송비가 유효하지 않습니다. %s";
+
+    public InvalidIslandSurchargeException(String detail) {
+        super(String.format(MESSAGE, detail));
+    }
+}

--- a/product-service/product-domain/src/main/java/com/personal/marketnote/product/domain/shipping/InvalidJejuSurchargeException.java
+++ b/product-service/product-domain/src/main/java/com/personal/marketnote/product/domain/shipping/InvalidJejuSurchargeException.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.product.domain.shipping;
+
+public class InvalidJejuSurchargeException extends IllegalArgumentException {
+    private static final String MESSAGE = "ERR_SHIPPING_POLICY_03::제주 추가 배송비가 유효하지 않습니다. %s";
+
+    public InvalidJejuSurchargeException(String detail) {
+        super(String.format(MESSAGE, detail));
+    }
+}

--- a/product-service/product-domain/src/main/java/com/personal/marketnote/product/domain/shipping/ShippingPolicy.java
+++ b/product-service/product-domain/src/main/java/com/personal/marketnote/product/domain/shipping/ShippingPolicy.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.product.domain.shipping;
 
 import com.personal.marketnote.common.domain.BaseDomain;
+import com.personal.marketnote.common.utility.FormatValidator;
 import lombok.*;
 
 import java.time.LocalDateTime;
@@ -15,6 +16,8 @@ public class ShippingPolicy extends BaseDomain {
     private String deliveryCompany;
     private Long shippingFee;
     private Long freeShippingThreshold;
+    private Long jejuSurcharge;
+    private Long islandSurcharge;
     private LocalDateTime createdAt;
     private LocalDateTime modifiedAt;
 
@@ -22,11 +25,18 @@ public class ShippingPolicy extends BaseDomain {
         validateShippingFee(state.getShippingFee());
         validateFreeShippingThreshold(state.getFreeShippingThreshold());
 
+        Long resolvedJejuSurcharge = resolveDefaultSurcharge(state.getJejuSurcharge());
+        Long resolvedIslandSurcharge = resolveDefaultSurcharge(state.getIslandSurcharge());
+        validateJejuSurcharge(resolvedJejuSurcharge);
+        validateIslandSurcharge(resolvedIslandSurcharge);
+
         ShippingPolicy policy = ShippingPolicy.builder()
                 .sellerId(state.getSellerId())
                 .deliveryCompany(state.getDeliveryCompany())
                 .shippingFee(state.getShippingFee())
                 .freeShippingThreshold(state.getFreeShippingThreshold())
+                .jejuSurcharge(resolvedJejuSurcharge)
+                .islandSurcharge(resolvedIslandSurcharge)
                 .build();
         policy.activate();
         return policy;
@@ -39,6 +49,8 @@ public class ShippingPolicy extends BaseDomain {
                 .deliveryCompany(state.getDeliveryCompany())
                 .shippingFee(state.getShippingFee())
                 .freeShippingThreshold(state.getFreeShippingThreshold())
+                .jejuSurcharge(state.getJejuSurcharge())
+                .islandSurcharge(state.getIslandSurcharge())
                 .createdAt(state.getCreatedAt())
                 .modifiedAt(state.getModifiedAt())
                 .build();
@@ -46,13 +58,21 @@ public class ShippingPolicy extends BaseDomain {
         return policy;
     }
 
-    public void update(String deliveryCompany, Long shippingFee, Long freeShippingThreshold) {
+    public void update(String deliveryCompany, Long shippingFee, Long freeShippingThreshold,
+                       Long jejuSurcharge, Long islandSurcharge) {
         validateShippingFee(shippingFee);
         validateFreeShippingThreshold(freeShippingThreshold);
+
+        Long resolvedJejuSurcharge = resolveDefaultSurcharge(jejuSurcharge);
+        Long resolvedIslandSurcharge = resolveDefaultSurcharge(islandSurcharge);
+        validateJejuSurcharge(resolvedJejuSurcharge);
+        validateIslandSurcharge(resolvedIslandSurcharge);
 
         this.deliveryCompany = deliveryCompany;
         this.shippingFee = shippingFee;
         this.freeShippingThreshold = freeShippingThreshold;
+        this.jejuSurcharge = resolvedJejuSurcharge;
+        this.islandSurcharge = resolvedIslandSurcharge;
     }
 
     @Override
@@ -81,5 +101,24 @@ public class ShippingPolicy extends BaseDomain {
         if (freeShippingThreshold < 0) {
             throw new InvalidFreeShippingThresholdException("무료배송 기준금액은 0 이상이어야 합니다. 입력값=" + freeShippingThreshold);
         }
+    }
+
+    private static void validateJejuSurcharge(Long jejuSurcharge) {
+        if (jejuSurcharge < 0) {
+            throw new InvalidJejuSurchargeException("제주 추가 배송비는 0 이상이어야 합니다. 입력값=" + jejuSurcharge);
+        }
+    }
+
+    private static void validateIslandSurcharge(Long islandSurcharge) {
+        if (islandSurcharge < 0) {
+            throw new InvalidIslandSurchargeException("도서산간 추가 배송비는 0 이상이어야 합니다. 입력값=" + islandSurcharge);
+        }
+    }
+
+    private static Long resolveDefaultSurcharge(Long surcharge) {
+        if (FormatValidator.hasNoValue(surcharge)) {
+            return 0L;
+        }
+        return surcharge;
     }
 }

--- a/product-service/product-domain/src/main/java/com/personal/marketnote/product/domain/shipping/ShippingPolicyCreateState.java
+++ b/product-service/product-domain/src/main/java/com/personal/marketnote/product/domain/shipping/ShippingPolicyCreateState.java
@@ -11,4 +11,6 @@ public class ShippingPolicyCreateState {
     private String deliveryCompany;
     private Long shippingFee;
     private Long freeShippingThreshold;
+    private Long jejuSurcharge;
+    private Long islandSurcharge;
 }

--- a/product-service/product-domain/src/main/java/com/personal/marketnote/product/domain/shipping/ShippingPolicySnapshotState.java
+++ b/product-service/product-domain/src/main/java/com/personal/marketnote/product/domain/shipping/ShippingPolicySnapshotState.java
@@ -15,6 +15,8 @@ public class ShippingPolicySnapshotState {
     private String deliveryCompany;
     private Long shippingFee;
     private Long freeShippingThreshold;
+    private Long jejuSurcharge;
+    private Long islandSurcharge;
     private EntityStatus status;
     private LocalDateTime createdAt;
     private LocalDateTime modifiedAt;

--- a/product-service/product-domain/src/test/java/com/personal/marketnote/product/domain/shipping/ShippingPolicyTest.java
+++ b/product-service/product-domain/src/test/java/com/personal/marketnote/product/domain/shipping/ShippingPolicyTest.java
@@ -88,6 +88,84 @@ class ShippingPolicyTest {
             assertThat(policy.getShippingFee()).isZero();
             assertThat(policy.getFreeShippingThreshold()).isZero();
         }
+
+        @Test
+        @DisplayName("제주/도서산간 추가 배송비를 포함하여 정책을 생성한다")
+        void shouldCreateShippingPolicyWithSurcharges() {
+            // given
+            ShippingPolicyCreateState state = ShippingPolicyCreateState.builder()
+                    .sellerId(1L)
+                    .deliveryCompany("한진택배")
+                    .shippingFee(3000L)
+                    .freeShippingThreshold(20000L)
+                    .jejuSurcharge(3000L)
+                    .islandSurcharge(5000L)
+                    .build();
+
+            // when
+            ShippingPolicy policy = ShippingPolicy.from(state);
+
+            // then
+            assertThat(policy.getJejuSurcharge()).isEqualTo(3000L);
+            assertThat(policy.getIslandSurcharge()).isEqualTo(5000L);
+        }
+
+        @Test
+        @DisplayName("제주 추가 배송비가 null이면 0으로 기본값 설정된다")
+        void shouldDefaultJejuSurchargeToZeroWhenNull() {
+            // given
+            ShippingPolicyCreateState state = ShippingPolicyCreateState.builder()
+                    .sellerId(1L)
+                    .deliveryCompany("한진택배")
+                    .shippingFee(3000L)
+                    .freeShippingThreshold(20000L)
+                    .jejuSurcharge(null)
+                    .islandSurcharge(null)
+                    .build();
+
+            // when
+            ShippingPolicy policy = ShippingPolicy.from(state);
+
+            // then
+            assertThat(policy.getJejuSurcharge()).isZero();
+            assertThat(policy.getIslandSurcharge()).isZero();
+        }
+
+        @Test
+        @DisplayName("제주 추가 배송비가 음수이면 예외가 발생한다")
+        void shouldThrowExceptionWhenJejuSurchargeIsNegative() {
+            // given
+            ShippingPolicyCreateState state = ShippingPolicyCreateState.builder()
+                    .sellerId(1L)
+                    .deliveryCompany("한진택배")
+                    .shippingFee(3000L)
+                    .freeShippingThreshold(20000L)
+                    .jejuSurcharge(-1L)
+                    .islandSurcharge(0L)
+                    .build();
+
+            // when & then
+            assertThatThrownBy(() -> ShippingPolicy.from(state))
+                    .isInstanceOf(InvalidJejuSurchargeException.class);
+        }
+
+        @Test
+        @DisplayName("도서산간 추가 배송비가 음수이면 예외가 발생한다")
+        void shouldThrowExceptionWhenIslandSurchargeIsNegative() {
+            // given
+            ShippingPolicyCreateState state = ShippingPolicyCreateState.builder()
+                    .sellerId(1L)
+                    .deliveryCompany("한진택배")
+                    .shippingFee(3000L)
+                    .freeShippingThreshold(20000L)
+                    .jejuSurcharge(0L)
+                    .islandSurcharge(-1L)
+                    .build();
+
+            // when & then
+            assertThatThrownBy(() -> ShippingPolicy.from(state))
+                    .isInstanceOf(InvalidIslandSurchargeException.class);
+        }
     }
 
     @Nested
@@ -105,6 +183,8 @@ class ShippingPolicyTest {
                     .deliveryCompany("CJ대한통운")
                     .shippingFee(2500L)
                     .freeShippingThreshold(30000L)
+                    .jejuSurcharge(3000L)
+                    .islandSurcharge(5000L)
                     .status(EntityStatus.INACTIVE)
                     .createdAt(now)
                     .modifiedAt(now)
@@ -119,9 +199,37 @@ class ShippingPolicyTest {
             assertThat(policy.getDeliveryCompany()).isEqualTo("CJ대한통운");
             assertThat(policy.getShippingFee()).isEqualTo(2500L);
             assertThat(policy.getFreeShippingThreshold()).isEqualTo(30000L);
+            assertThat(policy.getJejuSurcharge()).isEqualTo(3000L);
+            assertThat(policy.getIslandSurcharge()).isEqualTo(5000L);
             assertThat(policy.isInactive()).isTrue();
             assertThat(policy.getCreatedAt()).isEqualTo(now);
             assertThat(policy.getModifiedAt()).isEqualTo(now);
+        }
+
+        @Test
+        @DisplayName("DB 스냅샷에 추가 배송비가 null이면 null로 복원한다")
+        void shouldRestoreNullSurchargesFromSnapshot() {
+            // given
+            LocalDateTime now = LocalDateTime.of(2026, 3, 10, 12, 0);
+            ShippingPolicySnapshotState state = ShippingPolicySnapshotState.builder()
+                    .id(10L)
+                    .sellerId(1L)
+                    .deliveryCompany("CJ대한통운")
+                    .shippingFee(2500L)
+                    .freeShippingThreshold(30000L)
+                    .jejuSurcharge(null)
+                    .islandSurcharge(null)
+                    .status(EntityStatus.ACTIVE)
+                    .createdAt(now)
+                    .modifiedAt(now)
+                    .build();
+
+            // when
+            ShippingPolicy policy = ShippingPolicy.from(state);
+
+            // then
+            assertThat(policy.getJejuSurcharge()).isNull();
+            assertThat(policy.getIslandSurcharge()).isNull();
         }
     }
 
@@ -136,12 +244,14 @@ class ShippingPolicyTest {
             ShippingPolicy policy = createDefaultPolicy();
 
             // when
-            policy.update("CJ대한통운", 2500L, 30000L);
+            policy.update("CJ대한통운", 2500L, 30000L, 4000L, 6000L);
 
             // then
             assertThat(policy.getDeliveryCompany()).isEqualTo("CJ대한통운");
             assertThat(policy.getShippingFee()).isEqualTo(2500L);
             assertThat(policy.getFreeShippingThreshold()).isEqualTo(30000L);
+            assertThat(policy.getJejuSurcharge()).isEqualTo(4000L);
+            assertThat(policy.getIslandSurcharge()).isEqualTo(6000L);
         }
 
         @Test
@@ -151,7 +261,7 @@ class ShippingPolicyTest {
             ShippingPolicy policy = createDefaultPolicy();
 
             // when & then
-            assertThatThrownBy(() -> policy.update("CJ대한통운", -1L, 30000L))
+            assertThatThrownBy(() -> policy.update("CJ대한통운", -1L, 30000L, 0L, 0L))
                     .isInstanceOf(InvalidShippingFeeException.class);
         }
 
@@ -162,8 +272,44 @@ class ShippingPolicyTest {
             ShippingPolicy policy = createDefaultPolicy();
 
             // when & then
-            assertThatThrownBy(() -> policy.update("CJ대한통운", 3000L, -1L))
+            assertThatThrownBy(() -> policy.update("CJ대한통운", 3000L, -1L, 0L, 0L))
                     .isInstanceOf(InvalidFreeShippingThresholdException.class);
+        }
+
+        @Test
+        @DisplayName("수정 시 제주 추가 배송비가 음수이면 예외가 발생한다")
+        void shouldThrowExceptionWhenUpdateWithNegativeJejuSurcharge() {
+            // given
+            ShippingPolicy policy = createDefaultPolicy();
+
+            // when & then
+            assertThatThrownBy(() -> policy.update("CJ대한통운", 3000L, 30000L, -1L, 0L))
+                    .isInstanceOf(InvalidJejuSurchargeException.class);
+        }
+
+        @Test
+        @DisplayName("수정 시 도서산간 추가 배송비가 음수이면 예외가 발생한다")
+        void shouldThrowExceptionWhenUpdateWithNegativeIslandSurcharge() {
+            // given
+            ShippingPolicy policy = createDefaultPolicy();
+
+            // when & then
+            assertThatThrownBy(() -> policy.update("CJ대한통운", 3000L, 30000L, 0L, -1L))
+                    .isInstanceOf(InvalidIslandSurchargeException.class);
+        }
+
+        @Test
+        @DisplayName("수정 시 제주/도서산간 추가 배송비가 null이면 0으로 기본값 설정된다")
+        void shouldDefaultSurchargesToZeroWhenNullOnUpdate() {
+            // given
+            ShippingPolicy policy = createDefaultPolicy();
+
+            // when
+            policy.update("CJ대한통운", 2500L, 30000L, null, null);
+
+            // then
+            assertThat(policy.getJejuSurcharge()).isZero();
+            assertThat(policy.getIslandSurcharge()).isZero();
         }
     }
 


### PR DESCRIPTION
## partially addresses #216
## resolves #2342

## Task
- [x] FulfillmentCancelSagaPayload record 추가 (orderId, originalStatus)
- [x] OrderCancelFulfillmentSagaConsumer 추가 (saga.order-cancel.fulfillment 토픽)
- [x] PREPARING 상태일 때만 CancelFulfillmentReleasePort.cancelRelease() 호출
- [x] PAID 상태일 때 풀필먼트 취소 skip하고 즉시 성공 응답
- [x] 풀필먼트 취소 거부/통신 실패 시 SAGA 실패 응답 발행
- [x] orderId 누락 시 페이로드 검증 실패 응답 발행