### PR TITLE
[#216][#2234] feat: 주문 등록 시 배송지 지역 구분 기반 추가 배송비 검증 기능 추가

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/ShippingAddressChangedReadModelConsumer.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/ShippingAddressChangedReadModelConsumer.java
@@ -81,7 +81,8 @@ public class ShippingAddressChangedReadModelConsumer {
             saveShippingAddressReadModelPort.upsert(
                     payload.shippingAddressId(), payload.userId(),
                     payload.recipientName(), payload.recipientPhoneNumber(),
-                    payload.address(), payload.addressDetail()
+                    payload.address(), payload.addressDetail(),
+                    payload.regionType()
             );
             log.info("배송지 Read Model 저장 완료. shippingAddressId={}, userId={}",
                     payload.shippingAddressId(), payload.userId());

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/shipping/ShippingAddressReadModelPersistenceAdapter.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/shipping/ShippingAddressReadModelPersistenceAdapter.java
@@ -35,30 +35,31 @@ public class ShippingAddressReadModelPersistenceAdapter implements FindUserShipp
                 entity.getRecipientName(),
                 entity.getRecipientPhoneNumber(),
                 entity.getAddress(),
-                entity.getAddressDetail()
+                entity.getAddressDetail(),
+                entity.getRegionType()
         );
     }
 
     @Override
     @Transactional(isolation = READ_COMMITTED)
