### PR TITLE
[#2090][#2564] test: 알림 발송 정책 분류 체계 구축 기능 자동화 테스트 추가

### DIFF
--- a/notification-service/notification-application/src/test/java/com/personal/marketnote/notification/service/template/DeleteNotificationTemplateUseCaseTest.java
+++ b/notification-service/notification-application/src/test/java/com/personal/marketnote/notification/service/template/DeleteNotificationTemplateUseCaseTest.java
@@ -1,9 +1,6 @@
 package com.personal.marketnote.notification.service.template;
 
-import com.personal.marketnote.notification.domain.template.NotificationTemplate;
-import com.personal.marketnote.notification.domain.template.NotificationTemplateCreateState;
-import com.personal.marketnote.notification.domain.template.NotificationTemplateNotFoundException;
-import com.personal.marketnote.notification.domain.template.NotificationType;
+import com.personal.marketnote.notification.domain.template.*;
 import com.personal.marketnote.notification.port.out.template.FindNotificationTemplatePort;
 import com.personal.marketnote.notification.port.out.template.UpdateNotificationTemplatePort;
 import org.junit.jupiter.api.DisplayName;
@@ -40,6 +37,7 @@ class DeleteNotificationTemplateUseCaseTest {
         NotificationTemplate template = NotificationTemplate.from(NotificationTemplateCreateState.builder()
                 .templateCode("ORDER_PAYMENT_COMPLETED")
                 .notificationType(NotificationType.ORDER_PAYMENT_COMPLETED)
+                .notificationCategory(NotificationCategory.INFORMATIONAL)
                 .title("주문이 완료되었습니다")
                 .bodyTemplate("본문")
                 .urlTemplate("/order/{orderId}")

--- a/notification-service/notification-application/src/test/java/com/personal/marketnote/notification/service/template/GetNotificationTemplateUseCaseTest.java
+++ b/notification-service/notification-application/src/test/java/com/personal/marketnote/notification/service/template/GetNotificationTemplateUseCaseTest.java
@@ -1,9 +1,6 @@
 package com.personal.marketnote.notification.service.template;
 
-import com.personal.marketnote.notification.domain.template.NotificationTemplate;
-import com.personal.marketnote.notification.domain.template.NotificationTemplateCreateState;
-import com.personal.marketnote.notification.domain.template.NotificationTemplateNotFoundException;
-import com.personal.marketnote.notification.domain.template.NotificationType;
+import com.personal.marketnote.notification.domain.template.*;
 import com.personal.marketnote.notification.port.in.result.template.GetNotificationTemplateResult;
 import com.personal.marketnote.notification.port.out.template.FindNotificationTemplatePort;
 import org.junit.jupiter.api.DisplayName;
@@ -102,6 +99,7 @@ class GetNotificationTemplateUseCaseTest {
         return NotificationTemplate.from(NotificationTemplateCreateState.builder()
                 .templateCode(templateCode)
                 .notificationType(type)
+                .notificationCategory(NotificationCategory.INFORMATIONAL)
                 .title(title)
                 .bodyTemplate("본문")
                 .urlTemplate("/order/{orderId}")

--- a/notification-service/notification-application/src/test/java/com/personal/marketnote/notification/service/template/RegisterNotificationTemplateUseCaseTest.java
+++ b/notification-service/notification-application/src/test/java/com/personal/marketnote/notification/service/template/RegisterNotificationTemplateUseCaseTest.java
@@ -1,9 +1,6 @@
 package com.personal.marketnote.notification.service.template;
 
-import com.personal.marketnote.notification.domain.template.DuplicateNotificationTemplateException;
-import com.personal.marketnote.notification.domain.template.NotificationTemplate;
-import com.personal.marketnote.notification.domain.template.NotificationTemplateCreateState;
-import com.personal.marketnote.notification.domain.template.NotificationType;
+import com.personal.marketnote.notification.domain.template.*;
 import com.personal.marketnote.notification.port.in.command.RegisterNotificationTemplateCommand;
 import com.personal.marketnote.notification.port.in.result.template.RegisterNotificationTemplateResult;
 import com.personal.marketnote.notification.port.out.template.FindNotificationTemplatePort;
@@ -41,6 +38,7 @@ class RegisterNotificationTemplateUseCaseTest {
         RegisterNotificationTemplateCommand command = new RegisterNotificationTemplateCommand(
                 "ORDER_PAYMENT_COMPLETED",
                 "ORDER_PAYMENT_COMPLETED",
+                "INFORMATIONAL",
                 "주문이 완료되었습니다",
                 "{productName} 외 {count}건이 결제되었습니다.",
                 "/order/{orderId}"
@@ -67,6 +65,7 @@ class RegisterNotificationTemplateUseCaseTest {
         RegisterNotificationTemplateCommand command = new RegisterNotificationTemplateCommand(
                 "ORDER_PAYMENT_COMPLETED",
                 "ORDER_PAYMENT_COMPLETED",
+                "INFORMATIONAL",
                 "주문이 완료되었습니다",
                 "본문",
                 "/order/{orderId}"
@@ -75,6 +74,7 @@ class RegisterNotificationTemplateUseCaseTest {
         NotificationTemplate existing = NotificationTemplate.from(NotificationTemplateCreateState.builder()
                 .templateCode("ORDER_PAYMENT_COMPLETED")
                 .notificationType(NotificationType.ORDER_PAYMENT_COMPLETED)
+                .notificationCategory(NotificationCategory.INFORMATIONAL)
                 .title("기존 제목")
                 .bodyTemplate("기존 본문")
                 .urlTemplate("/order/{orderId}")

--- a/notification-service/notification-application/src/test/java/com/personal/marketnote/notification/service/template/UpdateNotificationTemplateUseCaseTest.java
+++ b/notification-service/notification-application/src/test/java/com/personal/marketnote/notification/service/template/UpdateNotificationTemplateUseCaseTest.java
@@ -1,9 +1,6 @@
 package com.personal.marketnote.notification.service.template;
 
-import com.personal.marketnote.notification.domain.template.NotificationTemplate;
-import com.personal.marketnote.notification.domain.template.NotificationTemplateCreateState;
-import com.personal.marketnote.notification.domain.template.NotificationTemplateNotFoundException;
-import com.personal.marketnote.notification.domain.template.NotificationType;
+import com.personal.marketnote.notification.domain.template.*;
 import com.personal.marketnote.notification.port.in.command.UpdateNotificationTemplateCommand;
 import com.personal.marketnote.notification.port.in.result.template.UpdateNotificationTemplateResult;
 import com.personal.marketnote.notification.port.out.template.FindNotificationTemplatePort;
@@ -41,6 +38,7 @@ class UpdateNotificationTemplateUseCaseTest {
         NotificationTemplate template = NotificationTemplate.from(NotificationTemplateCreateState.builder()
                 .templateCode("ORDER_PAYMENT_COMPLETED")
                 .notificationType(NotificationType.ORDER_PAYMENT_COMPLETED)
+                .notificationCategory(NotificationCategory.INFORMATIONAL)
                 .title("주문이 완료되었습니다")
                 .bodyTemplate("기존 본문")
                 .urlTemplate("/order/{orderId}")

--- a/notification-service/notification-domain/src/test/java/com/personal/marketnote/notification/domain/template/NotificationCategoryTest.java
+++ b/notification-service/notification-domain/src/test/java/com/personal/marketnote/notification/domain/template/NotificationCategoryTest.java
@@ -1,0 +1,79 @@
+package com.personal.marketnote.notification.domain.template;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class NotificationCategoryTest {
+
+    @Nested
+    @DisplayName("MANDATORY 카테고리")
+    class Mandatory {
+
+        @Test
+        @DisplayName("수신 동의가 불필요하다")
+        void shouldNotRequireConsent() {
+            assertThat(NotificationCategory.MANDATORY.requiresConsent()).isFalse();
+        }
+
+        @Test
+        @DisplayName("야간 발송 제한이 없다")
+        void shouldNotHaveNightRestriction() {
+            assertThat(NotificationCategory.MANDATORY.hasNightRestriction()).isFalse();
+        }
+
+        @Test
+        @DisplayName("광고 표기가 불필요하다")
+        void shouldNotRequireAdLabel() {
+            assertThat(NotificationCategory.MANDATORY.requiresAdLabel()).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("INFORMATIONAL 카테고리")
+    class Informational {
+
+        @Test
+        @DisplayName("수신 동의가 불필요하다")
+        void shouldNotRequireConsent() {
+            assertThat(NotificationCategory.INFORMATIONAL.requiresConsent()).isFalse();
+        }
+
+        @Test
+        @DisplayName("야간 발송 제한이 없다")
+        void shouldNotHaveNightRestriction() {
+            assertThat(NotificationCategory.INFORMATIONAL.hasNightRestriction()).isFalse();
+        }
+
+        @Test
+        @DisplayName("광고 표기가 불필요하다")
+        void shouldNotRequireAdLabel() {
+            assertThat(NotificationCategory.INFORMATIONAL.requiresAdLabel()).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("PROMOTIONAL 카테고리")
+    class Promotional {
+
+        @Test
+        @DisplayName("수신 동의가 필요하다")
+        void shouldRequireConsent() {
+            assertThat(NotificationCategory.PROMOTIONAL.requiresConsent()).isTrue();
+        }
+
+        @Test
+        @DisplayName("야간 발송 제한이 있다")
+        void shouldHaveNightRestriction() {
+            assertThat(NotificationCategory.PROMOTIONAL.hasNightRestriction()).isTrue();
+        }
+
+        @Test
+        @DisplayName("광고 표기가 필요하다")
+        void shouldRequireAdLabel() {
+            assertThat(NotificationCategory.PROMOTIONAL.requiresAdLabel()).isTrue();
+        }
+    }
+}

--- a/notification-service/notification-domain/src/test/java/com/personal/marketnote/notification/domain/template/NotificationTemplateTest.java
+++ b/notification-service/notification-domain/src/test/java/com/personal/marketnote/notification/domain/template/NotificationTemplateTest.java
@@ -23,6 +23,7 @@ class NotificationTemplateTest {
             NotificationTemplateCreateState state = NotificationTemplateCreateState.builder()
                     .templateCode("ORDER_PAYMENT_COMPLETED")
                     .notificationType(NotificationType.ORDER_PAYMENT_COMPLETED)
+                    .notificationCategory(NotificationCategory.INFORMATIONAL)
                     .title("주문이 완료되었습니다")
                     .bodyTemplate("{productName} 외 {count}건이 결제되었습니다.")
                     .urlTemplate("/order/{orderId}")
@@ -34,6 +35,7 @@ class NotificationTemplateTest {
             // then
             assertThat(template.getTemplateCode()).isEqualTo("ORDER_PAYMENT_COMPLETED");
             assertThat(template.getNotificationType()).isEqualTo(NotificationType.ORDER_PAYMENT_COMPLETED);
+            assertThat(template.getNotificationCategory()).isEqualTo(NotificationCategory.INFORMATIONAL);
             assertThat(template.getTitle()).isEqualTo("주문이 완료되었습니다");
             assertThat(template.getBodyTemplate()).isEqualTo("{productName} 외 {count}건이 결제되었습니다.");
             assertThat(template.getUrlTemplate()).isEqualTo("/order/{orderId}");
@@ -47,6 +49,7 @@ class NotificationTemplateTest {
             NotificationTemplateCreateState state = NotificationTemplateCreateState.builder()
                     .templateCode(null)
                     .notificationType(NotificationType.ORDER_PAYMENT_COMPLETED)
+                    .notificationCategory(NotificationCategory.INFORMATIONAL)
                     .title("주문이 완료되었습니다")
                     .bodyTemplate("본문")
                     .urlTemplate("/order/{orderId}")
@@ -64,6 +67,7 @@ class NotificationTemplateTest {
             NotificationTemplateCreateState state = NotificationTemplateCreateState.builder()
                     .templateCode("   ")
                     .notificationType(NotificationType.ORDER_PAYMENT_COMPLETED)
+                    .notificationCategory(NotificationCategory.INFORMATIONAL)
                     .title("주문이 완료되었습니다")
                     .bodyTemplate("본문")
                     .urlTemplate("/order/{orderId}")
@@ -81,6 +85,7 @@ class NotificationTemplateTest {
             NotificationTemplateCreateState state = NotificationTemplateCreateState.builder()
                     .templateCode("POINT_ACCRUAL")
                     .notificationType(NotificationType.POINT_ACCRUAL)
+                    .notificationCategory(NotificationCategory.INFORMATIONAL)
                     .title("포인트가 적립되었습니다")
                     .bodyTemplate("{amount}P가 적립되었습니다.")
                     .urlTemplate(null)
@@ -107,6 +112,7 @@ class NotificationTemplateTest {
                     .id(1L)
                     .templateCode("SHIPPING_STARTED")
                     .notificationType(NotificationType.SHIPPING_STARTED)
+                    .notificationCategory(NotificationCategory.INFORMATIONAL)
                     .title("배송이 시작되었습니다")
                     .bodyTemplate("{productName} 상품이 발송되었습니다.")
                     .urlTemplate("/order/{orderId}")
@@ -122,6 +128,7 @@ class NotificationTemplateTest {
             assertThat(template.getId()).isEqualTo(1L);
             assertThat(template.getTemplateCode()).isEqualTo("SHIPPING_STARTED");
             assertThat(template.getNotificationType()).isEqualTo(NotificationType.SHIPPING_STARTED);
+            assertThat(template.getNotificationCategory()).isEqualTo(NotificationCategory.INFORMATIONAL);
             assertThat(template.getTitle()).isEqualTo("배송이 시작되었습니다");
             assertThat(template.getBodyTemplate()).isEqualTo("{productName} 상품이 발송되었습니다.");
             assertThat(template.getUrlTemplate()).isEqualTo("/order/{orderId}");
@@ -139,6 +146,7 @@ class NotificationTemplateTest {
                     .id(2L)
                     .templateCode("OLD_TEMPLATE")
                     .notificationType(NotificationType.NOTICE)
+                    .notificationCategory(NotificationCategory.PROMOTIONAL)
                     .title("공지사항")
                     .bodyTemplate("공지사항 본문")
                     .urlTemplate("/notice/{postId}")
@@ -211,6 +219,7 @@ class NotificationTemplateTest {
         NotificationTemplateCreateState state = NotificationTemplateCreateState.builder()
                 .templateCode("ORDER_PAYMENT_COMPLETED")
                 .notificationType(NotificationType.ORDER_PAYMENT_COMPLETED)
+                .notificationCategory(NotificationCategory.INFORMATIONAL)
                 .title("주문이 완료되었습니다")
                 .bodyTemplate("{productName} 외 {count}건이 결제되었습니다.")
                 .urlTemplate("/order/{orderId}")


### PR DESCRIPTION
## partially addresses #2090
## resolves #2564

## Test Case
- [x] MANDATORY 카테고리 - 수신 동의가 불필요하다
- [x] MANDATORY 카테고리 - 야간 발송 제한이 없다
- [x] MANDATORY 카테고리 - 광고 표기가 불필요하다
- [x] INFORMATIONAL 카테고리 - 수신 동의가 불필요하다
- [x] INFORMATIONAL 카테고리 - 야간 발송 제한이 없다
- [x] INFORMATIONAL 카테고리 - 광고 표기가 불필요하다
- [x] PROMOTIONAL 카테고리 - 수신 동의가 필요하다
- [x] PROMOTIONAL 카테고리 - 야간 발송 제한이 있다
- [x] PROMOTIONAL 카테고리 - 광고 표기가 필요하다
- [x] 기존 NotificationTemplate/UseCase 테스트에 notificationCategory 필드 반영