### PR TITLE
[#43][#2412] fix: 로그인 이력 조회 API Swagger 문서 loggedInAt 필드 누락 수정

### DIFF
--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/user/controller/apidocs/GetLoginHistoriesApiDocs.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/user/controller/apidocs/GetLoginHistoriesApiDocs.java
@@ -76,6 +76,7 @@ import java.lang.annotation.*;
                 | userId | number | 회원 ID | 1 |
                 | authVendor | string | 인증 제공자 | "NATIVE"/"KAKAO"/"GOOGLE"/"APPLE" |
                 | ipAddress | string | 로그인 IP | "203.0.113.10" |
+                | loggedInAt | string(datetime) | 로그인 일시 | "2025-12-30T13:31:08.926108" |
                 """, security = {@SecurityRequirement(name = "bearer"),
         @SecurityRequirement(name = "admin")}, parameters = {
         @Parameter(


### PR DESCRIPTION
## partially addresses #43
## resolves #2412

## Task
- [x] 응답 histories 배열 항목에 loggedInAt (datetime) 필드 추가