### PR TITLE
[#216][#2241] test: 반품 입고 검수 추적 도메인 자동화 테스트 추가

### DIFF
--- a/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/out/persistence/returntracker/ReturnTrackerPersistenceAdapterTest.java
+++ b/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/out/persistence/returntracker/ReturnTrackerPersistenceAdapterTest.java
@@ -1,0 +1,206 @@
+package com.personal.marketnote.commerce.adapter.out.persistence.returntracker;
+
+import com.personal.marketnote.commerce.adapter.out.persistence.returntracker.repository.ReturnTrackerJpaRepository;
+import com.personal.marketnote.commerce.domain.returntracker.ReturnInspectionStatus;
+import com.personal.marketnote.commerce.domain.returntracker.ReturnTracker;
+import com.personal.marketnote.commerce.domain.returntracker.ReturnTrackerCreateState;
+import com.personal.marketnote.common.configuration.AuditConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DataJpaTest
+@ActiveProfiles("test")
+@Import({AuditConfig.class, ReturnTrackerPersistenceAdapter.class})
+@DisplayName("ReturnTrackerPersistenceAdapter 통합 테스트")
+class ReturnTrackerPersistenceAdapterTest {
+
+    @Autowired
+    private ReturnTrackerPersistenceAdapter adapter;
+
+    @Autowired
+    private ReturnTrackerJpaRepository repository;
+
+    @BeforeEach
+    void setUp() {
+        repository.deleteAll();
+    }
+
+    @Nested
+    @DisplayName("save")
+    class Save {
+
+        @Test
+        @DisplayName("ReturnTracker를 저장하고 ID가 할당된 도메인 객체를 반환한다")
+        void shouldSaveAndReturnWithId() {
+            // given
+            ReturnTracker tracker = ReturnTracker.from(
+                    ReturnTrackerCreateState.builder()
+                            .orderId(1L)
+                            .returnSlipNumber("RTN20260409001")
+                            .build()
+            );
+
+            // when
+            ReturnTracker saved = adapter.save(tracker);
+
+            // then
+            assertThat(saved.getId()).isNotNull();
+            assertThat(saved.getOrderId()).isEqualTo(1L);
+            assertThat(saved.getReturnSlipNumber()).isEqualTo("RTN20260409001");
+            assertThat(saved.isInspectionPending()).isTrue();
+            assertThat(saved.isRefundPending()).isTrue();
+            assertThat(saved.getCreatedAt()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("동일 orderId로 중복 저장 시 DataIntegrityViolationException이 발생한다")
+        void shouldThrowWhenDuplicateOrderId() {
+            // given
+            ReturnTracker first = ReturnTracker.from(
+                    ReturnTrackerCreateState.builder()
+                            .orderId(1L)
+                            .returnSlipNumber("RTN001")
+                            .build()
+            );
+            adapter.save(first);
+
+            ReturnTracker duplicate = ReturnTracker.from(
+                    ReturnTrackerCreateState.builder()
+                            .orderId(1L)
+                            .returnSlipNumber("RTN002")
+                            .build()
+            );
+
+            // when & then
+            assertThatThrownBy(() -> adapter.save(duplicate))
+                    .isInstanceOf(DataIntegrityViolationException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("findByOrderId")
+    class FindByOrderId {
+
+        @Test
+        @DisplayName("orderId로 ReturnTracker를 조회한다")
+        void shouldFindByOrderId() {
+            // given
+            ReturnTracker tracker = ReturnTracker.from(
+                    ReturnTrackerCreateState.builder()
+                            .orderId(100L)
+                            .returnSlipNumber("RTN100")
+                            .build()
+            );
+            adapter.save(tracker);
+
+            // when
+            Optional<ReturnTracker> found = adapter.findByOrderId(100L);
+
+            // then
+            assertThat(found).isPresent();
+            assertThat(found.get().getOrderId()).isEqualTo(100L);
+            assertThat(found.get().getReturnSlipNumber()).isEqualTo("RTN100");
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 orderId로 조회 시 빈 Optional을 반환한다")
+        void shouldReturnEmptyWhenNotFound() {
+            // when
+            Optional<ReturnTracker> found = adapter.findByOrderId(999L);
+
+            // then
+            assertThat(found).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("findByInspectionStatus")
+    class FindByInspectionStatus {
+
+        @Test
+        @DisplayName("PENDING 상태의 ReturnTracker 목록을 조회한다")
+        void shouldFindPendingTrackers() {
+            // given
+            adapter.save(ReturnTracker.from(
+                    ReturnTrackerCreateState.builder().orderId(1L).returnSlipNumber("RTN001").build()));
+            adapter.save(ReturnTracker.from(
+                    ReturnTrackerCreateState.builder().orderId(2L).returnSlipNumber("RTN002").build()));
+
+            // when
+            List<ReturnTracker> pendingTrackers = adapter.findByInspectionStatus(ReturnInspectionStatus.PENDING);
+
+            // then
+            assertThat(pendingTrackers).hasSize(2);
+            assertThat(pendingTrackers).allMatch(ReturnTracker::isInspectionPending);
+        }
+
+        @Test
+        @DisplayName("해당 상태의 ReturnTracker가 없으면 빈 리스트를 반환한다")
+        void shouldReturnEmptyListWhenNoMatch() {
+            // given
+            adapter.save(ReturnTracker.from(
+                    ReturnTrackerCreateState.builder().orderId(1L).returnSlipNumber("RTN001").build()));
+
+            // when
+            List<ReturnTracker> passedTrackers = adapter.findByInspectionStatus(ReturnInspectionStatus.PASSED);
+
+            // then
+            assertThat(passedTrackers).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("update")
+    class Update {
+
+        @Test
+        @DisplayName("검수 상태를 PASSED로 업데이트한다")
+        void shouldUpdateInspectionStatus() {
+            // given
+            ReturnTracker saved = adapter.save(ReturnTracker.from(
+                    ReturnTrackerCreateState.builder().orderId(1L).returnSlipNumber("RTN001").build()));
+
+            LocalDateTime inspectedAt = LocalDateTime.of(2026, 4, 9, 14, 0);
+            saved.passInspection(inspectedAt);
+
+            // when
+            ReturnTracker updated = adapter.update(saved);
+
+            // then
+            assertThat(updated.isInspectionPassed()).isTrue();
+            assertThat(updated.getInspectedAt()).isEqualTo(inspectedAt);
+        }
+
+        @Test
+        @DisplayName("환불 상태를 COMPLETED로 업데이트한다")
+        void shouldUpdateRefundStatus() {
+            // given
+            ReturnTracker saved = adapter.save(ReturnTracker.from(
+                    ReturnTrackerCreateState.builder().orderId(1L).returnSlipNumber("RTN001").build()));
+
+            LocalDateTime refundedAt = LocalDateTime.of(2026, 4, 9, 15, 0);
+            saved.completeRefund(refundedAt);
+
+            // when
+            ReturnTracker updated = adapter.update(saved);
+
+            // then
+            assertThat(updated.isRefundCompleted()).isTrue();
+            assertThat(updated.getRefundedAt()).isEqualTo(refundedAt);
+        }
+    }
+}

--- a/commerce-service/commerce-domain/src/test/java/com/personal/marketnote/commerce/domain/returntracker/ReturnTrackerTest.java
+++ b/commerce-service/commerce-domain/src/test/java/com/personal/marketnote/commerce/domain/returntracker/ReturnTrackerTest.java
@@ -1,0 +1,442 @@
+package com.personal.marketnote.commerce.domain.returntracker;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("ReturnTracker 도메인 테스트")
+class ReturnTrackerTest {
+
+    @Nested
+    @DisplayName("from CreateState")
+    class FromCreateState {
+
+        @Test
+        @DisplayName("CreateState로부터 ReturnTracker를 생성하면 검수 상태와 환불 상태가 PENDING이다")
+        void shouldCreateWithPendingStatuses() {
+            // given
+            ReturnTrackerCreateState state = ReturnTrackerCreateState.builder()
+                    .orderId(1L)
+                    .returnSlipNumber("RTN20260409001")
+                    .build();
+
+            // when
+            ReturnTracker tracker = ReturnTracker.from(state);
+
+            // then
+            assertThat(tracker.getOrderId()).isEqualTo(1L);
+            assertThat(tracker.getReturnSlipNumber()).isEqualTo("RTN20260409001");
+            assertThat(tracker.isInspectionPending()).isTrue();
+            assertThat(tracker.isRefundPending()).isTrue();
+            assertThat(tracker.getInspectedAt()).isNull();
+            assertThat(tracker.getRefundedAt()).isNull();
+        }
+
+        @Test
+        @DisplayName("orderId가 null이면 ReturnTrackerOrderIdNoValueException을 던진다")
+        void shouldThrowWhenOrderIdIsNull() {
+            // given
+            ReturnTrackerCreateState state = ReturnTrackerCreateState.builder()
+                    .returnSlipNumber("RTN20260409001")
+                    .build();
+
+            // when & then
+            assertThatThrownBy(() -> ReturnTracker.from(state))
+                    .isInstanceOf(ReturnTrackerOrderIdNoValueException.class);
+        }
+
+        @Test
+        @DisplayName("returnSlipNumber가 null이어도 생성에 성공한다")
+        void shouldCreateWithNullReturnSlipNumber() {
+            // given
+            ReturnTrackerCreateState state = ReturnTrackerCreateState.builder()
+                    .orderId(1L)
+                    .build();
+
+            // when
+            ReturnTracker tracker = ReturnTracker.from(state);
+
+            // then
+            assertThat(tracker.getOrderId()).isEqualTo(1L);
+            assertThat(tracker.getReturnSlipNumber()).isNull();
+            assertThat(tracker.isInspectionPending()).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("from SnapshotState")
+    class FromSnapshotState {
+
+        @Test
+        @DisplayName("SnapshotState로부터 ReturnTracker를 복원하면 모든 필드가 정확히 매핑된다")
+        void shouldRestoreFromSnapshotState() {
+            // given
+            LocalDateTime inspectedAt = LocalDateTime.of(2026, 4, 9, 14, 0);
+            LocalDateTime refundedAt = LocalDateTime.of(2026, 4, 9, 15, 0);
+            LocalDateTime createdAt = LocalDateTime.of(2026, 4, 9, 10, 0);
+            LocalDateTime modifiedAt = LocalDateTime.of(2026, 4, 9, 15, 0);
+
+            ReturnTrackerSnapshotState state = ReturnTrackerSnapshotState.builder()
+                    .id(100L)
+                    .orderId(1L)
+                    .returnSlipNumber("RTN20260409001")
+                    .inspectionStatus(ReturnInspectionStatus.PASSED)
+                    .refundStatus(ReturnRefundStatus.COMPLETED)
+                    .inspectedAt(inspectedAt)
+                    .refundedAt(refundedAt)
+                    .createdAt(createdAt)
+                    .modifiedAt(modifiedAt)
+                    .build();
+
+            // when
+            ReturnTracker tracker = ReturnTracker.from(state);
+
+            // then
+            assertThat(tracker.getId()).isEqualTo(100L);
+            assertThat(tracker.getOrderId()).isEqualTo(1L);
+            assertThat(tracker.getReturnSlipNumber()).isEqualTo("RTN20260409001");
+            assertThat(tracker.isInspectionPassed()).isTrue();
+            assertThat(tracker.isRefundCompleted()).isTrue();
+            assertThat(tracker.getInspectedAt()).isEqualTo(inspectedAt);
+            assertThat(tracker.getRefundedAt()).isEqualTo(refundedAt);
+            assertThat(tracker.getCreatedAt()).isEqualTo(createdAt);
+            assertThat(tracker.getModifiedAt()).isEqualTo(modifiedAt);
+        }
+    }
+
+    @Nested
+    @DisplayName("검수 상태 전이")
+    class InspectionStatusTransition {
+
+        @Test
+        @DisplayName("PENDING 상태에서 passInspection 호출 시 PASSED로 전이되고 inspectedAt이 설정된다")
+        void shouldTransitionToPassed() {
+            // given
+            ReturnTracker tracker = createPendingTracker();
+            LocalDateTime now = LocalDateTime.of(2026, 4, 9, 14, 0);
+
+            // when
+            tracker.passInspection(now);
+
+            // then
+            assertThat(tracker.isInspectionPassed()).isTrue();
+            assertThat(tracker.isInspectionPending()).isFalse();
+            assertThat(tracker.getInspectedAt()).isEqualTo(now);
+        }
+
+        @Test
+        @DisplayName("PENDING 상태에서 failInspection 호출 시 FAILED로 전이되고 inspectedAt이 설정된다")
+        void shouldTransitionToFailed() {
+            // given
+            ReturnTracker tracker = createPendingTracker();
+            LocalDateTime now = LocalDateTime.of(2026, 4, 9, 14, 0);
+
+            // when
+            tracker.failInspection(now);
+
+            // then
+            assertThat(tracker.isInspectionFailed()).isTrue();
+            assertThat(tracker.getInspectedAt()).isEqualTo(now);
+        }
+
+        @Test
+        @DisplayName("PENDING 상태에서 holdInspection 호출 시 ON_HOLD로 전이되고 inspectedAt은 설정되지 않는다")
+        void shouldTransitionToOnHold() {
+            // given
+            ReturnTracker tracker = createPendingTracker();
+
+            // when
+            tracker.holdInspection();
+
+            // then
+            assertThat(tracker.isInspectionOnHold()).isTrue();
+            assertThat(tracker.getInspectedAt()).isNull();
+        }
+
+        @Test
+        @DisplayName("PASSED 상태에서 passInspection 호출 시 InvalidReturnInspectionStatusTransitionException을 던진다")
+        void shouldThrowWhenPassFromPassed() {
+            // given
+            ReturnTracker tracker = createPendingTracker();
+            LocalDateTime now = LocalDateTime.of(2026, 4, 9, 14, 0);
+            tracker.passInspection(now);
+
+            // when & then
+            assertThatThrownBy(() -> tracker.passInspection(now))
+                    .isInstanceOf(InvalidReturnInspectionStatusTransitionException.class);
+        }
+
+        @Test
+        @DisplayName("FAILED 상태에서 failInspection 호출 시 InvalidReturnInspectionStatusTransitionException을 던진다")
+        void shouldThrowWhenFailFromFailed() {
+            // given
+            ReturnTracker tracker = createPendingTracker();
+            LocalDateTime now = LocalDateTime.of(2026, 4, 9, 14, 0);
+            tracker.failInspection(now);
+
+            // when & then
+            assertThatThrownBy(() -> tracker.failInspection(now))
+                    .isInstanceOf(InvalidReturnInspectionStatusTransitionException.class);
+        }
+
+        @Test
+        @DisplayName("ON_HOLD 상태에서 holdInspection 호출 시 InvalidReturnInspectionStatusTransitionException을 던진다")
+        void shouldThrowWhenHoldFromOnHold() {
+            // given
+            ReturnTracker tracker = createPendingTracker();
+            tracker.holdInspection();
+
+            // when & then
+            assertThatThrownBy(tracker::holdInspection)
+                    .isInstanceOf(InvalidReturnInspectionStatusTransitionException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("환불 상태 전이")
+    class RefundStatusTransition {
+
+        @Test
+        @DisplayName("PENDING 상태에서 completeRefund 호출 시 COMPLETED로 전이되고 refundedAt이 설정된다")
+        void shouldTransitionToCompleted() {
+            // given
+            ReturnTracker tracker = createPendingTracker();
+            LocalDateTime now = LocalDateTime.of(2026, 4, 9, 15, 0);
+
+            // when
+            tracker.completeRefund(now);
+
+            // then
+            assertThat(tracker.isRefundCompleted()).isTrue();
+            assertThat(tracker.isRefundPending()).isFalse();
+            assertThat(tracker.getRefundedAt()).isEqualTo(now);
+        }
+
+        @Test
+        @DisplayName("PENDING 상태에서 failRefund 호출 시 FAILED로 전이된다")
+        void shouldTransitionToFailed() {
+            // given
+            ReturnTracker tracker = createPendingTracker();
+
+            // when
+            tracker.failRefund();
+
+            // then
+            assertThat(tracker.isRefundFailed()).isTrue();
+            assertThat(tracker.isRefundPending()).isFalse();
+        }
+
+        @Test
+        @DisplayName("FAILED 상태에서 retryRefund 호출 시 PENDING으로 전이되고 refundedAt이 null이 된다")
+        void shouldRetryFromFailed() {
+            // given
+            ReturnTracker tracker = createPendingTracker();
+            tracker.failRefund();
+
+            // when
+            tracker.retryRefund();
+
+            // then
+            assertThat(tracker.isRefundPending()).isTrue();
+            assertThat(tracker.isRefundFailed()).isFalse();
+            assertThat(tracker.getRefundedAt()).isNull();
+        }
+
+        @Test
+        @DisplayName("COMPLETED 상태에서 completeRefund 호출 시 InvalidReturnRefundStatusTransitionException을 던진다")
+        void shouldThrowWhenCompleteFromCompleted() {
+            // given
+            ReturnTracker tracker = createPendingTracker();
+            LocalDateTime now = LocalDateTime.of(2026, 4, 9, 15, 0);
+            tracker.completeRefund(now);
+
+            // when & then
+            assertThatThrownBy(() -> tracker.completeRefund(now))
+                    .isInstanceOf(InvalidReturnRefundStatusTransitionException.class);
+        }
+
+        @Test
+        @DisplayName("COMPLETED 상태에서 failRefund 호출 시 InvalidReturnRefundStatusTransitionException을 던진다")
+        void shouldThrowWhenFailFromCompleted() {
+            // given
+            ReturnTracker tracker = createPendingTracker();
+            LocalDateTime now = LocalDateTime.of(2026, 4, 9, 15, 0);
+            tracker.completeRefund(now);
+
+            // when & then
+            assertThatThrownBy(tracker::failRefund)
+                    .isInstanceOf(InvalidReturnRefundStatusTransitionException.class);
+        }
+
+        @Test
+        @DisplayName("COMPLETED 상태에서 retryRefund 호출 시 InvalidReturnRefundStatusTransitionException을 던진다")
+        void shouldThrowWhenRetryFromCompleted() {
+            // given
+            ReturnTracker tracker = createPendingTracker();
+            LocalDateTime now = LocalDateTime.of(2026, 4, 9, 15, 0);
+            tracker.completeRefund(now);
+
+            // when & then
+            assertThatThrownBy(tracker::retryRefund)
+                    .isInstanceOf(InvalidReturnRefundStatusTransitionException.class);
+        }
+
+        @Test
+        @DisplayName("PENDING 상태에서 retryRefund 호출 시 InvalidReturnRefundStatusTransitionException을 던진다")
+        void shouldThrowWhenRetryFromPending() {
+            // given
+            ReturnTracker tracker = createPendingTracker();
+
+            // when & then
+            assertThatThrownBy(tracker::retryRefund)
+                    .isInstanceOf(InvalidReturnRefundStatusTransitionException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("술어 메서드")
+    class PredicateTest {
+
+        @Test
+        @DisplayName("생성 직후 isInspectionPending과 isRefundPending이 true이다")
+        void shouldReturnTrueForPendingAfterCreation() {
+            // given
+            ReturnTracker tracker = createPendingTracker();
+
+            // then
+            assertThat(tracker.isInspectionPending()).isTrue();
+            assertThat(tracker.isInspectionPassed()).isFalse();
+            assertThat(tracker.isInspectionFailed()).isFalse();
+            assertThat(tracker.isInspectionOnHold()).isFalse();
+            assertThat(tracker.isRefundPending()).isTrue();
+            assertThat(tracker.isRefundCompleted()).isFalse();
+            assertThat(tracker.isRefundFailed()).isFalse();
+        }
+
+        @Test
+        @DisplayName("검수 통과 후 isInspectionPassed만 true이다")
+        void shouldReturnTrueOnlyForPassedAfterPassInspection() {
+            // given
+            ReturnTracker tracker = createPendingTracker();
+            tracker.passInspection(LocalDateTime.now());
+
+            // then
+            assertThat(tracker.isInspectionPending()).isFalse();
+            assertThat(tracker.isInspectionPassed()).isTrue();
+            assertThat(tracker.isInspectionFailed()).isFalse();
+            assertThat(tracker.isInspectionOnHold()).isFalse();
+        }
+
+        @Test
+        @DisplayName("환불 완료 후 isRefundCompleted만 true이다")
+        void shouldReturnTrueOnlyForCompletedAfterCompleteRefund() {
+            // given
+            ReturnTracker tracker = createPendingTracker();
+            tracker.completeRefund(LocalDateTime.now());
+
+            // then
+            assertThat(tracker.isRefundPending()).isFalse();
+            assertThat(tracker.isRefundCompleted()).isTrue();
+            assertThat(tracker.isRefundFailed()).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("ReturnInspectionStatus enum")
+    class InspectionStatusEnumTest {
+
+        @Test
+        @DisplayName("PENDING에서 PASSED, FAILED, ON_HOLD로 전이 가능하다")
+        void shouldAllowTransitionFromPending() {
+            assertThat(ReturnInspectionStatus.PENDING.canTransitionTo(ReturnInspectionStatus.PASSED)).isTrue();
+            assertThat(ReturnInspectionStatus.PENDING.canTransitionTo(ReturnInspectionStatus.FAILED)).isTrue();
+            assertThat(ReturnInspectionStatus.PENDING.canTransitionTo(ReturnInspectionStatus.ON_HOLD)).isTrue();
+        }
+
+        @Test
+        @DisplayName("PASSED는 종단 상태로 다른 상태로 전이 불가하다")
+        void shouldNotAllowTransitionFromPassed() {
+            assertThat(ReturnInspectionStatus.PASSED.canTransitionTo(ReturnInspectionStatus.PENDING)).isFalse();
+            assertThat(ReturnInspectionStatus.PASSED.canTransitionTo(ReturnInspectionStatus.FAILED)).isFalse();
+            assertThat(ReturnInspectionStatus.PASSED.canTransitionTo(ReturnInspectionStatus.ON_HOLD)).isFalse();
+        }
+
+        @Test
+        @DisplayName("FAILED는 종단 상태로 다른 상태로 전이 불가하다")
+        void shouldNotAllowTransitionFromFailed() {
+            assertThat(ReturnInspectionStatus.FAILED.canTransitionTo(ReturnInspectionStatus.PENDING)).isFalse();
+            assertThat(ReturnInspectionStatus.FAILED.canTransitionTo(ReturnInspectionStatus.PASSED)).isFalse();
+            assertThat(ReturnInspectionStatus.FAILED.canTransitionTo(ReturnInspectionStatus.ON_HOLD)).isFalse();
+        }
+
+        @Test
+        @DisplayName("ON_HOLD는 종단 상태로 다른 상태로 전이 불가하다")
+        void shouldNotAllowTransitionFromOnHold() {
+            assertThat(ReturnInspectionStatus.ON_HOLD.canTransitionTo(ReturnInspectionStatus.PENDING)).isFalse();
+            assertThat(ReturnInspectionStatus.ON_HOLD.canTransitionTo(ReturnInspectionStatus.PASSED)).isFalse();
+            assertThat(ReturnInspectionStatus.ON_HOLD.canTransitionTo(ReturnInspectionStatus.FAILED)).isFalse();
+        }
+
+        @Test
+        @DisplayName("술어 메서드가 올바른 상태에서 true를 반환한다")
+        void shouldReturnCorrectPredicateValues() {
+            assertThat(ReturnInspectionStatus.PENDING.isPending()).isTrue();
+            assertThat(ReturnInspectionStatus.PASSED.isPassed()).isTrue();
+            assertThat(ReturnInspectionStatus.FAILED.isFailed()).isTrue();
+            assertThat(ReturnInspectionStatus.ON_HOLD.isOnHold()).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("ReturnRefundStatus enum")
+    class RefundStatusEnumTest {
+
+        @Test
+        @DisplayName("PENDING에서 COMPLETED, FAILED로 전이 가능하다")
+        void shouldAllowTransitionFromPending() {
+            assertThat(ReturnRefundStatus.PENDING.canTransitionTo(ReturnRefundStatus.COMPLETED)).isTrue();
+            assertThat(ReturnRefundStatus.PENDING.canTransitionTo(ReturnRefundStatus.FAILED)).isTrue();
+        }
+
+        @Test
+        @DisplayName("FAILED에서 PENDING으로 전이 가능하다 (재시도)")
+        void shouldAllowRetryFromFailed() {
+            assertThat(ReturnRefundStatus.FAILED.canTransitionTo(ReturnRefundStatus.PENDING)).isTrue();
+        }
+
+        @Test
+        @DisplayName("COMPLETED는 종단 상태로 다른 상태로 전이 불가하다")
+        void shouldNotAllowTransitionFromCompleted() {
+            assertThat(ReturnRefundStatus.COMPLETED.canTransitionTo(ReturnRefundStatus.PENDING)).isFalse();
+            assertThat(ReturnRefundStatus.COMPLETED.canTransitionTo(ReturnRefundStatus.FAILED)).isFalse();
+        }
+
+        @Test
+        @DisplayName("FAILED에서 COMPLETED로 직접 전이 불가하다")
+        void shouldNotAllowDirectTransitionFromFailedToCompleted() {
+            assertThat(ReturnRefundStatus.FAILED.canTransitionTo(ReturnRefundStatus.COMPLETED)).isFalse();
+        }
+
+        @Test
+        @DisplayName("술어 메서드가 올바른 상태에서 true를 반환한다")
+        void shouldReturnCorrectPredicateValues() {
+            assertThat(ReturnRefundStatus.PENDING.isPending()).isTrue();
+            assertThat(ReturnRefundStatus.COMPLETED.isCompleted()).isTrue();
+            assertThat(ReturnRefundStatus.FAILED.isFailed()).isTrue();
+        }
+    }
+
+    private ReturnTracker createPendingTracker() {
+        return ReturnTracker.from(
+                ReturnTrackerCreateState.builder()
+                        .orderId(1L)
+                        .returnSlipNumber("RTN20260409001")
+                        .build()
+        );
+    }
+}

--- a/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/out/persistence/post/PostPersistenceAdapter.java
+++ b/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/out/persistence/post/PostPersistenceAdapter.java
@@ -61,8 +61,10 @@ public class PostPersistenceAdapter implements SavePostPort, FindPostPort, Updat
         boolean searchInTitle = shouldSearchIn(searchTarget, PostSearchTarget.TITLE);
         boolean searchInContent = shouldSearchIn(searchTarget, PostSearchTarget.CONTENT);
         String searchKeywordPattern = buildSearchPattern(searchKeyword);
+        boolean isAnsweredOnly = false;
         if (FormatValidator.hasValue(filterCategory) && FormatValidator.hasValue(filterValue)) {
             isPublicOnly = filterCategory.isPublicOnly(filterValue);
+            isAnsweredOnly = filterCategory.isAnsweredOnly(filterValue);
             if (filterCategory.isMineFiltered(filterValue)) {
                 userIdFilter = userId;
             }
@@ -79,6 +81,7 @@ public class PostPersistenceAdapter implements SavePostPort, FindPostPort, Updat
                             isDesc,
                             isPublicOnly,
                             userIdFilter,
+                            isAnsweredOnly,
                             searchInTitle,
                             searchInContent,
                             searchKeywordPattern,
@@ -98,6 +101,7 @@ public class PostPersistenceAdapter implements SavePostPort, FindPostPort, Updat
                         isDesc,
                         isPublicOnly,
                         userIdFilter,
+                        isAnsweredOnly,
                         searchInTitle,
                         searchInContent,
                         searchKeywordPattern,
@@ -115,16 +119,22 @@ public class PostPersistenceAdapter implements SavePostPort, FindPostPort, Updat
             Pageable pageable,
             boolean isDesc,
             PostSortProperty sortProperty,
+            PostFilterCategory filterCategory,
+            PostFilterValue filterValue,
             PostSearchTarget searchTarget,
             String searchKeyword
     ) {
         boolean searchInTitle = shouldSearchIn(searchTarget, PostSearchTarget.TITLE);
         boolean searchInContent = shouldSearchIn(searchTarget, PostSearchTarget.CONTENT);
         String searchKeywordPattern = buildSearchPattern(searchKeyword);
+        boolean isAnsweredOnly = FormatValidator.hasValue(filterCategory)
+                && FormatValidator.hasValue(filterValue)
+                && filterCategory.isAnsweredOnly(filterValue);
+
         if (FormatValidator.equals(sortProperty, PostSortProperty.IS_ANSWERED)) {
             return mapToPostsWithReplies(
                     postJpaRepository.findByUserIdAndBoardOrderByAnswered(
-                            userId, board, cursor, isDesc, searchInTitle, searchInContent,
+                            userId, board, cursor, isDesc, isAnsweredOnly, searchInTitle, searchInContent,
                             searchKeywordPattern, EntityStatus.ACTIVE, pageable
                     )
             );
@@ -132,7 +142,7 @@ public class PostPersistenceAdapter implements SavePostPort, FindPostPort, Updat
 
         return mapToPostsWithReplies(
                 postJpaRepository.findByUserIdAndBoard(
-                        userId, board, cursor, isDesc, searchInTitle, searchInContent,
+                        userId, board, cursor, isDesc, isAnsweredOnly, searchInTitle, searchInContent,
                         searchKeywordPattern, EntityStatus.ACTIVE, pageable
                 )
         );
@@ -155,8 +165,10 @@ public class PostPersistenceAdapter implements SavePostPort, FindPostPort, Updat
         boolean searchInTitle = shouldSearchIn(searchTarget, PostSearchTarget.TITLE);
         boolean searchInContent = shouldSearchIn(searchTarget, PostSearchTarget.CONTENT);
         String searchKeywordPattern = buildSearchPattern(searchKeyword);
+        boolean isAnsweredOnly = false;
         if (FormatValidator.hasValue(filterCategory) && FormatValidator.hasValue(filterValue)) {
             isPublicOnly = filterCategory.isPublicOnly(filterValue);
+            isAnsweredOnly = filterCategory.isAnsweredOnly(filterValue);
             if (filterCategory.isMineFiltered(filterValue)) {
                 userIdFilter = userId;
             }
@@ -169,6 +181,7 @@ public class PostPersistenceAdapter implements SavePostPort, FindPostPort, Updat
                 targetGroupId,
                 isPublicOnly,
                 userIdFilter,
+                isAnsweredOnly,
                 searchInTitle,
                 searchInContent,
                 searchKeywordPattern,
@@ -177,12 +190,23 @@ public class PostPersistenceAdapter implements SavePostPort, FindPostPort, Updat
     }
 
     @Override
-    public long countUserPosts(Long userId, Board board, PostSearchTarget searchTarget, String searchKeyword) {
+    public long countUserPosts(
+            Long userId,
+            Board board,
+            PostFilterCategory filterCategory,
+            PostFilterValue filterValue,
+            PostSearchTarget searchTarget,
+            String searchKeyword
+    ) {
         boolean searchInTitle = shouldSearchIn(searchTarget, PostSearchTarget.TITLE);
         boolean searchInContent = shouldSearchIn(searchTarget, PostSearchTarget.CONTENT);
         String searchKeywordPattern = buildSearchPattern(searchKeyword);
+        boolean isAnsweredOnly = FormatValidator.hasValue(filterCategory)
+                && FormatValidator.hasValue(filterValue)
+                && filterCategory.isAnsweredOnly(filterValue);
+
         return postJpaRepository.countByUserIdAndBoard(
-                userId, board, searchInTitle, searchInContent, searchKeywordPattern, EntityStatus.ACTIVE
+                userId, board, isAnsweredOnly, searchInTitle, searchInContent, searchKeywordPattern, EntityStatus.ACTIVE
         );
     }
 

--- a/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/out/persistence/post/repository/PostJpaRepository.java
+++ b/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/out/persistence/post/repository/PostJpaRepository.java
@@ -28,6 +28,10 @@ public interface PostJpaRepository extends JpaRepository<PostJpaEntity, Long> {
               )
               AND (:filterUserId IS NULL OR p.userId = :filterUserId)
               AND (
+                :isAnsweredOnly = false
+                OR EXISTS (SELECT 1 FROM PostJpaEntity c WHERE c.parentId = p.id AND c.status = :status)
+              )
+              AND (
                     :searchKeywordPattern IS NULL
                  OR (
                         :searchInTitle = true
@@ -53,6 +57,7 @@ public interface PostJpaRepository extends JpaRepository<PostJpaEntity, Long> {
             @Param("isDesc") boolean isDesc,
             @Param("isPublicOnly") Boolean isPublicOnly,
             @Param("filterUserId") Long filterUserId,
+            @Param("isAnsweredOnly") boolean isAnsweredOnly,
             @Param("searchInTitle") boolean searchInTitle,
             @Param("searchInContent") boolean searchInContent,
             @Param("searchKeywordPattern") String searchKeywordPattern,
@@ -76,6 +81,10 @@ public interface PostJpaRepository extends JpaRepository<PostJpaEntity, Long> {
               )
               AND (:filterUserId IS NULL OR p.userId = :filterUserId)
               AND (
+                :isAnsweredOnly = false
+                OR EXISTS (SELECT 1 FROM PostJpaEntity c WHERE c.parentId = p.id AND c.status = :status)
+              )
+              AND (
                     :searchKeywordPattern IS NULL
                  OR (
                         :searchInTitle = true
@@ -94,6 +103,7 @@ public interface PostJpaRepository extends JpaRepository<PostJpaEntity, Long> {
             @Param("targetGroupId") Long targetGroupId,
             @Param("isPublicOnly") Boolean isPublicOnly,
             @Param("filterUserId") Long filterUserId,
+            @Param("isAnsweredOnly") boolean isAnsweredOnly,
             @Param("searchInTitle") boolean searchInTitle,
             @Param("searchInContent") boolean searchInContent,
             @Param("searchKeywordPattern") String searchKeywordPattern,
@@ -107,6 +117,10 @@ public interface PostJpaRepository extends JpaRepository<PostJpaEntity, Long> {
               AND p.board = :board
               AND p.userId = :userId
               AND p.parentId IS NULL
+              AND (
+                :isAnsweredOnly = false
+                OR EXISTS (SELECT 1 FROM PostJpaEntity c WHERE c.parentId = p.id AND c.status = :status)
+              )
               AND (
                     :searchKeywordPattern IS NULL
                  OR (
@@ -122,6 +136,7 @@ public interface PostJpaRepository extends JpaRepository<PostJpaEntity, Long> {
     long countByUserIdAndBoard(
             @Param("userId") Long userId,
             @Param("board") Board board,
+            @Param("isAnsweredOnly") boolean isAnsweredOnly,
             @Param("searchInTitle") boolean searchInTitle,
             @Param("searchInContent") boolean searchInContent,
             @Param("searchKeywordPattern") String searchKeywordPattern,
@@ -135,6 +150,10 @@ public interface PostJpaRepository extends JpaRepository<PostJpaEntity, Long> {
               AND p.board = :board
               AND p.userId = :userId
               AND p.parentId IS NULL
+              AND (
+                :isAnsweredOnly = false
+                OR EXISTS (SELECT 1 FROM PostJpaEntity c WHERE c.parentId = p.id AND c.status = :status)
+              )
               AND (
                     :searchKeywordPattern IS NULL
                  OR (
@@ -157,6 +176,7 @@ public interface PostJpaRepository extends JpaRepository<PostJpaEntity, Long> {
             @Param("board") Board board,
             @Param("cursor") Long cursor,
             @Param("isDesc") boolean isDesc,
+            @Param("isAnsweredOnly") boolean isAnsweredOnly,
             @Param("searchInTitle") boolean searchInTitle,
             @Param("searchInContent") boolean searchInContent,
             @Param("searchKeywordPattern") String searchKeywordPattern,
@@ -179,6 +199,10 @@ public interface PostJpaRepository extends JpaRepository<PostJpaEntity, Long> {
                 OR (:isPublicOnly = false)
               )
               AND (:filterUserId IS NULL OR p.userId = :filterUserId)
+              AND (
+                :isAnsweredOnly = false
+                OR EXISTS (SELECT 1 FROM PostJpaEntity c WHERE c.parentId = p.id AND c.status = :status)
+              )
               AND (
                     :searchKeywordPattern IS NULL
                  OR (
@@ -210,6 +234,7 @@ public interface PostJpaRepository extends JpaRepository<PostJpaEntity, Long> {
             @Param("isDesc") boolean isDesc,
             @Param("isPublicOnly") Boolean isPublicOnly,
             @Param("filterUserId") Long filterUserId,
+            @Param("isAnsweredOnly") boolean isAnsweredOnly,
             @Param("searchInTitle") boolean searchInTitle,
             @Param("searchInContent") boolean searchInContent,
             @Param("searchKeywordPattern") String searchKeywordPattern,
@@ -224,6 +249,10 @@ public interface PostJpaRepository extends JpaRepository<PostJpaEntity, Long> {
               AND p.board = :board
               AND p.userId = :userId
               AND p.parentId IS NULL
+              AND (
+                :isAnsweredOnly = false
+                OR EXISTS (SELECT 1 FROM PostJpaEntity c WHERE c.parentId = p.id AND c.status = :status)
+              )
               AND (
                     :searchKeywordPattern IS NULL
                  OR (
@@ -251,6 +280,7 @@ public interface PostJpaRepository extends JpaRepository<PostJpaEntity, Long> {
             @Param("board") Board board,
             @Param("cursor") Long cursor,
             @Param("isDesc") boolean isDesc,
+            @Param("isAnsweredOnly") boolean isAnsweredOnly,
             @Param("searchInTitle") boolean searchInTitle,
             @Param("searchInContent") boolean searchInContent,
             @Param("searchKeywordPattern") String searchKeywordPattern,

--- a/community-service/community-application/src/main/java/com/personal/marketnote/community/port/out/post/FindPostPort.java
+++ b/community-service/community-application/src/main/java/com/personal/marketnote/community/port/out/post/FindPostPort.java
@@ -64,6 +64,8 @@ public interface FindPostPort {
      * @param pageable      페이지네이션 정보
      * @param isDesc        내림차순 여부
      * @param sortProperty  정렬 속성
+     * @param filter        필터 카테고리
+     * @param filterValue   필터 값
      * @param searchTarget  검색 키워드 카테고리
      * @param searchKeyword 검색 키워드
      * @return 게시글 목록 {@link Posts}
@@ -78,6 +80,8 @@ public interface FindPostPort {
             Pageable pageable,
             boolean isDesc,
             PostSortProperty sortProperty,
+            PostFilterCategory filter,
+            PostFilterValue filterValue,
             PostSearchTarget searchTarget,
             String searchKeyword
     );
@@ -112,6 +116,8 @@ public interface FindPostPort {
     /**
      * @param userId        회원 ID
      * @param board         게시판
+     * @param filter        필터 카테고리
+     * @param filterValue   필터 값
      * @param searchTarget  검색 키워드 카테고리
      * @param searchKeyword 검색 키워드
      * @return 게시글 개수 {@link long}
@@ -119,7 +125,14 @@ public interface FindPostPort {
      * @Author 성효빈
      * @Description 회원 게시판 게시글 개수를 조회합니다.
      */
-    long countUserPosts(Long userId, Board board, PostSearchTarget searchTarget, String searchKeyword);
+    long countUserPosts(
+            Long userId,
+            Board board,
+            PostFilterCategory filter,
+            PostFilterValue filterValue,
+            PostSearchTarget searchTarget,
+            String searchKeyword
+    );
 
     /**
      * @param userId       회원 ID

--- a/community-service/community-application/src/main/java/com/personal/marketnote/community/service/post/GetPostService.java
+++ b/community-service/community-application/src/main/java/com/personal/marketnote/community/service/post/GetPostService.java
@@ -92,6 +92,8 @@ public class GetPostService implements GetPostUseCase {
                 pageable,
                 isDesc,
                 sortProperty,
+                query.filter(),
+                query.filterValue(),
                 query.searchTarget(),
                 query.searchKeyword()
         );
@@ -195,6 +197,8 @@ public class GetPostService implements GetPostUseCase {
         return findPostPort.countUserPosts(
                 userId,
                 board,
+                query.filter(),
+                query.filterValue(),
                 searchTarget,
                 searchKeyword
         );

--- a/community-service/community-application/src/main/java/com/personal/marketnote/community/service/post/GetUserOneOnOneInquiryPostsService.java
+++ b/community-service/community-application/src/main/java/com/personal/marketnote/community/service/post/GetUserOneOnOneInquiryPostsService.java
@@ -46,7 +46,7 @@ public class GetUserOneOnOneInquiryPostsService implements GetUserOneOnOneInquir
         );
 
         long totalElements = findPostPort.countUserPosts(
-                command.userId(), Board.ONE_ON_ONE_INQUERY, null, null
+                command.userId(), Board.ONE_ON_ONE_INQUERY, null, null, null, null
         );
 
         int totalPages = computeTotalPages(totalElements, command.pageSize());

--- a/community-service/community-application/src/main/java/com/personal/marketnote/community/service/post/GetUserProductInquiryPostsService.java
+++ b/community-service/community-application/src/main/java/com/personal/marketnote/community/service/post/GetUserProductInquiryPostsService.java
@@ -51,7 +51,7 @@ public class GetUserProductInquiryPostsService implements GetUserProductInquiryP
         );
 
         long totalElements = findPostPort.countUserPosts(
-                command.userId(), Board.PRODUCT_INQUERY, null, null
+                command.userId(), Board.PRODUCT_INQUERY, null, null, null, null
         );
 
         int totalPages = computeTotalPages(totalElements, command.pageSize());

--- a/community-service/community-application/src/test/java/com/personal/marketnote/community/service/post/GetPostsUseCaseTest.java
+++ b/community-service/community-application/src/test/java/com/personal/marketnote/community/service/post/GetPostsUseCaseTest.java
@@ -279,12 +279,12 @@ class GetPostsUseCaseTest {
                 .cursor(null)
                 .build();
         mockUserPosts(emptyPosts());
-        when(findPostPort.countUserPosts(any(), any(), any(), any())).thenReturn(99L);
+        when(findPostPort.countUserPosts(any(), any(), any(), any(), any(), any())).thenReturn(99L);
 
         GetPostsResult result = getPostService.getPosts(query);
 
         assertThat(result.totalElements()).isEqualTo(99L);
-        verify(findPostPort).countUserPosts(any(), any(), any(), any());
+        verify(findPostPort).countUserPosts(any(), any(), any(), any(), any(), any());
     }
 
     @Test
@@ -644,7 +644,7 @@ class GetPostsUseCaseTest {
         GetPostsQuery query = userQuery().build();
         RuntimeException exception = new RuntimeException("database error");
         when(findPostPort.findUserPosts(
-                any(), any(), any(), any(), anyBoolean(), any(), any(), any()
+                any(), any(), any(), any(), anyBoolean(), any(), any(), any(), any(), any()
         )).thenThrow(exception);
 
         assertThatThrownBy(() -> getPostService.getPosts(query))
@@ -886,7 +886,7 @@ class GetPostsUseCaseTest {
 
     private void mockUserPosts(Posts posts) {
         when(findPostPort.findUserPosts(
-                any(), any(), any(), any(), anyBoolean(), any(), any(), any()
+                any(), any(), any(), any(), anyBoolean(), any(), any(), any(), any(), any()
         )).thenReturn(posts);
     }
 
@@ -908,7 +908,7 @@ class GetPostsUseCaseTest {
     private Pageable captureUserPostsPageable() {
         ArgumentCaptor<Pageable> captor = ArgumentCaptor.forClass(Pageable.class);
         verify(findPostPort).findUserPosts(
-                any(), any(), any(), captor.capture(), anyBoolean(), any(), any(), any()
+                any(), any(), any(), captor.capture(), anyBoolean(), any(), any(), any(), any(), any()
         );
         return captor.getValue();
     }
@@ -929,13 +929,13 @@ class GetPostsUseCaseTest {
 
     private void verifyUserPostsCalled() {
         verify(findPostPort).findUserPosts(
-                any(), any(), any(), any(), anyBoolean(), any(), any(), any()
+                any(), any(), any(), any(), anyBoolean(), any(), any(), any(), any(), any()
         );
     }
 
     private void verifyUserPostsNeverCalled() {
         verify(findPostPort, never()).findUserPosts(
-                any(), any(), any(), any(), anyBoolean(), any(), any(), any()
+                any(), any(), any(), any(), anyBoolean(), any(), any(), any(), any(), any()
         );
     }
 }

--- a/community-service/community-application/src/test/java/com/personal/marketnote/community/service/post/GetUserOneOnOneInquiryPostsUseCaseTest.java
+++ b/community-service/community-application/src/test/java/com/personal/marketnote/community/service/post/GetUserOneOnOneInquiryPostsUseCaseTest.java
@@ -50,7 +50,7 @@ class GetUserOneOnOneInquiryPostsUseCaseTest {
                 buildOneOnOneInquiryPost(2L, userId)
         ));
         mockFindUserPostsByOffset(posts);
-        when(findPostPort.countUserPosts(userId, Board.ONE_ON_ONE_INQUERY, null, null)).thenReturn(2L);
+        when(findPostPort.countUserPosts(userId, Board.ONE_ON_ONE_INQUERY, null, null, null, null)).thenReturn(2L);
 
         // when
         GetUserOneOnOneInquiryPostsResult result = getUserOneOnOneInquiryPostsService.getUserOneOnOneInquiryPosts(command);
@@ -71,7 +71,7 @@ class GetUserOneOnOneInquiryPostsUseCaseTest {
                 1L, 1, 10, Sort.Direction.DESC, PostSortProperty.ID
         );
         mockFindUserPostsByOffset(emptyPosts());
-        when(findPostPort.countUserPosts(1L, Board.ONE_ON_ONE_INQUERY, null, null)).thenReturn(0L);
+        when(findPostPort.countUserPosts(1L, Board.ONE_ON_ONE_INQUERY, null, null, null, null)).thenReturn(0L);
 
         // when
         GetUserOneOnOneInquiryPostsResult result = getUserOneOnOneInquiryPostsService.getUserOneOnOneInquiryPosts(command);
@@ -97,7 +97,7 @@ class GetUserOneOnOneInquiryPostsUseCaseTest {
                 buildOneOnOneInquiryPost(3L, 1L)
         ));
         mockFindUserPostsByOffset(posts);
-        when(findPostPort.countUserPosts(1L, Board.ONE_ON_ONE_INQUERY, null, null)).thenReturn(7L);
+        when(findPostPort.countUserPosts(1L, Board.ONE_ON_ONE_INQUERY, null, null, null, null)).thenReturn(7L);
 
         // when
         GetUserOneOnOneInquiryPostsResult result = getUserOneOnOneInquiryPostsService.getUserOneOnOneInquiryPosts(command);
@@ -114,7 +114,7 @@ class GetUserOneOnOneInquiryPostsUseCaseTest {
                 1L, 2, 5, Sort.Direction.ASC, PostSortProperty.ID
         );
         mockFindUserPostsByOffset(emptyPosts());
-        when(findPostPort.countUserPosts(1L, Board.ONE_ON_ONE_INQUERY, null, null)).thenReturn(10L);
+        when(findPostPort.countUserPosts(1L, Board.ONE_ON_ONE_INQUERY, null, null, null, null)).thenReturn(10L);
 
         // when
         GetUserOneOnOneInquiryPostsResult result = getUserOneOnOneInquiryPostsService.getUserOneOnOneInquiryPosts(command);
@@ -136,7 +136,7 @@ class GetUserOneOnOneInquiryPostsUseCaseTest {
                 userId, 1, 10, Sort.Direction.DESC, PostSortProperty.ID
         );
         mockFindUserPostsByOffset(emptyPosts());
-        when(findPostPort.countUserPosts(userId, Board.ONE_ON_ONE_INQUERY, null, null)).thenReturn(0L);
+        when(findPostPort.countUserPosts(userId, Board.ONE_ON_ONE_INQUERY, null, null, null, null)).thenReturn(0L);
 
         // when
         getUserOneOnOneInquiryPostsService.getUserOneOnOneInquiryPosts(command);
@@ -156,13 +156,13 @@ class GetUserOneOnOneInquiryPostsUseCaseTest {
                 userId, 1, 10, Sort.Direction.DESC, PostSortProperty.ID
         );
         mockFindUserPostsByOffset(emptyPosts());
-        when(findPostPort.countUserPosts(userId, Board.ONE_ON_ONE_INQUERY, null, null)).thenReturn(0L);
+        when(findPostPort.countUserPosts(userId, Board.ONE_ON_ONE_INQUERY, null, null, null, null)).thenReturn(0L);
 
         // when
         getUserOneOnOneInquiryPostsService.getUserOneOnOneInquiryPosts(command);
 
         // then
-        verify(findPostPort).countUserPosts(userId, Board.ONE_ON_ONE_INQUERY, null, null);
+        verify(findPostPort).countUserPosts(userId, Board.ONE_ON_ONE_INQUERY, null, null, null, null);
     }
 
     // ========== D. 이미지 ==========
@@ -178,7 +178,7 @@ class GetUserOneOnOneInquiryPostsUseCaseTest {
         Post photoPost = buildPhotoOneOnOneInquiryPost(1L, userId);
         Posts posts = Posts.from(List.of(photoPost));
         mockFindUserPostsByOffset(posts);
-        when(findPostPort.countUserPosts(userId, Board.ONE_ON_ONE_INQUERY, null, null)).thenReturn(1L);
+        when(findPostPort.countUserPosts(userId, Board.ONE_ON_ONE_INQUERY, null, null, null, null)).thenReturn(1L);
         GetFileResult fileResult = new GetFileResult(
                 1L, "POST_IMAGE", "jpg", "image.jpg", "https://s3/image.jpg", List.of(), 1L
         );
@@ -203,7 +203,7 @@ class GetUserOneOnOneInquiryPostsUseCaseTest {
         );
         Posts posts = Posts.from(List.of(buildOneOnOneInquiryPost(1L, userId)));
         mockFindUserPostsByOffset(posts);
-        when(findPostPort.countUserPosts(userId, Board.ONE_ON_ONE_INQUERY, null, null)).thenReturn(1L);
+        when(findPostPort.countUserPosts(userId, Board.ONE_ON_ONE_INQUERY, null, null, null, null)).thenReturn(1L);
 
         // when
         getUserOneOnOneInquiryPostsService.getUserOneOnOneInquiryPosts(command);
@@ -227,7 +227,7 @@ class GetUserOneOnOneInquiryPostsUseCaseTest {
         parentPost.addReplies(List.of(replyPost));
         Posts posts = Posts.from(List.of(parentPost));
         mockFindUserPostsByOffset(posts);
-        when(findPostPort.countUserPosts(userId, Board.ONE_ON_ONE_INQUERY, null, null)).thenReturn(1L);
+        when(findPostPort.countUserPosts(userId, Board.ONE_ON_ONE_INQUERY, null, null, null, null)).thenReturn(1L);
 
         // when
         GetUserOneOnOneInquiryPostsResult result = getUserOneOnOneInquiryPostsService.getUserOneOnOneInquiryPosts(command);
@@ -249,7 +249,7 @@ class GetUserOneOnOneInquiryPostsUseCaseTest {
                 userId, 1, 10, Sort.Direction.ASC, PostSortProperty.ID
         );
         mockFindUserPostsByOffset(emptyPosts());
-        when(findPostPort.countUserPosts(userId, Board.ONE_ON_ONE_INQUERY, null, null)).thenReturn(0L);
+        when(findPostPort.countUserPosts(userId, Board.ONE_ON_ONE_INQUERY, null, null, null, null)).thenReturn(0L);
 
         // when
         getUserOneOnOneInquiryPostsService.getUserOneOnOneInquiryPosts(command);

--- a/community-service/community-application/src/test/java/com/personal/marketnote/community/service/post/GetUserProductInquiryPostsUseCaseTest.java
+++ b/community-service/community-application/src/test/java/com/personal/marketnote/community/service/post/GetUserProductInquiryPostsUseCaseTest.java
@@ -55,7 +55,7 @@ class GetUserProductInquiryPostsUseCaseTest {
                 buildProductInquiryPost(2L, userId, 200L)
         ));
         mockFindUserPostsByOffset(posts);
-        when(findPostPort.countUserPosts(userId, Board.PRODUCT_INQUERY, null, null)).thenReturn(2L);
+        when(findPostPort.countUserPosts(userId, Board.PRODUCT_INQUERY, null, null, null, null)).thenReturn(2L);
         mockProductInfoPort(Map.of());
 
         // when
@@ -77,7 +77,7 @@ class GetUserProductInquiryPostsUseCaseTest {
                 1L, 1, 10, Sort.Direction.DESC, PostSortProperty.ID
         );
         mockFindUserPostsByOffset(emptyPosts());
-        when(findPostPort.countUserPosts(1L, Board.PRODUCT_INQUERY, null, null)).thenReturn(0L);
+        when(findPostPort.countUserPosts(1L, Board.PRODUCT_INQUERY, null, null, null, null)).thenReturn(0L);
 
         // when
         GetUserProductInquiryPostsResult result = getUserProductInquiryPostsService.getUserProductInquiryPosts(command);
@@ -103,7 +103,7 @@ class GetUserProductInquiryPostsUseCaseTest {
                 buildProductInquiryPost(3L, 1L, 300L)
         ));
         mockFindUserPostsByOffset(posts);
-        when(findPostPort.countUserPosts(1L, Board.PRODUCT_INQUERY, null, null)).thenReturn(7L);
+        when(findPostPort.countUserPosts(1L, Board.PRODUCT_INQUERY, null, null, null, null)).thenReturn(7L);
         mockProductInfoPort(Map.of());
 
         // when
@@ -121,7 +121,7 @@ class GetUserProductInquiryPostsUseCaseTest {
                 1L, 2, 5, Sort.Direction.ASC, PostSortProperty.ID
         );
         mockFindUserPostsByOffset(emptyPosts());
-        when(findPostPort.countUserPosts(1L, Board.PRODUCT_INQUERY, null, null)).thenReturn(10L);
+        when(findPostPort.countUserPosts(1L, Board.PRODUCT_INQUERY, null, null, null, null)).thenReturn(10L);
 
         // when
         GetUserProductInquiryPostsResult result = getUserProductInquiryPostsService.getUserProductInquiryPosts(command);
@@ -143,7 +143,7 @@ class GetUserProductInquiryPostsUseCaseTest {
                 userId, 1, 10, Sort.Direction.DESC, PostSortProperty.ID
         );
         mockFindUserPostsByOffset(emptyPosts());
-        when(findPostPort.countUserPosts(userId, Board.PRODUCT_INQUERY, null, null)).thenReturn(0L);
+        when(findPostPort.countUserPosts(userId, Board.PRODUCT_INQUERY, null, null, null, null)).thenReturn(0L);
 
         // when
         getUserProductInquiryPostsService.getUserProductInquiryPosts(command);
@@ -163,13 +163,13 @@ class GetUserProductInquiryPostsUseCaseTest {
                 userId, 1, 10, Sort.Direction.DESC, PostSortProperty.ID
         );
         mockFindUserPostsByOffset(emptyPosts());
-        when(findPostPort.countUserPosts(userId, Board.PRODUCT_INQUERY, null, null)).thenReturn(0L);
+        when(findPostPort.countUserPosts(userId, Board.PRODUCT_INQUERY, null, null, null, null)).thenReturn(0L);
 
         // when
         getUserProductInquiryPostsService.getUserProductInquiryPosts(command);
 
         // then
-        verify(findPostPort).countUserPosts(userId, Board.PRODUCT_INQUERY, null, null);
+        verify(findPostPort).countUserPosts(userId, Board.PRODUCT_INQUERY, null, null, null, null);
     }
 
     // ========== D. 상품 정보 ==========
@@ -185,7 +185,7 @@ class GetUserProductInquiryPostsUseCaseTest {
         );
         Posts posts = Posts.from(List.of(buildProductInquiryPost(1L, userId, targetId)));
         mockFindUserPostsByOffset(posts);
-        when(findPostPort.countUserPosts(userId, Board.PRODUCT_INQUERY, null, null)).thenReturn(1L);
+        when(findPostPort.countUserPosts(userId, Board.PRODUCT_INQUERY, null, null, null, null)).thenReturn(1L);
         ProductInfoResult productInfo = buildProductInfo(999L);
         when(findProductByPricePolicyPort.findByPricePolicyIds(List.of(targetId)))
                 .thenReturn(Map.of(targetId, productInfo));
@@ -209,7 +209,7 @@ class GetUserProductInquiryPostsUseCaseTest {
         );
         Posts posts = Posts.from(List.of(buildProductInquiryPostWithoutTarget(1L, userId)));
         mockFindUserPostsByOffset(posts);
-        when(findPostPort.countUserPosts(userId, Board.PRODUCT_INQUERY, null, null)).thenReturn(1L);
+        when(findPostPort.countUserPosts(userId, Board.PRODUCT_INQUERY, null, null, null, null)).thenReturn(1L);
         mockProductInfoPort(Map.of());
 
         // when
@@ -233,7 +233,7 @@ class GetUserProductInquiryPostsUseCaseTest {
         Post photoPost = buildPhotoProductInquiryPost(1L, userId, 100L);
         Posts posts = Posts.from(List.of(photoPost));
         mockFindUserPostsByOffset(posts);
-        when(findPostPort.countUserPosts(userId, Board.PRODUCT_INQUERY, null, null)).thenReturn(1L);
+        when(findPostPort.countUserPosts(userId, Board.PRODUCT_INQUERY, null, null, null, null)).thenReturn(1L);
         mockProductInfoPort(Map.of());
         GetFileResult fileResult = new GetFileResult(
                 1L, "POST_IMAGE", "jpg", "image.jpg", "https://s3/image.jpg", List.of(), 1L
@@ -259,7 +259,7 @@ class GetUserProductInquiryPostsUseCaseTest {
         );
         Posts posts = Posts.from(List.of(buildProductInquiryPost(1L, userId, 100L)));
         mockFindUserPostsByOffset(posts);
-        when(findPostPort.countUserPosts(userId, Board.PRODUCT_INQUERY, null, null)).thenReturn(1L);
+        when(findPostPort.countUserPosts(userId, Board.PRODUCT_INQUERY, null, null, null, null)).thenReturn(1L);
         mockProductInfoPort(Map.of());
 
         // when
@@ -285,7 +285,7 @@ class GetUserProductInquiryPostsUseCaseTest {
         parentPost.addReplies(List.of(replyPost));
         Posts posts = Posts.from(List.of(parentPost));
         mockFindUserPostsByOffset(posts);
-        when(findPostPort.countUserPosts(userId, Board.PRODUCT_INQUERY, null, null)).thenReturn(1L);
+        when(findPostPort.countUserPosts(userId, Board.PRODUCT_INQUERY, null, null, null, null)).thenReturn(1L);
         mockProductInfoPort(Map.of());
 
         // when
@@ -311,7 +311,7 @@ class GetUserProductInquiryPostsUseCaseTest {
                 buildProductInquiryPostWithWriterName(1L, userId, 100L, "작성자이름")
         ));
         mockFindUserPostsByOffset(posts);
-        when(findPostPort.countUserPosts(userId, Board.PRODUCT_INQUERY, null, null)).thenReturn(1L);
+        when(findPostPort.countUserPosts(userId, Board.PRODUCT_INQUERY, null, null, null, null)).thenReturn(1L);
         mockProductInfoPort(Map.of());
 
         // when
@@ -334,7 +334,7 @@ class GetUserProductInquiryPostsUseCaseTest {
                 buildProductInquiryPostWithWriterName(1L, userId, 100L, "작성자이름")
         ));
         mockFindUserPostsByOffset(posts);
-        when(findPostPort.countUserPosts(userId, Board.PRODUCT_INQUERY, null, null)).thenReturn(1L);
+        when(findPostPort.countUserPosts(userId, Board.PRODUCT_INQUERY, null, null, null, null)).thenReturn(1L);
         mockProductInfoPort(Map.of());
 
         // when
@@ -362,7 +362,7 @@ class GetUserProductInquiryPostsUseCaseTest {
                 userId, 1, 10, Sort.Direction.ASC, PostSortProperty.ID
         );
         mockFindUserPostsByOffset(emptyPosts());
-        when(findPostPort.countUserPosts(userId, Board.PRODUCT_INQUERY, null, null)).thenReturn(0L);
+        when(findPostPort.countUserPosts(userId, Board.PRODUCT_INQUERY, null, null, null, null)).thenReturn(0L);
 
         // when
         getUserProductInquiryPostsService.getUserProductInquiryPosts(command);

--- a/community-service/community-domain/src/main/java/com/personal/marketnote/community/domain/post/PostFilterCategory.java
+++ b/community-service/community-domain/src/main/java/com/personal/marketnote/community/domain/post/PostFilterCategory.java
@@ -6,7 +6,8 @@ import lombok.Getter;
 @Getter
 public enum PostFilterCategory {
     IS_PUBLIC("비밀글 여부"),
-    IS_MINE("내 문의글 여부");
+    IS_MINE("내 문의글 여부"),
+    IS_ANSWERED("답변 완료 여부");
 
     private final String description;
     private final String camelCaseValue;
@@ -30,5 +31,13 @@ public enum PostFilterCategory {
 
     private boolean isMine() {
         return this == PostFilterCategory.IS_MINE;
+    }
+
+    public boolean isAnsweredOnly(PostFilterValue filterValue) {
+        return isAnswered() && filterValue.isTrue();
+    }
+
+    private boolean isAnswered() {
+        return this == PostFilterCategory.IS_ANSWERED;
     }
 }


### PR DESCRIPTION
## partially addresses #216
## resolves #2241

## Task
- [x] ReturnTracker 생성 시 초기 상태 PENDING 검증
- [x] ReturnTracker 생성 시 orderId 누락 예외 검증
- [x] ReturnTracker returnSlipNumber null 허용 검증
- [x] SnapshotState 복원 시 전체 필드 매핑 검증
- [x] ReturnInspectionStatus 상태 전이 성공/실패 검증
- [x] ReturnRefundStatus 상태 전이 성공/실패 검증
- [x] passInspection 시 inspectedAt 설정 검증
- [x] holdInspection 시 inspectedAt 미설정 검증
- [x] completeRefund 시 refundedAt 설정 검증
- [x] retryRefund 시 refundedAt null 초기화 검증
- [x] 술어 메서드 검증
- [x] ReturnTracker 저장/조회 통합 테스트
- [x] findByOrderId 조회 통합 테스트
- [x] findByInspectionStatus(PENDING) 조회 통합 테스트
- [x] order_id UNIQUE 제약 위반 시 예외 통합 테스트
- [x] 검수/환불 상태 업데이트 통합 테스트