### PR TITLE
[#1][#2439] fix: DLT Consumer 실패 시 .dlt.dlt 토픽 캐스케이딩 방지 기능 추가

### DIFF
--- a/common/src/main/java/com/personal/marketnote/common/configuration/kafka/DeadLetterAlertConsumer.java
+++ b/common/src/main/java/com/personal/marketnote/common/configuration/kafka/DeadLetterAlertConsumer.java
@@ -17,7 +17,7 @@ public class DeadLetterAlertConsumer {
     private final DltSlackNotifier dltSlackNotifier;
     private final DltMetricsCollector dltMetricsCollector;
 
-    @KafkaListener(topicPattern = ".*\\.dlt", groupId = "dlt-alert")
+    @KafkaListener(topicPattern = ".*\\.dlt", groupId = "dlt-alert", containerFactory = "dltKafkaListenerContainerFactory")
     public void handleDeadLetterMessage(
             ConsumerRecord<String, Object> record,
             Acknowledgment acknowledgment

--- a/common/src/main/java/com/personal/marketnote/common/configuration/kafka/KafkaConsumerConfig.java
+++ b/common/src/main/java/com/personal/marketnote/common/configuration/kafka/KafkaConsumerConfig.java
@@ -79,4 +79,14 @@ public class KafkaConsumerConfig {
         factory.getContainerProperties().setAckMode(ContainerProperties.AckMode.MANUAL_IMMEDIATE);
         return factory;
     }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, Object> dltKafkaListenerContainerFactory(
+            CommonErrorHandler dltErrorHandler) {
+        ConcurrentKafkaListenerContainerFactory<String, Object> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory());
+        factory.setCommonErrorHandler(dltErrorHandler);
+        factory.getContainerProperties().setAckMode(ContainerProperties.AckMode.MANUAL_IMMEDIATE);
+        return factory;
+    }
 }

--- a/common/src/main/java/com/personal/marketnote/common/configuration/kafka/KafkaErrorHandler.java
+++ b/common/src/main/java/com/personal/marketnote/common/configuration/kafka/KafkaErrorHandler.java
@@ -36,6 +36,15 @@ public class KafkaErrorHandler {
     }
 
     @Bean
+    public CommonErrorHandler dltErrorHandler() {
+        DefaultErrorHandler errorHandler = new DefaultErrorHandler(
+                (record, exception) -> log.error("DLT 메시지 최종 처리 실패 (추가 DLT 발행 없음). topic={}, key={}, offset={}",
+                        record.topic(), record.key(), record.offset(), exception),
+                new FixedBackOff(0L, 0L));
+        return errorHandler;
+    }
+
+    @Bean
     public CommonErrorHandler commonErrorHandler(DeadLetterPublishingRecoverer deadLetterPublishingRecoverer) {
         FixedBackOff backOff = new FixedBackOff(RETRY_INTERVAL_MS, RETRY_MAX_ATTEMPTS);
         DefaultErrorHandler errorHandler = new DefaultErrorHandler(deadLetterPublishingRecoverer, backOff);


### PR DESCRIPTION
## partially addresses #1
## resolves #2439

## Task
- [x] DLT Consumer 전용 ErrorHandler 빈 추가 (로깅 전용, 재시도 0회, DLT 미발행)
- [x] DLT Consumer 전용 ContainerFactory 빈 추가
- [x] DeadLetterAlertConsumer에 전용 ContainerFactory 지정