### PR TITLE
[#216][#2346] feat: 주문 취소 SAGA 완료 처리 Step Consumer 추가

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/saga/OrderCancelCompleteSagaConsumer.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/saga/OrderCancelCompleteSagaConsumer.java
@@ -1,0 +1,119 @@
+package com.personal.marketnote.commerce.adapter.in.event.saga;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.commerce.adapter.in.event.saga.payload.CompleteCancellationSagaPayload;
+import com.personal.marketnote.commerce.port.in.command.order.CompleteCancelOrderCommand;
+import com.personal.marketnote.commerce.port.in.usecase.order.CompleteCancelOrderUseCase;
+import com.personal.marketnote.common.kafka.KafkaTopicConstants;
+import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.EventPayloadValidator;
+import com.personal.marketnote.common.saga.SagaResponsePublisher;
+import com.personal.marketnote.common.saga.SagaStepMessage;
+import com.personal.marketnote.common.utility.FormatValidator;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@ConditionalOnProperty(prefix = "saga", name = "enabled", havingValue = "true")
+@RequiredArgsConstructor
+public class OrderCancelCompleteSagaConsumer {
+
+    private final ObjectMapper objectMapper;
+    private final CompleteCancelOrderUseCase completeCancelOrderUseCase;
+    private final SagaResponsePublisher sagaResponsePublisher;
+
+    @KafkaListener(
+            topics = KafkaTopicConstants.SAGA_ORDER_CANCEL_COMPLETED,
+            groupId = "saga-order-cancel-completed"
+    )
+    public void handleCompleteCancellationStep(
+            ConsumerRecord<String, EventEnvelope<?>> record,
+            Acknowledgment acknowledgment
+    ) {
+        try {
+            EventEnvelope<?> envelope = record.value();
+
+            if (EventPayloadValidator.hasInvalidEnvelope(envelope, record)) {
+                return;
+            }
+
+            SagaStepMessage stepMessage = envelope.getPayloadAs(SagaStepMessage.class, objectMapper);
+
+            log.info("SAGA 주문 취소 완료 스텝 수신. sagaId={}, messageType={}",
+                    stepMessage.sagaId(), stepMessage.messageType());
+
+            if (SagaStepMessage.ACTION.equals(stepMessage.messageType())) {
+                handleAction(stepMessage);
+                return;
+            }
+
+            log.warn("주문 취소 완료 스텝은 보상이 없음. 알 수 없는 messageType. sagaId={}, messageType={}",
+                    stepMessage.sagaId(), stepMessage.messageType());
+        } catch (Exception e) {
+            log.error("SAGA 주문 취소 완료 스텝 메시지 처리 실패. topic={}, partition={}, offset={}, error={}",
+                    record.topic(), record.partition(), record.offset(), e.getMessage(), e);
+        } finally {
+            acknowledgment.acknowledge();
+        }
+    }
+
+    private void handleAction(SagaStepMessage stepMessage) {
+        try {
+            CompleteCancellationSagaPayload payload = objectMapper.readValue(
+                    stepMessage.payload(), CompleteCancellationSagaPayload.class);
+
+            if (FormatValidator.hasNoValue(payload.orderId())) {
+                publishValidationFailure(stepMessage, "orderId 누락");
+                return;
+            }
+
+            if (FormatValidator.hasNoValue(payload.orderKey())) {
+                publishValidationFailure(stepMessage, "orderKey 누락");
+                return;
+            }
+
+            CompleteCancelOrderCommand command = CompleteCancelOrderCommand.builder()
+                    .orderId(payload.orderId())
+                    .orderKey(payload.orderKey())
+                    .buyerId(payload.buyerId())
+                    .cancelAmount(payload.cancelAmount())
+                    .paymentAmount(payload.paymentAmount())
+                    .pointAmount(payload.pointAmount())
+                    .shippingFee(payload.shippingFee())
+                    .isFullCancel(payload.isFullCancel())
+                    .alreadyRefunded(payload.alreadyRefunded())
+                    .reasonCategory(payload.reasonCategory())
+                    .reason(payload.reason())
+                    .build();
+
+            completeCancelOrderUseCase.completeCancellation(command);
+
+            sagaResponsePublisher.publishSuccess(
+                    stepMessage.sagaId(), stepMessage.sagaType(), stepMessage.stepName(),
+                    stepMessage.messageType(), "{\"success\":true}");
+
+            log.info("SAGA 주문 취소 완료 처리 성공. sagaId={}, orderId={}, orderKey={}",
+                    stepMessage.sagaId(), payload.orderId(), payload.orderKey());
+        } catch (Exception e) {
+            log.error("SAGA 주문 취소 완료 처리 실패. sagaId={}, error={}",
+                    stepMessage.sagaId(), e.getMessage(), e);
+            sagaResponsePublisher.publishFailure(
+                    stepMessage.sagaId(), stepMessage.sagaType(), stepMessage.stepName(),
+                    stepMessage.messageType(), "주문 취소 완료 처리 실패");
+        }
+    }
+
+    private void publishValidationFailure(SagaStepMessage stepMessage, String reason) {
+        log.warn("SAGA 주문 취소 완료 스텝 페이로드 검증 실패. sagaId={}, reason={}",
+                stepMessage.sagaId(), reason);
+        sagaResponsePublisher.publishFailure(
+                stepMessage.sagaId(), stepMessage.sagaType(), stepMessage.stepName(),
+                stepMessage.messageType(), "페이로드 검증 실패: " + reason);
+    }
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/saga/payload/CompleteCancellationSagaPayload.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/saga/payload/CompleteCancellationSagaPayload.java
@@ -1,0 +1,27 @@
+package com.personal.marketnote.commerce.adapter.in.event.saga.payload;
+
+import java.util.List;
+import java.util.UUID;
+
+public record CompleteCancellationSagaPayload(
+        Long orderId,
+        String orderKey,
+        Long buyerId,
+        Long cancelAmount,
+        Long paymentAmount,
+        Long pointAmount,
+        Long shippingFee,
+        boolean isFullCancel,
+        Long alreadyRefunded,
+        String reasonCategory,
+        String reason,
+        List<OrderProductItem> orderProducts
+) {
+    public record OrderProductItem(
+            Long pricePolicyId,
+            UUID sharerKey,
+            Integer quantity,
+            Long unitAmount
+    ) {
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/command/order/CompleteCancelOrderCommand.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/command/order/CompleteCancelOrderCommand.java
@@ -1,0 +1,19 @@
+package com.personal.marketnote.commerce.port.in.command.order;
+
+import lombok.Builder;
+
+@Builder
+public record CompleteCancelOrderCommand(
+        Long orderId,
+        String orderKey,
+        Long buyerId,
+        Long cancelAmount,
+        Long paymentAmount,
+        Long pointAmount,
+        Long shippingFee,
+        boolean isFullCancel,
+        Long alreadyRefunded,
+        String reasonCategory,
+        String reason
+) {
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/order/CompleteCancelOrderUseCase.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/order/CompleteCancelOrderUseCase.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.commerce.port.in.usecase.order;
+
+import com.personal.marketnote.commerce.port.in.command.order.CompleteCancelOrderCommand;
+
+public interface CompleteCancelOrderUseCase {
+    void completeCancellation(CompleteCancelOrderCommand command);
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/CompleteCancelOrderService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/CompleteCancelOrderService.java
@@ -1,0 +1,86 @@
+package com.personal.marketnote.commerce.service.order;
+
+import com.personal.marketnote.commerce.domain.order.Order;
+import com.personal.marketnote.commerce.domain.order.OrderStatus;
+import com.personal.marketnote.commerce.domain.order.OrderStatusHistory;
+import com.personal.marketnote.commerce.domain.order.OrderStatusHistoryCreateState;
+import com.personal.marketnote.commerce.domain.order.OrderStatusReasonCategory;
+import com.personal.marketnote.commerce.exception.InvalidOrderStatusTransitionException;
+import com.personal.marketnote.commerce.port.in.command.order.CompleteCancelOrderCommand;
+import com.personal.marketnote.commerce.port.in.usecase.order.CompleteCancelOrderUseCase;
+import com.personal.marketnote.commerce.port.in.usecase.order.GetOrderUseCase;
+import com.personal.marketnote.commerce.port.out.event.PublishOrderEventPort;
+import com.personal.marketnote.commerce.port.out.order.UpdateOrderPort;
+import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.common.utility.FormatValidator;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.transaction.annotation.Isolation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+
+@UseCase
+@RequiredArgsConstructor
+@Slf4j
+public class CompleteCancelOrderService implements CompleteCancelOrderUseCase {
+
+    private final GetOrderUseCase getOrderUseCase;
+    private final UpdateOrderPort updateOrderPort;
+    private final PublishOrderEventPort publishOrderEventPort;
+    private final Clock clock;
+
+    @Override
+    @Transactional(isolation = Isolation.READ_COMMITTED)
+    public void completeCancellation(CompleteCancelOrderCommand command) {
+        Order order = getOrderUseCase.getOrder(command.orderId());
+
+        validateCancelRequestedStatus(order);
+
+        LocalDateTime now = LocalDateTime.now(clock);
+        order.changeAllProductsStatus(OrderStatus.CANCELLED, now);
+
+        OrderStatusReasonCategory reasonCategory = resolveReasonCategory(command.reasonCategory());
+
+        OrderStatusHistory orderStatusHistory = OrderStatusHistory.from(
+                OrderStatusHistoryCreateState.builder()
+                        .orderId(command.orderId())
+                        .orderStatus(OrderStatus.CANCELLED)
+                        .reasonCategory(reasonCategory)
+                        .reason(command.reason())
+                        .build()
+        );
+
+        updateOrderPort.update(order, orderStatusHistory);
+
+        publishOrderEventPort.publishOrderCancelledEvent(
+                command.orderId(),
+                command.orderKey(),
+                command.buyerId(),
+                command.cancelAmount(),
+                command.paymentAmount(),
+                command.pointAmount(),
+                command.shippingFee(),
+                command.isFullCancel(),
+                command.alreadyRefunded(),
+                order.getOrderProducts(),
+                order.getOrderProducts()
+        );
+
+        log.info("주문 취소 완료 처리. orderId={}, orderKey={}", command.orderId(), command.orderKey());
+    }
+
+    private void validateCancelRequestedStatus(Order order) {
+        if (!order.getOrderStatus().isCancelRequested()) {
+            throw new InvalidOrderStatusTransitionException(order.getOrderStatus(), OrderStatus.CANCELLED);
+        }
+    }
+
+    private OrderStatusReasonCategory resolveReasonCategory(String reasonCategoryStr) {
+        if (FormatValidator.hasNoValue(reasonCategoryStr)) {
+            return null;
+        }
+        return OrderStatusReasonCategory.valueOf(reasonCategoryStr);
+    }
+}


### PR DESCRIPTION
## partially addresses #216
## resolves #2346

## Task
- [x] CompleteCancelOrderUseCase + CompleteCancelOrderCommand + CompleteCancelOrderService 추가
- [x] CompleteCancellationSagaPayload + OrderCancelCompleteSagaConsumer 추가
- [x] CANCEL_REQUESTED → CANCELLED 상태 전이, OrderStatusHistory 생성, ORDER_CANCELLED 이벤트 발행
- [x] 필수 필드 검증, Poison pill 방지