### PR TITLE
[#128][#2417] fix: 카테고리 등록 API Swagger 문서 응답 필드명 불일치 수정

### DIFF
--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/category/controller/apidocs/RegisterCategoryApiDocs.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/web/category/controller/apidocs/RegisterCategoryApiDocs.java
@@ -59,7 +59,7 @@ import java.lang.annotation.*;
                 
                  | **키** | **타입** | **설명** | **예시** |
                  | --- | --- | --- | --- |
-                 | optionCategoryId | number | 생성된 카테고리 ID | 10004 |
+                 | id | number | 생성된 카테고리 ID | 10004 |
                  | parentCategoryId | number | 상위 카테고리 ID | 1 |
                  | name | string | 카테고리명 | "루테인" |
                 """,
@@ -88,7 +88,7 @@ import java.lang.annotation.*;
                                           "code": "SUC01",
                                           "timestamp": "2025-12-31T16:06:44.009132",
                                           "content": {
-                                            "optionCategoryId": 10004,
+                                            "id": 10004,
                                             "parentCategoryId": 1001,
                                             "name": "루테인"
                                           },


### PR DESCRIPTION
## partially addresses #128
## resolves #2417

## Task
- [x] RegisterCategoryApiDocs: 응답 content 필드명 optionCategoryId → id 수정