### PR TITLE
[#216][#2367] feat: 반품 요청 시 반품 입고 추적 데이터 생성 기능 추가

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/web/fulfillment/FulfillmentServiceClient.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/web/fulfillment/FulfillmentServiceClient.java
@@ -4,6 +4,9 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.personal.marketnote.commerce.port.out.fulfillment.CancelFulfillmentReleasePort;
 import com.personal.marketnote.commerce.port.out.fulfillment.CancelFulfillmentReleaseResult;
 import com.personal.marketnote.commerce.port.out.fulfillment.GetFulfillmentWorkStatusPort;
+import com.personal.marketnote.commerce.port.out.fulfillment.RegisterFulfillmentReturnDeliveryCommand;
+import com.personal.marketnote.commerce.port.out.fulfillment.RegisterFulfillmentReturnDeliveryPort;
+import com.personal.marketnote.commerce.port.out.fulfillment.RegisterFulfillmentReturnDeliveryResult;
 import com.personal.marketnote.common.adapter.out.ServiceAdapter;
 import com.personal.marketnote.common.exception.FulfillmentServiceRequestFailedException;
 import com.personal.marketnote.common.security.hmac.HmacServiceAuthHeaderBuilder;
@@ -17,11 +20,13 @@ import org.springframework.web.util.UriComponentsBuilder;
 
 import java.io.IOException;
 import java.net.URI;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 @ServiceAdapter
 @Slf4j
-public class FulfillmentServiceClient implements GetFulfillmentWorkStatusPort, CancelFulfillmentReleasePort {
+public class FulfillmentServiceClient implements GetFulfillmentWorkStatusPort, CancelFulfillmentReleasePort, RegisterFulfillmentReturnDeliveryPort {
     private final RestClient restClient;
     private final String fulfillmentServiceBaseUrl;
     private final HmacServiceAuthHeaderBuilder hmacServiceAuthHeaderBuilder;
@@ -103,6 +108,85 @@ public class FulfillmentServiceClient implements GetFulfillmentWorkStatusPort, C
             log.error("풀필먼트 출고 취소 실패 - orderId: {}", orderId, e);
             throw new FulfillmentServiceRequestFailedException(new IOException(e));
         }
+    }
+
+    @Override
+    public RegisterFulfillmentReturnDeliveryResult registerReturnDelivery(RegisterFulfillmentReturnDeliveryCommand command) {
+        URI uri = buildReturnDeliveryUri();
+
+        Map<String, Object> body = buildReturnDeliveryBody(command);
+
+        try {
+            ResponseEntity<JsonNode> responseEntity = restClient.post()
+                    .uri(uri)
+                    .headers(headers -> hmacServiceAuthHeaderBuilder.applyHeaders(headers, "POST", uri.getPath()))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .body(body)
+                    .retrieve()
+                    .toEntity(JsonNode.class);
+
+            if (responseEntity.getStatusCode().isError()) {
+                throw new FulfillmentServiceRequestFailedException(
+                        new IOException("Fulfillment service returned error: " + responseEntity.getStatusCode()));
+            }
+
+            if (responseEntity.getStatusCode().is2xxSuccessful()
+                    && FormatValidator.hasValue(responseEntity.getBody())) {
+                JsonNode content = responseEntity.getBody().path("content");
+                return RegisterFulfillmentReturnDeliveryResult.of(
+                        content.path("orderId").asLong(),
+                        content.path("returnSlipNumber").asText(null),
+                        content.path("registered").asBoolean(),
+                        content.path("message").asText(null)
+                );
+            }
+
+            throw new FulfillmentServiceRequestFailedException(
+                    new IOException("풀필먼트 반품 등록 비정상 응답 - orderId: " + command.orderId()));
+        } catch (FulfillmentServiceRequestFailedException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("풀필먼트 반품 등록 실패 - orderId: {}", command.orderId(), e);
+            throw new FulfillmentServiceRequestFailedException(new IOException(e));
+        }
+    }
+
+    private Map<String, Object> buildReturnDeliveryBody(RegisterFulfillmentReturnDeliveryCommand command) {
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("orderId", command.orderId());
+        body.put("orderDate", command.orderDate());
+        body.put("recipientName", command.recipientName());
+        body.put("recipientPhoneNumber", command.recipientPhoneNumber());
+        body.put("recipientAddress", command.recipientAddress());
+        body.put("pickupRecipientName", command.pickupRecipientName());
+        body.put("pickupRecipientPhoneNumber", command.pickupRecipientPhoneNumber());
+        body.put("pickupZipCode", command.pickupZipCode());
+        body.put("pickupAddress", command.pickupAddress());
+        body.put("pickupAddressDetail", command.pickupAddressDetail());
+        body.put("returnReason", command.returnReason());
+        body.put("returnDetailReason", command.returnDetailReason());
+        body.put("returnShippingRequest", command.returnShippingRequest());
+
+        if (FormatValidator.hasValue(command.products())) {
+            List<Map<String, Object>> products = command.products().stream()
+                    .map(item -> {
+                        Map<String, Object> productMap = new LinkedHashMap<>();
+                        productMap.put("productCode", item.productCode());
+                        productMap.put("quantity", item.quantity());
+                        return productMap;
+                    })
+                    .toList();
+            body.put("products", products);
+        }
+
+        return body;
+    }
+
+    private URI buildReturnDeliveryUri() {
+        return UriComponentsBuilder.fromHttpUrl(fulfillmentServiceBaseUrl)
+                .path("/api/v1/internal/fulfillment/deliveries/return")
+                .build()
+                .toUri();
     }
 
     private URI buildWorkStatusUri(Long orderId) {

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/fulfillment/RegisterFulfillmentReturnDeliveryCommand.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/fulfillment/RegisterFulfillmentReturnDeliveryCommand.java
@@ -1,0 +1,32 @@
+package com.personal.marketnote.commerce.port.out.fulfillment;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record RegisterFulfillmentReturnDeliveryCommand(
+        Long orderId,
+        String orderDate,
+        String recipientName,
+        String recipientPhoneNumber,
+        String recipientAddress,
+        String pickupRecipientName,
+        String pickupRecipientPhoneNumber,
+        String pickupZipCode,
+        String pickupAddress,
+        String pickupAddressDetail,
+        String returnReason,
+        String returnDetailReason,
+        String returnShippingRequest,
+        List<ProductItem> products
+) {
+    public record ProductItem(
+            String productCode,
+            Integer quantity
+    ) {
+        public static ProductItem of(String productCode, Integer quantity) {
+            return new ProductItem(productCode, quantity);
+        }
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/fulfillment/RegisterFulfillmentReturnDeliveryPort.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/fulfillment/RegisterFulfillmentReturnDeliveryPort.java
@@ -1,0 +1,5 @@
+package com.personal.marketnote.commerce.port.out.fulfillment;
+
+public interface RegisterFulfillmentReturnDeliveryPort {
+    RegisterFulfillmentReturnDeliveryResult registerReturnDelivery(RegisterFulfillmentReturnDeliveryCommand command);
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/fulfillment/RegisterFulfillmentReturnDeliveryResult.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/fulfillment/RegisterFulfillmentReturnDeliveryResult.java
@@ -1,0 +1,17 @@
+package com.personal.marketnote.commerce.port.out.fulfillment;
+
+public record RegisterFulfillmentReturnDeliveryResult(
+        Long orderId,
+        String returnSlipNumber,
+        boolean registered,
+        String message
+) {
+    public static RegisterFulfillmentReturnDeliveryResult of(
+            Long orderId,
+            String returnSlipNumber,
+            boolean registered,
+            String message
+    ) {
+        return new RegisterFulfillmentReturnDeliveryResult(orderId, returnSlipNumber, registered, message);
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/RequestReturnService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/RequestReturnService.java
@@ -8,15 +8,21 @@ import com.personal.marketnote.commerce.exception.UnauthorizedOrderAccessExcepti
 import com.personal.marketnote.commerce.port.in.command.order.RequestReturnCommand;
 import com.personal.marketnote.commerce.port.in.usecase.order.GetOrderUseCase;
 import com.personal.marketnote.commerce.port.in.usecase.order.RequestReturnUseCase;
+import com.personal.marketnote.commerce.port.out.fulfillment.RegisterFulfillmentReturnDeliveryCommand;
 import com.personal.marketnote.commerce.port.out.order.UpdateOrderPort;
+import com.personal.marketnote.commerce.service.returntracker.CreateReturnTrackerAfterReturnRequestService;
 import com.personal.marketnote.common.application.UseCase;
 import com.personal.marketnote.common.utility.FormatValidator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import java.time.Clock;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
 
 import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
 
@@ -27,7 +33,10 @@ import static org.springframework.transaction.annotation.Isolation.READ_COMMITTE
 public class RequestReturnService implements RequestReturnUseCase {
     private final GetOrderUseCase getOrderUseCase;
     private final UpdateOrderPort updateOrderPort;
+    private final CreateReturnTrackerAfterReturnRequestService createReturnTrackerAfterReturnRequestService;
     private final Clock clock;
+
+    private static final DateTimeFormatter ORDER_DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd");
 
     private static final OrderStatus TARGET_STATUS = OrderStatus.RETURN_REQUESTED;
 
@@ -53,6 +62,9 @@ public class RequestReturnService implements RequestReturnUseCase {
         );
 
         updateOrderPort.update(order, orderStatusHistory);
+
+        RegisterFulfillmentReturnDeliveryCommand returnDeliveryCommand = buildReturnDeliveryCommand(command, order);
+        runAfterCommit(() -> createReturnTrackerAfterReturnRequestService.createReturnTracker(returnDeliveryCommand));
     }
 
     private void validateBuyerOwnership(RequestReturnCommand command, Order order) {
@@ -94,5 +106,69 @@ public class RequestReturnService implements RequestReturnUseCase {
                 null,
                 command.pickupRequestMessage()
         );
+    }
+
+    private RegisterFulfillmentReturnDeliveryCommand buildReturnDeliveryCommand(
+            RequestReturnCommand command,
+            Order order
+    ) {
+        ShippingAddress shippingAddress = order.getShippingAddress();
+        String orderDate = FormatValidator.hasValue(order.getCreatedAt())
+                ? order.getCreatedAt().format(ORDER_DATE_FORMATTER)
+                : "";
+
+        String fullAddress = buildFullAddress(shippingAddress);
+
+        List<RegisterFulfillmentReturnDeliveryCommand.ProductItem> products = order.getOrderProducts().stream()
+                .map(op -> RegisterFulfillmentReturnDeliveryCommand.ProductItem.of(
+                        String.valueOf(op.getPricePolicyId()),
+                        op.getQuantity()
+                ))
+                .toList();
+
+        String reasonCategory = FormatValidator.hasValue(command.reasonCategory())
+                ? command.reasonCategory().getDescription()
+                : "";
+
+        return RegisterFulfillmentReturnDeliveryCommand.builder()
+                .orderId(command.id())
+                .orderDate(orderDate)
+                .recipientName(shippingAddress.getRecipientName())
+                .recipientPhoneNumber(shippingAddress.getRecipientPhoneNumber())
+                .recipientAddress(fullAddress)
+                .pickupRecipientName(command.pickupRecipientName())
+                .pickupRecipientPhoneNumber(command.pickupRecipientPhoneNumber())
+                .pickupZipCode(command.pickupZipCode())
+                .pickupAddress(command.pickupAddress())
+                .pickupAddressDetail(command.pickupAddressDetail())
+                .returnReason(reasonCategory)
+                .returnDetailReason(command.reason())
+                .returnShippingRequest(command.pickupRequestMessage())
+                .products(products)
+                .build();
+    }
+
+    private String buildFullAddress(ShippingAddress shippingAddress) {
+        String address = FormatValidator.hasValue(shippingAddress.getAddress())
+                ? shippingAddress.getAddress()
+                : "";
+        String detail = FormatValidator.hasValue(shippingAddress.getAddressDetail())
+                ? " " + shippingAddress.getAddressDetail()
+                : "";
+        return address + detail;
+    }
+
+    private void runAfterCommit(Runnable action) {
+        if (TransactionSynchronizationManager.isActualTransactionActive()) {
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCommit() {
+                    action.run();
+                }
+            });
+            return;
+        }
+
+        action.run();
     }
 }

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/returntracker/CreateReturnTrackerAfterReturnRequestService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/returntracker/CreateReturnTrackerAfterReturnRequestService.java
@@ -1,0 +1,49 @@
+package com.personal.marketnote.commerce.service.returntracker;
+
+import com.personal.marketnote.commerce.port.out.fulfillment.RegisterFulfillmentReturnDeliveryCommand;
+import com.personal.marketnote.commerce.port.out.fulfillment.RegisterFulfillmentReturnDeliveryPort;
+import com.personal.marketnote.commerce.port.out.fulfillment.RegisterFulfillmentReturnDeliveryResult;
+import com.personal.marketnote.common.exception.FulfillmentServiceRequestFailedException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataAccessException;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class CreateReturnTrackerAfterReturnRequestService {
+    private final RegisterFulfillmentReturnDeliveryPort registerFulfillmentReturnDeliveryPort;
+    private final ReturnTrackerPersistenceService returnTrackerPersistenceService;
+
+    public void createReturnTracker(RegisterFulfillmentReturnDeliveryCommand command) {
+        RegisterFulfillmentReturnDeliveryResult result = registerReturnDelivery(command);
+        if (result == null) {
+            return;
+        }
+
+        persistReturnTracker(command.orderId(), result.returnSlipNumber());
+    }
+
+    private RegisterFulfillmentReturnDeliveryResult registerReturnDelivery(RegisterFulfillmentReturnDeliveryCommand command) {
+        try {
+            return registerFulfillmentReturnDeliveryPort.registerReturnDelivery(command);
+        } catch (FulfillmentServiceRequestFailedException e) {
+            log.error("풀필먼트 반품 등록 실패 - orderId: {}, error: {}",
+                    command.orderId(), e.getMessage(), e);
+            return null;
+        }
+    }
+
+    private void persistReturnTracker(Long orderId, String returnSlipNumber) {
+        try {
+            returnTrackerPersistenceService.saveReturnTracker(orderId, returnSlipNumber);
+        } catch (DataIntegrityViolationException e) {
+            log.warn("ReturnTracker 이미 존재 - orderId: {} (멱등 처리)", orderId);
+        } catch (DataAccessException e) {
+            log.error("ReturnTracker 저장 실패 - orderId: {}, returnSlipNumber: {}, error: {}",
+                    orderId, returnSlipNumber, e.getMessage(), e);
+        }
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/returntracker/ReturnTrackerPersistenceService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/returntracker/ReturnTrackerPersistenceService.java
@@ -1,0 +1,35 @@
+package com.personal.marketnote.commerce.service.returntracker;
+
+import com.personal.marketnote.commerce.domain.returntracker.ReturnTracker;
+import com.personal.marketnote.commerce.domain.returntracker.ReturnTrackerCreateState;
+import com.personal.marketnote.commerce.port.out.returntracker.SaveReturnTrackerPort;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataAccessException;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ReturnTrackerPersistenceService {
+    private final SaveReturnTrackerPort saveReturnTrackerPort;
+
+    @Transactional(isolation = READ_COMMITTED)
+    public void saveReturnTracker(Long orderId, String returnSlipNumber) {
+        ReturnTracker returnTracker = ReturnTracker.from(
+                ReturnTrackerCreateState.builder()
+                        .orderId(orderId)
+                        .returnSlipNumber(returnSlipNumber)
+                        .build()
+        );
+
+        saveReturnTrackerPort.save(returnTracker);
+
+        log.info("ReturnTracker 생성 완료 - orderId: {}, returnSlipNumber: {}",
+                orderId, returnSlipNumber);
+    }
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/delivery/controller/InternalFulfillmentDeliveryController.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/delivery/controller/InternalFulfillmentDeliveryController.java
@@ -3,21 +3,31 @@ package com.personal.marketnote.fulfillment.adapter.in.web.delivery.controller;
 import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
 import com.personal.marketnote.fulfillment.adapter.in.web.delivery.controller.apidocs.CancelInternalFulfillmentDeliveryApiDocs;
 import com.personal.marketnote.fulfillment.adapter.in.web.delivery.controller.apidocs.GetFulfillmentWorkStatusApiDocs;
+import com.personal.marketnote.fulfillment.adapter.in.web.delivery.controller.apidocs.RegisterInternalReturnDeliveryApiDocs;
 import com.personal.marketnote.fulfillment.adapter.in.web.delivery.request.CancelInternalFulfillmentDeliveryRequest;
+import com.personal.marketnote.fulfillment.adapter.in.web.delivery.request.RegisterInternalReturnDeliveryRequest;
 import com.personal.marketnote.fulfillment.adapter.in.web.delivery.response.CancelInternalFulfillmentDeliveryResponse;
 import com.personal.marketnote.fulfillment.adapter.in.web.delivery.response.GetFulfillmentWorkStatusResponse;
+import com.personal.marketnote.fulfillment.adapter.in.web.delivery.response.RegisterInternalReturnDeliveryResponse;
 import com.personal.marketnote.fulfillment.port.in.command.CancelInternalFulfillmentDeliveryCommand;
 import com.personal.marketnote.fulfillment.port.in.command.GetFulfillmentWorkStatusCommand;
+import com.personal.marketnote.fulfillment.port.in.command.RegisterInternalReturnDeliveryCommand;
+import com.personal.marketnote.fulfillment.port.in.command.RegisterInternalReturnDeliveryProductCommand;
 import com.personal.marketnote.fulfillment.port.in.result.CancelInternalFulfillmentDeliveryResult;
 import com.personal.marketnote.fulfillment.port.in.result.GetFulfillmentWorkStatusResult;
+import com.personal.marketnote.fulfillment.port.in.result.RegisterInternalReturnDeliveryResult;
 import com.personal.marketnote.fulfillment.port.in.usecase.CancelInternalFulfillmentDeliveryUseCase;
 import com.personal.marketnote.fulfillment.port.in.usecase.GetFulfillmentWorkStatusUseCase;
+import com.personal.marketnote.fulfillment.port.in.usecase.RegisterInternalReturnDeliveryUseCase;
+import com.personal.marketnote.common.utility.FormatValidator;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 import static com.personal.marketnote.common.domain.exception.ExceptionCode.DEFAULT_SUCCESS_CODE;
 
@@ -34,6 +44,7 @@ import static com.personal.marketnote.common.domain.exception.ExceptionCode.DEFA
 public class InternalFulfillmentDeliveryController {
     private final GetFulfillmentWorkStatusUseCase getFulfillmentWorkStatusUseCase;
     private final CancelInternalFulfillmentDeliveryUseCase cancelInternalFulfillmentDeliveryUseCase;
+    private final RegisterInternalReturnDeliveryUseCase registerInternalReturnDeliveryUseCase;
 
     /**
      * 풀필먼트 작업 상태 조회 (서비스 간 통신용)
@@ -83,5 +94,61 @@ public class InternalFulfillmentDeliveryController {
                 ),
                 HttpStatus.OK
         );
+    }
+
+    /**
+     * 풀필먼트 반품 등록 (서비스 간 통신용)
+     *
+     * @param request 반품 등록 요청 (orderId, 회수지 정보, 반품 사유, 상품 목록)
+     */
+    @PostMapping("/return")
+    @RegisterInternalReturnDeliveryApiDocs
+    public ResponseEntity<BaseResponse<RegisterInternalReturnDeliveryResponse>> registerReturnDelivery(
+            @Valid @RequestBody RegisterInternalReturnDeliveryRequest request
+    ) {
+        RegisterInternalReturnDeliveryCommand command = mapToCommand(request);
+        RegisterInternalReturnDeliveryResult result = registerInternalReturnDeliveryUseCase.registerReturnDelivery(command);
+
+        return new ResponseEntity<>(
+                BaseResponse.of(
+                        RegisterInternalReturnDeliveryResponse.from(result),
+                        HttpStatus.CREATED,
+                        DEFAULT_SUCCESS_CODE,
+                        "풀필먼트 반품 등록 성공"
+                ),
+                HttpStatus.CREATED
+        );
+    }
+
+    private RegisterInternalReturnDeliveryCommand mapToCommand(RegisterInternalReturnDeliveryRequest request) {
+        List<RegisterInternalReturnDeliveryProductCommand> products = mapProducts(request.products());
+
+        return RegisterInternalReturnDeliveryCommand.builder()
+                .orderId(request.orderId())
+                .orderDate(request.orderDate())
+                .recipientName(request.recipientName())
+                .recipientPhoneNumber(request.recipientPhoneNumber())
+                .recipientAddress(request.recipientAddress())
+                .pickupRecipientName(request.pickupRecipientName())
+                .pickupRecipientPhoneNumber(request.pickupRecipientPhoneNumber())
+                .pickupZipCode(request.pickupZipCode())
+                .pickupAddress(request.pickupAddress())
+                .pickupAddressDetail(request.pickupAddressDetail())
+                .returnReason(request.returnReason())
+                .returnDetailReason(request.returnDetailReason())
+                .returnShippingRequest(request.returnShippingRequest())
+                .products(products)
+                .build();
+    }
+
+    private List<RegisterInternalReturnDeliveryProductCommand> mapProducts(
+            List<RegisterInternalReturnDeliveryRequest.ProductItem> items
+    ) {
+        if (FormatValidator.hasNoValue(items)) {
+            return List.of();
+        }
+        return items.stream()
+                .map(item -> RegisterInternalReturnDeliveryProductCommand.of(item.productCode(), item.quantity()))
+                .toList();
     }
 }

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/delivery/controller/apidocs/RegisterInternalReturnDeliveryApiDocs.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/delivery/controller/apidocs/RegisterInternalReturnDeliveryApiDocs.java
@@ -1,0 +1,36 @@
+package com.personal.marketnote.fulfillment.adapter.in.web.delivery.controller.apidocs;
+
+import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
+import com.personal.marketnote.fulfillment.adapter.in.web.delivery.request.RegisterInternalReturnDeliveryRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Operation(
+        summary = "풀필먼트 반품 등록",
+        description = "주문 ID와 반품 정보를 기반으로 파스토에 반품을 등록합니다. 서비스 간 통신용 내부 API입니다.",
+        requestBody = @RequestBody(
+                required = true,
+                content = @Content(
+                        schema = @Schema(implementation = RegisterInternalReturnDeliveryRequest.class)
+                )
+        ),
+        responses = {
+                @ApiResponse(
+                        responseCode = "201",
+                        description = "풀필먼트 반품 등록 성공",
+                        content = @Content(schema = @Schema(implementation = BaseResponse.class))
+                )
+        }
+)
+public @interface RegisterInternalReturnDeliveryApiDocs {
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/delivery/request/RegisterInternalReturnDeliveryRequest.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/delivery/request/RegisterInternalReturnDeliveryRequest.java
@@ -1,0 +1,45 @@
+package com.personal.marketnote.fulfillment.adapter.in.web.delivery.request;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
+
+public record RegisterInternalReturnDeliveryRequest(
+        @NotNull(message = "주문 ID는 필수입니다")
+        Long orderId,
+        @NotBlank(message = "주문일은 필수입니다")
+        String orderDate,
+        @NotBlank(message = "수령인명은 필수입니다")
+        String recipientName,
+        @NotBlank(message = "수령인 전화번호는 필수입니다")
+        String recipientPhoneNumber,
+        String recipientAddress,
+        @NotBlank(message = "회수지 수령인명은 필수입니다")
+        String pickupRecipientName,
+        @NotBlank(message = "회수지 전화번호는 필수입니다")
+        String pickupRecipientPhoneNumber,
+        @NotBlank(message = "회수지 우편번호는 필수입니다")
+        String pickupZipCode,
+        @NotBlank(message = "회수지 주소는 필수입니다")
+        String pickupAddress,
+        String pickupAddressDetail,
+        String returnReason,
+        String returnDetailReason,
+        String returnShippingRequest,
+        @NotEmpty(message = "반품 상품 목록은 필수입니다")
+        @Valid
+        List<ProductItem> products
+) {
+    public record ProductItem(
+            @NotBlank(message = "상품 코드는 필수입니다")
+            String productCode,
+            @NotNull(message = "수량은 필수입니다")
+            @Min(value = 1, message = "수량은 1 이상이어야 합니다")
+            Integer quantity
+    ) {
+    }
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/delivery/response/RegisterInternalReturnDeliveryResponse.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/delivery/response/RegisterInternalReturnDeliveryResponse.java
@@ -1,0 +1,19 @@
+package com.personal.marketnote.fulfillment.adapter.in.web.delivery.response;
+
+import com.personal.marketnote.fulfillment.port.in.result.RegisterInternalReturnDeliveryResult;
+
+public record RegisterInternalReturnDeliveryResponse(
+        Long orderId,
+        String returnSlipNumber,
+        boolean registered,
+        String message
+) {
+    public static RegisterInternalReturnDeliveryResponse from(RegisterInternalReturnDeliveryResult result) {
+        return new RegisterInternalReturnDeliveryResponse(
+                result.orderId(),
+                result.returnSlipNumber(),
+                result.registered(),
+                result.message()
+        );
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/RegisterInternalReturnDeliveryCommand.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/RegisterInternalReturnDeliveryCommand.java
@@ -1,0 +1,24 @@
+package com.personal.marketnote.fulfillment.port.in.command;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record RegisterInternalReturnDeliveryCommand(
+        Long orderId,
+        String orderDate,
+        String recipientName,
+        String recipientPhoneNumber,
+        String recipientAddress,
+        String pickupRecipientName,
+        String pickupRecipientPhoneNumber,
+        String pickupZipCode,
+        String pickupAddress,
+        String pickupAddressDetail,
+        String returnReason,
+        String returnDetailReason,
+        String returnShippingRequest,
+        List<RegisterInternalReturnDeliveryProductCommand> products
+) {
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/RegisterInternalReturnDeliveryProductCommand.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/RegisterInternalReturnDeliveryProductCommand.java
@@ -1,0 +1,10 @@
+package com.personal.marketnote.fulfillment.port.in.command;
+
+public record RegisterInternalReturnDeliveryProductCommand(
+        String productCode,
+        Integer quantity
+) {
+    public static RegisterInternalReturnDeliveryProductCommand of(String productCode, Integer quantity) {
+        return new RegisterInternalReturnDeliveryProductCommand(productCode, quantity);
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/vendor/RegisterFulfillmentDeliveryGoodsCommand.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/vendor/RegisterFulfillmentDeliveryGoodsCommand.java
@@ -12,4 +12,11 @@ public record RegisterFulfillmentDeliveryGoodsCommand(
     ) {
         return new RegisterFulfillmentDeliveryGoodsCommand(productCode, expirationDate, orderQuantity);
     }
+
+    public static RegisterFulfillmentDeliveryGoodsCommand of(
+            String productCode,
+            Integer orderQuantity
+    ) {
+        return new RegisterFulfillmentDeliveryGoodsCommand(productCode, null, orderQuantity);
+    }
 }

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/result/RegisterInternalReturnDeliveryResult.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/result/RegisterInternalReturnDeliveryResult.java
@@ -1,0 +1,17 @@
+package com.personal.marketnote.fulfillment.port.in.result;
+
+public record RegisterInternalReturnDeliveryResult(
+        Long orderId,
+        String returnSlipNumber,
+        boolean registered,
+        String message
+) {
+    public static RegisterInternalReturnDeliveryResult of(
+            Long orderId,
+            String returnSlipNumber,
+            boolean registered,
+            String message
+    ) {
+        return new RegisterInternalReturnDeliveryResult(orderId, returnSlipNumber, registered, message);
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/usecase/RegisterInternalReturnDeliveryUseCase.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/usecase/RegisterInternalReturnDeliveryUseCase.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.fulfillment.port.in.usecase;
+
+import com.personal.marketnote.fulfillment.port.in.command.RegisterInternalReturnDeliveryCommand;
+import com.personal.marketnote.fulfillment.port.in.result.RegisterInternalReturnDeliveryResult;
+
+public interface RegisterInternalReturnDeliveryUseCase {
+    RegisterInternalReturnDeliveryResult registerReturnDelivery(RegisterInternalReturnDeliveryCommand command);
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/RegisterInternalReturnDeliveryService.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/RegisterInternalReturnDeliveryService.java
@@ -1,0 +1,97 @@
+package com.personal.marketnote.fulfillment.service;
+
+import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.fulfillment.domain.FulfillmentAccessToken;
+import com.personal.marketnote.fulfillment.port.in.command.RegisterInternalReturnDeliveryCommand;
+import com.personal.marketnote.fulfillment.port.in.command.vendor.RegisterFulfillmentDeliveryGoodsCommand;
+import com.personal.marketnote.fulfillment.port.in.command.vendor.RegisterFulfillmentReturnDeliveryCommand;
+import com.personal.marketnote.fulfillment.port.in.command.vendor.RegisterFulfillmentReturnDeliveryItemCommand;
+import com.personal.marketnote.fulfillment.port.in.result.RegisterInternalReturnDeliveryResult;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.RegisterFulfillmentDeliveryItemResult;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.RegisterFulfillmentDeliveryResult;
+import com.personal.marketnote.fulfillment.port.in.usecase.RegisterInternalReturnDeliveryUseCase;
+import com.personal.marketnote.fulfillment.port.out.vendor.DisconnectFulfillmentAuthPort;
+import com.personal.marketnote.fulfillment.port.out.vendor.GetFulfillmentCustomerCodePort;
+import com.personal.marketnote.fulfillment.port.out.vendor.RegisterFulfillmentReturnDeliveryPort;
+import com.personal.marketnote.fulfillment.port.out.vendor.RequestFulfillmentAuthPort;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+@UseCase
+@RequiredArgsConstructor
+public class RegisterInternalReturnDeliveryService implements RegisterInternalReturnDeliveryUseCase {
+    private static final String FASSTO_RETURN_TYPE_NORMAL = "01";
+
+    private final GetFulfillmentCustomerCodePort getFulfillmentCustomerCodePort;
+    private final RequestFulfillmentAuthPort requestFulfillmentAuthPort;
+    private final DisconnectFulfillmentAuthPort disconnectFulfillmentAuthPort;
+    private final RegisterFulfillmentReturnDeliveryPort registerFulfillmentReturnDeliveryPort;
+
+    @Override
+    public RegisterInternalReturnDeliveryResult registerReturnDelivery(RegisterInternalReturnDeliveryCommand command) {
+        FulfillmentAccessToken accessToken = requestFulfillmentAuthPort.requestAccessToken();
+        try {
+            String customerCode = getFulfillmentCustomerCodePort.getCustomerCode();
+            RegisterFulfillmentReturnDeliveryCommand fasstoCommand = buildFasstoCommand(
+                    customerCode, accessToken.getValue(), command
+            );
+            RegisterFulfillmentDeliveryResult fasstoResult = registerFulfillmentReturnDeliveryPort.registerReturnDelivery(fasstoCommand);
+
+            return mapToResult(command.orderId(), fasstoResult);
+        } finally {
+            disconnectFulfillmentAuthPort.disconnectAccessToken(accessToken.getValue());
+        }
+    }
+
+    private RegisterFulfillmentReturnDeliveryCommand buildFasstoCommand(
+            String customerCode,
+            String accessToken,
+            RegisterInternalReturnDeliveryCommand command
+    ) {
+        String orderNumber = String.valueOf(command.orderId());
+
+        List<RegisterFulfillmentDeliveryGoodsCommand> goods = command.products().stream()
+                .map(product -> RegisterFulfillmentDeliveryGoodsCommand.of(
+                        product.productCode(), product.quantity()
+                ))
+                .toList();
+
+        RegisterFulfillmentReturnDeliveryItemCommand itemCommand = RegisterFulfillmentReturnDeliveryItemCommand.builder()
+                .orderDate(command.orderDate())
+                .orderNumber(orderNumber)
+                .courierCode("")
+                .invoiceNumber("")
+                .recipientName(command.recipientName())
+                .recipientPhoneNumber(command.recipientPhoneNumber())
+                .recipientAddress(command.recipientAddress())
+                .returnReceiverName(command.pickupRecipientName())
+                .returnReceiverPhoneNumber(command.pickupRecipientPhoneNumber())
+                .returnZipCode(command.pickupZipCode())
+                .returnAddress1(command.pickupAddress())
+                .returnAddress2(command.pickupAddressDetail())
+                .returnType(FASSTO_RETURN_TYPE_NORMAL)
+                .returnReason(command.returnReason())
+                .returnDetailReason(command.returnDetailReason())
+                .returnShippingRequest(command.returnShippingRequest())
+                .products(goods)
+                .build();
+
+        return RegisterFulfillmentReturnDeliveryCommand.of(customerCode, accessToken, List.of(itemCommand));
+    }
+
+    private RegisterInternalReturnDeliveryResult mapToResult(Long orderId, RegisterFulfillmentDeliveryResult fasstoResult) {
+        if (FormatValidator.hasNoValue(fasstoResult.deliveries()) || fasstoResult.deliveries().isEmpty()) {
+            return RegisterInternalReturnDeliveryResult.of(orderId, null, false, "반품 등록 응답 없음");
+        }
+
+        RegisterFulfillmentDeliveryItemResult firstDelivery = fasstoResult.deliveries().get(0);
+        return RegisterInternalReturnDeliveryResult.of(
+                orderId,
+                firstDelivery.fulfillmentSlipNumber(),
+                true,
+                firstDelivery.message()
+        );
+    }
+}


### PR DESCRIPTION
## partially addresses #216
## resolves #2367

## Task
- [x] fulfillment-service 내부 반품 등록 API 추가 (POST /api/v1/internal/fulfillment/deliveries/return)
- [x] RegisterInternalReturnDeliveryService: Fassto 인증 → 반품 등록 → 인증 해제
- [x] commerce-service RegisterFulfillmentReturnDeliveryPort + FulfillmentServiceClient 구현
- [x] CreateReturnTrackerAfterReturnRequestService: 풀필먼트 반품 등록 후 ReturnTracker 생성
- [x] ReturnTrackerPersistenceService: 별도 빈 @Transactional로 self-invocation 방지
- [x] RequestReturnService: afterCommit에서 파스토 반품 등록 + ReturnTracker 생성 호출
- [x] RegisterInternalReturnDeliveryRequest: Bean Validation 적용 (@NotBlank, @NotEmpty, @Valid, @Min)