### PR TITLE
[#216][#2235] feat: 반품 시 귀책 사유별 반품 택배비 계산 기능 추가

### DIFF
--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/exception/ReasonCategoryNoValueException.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/exception/ReasonCategoryNoValueException.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.commerce.exception;
+
+public class ReasonCategoryNoValueException extends RuntimeException {
+
+    public ReasonCategoryNoValueException() {
+        super("반품 택배비 계산을 위해 반품 사유 카테고리가 필요합니다.");
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/exception/ShippingPolicyNotFoundException.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/exception/ShippingPolicyNotFoundException.java
@@ -1,0 +1,10 @@
+package com.personal.marketnote.commerce.exception;
+
+import com.personal.marketnote.common.domain.exception.DomainNotFoundException;
+
+public class ShippingPolicyNotFoundException extends DomainNotFoundException {
+
+    public ShippingPolicyNotFoundException(Long sellerId) {
+        super("해당 판매자의 배송비 정책을 찾을 수 없습니다. sellerId=" + sellerId);
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/command/order/CalculateReturnShippingFeeCommand.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/command/order/CalculateReturnShippingFeeCommand.java
@@ -1,0 +1,14 @@
+package com.personal.marketnote.commerce.port.in.command.order;
+
+import com.personal.marketnote.commerce.domain.order.OrderStatusReasonCategory;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record CalculateReturnShippingFeeCommand(
+        Long orderId,
+        OrderStatusReasonCategory reasonCategory,
+        List<Long> returnPricePolicyIds
+) {
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/result/order/CalculateReturnShippingFeeResult.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/result/order/CalculateReturnShippingFeeResult.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.commerce.port.in.result.order;
+
+import lombok.Builder;
+
+@Builder
+public record CalculateReturnShippingFeeResult(
+        long returnShippingFee
+) {
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/order/CalculateReturnShippingFeeUseCase.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/order/CalculateReturnShippingFeeUseCase.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.commerce.port.in.usecase.order;
+
+import com.personal.marketnote.commerce.port.in.command.order.CalculateReturnShippingFeeCommand;
+import com.personal.marketnote.commerce.port.in.result.order.CalculateReturnShippingFeeResult;
+
+public interface CalculateReturnShippingFeeUseCase {
+
+    CalculateReturnShippingFeeResult calculateReturnShippingFee(CalculateReturnShippingFeeCommand command);
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/CalculateReturnShippingFeeService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/CalculateReturnShippingFeeService.java
@@ -1,0 +1,179 @@
+package com.personal.marketnote.commerce.service.order;
+
+import com.personal.marketnote.commerce.domain.order.Order;
+import com.personal.marketnote.commerce.domain.order.OrderProduct;
+import com.personal.marketnote.commerce.domain.returnshipping.*;
+import com.personal.marketnote.commerce.domain.settlement.PaymentAllocation;
+import com.personal.marketnote.commerce.exception.InvalidReasonCategoryException;
+import com.personal.marketnote.commerce.exception.ReasonCategoryNoValueException;
+import com.personal.marketnote.commerce.exception.ShippingPolicyNotFoundException;
+import com.personal.marketnote.commerce.port.in.command.order.CalculateReturnShippingFeeCommand;
+import com.personal.marketnote.commerce.port.in.result.order.CalculateReturnShippingFeeResult;
+import com.personal.marketnote.commerce.port.in.usecase.order.CalculateReturnShippingFeeUseCase;
+import com.personal.marketnote.commerce.port.in.usecase.order.GetOrderUseCase;
+import com.personal.marketnote.commerce.port.out.result.shipping.ShippingPolicyInfoResult;
+import com.personal.marketnote.commerce.port.out.settlement.FindPaymentAllocationPort;
+import com.personal.marketnote.commerce.port.out.shipping.FindShippingPolicyBySellerIdsPort;
+import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.common.utility.FormatValidator;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional(isolation = READ_COMMITTED, readOnly = true)
+public class CalculateReturnShippingFeeService implements CalculateReturnShippingFeeUseCase {
+
+    private final GetOrderUseCase getOrderUseCase;
+    private final FindPaymentAllocationPort findPaymentAllocationPort;
+    private final FindShippingPolicyBySellerIdsPort findShippingPolicyBySellerIdsPort;
+
+    @Override
+    public CalculateReturnShippingFeeResult calculateReturnShippingFee(CalculateReturnShippingFeeCommand command) {
+        validateReasonCategory(command);
+
+        FaultType faultType = command.reasonCategory().getFaultType();
+        Order order = getOrderUseCase.getOrder(command.orderId());
+        List<OrderProduct> orderProducts = order.getOrderProducts();
+
+        Set<Long> returnPricePolicyIdSet = resolveReturnPricePolicyIdSet(command, orderProducts);
+        ReturnType returnType = resolveReturnType(returnPricePolicyIdSet, orderProducts);
+
+        List<Long> sellerIds = extractDistinctSellerIds(orderProducts);
+        Map<Long, Long> initialShippingFeeBySellerIdMap = buildInitialShippingFeeMap(command.orderId());
+        Map<Long, ShippingPolicyInfoResult> shippingPolicyMap = findShippingPolicyBySellerIdsPort.findBySellerIds(sellerIds);
+
+        long totalReturnShippingFee = calculateTotalReturnShippingFee(
+                faultType, returnType, orderProducts, returnPricePolicyIdSet,
+                initialShippingFeeBySellerIdMap, shippingPolicyMap
+        );
+
+        return CalculateReturnShippingFeeResult.builder()
+                .returnShippingFee(totalReturnShippingFee)
+                .build();
+    }
+
+    private void validateReasonCategory(CalculateReturnShippingFeeCommand command) {
+        if (FormatValidator.hasNoValue(command.reasonCategory())) {
+            throw new ReasonCategoryNoValueException();
+        }
+        if (!command.reasonCategory().isReturnReason()) {
+            throw new InvalidReasonCategoryException(command.reasonCategory());
+        }
+    }
+
+    private Set<Long> resolveReturnPricePolicyIdSet(CalculateReturnShippingFeeCommand command, List<OrderProduct> orderProducts) {
+        Set<Long> validPricePolicyIds = orderProducts.stream()
+                .map(OrderProduct::getPricePolicyId)
+                .collect(Collectors.toSet());
+
+        if (FormatValidator.hasNoValue(command.returnPricePolicyIds())) {
+            return validPricePolicyIds;
+        }
+
+        Set<Long> requestedIds = new HashSet<>(command.returnPricePolicyIds());
+        requestedIds.retainAll(validPricePolicyIds);
+        return requestedIds;
+    }
+
+    private ReturnType resolveReturnType(Set<Long> returnPricePolicyIdSet, List<OrderProduct> orderProducts) {
+        if (returnPricePolicyIdSet.size() >= orderProducts.size()) {
+            return ReturnType.FULL_RETURN;
+        }
+        return ReturnType.PARTIAL_RETURN;
+    }
+
+    private List<Long> extractDistinctSellerIds(List<OrderProduct> orderProducts) {
+        return orderProducts.stream()
+                .map(OrderProduct::getSellerId)
+                .distinct()
+                .toList();
+    }
+
+    private Map<Long, Long> buildInitialShippingFeeMap(Long orderId) {
+        List<PaymentAllocation> allocations = findPaymentAllocationPort.findByOrderId(orderId);
+        return allocations.stream()
+                .collect(Collectors.toMap(
+                        PaymentAllocation::getSellerId,
+                        PaymentAllocation::getShippingFee,
+                        (existing, replacement) -> existing
+                ));
+    }
+
+    private long calculateTotalReturnShippingFee(
+            FaultType faultType,
+            ReturnType returnType,
+            List<OrderProduct> orderProducts,
+            Set<Long> returnPricePolicyIdSet,
+            Map<Long, Long> initialShippingFeeBySellerIdMap,
+            Map<Long, ShippingPolicyInfoResult> shippingPolicyMap
+    ) {
+        Map<Long, List<OrderProduct>> productsBySeller = orderProducts.stream()
+                .collect(Collectors.groupingBy(OrderProduct::getSellerId));
+
+        long totalFee = 0L;
+        for (Map.Entry<Long, List<OrderProduct>> entry : productsBySeller.entrySet()) {
+            Long sellerId = entry.getKey();
+            List<OrderProduct> sellerProducts = entry.getValue();
+
+            boolean hasReturnTarget = sellerProducts.stream()
+                    .anyMatch(product -> returnPricePolicyIdSet.contains(product.getPricePolicyId()));
+            if (!hasReturnTarget) {
+                continue;
+            }
+
+            long initialShippingFee = initialShippingFeeBySellerIdMap.getOrDefault(sellerId, 0L);
+            InitialShippingType initialShippingType = InitialShippingType.from(initialShippingFee);
+
+            ShippingPolicyInfoResult policy = shippingPolicyMap.get(sellerId);
+            if (FormatValidator.hasNoValue(policy)) {
+                throw new ShippingPolicyNotFoundException(sellerId);
+            }
+            long oneWayFee = policy.shippingFee();
+            long freeShippingThreshold = policy.freeShippingThreshold();
+
+            ReturnType sellerReturnType = resolveSellerReturnType(sellerProducts, returnPricePolicyIdSet, returnType);
+            long remainingAmount = calculateRemainingAmount(sellerProducts, returnPricePolicyIdSet);
+
+            ReturnShippingFeeContext context = ReturnShippingFeeContext.of(
+                    faultType, initialShippingType, sellerReturnType,
+                    remainingAmount, freeShippingThreshold, oneWayFee
+            );
+
+            totalFee = Math.addExact(totalFee, ReturnShippingFeeCalculator.calculate(context));
+        }
+        return totalFee;
+    }
+
+    private ReturnType resolveSellerReturnType(
+            List<OrderProduct> sellerProducts,
+            Set<Long> returnPricePolicyIdSet,
+            ReturnType orderReturnType
+    ) {
+        if (orderReturnType.isFullReturn()) {
+            return ReturnType.FULL_RETURN;
+        }
+
+        boolean allReturned = sellerProducts.stream()
+                .allMatch(product -> returnPricePolicyIdSet.contains(product.getPricePolicyId()));
+        if (allReturned) {
+            return ReturnType.FULL_RETURN;
+        }
+        return ReturnType.PARTIAL_RETURN;
+    }
+
+    private long calculateRemainingAmount(List<OrderProduct> sellerProducts, Set<Long> returnPricePolicyIdSet) {
+        return sellerProducts.stream()
+                .filter(product -> !returnPricePolicyIdSet.contains(product.getPricePolicyId()))
+                .mapToLong(product -> Math.multiplyExact(product.getUnitAmount(), product.getQuantity().longValue()))
+                .reduce(0L, Math::addExact);
+    }
+}

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/order/OrderStatusReasonCategory.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/order/OrderStatusReasonCategory.java
@@ -1,23 +1,25 @@
 package com.personal.marketnote.commerce.domain.order;
 
+import com.personal.marketnote.commerce.domain.returnshipping.FaultType;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 @Getter
 public enum OrderStatusReasonCategory {
-    CANCEL_ORDER("구매 의사 취소", ReasonType.CANCEL),
-    CHANGE_OPTION("색상, 사이즈 등 변경", ReasonType.CANCEL),
-    MISTAKE("주문 실수", ReasonType.BOTH),
-    ETC("직접 입력", ReasonType.BOTH),
-    SIMPLE_CHANGE_OF_MIND("단순 변심", ReasonType.RETURN),
-    PRODUCT_DAMAGE("상품 파손/변질", ReasonType.RETURN),
-    PRODUCT_MISMATCH("상품이 설명과 다름", ReasonType.RETURN),
-    WRONG_DELIVERY("다른 상품이 배송됨", ReasonType.RETURN),
-    MISSING_COMPONENTS("상품/구성품 누락", ReasonType.RETURN);
+    CANCEL_ORDER("구매 의사 취소", ReasonType.CANCEL, FaultType.BUYER),
+    CHANGE_OPTION("색상, 사이즈 등 변경", ReasonType.CANCEL, FaultType.BUYER),
+    MISTAKE("주문 실수", ReasonType.BOTH, FaultType.BUYER),
+    ETC("직접 입력", ReasonType.BOTH, FaultType.BUYER),
+    SIMPLE_CHANGE_OF_MIND("단순 변심", ReasonType.RETURN, FaultType.BUYER),
+    PRODUCT_DAMAGE("상품 파손/변질", ReasonType.RETURN, FaultType.SELLER),
+    PRODUCT_MISMATCH("상품이 설명과 다름", ReasonType.RETURN, FaultType.SELLER),
+    WRONG_DELIVERY("다른 상품이 배송됨", ReasonType.RETURN, FaultType.SELLER),
+    MISSING_COMPONENTS("상품/구성품 누락", ReasonType.RETURN, FaultType.SELLER);
 
     private final String description;
     private final ReasonType reasonType;
+    private final FaultType faultType;
 
     public boolean isCancelReason() {
         return reasonType == ReasonType.CANCEL || reasonType == ReasonType.BOTH;
@@ -25,6 +27,14 @@ public enum OrderStatusReasonCategory {
 
     public boolean isReturnReason() {
         return reasonType == ReasonType.RETURN || reasonType == ReasonType.BOTH;
+    }
+
+    public boolean isBuyerFault() {
+        return faultType.isBuyer();
+    }
+
+    public boolean isSellerFault() {
+        return faultType.isSeller();
     }
 
     public enum ReasonType {

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/returnshipping/FaultType.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/returnshipping/FaultType.java
@@ -1,0 +1,21 @@
+package com.personal.marketnote.commerce.domain.returnshipping;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum FaultType {
+    BUYER("고객 귀책"),
+    SELLER("판매자 귀책");
+
+    private final String description;
+
+    public boolean isBuyer() {
+        return this == BUYER;
+    }
+
+    public boolean isSeller() {
+        return this == SELLER;
+    }
+}

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/returnshipping/InitialShippingType.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/returnshipping/InitialShippingType.java
@@ -1,0 +1,28 @@
+package com.personal.marketnote.commerce.domain.returnshipping;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum InitialShippingType {
+    FREE_SHIPPING("무료 배송"),
+    PAID_SHIPPING("유료 배송");
+
+    private final String description;
+
+    public static InitialShippingType from(long shippingFee) {
+        if (shippingFee <= 0) {
+            return FREE_SHIPPING;
+        }
+        return PAID_SHIPPING;
+    }
+
+    public boolean isFreeShipping() {
+        return this == FREE_SHIPPING;
+    }
+
+    public boolean isPaidShipping() {
+        return this == PAID_SHIPPING;
+    }
+}

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/returnshipping/ReturnShippingFeeCalculator.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/returnshipping/ReturnShippingFeeCalculator.java
@@ -1,0 +1,27 @@
+package com.personal.marketnote.commerce.domain.returnshipping;
+
+public class ReturnShippingFeeCalculator {
+
+    private ReturnShippingFeeCalculator() {
+    }
+
+    public static long calculate(ReturnShippingFeeContext context) {
+        if (context.isSellerFault()) {
+            return 0L;
+        }
+
+        if (context.wasPaidShipping()) {
+            return context.getShippingFee();
+        }
+
+        if (context.isFullReturn()) {
+            return Math.multiplyExact(context.getShippingFee(), 2L);
+        }
+
+        if (context.isBelowFreeShippingThreshold()) {
+            return Math.multiplyExact(context.getShippingFee(), 2L);
+        }
+
+        return context.getShippingFee();
+    }
+}

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/returnshipping/ReturnShippingFeeContext.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/returnshipping/ReturnShippingFeeContext.java
@@ -1,0 +1,50 @@
+package com.personal.marketnote.commerce.domain.returnshipping;
+
+import lombok.*;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+@Getter
+public class ReturnShippingFeeContext {
+    private FaultType faultType;
+    private InitialShippingType initialShippingType;
+    private ReturnType returnType;
+    private long remainingAmount;
+    private long freeShippingThreshold;
+    private long shippingFee;
+
+    public static ReturnShippingFeeContext of(
+            FaultType faultType,
+            InitialShippingType initialShippingType,
+            ReturnType returnType,
+            long remainingAmount,
+            long freeShippingThreshold,
+            long shippingFee
+    ) {
+        return ReturnShippingFeeContext.builder()
+                .faultType(faultType)
+                .initialShippingType(initialShippingType)
+                .returnType(returnType)
+                .remainingAmount(remainingAmount)
+                .freeShippingThreshold(freeShippingThreshold)
+                .shippingFee(shippingFee)
+                .build();
+    }
+
+    public boolean isSellerFault() {
+        return faultType.isSeller();
+    }
+
+    public boolean wasPaidShipping() {
+        return initialShippingType.isPaidShipping();
+    }
+
+    public boolean isFullReturn() {
+        return returnType.isFullReturn();
+    }
+
+    public boolean isBelowFreeShippingThreshold() {
+        return remainingAmount < freeShippingThreshold;
+    }
+}

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/returnshipping/ReturnType.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/returnshipping/ReturnType.java
@@ -1,0 +1,21 @@
+package com.personal.marketnote.commerce.domain.returnshipping;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum ReturnType {
+    FULL_RETURN("전체 반품"),
+    PARTIAL_RETURN("부분 반품");
+
+    private final String description;
+
+    public boolean isFullReturn() {
+        return this == FULL_RETURN;
+    }
+
+    public boolean isPartialReturn() {
+        return this == PARTIAL_RETURN;
+    }
+}

--- a/file-service/file-adapters/src/main/resources/application.yml
+++ b/file-service/file-adapters/src/main/resources/application.yml
@@ -95,6 +95,11 @@ management:
     tags:
       application: ${spring.application.name}
 
+outbox:
+  enabled: ${OUTBOX_ENABLED:true}
+  polling-interval-ms: ${OUTBOX_POLLING_INTERVAL_MS:3000}
+  batch-size: ${OUTBOX_BATCH_SIZE:100}
+
 file:
   s3:
     credentials:


### PR DESCRIPTION
## partially addresses #216
## resolves #2235

## Task
- [x] 반품 사유 구분 (고객 귀책 / 판매자 귀책)
- [x] 초기 배송비 유형 판단 (무료 / 유료)
- [x] 반품 유형 판단 (전체 / 부분)
- [x] 부분 반품 시 잔여 금액 대비 무료 배송 기준 유지 여부 판단
- [x] 반품 택배비 계산 로직 구현