### PR TITLE
[#216][#2385] feat: 반품 검수 불량/보류 시 주문 상태 반품 검수 중 전이 기능 추가

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/apidocs/ChangeOrderStatusApiDocs.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/apidocs/ChangeOrderStatusApiDocs.java
@@ -56,7 +56,9 @@ import java.lang.annotation.*;
                     - "RETURN_REQUESTED": 반품 요청됨
                 
                     - "RETURN_IN_PROGRESS": 반품 진행 중
-                
+
+                    - "RETURN_INSPECTING": 반품 검수 중
+
                     - "PARTIALLY_RETURNED": 부분 반품됨
                 
                     - "RETURNED": 반품 완료

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/apidocs/GetOrderInfoApiDocs.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/apidocs/GetOrderInfoApiDocs.java
@@ -50,7 +50,9 @@ import java.lang.annotation.*;
                     - "RETURN_REQUESTED": 반품 요청됨
                 
                     - "RETURN_IN_PROGRESS": 반품 진행 중
-                
+
+                    - "RETURN_INSPECTING": 반품 검수 중
+
                     - "PARTIALLY_RETURNED": 부분 반품됨
                 
                     - "RETURNED": 반품 완료

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/apidocs/GetOrdersApiDocs.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/apidocs/GetOrdersApiDocs.java
@@ -47,7 +47,9 @@ import java.lang.annotation.*;
                     - "RETURN_REQUESTED": 반품 요청됨
                 
                     - "RETURN_IN_PROGRESS": 반품 진행 중
-                
+
+                    - "RETURN_INSPECTING": 반품 검수 중
+
                     - "PARTIALLY_RETURNED": 부분 반품됨
                 
                     - "RETURNED": 반품 완료

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/returntracker/HandleInspectionFailedOrHoldService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/returntracker/HandleInspectionFailedOrHoldService.java
@@ -1,0 +1,70 @@
+package com.personal.marketnote.commerce.service.returntracker;
+
+import com.personal.marketnote.commerce.domain.order.Order;
+import com.personal.marketnote.commerce.domain.order.OrderStatus;
+import com.personal.marketnote.commerce.domain.order.OrderStatusHistory;
+import com.personal.marketnote.commerce.domain.order.OrderStatusHistoryCreateState;
+import com.personal.marketnote.commerce.domain.returntracker.ReturnTracker;
+import com.personal.marketnote.commerce.port.in.usecase.order.GetOrderUseCase;
+import com.personal.marketnote.commerce.port.out.order.UpdateOrderPort;
+import com.personal.marketnote.commerce.port.out.returntracker.UpdateReturnTrackerPort;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class HandleInspectionFailedOrHoldService {
+
+    private static final String INSPECTION_FAILED = "02";
+    private static final String INSPECTION_ON_HOLD = "03";
+
+    private final UpdateReturnTrackerPort updateReturnTrackerPort;
+    private final GetOrderUseCase getOrderUseCase;
+    private final UpdateOrderPort updateOrderPort;
+
+    @Transactional(isolation = READ_COMMITTED)
+    public void handleFailedOrHold(ReturnTracker tracker, String overallStatus, LocalDateTime now) {
+        if (!INSPECTION_FAILED.equals(overallStatus) && !INSPECTION_ON_HOLD.equals(overallStatus)) {
+            log.warn("예상하지 못한 검수 상태 코드: {}, orderId: {}", overallStatus, tracker.getOrderId());
+            return;
+        }
+
+        applyInspectionStatus(tracker, overallStatus, now);
+        updateReturnTrackerPort.update(tracker);
+
+        Order order = getOrderUseCase.getOrder(tracker.getOrderId());
+        if (order.isReturnInspecting()) {
+            log.info("이미 반품 검수 중 상태 (멱등). orderId={}", tracker.getOrderId());
+            return;
+        }
+
+        order.changeAllProductsStatus(OrderStatus.RETURN_INSPECTING, now);
+
+        OrderStatusHistory history = OrderStatusHistory.from(
+                OrderStatusHistoryCreateState.builder()
+                        .orderId(order.getId())
+                        .orderStatus(OrderStatus.RETURN_INSPECTING)
+                        .build()
+        );
+        updateOrderPort.update(order, history);
+
+        log.info("반품 검수 불량/보류 처리 완료 - orderId: {}, status: {}", tracker.getOrderId(), overallStatus);
+    }
+
+    private void applyInspectionStatus(ReturnTracker tracker, String status, LocalDateTime now) {
+        if (INSPECTION_FAILED.equals(status)) {
+            tracker.failInspection(now);
+            return;
+        }
+        if (INSPECTION_ON_HOLD.equals(status)) {
+            tracker.holdInspection();
+        }
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/returntracker/PollReturnInspectionService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/returntracker/PollReturnInspectionService.java
@@ -8,7 +8,6 @@ import com.personal.marketnote.commerce.port.out.fulfillment.ReturnInspectionRes
 import com.personal.marketnote.commerce.port.out.fulfillment.ReturnInspectionResult.ReturnInspectionGoodsItem;
 import com.personal.marketnote.commerce.port.out.fulfillment.ReturnInspectionResult.ReturnInspectionResultItem;
 import com.personal.marketnote.commerce.port.out.returntracker.FindReturnTrackerPort;
-import com.personal.marketnote.commerce.port.out.returntracker.UpdateReturnTrackerPort;
 import com.personal.marketnote.common.application.UseCase;
 import com.personal.marketnote.common.utility.FormatValidator;
 import lombok.RequiredArgsConstructor;
@@ -29,9 +28,9 @@ public class PollReturnInspectionService implements PollReturnInspectionUseCase 
     private static final String INSPECTION_ON_HOLD = "03";
 
     private final FindReturnTrackerPort findReturnTrackerPort;
-    private final UpdateReturnTrackerPort updateReturnTrackerPort;
     private final GetReturnInspectionResultPort getReturnInspectionResultPort;
     private final CompleteReturnInspectionService completeReturnInspectionService;
+    private final HandleInspectionFailedOrHoldService handleInspectionFailedOrHoldService;
     private final Clock clock;
 
     @Override
@@ -131,9 +130,7 @@ public class PollReturnInspectionService implements PollReturnInspectionUseCase 
             return;
         }
 
-        applyInspectionStatus(tracker, overallStatus, now);
-        updateReturnTrackerPort.update(tracker);
-        log.info("반품 검수 상태 업데이트 - orderId: {}, status: {}", tracker.getOrderId(), overallStatus);
+        handleInspectionFailedOrHoldService.handleFailedOrHold(tracker, overallStatus, now);
     }
 
     private String resolveOverallInspectionStatus(List<ReturnInspectionGoodsItem> products) {
@@ -162,15 +159,5 @@ public class PollReturnInspectionService implements PollReturnInspectionUseCase 
         log.warn("반품 검수 폴링: 분류 불가능한 상태 조합 - statuses: {}",
                 products.stream().map(ReturnInspectionGoodsItem::returnProductCheckStatus).toList());
         return null;
-    }
-
-    private void applyInspectionStatus(ReturnTracker tracker, String status, LocalDateTime now) {
-        if (INSPECTION_FAILED.equals(status)) {
-            tracker.failInspection(now);
-            return;
-        }
-        if (INSPECTION_ON_HOLD.equals(status)) {
-            tracker.holdInspection();
-        }
     }
 }

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/GetBuyerOrderCountUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/GetBuyerOrderCountUseCaseTest.java
@@ -586,6 +586,7 @@ class GetBuyerOrderCountUseCaseTest {
                     OrderStatus.CANCELLED,
                     OrderStatus.RETURN_REQUESTED,
                     OrderStatus.RETURN_IN_PROGRESS,
+                    OrderStatus.RETURN_INSPECTING,
                     OrderStatus.PARTIALLY_RETURNED,
                     OrderStatus.RETURNED
             );

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/GetBuyerOrderHistoryUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/GetBuyerOrderHistoryUseCaseTest.java
@@ -686,6 +686,7 @@ class GetBuyerOrderHistoryUseCaseTest {
                     OrderStatus.CANCELLED,
                     OrderStatus.RETURN_REQUESTED,
                     OrderStatus.RETURN_IN_PROGRESS,
+                    OrderStatus.RETURN_INSPECTING,
                     OrderStatus.PARTIALLY_RETURNED,
                     OrderStatus.RETURNED
             );

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/order/Order.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/order/Order.java
@@ -86,6 +86,10 @@ public class Order {
         return this.orderStatus.isFailed();
     }
 
