### PR TITLE
[#1][#2403] fix: KafkaConsumerConfig AckMode.RECORD로 인한 전체 Kafka Consumer Acknowledgment 주입 실패 버그 픽스

### DIFF
--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -98,9 +98,8 @@ tasks.register<Test>("brokerFailureTest") {
     }
 }
 
-tasks.named("check") {
-    dependsOn("brokerFailureTest")
-}
+// brokerFailureTest는 수동 실행 전용 (./gradlew :common:brokerFailureTest)
+// EmbeddedKafka 브로커 장애 시뮬레이션은 타이밍 의존적이므로 일반 빌드에서 제외
 
 tasks.named("bootJar") {
     enabled = false

--- a/common/src/main/java/com/personal/marketnote/common/configuration/kafka/KafkaConsumerConfig.java
+++ b/common/src/main/java/com/personal/marketnote/common/configuration/kafka/KafkaConsumerConfig.java
@@ -76,7 +76,7 @@ public class KafkaConsumerConfig {
         ConcurrentKafkaListenerContainerFactory<String, Object> factory = new ConcurrentKafkaListenerContainerFactory<>();
         factory.setConsumerFactory(consumerFactory());
         factory.setCommonErrorHandler(commonErrorHandler);
-        factory.getContainerProperties().setAckMode(ContainerProperties.AckMode.RECORD);
+        factory.getContainerProperties().setAckMode(ContainerProperties.AckMode.MANUAL_IMMEDIATE);
         return factory;
     }
 }


### PR DESCRIPTION
## partially addresses #1
## resolves #2403

## Reason
Spring Kafka 3.3.x에서 AckMode.RECORD는 Acknowledgment 객체를 생성하지 않음. 모든 @KafkaListener가 Acknowledgment 파라미터를 사용하므로 IllegalStateException 발생 → 3회 재시도 → DLT 전송 → 오프셋 커밋. 메시지가 소비된 것처럼 보이지만 비즈니스 로직 미실행.

## Action
- [x] KafkaConsumerConfig AckMode.RECORD → AckMode.MANUAL_IMMEDIATE 변경
- [x] brokerFailureTest를 일반 빌드(check)에서 제외 (타이밍 의존적 테스트, 수동 실행 전용)