### PR TITLE
[#216][#2374] test: 반품 검수 정상 시 반품 완료 상태 전이 및 PG 환불 연동 기능 자동화 테스트 추가

### DIFF
--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/returntracker/CompleteReturnInspectionServiceTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/returntracker/CompleteReturnInspectionServiceTest.java
@@ -1,0 +1,54 @@
+package com.personal.marketnote.commerce.service.returntracker;
+
+import com.personal.marketnote.commerce.domain.returntracker.ReturnInspectionStatus;
+import com.personal.marketnote.commerce.domain.returntracker.ReturnRefundStatus;
+import com.personal.marketnote.commerce.domain.returntracker.ReturnTracker;
+import com.personal.marketnote.commerce.domain.returntracker.ReturnTrackerSnapshotState;
+import com.personal.marketnote.commerce.port.out.event.PublishReturnTrackerEventPort;
+import com.personal.marketnote.commerce.port.out.returntracker.UpdateReturnTrackerPort;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("CompleteReturnInspectionService 테스트")
+class CompleteReturnInspectionServiceTest {
+
+    @InjectMocks
+    private CompleteReturnInspectionService service;
+
+    @Mock
+    private UpdateReturnTrackerPort updateReturnTrackerPort;
+
+    @Mock
+    private PublishReturnTrackerEventPort publishReturnTrackerEventPort;
+
+    @Test
+    @DisplayName("검수 PASSED 시 ReturnTracker를 업데이트하고 이벤트를 발행한다")
+    void shouldPassInspectionAndPublishEvent() {
+        ReturnTracker tracker = ReturnTracker.from(ReturnTrackerSnapshotState.builder()
+                .id(1L)
+                .orderId(100L)
+                .returnSlipNumber("RS-001")
+                .inspectionStatus(ReturnInspectionStatus.PENDING)
+                .refundStatus(ReturnRefundStatus.PENDING)
+                .build());
+
+        LocalDateTime now = LocalDateTime.of(2026, 4, 9, 19, 0);
+
+        service.completeInspection(tracker, now);
+
+        assertThat(tracker.isInspectionPassed()).isTrue();
+        assertThat(tracker.getInspectedAt()).isEqualTo(now);
+        verify(updateReturnTrackerPort).update(tracker);
+        verify(publishReturnTrackerEventPort).publishReturnInspectionCompletedEvent(100L);
+    }
+}

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/returntracker/CompleteReturnRefundServiceTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/returntracker/CompleteReturnRefundServiceTest.java
@@ -1,0 +1,161 @@
+package com.personal.marketnote.commerce.service.returntracker;
+
+import com.personal.marketnote.commerce.domain.returntracker.ReturnInspectionStatus;
+import com.personal.marketnote.commerce.domain.returntracker.ReturnRefundStatus;
+import com.personal.marketnote.commerce.domain.returntracker.ReturnTracker;
+import com.personal.marketnote.commerce.domain.returntracker.ReturnTrackerSnapshotState;
+import com.personal.marketnote.commerce.exception.PaymentAlreadyRefundedException;
+import com.personal.marketnote.commerce.exception.PaymentCancelException;
+import com.personal.marketnote.commerce.exception.ReturnTrackerNotFoundException;
+import com.personal.marketnote.commerce.port.in.command.payment.RefundPaymentCommand;
+import com.personal.marketnote.commerce.port.in.command.returntracker.CompleteReturnRefundCommand;
+import com.personal.marketnote.commerce.port.in.usecase.payment.RefundPaymentUseCase;
+import com.personal.marketnote.commerce.port.out.returntracker.FindReturnTrackerPort;
+import com.personal.marketnote.commerce.port.out.returntracker.UpdateReturnTrackerPort;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("CompleteReturnRefundService 테스트")
+class CompleteReturnRefundServiceTest {
+
+    @InjectMocks
+    private CompleteReturnRefundService service;
+
+    @Mock
+    private RefundPaymentUseCase refundPaymentUseCase;
+
+    @Mock
+    private FindReturnTrackerPort findReturnTrackerPort;
+
+    @Mock
+    private UpdateReturnTrackerPort updateReturnTrackerPort;
+
+    @Spy
+    private Clock clock = Clock.fixed(Instant.parse("2026-04-09T10:00:00Z"), ZoneId.of("Asia/Seoul"));
+
+    @Nested
+    @DisplayName("PG 환불 성공")
+    class RefundSuccess {
+
+        @Test
+        @DisplayName("PG 환불 성공 시 ReturnTracker refundStatus가 COMPLETED로 변경된다")
+        void shouldCompleteRefundAndUpdateTrackerStatus() {
+            ReturnTracker tracker = createTracker(ReturnRefundStatus.PENDING);
+            when(findReturnTrackerPort.findByOrderId(1L)).thenReturn(Optional.of(tracker));
+
+            CompleteReturnRefundCommand command = createCommand();
+
+            service.completeReturnRefund(command);
+
+            verify(refundPaymentUseCase).refund(argThat(cmd ->
+                    cmd.orderKey().equals("ORDER-KEY-001")
+                            && cmd.orderId().equals(1L)
+                            && cmd.cancelAmount().equals(30000L)
+                            && cmd.paymentAmount().equals(50000L)
+                            && cmd.isFullCancel()
+                            && cmd.returnShippingFee().equals(3000L)));
+            assertThat(tracker.isRefundCompleted()).isTrue();
+            verify(updateReturnTrackerPort).update(tracker);
+        }
+    }
+
+    @Nested
+    @DisplayName("PG 환불 실패")
+    class RefundFailure {
+
+        @Test
+        @DisplayName("PG 환불 실패 시 ReturnTracker refundStatus가 FAILED로 변경된다")
+        void shouldMarkRefundAsFailedOnPgError() {
+            ReturnTracker tracker = createTracker(ReturnRefundStatus.PENDING);
+            when(findReturnTrackerPort.findByOrderId(1L)).thenReturn(Optional.of(tracker));
+            doThrow(new PaymentCancelException("PG 환불 실패"))
+                    .when(refundPaymentUseCase).refund(any(RefundPaymentCommand.class));
+
+            CompleteReturnRefundCommand command = createCommand();
+
+            service.completeReturnRefund(command);
+
+            assertThat(tracker.isRefundFailed()).isTrue();
+            verify(updateReturnTrackerPort).update(tracker);
+        }
+
+        @Test
+        @DisplayName("ReturnTracker를 찾을 수 없으면 ReturnTrackerNotFoundException을 던진다")
+        void shouldThrowWhenTrackerNotFound() {
+            when(findReturnTrackerPort.findByOrderId(1L)).thenReturn(Optional.empty());
+
+            CompleteReturnRefundCommand command = createCommand();
+
+            assertThatThrownBy(() -> service.completeReturnRefund(command))
+                    .isInstanceOf(ReturnTrackerNotFoundException.class);
+
+            verifyNoInteractions(refundPaymentUseCase);
+            verifyNoInteractions(updateReturnTrackerPort);
+        }
+    }
+
+    @Nested
+    @DisplayName("멱등성 처리")
+    class Idempotency {
+
+        @Test
+        @DisplayName("이미 환불 완료된 결제이면 refundStatus를 변경하지 않고 정상 종료한다")
+        void shouldHandleAlreadyRefundedPayment() {
+            ReturnTracker tracker = createTracker(ReturnRefundStatus.PENDING);
+            when(findReturnTrackerPort.findByOrderId(1L)).thenReturn(Optional.of(tracker));
+            doThrow(new PaymentAlreadyRefundedException("ORDER-KEY-001"))
+                    .when(refundPaymentUseCase).refund(any(RefundPaymentCommand.class));
+
+            CompleteReturnRefundCommand command = createCommand();
+
+            service.completeReturnRefund(command);
+
+            assertThat(tracker.isRefundCompleted()).isTrue();
+            verify(updateReturnTrackerPort).update(tracker);
+        }
+    }
+
+    private CompleteReturnRefundCommand createCommand() {
+        return CompleteReturnRefundCommand.builder()
+                .orderId(1L)
+                .orderKey("ORDER-KEY-001")
+                .buyerId(100L)
+                .returnAmount(30000L)
+                .paymentAmount(50000L)
+                .pointAmount(1000L)
+                .shippingFee(3000L)
+                .isFullReturn(true)
+                .returnShippingFee(3000L)
+                .build();
+    }
+
+    private ReturnTracker createTracker(ReturnRefundStatus refundStatus) {
+        return ReturnTracker.from(ReturnTrackerSnapshotState.builder()
+                .id(1L)
+                .orderId(1L)
+                .returnSlipNumber("RS-001")
+                .inspectionStatus(ReturnInspectionStatus.PASSED)
+                .refundStatus(refundStatus)
+                .inspectedAt(LocalDateTime.of(2026, 4, 9, 10, 0))
+                .build());
+    }
+}

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/returntracker/CompleteReturnServiceTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/returntracker/CompleteReturnServiceTest.java
@@ -1,0 +1,184 @@
+package com.personal.marketnote.commerce.service.returntracker;
+
+import com.personal.marketnote.commerce.domain.order.*;
+import com.personal.marketnote.commerce.exception.InvalidOrderStatusTransitionException;
+import com.personal.marketnote.commerce.port.in.command.order.CalculateReturnShippingFeeCommand;
+import com.personal.marketnote.commerce.port.in.command.returntracker.CompleteReturnCommand;
+import com.personal.marketnote.commerce.port.in.result.order.CalculateReturnShippingFeeResult;
+import com.personal.marketnote.commerce.port.in.usecase.order.CalculateReturnShippingFeeUseCase;
+import com.personal.marketnote.commerce.port.in.usecase.order.GetOrderUseCase;
+import com.personal.marketnote.commerce.port.out.event.PublishOrderEventPort;
+import com.personal.marketnote.commerce.port.out.order.UpdateOrderPort;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("CompleteReturnService 테스트")
+class CompleteReturnServiceTest {
+
+    @InjectMocks
+    private CompleteReturnService service;
+
+    @Mock
+    private GetOrderUseCase getOrderUseCase;
+
+    @Mock
+    private UpdateOrderPort updateOrderPort;
+
+    @Mock
+    private PublishOrderEventPort publishOrderEventPort;
+
+    @Mock
+    private CalculateReturnShippingFeeUseCase calculateReturnShippingFeeUseCase;
+
+    @Spy
+    private Clock clock = Clock.fixed(Instant.parse("2026-04-09T10:00:00Z"), ZoneId.of("Asia/Seoul"));
+
+    @Nested
+    @DisplayName("반품 완료 처리 성공")
+    class CompleteReturnSuccess {
+
+        @Test
+        @DisplayName("RETURN_REQUESTED 상태의 주문을 RETURNED로 전이하고 OrderReturnedEvent를 발행한다")
+        void shouldTransitionFromReturnRequestedToReturnedAndPublishEvent() {
+            Order order = createReturnableOrder(OrderStatus.RETURN_REQUESTED);
+            when(getOrderUseCase.getOrder(1L)).thenReturn(order);
+            when(calculateReturnShippingFeeUseCase.calculateReturnShippingFee(any(CalculateReturnShippingFeeCommand.class)))
+                    .thenReturn(CalculateReturnShippingFeeResult.builder().returnShippingFee(3000L).build());
+
+            CompleteReturnCommand command = new CompleteReturnCommand(1L);
+
+            service.completeReturn(command);
+
+            verify(order).changeAllProductsStatus(eq(OrderStatus.RETURN_IN_PROGRESS), any());
+            verify(order).changeAllProductsStatus(eq(OrderStatus.RETURNED), any());
+            verify(updateOrderPort).update(eq(order), any(OrderStatusHistory.class));
+            verify(publishOrderEventPort).publishOrderReturnedEvent(
+                    eq(1L), anyString(), eq(100L),
+                    eq(30000L), eq(49000L), eq(1000L), eq(3000L),
+                    eq(true), eq(3000L), anyList());
+        }
+
+        @Test
+        @DisplayName("RETURN_IN_PROGRESS 상태의 주문을 RETURNED로 바로 전이한다")
+        void shouldTransitionFromReturnInProgressToReturned() {
+            Order order = createReturnableOrder(OrderStatus.RETURN_IN_PROGRESS);
+            when(getOrderUseCase.getOrder(1L)).thenReturn(order);
+            when(calculateReturnShippingFeeUseCase.calculateReturnShippingFee(any(CalculateReturnShippingFeeCommand.class)))
+                    .thenReturn(CalculateReturnShippingFeeResult.builder().returnShippingFee(0L).build());
+
+            CompleteReturnCommand command = new CompleteReturnCommand(1L);
+
+            service.completeReturn(command);
+
+            verify(order, never()).changeAllProductsStatus(eq(OrderStatus.RETURN_IN_PROGRESS), any());
+            verify(order).changeAllProductsStatus(eq(OrderStatus.RETURNED), any());
+            verify(updateOrderPort).update(eq(order), any(OrderStatusHistory.class));
+            verify(publishOrderEventPort).publishOrderReturnedEvent(
+                    eq(1L), anyString(), eq(100L),
+                    eq(30000L), eq(49000L), eq(1000L), eq(3000L),
+                    eq(true), eq(0L), anyList());
+        }
+
+        @Test
+        @DisplayName("반품 배송비를 CalculateReturnShippingFeeUseCase로 계산하여 이벤트에 포함한다")
+        void shouldCalculateReturnShippingFeeAndIncludeInEvent() {
+            Order order = createReturnableOrder(OrderStatus.RETURN_REQUESTED);
+            when(getOrderUseCase.getOrder(1L)).thenReturn(order);
+            when(calculateReturnShippingFeeUseCase.calculateReturnShippingFee(any(CalculateReturnShippingFeeCommand.class)))
+                    .thenReturn(CalculateReturnShippingFeeResult.builder().returnShippingFee(5000L).build());
+
+            CompleteReturnCommand command = new CompleteReturnCommand(1L);
+
+            service.completeReturn(command);
+
+            verify(calculateReturnShippingFeeUseCase).calculateReturnShippingFee(
+                    argThat(cmd -> cmd.orderId().equals(1L)
+                            && cmd.reasonCategory() == OrderStatusReasonCategory.SIMPLE_CHANGE_OF_MIND));
+            verify(publishOrderEventPort).publishOrderReturnedEvent(
+                    eq(1L), anyString(), eq(100L),
+                    eq(30000L), eq(49000L), eq(1000L), eq(3000L),
+                    eq(true), eq(5000L), anyList());
+        }
+    }
+
+    @Nested
+    @DisplayName("반품 완료 처리 실패")
+    class CompleteReturnFailure {
+
+        @Test
+        @DisplayName("RETURN_REQUESTED/RETURN_IN_PROGRESS가 아닌 상태이면 InvalidOrderStatusTransitionException을 던진다")
+        void shouldThrowOnInvalidStatus() {
+            Order order = mock(Order.class);
+            when(order.getOrderStatus()).thenReturn(OrderStatus.PAID);
+            when(getOrderUseCase.getOrder(1L)).thenReturn(order);
+
+            CompleteReturnCommand command = new CompleteReturnCommand(1L);
+
+            assertThatThrownBy(() -> service.completeReturn(command))
+                    .isInstanceOf(InvalidOrderStatusTransitionException.class);
+
+            verifyNoInteractions(updateOrderPort);
+            verifyNoInteractions(publishOrderEventPort);
+            verifyNoInteractions(calculateReturnShippingFeeUseCase);
+        }
+    }
+
+    @Nested
+    @DisplayName("멱등성 처리")
+    class Idempotency {
+
+        @Test
+        @DisplayName("이미 RETURNED 상태인 주문이면 아무 처리 없이 정상 종료한다")
+        void shouldSkipAlreadyReturnedOrder() {
+            Order order = mock(Order.class);
+            when(order.getOrderStatus()).thenReturn(OrderStatus.RETURNED);
+            when(getOrderUseCase.getOrder(1L)).thenReturn(order);
+
+            CompleteReturnCommand command = new CompleteReturnCommand(1L);
+
+            service.completeReturn(command);
+
+            verifyNoInteractions(updateOrderPort);
+            verifyNoInteractions(publishOrderEventPort);
+            verifyNoInteractions(calculateReturnShippingFeeUseCase);
+        }
+    }
+
+    private Order createReturnableOrder(OrderStatus status) {
+        Order order = mock(Order.class);
+        when(order.getId()).thenReturn(1L);
+        when(order.getBuyerId()).thenReturn(100L);
+        when(order.getOrderKey()).thenReturn(UUID.fromString("11111111-1111-1111-1111-111111111111"));
+        when(order.getOrderStatus()).thenReturn(status);
+        when(order.getStatusChangeReasonCategory()).thenReturn(OrderStatusReasonCategory.SIMPLE_CHANGE_OF_MIND);
+
+        OrderAmount amount = OrderAmount.of(50000L, 49000L, 0L, 1000L, 3000L);
+        when(order.getAmount()).thenReturn(amount);
+
+        OrderProduct product = mock(OrderProduct.class);
+        when(product.getPricePolicyId()).thenReturn(10L);
+        when(product.getQuantity()).thenReturn(3);
+        when(product.getUnitAmount()).thenReturn(10000L);
+        when(product.getOrderStatus()).thenReturn(OrderStatus.RETURNED);
+        when(order.getOrderProducts()).thenReturn(List.of(product));
+
+        return order;
+    }
+}


### PR DESCRIPTION
## partially addresses #216
## resolves #2374

## Test Case
- [x] 검수 정상 이벤트 수신 시 주문 상태가 즉시 RETURNED로 전이되는지 검증
- [x] ReturnTracker inspectionStatus가 PASSED로 변경되는지 검증
- [x] OrderReturnedEvent가 발행되는지 검증
- [x] PG 환불 컨슈머에서 RefundPaymentUseCase가 호출되는지 검증
- [x] PG 환불 성공 시 ReturnTracker refundStatus가 COMPLETED로 변경되는지 검증