### PR TITLE
[#128][#2415] fix: 관리자 상품 목록 조회 API Swagger 문서 예시 JSON optionIds 누락 수정

### DIFF
--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/product/controller/apidocs/GetAdminProductsApiDocs.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/product/controller/apidocs/GetAdminProductsApiDocs.java
@@ -249,7 +249,8 @@ import java.lang.annotation.*;
                                                     "price": 45000,
                                                     "discountPrice": 37000,
                                                     "discountRate": 3.2,
-                                                    "accumulatedPoint": 1200
+                                                    "accumulatedPoint": 1200,
+                                                    "optionIds": [8, 11]
                                                   },
                                                   "sales": 0,
                                                   "productTags": [


### PR DESCRIPTION
## partially addresses #128
## resolves #2415

## Task
- [x] GetAdminProductsApiDocs: 예시 JSON pricePolicy에 optionIds 필드 추가