### PR TITLE
[#43][#2411] fix: 닉네임 중복 확인 API Swagger 문서 containsProfanity 필드 누락 수정

### DIFF
--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/user/controller/apidocs/CheckNicknameApiDocs.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/user/controller/apidocs/CheckNicknameApiDocs.java
@@ -51,6 +51,7 @@ import java.lang.annotation.*;
                 | **키** | **타입** | **설명** | **예시** |
                 | --- | --- | --- | --- |
                 | isDuplicated | boolean | 닉네임 중복 여부 | true / false |
+                | containsProfanity | boolean | 비속어 포함 여부 | true / false |
                 """,
         security = {@SecurityRequirement(name = "bearer")},
         responses = {
@@ -64,7 +65,8 @@ import java.lang.annotation.*;
                                           "code": "SUC01",
                                           "timestamp": "2026-03-19T12:00:00.000000",
                                           "content": {
-                                            "isDuplicated": false
+                                            "isDuplicated": false,
+                                            "containsProfanity": false
                                           },
                                           "message": "닉네임 중복 여부 조회 성공"
                                         }


### PR DESCRIPTION
## partially addresses #43
## resolves #2411

## Task
- [x] 응답 content에 containsProfanity (boolean) 필드 추가