### PR TITLE
[#1][#2478] fix: Gradle Configuration Cache 호환 printProjectName/printProjectVersion 태스크 수정

### DIFF
--- a/commerce-service/commerce-adapters/build.gradle.kts
+++ b/commerce-service/commerce-adapters/build.gradle.kts
@@ -136,14 +136,16 @@ tasks.withType<JavaCompile>().configureEach {
 }
 
 tasks.register("printProjectName") {
+    val name = serviceName
     doLast {
-        println(serviceName)
+        println(name)
     }
 }
 
 tasks.register("printProjectVersion") {
+    val ver = version.toString()
     doLast {
-        println(version)
+        println(ver)
     }
 }
 

--- a/commerce-service/commerce-application/build.gradle.kts
+++ b/commerce-service/commerce-application/build.gradle.kts
@@ -121,14 +121,16 @@ springBoot {
 }
 
 tasks.register("printProjectName") {
+    val name = project.name
     doLast {
-        println(project.name)
+        println(name)
     }
 }
 
 tasks.register("printProjectVersion") {
+    val ver = version.toString()
     doLast {
-        println(version)
+        println(ver)
     }
 }
 

--- a/commerce-service/commerce-domain/build.gradle.kts
+++ b/commerce-service/commerce-domain/build.gradle.kts
@@ -119,14 +119,16 @@ springBoot {
 }
 
 tasks.register("printProjectName") {
+    val name = project.name
     doLast {
-        println(project.name)
+        println(name)
     }
 }
 
 tasks.register("printProjectVersion") {
+    val ver = version.toString()
     doLast {
-        println(version)
+        println(ver)
     }
 }
 

--- a/community-service/community-adapters/build.gradle.kts
+++ b/community-service/community-adapters/build.gradle.kts
@@ -133,14 +133,16 @@ tasks.withType<JavaCompile>().configureEach {
 }
 
 tasks.register("printProjectName") {
+    val name = serviceName
     doLast {
-        println(serviceName)
+        println(name)
     }
 }
 
 tasks.register("printProjectVersion") {
+    val ver = version.toString()
     doLast {
-        println(version)
+        println(ver)
     }
 }
 

--- a/community-service/community-application/build.gradle.kts
+++ b/community-service/community-application/build.gradle.kts
@@ -121,14 +121,16 @@ springBoot {
 }
 
 tasks.register("printProjectName") {
+    val name = project.name
     doLast {
-        println(project.name)
+        println(name)
     }
 }
 
 tasks.register("printProjectVersion") {
+    val ver = version.toString()
     doLast {
-        println(version)
+        println(ver)
     }
 }
 

--- a/community-service/community-domain/build.gradle.kts
+++ b/community-service/community-domain/build.gradle.kts
@@ -119,14 +119,16 @@ springBoot {
 }
 
 tasks.register("printProjectName") {
+    val name = project.name
     doLast {
-        println(project.name)
+        println(name)
     }
 }
 
 tasks.register("printProjectVersion") {
+    val ver = version.toString()
     doLast {
-        println(version)
+        println(ver)
     }
 }
 

--- a/file-service/file-adapters/build.gradle.kts
+++ b/file-service/file-adapters/build.gradle.kts
@@ -145,14 +145,16 @@ tasks.withType<JavaCompile>().configureEach {
 }
 
 tasks.register("printProjectName") {
+    val name = serviceName
     doLast {
-        println(serviceName)
+        println(name)
     }
 }
 
 tasks.register("printProjectVersion") {
+    val ver = version.toString()
     doLast {
-        println(version)
+        println(ver)
     }
 }
 

--- a/file-service/file-application/build.gradle.kts
+++ b/file-service/file-application/build.gradle.kts
@@ -125,14 +125,16 @@ springBoot {
 }
 
 tasks.register("printProjectName") {
+    val name = project.name
     doLast {
-        println(project.name)
+        println(name)
     }
 }
 
 tasks.register("printProjectVersion") {
+    val ver = version.toString()
     doLast {
-        println(version)
+        println(ver)
     }
 }
 

--- a/file-service/file-domain/build.gradle.kts
+++ b/file-service/file-domain/build.gradle.kts
@@ -118,14 +118,16 @@ springBoot {
 }
 
 tasks.register("printProjectName") {
+    val name = project.name
     doLast {
-        println(project.name)
+        println(name)
     }
 }
 
 tasks.register("printProjectVersion") {
+    val ver = version.toString()
     doLast {
-        println(version)
+        println(ver)
     }
 }
 

--- a/fulfillment-service/fulfillment-adapters/build.gradle.kts
+++ b/fulfillment-service/fulfillment-adapters/build.gradle.kts
@@ -130,14 +130,16 @@ tasks.withType<JavaCompile>().configureEach {
 }
 
 tasks.register("printProjectName") {
+    val name = serviceName
     doLast {
-        println(serviceName)
+        println(name)
     }
 }
 
 tasks.register("printProjectVersion") {
+    val ver = version.toString()
     doLast {
-        println(version)
+        println(ver)
     }
 }
 

--- a/fulfillment-service/fulfillment-application/build.gradle.kts
+++ b/fulfillment-service/fulfillment-application/build.gradle.kts
@@ -121,14 +121,16 @@ springBoot {
 }
 
 tasks.register("printProjectName") {
+    val name = project.name
     doLast {
-        println(project.name)
+        println(name)
     }
 }
 
 tasks.register("printProjectVersion") {
+    val ver = version.toString()
     doLast {
-        println(version)
+        println(ver)
     }
 }
 

--- a/fulfillment-service/fulfillment-domain/build.gradle.kts
+++ b/fulfillment-service/fulfillment-domain/build.gradle.kts
@@ -119,14 +119,16 @@ springBoot {
 }
 
 tasks.register("printProjectName") {
+    val name = project.name
     doLast {
-        println(project.name)
+        println(name)
     }
 }
 
 tasks.register("printProjectVersion") {
+    val ver = version.toString()
     doLast {
-        println(version)
+        println(ver)
     }
 }
 

--- a/product-service/product-adapters/build.gradle.kts
+++ b/product-service/product-adapters/build.gradle.kts
@@ -145,14 +145,16 @@ tasks.withType<JavaCompile>().configureEach {
 }
 
 tasks.register("printProjectName") {
+    val name = serviceName
     doLast {
-        println(serviceName)
+        println(name)
     }
 }
 
 tasks.register("printProjectVersion") {
+    val ver = version.toString()
     doLast {
-        println(version)
+        println(ver)
     }
 }
 

--- a/product-service/product-application/build.gradle.kts
+++ b/product-service/product-application/build.gradle.kts
@@ -121,14 +121,16 @@ springBoot {
 }
 
 tasks.register("printProjectName") {
+    val name = project.name
     doLast {
-        println(project.name)
+        println(name)
     }
 }
 
 tasks.register("printProjectVersion") {
+    val ver = version.toString()
     doLast {
-        println(version)
+        println(ver)
     }
 }
 

--- a/product-service/product-domain/build.gradle.kts
+++ b/product-service/product-domain/build.gradle.kts
@@ -119,14 +119,16 @@ springBoot {
 }
 
 tasks.register("printProjectName") {
+    val name = project.name
     doLast {
-        println(project.name)
+        println(name)
     }
 }
 
 tasks.register("printProjectVersion") {
+    val ver = version.toString()
     doLast {
-        println(version)
+        println(ver)
     }
 }
 

--- a/reward-service/reward-adapters/build.gradle.kts
+++ b/reward-service/reward-adapters/build.gradle.kts
@@ -133,14 +133,16 @@ tasks.withType<JavaCompile>().configureEach {
 }
 
 tasks.register("printProjectName") {
+    val name = serviceName
     doLast {
-        println(serviceName)
+        println(name)
     }
 }
 
 tasks.register("printProjectVersion") {
+    val ver = version.toString()
     doLast {
-        println(version)
+        println(ver)
     }
 }
 

--- a/reward-service/reward-application/build.gradle.kts
+++ b/reward-service/reward-application/build.gradle.kts
@@ -121,14 +121,16 @@ springBoot {
 }
 
 tasks.register("printProjectName") {
+    val name = project.name
     doLast {
-        println(project.name)
+        println(name)
     }
 }
 
 tasks.register("printProjectVersion") {
+    val ver = version.toString()
     doLast {
-        println(version)
+        println(ver)
     }
 }
 

--- a/reward-service/reward-domain/build.gradle.kts
+++ b/reward-service/reward-domain/build.gradle.kts
@@ -119,14 +119,16 @@ springBoot {
 }
 
 tasks.register("printProjectName") {
+    val name = project.name
     doLast {
-        println(project.name)
+        println(name)
     }
 }
 
 tasks.register("printProjectVersion") {
+    val ver = version.toString()
     doLast {
-        println(version)
+        println(ver)
     }
 }
 

--- a/user-service/user-adapters/build.gradle.kts
+++ b/user-service/user-adapters/build.gradle.kts
@@ -144,14 +144,16 @@ tasks.withType<JavaCompile>().configureEach {
 }
 
 tasks.register("printProjectName") {
+    val name = serviceName
     doLast {
-        println(serviceName)
+        println(name)
     }
 }
 
 tasks.register("printProjectVersion") {
+    val ver = version.toString()
     doLast {
-        println(version)
+        println(ver)
     }
 }
 

--- a/user-service/user-application/build.gradle.kts
+++ b/user-service/user-application/build.gradle.kts
@@ -134,14 +134,16 @@ springBoot {
 }
 
 tasks.register("printProjectName") {
+    val name = project.name
     doLast {
-        println(project.name)
+        println(name)
     }
 }
 
 tasks.register("printProjectVersion") {
+    val ver = version.toString()
     doLast {
-        println(version)
+        println(ver)
     }
 }
 

--- a/user-service/user-domain/build.gradle.kts
+++ b/user-service/user-domain/build.gradle.kts
@@ -123,14 +123,16 @@ springBoot {
 }
 
 tasks.register("printProjectName") {
+    val name = project.name
     doLast {
-        println(project.name)
+        println(name)
     }
 }
 
 tasks.register("printProjectVersion") {
+    val ver = version.toString()
     doLast {
-        println(version)
+        println(ver)
     }
 }
 


### PR DESCRIPTION
## partially addresses #1
## resolves #2478

## Task
- [x] 21개 build.gradle.kts 파일의 doLast 블록에서 빌드 스크립트 객체 참조를 configuration 시점 로컬 변수 캡처로 변경