+    public boolean isReturnInspecting() {
+        return this.orderStatus.isReturnInspecting();
+    }
+
     public void changeProductsStatus(List<Long> pricePolicyIds, OrderStatus orderStatus, LocalDateTime now) {
         orderProducts.stream()
                 .filter(orderProduct -> pricePolicyIds.contains(orderProduct.getPricePolicyId()))

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/order/OrderStatus.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/order/OrderStatus.java
@@ -23,6 +23,7 @@ public enum OrderStatus {
     CONFIRMED("구매 확정"),
     RETURN_REQUESTED("반품 요청됨"),
     RETURN_IN_PROGRESS("반품 진행 중"),
+    RETURN_INSPECTING("반품 검수 중"),
     PARTIALLY_RETURNED("부분 반품됨"),
     RETURNED("반품 완료");
 
@@ -45,7 +46,8 @@ public enum OrderStatus {
         ALLOWED_TRANSITIONS.put(PARTIALLY_CONFIRMED, EnumSet.of(CONFIRMED, RETURN_REQUESTED));
         ALLOWED_TRANSITIONS.put(CONFIRMED, EnumSet.noneOf(OrderStatus.class));
         ALLOWED_TRANSITIONS.put(RETURN_REQUESTED, EnumSet.of(RETURN_IN_PROGRESS));
-        ALLOWED_TRANSITIONS.put(RETURN_IN_PROGRESS, EnumSet.of(RETURNED));
+        ALLOWED_TRANSITIONS.put(RETURN_IN_PROGRESS, EnumSet.of(RETURNED, RETURN_INSPECTING));
+        ALLOWED_TRANSITIONS.put(RETURN_INSPECTING, EnumSet.of(RETURNED));
         ALLOWED_TRANSITIONS.put(PARTIALLY_RETURNED, EnumSet.of(RETURN_REQUESTED, RETURNED));
         ALLOWED_TRANSITIONS.put(RETURNED, EnumSet.noneOf(OrderStatus.class));
     }
@@ -112,6 +114,10 @@ public enum OrderStatus {
 
     public boolean isReturnRequested() {
         return this == RETURN_REQUESTED;
+    }
+
+    public boolean isReturnInspecting() {
+        return this == RETURN_INSPECTING;
     }
 
     public boolean requiresFulfillmentCancellation() {

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/order/OrderStatusFilter.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/order/OrderStatusFilter.java
@@ -25,6 +25,7 @@ public enum OrderStatusFilter {
                     OrderStatus.CANCELLED,
                     OrderStatus.RETURN_REQUESTED,
                     OrderStatus.RETURN_IN_PROGRESS,
+                    OrderStatus.RETURN_INSPECTING,
                     OrderStatus.PARTIALLY_RETURNED,
                     OrderStatus.RETURNED
             )

--- a/user-service/user-application/src/main/java/com/personal/marketnote/user/service/user/RegisterReferredUserCodeService.java
+++ b/user-service/user-application/src/main/java/com/personal/marketnote/user/service/user/RegisterReferredUserCodeService.java
@@ -3,6 +3,8 @@ package com.personal.marketnote.user.service.user;
 import com.personal.marketnote.common.application.UseCase;
 import com.personal.marketnote.common.exception.UserNotFoundException;
 import com.personal.marketnote.user.domain.user.User;
+import com.personal.marketnote.user.exception.MutualReferralNotAllowedException;
+import com.personal.marketnote.user.exception.SelfReferralNotAllowedException;
 import com.personal.marketnote.user.port.in.usecase.user.GetUserUseCase;
 import com.personal.marketnote.user.port.in.usecase.user.RegisterReferredUserCodeUseCase;
 import com.personal.marketnote.user.port.out.event.PublishUserEventPort;
@@ -10,6 +12,7 @@ import com.personal.marketnote.user.port.out.user.UpdateUserPort;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
 
+import static com.personal.marketnote.common.domain.exception.ExceptionCode.FIRST_ERROR_CODE;
 import static com.personal.marketnote.user.exception.ExceptionMessage.USER_REFERENCE_CODE_NOT_FOUND_EXCEPTION_MESSAGE;
 import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
 
@@ -30,11 +33,13 @@ public class RegisterReferredUserCodeService implements RegisterReferredUserCode
         }
 
         User requestUser = getUserUseCase.getUser(requestUserId);
-        requestUser.registerReferredUserCode(referredUserCode);
-
-        updateUserPort.update(requestUser);
+        validateNotSelfReferral(requestUser, referredUserCode);
 
         User referredUser = getUserUseCase.getUser(referredUserCode);
+        validateNotMutualReferral(referredUser, requestUser);
+
+        requestUser.registerReferredUserCode(referredUserCode);
+        updateUserPort.update(requestUser);
 
         // Outbox 이벤트 저장 (트랜잭션 내)
         // [#929][#1037] 추천 포인트 적립은 Kafka Consumer(UserReferralCompletedRewardConsumer)로 전환 완료
@@ -44,6 +49,18 @@ public class RegisterReferredUserCodeService implements RegisterReferredUserCode
             requestUser.removeReferredUserCode();
             updateUserPort.update(requestUser);
             throw e;
+        }
+    }
+
+    private void validateNotSelfReferral(User requestUser, String referredUserCode) {
+        if (requestUser.isSelfReferral(referredUserCode)) {
+            throw new SelfReferralNotAllowedException(FIRST_ERROR_CODE);
+        }
+    }
+
+    private void validateNotMutualReferral(User referredUser, User requestUser) {
+        if (referredUser.isMutualReferralWith(requestUser)) {
+            throw new MutualReferralNotAllowedException(FIRST_ERROR_CODE);
         }
     }
 }