-    public void upsert(Long shippingAddressId, Long userId, String recipientName, String recipientPhoneNumber, String address, String addressDetail) {
+    public void upsert(Long shippingAddressId, Long userId, String recipientName, String recipientPhoneNumber, String address, String addressDetail, String regionType) {
         Optional<ShippingAddressReadModelJpaEntity> existing =
                 shippingAddressReadModelJpaRepository.findByShippingAddressId(shippingAddressId);
 
         if (existing.isPresent()) {
-            existing.get().updateFrom(recipientName, recipientPhoneNumber, address, addressDetail);
+            existing.get().updateFrom(recipientName, recipientPhoneNumber, address, addressDetail, regionType);
             return;
         }
 
         try {
             ShippingAddressReadModelJpaEntity entity = ShippingAddressReadModelJpaEntity.of(
-                    shippingAddressId, userId, recipientName, recipientPhoneNumber, address, addressDetail
+                    shippingAddressId, userId, recipientName, recipientPhoneNumber, address, addressDetail, regionType
             );
             shippingAddressReadModelJpaRepository.saveAndFlush(entity);
         } catch (DataIntegrityViolationException e) {
             log.info("배송지 Read Model 중복 저장 (멱등 처리). shippingAddressId={}", shippingAddressId);
             shippingAddressReadModelJpaRepository.findByShippingAddressId(shippingAddressId)
-                    .ifPresent(entity -> entity.updateFrom(recipientName, recipientPhoneNumber, address, addressDetail));
+                    .ifPresent(entity -> entity.updateFrom(recipientName, recipientPhoneNumber, address, addressDetail, regionType));
         }
     }
 

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/shipping/entity/ShippingAddressReadModelJpaEntity.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/persistence/shipping/entity/ShippingAddressReadModelJpaEntity.java
@@ -39,10 +39,13 @@ public class ShippingAddressReadModelJpaEntity extends BaseGeneralEntity {
     @Column(name = "address_detail", nullable = false)
     private String addressDetail;
 
+    @Column(name = "region_type", length = 20)
+    private String regionType;
+
     public static ShippingAddressReadModelJpaEntity of(
             Long shippingAddressId, Long userId,
             String recipientName, String recipientPhoneNumber,
-            String address, String addressDetail
+            String address, String addressDetail, String regionType
     ) {
         return ShippingAddressReadModelJpaEntity.builder()
                 .shippingAddressId(shippingAddressId)
@@ -51,17 +54,19 @@ public class ShippingAddressReadModelJpaEntity extends BaseGeneralEntity {
                 .recipientPhoneNumber(recipientPhoneNumber)
                 .address(address)
                 .addressDetail(addressDetail)
+                .regionType(regionType)
                 .build();
     }
 
     public void updateFrom(
             String recipientName, String recipientPhoneNumber,
-            String address, String addressDetail
+            String address, String addressDetail, String regionType
     ) {
         this.recipientName = recipientName;
         this.recipientPhoneNumber = recipientPhoneNumber;
         this.address = address;
         this.addressDetail = addressDetail;
+        this.regionType = regionType;
         activate();
     }
 

--- a/commerce-service/commerce-adapters/src/main/resources/db/migration/V915__add_region_type_to_shipping_address_read_models.sql
+++ b/commerce-service/commerce-adapters/src/main/resources/db/migration/V915__add_region_type_to_shipping_address_read_models.sql
@@ -1,0 +1,1 @@
+ALTER TABLE shipping_address_read_models ADD COLUMN region_type VARCHAR(20);

--- a/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/event/ShippingAddressChangedReadModelConsumerTest.java
+++ b/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/event/ShippingAddressChangedReadModelConsumerTest.java
@@ -58,7 +58,7 @@ class ShippingAddressChangedReadModelConsumerTest {
     void handleShippingAddressChangedEvent_created_upsertsReadModel() {
         // given
         ShippingAddressChangedEvent payload = new ShippingAddressChangedEvent(
-                1L, 100L, "홍길동", "010-1234-5678", "서울시 강남구 테헤란로 123", "101동 1001호", ShippingAddressChangeAction.CREATED
+                1L, 100L, "홍길동", "010-1234-5678", "서울시 강남구 테헤란로 123", "101동 1001호", "NORMAL", ShippingAddressChangeAction.CREATED
         );
         EventEnvelope<ShippingAddressChangedEvent> envelope = createEnvelope(payload);
         ConsumerRecord<String, EventEnvelope<?>> record = createRecord(envelope);
@@ -67,7 +67,7 @@ class ShippingAddressChangedReadModelConsumerTest {
         consumer.handleShippingAddressChangedEvent(record, acknowledgment);
 
         // then
-        verify(saveShippingAddressReadModelPort).upsert(1L, 100L, "홍길동", "010-1234-5678", "서울시 강남구 테헤란로 123", "101동 1001호");
+        verify(saveShippingAddressReadModelPort).upsert(1L, 100L, "홍길동", "010-1234-5678", "서울시 강남구 테헤란로 123", "101동 1001호", "NORMAL");
         verify(acknowledgment).acknowledge();
     }
 
@@ -76,7 +76,7 @@ class ShippingAddressChangedReadModelConsumerTest {
     void handleShippingAddressChangedEvent_updated_upsertsReadModel() {
         // given
         ShippingAddressChangedEvent payload = new ShippingAddressChangedEvent(
-                2L, 200L, "김철수", "010-9876-5432", "서울시 서초구 서초대로 456", "202동 303호", ShippingAddressChangeAction.UPDATED
+                2L, 200L, "김철수", "010-9876-5432", "서울시 서초구 서초대로 456", "202동 303호", "JEJU", ShippingAddressChangeAction.UPDATED
         );
         EventEnvelope<ShippingAddressChangedEvent> envelope = createEnvelope(payload);
         ConsumerRecord<String, EventEnvelope<?>> record = createRecord(envelope);
@@ -85,7 +85,7 @@ class ShippingAddressChangedReadModelConsumerTest {
         consumer.handleShippingAddressChangedEvent(record, acknowledgment);
 
         // then
-        verify(saveShippingAddressReadModelPort).upsert(2L, 200L, "김철수", "010-9876-5432", "서울시 서초구 서초대로 456", "202동 303호");
+        verify(saveShippingAddressReadModelPort).upsert(2L, 200L, "김철수", "010-9876-5432", "서울시 서초구 서초대로 456", "202동 303호", "JEJU");
         verify(acknowledgment).acknowledge();
     }
 
@@ -94,7 +94,7 @@ class ShippingAddressChangedReadModelConsumerTest {
     void handleShippingAddressChangedEvent_deleted_deactivatesReadModel() {
         // given
         ShippingAddressChangedEvent payload = new ShippingAddressChangedEvent(
-                1L, 100L, "홍길동", "010-1234-5678", "서울시 강남구 테헤란로 123", "101동 1001호", ShippingAddressChangeAction.DELETED
+                1L, 100L, "홍길동", "010-1234-5678", "서울시 강남구 테헤란로 123", "101동 1001호", null, ShippingAddressChangeAction.DELETED
         );
         EventEnvelope<ShippingAddressChangedEvent> envelope = createEnvelope(payload);
         ConsumerRecord<String, EventEnvelope<?>> record = createRecord(envelope);
@@ -129,7 +129,7 @@ class ShippingAddressChangedReadModelConsumerTest {
     void handleShippingAddressChangedEvent_eventTypeMismatch_acknowledges() {
         // given
         ShippingAddressChangedEvent payload = new ShippingAddressChangedEvent(
-                1L, 100L, "홍길동", "010-1234-5678", "서울시 강남구 테헤란로 123", "101동 1001호", ShippingAddressChangeAction.CREATED
+                1L, 100L, "홍길동", "010-1234-5678", "서울시 강남구 테헤란로 123", "101동 1001호", "NORMAL", ShippingAddressChangeAction.CREATED
         );
         EventEnvelope<ShippingAddressChangedEvent> envelope = new EventEnvelope<>(
                 "test-event-id",
@@ -153,7 +153,7 @@ class ShippingAddressChangedReadModelConsumerTest {
     void handleShippingAddressChangedEvent_nullShippingAddressId_acknowledges() {
         // given
         ShippingAddressChangedEvent payload = new ShippingAddressChangedEvent(
-                null, 100L, "홍길동", "010-1234-5678", "서울시 강남구 테헤란로 123", "101동 1001호", ShippingAddressChangeAction.CREATED
+                null, 100L, "홍길동", "010-1234-5678", "서울시 강남구 테헤란로 123", "101동 1001호", "NORMAL", ShippingAddressChangeAction.CREATED
         );
         EventEnvelope<ShippingAddressChangedEvent> envelope = createEnvelope(payload);
         ConsumerRecord<String, EventEnvelope<?>> record = createRecord(envelope);
@@ -171,7 +171,7 @@ class ShippingAddressChangedReadModelConsumerTest {
     void handleShippingAddressChangedEvent_nullUserId_acknowledges() {
         // given
         ShippingAddressChangedEvent payload = new ShippingAddressChangedEvent(
-                1L, null, "홍길동", "010-1234-5678", "서울시 강남구 테헤란로 123", "101동 1001호", ShippingAddressChangeAction.CREATED
+                1L, null, "홍길동", "010-1234-5678", "서울시 강남구 테헤란로 123", "101동 1001호", "NORMAL", ShippingAddressChangeAction.CREATED
         );
         EventEnvelope<ShippingAddressChangedEvent> envelope = createEnvelope(payload);
         ConsumerRecord<String, EventEnvelope<?>> record = createRecord(envelope);
@@ -189,7 +189,7 @@ class ShippingAddressChangedReadModelConsumerTest {
     void handleShippingAddressChangedEvent_nullAction_acknowledges() {
         // given
         ShippingAddressChangedEvent payload = new ShippingAddressChangedEvent(
-                1L, 100L, "홍길동", "010-1234-5678", "서울시 강남구 테헤란로 123", "101동 1001호", null
+                1L, 100L, "홍길동", "010-1234-5678", "서울시 강남구 테헤란로 123", "101동 1001호", "NORMAL", null
         );
         EventEnvelope<ShippingAddressChangedEvent> envelope = createEnvelope(payload);
         ConsumerRecord<String, EventEnvelope<?>> record = createRecord(envelope);
@@ -207,7 +207,7 @@ class ShippingAddressChangedReadModelConsumerTest {
     void handleShippingAddressChangedEvent_zeroShippingAddressId_acknowledges() {
         // given
         ShippingAddressChangedEvent payload = new ShippingAddressChangedEvent(
-                0L, 100L, "홍길동", "010-1234-5678", "서울시 강남구 테헤란로 123", "101동 1001호", ShippingAddressChangeAction.CREATED
+                0L, 100L, "홍길동", "010-1234-5678", "서울시 강남구 테헤란로 123", "101동 1001호", "NORMAL", ShippingAddressChangeAction.CREATED
         );
         EventEnvelope<ShippingAddressChangedEvent> envelope = createEnvelope(payload);
         ConsumerRecord<String, EventEnvelope<?>> record = createRecord(envelope);
@@ -225,7 +225,7 @@ class ShippingAddressChangedReadModelConsumerTest {
     void handleShippingAddressChangedEvent_negativeShippingAddressId_acknowledges() {
         // given
         ShippingAddressChangedEvent payload = new ShippingAddressChangedEvent(
-                -1L, 100L, "홍길동", "010-1234-5678", "서울시 강남구 테헤란로 123", "101동 1001호", ShippingAddressChangeAction.CREATED
+                -1L, 100L, "홍길동", "010-1234-5678", "서울시 강남구 테헤란로 123", "101동 1001호", "NORMAL", ShippingAddressChangeAction.CREATED
         );
         EventEnvelope<ShippingAddressChangedEvent> envelope = createEnvelope(payload);
         ConsumerRecord<String, EventEnvelope<?>> record = createRecord(envelope);
@@ -243,7 +243,7 @@ class ShippingAddressChangedReadModelConsumerTest {
     void handleShippingAddressChangedEvent_nullRecipientName_acknowledges() {
         // given
         ShippingAddressChangedEvent payload = new ShippingAddressChangedEvent(
-                1L, 100L, null, "010-1234-5678", "서울시 강남구 테헤란로 123", "101동 1001호", ShippingAddressChangeAction.CREATED
+                1L, 100L, null, "010-1234-5678", "서울시 강남구 테헤란로 123", "101동 1001호", "NORMAL", ShippingAddressChangeAction.CREATED
         );
         EventEnvelope<ShippingAddressChangedEvent> envelope = createEnvelope(payload);
         ConsumerRecord<String, EventEnvelope<?>> record = createRecord(envelope);
@@ -261,7 +261,7 @@ class ShippingAddressChangedReadModelConsumerTest {
     void handleShippingAddressChangedEvent_nullAddress_acknowledges() {
         // given
         ShippingAddressChangedEvent payload = new ShippingAddressChangedEvent(
-                1L, 100L, "홍길동", "010-1234-5678", null, "101동 1001호", ShippingAddressChangeAction.CREATED
+                1L, 100L, "홍길동", "010-1234-5678", null, "101동 1001호", "NORMAL", ShippingAddressChangeAction.CREATED
         );
         EventEnvelope<ShippingAddressChangedEvent> envelope = createEnvelope(payload);
         ConsumerRecord<String, EventEnvelope<?>> record = createRecord(envelope);

--- a/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/out/persistence/shipping/ShippingAddressReadModelPersistenceAdapterTest.java
+++ b/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/out/persistence/shipping/ShippingAddressReadModelPersistenceAdapterTest.java
@@ -46,7 +46,7 @@ class ShippingAddressReadModelPersistenceAdapterTest {
         @DisplayName("ACTIVE 상태의 배송지를 조회하여 ShippingAddressInfoResult를 반환한다")
         void returnsActiveShippingAddress() {
             // given
-            adapter.upsert(1L, 100L, "홍길동", "010-1234-5678", "서울시 강남구 테헤란로 123", "101동 1001호");
+            adapter.upsert(1L, 100L, "홍길동", "010-1234-5678", "서울시 강남구 테헤란로 123", "101동 1001호", "NORMAL");
 
             // when
             ShippingAddressInfoResult result = adapter.findByIdAndUserId(1L, 100L);
@@ -70,7 +70,7 @@ class ShippingAddressReadModelPersistenceAdapterTest {
         @DisplayName("비활성화된 배송지는 조회되지 않는다")
         void doesNotReturnInactiveAddress() {
             // given
-            adapter.upsert(1L, 100L, "홍길동", "010-1234-5678", "서울시 강남구 테헤란로 123", "101동 1001호");
+            adapter.upsert(1L, 100L, "홍길동", "010-1234-5678", "서울시 강남구 테헤란로 123", "101동 1001호", "NORMAL");
             adapter.deactivateByShippingAddressId(1L);
 
             // when & then
@@ -82,7 +82,7 @@ class ShippingAddressReadModelPersistenceAdapterTest {
         @DisplayName("userId가 일치하지 않으면 ShippingAddressNotFoundException이 발생한다")
         void throwsNotFoundForMismatchedUserId() {
             // given
-            adapter.upsert(1L, 100L, "홍길동", "010-1234-5678", "서울시 강남구 테헤란로 123", "101동 1001호");
+            adapter.upsert(1L, 100L, "홍길동", "010-1234-5678", "서울시 강남구 테헤란로 123", "101동 1001호", "NORMAL");
 
             // when & then
             assertThatThrownBy(() -> adapter.findByIdAndUserId(1L, 999L))
@@ -98,7 +98,7 @@ class ShippingAddressReadModelPersistenceAdapterTest {
         @DisplayName("신규 배송지를 저장한다")
         void insertsNewAddress() {
             // when
-            adapter.upsert(1L, 100L, "홍길동", "010-1234-5678", "서울시 강남구 테헤란로 123", "101동 1001호");
+            adapter.upsert(1L, 100L, "홍길동", "010-1234-5678", "서울시 강남구 테헤란로 123", "101동 1001호", "NORMAL");
 
             // then
             Optional<ShippingAddressReadModelJpaEntity> entity =
@@ -117,10 +117,10 @@ class ShippingAddressReadModelPersistenceAdapterTest {
         @DisplayName("동일한 shippingAddressId로 upsert 시 기존 데이터를 업데이트한다")
         void updatesExistingAddress() {
             // given
-            adapter.upsert(1L, 100L, "홍길동", "010-1234-5678", "서울시 강남구 테헤란로 123", "101동 1001호");
+            adapter.upsert(1L, 100L, "홍길동", "010-1234-5678", "서울시 강남구 테헤란로 123", "101동 1001호", "NORMAL");
 
             // when
-            adapter.upsert(1L, 100L, "김철수", "010-9876-5432", "서울시 서초구 서초대로 456", "202동 303호");
+            adapter.upsert(1L, 100L, "김철수", "010-9876-5432", "서울시 서초구 서초대로 456", "202동 303호", "NORMAL");
 
             // then
             Optional<ShippingAddressReadModelJpaEntity> entity =
@@ -136,11 +136,11 @@ class ShippingAddressReadModelPersistenceAdapterTest {
         @DisplayName("비활성화된 배송지에 대해 upsert 시 다시 활성화된다")
         void reactivatesInactiveAddress() {
             // given
-            adapter.upsert(1L, 100L, "홍길동", "010-1234-5678", "서울시 강남구 테헤란로 123", "101동 1001호");
+            adapter.upsert(1L, 100L, "홍길동", "010-1234-5678", "서울시 강남구 테헤란로 123", "101동 1001호", "NORMAL");
             adapter.deactivateByShippingAddressId(1L);
 
             // when
-            adapter.upsert(1L, 100L, "김철수", "010-9876-5432", "서울시 서초구 서초대로 456", "202동 303호");
+            adapter.upsert(1L, 100L, "김철수", "010-9876-5432", "서울시 서초구 서초대로 456", "202동 303호", "NORMAL");
 
             // then
             Optional<ShippingAddressReadModelJpaEntity> entity =
@@ -159,7 +159,7 @@ class ShippingAddressReadModelPersistenceAdapterTest {
         @DisplayName("배송지를 비활성화한다")
         void deactivatesAddress() {
             // given
-            adapter.upsert(1L, 100L, "홍길동", "010-1234-5678", "서울시 강남구 테헤란로 123", "101동 1001호");
+            adapter.upsert(1L, 100L, "홍길동", "010-1234-5678", "서울시 강남구 테헤란로 123", "101동 1001호", "NORMAL");
 
             // when
             adapter.deactivateByShippingAddressId(1L);

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/result/shipping/ShippingRegionType.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/result/shipping/ShippingRegionType.java
@@ -1,0 +1,32 @@
+package com.personal.marketnote.commerce.port.out.result.shipping;
+
+import com.personal.marketnote.common.utility.FormatValidator;
+
+public enum ShippingRegionType {
+    NORMAL,
+    JEJU,
+    ISLAND;
+
+    public boolean isNormal() {
+        return this == NORMAL;
+    }
+
+    public boolean isJeju() {
+        return this == JEJU;
+    }
+
+    public boolean isIsland() {
+        return this == ISLAND;
+    }
+
+    public static ShippingRegionType from(String regionType) {
+        if (FormatValidator.hasNoValue(regionType)) {
+            return NORMAL;
+        }
+        try {
+            return valueOf(regionType);
+        } catch (IllegalArgumentException e) {
+            return NORMAL;
+        }
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/result/user/ShippingAddressInfoResult.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/result/user/ShippingAddressInfoResult.java
@@ -4,6 +4,7 @@ public record ShippingAddressInfoResult(
         String recipientName,
         String recipientPhoneNumber,
         String address,
-        String addressDetail
+        String addressDetail,
+        String regionType
 ) {
 }

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/user/SaveShippingAddressReadModelPort.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/user/SaveShippingAddressReadModelPort.java
@@ -2,7 +2,7 @@ package com.personal.marketnote.commerce.port.out.user;
 
 public interface SaveShippingAddressReadModelPort {
 
-    void upsert(Long shippingAddressId, Long userId, String recipientName, String recipientPhoneNumber, String address, String addressDetail);
+    void upsert(Long shippingAddressId, Long userId, String recipientName, String recipientPhoneNumber, String address, String addressDetail, String regionType);
 
     void deactivateByShippingAddressId(Long shippingAddressId);
 }

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/CancelOrderService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/CancelOrderService.java
@@ -12,8 +12,6 @@ import com.personal.marketnote.commerce.exception.OrderCancellationNotAllowedExc
 import com.personal.marketnote.commerce.exception.OrderStatusAlreadyChangedException;
 import com.personal.marketnote.commerce.exception.UnauthorizedOrderAccessException;
 import com.personal.marketnote.commerce.port.in.command.order.CancelOrderCommand;
-import com.personal.marketnote.commerce.port.in.command.saga.OrderCancelSagaContext;
-import com.personal.marketnote.commerce.port.in.command.saga.OrderPaymentSagaContext.OrderProductItem;
 import com.personal.marketnote.commerce.port.in.usecase.order.CancelOrderUseCase;
 import com.personal.marketnote.commerce.port.in.usecase.order.GetOrderUseCase;
 import com.personal.marketnote.commerce.port.out.event.PublishOrderEventPort;
@@ -22,8 +20,6 @@ import com.personal.marketnote.commerce.port.out.fulfillment.CancelFulfillmentRe
 import com.personal.marketnote.commerce.port.out.order.UpdateOrderPort;
 import com.personal.marketnote.common.application.UseCase;
 import com.personal.marketnote.common.exception.FulfillmentServiceRequestFailedException;
-import com.personal.marketnote.common.saga.SagaDefinition;
-import com.personal.marketnote.common.saga.SagaOrchestrator;
 import com.personal.marketnote.common.utility.FormatValidator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -33,8 +29,6 @@ import org.springframework.transaction.support.TransactionTemplate;
 
 import java.time.Clock;
 import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Optional;
 
 @UseCase
 @RequiredArgsConstructor
@@ -46,8 +40,6 @@ public class CancelOrderService implements CancelOrderUseCase {
     private final PublishOrderEventPort publishOrderEventPort;
     private final PlatformTransactionManager transactionManager;
     private final Clock clock;
-    private final Optional<SagaOrchestrator> sagaOrchestrator;
-    private final Optional<SagaDefinition<OrderCancelSagaContext>> orderCancelSagaDefinition;
 
     @Override
     public void cancelOrder(CancelOrderCommand command) {
@@ -61,79 +53,9 @@ public class CancelOrderService implements CancelOrderUseCase {
 
         OrderStatus originalStatus = order.getOrderStatus();
 
-        if (useSagaMode() && originalStatus.requiresPaymentRefund()) {
-            cancelOrderViaSaga(command, order, originalStatus);
-            return;
-        }
-
-        cancelOrderSync(command, order, originalStatus, targetStatus);
-    }
-
-    private boolean useSagaMode() {
-        return sagaOrchestrator.isPresent() && orderCancelSagaDefinition.isPresent();
-    }
-
-    private void cancelOrderViaSaga(CancelOrderCommand command, Order order, OrderStatus originalStatus) {
-        persistStatusChange(command, order, OrderStatus.CANCEL_REQUESTED);
-
-        OrderAmount amount = order.getAmount();
-        String sagaId = "ORDER_CANCEL:" + order.getId();
-
-        List<OrderProductItem> orderProductItems = order.getOrderProducts().stream()
-                .map(op -> new OrderProductItem(
-                        op.getPricePolicyId(), op.getSharerKey(),
-                        op.getQuantity(), op.getUnitAmount()))
-                .toList();
-
-        OrderCancelSagaContext context = new OrderCancelSagaContext(
-                order.getId(),
-                order.getOrderKey().toString(),
-                order.getBuyerId(),
-                amount.getPaidAmount(),
-                amount.getPaidAmount(),
-                amount.getPointAmount(),
-                amount.getShippingFee(),
-                true,
-                0L,
-                originalStatus.name(),
-                resolveReasonCategoryName(command.reasonCategory()),
-                command.reason(),
-                orderProductItems
-        );
-
-        sagaOrchestrator.get().start(orderCancelSagaDefinition.get(), sagaId, context);
-
-        log.info("주문 취소 SAGA 시작. orderId={}, sagaId={}", order.getId(), sagaId);
-    }
-
-    private void cancelOrderSync(CancelOrderCommand command, Order order,
-                                 OrderStatus originalStatus, OrderStatus targetStatus) {
         cancelFulfillmentIfRequired(order);
-        persistStatusChange(command, order, targetStatus);
 
-        if (originalStatus.requiresPaymentRefund()) {
-            publishOrderCancelledEvent(order);
-        }
-    }
-
-    private void persistStatusChange(CancelOrderCommand command, Order order, OrderStatus targetStatus) {
-        TransactionTemplate transactionTemplate = new TransactionTemplate(transactionManager);
-        transactionTemplate.setIsolationLevel(TransactionDefinition.ISOLATION_READ_COMMITTED);
-        transactionTemplate.executeWithoutResult(status -> {
-            LocalDateTime now = LocalDateTime.now(clock);
-            order.changeAllProductsStatus(targetStatus, now);
-
-            OrderStatusHistory orderStatusHistory = OrderStatusHistory.from(
-                    OrderStatusHistoryCreateState.builder()
-                            .orderId(command.id())
-                            .orderStatus(targetStatus)
-                            .reasonCategory(command.reasonCategory())
-                            .reason(command.reason())
-                            .build()
-            );
-
-            updateOrderPort.update(order, orderStatusHistory);
-        });
+        persistCancellation(command, order, originalStatus, targetStatus);
     }
 
     private OrderStatus resolveTargetStatus(Order order) {
@@ -158,6 +80,30 @@ public class CancelOrderService implements CancelOrderUseCase {
             log.error("풀필먼트 서비스 통신 실패로 주문 취소 거부 - orderId: {}", order.getId(), e);
             throw new OrderCancellationNotAllowedException(order.getId());
         }
+    }
+
+    private void persistCancellation(CancelOrderCommand command, Order order, OrderStatus originalStatus, OrderStatus targetStatus) {
+        TransactionTemplate transactionTemplate = new TransactionTemplate(transactionManager);
+        transactionTemplate.setIsolationLevel(TransactionDefinition.ISOLATION_READ_COMMITTED);
+        transactionTemplate.executeWithoutResult(status -> {
+            LocalDateTime now = LocalDateTime.now(clock);
+            order.changeAllProductsStatus(targetStatus, now);
+
+            OrderStatusHistory orderStatusHistory = OrderStatusHistory.from(
+                    OrderStatusHistoryCreateState.builder()
+                            .orderId(command.id())
+                            .orderStatus(targetStatus)
+                            .reasonCategory(command.reasonCategory())
+                            .reason(command.reason())
+                            .build()
+            );
+
+            updateOrderPort.update(order, orderStatusHistory);
+
+            if (originalStatus.requiresPaymentRefund()) {
+                publishOrderCancelledEvent(order);
+            }
+        });
     }
 
     private void publishOrderCancelledEvent(Order order) {
@@ -204,12 +150,5 @@ public class CancelOrderService implements CancelOrderUseCase {
         if (!order.getOrderStatus().canTransitionTo(targetStatus)) {
             throw new InvalidOrderStatusTransitionException(order.getOrderStatus(), targetStatus);
         }
-    }
-
-    private String resolveReasonCategoryName(OrderStatusReasonCategory reasonCategory) {
-        if (FormatValidator.hasNoValue(reasonCategory)) {
-            return null;
-        }
-        return reasonCategory.name();
     }
 }

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/RegisterOrderService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/RegisterOrderService.java
@@ -19,6 +19,7 @@ import com.personal.marketnote.commerce.port.out.payment.SavePaymentPort;
 import com.personal.marketnote.commerce.port.out.product.FindProductByPricePolicyPort;
 import com.personal.marketnote.commerce.port.out.result.product.ProductInfoResult;
 import com.personal.marketnote.commerce.port.out.result.shipping.ShippingPolicyInfoResult;
+import com.personal.marketnote.commerce.port.out.result.shipping.ShippingRegionType;
 import com.personal.marketnote.commerce.port.out.result.user.ShippingAddressInfoResult;
 import com.personal.marketnote.commerce.port.out.reward.ModifyUserPointPort;
 import com.personal.marketnote.commerce.port.out.settlement.SavePaymentAllocationPort;
@@ -83,7 +84,13 @@ public class RegisterOrderService implements RegisterOrderUseCase {
         Map<Long, ShippingPolicyInfoResult> shippingPolicies = joinFuture(shippingPolicyFuture);
 
         validateUnitAmountsAgainstActualPrices(command, productInfoMap);
-        validateShippingFee(command, shippingPolicies);
+
+        ShippingAddressInfoResult addressInfo = findUserShippingAddressPort.findByIdAndUserId(
+                command.shippingAddressId(), command.buyerId()
+        );
+        ShippingRegionType regionType = ShippingRegionType.from(addressInfo.regionType());
+
+        validateShippingFee(command, shippingPolicies, regionType);
 
         Map<Long, Long> productIdsByPricePolicyId = command.orderProducts().stream()
                 .collect(Collectors.toMap(
@@ -108,7 +115,7 @@ public class RegisterOrderService implements RegisterOrderUseCase {
                 OrderCommandToStateMapper.mapToOrderAmountState(command.amount())
         );
 
-        ShippingAddress shippingAddress = resolveShippingAddress(command);
+        ShippingAddress shippingAddress = resolveShippingAddress(command, addressInfo);
 
         Order savedOrder = saveOrderPort.save(
                 Order.from(
@@ -137,13 +144,14 @@ public class RegisterOrderService implements RegisterOrderUseCase {
                 )
         );
 
-        createPaymentAllocations(savedOrder.getId(), command.orderProducts(), shippingPolicies);
+        createPaymentAllocations(savedOrder.getId(), command.orderProducts(), shippingPolicies, regionType);
 
         return RegisterOrderResult.from(savedOrder);
     }
 
     private void createPaymentAllocations(Long orderId, List<OrderProductItemCommand> orderProducts,
-                                          Map<Long, ShippingPolicyInfoResult> shippingPolicies) {
+                                          Map<Long, ShippingPolicyInfoResult> shippingPolicies,
+                                          ShippingRegionType regionType) {
         Map<Long, Long> sellerGrossAmounts = orderProducts.stream()
                 .collect(Collectors.groupingBy(
                         OrderProductItemCommand::sellerId,
@@ -151,7 +159,7 @@ public class RegisterOrderService implements RegisterOrderUseCase {
                                 Math.multiplyExact(item.unitAmount(), (long) item.quantity()))
                 ));
 
-        Map<Long, Long> sellerShippingFees = calculateSellerShippingFees(sellerGrossAmounts, shippingPolicies);
+        Map<Long, Long> sellerShippingFees = calculateSellerShippingFees(sellerGrossAmounts, shippingPolicies, regionType);
 
         List<PaymentAllocation> allocations = sellerGrossAmounts.entrySet().stream()
                 .filter(entry -> entry.getValue() > 0)
@@ -172,7 +180,8 @@ public class RegisterOrderService implements RegisterOrderUseCase {
 
     private Map<Long, Long> calculateSellerShippingFees(
             Map<Long, Long> sellerAmounts,
-            Map<Long, ShippingPolicyInfoResult> shippingPolicies
+            Map<Long, ShippingPolicyInfoResult> shippingPolicies,
+            ShippingRegionType regionType
     ) {
         Map<Long, Long> sellerShippingFees = new java.util.HashMap<>();
         for (Map.Entry<Long, Long> entry : sellerAmounts.entrySet()) {
@@ -185,13 +194,21 @@ public class RegisterOrderService implements RegisterOrderUseCase {
                 continue;
             }
 
-            if (sellerAmount < policy.freeShippingThreshold()) {
-                sellerShippingFees.put(sellerId, policy.shippingFee());
-                continue;
-            }
-            sellerShippingFees.put(sellerId, 0L);
+            long baseFee = sellerAmount < policy.freeShippingThreshold() ? policy.shippingFee() : 0L;
+            long surcharge = resolveSurcharge(policy, regionType);
+            sellerShippingFees.put(sellerId, Math.addExact(baseFee, surcharge));
         }
         return sellerShippingFees;
+    }
+
+    private long resolveSurcharge(ShippingPolicyInfoResult policy, ShippingRegionType regionType) {
+        if (regionType.isJeju()) {
+            return resolveAmount(policy.jejuSurcharge());
+        }
+        if (regionType.isIsland()) {
+            return resolveAmount(policy.islandSurcharge());
+        }
+        return 0L;
     }
 
     private void validateTotalAmountConsistency(RegisterOrderCommand command) {
@@ -312,7 +329,8 @@ public class RegisterOrderService implements RegisterOrderUseCase {
     }
 
     private void validateShippingFee(RegisterOrderCommand command,
-                                     Map<Long, ShippingPolicyInfoResult> shippingPolicies) {
+                                     Map<Long, ShippingPolicyInfoResult> shippingPolicies,
+                                     ShippingRegionType regionType) {
         long requestedShippingFee = resolveAmount(command.amount().shippingFee());
 
         if (shippingPolicies.isEmpty()) {
@@ -321,7 +339,7 @@ public class RegisterOrderService implements RegisterOrderUseCase {
             return;
         }
 
-        long calculatedShippingFee = calculateExpectedShippingFee(command.orderProducts(), shippingPolicies);
+        long calculatedShippingFee = calculateExpectedShippingFee(command.orderProducts(), shippingPolicies, regionType);
 
         if (requestedShippingFee != calculatedShippingFee) {
             log.warn("배송비 불일치 - 전송된 배송비: {}, 계산된 배송비: {}", requestedShippingFee, calculatedShippingFee);
@@ -331,7 +349,8 @@ public class RegisterOrderService implements RegisterOrderUseCase {
 
     private long calculateExpectedShippingFee(
             List<OrderProductItemCommand> orderProducts,
-            Map<Long, ShippingPolicyInfoResult> shippingPolicies
+            Map<Long, ShippingPolicyInfoResult> shippingPolicies,
+            ShippingRegionType regionType
     ) {
         Map<Long, Long> sellerAmounts = orderProducts.stream()
                 .collect(Collectors.groupingBy(
@@ -340,7 +359,7 @@ public class RegisterOrderService implements RegisterOrderUseCase {
                                 Math.multiplyExact(item.unitAmount(), (long) item.quantity()))
                 ));
 
-        Map<Long, Long> sellerShippingFees = calculateSellerShippingFees(sellerAmounts, shippingPolicies);
+        Map<Long, Long> sellerShippingFees = calculateSellerShippingFees(sellerAmounts, shippingPolicies, regionType);
 
         long totalShippingFee = 0L;
         for (Long fee : sellerShippingFees.values()) {
@@ -349,11 +368,8 @@ public class RegisterOrderService implements RegisterOrderUseCase {
         return totalShippingFee;
     }
 
-    private ShippingAddress resolveShippingAddress(RegisterOrderCommand command) {
-        ShippingAddressInfoResult addressInfo = findUserShippingAddressPort.findByIdAndUserId(
-                command.shippingAddressId(), command.buyerId()
-        );
-
+    private ShippingAddress resolveShippingAddress(RegisterOrderCommand command,
+                                                   ShippingAddressInfoResult addressInfo) {
         return ShippingAddress.of(
                 addressInfo.recipientName(),
                 addressInfo.recipientPhoneNumber(),

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/CancelOrderUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/CancelOrderUseCaseTest.java
@@ -3,21 +3,22 @@ package com.personal.marketnote.commerce.service.order;
 import com.personal.marketnote.commerce.domain.order.*;
 import com.personal.marketnote.commerce.exception.InvalidOrderStatusTransitionException;
 import com.personal.marketnote.commerce.exception.InvalidReasonCategoryException;
+import com.personal.marketnote.commerce.exception.OrderCancellationNotAllowedException;
 import com.personal.marketnote.commerce.exception.OrderStatusAlreadyChangedException;
 import com.personal.marketnote.commerce.exception.UnauthorizedOrderAccessException;
 import com.personal.marketnote.commerce.port.in.command.order.CancelOrderCommand;
-import com.personal.marketnote.commerce.port.in.command.saga.OrderCancelSagaContext;
 import com.personal.marketnote.commerce.port.in.usecase.order.GetOrderUseCase;
 import com.personal.marketnote.commerce.port.out.event.PublishOrderEventPort;
 import com.personal.marketnote.commerce.port.out.fulfillment.CancelFulfillmentReleasePort;
+import com.personal.marketnote.commerce.port.out.fulfillment.CancelFulfillmentReleaseResult;
 import com.personal.marketnote.commerce.port.out.order.UpdateOrderPort;
-import com.personal.marketnote.common.saga.SagaDefinition;
-import com.personal.marketnote.common.saga.SagaOrchestrator;
+import com.personal.marketnote.common.exception.FulfillmentServiceRequestFailedException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -25,12 +26,12 @@ import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.TransactionStatus;
 
+import java.io.IOException;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThatCode;
@@ -53,32 +54,18 @@ class CancelOrderUseCaseTest {
     private PlatformTransactionManager transactionManager;
     @Spy
     private Clock clock = Clock.fixed(Instant.parse("2026-04-05T00:00:00Z"), ZoneId.of("Asia/Seoul"));
-    @Mock
-    private SagaOrchestrator sagaOrchestrator;
-    @Mock
-    private SagaDefinition<OrderCancelSagaContext> orderCancelSagaDefinition;
 
+    @InjectMocks
     private CancelOrderService cancelOrderService;
 
     @BeforeEach
     void setUp() {
         lenient().when(transactionManager.getTransaction(any(TransactionDefinition.class)))
                 .thenReturn(mock(TransactionStatus.class));
-
-        cancelOrderService = new CancelOrderService(
-                getOrderUseCase,
-                updateOrderPort,
-                cancelFulfillmentReleasePort,
-                publishOrderEventPort,
-                transactionManager,
-                clock,
-                Optional.of(sagaOrchestrator),
-                Optional.of(orderCancelSagaDefinition)
-        );
     }
 
     // ==================================================================================
-    // 결제 대기 상태 취소 (SAGA 미사용)
+    // 결제 대기 상태 취소
     // ==================================================================================
 
     @Nested
@@ -86,8 +73,8 @@ class CancelOrderUseCaseTest {
     class PaymentPendingCancelTest {
 
         @Test
-        @DisplayName("결제 대기 상태의 주문을 취소하면 풀필먼트 취소와 SAGA 없이 즉시 CANCELLED 처리된다")
-        void cancelOrder_fromPaymentPending_cancelledWithoutSaga() {
+        @DisplayName("결제 대기 상태의 주문을 취소하면 풀필먼트 취소 없이 즉시 CANCELLED 처리된다")
+        void cancelOrder_fromPaymentPending_cancelledWithoutFulfillmentAndEvent() {
             Long orderId = 1L;
             Long buyerId = 100L;
             Order order = createOrder(orderId, buyerId, OrderStatus.PAYMENT_PENDING);
@@ -100,21 +87,20 @@ class CancelOrderUseCaseTest {
             verify(updateOrderPort).update(any(Order.class), any(OrderStatusHistory.class));
             verifyNoInteractions(cancelFulfillmentReleasePort);
             verifyNoInteractions(publishOrderEventPort);
-            verifyNoInteractions(sagaOrchestrator);
         }
     }
 
     // ==================================================================================
-    // SAGA 모드 — 결제 완료 상태 취소
+    // 결제 완료 상태 취소
     // ==================================================================================
 
     @Nested
-    @DisplayName("SAGA 모드 — 결제 완료 상태 취소")
-    class SagaModePaidCancelTest {
+    @DisplayName("결제 완료 상태 취소")
+    class PaidCancelTest {
 
         @Test
-        @DisplayName("결제 완료 상태의 주문을 취소하면 CANCEL_REQUESTED로 변경 후 SAGA를 시작한다")
-        void cancelOrder_fromPaid_startsSaga() {
+        @DisplayName("결제 완료 상태의 주문을 취소하면 풀필먼트 취소 없이 이벤트를 발행한다")
+        void cancelOrder_fromPaid_publishesEventWithoutFulfillmentCancel() {
             Long orderId = 1L;
             Long buyerId = 100L;
             Order order = createOrder(orderId, buyerId, OrderStatus.PAID);
@@ -125,41 +111,94 @@ class CancelOrderUseCaseTest {
             cancelOrderService.cancelOrder(command);
 
             verify(updateOrderPort).update(any(Order.class), any(OrderStatusHistory.class));
-            verify(sagaOrchestrator).start(
-                    eq(orderCancelSagaDefinition),
-                    eq("ORDER_CANCEL:" + orderId),
-                    any(OrderCancelSagaContext.class));
             verifyNoInteractions(cancelFulfillmentReleasePort);
-            verifyNoInteractions(publishOrderEventPort);
+            verify(publishOrderEventPort).publishOrderCancelledEvent(
+                    eq(orderId), any(String.class), eq(buyerId),
+                    eq(50000L), eq(50000L), eq(0L),
+                    eq(3000L), eq(true), eq(0L),
+                    any(), any()
+            );
         }
     }
 
     // ==================================================================================
-    // SAGA 모드 — 상품 준비중 상태 취소
+    // 상품 준비중 상태 취소 — 풀필먼트 취소 성공
     // ==================================================================================
 
     @Nested
-    @DisplayName("SAGA 모드 — 상품 준비중 상태 취소")
-    class SagaModePreparingCancelTest {
+    @DisplayName("상품 준비중 상태 취소 — 풀필먼트 취소 성공")
+    class PreparingCancelSuccessTest {
 
         @Test
-        @DisplayName("상품 준비중 상태의 주문을 취소하면 CANCEL_REQUESTED로 변경 후 SAGA를 시작한다")
-        void cancelOrder_fromPreparing_startsSaga() {
+        @DisplayName("상품 준비중 상태에서 풀필먼트 취소 성공 시 CANCELLED 처리되고 이벤트를 발행한다")
+        void cancelOrder_fromPreparing_fulfillmentApproved_cancelledAndPublishesEvent() {
             Long orderId = 1L;
             Long buyerId = 100L;
             Order order = createOrder(orderId, buyerId, OrderStatus.PREPARING);
             when(getOrderUseCase.getOrder(orderId)).thenReturn(order);
+            when(cancelFulfillmentReleasePort.cancelRelease(orderId))
+                    .thenReturn(new CancelFulfillmentReleaseResult(orderId, true, "취소 성공"));
 
             CancelOrderCommand command = createCommand(orderId, buyerId);
 
             cancelOrderService.cancelOrder(command);
 
+            verify(cancelFulfillmentReleasePort).cancelRelease(orderId);
             verify(updateOrderPort).update(any(Order.class), any(OrderStatusHistory.class));
-            verify(sagaOrchestrator).start(
-                    eq(orderCancelSagaDefinition),
-                    eq("ORDER_CANCEL:" + orderId),
-                    any(OrderCancelSagaContext.class));
-            verifyNoInteractions(cancelFulfillmentReleasePort);
+            verify(publishOrderEventPort).publishOrderCancelledEvent(
+                    eq(orderId), any(String.class), eq(buyerId),
+                    eq(50000L), eq(50000L), eq(0L),
+                    eq(3000L), eq(true), eq(0L),
+                    any(), any()
+            );
+        }
+    }
+
+    // ==================================================================================
+    // 풀필먼트 취소 실패
+    // ==================================================================================
+
+    @Nested
+    @DisplayName("풀필먼트 취소 실패")
+    class FulfillmentCancelFailureTest {
+
+        @Test
+        @DisplayName("풀필먼트가 출고 취소를 거부하면 OrderCancellationNotAllowedException이 발생한다")
+        void cancelOrder_fulfillmentRejected_throwsException() {
+            Long orderId = 1L;
+            Long buyerId = 100L;
+            Order order = createOrder(orderId, buyerId, OrderStatus.PREPARING);
+            when(getOrderUseCase.getOrder(orderId)).thenReturn(order);
+            when(cancelFulfillmentReleasePort.cancelRelease(orderId))
+                    .thenReturn(new CancelFulfillmentReleaseResult(orderId, false, "피킹 완료"));
+
+            CancelOrderCommand command = createCommand(orderId, buyerId);
+
+            assertThatThrownBy(() -> cancelOrderService.cancelOrder(command))
+                    .isInstanceOf(OrderCancellationNotAllowedException.class)
+                    .hasMessageContaining("피킹완료 이후에는 주문 취소가 불가능합니다. 반품으로 처리해 주세요.");
+
+            verifyNoInteractions(updateOrderPort);
+            verifyNoInteractions(publishOrderEventPort);
+        }
+
+        @Test
+        @DisplayName("풀필먼트 서비스 통신 실패 시 OrderCancellationNotAllowedException이 발생한다")
+        void cancelOrder_fulfillmentCommunicationFailure_throwsException() {
+            Long orderId = 1L;
+            Long buyerId = 100L;
+            Order order = createOrder(orderId, buyerId, OrderStatus.PREPARING);
+            when(getOrderUseCase.getOrder(orderId)).thenReturn(order);
+            when(cancelFulfillmentReleasePort.cancelRelease(orderId))
+                    .thenThrow(new FulfillmentServiceRequestFailedException(new IOException("connection refused")));
+
+            CancelOrderCommand command = createCommand(orderId, buyerId);
+
+            assertThatThrownBy(() -> cancelOrderService.cancelOrder(command))
+                    .isInstanceOf(OrderCancellationNotAllowedException.class)
+                    .hasMessageContaining("피킹완료 이후에는 주문 취소가 불가능합니다. 반품으로 처리해 주세요.");
+
+            verifyNoInteractions(updateOrderPort);
             verifyNoInteractions(publishOrderEventPort);
         }
     }
@@ -191,7 +230,8 @@ class CancelOrderUseCaseTest {
                     .isInstanceOf(InvalidReasonCategoryException.class);
 
             verifyNoInteractions(updateOrderPort);
-            verifyNoInteractions(sagaOrchestrator);
+            verifyNoInteractions(cancelFulfillmentReleasePort);
+            verifyNoInteractions(publishOrderEventPort);
         }
 
         @Test
@@ -256,7 +296,8 @@ class CancelOrderUseCaseTest {
                     .isInstanceOf(UnauthorizedOrderAccessException.class);
 
             verifyNoInteractions(updateOrderPort);
-            verifyNoInteractions(sagaOrchestrator);
+            verifyNoInteractions(cancelFulfillmentReleasePort);
+            verifyNoInteractions(publishOrderEventPort);
         }
     }
 
@@ -282,7 +323,8 @@ class CancelOrderUseCaseTest {
                     .isInstanceOf(InvalidOrderStatusTransitionException.class);
 
             verifyNoInteractions(updateOrderPort);
-            verifyNoInteractions(sagaOrchestrator);
+            verifyNoInteractions(cancelFulfillmentReleasePort);
+            verifyNoInteractions(publishOrderEventPort);
         }
 
         @Test
@@ -299,7 +341,8 @@ class CancelOrderUseCaseTest {
                     .isInstanceOf(OrderStatusAlreadyChangedException.class);
 
             verifyNoInteractions(updateOrderPort);
-            verifyNoInteractions(sagaOrchestrator);
+            verifyNoInteractions(cancelFulfillmentReleasePort);
+            verifyNoInteractions(publishOrderEventPort);
         }
 
         @Test
@@ -316,7 +359,8 @@ class CancelOrderUseCaseTest {
                     .isInstanceOf(InvalidOrderStatusTransitionException.class);
 
             verifyNoInteractions(updateOrderPort);
-            verifyNoInteractions(sagaOrchestrator);
+            verifyNoInteractions(cancelFulfillmentReleasePort);
+            verifyNoInteractions(publishOrderEventPort);
         }
     }
 

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/ChangeOrderStatusPickupAddressUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/ChangeOrderStatusPickupAddressUseCaseTest.java
@@ -67,7 +67,7 @@ class ChangeOrderStatusPickupAddressUseCaseTest {
             Order order = createOrderWithBuyerId(orderId, buyerId, OrderStatus.DELIVERED);
             when(getOrderUseCase.getOrder(orderId)).thenReturn(order);
             when(findUserShippingAddressPort.findByIdAndUserId(pickupAddressId, buyerId))
-                    .thenReturn(new ShippingAddressInfoResult("회수 수령인", "01099998888", "회수지 주소", "회수지 상세주소"));
+                    .thenReturn(new ShippingAddressInfoResult("회수 수령인", "01099998888", "회수지 주소", "회수지 상세주소", "NORMAL"));
 
             ChangeOrderStatusCommand command = ChangeOrderStatusCommand.builder()
                     .id(orderId)
@@ -124,7 +124,7 @@ class ChangeOrderStatusPickupAddressUseCaseTest {
             Order order = createOrderWithBuyerId(orderId, buyerId, OrderStatus.DELIVERED);
             when(getOrderUseCase.getOrder(orderId)).thenReturn(order);
             when(findUserShippingAddressPort.findByIdAndUserId(pickupAddressId, buyerId))
-                    .thenReturn(new ShippingAddressInfoResult("회수 수령인", "01099998888", "회수지 주소", "회수지 상세주소"));
+                    .thenReturn(new ShippingAddressInfoResult("회수 수령인", "01099998888", "회수지 주소", "회수지 상세주소", "NORMAL"));
 
             ChangeOrderStatusCommand command = ChangeOrderStatusCommand.builder()
                     .id(orderId)
@@ -158,7 +158,7 @@ class ChangeOrderStatusPickupAddressUseCaseTest {
             Order order = createOrderWithBuyerId(orderId, buyerId, OrderStatus.DELIVERED);
             when(getOrderUseCase.getOrder(orderId)).thenReturn(order);
             when(findUserShippingAddressPort.findByIdAndUserId(pickupAddressId, buyerId))
-                    .thenReturn(new ShippingAddressInfoResult("회수 수령인", "01099998888", "회수지 주소", "회수지 상세주소"));
+                    .thenReturn(new ShippingAddressInfoResult("회수 수령인", "01099998888", "회수지 주소", "회수지 상세주소", "NORMAL"));
 
             ChangeOrderStatusCommand command = ChangeOrderStatusCommand.builder()
                     .id(orderId)

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/RegisterOrderUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/RegisterOrderUseCaseTest.java
@@ -69,7 +69,7 @@ class RegisterOrderUseCaseTest {
         lenient().when(findShippingPolicyBySellerIdsPort.findBySellerIds(anyList()))
                 .thenReturn(Map.of());
         lenient().when(findUserShippingAddressPort.findByIdAndUserId(any(), any()))
-                .thenReturn(new ShippingAddressInfoResult("홍길동", "01012345678", "서울시 강남구", "101호"));
+                .thenReturn(new ShippingAddressInfoResult("홍길동", "01012345678", "서울시 강남구", "101호", "NORMAL"));
     }
 
     // ==================================================================================

--- a/common/src/main/java/com/personal/marketnote/common/kafka/event/ShippingAddressChangedEvent.java
+++ b/common/src/main/java/com/personal/marketnote/common/kafka/event/ShippingAddressChangedEvent.java
@@ -7,6 +7,7 @@ public record ShippingAddressChangedEvent(
         String recipientPhoneNumber,
         String address,
         String addressDetail,
+        String regionType,
         ShippingAddressChangeAction action
 ) {
 }

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/out/event/ShippingAddressEventKafkaProducer.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/out/event/ShippingAddressEventKafkaProducer.java
@@ -25,8 +25,8 @@ public class ShippingAddressEventKafkaProducer implements PublishShippingAddress
     private final Clock clock;
 
     @Override
-    public void publishShippingAddressChangedEvent(Long shippingAddressId, Long userId, String recipientName, String recipientPhoneNumber, String address, String addressDetail, ShippingAddressChangeAction action) {
-        ShippingAddressChangedEvent payload = new ShippingAddressChangedEvent(shippingAddressId, userId, recipientName, recipientPhoneNumber, address, addressDetail, action);
+    public void publishShippingAddressChangedEvent(Long shippingAddressId, Long userId, String recipientName, String recipientPhoneNumber, String address, String addressDetail, String regionType, ShippingAddressChangeAction action) {
+        ShippingAddressChangedEvent payload = new ShippingAddressChangedEvent(shippingAddressId, userId, recipientName, recipientPhoneNumber, address, addressDetail, regionType, action);
         String topic = KafkaTopicConstants.SHIPPING_ADDRESS_CHANGED;
         EventEnvelope<ShippingAddressChangedEvent> envelope = EventEnvelope.of(topic, SOURCE, payload, clock);
 

--- a/user-service/user-adapters/src/test/java/com/personal/marketnote/user/adapter/out/event/ShippingAddressEventKafkaProducerTest.java
+++ b/user-service/user-adapters/src/test/java/com/personal/marketnote/user/adapter/out/event/ShippingAddressEventKafkaProducerTest.java
@@ -55,7 +55,7 @@ class ShippingAddressEventKafkaProducerTest {
 
         // when
         shippingAddressEventKafkaProducer.publishShippingAddressChangedEvent(
-                1L, 100L, "홍길동", "010-1234-5678", "서울시 강남구 테헤란로 123", "101동 1001호", ShippingAddressChangeAction.CREATED
+                1L, 100L, "홍길동", "010-1234-5678", "서울시 강남구 테헤란로 123", "101동 1001호", "NORMAL", ShippingAddressChangeAction.CREATED
         );
 
         // then
@@ -79,7 +79,7 @@ class ShippingAddressEventKafkaProducerTest {
 
         // when
         shippingAddressEventKafkaProducer.publishShippingAddressChangedEvent(
-                1L, 100L, "홍길동", "010-1234-5678", "서울시 강남구 테헤란로 123", "101동 1001호", ShippingAddressChangeAction.CREATED
+                1L, 100L, "홍길동", "010-1234-5678", "서울시 강남구 테헤란로 123", "101동 1001호", "NORMAL", ShippingAddressChangeAction.CREATED
         );
 
         // then
@@ -112,7 +112,7 @@ class ShippingAddressEventKafkaProducerTest {
 
         // when
         shippingAddressEventKafkaProducer.publishShippingAddressChangedEvent(
-                2L, 200L, "김철수", "010-9876-5432", "서울시 서초구 서초대로 456", "202동 303호", ShippingAddressChangeAction.UPDATED
+                2L, 200L, "김철수", "010-9876-5432", "서울시 서초구 서초대로 456", "202동 303호", "NORMAL", ShippingAddressChangeAction.UPDATED
         );
 
         // then
@@ -135,7 +135,7 @@ class ShippingAddressEventKafkaProducerTest {
 
         // when
         shippingAddressEventKafkaProducer.publishShippingAddressChangedEvent(
-                3L, 300L, "이영희", "010-5555-6666", "서울시 마포구 월드컵로 789", "301동 501호", ShippingAddressChangeAction.DELETED
+                3L, 300L, "이영희", "010-5555-6666", "서울시 마포구 월드컵로 789", "301동 501호", null, ShippingAddressChangeAction.DELETED
         );
 
         // then

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/port/out/event/PublishShippingAddressEventPort.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/port/out/event/PublishShippingAddressEventPort.java
@@ -4,5 +4,5 @@ import com.personal.marketnote.common.kafka.event.ShippingAddressChangeAction;
 
 public interface PublishShippingAddressEventPort {
 
-    void publishShippingAddressChangedEvent(Long shippingAddressId, Long userId, String recipientName, String recipientPhoneNumber, String address, String addressDetail, ShippingAddressChangeAction action);
+    void publishShippingAddressChangedEvent(Long shippingAddressId, Long userId, String recipientName, String recipientPhoneNumber, String address, String addressDetail, String regionType, ShippingAddressChangeAction action);
 }

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/service/shippingaddress/DeleteShippingAddressService.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/service/shippingaddress/DeleteShippingAddressService.java
@@ -34,6 +34,7 @@ public class DeleteShippingAddressService implements DeleteShippingAddressUseCas
                 shippingAddressId, userId,
                 shippingAddress.getRecipientName(), shippingAddress.getRecipientPhoneNumber(),
                 shippingAddress.getAddress(), shippingAddress.getAddressDetail(),
+                null,
                 ShippingAddressChangeAction.DELETED
         );
     }

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/service/shippingaddress/RegisterShippingAddressService.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/service/shippingaddress/RegisterShippingAddressService.java
@@ -64,6 +64,7 @@ public class RegisterShippingAddressService implements RegisterShippingAddressUs
                 savedShippingAddress.getId(), savedShippingAddress.getUserId(),
                 savedShippingAddress.getRecipientName(), savedShippingAddress.getRecipientPhoneNumber(),
                 savedShippingAddress.getAddress(), savedShippingAddress.getAddressDetail(),
+                regionType.name(),
                 ShippingAddressChangeAction.CREATED
         );
 

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/service/shippingaddress/UpdateShippingAddressService.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/service/shippingaddress/UpdateShippingAddressService.java
@@ -50,6 +50,7 @@ public class UpdateShippingAddressService implements UpdateShippingAddressUseCas
                 shippingAddressId, userId,
                 shippingAddress.getRecipientName(), shippingAddress.getRecipientPhoneNumber(),
                 shippingAddress.getAddress(), shippingAddress.getAddressDetail(),
+                regionType.name(),
                 ShippingAddressChangeAction.UPDATED
         );
     }

--- a/user-service/user-application/src/test/java/com/personal/marketnote/user/service/shippingaddress/DeleteShippingAddressUseCaseTest.java
+++ b/user-service/user-application/src/test/java/com/personal/marketnote/user/service/shippingaddress/DeleteShippingAddressUseCaseTest.java
@@ -67,7 +67,7 @@ class DeleteShippingAddressUseCaseTest {
         verify(findShippingAddressPort).findByIdAndUserId(shippingAddressId, userId);
         verify(updateShippingAddressPort).update(shippingAddress);
         verify(publishShippingAddressEventPort).publishShippingAddressChangedEvent(
-                1L, 100L, "홍길동", "010-1234-5678", "서울시 강남구 테헤란로 123", "4층", ShippingAddressChangeAction.DELETED
+                1L, 100L, "홍길동", "010-1234-5678", "서울시 강남구 테헤란로 123", "4층", null, ShippingAddressChangeAction.DELETED
         );
         verifyNoMoreInteractions(findShippingAddressPort, updateShippingAddressPort);
     }

--- a/user-service/user-application/src/test/java/com/personal/marketnote/user/service/shippingaddress/RegisterShippingAddressUseCaseTest.java
+++ b/user-service/user-application/src/test/java/com/personal/marketnote/user/service/shippingaddress/RegisterShippingAddressUseCaseTest.java
@@ -89,7 +89,7 @@ class RegisterShippingAddressUseCaseTest {
         verify(classifyShippingAddressRegionPort).classify("서울시 강남구 테헤란로 123");
         verify(saveShippingAddressPort).save(any(ShippingAddress.class));
         verify(publishShippingAddressEventPort).publishShippingAddressChangedEvent(
-                1L, 1L, "홍길동", "010-1234-5678", "서울시 강남구 테헤란로 123", "101동 1001호", ShippingAddressChangeAction.CREATED
+                1L, 1L, "홍길동", "010-1234-5678", "서울시 강남구 테헤란로 123", "101동 1001호", "NORMAL", ShippingAddressChangeAction.CREATED
         );
         verifyNoInteractions(updateShippingAddressPort);
     }
@@ -141,7 +141,7 @@ class RegisterShippingAddressUseCaseTest {
         verify(classifyShippingAddressRegionPort).classify("서울시 마포구 월드컵로 456");
         verify(saveShippingAddressPort).save(any(ShippingAddress.class));
         verify(publishShippingAddressEventPort).publishShippingAddressChangedEvent(
-                2L, 1L, "홍길동", "010-1234-5678", "서울시 강남구 테헤란로 123", "101동 1001호", ShippingAddressChangeAction.CREATED
+                2L, 1L, "홍길동", "010-1234-5678", "서울시 강남구 테헤란로 123", "101동 1001호", "NORMAL", ShippingAddressChangeAction.CREATED
         );
     }
 
@@ -269,7 +269,7 @@ class RegisterShippingAddressUseCaseTest {
         verify(classifyShippingAddressRegionPort).classify("서울시 강남구 테헤란로 123");
         verify(saveShippingAddressPort).save(any(ShippingAddress.class));
         verify(publishShippingAddressEventPort).publishShippingAddressChangedEvent(
-                1L, 1L, "홍길동", "010-1234-5678", "서울시 강남구 테헤란로 123", "101동 1001호", ShippingAddressChangeAction.CREATED
+                1L, 1L, "홍길동", "010-1234-5678", "서울시 강남구 테헤란로 123", "101동 1001호", "NORMAL", ShippingAddressChangeAction.CREATED
         );
         verifyNoInteractions(updateShippingAddressPort);
     }
@@ -316,7 +316,7 @@ class RegisterShippingAddressUseCaseTest {
         verify(classifyShippingAddressRegionPort).classify("서울시 용산구 이태원로 200");
         verify(saveShippingAddressPort).save(any(ShippingAddress.class));
         verify(publishShippingAddressEventPort).publishShippingAddressChangedEvent(
-                3L, 1L, "홍길동", "010-1234-5678", "서울시 강남구 테헤란로 123", "101동 1001호", ShippingAddressChangeAction.CREATED
+                3L, 1L, "홍길동", "010-1234-5678", "서울시 강남구 테헤란로 123", "101동 1001호", "NORMAL", ShippingAddressChangeAction.CREATED
         );
         verifyNoInteractions(updateShippingAddressPort);
     }
@@ -362,7 +362,7 @@ class RegisterShippingAddressUseCaseTest {
                         && message.equals(sa.getDeliveryRequestMessage())
         ));
         verify(publishShippingAddressEventPort).publishShippingAddressChangedEvent(
-                1L, 1L, "홍길동", "010-1234-5678", "서울시 강남구 테헤란로 123", "101동 1001호", ShippingAddressChangeAction.CREATED
+                1L, 1L, "홍길동", "010-1234-5678", "서울시 강남구 테헤란로 123", "101동 1001호", "NORMAL", ShippingAddressChangeAction.CREATED
         );
     }
 
@@ -438,7 +438,7 @@ class RegisterShippingAddressUseCaseTest {
                         && sa.getDeliveryRequestMessage() == null
         ));
         verify(publishShippingAddressEventPort).publishShippingAddressChangedEvent(
-                1L, 1L, "홍길동", "010-1234-5678", "서울시 강남구 테헤란로 123", "101동 1001호", ShippingAddressChangeAction.CREATED
+                1L, 1L, "홍길동", "010-1234-5678", "서울시 강남구 테헤란로 123", "101동 1001호", "NORMAL", ShippingAddressChangeAction.CREATED
         );
     }
 
@@ -480,7 +480,7 @@ class RegisterShippingAddressUseCaseTest {
         verify(classifyShippingAddressRegionPort).classify("서울시 마포구 월드컵로 456");
         verify(saveShippingAddressPort).save(any(ShippingAddress.class));
         verify(publishShippingAddressEventPort).publishShippingAddressChangedEvent(
-                5L, 1L, "홍길동", "010-1234-5678", "서울시 강남구 테헤란로 123", "101동 1001호", ShippingAddressChangeAction.CREATED
+                5L, 1L, "홍길동", "010-1234-5678", "서울시 강남구 테헤란로 123", "101동 1001호", "NORMAL", ShippingAddressChangeAction.CREATED
         );
     }
 

--- a/user-service/user-application/src/test/java/com/personal/marketnote/user/service/shippingaddress/UpdateShippingAddressUseCaseTest.java
+++ b/user-service/user-application/src/test/java/com/personal/marketnote/user/service/shippingaddress/UpdateShippingAddressUseCaseTest.java
@@ -96,7 +96,7 @@ class UpdateShippingAddressUseCaseTest {
         verify(classifyShippingAddressRegionPort).classify("서울시 서초구 서초대로 456");
         verify(updateShippingAddressPort).update(shippingAddress);
         verify(publishShippingAddressEventPort).publishShippingAddressChangedEvent(
-                1L, 100L, "김철수", "010-9876-5432", "서울시 서초구 서초대로 456", "202동 303호", ShippingAddressChangeAction.UPDATED
+                1L, 100L, "김철수", "010-9876-5432", "서울시 서초구 서초대로 456", "202동 303호", "NORMAL", ShippingAddressChangeAction.UPDATED
         );
         verifyNoMoreInteractions(findShippingAddressPort, updateShippingAddressPort);
     }
@@ -178,7 +178,7 @@ class UpdateShippingAddressUseCaseTest {
         verify(classifyShippingAddressRegionPort).classify("서울시 강남구 테헤란로 123");
         verify(updateShippingAddressPort).update(shippingAddress);
         verify(publishShippingAddressEventPort).publishShippingAddressChangedEvent(
-                3L, 300L, "홍길동", "010-1234-5678", "서울시 강남구 테헤란로 123", "101동 201호", ShippingAddressChangeAction.UPDATED
+                3L, 300L, "홍길동", "010-1234-5678", "서울시 강남구 테헤란로 123", "101동 201호", "NORMAL", ShippingAddressChangeAction.UPDATED
         );
     }
 
@@ -227,7 +227,7 @@ class UpdateShippingAddressUseCaseTest {
         verify(classifyShippingAddressRegionPort).classify("서울시 강남구 테헤란로 123");
         verify(updateShippingAddressPort).update(shippingAddress);
         verify(publishShippingAddressEventPort).publishShippingAddressChangedEvent(
-                4L, 400L, "홍길동", "010-1234-5678", "서울시 강남구 테헤란로 123", "101동 201호", ShippingAddressChangeAction.UPDATED
+                4L, 400L, "홍길동", "010-1234-5678", "서울시 강남구 테헤란로 123", "101동 201호", "NORMAL", ShippingAddressChangeAction.UPDATED
         );
     }
 
@@ -278,7 +278,7 @@ class UpdateShippingAddressUseCaseTest {
         verify(classifyShippingAddressRegionPort).classify("서울시 강남구 선릉로 100");
         verify(updateShippingAddressPort).update(shippingAddress);
         verify(publishShippingAddressEventPort).publishShippingAddressChangedEvent(
-                2L, 200L, "박민수", "010-7777-8888", "서울시 강남구 선릉로 100", "10층", ShippingAddressChangeAction.UPDATED
+                2L, 200L, "박민수", "010-7777-8888", "서울시 강남구 선릉로 100", "10층", "NORMAL", ShippingAddressChangeAction.UPDATED
         );
         verifyNoMoreInteractions(findShippingAddressPort, updateShippingAddressPort);
     }


### PR DESCRIPTION
## partially addresses #216
## resolves #2234

## Task
- [x] ShippingAddressChangedEvent에 regionType 필드 추가 (common)
- [x] user-service 배송지 이벤트 발행 시 regionType 포함
- [x] commerce-service ReadModel에 regionType 저장 (엔티티, Consumer, Adapter)
- [x] ShippingRegionType enum 추가 (commerce-application)
- [x] RegisterOrderService 배송비 검증 로직에 추가 배송비 반영
- [x] calculateExpectedShippingFee에 지역 구분별 추가 배송비 합산
- [x] resolveSurcharge 메서드 추가
- [x] 배송지 지역 구분 조회 연동 (Read Model 기반)
- [x] Flyway 마이그레이션 V915 추가
- [x] 기존 테스트 Mock 수정 (ShippingAddressInfoResult regionType 필드 추가 대응)