### PR TITLE
[#216][#2486] feat: CS 반품 검수 승인 시 반품 완료 전이 기능 추가

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/OrderController.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/OrderController.java
@@ -18,6 +18,8 @@ import com.personal.marketnote.commerce.port.in.command.order.GetReturnRefundInf
 import com.personal.marketnote.commerce.port.in.command.order.UpdateOrderProductReviewStatusCommand;
 import com.personal.marketnote.commerce.port.in.result.order.*;
 import com.personal.marketnote.commerce.port.in.usecase.order.*;
+import com.personal.marketnote.commerce.port.in.command.returntracker.ApproveReturnInspectionCommand;
+import com.personal.marketnote.commerce.port.in.usecase.returntracker.ApproveReturnInspectionUseCase;
 import com.personal.marketnote.commerce.port.out.user.UpdateUserShippingAddressDeliveryRequestPort;
 import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
 import com.personal.marketnote.common.utility.ElementExtractor;
@@ -62,6 +64,7 @@ public class OrderController {
     private final GetAdminOrdersUseCase getAdminOrdersUseCase;
     private final GetOrderStatusHistoryUseCase getOrderStatusHistoryUseCase;
     private final GetReturnRefundInfoUseCase getReturnRefundInfoUseCase;
+    private final ApproveReturnInspectionUseCase approveReturnInspectionUseCase;
 
     /**
      * 주문 등록
@@ -521,6 +524,35 @@ public class OrderController {
                         HttpStatus.OK,
                         DEFAULT_SUCCESS_CODE,
                         "주문 상태 이력 조회 성공"
+                ),
+                HttpStatus.OK
+        );
+    }
+
+    /**
+     * CS 반��� 검수 승인
+     *
+     * @param id 주문 ID
+     * @Author 성효빈
+     * @Date 2026-06-03
+     * @Description CS 담당��가 반품 검수 중 상태의 주문을 반품 완료로 ��이합니다.
+     */
+    @PostMapping("/api/v1/admin/orders/{id}/approve-return-inspection")
+    @PreAuthorize(ADMIN_POINTCUT)
+    @ApproveReturnInspectionApiDocs
+    public ResponseEntity<BaseResponse<Void>> approveReturnInspection(
+            @PathVariable("id") Long id
+    ) {
+        approveReturnInspectionUseCase.approveReturnInspection(
+                new ApproveReturnInspectionCommand(id)
+        );
+
+        return new ResponseEntity<>(
+                BaseResponse.of(
+                        null,
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "반품 검수 승인 성공"
                 ),
                 HttpStatus.OK
         );

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/apidocs/ApproveReturnInspectionApiDocs.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/apidocs/ApproveReturnInspectionApiDocs.java
@@ -1,0 +1,126 @@
+package com.personal.marketnote.commerce.adapter.in.web.order.controller.apidocs;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Operation(
+        summary = "CS 반품 검수 승인",
+        description = """
+                작성일자: 2026-06-03
+
+                작성자: 성효빈
+
+                ---
+
+                ## Description
+
+                - CS 담당자가 반품 검수 중(RETURN_INSPECTING) 상태의 주문을 반품 완료(RETURNED)로 전이합니다.
+
+                - 반품 완료 전이 후 환불 프로세스(PG 환불, 정산 취소, 재고 복원, 포인트 환불)가 자동으로 진행됩니다.
+
+                - 이미 반품 완료(RETURNED) 상태인 주문에 대해 호출하면 멱등하게 처리됩니다.
+
+                - RETURN_INSPECTING 상태가 아닌 주문에 대해 호출하면 400 에러가 반환됩니다.
+
+                ---
+
+                ## Request
+
+                - Request Body 없음 (Path Variable만 사용)
+
+                ---
+
+                ## Response
+
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | statusCode | number | 상태 코드 | 200: 성공 / 400: 상태 전이 불가 / 401: 인증 실패 / 403: 권한 없음 |
+                | code | string | 응답 코드 | "SUC01" / "BAD_REQUEST" / "UNAUTHORIZED" / "FORBIDDEN" |
+                | timestamp | string(datetime) | 응답 일시 | "2026-06-03T12:00:00.000" |
+                | content | object | 응답 본문 | null |
+                | message | string | 처리 결과 | "반품 검수 승인 성공" |
+                """, security = {@SecurityRequirement(name = "bearer")},
+        parameters = {
+                @Parameter(
+                        name = "id",
+                        description = "주문 ID",
+                        in = ParameterIn.PATH,
+                        required = true,
+                        schema = @Schema(type = "number")
+                )
+        },
+        responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "반품 검수 승인 성공",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 200,
+                                          "code": "SUC01",
+                                          "timestamp": "2026-06-03T12:00:00.000",
+                                          "content": null,
+                                          "message": "반품 검수 승인 성공"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "400",
+                        description = "상태 전이 불가",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 400,
+                                          "code": "BAD_REQUEST",
+                                          "timestamp": "2026-06-03T12:00:00.000",
+                                          "content": null,
+                                          "message": "주문 상태를 반품 진행 중에서 반품 완료(으)로 변경할 수 없습니다."
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "401",
+                        description = "토큰 인증 실패",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 401,
+                                          "code": "UNAUTHORIZED",
+                                          "timestamp": "2026-06-03T12:00:00.000",
+                                          "content": null,
+                                          "message": "Invalid token"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "403",
+                        description = "관리자 권한 필요",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 403,
+                                          "code": "FORBIDDEN",
+                                          "timestamp": "2026-06-03T12:00:00.000",
+                                          "content": null,
+                                          "message": "Access Denied"
+                                        }
+                                        """)
+                        )
+                ),
+        })
+public @interface ApproveReturnInspectionApiDocs {
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/command/returntracker/ApproveReturnInspectionCommand.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/command/returntracker/ApproveReturnInspectionCommand.java
@@ -1,0 +1,6 @@
+package com.personal.marketnote.commerce.port.in.command.returntracker;
+
+public record ApproveReturnInspectionCommand(
+        Long orderId
+) {
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/returntracker/ApproveReturnInspectionUseCase.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/returntracker/ApproveReturnInspectionUseCase.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.commerce.port.in.usecase.returntracker;
+
+import com.personal.marketnote.commerce.port.in.command.returntracker.ApproveReturnInspectionCommand;
+
+public interface ApproveReturnInspectionUseCase {
+
+    void approveReturnInspection(ApproveReturnInspectionCommand command);
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/returntracker/ApproveReturnInspectionService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/returntracker/ApproveReturnInspectionService.java
@@ -1,0 +1,40 @@
+package com.personal.marketnote.commerce.service.returntracker;
+
+import com.personal.marketnote.commerce.domain.order.Order;
+import com.personal.marketnote.commerce.domain.order.OrderStatus;
+import com.personal.marketnote.commerce.exception.InvalidOrderStatusTransitionException;
+import com.personal.marketnote.commerce.port.in.command.returntracker.ApproveReturnInspectionCommand;
+import com.personal.marketnote.commerce.port.in.command.returntracker.CompleteReturnCommand;
+import com.personal.marketnote.commerce.port.in.usecase.order.GetOrderUseCase;
+import com.personal.marketnote.commerce.port.in.usecase.returntracker.ApproveReturnInspectionUseCase;
+import com.personal.marketnote.commerce.port.in.usecase.returntracker.CompleteReturnUseCase;
+import com.personal.marketnote.common.application.UseCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@UseCase
+@RequiredArgsConstructor
+public class ApproveReturnInspectionService implements ApproveReturnInspectionUseCase {
+
+    private final GetOrderUseCase getOrderUseCase;
+    private final CompleteReturnUseCase completeReturnUseCase;
+
+    @Override
+    public void approveReturnInspection(ApproveReturnInspectionCommand command) {
+        Order order = getOrderUseCase.getOrder(command.orderId());
+
+        if (order.isReturned()) {
+            log.info("이미 반품 완료 처리된 주문 (멱등). orderId={}", command.orderId());
+            return;
+        }
+
+        if (!order.isReturnInspecting()) {
+            throw new InvalidOrderStatusTransitionException(order.getOrderStatus(), OrderStatus.RETURNED);
+        }
+
+        completeReturnUseCase.completeReturn(new CompleteReturnCommand(command.orderId()));
+
+        log.info("CS 반품 검수 승인 완료. orderId={}", command.orderId());
+    }
+}

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/order/Order.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/order/Order.java
@@ -90,6 +90,10 @@ public class Order {
         return this.orderStatus.isReturnInspecting();
     }
 
+    public boolean isReturned() {
+        return this.orderStatus.isReturned();
+    }
+
     public void changeProductsStatus(List<Long> pricePolicyIds, OrderStatus orderStatus, LocalDateTime now) {
         orderProducts.stream()
                 .filter(orderProduct -> pricePolicyIds.contains(orderProduct.getPricePolicyId()))


### PR DESCRIPTION
## partially addresses #216
## resolves #2486

## Task
- [x] ApproveReturnInspectionCommand 생성
- [x] ApproveReturnInspectionUseCase 인터페이스 정의
- [x] ApproveReturnInspectionService 구현 (RETURN_INSPECTING 검증 + CompleteReturnUseCase 위임)
- [x] ApproveReturnInspectionApiDocs 생성
- [x] OrderController에 관리자 API 엔드포인트 추가 (POST /api/v1/admin/orders/{id}/approve-return-inspection)
- [x] Order 도메인에 isReturned() 술어 메서드 추가