### PR TITLE
[#43][#2413] fix: 배송지 API Swagger 문서 regionType 필드 누락 및 제약조건 불일치 수정

### DIFF
--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/shippingaddress/controller/apidocs/GetMyShippingAddressesApiDocs.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/shippingaddress/controller/apidocs/GetMyShippingAddressesApiDocs.java
@@ -71,6 +71,7 @@ import java.lang.annotation.*;
                 | deliveryRequestType | string(enum) | 배송 요청사항 타입 | "LEAVE_AT_DOOR" |
                 | deliveryRequestMessage | string | 직접입력 메시지 (CUSTOM 시) | "공동현관 비밀번호 *1234" |
                 | isDefault | boolean | 기본 배송지 여부 | true |
+                | regionType | string(enum) | 배송지 지역 타입 (NORMAL: 일반, JEJU: 제주, ISLAND: 도서산간) | "NORMAL" |
                 """,
         security = {@SecurityRequirement(name = "bearer")},
         responses = {
@@ -96,7 +97,8 @@ import java.lang.annotation.*;
                                                 "recipientPhoneNumber": "01000000000",
                                                 "deliveryRequestType": "LEAVE_AT_DOOR",
                                                 "deliveryRequestMessage": null,
-                                                "isDefault": true
+                                                "isDefault": true,
+                                                "regionType": "NORMAL"
                                               },
                                               {
                                                 "id": 2,
@@ -109,7 +111,8 @@ import java.lang.annotation.*;
                                                 "recipientPhoneNumber": "01000000000",
                                                 "deliveryRequestType": "LEAVE_AT_SECURITY",
                                                 "deliveryRequestMessage": null,
-                                                "isDefault": false
+                                                "isDefault": false,
+                                                "regionType": "NORMAL"
                                               },
                                               {
                                                 "id": 3,
@@ -122,7 +125,8 @@ import java.lang.annotation.*;
                                                 "recipientPhoneNumber": "01011112222",
                                                 "deliveryRequestType": "CUSTOM",
                                                 "deliveryRequestMessage": "공동현관 비밀번호 *1234",
-                                                "isDefault": false
+                                                "isDefault": false,
+                                                "regionType": "ISLAND"
                                               }
                                             ]
                                           },

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/shippingaddress/controller/apidocs/GetShippingAddressApiDocs.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/shippingaddress/controller/apidocs/GetShippingAddressApiDocs.java
@@ -65,6 +65,7 @@ import java.lang.annotation.*;
                 | deliveryRequestType | string(enum) | 배송 요청사항 타입 | "LEAVE_AT_DOOR" |
                 | deliveryRequestMessage | string | 직접입력 메시지 (CUSTOM 시) | "공동현관 비밀번호 *1234" |
                 | isDefault | boolean | 기본 배송지 여부 | true |
+                | regionType | string(enum) | 배송지 지역 타입 (NORMAL: 일반, JEJU: 제주, ISLAND: 도서산간) | "NORMAL" |
                 """,
         parameters = {
                 @Parameter(name = "id", description = "배송지 ID", required = true, example = "1")
@@ -91,7 +92,8 @@ import java.lang.annotation.*;
                                             "recipientPhoneNumber": "01000000000",
                                             "deliveryRequestType": "LEAVE_AT_DOOR",
                                             "deliveryRequestMessage": null,
-                                            "isDefault": true
+                                            "isDefault": true,
+                                            "regionType": "NORMAL"
                                           },
                                           "message": "배송지 조회 성공"
                                         }

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/shippingaddress/controller/apidocs/RegisterShippingAddressApiDocs.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/shippingaddress/controller/apidocs/RegisterShippingAddressApiDocs.java
@@ -38,7 +38,7 @@ import java.lang.annotation.*;
                 
                 - **OTHER** 타입일 때 `addressAlias`는 필수입니다.
                 
-                - `deliveryRequestType`이 **CUSTOM**일 때 `deliveryRequestMessage`는 필수이며, 최대 **30자**까지 입력 가능합니다.
+                - `deliveryRequestType`이 **CUSTOM**일 때 `deliveryRequestMessage`는 필수이며, 최대 **60자**까지 입력 가능합니다.
                 
                 ---
                 
