### PR TITLE
[#216][#2406] fix: 결제 취소 API Swagger 문서 cancelProducts 필드 누락 수정

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/payment/controller/apidocs/CancelPaymentApiDocs.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/payment/controller/apidocs/CancelPaymentApiDocs.java
@@ -46,6 +46,9 @@ import java.lang.annotation.*;
                 | cancelType | string | 취소 유형 (FULL/PARTIAL) | Y | "FULL" |
                 | cancelAmount | number | 취소 금액 (부분취소 시 필수) | N | 50000 |
                 | cancelReason | string | 취소 사유 | N | "고객 변심" |
+                | cancelProducts | array | 취소 대상 상품 목록 (부분취소 시 재고 복구용, 선택) | N | [{"pricePolicyId": 1, "quantity": 2}] |
+                | cancelProducts[].pricePolicyId | number | 가격 정책 ID | Y | 1 |
+                | cancelProducts[].quantity | number | 취소 수량 | Y | 2 |
                 """,
         security = {@SecurityRequirement(name = "bearer")},
         requestBody = @RequestBody(
@@ -56,7 +59,13 @@ import java.lang.annotation.*;
                                 {
                                   "cancelType": "FULL",
                                   "cancelAmount": null,
-                                  "cancelReason": "고객 변심"
+                                  "cancelReason": "고객 변심",
+                                  "cancelProducts": [
+                                    {
+                                      "pricePolicyId": 1,
+                                      "quantity": 2
+                                    }
+                                  ]
                                 }
                                 """)
                 )


### PR DESCRIPTION
## partially addresses #216
## resolves #2406

## Task
- [x] CancelPaymentApiDocs: cancelProducts 배열 필드 추가 (pricePolicyId, quantity)
- [x] 예시 JSON 업데이트