### PR TITLE
[#216][#2369] feat: 반품 입고 검수 상태 폴링 스케줄러 기능 추가

### DIFF
--- a/commerce-service/commerce-adapters/build.gradle.kts
+++ b/commerce-service/commerce-adapters/build.gradle.kts
@@ -136,14 +136,16 @@ tasks.withType<JavaCompile>().configureEach {
 }
 
 tasks.register("printProjectName") {
+    val name = serviceName
     doLast {
-        println(serviceName)
+        println(name)
     }
 }
 
 tasks.register("printProjectVersion") {
+    val ver = version.toString()
     doLast {
-        println(version)
+        println(ver)
     }
 }
 

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/scheduler/ReturnInspectionPollingScheduler.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/scheduler/ReturnInspectionPollingScheduler.java
@@ -1,0 +1,27 @@
+package com.personal.marketnote.commerce.adapter.in.scheduler;
+
+import com.personal.marketnote.commerce.port.in.usecase.returntracker.PollReturnInspectionUseCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(name = "return-inspection.scheduler.enabled", havingValue = "true", matchIfMissing = false)
+public class ReturnInspectionPollingScheduler {
+    private final PollReturnInspectionUseCase pollReturnInspectionUseCase;
+
+    @Scheduled(fixedDelayString = "${return-inspection.scheduler.fixed-delay-ms:1800000}")
+    public void pollReturnInspections() {
+        log.info("반품 검수 폴링 시작");
+        try {
+            pollReturnInspectionUseCase.pollPendingInspections();
+            log.info("반품 검수 폴링 완료");
+        } catch (Exception e) {
+            log.error("반품 검수 폴링 실패: {}", e.getMessage(), e);
+        }
+    }
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/web/fulfillment/FulfillmentServiceClient.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/web/fulfillment/FulfillmentServiceClient.java
@@ -4,6 +4,13 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.personal.marketnote.commerce.port.out.fulfillment.CancelFulfillmentReleasePort;
 import com.personal.marketnote.commerce.port.out.fulfillment.CancelFulfillmentReleaseResult;
 import com.personal.marketnote.commerce.port.out.fulfillment.GetFulfillmentWorkStatusPort;
+import com.personal.marketnote.commerce.port.out.fulfillment.GetReturnInspectionResultPort;
+import com.personal.marketnote.commerce.port.out.fulfillment.ReturnInspectionResult;
+import com.personal.marketnote.commerce.port.out.fulfillment.ReturnInspectionResult.ReturnInspectionGoodsItem;
+import com.personal.marketnote.commerce.port.out.fulfillment.ReturnInspectionResult.ReturnInspectionResultItem;
+import com.personal.marketnote.commerce.port.out.fulfillment.RegisterFulfillmentReturnDeliveryCommand;
+import com.personal.marketnote.commerce.port.out.fulfillment.RegisterFulfillmentReturnDeliveryPort;
+import com.personal.marketnote.commerce.port.out.fulfillment.RegisterFulfillmentReturnDeliveryResult;
 import com.personal.marketnote.common.adapter.out.ServiceAdapter;
 import com.personal.marketnote.common.exception.FulfillmentServiceRequestFailedException;
 import com.personal.marketnote.common.security.hmac.HmacServiceAuthHeaderBuilder;
@@ -17,11 +24,14 @@ import org.springframework.web.util.UriComponentsBuilder;
 
 import java.io.IOException;
 import java.net.URI;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 @ServiceAdapter
 @Slf4j
-public class FulfillmentServiceClient implements GetFulfillmentWorkStatusPort, CancelFulfillmentReleasePort {
+public class FulfillmentServiceClient implements GetFulfillmentWorkStatusPort, CancelFulfillmentReleasePort, RegisterFulfillmentReturnDeliveryPort, GetReturnInspectionResultPort {
     private final RestClient restClient;
     private final String fulfillmentServiceBaseUrl;
     private final HmacServiceAuthHeaderBuilder hmacServiceAuthHeaderBuilder;
@@ -103,6 +113,154 @@ public class FulfillmentServiceClient implements GetFulfillmentWorkStatusPort, C
             log.error("풀필먼트 출고 취소 실패 - orderId: {}", orderId, e);
             throw new FulfillmentServiceRequestFailedException(new IOException(e));
         }
+    }
+
+    @Override
+    public RegisterFulfillmentReturnDeliveryResult registerReturnDelivery(RegisterFulfillmentReturnDeliveryCommand command) {
+        URI uri = buildReturnDeliveryUri();
+
+        Map<String, Object> body = buildReturnDeliveryBody(command);
+
+        try {
+            ResponseEntity<JsonNode> responseEntity = restClient.post()
+                    .uri(uri)
+                    .headers(headers -> hmacServiceAuthHeaderBuilder.applyHeaders(headers, "POST", uri.getPath()))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .body(body)
+                    .retrieve()
+                    .toEntity(JsonNode.class);
+
+            if (responseEntity.getStatusCode().isError()) {
+                throw new FulfillmentServiceRequestFailedException(
+                        new IOException("Fulfillment service returned error: " + responseEntity.getStatusCode()));
+            }
+
+            if (responseEntity.getStatusCode().is2xxSuccessful()
+                    && FormatValidator.hasValue(responseEntity.getBody())) {
+                JsonNode content = responseEntity.getBody().path("content");
+                return RegisterFulfillmentReturnDeliveryResult.of(
+                        content.path("orderId").asLong(),
+                        content.path("returnSlipNumber").asText(null),
+                        content.path("registered").asBoolean(),
+                        content.path("message").asText(null)
+                );
+            }
+
+            throw new FulfillmentServiceRequestFailedException(
+                    new IOException("풀필먼트 반품 등록 비정상 응답 - orderId: " + command.orderId()));
+        } catch (FulfillmentServiceRequestFailedException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("풀필먼트 반품 등록 실패 - orderId: {}", command.orderId(), e);
+            throw new FulfillmentServiceRequestFailedException(new IOException(e));
+        }
+    }
+
+    @Override
+    public ReturnInspectionResult getReturnGodDetail(String returnSlipNumbers) {
+        URI uri = buildReturnGodDetailUri(returnSlipNumbers);
+
+        try {
+            ResponseEntity<JsonNode> responseEntity = restClient.get()
+                    .uri(uri)
+                    .headers(headers -> hmacServiceAuthHeaderBuilder.applyHeaders(headers, "GET", uri.getPath()))
+                    .retrieve()
+                    .toEntity(JsonNode.class);
+
+            if (responseEntity.getStatusCode().isError()) {
+                throw new FulfillmentServiceRequestFailedException(
+                        new IOException("Fulfillment service returned error: " + responseEntity.getStatusCode()));
+            }
+
+            if (responseEntity.getStatusCode().is2xxSuccessful()
+                    && FormatValidator.hasValue(responseEntity.getBody())) {
+                return parseReturnGodDetailResponse(responseEntity.getBody().path("content"));
+            }
+
+            throw new FulfillmentServiceRequestFailedException(
+                    new IOException("풀필먼트 반품 검수 상태 조회 비정상 응답"));
+        } catch (FulfillmentServiceRequestFailedException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("풀필먼트 반품 검수 상태 조회 실패 - returnSlipNumbers: {}", returnSlipNumbers, e);
+            throw new FulfillmentServiceRequestFailedException(new IOException(e));
+        }
+    }
+
+    private ReturnInspectionResult parseReturnGodDetailResponse(JsonNode content) {
+        Integer dataCount = content.has("dataCount") ? content.path("dataCount").asInt() : null;
+        JsonNode returnGodInfosNode = content.path("returnGodInfos");
+
+        List<ReturnInspectionResultItem> items = new ArrayList<>();
+        if (returnGodInfosNode.isArray()) {
+            for (JsonNode infoNode : returnGodInfosNode) {
+                List<ReturnInspectionGoodsItem> goods = new ArrayList<>();
+                JsonNode productsNode = infoNode.path("products");
+                if (productsNode.isArray()) {
+                    for (JsonNode goodsNode : productsNode) {
+                        goods.add(new ReturnInspectionGoodsItem(
+                                goodsNode.path("customerProductCode").asText(null),
+                                goodsNode.path("productName").asText(null),
+                                goodsNode.path("returnProductCheckStatus").asText(null),
+                                goodsNode.path("returnProductCheckStatusName").asText(null)
+                        ));
+                    }
+                }
+                items.add(new ReturnInspectionResultItem(
+                        infoNode.path("orderNumber").asText(null),
+                        infoNode.path("inboundOrderSlipNumber").asText(null),
+                        goods
+                ));
+            }
+        }
+
+        return new ReturnInspectionResult(dataCount, items);
+    }
+
+    private URI buildReturnGodDetailUri(String returnSlipNumbers) {
+        return UriComponentsBuilder.fromHttpUrl(fulfillmentServiceBaseUrl)
+                .path("/api/v1/internal/fulfillment/deliveries/return-god-detail")
+                .queryParam("return-slip-numbers", returnSlipNumbers)
+                .build()
+                .toUri();
+    }
+
+    private Map<String, Object> buildReturnDeliveryBody(RegisterFulfillmentReturnDeliveryCommand command) {
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("orderId", command.orderId());
+        body.put("orderDate", command.orderDate());
+        body.put("recipientName", command.recipientName());
+        body.put("recipientPhoneNumber", command.recipientPhoneNumber());
+        body.put("recipientAddress", command.recipientAddress());
+        body.put("pickupRecipientName", command.pickupRecipientName());
+        body.put("pickupRecipientPhoneNumber", command.pickupRecipientPhoneNumber());
+        body.put("pickupZipCode", command.pickupZipCode());
+        body.put("pickupAddress", command.pickupAddress());
+        body.put("pickupAddressDetail", command.pickupAddressDetail());
+        body.put("returnReason", command.returnReason());
+        body.put("returnDetailReason", command.returnDetailReason());
+        body.put("returnShippingRequest", command.returnShippingRequest());
+
+        if (FormatValidator.hasValue(command.products())) {
+            List<Map<String, Object>> products = command.products().stream()
+                    .map(item -> {
+                        Map<String, Object> productMap = new LinkedHashMap<>();
+                        productMap.put("productCode", item.productCode());
+                        productMap.put("quantity", item.quantity());
+                        return productMap;
+                    })
+                    .toList();
+            body.put("products", products);
+        }
+
+        return body;
+    }
+
+    private URI buildReturnDeliveryUri() {
+        return UriComponentsBuilder.fromHttpUrl(fulfillmentServiceBaseUrl)
+                .path("/api/v1/internal/fulfillment/deliveries/return")
+                .build()
+                .toUri();
     }
 
     private URI buildWorkStatusUri(Long orderId) {

--- a/commerce-service/commerce-adapters/src/main/resources/application.yml
+++ b/commerce-service/commerce-adapters/src/main/resources/application.yml
@@ -143,6 +143,11 @@ order:
       cron: ${ORDER_AUTO_CONFIRM_SCHEDULER_CRON:0 59 23 * * ?}
       auto-confirm-days: ${ORDER_AUTO_CONFIRM_DAYS:7}
 
+return-inspection:
+  scheduler:
+    enabled: ${RETURN_INSPECTION_SCHEDULER_ENABLED:false}
+    fixed-delay-ms: ${RETURN_INSPECTION_SCHEDULER_FIXED_DELAY_MS:1800000}
+
 management:
   endpoints:
     web:

--- a/commerce-service/commerce-application/build.gradle.kts
+++ b/commerce-service/commerce-application/build.gradle.kts
@@ -121,14 +121,16 @@ springBoot {
 }
 
 tasks.register("printProjectName") {
+    val name = project.name
     doLast {
-        println(project.name)
+        println(name)
     }
 }
 
 tasks.register("printProjectVersion") {
+    val ver = version.toString()
     doLast {
-        println(version)
+        println(ver)
     }
 }
 

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/returntracker/PollReturnInspectionUseCase.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/returntracker/PollReturnInspectionUseCase.java
@@ -1,0 +1,5 @@
+package com.personal.marketnote.commerce.port.in.usecase.returntracker;
+
+public interface PollReturnInspectionUseCase {
+    void pollPendingInspections();
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/fulfillment/GetReturnInspectionResultPort.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/fulfillment/GetReturnInspectionResultPort.java
@@ -1,0 +1,5 @@
+package com.personal.marketnote.commerce.port.out.fulfillment;
+
+public interface GetReturnInspectionResultPort {
+    ReturnInspectionResult getReturnGodDetail(String returnSlipNumbers);
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/fulfillment/RegisterFulfillmentReturnDeliveryCommand.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/fulfillment/RegisterFulfillmentReturnDeliveryCommand.java
@@ -1,0 +1,32 @@
+package com.personal.marketnote.commerce.port.out.fulfillment;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record RegisterFulfillmentReturnDeliveryCommand(
+        Long orderId,
+        String orderDate,
+        String recipientName,
+        String recipientPhoneNumber,
+        String recipientAddress,
+        String pickupRecipientName,
+        String pickupRecipientPhoneNumber,
+        String pickupZipCode,
+        String pickupAddress,
+        String pickupAddressDetail,
+        String returnReason,
+        String returnDetailReason,
+        String returnShippingRequest,
+        List<ProductItem> products
+) {
+    public record ProductItem(
+            String productCode,
+            Integer quantity
+    ) {
+        public static ProductItem of(String productCode, Integer quantity) {
+            return new ProductItem(productCode, quantity);
+        }
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/fulfillment/RegisterFulfillmentReturnDeliveryPort.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/fulfillment/RegisterFulfillmentReturnDeliveryPort.java
@@ -1,0 +1,5 @@
+package com.personal.marketnote.commerce.port.out.fulfillment;
+
+public interface RegisterFulfillmentReturnDeliveryPort {
+    RegisterFulfillmentReturnDeliveryResult registerReturnDelivery(RegisterFulfillmentReturnDeliveryCommand command);
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/fulfillment/RegisterFulfillmentReturnDeliveryResult.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/fulfillment/RegisterFulfillmentReturnDeliveryResult.java
@@ -1,0 +1,17 @@
+package com.personal.marketnote.commerce.port.out.fulfillment;
+
+public record RegisterFulfillmentReturnDeliveryResult(
+        Long orderId,
+        String returnSlipNumber,
+        boolean registered,
+        String message
+) {
+    public static RegisterFulfillmentReturnDeliveryResult of(
+            Long orderId,
+            String returnSlipNumber,
+            boolean registered,
+            String message
+    ) {
+        return new RegisterFulfillmentReturnDeliveryResult(orderId, returnSlipNumber, registered, message);
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/fulfillment/ReturnInspectionResult.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/fulfillment/ReturnInspectionResult.java
@@ -1,0 +1,23 @@
+package com.personal.marketnote.commerce.port.out.fulfillment;
+
+import java.util.List;
+
+public record ReturnInspectionResult(
+        Integer dataCount,
+        List<ReturnInspectionResultItem> returnGodInfos
+) {
+    public record ReturnInspectionResultItem(
+            String orderNumber,
+            String inboundOrderSlipNumber,
+            List<ReturnInspectionGoodsItem> products
+    ) {
+    }
+
+    public record ReturnInspectionGoodsItem(
+            String customerProductCode,
+            String productName,
+            String returnProductCheckStatus,
+            String returnProductCheckStatusName
+    ) {
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/RequestReturnService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/RequestReturnService.java
@@ -8,15 +8,21 @@ import com.personal.marketnote.commerce.exception.UnauthorizedOrderAccessExcepti
 import com.personal.marketnote.commerce.port.in.command.order.RequestReturnCommand;
 import com.personal.marketnote.commerce.port.in.usecase.order.GetOrderUseCase;
 import com.personal.marketnote.commerce.port.in.usecase.order.RequestReturnUseCase;
+import com.personal.marketnote.commerce.port.out.fulfillment.RegisterFulfillmentReturnDeliveryCommand;
 import com.personal.marketnote.commerce.port.out.order.UpdateOrderPort;
+import com.personal.marketnote.commerce.service.returntracker.CreateReturnTrackerAfterReturnRequestService;
 import com.personal.marketnote.common.application.UseCase;
 import com.personal.marketnote.common.utility.FormatValidator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import java.time.Clock;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
 
 import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
 
@@ -27,7 +33,10 @@ import static org.springframework.transaction.annotation.Isolation.READ_COMMITTE
 public class RequestReturnService implements RequestReturnUseCase {
     private final GetOrderUseCase getOrderUseCase;
     private final UpdateOrderPort updateOrderPort;
+    private final CreateReturnTrackerAfterReturnRequestService createReturnTrackerAfterReturnRequestService;
     private final Clock clock;
+
+    private static final DateTimeFormatter ORDER_DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd");
 
     private static final OrderStatus TARGET_STATUS = OrderStatus.RETURN_REQUESTED;
 
@@ -53,6 +62,9 @@ public class RequestReturnService implements RequestReturnUseCase {
         );
 
         updateOrderPort.update(order, orderStatusHistory);
+
+        RegisterFulfillmentReturnDeliveryCommand returnDeliveryCommand = buildReturnDeliveryCommand(command, order);
+        runAfterCommit(() -> createReturnTrackerAfterReturnRequestService.createReturnTracker(returnDeliveryCommand));
     }
 
     private void validateBuyerOwnership(RequestReturnCommand command, Order order) {
@@ -94,5 +106,69 @@ public class RequestReturnService implements RequestReturnUseCase {
                 null,
                 command.pickupRequestMessage()
         );
+    }
+
+    private RegisterFulfillmentReturnDeliveryCommand buildReturnDeliveryCommand(
+            RequestReturnCommand command,
+            Order order
+    ) {
+        ShippingAddress shippingAddress = order.getShippingAddress();
+        String orderDate = FormatValidator.hasValue(order.getCreatedAt())
+                ? order.getCreatedAt().format(ORDER_DATE_FORMATTER)
+                : "";
+
+        String fullAddress = buildFullAddress(shippingAddress);
+
+        List<RegisterFulfillmentReturnDeliveryCommand.ProductItem> products = order.getOrderProducts().stream()
+                .map(op -> RegisterFulfillmentReturnDeliveryCommand.ProductItem.of(
+                        String.valueOf(op.getPricePolicyId()),
+                        op.getQuantity()
+                ))
+                .toList();
+
+        String reasonCategory = FormatValidator.hasValue(command.reasonCategory())
+                ? command.reasonCategory().getDescription()
+                : "";
+
+        return RegisterFulfillmentReturnDeliveryCommand.builder()
+                .orderId(command.id())
+                .orderDate(orderDate)
+                .recipientName(shippingAddress.getRecipientName())
+                .recipientPhoneNumber(shippingAddress.getRecipientPhoneNumber())
+                .recipientAddress(fullAddress)
+                .pickupRecipientName(command.pickupRecipientName())
+                .pickupRecipientPhoneNumber(command.pickupRecipientPhoneNumber())
+                .pickupZipCode(command.pickupZipCode())
+                .pickupAddress(command.pickupAddress())
+                .pickupAddressDetail(command.pickupAddressDetail())
+                .returnReason(reasonCategory)
+                .returnDetailReason(command.reason())
+                .returnShippingRequest(command.pickupRequestMessage())
+                .products(products)
+                .build();
+    }
+
+    private String buildFullAddress(ShippingAddress shippingAddress) {
+        String address = FormatValidator.hasValue(shippingAddress.getAddress())
+                ? shippingAddress.getAddress()
+                : "";
+        String detail = FormatValidator.hasValue(shippingAddress.getAddressDetail())
+                ? " " + shippingAddress.getAddressDetail()
+                : "";
+        return address + detail;
+    }
+
+    private void runAfterCommit(Runnable action) {
+        if (TransactionSynchronizationManager.isActualTransactionActive()) {
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCommit() {
+                    action.run();
+                }
+            });
+            return;
+        }
+
+        action.run();
     }
 }

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/returntracker/CreateReturnTrackerAfterReturnRequestService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/returntracker/CreateReturnTrackerAfterReturnRequestService.java
@@ -1,0 +1,49 @@
+package com.personal.marketnote.commerce.service.returntracker;
+
+import com.personal.marketnote.commerce.port.out.fulfillment.RegisterFulfillmentReturnDeliveryCommand;
+import com.personal.marketnote.commerce.port.out.fulfillment.RegisterFulfillmentReturnDeliveryPort;
+import com.personal.marketnote.commerce.port.out.fulfillment.RegisterFulfillmentReturnDeliveryResult;
+import com.personal.marketnote.common.exception.FulfillmentServiceRequestFailedException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataAccessException;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class CreateReturnTrackerAfterReturnRequestService {
+    private final RegisterFulfillmentReturnDeliveryPort registerFulfillmentReturnDeliveryPort;
+    private final ReturnTrackerPersistenceService returnTrackerPersistenceService;
+
+    public void createReturnTracker(RegisterFulfillmentReturnDeliveryCommand command) {
+        RegisterFulfillmentReturnDeliveryResult result = registerReturnDelivery(command);
+        if (result == null) {
+            return;
+        }
+
+        persistReturnTracker(command.orderId(), result.returnSlipNumber());
+    }
+
+    private RegisterFulfillmentReturnDeliveryResult registerReturnDelivery(RegisterFulfillmentReturnDeliveryCommand command) {
+        try {
+            return registerFulfillmentReturnDeliveryPort.registerReturnDelivery(command);
+        } catch (FulfillmentServiceRequestFailedException e) {
+            log.error("풀필먼트 반품 등록 실패 - orderId: {}, error: {}",
+                    command.orderId(), e.getMessage(), e);
+            return null;
+        }
+    }
+
+    private void persistReturnTracker(Long orderId, String returnSlipNumber) {
+        try {
+            returnTrackerPersistenceService.saveReturnTracker(orderId, returnSlipNumber);
+        } catch (DataIntegrityViolationException e) {
+            log.warn("ReturnTracker 이미 존재 - orderId: {} (멱등 처리)", orderId);
+        } catch (DataAccessException e) {
+            log.error("ReturnTracker 저장 실패 - orderId: {}, returnSlipNumber: {}, error: {}",
+                    orderId, returnSlipNumber, e.getMessage(), e);
+        }
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/returntracker/PollReturnInspectionService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/returntracker/PollReturnInspectionService.java
@@ -1,0 +1,173 @@
+package com.personal.marketnote.commerce.service.returntracker;
+
+import com.personal.marketnote.commerce.domain.returntracker.ReturnInspectionStatus;
+import com.personal.marketnote.commerce.domain.returntracker.ReturnTracker;
+import com.personal.marketnote.commerce.port.in.usecase.returntracker.PollReturnInspectionUseCase;
+import com.personal.marketnote.commerce.port.out.fulfillment.GetReturnInspectionResultPort;
+import com.personal.marketnote.commerce.port.out.fulfillment.ReturnInspectionResult;
+import com.personal.marketnote.commerce.port.out.fulfillment.ReturnInspectionResult.ReturnInspectionGoodsItem;
+import com.personal.marketnote.commerce.port.out.fulfillment.ReturnInspectionResult.ReturnInspectionResultItem;
+import com.personal.marketnote.commerce.port.out.returntracker.FindReturnTrackerPort;
+import com.personal.marketnote.commerce.port.out.returntracker.UpdateReturnTrackerPort;
+import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.common.utility.FormatValidator;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Slf4j
+@UseCase
+@RequiredArgsConstructor
+public class PollReturnInspectionService implements PollReturnInspectionUseCase {
+    private static final String INSPECTION_PASSED = "01";
+    private static final String INSPECTION_FAILED = "02";
+    private static final String INSPECTION_ON_HOLD = "03";
+
+    private final FindReturnTrackerPort findReturnTrackerPort;
+    private final UpdateReturnTrackerPort updateReturnTrackerPort;
+    private final GetReturnInspectionResultPort getReturnInspectionResultPort;
+    private final Clock clock;
+
+    @Override
+    public void pollPendingInspections() {
+        List<ReturnTracker> pendingTrackers = findReturnTrackerPort.findByInspectionStatus(ReturnInspectionStatus.PENDING);
+        if (pendingTrackers.isEmpty()) {
+            return;
+        }
+
+        List<ReturnTracker> trackersWithSlipNumber = filterTrackersWithSlipNumber(pendingTrackers);
+        if (trackersWithSlipNumber.isEmpty()) {
+            return;
+        }
+
+        String returnSlipNumbers = buildReturnSlipNumbers(trackersWithSlipNumber);
+        ReturnInspectionResult response = fetchInspectionResults(returnSlipNumbers);
+        if (FormatValidator.hasNoValue(response) || FormatValidator.hasNoValue(response.returnGodInfos())) {
+            return;
+        }
+
+        Map<String, ReturnTracker> trackerByOrderId = buildTrackerByOrderIdMap(trackersWithSlipNumber);
+        processInspectionResults(response.returnGodInfos(), trackerByOrderId);
+    }
+
+    private List<ReturnTracker> filterTrackersWithSlipNumber(List<ReturnTracker> trackers) {
+        List<ReturnTracker> withSlipNumber = trackers.stream()
+                .filter(tracker -> FormatValidator.hasValue(tracker.getReturnSlipNumber()))
+                .toList();
+
+        int skippedCount = trackers.size() - withSlipNumber.size();
+        if (skippedCount > 0) {
+            log.warn("반품 검수 폴링: returnSlipNumber 없는 ReturnTracker {} 건 스킵", skippedCount);
+        }
+        return withSlipNumber;
+    }
+
+    private String buildReturnSlipNumbers(List<ReturnTracker> trackers) {
+        return trackers.stream()
+                .map(ReturnTracker::getReturnSlipNumber)
+                .collect(Collectors.joining(","));
+    }
+
+    private ReturnInspectionResult fetchInspectionResults(String returnSlipNumbers) {
+        try {
+            return getReturnInspectionResultPort.getReturnGodDetail(returnSlipNumbers);
+        } catch (Exception e) {
+            log.error("반품 검수 상태 조회 실패: {}", e.getMessage(), e);
+            return null;
+        }
+    }
+
+    private Map<String, ReturnTracker> buildTrackerByOrderIdMap(List<ReturnTracker> trackers) {
+        return trackers.stream()
+                .collect(Collectors.toMap(
+                        tracker -> String.valueOf(tracker.getOrderId()),
+                        tracker -> tracker,
+                        (existing, duplicate) -> {
+                            log.warn("반품 검수 폴링: 중복 orderId 발견 - orderId: {}", existing.getOrderId());
+                            return existing;
+                        }
+                ));
+    }
+
+    private void processInspectionResults(
+            List<ReturnInspectionResultItem> resultItems,
+            Map<String, ReturnTracker> trackerByOrderId
+    ) {
+        for (ReturnInspectionResultItem resultItem : resultItems) {
+            try {
+                processInspectionResult(resultItem, trackerByOrderId);
+            } catch (Exception e) {
+                log.error("반품 검수 상태 업데이트 실패 - orderNumber: {}, error: {}",
+                        resultItem.orderNumber(), e.getMessage(), e);
+            }
+        }
+    }
+
+    private void processInspectionResult(
+            ReturnInspectionResultItem resultItem,
+            Map<String, ReturnTracker> trackerByOrderId
+    ) {
+        ReturnTracker tracker = trackerByOrderId.get(resultItem.orderNumber());
+        if (FormatValidator.hasNoValue(tracker)) {
+            return;
+        }
+
+        String overallStatus = resolveOverallInspectionStatus(resultItem.products());
+        if (FormatValidator.hasNoValue(overallStatus)) {
+            return;
+        }
+
+        LocalDateTime now = LocalDateTime.now(clock);
+        applyInspectionStatus(tracker, overallStatus, now);
+        updateReturnTrackerPort.update(tracker);
+
+        log.info("반품 검수 상태 업데이트 - orderId: {}, status: {}", tracker.getOrderId(), overallStatus);
+    }
+
+    private String resolveOverallInspectionStatus(List<ReturnInspectionGoodsItem> products) {
+        if (FormatValidator.hasNoValue(products) || products.isEmpty()) {
+            return null;
+        }
+
+        boolean hasFailed = products.stream()
+                .anyMatch(goods -> INSPECTION_FAILED.equals(goods.returnProductCheckStatus()));
+        if (hasFailed) {
+            return INSPECTION_FAILED;
+        }
+
+        boolean hasOnHold = products.stream()
+                .anyMatch(goods -> INSPECTION_ON_HOLD.equals(goods.returnProductCheckStatus()));
+        if (hasOnHold) {
+            return INSPECTION_ON_HOLD;
+        }
+
+        boolean allPassed = products.stream()
+                .allMatch(goods -> INSPECTION_PASSED.equals(goods.returnProductCheckStatus()));
+        if (allPassed) {
+            return INSPECTION_PASSED;
+        }
+
+        log.warn("반품 검수 폴링: 분류 불가능한 상태 조합 - statuses: {}",
+                products.stream().map(ReturnInspectionGoodsItem::returnProductCheckStatus).toList());
+        return null;
+    }
+
+    private void applyInspectionStatus(ReturnTracker tracker, String status, LocalDateTime now) {
+        if (INSPECTION_PASSED.equals(status)) {
+            tracker.passInspection(now);
+            return;
+        }
+        if (INSPECTION_FAILED.equals(status)) {
+            tracker.failInspection(now);
+            return;
+        }
+        if (INSPECTION_ON_HOLD.equals(status)) {
+            tracker.holdInspection();
+        }
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/returntracker/ReturnTrackerPersistenceService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/returntracker/ReturnTrackerPersistenceService.java
@@ -1,0 +1,35 @@
+package com.personal.marketnote.commerce.service.returntracker;
+
+import com.personal.marketnote.commerce.domain.returntracker.ReturnTracker;
+import com.personal.marketnote.commerce.domain.returntracker.ReturnTrackerCreateState;
+import com.personal.marketnote.commerce.port.out.returntracker.SaveReturnTrackerPort;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataAccessException;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ReturnTrackerPersistenceService {
+    private final SaveReturnTrackerPort saveReturnTrackerPort;
+
+    @Transactional(isolation = READ_COMMITTED)
+    public void saveReturnTracker(Long orderId, String returnSlipNumber) {
+        ReturnTracker returnTracker = ReturnTracker.from(
+                ReturnTrackerCreateState.builder()
+                        .orderId(orderId)
+                        .returnSlipNumber(returnSlipNumber)
+                        .build()
+        );
+
+        saveReturnTrackerPort.save(returnTracker);
+
+        log.info("ReturnTracker 생성 완료 - orderId: {}, returnSlipNumber: {}",
+                orderId, returnSlipNumber);
+    }
+}

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/RequestReturnUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/RequestReturnUseCaseTest.java
@@ -8,6 +8,7 @@ import com.personal.marketnote.commerce.exception.UnauthorizedOrderAccessExcepti
 import com.personal.marketnote.commerce.port.in.command.order.RequestReturnCommand;
 import com.personal.marketnote.commerce.port.in.usecase.order.GetOrderUseCase;
 import com.personal.marketnote.commerce.port.out.order.UpdateOrderPort;
+import com.personal.marketnote.commerce.service.returntracker.CreateReturnTrackerAfterReturnRequestService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -34,6 +35,8 @@ class RequestReturnUseCaseTest {
     private GetOrderUseCase getOrderUseCase;
     @Mock
     private UpdateOrderPort updateOrderPort;
+    @Mock
+    private CreateReturnTrackerAfterReturnRequestService createReturnTrackerAfterReturnRequestService;
     @Spy
     private Clock clock = Clock.fixed(Instant.parse("2026-04-05T00:00:00Z"), ZoneId.of("Asia/Seoul"));
 

--- a/commerce-service/commerce-domain/build.gradle.kts
+++ b/commerce-service/commerce-domain/build.gradle.kts
@@ -119,14 +119,16 @@ springBoot {
 }
 
 tasks.register("printProjectName") {
+    val name = project.name
     doLast {
-        println(project.name)
+        println(name)
     }
 }
 
 tasks.register("printProjectVersion") {
+    val ver = version.toString()
     doLast {
-        println(version)
+        println(ver)
     }
 }
 

--- a/community-service/community-adapters/build.gradle.kts
+++ b/community-service/community-adapters/build.gradle.kts
@@ -133,14 +133,16 @@ tasks.withType<JavaCompile>().configureEach {
 }
 
 tasks.register("printProjectName") {
+    val name = serviceName
     doLast {
-        println(serviceName)
+        println(name)
     }
 }
 
 tasks.register("printProjectVersion") {
+    val ver = version.toString()
     doLast {
-        println(version)
+        println(ver)
     }
 }
 

--- a/community-service/community-application/build.gradle.kts
+++ b/community-service/community-application/build.gradle.kts
@@ -121,14 +121,16 @@ springBoot {
 }
 
 tasks.register("printProjectName") {
+    val name = project.name
     doLast {
-        println(project.name)
+        println(name)
     }
 }
 
 tasks.register("printProjectVersion") {
+    val ver = version.toString()
     doLast {
-        println(version)
+        println(ver)
     }
 }
 

--- a/community-service/community-domain/build.gradle.kts
+++ b/community-service/community-domain/build.gradle.kts
@@ -119,14 +119,16 @@ springBoot {
 }
 
 tasks.register("printProjectName") {
+    val name = project.name
     doLast {
-        println(project.name)
+        println(name)
     }
 }
 
 tasks.register("printProjectVersion") {
+    val ver = version.toString()
     doLast {
-        println(version)
+        println(ver)
     }
 }
 

--- a/file-service/file-adapters/build.gradle.kts
+++ b/file-service/file-adapters/build.gradle.kts
@@ -145,14 +145,16 @@ tasks.withType<JavaCompile>().configureEach {
 }
 
 tasks.register("printProjectName") {
+    val name = serviceName
     doLast {
-        println(serviceName)
+        println(name)
     }
 }
 
 tasks.register("printProjectVersion") {
+    val ver = version.toString()
     doLast {
-        println(version)
+        println(ver)
     }
 }
 

--- a/file-service/file-application/build.gradle.kts
+++ b/file-service/file-application/build.gradle.kts
@@ -125,14 +125,16 @@ springBoot {
 }
 
 tasks.register("printProjectName") {
+    val name = project.name
     doLast {
-        println(project.name)
+        println(name)
     }
 }
 
 tasks.register("printProjectVersion") {
+    val ver = version.toString()
     doLast {
-        println(version)
+        println(ver)
     }
 }
 

--- a/file-service/file-domain/build.gradle.kts
+++ b/file-service/file-domain/build.gradle.kts
@@ -118,14 +118,16 @@ springBoot {
 }
 
 tasks.register("printProjectName") {
+    val name = project.name
     doLast {
-        println(project.name)
+        println(name)
     }
 }
 
 tasks.register("printProjectVersion") {
+    val ver = version.toString()
     doLast {
-        println(version)
+        println(ver)
     }
 }
 

--- a/fulfillment-service/fulfillment-adapters/build.gradle.kts
+++ b/fulfillment-service/fulfillment-adapters/build.gradle.kts
@@ -130,14 +130,16 @@ tasks.withType<JavaCompile>().configureEach {
 }
 
 tasks.register("printProjectName") {
+    val name = serviceName
     doLast {
-        println(serviceName)
+        println(name)
     }
 }
 
 tasks.register("printProjectVersion") {
+    val ver = version.toString()
     doLast {
-        println(version)
+        println(ver)
     }
 }
 

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/delivery/controller/InternalFulfillmentDeliveryController.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/delivery/controller/InternalFulfillmentDeliveryController.java
@@ -3,21 +3,36 @@ package com.personal.marketnote.fulfillment.adapter.in.web.delivery.controller;
 import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
 import com.personal.marketnote.fulfillment.adapter.in.web.delivery.controller.apidocs.CancelInternalFulfillmentDeliveryApiDocs;
 import com.personal.marketnote.fulfillment.adapter.in.web.delivery.controller.apidocs.GetFulfillmentWorkStatusApiDocs;
+import com.personal.marketnote.fulfillment.adapter.in.web.delivery.controller.apidocs.GetInternalReturnGodDetailApiDocs;
+import com.personal.marketnote.fulfillment.adapter.in.web.delivery.controller.apidocs.RegisterInternalReturnDeliveryApiDocs;
 import com.personal.marketnote.fulfillment.adapter.in.web.delivery.request.CancelInternalFulfillmentDeliveryRequest;
+import com.personal.marketnote.fulfillment.adapter.in.web.delivery.request.RegisterInternalReturnDeliveryRequest;
 import com.personal.marketnote.fulfillment.adapter.in.web.delivery.response.CancelInternalFulfillmentDeliveryResponse;
 import com.personal.marketnote.fulfillment.adapter.in.web.delivery.response.GetFulfillmentWorkStatusResponse;
+import com.personal.marketnote.fulfillment.adapter.in.web.delivery.response.GetInternalReturnGodDetailResponse;
+import com.personal.marketnote.fulfillment.adapter.in.web.delivery.response.RegisterInternalReturnDeliveryResponse;
 import com.personal.marketnote.fulfillment.port.in.command.CancelInternalFulfillmentDeliveryCommand;
 import com.personal.marketnote.fulfillment.port.in.command.GetFulfillmentWorkStatusCommand;
+import com.personal.marketnote.fulfillment.port.in.command.GetInternalReturnGodDetailCommand;
+import com.personal.marketnote.fulfillment.port.in.command.RegisterInternalReturnDeliveryCommand;
+import com.personal.marketnote.fulfillment.port.in.command.RegisterInternalReturnDeliveryProductCommand;
 import com.personal.marketnote.fulfillment.port.in.result.CancelInternalFulfillmentDeliveryResult;
 import com.personal.marketnote.fulfillment.port.in.result.GetFulfillmentWorkStatusResult;
+import com.personal.marketnote.fulfillment.port.in.result.GetInternalReturnGodDetailResult;
+import com.personal.marketnote.fulfillment.port.in.result.RegisterInternalReturnDeliveryResult;
 import com.personal.marketnote.fulfillment.port.in.usecase.CancelInternalFulfillmentDeliveryUseCase;
 import com.personal.marketnote.fulfillment.port.in.usecase.GetFulfillmentWorkStatusUseCase;
+import com.personal.marketnote.fulfillment.port.in.usecase.GetInternalReturnGodDetailUseCase;
+import com.personal.marketnote.fulfillment.port.in.usecase.RegisterInternalReturnDeliveryUseCase;
+import com.personal.marketnote.common.utility.FormatValidator;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 import static com.personal.marketnote.common.domain.exception.ExceptionCode.DEFAULT_SUCCESS_CODE;
 
@@ -34,6 +49,8 @@ import static com.personal.marketnote.common.domain.exception.ExceptionCode.DEFA
 public class InternalFulfillmentDeliveryController {
     private final GetFulfillmentWorkStatusUseCase getFulfillmentWorkStatusUseCase;
     private final CancelInternalFulfillmentDeliveryUseCase cancelInternalFulfillmentDeliveryUseCase;
+    private final RegisterInternalReturnDeliveryUseCase registerInternalReturnDeliveryUseCase;
+    private final GetInternalReturnGodDetailUseCase getInternalReturnGodDetailUseCase;
 
     /**
      * 풀필먼트 작업 상태 조회 (서비스 간 통신용)
@@ -83,5 +100,86 @@ public class InternalFulfillmentDeliveryController {
                 ),
                 HttpStatus.OK
         );
+    }
+
+    /**
+     * 풀필먼트 반품 등록 (서비스 간 통신용)
+     *
+     * @param request 반품 등록 요청 (orderId, 회수지 정보, 반품 사유, 상품 목록)
+     */
+    @PostMapping("/return")
+    @RegisterInternalReturnDeliveryApiDocs
+    public ResponseEntity<BaseResponse<RegisterInternalReturnDeliveryResponse>> registerReturnDelivery(
+            @Valid @RequestBody RegisterInternalReturnDeliveryRequest request
+    ) {
+        RegisterInternalReturnDeliveryCommand command = mapToCommand(request);
+        RegisterInternalReturnDeliveryResult result = registerInternalReturnDeliveryUseCase.registerReturnDelivery(command);
+
+        return new ResponseEntity<>(
+                BaseResponse.of(
+                        RegisterInternalReturnDeliveryResponse.from(result),
+                        HttpStatus.CREATED,
+                        DEFAULT_SUCCESS_CODE,
+                        "풀필먼트 반품 등록 성공"
+                ),
+                HttpStatus.CREATED
+        );
+    }
+
+    /**
+     * 풀필먼트 반품 완료 상품 상세 조회 (서비스 간 통신용)
+     *
+     * @param returnSlipNumbers 반품 요청번호 (콤마 구분)
+     */
+    @GetMapping("/return-god-detail")
+    @GetInternalReturnGodDetailApiDocs
+    public ResponseEntity<BaseResponse<GetInternalReturnGodDetailResponse>> getReturnGodDetail(
+            @RequestParam("return-slip-numbers") String returnSlipNumbers
+    ) {
+        GetInternalReturnGodDetailResult result = getInternalReturnGodDetailUseCase.getReturnGodDetail(
+                GetInternalReturnGodDetailCommand.of(returnSlipNumbers)
+        );
+
+        return new ResponseEntity<>(
+                BaseResponse.of(
+                        GetInternalReturnGodDetailResponse.from(result),
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "풀필먼트 반품 완료 상품 상세 목록 조회 성공"
+                ),
+                HttpStatus.OK
+        );
+    }
+
+    private RegisterInternalReturnDeliveryCommand mapToCommand(RegisterInternalReturnDeliveryRequest request) {
+        List<RegisterInternalReturnDeliveryProductCommand> products = mapProducts(request.products());
+
+        return RegisterInternalReturnDeliveryCommand.builder()
+                .orderId(request.orderId())
+                .orderDate(request.orderDate())
+                .recipientName(request.recipientName())
+                .recipientPhoneNumber(request.recipientPhoneNumber())
+                .recipientAddress(request.recipientAddress())
+                .pickupRecipientName(request.pickupRecipientName())
+                .pickupRecipientPhoneNumber(request.pickupRecipientPhoneNumber())
+                .pickupZipCode(request.pickupZipCode())
+                .pickupAddress(request.pickupAddress())
+                .pickupAddressDetail(request.pickupAddressDetail())
+                .returnReason(request.returnReason())
+                .returnDetailReason(request.returnDetailReason())
+                .returnShippingRequest(request.returnShippingRequest())
+                .products(products)
+                .build();
+    }
+
+    private List<RegisterInternalReturnDeliveryProductCommand> mapProducts(
+            List<RegisterInternalReturnDeliveryRequest.ProductItem> items
+    ) {
+        if (FormatValidator.hasNoValue(items)) {
+            return List.of();
+        }
+        return items.stream()
+                .map(item -> RegisterInternalReturnDeliveryProductCommand.of(item.productCode(), item.quantity()))
+                .toList();
     }
 }

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/delivery/controller/apidocs/GetInternalReturnGodDetailApiDocs.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/delivery/controller/apidocs/GetInternalReturnGodDetailApiDocs.java
@@ -1,0 +1,33 @@
+package com.personal.marketnote.fulfillment.adapter.in.web.delivery.controller.apidocs;
+
+import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
+import com.personal.marketnote.fulfillment.adapter.in.web.delivery.response.GetInternalReturnGodDetailResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Operation(
+        summary = "(내부) 반품 완료 상품 상세 목록 조회",
+        description = "서비스 간 통신용 반품 완료 상품 상세 목록을 조회합니다.",
+        parameters = {
+                @Parameter(name = "return-slip-numbers", description = "반품 요청번호 (콤마 구분)", required = true)
+        },
+        responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "조회 성공",
+                        content = @Content(schema = @Schema(implementation = BaseResponse.class))
+                )
+        }
+)
+public @interface GetInternalReturnGodDetailApiDocs {
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/delivery/controller/apidocs/RegisterInternalReturnDeliveryApiDocs.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/delivery/controller/apidocs/RegisterInternalReturnDeliveryApiDocs.java
@@ -1,0 +1,36 @@
+package com.personal.marketnote.fulfillment.adapter.in.web.delivery.controller.apidocs;
+
+import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
+import com.personal.marketnote.fulfillment.adapter.in.web.delivery.request.RegisterInternalReturnDeliveryRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Operation(
+        summary = "풀필먼트 반품 등록",
+        description = "주문 ID와 반품 정보를 기반으로 파스토에 반품을 등록합니다. 서비스 간 통신용 내부 API입니다.",
+        requestBody = @RequestBody(
+                required = true,
+                content = @Content(
+                        schema = @Schema(implementation = RegisterInternalReturnDeliveryRequest.class)
+                )
+        ),
+        responses = {
+                @ApiResponse(
+                        responseCode = "201",
+                        description = "풀필먼트 반품 등록 성공",
+                        content = @Content(schema = @Schema(implementation = BaseResponse.class))
+                )
+        }
+)
+public @interface RegisterInternalReturnDeliveryApiDocs {
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/delivery/request/RegisterInternalReturnDeliveryRequest.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/delivery/request/RegisterInternalReturnDeliveryRequest.java
@@ -1,0 +1,45 @@
+package com.personal.marketnote.fulfillment.adapter.in.web.delivery.request;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
+
+public record RegisterInternalReturnDeliveryRequest(
+        @NotNull(message = "주문 ID는 필수입니다")
+        Long orderId,
+        @NotBlank(message = "주문일은 필수입니다")
+        String orderDate,
+        @NotBlank(message = "수령인명은 필수입니다")
+        String recipientName,
+        @NotBlank(message = "수령인 전화번호는 필수입니다")
+        String recipientPhoneNumber,
+        String recipientAddress,
+        @NotBlank(message = "회수지 수령인명은 필수입니다")
+        String pickupRecipientName,
+        @NotBlank(message = "회수지 전화번호는 필수입니다")
+        String pickupRecipientPhoneNumber,
+        @NotBlank(message = "회수지 우편번호는 필수입니다")
+        String pickupZipCode,
+        @NotBlank(message = "회수지 주소는 필수입니다")
+        String pickupAddress,
+        String pickupAddressDetail,
+        String returnReason,
+        String returnDetailReason,
+        String returnShippingRequest,
+        @NotEmpty(message = "반품 상품 목록은 필수입니다")
+        @Valid
+        List<ProductItem> products
+) {
+    public record ProductItem(
+            @NotBlank(message = "상품 코드는 필수입니다")
+            String productCode,
+            @NotNull(message = "수량은 필수입니다")
+            @Min(value = 1, message = "수량은 1 이상이어야 합니다")
+            Integer quantity
+    ) {
+    }
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/delivery/response/GetInternalReturnGodDetailResponse.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/delivery/response/GetInternalReturnGodDetailResponse.java
@@ -1,0 +1,48 @@
+package com.personal.marketnote.fulfillment.adapter.in.web.delivery.response;
+
+import com.personal.marketnote.fulfillment.port.in.result.GetInternalReturnGodDetailResult;
+import com.personal.marketnote.fulfillment.port.in.result.InternalReturnGodDetailGoodsResult;
+import com.personal.marketnote.fulfillment.port.in.result.InternalReturnGodDetailInfoResult;
+
+import java.util.List;
+
+public record GetInternalReturnGodDetailResponse(
+        Integer dataCount,
+        List<ReturnGodDetailInfo> returnGodInfos
+) {
+    public static GetInternalReturnGodDetailResponse from(GetInternalReturnGodDetailResult result) {
+        List<ReturnGodDetailInfo> infos = result.returnGodInfos().stream()
+                .map(ReturnGodDetailInfo::from)
+                .toList();
+        return new GetInternalReturnGodDetailResponse(result.dataCount(), infos);
+    }
+
+    public record ReturnGodDetailInfo(
+            String orderNumber,
+            String inboundOrderSlipNumber,
+            List<ReturnGodDetailGoods> products
+    ) {
+        public static ReturnGodDetailInfo from(InternalReturnGodDetailInfoResult result) {
+            List<ReturnGodDetailGoods> goods = result.products().stream()
+                    .map(ReturnGodDetailGoods::from)
+                    .toList();
+            return new ReturnGodDetailInfo(result.orderNumber(), result.inboundOrderSlipNumber(), goods);
+        }
+    }
+
+    public record ReturnGodDetailGoods(
+            String customerProductCode,
+            String productName,
+            String returnProductCheckStatus,
+            String returnProductCheckStatusName
+    ) {
+        public static ReturnGodDetailGoods from(InternalReturnGodDetailGoodsResult result) {
+            return new ReturnGodDetailGoods(
+                    result.customerProductCode(),
+                    result.productName(),
+                    result.returnProductCheckStatus(),
+                    result.returnProductCheckStatusName()
+            );
+        }
+    }
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/delivery/response/RegisterInternalReturnDeliveryResponse.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/delivery/response/RegisterInternalReturnDeliveryResponse.java
@@ -1,0 +1,19 @@
+package com.personal.marketnote.fulfillment.adapter.in.web.delivery.response;
+
+import com.personal.marketnote.fulfillment.port.in.result.RegisterInternalReturnDeliveryResult;
+
+public record RegisterInternalReturnDeliveryResponse(
+        Long orderId,
+        String returnSlipNumber,
+        boolean registered,
+        String message
+) {
+    public static RegisterInternalReturnDeliveryResponse from(RegisterInternalReturnDeliveryResult result) {
+        return new RegisterInternalReturnDeliveryResponse(
+                result.orderId(),
+                result.returnSlipNumber(),
+                result.registered(),
+                result.message()
+        );
+    }
+}

--- a/fulfillment-service/fulfillment-application/build.gradle.kts
+++ b/fulfillment-service/fulfillment-application/build.gradle.kts
@@ -121,14 +121,16 @@ springBoot {
 }
 
 tasks.register("printProjectName") {
+    val name = project.name
     doLast {
-        println(project.name)
+        println(name)
     }
 }
 
 tasks.register("printProjectVersion") {
+    val ver = version.toString()
     doLast {
-        println(version)
+        println(ver)
     }
 }
 

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/GetInternalReturnGodDetailCommand.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/GetInternalReturnGodDetailCommand.java
@@ -1,0 +1,21 @@
+package com.personal.marketnote.fulfillment.port.in.command;
+
+import com.personal.marketnote.common.utility.FormatValidator;
+
+public record GetInternalReturnGodDetailCommand(
+        String returnSlipNumbers
+) {
+    private static final int MAX_SLIP_NUMBER_COUNT = 100;
+
+    public static GetInternalReturnGodDetailCommand of(String returnSlipNumbers) {
+        if (FormatValidator.hasNoValue(returnSlipNumbers)) {
+            throw new IllegalArgumentException("returnSlipNumbers는 필수입니다.");
+        }
+        long count = returnSlipNumbers.chars().filter(c -> c == ',').count() + 1;
+        if (count > MAX_SLIP_NUMBER_COUNT) {
+            throw new IllegalArgumentException(
+                    "returnSlipNumbers 개수가 최대 제한(" + MAX_SLIP_NUMBER_COUNT + ")을 초과합니다: " + count);
+        }
+        return new GetInternalReturnGodDetailCommand(returnSlipNumbers);
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/RegisterInternalReturnDeliveryCommand.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/RegisterInternalReturnDeliveryCommand.java
@@ -1,0 +1,24 @@
+package com.personal.marketnote.fulfillment.port.in.command;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record RegisterInternalReturnDeliveryCommand(
+        Long orderId,
+        String orderDate,
+        String recipientName,
+        String recipientPhoneNumber,
+        String recipientAddress,
+        String pickupRecipientName,
+        String pickupRecipientPhoneNumber,
+        String pickupZipCode,
+        String pickupAddress,
+        String pickupAddressDetail,
+        String returnReason,
+        String returnDetailReason,
+        String returnShippingRequest,
+        List<RegisterInternalReturnDeliveryProductCommand> products
+) {
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/RegisterInternalReturnDeliveryProductCommand.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/RegisterInternalReturnDeliveryProductCommand.java
@@ -1,0 +1,10 @@
+package com.personal.marketnote.fulfillment.port.in.command;
+
+public record RegisterInternalReturnDeliveryProductCommand(
+        String productCode,
+        Integer quantity
+) {
+    public static RegisterInternalReturnDeliveryProductCommand of(String productCode, Integer quantity) {
+        return new RegisterInternalReturnDeliveryProductCommand(productCode, quantity);
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/vendor/RegisterFulfillmentDeliveryGoodsCommand.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/vendor/RegisterFulfillmentDeliveryGoodsCommand.java
@@ -12,4 +12,11 @@ public record RegisterFulfillmentDeliveryGoodsCommand(
     ) {
         return new RegisterFulfillmentDeliveryGoodsCommand(productCode, expirationDate, orderQuantity);
     }
+
+    public static RegisterFulfillmentDeliveryGoodsCommand of(
+            String productCode,
+            Integer orderQuantity
+    ) {
+        return new RegisterFulfillmentDeliveryGoodsCommand(productCode, null, orderQuantity);
+    }
 }

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/result/GetInternalReturnGodDetailResult.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/result/GetInternalReturnGodDetailResult.java
@@ -1,0 +1,15 @@
+package com.personal.marketnote.fulfillment.port.in.result;
+
+import java.util.List;
+
+public record GetInternalReturnGodDetailResult(
+        Integer dataCount,
+        List<InternalReturnGodDetailInfoResult> returnGodInfos
+) {
+    public static GetInternalReturnGodDetailResult of(
+            Integer dataCount,
+            List<InternalReturnGodDetailInfoResult> returnGodInfos
+    ) {
+        return new GetInternalReturnGodDetailResult(dataCount, returnGodInfos);
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/result/InternalReturnGodDetailGoodsResult.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/result/InternalReturnGodDetailGoodsResult.java
@@ -1,0 +1,19 @@
+package com.personal.marketnote.fulfillment.port.in.result;
+
+public record InternalReturnGodDetailGoodsResult(
+        String customerProductCode,
+        String productName,
+        String returnProductCheckStatus,
+        String returnProductCheckStatusName
+) {
+    public static InternalReturnGodDetailGoodsResult of(
+            String customerProductCode,
+            String productName,
+            String returnProductCheckStatus,
+            String returnProductCheckStatusName
+    ) {
+        return new InternalReturnGodDetailGoodsResult(
+                customerProductCode, productName, returnProductCheckStatus, returnProductCheckStatusName
+        );
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/result/InternalReturnGodDetailInfoResult.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/result/InternalReturnGodDetailInfoResult.java
@@ -1,0 +1,17 @@
+package com.personal.marketnote.fulfillment.port.in.result;
+
+import java.util.List;
+
+public record InternalReturnGodDetailInfoResult(
+        String orderNumber,
+        String inboundOrderSlipNumber,
+        List<InternalReturnGodDetailGoodsResult> products
+) {
+    public static InternalReturnGodDetailInfoResult of(
+            String orderNumber,
+            String inboundOrderSlipNumber,
+            List<InternalReturnGodDetailGoodsResult> products
+    ) {
+        return new InternalReturnGodDetailInfoResult(orderNumber, inboundOrderSlipNumber, products);
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/result/RegisterInternalReturnDeliveryResult.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/result/RegisterInternalReturnDeliveryResult.java
@@ -1,0 +1,17 @@
+package com.personal.marketnote.fulfillment.port.in.result;
+
+public record RegisterInternalReturnDeliveryResult(
+        Long orderId,
+        String returnSlipNumber,
+        boolean registered,
+        String message
+) {
+    public static RegisterInternalReturnDeliveryResult of(
+            Long orderId,
+            String returnSlipNumber,
+            boolean registered,
+            String message
+    ) {
+        return new RegisterInternalReturnDeliveryResult(orderId, returnSlipNumber, registered, message);
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/usecase/GetInternalReturnGodDetailUseCase.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/usecase/GetInternalReturnGodDetailUseCase.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.fulfillment.port.in.usecase;
+
+import com.personal.marketnote.fulfillment.port.in.command.GetInternalReturnGodDetailCommand;
+import com.personal.marketnote.fulfillment.port.in.result.GetInternalReturnGodDetailResult;
+
+public interface GetInternalReturnGodDetailUseCase {
+    GetInternalReturnGodDetailResult getReturnGodDetail(GetInternalReturnGodDetailCommand command);
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/usecase/RegisterInternalReturnDeliveryUseCase.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/usecase/RegisterInternalReturnDeliveryUseCase.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.fulfillment.port.in.usecase;
+
+import com.personal.marketnote.fulfillment.port.in.command.RegisterInternalReturnDeliveryCommand;
+import com.personal.marketnote.fulfillment.port.in.result.RegisterInternalReturnDeliveryResult;
+
+public interface RegisterInternalReturnDeliveryUseCase {
+    RegisterInternalReturnDeliveryResult registerReturnDelivery(RegisterInternalReturnDeliveryCommand command);
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/GetInternalReturnGodDetailService.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/GetInternalReturnGodDetailService.java
@@ -1,0 +1,88 @@
+package com.personal.marketnote.fulfillment.service;
+
+import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.fulfillment.domain.FulfillmentAccessToken;
+import com.personal.marketnote.fulfillment.port.in.command.GetInternalReturnGodDetailCommand;
+import com.personal.marketnote.fulfillment.port.in.command.vendor.GetFulfillmentReturnGodDetailCommand;
+import com.personal.marketnote.fulfillment.port.in.result.GetInternalReturnGodDetailResult;
+import com.personal.marketnote.fulfillment.port.in.result.InternalReturnGodDetailGoodsResult;
+import com.personal.marketnote.fulfillment.port.in.result.InternalReturnGodDetailInfoResult;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.FulfillmentReturnGodDetailGoodsResult;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.FulfillmentReturnGodDetailInfoResult;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.GetFulfillmentReturnGodDetailResult;
+import com.personal.marketnote.fulfillment.port.in.usecase.GetInternalReturnGodDetailUseCase;
+import com.personal.marketnote.fulfillment.port.out.vendor.DisconnectFulfillmentAuthPort;
+import com.personal.marketnote.fulfillment.port.out.vendor.GetFulfillmentCustomerCodePort;
+import com.personal.marketnote.fulfillment.port.out.vendor.GetFulfillmentReturnGodDetailPort;
+import com.personal.marketnote.fulfillment.port.out.vendor.RequestFulfillmentAuthPort;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+@UseCase
+@RequiredArgsConstructor
+public class GetInternalReturnGodDetailService implements GetInternalReturnGodDetailUseCase {
+    private final GetFulfillmentCustomerCodePort getFulfillmentCustomerCodePort;
+    private final RequestFulfillmentAuthPort requestFulfillmentAuthPort;
+    private final DisconnectFulfillmentAuthPort disconnectFulfillmentAuthPort;
+    private final GetFulfillmentReturnGodDetailPort getFulfillmentReturnGodDetailPort;
+
+    @Override
+    public GetInternalReturnGodDetailResult getReturnGodDetail(GetInternalReturnGodDetailCommand command) {
+        FulfillmentAccessToken accessToken = requestFulfillmentAuthPort.requestAccessToken();
+        try {
+            String customerCode = getFulfillmentCustomerCodePort.getCustomerCode();
+            GetFulfillmentReturnGodDetailCommand fasstoCommand = GetFulfillmentReturnGodDetailCommand.of(
+                    customerCode,
+                    accessToken.getValue(),
+                    null,
+                    null,
+                    command.returnSlipNumbers(),
+                    null
+            );
+            GetFulfillmentReturnGodDetailResult fasstoResult = getFulfillmentReturnGodDetailPort.getReturnGodDetail(fasstoCommand);
+
+            return mapToResult(fasstoResult);
+        } finally {
+            disconnectFulfillmentAuthPort.disconnectAccessToken(accessToken.getValue());
+        }
+    }
+
+    private GetInternalReturnGodDetailResult mapToResult(GetFulfillmentReturnGodDetailResult fasstoResult) {
+        if (FormatValidator.hasNoValue(fasstoResult) || FormatValidator.hasNoValue(fasstoResult.returnGodInfos())) {
+            return GetInternalReturnGodDetailResult.of(0, List.of());
+        }
+
+        List<InternalReturnGodDetailInfoResult> infos = fasstoResult.returnGodInfos().stream()
+                .map(this::mapToInfoResult)
+                .toList();
+
+        return GetInternalReturnGodDetailResult.of(fasstoResult.dataCount(), infos);
+    }
+
+    private InternalReturnGodDetailInfoResult mapToInfoResult(FulfillmentReturnGodDetailInfoResult info) {
+        if (FormatValidator.hasNoValue(info.products())) {
+            return InternalReturnGodDetailInfoResult.of(info.orderNumber(), info.inboundOrderSlipNumber(), List.of());
+        }
+
+        List<InternalReturnGodDetailGoodsResult> goods = info.products().stream()
+                .map(this::mapToGoodsResult)
+                .toList();
+
+        return InternalReturnGodDetailInfoResult.of(
+                info.orderNumber(),
+                info.inboundOrderSlipNumber(),
+                goods
+        );
+    }
+
+    private InternalReturnGodDetailGoodsResult mapToGoodsResult(FulfillmentReturnGodDetailGoodsResult goods) {
+        return InternalReturnGodDetailGoodsResult.of(
+                goods.customerProductCode(),
+                goods.productName(),
+                goods.returnProductCheckStatus(),
+                goods.returnProductCheckStatusName()
+        );
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/RegisterInternalReturnDeliveryService.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/RegisterInternalReturnDeliveryService.java
@@ -1,0 +1,97 @@
+package com.personal.marketnote.fulfillment.service;
+
+import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.fulfillment.domain.FulfillmentAccessToken;
+import com.personal.marketnote.fulfillment.port.in.command.RegisterInternalReturnDeliveryCommand;
+import com.personal.marketnote.fulfillment.port.in.command.vendor.RegisterFulfillmentDeliveryGoodsCommand;
+import com.personal.marketnote.fulfillment.port.in.command.vendor.RegisterFulfillmentReturnDeliveryCommand;
+import com.personal.marketnote.fulfillment.port.in.command.vendor.RegisterFulfillmentReturnDeliveryItemCommand;
+import com.personal.marketnote.fulfillment.port.in.result.RegisterInternalReturnDeliveryResult;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.RegisterFulfillmentDeliveryItemResult;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.RegisterFulfillmentDeliveryResult;
+import com.personal.marketnote.fulfillment.port.in.usecase.RegisterInternalReturnDeliveryUseCase;
+import com.personal.marketnote.fulfillment.port.out.vendor.DisconnectFulfillmentAuthPort;
+import com.personal.marketnote.fulfillment.port.out.vendor.GetFulfillmentCustomerCodePort;
+import com.personal.marketnote.fulfillment.port.out.vendor.RegisterFulfillmentReturnDeliveryPort;
+import com.personal.marketnote.fulfillment.port.out.vendor.RequestFulfillmentAuthPort;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+@UseCase
+@RequiredArgsConstructor
+public class RegisterInternalReturnDeliveryService implements RegisterInternalReturnDeliveryUseCase {
+    private static final String FASSTO_RETURN_TYPE_NORMAL = "01";
+
+    private final GetFulfillmentCustomerCodePort getFulfillmentCustomerCodePort;
+    private final RequestFulfillmentAuthPort requestFulfillmentAuthPort;
+    private final DisconnectFulfillmentAuthPort disconnectFulfillmentAuthPort;
+    private final RegisterFulfillmentReturnDeliveryPort registerFulfillmentReturnDeliveryPort;
+
+    @Override
+    public RegisterInternalReturnDeliveryResult registerReturnDelivery(RegisterInternalReturnDeliveryCommand command) {
+        FulfillmentAccessToken accessToken = requestFulfillmentAuthPort.requestAccessToken();
+        try {
+            String customerCode = getFulfillmentCustomerCodePort.getCustomerCode();
+            RegisterFulfillmentReturnDeliveryCommand fasstoCommand = buildFasstoCommand(
+                    customerCode, accessToken.getValue(), command
+            );
+            RegisterFulfillmentDeliveryResult fasstoResult = registerFulfillmentReturnDeliveryPort.registerReturnDelivery(fasstoCommand);
+
+            return mapToResult(command.orderId(), fasstoResult);
+        } finally {
+            disconnectFulfillmentAuthPort.disconnectAccessToken(accessToken.getValue());
+        }
+    }
+
+    private RegisterFulfillmentReturnDeliveryCommand buildFasstoCommand(
+            String customerCode,
+            String accessToken,
+            RegisterInternalReturnDeliveryCommand command
+    ) {
+        String orderNumber = String.valueOf(command.orderId());
+
+        List<RegisterFulfillmentDeliveryGoodsCommand> goods = command.products().stream()
+                .map(product -> RegisterFulfillmentDeliveryGoodsCommand.of(
+                        product.productCode(), product.quantity()
+                ))
+                .toList();
+
+        RegisterFulfillmentReturnDeliveryItemCommand itemCommand = RegisterFulfillmentReturnDeliveryItemCommand.builder()
+                .orderDate(command.orderDate())
+                .orderNumber(orderNumber)
+                .courierCode("")
+                .invoiceNumber("")
+                .recipientName(command.recipientName())
+                .recipientPhoneNumber(command.recipientPhoneNumber())
+                .recipientAddress(command.recipientAddress())
+                .returnReceiverName(command.pickupRecipientName())
+                .returnReceiverPhoneNumber(command.pickupRecipientPhoneNumber())
+                .returnZipCode(command.pickupZipCode())
+                .returnAddress1(command.pickupAddress())
+                .returnAddress2(command.pickupAddressDetail())
+                .returnType(FASSTO_RETURN_TYPE_NORMAL)
+                .returnReason(command.returnReason())
+                .returnDetailReason(command.returnDetailReason())
+                .returnShippingRequest(command.returnShippingRequest())
+                .products(goods)
+                .build();
+
+        return RegisterFulfillmentReturnDeliveryCommand.of(customerCode, accessToken, List.of(itemCommand));
+    }
+
+    private RegisterInternalReturnDeliveryResult mapToResult(Long orderId, RegisterFulfillmentDeliveryResult fasstoResult) {
+        if (FormatValidator.hasNoValue(fasstoResult.deliveries()) || fasstoResult.deliveries().isEmpty()) {
+            return RegisterInternalReturnDeliveryResult.of(orderId, null, false, "반품 등록 응답 없음");
+        }
+
+        RegisterFulfillmentDeliveryItemResult firstDelivery = fasstoResult.deliveries().get(0);
+        return RegisterInternalReturnDeliveryResult.of(
+                orderId,
+                firstDelivery.fulfillmentSlipNumber(),
+                true,
+                firstDelivery.message()
+        );
+    }
+}

--- a/fulfillment-service/fulfillment-domain/build.gradle.kts
+++ b/fulfillment-service/fulfillment-domain/build.gradle.kts
@@ -119,14 +119,16 @@ springBoot {
 }
 
 tasks.register("printProjectName") {
+    val name = project.name
     doLast {
-        println(project.name)
+        println(name)
     }
 }
 
 tasks.register("printProjectVersion") {
+    val ver = version.toString()
     doLast {
-        println(version)
+        println(ver)
     }
 }
 

--- a/product-service/product-adapters/build.gradle.kts
+++ b/product-service/product-adapters/build.gradle.kts
@@ -145,14 +145,16 @@ tasks.withType<JavaCompile>().configureEach {
 }
 
 tasks.register("printProjectName") {
+    val name = serviceName
     doLast {
-        println(serviceName)
+        println(name)
     }
 }
 
 tasks.register("printProjectVersion") {
+    val ver = version.toString()
     doLast {
-        println(version)
+        println(ver)
     }
 }
 

--- a/product-service/product-application/build.gradle.kts
+++ b/product-service/product-application/build.gradle.kts
@@ -121,14 +121,16 @@ springBoot {
 }
 
 tasks.register("printProjectName") {
+    val name = project.name
     doLast {
-        println(project.name)
+        println(name)
     }
 }
 
 tasks.register("printProjectVersion") {
+    val ver = version.toString()
     doLast {
-        println(version)
+        println(ver)
     }
 }
 

--- a/product-service/product-domain/build.gradle.kts
+++ b/product-service/product-domain/build.gradle.kts
@@ -119,14 +119,16 @@ springBoot {
 }
 
 tasks.register("printProjectName") {
+    val name = project.name
     doLast {
-        println(project.name)
+        println(name)
     }
 }
 
 tasks.register("printProjectVersion") {
+    val ver = version.toString()
     doLast {
-        println(version)
+        println(ver)
     }
 }
 

--- a/reward-service/reward-adapters/build.gradle.kts
+++ b/reward-service/reward-adapters/build.gradle.kts
@@ -133,14 +133,16 @@ tasks.withType<JavaCompile>().configureEach {
 }
 
 tasks.register("printProjectName") {
+    val name = serviceName
     doLast {
-        println(serviceName)
+        println(name)
     }
 }
 
 tasks.register("printProjectVersion") {
+    val ver = version.toString()
     doLast {
-        println(version)
+        println(ver)
     }
 }
 

--- a/reward-service/reward-application/build.gradle.kts
+++ b/reward-service/reward-application/build.gradle.kts
@@ -121,14 +121,16 @@ springBoot {
 }
 
 tasks.register("printProjectName") {
+    val name = project.name
     doLast {
-        println(project.name)
+        println(name)
     }
 }
 
 tasks.register("printProjectVersion") {
+    val ver = version.toString()
     doLast {
-        println(version)
+        println(ver)
     }
 }
 

--- a/reward-service/reward-domain/build.gradle.kts
+++ b/reward-service/reward-domain/build.gradle.kts
@@ -119,14 +119,16 @@ springBoot {
 }
 
 tasks.register("printProjectName") {
+    val name = project.name
     doLast {
-        println(project.name)
+        println(name)
     }
 }
 
 tasks.register("printProjectVersion") {
+    val ver = version.toString()
     doLast {
-        println(version)
+        println(ver)
     }
 }
 

--- a/user-service/user-adapters/build.gradle.kts
+++ b/user-service/user-adapters/build.gradle.kts
@@ -144,14 +144,16 @@ tasks.withType<JavaCompile>().configureEach {
 }
 
 tasks.register("printProjectName") {
+    val name = serviceName
     doLast {
-        println(serviceName)
+        println(name)
     }
 }
 
 tasks.register("printProjectVersion") {
+    val ver = version.toString()
     doLast {
-        println(version)
+        println(ver)
     }
 }
 

--- a/user-service/user-application/build.gradle.kts
+++ b/user-service/user-application/build.gradle.kts
@@ -134,14 +134,16 @@ springBoot {
 }
 
 tasks.register("printProjectName") {
+    val name = project.name
     doLast {
-        println(project.name)
+        println(name)
     }
 }
 
 tasks.register("printProjectVersion") {
+    val ver = version.toString()
     doLast {
-        println(version)
+        println(ver)
     }
 }
 

--- a/user-service/user-domain/build.gradle.kts
+++ b/user-service/user-domain/build.gradle.kts
@@ -123,14 +123,16 @@ springBoot {
 }
 
 tasks.register("printProjectName") {
+    val name = project.name
     doLast {
-        println(project.name)
+        println(name)
     }
 }
 
 tasks.register("printProjectVersion") {
+    val ver = version.toString()
     doLast {
-        println(version)
+        println(ver)
     }
 }
 


### PR DESCRIPTION
## partially addresses #216
## resolves #2369

## Task
- [x] 풀필먼트 서비스 내부 반품 검수 상태 조회 API 추가
- [x] 커머스 서비스 반품 검수 폴링 스케줄러 구현 (30분 간격)
- [x] PENDING ReturnTracker 배치 조회 후 Fassto 검수 상태 반영
- [x] 검수 상태 판정: 정상(01)→PASSED, 불량(02)→FAILED, 보류(03)→ON_HOLD
- [x] RequestReturnUseCaseTest Mock 누락 수정