### PR TITLE
[#300][#2426] fix: 게시판 및 게시글 API Swagger 문서 필드 불일치 수정

### DIFF
--- a/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/in/web/board/apidocs/GetBoardsApiDocs.java
+++ b/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/in/web/board/apidocs/GetBoardsApiDocs.java
@@ -45,11 +45,11 @@ import java.lang.annotation.*;
                 
                 | **키** | **타입** | **설명** | **예시** |
                 | --- | --- | --- | --- |
-                | boards | array | 게시판 목록 | [ ... ] |
-                
+                | categories | array | 게시판 목록 | [ ... ] |
+
                 ---
-                
-                ### Response > content > boards
+
+                ### Response > content > categories
                 
                 | **키** | **타입** | **설명** | **예시** |
                 | --- | --- | --- | --- |

--- a/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/in/web/post/controller/apidocs/UpdatePostApiDocs.java
+++ b/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/in/web/post/controller/apidocs/UpdatePostApiDocs.java
@@ -48,14 +48,8 @@ import java.lang.annotation.*;
                 | statusCode | number | HTTP 상태 코드 | 201 |
                 | code | string | 응답 코드 | "SUC01" |
                 | timestamp | string(datetime) | 응답 일시 | "2026-01-09T16:32:18.828188" |
-                | content | object | 응답 본문 | { ... } |
+                | content | null | 응답 본문 (Void) | null |
                 | message | string | 처리 결과 | "게시글 수정 성공" |
-                
-                ### Response > content
-                
-                | **키** | **타입** | **설명** | **예시** |
-                | --- | --- | --- | --- |
-                | id | number | 수정된 게시글 ID | 3 |
                 """,
         security = {@SecurityRequirement(name = "bearer")},
         parameters = {
@@ -89,9 +83,7 @@ import java.lang.annotation.*;
                                           "statusCode": 200,
                                           "code": "SUC01",
                                           "timestamp": "2026-01-13T16:39:31.057206",
-                                          "content": {
-                                            "id": 3
-                                          },
+                                          "content": null,
                                           "message": "게시글 수정 성공"
                                         }
                                         """)


### PR DESCRIPTION
## partially addresses #300
## resolves #2426

## Task
- [x] GetBoardsApiDocs: 응답 테이블 필드명 boards → categories 수정
- [x] UpdatePostApiDocs: 응답 content를 null(Void)로 수정