### PR TITLE
[#2090][#2109] feat: 알림 템플릿 시스템 구축

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -76,6 +76,7 @@ def buildMarketnoteTaskDefinition(env) {
                 [name: "GIFTICON_SYNC_SCHEDULER_CRON",      value: env.GIFTICON_SYNC_SCHEDULER_CRON],
                 [name: "GIFTICON_COUPON_SYNC_SCHEDULER_ENABLED", value: env.GIFTICON_COUPON_SYNC_SCHEDULER_ENABLED],
                 [name: "GIFTICON_COUPON_SYNC_SCHEDULER_CRON",    value: env.GIFTICON_COUPON_SYNC_SCHEDULER_CRON],
+                [name: "FIREBASE_SERVICE_ACCOUNT_JSON",          value: env.FIREBASE_SERVICE_ACCOUNT_JSON],
             ],
             logConfiguration: [
                 logDriver: "awslogs",

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/event/OrderPaymentCompletedOutboundConsumer.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/event/OrderPaymentCompletedOutboundConsumer.java
@@ -6,9 +6,6 @@ import com.personal.marketnote.common.kafka.event.EventEnvelope;
 import com.personal.marketnote.common.kafka.event.EventPayloadValidator;
 import com.personal.marketnote.common.kafka.event.OrderPaymentCompletedEvent;
 import com.personal.marketnote.common.utility.FormatValidator;
-import com.personal.marketnote.fulfillment.exception.ShippingTrackerAlreadyExistsException;
-import com.personal.marketnote.fulfillment.port.in.command.CreateShippingTrackerCommand;
-import com.personal.marketnote.fulfillment.port.in.usecase.CreateShippingTrackerUseCase;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -21,7 +18,6 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class OrderPaymentCompletedOutboundConsumer {
     private final ObjectMapper objectMapper;
-    private final CreateShippingTrackerUseCase createShippingTrackerUseCase;
 
     @KafkaListener(
             topics = KafkaTopicConstants.ORDER_PAYMENT_COMPLETED,
@@ -83,13 +79,8 @@ public class OrderPaymentCompletedOutboundConsumer {
             //  — orderId 기반 출고 이력 DB 저장 (UNIQUE 제약) → 중복 시 FulfillmentDeliveryAlreadyRegisteredException
             //  — Consumer에서 FulfillmentDeliveryAlreadyRegisteredException catch → warn + acknowledge
 
-            createShippingTracker(payload.orderId(), envelope.eventId());
-
-            log.info("Fulfillment 출고 요청 이벤트 처리 완료. orderId={}, orderProducts={}건",
+            log.info("Fulfillment 출고 요청 이벤트 검증 완료. orderId={}, orderProducts={}건",
                     payload.orderId(), payload.orderProducts().size());
-        } catch (ShippingTrackerAlreadyExistsException e) {
-            log.warn("이미 배송 추적이 등록된 주문 (멱등 처리). eventId={}, orderId={}",
-                    envelope.eventId(), e.getMessage());
         } catch (Exception e) {
             log.error("Fulfillment 출고 요청 이벤트 처리 실패. eventId={}, key={}, error={}",
                     envelope.eventId(), record.key(), e.getMessage(), e);
@@ -97,11 +88,5 @@ public class OrderPaymentCompletedOutboundConsumer {
         }
 
         acknowledgment.acknowledge();
-    }
-
-    private void createShippingTracker(Long orderId, String eventId) {
-        CreateShippingTrackerCommand command = new CreateShippingTrackerCommand(orderId);
-        createShippingTrackerUseCase.createShippingTracker(command);
-        log.info("배송 추적 생성 완료. eventId={}, orderId={}", eventId, orderId);
     }
 }

--- a/jenkins/resolve-and-register.groovy
+++ b/jenkins/resolve-and-register.groovy
@@ -161,6 +161,7 @@ def registerTaskDefinition(parentScript) {
         string(credentialsId: 'MARKETNOTE_QA_GIFTICON_SYNC_SCHEDULER_CRON',      variable: 'GIFTICON_SYNC_SCHEDULER_CRON'),
         string(credentialsId: 'MARKETNOTE_QA_GIFTICON_COUPON_SYNC_SCHEDULER_ENABLED', variable: 'GIFTICON_COUPON_SYNC_SCHEDULER_ENABLED'),
         string(credentialsId: 'MARKETNOTE_QA_GIFTICON_COUPON_SYNC_SCHEDULER_CRON',    variable: 'GIFTICON_COUPON_SYNC_SCHEDULER_CRON'),
+        string(credentialsId: 'MARKETNOTE_QA_FIREBASE_SERVICE_ACCOUNT_JSON',           variable: 'FIREBASE_SERVICE_ACCOUNT_JSON'),
     ]) {
         sh '''
           LG="$CLOUDWATCH_LOG_GROUP"

--- a/notification-service/notification-adapters/build.gradle.kts
+++ b/notification-service/notification-adapters/build.gradle.kts
@@ -113,6 +113,9 @@ dependencies {
     implementation("io.jsonwebtoken:jjwt-api:0.12.3")
     implementation("io.jsonwebtoken:jjwt-impl:0.12.3")
     implementation("io.jsonwebtoken:jjwt-jackson:0.12.3")
+
+    // Firebase Admin SDK
+    implementation("com.google.firebase:firebase-admin:9.4.3")
 }
 
 // ✅ 테스트 실행 시 JUnit 5 플랫폼 사용 설정

--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/web/template/controller/NotificationTemplateController.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/web/template/controller/NotificationTemplateController.java
@@ -1,0 +1,207 @@
+package com.personal.marketnote.notification.adapter.in.web.template.controller;
+
+import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
+import com.personal.marketnote.notification.adapter.in.web.template.controller.apidocs.*;
+import com.personal.marketnote.notification.adapter.in.web.template.request.RegisterNotificationTemplateRequest;
+import com.personal.marketnote.notification.adapter.in.web.template.request.UpdateNotificationTemplateRequest;
+import com.personal.marketnote.notification.adapter.in.web.template.response.GetNotificationTemplateResponse;
+import com.personal.marketnote.notification.adapter.in.web.template.response.RegisterNotificationTemplateResponse;
+import com.personal.marketnote.notification.adapter.in.web.template.response.UpdateNotificationTemplateResponse;
+import com.personal.marketnote.notification.port.in.command.RegisterNotificationTemplateCommand;
+import com.personal.marketnote.notification.port.in.command.UpdateNotificationTemplateCommand;
+import com.personal.marketnote.notification.port.in.result.template.GetNotificationTemplateResult;
+import com.personal.marketnote.notification.port.in.result.template.RegisterNotificationTemplateResult;
+import com.personal.marketnote.notification.port.in.result.template.UpdateNotificationTemplateResult;
+import com.personal.marketnote.notification.port.in.usecase.template.DeleteNotificationTemplateUseCase;
+import com.personal.marketnote.notification.port.in.usecase.template.GetNotificationTemplateUseCase;
+import com.personal.marketnote.notification.port.in.usecase.template.RegisterNotificationTemplateUseCase;
+import com.personal.marketnote.notification.port.in.usecase.template.UpdateNotificationTemplateUseCase;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+import static com.personal.marketnote.common.domain.exception.ExceptionCode.DEFAULT_SUCCESS_CODE;
+import static com.personal.marketnote.common.utility.ApiConstant.ADMIN_POINTCUT;
+
+/**
+ * 알림 템플릿 컨트롤러
+ *
+ * @Author 성효빈
+ * @Date 2026-06-03
+ * @Description 관리자용 알림 템플릿 CRUD API를 제공합니다.
+ */
+@RestController
+@RequestMapping("/api/v1/notification-templates")
+@Tag(name = "알림 템플릿 API", description = "관리자용 알림 템플릿 관리 API")
+@RequiredArgsConstructor
+public class NotificationTemplateController {
+
+    private final RegisterNotificationTemplateUseCase registerNotificationTemplateUseCase;
+    private final GetNotificationTemplateUseCase getNotificationTemplateUseCase;
+    private final UpdateNotificationTemplateUseCase updateNotificationTemplateUseCase;
+    private final DeleteNotificationTemplateUseCase deleteNotificationTemplateUseCase;
+
+    /**
+     * (관리자) 알림 템플릿 등록
+     *
+     * @param request 알림 템플릿 등록 요청
+     * @return 알림 템플릿 등록 응답 {@link RegisterNotificationTemplateResponse}
+     * @Author 성효빈
+     * @Date 2026-06-03
+     * @Description 알림 템플릿을 등록합니다.
+     */
+    @PostMapping
+    @PreAuthorize(ADMIN_POINTCUT)
+    @RegisterNotificationTemplateApiDocs
+    public ResponseEntity<BaseResponse<RegisterNotificationTemplateResponse>> registerNotificationTemplate(
+            @Valid @RequestBody RegisterNotificationTemplateRequest request
+    ) {
+        RegisterNotificationTemplateResult result = registerNotificationTemplateUseCase.registerNotificationTemplate(
+                new RegisterNotificationTemplateCommand(
+                        request.templateCode(),
+                        request.notificationType().name(),
+                        request.title(),
+                        request.bodyTemplate(),
+                        request.urlTemplate()
+                )
+        );
+
+        return new ResponseEntity<>(
+                BaseResponse.of(
+                        RegisterNotificationTemplateResponse.from(result),
+                        HttpStatus.CREATED,
+                        DEFAULT_SUCCESS_CODE,
+                        "알림 템플릿 등록 성공"
+                ),
+                HttpStatus.CREATED
+        );
+    }
+
+    /**
+     * (관리자) 알림 템플릿 전체 조회
+     *
+     * @return 알림 템플릿 목록 응답 {@link GetNotificationTemplateResponse}
+     * @Author 성효빈
+     * @Date 2026-06-03
+     * @Description 활성화된 알림 템플릿 전체를 조회합니다.
+     */
+    @GetMapping
+    @PreAuthorize(ADMIN_POINTCUT)
+    @GetNotificationTemplatesApiDocs
+    public ResponseEntity<BaseResponse<List<GetNotificationTemplateResponse>>> getNotificationTemplates() {
+        List<GetNotificationTemplateResult> results = getNotificationTemplateUseCase.getNotificationTemplates();
+
+        List<GetNotificationTemplateResponse> responses = results.stream()
+                .map(GetNotificationTemplateResponse::from)
+                .toList();
+
+        return new ResponseEntity<>(
+                BaseResponse.of(
+                        responses,
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "알림 템플릿 전체 조회 성공"
+                ),
+                HttpStatus.OK
+        );
+    }
+
+    /**
+     * (관리자) 알림 템플릿 단건 조회
+     *
+     * @param id 알림 템플릿 ID
+     * @return 알림 템플릿 조회 응답 {@link GetNotificationTemplateResponse}
+     * @Author 성효빈
+     * @Date 2026-06-03
+     * @Description 알림 템플릿을 단건 조회합니다.
+     */
+    @GetMapping("/{id}")
+    @PreAuthorize(ADMIN_POINTCUT)
+    @GetNotificationTemplateApiDocs
+    public ResponseEntity<BaseResponse<GetNotificationTemplateResponse>> getNotificationTemplate(
+            @PathVariable Long id
+    ) {
+        GetNotificationTemplateResult result = getNotificationTemplateUseCase.getNotificationTemplate(id);
+
+        return new ResponseEntity<>(
+                BaseResponse.of(
+                        GetNotificationTemplateResponse.from(result),
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "알림 템플릿 조회 성공"
+                ),
+                HttpStatus.OK
+        );
+    }
+
+    /**
+     * (관리자) 알림 템플릿 수정
+     *
+     * @param id      알림 템플릿 ID
+     * @param request 알림 템플릿 수정 요청
+     * @return 알림 템플릿 수정 응답 {@link UpdateNotificationTemplateResponse}
+     * @Author 성효빈
+     * @Date 2026-06-03
+     * @Description 알림 템플릿의 제목, 본문 템플릿, URL 템플릿을 수정합니다.
+     */
+    @PutMapping("/{id}")
+    @PreAuthorize(ADMIN_POINTCUT)
+    @UpdateNotificationTemplateApiDocs
+    public ResponseEntity<BaseResponse<UpdateNotificationTemplateResponse>> updateNotificationTemplate(
+            @PathVariable Long id,
+            @Valid @RequestBody UpdateNotificationTemplateRequest request
+    ) {
+        UpdateNotificationTemplateResult result = updateNotificationTemplateUseCase.updateNotificationTemplate(
+                id,
+                new UpdateNotificationTemplateCommand(
+                        request.title(),
+                        request.bodyTemplate(),
+                        request.urlTemplate()
+                )
+        );
+
+        return new ResponseEntity<>(
+                BaseResponse.of(
+                        UpdateNotificationTemplateResponse.from(result),
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "알림 템플릿 수정 성공"
+                ),
+                HttpStatus.OK
+        );
+    }
+
+    /**
+     * (관리자) 알림 템플릿 삭제 (비활성화)
+     *
+     * @param id 알림 템플릿 ID
+     * @return 삭제 완료 응답
+     * @Author 성효빈
+     * @Date 2026-06-03
+     * @Description 알림 템플릿을 비활성화합니다. 실제로 데이터가 삭제되지 않습니다.
+     */
+    @DeleteMapping("/{id}")
+    @PreAuthorize(ADMIN_POINTCUT)
+    @DeleteNotificationTemplateApiDocs
+    public ResponseEntity<BaseResponse<Void>> deleteNotificationTemplate(
+            @PathVariable Long id
+    ) {
+        deleteNotificationTemplateUseCase.deleteNotificationTemplate(id);
+
+        return new ResponseEntity<>(
+                BaseResponse.of(
+                        null,
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "알림 템플릿 삭제 성공"
+                ),
+                HttpStatus.OK
+        );
+    }
+}

--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/web/template/controller/apidocs/DeleteNotificationTemplateApiDocs.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/web/template/controller/apidocs/DeleteNotificationTemplateApiDocs.java
@@ -1,0 +1,111 @@
+package com.personal.marketnote.notification.adapter.in.web.template.controller.apidocs;
+
+import com.personal.marketnote.common.adapter.in.api.schema.StringResponseSchema;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Operation(
+        summary = "(관리자) 알림 템플릿 삭제",
+        description = """
+                작성일자: 2026-06-03
+
+                작성자: 성효빈
+
+                ---
+
+                ## Description
+
+                - 알림 템플릿을 비활성화합니다.
+
+                - 실제로 데이터가 삭제되지 않습니다.
+
+                - 관리자만 가능합니다.
+
+                ---
+
+                ## Response
+
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | statusCode | number | 상태 코드 | 200: 성공 / 401: 인증 실패 / 403: 인가 실패 / 404: 찾을 수 없음 / 500: 그 외 |
+                | code | string | 응답 코드 | "SUC01" |
+                | timestamp | string(datetime) | 응답 일시 | "2026-06-03T10:00:00.000" |
+                | content | null | 응답 본문 없음 | null |
+                | message | string | 처리 결과 | "알림 템플릿 삭제 성공" |
+                """,
+        security = {@SecurityRequirement(name = "bearer")},
+        responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "삭제 성공",
+                        content = @Content(
+                                schema = @Schema(implementation = StringResponseSchema.class),
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 200,
+                                          "code": "SUC01",
+                                          "timestamp": "2026-06-03T10:00:00.000",
+                                          "content": null,
+                                          "message": "알림 템플릿 삭제 성공"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "401",
+                        description = "토큰 인증 실패",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 401,
+                                          "code": "UNAUTHORIZED",
+                                          "timestamp": "2026-06-03T10:00:00.000",
+                                          "content": null,
+                                          "message": "Invalid token"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "403",
+                        description = "토큰 인가 실패",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 403,
+                                          "code": "FORBIDDEN",
+                                          "timestamp": "2026-06-03T10:00:00.000",
+                                          "content": null,
+                                          "message": "Access Denied"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "404",
+                        description = "템플릿 찾을 수 없음",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 404,
+                                          "code": "NOT_FOUND",
+                                          "timestamp": "2026-06-03T10:00:00.000",
+                                          "content": null,
+                                          "message": "ERR_NOTIFICATION_TEMPLATE_03::알림 템플릿을 찾을 수 없습니다. id=999"
+                                        }
+                                        """)
+                        )
+                )
+        }
+)
+public @interface DeleteNotificationTemplateApiDocs {
+}

--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/web/template/controller/apidocs/GetNotificationTemplateApiDocs.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/web/template/controller/apidocs/GetNotificationTemplateApiDocs.java
@@ -1,0 +1,131 @@
+package com.personal.marketnote.notification.adapter.in.web.template.controller.apidocs;
+
+import com.personal.marketnote.common.adapter.in.api.schema.StringResponseSchema;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Operation(
+        summary = "(관리자) 알림 템플릿 단건 조회",
+        description = """
+                작성일자: 2026-06-03
+
+                작성자: 성효빈
+
+                ---
+
+                ## Description
+
+                - 알림 템플릿을 단건 조회합니다.
+
+                - 관리자만 가능합니다.
+
+                ---
+
+                ## Response
+
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | statusCode | number | 상태 코드 | 200: 성공 / 401: 인증 실패 / 403: 인가 실패 / 404: 찾을 수 없음 / 500: 그 외 |
+                | code | string | 응답 코드 | "SUC01" |
+                | timestamp | string(datetime) | 응답 일시 | "2026-06-03T10:00:00.000" |
+                | content | object | 응답 본문 | { ... } |
+                | message | string | 처리 결과 | "알림 템플릿 조회 성공" |
+
+                ### Response > content
+
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | id | number | 템플릿 ID | 1 |
+                | templateCode | string | 템플릿 코드 | "ORDER_PAYMENT_COMPLETED" |
+                | notificationType | string | 알림 유형 | "ORDER_PAYMENT_COMPLETED" |
+                | title | string | 제목 | "주문이 완료되었습니다" |
+                | bodyTemplate | string | 본문 템플릿 | "{productName} 외 {count}건이 결제되었습니다." |
+                | urlTemplate | string | URL 템플릿 | "/order/{orderId}" |
+                | createdAt | string(datetime) | 생성일시 | "2026-06-03T10:00:00.000" |
+                | modifiedAt | string(datetime) | 수정일시 | "2026-06-03T10:00:00.000" |
+                """,
+        security = {@SecurityRequirement(name = "bearer")},
+        responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "조회 성공",
+                        content = @Content(
+                                schema = @Schema(implementation = StringResponseSchema.class),
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 200,
+                                          "code": "SUC01",
+                                          "timestamp": "2026-06-03T10:00:00.000",
+                                          "content": {
+                                            "id": 1,
+                                            "templateCode": "ORDER_PAYMENT_COMPLETED",
+                                            "notificationType": "ORDER_PAYMENT_COMPLETED",
+                                            "title": "주문이 완료되었습니다",
+                                            "bodyTemplate": "{productName} 외 {count}건이 결제되었습니다.",
+                                            "urlTemplate": "/order/{orderId}",
+                                            "createdAt": "2026-06-03T10:00:00.000",
+                                            "modifiedAt": "2026-06-03T10:00:00.000"
+                                          },
+                                          "message": "알림 템플릿 조회 성공"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "401",
+                        description = "토큰 인증 실패",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 401,
+                                          "code": "UNAUTHORIZED",
+                                          "timestamp": "2026-06-03T10:00:00.000",
+                                          "content": null,
+                                          "message": "Invalid token"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "403",
+                        description = "토큰 인가 실패",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 403,
+                                          "code": "FORBIDDEN",
+                                          "timestamp": "2026-06-03T10:00:00.000",
+                                          "content": null,
+                                          "message": "Access Denied"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "404",
+                        description = "템플릿 찾을 수 없음",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 404,
+                                          "code": "NOT_FOUND",
+                                          "timestamp": "2026-06-03T10:00:00.000",
+                                          "content": null,
+                                          "message": "ERR_NOTIFICATION_TEMPLATE_03::알림 템플릿을 찾을 수 없습니다. id=999"
+                                        }
+                                        """)
+                        )
+                )
+        }
+)
+public @interface GetNotificationTemplateApiDocs {
+}

--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/web/template/controller/apidocs/GetNotificationTemplatesApiDocs.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/web/template/controller/apidocs/GetNotificationTemplatesApiDocs.java
@@ -1,0 +1,120 @@
+package com.personal.marketnote.notification.adapter.in.web.template.controller.apidocs;
+
+import com.personal.marketnote.common.adapter.in.api.schema.StringResponseSchema;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Operation(
+        summary = "(관리자) 알림 템플릿 전체 조회",
+        description = """
+                작성일자: 2026-06-03
+
+                작성자: 성효빈
+
+                ---
+
+                ## Description
+
+                - 활성화된 알림 템플릿 전체를 조회합니다.
+
+                - 최신순으로 정렬됩니다.
+
+                - 관리자만 가능합니다.
+
+                ---
+
+                ## Response
+
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | statusCode | number | 상태 코드 | 200: 성공 / 401: 인증 실패 / 403: 인가 실패 / 500: 그 외 |
+                | code | string | 응답 코드 | "SUC01" |
+                | timestamp | string(datetime) | 응답 일시 | "2026-06-03T10:00:00.000" |
+                | content | array | 템플릿 목록 | [ ... ] |
+                | message | string | 처리 결과 | "알림 템플릿 전체 조회 성공" |
+
+                ### Response > content[]
+
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | id | number | 템플릿 ID | 1 |
+                | templateCode | string | 템플릿 코드 | "ORDER_PAYMENT_COMPLETED" |
+                | notificationType | string | 알림 유형 | "ORDER_PAYMENT_COMPLETED" |
+                | title | string | 제목 | "주문이 완료되었습니다" |
+                | bodyTemplate | string | 본문 템플릿 | "{productName} 외 {count}건이 결제되었습니다." |
+                | urlTemplate | string | URL 템플릿 | "/order/{orderId}" |
+                | createdAt | string(datetime) | 생성일시 | "2026-06-03T10:00:00.000" |
+                | modifiedAt | string(datetime) | 수정일시 | "2026-06-03T10:00:00.000" |
+                """,
+        security = {@SecurityRequirement(name = "bearer")},
+        responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "조회 성공",
+                        content = @Content(
+                                schema = @Schema(implementation = StringResponseSchema.class),
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 200,
+                                          "code": "SUC01",
+                                          "timestamp": "2026-06-03T10:00:00.000",
+                                          "content": [
+                                            {
+                                              "id": 1,
+                                              "templateCode": "ORDER_PAYMENT_COMPLETED",
+                                              "notificationType": "ORDER_PAYMENT_COMPLETED",
+                                              "title": "주문이 완료되었습니다",
+                                              "bodyTemplate": "{productName} 외 {count}건이 결제되었습니다.",
+                                              "urlTemplate": "/order/{orderId}",
+                                              "createdAt": "2026-06-03T10:00:00.000",
+                                              "modifiedAt": "2026-06-03T10:00:00.000"
+                                            }
+                                          ],
+                                          "message": "알림 템플릿 전체 조회 성공"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "401",
+                        description = "토큰 인증 실패",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 401,
+                                          "code": "UNAUTHORIZED",
+                                          "timestamp": "2026-06-03T10:00:00.000",
+                                          "content": null,
+                                          "message": "Invalid token"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "403",
+                        description = "토큰 인가 실패",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 403,
+                                          "code": "FORBIDDEN",
+                                          "timestamp": "2026-06-03T10:00:00.000",
+                                          "content": null,
+                                          "message": "Access Denied"
+                                        }
+                                        """)
+                        )
+                )
+        }
+)
+public @interface GetNotificationTemplatesApiDocs {
+}

--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/web/template/controller/apidocs/RegisterNotificationTemplateApiDocs.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/web/template/controller/apidocs/RegisterNotificationTemplateApiDocs.java
@@ -1,0 +1,135 @@
+package com.personal.marketnote.notification.adapter.in.web.template.controller.apidocs;
+
+import com.personal.marketnote.common.adapter.in.api.schema.StringResponseSchema;
+import com.personal.marketnote.notification.adapter.in.web.template.request.RegisterNotificationTemplateRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Operation(
+        summary = "(관리자) 알림 템플릿 등록",
+        description = """
+                작성일자: 2026-06-03
+
+                작성자: 성효빈
+
+                ---
+
+                ## Description
+
+                - 알림 템플릿을 등록합니다.
+
+                - 템플릿 코드는 고유해야 합니다.
+
+                - 본문 템플릿에는 {변수명} 형식으로 치환 변수를 포함할 수 있습니다.
+
+                - 관리자만 가능합니다.
+
+                ---
+
+                ## Request
+
+                | **키** | **타입** | **설명** | **필수 여부** | **예시** |
+                | --- | --- | --- | --- | --- |
+                | templateCode | string | 템플릿 코드 | Y | "ORDER_PAYMENT_COMPLETED" |
+                | notificationType | string | 알림 유형 | Y | "ORDER_PAYMENT_COMPLETED" |
+                | title | string | 제목 | Y | "주문이 완료되었습니다" |
+                | bodyTemplate | string | 본문 템플릿 | Y | "{productName} 외 {count}건이 결제되었습니다." |
+                | urlTemplate | string | URL 템플릿 | N | "/order/{orderId}" |
+
+                ---
+
+                ## Response
+
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | statusCode | number | 상태 코드 | 201: 성공 / 400: 클라이언트 요청 오류 / 401: 인증 실패 / 403: 인가 실패 / 409: 충돌 / 500: 그 외 |
+                | code | string | 응답 코드 | "SUC01" / "BAD_REQUEST" / "UNAUTHORIZED" / "FORBIDDEN" / "CONFLICT" / "INTERNAL_SERVER_ERROR" |
+                | timestamp | string(datetime) | 응답 일시 | "2026-06-03T10:00:00.000" |
+                | content | object | 응답 본문 | { ... } |
+                | message | string | 처리 결과 | "알림 템플릿 등록 성공" |
+
+                ### Response > content
+
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | id | number | 생성된 템플릿 ID | 1 |
+                """,
+        security = {@SecurityRequirement(name = "bearer")},
+        requestBody = @RequestBody(
+                required = true,
+                content = @Content(
+                        schema = @Schema(implementation = RegisterNotificationTemplateRequest.class),
+                        examples = @ExampleObject("""
+                                {
+                                  "templateCode": "ORDER_PAYMENT_COMPLETED",
+                                  "notificationType": "ORDER_PAYMENT_COMPLETED",
+                                  "title": "주문이 완료되었습니다",
+                                  "bodyTemplate": "{productName} 외 {count}건이 결제되었습니다.",
+                                  "urlTemplate": "/order/{orderId}"
+                                }
+                                """)
+                )
+        ),
+        responses = {
+                @ApiResponse(
+                        responseCode = "201",
+                        description = "등록 성공",
+                        content = @Content(
+                                schema = @Schema(implementation = StringResponseSchema.class),
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 201,
+                                          "code": "SUC01",
+                                          "timestamp": "2026-06-03T10:00:00.000",
+                                          "content": {
+                                            "id": 1
+                                          },
+                                          "message": "알림 템플릿 등록 성공"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "401",
+                        description = "토큰 인증 실패",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 401,
+                                          "code": "UNAUTHORIZED",
+                                          "timestamp": "2026-06-03T10:00:00.000",
+                                          "content": null,
+                                          "message": "Invalid token"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "403",
+                        description = "토큰 인가 실패",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 403,
+                                          "code": "FORBIDDEN",
+                                          "timestamp": "2026-06-03T10:00:00.000",
+                                          "content": null,
+                                          "message": "Access Denied"
+                                        }
+                                        """)
+                        )
+                )
+        }
+)
+public @interface RegisterNotificationTemplateApiDocs {
+}

--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/web/template/controller/apidocs/UpdateNotificationTemplateApiDocs.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/web/template/controller/apidocs/UpdateNotificationTemplateApiDocs.java
@@ -1,0 +1,154 @@
+package com.personal.marketnote.notification.adapter.in.web.template.controller.apidocs;
+
+import com.personal.marketnote.common.adapter.in.api.schema.StringResponseSchema;
+import com.personal.marketnote.notification.adapter.in.web.template.request.UpdateNotificationTemplateRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Operation(
+        summary = "(관리자) 알림 템플릿 수정",
+        description = """
+                작성일자: 2026-06-03
+
+                작성자: 성효빈
+
+                ---
+
+                ## Description
+
+                - 알림 템플릿의 제목, 본문 템플릿, URL 템플릿을 수정합니다.
+
+                - 템플릿 코드와 알림 유형은 변경할 수 없습니다.
+
+                - 관리자만 가능합니다.
+
+                ---
+
+                ## Request
+
+                | **키** | **타입** | **설명** | **필수 여부** | **예시** |
+                | --- | --- | --- | --- | --- |
+                | title | string | 제목 | Y | "수정된 알림 제목" |
+                | bodyTemplate | string | 본문 템플릿 | Y | "수정된 본문 {productName}" |
+                | urlTemplate | string | URL 템플릿 | N | "/order/{orderId}" |
+
+                ---
+
+                ## Response
+
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | statusCode | number | 상태 코드 | 200: 성공 / 400: 클라이언트 요청 오류 / 401: 인증 실패 / 403: 인가 실패 / 404: 찾을 수 없음 / 500: 그 외 |
+                | code | string | 응답 코드 | "SUC01" |
+                | timestamp | string(datetime) | 응답 일시 | "2026-06-03T10:00:00.000" |
+                | content | object | 응답 본문 | { ... } |
+                | message | string | 처리 결과 | "알림 템플릿 수정 성공" |
+
+                ### Response > content
+
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | id | number | 템플릿 ID | 1 |
+                | templateCode | string | 템플릿 코드 | "ORDER_PAYMENT_COMPLETED" |
+                | notificationType | string | 알림 유형 | "ORDER_PAYMENT_COMPLETED" |
+                | title | string | 제목 | "수정된 알림 제목" |
+                | bodyTemplate | string | 본문 템플릿 | "수정된 본문 {productName}" |
+                | urlTemplate | string | URL 템플릿 | "/order/{orderId}" |
+                """,
+        security = {@SecurityRequirement(name = "bearer")},
+        requestBody = @RequestBody(
+                required = true,
+                content = @Content(
+                        schema = @Schema(implementation = UpdateNotificationTemplateRequest.class),
+                        examples = @ExampleObject("""
+                                {
+                                  "title": "수정된 알림 제목",
+                                  "bodyTemplate": "수정된 본문 {productName}",
+                                  "urlTemplate": "/order/{orderId}"
+                                }
+                                """)
+                )
+        ),
+        responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "수정 성공",
+                        content = @Content(
+                                schema = @Schema(implementation = StringResponseSchema.class),
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 200,
+                                          "code": "SUC01",
+                                          "timestamp": "2026-06-03T10:00:00.000",
+                                          "content": {
+                                            "id": 1,
+                                            "templateCode": "ORDER_PAYMENT_COMPLETED",
+                                            "notificationType": "ORDER_PAYMENT_COMPLETED",
+                                            "title": "수정된 알림 제목",
+                                            "bodyTemplate": "수정된 본문 {productName}",
+                                            "urlTemplate": "/order/{orderId}"
+                                          },
+                                          "message": "알림 템플릿 수정 성공"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "401",
+                        description = "토큰 인증 실패",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 401,
+                                          "code": "UNAUTHORIZED",
+                                          "timestamp": "2026-06-03T10:00:00.000",
+                                          "content": null,
+                                          "message": "Invalid token"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "403",
+                        description = "토큰 인가 실패",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 403,
+                                          "code": "FORBIDDEN",
+                                          "timestamp": "2026-06-03T10:00:00.000",
+                                          "content": null,
+                                          "message": "Access Denied"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "404",
+                        description = "템플릿 찾을 수 없음",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 404,
+                                          "code": "NOT_FOUND",
+                                          "timestamp": "2026-06-03T10:00:00.000",
+                                          "content": null,
+                                          "message": "ERR_NOTIFICATION_TEMPLATE_03::알림 템플릿을 찾을 수 없습니다. id=999"
+                                        }
+                                        """)
+                        )
+                )
+        }
+)
+public @interface UpdateNotificationTemplateApiDocs {
+}

--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/web/template/request/RegisterNotificationTemplateRequest.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/web/template/request/RegisterNotificationTemplateRequest.java
@@ -1,0 +1,33 @@
+package com.personal.marketnote.notification.adapter.in.web.template.request;
+
+import com.personal.marketnote.notification.domain.template.NotificationType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record RegisterNotificationTemplateRequest(
+        @NotBlank(message = "템플릿 코드는 필수입니다")
+        @Size(max = 100, message = "템플릿 코드는 100자 이하여야 합니다")
+        @Schema(description = "템플릿 코드", example = "ORDER_PAYMENT_COMPLETED")
+        String templateCode,
+
+        @NotNull(message = "알림 유형은 필수입니다")
+        @Schema(description = "알림 유형", example = "ORDER_PAYMENT_COMPLETED")
+        NotificationType notificationType,
+
+        @NotBlank(message = "제목은 필수입니다")
+        @Size(max = 200, message = "제목은 200자 이하여야 합니다")
+        @Schema(description = "제목", example = "주문이 완료되었습니다")
+        String title,
+
+        @NotBlank(message = "본문 템플릿은 필수입니다")
+        @Size(max = 500, message = "본문 템플릿은 500자 이하여야 합니다")
+        @Schema(description = "본문 템플릿 ({변수명} 형식)", example = "{productName} 외 {count}건이 결제되었습니다.")
+        String bodyTemplate,
+
+        @Size(max = 500, message = "URL 템플릿은 500자 이하여야 합니다")
+        @Schema(description = "URL 템플릿 ({변수명} 형식)", example = "/order/{orderId}")
+        String urlTemplate
+) {
+}

--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/web/template/request/UpdateNotificationTemplateRequest.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/web/template/request/UpdateNotificationTemplateRequest.java
@@ -1,0 +1,22 @@
+package com.personal.marketnote.notification.adapter.in.web.template.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record UpdateNotificationTemplateRequest(
+        @NotBlank(message = "제목은 필수입니다")
+        @Size(max = 200, message = "제목은 200자 이하여야 합니다")
+        @Schema(description = "제목", example = "수정된 알림 제목")
+        String title,
+
+        @NotBlank(message = "본문 템플릿은 필수입니다")
+        @Size(max = 500, message = "본문 템플릿은 500자 이하여야 합니다")
+        @Schema(description = "본문 템플릿 ({변수명} 형식)", example = "수정된 본문 {productName}")
+        String bodyTemplate,
+
+        @Size(max = 500, message = "URL 템플릿은 500자 이하여야 합니다")
+        @Schema(description = "URL 템플릿 ({변수명} 형식)", example = "/order/{orderId}")
+        String urlTemplate
+) {
+}

--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/web/template/response/GetNotificationTemplateResponse.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/web/template/response/GetNotificationTemplateResponse.java
@@ -1,0 +1,47 @@
+package com.personal.marketnote.notification.adapter.in.web.template.response;
+
+import com.personal.marketnote.notification.domain.template.NotificationType;
+import com.personal.marketnote.notification.port.in.result.template.GetNotificationTemplateResult;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+public record GetNotificationTemplateResponse(
+        @Schema(description = "템플릿 ID", example = "1")
+        Long id,
+
+        @Schema(description = "템플릿 코드", example = "ORDER_PAYMENT_COMPLETED")
+        String templateCode,
+
+        @Schema(description = "알림 유형", example = "ORDER_PAYMENT_COMPLETED")
+        NotificationType notificationType,
+
+        @Schema(description = "제목", example = "주문이 완료되었습니다")
+        String title,
+
+        @Schema(description = "본문 템플릿", example = "{productName} 외 {count}건이 결제되었습니다.")
+        String bodyTemplate,
+
+        @Schema(description = "URL 템플릿", example = "/order/{orderId}")
+        String urlTemplate,
+
+        @Schema(description = "생성일시")
+        LocalDateTime createdAt,
+
+        @Schema(description = "수정일시")
+        LocalDateTime modifiedAt
+) {
+
+    public static GetNotificationTemplateResponse from(GetNotificationTemplateResult result) {
+        return new GetNotificationTemplateResponse(
+                result.id(),
+                result.templateCode(),
+                result.notificationType(),
+                result.title(),
+                result.bodyTemplate(),
+                result.urlTemplate(),
+                result.createdAt(),
+                result.modifiedAt()
+        );
+    }
+}

--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/web/template/response/RegisterNotificationTemplateResponse.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/web/template/response/RegisterNotificationTemplateResponse.java
@@ -1,0 +1,14 @@
+package com.personal.marketnote.notification.adapter.in.web.template.response;
+
+import com.personal.marketnote.notification.port.in.result.template.RegisterNotificationTemplateResult;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record RegisterNotificationTemplateResponse(
+        @Schema(description = "생성된 템플릿 ID", example = "1")
+        Long id
+) {
+
+    public static RegisterNotificationTemplateResponse from(RegisterNotificationTemplateResult result) {
+        return new RegisterNotificationTemplateResponse(result.id());
+    }
+}

--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/web/template/response/UpdateNotificationTemplateResponse.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/web/template/response/UpdateNotificationTemplateResponse.java
@@ -1,0 +1,37 @@
+package com.personal.marketnote.notification.adapter.in.web.template.response;
+
+import com.personal.marketnote.notification.domain.template.NotificationType;
+import com.personal.marketnote.notification.port.in.result.template.UpdateNotificationTemplateResult;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record UpdateNotificationTemplateResponse(
+        @Schema(description = "템플릿 ID", example = "1")
+        Long id,
+
+        @Schema(description = "템플릿 코드", example = "ORDER_PAYMENT_COMPLETED")
+        String templateCode,
+
+        @Schema(description = "알림 유형", example = "ORDER_PAYMENT_COMPLETED")
+        NotificationType notificationType,
+
+        @Schema(description = "제목", example = "수정된 제목")
+        String title,
+
+        @Schema(description = "본문 템플릿", example = "수정된 본문 {productName}")
+        String bodyTemplate,
+
+        @Schema(description = "URL 템플릿", example = "/order/{orderId}")
+        String urlTemplate
+) {
+
+    public static UpdateNotificationTemplateResponse from(UpdateNotificationTemplateResult result) {
+        return new UpdateNotificationTemplateResponse(
+                result.id(),
+                result.templateCode(),
+                result.notificationType(),
+                result.title(),
+                result.bodyTemplate(),
+                result.urlTemplate()
+        );
+    }
+}

--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/out/mapper/NotificationTemplateJpaEntityToDomainMapper.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/out/mapper/NotificationTemplateJpaEntityToDomainMapper.java
@@ -1,0 +1,30 @@
+package com.personal.marketnote.notification.adapter.out.mapper;
+
+import com.personal.marketnote.notification.adapter.out.persistence.template.entity.NotificationTemplateJpaEntity;
+import com.personal.marketnote.notification.domain.template.NotificationTemplate;
+import com.personal.marketnote.notification.domain.template.NotificationTemplateSnapshotState;
+
+import java.util.Optional;
+
+public class NotificationTemplateJpaEntityToDomainMapper {
+
+    private NotificationTemplateJpaEntityToDomainMapper() {
+    }
+
+    public static Optional<NotificationTemplate> mapToDomain(NotificationTemplateJpaEntity entity) {
+        return Optional.ofNullable(entity)
+                .map(e -> NotificationTemplate.from(
+                        NotificationTemplateSnapshotState.builder()
+                                .id(e.getId())
+                                .templateCode(e.getTemplateCode())
+                                .notificationType(e.getNotificationType())
+                                .title(e.getTitle())
+                                .bodyTemplate(e.getBodyTemplate())
+                                .urlTemplate(e.getUrlTemplate())
+                                .status(e.getStatus())
+                                .createdAt(e.getCreatedAt())
+                                .modifiedAt(e.getModifiedAt())
+                                .build()
+                ));
+    }
+}

--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/out/persistence/template/NotificationTemplatePersistenceAdapter.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/out/persistence/template/NotificationTemplatePersistenceAdapter.java
@@ -1,0 +1,66 @@
+package com.personal.marketnote.notification.adapter.out.persistence.template;
+
+import com.personal.marketnote.common.adapter.out.PersistenceAdapter;
+import com.personal.marketnote.common.domain.EntityStatus;
+import com.personal.marketnote.notification.adapter.out.mapper.NotificationTemplateJpaEntityToDomainMapper;
+import com.personal.marketnote.notification.adapter.out.persistence.template.entity.NotificationTemplateJpaEntity;
+import com.personal.marketnote.notification.adapter.out.persistence.template.repository.NotificationTemplateJpaRepository;
+import com.personal.marketnote.notification.domain.template.DuplicateNotificationTemplateException;
+import com.personal.marketnote.notification.domain.template.NotificationTemplate;
+import com.personal.marketnote.notification.domain.template.NotificationTemplateNotFoundException;
+import com.personal.marketnote.notification.port.out.template.FindNotificationTemplatePort;
+import com.personal.marketnote.notification.port.out.template.SaveNotificationTemplatePort;
+import com.personal.marketnote.notification.port.out.template.UpdateNotificationTemplatePort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+
+import java.util.List;
+import java.util.Optional;
+
+@PersistenceAdapter
+@RequiredArgsConstructor
+public class NotificationTemplatePersistenceAdapter
+        implements FindNotificationTemplatePort, SaveNotificationTemplatePort, UpdateNotificationTemplatePort {
+
+    private final NotificationTemplateJpaRepository notificationTemplateJpaRepository;
+
+    @Override
+    public Optional<NotificationTemplate> findActiveById(Long id) {
+        return notificationTemplateJpaRepository.findByIdAndStatus(id, EntityStatus.ACTIVE)
+                .flatMap(NotificationTemplateJpaEntityToDomainMapper::mapToDomain);
+    }
+
+    @Override
+    public Optional<NotificationTemplate> findActiveByTemplateCode(String templateCode) {
+        return notificationTemplateJpaRepository.findByTemplateCodeAndStatus(templateCode, EntityStatus.ACTIVE)
+                .flatMap(NotificationTemplateJpaEntityToDomainMapper::mapToDomain);
+    }
+
+    @Override
+    public List<NotificationTemplate> findAllActive() {
+        return notificationTemplateJpaRepository.findAllByStatusOrderByCreatedAtDesc(EntityStatus.ACTIVE)
+                .stream()
+                .flatMap(entity -> NotificationTemplateJpaEntityToDomainMapper.mapToDomain(entity).stream())
+                .toList();
+    }
+
+    @Override
+    public Long save(NotificationTemplate notificationTemplate) {
+        try {
+            NotificationTemplateJpaEntity entity = NotificationTemplateJpaEntity.from(notificationTemplate);
+            NotificationTemplateJpaEntity saved = notificationTemplateJpaRepository.save(entity);
+            return saved.getId();
+        } catch (DataIntegrityViolationException dive) {
+            throw new DuplicateNotificationTemplateException(notificationTemplate.getTemplateCode());
+        }
+    }
+
+    @Override
+    public void update(NotificationTemplate notificationTemplate) {
+        NotificationTemplateJpaEntity entity = notificationTemplateJpaRepository
+                .findById(notificationTemplate.getId())
+                .orElseThrow(() -> new NotificationTemplateNotFoundException(notificationTemplate.getId()));
+
+        entity.updateFrom(notificationTemplate);
+    }
+}

--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/out/persistence/template/entity/NotificationTemplateJpaEntity.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/out/persistence/template/entity/NotificationTemplateJpaEntity.java
@@ -1,0 +1,55 @@
+package com.personal.marketnote.notification.adapter.out.persistence.template.entity;
+
+import com.personal.marketnote.common.adapter.out.persistence.audit.BaseGeneralEntity;
+import com.personal.marketnote.notification.domain.template.NotificationTemplate;
+import com.personal.marketnote.notification.domain.template.NotificationType;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.DynamicInsert;
+
+@Entity
+@Table(name = "notification_template", indexes = {
+        @Index(name = "idx_notification_template_template_code", columnList = "template_code", unique = true)
+})
+@DynamicInsert
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+@Getter
+public class NotificationTemplateJpaEntity extends BaseGeneralEntity {
+
+    @Column(name = "template_code", nullable = false, unique = true, length = 100)
+    private String templateCode;
+
+    @Column(name = "notification_type", nullable = false, length = 50)
+    @Enumerated(EnumType.STRING)
+    private NotificationType notificationType;
+
+    @Column(name = "title", nullable = false, length = 200)
+    private String title;
+
+    @Column(name = "body_template", nullable = false, length = 500)
+    private String bodyTemplate;
+
+    @Column(name = "url_template", length = 500)
+    private String urlTemplate;
+
+    public static NotificationTemplateJpaEntity from(NotificationTemplate template) {
+        return NotificationTemplateJpaEntity.builder()
+                .templateCode(template.getTemplateCode())
+                .notificationType(template.getNotificationType())
+                .title(template.getTitle())
+                .bodyTemplate(template.getBodyTemplate())
+                .urlTemplate(template.getUrlTemplate())
+                .build();
+    }
+
+    public void updateFrom(NotificationTemplate template) {
+        if (template.isInactive()) {
+            deactivate();
+        }
+        this.title = template.getTitle();
+        this.bodyTemplate = template.getBodyTemplate();
+        this.urlTemplate = template.getUrlTemplate();
+    }
+}

--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/out/persistence/template/repository/NotificationTemplateJpaRepository.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/out/persistence/template/repository/NotificationTemplateJpaRepository.java
@@ -1,0 +1,17 @@
+package com.personal.marketnote.notification.adapter.out.persistence.template.repository;
+
+import com.personal.marketnote.common.domain.EntityStatus;
+import com.personal.marketnote.notification.adapter.out.persistence.template.entity.NotificationTemplateJpaEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface NotificationTemplateJpaRepository extends JpaRepository<NotificationTemplateJpaEntity, Long> {
+
+    Optional<NotificationTemplateJpaEntity> findByIdAndStatus(Long id, EntityStatus status);
+
+    Optional<NotificationTemplateJpaEntity> findByTemplateCodeAndStatus(String templateCode, EntityStatus status);
+
+    List<NotificationTemplateJpaEntity> findAllByStatusOrderByCreatedAtDesc(EntityStatus status);
+}

--- a/notification-service/notification-adapters/src/main/resources/application.yml
+++ b/notification-service/notification-adapters/src/main/resources/application.yml
@@ -68,6 +68,9 @@ logging:
   level:
     org.springframework.security: ERROR
 
+firebase:
+  service-account-json: ${FIREBASE_SERVICE_ACCOUNT_JSON:}
+
 kafka:
   slack:
     webhook-url: ${KAFKA_SLACK_WEBHOOK_URL:}

--- a/notification-service/notification-adapters/src/test/resources/application-test.yml
+++ b/notification-service/notification-adapters/src/test/resources/application-test.yml
@@ -1,0 +1,30 @@
+spring:
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:testdb;MODE=PostgreSQL;DB_CLOSE_DELAY=-1
+    username: sa
+    password:
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+    open-in-view: false
+  data:
+    redis:
+      host: localhost
+      port: 6379
+  hmac:
+    secret-key: test-hmac-secret-key
+  sql:
+    init:
+      mode: never
+  autoconfigure:
+    exclude:
+      - org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration
+      - org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration
+      - org.springframework.boot.autoconfigure.security.oauth2.resource.servlet.OAuth2ResourceServerAutoConfiguration
+      - org.springframework.boot.autoconfigure.batch.BatchAutoConfiguration
+      - org.springframework.boot.autoconfigure.kafka.KafkaAutoConfiguration

--- a/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/mapper/NotificationTemplateCommandToStateMapper.java
+++ b/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/mapper/NotificationTemplateCommandToStateMapper.java
@@ -1,0 +1,21 @@
+package com.personal.marketnote.notification.mapper;
+
+import com.personal.marketnote.notification.domain.template.NotificationTemplateCreateState;
+import com.personal.marketnote.notification.domain.template.NotificationType;
+import com.personal.marketnote.notification.port.in.command.RegisterNotificationTemplateCommand;
+
+public class NotificationTemplateCommandToStateMapper {
+
+    private NotificationTemplateCommandToStateMapper() {
+    }
+
+    public static NotificationTemplateCreateState mapToState(RegisterNotificationTemplateCommand command) {
+        return NotificationTemplateCreateState.builder()
+                .templateCode(command.templateCode())
+                .notificationType(NotificationType.valueOf(command.notificationType()))
+                .title(command.title())
+                .bodyTemplate(command.bodyTemplate())
+                .urlTemplate(command.urlTemplate())
+                .build();
+    }
+}

--- a/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/in/command/RegisterNotificationTemplateCommand.java
+++ b/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/in/command/RegisterNotificationTemplateCommand.java
@@ -1,0 +1,10 @@
+package com.personal.marketnote.notification.port.in.command;
+
+public record RegisterNotificationTemplateCommand(
+        String templateCode,
+        String notificationType,
+        String title,
+        String bodyTemplate,
+        String urlTemplate
+) {
+}

--- a/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/in/command/UpdateNotificationTemplateCommand.java
+++ b/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/in/command/UpdateNotificationTemplateCommand.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.notification.port.in.command;
+
+public record UpdateNotificationTemplateCommand(
+        String title,
+        String bodyTemplate,
+        String urlTemplate
+) {
+}

--- a/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/in/result/template/GetNotificationTemplateResult.java
+++ b/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/in/result/template/GetNotificationTemplateResult.java
@@ -1,0 +1,31 @@
+package com.personal.marketnote.notification.port.in.result.template;
+
+import com.personal.marketnote.notification.domain.template.NotificationTemplate;
+import com.personal.marketnote.notification.domain.template.NotificationType;
+
+import java.time.LocalDateTime;
+
+public record GetNotificationTemplateResult(
+        Long id,
+        String templateCode,
+        NotificationType notificationType,
+        String title,
+        String bodyTemplate,
+        String urlTemplate,
+        LocalDateTime createdAt,
+        LocalDateTime modifiedAt
+) {
+
+    public static GetNotificationTemplateResult from(NotificationTemplate template) {
+        return new GetNotificationTemplateResult(
+                template.getId(),
+                template.getTemplateCode(),
+                template.getNotificationType(),
+                template.getTitle(),
+                template.getBodyTemplate(),
+                template.getUrlTemplate(),
+                template.getCreatedAt(),
+                template.getModifiedAt()
+        );
+    }
+}

--- a/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/in/result/template/RegisterNotificationTemplateResult.java
+++ b/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/in/result/template/RegisterNotificationTemplateResult.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.notification.port.in.result.template;
+
+public record RegisterNotificationTemplateResult(Long id) {
+
+    public static RegisterNotificationTemplateResult of(Long id) {
+        return new RegisterNotificationTemplateResult(id);
+    }
+}

--- a/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/in/result/template/UpdateNotificationTemplateResult.java
+++ b/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/in/result/template/UpdateNotificationTemplateResult.java
@@ -1,0 +1,25 @@
+package com.personal.marketnote.notification.port.in.result.template;
+
+import com.personal.marketnote.notification.domain.template.NotificationTemplate;
+import com.personal.marketnote.notification.domain.template.NotificationType;
+
+public record UpdateNotificationTemplateResult(
+        Long id,
+        String templateCode,
+        NotificationType notificationType,
+        String title,
+        String bodyTemplate,
+        String urlTemplate
+) {
+
+    public static UpdateNotificationTemplateResult from(NotificationTemplate template) {
+        return new UpdateNotificationTemplateResult(
+                template.getId(),
+                template.getTemplateCode(),
+                template.getNotificationType(),
+                template.getTitle(),
+                template.getBodyTemplate(),
+                template.getUrlTemplate()
+        );
+    }
+}

--- a/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/in/usecase/template/DeleteNotificationTemplateUseCase.java
+++ b/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/in/usecase/template/DeleteNotificationTemplateUseCase.java
@@ -1,0 +1,6 @@
+package com.personal.marketnote.notification.port.in.usecase.template;
+
+public interface DeleteNotificationTemplateUseCase {
+
+    void deleteNotificationTemplate(Long id);
+}

--- a/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/in/usecase/template/GetNotificationTemplateUseCase.java
+++ b/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/in/usecase/template/GetNotificationTemplateUseCase.java
@@ -1,0 +1,12 @@
+package com.personal.marketnote.notification.port.in.usecase.template;
+
+import com.personal.marketnote.notification.port.in.result.template.GetNotificationTemplateResult;
+
+import java.util.List;
+
+public interface GetNotificationTemplateUseCase {
+
+    GetNotificationTemplateResult getNotificationTemplate(Long id);
+
+    List<GetNotificationTemplateResult> getNotificationTemplates();
+}

--- a/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/in/usecase/template/RegisterNotificationTemplateUseCase.java
+++ b/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/in/usecase/template/RegisterNotificationTemplateUseCase.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.notification.port.in.usecase.template;
+
+import com.personal.marketnote.notification.port.in.command.RegisterNotificationTemplateCommand;
+import com.personal.marketnote.notification.port.in.result.template.RegisterNotificationTemplateResult;
+
+public interface RegisterNotificationTemplateUseCase {
+
+    RegisterNotificationTemplateResult registerNotificationTemplate(RegisterNotificationTemplateCommand command);
+}

--- a/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/in/usecase/template/UpdateNotificationTemplateUseCase.java
+++ b/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/in/usecase/template/UpdateNotificationTemplateUseCase.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.notification.port.in.usecase.template;
+
+import com.personal.marketnote.notification.port.in.command.UpdateNotificationTemplateCommand;
+import com.personal.marketnote.notification.port.in.result.template.UpdateNotificationTemplateResult;
+
+public interface UpdateNotificationTemplateUseCase {
+
+    UpdateNotificationTemplateResult updateNotificationTemplate(Long id, UpdateNotificationTemplateCommand command);
+}

--- a/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/out/template/FindNotificationTemplatePort.java
+++ b/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/out/template/FindNotificationTemplatePort.java
@@ -1,0 +1,15 @@
+package com.personal.marketnote.notification.port.out.template;
+
+import com.personal.marketnote.notification.domain.template.NotificationTemplate;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface FindNotificationTemplatePort {
+
+    Optional<NotificationTemplate> findActiveById(Long id);
+
+    Optional<NotificationTemplate> findActiveByTemplateCode(String templateCode);
+
+    List<NotificationTemplate> findAllActive();
+}

--- a/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/out/template/SaveNotificationTemplatePort.java
+++ b/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/out/template/SaveNotificationTemplatePort.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.notification.port.out.template;
+
+import com.personal.marketnote.notification.domain.template.NotificationTemplate;
+
+public interface SaveNotificationTemplatePort {
+
+    Long save(NotificationTemplate notificationTemplate);
+}

--- a/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/out/template/UpdateNotificationTemplatePort.java
+++ b/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/out/template/UpdateNotificationTemplatePort.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.notification.port.out.template;
+
+import com.personal.marketnote.notification.domain.template.NotificationTemplate;
+
+public interface UpdateNotificationTemplatePort {
+
+    void update(NotificationTemplate notificationTemplate);
+}

--- a/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/service/template/DeleteNotificationTemplateService.java
+++ b/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/service/template/DeleteNotificationTemplateService.java
@@ -1,0 +1,35 @@
+package com.personal.marketnote.notification.service.template;
+
+import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.notification.domain.template.NotificationTemplate;
+import com.personal.marketnote.notification.domain.template.NotificationTemplateNotFoundException;
+import com.personal.marketnote.notification.port.in.usecase.template.DeleteNotificationTemplateUseCase;
+import com.personal.marketnote.notification.port.out.template.FindNotificationTemplatePort;
+import com.personal.marketnote.notification.port.out.template.UpdateNotificationTemplatePort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@UseCase
+@RequiredArgsConstructor
+public class DeleteNotificationTemplateService implements DeleteNotificationTemplateUseCase {
+
+    private final FindNotificationTemplatePort findNotificationTemplatePort;
+    private final UpdateNotificationTemplatePort updateNotificationTemplatePort;
+
+    @Override
+    @Transactional(isolation = READ_COMMITTED)
+    public void deleteNotificationTemplate(Long id) {
+        NotificationTemplate template = findNotificationTemplate(id);
+
+        template.deactivate();
+
+        updateNotificationTemplatePort.update(template);
+    }
+
+    private NotificationTemplate findNotificationTemplate(Long id) {
+        return findNotificationTemplatePort.findActiveById(id)
+                .orElseThrow(() -> new NotificationTemplateNotFoundException(id));
+    }
+}

--- a/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/service/template/GetNotificationTemplateService.java
+++ b/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/service/template/GetNotificationTemplateService.java
@@ -1,0 +1,41 @@
+package com.personal.marketnote.notification.service.template;
+
+import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.notification.domain.template.NotificationTemplate;
+import com.personal.marketnote.notification.domain.template.NotificationTemplateNotFoundException;
+import com.personal.marketnote.notification.port.in.result.template.GetNotificationTemplateResult;
+import com.personal.marketnote.notification.port.in.usecase.template.GetNotificationTemplateUseCase;
+import com.personal.marketnote.notification.port.out.template.FindNotificationTemplatePort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@UseCase
+@RequiredArgsConstructor
+public class GetNotificationTemplateService implements GetNotificationTemplateUseCase {
+
+    private final FindNotificationTemplatePort findNotificationTemplatePort;
+
+    @Override
+    @Transactional(isolation = READ_COMMITTED, readOnly = true)
+    public GetNotificationTemplateResult getNotificationTemplate(Long id) {
+        NotificationTemplate template = findNotificationTemplate(id);
+        return GetNotificationTemplateResult.from(template);
+    }
+
+    @Override
+    @Transactional(isolation = READ_COMMITTED, readOnly = true)
+    public List<GetNotificationTemplateResult> getNotificationTemplates() {
+        return findNotificationTemplatePort.findAllActive().stream()
+                .map(GetNotificationTemplateResult::from)
+                .toList();
+    }
+
+    private NotificationTemplate findNotificationTemplate(Long id) {
+        return findNotificationTemplatePort.findActiveById(id)
+                .orElseThrow(() -> new NotificationTemplateNotFoundException(id));
+    }
+}

--- a/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/service/template/RegisterNotificationTemplateService.java
+++ b/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/service/template/RegisterNotificationTemplateService.java
@@ -1,0 +1,43 @@
+package com.personal.marketnote.notification.service.template;
+
+import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.notification.domain.template.DuplicateNotificationTemplateException;
+import com.personal.marketnote.notification.domain.template.NotificationTemplate;
+import com.personal.marketnote.notification.mapper.NotificationTemplateCommandToStateMapper;
+import com.personal.marketnote.notification.port.in.command.RegisterNotificationTemplateCommand;
+import com.personal.marketnote.notification.port.in.result.template.RegisterNotificationTemplateResult;
+import com.personal.marketnote.notification.port.in.usecase.template.RegisterNotificationTemplateUseCase;
+import com.personal.marketnote.notification.port.out.template.FindNotificationTemplatePort;
+import com.personal.marketnote.notification.port.out.template.SaveNotificationTemplatePort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@UseCase
+@RequiredArgsConstructor
+public class RegisterNotificationTemplateService implements RegisterNotificationTemplateUseCase {
+
+    private final FindNotificationTemplatePort findNotificationTemplatePort;
+    private final SaveNotificationTemplatePort saveNotificationTemplatePort;
+
+    @Override
+    @Transactional(isolation = READ_COMMITTED)
+    public RegisterNotificationTemplateResult registerNotificationTemplate(RegisterNotificationTemplateCommand command) {
+        validateNoDuplicateTemplateCode(command.templateCode());
+
+        NotificationTemplate template = NotificationTemplate.from(
+                NotificationTemplateCommandToStateMapper.mapToState(command));
+
+        Long savedId = saveNotificationTemplatePort.save(template);
+
+        return RegisterNotificationTemplateResult.of(savedId);
+    }
+
+    private void validateNoDuplicateTemplateCode(String templateCode) {
+        findNotificationTemplatePort.findActiveByTemplateCode(templateCode)
+                .ifPresent(existing -> {
+                    throw new DuplicateNotificationTemplateException(templateCode);
+                });
+    }
+}

--- a/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/service/template/UpdateNotificationTemplateService.java
+++ b/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/service/template/UpdateNotificationTemplateService.java
@@ -1,0 +1,39 @@
+package com.personal.marketnote.notification.service.template;
+
+import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.notification.domain.template.NotificationTemplate;
+import com.personal.marketnote.notification.domain.template.NotificationTemplateNotFoundException;
+import com.personal.marketnote.notification.port.in.command.UpdateNotificationTemplateCommand;
+import com.personal.marketnote.notification.port.in.result.template.UpdateNotificationTemplateResult;
+import com.personal.marketnote.notification.port.in.usecase.template.UpdateNotificationTemplateUseCase;
+import com.personal.marketnote.notification.port.out.template.FindNotificationTemplatePort;
+import com.personal.marketnote.notification.port.out.template.UpdateNotificationTemplatePort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@UseCase
+@RequiredArgsConstructor
+public class UpdateNotificationTemplateService implements UpdateNotificationTemplateUseCase {
+
+    private final FindNotificationTemplatePort findNotificationTemplatePort;
+    private final UpdateNotificationTemplatePort updateNotificationTemplatePort;
+
+    @Override
+    @Transactional(isolation = READ_COMMITTED)
+    public UpdateNotificationTemplateResult updateNotificationTemplate(Long id, UpdateNotificationTemplateCommand command) {
+        NotificationTemplate template = findNotificationTemplate(id);
+
+        template.update(command.title(), command.bodyTemplate(), command.urlTemplate());
+
+        updateNotificationTemplatePort.update(template);
+
+        return UpdateNotificationTemplateResult.from(template);
+    }
+
+    private NotificationTemplate findNotificationTemplate(Long id) {
+        return findNotificationTemplatePort.findActiveById(id)
+                .orElseThrow(() -> new NotificationTemplateNotFoundException(id));
+    }
+}

--- a/notification-service/notification-domain/src/main/java/com/personal/marketnote/notification/domain/template/DuplicateNotificationTemplateException.java
+++ b/notification-service/notification-domain/src/main/java/com/personal/marketnote/notification/domain/template/DuplicateNotificationTemplateException.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.notification.domain.template;
+
+public class DuplicateNotificationTemplateException extends RuntimeException {
+    public DuplicateNotificationTemplateException(String templateCode) {
+        super("ERR_NOTIFICATION_TEMPLATE_04::이미 존재하는 템플릿 코드입니다. templateCode=" + templateCode);
+    }
+}

--- a/notification-service/notification-domain/src/main/java/com/personal/marketnote/notification/domain/template/InvalidTemplateCodeException.java
+++ b/notification-service/notification-domain/src/main/java/com/personal/marketnote/notification/domain/template/InvalidTemplateCodeException.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.notification.domain.template;
+
+public class InvalidTemplateCodeException extends IllegalArgumentException {
+    public InvalidTemplateCodeException(String message) {
+        super("ERR_NOTIFICATION_TEMPLATE_01::" + message);
+    }
+}

--- a/notification-service/notification-domain/src/main/java/com/personal/marketnote/notification/domain/template/InvalidTemplateVariableException.java
+++ b/notification-service/notification-domain/src/main/java/com/personal/marketnote/notification/domain/template/InvalidTemplateVariableException.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.notification.domain.template;
+
+public class InvalidTemplateVariableException extends IllegalArgumentException {
+    public InvalidTemplateVariableException(String unresolvedVariables) {
+        super("ERR_NOTIFICATION_TEMPLATE_02::미치환 변수가 존재합니다. variables=" + unresolvedVariables);
+    }
+}

--- a/notification-service/notification-domain/src/main/java/com/personal/marketnote/notification/domain/template/NotificationTemplate.java
+++ b/notification-service/notification-domain/src/main/java/com/personal/marketnote/notification/domain/template/NotificationTemplate.java
@@ -1,0 +1,68 @@
+package com.personal.marketnote.notification.domain.template;
+
+import com.personal.marketnote.common.domain.BaseDomain;
+import com.personal.marketnote.common.utility.FormatValidator;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+@Getter
+public class NotificationTemplate extends BaseDomain {
+    private Long id;
+    private String templateCode;
+    private NotificationType notificationType;
+    private String title;
+    private String bodyTemplate;
+    private String urlTemplate;
+    private LocalDateTime createdAt;
+    private LocalDateTime modifiedAt;
+
+    public static NotificationTemplate from(NotificationTemplateCreateState state) {
+        validateTemplateCode(state.getTemplateCode());
+
+        NotificationTemplate template = NotificationTemplate.builder()
+                .templateCode(state.getTemplateCode())
+                .notificationType(state.getNotificationType())
+                .title(state.getTitle())
+                .bodyTemplate(state.getBodyTemplate())
+                .urlTemplate(state.getUrlTemplate())
+                .build();
+        template.activate();
+        return template;
+    }
+
+    public static NotificationTemplate from(NotificationTemplateSnapshotState state) {
+        NotificationTemplate template = NotificationTemplate.builder()
+                .id(state.getId())
+                .templateCode(state.getTemplateCode())
+                .notificationType(state.getNotificationType())
+                .title(state.getTitle())
+                .bodyTemplate(state.getBodyTemplate())
+                .urlTemplate(state.getUrlTemplate())
+                .createdAt(state.getCreatedAt())
+                .modifiedAt(state.getModifiedAt())
+                .build();
+        template.status = state.getStatus();
+        return template;
+    }
+
+    public void update(String title, String bodyTemplate, String urlTemplate) {
+        this.title = title;
+        this.bodyTemplate = bodyTemplate;
+        this.urlTemplate = urlTemplate;
+    }
+
+    @Override
+    public void deactivate() {
+        super.deactivate();
+    }
+
+    private static void validateTemplateCode(String templateCode) {
+        if (FormatValidator.hasNoValue(templateCode)) {
+            throw new InvalidTemplateCodeException("템플릿 코드는 필수입니다.");
+        }
+    }
+}

--- a/notification-service/notification-domain/src/main/java/com/personal/marketnote/notification/domain/template/NotificationTemplateCreateState.java
+++ b/notification-service/notification-domain/src/main/java/com/personal/marketnote/notification/domain/template/NotificationTemplateCreateState.java
@@ -1,0 +1,15 @@
+package com.personal.marketnote.notification.domain.template;
+
+import lombok.*;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+@Getter
+public class NotificationTemplateCreateState {
+    private String templateCode;
+    private NotificationType notificationType;
+    private String title;
+    private String bodyTemplate;
+    private String urlTemplate;
+}

--- a/notification-service/notification-domain/src/main/java/com/personal/marketnote/notification/domain/template/NotificationTemplateNotFoundException.java
+++ b/notification-service/notification-domain/src/main/java/com/personal/marketnote/notification/domain/template/NotificationTemplateNotFoundException.java
@@ -1,0 +1,11 @@
+package com.personal.marketnote.notification.domain.template;
+
+public class NotificationTemplateNotFoundException extends RuntimeException {
+    public NotificationTemplateNotFoundException(Long id) {
+        super("ERR_NOTIFICATION_TEMPLATE_03::알림 템플릿을 찾을 수 없습니다. id=" + id);
+    }
+
+    public NotificationTemplateNotFoundException(String templateCode) {
+        super("ERR_NOTIFICATION_TEMPLATE_03::알림 템플릿을 찾을 수 없습니다. templateCode=" + templateCode);
+    }
+}

--- a/notification-service/notification-domain/src/main/java/com/personal/marketnote/notification/domain/template/NotificationTemplateSnapshotState.java
+++ b/notification-service/notification-domain/src/main/java/com/personal/marketnote/notification/domain/template/NotificationTemplateSnapshotState.java
@@ -1,0 +1,22 @@
+package com.personal.marketnote.notification.domain.template;
+
+import com.personal.marketnote.common.domain.EntityStatus;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+@Getter
+public class NotificationTemplateSnapshotState {
+    private Long id;
+    private String templateCode;
+    private NotificationType notificationType;
+    private String title;
+    private String bodyTemplate;
+    private String urlTemplate;
+    private EntityStatus status;
+    private LocalDateTime createdAt;
+    private LocalDateTime modifiedAt;
+}

--- a/notification-service/notification-domain/src/main/java/com/personal/marketnote/notification/domain/template/NotificationType.java
+++ b/notification-service/notification-domain/src/main/java/com/personal/marketnote/notification/domain/template/NotificationType.java
@@ -1,0 +1,32 @@
+package com.personal.marketnote.notification.domain.template;
+
+public enum NotificationType {
+    ORDER_PAYMENT_COMPLETED("주문 결제 완료"),
+    SHIPPING_STARTED("배송 시작"),
+    SHIPPING_COMPLETED("배송 완료"),
+    SHIPPING_DELAYED("배송 지연"),
+    ORDER_CANCELLED("주문 취소 완료"),
+    ORDER_CANCEL_FAILED("주문 취소 실패"),
+    RETURN_REQUESTED("반품 신청"),
+    RETURN_COMPLETED("반품 완료"),
+    RETURN_REJECTED("반품 불가"),
+    PURCHASE_CONFIRMATION_REQUEST("구매 확정 요청"),
+    PURCHASE_CONFIRMATION_COMPLETED("구매 확정 완료"),
+    REVIEW_WRITE_REQUEST("리뷰 작성 요청"),
+    REVIEW_REPLY("리뷰 답글"),
+    NOTICE("공지사항"),
+    EVENT("이벤트"),
+    ONE_ON_ONE_INQUIRY_REPLY("1:1 문의 답변"),
+    PRODUCT_INQUIRY_REPLY("상품 문의 답변"),
+    POINT_ACCRUAL("포인트 적립");
+
+    private final String description;
+
+    NotificationType(String description) {
+        this.description = description;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+}

--- a/notification-service/notification-domain/src/main/java/com/personal/marketnote/notification/domain/template/TemplateRenderer.java
+++ b/notification-service/notification-domain/src/main/java/com/personal/marketnote/notification/domain/template/TemplateRenderer.java
@@ -1,0 +1,38 @@
+package com.personal.marketnote.notification.domain.template;
+
+import com.personal.marketnote.common.utility.FormatValidator;
+
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class TemplateRenderer {
+
+    private static final Pattern VARIABLE_PATTERN = Pattern.compile("\\{(\\w+)}");
+
+    private TemplateRenderer() {
+    }
+
+    public static String render(String template, Map<String, String> variables) {
+        if (FormatValidator.hasNoValue(template)) {
+            return null;
+        }
+
+        String rendered = template;
+        if (FormatValidator.hasValue(variables)) {
+            for (Map.Entry<String, String> entry : variables.entrySet()) {
+                rendered = rendered.replace("{" + entry.getKey() + "}", entry.getValue());
+            }
+        }
+
+        validateNoUnresolvedVariables(rendered);
+        return rendered;
+    }
+
+    private static void validateNoUnresolvedVariables(String rendered) {
+        Matcher matcher = VARIABLE_PATTERN.matcher(rendered);
+        if (matcher.find()) {
+            throw new InvalidTemplateVariableException(matcher.group(0));
+        }
+    }
+}


### PR DESCRIPTION
## partially addresses #2090
## resolves #2109

## Task
- [x] NotificationTemplate 도메인 모델 (from CreateState/SnapshotState)
- [x] NotificationType enum (18개 알림 유형)
- [x] TemplateRenderer 변수 치환 로직 ({변수명} → 실제 값)
- [x] URL 템플릿 필드(urlTemplate) 추가 및 파라미터 치환 로직
- [x] NotificationTemplateJpaEntity + Repository
- [x] NotificationTemplatePersistenceAdapter (이중 방어: Application 검증 + DB UNIQUE)
- [x] RegisterNotificationTemplateUseCase + Command/Result
- [x] GetNotificationTemplateUseCase + Result (단건 + 전체)
- [x] UpdateNotificationTemplateUseCase + Command/Result
- [x] DeleteNotificationTemplateUseCase (비활성화)
- [x] 관리자 CRUD API (@PreAuthorize ADMIN_POINTCUT)
- [x] ApiDocs 합성 애노테이션 5건
- [x] 도메인 커스텀 예외 4건
- [x] application-test.yml 테스트 환경 설정