### PR TITLE
[#2143][#2145] feat: 출고 요청 시 ShippingTracker 생성 기능 추가

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -76,7 +76,6 @@ def buildMarketnoteTaskDefinition(env) {
                 [name: "GIFTICON_SYNC_SCHEDULER_CRON",      value: env.GIFTICON_SYNC_SCHEDULER_CRON],
                 [name: "GIFTICON_COUPON_SYNC_SCHEDULER_ENABLED", value: env.GIFTICON_COUPON_SYNC_SCHEDULER_ENABLED],
                 [name: "GIFTICON_COUPON_SYNC_SCHEDULER_CRON",    value: env.GIFTICON_COUPON_SYNC_SCHEDULER_CRON],
-                [name: "FIREBASE_SERVICE_ACCOUNT_JSON",          value: env.FIREBASE_SERVICE_ACCOUNT_JSON],
             ],
             logConfiguration: [
                 logDriver: "awslogs",

--- a/common/src/main/java/com/personal/marketnote/common/kafka/KafkaTopicConstants.java
+++ b/common/src/main/java/com/personal/marketnote/common/kafka/KafkaTopicConstants.java
@@ -53,6 +53,9 @@ public final class KafkaTopicConstants {
     // Shipping Policy 이벤트
     public static final String SHIPPING_POLICY_CHANGED = "product.shipping-policy.changed";
 
+    // Fulfillment 이벤트
+    public static final String SHIPPING_STATUS_CHANGED = "fulfillment.shipping.status-changed";
+
     // Dead Letter Topic 접미사
     public static final String DLT_SUFFIX = ".dlt";
 }

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/event/OrderPaymentCompletedOutboundConsumer.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/event/OrderPaymentCompletedOutboundConsumer.java
@@ -6,6 +6,9 @@ import com.personal.marketnote.common.kafka.event.EventEnvelope;
 import com.personal.marketnote.common.kafka.event.EventPayloadValidator;
 import com.personal.marketnote.common.kafka.event.OrderPaymentCompletedEvent;
 import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.fulfillment.exception.ShippingTrackerAlreadyExistsException;
+import com.personal.marketnote.fulfillment.port.in.command.CreateShippingTrackerCommand;
+import com.personal.marketnote.fulfillment.port.in.usecase.CreateShippingTrackerUseCase;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -18,6 +21,7 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class OrderPaymentCompletedOutboundConsumer {
     private final ObjectMapper objectMapper;
+    private final CreateShippingTrackerUseCase createShippingTrackerUseCase;
 
     @KafkaListener(
             topics = KafkaTopicConstants.ORDER_PAYMENT_COMPLETED,
@@ -79,8 +83,13 @@ public class OrderPaymentCompletedOutboundConsumer {
             //  — orderId 기반 출고 이력 DB 저장 (UNIQUE 제약) → 중복 시 FulfillmentDeliveryAlreadyRegisteredException
             //  — Consumer에서 FulfillmentDeliveryAlreadyRegisteredException catch → warn + acknowledge
 
-            log.info("Fulfillment 출고 요청 이벤트 검증 완료. orderId={}, orderProducts={}건",
+            createShippingTracker(payload.orderId(), envelope.eventId());
+
+            log.info("Fulfillment 출고 요청 이벤트 처리 완료. orderId={}, orderProducts={}건",
                     payload.orderId(), payload.orderProducts().size());
+        } catch (ShippingTrackerAlreadyExistsException e) {
+            log.warn("이미 배송 추적이 등록된 주문 (멱등 처리). eventId={}, orderId={}",
+                    envelope.eventId(), e.getMessage());
         } catch (Exception e) {
             log.error("Fulfillment 출고 요청 이벤트 처리 실패. eventId={}, key={}, error={}",
                     envelope.eventId(), record.key(), e.getMessage(), e);
@@ -88,5 +97,11 @@ public class OrderPaymentCompletedOutboundConsumer {
         }
 
         acknowledgment.acknowledge();
+    }
+
+    private void createShippingTracker(Long orderId, String eventId) {
+        CreateShippingTrackerCommand command = new CreateShippingTrackerCommand(orderId);
+        createShippingTrackerUseCase.createShippingTracker(command);
+        log.info("배송 추적 생성 완료. eventId={}, orderId={}", eventId, orderId);
     }
 }

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/persistence/shipping/ShippingTrackerPersistenceAdapter.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/persistence/shipping/ShippingTrackerPersistenceAdapter.java
@@ -1,0 +1,25 @@
+package com.personal.marketnote.fulfillment.adapter.out.persistence.shipping;
+
+import com.personal.marketnote.common.adapter.out.PersistenceAdapter;
+import com.personal.marketnote.fulfillment.adapter.out.persistence.shipping.entity.ShippingTrackerJpaEntity;
+import com.personal.marketnote.fulfillment.adapter.out.persistence.shipping.repository.ShippingTrackerJpaRepository;
+import com.personal.marketnote.fulfillment.domain.shipping.ShippingTracker;
+import com.personal.marketnote.fulfillment.exception.ShippingTrackerAlreadyExistsException;
+import com.personal.marketnote.fulfillment.port.out.shipping.SaveShippingTrackerPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+
+@PersistenceAdapter
+@RequiredArgsConstructor
+public class ShippingTrackerPersistenceAdapter implements SaveShippingTrackerPort {
+    private final ShippingTrackerJpaRepository repository;
+
+    @Override
+    public void save(ShippingTracker shippingTracker) {
+        try {
+            repository.saveAndFlush(ShippingTrackerJpaEntity.from(shippingTracker));
+        } catch (DataIntegrityViolationException e) {
+            throw new ShippingTrackerAlreadyExistsException(shippingTracker.getOrderId());
+        }
+    }
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/persistence/shipping/entity/ShippingTrackerJpaEntity.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/persistence/shipping/entity/ShippingTrackerJpaEntity.java
@@ -1,0 +1,83 @@
+package com.personal.marketnote.fulfillment.adapter.out.persistence.shipping.entity;
+
+import com.personal.marketnote.fulfillment.domain.shipping.ShippingStatus;
+import com.personal.marketnote.fulfillment.domain.shipping.ShippingTracker;
+import com.personal.marketnote.fulfillment.domain.shipping.ShippingTrackerSnapshotState;
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "shipping_tracker")
+@EntityListeners(value = AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+@Getter
+public class ShippingTrackerJpaEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "order_id", nullable = false, unique = true)
+    private Long orderId;
+
+    @Column(name = "tracking_number")
+    private String trackingNumber;
+
+    @Column(name = "carrier_code")
+    private String carrierCode;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "shipping_status", nullable = false)
+    private ShippingStatus shippingStatus;
+
+    @Column(name = "polling_active", nullable = false)
+    private boolean pollingActive;
+
+    @Column(name = "last_polled_at")
+    private LocalDateTime lastPolledAt;
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime modifiedAt;
+
+    public static ShippingTrackerJpaEntity from(ShippingTracker shippingTracker) {
+        return ShippingTrackerJpaEntity.builder()
+                .id(shippingTracker.getId())
+                .orderId(shippingTracker.getOrderId())
+                .trackingNumber(shippingTracker.getTrackingNumber())
+                .carrierCode(shippingTracker.getCarrierCode())
+                .shippingStatus(shippingTracker.getShippingStatus())
+                .pollingActive(shippingTracker.isPollingActive())
+                .lastPolledAt(shippingTracker.getLastPolledAt())
+                .createdAt(shippingTracker.getCreatedAt())
+                .modifiedAt(shippingTracker.getModifiedAt())
+                .build();
+    }
+
+    public ShippingTracker toDomain() {
+        return ShippingTracker.from(
+                ShippingTrackerSnapshotState.builder()
+                        .id(id)
+                        .orderId(orderId)
+                        .trackingNumber(trackingNumber)
+                        .carrierCode(carrierCode)
+                        .shippingStatus(shippingStatus)
+                        .pollingActive(pollingActive)
+                        .lastPolledAt(lastPolledAt)
+                        .createdAt(createdAt)
+                        .modifiedAt(modifiedAt)
+                        .build()
+        );
+    }
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/persistence/shipping/repository/ShippingTrackerJpaRepository.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/persistence/shipping/repository/ShippingTrackerJpaRepository.java
@@ -1,0 +1,10 @@
+package com.personal.marketnote.fulfillment.adapter.out.persistence.shipping.repository;
+
+import com.personal.marketnote.fulfillment.adapter.out.persistence.shipping.entity.ShippingTrackerJpaEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ShippingTrackerJpaRepository extends JpaRepository<ShippingTrackerJpaEntity, Long> {
+    Optional<ShippingTrackerJpaEntity> findByOrderId(Long orderId);
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/ShippingTrackerAlreadyExistsException.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/ShippingTrackerAlreadyExistsException.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.fulfillment.exception;
+
+public class ShippingTrackerAlreadyExistsException extends RuntimeException {
+
+    public ShippingTrackerAlreadyExistsException(Long orderId) {
+        super("이미 배송 추적이 등록된 주문입니다. orderId=" + orderId);
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/CreateShippingTrackerCommand.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/CreateShippingTrackerCommand.java
@@ -1,0 +1,6 @@
+package com.personal.marketnote.fulfillment.port.in.command;
+
+public record CreateShippingTrackerCommand(
+        Long orderId
+) {
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/usecase/CreateShippingTrackerUseCase.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/usecase/CreateShippingTrackerUseCase.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.fulfillment.port.in.usecase;
+
+import com.personal.marketnote.fulfillment.port.in.command.CreateShippingTrackerCommand;
+
+public interface CreateShippingTrackerUseCase {
+    void createShippingTracker(CreateShippingTrackerCommand command);
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/shipping/SaveShippingTrackerPort.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/shipping/SaveShippingTrackerPort.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.fulfillment.port.out.shipping;
+
+import com.personal.marketnote.fulfillment.domain.shipping.ShippingTracker;
+
+public interface SaveShippingTrackerPort {
+    void save(ShippingTracker shippingTracker);
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/shipping/CreateShippingTrackerService.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/shipping/CreateShippingTrackerService.java
@@ -1,0 +1,29 @@
+package com.personal.marketnote.fulfillment.service.shipping;
+
+import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.fulfillment.domain.shipping.ShippingTracker;
+import com.personal.marketnote.fulfillment.domain.shipping.ShippingTrackerCreateState;
+import com.personal.marketnote.fulfillment.port.in.command.CreateShippingTrackerCommand;
+import com.personal.marketnote.fulfillment.port.in.usecase.CreateShippingTrackerUseCase;
+import com.personal.marketnote.fulfillment.port.out.shipping.SaveShippingTrackerPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional(isolation = READ_COMMITTED)
+public class CreateShippingTrackerService implements CreateShippingTrackerUseCase {
+    private final SaveShippingTrackerPort saveShippingTrackerPort;
+
+    @Override
+    public void createShippingTracker(CreateShippingTrackerCommand command) {
+        ShippingTracker shippingTracker = ShippingTracker.from(
+                ShippingTrackerCreateState.builder()
+                        .orderId(command.orderId())
+                        .build()
+        );
+        saveShippingTrackerPort.save(shippingTracker);
+    }
+}

--- a/jenkins/resolve-and-register.groovy
+++ b/jenkins/resolve-and-register.groovy
@@ -161,7 +161,6 @@ def registerTaskDefinition(parentScript) {
         string(credentialsId: 'MARKETNOTE_QA_GIFTICON_SYNC_SCHEDULER_CRON',      variable: 'GIFTICON_SYNC_SCHEDULER_CRON'),
         string(credentialsId: 'MARKETNOTE_QA_GIFTICON_COUPON_SYNC_SCHEDULER_ENABLED', variable: 'GIFTICON_COUPON_SYNC_SCHEDULER_ENABLED'),
         string(credentialsId: 'MARKETNOTE_QA_GIFTICON_COUPON_SYNC_SCHEDULER_CRON',    variable: 'GIFTICON_COUPON_SYNC_SCHEDULER_CRON'),
-        string(credentialsId: 'MARKETNOTE_QA_FIREBASE_SERVICE_ACCOUNT_JSON',           variable: 'FIREBASE_SERVICE_ACCOUNT_JSON'),
     ]) {
         sh '''
           LG="$CLOUDWATCH_LOG_GROUP"

--- a/notification-service/notification-adapters/build.gradle.kts
+++ b/notification-service/notification-adapters/build.gradle.kts
@@ -113,9 +113,6 @@ dependencies {
     implementation("io.jsonwebtoken:jjwt-api:0.12.3")
     implementation("io.jsonwebtoken:jjwt-impl:0.12.3")
     implementation("io.jsonwebtoken:jjwt-jackson:0.12.3")
-
-    // Firebase Admin SDK
-    implementation("com.google.firebase:firebase-admin:9.4.3")
 }
 
 // ✅ 테스트 실행 시 JUnit 5 플랫폼 사용 설정

--- a/notification-service/notification-adapters/src/main/resources/application.yml
+++ b/notification-service/notification-adapters/src/main/resources/application.yml
@@ -68,9 +68,6 @@ logging:
   level:
     org.springframework.security: ERROR
 
-firebase:
-  service-account-json: ${FIREBASE_SERVICE_ACCOUNT_JSON:}
-
 kafka:
   slack:
     webhook-url: ${KAFKA_SLACK_WEBHOOK_URL:}


### PR DESCRIPTION
## partially addresses #2143
## resolves #2145

## Task
- [x] CreateShippingTrackerCommand record 추가
- [x] CreateShippingTrackerUseCase 인터페이스 추가
- [x] CreateShippingTrackerService UseCase 구현체 추가
- [x] SaveShippingTrackerPort 인터페이스 추가
- [x] ShippingTrackerAlreadyExistsException 도메인 예외 추가
- [x] ShippingTrackerJpaEntity JPA 엔티티 추가 (orderId UNIQUE)
- [x] ShippingTrackerJpaRepository 추가
- [x] ShippingTrackerPersistenceAdapter 추가
- [x] OrderPaymentCompletedOutboundConsumer에 ShippingTracker 생성 로직 연동