### PR TITLE
[#216][#2408] fix: 정산 정책 API Swagger 문서 필드 누락 수정

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/settlement/controller/apidocs/GetSettlementPolicyApiDocs.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/settlement/controller/apidocs/GetSettlementPolicyApiDocs.java
@@ -24,6 +24,22 @@ import java.lang.annotation.*;
                 ## Description
                 
                 - 정산 정책 ID로 단건 조회합니다.
+
+                ---
+
+                ## Response > content
+
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | id | number | 정산 정책 ID | 1 |
+                | sellerId | number | 판매자 ID | 100 |
+                | pgFeeRate | number | PG 수수료율 (basis point, 300 = 3%) | 300 |
+                | platformFeeRate | number | 플랫폼 수수료율 (basis point, 500 = 5%) | 500 |
+                | settlementCycle | string | 정산 주기 | "MONTHLY" |
+                | minPayoutAmount | number | 최소 지급 금액 | 10000 |
+                | status | string | 상태 | "ACTIVE" |
+                | createdAt | string | 생성일시 | "2026-03-02T12:00:00.000" |
+                | modifiedAt | string | 수정일시 | "2026-03-02T12:00:00.000" |
                 """,
         parameters = {
                 @Parameter(name = "id", description = "정산 정책 ID", required = true, example = "1")
@@ -46,7 +62,9 @@ import java.lang.annotation.*;
                                             "platformFeeRate": 500,
                                             "settlementCycle": "MONTHLY",
                                             "minPayoutAmount": 10000,
-                                            "status": "ACTIVE"
+                                            "status": "ACTIVE",
+                                            "createdAt": "2026-03-02T12:00:00.000",
+                                            "modifiedAt": "2026-03-02T12:00:00.000"
                                           },
                                           "message": "정산 정책 단건 조회 성공"
                                         }

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/settlement/controller/apidocs/RegisterSettlementPolicyApiDocs.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/settlement/controller/apidocs/RegisterSettlementPolicyApiDocs.java
@@ -1,8 +1,11 @@
 package com.personal.marketnote.commerce.adapter.in.web.settlement.controller.apidocs;
 
+import com.personal.marketnote.commerce.adapter.in.web.settlement.request.RegisterSettlementPolicyRequest;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 
@@ -27,8 +30,35 @@ import java.lang.annotation.*;
                 - 동일 판매자에 대해 활성 정책이 이미 존재하면 등록에 실패합니다.
                 
                 - 수수료율은 basis point 단위입니다 (300 = 3%, 10000 = 100%).
+
+                ---
+
+                ## Request
+
+                | **키** | **타입** | **설명** | **필수 여부** | **예시** |
+                | --- | --- | --- | --- | --- |
+                | sellerId | number | 판매자 ID | Y | 100 |
+                | pgFeeRate | number | PG 수수료율 (basis point, 0~10000) | Y | 300 |
+                | platformFeeRate | number | 플랫폼 수수료율 (basis point, 0~10000) | Y | 500 |
+                | settlementCycle | string | 정산 주기 | Y | "MONTHLY" |
+                | minPayoutAmount | number | 최소 지급 금액 | Y | 10000 |
                 """,
         security = {@SecurityRequirement(name = "bearer")},
+        requestBody = @RequestBody(
+                required = true,
+                content = @Content(
+                        schema = @Schema(implementation = RegisterSettlementPolicyRequest.class),
+                        examples = @ExampleObject("""
+                                {
+                                  "sellerId": 100,
+                                  "pgFeeRate": 300,
+                                  "platformFeeRate": 500,
+                                  "settlementCycle": "MONTHLY",
+                                  "minPayoutAmount": 10000
+                                }
+                                """)
+                )
+        ),
         responses = {
                 @ApiResponse(
                         responseCode = "200",

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/settlement/controller/apidocs/UpdateSettlementPolicyApiDocs.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/settlement/controller/apidocs/UpdateSettlementPolicyApiDocs.java
@@ -1,9 +1,12 @@
 package com.personal.marketnote.commerce.adapter.in.web.settlement.controller.apidocs;
 
+import com.personal.marketnote.commerce.adapter.in.web.settlement.request.UpdateSettlementPolicyRequest;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 
@@ -26,11 +29,36 @@ import java.lang.annotation.*;
                 - 정산 정책의 수수료율, 정산 주기, 최소 지급 금액을 수정합니다.
                 
                 - 수수료율은 basis point 단위입니다 (300 = 3%, 10000 = 100%).
+
+                ---
+
+                ## Request
+
+                | **키** | **타입** | **설명** | **필수 여부** | **예시** |
+                | --- | --- | --- | --- | --- |
+                | pgFeeRate | number | PG 수수료율 (basis point, 0~10000) | Y | 250 |
+                | platformFeeRate | number | 플랫폼 수수료율 (basis point, 0~10000) | Y | 400 |
+                | settlementCycle | string | 정산 주기 | Y | "BIWEEKLY" |
+                | minPayoutAmount | number | 최소 지급 금액 | Y | 5000 |
                 """,
         parameters = {
                 @Parameter(name = "id", description = "정산 정책 ID", required = true, example = "1")
         },
         security = {@SecurityRequirement(name = "bearer")},
+        requestBody = @RequestBody(
+                required = true,
+                content = @Content(
+                        schema = @Schema(implementation = UpdateSettlementPolicyRequest.class),
+                        examples = @ExampleObject("""
+                                {
+                                  "pgFeeRate": 250,
+                                  "platformFeeRate": 400,
+                                  "settlementCycle": "BIWEEKLY",
+                                  "minPayoutAmount": 5000
+                                }
+                                """)
+                )
+        ),
         responses = {
                 @ApiResponse(
                         responseCode = "200",


### PR DESCRIPTION
## partially addresses #216
## resolves #2408

## Task
- [x] GetSettlementPolicyApiDocs: createdAt, modifiedAt 필드 추가
- [x] RegisterSettlementPolicyApiDocs: RequestBody 필드 문서화
- [x] UpdateSettlementPolicyApiDocs: RequestBody 필드 문서화