### PR TITLE
[#216][#2498] feat: 반품 회송 요청 후 출고 처리 기능 추가

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/OrderController.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/OrderController.java
@@ -21,9 +21,11 @@ import com.personal.marketnote.commerce.port.in.usecase.order.*;
 import com.personal.marketnote.commerce.port.in.command.returntracker.ApproveReturnInspectionCommand;
 import com.personal.marketnote.commerce.port.in.command.returntracker.RejectReturnInspectionCommand;
 import com.personal.marketnote.commerce.port.in.command.returntracker.RequestReturnReshippingCommand;
+import com.personal.marketnote.commerce.port.in.command.returntracker.StartReturnReshippingCommand;
 import com.personal.marketnote.commerce.port.in.usecase.returntracker.ApproveReturnInspectionUseCase;
 import com.personal.marketnote.commerce.port.in.usecase.returntracker.RejectReturnInspectionUseCase;
 import com.personal.marketnote.commerce.port.in.usecase.returntracker.RequestReturnReshippingUseCase;
+import com.personal.marketnote.commerce.port.in.usecase.returntracker.StartReturnReshippingUseCase;
 import com.personal.marketnote.commerce.port.out.user.UpdateUserShippingAddressDeliveryRequestPort;
 import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
 import com.personal.marketnote.common.utility.ElementExtractor;
@@ -71,6 +73,7 @@ public class OrderController {
     private final ApproveReturnInspectionUseCase approveReturnInspectionUseCase;
     private final RejectReturnInspectionUseCase rejectReturnInspectionUseCase;
     private final RequestReturnReshippingUseCase requestReturnReshippingUseCase;
+    private final StartReturnReshippingUseCase startReturnReshippingUseCase;
 
     /**
      * 주문 등록
@@ -617,6 +620,35 @@ public class OrderController {
                         HttpStatus.OK,
                         DEFAULT_SUCCESS_CODE,
                         "회송 요청 성공"
+                ),
+                HttpStatus.OK
+        );
+    }
+
+    /**
+     * CS 회송 출고 처리
+     *
+     * @param id 주문 ID
+     * @Author 성효빈
+     * @Date 2026-06-03
+     * @Description CS 담당자가 회송 요청 상태의 주문에 대해 출고 처리합니다.
+     */
+    @PostMapping("/api/v1/admin/orders/{id}/start-return-reshipping")
+    @PreAuthorize(ADMIN_POINTCUT)
+    @StartReturnReshippingApiDocs
+    public ResponseEntity<BaseResponse<Void>> startReturnReshipping(
+            @PathVariable("id") Long id
+    ) {
+        startReturnReshippingUseCase.startReturnReshipping(
+                new StartReturnReshippingCommand(id)
+        );
+
+        return new ResponseEntity<>(
+                BaseResponse.of(
+                        null,
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "회송 출고 처리 성공"
                 ),
                 HttpStatus.OK
         );

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/apidocs/StartReturnReshippingApiDocs.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/apidocs/StartReturnReshippingApiDocs.java
@@ -1,0 +1,126 @@
+package com.personal.marketnote.commerce.adapter.in.web.order.controller.apidocs;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Operation(
+        summary = "CS 회송 출고 처리",
+        description = """
+                작성일자: 2026-06-03
+
+                작성자: 성효빈
+
+                ---
+
+                ## Description
+
+                - CS 담당자가 회송 요청됨(RETURN_RESHIPPING_REQUESTED) 상태의 주문에 대해 출고 처리합니다.
+
+                - 주문 상태를 회송 중(RETURN_RESHIPPING)으로 전이합니다.
+
+                - 이미 회송 중(RETURN_RESHIPPING) 상태인 주문에 대해 호출하면 멱등하게 처리됩니다.
+
+                - RETURN_RESHIPPING_REQUESTED 상태가 아닌 주문에 대해 호출하면 400 에러가 반환됩니다.
+
+                ---
+
+                ## Request
+
+                - Request Body 없음 (Path Variable만 사용)
+
+                ---
+
+                ## Response
+
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | statusCode | number | 상태 코드 | 200: 성공 / 400: 상태 전이 불가 / 401: 인증 실패 / 403: 권한 없음 |
+                | code | string | 응답 코드 | "SUC01" / "BAD_REQUEST" / "UNAUTHORIZED" / "FORBIDDEN" |
+                | timestamp | string(datetime) | 응답 일시 | "2026-06-03T12:00:00.000" |
+                | content | object | 응답 본문 | null |
+                | message | string | 처리 결과 | "회송 출고 처리 성공" |
+                """, security = {@SecurityRequirement(name = "bearer")},
+        parameters = {
+                @Parameter(
+                        name = "id",
+                        description = "주문 ID",
+                        in = ParameterIn.PATH,
+                        required = true,
+                        schema = @Schema(type = "number")
+                )
+        },
+        responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "회송 출고 처리 성공",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 200,
+                                          "code": "SUC01",
+                                          "timestamp": "2026-06-03T12:00:00.000",
+                                          "content": null,
+                                          "message": "회송 출고 처리 성공"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "400",
+                        description = "상태 전이 불가",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 400,
+                                          "code": "BAD_REQUEST",
+                                          "timestamp": "2026-06-03T12:00:00.000",
+                                          "content": null,
+                                          "message": "주문 상태를 결제 완료에서 회송 중(으)로 변경할 수 없습니다."
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "401",
+                        description = "토큰 인증 실패",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 401,
+                                          "code": "UNAUTHORIZED",
+                                          "timestamp": "2026-06-03T12:00:00.000",
+                                          "content": null,
+                                          "message": "Invalid token"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "403",
+                        description = "관리자 권한 필요",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 403,
+                                          "code": "FORBIDDEN",
+                                          "timestamp": "2026-06-03T12:00:00.000",
+                                          "content": null,
+                                          "message": "Access Denied"
+                                        }
+                                        """)
+                        )
+                ),
+        })
+public @interface StartReturnReshippingApiDocs {
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/command/returntracker/StartReturnReshippingCommand.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/command/returntracker/StartReturnReshippingCommand.java
@@ -1,0 +1,6 @@
+package com.personal.marketnote.commerce.port.in.command.returntracker;
+
+public record StartReturnReshippingCommand(
+        Long orderId
+) {
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/returntracker/StartReturnReshippingUseCase.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/returntracker/StartReturnReshippingUseCase.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.commerce.port.in.usecase.returntracker;
+
+import com.personal.marketnote.commerce.port.in.command.returntracker.StartReturnReshippingCommand;
+
+public interface StartReturnReshippingUseCase {
+
+    void startReturnReshipping(StartReturnReshippingCommand command);
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/returntracker/StartReturnReshippingService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/returntracker/StartReturnReshippingService.java
@@ -1,0 +1,59 @@
+package com.personal.marketnote.commerce.service.returntracker;
+
+import com.personal.marketnote.commerce.domain.order.Order;
+import com.personal.marketnote.commerce.domain.order.OrderStatus;
+import com.personal.marketnote.commerce.domain.order.OrderStatusHistory;
+import com.personal.marketnote.commerce.domain.order.OrderStatusHistoryCreateState;
+import com.personal.marketnote.commerce.exception.InvalidOrderStatusTransitionException;
+import com.personal.marketnote.commerce.port.in.command.returntracker.StartReturnReshippingCommand;
+import com.personal.marketnote.commerce.port.in.usecase.order.GetOrderUseCase;
+import com.personal.marketnote.commerce.port.in.usecase.returntracker.StartReturnReshippingUseCase;
+import com.personal.marketnote.commerce.port.out.order.UpdateOrderPort;
+import com.personal.marketnote.common.application.UseCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@Slf4j
+@UseCase
+@RequiredArgsConstructor
+public class StartReturnReshippingService implements StartReturnReshippingUseCase {
+
+    private final GetOrderUseCase getOrderUseCase;
+    private final UpdateOrderPort updateOrderPort;
+    private final Clock clock;
+
+    @Override
+    @Transactional(isolation = READ_COMMITTED)
+    public void startReturnReshipping(StartReturnReshippingCommand command) {
+        Order order = getOrderUseCase.getOrder(command.orderId());
+
+        if (order.isReturnReshipping()) {
+            log.info("이미 회송 출고 처리된 주문 (멱등). orderId={}", command.orderId());
+            return;
+        }
+
+        if (!order.isReturnReshippingRequested()) {
+            throw new InvalidOrderStatusTransitionException(order.getOrderStatus(), OrderStatus.RETURN_RESHIPPING);
+        }
+
+        LocalDateTime now = LocalDateTime.now(clock);
+        order.changeAllProductsStatus(OrderStatus.RETURN_RESHIPPING, now);
+
+        OrderStatusHistory history = OrderStatusHistory.from(
+                OrderStatusHistoryCreateState.builder()
+                        .orderId(order.getId())
+                        .orderStatus(OrderStatus.RETURN_RESHIPPING)
+                        .reasonCategory(order.getStatusChangeReasonCategory())
+                        .build()
+        );
+        updateOrderPort.update(order, history);
+
+        log.info("CS 회송 출고 처리 완료. orderId={}", command.orderId());
+    }
+}

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/order/Order.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/order/Order.java
@@ -102,6 +102,10 @@ public class Order {
         return this.orderStatus.isReturnReshippingRequested();
     }
 
+    public boolean isReturnReshipping() {
+        return this.orderStatus.isReturnReshipping();
+    }
+
     public void changeProductsStatus(List<Long> pricePolicyIds, OrderStatus orderStatus, LocalDateTime now) {
         orderProducts.stream()
                 .filter(orderProduct -> pricePolicyIds.contains(orderProduct.getPricePolicyId()))

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/order/OrderStatus.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/order/OrderStatus.java
@@ -27,7 +27,8 @@ public enum OrderStatus {
     PARTIALLY_RETURNED("부분 반품됨"),
     RETURNED("반품 완료"),
     RETURN_REJECTED("반품 불가"),
-    RETURN_RESHIPPING_REQUESTED("회송 요청됨");
+    RETURN_RESHIPPING_REQUESTED("회송 요청됨"),
+    RETURN_RESHIPPING("회송 중");
 
     private final String description;
 
@@ -53,7 +54,8 @@ public enum OrderStatus {
         ALLOWED_TRANSITIONS.put(PARTIALLY_RETURNED, EnumSet.of(RETURN_REQUESTED, RETURNED));
         ALLOWED_TRANSITIONS.put(RETURNED, EnumSet.noneOf(OrderStatus.class));
         ALLOWED_TRANSITIONS.put(RETURN_REJECTED, EnumSet.of(RETURN_RESHIPPING_REQUESTED));
-        ALLOWED_TRANSITIONS.put(RETURN_RESHIPPING_REQUESTED, EnumSet.noneOf(OrderStatus.class));
+        ALLOWED_TRANSITIONS.put(RETURN_RESHIPPING_REQUESTED, EnumSet.of(RETURN_RESHIPPING));
+        ALLOWED_TRANSITIONS.put(RETURN_RESHIPPING, EnumSet.noneOf(OrderStatus.class));
     }
 
     public boolean canTransitionTo(OrderStatus target) {
@@ -130,6 +132,10 @@ public enum OrderStatus {
 
     public boolean isReturnReshippingRequested() {
         return this == RETURN_RESHIPPING_REQUESTED;
+    }
+
+    public boolean isReturnReshipping() {
+        return this == RETURN_RESHIPPING;
     }
 
     public boolean requiresFulfillmentCancellation() {


### PR DESCRIPTION
## partially addresses #216
## resolves #2498

## Task
- [x] OrderStatus에 RETURN_RESHIPPING 추가 및 전이 규칙 등록
- [x] Order에 isReturnReshipping() 위임 메서드 추가
- [x] StartReturnReshippingUseCase 인터페이스 정의
- [x] StartReturnReshippingCommand record 정의
- [x] StartReturnReshippingService 구현 (RETURN_RESHIPPING_REQUESTED → RETURN_RESHIPPING)
- [x] StartReturnReshippingApiDocs 어노테이션 추가
- [x] OrderController에 POST /api/v1/admin/orders/{id}/start-return-reshipping 엔드포인트 추가