### PR TITLE
[#2143][#2146] feat: 파스토 배송 상태 폴링 스케줄러 추가

### DIFF
--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/scheduler/FulfillmentDeliveryStatusPollingScheduler.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/scheduler/FulfillmentDeliveryStatusPollingScheduler.java
@@ -1,0 +1,55 @@
+package com.personal.marketnote.fulfillment.adapter.in.scheduler;
+
+import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.fulfillment.configuration.FulfillmentAuthProperties;
+import com.personal.marketnote.fulfillment.port.in.command.PollShippingStatusCommand;
+import com.personal.marketnote.fulfillment.port.in.usecase.PollShippingStatusUseCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.Clock;
+import java.time.LocalTime;
+import java.time.ZoneId;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(prefix = "fulfillment.delivery-polling", name = "enabled", havingValue = "true")
+public class FulfillmentDeliveryStatusPollingScheduler {
+
+    private static final ZoneId POLLING_ZONE = ZoneId.of("Asia/Seoul");
+    private static final LocalTime POLLING_START_TIME = LocalTime.of(8, 0);
+    private static final LocalTime POLLING_END_TIME = LocalTime.of(21, 0);
+
+    private final PollShippingStatusUseCase pollShippingStatusUseCase;
+    private final FulfillmentAuthProperties fasstoAuthProperties;
+    private final Clock clock;
+
+    @Scheduled(fixedDelayString = "${fulfillment.delivery-polling.interval-ms:1800000}")
+    public void pollDeliveryStatuses() {
+        if (!isWithinPollingWindow()) {
+            log.debug("폴링 시간대(08~21시)가 아닙니다. 스킵합니다.");
+            return;
+        }
+
+        String customerCode = fasstoAuthProperties.getCustomerCode();
+        if (FormatValidator.hasNoValue(customerCode)) {
+            log.warn("Fulfillment customer code가 설정되지 않았습니다. 배송 상태 폴링을 스킵합니다.");
+            return;
+        }
+
+        try {
+            pollShippingStatusUseCase.pollShippingStatuses(new PollShippingStatusCommand(customerCode));
+        } catch (Exception e) {
+            log.error("배송 상태 폴링 실패: customerCode={}", customerCode, e);
+        }
+    }
+
+    private boolean isWithinPollingWindow() {
+        LocalTime now = LocalTime.now(clock.withZone(POLLING_ZONE));
+        return !now.isBefore(POLLING_START_TIME) && now.isBefore(POLLING_END_TIME);
+    }
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/persistence/shipping/ShippingTrackerPersistenceAdapter.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/persistence/shipping/ShippingTrackerPersistenceAdapter.java
@@ -1,17 +1,28 @@
 package com.personal.marketnote.fulfillment.adapter.out.persistence.shipping;
 
 import com.personal.marketnote.common.adapter.out.PersistenceAdapter;
+import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.fulfillment.adapter.out.persistence.shipping.entity.ShippingTrackerJpaEntity;
 import com.personal.marketnote.fulfillment.adapter.out.persistence.shipping.repository.ShippingTrackerJpaRepository;
 import com.personal.marketnote.fulfillment.domain.shipping.ShippingTracker;
+import com.personal.marketnote.fulfillment.domain.exception.ShippingTrackerNotFoundException;
 import com.personal.marketnote.fulfillment.exception.ShippingTrackerAlreadyExistsException;
+import com.personal.marketnote.fulfillment.port.out.shipping.FindShippingTrackerPort;
 import com.personal.marketnote.fulfillment.port.out.shipping.SaveShippingTrackerPort;
+import com.personal.marketnote.fulfillment.port.out.shipping.UpdateShippingTrackerPort;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
 
+import java.util.List;
+import java.util.Optional;
+
 @PersistenceAdapter
 @RequiredArgsConstructor
-public class ShippingTrackerPersistenceAdapter implements SaveShippingTrackerPort {
+public class ShippingTrackerPersistenceAdapter implements
+        SaveShippingTrackerPort,
+        FindShippingTrackerPort,
+        UpdateShippingTrackerPort {
+
     private final ShippingTrackerJpaRepository repository;
 
     @Override
@@ -21,5 +32,26 @@ public class ShippingTrackerPersistenceAdapter implements SaveShippingTrackerPor
         } catch (DataIntegrityViolationException e) {
             throw new ShippingTrackerAlreadyExistsException(shippingTracker.getOrderId());
         }
+    }
+
+    @Override
+    public List<ShippingTracker> findAllPollingActive() {
+        return repository.findByPollingActiveTrue().stream()
+                .map(ShippingTrackerJpaEntity::toDomain)
+                .toList();
+    }
+
+    @Override
+    public Optional<ShippingTracker> findByOrderId(Long orderId) {
+        return repository.findByOrderId(orderId)
+                .map(ShippingTrackerJpaEntity::toDomain);
+    }
+
+    @Override
+    public void update(ShippingTracker shippingTracker) {
+        if (FormatValidator.hasNoValue(shippingTracker.getId())) {
+            throw new ShippingTrackerNotFoundException(shippingTracker.getOrderId());
+        }
+        repository.saveAndFlush(ShippingTrackerJpaEntity.from(shippingTracker));
     }
 }

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/persistence/shipping/repository/ShippingTrackerJpaRepository.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/persistence/shipping/repository/ShippingTrackerJpaRepository.java
@@ -3,8 +3,11 @@ package com.personal.marketnote.fulfillment.adapter.out.persistence.shipping.rep
 import com.personal.marketnote.fulfillment.adapter.out.persistence.shipping.entity.ShippingTrackerJpaEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ShippingTrackerJpaRepository extends JpaRepository<ShippingTrackerJpaEntity, Long> {
     Optional<ShippingTrackerJpaEntity> findByOrderId(Long orderId);
+
+    List<ShippingTrackerJpaEntity> findByPollingActiveTrue();
 }

--- a/fulfillment-service/fulfillment-adapters/src/main/resources/application.yml
+++ b/fulfillment-service/fulfillment-adapters/src/main/resources/application.yml
@@ -103,6 +103,11 @@ vendor:
       api-cd: ${FASSTO_API_CD:change-me}
       api-key: ${FASSTO_API_KEY:change-me}
 
+fulfillment:
+  delivery-polling:
+    enabled: ${FULFILLMENT_DELIVERY_POLLING_ENABLED:false}
+    interval-ms: ${FULFILLMENT_DELIVERY_POLLING_INTERVAL_MS:1800000}
+
 commerce-service:
   base-url: ${COMMERCE_SERVICE_SERVER_ORIGIN:http://localhost:8082}
 

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/PollShippingStatusCommand.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/PollShippingStatusCommand.java
@@ -1,0 +1,6 @@
+package com.personal.marketnote.fulfillment.port.in.command;
+
+public record PollShippingStatusCommand(
+        String customerCode
+) {
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/usecase/PollShippingStatusUseCase.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/usecase/PollShippingStatusUseCase.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.fulfillment.port.in.usecase;
+
+import com.personal.marketnote.fulfillment.port.in.command.PollShippingStatusCommand;
+
+public interface PollShippingStatusUseCase {
+    void pollShippingStatuses(PollShippingStatusCommand command);
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/shipping/FindShippingTrackerPort.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/shipping/FindShippingTrackerPort.java
@@ -1,0 +1,12 @@
+package com.personal.marketnote.fulfillment.port.out.shipping;
+
+import com.personal.marketnote.fulfillment.domain.shipping.ShippingTracker;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface FindShippingTrackerPort {
+    List<ShippingTracker> findAllPollingActive();
+
+    Optional<ShippingTracker> findByOrderId(Long orderId);
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/shipping/UpdateShippingTrackerPort.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/shipping/UpdateShippingTrackerPort.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.fulfillment.port.out.shipping;
+
+import com.personal.marketnote.fulfillment.domain.shipping.ShippingTracker;
+
+public interface UpdateShippingTrackerPort {
+    void update(ShippingTracker shippingTracker);
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/shipping/FasstoCargoStatusMapper.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/shipping/FasstoCargoStatusMapper.java
@@ -1,0 +1,32 @@
+package com.personal.marketnote.fulfillment.service.shipping;
+
+import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.fulfillment.domain.shipping.ShippingStatus;
+
+import java.util.Set;
+
+class FasstoCargoStatusMapper {
+
+    private static final Set<String> PREPARING_STATUSES = Set.of("출고요청", "출고지시", "피킹중");
+    private static final String DELIVERED_STATUS = "배송완료";
+    private static final String DELIVERY_FAILED_STATUS = "배송불가";
+
+    private FasstoCargoStatusMapper() {
+    }
+
+    static ShippingStatus toShippingStatus(String cargoStatusName) {
+        if (FormatValidator.hasNoValue(cargoStatusName)) {
+            return ShippingStatus.PREPARING;
+        }
+        if (PREPARING_STATUSES.contains(cargoStatusName)) {
+            return ShippingStatus.PREPARING;
+        }
+        if (DELIVERED_STATUS.equals(cargoStatusName)) {
+            return ShippingStatus.DELIVERED;
+        }
+        if (DELIVERY_FAILED_STATUS.equals(cargoStatusName)) {
+            return ShippingStatus.DELIVERY_FAILED;
+        }
+        return ShippingStatus.SHIPPING;
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/shipping/PollShippingStatusService.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/shipping/PollShippingStatusService.java
@@ -1,0 +1,203 @@
+package com.personal.marketnote.fulfillment.service.shipping;
+
+import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.fulfillment.domain.FulfillmentAccessToken;
+import com.personal.marketnote.fulfillment.domain.shipping.ShippingStatus;
+import com.personal.marketnote.fulfillment.domain.shipping.ShippingTracker;
+import com.personal.marketnote.fulfillment.port.in.command.PollShippingStatusCommand;
+import com.personal.marketnote.fulfillment.port.in.command.vendor.GetFulfillmentDeliveryStatusesCommand;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.FulfillmentDeliveryStatusInfoResult;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.GetFulfillmentDeliveryStatusesResult;
+import com.personal.marketnote.fulfillment.port.in.usecase.PollShippingStatusUseCase;
+import com.personal.marketnote.fulfillment.port.in.usecase.vendor.RequestFulfillmentAuthUseCase;
+import com.personal.marketnote.fulfillment.port.out.shipping.FindShippingTrackerPort;
+import com.personal.marketnote.fulfillment.port.out.shipping.UpdateShippingTrackerPort;
+import com.personal.marketnote.fulfillment.port.out.vendor.GetFulfillmentDeliveryStatusesPort;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.Isolation;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Slf4j
+@UseCase
+public class PollShippingStatusService implements PollShippingStatusUseCase {
+
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd");
+    private static final String OUTBOUND_RELEASE_TYPE = "1";
+
+    private final FindShippingTrackerPort findShippingTrackerPort;
+    private final UpdateShippingTrackerPort updateShippingTrackerPort;
+    private final RequestFulfillmentAuthUseCase requestFulfillmentAuthUseCase;
+    private final GetFulfillmentDeliveryStatusesPort getDeliveryStatusesPort;
+    private final Clock clock;
+    private final TransactionTemplate transactionTemplate;
+
+    public PollShippingStatusService(
+            FindShippingTrackerPort findShippingTrackerPort,
+            UpdateShippingTrackerPort updateShippingTrackerPort,
+            RequestFulfillmentAuthUseCase requestFulfillmentAuthUseCase,
+            GetFulfillmentDeliveryStatusesPort getDeliveryStatusesPort,
+            Clock clock,
+            PlatformTransactionManager transactionManager
+    ) {
+        this.findShippingTrackerPort = findShippingTrackerPort;
+        this.updateShippingTrackerPort = updateShippingTrackerPort;
+        this.requestFulfillmentAuthUseCase = requestFulfillmentAuthUseCase;
+        this.getDeliveryStatusesPort = getDeliveryStatusesPort;
+        this.clock = clock;
+        this.transactionTemplate = new TransactionTemplate(transactionManager);
+        this.transactionTemplate.setIsolationLevel(Isolation.READ_COMMITTED.value());
+    }
+
+    @Override
+    public void pollShippingStatuses(PollShippingStatusCommand command) {
+        List<ShippingTracker> activeTrackers = findShippingTrackerPort.findAllPollingActive();
+        if (activeTrackers.isEmpty()) {
+            log.debug("폴링 대상 ShippingTracker가 없습니다.");
+            return;
+        }
+
+        FulfillmentAccessToken token = requestFulfillmentAuthUseCase.requestAccessToken();
+
+        LocalDate startDate = resolveStartDate(activeTrackers);
+        LocalDate endDate = LocalDate.now(clock);
+
+        GetFulfillmentDeliveryStatusesResult result = getDeliveryStatusesPort.getDeliveryStatuses(
+                GetFulfillmentDeliveryStatusesCommand.of(
+                        command.customerCode(),
+                        token.getValue(),
+                        startDate.format(DATE_FORMATTER),
+                        endDate.format(DATE_FORMATTER),
+                        OUTBOUND_RELEASE_TYPE
+                )
+        );
+
+        Map<String, FulfillmentDeliveryStatusInfoResult> statusMap = buildStatusMap(result);
+        LocalDateTime now = LocalDateTime.now(clock);
+
+        for (ShippingTracker tracker : activeTrackers) {
+            try {
+                transactionTemplate.executeWithoutResult(status -> processTracker(tracker, statusMap, now));
+            } catch (Exception e) {
+                log.error("배송 상태 폴링 처리 실패: orderId={}", tracker.getOrderId(), e);
+            }
+        }
+    }
+
+    private void processTracker(
+            ShippingTracker tracker,
+            Map<String, FulfillmentDeliveryStatusInfoResult> statusMap,
+            LocalDateTime now
+    ) {
+        ShippingTracker reloaded = findShippingTrackerPort.findByOrderId(tracker.getOrderId())
+                .orElse(tracker);
+        if (!reloaded.isPollingActive()) {
+            return;
+        }
+
+        String ordNo = String.valueOf(reloaded.getOrderId());
+        FulfillmentDeliveryStatusInfoResult deliveryStatus = statusMap.get(ordNo);
+
+        if (FormatValidator.hasNoValue(deliveryStatus)) {
+            reloaded.updateLastPolledAt(now);
+            updateShippingTrackerPort.update(reloaded);
+            return;
+        }
+
+        ShippingStatus newStatus = FasstoCargoStatusMapper.toShippingStatus(deliveryStatus.cargoStatusName());
+
+        if (isSameStatusWithNoTrackingUpdate(reloaded, newStatus, deliveryStatus)) {
+            reloaded.updateLastPolledAt(now);
+            updateShippingTrackerPort.update(reloaded);
+            return;
+        }
+
+        applyStatusTransition(reloaded, newStatus, deliveryStatus);
+        reloaded.updateLastPolledAt(now);
+        updateShippingTrackerPort.update(reloaded);
+    }
+
+    private boolean isSameStatusWithNoTrackingUpdate(
+            ShippingTracker tracker,
+            ShippingStatus newStatus,
+            FulfillmentDeliveryStatusInfoResult deliveryStatus
+    ) {
+        if (!tracker.hasStatus(newStatus)) {
+            return false;
+        }
+        if (tracker.isShipping()
+                && tracker.hasNoTrackingNumber()
+                && FormatValidator.hasValue(deliveryStatus.invoiceNumber())) {
+            return false;
+        }
+        return true;
+    }
+
+    private void applyStatusTransition(
+            ShippingTracker tracker,
+            ShippingStatus newStatus,
+            FulfillmentDeliveryStatusInfoResult deliveryStatus
+    ) {
+        if (newStatus.isShipping() && tracker.isPreparing()) {
+            applyShippingTransition(tracker, deliveryStatus);
+            return;
+        }
+        if (newStatus.isShipping() && tracker.isShipping()) {
+            applyTrackingInfoUpdate(tracker, deliveryStatus);
+            return;
+        }
+        if (newStatus.isDelivered()) {
+            tracker.completeDelivery();
+            return;
+        }
+        if (newStatus.isDeliveryFailed()) {
+            tracker.markDeliveryFailed();
+        }
+    }
+
+    private void applyShippingTransition(ShippingTracker tracker, FulfillmentDeliveryStatusInfoResult deliveryStatus) {
+        if (FormatValidator.hasValue(deliveryStatus.invoiceNumber())) {
+            tracker.startShipping(deliveryStatus.invoiceNumber(), deliveryStatus.courierCode());
+            return;
+        }
+        tracker.advanceToShipping();
+    }
+
+    private void applyTrackingInfoUpdate(ShippingTracker tracker, FulfillmentDeliveryStatusInfoResult deliveryStatus) {
+        if (tracker.hasNoTrackingNumber() && FormatValidator.hasValue(deliveryStatus.invoiceNumber())) {
+            tracker.updateTrackingInfo(deliveryStatus.invoiceNumber(), deliveryStatus.courierCode());
+        }
+    }
+
+    private LocalDate resolveStartDate(List<ShippingTracker> trackers) {
+        return trackers.stream()
+                .map(ShippingTracker::getCreatedAt)
+                .filter(FormatValidator::hasValue)
+                .min(LocalDateTime::compareTo)
+                .map(LocalDateTime::toLocalDate)
+                .orElse(LocalDate.now(clock));
+    }
+
+    private Map<String, FulfillmentDeliveryStatusInfoResult> buildStatusMap(GetFulfillmentDeliveryStatusesResult result) {
+        if (FormatValidator.hasNoValue(result) || FormatValidator.hasNoValue(result.deliveryStatuses())) {
+            return Map.of();
+        }
+        return result.deliveryStatuses().stream()
+                .filter(status -> FormatValidator.hasValue(status.orderNumber()))
+                .collect(Collectors.toMap(
+                        FulfillmentDeliveryStatusInfoResult::orderNumber,
+                        Function.identity(),
+                        (existing, replacement) -> replacement
+                ));
+    }
+}

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/shipping/ShippingStatus.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/shipping/ShippingStatus.java
@@ -15,7 +15,8 @@ public enum ShippingStatus {
     DELIVERED("배송 완료"),
     CANCELLED("추적 종료"),
     RETURN_SHIPPING("회수 배송중"),
-    RETURN_DELIVERED("회수 완료");
+    RETURN_DELIVERED("회수 완료"),
+    DELIVERY_FAILED("배송불가");
 
     private final String description;
 
@@ -24,16 +25,17 @@ public enum ShippingStatus {
     );
 
     private static final Set<ShippingStatus> TERMINAL_STATUSES = EnumSet.of(
-            DELIVERED, CANCELLED, RETURN_DELIVERED
+            DELIVERED, CANCELLED, RETURN_DELIVERED, DELIVERY_FAILED
     );
 
-    private static final Map<ShippingStatus, Set<ShippingStatus>> ALLOWED_TRANSITIONS = Map.of(
-            PREPARING, EnumSet.of(SHIPPING, CANCELLED),
-            SHIPPING, EnumSet.of(DELIVERED, CANCELLED),
-            DELIVERED, EnumSet.of(RETURN_SHIPPING),
-            RETURN_SHIPPING, EnumSet.of(RETURN_DELIVERED),
-            CANCELLED, EnumSet.noneOf(ShippingStatus.class),
-            RETURN_DELIVERED, EnumSet.noneOf(ShippingStatus.class)
+    private static final Map<ShippingStatus, Set<ShippingStatus>> ALLOWED_TRANSITIONS = Map.ofEntries(
+            Map.entry(PREPARING, EnumSet.of(SHIPPING, CANCELLED)),
+            Map.entry(SHIPPING, EnumSet.of(DELIVERED, CANCELLED, DELIVERY_FAILED)),
+            Map.entry(DELIVERED, EnumSet.of(RETURN_SHIPPING)),
+            Map.entry(RETURN_SHIPPING, EnumSet.of(RETURN_DELIVERED)),
+            Map.entry(CANCELLED, EnumSet.noneOf(ShippingStatus.class)),
+            Map.entry(RETURN_DELIVERED, EnumSet.noneOf(ShippingStatus.class)),
+            Map.entry(DELIVERY_FAILED, EnumSet.noneOf(ShippingStatus.class))
     );
 
     public boolean isPreparing() {
@@ -58,6 +60,10 @@ public enum ShippingStatus {
 
     public boolean isReturnDelivered() {
         return this == RETURN_DELIVERED;
+    }
+
+    public boolean isDeliveryFailed() {
+        return this == DELIVERY_FAILED;
     }
 
     public boolean isPollingTarget() {

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/shipping/ShippingTracker.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/shipping/ShippingTracker.java
@@ -84,6 +84,31 @@ public class ShippingTracker {
         this.pollingActive = false;
     }
 
+    public void markDeliveryFailed() {
+        validateTransition(ShippingStatus.DELIVERY_FAILED);
+        this.shippingStatus = ShippingStatus.DELIVERY_FAILED;
+        this.pollingActive = false;
+    }
+
+    public void advanceToShipping() {
+        validateTransition(ShippingStatus.SHIPPING);
+        this.shippingStatus = ShippingStatus.SHIPPING;
+    }
+
+    public void updateTrackingInfo(String trackingNumber, String carrierCode) {
+        if (!isShipping()) {
+            throw new InvalidShippingStatusTransitionException(this.shippingStatus, ShippingStatus.SHIPPING);
+        }
+        if (FormatValidator.hasNoValue(trackingNumber)) {
+            throw new FulfillmentQueryParameterNoValueException("trackingNumber", "updateTrackingInfo");
+        }
+        if (FormatValidator.hasNoValue(carrierCode)) {
+            throw new FulfillmentQueryParameterNoValueException("carrierCode", "updateTrackingInfo");
+        }
+        this.trackingNumber = trackingNumber;
+        this.carrierCode = carrierCode;
+    }
+
     public void updateLastPolledAt(LocalDateTime polledAt) {
         if (FormatValidator.hasNoValue(polledAt)) {
             throw new FulfillmentQueryParameterNoValueException("polledAt", "updateLastPolledAt");
@@ -113,6 +138,18 @@ public class ShippingTracker {
 
     public boolean isReturnDelivered() {
         return shippingStatus.isReturnDelivered();
+    }
+
+    public boolean isDeliveryFailed() {
+        return shippingStatus.isDeliveryFailed();
+    }
+
+    public boolean hasStatus(ShippingStatus status) {
+        return this.shippingStatus == status;
+    }
+
+    public boolean hasNoTrackingNumber() {
+        return FormatValidator.hasNoValue(trackingNumber);
     }
 
     private void validateTransition(ShippingStatus target) {


### PR DESCRIPTION
## partially addresses #2143
## resolves #2146

## Task
- [x] ShippingStatus에 DELIVERY_FAILED 상태 추가 (SHIPPING 전이 허용, terminal)
- [x] ShippingTracker에 markDeliveryFailed/advanceToShipping/updateTrackingInfo/hasStatus/hasNoTrackingNumber 추가
- [x] FindShippingTrackerPort/UpdateShippingTrackerPort 정의
- [x] PollShippingStatusUseCase/Service 구현 (파스토 배송 상태 조회 → 로컬 상태 비교 → 업데이트)
- [x] FasstoCargoStatusMapper: 출고요청/출고지시/피킹중→PREPARING, 배송완료→DELIVERED, 배송불가→DELIVERY_FAILED, 그 외→SHIPPING
- [x] 개별 tracker TransactionTemplate 격리 (파스토 API 호출은 트랜잭션 밖)
- [x] processTracker 재조회 + isPollingActive guard (TOCTOU 방어)
- [x] ShippingTrackerJpaRepository.findByPollingActiveTrue 추가
- [x] ShippingTrackerPersistenceAdapter에 Find/Update 구현 추가 (update 시 id null 방어)
- [x] FulfillmentDeliveryStatusPollingScheduler 신규 (@ConditionalOnProperty, 30분 fixedDelay, 08~21시 제약)
- [x] application.yml에 fulfillment.delivery-polling.enabled/interval-ms 설정 추가