### PR TITLE
[#216][#2387] feat: 반품 PG 환불 실패 DLT 처리 기능 추가

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -50,8 +50,7 @@ def buildMarketnoteTaskDefinition(env) {
                 [name: "COMMERCE_SERVICE_SERVER_ORIGIN",    value: env.COMMERCE_SERVICE_SERVER_ORIGIN],
                 [name: "COMMUNITY_SERVICE_SERVER_ORIGIN",   value: env.COMMUNITY_SERVICE_SERVER_ORIGIN],
                 [name: "REWARD_SERVICE_SERVER_ORIGIN",      value: env.REWARD_SERVICE_SERVER_ORIGIN],
-                [name: "FULFILLMENT_SERVICE_SERVER_ORIGIN",    value: env.FULFILLMENT_SERVICE_SERVER_ORIGIN],
-                [name: "NOTIFICATION_SERVICE_SERVER_ORIGIN", value: env.NOTIFICATION_SERVICE_SERVER_ORIGIN],
+                [name: "FULFILLMENT_SERVICE_SERVER_ORIGIN", value: env.FULFILLMENT_SERVICE_SERVER_ORIGIN],
                 [name: "JWT_ADMIN_ACCESS_TOKEN",            value: env.JWT_ADMIN_ACCESS_TOKEN],
                 [name: "ADPOPCORN_ANDROID_HASH_KEY",        value: env.ADPOPCORN_ANDROID_HASH_KEY],
                 [name: "ADPOPCORN_IOS_HASH_KEY",            value: env.ADPOPCORN_IOS_HASH_KEY],
@@ -217,8 +216,7 @@ def resolveServiceMapping(svc, credentials) {
         'community-service'  : [ecr: credentials.COMMUNITY_SERVICE_ECR_REPOSITORY,   ecs: credentials.COMMUNITY_SERVICE_ECS_SERVICE_NAME,   tg: credentials.COMMUNITY_SERVICE_TARGET_GROUP_ARN,   origin: credentials.COMMUNITY_SERVICE_SERVER_ORIGIN,   dbUrl: credentials.COMMUNITY_SERVICE_DB_URL,   dbPw: credentials.COMMUNITY_SERVICE_DB_PASSWORD],
         'reward-service'     : [ecr: credentials.REWARD_SERVICE_ECR_REPOSITORY,      ecs: credentials.REWARD_SERVICE_ECS_SERVICE_NAME,      tg: credentials.REWARD_SERVICE_TARGET_GROUP_ARN,      origin: credentials.REWARD_SERVICE_SERVER_ORIGIN,      dbUrl: credentials.REWARD_SERVICE_DB_URL,      dbPw: credentials.REWARD_SERVICE_DB_PASSWORD],
         'fulfillment-service': [ecr: credentials.FULFILLMENT_SERVICE_ECR_REPOSITORY, ecs: credentials.FULFILLMENT_SERVICE_ECS_SERVICE_NAME, tg: credentials.FULFILLMENT_SERVICE_TARGET_GROUP_ARN, origin: credentials.FULFILLMENT_SERVICE_SERVER_ORIGIN, dbUrl: credentials.FULFILLMENT_SERVICE_DB_URL, dbPw: credentials.FULFILLMENT_SERVICE_DB_PASSWORD],
-        'file-service'           : [ecr: credentials.FILE_SERVICE_ECR_REPOSITORY,            ecs: credentials.FILE_SERVICE_ECS_SERVICE_NAME,            tg: credentials.FILE_SERVICE_TARGET_GROUP_ARN,            origin: credentials.FILE_SERVICE_SERVER_ORIGIN,            dbUrl: credentials.FILE_SERVICE_DB_URL,            dbPw: credentials.FILE_SERVICE_DB_PASSWORD],
-        'notification-service'   : [ecr: credentials.NOTIFICATION_SERVICE_ECR_REPOSITORY,    ecs: credentials.NOTIFICATION_SERVICE_ECS_SERVICE_NAME,    tg: credentials.NOTIFICATION_SERVICE_TARGET_GROUP_ARN,    origin: credentials.NOTIFICATION_SERVICE_SERVER_ORIGIN,    dbUrl: credentials.NOTIFICATION_SERVICE_DB_URL,    dbPw: credentials.NOTIFICATION_SERVICE_DB_PASSWORD],
+        'file-service'       : [ecr: credentials.FILE_SERVICE_ECR_REPOSITORY,        ecs: credentials.FILE_SERVICE_ECS_SERVICE_NAME,        tg: credentials.FILE_SERVICE_TARGET_GROUP_ARN,        origin: credentials.FILE_SERVICE_SERVER_ORIGIN,        dbUrl: credentials.FILE_SERVICE_DB_URL,        dbPw: credentials.FILE_SERVICE_DB_PASSWORD],
     ]
     mappings[svc]
 }
@@ -227,7 +225,7 @@ pipeline {
 	agent any
 
 	parameters {
-		choice(name: 'SERVICE', choices: ['auto','user-service','product-service','commerce-service','community-service','reward-service','fulfillment-service','file-service','notification-service'], description: '배포 대상 서비스')
+		choice(name: 'SERVICE', choices: ['auto','user-service','product-service','commerce-service','community-service','reward-service','fulfillment-service','file-service'], description: '배포 대상 서비스')
 	}
 
 	environment {
@@ -254,9 +252,8 @@ pipeline {
 						'commerce-service'   : 'commerce-adapters',
 						'community-service'  : 'community-adapters',
 						'reward-service'     : 'reward-adapters',
-						'fulfillment-service'    : 'fulfillment-adapters',
-						'file-service'           : 'file-adapters',
-						'notification-service'   : 'notification-adapters',
+						'fulfillment-service': 'fulfillment-adapters',
+						'file-service'       : 'file-adapters',
 					]
 
 					def serviceTouched = {
@@ -424,8 +421,7 @@ pipeline {
 						string(credentialsId: 'MARKETNOTE_QA_COMMUNITY_SERVICE_ECR_REPOSITORY',   variable: 'COMMUNITY_SERVICE_ECR_REPOSITORY'),
 						string(credentialsId: 'MARKETNOTE_QA_REWARD_SERVICE_ECR_REPOSITORY',      variable: 'REWARD_SERVICE_ECR_REPOSITORY'),
 						string(credentialsId: 'MARKETNOTE_QA_FULFILLMENT_SERVICE_ECR_REPOSITORY', variable: 'FULFILLMENT_SERVICE_ECR_REPOSITORY'),
-						string(credentialsId: 'MARKETNOTE_QA_FILE_SERVICE_ECR_REPOSITORY',            variable: 'FILE_SERVICE_ECR_REPOSITORY'),
-						string(credentialsId: 'MARKETNOTE_QA_NOTIFICATION_SERVICE_ECR_REPOSITORY',    variable: 'NOTIFICATION_SERVICE_ECR_REPOSITORY'),
+						string(credentialsId: 'MARKETNOTE_QA_FILE_SERVICE_ECR_REPOSITORY',        variable: 'FILE_SERVICE_ECR_REPOSITORY'),
 
 						string(credentialsId: 'MARKETNOTE_QA_USER_SERVICE_ECS_SERVICE_NAME',          variable: 'USER_SERVICE_ECS_SERVICE_NAME'),
 						string(credentialsId: 'MARKETNOTE_QA_PRODUCT_SERVICE_ECS_SERVICE_NAME',       variable: 'PRODUCT_SERVICE_ECS_SERVICE_NAME'),
@@ -433,8 +429,7 @@ pipeline {
 						string(credentialsId: 'MARKETNOTE_QA_COMMUNITY_SERVICE_ECS_SERVICE_NAME',     variable: 'COMMUNITY_SERVICE_ECS_SERVICE_NAME'),
 						string(credentialsId: 'MARKETNOTE_QA_REWARD_SERVICE_ECS_SERVICE_NAME',        variable: 'REWARD_SERVICE_ECS_SERVICE_NAME'),
 						string(credentialsId: 'MARKETNOTE_QA_FULFILLMENT_SERVICE_ECS_SERVICE_NAME',   variable: 'FULFILLMENT_SERVICE_ECS_SERVICE_NAME'),
-						string(credentialsId: 'MARKETNOTE_QA_FILE_SERVICE_ECS_SERVICE_NAME',              variable: 'FILE_SERVICE_ECS_SERVICE_NAME'),
-						string(credentialsId: 'MARKETNOTE_QA_NOTIFICATION_SERVICE_ECS_SERVICE_NAME',  variable: 'NOTIFICATION_SERVICE_ECS_SERVICE_NAME'),
+						string(credentialsId: 'MARKETNOTE_QA_FILE_SERVICE_ECS_SERVICE_NAME',          variable: 'FILE_SERVICE_ECS_SERVICE_NAME'),
 
 						string(credentialsId: 'MARKETNOTE_QA_USER_SERVICE_TARGET_GROUP_ARN',          variable: 'USER_SERVICE_TARGET_GROUP_ARN'),
 						string(credentialsId: 'MARKETNOTE_QA_PRODUCT_SERVICE_TARGET_GROUP_ARN',       variable: 'PRODUCT_SERVICE_TARGET_GROUP_ARN'),
@@ -442,8 +437,7 @@ pipeline {
 						string(credentialsId: 'MARKETNOTE_QA_COMMUNITY_SERVICE_TARGET_GROUP_ARN',     variable: 'COMMUNITY_SERVICE_TARGET_GROUP_ARN'),
 						string(credentialsId: 'MARKETNOTE_QA_REWARD_SERVICE_TARGET_GROUP_ARN',        variable: 'REWARD_SERVICE_TARGET_GROUP_ARN'),
 						string(credentialsId: 'MARKETNOTE_QA_FULFILLMENT_SERVICE_TARGET_GROUP_ARN',   variable: 'FULFILLMENT_SERVICE_TARGET_GROUP_ARN'),
-						string(credentialsId: 'MARKETNOTE_QA_FILE_SERVICE_TARGET_GROUP_ARN',              variable: 'FILE_SERVICE_TARGET_GROUP_ARN'),
-						string(credentialsId: 'MARKETNOTE_QA_NOTIFICATION_SERVICE_TARGET_GROUP_ARN',  variable: 'NOTIFICATION_SERVICE_TARGET_GROUP_ARN'),
+						string(credentialsId: 'MARKETNOTE_QA_FILE_SERVICE_TARGET_GROUP_ARN',          variable: 'FILE_SERVICE_TARGET_GROUP_ARN'),
 
 						string(credentialsId: 'MARKETNOTE_QA_USER_SERVICE_SERVER_ORIGIN',         variable: 'USER_SERVICE_SERVER_ORIGIN'),
 						string(credentialsId: 'MARKETNOTE_QA_PRODUCT_SERVICE_SERVER_ORIGIN',      variable: 'PRODUCT_SERVICE_SERVER_ORIGIN'),
@@ -451,8 +445,7 @@ pipeline {
 						string(credentialsId: 'MARKETNOTE_QA_COMMUNITY_SERVICE_SERVER_ORIGIN',    variable: 'COMMUNITY_SERVICE_SERVER_ORIGIN'),
 						string(credentialsId: 'MARKETNOTE_QA_REWARD_SERVICE_SERVER_ORIGIN',       variable: 'REWARD_SERVICE_SERVER_ORIGIN'),
 						string(credentialsId: 'MARKETNOTE_QA_FULFILLMENT_SERVICE_SERVER_ORIGIN',  variable: 'FULFILLMENT_SERVICE_SERVER_ORIGIN'),
-						string(credentialsId: 'MARKETNOTE_QA_FILE_SERVICE_SERVER_ORIGIN',             variable: 'FILE_SERVICE_SERVER_ORIGIN'),
-						string(credentialsId: 'MARKETNOTE_QA_NOTIFICATION_SERVICE_SERVER_ORIGIN', variable: 'NOTIFICATION_SERVICE_SERVER_ORIGIN'),
+						string(credentialsId: 'MARKETNOTE_QA_FILE_SERVICE_SERVER_ORIGIN',         variable: 'FILE_SERVICE_SERVER_ORIGIN'),
 
 						string(credentialsId: 'MARKETNOTE_QA_USER_SERVICE_DB_URL',              variable: 'USER_SERVICE_DB_URL'),
                         string(credentialsId: 'MARKETNOTE_QA_PRODUCT_SERVICE_DB_URL',           variable: 'PRODUCT_SERVICE_DB_URL'),
@@ -460,8 +453,7 @@ pipeline {
                         string(credentialsId: 'MARKETNOTE_QA_COMMUNITY_SERVICE_DB_URL',         variable: 'COMMUNITY_SERVICE_DB_URL'),
                         string(credentialsId: 'MARKETNOTE_QA_REWARD_SERVICE_DB_URL',            variable: 'REWARD_SERVICE_DB_URL'),
                         string(credentialsId: 'MARKETNOTE_QA_FULFILLMENT_SERVICE_DB_URL',       variable: 'FULFILLMENT_SERVICE_DB_URL'),
-                        string(credentialsId: 'MARKETNOTE_QA_FILE_SERVICE_DB_URL',                  variable: 'FILE_SERVICE_DB_URL'),
-                        string(credentialsId: 'MARKETNOTE_QA_NOTIFICATION_SERVICE_DB_URL',       variable: 'NOTIFICATION_SERVICE_DB_URL'),
+                        string(credentialsId: 'MARKETNOTE_QA_FILE_SERVICE_DB_URL',              variable: 'FILE_SERVICE_DB_URL'),
 
                         string(credentialsId: 'MARKETNOTE_QA_USER_SERVICE_DB_PASSWORD',         variable: 'USER_SERVICE_DB_PASSWORD'),
                         string(credentialsId: 'MARKETNOTE_QA_PRODUCT_SERVICE_DB_PASSWORD',      variable: 'PRODUCT_SERVICE_DB_PASSWORD'),
@@ -469,8 +461,7 @@ pipeline {
                         string(credentialsId: 'MARKETNOTE_QA_COMMUNITY_SERVICE_DB_PASSWORD',    variable: 'COMMUNITY_SERVICE_DB_PASSWORD'),
                         string(credentialsId: 'MARKETNOTE_QA_REWARD_SERVICE_DB_PASSWORD',       variable: 'REWARD_SERVICE_DB_PASSWORD'),
                         string(credentialsId: 'MARKETNOTE_QA_FULFILLMENT_SERVICE_DB_PASSWORD',  variable: 'FULFILLMENT_SERVICE_DB_PASSWORD'),
-                        string(credentialsId: 'MARKETNOTE_QA_FILE_SERVICE_DB_PASSWORD',             variable: 'FILE_SERVICE_DB_PASSWORD'),
-                        string(credentialsId: 'MARKETNOTE_QA_NOTIFICATION_SERVICE_DB_PASSWORD',  variable: 'NOTIFICATION_SERVICE_DB_PASSWORD'),
+                        string(credentialsId: 'MARKETNOTE_QA_FILE_SERVICE_DB_PASSWORD',         variable: 'FILE_SERVICE_DB_PASSWORD'),
 					]) {
 						def creds = [
 						USER_SERVICE_ECR_REPOSITORY: USER_SERVICE_ECR_REPOSITORY, USER_SERVICE_ECS_SERVICE_NAME: USER_SERVICE_ECS_SERVICE_NAME, USER_SERVICE_TARGET_GROUP_ARN: USER_SERVICE_TARGET_GROUP_ARN, USER_SERVICE_SERVER_ORIGIN: USER_SERVICE_SERVER_ORIGIN, USER_SERVICE_DB_URL: USER_SERVICE_DB_URL, USER_SERVICE_DB_PASSWORD: USER_SERVICE_DB_PASSWORD,
@@ -480,7 +471,6 @@ pipeline {
 						REWARD_SERVICE_ECR_REPOSITORY: REWARD_SERVICE_ECR_REPOSITORY, REWARD_SERVICE_ECS_SERVICE_NAME: REWARD_SERVICE_ECS_SERVICE_NAME, REWARD_SERVICE_TARGET_GROUP_ARN: REWARD_SERVICE_TARGET_GROUP_ARN, REWARD_SERVICE_SERVER_ORIGIN: REWARD_SERVICE_SERVER_ORIGIN, REWARD_SERVICE_DB_URL: REWARD_SERVICE_DB_URL, REWARD_SERVICE_DB_PASSWORD: REWARD_SERVICE_DB_PASSWORD,
 						FULFILLMENT_SERVICE_ECR_REPOSITORY: FULFILLMENT_SERVICE_ECR_REPOSITORY, FULFILLMENT_SERVICE_ECS_SERVICE_NAME: FULFILLMENT_SERVICE_ECS_SERVICE_NAME, FULFILLMENT_SERVICE_TARGET_GROUP_ARN: FULFILLMENT_SERVICE_TARGET_GROUP_ARN, FULFILLMENT_SERVICE_SERVER_ORIGIN: FULFILLMENT_SERVICE_SERVER_ORIGIN, FULFILLMENT_SERVICE_DB_URL: FULFILLMENT_SERVICE_DB_URL, FULFILLMENT_SERVICE_DB_PASSWORD: FULFILLMENT_SERVICE_DB_PASSWORD,
 						FILE_SERVICE_ECR_REPOSITORY: FILE_SERVICE_ECR_REPOSITORY, FILE_SERVICE_ECS_SERVICE_NAME: FILE_SERVICE_ECS_SERVICE_NAME, FILE_SERVICE_TARGET_GROUP_ARN: FILE_SERVICE_TARGET_GROUP_ARN, FILE_SERVICE_SERVER_ORIGIN: FILE_SERVICE_SERVER_ORIGIN, FILE_SERVICE_DB_URL: FILE_SERVICE_DB_URL, FILE_SERVICE_DB_PASSWORD: FILE_SERVICE_DB_PASSWORD,
-						NOTIFICATION_SERVICE_ECR_REPOSITORY: NOTIFICATION_SERVICE_ECR_REPOSITORY, NOTIFICATION_SERVICE_ECS_SERVICE_NAME: NOTIFICATION_SERVICE_ECS_SERVICE_NAME, NOTIFICATION_SERVICE_TARGET_GROUP_ARN: NOTIFICATION_SERVICE_TARGET_GROUP_ARN, NOTIFICATION_SERVICE_SERVER_ORIGIN: NOTIFICATION_SERVICE_SERVER_ORIGIN, NOTIFICATION_SERVICE_DB_URL: NOTIFICATION_SERVICE_DB_URL, NOTIFICATION_SERVICE_DB_PASSWORD: NOTIFICATION_SERVICE_DB_PASSWORD,
 					]
 					def mapping = resolveServiceMapping(env.SERVICE_NAME, creds)
 					if (!mapping) {
@@ -704,8 +694,7 @@ pipeline {
                         string(credentialsId: 'MARKETNOTE_QA_COMMERCE_SERVICE_SERVER_ORIGIN',     variable: 'COMMERCE_SERVICE_SERVER_ORIGIN'),
                         string(credentialsId: 'MARKETNOTE_QA_COMMUNITY_SERVICE_SERVER_ORIGIN',    variable: 'COMMUNITY_SERVICE_SERVER_ORIGIN'),
                         string(credentialsId: 'MARKETNOTE_QA_REWARD_SERVICE_SERVER_ORIGIN',       variable: 'REWARD_SERVICE_SERVER_ORIGIN'),
-                        string(credentialsId: 'MARKETNOTE_QA_FULFILLMENT_SERVICE_SERVER_ORIGIN',      variable: 'FULFILLMENT_SERVICE_SERVER_ORIGIN'),
-                        string(credentialsId: 'MARKETNOTE_QA_NOTIFICATION_SERVICE_SERVER_ORIGIN',  variable: 'NOTIFICATION_SERVICE_SERVER_ORIGIN'),
+                        string(credentialsId: 'MARKETNOTE_QA_FULFILLMENT_SERVICE_SERVER_ORIGIN',  variable: 'FULFILLMENT_SERVICE_SERVER_ORIGIN'),
                         string(credentialsId: 'MARKETNOTE_QA_JWT_ADMIN_ACCESS_TOKEN',             variable: 'JWT_ADMIN_ACCESS_TOKEN'),
                         string(credentialsId: 'MARKETNOTE_QA_ADPOPCORN_ANDROID_HASH_KEY',         variable: 'ADPOPCORN_ANDROID_HASH_KEY'),
                         string(credentialsId: 'MARKETNOTE_QA_ADPOPCORN_IOS_HASH_KEY',             variable: 'ADPOPCORN_IOS_HASH_KEY'),

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/OrderReturnedPgRefundConsumer.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/OrderReturnedPgRefundConsumer.java
@@ -52,27 +52,21 @@ public class OrderReturnedPgRefundConsumer {
             return;
         }
 
-        try {
-            CompleteReturnRefundCommand command = CompleteReturnRefundCommand.builder()
-                    .orderId(payload.orderId())
-                    .orderKey(payload.orderKey())
-                    .buyerId(payload.buyerId())
-                    .returnAmount(payload.returnAmount())
-                    .paymentAmount(payload.paymentAmount())
-                    .pointAmount(payload.pointAmount())
-                    .shippingFee(payload.shippingFee())
-                    .isFullReturn(payload.isFullReturn())
-                    .returnShippingFee(payload.returnShippingFee() != null ? payload.returnShippingFee() : 0L)
-                    .build();
+        CompleteReturnRefundCommand command = CompleteReturnRefundCommand.builder()
+                .orderId(payload.orderId())
+                .orderKey(payload.orderKey())
+                .buyerId(payload.buyerId())
+                .returnAmount(payload.returnAmount())
+                .paymentAmount(payload.paymentAmount())
+                .pointAmount(payload.pointAmount())
+                .shippingFee(payload.shippingFee())
+                .isFullReturn(payload.isFullReturn())
+                .returnShippingFee(payload.returnShippingFee() != null ? payload.returnShippingFee() : 0L)
+                .build();
 
-            completeReturnRefundUseCase.completeReturnRefund(command);
+        completeReturnRefundUseCase.completeReturnRefund(command);
 
-            log.info("반품 PG 환불 처리 완료. orderId={}", payload.orderId());
-        } catch (Exception e) {
-            log.error("반품 PG 환불 처리 실패. orderId={}, error={}",
-                    payload.orderId(), e.getMessage(), e);
-        }
-
+        log.info("반품 PG 환불 처리 완료. orderId={}", payload.orderId());
         acknowledgment.acknowledge();
     }
 }

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/OrderController.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/OrderController.java
@@ -18,6 +18,16 @@ import com.personal.marketnote.commerce.port.in.command.order.GetReturnRefundInf
 import com.personal.marketnote.commerce.port.in.command.order.UpdateOrderProductReviewStatusCommand;
 import com.personal.marketnote.commerce.port.in.result.order.*;
 import com.personal.marketnote.commerce.port.in.usecase.order.*;
+import com.personal.marketnote.commerce.port.in.command.returntracker.ApproveReturnInspectionCommand;
+import com.personal.marketnote.commerce.port.in.command.returntracker.RejectReturnInspectionCommand;
+import com.personal.marketnote.commerce.port.in.command.returntracker.RequestReturnReshippingCommand;
+import com.personal.marketnote.commerce.port.in.command.returntracker.StartReturnReshippingCommand;
+import com.personal.marketnote.commerce.port.in.command.returntracker.CompleteReturnReshippingCommand;
+import com.personal.marketnote.commerce.port.in.usecase.returntracker.ApproveReturnInspectionUseCase;
+import com.personal.marketnote.commerce.port.in.usecase.returntracker.RejectReturnInspectionUseCase;
+import com.personal.marketnote.commerce.port.in.usecase.returntracker.RequestReturnReshippingUseCase;
+import com.personal.marketnote.commerce.port.in.usecase.returntracker.StartReturnReshippingUseCase;
+import com.personal.marketnote.commerce.port.in.usecase.returntracker.CompleteReturnReshippingUseCase;
 import com.personal.marketnote.commerce.port.out.user.UpdateUserShippingAddressDeliveryRequestPort;
 import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
 import com.personal.marketnote.common.utility.ElementExtractor;
@@ -62,6 +72,11 @@ public class OrderController {
     private final GetAdminOrdersUseCase getAdminOrdersUseCase;
     private final GetOrderStatusHistoryUseCase getOrderStatusHistoryUseCase;
     private final GetReturnRefundInfoUseCase getReturnRefundInfoUseCase;
+    private final ApproveReturnInspectionUseCase approveReturnInspectionUseCase;
+    private final RejectReturnInspectionUseCase rejectReturnInspectionUseCase;
+    private final RequestReturnReshippingUseCase requestReturnReshippingUseCase;
+    private final StartReturnReshippingUseCase startReturnReshippingUseCase;
+    private final CompleteReturnReshippingUseCase completeReturnReshippingUseCase;
 
     /**
      * 주문 등록
@@ -521,6 +536,151 @@ public class OrderController {
                         HttpStatus.OK,
                         DEFAULT_SUCCESS_CODE,
                         "주문 상태 이력 조회 성공"
+                ),
+                HttpStatus.OK
+        );
+    }
+
+    /**
+     * CS 반��� 검수 승인
+     *
+     * @param id 주문 ID
+     * @Author 성효빈
+     * @Date 2026-06-03
+     * @Description CS 담당��가 반품 검수 중 상태의 주문을 반품 완료로 ��이합니다.
+     */
+    @PostMapping("/api/v1/admin/orders/{id}/approve-return-inspection")
+    @PreAuthorize(ADMIN_POINTCUT)
+    @ApproveReturnInspectionApiDocs
+    public ResponseEntity<BaseResponse<Void>> approveReturnInspection(
+            @PathVariable("id") Long id
+    ) {
+        approveReturnInspectionUseCase.approveReturnInspection(
+                new ApproveReturnInspectionCommand(id)
+        );
+
+        return new ResponseEntity<>(
+                BaseResponse.of(
+                        null,
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "반품 검수 승인 성공"
+                ),
+                HttpStatus.OK
+        );
+    }
+
+    /**
+     * CS 반품 불가 판정
+     *
+     * @param id 주문 ID
+     * @Author 성효빈
+     * @Date 2026-06-03
+     * @Description CS 담당자가 반품 검수 중 상태의 주문을 반품 불가로 전이합니다.
+     */
+    @PostMapping("/api/v1/admin/orders/{id}/reject-return-inspection")
+    @PreAuthorize(ADMIN_POINTCUT)
+    @RejectReturnInspectionApiDocs
+    public ResponseEntity<BaseResponse<Void>> rejectReturnInspection(
+            @PathVariable("id") Long id
+    ) {
+        rejectReturnInspectionUseCase.rejectReturnInspection(
+                new RejectReturnInspectionCommand(id)
+        );
+
+        return new ResponseEntity<>(
+                BaseResponse.of(
+                        null,
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "반품 불가 판정 성공"
+                ),
+                HttpStatus.OK
+        );
+    }
+
+    /**
+     * CS 회송 요청
+     *
+     * @param id 주문 ID
+     * @Author 성효빈
+     * @Date 2026-06-03
+     * @Description CS 담당자가 반품 불가 상태의 주문에 대해 회송을 요청합니다.
+     */
+    @PostMapping("/api/v1/admin/orders/{id}/request-return-reshipping")
+    @PreAuthorize(ADMIN_POINTCUT)
+    @RequestReturnReshippingApiDocs
+    public ResponseEntity<BaseResponse<Void>> requestReturnReshipping(
+            @PathVariable("id") Long id
+    ) {
+        requestReturnReshippingUseCase.requestReturnReshipping(
+                new RequestReturnReshippingCommand(id)
+        );
+
+        return new ResponseEntity<>(
+                BaseResponse.of(
+                        null,
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "회송 요청 성공"
+                ),
+                HttpStatus.OK
+        );
+    }
+
+    /**
+     * CS 회송 출고 처리
+     *
+     * @param id 주문 ID
+     * @Author 성효빈
+     * @Date 2026-06-03
+     * @Description CS 담당자가 회송 요청 상태의 주문에 대해 출고 처리합니다.
+     */
+    @PostMapping("/api/v1/admin/orders/{id}/start-return-reshipping")
+    @PreAuthorize(ADMIN_POINTCUT)
+    @StartReturnReshippingApiDocs
+    public ResponseEntity<BaseResponse<Void>> startReturnReshipping(
+            @PathVariable("id") Long id
+    ) {
+        startReturnReshippingUseCase.startReturnReshipping(
+                new StartReturnReshippingCommand(id)
+        );
+
+        return new ResponseEntity<>(
+                BaseResponse.of(
+                        null,
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "회송 출고 처리 성공"
+                ),
+                HttpStatus.OK
+        );
+    }
+
+    /**
+     * CS 회송 완료 처리
+     *
+     * @param id 주문 ID
+     * @Author 성효빈
+     * @Date 2026-06-03
+     * @Description CS 담당자가 회송 중 상태의 주문에 대해 회송 완료 처리합니다.
+     */
+    @PostMapping("/api/v1/admin/orders/{id}/complete-return-reshipping")
+    @PreAuthorize(ADMIN_POINTCUT)
+    @CompleteReturnReshippingApiDocs
+    public ResponseEntity<BaseResponse<Void>> completeReturnReshipping(
+            @PathVariable("id") Long id
+    ) {
+        completeReturnReshippingUseCase.completeReturnReshipping(
+                new CompleteReturnReshippingCommand(id)
+        );
+
+        return new ResponseEntity<>(
+                BaseResponse.of(
+                        null,
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "회송 완료 처리 성공"
                 ),
                 HttpStatus.OK
         );

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/apidocs/ApproveReturnInspectionApiDocs.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/apidocs/ApproveReturnInspectionApiDocs.java
@@ -1,0 +1,126 @@
+package com.personal.marketnote.commerce.adapter.in.web.order.controller.apidocs;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Operation(
+        summary = "CS 반품 검수 승인",
+        description = """
+                작성일자: 2026-06-03
+
+                작성자: 성효빈
+
+                ---
+
+                ## Description
+
+                - CS 담당자가 반품 검수 중(RETURN_INSPECTING) 상태의 주문을 반품 완료(RETURNED)로 전이합니다.
+
+                - 반품 완료 전이 후 환불 프로세스(PG 환불, 정산 취소, 재고 복원, 포인트 환불)가 자동으로 진행됩니다.
+
+                - 이미 반품 완료(RETURNED) 상태인 주문에 대해 호출하면 멱등하게 처리됩니다.
+
+                - RETURN_INSPECTING 상태가 아닌 주문에 대해 호출하면 400 에러가 반환됩니다.
+
+                ---
+
+                ## Request
+
+                - Request Body 없음 (Path Variable만 사용)
+
+                ---
+
+                ## Response
+
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | statusCode | number | 상태 코드 | 200: 성공 / 400: 상태 전이 불가 / 401: 인증 실패 / 403: 권한 없음 |
+                | code | string | 응답 코드 | "SUC01" / "BAD_REQUEST" / "UNAUTHORIZED" / "FORBIDDEN" |
+                | timestamp | string(datetime) | 응답 일시 | "2026-06-03T12:00:00.000" |
+                | content | object | 응답 본문 | null |
+                | message | string | 처리 결과 | "반품 검수 승인 성공" |
+                """, security = {@SecurityRequirement(name = "bearer")},
+        parameters = {
+                @Parameter(
+                        name = "id",
+                        description = "주문 ID",
+                        in = ParameterIn.PATH,
+                        required = true,
+                        schema = @Schema(type = "number")
+                )
+        },
+        responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "반품 검수 승인 성공",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 200,
+                                          "code": "SUC01",
+                                          "timestamp": "2026-06-03T12:00:00.000",
+                                          "content": null,
+                                          "message": "반품 검수 승인 성공"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "400",
+                        description = "상태 전이 불가",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 400,
+                                          "code": "BAD_REQUEST",
+                                          "timestamp": "2026-06-03T12:00:00.000",
+                                          "content": null,
+                                          "message": "주문 상태를 반품 진행 중에서 반품 완료(으)로 변경할 수 없습니다."
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "401",
+                        description = "토큰 인증 실패",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 401,
+                                          "code": "UNAUTHORIZED",
+                                          "timestamp": "2026-06-03T12:00:00.000",
+                                          "content": null,
+                                          "message": "Invalid token"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "403",
+                        description = "관리자 권한 필요",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 403,
+                                          "code": "FORBIDDEN",
+                                          "timestamp": "2026-06-03T12:00:00.000",
+                                          "content": null,
+                                          "message": "Access Denied"
+                                        }
+                                        """)
+                        )
+                ),
+        })
+public @interface ApproveReturnInspectionApiDocs {
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/apidocs/ChangeOrderStatusApiDocs.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/apidocs/ChangeOrderStatusApiDocs.java
@@ -56,7 +56,9 @@ import java.lang.annotation.*;
                     - "RETURN_REQUESTED": 반품 요청됨
                 
                     - "RETURN_IN_PROGRESS": 반품 진행 중
-                
+
+                    - "RETURN_INSPECTING": 반품 검수 중
+
                     - "PARTIALLY_RETURNED": 부분 반품됨
                 
                     - "RETURNED": 반품 완료

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/apidocs/CompleteReturnReshippingApiDocs.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/apidocs/CompleteReturnReshippingApiDocs.java
@@ -1,0 +1,126 @@
+package com.personal.marketnote.commerce.adapter.in.web.order.controller.apidocs;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Operation(
+        summary = "CS 회송 완료 처리",
+        description = """
+                작성일자: 2026-06-03
+
+                작성자: 성효빈
+
+                ---
+
+                ## Description
+
+                - CS 담당자가 회송 중(RETURN_RESHIPPING) 상태의 주문에 대해 회송 완료 처리합니다.
+
+                - 주문 상태를 회송 완료(RETURN_RESHIPPED)로 전이합니다.
+
+                - 이미 회송 완료(RETURN_RESHIPPED) 상태인 주문에 대해 호출하면 멱등하게 처리됩니다.
+
+                - RETURN_RESHIPPING 상태가 아닌 주문에 대해 호출하면 400 에러가 반환됩니다.
+
+                ---
+
+                ## Request
+
+                - Request Body 없음 (Path Variable만 사용)
+
+                ---
+
+                ## Response
+
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | statusCode | number | 상태 코드 | 200: 성공 / 400: 상태 전이 불가 / 401: 인증 실패 / 403: 권한 없음 |
+                | code | string | 응답 코드 | "SUC01" / "BAD_REQUEST" / "UNAUTHORIZED" / "FORBIDDEN" |
+                | timestamp | string(datetime) | 응답 일시 | "2026-06-03T12:00:00.000" |
+                | content | object | 응답 본문 | null |
+                | message | string | 처리 결과 | "회송 완료 처리 성공" |
+                """, security = {@SecurityRequirement(name = "bearer")},
+        parameters = {
+                @Parameter(
+                        name = "id",
+                        description = "주문 ID",
+                        in = ParameterIn.PATH,
+                        required = true,
+                        schema = @Schema(type = "number")
+                )
+        },
+        responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "회송 완료 처리 성공",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 200,
+                                          "code": "SUC01",
+                                          "timestamp": "2026-06-03T12:00:00.000",
+                                          "content": null,
+                                          "message": "회송 완료 처리 성공"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "400",
+                        description = "상태 전이 불가",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 400,
+                                          "code": "BAD_REQUEST",
+                                          "timestamp": "2026-06-03T12:00:00.000",
+                                          "content": null,
+                                          "message": "주문 상태를 결제 완료에서 회송 완료(으)로 변경할 수 없습니다."
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "401",
+                        description = "토큰 인증 실패",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 401,
+                                          "code": "UNAUTHORIZED",
+                                          "timestamp": "2026-06-03T12:00:00.000",
+                                          "content": null,
+                                          "message": "Invalid token"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "403",
+                        description = "관리자 권한 필요",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 403,
+                                          "code": "FORBIDDEN",
+                                          "timestamp": "2026-06-03T12:00:00.000",
+                                          "content": null,
+                                          "message": "Access Denied"
+                                        }
+                                        """)
+                        )
+                ),
+        })
+public @interface CompleteReturnReshippingApiDocs {
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/apidocs/GetOrderInfoApiDocs.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/apidocs/GetOrderInfoApiDocs.java
@@ -50,7 +50,9 @@ import java.lang.annotation.*;
                     - "RETURN_REQUESTED": 반품 요청됨
                 
                     - "RETURN_IN_PROGRESS": 반품 진행 중
-                
+
+                    - "RETURN_INSPECTING": 반품 검수 중
+
                     - "PARTIALLY_RETURNED": 부분 반품됨
                 
                     - "RETURNED": 반품 완료

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/apidocs/GetOrdersApiDocs.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/apidocs/GetOrdersApiDocs.java
@@ -47,7 +47,9 @@ import java.lang.annotation.*;
                     - "RETURN_REQUESTED": 반품 요청됨
                 
                     - "RETURN_IN_PROGRESS": 반품 진행 중
-                
+
+                    - "RETURN_INSPECTING": 반품 검수 중
+
                     - "PARTIALLY_RETURNED": 부분 반품됨
                 
                     - "RETURNED": 반품 완료

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/apidocs/RejectReturnInspectionApiDocs.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/apidocs/RejectReturnInspectionApiDocs.java
@@ -1,0 +1,126 @@
+package com.personal.marketnote.commerce.adapter.in.web.order.controller.apidocs;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Operation(
+        summary = "CS 반품 불가 판정",
+        description = """
+                작성일자: 2026-06-03
+
+                작성자: 성효빈
+
+                ---
+
+                ## Description
+
+                - CS 담당자가 반품 검수 중(RETURN_INSPECTING) 상태의 주문을 반품 불가(RETURN_REJECTED)로 전이합니다.
+
+                - 반품 불가 판정 시 환불 프로세스는 진행되지 않습니다.
+
+                - 이미 반품 불가(RETURN_REJECTED) 상태인 주문에 대해 호출하면 멱등하게 처리됩니다.
+
+                - RETURN_INSPECTING 상태가 아닌 주문에 대해 호출하면 400 에러가 반환됩니다.
+
+                ---
+
+                ## Request
+
+                - Request Body 없음 (Path Variable만 사용)
+
+                ---
+
+                ## Response
+
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | statusCode | number | 상태 코드 | 200: 성공 / 400: 상태 전이 불가 / 401: 인증 실패 / 403: 권한 없음 |
+                | code | string | 응답 코드 | "SUC01" / "BAD_REQUEST" / "UNAUTHORIZED" / "FORBIDDEN" |
+                | timestamp | string(datetime) | 응답 일시 | "2026-06-03T12:00:00.000" |
+                | content | object | 응답 본문 | null |
+                | message | string | 처리 결과 | "반품 불가 판정 성공" |
+                """, security = {@SecurityRequirement(name = "bearer")},
+        parameters = {
+                @Parameter(
+                        name = "id",
+                        description = "주문 ID",
+                        in = ParameterIn.PATH,
+                        required = true,
+                        schema = @Schema(type = "number")
+                )
+        },
+        responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "반품 불가 판정 성공",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 200,
+                                          "code": "SUC01",
+                                          "timestamp": "2026-06-03T12:00:00.000",
+                                          "content": null,
+                                          "message": "반품 불가 판정 성공"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "400",
+                        description = "상태 전이 불가",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 400,
+                                          "code": "BAD_REQUEST",
+                                          "timestamp": "2026-06-03T12:00:00.000",
+                                          "content": null,
+                                          "message": "주문 상태를 반품 진행 중에서 반품 불가(으)로 변경할 수 없습니다."
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "401",
+                        description = "토큰 인증 실패",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 401,
+                                          "code": "UNAUTHORIZED",
+                                          "timestamp": "2026-06-03T12:00:00.000",
+                                          "content": null,
+                                          "message": "Invalid token"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "403",
+                        description = "관리자 권한 필요",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 403,
+                                          "code": "FORBIDDEN",
+                                          "timestamp": "2026-06-03T12:00:00.000",
+                                          "content": null,
+                                          "message": "Access Denied"
+                                        }
+                                        """)
+                        )
+                ),
+        })
+public @interface RejectReturnInspectionApiDocs {
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/apidocs/RequestReturnReshippingApiDocs.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/apidocs/RequestReturnReshippingApiDocs.java
@@ -1,0 +1,126 @@
+package com.personal.marketnote.commerce.adapter.in.web.order.controller.apidocs;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Operation(
+        summary = "CS 회송 요청",
+        description = """
+                작성일자: 2026-06-03
+
+                작성자: 성효빈
+
+                ---
+
+                ## Description
+
+                - CS 담당자가 반품 불가(RETURN_REJECTED) 상태의 주문에 대해 회송을 요청합니다.
+
+                - 주문 상태를 회송 요청됨(RETURN_RESHIPPING_REQUESTED)으로 전이합니다.
+
+                - 이미 회송 요청됨(RETURN_RESHIPPING_REQUESTED) 상태인 주문에 대해 호출하면 멱등하게 처리됩니다.
+
+                - RETURN_REJECTED 상태가 아닌 주문에 대해 호출하면 400 에러가 반환됩니다.
+
+                ---
+
+                ## Request
+
+                - Request Body 없음 (Path Variable만 사용)
+
+                ---
+
+                ## Response
+
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | statusCode | number | 상태 코드 | 200: 성공 / 400: 상태 전이 불가 / 401: 인증 실패 / 403: 권한 없음 |
+                | code | string | 응답 코드 | "SUC01" / "BAD_REQUEST" / "UNAUTHORIZED" / "FORBIDDEN" |
+                | timestamp | string(datetime) | 응답 일시 | "2026-06-03T12:00:00.000" |
+                | content | object | 응답 본문 | null |
+                | message | string | 처리 결과 | "회송 요청 성공" |
+                """, security = {@SecurityRequirement(name = "bearer")},
+        parameters = {
+                @Parameter(
+                        name = "id",
+                        description = "주문 ID",
+                        in = ParameterIn.PATH,
+                        required = true,
+                        schema = @Schema(type = "number")
+                )
+        },
+        responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "회송 요청 성공",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 200,
+                                          "code": "SUC01",
+                                          "timestamp": "2026-06-03T12:00:00.000",
+                                          "content": null,
+                                          "message": "회송 요청 성공"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "400",
+                        description = "상태 전이 불가",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 400,
+                                          "code": "BAD_REQUEST",
+                                          "timestamp": "2026-06-03T12:00:00.000",
+                                          "content": null,
+                                          "message": "주문 상태를 반품 검수 중에서 회송 요청됨(으)로 변경할 수 없습니다."
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "401",
+                        description = "토큰 인증 실패",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 401,
+                                          "code": "UNAUTHORIZED",
+                                          "timestamp": "2026-06-03T12:00:00.000",
+                                          "content": null,
+                                          "message": "Invalid token"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "403",
+                        description = "관리자 권한 필요",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 403,
+                                          "code": "FORBIDDEN",
+                                          "timestamp": "2026-06-03T12:00:00.000",
+                                          "content": null,
+                                          "message": "Access Denied"
+                                        }
+                                        """)
+                        )
+                ),
+        })
+public @interface RequestReturnReshippingApiDocs {
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/apidocs/StartReturnReshippingApiDocs.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/web/order/controller/apidocs/StartReturnReshippingApiDocs.java
@@ -1,0 +1,126 @@
+package com.personal.marketnote.commerce.adapter.in.web.order.controller.apidocs;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Operation(
+        summary = "CS 회송 출고 처리",
+        description = """
+                작성일자: 2026-06-03
+
+                작성자: 성효빈
+
+                ---
+
+                ## Description
+
+                - CS 담당자가 회송 요청됨(RETURN_RESHIPPING_REQUESTED) 상태의 주문에 대해 출고 처리합니다.
+
+                - 주문 상태를 회송 중(RETURN_RESHIPPING)으로 전이합니다.
+
+                - 이미 회송 중(RETURN_RESHIPPING) 상태인 주문에 대해 호출하면 멱등하게 처리됩니다.
+
+                - RETURN_RESHIPPING_REQUESTED 상태가 아닌 주문에 대해 호출하면 400 에러가 반환됩니다.
+
+                ---
+
+                ## Request
+
+                - Request Body 없음 (Path Variable만 사용)
+
+                ---
+
+                ## Response
+
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | statusCode | number | 상태 코드 | 200: 성공 / 400: 상태 전이 불가 / 401: 인증 실패 / 403: 권한 없음 |
+                | code | string | 응답 코드 | "SUC01" / "BAD_REQUEST" / "UNAUTHORIZED" / "FORBIDDEN" |
+                | timestamp | string(datetime) | 응답 일시 | "2026-06-03T12:00:00.000" |
+                | content | object | 응답 본문 | null |
+                | message | string | 처리 결과 | "회송 출고 처리 성공" |
+                """, security = {@SecurityRequirement(name = "bearer")},
+        parameters = {
+                @Parameter(
+                        name = "id",
+                        description = "주문 ID",
+                        in = ParameterIn.PATH,
+                        required = true,
+                        schema = @Schema(type = "number")
+                )
+        },
+        responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "회송 출고 처리 성공",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 200,
+                                          "code": "SUC01",
+                                          "timestamp": "2026-06-03T12:00:00.000",
+                                          "content": null,
+                                          "message": "회송 출고 처리 성공"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "400",
+                        description = "상태 전이 불가",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 400,
+                                          "code": "BAD_REQUEST",
+                                          "timestamp": "2026-06-03T12:00:00.000",
+                                          "content": null,
+                                          "message": "주문 상태를 결제 완료에서 회송 중(으)로 변경할 수 없습니다."
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "401",
+                        description = "토큰 인증 실패",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 401,
+                                          "code": "UNAUTHORIZED",
+                                          "timestamp": "2026-06-03T12:00:00.000",
+                                          "content": null,
+                                          "message": "Invalid token"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "403",
+                        description = "관리자 권한 필요",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 403,
+                                          "code": "FORBIDDEN",
+                                          "timestamp": "2026-06-03T12:00:00.000",
+                                          "content": null,
+                                          "message": "Access Denied"
+                                        }
+                                        """)
+                        )
+                ),
+        })
+public @interface StartReturnReshippingApiDocs {
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/slack/SlackConfiguration.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/slack/SlackConfiguration.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.commerce.adapter.out.slack;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(SlackProperties.class)
+public class SlackConfiguration {
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/slack/SlackProperties.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/slack/SlackProperties.java
@@ -1,0 +1,12 @@
+package com.personal.marketnote.commerce.adapter.out.slack;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "slack")
+public class SlackProperties {
+    private String webhookUrl;
+}

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/slack/SlackWebhookAdapter.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/slack/SlackWebhookAdapter.java
@@ -1,0 +1,65 @@
+package com.personal.marketnote.commerce.adapter.out.slack;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.commerce.port.out.slack.SendSlackAlertPort;
+import com.personal.marketnote.common.utility.FormatValidator;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SlackWebhookAdapter implements SendSlackAlertPort {
+
+    private static final HttpClient HTTP_CLIENT = HttpClient.newBuilder()
+            .connectTimeout(Duration.ofSeconds(5))
+            .build();
+
+    private final SlackProperties slackProperties;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void sendInspectionFailedOrHoldAlert(Long orderId, String inspectionStatus, LocalDateTime inspectedAt) {
+        String webhookUrl = slackProperties.getWebhookUrl();
+        if (FormatValidator.hasNoValue(webhookUrl)) {
+            return;
+        }
+
+        String text = """
+                [검수 알림] 반품 검수 불량/보류 발생
+
+                • orderId: %d
+                • 검수 상태: %s
+                • 검수 시각: %s""".formatted(orderId, inspectionStatus, inspectedAt);
+
+        try {
+            Map<String, String> payload = Map.of("text", text);
+            String jsonBody = objectMapper.writeValueAsString(payload);
+
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(webhookUrl))
+                    .header("Content-Type", "application/json")
+                    .POST(HttpRequest.BodyPublishers.ofString(jsonBody))
+                    .timeout(Duration.ofSeconds(10))
+                    .build();
+
+            HTTP_CLIENT.sendAsync(request, HttpResponse.BodyHandlers.discarding())
+                    .thenAccept(response -> log.info("Slack 검수 알림 전송 성공. orderId={}", orderId))
+                    .exceptionally(ex -> {
+                        log.warn("Slack 검수 알림 전송 실패. orderId={}", orderId, ex);
+                        return null;
+                    });
+        } catch (Exception e) {
+            log.warn("Slack 검수 알림 메시지 생성 실패. orderId={}", orderId, e);
+        }
+    }
+}

--- a/commerce-service/commerce-adapters/src/main/resources/application.yml
+++ b/commerce-service/commerce-adapters/src/main/resources/application.yml
@@ -78,6 +78,9 @@ kafka:
   slack:
     webhook-url: ${KAFKA_SLACK_WEBHOOK_URL:}
 
+slack:
+  webhook-url: ${SLACK_WEBHOOK_URL:}
+
 user-service:
   base-url: ${USER_SERVICE_SERVER_ORIGIN:http://localhost:8080}
 

--- a/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/out/slack/SlackWebhookAdapterTest.java
+++ b/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/out/slack/SlackWebhookAdapterTest.java
@@ -1,0 +1,51 @@
+package com.personal.marketnote.commerce.adapter.out.slack;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+
+import static org.mockito.Mockito.verifyNoInteractions;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("SlackWebhookAdapter 테스트")
+class SlackWebhookAdapterTest {
+
+    @InjectMocks
+    private SlackWebhookAdapter adapter;
+
+    @Mock
+    private SlackProperties slackProperties;
+
+    @Mock
+    private ObjectMapper objectMapper;
+
+    private static final LocalDateTime NOW = LocalDateTime.of(2026, 4, 9, 19, 0);
+
+    @Nested
+    @DisplayName("웹훅 URL이 없는 경우")
+    class WhenWebhookUrlIsEmpty {
+
+        @Test
+        @DisplayName("webhookUrl이 null이면 Slack 호출을 건너뛴다")
+        void shouldSkipWhenWebhookUrlIsNull() {
+            adapter.sendInspectionFailedOrHoldAlert(100L, "검수 실패", NOW);
+
+            verifyNoInteractions(objectMapper);
+        }
+
+        @Test
+        @DisplayName("webhookUrl이 빈 문자열이면 Slack 호출을 건너뛴다")
+        void shouldSkipWhenWebhookUrlIsEmpty() {
+            adapter.sendInspectionFailedOrHoldAlert(100L, "검수 보류", NOW);
+
+            verifyNoInteractions(objectMapper);
+        }
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/exception/ReturnPgRefundFailedException.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/exception/ReturnPgRefundFailedException.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.commerce.exception;
+
+public class ReturnPgRefundFailedException extends RuntimeException {
+    public ReturnPgRefundFailedException(Long orderId, Throwable cause) {
+        super("반품 PG 환불 실패. orderId=" + orderId, cause);
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/command/returntracker/ApproveReturnInspectionCommand.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/command/returntracker/ApproveReturnInspectionCommand.java
@@ -1,0 +1,6 @@
+package com.personal.marketnote.commerce.port.in.command.returntracker;
+
+public record ApproveReturnInspectionCommand(
+        Long orderId
+) {
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/command/returntracker/CompleteReturnReshippingCommand.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/command/returntracker/CompleteReturnReshippingCommand.java
@@ -1,0 +1,6 @@
+package com.personal.marketnote.commerce.port.in.command.returntracker;
+
+public record CompleteReturnReshippingCommand(
+        Long orderId
+) {
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/command/returntracker/RejectReturnInspectionCommand.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/command/returntracker/RejectReturnInspectionCommand.java
@@ -1,0 +1,6 @@
+package com.personal.marketnote.commerce.port.in.command.returntracker;
+
+public record RejectReturnInspectionCommand(
+        Long orderId
+) {
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/command/returntracker/RequestReturnReshippingCommand.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/command/returntracker/RequestReturnReshippingCommand.java
@@ -1,0 +1,6 @@
+package com.personal.marketnote.commerce.port.in.command.returntracker;
+
+public record RequestReturnReshippingCommand(
+        Long orderId
+) {
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/command/returntracker/StartReturnReshippingCommand.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/command/returntracker/StartReturnReshippingCommand.java
@@ -1,0 +1,6 @@
+package com.personal.marketnote.commerce.port.in.command.returntracker;
+
+public record StartReturnReshippingCommand(
+        Long orderId
+) {
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/returntracker/ApproveReturnInspectionUseCase.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/returntracker/ApproveReturnInspectionUseCase.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.commerce.port.in.usecase.returntracker;
+
+import com.personal.marketnote.commerce.port.in.command.returntracker.ApproveReturnInspectionCommand;
+
+public interface ApproveReturnInspectionUseCase {
+
+    void approveReturnInspection(ApproveReturnInspectionCommand command);
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/returntracker/CompleteReturnReshippingUseCase.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/returntracker/CompleteReturnReshippingUseCase.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.commerce.port.in.usecase.returntracker;
+
+import com.personal.marketnote.commerce.port.in.command.returntracker.CompleteReturnReshippingCommand;
+
+public interface CompleteReturnReshippingUseCase {
+
+    void completeReturnReshipping(CompleteReturnReshippingCommand command);
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/returntracker/RejectReturnInspectionUseCase.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/returntracker/RejectReturnInspectionUseCase.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.commerce.port.in.usecase.returntracker;
+
+import com.personal.marketnote.commerce.port.in.command.returntracker.RejectReturnInspectionCommand;
+
+public interface RejectReturnInspectionUseCase {
+
+    void rejectReturnInspection(RejectReturnInspectionCommand command);
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/returntracker/RequestReturnReshippingUseCase.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/returntracker/RequestReturnReshippingUseCase.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.commerce.port.in.usecase.returntracker;
+
+import com.personal.marketnote.commerce.port.in.command.returntracker.RequestReturnReshippingCommand;
+
+public interface RequestReturnReshippingUseCase {
+
+    void requestReturnReshipping(RequestReturnReshippingCommand command);
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/returntracker/StartReturnReshippingUseCase.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/in/usecase/returntracker/StartReturnReshippingUseCase.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.commerce.port.in.usecase.returntracker;
+
+import com.personal.marketnote.commerce.port.in.command.returntracker.StartReturnReshippingCommand;
+
+public interface StartReturnReshippingUseCase {
+
+    void startReturnReshipping(StartReturnReshippingCommand command);
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/slack/SendSlackAlertPort.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/slack/SendSlackAlertPort.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.commerce.port.out.slack;
+
+import java.time.LocalDateTime;
+
+public interface SendSlackAlertPort {
+    void sendInspectionFailedOrHoldAlert(Long orderId, String inspectionStatus, LocalDateTime inspectedAt);
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/returntracker/ApproveReturnInspectionService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/returntracker/ApproveReturnInspectionService.java
@@ -1,0 +1,40 @@
+package com.personal.marketnote.commerce.service.returntracker;
+
+import com.personal.marketnote.commerce.domain.order.Order;
+import com.personal.marketnote.commerce.domain.order.OrderStatus;
+import com.personal.marketnote.commerce.exception.InvalidOrderStatusTransitionException;
+import com.personal.marketnote.commerce.port.in.command.returntracker.ApproveReturnInspectionCommand;
+import com.personal.marketnote.commerce.port.in.command.returntracker.CompleteReturnCommand;
+import com.personal.marketnote.commerce.port.in.usecase.order.GetOrderUseCase;
+import com.personal.marketnote.commerce.port.in.usecase.returntracker.ApproveReturnInspectionUseCase;
+import com.personal.marketnote.commerce.port.in.usecase.returntracker.CompleteReturnUseCase;
+import com.personal.marketnote.common.application.UseCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@UseCase
+@RequiredArgsConstructor
+public class ApproveReturnInspectionService implements ApproveReturnInspectionUseCase {
+
+    private final GetOrderUseCase getOrderUseCase;
+    private final CompleteReturnUseCase completeReturnUseCase;
+
+    @Override
+    public void approveReturnInspection(ApproveReturnInspectionCommand command) {
+        Order order = getOrderUseCase.getOrder(command.orderId());
+
+        if (order.isReturned()) {
+            log.info("이미 반품 완료 처리된 주문 (멱등). orderId={}", command.orderId());
+            return;
+        }
+
+        if (!order.isReturnInspecting()) {
+            throw new InvalidOrderStatusTransitionException(order.getOrderStatus(), OrderStatus.RETURNED);
+        }
+
+        completeReturnUseCase.completeReturn(new CompleteReturnCommand(command.orderId()));
+
+        log.info("CS 반품 검수 승인 완료. orderId={}", command.orderId());
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/returntracker/CompleteReturnRefundService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/returntracker/CompleteReturnRefundService.java
@@ -3,6 +3,7 @@ package com.personal.marketnote.commerce.service.returntracker;
 import com.personal.marketnote.commerce.domain.returntracker.ReturnTracker;
 import com.personal.marketnote.commerce.exception.PaymentAlreadyRefundedException;
 import com.personal.marketnote.commerce.exception.PaymentCancelException;
+import com.personal.marketnote.commerce.exception.ReturnPgRefundFailedException;
 import com.personal.marketnote.commerce.exception.ReturnTrackerNotFoundException;
 import com.personal.marketnote.commerce.port.in.command.payment.RefundPaymentCommand;
 import com.personal.marketnote.commerce.port.in.command.returntracker.CompleteReturnRefundCommand;
@@ -32,6 +33,17 @@ public class CompleteReturnRefundService implements CompleteReturnRefundUseCase 
         ReturnTracker tracker = findReturnTrackerPort.findByOrderId(command.orderId())
                 .orElseThrow(() -> new ReturnTrackerNotFoundException(command.orderId()));
 
+        if (tracker.isRefundCompleted()) {
+            log.info("이미 환불 완료된 ReturnTracker (멱등). orderId={}", command.orderId());
+            return;
+        }
+
+        if (tracker.isRefundFailed()) {
+            tracker.retryRefund();
+            updateReturnTrackerPort.update(tracker);
+            log.info("FAILED 상태 ReturnTracker를 PENDING으로 리셋 (재시도). orderId={}", command.orderId());
+        }
+
         RefundPaymentCommand refundCommand = buildRefundCommand(command);
 
         try {
@@ -44,6 +56,7 @@ public class CompleteReturnRefundService implements CompleteReturnRefundUseCase 
         } catch (PaymentCancelException e) {
             log.error("PG 환불 실패. orderId={}, message={}", command.orderId(), e.getMessage());
             failRefund(tracker);
+            throw new ReturnPgRefundFailedException(command.orderId(), e);
         }
     }
 

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/returntracker/CompleteReturnReshippingService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/returntracker/CompleteReturnReshippingService.java
@@ -1,0 +1,59 @@
+package com.personal.marketnote.commerce.service.returntracker;
+
+import com.personal.marketnote.commerce.domain.order.Order;
+import com.personal.marketnote.commerce.domain.order.OrderStatus;
+import com.personal.marketnote.commerce.domain.order.OrderStatusHistory;
+import com.personal.marketnote.commerce.domain.order.OrderStatusHistoryCreateState;
+import com.personal.marketnote.commerce.exception.InvalidOrderStatusTransitionException;
+import com.personal.marketnote.commerce.port.in.command.returntracker.CompleteReturnReshippingCommand;
+import com.personal.marketnote.commerce.port.in.usecase.order.GetOrderUseCase;
+import com.personal.marketnote.commerce.port.in.usecase.returntracker.CompleteReturnReshippingUseCase;
+import com.personal.marketnote.commerce.port.out.order.UpdateOrderPort;
+import com.personal.marketnote.common.application.UseCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@Slf4j
+@UseCase
+@RequiredArgsConstructor
+public class CompleteReturnReshippingService implements CompleteReturnReshippingUseCase {
+
+    private final GetOrderUseCase getOrderUseCase;
+    private final UpdateOrderPort updateOrderPort;
+    private final Clock clock;
+
+    @Override
+    @Transactional(isolation = READ_COMMITTED)
+    public void completeReturnReshipping(CompleteReturnReshippingCommand command) {
+        Order order = getOrderUseCase.getOrder(command.orderId());
+
+        if (order.isReturnReshipped()) {
+            log.info("이미 회송 완료된 주문 (멱등). orderId={}", command.orderId());
+            return;
+        }
+
+        if (!order.isReturnReshipping()) {
+            throw new InvalidOrderStatusTransitionException(order.getOrderStatus(), OrderStatus.RETURN_RESHIPPED);
+        }
+
+        LocalDateTime now = LocalDateTime.now(clock);
+        order.changeAllProductsStatus(OrderStatus.RETURN_RESHIPPED, now);
+
+        OrderStatusHistory history = OrderStatusHistory.from(
+                OrderStatusHistoryCreateState.builder()
+                        .orderId(order.getId())
+                        .orderStatus(OrderStatus.RETURN_RESHIPPED)
+                        .reasonCategory(order.getStatusChangeReasonCategory())
+                        .build()
+        );
+        updateOrderPort.update(order, history);
+
+        log.info("CS 회송 완료 처리. orderId={}", command.orderId());
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/returntracker/HandleInspectionFailedOrHoldService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/returntracker/HandleInspectionFailedOrHoldService.java
@@ -1,0 +1,70 @@
+package com.personal.marketnote.commerce.service.returntracker;
+
+import com.personal.marketnote.commerce.domain.order.Order;
+import com.personal.marketnote.commerce.domain.order.OrderStatus;
+import com.personal.marketnote.commerce.domain.order.OrderStatusHistory;
+import com.personal.marketnote.commerce.domain.order.OrderStatusHistoryCreateState;
+import com.personal.marketnote.commerce.domain.returntracker.ReturnTracker;
+import com.personal.marketnote.commerce.port.in.usecase.order.GetOrderUseCase;
+import com.personal.marketnote.commerce.port.out.order.UpdateOrderPort;
+import com.personal.marketnote.commerce.port.out.returntracker.UpdateReturnTrackerPort;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class HandleInspectionFailedOrHoldService {
+
+    private static final String INSPECTION_FAILED = "02";
+    private static final String INSPECTION_ON_HOLD = "03";
+
+    private final UpdateReturnTrackerPort updateReturnTrackerPort;
+    private final GetOrderUseCase getOrderUseCase;
+    private final UpdateOrderPort updateOrderPort;
+
+    @Transactional(isolation = READ_COMMITTED)
+    public void handleFailedOrHold(ReturnTracker tracker, String overallStatus, LocalDateTime now) {
+        if (!INSPECTION_FAILED.equals(overallStatus) && !INSPECTION_ON_HOLD.equals(overallStatus)) {
+            log.warn("예상하지 못한 검수 상태 코드: {}, orderId: {}", overallStatus, tracker.getOrderId());
+            return;
+        }
+
+        applyInspectionStatus(tracker, overallStatus, now);
+        updateReturnTrackerPort.update(tracker);
+
+        Order order = getOrderUseCase.getOrder(tracker.getOrderId());
+        if (order.isReturnInspecting()) {
+            log.info("이미 반품 검수 중 상태 (멱등). orderId={}", tracker.getOrderId());
+            return;
+        }
+
+        order.changeAllProductsStatus(OrderStatus.RETURN_INSPECTING, now);
+
+        OrderStatusHistory history = OrderStatusHistory.from(
+                OrderStatusHistoryCreateState.builder()
+                        .orderId(order.getId())
+                        .orderStatus(OrderStatus.RETURN_INSPECTING)
+                        .build()
+        );
+        updateOrderPort.update(order, history);
+
+        log.info("반품 검수 불량/보류 처리 완료 - orderId: {}, status: {}", tracker.getOrderId(), overallStatus);
+    }
+
+    private void applyInspectionStatus(ReturnTracker tracker, String status, LocalDateTime now) {
+        if (INSPECTION_FAILED.equals(status)) {
+            tracker.failInspection(now);
+            return;
+        }
+        if (INSPECTION_ON_HOLD.equals(status)) {
+            tracker.holdInspection();
+        }
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/returntracker/PollReturnInspectionService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/returntracker/PollReturnInspectionService.java
@@ -4,11 +4,11 @@ import com.personal.marketnote.commerce.domain.returntracker.ReturnInspectionSta
 import com.personal.marketnote.commerce.domain.returntracker.ReturnTracker;
 import com.personal.marketnote.commerce.port.in.usecase.returntracker.PollReturnInspectionUseCase;
 import com.personal.marketnote.commerce.port.out.fulfillment.GetReturnInspectionResultPort;
+import com.personal.marketnote.commerce.port.out.slack.SendSlackAlertPort;
 import com.personal.marketnote.commerce.port.out.fulfillment.ReturnInspectionResult;
 import com.personal.marketnote.commerce.port.out.fulfillment.ReturnInspectionResult.ReturnInspectionGoodsItem;
 import com.personal.marketnote.commerce.port.out.fulfillment.ReturnInspectionResult.ReturnInspectionResultItem;
 import com.personal.marketnote.commerce.port.out.returntracker.FindReturnTrackerPort;
-import com.personal.marketnote.commerce.port.out.returntracker.UpdateReturnTrackerPort;
 import com.personal.marketnote.common.application.UseCase;
 import com.personal.marketnote.common.utility.FormatValidator;
 import lombok.RequiredArgsConstructor;
@@ -29,9 +29,10 @@ public class PollReturnInspectionService implements PollReturnInspectionUseCase 
     private static final String INSPECTION_ON_HOLD = "03";
 
     private final FindReturnTrackerPort findReturnTrackerPort;
-    private final UpdateReturnTrackerPort updateReturnTrackerPort;
     private final GetReturnInspectionResultPort getReturnInspectionResultPort;
     private final CompleteReturnInspectionService completeReturnInspectionService;
+    private final HandleInspectionFailedOrHoldService handleInspectionFailedOrHoldService;
+    private final SendSlackAlertPort sendSlackAlertPort;
     private final Clock clock;
 
     @Override
@@ -131,9 +132,23 @@ public class PollReturnInspectionService implements PollReturnInspectionUseCase 
             return;
         }
 
-        applyInspectionStatus(tracker, overallStatus, now);
-        updateReturnTrackerPort.update(tracker);
-        log.info("반품 검수 상태 업데이트 - orderId: {}, status: {}", tracker.getOrderId(), overallStatus);
+        handleInspectionFailedOrHoldService.handleFailedOrHold(tracker, overallStatus, now);
+        sendInspectionAlert(tracker.getOrderId(), overallStatus, now);
+    }
+
+    private void sendInspectionAlert(Long orderId, String overallStatus, LocalDateTime now) {
+        String inspectionStatus = resolveInspectionStatusDescription(overallStatus);
+        sendSlackAlertPort.sendInspectionFailedOrHoldAlert(orderId, inspectionStatus, now);
+    }
+
+    private String resolveInspectionStatusDescription(String overallStatus) {
+        if (INSPECTION_FAILED.equals(overallStatus)) {
+            return "검수 실패";
+        }
+        if (INSPECTION_ON_HOLD.equals(overallStatus)) {
+            return "검수 보류";
+        }
+        return "알 수 없는 상태: " + overallStatus;
     }
 
     private String resolveOverallInspectionStatus(List<ReturnInspectionGoodsItem> products) {
@@ -162,15 +177,5 @@ public class PollReturnInspectionService implements PollReturnInspectionUseCase 
         log.warn("반품 검수 폴링: 분류 불가능한 상태 조합 - statuses: {}",
                 products.stream().map(ReturnInspectionGoodsItem::returnProductCheckStatus).toList());
         return null;
-    }
-
-    private void applyInspectionStatus(ReturnTracker tracker, String status, LocalDateTime now) {
-        if (INSPECTION_FAILED.equals(status)) {
-            tracker.failInspection(now);
-            return;
-        }
-        if (INSPECTION_ON_HOLD.equals(status)) {
-            tracker.holdInspection();
-        }
     }
 }

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/returntracker/RejectReturnInspectionService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/returntracker/RejectReturnInspectionService.java
@@ -1,0 +1,59 @@
+package com.personal.marketnote.commerce.service.returntracker;
+
+import com.personal.marketnote.commerce.domain.order.Order;
+import com.personal.marketnote.commerce.domain.order.OrderStatus;
+import com.personal.marketnote.commerce.domain.order.OrderStatusHistory;
+import com.personal.marketnote.commerce.domain.order.OrderStatusHistoryCreateState;
+import com.personal.marketnote.commerce.exception.InvalidOrderStatusTransitionException;
+import com.personal.marketnote.commerce.port.in.command.returntracker.RejectReturnInspectionCommand;
+import com.personal.marketnote.commerce.port.in.usecase.order.GetOrderUseCase;
+import com.personal.marketnote.commerce.port.in.usecase.returntracker.RejectReturnInspectionUseCase;
+import com.personal.marketnote.commerce.port.out.order.UpdateOrderPort;
+import com.personal.marketnote.common.application.UseCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@Slf4j
+@UseCase
+@RequiredArgsConstructor
+public class RejectReturnInspectionService implements RejectReturnInspectionUseCase {
+
+    private final GetOrderUseCase getOrderUseCase;
+    private final UpdateOrderPort updateOrderPort;
+    private final Clock clock;
+
+    @Override
+    @Transactional(isolation = READ_COMMITTED)
+    public void rejectReturnInspection(RejectReturnInspectionCommand command) {
+        Order order = getOrderUseCase.getOrder(command.orderId());
+
+        if (order.isReturnRejected()) {
+            log.info("이미 반품 불가 처리된 주문 (멱등). orderId={}", command.orderId());
+            return;
+        }
+
+        if (!order.isReturnInspecting()) {
+            throw new InvalidOrderStatusTransitionException(order.getOrderStatus(), OrderStatus.RETURN_REJECTED);
+        }
+
+        LocalDateTime now = LocalDateTime.now(clock);
+        order.changeAllProductsStatus(OrderStatus.RETURN_REJECTED, now);
+
+        OrderStatusHistory history = OrderStatusHistory.from(
+                OrderStatusHistoryCreateState.builder()
+                        .orderId(order.getId())
+                        .orderStatus(OrderStatus.RETURN_REJECTED)
+                        .reasonCategory(order.getStatusChangeReasonCategory())
+                        .build()
+        );
+        updateOrderPort.update(order, history);
+
+        log.info("CS 반품 불가 판정 완료. orderId={}", command.orderId());
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/returntracker/RequestReturnReshippingService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/returntracker/RequestReturnReshippingService.java
@@ -1,0 +1,59 @@
+package com.personal.marketnote.commerce.service.returntracker;
+
+import com.personal.marketnote.commerce.domain.order.Order;
+import com.personal.marketnote.commerce.domain.order.OrderStatus;
+import com.personal.marketnote.commerce.domain.order.OrderStatusHistory;
+import com.personal.marketnote.commerce.domain.order.OrderStatusHistoryCreateState;
+import com.personal.marketnote.commerce.exception.InvalidOrderStatusTransitionException;
+import com.personal.marketnote.commerce.port.in.command.returntracker.RequestReturnReshippingCommand;
+import com.personal.marketnote.commerce.port.in.usecase.order.GetOrderUseCase;
+import com.personal.marketnote.commerce.port.in.usecase.returntracker.RequestReturnReshippingUseCase;
+import com.personal.marketnote.commerce.port.out.order.UpdateOrderPort;
+import com.personal.marketnote.common.application.UseCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@Slf4j
+@UseCase
+@RequiredArgsConstructor
+public class RequestReturnReshippingService implements RequestReturnReshippingUseCase {
+
+    private final GetOrderUseCase getOrderUseCase;
+    private final UpdateOrderPort updateOrderPort;
+    private final Clock clock;
+
+    @Override
+    @Transactional(isolation = READ_COMMITTED)
+    public void requestReturnReshipping(RequestReturnReshippingCommand command) {
+        Order order = getOrderUseCase.getOrder(command.orderId());
+
+        if (order.isReturnReshippingRequested()) {
+            log.info("이미 회송 요청된 주문 (멱등). orderId={}", command.orderId());
+            return;
+        }
+
+        if (!order.isReturnRejected()) {
+            throw new InvalidOrderStatusTransitionException(order.getOrderStatus(), OrderStatus.RETURN_RESHIPPING_REQUESTED);
+        }
+
+        LocalDateTime now = LocalDateTime.now(clock);
+        order.changeAllProductsStatus(OrderStatus.RETURN_RESHIPPING_REQUESTED, now);
+
+        OrderStatusHistory history = OrderStatusHistory.from(
+                OrderStatusHistoryCreateState.builder()
+                        .orderId(order.getId())
+                        .orderStatus(OrderStatus.RETURN_RESHIPPING_REQUESTED)
+                        .reasonCategory(order.getStatusChangeReasonCategory())
+                        .build()
+        );
+        updateOrderPort.update(order, history);
+
+        log.info("CS 회송 요청 완료. orderId={}", command.orderId());
+    }
+}

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/returntracker/StartReturnReshippingService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/returntracker/StartReturnReshippingService.java
@@ -1,0 +1,59 @@
+package com.personal.marketnote.commerce.service.returntracker;
+
+import com.personal.marketnote.commerce.domain.order.Order;
+import com.personal.marketnote.commerce.domain.order.OrderStatus;
+import com.personal.marketnote.commerce.domain.order.OrderStatusHistory;
+import com.personal.marketnote.commerce.domain.order.OrderStatusHistoryCreateState;
+import com.personal.marketnote.commerce.exception.InvalidOrderStatusTransitionException;
+import com.personal.marketnote.commerce.port.in.command.returntracker.StartReturnReshippingCommand;
+import com.personal.marketnote.commerce.port.in.usecase.order.GetOrderUseCase;
+import com.personal.marketnote.commerce.port.in.usecase.returntracker.StartReturnReshippingUseCase;
+import com.personal.marketnote.commerce.port.out.order.UpdateOrderPort;
+import com.personal.marketnote.common.application.UseCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@Slf4j
+@UseCase
+@RequiredArgsConstructor
+public class StartReturnReshippingService implements StartReturnReshippingUseCase {
+
+    private final GetOrderUseCase getOrderUseCase;
+    private final UpdateOrderPort updateOrderPort;
+    private final Clock clock;
+
+    @Override
+    @Transactional(isolation = READ_COMMITTED)
+    public void startReturnReshipping(StartReturnReshippingCommand command) {
+        Order order = getOrderUseCase.getOrder(command.orderId());
+
+        if (order.isReturnReshipping()) {
+            log.info("이미 회송 출고 처리된 주문 (멱등). orderId={}", command.orderId());
+            return;
+        }
+
+        if (!order.isReturnReshippingRequested()) {
+            throw new InvalidOrderStatusTransitionException(order.getOrderStatus(), OrderStatus.RETURN_RESHIPPING);
+        }
+
+        LocalDateTime now = LocalDateTime.now(clock);
+        order.changeAllProductsStatus(OrderStatus.RETURN_RESHIPPING, now);
+
+        OrderStatusHistory history = OrderStatusHistory.from(
+                OrderStatusHistoryCreateState.builder()
+                        .orderId(order.getId())
+                        .orderStatus(OrderStatus.RETURN_RESHIPPING)
+                        .reasonCategory(order.getStatusChangeReasonCategory())
+                        .build()
+        );
+        updateOrderPort.update(order, history);
+
+        log.info("CS 회송 출고 처리 완료. orderId={}", command.orderId());
+    }
+}

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/GetBuyerOrderCountUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/GetBuyerOrderCountUseCaseTest.java
@@ -586,8 +586,11 @@ class GetBuyerOrderCountUseCaseTest {
                     OrderStatus.CANCELLED,
                     OrderStatus.RETURN_REQUESTED,
                     OrderStatus.RETURN_IN_PROGRESS,
+                    OrderStatus.RETURN_INSPECTING,
                     OrderStatus.PARTIALLY_RETURNED,
-                    OrderStatus.RETURNED
+                    OrderStatus.RETURNED,
+                    OrderStatus.RETURN_REJECTED,
+                    OrderStatus.RETURN_RESHIPPING_REQUESTED
             );
         }
 

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/GetBuyerOrderHistoryUseCaseTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/order/GetBuyerOrderHistoryUseCaseTest.java
@@ -686,8 +686,11 @@ class GetBuyerOrderHistoryUseCaseTest {
                     OrderStatus.CANCELLED,
                     OrderStatus.RETURN_REQUESTED,
                     OrderStatus.RETURN_IN_PROGRESS,
+                    OrderStatus.RETURN_INSPECTING,
                     OrderStatus.PARTIALLY_RETURNED,
-                    OrderStatus.RETURNED
+                    OrderStatus.RETURNED,
+                    OrderStatus.RETURN_REJECTED,
+                    OrderStatus.RETURN_RESHIPPING_REQUESTED
             );
         }
     }

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/returntracker/ApproveReturnInspectionServiceTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/returntracker/ApproveReturnInspectionServiceTest.java
@@ -1,0 +1,103 @@
+package com.personal.marketnote.commerce.service.returntracker;
+
+import com.personal.marketnote.commerce.domain.order.Order;
+import com.personal.marketnote.commerce.domain.order.OrderStatus;
+import com.personal.marketnote.commerce.exception.InvalidOrderStatusTransitionException;
+import com.personal.marketnote.commerce.port.in.command.returntracker.ApproveReturnInspectionCommand;
+import com.personal.marketnote.commerce.port.in.command.returntracker.CompleteReturnCommand;
+import com.personal.marketnote.commerce.port.in.usecase.order.GetOrderUseCase;
+import com.personal.marketnote.commerce.port.in.usecase.returntracker.CompleteReturnUseCase;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ApproveReturnInspectionService 테스트")
+class ApproveReturnInspectionServiceTest {
+
+    @InjectMocks
+    private ApproveReturnInspectionService service;
+
+    @Mock
+    private GetOrderUseCase getOrderUseCase;
+
+    @Mock
+    private CompleteReturnUseCase completeReturnUseCase;
+
+    private static final Long ORDER_ID = 100L;
+
+    @Nested
+    @DisplayName("반품 검수 승인 성공")
+    class ApproveSuccess {
+
+        @Test
+        @DisplayName("RETURN_INSPECTING 상태의 주문에서 CompleteReturnUseCase.completeReturn이 호출된다")
+        void shouldDelegateToCompleteReturnUseCaseWhenReturnInspecting() {
+            Order order = createReturnInspectingOrder();
+            when(getOrderUseCase.getOrder(ORDER_ID)).thenReturn(order);
+
+            service.approveReturnInspection(new ApproveReturnInspectionCommand(ORDER_ID));
+
+            verify(completeReturnUseCase).completeReturn(new CompleteReturnCommand(ORDER_ID));
+        }
+    }
+
+    @Nested
+    @DisplayName("멱등성 처리")
+    class Idempotency {
+
+        @Test
+        @DisplayName("이미 RETURNED 상태이면 아무 처리 없이 정상 종료한다")
+        void shouldReturnEarlyWhenAlreadyReturned() {
+            Order order = createReturnedOrder();
+            when(getOrderUseCase.getOrder(ORDER_ID)).thenReturn(order);
+
+            service.approveReturnInspection(new ApproveReturnInspectionCommand(ORDER_ID));
+
+            verifyNoInteractions(completeReturnUseCase);
+        }
+    }
+
+    @Nested
+    @DisplayName("상태 전이 실패")
+    class TransitionFailure {
+
+        @Test
+        @DisplayName("RETURN_INSPECTING이 아닌 상태이면 InvalidOrderStatusTransitionException을 던진다")
+        void shouldThrowExceptionWhenNotReturnInspecting() {
+            Order order = createNonInspectingOrder();
+            when(getOrderUseCase.getOrder(ORDER_ID)).thenReturn(order);
+
+            assertThatThrownBy(() ->
+                    service.approveReturnInspection(new ApproveReturnInspectionCommand(ORDER_ID))
+            ).isInstanceOf(InvalidOrderStatusTransitionException.class);
+
+            verifyNoInteractions(completeReturnUseCase);
+        }
+    }
+
+    private Order createReturnInspectingOrder() {
+        Order order = mock(Order.class);
+        when(order.isReturnInspecting()).thenReturn(true);
+        return order;
+    }
+
+    private Order createReturnedOrder() {
+        Order order = mock(Order.class);
+        when(order.isReturned()).thenReturn(true);
+        return order;
+    }
+
+    private Order createNonInspectingOrder() {
+        Order order = mock(Order.class);
+        when(order.getOrderStatus()).thenReturn(OrderStatus.RETURN_IN_PROGRESS);
+        return order;
+    }
+}

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/returntracker/CompleteReturnReshippingServiceTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/returntracker/CompleteReturnReshippingServiceTest.java
@@ -1,0 +1,115 @@
+package com.personal.marketnote.commerce.service.returntracker;
+
+import com.personal.marketnote.commerce.domain.order.Order;
+import com.personal.marketnote.commerce.domain.order.OrderStatus;
+import com.personal.marketnote.commerce.domain.order.OrderStatusHistory;
+import com.personal.marketnote.commerce.exception.InvalidOrderStatusTransitionException;
+import com.personal.marketnote.commerce.port.in.command.returntracker.CompleteReturnReshippingCommand;
+import com.personal.marketnote.commerce.port.in.usecase.order.GetOrderUseCase;
+import com.personal.marketnote.commerce.port.out.order.UpdateOrderPort;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("CompleteReturnReshippingService 테스트")
+class CompleteReturnReshippingServiceTest {
+
+    @InjectMocks
+    private CompleteReturnReshippingService service;
+
+    @Mock
+    private GetOrderUseCase getOrderUseCase;
+
+    @Mock
+    private UpdateOrderPort updateOrderPort;
+
+    @Spy
+    private Clock clock = Clock.fixed(Instant.parse("2026-06-03T10:00:00Z"), ZoneId.of("Asia/Seoul"));
+
+    private static final Long ORDER_ID = 100L;
+
+    @Nested
+    @DisplayName("회송 완료 처리 성공")
+    class CompleteSuccess {
+
+        @Test
+        @DisplayName("RETURN_RESHIPPING 상태의 주문을 RETURN_RESHIPPED로 전이하고 이력을 저장한다")
+        void shouldTransitionToReturnReshippedAndSaveHistory() {
+            Order order = createReturnReshippingOrder();
+            when(getOrderUseCase.getOrder(ORDER_ID)).thenReturn(order);
+
+            service.completeReturnReshipping(new CompleteReturnReshippingCommand(ORDER_ID));
+
+            verify(order).changeAllProductsStatus(eq(OrderStatus.RETURN_RESHIPPED), any());
+            verify(updateOrderPort).update(eq(order), any(OrderStatusHistory.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("멱등성 처리")
+    class Idempotency {
+
+        @Test
+        @DisplayName("이미 RETURN_RESHIPPED 상태이면 아무 처리 없이 정상 종료한다")
+        void shouldReturnEarlyWhenAlreadyReturnReshipped() {
+            Order order = createReturnReshippedOrder();
+            when(getOrderUseCase.getOrder(ORDER_ID)).thenReturn(order);
+
+            service.completeReturnReshipping(new CompleteReturnReshippingCommand(ORDER_ID));
+
+            verifyNoInteractions(updateOrderPort);
+        }
+    }
+
+    @Nested
+    @DisplayName("상태 전이 실패")
+    class TransitionFailure {
+
+        @Test
+        @DisplayName("RETURN_RESHIPPING이 아닌 상태이면 InvalidOrderStatusTransitionException을 던진다")
+        void shouldThrowExceptionWhenNotReturnReshipping() {
+            Order order = createNonReshippingOrder();
+            when(getOrderUseCase.getOrder(ORDER_ID)).thenReturn(order);
+
+            assertThatThrownBy(() ->
+                    service.completeReturnReshipping(new CompleteReturnReshippingCommand(ORDER_ID))
+            ).isInstanceOf(InvalidOrderStatusTransitionException.class);
+
+            verifyNoInteractions(updateOrderPort);
+        }
+    }
+
+    private Order createReturnReshippingOrder() {
+        Order order = mock(Order.class);
+        when(order.getId()).thenReturn(ORDER_ID);
+        when(order.isReturnReshipping()).thenReturn(true);
+        return order;
+    }
+
+    private Order createReturnReshippedOrder() {
+        Order order = mock(Order.class);
+        when(order.isReturnReshipped()).thenReturn(true);
+        return order;
+    }
+
+    private Order createNonReshippingOrder() {
+        Order order = mock(Order.class);
+        when(order.getOrderStatus()).thenReturn(OrderStatus.RETURN_INSPECTING);
+        return order;
+    }
+}

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/returntracker/CompleteReturnServiceTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/returntracker/CompleteReturnServiceTest.java
@@ -76,6 +76,27 @@ class CompleteReturnServiceTest {
         }
 
         @Test
+        @DisplayName("RETURN_INSPECTING 상태의 주문을 RETURNED로 바로 전이한다")
+        void shouldTransitionFromReturnInspectingToReturned() {
+            Order order = createReturnableOrder(OrderStatus.RETURN_INSPECTING);
+            when(getOrderUseCase.getOrder(1L)).thenReturn(order);
+            when(calculateReturnShippingFeeUseCase.calculateReturnShippingFee(any(CalculateReturnShippingFeeCommand.class)))
+                    .thenReturn(CalculateReturnShippingFeeResult.builder().returnShippingFee(0L).build());
+
+            CompleteReturnCommand command = new CompleteReturnCommand(1L);
+
+            service.completeReturn(command);
+
+            verify(order, never()).changeAllProductsStatus(eq(OrderStatus.RETURN_IN_PROGRESS), any());
+            verify(order).changeAllProductsStatus(eq(OrderStatus.RETURNED), any());
+            verify(updateOrderPort).update(eq(order), any(OrderStatusHistory.class));
+            verify(publishOrderEventPort).publishOrderReturnedEvent(
+                    eq(1L), anyString(), eq(100L),
+                    eq(30000L), eq(49000L), eq(1000L), eq(3000L),
+                    eq(true), eq(0L), anyList());
+        }
+
+        @Test
         @DisplayName("RETURN_IN_PROGRESS 상태의 주문을 RETURNED로 바로 전이한다")
         void shouldTransitionFromReturnInProgressToReturned() {
             Order order = createReturnableOrder(OrderStatus.RETURN_IN_PROGRESS);
@@ -123,7 +144,7 @@ class CompleteReturnServiceTest {
     class CompleteReturnFailure {
 
         @Test
-        @DisplayName("RETURN_REQUESTED/RETURN_IN_PROGRESS가 아닌 상태이면 InvalidOrderStatusTransitionException을 던진다")
+        @DisplayName("반품 처리 가능한 상태가 아니면 InvalidOrderStatusTransitionException을 던진다")
         void shouldThrowOnInvalidStatus() {
             Order order = mock(Order.class);
             when(order.getOrderStatus()).thenReturn(OrderStatus.PAID);

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/returntracker/HandleInspectionFailedOrHoldServiceTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/returntracker/HandleInspectionFailedOrHoldServiceTest.java
@@ -1,0 +1,123 @@
+package com.personal.marketnote.commerce.service.returntracker;
+
+import com.personal.marketnote.commerce.domain.order.Order;
+import com.personal.marketnote.commerce.domain.order.OrderStatus;
+import com.personal.marketnote.commerce.domain.order.OrderStatusHistory;
+import com.personal.marketnote.commerce.domain.returntracker.ReturnInspectionStatus;
+import com.personal.marketnote.commerce.domain.returntracker.ReturnRefundStatus;
+import com.personal.marketnote.commerce.domain.returntracker.ReturnTracker;
+import com.personal.marketnote.commerce.domain.returntracker.ReturnTrackerSnapshotState;
+import com.personal.marketnote.commerce.port.in.usecase.order.GetOrderUseCase;
+import com.personal.marketnote.commerce.port.out.order.UpdateOrderPort;
+import com.personal.marketnote.commerce.port.out.returntracker.UpdateReturnTrackerPort;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("HandleInspectionFailedOrHoldService 테스트")
+class HandleInspectionFailedOrHoldServiceTest {
+
+    @InjectMocks
+    private HandleInspectionFailedOrHoldService service;
+
+    @Mock
+    private UpdateReturnTrackerPort updateReturnTrackerPort;
+
+    @Mock
+    private GetOrderUseCase getOrderUseCase;
+
+    @Mock
+    private UpdateOrderPort updateOrderPort;
+
+    private static final LocalDateTime NOW = LocalDateTime.of(2026, 4, 9, 19, 0);
+
+    @Nested
+    @DisplayName("검수 불량 처리")
+    class HandleInspectionFailed {
+
+        @Test
+        @DisplayName("검수 불량 시 ReturnTracker를 FAILED로 업데이트하고 주문 상태를 RETURN_INSPECTING으로 전이한다")
+        void shouldFailInspectionAndTransitionOrderToReturnInspecting() {
+            ReturnTracker tracker = createPendingTracker();
+            Order order = createReturnInProgressOrder();
+            when(getOrderUseCase.getOrder(100L)).thenReturn(order);
+
+            service.handleFailedOrHold(tracker, "02", NOW);
+
+            assertThat(tracker.isInspectionFailed()).isTrue();
+            assertThat(tracker.getInspectedAt()).isEqualTo(NOW);
+            verify(updateReturnTrackerPort).update(tracker);
+            verify(order).changeAllProductsStatus(eq(OrderStatus.RETURN_INSPECTING), eq(NOW));
+            verify(updateOrderPort).update(eq(order), any(OrderStatusHistory.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("검수 보류 처리")
+    class HandleInspectionOnHold {
+
+        @Test
+        @DisplayName("검수 보류 시 ReturnTracker를 ON_HOLD로 업데이트하고 주문 상태를 RETURN_INSPECTING으로 전이한다")
+        void shouldHoldInspectionAndTransitionOrderToReturnInspecting() {
+            ReturnTracker tracker = createPendingTracker();
+            Order order = createReturnInProgressOrder();
+            when(getOrderUseCase.getOrder(100L)).thenReturn(order);
+
+            service.handleFailedOrHold(tracker, "03", NOW);
+
+            assertThat(tracker.isInspectionOnHold()).isTrue();
+            verify(updateReturnTrackerPort).update(tracker);
+            verify(order).changeAllProductsStatus(eq(OrderStatus.RETURN_INSPECTING), eq(NOW));
+            verify(updateOrderPort).update(eq(order), any(OrderStatusHistory.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("멱등성 처리")
+    class Idempotency {
+
+        @Test
+        @DisplayName("주문이 이미 RETURN_INSPECTING 상태이면 주문 상태 변경 없이 ReturnTracker만 업데이트한다")
+        void shouldSkipOrderTransitionWhenAlreadyReturnInspecting() {
+            ReturnTracker tracker = createPendingTracker();
+            Order order = mock(Order.class);
+            when(order.isReturnInspecting()).thenReturn(true);
+            when(getOrderUseCase.getOrder(100L)).thenReturn(order);
+
+            service.handleFailedOrHold(tracker, "02", NOW);
+
+            assertThat(tracker.isInspectionFailed()).isTrue();
+            verify(updateReturnTrackerPort).update(tracker);
+            verify(order, never()).changeAllProductsStatus(any(), any());
+            verifyNoInteractions(updateOrderPort);
+        }
+    }
+
+    private ReturnTracker createPendingTracker() {
+        return ReturnTracker.from(ReturnTrackerSnapshotState.builder()
+                .id(1L)
+                .orderId(100L)
+                .returnSlipNumber("RS-001")
+                .inspectionStatus(ReturnInspectionStatus.PENDING)
+                .refundStatus(ReturnRefundStatus.PENDING)
+                .build());
+    }
+
+    private Order createReturnInProgressOrder() {
+        Order order = mock(Order.class);
+        when(order.getId()).thenReturn(100L);
+        return order;
+    }
+}

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/returntracker/RejectReturnInspectionServiceTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/returntracker/RejectReturnInspectionServiceTest.java
@@ -1,0 +1,115 @@
+package com.personal.marketnote.commerce.service.returntracker;
+
+import com.personal.marketnote.commerce.domain.order.Order;
+import com.personal.marketnote.commerce.domain.order.OrderStatus;
+import com.personal.marketnote.commerce.domain.order.OrderStatusHistory;
+import com.personal.marketnote.commerce.exception.InvalidOrderStatusTransitionException;
+import com.personal.marketnote.commerce.port.in.command.returntracker.RejectReturnInspectionCommand;
+import com.personal.marketnote.commerce.port.in.usecase.order.GetOrderUseCase;
+import com.personal.marketnote.commerce.port.out.order.UpdateOrderPort;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("RejectReturnInspectionService 테스트")
+class RejectReturnInspectionServiceTest {
+
+    @InjectMocks
+    private RejectReturnInspectionService service;
+
+    @Mock
+    private GetOrderUseCase getOrderUseCase;
+
+    @Mock
+    private UpdateOrderPort updateOrderPort;
+
+    @Spy
+    private Clock clock = Clock.fixed(Instant.parse("2026-06-03T10:00:00Z"), ZoneId.of("Asia/Seoul"));
+
+    private static final Long ORDER_ID = 100L;
+
+    @Nested
+    @DisplayName("반품 불가 판정 성공")
+    class RejectSuccess {
+
+        @Test
+        @DisplayName("RETURN_INSPECTING 상태의 주문을 RETURN_REJECTED로 전이하고 이력을 저장한다")
+        void shouldTransitionToReturnRejectedAndSaveHistory() {
+            Order order = createReturnInspectingOrder();
+            when(getOrderUseCase.getOrder(ORDER_ID)).thenReturn(order);
+
+            service.rejectReturnInspection(new RejectReturnInspectionCommand(ORDER_ID));
+
+            verify(order).changeAllProductsStatus(eq(OrderStatus.RETURN_REJECTED), any());
+            verify(updateOrderPort).update(eq(order), any(OrderStatusHistory.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("멱등성 처리")
+    class Idempotency {
+
+        @Test
+        @DisplayName("이미 RETURN_REJECTED 상태이면 아무 처리 없이 정상 종료한다")
+        void shouldReturnEarlyWhenAlreadyReturnRejected() {
+            Order order = createReturnRejectedOrder();
+            when(getOrderUseCase.getOrder(ORDER_ID)).thenReturn(order);
+
+            service.rejectReturnInspection(new RejectReturnInspectionCommand(ORDER_ID));
+
+            verifyNoInteractions(updateOrderPort);
+        }
+    }
+
+    @Nested
+    @DisplayName("상태 전이 실패")
+    class TransitionFailure {
+
+        @Test
+        @DisplayName("RETURN_INSPECTING이 아닌 상태이면 InvalidOrderStatusTransitionException을 던진다")
+        void shouldThrowExceptionWhenNotReturnInspecting() {
+            Order order = createNonInspectingOrder();
+            when(getOrderUseCase.getOrder(ORDER_ID)).thenReturn(order);
+
+            assertThatThrownBy(() ->
+                    service.rejectReturnInspection(new RejectReturnInspectionCommand(ORDER_ID))
+            ).isInstanceOf(InvalidOrderStatusTransitionException.class);
+
+            verifyNoInteractions(updateOrderPort);
+        }
+    }
+
+    private Order createReturnInspectingOrder() {
+        Order order = mock(Order.class);
+        when(order.getId()).thenReturn(ORDER_ID);
+        when(order.isReturnInspecting()).thenReturn(true);
+        return order;
+    }
+
+    private Order createReturnRejectedOrder() {
+        Order order = mock(Order.class);
+        when(order.isReturnRejected()).thenReturn(true);
+        return order;
+    }
+
+    private Order createNonInspectingOrder() {
+        Order order = mock(Order.class);
+        when(order.getOrderStatus()).thenReturn(OrderStatus.RETURN_IN_PROGRESS);
+        return order;
+    }
+}

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/returntracker/RequestReturnReshippingServiceTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/returntracker/RequestReturnReshippingServiceTest.java
@@ -1,0 +1,115 @@
+package com.personal.marketnote.commerce.service.returntracker;
+
+import com.personal.marketnote.commerce.domain.order.Order;
+import com.personal.marketnote.commerce.domain.order.OrderStatus;
+import com.personal.marketnote.commerce.domain.order.OrderStatusHistory;
+import com.personal.marketnote.commerce.exception.InvalidOrderStatusTransitionException;
+import com.personal.marketnote.commerce.port.in.command.returntracker.RequestReturnReshippingCommand;
+import com.personal.marketnote.commerce.port.in.usecase.order.GetOrderUseCase;
+import com.personal.marketnote.commerce.port.out.order.UpdateOrderPort;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("RequestReturnReshippingService 테스트")
+class RequestReturnReshippingServiceTest {
+
+    @InjectMocks
+    private RequestReturnReshippingService service;
+
+    @Mock
+    private GetOrderUseCase getOrderUseCase;
+
+    @Mock
+    private UpdateOrderPort updateOrderPort;
+
+    @Spy
+    private Clock clock = Clock.fixed(Instant.parse("2026-06-03T10:00:00Z"), ZoneId.of("Asia/Seoul"));
+
+    private static final Long ORDER_ID = 100L;
+
+    @Nested
+    @DisplayName("회송 요청 성공")
+    class RequestSuccess {
+
+        @Test
+        @DisplayName("RETURN_REJECTED 상태의 주문을 RETURN_RESHIPPING_REQUESTED로 전이하고 이력을 저장한다")
+        void shouldTransitionToReturnReshippingRequestedAndSaveHistory() {
+            Order order = createReturnRejectedOrder();
+            when(getOrderUseCase.getOrder(ORDER_ID)).thenReturn(order);
+
+            service.requestReturnReshipping(new RequestReturnReshippingCommand(ORDER_ID));
+
+            verify(order).changeAllProductsStatus(eq(OrderStatus.RETURN_RESHIPPING_REQUESTED), any());
+            verify(updateOrderPort).update(eq(order), any(OrderStatusHistory.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("멱등성 처리")
+    class Idempotency {
+
+        @Test
+        @DisplayName("이미 RETURN_RESHIPPING_REQUESTED 상태이면 아무 처리 없이 정상 종료한다")
+        void shouldReturnEarlyWhenAlreadyReturnReshippingRequested() {
+            Order order = createReturnReshippingRequestedOrder();
+            when(getOrderUseCase.getOrder(ORDER_ID)).thenReturn(order);
+
+            service.requestReturnReshipping(new RequestReturnReshippingCommand(ORDER_ID));
+
+            verifyNoInteractions(updateOrderPort);
+        }
+    }
+
+    @Nested
+    @DisplayName("상태 전이 실패")
+    class TransitionFailure {
+
+        @Test
+        @DisplayName("RETURN_REJECTED가 아닌 상태이면 InvalidOrderStatusTransitionException을 던진다")
+        void shouldThrowExceptionWhenNotReturnRejected() {
+            Order order = createNonRejectedOrder();
+            when(getOrderUseCase.getOrder(ORDER_ID)).thenReturn(order);
+
+            assertThatThrownBy(() ->
+                    service.requestReturnReshipping(new RequestReturnReshippingCommand(ORDER_ID))
+            ).isInstanceOf(InvalidOrderStatusTransitionException.class);
+
+            verifyNoInteractions(updateOrderPort);
+        }
+    }
+
+    private Order createReturnRejectedOrder() {
+        Order order = mock(Order.class);
+        when(order.getId()).thenReturn(ORDER_ID);
+        when(order.isReturnRejected()).thenReturn(true);
+        return order;
+    }
+
+    private Order createReturnReshippingRequestedOrder() {
+        Order order = mock(Order.class);
+        when(order.isReturnReshippingRequested()).thenReturn(true);
+        return order;
+    }
+
+    private Order createNonRejectedOrder() {
+        Order order = mock(Order.class);
+        when(order.getOrderStatus()).thenReturn(OrderStatus.RETURN_INSPECTING);
+        return order;
+    }
+}

--- a/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/returntracker/StartReturnReshippingServiceTest.java
+++ b/commerce-service/commerce-application/src/test/java/com/personal/marketnote/commerce/service/returntracker/StartReturnReshippingServiceTest.java
@@ -1,0 +1,115 @@
+package com.personal.marketnote.commerce.service.returntracker;
+
+import com.personal.marketnote.commerce.domain.order.Order;
+import com.personal.marketnote.commerce.domain.order.OrderStatus;
+import com.personal.marketnote.commerce.domain.order.OrderStatusHistory;
+import com.personal.marketnote.commerce.exception.InvalidOrderStatusTransitionException;
+import com.personal.marketnote.commerce.port.in.command.returntracker.StartReturnReshippingCommand;
+import com.personal.marketnote.commerce.port.in.usecase.order.GetOrderUseCase;
+import com.personal.marketnote.commerce.port.out.order.UpdateOrderPort;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("StartReturnReshippingService 테스트")
+class StartReturnReshippingServiceTest {
+
+    @InjectMocks
+    private StartReturnReshippingService service;
+
+    @Mock
+    private GetOrderUseCase getOrderUseCase;
+
+    @Mock
+    private UpdateOrderPort updateOrderPort;
+
+    @Spy
+    private Clock clock = Clock.fixed(Instant.parse("2026-06-03T10:00:00Z"), ZoneId.of("Asia/Seoul"));
+
+    private static final Long ORDER_ID = 100L;
+
+    @Nested
+    @DisplayName("회송 출고 처리 성공")
+    class StartSuccess {
+
+        @Test
+        @DisplayName("RETURN_RESHIPPING_REQUESTED 상태의 주문을 RETURN_RESHIPPING으로 전이하고 이력을 저장한다")
+        void shouldTransitionToReturnReshippingAndSaveHistory() {
+            Order order = createReturnReshippingRequestedOrder();
+            when(getOrderUseCase.getOrder(ORDER_ID)).thenReturn(order);
+
+            service.startReturnReshipping(new StartReturnReshippingCommand(ORDER_ID));
+
+            verify(order).changeAllProductsStatus(eq(OrderStatus.RETURN_RESHIPPING), any());
+            verify(updateOrderPort).update(eq(order), any(OrderStatusHistory.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("멱등성 처리")
+    class Idempotency {
+
+        @Test
+        @DisplayName("이미 RETURN_RESHIPPING 상태이면 아무 처리 없이 정상 종료한다")
+        void shouldReturnEarlyWhenAlreadyReturnReshipping() {
+            Order order = createReturnReshippingOrder();
+            when(getOrderUseCase.getOrder(ORDER_ID)).thenReturn(order);
+
+            service.startReturnReshipping(new StartReturnReshippingCommand(ORDER_ID));
+
+            verifyNoInteractions(updateOrderPort);
+        }
+    }
+
+    @Nested
+    @DisplayName("상태 전이 실패")
+    class TransitionFailure {
+
+        @Test
+        @DisplayName("RETURN_RESHIPPING_REQUESTED가 아닌 상태이면 InvalidOrderStatusTransitionException을 던진다")
+        void shouldThrowExceptionWhenNotReturnReshippingRequested() {
+            Order order = createNonReshippingRequestedOrder();
+            when(getOrderUseCase.getOrder(ORDER_ID)).thenReturn(order);
+
+            assertThatThrownBy(() ->
+                    service.startReturnReshipping(new StartReturnReshippingCommand(ORDER_ID))
+            ).isInstanceOf(InvalidOrderStatusTransitionException.class);
+
+            verifyNoInteractions(updateOrderPort);
+        }
+    }
+
+    private Order createReturnReshippingRequestedOrder() {
+        Order order = mock(Order.class);
+        when(order.getId()).thenReturn(ORDER_ID);
+        when(order.isReturnReshippingRequested()).thenReturn(true);
+        return order;
+    }
+
+    private Order createReturnReshippingOrder() {
+        Order order = mock(Order.class);
+        when(order.isReturnReshipping()).thenReturn(true);
+        return order;
+    }
+
+    private Order createNonReshippingRequestedOrder() {
+        Order order = mock(Order.class);
+        when(order.getOrderStatus()).thenReturn(OrderStatus.RETURN_INSPECTING);
+        return order;
+    }
+}

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/order/Order.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/order/Order.java
@@ -86,6 +86,30 @@ public class Order {
         return this.orderStatus.isFailed();
     }
 
+    public boolean isReturnInspecting() {
+        return this.orderStatus.isReturnInspecting();
+    }
+
+    public boolean isReturned() {
+        return this.orderStatus.isReturned();
+    }
+
+    public boolean isReturnRejected() {
+        return this.orderStatus.isReturnRejected();
+    }
+
+    public boolean isReturnReshippingRequested() {
+        return this.orderStatus.isReturnReshippingRequested();
+    }
+
+    public boolean isReturnReshipping() {
+        return this.orderStatus.isReturnReshipping();
+    }
+
+    public boolean isReturnReshipped() {
+        return this.orderStatus.isReturnReshipped();
+    }
+
     public void changeProductsStatus(List<Long> pricePolicyIds, OrderStatus orderStatus, LocalDateTime now) {
         orderProducts.stream()
                 .filter(orderProduct -> pricePolicyIds.contains(orderProduct.getPricePolicyId()))

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/order/OrderStatus.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/order/OrderStatus.java
@@ -23,8 +23,13 @@ public enum OrderStatus {
     CONFIRMED("구매 확정"),
     RETURN_REQUESTED("반품 요청됨"),
     RETURN_IN_PROGRESS("반품 진행 중"),
+    RETURN_INSPECTING("반품 검수 중"),
     PARTIALLY_RETURNED("부분 반품됨"),
-    RETURNED("반품 완료");
+    RETURNED("반품 완료"),
+    RETURN_REJECTED("반품 불가"),
+    RETURN_RESHIPPING_REQUESTED("회송 요청됨"),
+    RETURN_RESHIPPING("회송 중"),
+    RETURN_RESHIPPED("회송 완료");
 
     private final String description;
 
@@ -45,9 +50,14 @@ public enum OrderStatus {
         ALLOWED_TRANSITIONS.put(PARTIALLY_CONFIRMED, EnumSet.of(CONFIRMED, RETURN_REQUESTED));
         ALLOWED_TRANSITIONS.put(CONFIRMED, EnumSet.noneOf(OrderStatus.class));
         ALLOWED_TRANSITIONS.put(RETURN_REQUESTED, EnumSet.of(RETURN_IN_PROGRESS));
-        ALLOWED_TRANSITIONS.put(RETURN_IN_PROGRESS, EnumSet.of(RETURNED));
+        ALLOWED_TRANSITIONS.put(RETURN_IN_PROGRESS, EnumSet.of(RETURNED, RETURN_INSPECTING));
+        ALLOWED_TRANSITIONS.put(RETURN_INSPECTING, EnumSet.of(RETURNED, RETURN_REJECTED));
         ALLOWED_TRANSITIONS.put(PARTIALLY_RETURNED, EnumSet.of(RETURN_REQUESTED, RETURNED));
         ALLOWED_TRANSITIONS.put(RETURNED, EnumSet.noneOf(OrderStatus.class));
+        ALLOWED_TRANSITIONS.put(RETURN_REJECTED, EnumSet.of(RETURN_RESHIPPING_REQUESTED));
+        ALLOWED_TRANSITIONS.put(RETURN_RESHIPPING_REQUESTED, EnumSet.of(RETURN_RESHIPPING));
+        ALLOWED_TRANSITIONS.put(RETURN_RESHIPPING, EnumSet.of(RETURN_RESHIPPED));
+        ALLOWED_TRANSITIONS.put(RETURN_RESHIPPED, EnumSet.noneOf(OrderStatus.class));
     }
 
     public boolean canTransitionTo(OrderStatus target) {
@@ -112,6 +122,26 @@ public enum OrderStatus {
 
     public boolean isReturnRequested() {
         return this == RETURN_REQUESTED;
+    }
+
+    public boolean isReturnInspecting() {
+        return this == RETURN_INSPECTING;
+    }
+
+    public boolean isReturnRejected() {
+        return this == RETURN_REJECTED;
+    }
+
+    public boolean isReturnReshippingRequested() {
+        return this == RETURN_RESHIPPING_REQUESTED;
+    }
+
+    public boolean isReturnReshipping() {
+        return this == RETURN_RESHIPPING;
+    }
+
+    public boolean isReturnReshipped() {
+        return this == RETURN_RESHIPPED;
     }
 
     public boolean requiresFulfillmentCancellation() {

--- a/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/order/OrderStatusFilter.java
+++ b/commerce-service/commerce-domain/src/main/java/com/personal/marketnote/commerce/domain/order/OrderStatusFilter.java
@@ -25,8 +25,11 @@ public enum OrderStatusFilter {
                     OrderStatus.CANCELLED,
                     OrderStatus.RETURN_REQUESTED,
                     OrderStatus.RETURN_IN_PROGRESS,
+                    OrderStatus.RETURN_INSPECTING,
                     OrderStatus.PARTIALLY_RETURNED,
-                    OrderStatus.RETURNED
+                    OrderStatus.RETURNED,
+                    OrderStatus.RETURN_REJECTED,
+                    OrderStatus.RETURN_RESHIPPING_REQUESTED
             )
     ),
     ALL(Collections.emptyList());

--- a/commerce-service/commerce-domain/src/test/java/com/personal/marketnote/commerce/domain/order/OrderStatusTest.java
+++ b/commerce-service/commerce-domain/src/test/java/com/personal/marketnote/commerce/domain/order/OrderStatusTest.java
@@ -85,6 +85,12 @@ class OrderStatusTest {
         }
 
         @Test
+        @DisplayName("RETURN_INSPECTING는 구매자가 변경할 수 없는 상태이다")
+        void returnInspecting_isNotBuyerAllowed() {
+            assertThat(OrderStatus.RETURN_INSPECTING.isBuyerAllowed()).isFalse();
+        }
+
+        @Test
         @DisplayName("PARTIALLY_RETURNED는 구매자가 변경할 수 없는 상태이다")
         void partiallyReturned_isNotBuyerAllowed() {
             assertThat(OrderStatus.PARTIALLY_RETURNED.isBuyerAllowed()).isFalse();
@@ -219,6 +225,64 @@ class OrderStatusTest {
         @DisplayName("RETURN_IN_PROGRESS에서 RETURNED로 전이할 수 있다")
         void returnInProgress_canTransitionTo_returned() {
             assertThat(OrderStatus.RETURN_IN_PROGRESS.canTransitionTo(OrderStatus.RETURNED)).isTrue();
+        }
+
+        @Test
+        @DisplayName("RETURN_IN_PROGRESS에서 RETURN_INSPECTING로 전이할 수 있다")
+        void returnInProgress_canTransitionTo_returnInspecting() {
+            assertThat(OrderStatus.RETURN_IN_PROGRESS.canTransitionTo(OrderStatus.RETURN_INSPECTING)).isTrue();
+        }
+
+        @Test
+        @DisplayName("RETURN_INSPECTING에서 RETURNED로 전이할 수 있다")
+        void returnInspecting_canTransitionTo_returned() {
+            assertThat(OrderStatus.RETURN_INSPECTING.canTransitionTo(OrderStatus.RETURNED)).isTrue();
+        }
+
+        @Test
+        @DisplayName("RETURN_INSPECTING에서 RETURN_REJECTED로 전이할 수 있다")
+        void returnInspecting_canTransitionTo_returnRejected() {
+            assertThat(OrderStatus.RETURN_INSPECTING.canTransitionTo(OrderStatus.RETURN_REJECTED)).isTrue();
+        }
+
+        @Test
+        @DisplayName("RETURN_INSPECTING에서 RETURNED/RETURN_REJECTED 외 다른 상태로 전이할 수 없다")
+        void returnInspecting_cannotTransitionTo_otherStatuses() {
+            for (OrderStatus target : OrderStatus.values()) {
+                if (target == OrderStatus.RETURNED || target == OrderStatus.RETURN_REJECTED) {
+                    continue;
+                }
+                assertThat(OrderStatus.RETURN_INSPECTING.canTransitionTo(target))
+                        .as("RETURN_INSPECTING → %s는 불가해야 한다", target)
+                        .isFalse();
+            }
+        }
+
+        @Test
+        @DisplayName("RETURN_REJECTED에서 RETURN_RESHIPPING_REQUESTED로 전이할 수 있다")
+        void returnRejected_canTransitionTo_returnReshippingRequested() {
+            assertThat(OrderStatus.RETURN_REJECTED.canTransitionTo(OrderStatus.RETURN_RESHIPPING_REQUESTED)).isTrue();
+        }
+
+        @Test
+        @DisplayName("RETURN_REJECTED에서 RETURN_RESHIPPING_REQUESTED 외 다른 상태로 전이할 수 없다")
+        void returnRejected_cannotTransitionTo_otherStatuses() {
+            for (OrderStatus target : OrderStatus.values()) {
+                if (target == OrderStatus.RETURN_RESHIPPING_REQUESTED) {
+                    continue;
+                }
+                assertThat(OrderStatus.RETURN_REJECTED.canTransitionTo(target))
+                        .as("RETURN_REJECTED → %s는 불가해야 한다", target)
+                        .isFalse();
+            }
+        }
+
+        @Test
+        @DisplayName("RETURN_RESHIPPING_REQUESTED에서 어떤 상태로도 전이할 수 없다")
+        void returnReshippingRequested_cannotTransitionToAny() {
+            for (OrderStatus target : OrderStatus.values()) {
+                assertThat(OrderStatus.RETURN_RESHIPPING_REQUESTED.canTransitionTo(target)).isFalse();
+            }
         }
 
         @Test
@@ -368,6 +432,12 @@ class OrderStatusTest {
         }
 
         @Test
+        @DisplayName("RETURN_INSPECTING는 최종 상태가 아니다")
+        void returnInspecting_isNotTerminal() {
+            assertThat(OrderStatus.RETURN_INSPECTING.isTerminal()).isFalse();
+        }
+
+        @Test
         @DisplayName("PARTIALLY_RETURNED는 최종 상태가 아니다")
         void partiallyReturned_isNotTerminal() {
             assertThat(OrderStatus.PARTIALLY_RETURNED.isTerminal()).isFalse();
@@ -417,6 +487,29 @@ class OrderStatusTest {
         @DisplayName("CONFIRMED는 배송 완료 상태가 아니다")
         void confirmed_isNotDelivered() {
             assertThat(OrderStatus.CONFIRMED.isDelivered()).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("반품 검수 중 상태 검증 (isReturnInspecting)")
+    class IsReturnInspectingTest {
+
+        @Test
+        @DisplayName("RETURN_INSPECTING는 반품 검수 중 상태이다")
+        void returnInspecting_isReturnInspecting() {
+            assertThat(OrderStatus.RETURN_INSPECTING.isReturnInspecting()).isTrue();
+        }
+
+        @Test
+        @DisplayName("RETURN_IN_PROGRESS는 반품 검수 중 상태가 아니다")
+        void returnInProgress_isNotReturnInspecting() {
+            assertThat(OrderStatus.RETURN_IN_PROGRESS.isReturnInspecting()).isFalse();
+        }
+
+        @Test
+        @DisplayName("RETURNED는 반품 검수 중 상태가 아니다")
+        void returned_isNotReturnInspecting() {
+            assertThat(OrderStatus.RETURNED.isReturnInspecting()).isFalse();
         }
     }
 }

--- a/common/src/main/java/com/personal/marketnote/common/kafka/DltTopicRegistry.java
+++ b/common/src/main/java/com/personal/marketnote/common/kafka/DltTopicRegistry.java
@@ -17,7 +17,8 @@ public final class DltTopicRegistry {
             KafkaTopicConstants.PRODUCT_UPDATED,
             KafkaTopicConstants.USER_SIGNUP_COMPLETED,
             KafkaTopicConstants.USER_REFERRAL_COMPLETED,
-            KafkaTopicConstants.REVIEW_REGISTERED
+            KafkaTopicConstants.REVIEW_REGISTERED,
+            KafkaTopicConstants.ORDER_RETURNED
     );
 
     private DltTopicRegistry() {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -36,8 +36,3 @@ include("file-service")
 include("file-service:file-adapters")
 include("file-service:file-application")
 include("file-service:file-domain")
-
-include("notification-service")
-include("notification-service:notification-adapters")
-include("notification-service:notification-application")
-include("notification-service:notification-domain")


### PR DESCRIPTION
## partially addresses #216
## resolves #2387

## Task
- [x] DltTopicRegistry에 ORDER_RETURNED 토픽 등록
- [x] OrderReturnedPgRefundConsumer에서 예외 전파 (DLT 라우팅 활성화)
- [x] CompleteReturnRefundService PG 환불 실패 시 ReturnPgRefundFailedException re-throw
- [x] CompleteReturnRefundService FAILED 상태 ReturnTracker 재시도 핸들링 (retryRefund)
- [x] CompleteReturnRefundService COMPLETED 상태 ReturnTracker 멱등 처리
- [x] ReturnPgRefundFailedException 신규 예외 클래스 추가