### PR TITLE
[#216][#2490] feat: 반품 불가 판정 후 CS 회송 요청 기능 추가

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/OrderController.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/OrderController.java
@@ -20,8 +20,10 @@ import com.personal.marketnote.commerce.port.in.result.order.*;
 import com.personal.marketnote.commerce.port.in.usecase.order.*;
 import com.personal.marketnote.commerce.port.in.command.returntracker.ApproveReturnInspectionCommand;
 import com.personal.marketnote.commerce.port.in.command.returntracker.RejectReturnInspectionCommand;
+import com.personal.marketnote.commerce.port.in.command.returntracker.RequestReturnReshippingCommand;
 import com.personal.marketnote.commerce.port.in.usecase.returntracker.ApproveReturnInspectionUseCase;
 import com.personal.marketnote.commerce.port.in.usecase.returntracker.RejectReturnInspectionUseCase;
+import com.personal.marketnote.commerce.port.in.usecase.returntracker.RequestReturnReshippingUseCase;
 import com.personal.marketnote.commerce.port.out.user.UpdateUserShippingAddressDeliveryRequestPort;
 import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
 import com.personal.marketnote.common.utility.ElementExtractor;
@@ -68,6 +70,7 @@ public class OrderController {
     private final GetReturnRefundInfoUseCase getReturnRefundInfoUseCase;
     private final ApproveReturnInspectionUseCase approveReturnInspectionUseCase;
     private final RejectReturnInspectionUseCase rejectReturnInspectionUseCase;
+    private final RequestReturnReshippingUseCase requestReturnReshippingUseCase;
 
     /**
      * 주문 등록
@@ -585,6 +588,35 @@ public class OrderController {
                         HttpStatus.OK,
                         DEFAULT_SUCCESS_CODE,
                         "반품 불가 판정 성공"
+                ),
+                HttpStatus.OK
+        );
+    }
+
+    /**
+     * CS 회송 요청
+     *
+     * @param id 주문 ID
+     * @Author 성효빈
+     * @Date 2026-06-03
+     * @Description CS 담당자가 반품 불가 상태의 주문에 대해 회송을 요청합니다.
+     */
+    @PostMapping("/api/v1/admin/orders/{id}/request-return-reshipping")
+    @PreAuthorize(ADMIN_POINTCUT)
+    @RequestReturnReshippingApiDocs
+    public ResponseEntity<BaseResponse<Void>> requestReturnReshipping(
+            @PathVariable("id") Long id
+    ) {
+        requestReturnReshippingUseCase.requestReturnReshipping(
+                new RequestReturnReshippingCommand(id)
+        );
+
+        return new ResponseEntity<>(
+                BaseResponse.of(
+                        null,
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "회송 요청 성공"
                 ),
                 HttpStatus.OK
         );

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/apidocs/RequestReturnReshippingApiDocs.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/apidocs/RequestReturnReshippingApiDocs.java
@@ -1,0 +1,126 @@
+package com.personal.marketnote.commerce.adapter.in.web.order.controller.apidocs;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Operation(
+        summary = "CS 회송 요청",
+        description = """
+                작성일자: 2026-06-03
+
+                작성자: 성효빈
+
+                ---
+
+                ## Description
+
+                - CS 담당자가 반품 불가(RETURN_REJECTED) 상태의 주문에 대해 회송을 요청합니다.
+
+                - 주문 상태를 회송 요청됨(RETURN_RESHIPPING_REQUESTED)으로 전이합니다.
+
+                - 이미 회송 요청됨(RETURN_RESHIPPING_REQUESTED) 상태인 주문에 대해 호출하면 멱등하게 처리됩니다.
+
+                - RETURN_REJECTED 상태가 아닌 주문에 대해 호출하면 400 에러가 반환됩니다.
+
+                ---
+
+                ## Request
+
+                - Request Body 없음 (Path Variable만 사용)
+
+                ---
+
+                ## Response
+
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | statusCode | number | 상태 코드 | 200: 성공 / 400: 상태 전이 불가 / 401: 인증 실패 / 403: 권한 없음 |
+                | code | string | 응답 코드 | "SUC01" / "BAD_REQUEST" / "UNAUTHORIZED" / "FORBIDDEN" |
+                | timestamp | string(datetime) | 응답 일시 | "2026-06-03T12:00:00.000" |
+                | content | object | 응답 본문 | null |
+                | message | string | 처리 결과 | "회송 요청 성공" |
+                """, security = {@SecurityRequirement(name = "bearer")},
+        parameters = {
+                @Parameter(
+                        name = "id",
+                        description = "주문 ID",
+                        in = ParameterIn.PATH,
+                        required = true,
+                        schema = @Schema(type = "number")
+                )
+        },
+        responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "회송 요청 성공",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 200,
+                                          "code": "SUC01",
+                                          "timestamp": "2026-06-03T12:00:00.000",
+                                          "content": null,
+                                          "message": "회송 요청 성공"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "400",
+                        description = "상태 전이 불가",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 400,
+                                          "code": "BAD_REQUEST",
+                                          "timestamp": "2026-06-03T12:00:00.000",
+                                          "content": null,
+                                          "message": "주문 상태를 반품 검수 중에서 회송 요청됨(으)로 변경할 수 없습니다."
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "401",
+                        description = "토큰 인증 실패",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 401,
+                                          "code": "UNAUTHORIZED",
+                                          "timestamp": "2026-06-03T12:00:00.000",
+                                          "content": null,
+                                          "message": "Invalid token"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "403",
+                        description = "관리자 권한 필요",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 403,
+                                          "code": "FORBIDDEN",
+                                          "timestamp": "2026-06-03T12:00:00.000",
+                                          "content": null,
+                                          "message": "Access Denied"
+                                        }
+                                        """)
+                        )
+                ),
+        })
+public @interface RequestReturnReshippingApiDocs {
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/command/returntracker/RequestReturnReshippingCommand.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/command/returntracker/RequestReturnReshippingCommand.java
@@ -1,0 +1,6 @@
+package com.personal.marketnote.commerce.port.in.command.returntracker;
+
+public record RequestReturnReshippingCommand(
+        Long orderId
+) {
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/returntracker/RequestReturnReshippingUseCase.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/returntracker/RequestReturnReshippingUseCase.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.commerce.port.in.usecase.returntracker;
+
+import com.personal.marketnote.commerce.port.in.command.returntracker.RequestReturnReshippingCommand;
+
+public interface RequestReturnReshippingUseCase {
+
+    void requestReturnReshipping(RequestReturnReshippingCommand command);
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/returntracker/RequestReturnReshippingService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/returntracker/RequestReturnReshippingService.java
@@ -1,0 +1,59 @@
+package com.personal.marketnote.commerce.service.returntracker;
+
+import com.personal.marketnote.commerce.domain.order.Order;
+import com.personal.marketnote.commerce.domain.order.OrderStatus;
+import com.personal.marketnote.commerce.domain.order.OrderStatusHistory;
+import com.personal.marketnote.commerce.domain.order.OrderStatusHistoryCreateState;
+import com.personal.marketnote.commerce.exception.InvalidOrderStatusTransitionException;
+import com.personal.marketnote.commerce.port.in.command.returntracker.RequestReturnReshippingCommand;
+import com.personal.marketnote.commerce.port.in.usecase.order.GetOrderUseCase;
+import com.personal.marketnote.commerce.port.in.usecase.returntracker.RequestReturnReshippingUseCase;
+import com.personal.marketnote.commerce.port.out.order.UpdateOrderPort;
+import com.personal.marketnote.common.application.UseCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@Slf4j
+@UseCase
+@RequiredArgsConstructor
+public class RequestReturnReshippingService implements RequestReturnReshippingUseCase {
+
+    private final GetOrderUseCase getOrderUseCase;
+    private final UpdateOrderPort updateOrderPort;
+    private final Clock clock;
+
+    @Override
+    @Transactional(isolation = READ_COMMITTED)
+    public void requestReturnReshipping(RequestReturnReshippingCommand command) {
+        Order order = getOrderUseCase.getOrder(command.orderId());
+
+        if (order.isReturnReshippingRequested()) {
+            log.info("이미 회송 요청된 주문 (멱등). orderId={}", command.orderId());
+            return;
+        }
+
+        if (!order.isReturnRejected()) {
+            throw new InvalidOrderStatusTransitionException(order.getOrderStatus(), OrderStatus.RETURN_RESHIPPING_REQUESTED);
+        }
+
+        LocalDateTime now = LocalDateTime.now(clock);
+        order.changeAllProductsStatus(OrderStatus.RETURN_RESHIPPING_REQUESTED, now);
+
+        OrderStatusHistory history = OrderStatusHistory.from(
+                OrderStatusHistoryCreateState.builder()
+                        .orderId(order.getId())
+                        .orderStatus(OrderStatus.RETURN_RESHIPPING_REQUESTED)
+                        .reasonCategory(order.getStatusChangeReasonCategory())
+                        .build()
+        );
+        updateOrderPort.update(order, history);
+
+        log.info("CS 회송 요청 완료. orderId={}", command.orderId());
+    }
+}

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/order/Order.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/order/Order.java
@@ -98,6 +98,10 @@ public class Order {
         return this.orderStatus.isReturnRejected();
     }
 
+    public boolean isReturnReshippingRequested() {
+        return this.orderStatus.isReturnReshippingRequested();
+    }
+
     public void changeProductsStatus(List<Long> pricePolicyIds, OrderStatus orderStatus, LocalDateTime now) {
         orderProducts.stream()
                 .filter(orderProduct -> pricePolicyIds.contains(orderProduct.getPricePolicyId()))

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/order/OrderStatus.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/order/OrderStatus.java
@@ -26,7 +26,8 @@ public enum OrderStatus {
     RETURN_INSPECTING("반품 검수 중"),
     PARTIALLY_RETURNED("부분 반품됨"),
     RETURNED("반품 완료"),
-    RETURN_REJECTED("반품 불가");
+    RETURN_REJECTED("반품 불가"),
+    RETURN_RESHIPPING_REQUESTED("회송 요청됨");
 
     private final String description;
 
@@ -51,7 +52,8 @@ public enum OrderStatus {
         ALLOWED_TRANSITIONS.put(RETURN_INSPECTING, EnumSet.of(RETURNED, RETURN_REJECTED));
         ALLOWED_TRANSITIONS.put(PARTIALLY_RETURNED, EnumSet.of(RETURN_REQUESTED, RETURNED));
         ALLOWED_TRANSITIONS.put(RETURNED, EnumSet.noneOf(OrderStatus.class));
-        ALLOWED_TRANSITIONS.put(RETURN_REJECTED, EnumSet.noneOf(OrderStatus.class));
+        ALLOWED_TRANSITIONS.put(RETURN_REJECTED, EnumSet.of(RETURN_RESHIPPING_REQUESTED));
+        ALLOWED_TRANSITIONS.put(RETURN_RESHIPPING_REQUESTED, EnumSet.noneOf(OrderStatus.class));
     }
 
     public boolean canTransitionTo(OrderStatus target) {
@@ -124,6 +126,10 @@ public enum OrderStatus {
 
     public boolean isReturnRejected() {
         return this == RETURN_REJECTED;
+    }
+
+    public boolean isReturnReshippingRequested() {
+        return this == RETURN_RESHIPPING_REQUESTED;
     }
 
     public boolean requiresFulfillmentCancellation() {

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/order/OrderStatusFilter.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/order/OrderStatusFilter.java
@@ -28,7 +28,8 @@ public enum OrderStatusFilter {
                     OrderStatus.RETURN_INSPECTING,
                     OrderStatus.PARTIALLY_RETURNED,
                     OrderStatus.RETURNED,
-                    OrderStatus.RETURN_REJECTED
+                    OrderStatus.RETURN_REJECTED,
+                    OrderStatus.RETURN_RESHIPPING_REQUESTED
             )
     ),
     ALL(Collections.emptyList());


### PR DESCRIPTION
## partially addresses #216
## resolves #2490

## Task
- [x] OrderStatus enum에 RETURN_RESHIPPING_REQUESTED 추가 및 전이 규칙 정의
- [x] RETURN_REJECTED → RETURN_RESHIPPING_REQUESTED 전이 규칙 추가
- [x] OrderStatusFilter CANCEL_RETURN 그룹에 RETURN_RESHIPPING_REQUESTED 추가
- [x] Order 도메인에 isReturnReshippingRequested() 술어 메서드 추가
- [x] RequestReturnReshippingCommand 생성
- [x] RequestReturnReshippingUseCase 인터페이스 정의
- [x] RequestReturnReshippingService 구현 (RETURN_REJECTED 검증 + 직접 상태 전이)
- [x] RequestReturnReshippingApiDocs 생성
- [x] OrderController에 관리자 API 엔드포인트 추가 (POST /api/v1/admin/orders/{id}/request-return-reshipping)
- [x] 기존 GetBuyerOrderHistoryUseCaseTest, GetBuyerOrderCountUseCaseTest CANCEL_RETURN 검증 업데이트