### PR TITLE
[#216][#2405] fix: 주문 조회 API Swagger 문서 필드 불일치 수정

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/apidocs/GetAdminOrdersApiDocs.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/apidocs/GetAdminOrdersApiDocs.java
@@ -52,6 +52,15 @@ import java.lang.annotation.*;
                 | orders[].orderInfo.orderStatus | string | 주문 상태 | "PAID" |
                 | orders[].orderInfo.totalAmount | number | 총 금액 | 100000 |
                 | orders[].orderInfo.paidAmount | number | 결제 금액 | 95000 |
+                | orders[].orderInfo.couponAmount | number | 쿠폰 할인 금액 | 3000 |
+                | orders[].orderInfo.pointAmount | number | 포인트 사용 금액 | 2000 |
+                | orders[].orderInfo.recipientName | string | 수령인 이름 | "홍길동" |
+                | orders[].orderInfo.recipientPhoneNumber | string | 수령인 전화번호 | "01012345678" |
+                | orders[].orderInfo.zipCode | string | 우편번호 | "06234" |
+                | orders[].orderInfo.address | string | 배송지 주소 | "서울특별시 강남구 테헤란로 123" |
+                | orders[].orderInfo.addressDetail | string | 배송지 상세 주소 | "101동 202호" |
+                | orders[].orderInfo.deliveryRequestType | string | 배송 요청사항 유형 | "LEAVE_AT_DOOR" |
+                | orders[].orderInfo.deliveryRequestMessage | string | 배송 요청사항 메시지 | "문 앞에 놓아주세요" |
                 | orders[].orderInfo.orderProducts | array | 주문 상품 목록 | - |
                 """,
         security = {@SecurityRequirement(name = "bearer")},
@@ -77,6 +86,13 @@ import java.lang.annotation.*;
                                                   "paidAmount": 95000,
                                                   "couponAmount": 3000,
                                                   "pointAmount": 2000,
+                                                  "recipientName": "홍길동",
+                                                  "recipientPhoneNumber": "01012345678",
+                                                  "zipCode": "06234",
+                                                  "address": "서울특별시 강남구 테헤란로 123",
+                                                  "addressDetail": "101동 202호",
+                                                  "deliveryRequestType": "LEAVE_AT_DOOR",
+                                                  "deliveryRequestMessage": "문 앞에 놓아주세요",
                                                   "orderProducts": [
                                                     {
                                                       "sellerId": 10,

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/apidocs/GetOrderInfoApiDocs.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/apidocs/GetOrderInfoApiDocs.java
@@ -101,6 +101,21 @@ import java.lang.annotation.*;
                 | paidAmount | number | 결제 금액(원) | 100000 |
                 | couponAmount | number | 쿠폰 할인 금액(원) | 5000 |
                 | pointAmount | number | 포인트 사용 금액(원) | 5000 |
+                | shippingFee | number | 배송비(원) | 3000 |
+                | recipientName | string | 수령인 이름 | "홍길동" |
+                | recipientPhoneNumber | string | 수령인 전화번호 | "01012345678" |
+                | zipCode | string | 우편번호 | "06234" |
+                | address | string | 배송지 주소 | "서울특별시 강남구 테헤란로 123" |
+                | addressDetail | string | 배송지 상세 주소 | "101동 202호" |
+                | deliveryRequestType | string | 배송 요청사항 유형 | "LEAVE_AT_DOOR" |
+                | deliveryRequestMessage | string | 배송 요청사항 메시지 | "문 앞에 놓아주세요" |
+                | pickupRecipientName | string | 회수지 수령인 이름 | "홍길동" |
+                | pickupRecipientPhoneNumber | string | 회수지 수령인 전화번호 | "01012345678" |
+                | pickupZipCode | string | 회수지 우편번호 | "06234" |
+                | pickupAddress | string | 회수지 주소 | "서울특별시 강남구 테헤란로 123" |
+                | pickupAddressDetail | string | 회수지 상세 주소 | "101동 202호" |
+                | pickupDeliveryRequestType | string | 회수 요청사항 유형 | "LEAVE_AT_DOOR" |
+                | pickupDeliveryRequestMessage | string | 회수 요청사항 메시지 | "문 앞에 놓아주세요" |
                 | orderProducts | array | 주문 상품 목록 | [ ... ] |
                 
                 ---
@@ -163,7 +178,22 @@ import java.lang.annotation.*;
                                               "paidAmount": 120000,
                                               "couponAmount": 5000,
                                               "pointAmount": 5000,
-                                              "orderPrducts": [
+                                              "shippingFee": 3000,
+                                              "recipientName": "홍길동",
+                                              "recipientPhoneNumber": "01012345678",
+                                              "zipCode": "06234",
+                                              "address": "서울특별시 강남구 테헤란로 123",
+                                              "addressDetail": "101동 202호",
+                                              "deliveryRequestType": "LEAVE_AT_DOOR",
+                                              "deliveryRequestMessage": "문 앞에 놓아주세요",
+                                              "pickupRecipientName": "홍길동",
+                                              "pickupRecipientPhoneNumber": "01012345678",
+                                              "pickupZipCode": "06234",
+                                              "pickupAddress": "서울특별시 강남구 테헤란로 123",
+                                              "pickupAddressDetail": "101동 202호",
+                                              "pickupDeliveryRequestType": "LEAVE_AT_DOOR",
+                                              "pickupDeliveryRequestMessage": "문 앞에 놓아주세요",
+                                              "orderProducts": [
                                                 {
                                                   "sellerId": 12,
                                                   "productId": 1,

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/apidocs/GetOrdersApiDocs.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/apidocs/GetOrdersApiDocs.java
@@ -80,21 +80,21 @@ import java.lang.annotation.*;
                 
                 | **키** | **타입** | **설명** | **예시** |
                 | --- | --- | --- | --- |
-                | orderHistories | array | 날짜별 주문 내역 묶음 | [ ... ] |
-                
+                | orderHistory | array | 날짜별 주문 내역 묶음 | [ ... ] |
+
                 ---
-                ### Response > content > orderHistories
-                
+                ### Response > content > orderHistory
+
                 | **키** | **타입** | **설명** | **예시** |
                 | --- | --- | --- | --- |
                 | orderDate | string(date) | 주문 생성일(일 단위) | "2025-11-01" |
                 | count | number | 해당 날짜의 주문 건수 | 3 |
                 | orders | array | 주문 목록(주문 ID 내림차순) | [ ... ] |
-                
+
                 ---
-                
-                ### Response > content > orderHistories > orders
-                
+
+                ### Response > content > orderHistory > orders
+
                 | **키** | **타입** | **설명** | **예시** |
                 | --- | --- | --- | --- |
                 | id | number | 주문 ID | 1 |
@@ -106,11 +106,11 @@ import java.lang.annotation.*;
                 | couponAmount | number | 쿠폰 할인 금액(원) | 5000 |
                 | pointAmount | number | 포인트 사용 금액(원) | 5000 |
                 | orderProducts | array | 주문 상품 목록 | [ ... ] |
-                
+
                 ---
-                
-                ### Response > content > orderHistories > orders > orderProducts
-                
+
+                ### Response > content > orderHistory > orders > orderProducts
+
                 | **키** | **타입** | **설명** | **예시** |
                 | --- | --- | --- | --- |
                 | sellerId | number | 판매자 회원 ID | 1 |
@@ -125,10 +125,10 @@ import java.lang.annotation.*;
                 | productName | string | 상품명 | "공책" |
                 | selectedOptions | array | 선택 옵션 목록 | [ ... ] |
                 | isReviewed | boolean | 리뷰 작성 여부 | true |
-                
+
                 ---
-                
-                ### Response > content > orderHistories > orders > orderProducts > selectedOptions
+
+                ### Response > content > orderHistory > orders > orderProducts > selectedOptions
                 
                 | **키** | **타입** | **설명** | **예시** |
                 | --- | --- | --- | --- |

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/apidocs/RegisterOrderApiDocs.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/apidocs/RegisterOrderApiDocs.java
@@ -38,10 +38,8 @@ import java.lang.annotation.*;
                 | totalAmount | number | 총 주문 금액(원) | Y | 100000 |
                 | couponAmount | number | 쿠폰 할인 금액(원) | N | 5000 |
                 | pointAmount | number | 포인트 사용 금액(원) | N | 5000 |
-                | shippingFee | number | 배송비(원) | N | 3000 |
                 | shippingAddressId | number | 배송지 ID | Y | 1 |
-                | deliveryRequestType | string | 배송 요청사항 타입 (NONE, LEAVE_AT_DOOR, RECEIVE_OR_LEAVE_AT_DOOR, LEAVE_AT_SECURITY, LEAVE_AT_DELIVERY_BOX, CUSTOM) | N | "CUSTOM" |
-                | deliveryRequestMessage | string | 배송 요청사항 직접입력 메시지 (최대 60자, CUSTOM 타입일 때 필수) | N | "문 앞에 놓아주세요" |
+                | requestMessage | string | 배송 요청사항 | N | "문 앞에 놓아주세요" |
                 | orderProducts | array | 주문 상품 목록 | Y | [ ... ] |
                 
                 ---
@@ -89,10 +87,8 @@ import java.lang.annotation.*;
                                   "totalAmount": 120000,
                                   "couponAmount": 5000,
                                   "pointAmount": 5000,
-                                  "shippingFee": 3000,
                                   "shippingAddressId": 1,
-                                  "deliveryRequestType": "CUSTOM",
-                                  "deliveryRequestMessage": "문 앞에 놓아주세요",
+                                  "requestMessage": "문 앞에 놓아주세요",
                                   "orderProducts": [
                                     {
                                       "productId": 245,


### PR DESCRIPTION
## partially addresses #216
## resolves #2405

## Task
- [x] GetOrdersApiDocs: 테이블 필드명 `orderHistories` → `orderHistory` 수정
- [x] GetOrderInfoApiDocs: 예시 JSON 오타 `orderPrducts` → `orderProducts` 수정
- [x] GetOrderInfoApiDocs: 배송지/배송요청사항/회수지/회수요청사항/shippingFee 필드 추가
- [x] GetAdminOrdersApiDocs: couponAmount, pointAmount, 배송지, 배송요청사항 필드 추가