### PR TITLE
[#2143][#2148] feat: KafkaTopicConstants + ShippingStatusChangedEvent 기능 추가

### DIFF
--- a/common/src/main/java/com/personal/marketnote/common/kafka/KafkaTopicConstants.java
+++ b/common/src/main/java/com/personal/marketnote/common/kafka/KafkaTopicConstants.java
@@ -53,6 +53,9 @@ public final class KafkaTopicConstants {
     // Shipping Policy 이벤트
     public static final String SHIPPING_POLICY_CHANGED = "product.shipping-policy.changed";
 
+    // Fulfillment 이벤트
+    public static final String SHIPPING_STATUS_CHANGED = "fulfillment.shipping.status-changed";
+
     // Dead Letter Topic 접미사
     public static final String DLT_SUFFIX = ".dlt";
 }

--- a/common/src/main/java/com/personal/marketnote/common/kafka/event/ShippingStatusChangedEvent.java
+++ b/common/src/main/java/com/personal/marketnote/common/kafka/event/ShippingStatusChangedEvent.java
@@ -1,0 +1,12 @@
+package com.personal.marketnote.common.kafka.event;
+
+import java.time.LocalDateTime;
+
+public record ShippingStatusChangedEvent(
+        Long orderId,
+        String shippingStatus,
+        String trackingNumber,
+        String carrierCode,
+        LocalDateTime occurredAt
+) {
+}


### PR DESCRIPTION
## partially addresses #2143
## resolves #2148

## Task
- [x] KafkaTopicConstants에 SHIPPING_STATUS_CHANGED 토픽 상수 추가 (fulfillment.shipping.status-changed)
- [x] ShippingStatusChangedEvent record 추가 (orderId, shippingStatus, trackingNumber, carrierCode, occurredAt)