### PR TITLE
[#2090][#2118] feat: 알림 발송 정책 분류 체계 구축

### DIFF
--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/event/OrderPaymentCompletedOutboundConsumer.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/event/OrderPaymentCompletedOutboundConsumer.java
@@ -6,6 +6,9 @@ import com.personal.marketnote.common.kafka.event.EventEnvelope;
 import com.personal.marketnote.common.kafka.event.EventPayloadValidator;
 import com.personal.marketnote.common.kafka.event.OrderPaymentCompletedEvent;
 import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.fulfillment.exception.ShippingTrackerAlreadyExistsException;
+import com.personal.marketnote.fulfillment.port.in.command.CreateShippingTrackerCommand;
+import com.personal.marketnote.fulfillment.port.in.usecase.CreateShippingTrackerUseCase;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -18,6 +21,7 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class OrderPaymentCompletedOutboundConsumer {
     private final ObjectMapper objectMapper;
+    private final CreateShippingTrackerUseCase createShippingTrackerUseCase;
 
     @KafkaListener(
             topics = KafkaTopicConstants.ORDER_PAYMENT_COMPLETED,
@@ -79,8 +83,13 @@ public class OrderPaymentCompletedOutboundConsumer {
             //  — orderId 기반 출고 이력 DB 저장 (UNIQUE 제약) → 중복 시 FulfillmentDeliveryAlreadyRegisteredException
             //  — Consumer에서 FulfillmentDeliveryAlreadyRegisteredException catch → warn + acknowledge
 
-            log.info("Fulfillment 출고 요청 이벤트 검증 완료. orderId={}, orderProducts={}건",
+            createShippingTracker(payload.orderId(), envelope.eventId());
+
+            log.info("Fulfillment 출고 요청 이벤트 처리 완료. orderId={}, orderProducts={}건",
                     payload.orderId(), payload.orderProducts().size());
+        } catch (ShippingTrackerAlreadyExistsException e) {
+            log.warn("이미 배송 추적이 등록된 주문 (멱등 처리). eventId={}, orderId={}",
+                    envelope.eventId(), e.getMessage());
         } catch (Exception e) {
             log.error("Fulfillment 출고 요청 이벤트 처리 실패. eventId={}, key={}, error={}",
                     envelope.eventId(), record.key(), e.getMessage(), e);
@@ -88,5 +97,11 @@ public class OrderPaymentCompletedOutboundConsumer {
         }
 
         acknowledgment.acknowledge();
+    }
+
+    private void createShippingTracker(Long orderId, String eventId) {
+        CreateShippingTrackerCommand command = new CreateShippingTrackerCommand(orderId);
+        createShippingTrackerUseCase.createShippingTracker(command);
+        log.info("배송 추적 생성 완료. eventId={}, orderId={}", eventId, orderId);
     }
 }

--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/web/template/controller/NotificationTemplateController.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/web/template/controller/NotificationTemplateController.java
@@ -66,6 +66,7 @@ public class NotificationTemplateController {
                 new RegisterNotificationTemplateCommand(
                         request.templateCode(),
                         request.notificationType().name(),
+                        request.notificationCategory().name(),
                         request.title(),
                         request.bodyTemplate(),
                         request.urlTemplate()

--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/web/template/controller/apidocs/GetNotificationTemplateApiDocs.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/web/template/controller/apidocs/GetNotificationTemplateApiDocs.java
@@ -47,6 +47,7 @@ import java.lang.annotation.*;
                 | id | number | 템플릿 ID | 1 |
                 | templateCode | string | 템플릿 코드 | "ORDER_PAYMENT_COMPLETED" |
                 | notificationType | string | 알림 유형 | "ORDER_PAYMENT_COMPLETED" |
+                | notificationCategory | string | 알림 카테고리 | "INFORMATIONAL" |
                 | title | string | 제목 | "주문이 완료되었습니다" |
                 | bodyTemplate | string | 본문 템플릿 | "{productName} 외 {count}건이 결제되었습니다." |
                 | urlTemplate | string | URL 템플릿 | "/order/{orderId}" |
@@ -69,6 +70,7 @@ import java.lang.annotation.*;
                                             "id": 1,
                                             "templateCode": "ORDER_PAYMENT_COMPLETED",
                                             "notificationType": "ORDER_PAYMENT_COMPLETED",
+                                            "notificationCategory": "INFORMATIONAL",
                                             "title": "주문이 완료되었습니다",
                                             "bodyTemplate": "{productName} 외 {count}건이 결제되었습니다.",
                                             "urlTemplate": "/order/{orderId}",

--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/web/template/controller/apidocs/GetNotificationTemplatesApiDocs.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/web/template/controller/apidocs/GetNotificationTemplatesApiDocs.java
@@ -49,6 +49,7 @@ import java.lang.annotation.*;
                 | id | number | 템플릿 ID | 1 |
                 | templateCode | string | 템플릿 코드 | "ORDER_PAYMENT_COMPLETED" |
                 | notificationType | string | 알림 유형 | "ORDER_PAYMENT_COMPLETED" |
+                | notificationCategory | string | 알림 카테고리 | "INFORMATIONAL" |
                 | title | string | 제목 | "주문이 완료되었습니다" |
                 | bodyTemplate | string | 본문 템플릿 | "{productName} 외 {count}건이 결제되었습니다." |
                 | urlTemplate | string | URL 템플릿 | "/order/{orderId}" |
@@ -72,6 +73,7 @@ import java.lang.annotation.*;
                                               "id": 1,
                                               "templateCode": "ORDER_PAYMENT_COMPLETED",
                                               "notificationType": "ORDER_PAYMENT_COMPLETED",
+                                              "notificationCategory": "INFORMATIONAL",
                                               "title": "주문이 완료되었습니다",
                                               "bodyTemplate": "{productName} 외 {count}건이 결제되었습니다.",
                                               "urlTemplate": "/order/{orderId}",

--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/web/template/controller/apidocs/RegisterNotificationTemplateApiDocs.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/web/template/controller/apidocs/RegisterNotificationTemplateApiDocs.java
@@ -42,6 +42,7 @@ import java.lang.annotation.*;
                 | --- | --- | --- | --- | --- |
                 | templateCode | string | 템플릿 코드 | Y | "ORDER_PAYMENT_COMPLETED" |
                 | notificationType | string | 알림 유형 | Y | "ORDER_PAYMENT_COMPLETED" |
+                | notificationCategory | string | 알림 카테고리 (MANDATORY/INFORMATIONAL/PROMOTIONAL) | Y | "INFORMATIONAL" |
                 | title | string | 제목 | Y | "주문이 완료되었습니다" |
                 | bodyTemplate | string | 본문 템플릿 | Y | "{productName} 외 {count}건이 결제되었습니다." |
                 | urlTemplate | string | URL 템플릿 | N | "/order/{orderId}" |
@@ -63,6 +64,7 @@ import java.lang.annotation.*;
                 | **키** | **타입** | **설명** | **예시** |
                 | --- | --- | --- | --- |
                 | id | number | 생성된 템플릿 ID | 1 |
+                | notificationCategory | string | 알림 카테고리 | "INFORMATIONAL" |
                 """,
         security = {@SecurityRequirement(name = "bearer")},
         requestBody = @RequestBody(
@@ -73,6 +75,7 @@ import java.lang.annotation.*;
                                 {
                                   "templateCode": "ORDER_PAYMENT_COMPLETED",
                                   "notificationType": "ORDER_PAYMENT_COMPLETED",
+                                  "notificationCategory": "INFORMATIONAL",
                                   "title": "주문이 완료되었습니다",
                                   "bodyTemplate": "{productName} 외 {count}건이 결제되었습니다.",
                                   "urlTemplate": "/order/{orderId}"

--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/web/template/controller/apidocs/UpdateNotificationTemplateApiDocs.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/web/template/controller/apidocs/UpdateNotificationTemplateApiDocs.java
@@ -61,6 +61,7 @@ import java.lang.annotation.*;
                 | id | number | 템플릿 ID | 1 |
                 | templateCode | string | 템플릿 코드 | "ORDER_PAYMENT_COMPLETED" |
                 | notificationType | string | 알림 유형 | "ORDER_PAYMENT_COMPLETED" |
+                | notificationCategory | string | 알림 카테고리 | "INFORMATIONAL" |
                 | title | string | 제목 | "수정된 알림 제목" |
                 | bodyTemplate | string | 본문 템플릿 | "수정된 본문 {productName}" |
                 | urlTemplate | string | URL 템플릿 | "/order/{orderId}" |
@@ -94,6 +95,7 @@ import java.lang.annotation.*;
                                             "id": 1,
                                             "templateCode": "ORDER_PAYMENT_COMPLETED",
                                             "notificationType": "ORDER_PAYMENT_COMPLETED",
+                                            "notificationCategory": "INFORMATIONAL",
                                             "title": "수정된 알림 제목",
                                             "bodyTemplate": "수정된 본문 {productName}",
                                             "urlTemplate": "/order/{orderId}"

--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/web/template/request/RegisterNotificationTemplateRequest.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/web/template/request/RegisterNotificationTemplateRequest.java
@@ -1,5 +1,6 @@
 package com.personal.marketnote.notification.adapter.in.web.template.request;
 
+import com.personal.marketnote.notification.domain.template.NotificationCategory;
 import com.personal.marketnote.notification.domain.template.NotificationType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
@@ -15,6 +16,10 @@ public record RegisterNotificationTemplateRequest(
         @NotNull(message = "알림 유형은 필수입니다")
         @Schema(description = "알림 유형", example = "ORDER_PAYMENT_COMPLETED")
         NotificationType notificationType,
+
+        @NotNull(message = "알림 카테고리는 필수입니다")
+        @Schema(description = "알림 카테고리", example = "INFORMATIONAL")
+        NotificationCategory notificationCategory,
 
         @NotBlank(message = "제목은 필수입니다")
         @Size(max = 200, message = "제목은 200자 이하여야 합니다")

--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/web/template/response/GetNotificationTemplateResponse.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/web/template/response/GetNotificationTemplateResponse.java
@@ -1,5 +1,6 @@
 package com.personal.marketnote.notification.adapter.in.web.template.response;
 
+import com.personal.marketnote.notification.domain.template.NotificationCategory;
 import com.personal.marketnote.notification.domain.template.NotificationType;
 import com.personal.marketnote.notification.port.in.result.template.GetNotificationTemplateResult;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -15,6 +16,9 @@ public record GetNotificationTemplateResponse(
 
         @Schema(description = "알림 유형", example = "ORDER_PAYMENT_COMPLETED")
         NotificationType notificationType,
+
+        @Schema(description = "알림 카테고리", example = "INFORMATIONAL")
+        NotificationCategory notificationCategory,
 
         @Schema(description = "제목", example = "주문이 완료되었습니다")
         String title,
@@ -37,6 +41,7 @@ public record GetNotificationTemplateResponse(
                 result.id(),
                 result.templateCode(),
                 result.notificationType(),
+                result.notificationCategory(),
                 result.title(),
                 result.bodyTemplate(),
                 result.urlTemplate(),

--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/web/template/response/UpdateNotificationTemplateResponse.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/web/template/response/UpdateNotificationTemplateResponse.java
@@ -1,5 +1,6 @@
 package com.personal.marketnote.notification.adapter.in.web.template.response;
 
+import com.personal.marketnote.notification.domain.template.NotificationCategory;
 import com.personal.marketnote.notification.domain.template.NotificationType;
 import com.personal.marketnote.notification.port.in.result.template.UpdateNotificationTemplateResult;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -13,6 +14,9 @@ public record UpdateNotificationTemplateResponse(
 
         @Schema(description = "알림 유형", example = "ORDER_PAYMENT_COMPLETED")
         NotificationType notificationType,
+
+        @Schema(description = "알림 카테고리", example = "INFORMATIONAL")
+        NotificationCategory notificationCategory,
 
         @Schema(description = "제목", example = "수정된 제목")
         String title,
@@ -29,6 +33,7 @@ public record UpdateNotificationTemplateResponse(
                 result.id(),
                 result.templateCode(),
                 result.notificationType(),
+                result.notificationCategory(),
                 result.title(),
                 result.bodyTemplate(),
                 result.urlTemplate()

--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/out/mapper/NotificationTemplateJpaEntityToDomainMapper.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/out/mapper/NotificationTemplateJpaEntityToDomainMapper.java
@@ -18,6 +18,7 @@ public class NotificationTemplateJpaEntityToDomainMapper {
                                 .id(e.getId())
                                 .templateCode(e.getTemplateCode())
                                 .notificationType(e.getNotificationType())
+                                .notificationCategory(e.getNotificationCategory())
                                 .title(e.getTitle())
                                 .bodyTemplate(e.getBodyTemplate())
                                 .urlTemplate(e.getUrlTemplate())

--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/out/persistence/template/entity/NotificationTemplateJpaEntity.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/out/persistence/template/entity/NotificationTemplateJpaEntity.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.notification.adapter.out.persistence.template.entity;
 
 import com.personal.marketnote.common.adapter.out.persistence.audit.BaseGeneralEntity;
+import com.personal.marketnote.notification.domain.template.NotificationCategory;
 import com.personal.marketnote.notification.domain.template.NotificationTemplate;
 import com.personal.marketnote.notification.domain.template.NotificationType;
 import jakarta.persistence.*;
@@ -25,6 +26,10 @@ public class NotificationTemplateJpaEntity extends BaseGeneralEntity {
     @Enumerated(EnumType.STRING)
     private NotificationType notificationType;
 
+    @Column(name = "notification_category", nullable = false, length = 30)
+    @Enumerated(EnumType.STRING)
+    private NotificationCategory notificationCategory;
+
     @Column(name = "title", nullable = false, length = 200)
     private String title;
 
@@ -38,6 +43,7 @@ public class NotificationTemplateJpaEntity extends BaseGeneralEntity {
         return NotificationTemplateJpaEntity.builder()
                 .templateCode(template.getTemplateCode())
                 .notificationType(template.getNotificationType())
+                .notificationCategory(template.getNotificationCategory())
                 .title(template.getTitle())
                 .bodyTemplate(template.getBodyTemplate())
                 .urlTemplate(template.getUrlTemplate())

--- a/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/mapper/NotificationTemplateCommandToStateMapper.java
+++ b/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/mapper/NotificationTemplateCommandToStateMapper.java
@@ -1,5 +1,6 @@
 package com.personal.marketnote.notification.mapper;
 
+import com.personal.marketnote.notification.domain.template.NotificationCategory;
 import com.personal.marketnote.notification.domain.template.NotificationTemplateCreateState;
 import com.personal.marketnote.notification.domain.template.NotificationType;
 import com.personal.marketnote.notification.port.in.command.RegisterNotificationTemplateCommand;
@@ -13,6 +14,7 @@ public class NotificationTemplateCommandToStateMapper {
         return NotificationTemplateCreateState.builder()
                 .templateCode(command.templateCode())
                 .notificationType(NotificationType.valueOf(command.notificationType()))
+                .notificationCategory(NotificationCategory.valueOf(command.notificationCategory()))
                 .title(command.title())
                 .bodyTemplate(command.bodyTemplate())
                 .urlTemplate(command.urlTemplate())

--- a/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/in/command/RegisterNotificationTemplateCommand.java
+++ b/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/in/command/RegisterNotificationTemplateCommand.java
@@ -3,6 +3,7 @@ package com.personal.marketnote.notification.port.in.command;
 public record RegisterNotificationTemplateCommand(
         String templateCode,
         String notificationType,
+        String notificationCategory,
         String title,
         String bodyTemplate,
         String urlTemplate

--- a/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/in/result/template/GetNotificationTemplateResult.java
+++ b/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/in/result/template/GetNotificationTemplateResult.java
@@ -1,5 +1,6 @@
 package com.personal.marketnote.notification.port.in.result.template;
 
+import com.personal.marketnote.notification.domain.template.NotificationCategory;
 import com.personal.marketnote.notification.domain.template.NotificationTemplate;
 import com.personal.marketnote.notification.domain.template.NotificationType;
 
@@ -9,6 +10,7 @@ public record GetNotificationTemplateResult(
         Long id,
         String templateCode,
         NotificationType notificationType,
+        NotificationCategory notificationCategory,
         String title,
         String bodyTemplate,
         String urlTemplate,
@@ -21,6 +23,7 @@ public record GetNotificationTemplateResult(
                 template.getId(),
                 template.getTemplateCode(),
                 template.getNotificationType(),
+                template.getNotificationCategory(),
                 template.getTitle(),
                 template.getBodyTemplate(),
                 template.getUrlTemplate(),

--- a/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/in/result/template/UpdateNotificationTemplateResult.java
+++ b/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/in/result/template/UpdateNotificationTemplateResult.java
@@ -1,5 +1,6 @@
 package com.personal.marketnote.notification.port.in.result.template;
 
+import com.personal.marketnote.notification.domain.template.NotificationCategory;
 import com.personal.marketnote.notification.domain.template.NotificationTemplate;
 import com.personal.marketnote.notification.domain.template.NotificationType;
 
@@ -7,6 +8,7 @@ public record UpdateNotificationTemplateResult(
         Long id,
         String templateCode,
         NotificationType notificationType,
+        NotificationCategory notificationCategory,
         String title,
         String bodyTemplate,
         String urlTemplate
@@ -17,6 +19,7 @@ public record UpdateNotificationTemplateResult(
                 template.getId(),
                 template.getTemplateCode(),
                 template.getNotificationType(),
+                template.getNotificationCategory(),
                 template.getTitle(),
                 template.getBodyTemplate(),
                 template.getUrlTemplate()

--- a/notification-service/notification-domain/src/main/java/com/personal/marketnote/notification/domain/template/NotificationCategory.java
+++ b/notification-service/notification-domain/src/main/java/com/personal/marketnote/notification/domain/template/NotificationCategory.java
@@ -1,0 +1,36 @@
+package com.personal.marketnote.notification.domain.template;
+
+public enum NotificationCategory {
+    MANDATORY("필수", false, false, false),
+    INFORMATIONAL("정보성", false, false, false),
+    PROMOTIONAL("광고성", true, true, true);
+
+    private final String description;
+    private final boolean consentRequired;
+    private final boolean nightRestricted;
+    private final boolean adLabelRequired;
+
+    NotificationCategory(String description, boolean consentRequired,
+                          boolean nightRestricted, boolean adLabelRequired) {
+        this.description = description;
+        this.consentRequired = consentRequired;
+        this.nightRestricted = nightRestricted;
+        this.adLabelRequired = adLabelRequired;
+    }
+
+    public boolean requiresConsent() {
+        return consentRequired;
+    }
+
+    public boolean hasNightRestriction() {
+        return nightRestricted;
+    }
+
+    public boolean requiresAdLabel() {
+        return adLabelRequired;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+}

--- a/notification-service/notification-domain/src/main/java/com/personal/marketnote/notification/domain/template/NotificationTemplate.java
+++ b/notification-service/notification-domain/src/main/java/com/personal/marketnote/notification/domain/template/NotificationTemplate.java
@@ -14,6 +14,7 @@ public class NotificationTemplate extends BaseDomain {
     private Long id;
     private String templateCode;
     private NotificationType notificationType;
+    private NotificationCategory notificationCategory;
     private String title;
     private String bodyTemplate;
     private String urlTemplate;
@@ -26,6 +27,7 @@ public class NotificationTemplate extends BaseDomain {
         NotificationTemplate template = NotificationTemplate.builder()
                 .templateCode(state.getTemplateCode())
                 .notificationType(state.getNotificationType())
+                .notificationCategory(state.getNotificationCategory())
                 .title(state.getTitle())
                 .bodyTemplate(state.getBodyTemplate())
                 .urlTemplate(state.getUrlTemplate())
@@ -39,6 +41,7 @@ public class NotificationTemplate extends BaseDomain {
                 .id(state.getId())
                 .templateCode(state.getTemplateCode())
                 .notificationType(state.getNotificationType())
+                .notificationCategory(state.getNotificationCategory())
                 .title(state.getTitle())
                 .bodyTemplate(state.getBodyTemplate())
                 .urlTemplate(state.getUrlTemplate())

--- a/notification-service/notification-domain/src/main/java/com/personal/marketnote/notification/domain/template/NotificationTemplateCreateState.java
+++ b/notification-service/notification-domain/src/main/java/com/personal/marketnote/notification/domain/template/NotificationTemplateCreateState.java
@@ -9,6 +9,7 @@ import lombok.*;
 public class NotificationTemplateCreateState {
     private String templateCode;
     private NotificationType notificationType;
+    private NotificationCategory notificationCategory;
     private String title;
     private String bodyTemplate;
     private String urlTemplate;

--- a/notification-service/notification-domain/src/main/java/com/personal/marketnote/notification/domain/template/NotificationTemplateSnapshotState.java
+++ b/notification-service/notification-domain/src/main/java/com/personal/marketnote/notification/domain/template/NotificationTemplateSnapshotState.java
@@ -13,6 +13,7 @@ public class NotificationTemplateSnapshotState {
     private Long id;
     private String templateCode;
     private NotificationType notificationType;
+    private NotificationCategory notificationCategory;
     private String title;
     private String bodyTemplate;
     private String urlTemplate;


### PR DESCRIPTION
## partially addresses #2090
## resolves #2118

## Task
- [x] NotificationCategory enum 정의 (MANDATORY, INFORMATIONAL, PROMOTIONAL)
- [x] MANDATORY: 수신 설정 무시, 필수 발송 (약관 변경, 배송 취소 등)
- [x] INFORMATIONAL: 별도 동의 불필요, 발송 (주문/배송 상태)
- [x] PROMOTIONAL: 수신 동의 확인 후 발송 (이벤트, 혜택)
- [x] NotificationTemplate 도메인/엔티티/DTO 전 계층에 notificationCategory 필드 추가
- [x] 카테고리별 정책 술어 메서드 구현 (requiresConsent, hasNightRestriction, requiresAdLabel)
- [x] RegisterNotificationTemplateCommand에 notificationCategory 필드 추가
- [x] ApiDocs 합성 애노테이션 4건 동기화 (Request/Response 테이블 + JSON 예시)