### PR TITLE
[#216][#2377] feat: 반품 완료 시 분개 역처리 연동 기능 추가

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/OrderReturnedLedgerConsumer.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/OrderReturnedLedgerConsumer.java
@@ -1,0 +1,72 @@
+package com.personal.marketnote.commerce.adapter.in.event;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.commerce.exception.DuplicateLedgerTransactionException;
+import com.personal.marketnote.commerce.port.in.usecase.ledger.RecordLedgerEntryUseCase;
+import com.personal.marketnote.common.kafka.KafkaTopicConstants;
+import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.EventPayloadValidator;
+import com.personal.marketnote.common.kafka.event.OrderReturnedEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OrderReturnedLedgerConsumer {
+    private static final String IDEMPOTENCY_KEY_PREFIX = "ORDER_RETURN:";
+
+    private final ObjectMapper objectMapper;
+    private final RecordLedgerEntryUseCase recordLedgerEntryUseCase;
+
+    @KafkaListener(
+            topics = KafkaTopicConstants.ORDER_RETURNED,
+            groupId = "commerce-order-returned-ledger"
+    )
+    public void handleOrderReturnedEvent(
+            ConsumerRecord<String, EventEnvelope<?>> record,
+            Acknowledgment acknowledgment
+    ) {
+        EventEnvelope<?> envelope = record.value();
+
+        if (EventPayloadValidator.hasInvalidEnvelope(envelope, record)) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        if (EventPayloadValidator.hasEventTypeMismatch(envelope, KafkaTopicConstants.ORDER_RETURNED)) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        OrderReturnedEvent payload = envelope.getPayloadAs(OrderReturnedEvent.class, objectMapper);
+
+        log.info("반품 완료 이벤트 수신 (회계 역분개). eventId={}, orderId={}, isFullReturn={}, returnAmount={}",
+                envelope.eventId(), payload.orderId(), payload.isFullReturn(), payload.returnAmount());
+
+        if (EventPayloadValidator.hasInvalidIds(envelope.eventId(),
+                EventPayloadValidator.id("orderId", payload.orderId()))) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        String idempotencyKey = IDEMPOTENCY_KEY_PREFIX + payload.orderId();
+
+        try {
+            recordLedgerEntryUseCase.recordPaymentCancellation(
+                    payload.orderId(), payload.returnAmount(), idempotencyKey
+            );
+            log.info("반품 완료 역분개 완료. orderId={}, returnAmount={}, idempotencyKey={}",
+                    payload.orderId(), payload.returnAmount(), idempotencyKey);
+        } catch (DuplicateLedgerTransactionException e) {
+            log.info("이미 처리된 반품 완료 역분개 이벤트 (멱등 처리). eventId={}, message={}",
+                    envelope.eventId(), e.getMessage());
+        }
+
+        acknowledgment.acknowledge();
+    }
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/OrderController.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/OrderController.java
@@ -326,7 +326,7 @@ public class OrderController {
      * @param principal            인증된 사용자 정보
      * @return 반품 환불 예정 정보 조회 응답 {@link GetReturnRefundInfoResponse}
      * @Author 성효빈
-     * @Date 2026-04-09
+     * @Date 2026-06-03
      * @Description 반품 신청 전 환불 예정 정보를 조회합니다. 구매자 소유권 및 반품 가능 상태 검증을 수행합니다.
      */
     @GetMapping("/api/v1/orders/{id}/return-refund-info")

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/apidocs/GetReturnRefundInfoApiDocs.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/apidocs/GetReturnRefundInfoApiDocs.java
@@ -17,7 +17,7 @@ import java.lang.annotation.*;
 @Operation(
         summary = "반품 환불 예정 정보 조회",
         description = """
-                작성일자: 2026-04-09
+                작성일자: 2026-06-03
                 
                 작성자: 성효빈
                 
@@ -46,7 +46,7 @@ import java.lang.annotation.*;
                 | --- | --- | --- | --- |
                 | statusCode | number | 상태 코드 | 200: 성공 / 401: 인증 실패 / 403: 인가 실패 / 404: 리소스 조회 실패 / 500: 그 외 |
                 | code | string | 응답 코드 | "SUC01" / "UNAUTHORIZED" / "FORBIDDEN" / "NOT_FOUND" / "INTERNAL_SERVER_ERROR" |
-                | timestamp | string(datetime) | 응답 일시 | "2026-04-09T12:00:00.000" |
+                | timestamp | string(datetime) | 응답 일시 | "2026-06-03T12:00:00.000" |
                 | content | object | 응답 본문 | { ... } |
                 | message | string | 처리 결과 | "반품 환불 예정 정보 조회 성공" |
                 
@@ -95,7 +95,7 @@ import java.lang.annotation.*;
                                         {
                                           "statusCode": 200,
                                           "code": "SUC01",
-                                          "timestamp": "2026-04-09T12:00:00.000",
+                                          "timestamp": "2026-06-03T12:00:00.000",
                                           "content": {
                                             "totalProductAmount": 50000,
                                             "returnShippingFee": 3000,
@@ -116,7 +116,7 @@ import java.lang.annotation.*;
                                         {
                                           "statusCode": 401,
                                           "code": "UNAUTHORIZED",
-                                          "timestamp": "2026-04-09T12:00:00.000",
+                                          "timestamp": "2026-06-03T12:00:00.000",
                                           "content": null,
                                           "message": "Invalid token"
                                         }
@@ -131,7 +131,7 @@ import java.lang.annotation.*;
                                         {
                                           "statusCode": 403,
                                           "code": "FORBIDDEN",
-                                          "timestamp": "2026-04-09T12:00:00.000",
+                                          "timestamp": "2026-06-03T12:00:00.000",
                                           "content": null,
                                           "message": "Access Denied"
                                         }
@@ -146,7 +146,7 @@ import java.lang.annotation.*;
                                         {
                                           "statusCode": 404,
                                           "code": "NOT_FOUND",
-                                          "timestamp": "2026-04-09T12:00:00.000",
+                                          "timestamp": "2026-06-03T12:00:00.000",
                                           "content": null,
                                           "message": "주문을 찾을 수 없습니다."
                                         }

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/returntracker/CompleteReturnRefundServiceTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/returntracker/CompleteReturnRefundServiceTest.java
@@ -50,7 +50,7 @@ class CompleteReturnRefundServiceTest {
     private UpdateReturnTrackerPort updateReturnTrackerPort;
 
     @Spy
-    private Clock clock = Clock.fixed(Instant.parse("2026-04-09T10:00:00Z"), ZoneId.of("Asia/Seoul"));
+    private Clock clock = Clock.fixed(Instant.parse("2026-06-03T10:00:00Z"), ZoneId.of("Asia/Seoul"));
 
     @Nested
     @DisplayName("PG 환불 성공")

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/returntracker/CompleteReturnServiceTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/returntracker/CompleteReturnServiceTest.java
@@ -48,7 +48,7 @@ class CompleteReturnServiceTest {
     private CalculateReturnShippingFeeUseCase calculateReturnShippingFeeUseCase;
 
     @Spy
-    private Clock clock = Clock.fixed(Instant.parse("2026-04-09T10:00:00Z"), ZoneId.of("Asia/Seoul"));
+    private Clock clock = Clock.fixed(Instant.parse("2026-06-03T10:00:00Z"), ZoneId.of("Asia/Seoul"));
 
     @Nested
     @DisplayName("반품 완료 처리 성공")

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/event/UserReferralCompletedRewardConsumer.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/event/UserReferralCompletedRewardConsumer.java
@@ -67,7 +67,7 @@ public class UserReferralCompletedRewardConsumer {
             Long referrerId = payload.referredUserId();
             Long referredId = payload.requestUserId();
 
-            accrueReferrerPointWithBonus(envelope.eventId(), referrerId, referredId);
+            accrueReferrerPointIfEligible(envelope.eventId(), referrerId, referredId);
             accrueReferredPointIdempotent(envelope.eventId(), referredId, referrerId);
 
             log.info("Kafka 이벤트로 추천 포인트 적립 완료. requestUserId={}, referredUserId={}",
@@ -81,7 +81,7 @@ public class UserReferralCompletedRewardConsumer {
         acknowledgment.acknowledge();
     }
 
-    private void accrueReferrerPointWithBonus(String eventId, Long referrerId, Long referredId) {
+    private void accrueReferrerPointIfEligible(String eventId, Long referrerId, Long referredId) {
         long referralCount = getReferralStatusUseCase.countCompletedReferrals(referrerId);
 
         if (ReferralBonusTier.isMaxReached(referralCount)) {
@@ -91,10 +91,6 @@ public class UserReferralCompletedRewardConsumer {
         }
 
         accrueReferrerPointIdempotent(eventId, referrerId, referredId);
-
-        long newCount = referralCount + 1;
-        ReferralBonusTier.findNewlyAchievedTier(newCount)
-                .ifPresent(tier -> accrueBonusIdempotent(eventId, referrerId, tier));
     }
 
     private void accrueReferrerPointIdempotent(String eventId, Long referrerId, Long referredId) {
@@ -112,15 +108,6 @@ public class UserReferralCompletedRewardConsumer {
         } catch (DuplicateUserPointHistoryException e) {
             log.info("이미 처리된 피추천인 포인트 적립 이벤트 (멱등 처리). eventId={}, message={}",
                     eventId, e.getMessage());
-        }
-    }
-
-    private void accrueBonusIdempotent(String eventId, Long userId, ReferralBonusTier tier) {
-        try {
-            accrueBonus(userId, tier);
-        } catch (DuplicateUserPointHistoryException e) {
-            log.info("이미 처리된 누적 보너스 적립 이벤트 (멱등 처리). eventId={}, tier={}, message={}",
-                    eventId, tier, e.getMessage());
         }
     }
 
@@ -146,17 +133,5 @@ public class UserReferralCompletedRewardConsumer {
                 .reason(REFERRED_POINT_REASON)
                 .build();
         modifyUserPointUseCase.modify(referredCommand);
-    }
-
-    private void accrueBonus(Long userId, ReferralBonusTier tier) {
-        ModifyUserPointCommand bonusCommand = ModifyUserPointCommand.builder()
-                .userId(userId)
-                .changeType(UserPointChangeType.ACCRUAL)
-                .amount((long) tier.getBonusAmount())
-                .sourceType(UserPointSourceType.USER)
-                .sourceId(userId)
-                .reason(tier.getReason())
-                .build();
-        modifyUserPointUseCase.modify(bonusCommand);
     }
 }

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/point/PointController.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/point/PointController.java
@@ -7,13 +7,16 @@ import com.personal.marketnote.common.utility.Role;
 import com.personal.marketnote.reward.adapter.in.web.point.apidocs.*;
 import com.personal.marketnote.reward.adapter.in.web.point.mapper.PointRequestToCommandMapper;
 import com.personal.marketnote.reward.adapter.in.web.point.request.CancelPendingPointRequest;
+import com.personal.marketnote.reward.adapter.in.web.point.request.ClaimReferralBonusRequest;
 import com.personal.marketnote.reward.adapter.in.web.point.request.ConfirmPendingPointRequest;
 import com.personal.marketnote.reward.adapter.in.web.point.request.ModifyPendingPointRequest;
 import com.personal.marketnote.reward.adapter.in.web.point.request.ModifyUserPointRequest;
 import com.personal.marketnote.reward.adapter.in.web.point.response.*;
 import com.personal.marketnote.reward.domain.point.UserPointHistoryFilter;
+import com.personal.marketnote.reward.port.in.command.point.ClaimReferralBonusCommand;
 import com.personal.marketnote.reward.port.in.command.point.GetUserPointHistoryCommand;
 import com.personal.marketnote.reward.port.in.command.point.RegisterUserPointCommand;
+import com.personal.marketnote.reward.port.in.result.point.ClaimReferralBonusResult;
 import com.personal.marketnote.reward.port.in.result.point.GetReferralStatusResult;
 import com.personal.marketnote.reward.port.in.result.point.GetUserPointHistoryResult;
 import com.personal.marketnote.reward.port.in.result.point.GetUserPointResult;
@@ -50,6 +53,7 @@ public class PointController {
     private final GetUserPointUseCase getUserPointUseCase;
     private final GetUserPointHistoryUseCase getUserPointHistoryUseCase;
     private final GetReferralStatusUseCase getReferralStatusUseCase;
+    private final ClaimReferralBonusUseCase claimReferralBonusUseCase;
 
     /**
      * (관리자) 회원 포인트 정보 생성
@@ -307,6 +311,39 @@ public class PointController {
                         HttpStatus.OK,
                         DEFAULT_SUCCESS_CODE,
                         "친구 초대 현황 조회 성공"
+                )
+        );
+    }
+
+    /**
+     * 친구 초대 누적 보너스 클레임 요청
+     *
+     * @param principal 인증된 사용자 정보
+     * @param request   보너스 클레임 요청 {@link ClaimReferralBonusRequest}
+     * @return 보너스 클레임 결과 {@link ClaimReferralBonusResponse}
+     * @Author 성효빈
+     * @Date 2026-06-03
+     * @Description 사용자가 달성한 누적 보너스 티어의 보너스를 클레임합니다.
+     */
+    @PostMapping("/me/referral-bonus")
+    @ClaimReferralBonusApiDocs
+    public ResponseEntity<BaseResponse<ClaimReferralBonusResponse>> claimReferralBonus(
+            @AuthenticationPrincipal OAuth2AuthenticatedPrincipal principal,
+            @RequestBody @Valid ClaimReferralBonusRequest request
+    ) {
+        ClaimReferralBonusResult result = claimReferralBonusUseCase.claim(
+                new ClaimReferralBonusCommand(
+                        ElementExtractor.extractUserId(principal),
+                        request.tier()
+                )
+        );
+
+        return ResponseEntity.ok(
+                BaseResponse.of(
+                        ClaimReferralBonusResponse.from(result),
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "보너스 클레임 성공"
                 )
         );
     }

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/point/apidocs/ClaimReferralBonusApiDocs.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/point/apidocs/ClaimReferralBonusApiDocs.java
@@ -1,0 +1,85 @@
+package com.personal.marketnote.reward.adapter.in.web.point.apidocs;
+
+import com.personal.marketnote.reward.adapter.in.web.point.response.ClaimReferralBonusResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Operation(
+        summary = "친구 초대 누적 보너스 클레임",
+        description = """
+                작성일자: 2026-06-03
+
+                작성자: 성효빈
+
+                ---
+
+                ## Description
+
+                달성한 누적 보너스 티어의 보너스를 클레임(수령)합니다.
+                티어 미달성 시 또는 이미 수령한 보너스를 중복 요청하면 에러를 반환합니다.
+
+                ---
+
+                ## Request
+
+                | **키** | **타입** | **설명** | **필수 여부** | **예시** |
+                | --- | --- | --- | --- | --- |
+                | tier | string | 보너스 티어 (TIER_1, TIER_2, TIER_3) | 필수 | "TIER_1" |
+
+                ---
+
+                ## Response
+
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | statusCode | number | HTTP 상태 코드 | 200 |
+                | code | string | 응답 코드 | "SUC01" |
+                | timestamp | string(datetime) | 응답 시간 | "2026-06-03T12:00:00.000" |
+                | content | object | 응답 본문 | { ... } |
+                | message | string | 처리 결과 | "보너스 클레임 성공" |
+
+                ---
+
+                ### Response > content
+
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | requiredCount | number | 달성 필요 초대 수 | 5 |
+                | bonusAmount | number | 적립된 보너스 캐시 | 1000 |
+                | reason | string | 적립 사유 | "친구 초대 누적 보너스 (5명)" |
+                """,
+        security = {@SecurityRequirement(name = "bearer")},
+        responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "보너스 클레임 성공",
+                        content = @Content(
+                                schema = @Schema(implementation = ClaimReferralBonusResponse.class),
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 200,
+                                          "code": "SUC01",
+                                          "timestamp": "2026-06-03T18:01:50.214036",
+                                          "content": {
+                                            "requiredCount": 5,
+                                            "bonusAmount": 1000,
+                                            "reason": "친구 초대 누적 보너스 (5명)"
+                                          },
+                                          "message": "보너스 클레임 성공"
+                                        }
+                                        """)
+                        )
+                )
+        }
+)
+public @interface ClaimReferralBonusApiDocs {
+}

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/point/apidocs/GetReferralStatusApiDocs.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/point/apidocs/GetReferralStatusApiDocs.java
@@ -17,26 +17,26 @@ import java.lang.annotation.*;
         summary = "친구 초대 현황 조회",
         description = """
                 작성일자: 2026-03-21
-                
+
                 작성자: 성효빈
-                
+
                 ---
-                
+
                 ## Description
-                
+
                 나의 친구 초대 현황을 조회합니다. 초대한 친구 수, 받은 총 캐시, 누적 보너스 달성 현황을 포함합니다.
-                
+
                 ---
-                
+
                 ## Request
-                
+
                 | **키** | **타입** | **설명** | **필수 여부** | **예시** |
                 | --- | --- | --- | --- | --- |
-                
+
                 ---
-                
+
                 ## Response
-                
+
                 | **키** | **타입** | **설명** | **예시** |
                 | --- | --- | --- | --- |
                 | statusCode | number | HTTP 상태 코드 | 200 |
@@ -44,27 +44,29 @@ import java.lang.annotation.*;
                 | timestamp | string(datetime) | 응답 시간 | "2026-03-21T12:00:00.000" |
                 | content | object | 응답 본문 | { ... } |
                 | message | string | 처리 결과 | "친구 초대 현황 조회 성공" |
-                
+
                 ---
-                
+
                 ### Response > content
-                
+
                 | **키** | **타입** | **설명** | **예시** |
                 | --- | --- | --- | --- |
                 | totalInvitedCount | number | 내가 초대한 친구 수 | 7 |
                 | totalEarnedCash | number | 받은 총 캐시 | 4500 |
                 | maxInviteCount | number | 최대 초대 가능 인원 | 20 |
                 | tiers | array | 누적 보너스 단계 목록 | [ ... ] |
-                
+
                 ---
-                
+
                 ### Response > content > tiers[]
-                
+
                 | **키** | **타입** | **설명** | **예시** |
                 | --- | --- | --- | --- |
                 | requiredCount | number | 달성 필요 초대 수 | 5 |
                 | bonusAmount | number | 보너스 캐시 | 1000 |
                 | achieved | boolean | 달성 여부 | true |
+                | claimed | boolean | 수령 여부 | true |
+                | claimable | boolean | 클레임 가능 여부 (달성 && 미수령) | false |
                 """,
         security = {@SecurityRequirement(name = "bearer")},
         responses = {
@@ -77,15 +79,15 @@ import java.lang.annotation.*;
                                         {
                                           "statusCode": 200,
                                           "code": "SUC01",
-                                          "timestamp": "2026-03-21T18:01:50.214036",
+                                          "timestamp": "2026-06-03T18:01:50.214036",
                                           "content": {
                                             "totalInvitedCount": 7,
                                             "totalEarnedCash": 4500,
                                             "maxInviteCount": 20,
                                             "tiers": [
-                                              { "requiredCount": 5, "bonusAmount": 1000, "achieved": true },
-                                              { "requiredCount": 10, "bonusAmount": 1500, "achieved": false },
-                                              { "requiredCount": 20, "bonusAmount": 2000, "achieved": false }
+                                              { "requiredCount": 5, "bonusAmount": 1000, "achieved": true, "claimed": true, "claimable": false },
+                                              { "requiredCount": 10, "bonusAmount": 1500, "achieved": false, "claimed": false, "claimable": false },
+                                              { "requiredCount": 20, "bonusAmount": 2000, "achieved": false, "claimed": false, "claimable": false }
                                             ]
                                           },
                                           "message": "친구 초대 현황 조회 성공"

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/point/request/ClaimReferralBonusRequest.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/point/request/ClaimReferralBonusRequest.java
@@ -1,0 +1,10 @@
+package com.personal.marketnote.reward.adapter.in.web.point.request;
+
+import com.personal.marketnote.reward.domain.point.ReferralBonusTier;
+import jakarta.validation.constraints.NotNull;
+
+public record ClaimReferralBonusRequest(
+        @NotNull(message = "보너스 티어는 필수입니다")
+        ReferralBonusTier tier
+) {
+}

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/point/response/ClaimReferralBonusResponse.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/point/response/ClaimReferralBonusResponse.java
@@ -1,0 +1,20 @@
+package com.personal.marketnote.reward.adapter.in.web.point.response;
+
+import com.personal.marketnote.reward.port.in.result.point.ClaimReferralBonusResult;
+import lombok.AccessLevel;
+import lombok.Builder;
+
+@Builder(access = AccessLevel.PRIVATE)
+public record ClaimReferralBonusResponse(
+        int requiredCount,
+        int bonusAmount,
+        String reason
+) {
+    public static ClaimReferralBonusResponse from(ClaimReferralBonusResult result) {
+        return ClaimReferralBonusResponse.builder()
+                .requiredCount(result.requiredCount())
+                .bonusAmount(result.bonusAmount())
+                .reason(result.reason())
+                .build();
+    }
+}

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/point/response/GetReferralStatusResponse.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/web/point/response/GetReferralStatusResponse.java
@@ -17,13 +17,17 @@ public record GetReferralStatusResponse(
     public record BonusTierResponse(
             int requiredCount,
             int bonusAmount,
-            boolean achieved
+            boolean achieved,
+            boolean claimed,
+            boolean claimable
     ) {
         public static BonusTierResponse from(GetReferralStatusResult.BonusTierStatus status) {
             return BonusTierResponse.builder()
                     .requiredCount(status.requiredCount())
                     .bonusAmount(status.bonusAmount())
                     .achieved(status.achieved())
+                    .claimed(status.claimed())
+                    .claimable(status.claimable())
                     .build();
         }
     }

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/point/UserPointHistoryPersistenceAdapter.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/point/UserPointHistoryPersistenceAdapter.java
@@ -7,6 +7,8 @@ import com.personal.marketnote.reward.domain.point.UserPointHistory;
 import com.personal.marketnote.reward.domain.point.UserPointHistoryFilter;
 import com.personal.marketnote.reward.domain.point.UserPointSourceType;
 import com.personal.marketnote.reward.exception.DuplicateUserPointHistoryException;
+import com.personal.marketnote.reward.domain.point.ReferralBonusTier;
+import com.personal.marketnote.reward.port.out.point.CheckReferralBonusClaimedPort;
 import com.personal.marketnote.reward.port.out.point.CountReferralPort;
 import com.personal.marketnote.reward.port.out.point.FindUserPointHistoryPort;
 import com.personal.marketnote.reward.port.out.point.SaveUserPointHistoryPort;
@@ -24,7 +26,7 @@ import static com.personal.marketnote.common.utility.AccrualPointAmountConstant.
 
 @PersistenceAdapter
 @RequiredArgsConstructor
-public class UserPointHistoryPersistenceAdapter implements SaveUserPointHistoryPort, FindUserPointHistoryPort, UpdateUserPointHistoryPort, CountReferralPort {
+public class UserPointHistoryPersistenceAdapter implements SaveUserPointHistoryPort, FindUserPointHistoryPort, UpdateUserPointHistoryPort, CountReferralPort, CheckReferralBonusClaimedPort {
     private final UserPointHistoryJpaRepository repository;
 
     @Override
@@ -97,6 +99,13 @@ public class UserPointHistoryPersistenceAdapter implements SaveUserPointHistoryP
     public long sumReferralEarnedAmount(Long userId) {
         return repository.sumReferralEarnedAmount(
                 userId, UserPointSourceType.USER, REFERRER_POINT_REASON, REFERRAL_BONUS_REASON_PREFIX
+        );
+    }
+
+    @Override
+    public boolean isAlreadyClaimed(Long userId, ReferralBonusTier tier) {
+        return repository.existsByUserIdAndSourceTypeAndSourceIdAndReason(
+                userId, UserPointSourceType.USER, userId, tier.getReason()
         );
     }
 }

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/point/repository/UserPointHistoryJpaRepository.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/out/persistence/point/repository/UserPointHistoryJpaRepository.java
@@ -75,6 +75,10 @@ public interface UserPointHistoryJpaRepository extends JpaRepository<UserPointHi
             Long userId, UserPointSourceType sourceType, String reason
     );
 
+    boolean existsByUserIdAndSourceTypeAndSourceIdAndReason(
+            Long userId, UserPointSourceType sourceType, Long sourceId, String reason
+    );
+
     @Query("""
             SELECT COALESCE(SUM(h.amount), 0) FROM UserPointHistoryJpaEntity h
             WHERE h.userId = :userId

--- a/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/adapter/in/event/UserReferralCompletedRewardConsumerTest.java
+++ b/reward-service/reward-adapters/src/test/java/com/personal/marketnote/reward/adapter/in/event/UserReferralCompletedRewardConsumerTest.java
@@ -3,7 +3,6 @@ package com.personal.marketnote.reward.adapter.in.event;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.personal.marketnote.common.kafka.event.EventEnvelope;
 import com.personal.marketnote.common.kafka.event.UserReferralCompletedEvent;
-import com.personal.marketnote.reward.domain.point.ReferralBonusTier;
 import com.personal.marketnote.reward.domain.point.UserPointChangeType;
 import com.personal.marketnote.reward.domain.point.UserPointSourceType;
 import com.personal.marketnote.reward.exception.DuplicateUserPointHistoryException;
@@ -307,8 +306,6 @@ class UserReferralCompletedRewardConsumerTest {
         verify(acknowledgment).acknowledge();
     }
 
-    // === 누적 보너스 관련 테스트 ===
-
     @Test
     @DisplayName("최대 초대 수(20명)에 도달한 추천인은 추천인 포인트를 적립하지 않고 피추천인만 적립한다")
     void handleUserReferralCompletedEvent_maxReached_skipsReferrerAndAccruesReferred() {
@@ -331,89 +328,36 @@ class UserReferralCompletedRewardConsumerTest {
     }
 
     @Test
-    @DisplayName("초대 수가 정확히 5가 되면 TIER_1 보너스를 추가 적립한다")
-    void handleUserReferralCompletedEvent_count5_accruesTier1Bonus() {
-        // given
+    @DisplayName("Consumer에서 보너스 자동 적립 없이 기본 500캐시만 적립한다")
+    void handleUserReferralCompletedEvent_tierMilestone_noBonusOnlyBasicAccrual() {
+        // given — 초대 수가 정확히 5가 되는 시점 (기존에는 보너스 자동 적립 발생)
         ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, 2L);
         when(getReferralStatusUseCase.countCompletedReferrals(2L)).thenReturn(4L);
 
         // when
         userReferralCompletedRewardConsumer.handleUserReferralCompletedEvent(record, acknowledgment);
 
-        // then
+        // then — 보너스 없이 기본 적립만 2회 (추천인 500 + 피추천인 500)
         ArgumentCaptor<ModifyUserPointCommand> captor = ArgumentCaptor.forClass(ModifyUserPointCommand.class);
-        verify(modifyUserPointUseCase, times(3)).modify(captor.capture());
+        verify(modifyUserPointUseCase, times(2)).modify(captor.capture());
 
         List<ModifyUserPointCommand> commands = captor.getAllValues();
 
-        // 추천인 기본 적립
+        // 추천인 기본 적립 500원
         assertThat(commands.get(0).userId()).isEqualTo(2L);
         assertThat(commands.get(0).amount()).isEqualTo((long) REFERRER_USER_POINT_AMOUNT);
         assertThat(commands.get(0).reason()).isEqualTo(REFERRER_POINT_REASON);
 
-        // TIER_1 보너스 적립
-        assertThat(commands.get(1).userId()).isEqualTo(2L);
-        assertThat(commands.get(1).amount()).isEqualTo((long) ReferralBonusTier.TIER_1.getBonusAmount());
-        assertThat(commands.get(1).sourceId()).isEqualTo(2L);
-        assertThat(commands.get(1).reason()).isEqualTo(ReferralBonusTier.TIER_1.getReason());
-
-        // 피추천인 기본 적립
-        assertThat(commands.get(2).userId()).isEqualTo(1L);
-        assertThat(commands.get(2).reason()).isEqualTo(REFERRED_POINT_REASON);
+        // 피추천인 기본 적립 500원
+        assertThat(commands.get(1).userId()).isEqualTo(1L);
+        assertThat(commands.get(1).amount()).isEqualTo((long) REFERRED_USER_POINT_AMOUNT);
+        assertThat(commands.get(1).reason()).isEqualTo(REFERRED_POINT_REASON);
 
         verify(acknowledgment).acknowledge();
     }
 
     @Test
-    @DisplayName("초대 수가 정확히 10이 되면 TIER_2 보너스를 추가 적립한다")
-    void handleUserReferralCompletedEvent_count10_accruesTier2Bonus() {
-        // given
-        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, 2L);
-        when(getReferralStatusUseCase.countCompletedReferrals(2L)).thenReturn(9L);
-
-        // when
-        userReferralCompletedRewardConsumer.handleUserReferralCompletedEvent(record, acknowledgment);
-
-        // then
-        ArgumentCaptor<ModifyUserPointCommand> captor = ArgumentCaptor.forClass(ModifyUserPointCommand.class);
-        verify(modifyUserPointUseCase, times(3)).modify(captor.capture());
-
-        List<ModifyUserPointCommand> commands = captor.getAllValues();
-
-        // TIER_2 보너스 적립
-        assertThat(commands.get(1).userId()).isEqualTo(2L);
-        assertThat(commands.get(1).amount()).isEqualTo((long) ReferralBonusTier.TIER_2.getBonusAmount());
-        assertThat(commands.get(1).reason()).isEqualTo(ReferralBonusTier.TIER_2.getReason());
-
-        verify(acknowledgment).acknowledge();
-    }
-
-    @Test
-    @DisplayName("초대 수가 정확히 20이 되면 TIER_3 보너스를 추가 적립한다")
-    void handleUserReferralCompletedEvent_count20_accruesTier3Bonus() {
-        // given
-        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, 2L);
-        when(getReferralStatusUseCase.countCompletedReferrals(2L)).thenReturn(19L);
-
-        // when
-        userReferralCompletedRewardConsumer.handleUserReferralCompletedEvent(record, acknowledgment);
-
-        // then
-        ArgumentCaptor<ModifyUserPointCommand> captor = ArgumentCaptor.forClass(ModifyUserPointCommand.class);
-        verify(modifyUserPointUseCase, times(3)).modify(captor.capture());
-
-        List<ModifyUserPointCommand> commands = captor.getAllValues();
-
-        // TIER_3 보너스 적립
-        assertThat(commands.get(1).userId()).isEqualTo(2L);
-        assertThat(commands.get(1).amount()).isEqualTo((long) ReferralBonusTier.TIER_3.getBonusAmount());
-        assertThat(commands.get(1).reason()).isEqualTo(ReferralBonusTier.TIER_3.getReason());
-
-        verify(acknowledgment).acknowledge();
-    }
-
-    @Test
-    @DisplayName("보너스 단계에 해당하지 않는 초대 수이면 보너스를 적립하지 않는다")
+    @DisplayName("보너스 단계에 해당하지 않는 초대 수이면 기본 적립만 수행한다")
     void handleUserReferralCompletedEvent_nonTierCount_noBonusAccrued() {
         // given
         ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, 2L);
@@ -424,26 +368,6 @@ class UserReferralCompletedRewardConsumerTest {
 
         // then
         verify(modifyUserPointUseCase, times(2)).modify(any(ModifyUserPointCommand.class));
-        verify(acknowledgment).acknowledge();
-    }
-
-    @Test
-    @DisplayName("보너스 적립 시 DuplicateUserPointHistoryException이 발생하면 멱등 처리하고 피추천인 적립은 정상 진행한다")
-    void handleUserReferralCompletedEvent_bonusDuplicate_idempotentAndContinues() {
-        // given
-        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, 2L);
-        when(getReferralStatusUseCase.countCompletedReferrals(2L)).thenReturn(4L);
-        when(modifyUserPointUseCase.modify(any(ModifyUserPointCommand.class)))
-                .thenReturn(null)  // 추천인 기본 적립 성공
-                .thenThrow(new DuplicateUserPointHistoryException(
-                        2L, UserPointSourceType.USER, 2L, ReferralBonusTier.TIER_1.getReason()))  // 보너스 중복
-                .thenReturn(null);  // 피추천인 적립 성공
-
-        // when
-        userReferralCompletedRewardConsumer.handleUserReferralCompletedEvent(record, acknowledgment);
-
-        // then
-        verify(modifyUserPointUseCase, times(3)).modify(any(ModifyUserPointCommand.class));
         verify(acknowledgment).acknowledge();
     }
 }

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/exception/DuplicateReferralBonusClaimException.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/exception/DuplicateReferralBonusClaimException.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.reward.exception;
+
+import com.personal.marketnote.reward.domain.point.ReferralBonusTier;
+
+public class DuplicateReferralBonusClaimException extends RuntimeException {
+    public DuplicateReferralBonusClaimException(Long userId, ReferralBonusTier tier) {
+        super("ERR_REFERRAL_02::이미 수령한 보너스입니다. userId=" + userId + ", tier=" + tier);
+    }
+}

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/exception/ReferralBonusTierNotAchievedException.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/exception/ReferralBonusTierNotAchievedException.java
@@ -1,0 +1,11 @@
+package com.personal.marketnote.reward.exception;
+
+import com.personal.marketnote.reward.domain.point.ReferralBonusTier;
+
+public class ReferralBonusTierNotAchievedException extends RuntimeException {
+    public ReferralBonusTierNotAchievedException(ReferralBonusTier tier, long currentCount) {
+        super("ERR_REFERRAL_01::보너스 티어가 달성되지 않았습니다. tier=" + tier
+                + ", requiredCount=" + tier.getRequiredCount()
+                + ", currentCount=" + currentCount);
+    }
+}

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/command/point/ClaimReferralBonusCommand.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/command/point/ClaimReferralBonusCommand.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.reward.port.in.command.point;
+
+import com.personal.marketnote.reward.domain.point.ReferralBonusTier;
+
+public record ClaimReferralBonusCommand(
+        Long userId,
+        ReferralBonusTier tier
+) {
+}

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/result/point/ClaimReferralBonusResult.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/result/point/ClaimReferralBonusResult.java
@@ -1,0 +1,17 @@
+package com.personal.marketnote.reward.port.in.result.point;
+
+import com.personal.marketnote.reward.domain.point.ReferralBonusTier;
+
+public record ClaimReferralBonusResult(
+        int requiredCount,
+        int bonusAmount,
+        String reason
+) {
+    public static ClaimReferralBonusResult from(ReferralBonusTier tier) {
+        return new ClaimReferralBonusResult(
+                tier.getRequiredCount(),
+                tier.getBonusAmount(),
+                tier.getReason()
+        );
+    }
+}

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/result/point/GetReferralStatusResult.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/result/point/GetReferralStatusResult.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 @Builder(access = AccessLevel.PRIVATE)
 public record GetReferralStatusResult(
@@ -18,20 +19,29 @@ public record GetReferralStatusResult(
     public record BonusTierStatus(
             int requiredCount,
             int bonusAmount,
-            boolean achieved
+            boolean achieved,
+            boolean claimed,
+            boolean claimable
     ) {
-        public static BonusTierStatus of(ReferralBonusTier tier, boolean achieved) {
+        public static BonusTierStatus of(ReferralBonusTier tier, boolean achieved, boolean claimed) {
             return BonusTierStatus.builder()
                     .requiredCount(tier.getRequiredCount())
                     .bonusAmount(tier.getBonusAmount())
                     .achieved(achieved)
+                    .claimed(claimed)
+                    .claimable(achieved && !claimed)
                     .build();
         }
     }
 
-    public static GetReferralStatusResult of(long totalInvitedCount, long totalEarnedCash) {
+    public static GetReferralStatusResult of(long totalInvitedCount, long totalEarnedCash,
+                                              Map<ReferralBonusTier, Boolean> claimedMap) {
         List<BonusTierStatus> tiers = Arrays.stream(ReferralBonusTier.values())
-                .map(tier -> BonusTierStatus.of(tier, tier.isAchieved(totalInvitedCount)))
+                .map(tier -> BonusTierStatus.of(
+                        tier,
+                        tier.isAchieved(totalInvitedCount),
+                        claimedMap.getOrDefault(tier, false)
+                ))
                 .toList();
 
         return GetReferralStatusResult.builder()

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/usecase/point/ClaimReferralBonusUseCase.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/in/usecase/point/ClaimReferralBonusUseCase.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.reward.port.in.usecase.point;
+
+import com.personal.marketnote.reward.port.in.command.point.ClaimReferralBonusCommand;
+import com.personal.marketnote.reward.port.in.result.point.ClaimReferralBonusResult;
+
+public interface ClaimReferralBonusUseCase {
+    ClaimReferralBonusResult claim(ClaimReferralBonusCommand command);
+}

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/out/point/CheckReferralBonusClaimedPort.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/port/out/point/CheckReferralBonusClaimedPort.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.reward.port.out.point;
+
+import com.personal.marketnote.reward.domain.point.ReferralBonusTier;
+
+public interface CheckReferralBonusClaimedPort {
+    boolean isAlreadyClaimed(Long userId, ReferralBonusTier tier);
+}

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/service/point/ClaimReferralBonusService.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/service/point/ClaimReferralBonusService.java
@@ -1,0 +1,62 @@
+package com.personal.marketnote.reward.service.point;
+
+import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.reward.domain.point.ReferralBonusTier;
+import com.personal.marketnote.reward.domain.point.UserPointChangeType;
+import com.personal.marketnote.reward.domain.point.UserPointSourceType;
+import com.personal.marketnote.reward.exception.DuplicateReferralBonusClaimException;
+import com.personal.marketnote.reward.exception.DuplicateUserPointHistoryException;
+import com.personal.marketnote.reward.exception.ReferralBonusTierNotAchievedException;
+import com.personal.marketnote.reward.port.in.command.point.ClaimReferralBonusCommand;
+import com.personal.marketnote.reward.port.in.command.point.ModifyUserPointCommand;
+import com.personal.marketnote.reward.port.in.result.point.ClaimReferralBonusResult;
+import com.personal.marketnote.reward.port.in.usecase.point.ClaimReferralBonusUseCase;
+import com.personal.marketnote.reward.port.in.usecase.point.ModifyUserPointUseCase;
+import com.personal.marketnote.reward.port.out.point.CheckReferralBonusClaimedPort;
+import com.personal.marketnote.reward.port.out.point.CountReferralPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional(isolation = READ_COMMITTED)
+public class ClaimReferralBonusService implements ClaimReferralBonusUseCase {
+    private final CountReferralPort countReferralPort;
+    private final CheckReferralBonusClaimedPort checkReferralBonusClaimedPort;
+    private final ModifyUserPointUseCase modifyUserPointUseCase;
+
+    @Override
+    public ClaimReferralBonusResult claim(ClaimReferralBonusCommand command) {
+        Long userId = command.userId();
+        ReferralBonusTier tier = command.tier();
+
+        long referralCount = countReferralPort.countCompletedReferrals(userId);
+
+        if (!tier.isAchieved(referralCount)) {
+            throw new ReferralBonusTierNotAchievedException(tier, referralCount);
+        }
+
+        if (checkReferralBonusClaimedPort.isAlreadyClaimed(userId, tier)) {
+            throw new DuplicateReferralBonusClaimException(userId, tier);
+        }
+
+        ModifyUserPointCommand modifyCommand = ModifyUserPointCommand.builder()
+                .userId(userId)
+                .changeType(UserPointChangeType.ACCRUAL)
+                .amount((long) tier.getBonusAmount())
+                .sourceType(UserPointSourceType.USER)
+                .sourceId(userId)
+                .reason(tier.getReason())
+                .build();
+
+        try {
+            modifyUserPointUseCase.modify(modifyCommand);
+        } catch (DuplicateUserPointHistoryException e) {
+            throw new DuplicateReferralBonusClaimException(userId, tier);
+        }
+
+        return ClaimReferralBonusResult.from(tier);
+    }
+}

--- a/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/service/point/GetReferralStatusService.java
+++ b/reward-service/reward-application/src/main/java/com/personal/marketnote/reward/service/point/GetReferralStatusService.java
@@ -1,11 +1,17 @@
 package com.personal.marketnote.reward.service.point;
 
 import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.reward.domain.point.ReferralBonusTier;
 import com.personal.marketnote.reward.port.in.result.point.GetReferralStatusResult;
 import com.personal.marketnote.reward.port.in.usecase.point.GetReferralStatusUseCase;
+import com.personal.marketnote.reward.port.out.point.CheckReferralBonusClaimedPort;
 import com.personal.marketnote.reward.port.out.point.CountReferralPort;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
 
@@ -14,13 +20,20 @@ import static org.springframework.transaction.annotation.Isolation.READ_COMMITTE
 @Transactional(isolation = READ_COMMITTED, readOnly = true)
 public class GetReferralStatusService implements GetReferralStatusUseCase {
     private final CountReferralPort countReferralPort;
+    private final CheckReferralBonusClaimedPort checkReferralBonusClaimedPort;
 
     @Override
     public GetReferralStatusResult getReferralStatus(Long userId) {
         long totalInvitedCount = countReferralPort.countCompletedReferrals(userId);
         long totalEarnedCash = countReferralPort.sumReferralEarnedAmount(userId);
 
-        return GetReferralStatusResult.of(totalInvitedCount, totalEarnedCash);
+        Map<ReferralBonusTier, Boolean> claimedMap = Arrays.stream(ReferralBonusTier.values())
+                .collect(Collectors.toMap(
+                        tier -> tier,
+                        tier -> checkReferralBonusClaimedPort.isAlreadyClaimed(userId, tier)
+                ));
+
+        return GetReferralStatusResult.of(totalInvitedCount, totalEarnedCash, claimedMap);
     }
 
     @Override

--- a/reward-service/reward-application/src/test/java/com/personal/marketnote/reward/service/point/ClaimReferralBonusUseCaseTest.java
+++ b/reward-service/reward-application/src/test/java/com/personal/marketnote/reward/service/point/ClaimReferralBonusUseCaseTest.java
@@ -1,0 +1,141 @@
+package com.personal.marketnote.reward.service.point;
+
+import com.personal.marketnote.reward.domain.point.ReferralBonusTier;
+import com.personal.marketnote.reward.domain.point.UserPointChangeType;
+import com.personal.marketnote.reward.domain.point.UserPointSourceType;
+import com.personal.marketnote.reward.exception.DuplicateReferralBonusClaimException;
+import com.personal.marketnote.reward.exception.ReferralBonusTierNotAchievedException;
+import com.personal.marketnote.reward.port.in.command.point.ClaimReferralBonusCommand;
+import com.personal.marketnote.reward.port.in.command.point.ModifyUserPointCommand;
+import com.personal.marketnote.reward.port.in.result.point.ClaimReferralBonusResult;
+import com.personal.marketnote.reward.port.in.usecase.point.ModifyUserPointUseCase;
+import com.personal.marketnote.reward.port.out.point.CheckReferralBonusClaimedPort;
+import com.personal.marketnote.reward.port.out.point.CountReferralPort;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ClaimReferralBonusUseCaseTest {
+    @InjectMocks
+    private ClaimReferralBonusService claimReferralBonusService;
+
+    @Mock
+    private CountReferralPort countReferralPort;
+
+    @Mock
+    private CheckReferralBonusClaimedPort checkReferralBonusClaimedPort;
+
+    @Mock
+    private ModifyUserPointUseCase modifyUserPointUseCase;
+
+    private static final Long USER_ID = 1L;
+
+    @Test
+    @DisplayName("5명 티어 달성 시 보너스 클레임 요청에 성공한다")
+    void shouldClaimTier1BonusWhenCount5Achieved() {
+        // given
+        ClaimReferralBonusCommand command = new ClaimReferralBonusCommand(USER_ID, ReferralBonusTier.TIER_1);
+        when(countReferralPort.countCompletedReferrals(USER_ID)).thenReturn(5L);
+        when(checkReferralBonusClaimedPort.isAlreadyClaimed(USER_ID, ReferralBonusTier.TIER_1)).thenReturn(false);
+
+        // when
+        ClaimReferralBonusResult result = claimReferralBonusService.claim(command);
+
+        // then
+        assertThat(result.requiredCount()).isEqualTo(5);
+        assertThat(result.bonusAmount()).isEqualTo(1_000);
+        assertThat(result.reason()).isEqualTo(ReferralBonusTier.TIER_1.getReason());
+
+        ArgumentCaptor<ModifyUserPointCommand> captor = ArgumentCaptor.forClass(ModifyUserPointCommand.class);
+        verify(modifyUserPointUseCase).modify(captor.capture());
+
+        ModifyUserPointCommand modifyCommand = captor.getValue();
+        assertThat(modifyCommand.userId()).isEqualTo(USER_ID);
+        assertThat(modifyCommand.changeType()).isEqualTo(UserPointChangeType.ACCRUAL);
+        assertThat(modifyCommand.amount()).isEqualTo(1_000L);
+        assertThat(modifyCommand.sourceType()).isEqualTo(UserPointSourceType.USER);
+        assertThat(modifyCommand.sourceId()).isEqualTo(USER_ID);
+        assertThat(modifyCommand.reason()).isEqualTo(ReferralBonusTier.TIER_1.getReason());
+    }
+
+    @Test
+    @DisplayName("10명 티어 달성 시 보너스 클레임 요청에 성공한다")
+    void shouldClaimTier2BonusWhenCount10Achieved() {
+        // given
+        ClaimReferralBonusCommand command = new ClaimReferralBonusCommand(USER_ID, ReferralBonusTier.TIER_2);
+        when(countReferralPort.countCompletedReferrals(USER_ID)).thenReturn(12L);
+        when(checkReferralBonusClaimedPort.isAlreadyClaimed(USER_ID, ReferralBonusTier.TIER_2)).thenReturn(false);
+
+        // when
+        ClaimReferralBonusResult result = claimReferralBonusService.claim(command);
+
+        // then
+        assertThat(result.requiredCount()).isEqualTo(10);
+        assertThat(result.bonusAmount()).isEqualTo(1_500);
+        assertThat(result.reason()).isEqualTo(ReferralBonusTier.TIER_2.getReason());
+
+        verify(modifyUserPointUseCase).modify(any(ModifyUserPointCommand.class));
+    }
+
+    @Test
+    @DisplayName("20명 티어 달성 시 보너스 클레임 요청에 성공한다")
+    void shouldClaimTier3BonusWhenCount20Achieved() {
+        // given
+        ClaimReferralBonusCommand command = new ClaimReferralBonusCommand(USER_ID, ReferralBonusTier.TIER_3);
+        when(countReferralPort.countCompletedReferrals(USER_ID)).thenReturn(20L);
+        when(checkReferralBonusClaimedPort.isAlreadyClaimed(USER_ID, ReferralBonusTier.TIER_3)).thenReturn(false);
+
+        // when
+        ClaimReferralBonusResult result = claimReferralBonusService.claim(command);
+
+        // then
+        assertThat(result.requiredCount()).isEqualTo(20);
+        assertThat(result.bonusAmount()).isEqualTo(2_000);
+        assertThat(result.reason()).isEqualTo(ReferralBonusTier.TIER_3.getReason());
+
+        ArgumentCaptor<ModifyUserPointCommand> captor = ArgumentCaptor.forClass(ModifyUserPointCommand.class);
+        verify(modifyUserPointUseCase).modify(captor.capture());
+
+        ModifyUserPointCommand modifyCommand = captor.getValue();
+        assertThat(modifyCommand.amount()).isEqualTo(2_000L);
+    }
+
+    @Test
+    @DisplayName("티어 미달성 시 보너스 클레임 요청에 실패한다")
+    void shouldThrowExceptionWhenTierNotAchieved() {
+        // given
+        ClaimReferralBonusCommand command = new ClaimReferralBonusCommand(USER_ID, ReferralBonusTier.TIER_2);
+        when(countReferralPort.countCompletedReferrals(USER_ID)).thenReturn(7L);
+
+        // expect
+        assertThatThrownBy(() -> claimReferralBonusService.claim(command))
+                .isInstanceOf(ReferralBonusTierNotAchievedException.class);
+
+        verifyNoInteractions(checkReferralBonusClaimedPort);
+        verifyNoInteractions(modifyUserPointUseCase);
+    }
+
+    @Test
+    @DisplayName("이미 수령한 보너스를 중복 클레임하면 실패한다")
+    void shouldThrowExceptionWhenAlreadyClaimed() {
+        // given
+        ClaimReferralBonusCommand command = new ClaimReferralBonusCommand(USER_ID, ReferralBonusTier.TIER_1);
+        when(countReferralPort.countCompletedReferrals(USER_ID)).thenReturn(5L);
+        when(checkReferralBonusClaimedPort.isAlreadyClaimed(USER_ID, ReferralBonusTier.TIER_1)).thenReturn(true);
+
+        // expect
+        assertThatThrownBy(() -> claimReferralBonusService.claim(command))
+                .isInstanceOf(DuplicateReferralBonusClaimException.class);
+
+        verifyNoInteractions(modifyUserPointUseCase);
+    }
+}

--- a/reward-service/reward-application/src/test/java/com/personal/marketnote/reward/service/point/GetReferralStatusUseCaseTest.java
+++ b/reward-service/reward-application/src/test/java/com/personal/marketnote/reward/service/point/GetReferralStatusUseCaseTest.java
@@ -2,6 +2,7 @@ package com.personal.marketnote.reward.service.point;
 
 import com.personal.marketnote.reward.domain.point.ReferralBonusTier;
 import com.personal.marketnote.reward.port.in.result.point.GetReferralStatusResult;
+import com.personal.marketnote.reward.port.out.point.CheckReferralBonusClaimedPort;
 import com.personal.marketnote.reward.port.out.point.CountReferralPort;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -22,6 +23,9 @@ class GetReferralStatusUseCaseTest {
     @Mock
     private CountReferralPort countReferralPort;
 
+    @Mock
+    private CheckReferralBonusClaimedPort checkReferralBonusClaimedPort;
+
     private static final Long USER_ID = 1L;
 
     @Test
@@ -30,6 +34,9 @@ class GetReferralStatusUseCaseTest {
         // given
         when(countReferralPort.countCompletedReferrals(USER_ID)).thenReturn(7L);
         when(countReferralPort.sumReferralEarnedAmount(USER_ID)).thenReturn(4_500L);
+        when(checkReferralBonusClaimedPort.isAlreadyClaimed(USER_ID, ReferralBonusTier.TIER_1)).thenReturn(true);
+        when(checkReferralBonusClaimedPort.isAlreadyClaimed(USER_ID, ReferralBonusTier.TIER_2)).thenReturn(false);
+        when(checkReferralBonusClaimedPort.isAlreadyClaimed(USER_ID, ReferralBonusTier.TIER_3)).thenReturn(false);
 
         // when
         GetReferralStatusResult result = getReferralStatusService.getReferralStatus(USER_ID);
@@ -39,12 +46,22 @@ class GetReferralStatusUseCaseTest {
         assertThat(result.totalEarnedCash()).isEqualTo(4_500L);
         assertThat(result.maxInviteCount()).isEqualTo(20);
         assertThat(result.tiers()).hasSize(3);
+
+        // TIER_1: achieved=true, claimed=true, claimable=false
         assertThat(result.tiers().get(0).requiredCount()).isEqualTo(5);
         assertThat(result.tiers().get(0).achieved()).isTrue();
+        assertThat(result.tiers().get(0).claimed()).isTrue();
+        assertThat(result.tiers().get(0).claimable()).isFalse();
+
+        // TIER_2: achieved=false, claimed=false, claimable=false
         assertThat(result.tiers().get(1).requiredCount()).isEqualTo(10);
         assertThat(result.tiers().get(1).achieved()).isFalse();
+        assertThat(result.tiers().get(1).claimable()).isFalse();
+
+        // TIER_3: achieved=false, claimed=false, claimable=false
         assertThat(result.tiers().get(2).requiredCount()).isEqualTo(20);
         assertThat(result.tiers().get(2).achieved()).isFalse();
+        assertThat(result.tiers().get(2).claimable()).isFalse();
 
         verify(countReferralPort).countCompletedReferrals(USER_ID);
         verify(countReferralPort).sumReferralEarnedAmount(USER_ID);
@@ -56,6 +73,9 @@ class GetReferralStatusUseCaseTest {
         // given
         when(countReferralPort.countCompletedReferrals(USER_ID)).thenReturn(0L);
         when(countReferralPort.sumReferralEarnedAmount(USER_ID)).thenReturn(0L);
+        when(checkReferralBonusClaimedPort.isAlreadyClaimed(USER_ID, ReferralBonusTier.TIER_1)).thenReturn(false);
+        when(checkReferralBonusClaimedPort.isAlreadyClaimed(USER_ID, ReferralBonusTier.TIER_2)).thenReturn(false);
+        when(checkReferralBonusClaimedPort.isAlreadyClaimed(USER_ID, ReferralBonusTier.TIER_3)).thenReturn(false);
 
         // when
         GetReferralStatusResult result = getReferralStatusService.getReferralStatus(USER_ID);
@@ -64,7 +84,11 @@ class GetReferralStatusUseCaseTest {
         assertThat(result.totalInvitedCount()).isEqualTo(0L);
         assertThat(result.totalEarnedCash()).isEqualTo(0L);
         assertThat(result.tiers()).hasSize(3);
-        assertThat(result.tiers()).allSatisfy(tier -> assertThat(tier.achieved()).isFalse());
+        assertThat(result.tiers()).allSatisfy(tier -> {
+            assertThat(tier.achieved()).isFalse();
+            assertThat(tier.claimed()).isFalse();
+            assertThat(tier.claimable()).isFalse();
+        });
     }
 
     @Test
@@ -74,6 +98,9 @@ class GetReferralStatusUseCaseTest {
         long expectedTotalCash = 20L * 500L + 1_000L + 1_500L + 2_000L;
         when(countReferralPort.countCompletedReferrals(USER_ID)).thenReturn(20L);
         when(countReferralPort.sumReferralEarnedAmount(USER_ID)).thenReturn(expectedTotalCash);
+        when(checkReferralBonusClaimedPort.isAlreadyClaimed(USER_ID, ReferralBonusTier.TIER_1)).thenReturn(true);
+        when(checkReferralBonusClaimedPort.isAlreadyClaimed(USER_ID, ReferralBonusTier.TIER_2)).thenReturn(true);
+        when(checkReferralBonusClaimedPort.isAlreadyClaimed(USER_ID, ReferralBonusTier.TIER_3)).thenReturn(true);
 
         // when
         GetReferralStatusResult result = getReferralStatusService.getReferralStatus(USER_ID);
@@ -82,7 +109,11 @@ class GetReferralStatusUseCaseTest {
         assertThat(result.totalInvitedCount()).isEqualTo(20L);
         assertThat(result.totalEarnedCash()).isEqualTo(expectedTotalCash);
         assertThat(result.tiers()).hasSize(3);
-        assertThat(result.tiers()).allSatisfy(tier -> assertThat(tier.achieved()).isTrue());
+        assertThat(result.tiers()).allSatisfy(tier -> {
+            assertThat(tier.achieved()).isTrue();
+            assertThat(tier.claimed()).isTrue();
+            assertThat(tier.claimable()).isFalse();
+        });
     }
 
     @Test
@@ -91,6 +122,9 @@ class GetReferralStatusUseCaseTest {
         // given
         when(countReferralPort.countCompletedReferrals(USER_ID)).thenReturn(10L);
         when(countReferralPort.sumReferralEarnedAmount(USER_ID)).thenReturn(6_500L);
+        when(checkReferralBonusClaimedPort.isAlreadyClaimed(USER_ID, ReferralBonusTier.TIER_1)).thenReturn(false);
+        when(checkReferralBonusClaimedPort.isAlreadyClaimed(USER_ID, ReferralBonusTier.TIER_2)).thenReturn(false);
+        when(checkReferralBonusClaimedPort.isAlreadyClaimed(USER_ID, ReferralBonusTier.TIER_3)).thenReturn(false);
 
         // when
         GetReferralStatusResult result = getReferralStatusService.getReferralStatus(USER_ID);
@@ -113,5 +147,38 @@ class GetReferralStatusUseCaseTest {
         // then
         assertThat(count).isEqualTo(12L);
         verify(countReferralPort).countCompletedReferrals(USER_ID);
+    }
+
+    @Test
+    @DisplayName("현황 조회 시 티어별 클레임 가능 여부가 정확히 반환된다")
+    void shouldReturnCorrectClaimableStatusForEachTier() {
+        // given
+        when(countReferralPort.countCompletedReferrals(USER_ID)).thenReturn(12L);
+        when(countReferralPort.sumReferralEarnedAmount(USER_ID)).thenReturn(7_000L);
+        // TIER_1(5명): achieved + claimed → claimable=false
+        when(checkReferralBonusClaimedPort.isAlreadyClaimed(USER_ID, ReferralBonusTier.TIER_1)).thenReturn(true);
+        // TIER_2(10명): achieved + unclaimed → claimable=true
+        when(checkReferralBonusClaimedPort.isAlreadyClaimed(USER_ID, ReferralBonusTier.TIER_2)).thenReturn(false);
+        // TIER_3(20명): not achieved → claimable=false
+        when(checkReferralBonusClaimedPort.isAlreadyClaimed(USER_ID, ReferralBonusTier.TIER_3)).thenReturn(false);
+
+        // when
+        GetReferralStatusResult result = getReferralStatusService.getReferralStatus(USER_ID);
+
+        // then
+        // TIER_1: achieved=true, claimed=true → claimable=false
+        assertThat(result.tiers().get(0).achieved()).isTrue();
+        assertThat(result.tiers().get(0).claimed()).isTrue();
+        assertThat(result.tiers().get(0).claimable()).isFalse();
+
+        // TIER_2: achieved=true, claimed=false → claimable=true
+        assertThat(result.tiers().get(1).achieved()).isTrue();
+        assertThat(result.tiers().get(1).claimed()).isFalse();
+        assertThat(result.tiers().get(1).claimable()).isTrue();
+
+        // TIER_3: achieved=false, claimed=false → claimable=false
+        assertThat(result.tiers().get(2).achieved()).isFalse();
+        assertThat(result.tiers().get(2).claimed()).isFalse();
+        assertThat(result.tiers().get(2).claimable()).isFalse();
     }
 }


### PR DESCRIPTION
## partially addresses #216
## resolves #2377

## Task
- [x] OrderReturnedLedgerConsumer 생성 (ORDER_RETURNED 토픽 구독)
- [x] RecordLedgerEntryUseCase.recordPaymentCancellation() 호출로 역분개 기록
- [x] 멱등성 키 ORDER_RETURN:orderId 사용
- [x] DuplicateLedgerTransactionException 멱등 처리
- [x] EventPayloadValidator 기반 envelope / eventType / orderId 검증