### PR TITLE
[#300][#2425] fix: 리뷰 등록 API Swagger 문서 unitAmount 필드 누락 수정

### DIFF
--- a/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/in/web/review/controller/apidocs/RegisterReviewApiDocs.java
+++ b/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/in/web/review/controller/apidocs/RegisterReviewApiDocs.java
@@ -44,6 +44,7 @@ import java.lang.annotation.*;
                 | reviewerName | string | 리뷰 작성자 이름 | Y | "홍길동" |
                 | rating | number | 리뷰 평점(0.0~5.0, 소수점 1자리) | Y | 4.5 |
                 | content | string | 리뷰 내용(10자 이상) | Y | "배송이 빠르고 포장 상태도 좋았습니다." |
+                | unitAmount | number | 주문 상품 구매 시점 단가 | N | 29000 |
                 | isPhoto | boolean | 포토 리뷰 여부 | Y | false |
                 
                 ---
@@ -77,6 +78,7 @@ import java.lang.annotation.*;
                                   "productImageUrl": "https://example.com/image.jpg",
                                   "selectedOptions": "30개입, 5박스",
                                   "quantity": 2,
+                                  "unitAmount": 29000,
                                   "reviewerName": "홍길동",
                                   "rating": 5,
                                   "content": "배송이 빠르고 포장 상태도 좋았습니다.",


### PR DESCRIPTION
## partially addresses #300
## resolves #2425

## Task
- [x] RegisterReviewApiDocs: 요청 테이블에 unitAmount 필드 추가
- [x] RegisterReviewApiDocs: 예시 JSON에 unitAmount 추가