--- a/user-service/user-application/src/test/java/com/personal/marketnote/user/service/user/RegisterReferredUserCodeUseCaseTest.java
+++ b/user-service/user-application/src/test/java/com/personal/marketnote/user/service/user/RegisterReferredUserCodeUseCaseTest.java
@@ -3,7 +3,9 @@ package com.personal.marketnote.user.service.user;
 import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.common.exception.UserNotFoundException;
 import com.personal.marketnote.user.domain.user.User;
+import com.personal.marketnote.user.exception.MutualReferralNotAllowedException;
 import com.personal.marketnote.user.exception.ReferredUserCodeAlreadyExistsException;
+import com.personal.marketnote.user.exception.SelfReferralNotAllowedException;
 import com.personal.marketnote.user.port.in.usecase.user.GetUserUseCase;
 import com.personal.marketnote.user.port.out.event.PublishUserEventPort;
 import com.personal.marketnote.user.port.out.user.UpdateUserPort;
@@ -16,6 +18,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
 
+import static com.personal.marketnote.common.domain.exception.ExceptionCode.FIRST_ERROR_CODE;
 import static com.personal.marketnote.common.domain.exception.ExceptionCode.SECOND_ERROR_CODE;
 import static com.personal.marketnote.user.exception.ExceptionMessage.USER_REFERENCE_CODE_NOT_FOUND_EXCEPTION_MESSAGE;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -38,7 +41,7 @@ class RegisterReferredUserCodeUseCaseTest {
     void registerReferredUserCode_notExists_throws() {
         // given
         Long requestUserId = 1L;
-        String referredUserCode = "ref-123";
+        String referredUserCode = "ref-456";
 
         when(getUserUseCase.existsUser(referredUserCode)).thenReturn(false);
 
@@ -59,7 +62,7 @@ class RegisterReferredUserCodeUseCaseTest {
     void registerReferredUserCode_success_publishesEvent() {
         // given
         Long requestUserId = 1L;
-        String referredUserCode = "ref-123";
+        String referredUserCode = "ref-456";
         Long referredUserId = 2L;
         User requestUser = spy(UserTestObjectFactory.createDefaultUser(
                 requestUserId, EntityStatus.ACTIVE, false, List.of()
@@ -77,9 +80,11 @@ class RegisterReferredUserCodeUseCaseTest {
         // then
         verify(getUserUseCase).existsUser(referredUserCode);
         verify(getUserUseCase).getUser(requestUserId);
+        verify(requestUser).isSelfReferral(referredUserCode);
+        verify(getUserUseCase).getUser(referredUserCode);
+        verify(referredUser).isMutualReferralWith(requestUser);
         verify(requestUser).registerReferredUserCode(referredUserCode);
         verify(updateUserPort).update(requestUser);
-        verify(getUserUseCase).getUser(referredUserCode);
         verify(referredUser).getId();
         verify(requestUser).getId();
         verify(publishUserEventPort).publishUserReferralCompletedEvent(requestUserId, referredUserId);
@@ -92,14 +97,16 @@ class RegisterReferredUserCodeUseCaseTest {
     void registerReferredUserCode_alreadyRegistered_throws() {
         // given
         Long requestUserId = 1L;
-        String referredUserCode = "ref-123";
+        String referredUserCode = "ref-456";
         User requestUser = spy(UserTestObjectFactory.createDefaultUser(
                 requestUserId, EntityStatus.ACTIVE, false, List.of()
         ));
         requestUser.registerReferredUserCode("existing");
+        User referredUser = mock(User.class);
 
         when(getUserUseCase.existsUser(referredUserCode)).thenReturn(true);
         when(getUserUseCase.getUser(requestUserId)).thenReturn(requestUser);
+        when(getUserUseCase.getUser(referredUserCode)).thenReturn(referredUser);
 
         // expect
         assertThatThrownBy(() -> registerReferredUserCodeService.registerReferredUserCode(requestUserId, referredUserCode))
@@ -108,10 +115,12 @@ class RegisterReferredUserCodeUseCaseTest {
 
         verify(getUserUseCase).existsUser(referredUserCode);
         verify(getUserUseCase).getUser(requestUserId);
+        verify(requestUser).isSelfReferral(referredUserCode);
+        verify(getUserUseCase).getUser(referredUserCode);
+        verify(referredUser).isMutualReferralWith(requestUser);
         verify(requestUser).registerReferredUserCode(referredUserCode);
-        verify(getUserUseCase, never()).getUser(referredUserCode);
         verifyNoInteractions(updateUserPort, publishUserEventPort);
-        verifyNoMoreInteractions(getUserUseCase);
+        verifyNoMoreInteractions(getUserUseCase, referredUser);
     }
 
     @Test
@@ -119,7 +128,7 @@ class RegisterReferredUserCodeUseCaseTest {
     void registerReferredUserCode_requestUserNotFound_throws() {
         // given
         Long requestUserId = 1L;
-        String referredUserCode = "ref-123";
+        String referredUserCode = "ref-456";
         UserNotFoundException exception = new UserNotFoundException("not found");
 
         when(getUserUseCase.existsUser(referredUserCode)).thenReturn(true);
@@ -141,7 +150,7 @@ class RegisterReferredUserCodeUseCaseTest {
     void registerReferredUserCode_referredUserNotFound_throws() {
         // given
         Long requestUserId = 1L;
-        String referredUserCode = "ref-123";
+        String referredUserCode = "ref-456";
         User requestUser = spy(UserTestObjectFactory.createDefaultUser(
                 requestUserId, EntityStatus.ACTIVE, false, List.of()
         ));
@@ -157,11 +166,69 @@ class RegisterReferredUserCodeUseCaseTest {
 
         verify(getUserUseCase).existsUser(referredUserCode);
         verify(getUserUseCase).getUser(requestUserId);
-        verify(requestUser).registerReferredUserCode(referredUserCode);
-        verify(updateUserPort).update(requestUser);
+        verify(requestUser).isSelfReferral(referredUserCode);
         verify(getUserUseCase).getUser(referredUserCode);
-        verifyNoInteractions(publishUserEventPort);
-        verify(requestUser, never()).removeReferredUserCode();
-        verifyNoMoreInteractions(getUserUseCase, updateUserPort);
+        verify(requestUser, never()).registerReferredUserCode(referredUserCode);
+        verifyNoInteractions(updateUserPort, publishUserEventPort);
+        verifyNoMoreInteractions(getUserUseCase);
+    }
+
+    @Test
+    @DisplayName("자기 자신의 referenceCode 입력 시 예외가 발생한다")
+    void registerReferredUserCode_selfReferral_throws() {
+        // given
+        Long requestUserId = 1L;
+        String referredUserCode = "ref-123"; // requestUser의 referenceCode와 동일
+        User requestUser = spy(UserTestObjectFactory.createDefaultUser(
+                requestUserId, EntityStatus.ACTIVE, false, List.of()
+        ));
+
+        when(getUserUseCase.existsUser(referredUserCode)).thenReturn(true);
+        when(getUserUseCase.getUser(requestUserId)).thenReturn(requestUser);
+
+        // expect
+        assertThatThrownBy(() -> registerReferredUserCodeService.registerReferredUserCode(requestUserId, referredUserCode))
+                .isInstanceOf(SelfReferralNotAllowedException.class)
+                .hasMessage(new SelfReferralNotAllowedException(FIRST_ERROR_CODE).getMessage());
+
+        verify(getUserUseCase).existsUser(referredUserCode);
+        verify(getUserUseCase).getUser(requestUserId);
+        verify(requestUser).isSelfReferral(referredUserCode);
+        verify(requestUser, never()).registerReferredUserCode(referredUserCode);
+        verify(getUserUseCase, never()).getUser(referredUserCode);
+        verifyNoInteractions(updateUserPort, publishUserEventPort);
+        verifyNoMoreInteractions(getUserUseCase);
+    }
+
+    @Test
+    @DisplayName("상호 초대(A→B, B→A) 시 예외가 발생한다")
+    void registerReferredUserCode_mutualReferral_throws() {
+        // given
+        Long requestUserId = 1L;
+        String referredUserCode = "ref-456";
+        User requestUser = spy(UserTestObjectFactory.createDefaultUser(
+                requestUserId, EntityStatus.ACTIVE, false, List.of()
+        ));
+        User referredUser = mock(User.class);
+
+        // referredUser가 이미 requestUser의 referenceCode를 등록한 상태
+        when(getUserUseCase.existsUser(referredUserCode)).thenReturn(true);
+        when(getUserUseCase.getUser(requestUserId)).thenReturn(requestUser);
+        when(getUserUseCase.getUser(referredUserCode)).thenReturn(referredUser);
+        when(referredUser.isMutualReferralWith(requestUser)).thenReturn(true);
+
+        // expect
+        assertThatThrownBy(() -> registerReferredUserCodeService.registerReferredUserCode(requestUserId, referredUserCode))
+                .isInstanceOf(MutualReferralNotAllowedException.class)
+                .hasMessage(new MutualReferralNotAllowedException(FIRST_ERROR_CODE).getMessage());
+
+        verify(getUserUseCase).existsUser(referredUserCode);
+        verify(getUserUseCase).getUser(requestUserId);
+        verify(requestUser).isSelfReferral(referredUserCode);
+        verify(getUserUseCase).getUser(referredUserCode);
+        verify(referredUser).isMutualReferralWith(requestUser);
+        verify(requestUser, never()).registerReferredUserCode(referredUserCode);
+        verifyNoInteractions(updateUserPort, publishUserEventPort);
+        verifyNoMoreInteractions(getUserUseCase, referredUser);
     }
 }

--- a/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/user/User.java
+++ b/user-service/user-domain/src/main/java/com/personal/marketnote/user/domain/user/User.java
@@ -182,6 +182,16 @@ public class User extends BaseDomain {
         this.password = passwordEncoder.encode(password);
     }
 
+    public boolean isSelfReferral(String code) {
+        return FormatValidator.hasValue(referenceCode) && referenceCode.equals(code);
+    }
+
+    public boolean isMutualReferralWith(User otherUser) {
+        return FormatValidator.hasValue(this.referredUserCode)
+                && FormatValidator.hasValue(otherUser.referenceCode)
+                && this.referredUserCode.equals(otherUser.referenceCode);
+    }
+
     public void registerReferredUserCode(String referredUserCode) {
         if (FormatValidator.hasValue(this.referredUserCode)) {
             throw new ReferredUserCodeAlreadyExistsException(SECOND_ERROR_CODE);

--- a/user-service/user-domain/src/main/java/com/personal/marketnote/user/exception/MutualReferralNotAllowedException.java
+++ b/user-service/user-domain/src/main/java/com/personal/marketnote/user/exception/MutualReferralNotAllowedException.java
@@ -1,0 +1,13 @@
+package com.personal.marketnote.user.exception;
+
+import lombok.Getter;
+
+@Getter
+public class MutualReferralNotAllowedException extends IllegalArgumentException {
+    private static final String MUTUAL_REFERRAL_NOT_ALLOWED_EXCEPTION_MESSAGE
+            = "%s:: 상호 추천은 허용되지 않습니다.";
+
+    public MutualReferralNotAllowedException(String code) {
+        super(String.format(MUTUAL_REFERRAL_NOT_ALLOWED_EXCEPTION_MESSAGE, code));
+    }
+}

--- a/user-service/user-domain/src/main/java/com/personal/marketnote/user/exception/SelfReferralNotAllowedException.java
+++ b/user-service/user-domain/src/main/java/com/personal/marketnote/user/exception/SelfReferralNotAllowedException.java
@@ -1,0 +1,13 @@
+package com.personal.marketnote.user.exception;
+
+import lombok.Getter;
+
+@Getter
+public class SelfReferralNotAllowedException extends IllegalArgumentException {
+    private static final String SELF_REFERRAL_NOT_ALLOWED_EXCEPTION_MESSAGE
+            = "%s:: 자기 자신의 추천 회원 초대 코드는 등록할 수 없습니다.";
+
+    public SelfReferralNotAllowedException(String code) {
+        super(String.format(SELF_REFERRAL_NOT_ALLOWED_EXCEPTION_MESSAGE, code));
+    }
+}


### PR DESCRIPTION
## partially addresses #216
## resolves #2385

## Task
- [x] OrderStatus enum에 RETURN_INSPECTING 상태 추가 및 전이 규칙 등록
- [x] Order 도메인에 isReturnInspecting() 위임 메서드 추가
- [x] OrderStatusFilter.CANCEL_RETURN에 RETURN_INSPECTING 포함
- [x] HandleInspectionFailedOrHoldService 신규 생성
- [x] PollReturnInspectionService 리팩토링
- [x] Swagger ApiDocs 3개 파일 RETURN_INSPECTING 반영
- [x] 기존 CANCEL_RETURN 필터 테스트 수정