### PR TITLE
[#2143][#2144] feat: ShippingTracker 도메인 + ShippingStatus enum 기능 추가

### DIFF
--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/exception/InvalidShippingStatusTransitionException.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/exception/InvalidShippingStatusTransitionException.java
@@ -1,0 +1,14 @@
+package com.personal.marketnote.fulfillment.domain.exception;
+
+import com.personal.marketnote.fulfillment.domain.shipping.ShippingStatus;
+
+public class InvalidShippingStatusTransitionException extends IllegalStateException {
+
+    public InvalidShippingStatusTransitionException(ShippingStatus currentStatus, ShippingStatus targetStatus) {
+        super("배송 상태를 " + currentStatus.getDescription() + "에서 " + targetStatus.getDescription() + "(으)로 변경할 수 없습니다.");
+    }
+
+    public InvalidShippingStatusTransitionException(ShippingStatus currentStatus) {
+        super("현재 배송 상태(" + currentStatus.getDescription() + ")에서는 해당 작업을 수행할 수 없습니다.");
+    }
+}

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/exception/ShippingTrackerNotFoundException.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/exception/ShippingTrackerNotFoundException.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.fulfillment.domain.exception;
+
+public class ShippingTrackerNotFoundException extends RuntimeException {
+
+    public ShippingTrackerNotFoundException(Long orderId) {
+        super("배송 추적 정보를 찾을 수 없습니다. orderId=" + orderId);
+    }
+}

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/shipping/ShippingStatus.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/shipping/ShippingStatus.java
@@ -1,0 +1,74 @@
+package com.personal.marketnote.fulfillment.domain.shipping;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.EnumSet;
+import java.util.Map;
+import java.util.Set;
+
+@RequiredArgsConstructor
+@Getter
+public enum ShippingStatus {
+    PREPARING("배송 준비중"),
+    SHIPPING("배송중"),
+    DELIVERED("배송 완료"),
+    CANCELLED("추적 종료"),
+    RETURN_SHIPPING("회수 배송중"),
+    RETURN_DELIVERED("회수 완료");
+
+    private final String description;
+
+    private static final Set<ShippingStatus> POLLING_TARGET_STATUSES = EnumSet.of(
+            PREPARING, SHIPPING, RETURN_SHIPPING
+    );
+
+    private static final Set<ShippingStatus> TERMINAL_STATUSES = EnumSet.of(
+            DELIVERED, CANCELLED, RETURN_DELIVERED
+    );
+
+    private static final Map<ShippingStatus, Set<ShippingStatus>> ALLOWED_TRANSITIONS = Map.of(
+            PREPARING, EnumSet.of(SHIPPING, CANCELLED),
+            SHIPPING, EnumSet.of(DELIVERED, CANCELLED),
+            DELIVERED, EnumSet.of(RETURN_SHIPPING),
+            RETURN_SHIPPING, EnumSet.of(RETURN_DELIVERED),
+            CANCELLED, EnumSet.noneOf(ShippingStatus.class),
+            RETURN_DELIVERED, EnumSet.noneOf(ShippingStatus.class)
+    );
+
+    public boolean isPreparing() {
+        return this == PREPARING;
+    }
+
+    public boolean isShipping() {
+        return this == SHIPPING;
+    }
+
+    public boolean isDelivered() {
+        return this == DELIVERED;
+    }
+
+    public boolean isCancelled() {
+        return this == CANCELLED;
+    }
+
+    public boolean isReturnShipping() {
+        return this == RETURN_SHIPPING;
+    }
+
+    public boolean isReturnDelivered() {
+        return this == RETURN_DELIVERED;
+    }
+
+    public boolean isPollingTarget() {
+        return POLLING_TARGET_STATUSES.contains(this);
+    }
+
+    public boolean isTerminal() {
+        return TERMINAL_STATUSES.contains(this);
+    }
+
+    public boolean canTransitionTo(ShippingStatus target) {
+        return ALLOWED_TRANSITIONS.getOrDefault(this, EnumSet.noneOf(ShippingStatus.class)).contains(target);
+    }
+}

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/shipping/ShippingTracker.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/shipping/ShippingTracker.java
@@ -1,0 +1,123 @@
+package com.personal.marketnote.fulfillment.domain.shipping;
+
+import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.fulfillment.domain.exception.FulfillmentQueryParameterNoValueException;
+import com.personal.marketnote.fulfillment.domain.exception.InvalidShippingStatusTransitionException;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+@Getter
+public class ShippingTracker {
+    private Long id;
+    private Long orderId;
+    private String trackingNumber;
+    private String carrierCode;
+    private ShippingStatus shippingStatus;
+    private boolean pollingActive;
+    private LocalDateTime lastPolledAt;
+    private LocalDateTime createdAt;
+    private LocalDateTime modifiedAt;
+
+    public static ShippingTracker from(ShippingTrackerCreateState state) {
+        if (FormatValidator.hasNoValue(state.getOrderId())) {
+            throw new FulfillmentQueryParameterNoValueException("orderId");
+        }
+        return ShippingTracker.builder()
+                .orderId(state.getOrderId())
+                .shippingStatus(ShippingStatus.PREPARING)
+                .pollingActive(true)
+                .build();
+    }
+
+    public static ShippingTracker from(ShippingTrackerSnapshotState state) {
+        return ShippingTracker.builder()
+                .id(state.getId())
+                .orderId(state.getOrderId())
+                .trackingNumber(state.getTrackingNumber())
+                .carrierCode(state.getCarrierCode())
+                .shippingStatus(state.getShippingStatus())
+                .pollingActive(state.isPollingActive())
+                .lastPolledAt(state.getLastPolledAt())
+                .createdAt(state.getCreatedAt())
+                .modifiedAt(state.getModifiedAt())
+                .build();
+    }
+
+    public void startShipping(String trackingNumber, String carrierCode) {
+        if (FormatValidator.hasNoValue(trackingNumber)) {
+            throw new FulfillmentQueryParameterNoValueException("trackingNumber", "startShipping");
+        }
+        if (FormatValidator.hasNoValue(carrierCode)) {
+            throw new FulfillmentQueryParameterNoValueException("carrierCode", "startShipping");
+        }
+        validateTransition(ShippingStatus.SHIPPING);
+        this.shippingStatus = ShippingStatus.SHIPPING;
+        this.trackingNumber = trackingNumber;
+        this.carrierCode = carrierCode;
+    }
+
+    public void completeDelivery() {
+        validateTransition(ShippingStatus.DELIVERED);
+        this.shippingStatus = ShippingStatus.DELIVERED;
+        this.pollingActive = false;
+    }
+
+    public void cancel() {
+        validateTransition(ShippingStatus.CANCELLED);
+        this.shippingStatus = ShippingStatus.CANCELLED;
+        this.pollingActive = false;
+    }
+
+    public void startReturnShipping() {
+        validateTransition(ShippingStatus.RETURN_SHIPPING);
+        this.shippingStatus = ShippingStatus.RETURN_SHIPPING;
+        this.pollingActive = true;
+    }
+
+    public void completeReturnDelivery() {
+        validateTransition(ShippingStatus.RETURN_DELIVERED);
+        this.shippingStatus = ShippingStatus.RETURN_DELIVERED;
+        this.pollingActive = false;
+    }
+
+    public void updateLastPolledAt(LocalDateTime polledAt) {
+        if (FormatValidator.hasNoValue(polledAt)) {
+            throw new FulfillmentQueryParameterNoValueException("polledAt", "updateLastPolledAt");
+        }
+        this.lastPolledAt = polledAt;
+    }
+
+    public boolean isPreparing() {
+        return shippingStatus.isPreparing();
+    }
+
+    public boolean isShipping() {
+        return shippingStatus.isShipping();
+    }
+
+    public boolean isDelivered() {
+        return shippingStatus.isDelivered();
+    }
+
+    public boolean isCancelled() {
+        return shippingStatus.isCancelled();
+    }
+
+    public boolean isReturnShipping() {
+        return shippingStatus.isReturnShipping();
+    }
+
+    public boolean isReturnDelivered() {
+        return shippingStatus.isReturnDelivered();
+    }
+
+    private void validateTransition(ShippingStatus target) {
+        if (!this.shippingStatus.canTransitionTo(target)) {
+            throw new InvalidShippingStatusTransitionException(this.shippingStatus, target);
+        }
+    }
+}

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/shipping/ShippingTrackerCreateState.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/shipping/ShippingTrackerCreateState.java
@@ -1,0 +1,10 @@
+package com.personal.marketnote.fulfillment.domain.shipping;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ShippingTrackerCreateState {
+    private final Long orderId;
+}

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/shipping/ShippingTrackerSnapshotState.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/shipping/ShippingTrackerSnapshotState.java
@@ -1,0 +1,20 @@
+package com.personal.marketnote.fulfillment.domain.shipping;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class ShippingTrackerSnapshotState {
+    private final Long id;
+    private final Long orderId;
+    private final String trackingNumber;
+    private final String carrierCode;
+    private final ShippingStatus shippingStatus;
+    private final boolean pollingActive;
+    private final LocalDateTime lastPolledAt;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime modifiedAt;
+}


### PR DESCRIPTION
## partially addresses #2143
## resolves #2144

## Task
- [x] ShippingStatus enum 추가 (PREPARING/SHIPPING/DELIVERED/CANCELLED/RETURN_SHIPPING/RETURN_DELIVERED)
- [x] ShippingStatus 상태 전이 규칙 내장 (canTransitionTo, isPollingTarget, isTerminal)
- [x] ShippingTracker 도메인 추가 (from CreateState/SnapshotState 팩토리 메서드)
- [x] ShippingTracker 상태 전이 메서드 (startShipping, completeDelivery, cancel, startReturnShipping, completeReturnDelivery)
- [x] InvalidShippingStatusTransitionException 도메인 예외 추가
- [x] ShippingTrackerNotFoundException 도메인 예외 추가