### PR TITLE
[#216][#2404] fix: 주문 등록 API Swagger 문서 필드 불일치 수정

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/apidocs/RegisterOrderApiDocs.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/apidocs/RegisterOrderApiDocs.java
@@ -38,8 +38,10 @@ import java.lang.annotation.*;
                 | totalAmount | number | 총 주문 금액(원) | Y | 100000 |
                 | couponAmount | number | 쿠폰 할인 금액(원) | N | 5000 |
                 | pointAmount | number | 포인트 사용 금액(원) | N | 5000 |
+                | shippingFee | number | 배송비(원) | N | 3000 |
                 | shippingAddressId | number | 배송지 ID | Y | 1 |
-                | requestMessage | string | 배송 요청사항 | N | "문 앞에 놓아주세요" |
+                | deliveryRequestType | string | 배송 요청사항 타입 (NONE, LEAVE_AT_DOOR, RECEIVE_OR_LEAVE_AT_DOOR, LEAVE_AT_SECURITY, LEAVE_AT_DELIVERY_BOX, CUSTOM) | N | "CUSTOM" |
+                | deliveryRequestMessage | string | 배송 요청사항 직접입력 메시지 (최대 60자, CUSTOM 타입일 때 필수) | N | "문 앞에 놓아주세요" |
                 | orderProducts | array | 주문 상품 목록 | Y | [ ... ] |
                 
                 ---
@@ -87,8 +89,10 @@ import java.lang.annotation.*;
                                   "totalAmount": 120000,
                                   "couponAmount": 5000,
                                   "pointAmount": 5000,
+                                  "shippingFee": 3000,
                                   "shippingAddressId": 1,
-                                  "requestMessage": "문 앞에 놓아주세요",
+                                  "deliveryRequestType": "CUSTOM",
+                                  "deliveryRequestMessage": "문 앞에 놓아주세요",
                                   "orderProducts": [
                                     {
                                       "productId": 245,


### PR DESCRIPTION
## partially addresses #216
## resolves #2404

## Task
- [x] `requestMessage` → `deliveryRequestMessage`로 필드명 수정
- [x] `shippingFee` 필드 추가
- [x] `deliveryRequestType` 필드 추가
- [x] 예시 JSON 업데이트