### PR TITLE
[#2090][#2560] test: 알림 템플릿 시스템 구축 기능 자동화 테스트 추가

### DIFF
--- a/notification-service/notification-application/src/test/java/com/personal/marketnote/notification/service/template/DeleteNotificationTemplateUseCaseTest.java
+++ b/notification-service/notification-application/src/test/java/com/personal/marketnote/notification/service/template/DeleteNotificationTemplateUseCaseTest.java
@@ -1,0 +1,72 @@
+package com.personal.marketnote.notification.service.template;
+
+import com.personal.marketnote.notification.domain.template.NotificationTemplate;
+import com.personal.marketnote.notification.domain.template.NotificationTemplateCreateState;
+import com.personal.marketnote.notification.domain.template.NotificationTemplateNotFoundException;
+import com.personal.marketnote.notification.domain.template.NotificationType;
+import com.personal.marketnote.notification.port.out.template.FindNotificationTemplatePort;
+import com.personal.marketnote.notification.port.out.template.UpdateNotificationTemplatePort;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class DeleteNotificationTemplateUseCaseTest {
+
+    @InjectMocks
+    private DeleteNotificationTemplateService deleteNotificationTemplateService;
+
+    @Mock
+    private FindNotificationTemplatePort findNotificationTemplatePort;
+
+    @Mock
+    private UpdateNotificationTemplatePort updateNotificationTemplatePort;
+
+    @Test
+    @DisplayName("알림 템플릿을 비활성화(삭제)한다")
+    void shouldDeactivateNotificationTemplate() {
+        // given
+        NotificationTemplate template = NotificationTemplate.from(NotificationTemplateCreateState.builder()
+                .templateCode("ORDER_PAYMENT_COMPLETED")
+                .notificationType(NotificationType.ORDER_PAYMENT_COMPLETED)
+                .title("주문이 완료되었습니다")
+                .bodyTemplate("본문")
+                .urlTemplate("/order/{orderId}")
+                .build());
+
+        when(findNotificationTemplatePort.findActiveById(1L))
+                .thenReturn(Optional.of(template));
+
+        // when
+        deleteNotificationTemplateService.deleteNotificationTemplate(1L);
+
+        // then
+        ArgumentCaptor<NotificationTemplate> captor = ArgumentCaptor.forClass(NotificationTemplate.class);
+        verify(updateNotificationTemplatePort).update(captor.capture());
+        assertThat(captor.getValue().isInactive()).isTrue();
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 템플릿을 삭제하면 예외가 발생한다")
+    void shouldThrowExceptionWhenTemplateNotFound() {
+        // given
+        when(findNotificationTemplatePort.findActiveById(999L))
+                .thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> deleteNotificationTemplateService.deleteNotificationTemplate(999L))
+                .isInstanceOf(NotificationTemplateNotFoundException.class);
+        verify(updateNotificationTemplatePort, never()).update(any());
+    }
+}

--- a/notification-service/notification-application/src/test/java/com/personal/marketnote/notification/service/template/GetNotificationTemplateUseCaseTest.java
+++ b/notification-service/notification-application/src/test/java/com/personal/marketnote/notification/service/template/GetNotificationTemplateUseCaseTest.java
@@ -1,0 +1,110 @@
+package com.personal.marketnote.notification.service.template;
+
+import com.personal.marketnote.notification.domain.template.NotificationTemplate;
+import com.personal.marketnote.notification.domain.template.NotificationTemplateCreateState;
+import com.personal.marketnote.notification.domain.template.NotificationTemplateNotFoundException;
+import com.personal.marketnote.notification.domain.template.NotificationType;
+import com.personal.marketnote.notification.port.in.result.template.GetNotificationTemplateResult;
+import com.personal.marketnote.notification.port.out.template.FindNotificationTemplatePort;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class GetNotificationTemplateUseCaseTest {
+
+    @InjectMocks
+    private GetNotificationTemplateService getNotificationTemplateService;
+
+    @Mock
+    private FindNotificationTemplatePort findNotificationTemplatePort;
+
+    @Test
+    @DisplayName("ID로 알림 템플릿을 조회한다")
+    void shouldGetNotificationTemplateById() {
+        // given
+        NotificationTemplate template = createTemplate("ORDER_PAYMENT_COMPLETED",
+                NotificationType.ORDER_PAYMENT_COMPLETED, "주문이 완료되었습니다");
+
+        when(findNotificationTemplatePort.findActiveById(1L))
+                .thenReturn(Optional.of(template));
+
+        // when
+        GetNotificationTemplateResult result = getNotificationTemplateService.getNotificationTemplate(1L);
+
+        // then
+        assertThat(result.templateCode()).isEqualTo("ORDER_PAYMENT_COMPLETED");
+        assertThat(result.notificationType()).isEqualTo(NotificationType.ORDER_PAYMENT_COMPLETED);
+        assertThat(result.title()).isEqualTo("주문이 완료되었습니다");
+        verify(findNotificationTemplatePort).findActiveById(1L);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 ID로 조회하면 예외가 발생한다")
+    void shouldThrowExceptionWhenTemplateNotFound() {
+        // given
+        when(findNotificationTemplatePort.findActiveById(999L))
+                .thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> getNotificationTemplateService.getNotificationTemplate(999L))
+                .isInstanceOf(NotificationTemplateNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("전체 알림 템플릿을 조회한다")
+    void shouldGetAllNotificationTemplates() {
+        // given
+        NotificationTemplate template1 = createTemplate("ORDER_PAYMENT_COMPLETED",
+                NotificationType.ORDER_PAYMENT_COMPLETED, "주문이 완료되었습니다");
+        NotificationTemplate template2 = createTemplate("SHIPPING_STARTED",
+                NotificationType.SHIPPING_STARTED, "배송이 시작되었습니다");
+
+        when(findNotificationTemplatePort.findAllActive())
+                .thenReturn(List.of(template1, template2));
+
+        // when
+        List<GetNotificationTemplateResult> results = getNotificationTemplateService.getNotificationTemplates();
+
+        // then
+        assertThat(results).hasSize(2);
+        assertThat(results.get(0).templateCode()).isEqualTo("ORDER_PAYMENT_COMPLETED");
+        assertThat(results.get(1).templateCode()).isEqualTo("SHIPPING_STARTED");
+        verify(findNotificationTemplatePort).findAllActive();
+    }
+
+    @Test
+    @DisplayName("알림 템플릿이 없으면 빈 목록을 반환한다")
+    void shouldReturnEmptyListWhenNoTemplates() {
+        // given
+        when(findNotificationTemplatePort.findAllActive())
+                .thenReturn(List.of());
+
+        // when
+        List<GetNotificationTemplateResult> results = getNotificationTemplateService.getNotificationTemplates();
+
+        // then
+        assertThat(results).isEmpty();
+    }
+
+    private NotificationTemplate createTemplate(String templateCode, NotificationType type, String title) {
+        return NotificationTemplate.from(NotificationTemplateCreateState.builder()
+                .templateCode(templateCode)
+                .notificationType(type)
+                .title(title)
+                .bodyTemplate("본문")
+                .urlTemplate("/order/{orderId}")
+                .build());
+    }
+}

--- a/notification-service/notification-application/src/test/java/com/personal/marketnote/notification/service/template/RegisterNotificationTemplateUseCaseTest.java
+++ b/notification-service/notification-application/src/test/java/com/personal/marketnote/notification/service/template/RegisterNotificationTemplateUseCaseTest.java
@@ -1,0 +1,91 @@
+package com.personal.marketnote.notification.service.template;
+
+import com.personal.marketnote.notification.domain.template.DuplicateNotificationTemplateException;
+import com.personal.marketnote.notification.domain.template.NotificationTemplate;
+import com.personal.marketnote.notification.domain.template.NotificationTemplateCreateState;
+import com.personal.marketnote.notification.domain.template.NotificationType;
+import com.personal.marketnote.notification.port.in.command.RegisterNotificationTemplateCommand;
+import com.personal.marketnote.notification.port.in.result.template.RegisterNotificationTemplateResult;
+import com.personal.marketnote.notification.port.out.template.FindNotificationTemplatePort;
+import com.personal.marketnote.notification.port.out.template.SaveNotificationTemplatePort;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class RegisterNotificationTemplateUseCaseTest {
+
+    @InjectMocks
+    private RegisterNotificationTemplateService registerNotificationTemplateService;
+
+    @Mock
+    private FindNotificationTemplatePort findNotificationTemplatePort;
+
+    @Mock
+    private SaveNotificationTemplatePort saveNotificationTemplatePort;
+
+    @Test
+    @DisplayName("알림 템플릿을 등록한다")
+    void shouldRegisterNotificationTemplate() {
+        // given
+        RegisterNotificationTemplateCommand command = new RegisterNotificationTemplateCommand(
+                "ORDER_PAYMENT_COMPLETED",
+                "ORDER_PAYMENT_COMPLETED",
+                "주문이 완료되었습니다",
+                "{productName} 외 {count}건이 결제되었습니다.",
+                "/order/{orderId}"
+        );
+
+        when(findNotificationTemplatePort.findActiveByTemplateCode("ORDER_PAYMENT_COMPLETED"))
+                .thenReturn(Optional.empty());
+        when(saveNotificationTemplatePort.save(any(NotificationTemplate.class)))
+                .thenReturn(1L);
+
+        // when
+        RegisterNotificationTemplateResult result = registerNotificationTemplateService.registerNotificationTemplate(command);
+
+        // then
+        assertThat(result.id()).isEqualTo(1L);
+        verify(findNotificationTemplatePort).findActiveByTemplateCode("ORDER_PAYMENT_COMPLETED");
+        verify(saveNotificationTemplatePort).save(any(NotificationTemplate.class));
+    }
+
+    @Test
+    @DisplayName("이미 존재하는 템플릿 코드로 등록하면 예외가 발생한다")
+    void shouldThrowExceptionWhenDuplicateTemplateCode() {
+        // given
+        RegisterNotificationTemplateCommand command = new RegisterNotificationTemplateCommand(
+                "ORDER_PAYMENT_COMPLETED",
+                "ORDER_PAYMENT_COMPLETED",
+                "주문이 완료되었습니다",
+                "본문",
+                "/order/{orderId}"
+        );
+
+        NotificationTemplate existing = NotificationTemplate.from(NotificationTemplateCreateState.builder()
+                .templateCode("ORDER_PAYMENT_COMPLETED")
+                .notificationType(NotificationType.ORDER_PAYMENT_COMPLETED)
+                .title("기존 제목")
+                .bodyTemplate("기존 본문")
+                .urlTemplate("/order/{orderId}")
+                .build());
+
+        when(findNotificationTemplatePort.findActiveByTemplateCode("ORDER_PAYMENT_COMPLETED"))
+                .thenReturn(Optional.of(existing));
+
+        // when & then
+        assertThatThrownBy(() -> registerNotificationTemplateService.registerNotificationTemplate(command))
+                .isInstanceOf(DuplicateNotificationTemplateException.class);
+        verify(saveNotificationTemplatePort, never()).save(any());
+    }
+}

--- a/notification-service/notification-application/src/test/java/com/personal/marketnote/notification/service/template/UpdateNotificationTemplateUseCaseTest.java
+++ b/notification-service/notification-application/src/test/java/com/personal/marketnote/notification/service/template/UpdateNotificationTemplateUseCaseTest.java
@@ -1,0 +1,84 @@
+package com.personal.marketnote.notification.service.template;
+
+import com.personal.marketnote.notification.domain.template.NotificationTemplate;
+import com.personal.marketnote.notification.domain.template.NotificationTemplateCreateState;
+import com.personal.marketnote.notification.domain.template.NotificationTemplateNotFoundException;
+import com.personal.marketnote.notification.domain.template.NotificationType;
+import com.personal.marketnote.notification.port.in.command.UpdateNotificationTemplateCommand;
+import com.personal.marketnote.notification.port.in.result.template.UpdateNotificationTemplateResult;
+import com.personal.marketnote.notification.port.out.template.FindNotificationTemplatePort;
+import com.personal.marketnote.notification.port.out.template.UpdateNotificationTemplatePort;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class UpdateNotificationTemplateUseCaseTest {
+
+    @InjectMocks
+    private UpdateNotificationTemplateService updateNotificationTemplateService;
+
+    @Mock
+    private FindNotificationTemplatePort findNotificationTemplatePort;
+
+    @Mock
+    private UpdateNotificationTemplatePort updateNotificationTemplatePort;
+
+    @Test
+    @DisplayName("알림 템플릿을 수정한다")
+    void shouldUpdateNotificationTemplate() {
+        // given
+        NotificationTemplate template = NotificationTemplate.from(NotificationTemplateCreateState.builder()
+                .templateCode("ORDER_PAYMENT_COMPLETED")
+                .notificationType(NotificationType.ORDER_PAYMENT_COMPLETED)
+                .title("주문이 완료되었습니다")
+                .bodyTemplate("기존 본문")
+                .urlTemplate("/order/{orderId}")
+                .build());
+
+        UpdateNotificationTemplateCommand command = new UpdateNotificationTemplateCommand(
+                "수정된 제목",
+                "수정된 본문 {productName}",
+                "/updated/{orderId}"
+        );
+
+        when(findNotificationTemplatePort.findActiveById(1L))
+                .thenReturn(Optional.of(template));
+
+        // when
+        UpdateNotificationTemplateResult result = updateNotificationTemplateService.updateNotificationTemplate(1L, command);
+
+        // then
+        assertThat(result.title()).isEqualTo("수정된 제목");
+        assertThat(result.bodyTemplate()).isEqualTo("수정된 본문 {productName}");
+        assertThat(result.urlTemplate()).isEqualTo("/updated/{orderId}");
+        verify(updateNotificationTemplatePort).update(any(NotificationTemplate.class));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 템플릿을 수정하면 예외가 발생한다")
+    void shouldThrowExceptionWhenTemplateNotFound() {
+        // given
+        UpdateNotificationTemplateCommand command = new UpdateNotificationTemplateCommand(
+                "제목", "본문", "/url"
+        );
+
+        when(findNotificationTemplatePort.findActiveById(999L))
+                .thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> updateNotificationTemplateService.updateNotificationTemplate(999L, command))
+                .isInstanceOf(NotificationTemplateNotFoundException.class);
+        verify(updateNotificationTemplatePort, never()).update(any());
+    }
+}

--- a/notification-service/notification-domain/src/test/java/com/personal/marketnote/notification/domain/template/NotificationTemplateTest.java
+++ b/notification-service/notification-domain/src/test/java/com/personal/marketnote/notification/domain/template/NotificationTemplateTest.java
@@ -1,0 +1,220 @@
+package com.personal.marketnote.notification.domain.template;
+
+import com.personal.marketnote.common.domain.EntityStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class NotificationTemplateTest {
+
+    @Nested
+    @DisplayName("from(CreateState) 팩토리 메서드")
+    class FromCreateState {
+
+        @Test
+        @DisplayName("유효한 값으로 알림 템플릿을 생성한다")
+        void shouldCreateNotificationTemplateWithValidValues() {
+            // given
+            NotificationTemplateCreateState state = NotificationTemplateCreateState.builder()
+                    .templateCode("ORDER_PAYMENT_COMPLETED")
+                    .notificationType(NotificationType.ORDER_PAYMENT_COMPLETED)
+                    .title("주문이 완료되었습니다")
+                    .bodyTemplate("{productName} 외 {count}건이 결제되었습니다.")
+                    .urlTemplate("/order/{orderId}")
+                    .build();
+
+            // when
+            NotificationTemplate template = NotificationTemplate.from(state);
+
+            // then
+            assertThat(template.getTemplateCode()).isEqualTo("ORDER_PAYMENT_COMPLETED");
+            assertThat(template.getNotificationType()).isEqualTo(NotificationType.ORDER_PAYMENT_COMPLETED);
+            assertThat(template.getTitle()).isEqualTo("주문이 완료되었습니다");
+            assertThat(template.getBodyTemplate()).isEqualTo("{productName} 외 {count}건이 결제되었습니다.");
+            assertThat(template.getUrlTemplate()).isEqualTo("/order/{orderId}");
+            assertThat(template.isActive()).isTrue();
+        }
+
+        @Test
+        @DisplayName("templateCode가 null이면 예외가 발생한다")
+        void shouldThrowExceptionWhenTemplateCodeIsNull() {
+            // given
+            NotificationTemplateCreateState state = NotificationTemplateCreateState.builder()
+                    .templateCode(null)
+                    .notificationType(NotificationType.ORDER_PAYMENT_COMPLETED)
+                    .title("주문이 완료되었습니다")
+                    .bodyTemplate("본문")
+                    .urlTemplate("/order/{orderId}")
+                    .build();
+
+            // when & then
+            assertThatThrownBy(() -> NotificationTemplate.from(state))
+                    .isInstanceOf(InvalidTemplateCodeException.class);
+        }
+
+        @Test
+        @DisplayName("templateCode가 빈 문자열이면 예외가 발생한다")
+        void shouldThrowExceptionWhenTemplateCodeIsBlank() {
+            // given
+            NotificationTemplateCreateState state = NotificationTemplateCreateState.builder()
+                    .templateCode("   ")
+                    .notificationType(NotificationType.ORDER_PAYMENT_COMPLETED)
+                    .title("주문이 완료되었습니다")
+                    .bodyTemplate("본문")
+                    .urlTemplate("/order/{orderId}")
+                    .build();
+
+            // when & then
+            assertThatThrownBy(() -> NotificationTemplate.from(state))
+                    .isInstanceOf(InvalidTemplateCodeException.class);
+        }
+
+        @Test
+        @DisplayName("urlTemplate이 null이면 null로 생성된다")
+        void shouldCreateTemplateWithNullUrlTemplate() {
+            // given
+            NotificationTemplateCreateState state = NotificationTemplateCreateState.builder()
+                    .templateCode("POINT_ACCRUAL")
+                    .notificationType(NotificationType.POINT_ACCRUAL)
+                    .title("포인트가 적립되었습니다")
+                    .bodyTemplate("{amount}P가 적립되었습니다.")
+                    .urlTemplate(null)
+                    .build();
+
+            // when
+            NotificationTemplate template = NotificationTemplate.from(state);
+
+            // then
+            assertThat(template.getUrlTemplate()).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("from(SnapshotState) 팩토리 메서드")
+    class FromSnapshotState {
+
+        @Test
+        @DisplayName("DB 스냅샷으로부터 알림 템플릿을 복원한다")
+        void shouldRestoreNotificationTemplateFromSnapshot() {
+            // given
+            LocalDateTime now = LocalDateTime.of(2026, 4, 9, 12, 0);
+            NotificationTemplateSnapshotState state = NotificationTemplateSnapshotState.builder()
+                    .id(1L)
+                    .templateCode("SHIPPING_STARTED")
+                    .notificationType(NotificationType.SHIPPING_STARTED)
+                    .title("배송이 시작되었습니다")
+                    .bodyTemplate("{productName} 상품이 발송되었습니다.")
+                    .urlTemplate("/order/{orderId}")
+                    .status(EntityStatus.ACTIVE)
+                    .createdAt(now)
+                    .modifiedAt(now)
+                    .build();
+
+            // when
+            NotificationTemplate template = NotificationTemplate.from(state);
+
+            // then
+            assertThat(template.getId()).isEqualTo(1L);
+            assertThat(template.getTemplateCode()).isEqualTo("SHIPPING_STARTED");
+            assertThat(template.getNotificationType()).isEqualTo(NotificationType.SHIPPING_STARTED);
+            assertThat(template.getTitle()).isEqualTo("배송이 시작되었습니다");
+            assertThat(template.getBodyTemplate()).isEqualTo("{productName} 상품이 발송되었습니다.");
+            assertThat(template.getUrlTemplate()).isEqualTo("/order/{orderId}");
+            assertThat(template.isActive()).isTrue();
+            assertThat(template.getCreatedAt()).isEqualTo(now);
+            assertThat(template.getModifiedAt()).isEqualTo(now);
+        }
+
+        @Test
+        @DisplayName("비활성화 상태의 템플릿도 그대로 복원한다")
+        void shouldRestoreInactiveTemplateFromSnapshot() {
+            // given
+            LocalDateTime now = LocalDateTime.of(2026, 4, 9, 12, 0);
+            NotificationTemplateSnapshotState state = NotificationTemplateSnapshotState.builder()
+                    .id(2L)
+                    .templateCode("OLD_TEMPLATE")
+                    .notificationType(NotificationType.NOTICE)
+                    .title("공지사항")
+                    .bodyTemplate("공지사항 본문")
+                    .urlTemplate("/notice/{postId}")
+                    .status(EntityStatus.INACTIVE)
+                    .createdAt(now)
+                    .modifiedAt(now)
+                    .build();
+
+            // when
+            NotificationTemplate template = NotificationTemplate.from(state);
+
+            // then
+            assertThat(template.isInactive()).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("update 메서드")
+    class Update {
+
+        @Test
+        @DisplayName("알림 템플릿 정보를 수정한다")
+        void shouldUpdateNotificationTemplateInfo() {
+            // given
+            NotificationTemplate template = createDefaultTemplate();
+
+            // when
+            template.update("수정된 제목", "수정된 본문 {name}", "/updated/{id}");
+
+            // then
+            assertThat(template.getTitle()).isEqualTo("수정된 제목");
+            assertThat(template.getBodyTemplate()).isEqualTo("수정된 본문 {name}");
+            assertThat(template.getUrlTemplate()).isEqualTo("/updated/{id}");
+        }
+
+        @Test
+        @DisplayName("urlTemplate을 null로 수정할 수 있다")
+        void shouldUpdateUrlTemplateToNull() {
+            // given
+            NotificationTemplate template = createDefaultTemplate();
+
+            // when
+            template.update("제목", "본문", null);
+
+            // then
+            assertThat(template.getUrlTemplate()).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("상태 전이 메서드")
+    class StatusTransition {
+
+        @Test
+        @DisplayName("알림 템플릿을 비활성화한다")
+        void shouldDeactivateNotificationTemplate() {
+            // given
+            NotificationTemplate template = createDefaultTemplate();
+            assertThat(template.isActive()).isTrue();
+
+            // when
+            template.deactivate();
+
+            // then
+            assertThat(template.isInactive()).isTrue();
+        }
+    }
+
+    private NotificationTemplate createDefaultTemplate() {
+        NotificationTemplateCreateState state = NotificationTemplateCreateState.builder()
+                .templateCode("ORDER_PAYMENT_COMPLETED")
+                .notificationType(NotificationType.ORDER_PAYMENT_COMPLETED)
+                .title("주문이 완료되었습니다")
+                .bodyTemplate("{productName} 외 {count}건이 결제되었습니다.")
+                .urlTemplate("/order/{orderId}")
+                .build();
+        return NotificationTemplate.from(state);
+    }
+}

--- a/notification-service/notification-domain/src/test/java/com/personal/marketnote/notification/domain/template/TemplateRendererTest.java
+++ b/notification-service/notification-domain/src/test/java/com/personal/marketnote/notification/domain/template/TemplateRendererTest.java
@@ -1,0 +1,125 @@
+package com.personal.marketnote.notification.domain.template;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class TemplateRendererTest {
+
+    @Nested
+    @DisplayName("render 메서드")
+    class Render {
+
+        @Test
+        @DisplayName("템플릿 변수를 치환한다")
+        void shouldReplaceTemplateVariables() {
+            // given
+            String template = "{productName} 외 {count}건이 결제되었습니다.";
+            Map<String, String> variables = Map.of(
+                    "productName", "비타민C",
+                    "count", "2"
+            );
+
+            // when
+            String result = TemplateRenderer.render(template, variables);
+
+            // then
+            assertThat(result).isEqualTo("비타민C 외 2건이 결제되었습니다.");
+        }
+
+        @Test
+        @DisplayName("변수가 없는 템플릿은 그대로 반환한다")
+        void shouldReturnTemplateAsIsWhenNoVariables() {
+            // given
+            String template = "주문이 완료되었습니다.";
+            Map<String, String> variables = Map.of();
+
+            // when
+            String result = TemplateRenderer.render(template, variables);
+
+            // then
+            assertThat(result).isEqualTo("주문이 완료되었습니다.");
+        }
+
+        @Test
+        @DisplayName("여러 변수를 동시에 치환한다")
+        void shouldReplaceMultipleVariables() {
+            // given
+            String template = "{userName}님, {productName} 주문이 {status}되었습니다.";
+            Map<String, String> variables = Map.of(
+                    "userName", "홍길동",
+                    "productName", "프로틴바",
+                    "status", "확인"
+            );
+
+            // when
+            String result = TemplateRenderer.render(template, variables);
+
+            // then
+            assertThat(result).isEqualTo("홍길동님, 프로틴바 주문이 확인되었습니다.");
+        }
+
+        @Test
+        @DisplayName("미치환 변수가 남으면 예외가 발생한다")
+        void shouldThrowExceptionWhenUnresolvedVariablesRemain() {
+            // given
+            String template = "{productName} 외 {count}건이 결제되었습니다.";
+            Map<String, String> variables = Map.of("productName", "비타민C");
+
+            // when & then
+            assertThatThrownBy(() -> TemplateRenderer.render(template, variables))
+                    .isInstanceOf(InvalidTemplateVariableException.class);
+        }
+
+        @Test
+        @DisplayName("null 템플릿이면 null을 반환한다")
+        void shouldReturnNullWhenTemplateIsNull() {
+            // when
+            String result = TemplateRenderer.render(null, Map.of());
+
+            // then
+            assertThat(result).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("renderUrl 메서드")
+    class RenderUrl {
+
+        @Test
+        @DisplayName("URL 템플릿 변수를 치환한다")
+        void shouldReplaceUrlTemplateVariables() {
+            // given
+            String urlTemplate = "/order/{orderId}";
+            Map<String, String> variables = Map.of("orderId", "12345");
+
+            // when
+            String result = TemplateRenderer.render(urlTemplate, variables);
+
+            // then
+            assertThat(result).isEqualTo("/order/12345");
+        }
+
+        @Test
+        @DisplayName("쿼리 파라미터가 포함된 URL 템플릿 변수를 치환한다")
+        void shouldReplaceUrlTemplateWithQueryParams() {
+            // given
+            String urlTemplate = "/review/create/{orderId}?pricePolicyId={pricePolicyId}";
+            Map<String, String> variables = Map.of(
+                    "orderId", "100",
+                    "pricePolicyId", "200"
+            );
+
+            // when
+            String result = TemplateRenderer.render(urlTemplate, variables);
+
+            // then
+            assertThat(result).isEqualTo("/review/create/100?pricePolicyId=200");
+        }
+    }
+}


### PR DESCRIPTION
## partially addresses #2090
## resolves #2560

## Test Case
- [x] 유효한 값으로 알림 템플릿을 생성한다
- [x] templateCode가 null이면 예외가 발생한다
- [x] templateCode가 빈 문자열이면 예외가 발생한다
- [x] urlTemplate이 null이면 null로 생성된다
- [x] DB 스냅샷으로부터 알림 템플릿을 복원한다
- [x] 비활성화 상태의 템플릿도 그대로 복원한다
- [x] 알림 템플릿 정보를 수정한다
- [x] urlTemplate을 null로 수정할 수 있다
- [x] 알림 템플릿을 비활성화한다
- [x] 템플릿 변수를 치환한다
- [x] 변수가 없는 템플릿은 그대로 반환한다
- [x] 여러 변수를 동시에 치환한다
- [x] 미치환 변수가 남으면 예외가 발생한다
- [x] null 템플릿이면 null을 반환한다
- [x] URL 템플릿 변수를 치환한다
- [x] 쿼리 파라미터가 포함된 URL 템플릿 변수를 치환한다
- [x] 알림 템플릿을 등록한다
- [x] 이미 존재하는 템플릿 코드로 등록하면 예외가 발생한다
- [x] ID로 알림 템플릿을 조회한다
- [x] 존재하지 않는 ID로 조회하면 예외가 발생한다
- [x] 전체 알림 템플릿을 조회한다
- [x] 알림 템플릿이 없으면 빈 목록을 반환한다
- [x] 알림 템플릿을 수정한다
- [x] 존재하지 않는 템플릿을 수정하면 예외가 발생한다
- [x] 알림 템플릿을 비활성화(삭제)한다
- [x] 존재하지 않는 템플릿을 삭제하면 예외가 발생한다