@@ -54,7 +54,7 @@ import java.lang.annotation.*;
                 | recipientName | string | 받는 분 | Y | "박구글" |
                 | recipientPhoneNumber | string | 휴대폰 번호 | Y | "01000000000" |
                 | deliveryRequestType | string(enum) | 배송 요청사항 타입 (NONE: 선택 안 함, LEAVE_AT_DOOR: 문 앞에 놓아주세요, RECEIVE_OR_LEAVE_AT_DOOR: 직접 받고 부재시 문 앞에 놓아 주세요, LEAVE_AT_SECURITY: 경비실에 맡겨주세요, LEAVE_AT_DELIVERY_BOX: 택배함에 넣어주세요, CUSTOM: 직접 입력) | N | "LEAVE_AT_DOOR" |
-                | deliveryRequestMessage | string | 직접입력 메시지 (CUSTOM 시 필수, 최대 30자) | N | "공동현관 비밀번호 *1234" |
+                | deliveryRequestMessage | string | 직접입력 메시지 (CUSTOM 시 필수, 최대 60자) | N | "공동현관 비밀번호 *1234" |
                 | isDefault | boolean | 기본 배송지 여부 | N | false |
                 
                 ---
@@ -78,6 +78,7 @@ import java.lang.annotation.*;
                 | id | number | 배송지 ID | 1 |
                 | addressType | string(enum) | 배송지 타입 | "HOME" |
                 | isDefault | boolean | 기본 배송지 여부 | true |
+                | regionType | string(enum) | 배송지 지역 타입 (NORMAL: 일반, JEJU: 제주, ISLAND: 도서산간) | "NORMAL" |
                 """,
         security = {@SecurityRequirement(name = "bearer")},
         requestBody = @RequestBody(
@@ -110,7 +111,8 @@ import java.lang.annotation.*;
                                           "content": {
                                             "id": 1,
                                             "addressType": "HOME",
-                                            "isDefault": true
+                                            "isDefault": true,
+                                            "regionType": "NORMAL"
                                           },
                                           "message": "배송지 등록 성공"
                                         }

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/shippingaddress/controller/apidocs/UpdateShippingAddressApiDocs.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/web/shippingaddress/controller/apidocs/UpdateShippingAddressApiDocs.java
@@ -35,7 +35,7 @@ import java.lang.annotation.*;
                 
                 - **OTHER** 타입일 때 `addressAlias`는 필수입니다.
                 
-                - `deliveryRequestType`이 **CUSTOM**일 때 `deliveryRequestMessage`는 필수이며, 최대 **30자**까지 입력 가능합니다.
+                - `deliveryRequestType`이 **CUSTOM**일 때 `deliveryRequestMessage`는 필수이며, 최대 **60자**까지 입력 가능합니다.
                 
                 ---
                 
@@ -50,7 +50,7 @@ import java.lang.annotation.*;
                 | recipientName | string | 받는 분 | Y | "박구글" |
                 | recipientPhoneNumber | string | 휴대폰 번호 | Y | "01000000000" |
                 | deliveryRequestType | string(enum) | 배송 요청사항 타입 (NONE: 선택 안 함, LEAVE_AT_DOOR: 문 앞에 놓아주세요, RECEIVE_OR_LEAVE_AT_DOOR: 직접 받고 부재시 문 앞에 놓아 주세요, LEAVE_AT_SECURITY: 경비실에 맡겨주세요, LEAVE_AT_DELIVERY_BOX: 택배함에 넣어주세요, CUSTOM: 직접 입력) | N | "LEAVE_AT_DOOR" |
-                | deliveryRequestMessage | string | 직접입력 메시지 (CUSTOM 시 필수, 최대 30자) | N | "공동현관 비밀번호 *1234" |
+                | deliveryRequestMessage | string | 직접입력 메시지 (CUSTOM 시 필수, 최대 60자) | N | "공동현관 비밀번호 *1234" |
                 
                 ---
                 


### PR DESCRIPTION
## partially addresses #43
## resolves #2413

## Task
- [x] RegisterShippingAddressApiDocs: deliveryRequestMessage 최대 길이 30자 → 60자 수정, regionType 필드 추가
- [x] UpdateShippingAddressApiDocs: deliveryRequestMessage 최대 길이 30자 → 60자 수정
- [x] GetShippingAddressApiDocs: regionType 필드 추가
- [x] GetMyShippingAddressesApiDocs: regionType 필드 추가