### PR TITLE
[#128][#2414] fix: 상품 상세 조회 API Swagger 문서 selectedOptionIds 필드 제거

### DIFF
--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/product/controller/apidocs/GetProductInfoApiDocs.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/product/controller/apidocs/GetProductInfoApiDocs.java
@@ -63,7 +63,6 @@ import java.lang.annotation.*;
                 | categories | array | 옵션 카테고리 목록 | [ ... ] |
                 | representativeImages | object | 상품 상세 정보 상단 대표 이미지 목록 | { ... } |
                 | contentImages | object | 상품 상세 정보 본문 이미지 목록 | { ... } |
-                | selectedOptionIds | array<number> | 선택된 옵션 ID 목록 | [4, 7] |
                 
                 ---
                 


### PR DESCRIPTION
## partially addresses #128
## resolves #2414

## Task
- [x] GetProductInfoApiDocs: 응답 content에서 selectedOptionIds 필드 제거