### PR TITLE
[#216][#2386] test: 반품 검수 불량/보류 시 주문 상태 반품 검수 중 전이 기능 자동화 테스트 추가

### DIFF
--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/returntracker/CompleteReturnServiceTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/returntracker/CompleteReturnServiceTest.java
@@ -76,6 +76,27 @@ class CompleteReturnServiceTest {
         }
 
         @Test
+        @DisplayName("RETURN_INSPECTING 상태의 주문을 RETURNED로 바로 전이한다")
+        void shouldTransitionFromReturnInspectingToReturned() {
+            Order order = createReturnableOrder(OrderStatus.RETURN_INSPECTING);
+            when(getOrderUseCase.getOrder(1L)).thenReturn(order);
+            when(calculateReturnShippingFeeUseCase.calculateReturnShippingFee(any(CalculateReturnShippingFeeCommand.class)))
+                    .thenReturn(CalculateReturnShippingFeeResult.builder().returnShippingFee(0L).build());
+
+            CompleteReturnCommand command = new CompleteReturnCommand(1L);
+
+            service.completeReturn(command);
+
+            verify(order, never()).changeAllProductsStatus(eq(OrderStatus.RETURN_IN_PROGRESS), any());
+            verify(order).changeAllProductsStatus(eq(OrderStatus.RETURNED), any());
+            verify(updateOrderPort).update(eq(order), any(OrderStatusHistory.class));
+            verify(publishOrderEventPort).publishOrderReturnedEvent(
+                    eq(1L), anyString(), eq(100L),
+                    eq(30000L), eq(49000L), eq(1000L), eq(3000L),
+                    eq(true), eq(0L), anyList());
+        }
+
+        @Test
         @DisplayName("RETURN_IN_PROGRESS 상태의 주문을 RETURNED로 바로 전이한다")
         void shouldTransitionFromReturnInProgressToReturned() {
             Order order = createReturnableOrder(OrderStatus.RETURN_IN_PROGRESS);
@@ -123,7 +144,7 @@ class CompleteReturnServiceTest {
     class CompleteReturnFailure {
 
         @Test
-        @DisplayName("RETURN_REQUESTED/RETURN_IN_PROGRESS가 아닌 상태이면 InvalidOrderStatusTransitionException을 던진다")
+        @DisplayName("반품 처리 가능한 상태가 아니면 InvalidOrderStatusTransitionException을 던진다")
         void shouldThrowOnInvalidStatus() {
             Order order = mock(Order.class);
             when(order.getOrderStatus()).thenReturn(OrderStatus.PAID);

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/returntracker/HandleInspectionFailedOrHoldServiceTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/returntracker/HandleInspectionFailedOrHoldServiceTest.java
@@ -1,0 +1,123 @@
+package com.personal.marketnote.commerce.service.returntracker;
+
+import com.personal.marketnote.commerce.domain.order.Order;
+import com.personal.marketnote.commerce.domain.order.OrderStatus;
+import com.personal.marketnote.commerce.domain.order.OrderStatusHistory;
+import com.personal.marketnote.commerce.domain.returntracker.ReturnInspectionStatus;
+import com.personal.marketnote.commerce.domain.returntracker.ReturnRefundStatus;
+import com.personal.marketnote.commerce.domain.returntracker.ReturnTracker;
+import com.personal.marketnote.commerce.domain.returntracker.ReturnTrackerSnapshotState;
+import com.personal.marketnote.commerce.port.in.usecase.order.GetOrderUseCase;
+import com.personal.marketnote.commerce.port.out.order.UpdateOrderPort;
+import com.personal.marketnote.commerce.port.out.returntracker.UpdateReturnTrackerPort;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("HandleInspectionFailedOrHoldService 테스트")
+class HandleInspectionFailedOrHoldServiceTest {
+
+    @InjectMocks
+    private HandleInspectionFailedOrHoldService service;
+
+    @Mock
+    private UpdateReturnTrackerPort updateReturnTrackerPort;
+
+    @Mock
+    private GetOrderUseCase getOrderUseCase;
+
+    @Mock
+    private UpdateOrderPort updateOrderPort;
+
+    private static final LocalDateTime NOW = LocalDateTime.of(2026, 4, 9, 19, 0);
+
+    @Nested
+    @DisplayName("검수 불량 처리")
+    class HandleInspectionFailed {
+
+        @Test
+        @DisplayName("검수 불량 시 ReturnTracker를 FAILED로 업데이트하고 주문 상태를 RETURN_INSPECTING으로 전이한다")
+        void shouldFailInspectionAndTransitionOrderToReturnInspecting() {
+            ReturnTracker tracker = createPendingTracker();
+            Order order = createReturnInProgressOrder();
+            when(getOrderUseCase.getOrder(100L)).thenReturn(order);
+
+            service.handleFailedOrHold(tracker, "02", NOW);
+
+            assertThat(tracker.isInspectionFailed()).isTrue();
+            assertThat(tracker.getInspectedAt()).isEqualTo(NOW);
+            verify(updateReturnTrackerPort).update(tracker);
+            verify(order).changeAllProductsStatus(eq(OrderStatus.RETURN_INSPECTING), eq(NOW));
+            verify(updateOrderPort).update(eq(order), any(OrderStatusHistory.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("검수 보류 처리")
+    class HandleInspectionOnHold {
+
+        @Test
+        @DisplayName("검수 보류 시 ReturnTracker를 ON_HOLD로 업데이트하고 주문 상태를 RETURN_INSPECTING으로 전이한다")
+        void shouldHoldInspectionAndTransitionOrderToReturnInspecting() {
+            ReturnTracker tracker = createPendingTracker();
+            Order order = createReturnInProgressOrder();
+            when(getOrderUseCase.getOrder(100L)).thenReturn(order);
+
+            service.handleFailedOrHold(tracker, "03", NOW);
+
+            assertThat(tracker.isInspectionOnHold()).isTrue();
+            verify(updateReturnTrackerPort).update(tracker);
+            verify(order).changeAllProductsStatus(eq(OrderStatus.RETURN_INSPECTING), eq(NOW));
+            verify(updateOrderPort).update(eq(order), any(OrderStatusHistory.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("멱등성 처리")
+    class Idempotency {
+
+        @Test
+        @DisplayName("주문이 이미 RETURN_INSPECTING 상태이면 주문 상태 변경 없이 ReturnTracker만 업데이트한다")
+        void shouldSkipOrderTransitionWhenAlreadyReturnInspecting() {
+            ReturnTracker tracker = createPendingTracker();
+            Order order = mock(Order.class);
+            when(order.isReturnInspecting()).thenReturn(true);
+            when(getOrderUseCase.getOrder(100L)).thenReturn(order);
+
+            service.handleFailedOrHold(tracker, "02", NOW);
+
+            assertThat(tracker.isInspectionFailed()).isTrue();
+            verify(updateReturnTrackerPort).update(tracker);
+            verify(order, never()).changeAllProductsStatus(any(), any());
+            verifyNoInteractions(updateOrderPort);
+        }
+    }
+
+    private ReturnTracker createPendingTracker() {
+        return ReturnTracker.from(ReturnTrackerSnapshotState.builder()
+                .id(1L)
+                .orderId(100L)
+                .returnSlipNumber("RS-001")
+                .inspectionStatus(ReturnInspectionStatus.PENDING)
+                .refundStatus(ReturnRefundStatus.PENDING)
+                .build());
+    }
+
+    private Order createReturnInProgressOrder() {
+        Order order = mock(Order.class);
+        when(order.getId()).thenReturn(100L);
+        return order;
+    }
+}

--- a/commerce-service/commerce-domain/src/test/java/com/personal/marketnote/commerce/domain/order/OrderStatusTest.java
+++ b/commerce-service/commerce-domain/src/test/java/com/personal/marketnote/commerce/domain/order/OrderStatusTest.java
@@ -85,6 +85,12 @@ class OrderStatusTest {
         }
 
         @Test
+        @DisplayName("RETURN_INSPECTING는 구매자가 변경할 수 없는 상태이다")
+        void returnInspecting_isNotBuyerAllowed() {
+            assertThat(OrderStatus.RETURN_INSPECTING.isBuyerAllowed()).isFalse();
+        }
+
+        @Test
         @DisplayName("PARTIALLY_RETURNED는 구매자가 변경할 수 없는 상태이다")
         void partiallyReturned_isNotBuyerAllowed() {
             assertThat(OrderStatus.PARTIALLY_RETURNED.isBuyerAllowed()).isFalse();
@@ -219,6 +225,31 @@ class OrderStatusTest {
         @DisplayName("RETURN_IN_PROGRESS에서 RETURNED로 전이할 수 있다")
         void returnInProgress_canTransitionTo_returned() {
             assertThat(OrderStatus.RETURN_IN_PROGRESS.canTransitionTo(OrderStatus.RETURNED)).isTrue();
+        }
+
+        @Test
+        @DisplayName("RETURN_IN_PROGRESS에서 RETURN_INSPECTING로 전이할 수 있다")
+        void returnInProgress_canTransitionTo_returnInspecting() {
+            assertThat(OrderStatus.RETURN_IN_PROGRESS.canTransitionTo(OrderStatus.RETURN_INSPECTING)).isTrue();
+        }
+
+        @Test
+        @DisplayName("RETURN_INSPECTING에서 RETURNED로 전이할 수 있다")
+        void returnInspecting_canTransitionTo_returned() {
+            assertThat(OrderStatus.RETURN_INSPECTING.canTransitionTo(OrderStatus.RETURNED)).isTrue();
+        }
+
+        @Test
+        @DisplayName("RETURN_INSPECTING에서 RETURNED 외 다른 상태로 전이할 수 없다")
+        void returnInspecting_cannotTransitionTo_otherStatuses() {
+            for (OrderStatus target : OrderStatus.values()) {
+                if (target == OrderStatus.RETURNED) {
+                    continue;
+                }
+                assertThat(OrderStatus.RETURN_INSPECTING.canTransitionTo(target))
+                        .as("RETURN_INSPECTING → %s는 불가해야 한다", target)
+                        .isFalse();
+            }
         }
 
         @Test
@@ -368,6 +399,12 @@ class OrderStatusTest {
         }
 
         @Test
+        @DisplayName("RETURN_INSPECTING는 최종 상태가 아니다")
+        void returnInspecting_isNotTerminal() {
+            assertThat(OrderStatus.RETURN_INSPECTING.isTerminal()).isFalse();
+        }
+
+        @Test
         @DisplayName("PARTIALLY_RETURNED는 최종 상태가 아니다")
         void partiallyReturned_isNotTerminal() {
             assertThat(OrderStatus.PARTIALLY_RETURNED.isTerminal()).isFalse();
@@ -417,6 +454,29 @@ class OrderStatusTest {
         @DisplayName("CONFIRMED는 배송 완료 상태가 아니다")
         void confirmed_isNotDelivered() {
             assertThat(OrderStatus.CONFIRMED.isDelivered()).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("반품 검수 중 상태 검증 (isReturnInspecting)")
+    class IsReturnInspectingTest {
+
+        @Test
+        @DisplayName("RETURN_INSPECTING는 반품 검수 중 상태이다")
+        void returnInspecting_isReturnInspecting() {
+            assertThat(OrderStatus.RETURN_INSPECTING.isReturnInspecting()).isTrue();
+        }
+
+        @Test
+        @DisplayName("RETURN_IN_PROGRESS는 반품 검수 중 상태가 아니다")
+        void returnInProgress_isNotReturnInspecting() {
+            assertThat(OrderStatus.RETURN_IN_PROGRESS.isReturnInspecting()).isFalse();
+        }
+
+        @Test
+        @DisplayName("RETURNED는 반품 검수 중 상태가 아니다")
+        void returned_isNotReturnInspecting() {
+            assertThat(OrderStatus.RETURNED.isReturnInspecting()).isFalse();
         }
     }
 }


### PR DESCRIPTION
## partially addresses #216
## resolves #2386

## Test Case
- [x] OrderStatus 전이 규칙 테스트 (RETURN_IN_PROGRESS -> RETURN_INSPECTING -> RETURNED)
- [x] OrderStatus 술어 메서드 테스트 (isReturnInspecting, isBuyerAllowed, isTerminal)
- [x] HandleInspectionFailedOrHoldService 검수 불량/보류/멱등성 테스트
- [x] CompleteReturnService RETURN_INSPECTING -> RETURNED 전이 테스트