### PR TITLE
[#216][#2407] fix: 정산 조회 API Swagger 문서 shippingFee 필드 누락 수정

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/apidocs/GetAdminOrdersApiDocs.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/apidocs/GetAdminOrdersApiDocs.java
@@ -52,15 +52,6 @@ import java.lang.annotation.*;
                 | orders[].orderInfo.orderStatus | string | 주문 상태 | "PAID" |
                 | orders[].orderInfo.totalAmount | number | 총 금액 | 100000 |
                 | orders[].orderInfo.paidAmount | number | 결제 금액 | 95000 |
-                | orders[].orderInfo.couponAmount | number | 쿠폰 할인 금액 | 3000 |
-                | orders[].orderInfo.pointAmount | number | 포인트 사용 금액 | 2000 |
-                | orders[].orderInfo.recipientName | string | 수령인 이름 | "홍길동" |
-                | orders[].orderInfo.recipientPhoneNumber | string | 수령인 전화번호 | "01012345678" |
-                | orders[].orderInfo.zipCode | string | 우편번호 | "06234" |
-                | orders[].orderInfo.address | string | 배송지 주소 | "서울특별시 강남구 테헤란로 123" |
-                | orders[].orderInfo.addressDetail | string | 배송지 상세 주소 | "101동 202호" |
-                | orders[].orderInfo.deliveryRequestType | string | 배송 요청사항 유형 | "LEAVE_AT_DOOR" |
-                | orders[].orderInfo.deliveryRequestMessage | string | 배송 요청사항 메시지 | "문 앞에 놓아주세요" |
                 | orders[].orderInfo.orderProducts | array | 주문 상품 목록 | - |
                 """,
         security = {@SecurityRequirement(name = "bearer")},
@@ -86,13 +77,6 @@ import java.lang.annotation.*;
                                                   "paidAmount": 95000,
                                                   "couponAmount": 3000,
                                                   "pointAmount": 2000,
-                                                  "recipientName": "홍길동",
-                                                  "recipientPhoneNumber": "01012345678",
-                                                  "zipCode": "06234",
-                                                  "address": "서울특별시 강남구 테헤란로 123",
-                                                  "addressDetail": "101동 202호",
-                                                  "deliveryRequestType": "LEAVE_AT_DOOR",
-                                                  "deliveryRequestMessage": "문 앞에 놓아주세요",
                                                   "orderProducts": [
                                                     {
                                                       "sellerId": 10,

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/apidocs/GetOrderInfoApiDocs.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/apidocs/GetOrderInfoApiDocs.java
@@ -101,21 +101,6 @@ import java.lang.annotation.*;
                 | paidAmount | number | 결제 금액(원) | 100000 |
                 | couponAmount | number | 쿠폰 할인 금액(원) | 5000 |
                 | pointAmount | number | 포인트 사용 금액(원) | 5000 |
-                | shippingFee | number | 배송비(원) | 3000 |
-                | recipientName | string | 수령인 이름 | "홍길동" |
-                | recipientPhoneNumber | string | 수령인 전화번호 | "01012345678" |
-                | zipCode | string | 우편번호 | "06234" |
-                | address | string | 배송지 주소 | "서울특별시 강남구 테헤란로 123" |
-                | addressDetail | string | 배송지 상세 주소 | "101동 202호" |
-                | deliveryRequestType | string | 배송 요청사항 유형 | "LEAVE_AT_DOOR" |
-                | deliveryRequestMessage | string | 배송 요청사항 메시지 | "문 앞에 놓아주세요" |
-                | pickupRecipientName | string | 회수지 수령인 이름 | "홍길동" |
-                | pickupRecipientPhoneNumber | string | 회수지 수령인 전화번호 | "01012345678" |
-                | pickupZipCode | string | 회수지 우편번호 | "06234" |
-                | pickupAddress | string | 회수지 주소 | "서울특별시 강남구 테헤란로 123" |
-                | pickupAddressDetail | string | 회수지 상세 주소 | "101동 202호" |
-                | pickupDeliveryRequestType | string | 회수 요청사항 유형 | "LEAVE_AT_DOOR" |
-                | pickupDeliveryRequestMessage | string | 회수 요청사항 메시지 | "문 앞에 놓아주세요" |
                 | orderProducts | array | 주문 상품 목록 | [ ... ] |
                 
                 ---
@@ -178,22 +163,7 @@ import java.lang.annotation.*;
                                               "paidAmount": 120000,
                                               "couponAmount": 5000,
                                               "pointAmount": 5000,
-                                              "shippingFee": 3000,
-                                              "recipientName": "홍길동",
-                                              "recipientPhoneNumber": "01012345678",
-                                              "zipCode": "06234",
-                                              "address": "서울특별시 강남구 테헤란로 123",
-                                              "addressDetail": "101동 202호",
-                                              "deliveryRequestType": "LEAVE_AT_DOOR",
-                                              "deliveryRequestMessage": "문 앞에 놓아주세요",
-                                              "pickupRecipientName": "홍길동",
-                                              "pickupRecipientPhoneNumber": "01012345678",
-                                              "pickupZipCode": "06234",
-                                              "pickupAddress": "서울특별시 강남구 테헤란로 123",
-                                              "pickupAddressDetail": "101동 202호",
-                                              "pickupDeliveryRequestType": "LEAVE_AT_DOOR",
-                                              "pickupDeliveryRequestMessage": "문 앞에 놓아주세요",
-                                              "orderProducts": [
+                                              "orderPrducts": [
                                                 {
                                                   "sellerId": 12,
                                                   "productId": 1,

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/apidocs/GetOrdersApiDocs.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/apidocs/GetOrdersApiDocs.java
@@ -80,21 +80,21 @@ import java.lang.annotation.*;
                 
                 | **키** | **타입** | **설명** | **예시** |
                 | --- | --- | --- | --- |
-                | orderHistory | array | 날짜별 주문 내역 묶음 | [ ... ] |
-
+                | orderHistories | array | 날짜별 주문 내역 묶음 | [ ... ] |
+                
                 ---
-                ### Response > content > orderHistory
-
+                ### Response > content > orderHistories
+                
                 | **키** | **타입** | **설명** | **예시** |
                 | --- | --- | --- | --- |
                 | orderDate | string(date) | 주문 생성일(일 단위) | "2025-11-01" |
                 | count | number | 해당 날짜의 주문 건수 | 3 |
                 | orders | array | 주문 목록(주문 ID 내림차순) | [ ... ] |
-
+                
                 ---
-
-                ### Response > content > orderHistory > orders
-
+                
+                ### Response > content > orderHistories > orders
+                
                 | **키** | **타입** | **설명** | **예시** |
                 | --- | --- | --- | --- |
                 | id | number | 주문 ID | 1 |
@@ -106,11 +106,11 @@ import java.lang.annotation.*;
                 | couponAmount | number | 쿠폰 할인 금액(원) | 5000 |
                 | pointAmount | number | 포인트 사용 금액(원) | 5000 |
                 | orderProducts | array | 주문 상품 목록 | [ ... ] |
-
+                
                 ---
-
-                ### Response > content > orderHistory > orders > orderProducts
-
+                
+                ### Response > content > orderHistories > orders > orderProducts
+                
                 | **키** | **타입** | **설명** | **예시** |
                 | --- | --- | --- | --- |
                 | sellerId | number | 판매자 회원 ID | 1 |
@@ -125,10 +125,10 @@ import java.lang.annotation.*;
                 | productName | string | 상품명 | "공책" |
                 | selectedOptions | array | 선택 옵션 목록 | [ ... ] |
                 | isReviewed | boolean | 리뷰 작성 여부 | true |
-
+                
                 ---
-
-                ### Response > content > orderHistory > orders > orderProducts > selectedOptions
+                
+                ### Response > content > orderHistories > orders > orderProducts > selectedOptions
                 
                 | **키** | **타입** | **설명** | **예시** |
                 | --- | --- | --- | --- |

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/payment/controller/apidocs/CancelPaymentApiDocs.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/payment/controller/apidocs/CancelPaymentApiDocs.java
@@ -46,9 +46,6 @@ import java.lang.annotation.*;
                 | cancelType | string | 취소 유형 (FULL/PARTIAL) | Y | "FULL" |
                 | cancelAmount | number | 취소 금액 (부분취소 시 필수) | N | 50000 |
                 | cancelReason | string | 취소 사유 | N | "고객 변심" |
-                | cancelProducts | array | 취소 대상 상품 목록 (부분취소 시 재고 복구용, 선택) | N | [{"pricePolicyId": 1, "quantity": 2}] |
-                | cancelProducts[].pricePolicyId | number | 가격 정책 ID | Y | 1 |
-                | cancelProducts[].quantity | number | 취소 수량 | Y | 2 |
                 """,
         security = {@SecurityRequirement(name = "bearer")},
         requestBody = @RequestBody(
@@ -59,13 +56,7 @@ import java.lang.annotation.*;
                                 {
                                   "cancelType": "FULL",
                                   "cancelAmount": null,
-                                  "cancelReason": "고객 변심",
-                                  "cancelProducts": [
-                                    {
-                                      "pricePolicyId": 1,
-                                      "quantity": 2
-                                    }
-                                  ]
+                                  "cancelReason": "고객 변심"
                                 }
                                 """)
                 )

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/settlement/controller/apidocs/GetFailedSettlementsApiDocs.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/settlement/controller/apidocs/GetFailedSettlementsApiDocs.java
@@ -51,6 +51,7 @@ import java.lang.annotation.*;
                                                 "year": 2026,
                                                 "month": 2,
                                                 "totalAllocatedAmount": 100000,
+                                                "shippingFee": 0,
                                                 "pgFeeAmount": 3000,
                                                 "platformFeeAmount": 5000,
                                                 "sellerPayoutAmount": 92000,

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/settlement/controller/apidocs/GetSellerSettlementsApiDocs.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/settlement/controller/apidocs/GetSellerSettlementsApiDocs.java
@@ -83,6 +83,7 @@ import java.lang.annotation.*;
                                                 "year": 2026,
                                                 "month": 1,
                                                 "totalAllocatedAmount": 100000,
+                                                "shippingFee": 0,
                                                 "pgFeeAmount": 3000,
                                                 "platformFeeAmount": 5000,
                                                 "sellerPayoutAmount": 92000,

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/settlement/controller/apidocs/GetSettlementApiDocs.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/settlement/controller/apidocs/GetSettlementApiDocs.java
@@ -43,6 +43,7 @@ import java.lang.annotation.*;
                 | year | number | 정산 연도 | 2026 |
                 | month | number | 정산 월 | 2 |
                 | totalAllocatedAmount | number | 총 배분 금액 | 100000 |
+                | shippingFee | number | 배송비 | 0 |
                 | pgFeeAmount | number | PG 수수료 | 3000 |
                 | platformFeeAmount | number | 플랫폼 수수료 | 5000 |
                 | sellerPayoutAmount | number | 판매자 지급액 | 92000 |
@@ -67,6 +68,7 @@ import java.lang.annotation.*;
                                             "year": 2026,
                                             "month": 2,
                                             "totalAllocatedAmount": 100000,
+                                            "shippingFee": 0,
                                             "pgFeeAmount": 3000,
                                             "platformFeeAmount": 5000,
                                             "sellerPayoutAmount": 92000,

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/settlement/controller/apidocs/GetSettlementDetailApiDocs.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/settlement/controller/apidocs/GetSettlementDetailApiDocs.java
@@ -42,6 +42,7 @@ import java.lang.annotation.*;
                 | orderId | number | 주문 ID | 100 |
                 | sellerId | number | 판매자 ID | 10 |
                 | allocatedAmount | number | 배분 금액 | 50000 |
+                | shippingFee | number | 배송비 | 0 |
                 | transactionType | string | 거래 유형 | "ORDER_REGISTRATION" |
                 | targetType | string | 대상 유형 | "ORDER" |
                 | createdAt | string | 생성일시 | "2026-02-15T14:30:00" |
@@ -63,6 +64,7 @@ import java.lang.annotation.*;
                                               "orderId": 100,
                                               "sellerId": 10,
                                               "allocatedAmount": 50000,
+                                              "shippingFee": 0,
                                               "transactionType": "ORDER_REGISTRATION",
                                               "targetType": "ORDER",
                                               "createdAt": "2026-02-15T14:30:00"
@@ -72,6 +74,7 @@ import java.lang.annotation.*;
                                               "orderId": 101,
                                               "sellerId": 10,
                                               "allocatedAmount": 30000,
+                                              "shippingFee": 0,
                                               "transactionType": "ORDER_REGISTRATION",
                                               "targetType": "ORDER",
                                               "createdAt": "2026-02-15T15:00:00"

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/settlement/controller/apidocs/GetSettlementsApiDocs.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/settlement/controller/apidocs/GetSettlementsApiDocs.java
@@ -79,6 +79,7 @@ import java.lang.annotation.*;
                                                 "year": 2026,
                                                 "month": 2,
                                                 "totalAllocatedAmount": 100000,
+                                                "shippingFee": 0,
                                                 "pgFeeAmount": 3000,
                                                 "platformFeeAmount": 5000,
                                                 "sellerPayoutAmount": 92000,


### PR DESCRIPTION
## partially addresses #216
## resolves #2407

## Task
- [x] GetSettlementApiDocs: shippingFee 필드 추가
- [x] GetSettlementDetailApiDocs: shippingFee 필드 추가
- [x] GetSellerSettlementsApiDocs: shippingFee 필드 추가
- [x] GetFailedSettlementsApiDocs: shippingFee 필드 추가
- [x] GetSettlementsApiDocs: shippingFee 필드 추가