### PR TITLE
[#2143][#2567] test: 파스토 배송 상태 폴링 스케줄러 기능 자동화 테스트 추가

### DIFF
--- a/fulfillment-service/fulfillment-application/src/test/java/com/personal/marketnote/fulfillment/service/shipping/FasstoCargoStatusMapperTest.java
+++ b/fulfillment-service/fulfillment-application/src/test/java/com/personal/marketnote/fulfillment/service/shipping/FasstoCargoStatusMapperTest.java
@@ -1,0 +1,57 @@
+package com.personal.marketnote.fulfillment.service.shipping;
+
+import com.personal.marketnote.fulfillment.domain.shipping.ShippingStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("FasstoCargoStatusMapper 테스트")
+class FasstoCargoStatusMapperTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {"출고요청", "출고지시", "피킹중"})
+    @DisplayName("출고요청/출고지시/피킹중은 PREPARING으로 매핑된다")
+    void preparingStatuses(String crgStNm) {
+        assertThat(FasstoCargoStatusMapper.toShippingStatus(crgStNm)).isEqualTo(ShippingStatus.PREPARING);
+    }
+
+    @Test
+    @DisplayName("배송완료는 DELIVERED로 매핑된다")
+    void deliveredStatus() {
+        assertThat(FasstoCargoStatusMapper.toShippingStatus("배송완료")).isEqualTo(ShippingStatus.DELIVERED);
+    }
+
+    @Test
+    @DisplayName("배송불가는 DELIVERY_FAILED로 매핑된다")
+    void deliveryFailedStatus() {
+        assertThat(FasstoCargoStatusMapper.toShippingStatus("배송불가")).isEqualTo(ShippingStatus.DELIVERY_FAILED);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"피킹완료", "패킹중", "패킹완료", "출고완료", "미집하", "운송장 등록", "집하완료", "상품출발", "화물도착", "배송출발", "배송중"})
+    @DisplayName("출고요청/출고지시/피킹중/배송완료/배송불가가 아닌 상태는 모두 SHIPPING으로 매핑된다")
+    void shippingStatuses(String crgStNm) {
+        assertThat(FasstoCargoStatusMapper.toShippingStatus(crgStNm)).isEqualTo(ShippingStatus.SHIPPING);
+    }
+
+    @Test
+    @DisplayName("null이면 PREPARING으로 매핑된다")
+    void nullStatus() {
+        assertThat(FasstoCargoStatusMapper.toShippingStatus(null)).isEqualTo(ShippingStatus.PREPARING);
+    }
+
+    @Test
+    @DisplayName("빈 문자열이면 PREPARING으로 매핑된다")
+    void emptyStatus() {
+        assertThat(FasstoCargoStatusMapper.toShippingStatus("")).isEqualTo(ShippingStatus.PREPARING);
+    }
+
+    @Test
+    @DisplayName("알 수 없는 상태명은 SHIPPING으로 매핑된다")
+    void unknownStatus() {
+        assertThat(FasstoCargoStatusMapper.toShippingStatus("알수없는상태")).isEqualTo(ShippingStatus.SHIPPING);
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/test/java/com/personal/marketnote/fulfillment/service/shipping/PollShippingStatusUseCaseTest.java
+++ b/fulfillment-service/fulfillment-application/src/test/java/com/personal/marketnote/fulfillment/service/shipping/PollShippingStatusUseCaseTest.java
@@ -1,0 +1,356 @@
+package com.personal.marketnote.fulfillment.service.shipping;
+
+import com.personal.marketnote.fulfillment.domain.FulfillmentAccessToken;
+import com.personal.marketnote.fulfillment.domain.shipping.ShippingStatus;
+import com.personal.marketnote.fulfillment.domain.shipping.ShippingTracker;
+import com.personal.marketnote.fulfillment.domain.shipping.ShippingTrackerCreateState;
+import com.personal.marketnote.fulfillment.domain.shipping.ShippingTrackerSnapshotState;
+import com.personal.marketnote.fulfillment.port.in.command.PollShippingStatusCommand;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.FulfillmentDeliveryStatusInfoResult;
+import com.personal.marketnote.fulfillment.port.in.result.vendor.GetFulfillmentDeliveryStatusesResult;
+import com.personal.marketnote.fulfillment.port.in.usecase.vendor.RequestFulfillmentAuthUseCase;
+import com.personal.marketnote.fulfillment.port.out.shipping.FindShippingTrackerPort;
+import com.personal.marketnote.fulfillment.port.out.shipping.UpdateShippingTrackerPort;
+import com.personal.marketnote.fulfillment.port.out.vendor.GetFulfillmentDeliveryStatusesPort;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.SimpleTransactionStatus;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("PollShippingStatusUseCase 테스트")
+class PollShippingStatusUseCaseTest {
+
+    private PollShippingStatusService pollShippingStatusService;
+
+    @Mock
+    private FindShippingTrackerPort findShippingTrackerPort;
+
+    @Mock
+    private UpdateShippingTrackerPort updateShippingTrackerPort;
+
+    @Mock
+    private RequestFulfillmentAuthUseCase requestFulfillmentAuthUseCase;
+
+    @Mock
+    private GetFulfillmentDeliveryStatusesPort getDeliveryStatusesPort;
+
+    @Mock
+    private PlatformTransactionManager transactionManager;
+
+    private final Clock clock = Clock.fixed(
+            Instant.parse("2026-06-03T10:00:00Z"),
+            ZoneId.of("Asia/Seoul")
+    );
+
+    @BeforeEach
+    void setUp() {
+        lenient().when(transactionManager.getTransaction(any())).thenReturn(new SimpleTransactionStatus());
+        pollShippingStatusService = new PollShippingStatusService(
+                findShippingTrackerPort,
+                updateShippingTrackerPort,
+                requestFulfillmentAuthUseCase,
+                getDeliveryStatusesPort,
+                clock,
+                transactionManager
+        );
+    }
+
+    @Test
+    @DisplayName("폴링 대상이 없으면 파스토 API를 호출하지 않는다")
+    void skipWhenNoActiveTrackers() {
+        // given
+        when(findShippingTrackerPort.findAllPollingActive()).thenReturn(Collections.emptyList());
+        PollShippingStatusCommand command = new PollShippingStatusCommand("CUST001");
+
+        // when
+        pollShippingStatusService.pollShippingStatuses(command);
+
+        // then
+        verifyNoInteractions(requestFulfillmentAuthUseCase);
+        verifyNoInteractions(getDeliveryStatusesPort);
+        verifyNoInteractions(updateShippingTrackerPort);
+    }
+
+    @Test
+    @DisplayName("파스토 상태가 SHIPPING으로 변경되면 송장번호와 함께 배송중으로 전이한다")
+    void transitionToShippingWithTrackingInfo() {
+        // given
+        ShippingTracker tracker = createPreparingTrackerWithId(1L, 100L);
+        when(findShippingTrackerPort.findAllPollingActive()).thenReturn(List.of(tracker));
+        when(findShippingTrackerPort.findByOrderId(100L)).thenReturn(Optional.of(tracker));
+        when(requestFulfillmentAuthUseCase.requestAccessToken())
+                .thenReturn(FulfillmentAccessToken.of("token123", "20260410100000"));
+        when(getDeliveryStatusesPort.getDeliveryStatuses(any()))
+                .thenReturn(createDeliveryStatusResult("100", "집하완료", "INV001", "CJ"));
+
+        PollShippingStatusCommand command = new PollShippingStatusCommand("CUST001");
+
+        // when
+        pollShippingStatusService.pollShippingStatuses(command);
+
+        // then
+        ArgumentCaptor<ShippingTracker> captor = ArgumentCaptor.forClass(ShippingTracker.class);
+        verify(updateShippingTrackerPort).update(captor.capture());
+
+        ShippingTracker updated = captor.getValue();
+        assertThat(updated.isShipping()).isTrue();
+        assertThat(updated.getTrackingNumber()).isEqualTo("INV001");
+        assertThat(updated.getCarrierCode()).isEqualTo("CJ");
+        assertThat(updated.getLastPolledAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("파스토 상태가 SHIPPING이지만 송장번호가 없으면 송장번호 없이 배송중으로 전이한다")
+    void transitionToShippingWithoutTrackingInfo() {
+        // given
+        ShippingTracker tracker = createPreparingTrackerWithId(1L, 100L);
+        when(findShippingTrackerPort.findAllPollingActive()).thenReturn(List.of(tracker));
+        when(findShippingTrackerPort.findByOrderId(100L)).thenReturn(Optional.of(tracker));
+        when(requestFulfillmentAuthUseCase.requestAccessToken())
+                .thenReturn(FulfillmentAccessToken.of("token123", "20260410100000"));
+        when(getDeliveryStatusesPort.getDeliveryStatuses(any()))
+                .thenReturn(createDeliveryStatusResult("100", "피킹완료", null, null));
+
+        PollShippingStatusCommand command = new PollShippingStatusCommand("CUST001");
+
+        // when
+        pollShippingStatusService.pollShippingStatuses(command);
+
+        // then
+        ArgumentCaptor<ShippingTracker> captor = ArgumentCaptor.forClass(ShippingTracker.class);
+        verify(updateShippingTrackerPort).update(captor.capture());
+
+        ShippingTracker updated = captor.getValue();
+        assertThat(updated.isShipping()).isTrue();
+        assertThat(updated.getTrackingNumber()).isNull();
+    }
+
+    @Test
+    @DisplayName("파스토 상태가 배송완료이면 DELIVERED로 전이한다")
+    void transitionToDelivered() {
+        // given
+        ShippingTracker tracker = createShippingTrackerWithId(1L, 100L);
+        when(findShippingTrackerPort.findAllPollingActive()).thenReturn(List.of(tracker));
+        when(findShippingTrackerPort.findByOrderId(100L)).thenReturn(Optional.of(tracker));
+        when(requestFulfillmentAuthUseCase.requestAccessToken())
+                .thenReturn(FulfillmentAccessToken.of("token123", "20260410100000"));
+        when(getDeliveryStatusesPort.getDeliveryStatuses(any()))
+                .thenReturn(createDeliveryStatusResult("100", "배송완료", "INV001", "CJ"));
+
+        PollShippingStatusCommand command = new PollShippingStatusCommand("CUST001");
+
+        // when
+        pollShippingStatusService.pollShippingStatuses(command);
+
+        // then
+        ArgumentCaptor<ShippingTracker> captor = ArgumentCaptor.forClass(ShippingTracker.class);
+        verify(updateShippingTrackerPort).update(captor.capture());
+
+        ShippingTracker updated = captor.getValue();
+        assertThat(updated.isDelivered()).isTrue();
+        assertThat(updated.isPollingActive()).isFalse();
+    }
+
+    @Test
+    @DisplayName("파스토 상태가 배송불가이면 DELIVERY_FAILED로 전이한다")
+    void transitionToDeliveryFailed() {
+        // given
+        ShippingTracker tracker = createShippingTrackerWithId(1L, 100L);
+        when(findShippingTrackerPort.findAllPollingActive()).thenReturn(List.of(tracker));
+        when(findShippingTrackerPort.findByOrderId(100L)).thenReturn(Optional.of(tracker));
+        when(requestFulfillmentAuthUseCase.requestAccessToken())
+                .thenReturn(FulfillmentAccessToken.of("token123", "20260410100000"));
+        when(getDeliveryStatusesPort.getDeliveryStatuses(any()))
+                .thenReturn(createDeliveryStatusResult("100", "배송불가", "INV001", "CJ"));
+
+        PollShippingStatusCommand command = new PollShippingStatusCommand("CUST001");
+
+        // when
+        pollShippingStatusService.pollShippingStatuses(command);
+
+        // then
+        ArgumentCaptor<ShippingTracker> captor = ArgumentCaptor.forClass(ShippingTracker.class);
+        verify(updateShippingTrackerPort).update(captor.capture());
+
+        ShippingTracker updated = captor.getValue();
+        assertThat(updated.isDeliveryFailed()).isTrue();
+        assertThat(updated.isPollingActive()).isFalse();
+    }
+
+    @Test
+    @DisplayName("상태가 동일하면 lastPolledAt만 갱신하고 상태는 변경하지 않는다")
+    void noTransitionWhenSameStatus() {
+        // given
+        ShippingTracker tracker = createPreparingTrackerWithId(1L, 100L);
+        when(findShippingTrackerPort.findAllPollingActive()).thenReturn(List.of(tracker));
+        when(findShippingTrackerPort.findByOrderId(100L)).thenReturn(Optional.of(tracker));
+        when(requestFulfillmentAuthUseCase.requestAccessToken())
+                .thenReturn(FulfillmentAccessToken.of("token123", "20260410100000"));
+        when(getDeliveryStatusesPort.getDeliveryStatuses(any()))
+                .thenReturn(createDeliveryStatusResult("100", "피킹중", null, null));
+
+        PollShippingStatusCommand command = new PollShippingStatusCommand("CUST001");
+
+        // when
+        pollShippingStatusService.pollShippingStatuses(command);
+
+        // then
+        ArgumentCaptor<ShippingTracker> captor = ArgumentCaptor.forClass(ShippingTracker.class);
+        verify(updateShippingTrackerPort).update(captor.capture());
+
+        ShippingTracker updated = captor.getValue();
+        assertThat(updated.isPreparing()).isTrue();
+        assertThat(updated.getLastPolledAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("파스토 응답에 해당 주문이 없으면 lastPolledAt만 갱신한다")
+    void noMatchingOrderInFasstoResponse() {
+        // given
+        ShippingTracker tracker = createPreparingTrackerWithId(1L, 100L);
+        when(findShippingTrackerPort.findAllPollingActive()).thenReturn(List.of(tracker));
+        when(findShippingTrackerPort.findByOrderId(100L)).thenReturn(Optional.of(tracker));
+        when(requestFulfillmentAuthUseCase.requestAccessToken())
+                .thenReturn(FulfillmentAccessToken.of("token123", "20260410100000"));
+        when(getDeliveryStatusesPort.getDeliveryStatuses(any()))
+                .thenReturn(GetFulfillmentDeliveryStatusesResult.of(0, Collections.emptyList()));
+
+        PollShippingStatusCommand command = new PollShippingStatusCommand("CUST001");
+
+        // when
+        pollShippingStatusService.pollShippingStatuses(command);
+
+        // then
+        ArgumentCaptor<ShippingTracker> captor = ArgumentCaptor.forClass(ShippingTracker.class);
+        verify(updateShippingTrackerPort).update(captor.capture());
+
+        ShippingTracker updated = captor.getValue();
+        assertThat(updated.isPreparing()).isTrue();
+        assertThat(updated.getLastPolledAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("개별 건 처리 중 예외가 발생해도 다른 건은 정상 처리된다")
+    void individualFailureDoesNotBlockOthers() {
+        // given
+        ShippingTracker tracker1 = createPreparingTrackerWithId(1L, 100L);
+        ShippingTracker tracker2 = createPreparingTrackerWithId(2L, 200L);
+        when(findShippingTrackerPort.findAllPollingActive()).thenReturn(List.of(tracker1, tracker2));
+        when(findShippingTrackerPort.findByOrderId(100L)).thenReturn(Optional.of(tracker1));
+        when(findShippingTrackerPort.findByOrderId(200L)).thenReturn(Optional.of(tracker2));
+        when(requestFulfillmentAuthUseCase.requestAccessToken())
+                .thenReturn(FulfillmentAccessToken.of("token123", "20260410100000"));
+
+        // tracker1은 배송완료 (PREPARING→DELIVERED는 전이 불가 → 예외)
+        // tracker2는 집하완료 (PREPARING→SHIPPING은 정상 전이)
+        GetFulfillmentDeliveryStatusesResult result = GetFulfillmentDeliveryStatusesResult.of(2, List.of(
+                createDeliveryStatusInfo("100", "배송완료", "INV001", "CJ"),
+                createDeliveryStatusInfo("200", "집하완료", "INV002", "HANJIN")
+        ));
+        when(getDeliveryStatusesPort.getDeliveryStatuses(any())).thenReturn(result);
+
+        PollShippingStatusCommand command = new PollShippingStatusCommand("CUST001");
+
+        // when
+        pollShippingStatusService.pollShippingStatuses(command);
+
+        // then - tracker2는 정상 처리됨 (최소 1회 update 호출)
+        verify(updateShippingTrackerPort, atLeastOnce()).update(any(ShippingTracker.class));
+    }
+
+    @Test
+    @DisplayName("SHIPPING 상태에서 송장번호가 없다가 파스토 응답에 송장번호가 생기면 갱신한다")
+    void updateTrackingInfoWhenBecomeAvailable() {
+        // given - SHIPPING이지만 송장번호 없는 상태 (advanceToShipping으로 전이된 경우)
+        ShippingTracker tracker = ShippingTracker.from(ShippingTrackerSnapshotState.builder()
+                .id(1L)
+                .orderId(100L)
+                .shippingStatus(ShippingStatus.SHIPPING)
+                .pollingActive(true)
+                .createdAt(LocalDateTime.of(2026, 4, 8, 10, 0))
+                .modifiedAt(LocalDateTime.of(2026, 4, 8, 10, 0))
+                .build());
+        when(findShippingTrackerPort.findAllPollingActive()).thenReturn(List.of(tracker));
+        when(findShippingTrackerPort.findByOrderId(100L)).thenReturn(Optional.of(tracker));
+        when(requestFulfillmentAuthUseCase.requestAccessToken())
+                .thenReturn(FulfillmentAccessToken.of("token123", "20260410100000"));
+        when(getDeliveryStatusesPort.getDeliveryStatuses(any()))
+                .thenReturn(createDeliveryStatusResult("100", "집하완료", "INV001", "CJ"));
+
+        PollShippingStatusCommand command = new PollShippingStatusCommand("CUST001");
+
+        // when
+        pollShippingStatusService.pollShippingStatuses(command);
+
+        // then
+        ArgumentCaptor<ShippingTracker> captor = ArgumentCaptor.forClass(ShippingTracker.class);
+        verify(updateShippingTrackerPort).update(captor.capture());
+
+        ShippingTracker updated = captor.getValue();
+        assertThat(updated.isShipping()).isTrue();
+        assertThat(updated.getTrackingNumber()).isEqualTo("INV001");
+        assertThat(updated.getCarrierCode()).isEqualTo("CJ");
+    }
+
+    // --- 테스트 헬퍼 ---
+
+    private ShippingTracker createPreparingTrackerWithId(Long id, Long orderId) {
+        return ShippingTracker.from(ShippingTrackerSnapshotState.builder()
+                .id(id)
+                .orderId(orderId)
+                .shippingStatus(ShippingStatus.PREPARING)
+                .pollingActive(true)
+                .createdAt(LocalDateTime.of(2026, 4, 8, 10, 0))
+                .modifiedAt(LocalDateTime.of(2026, 4, 8, 10, 0))
+                .build());
+    }
+
+    private ShippingTracker createShippingTrackerWithId(Long id, Long orderId) {
+        return ShippingTracker.from(ShippingTrackerSnapshotState.builder()
+                .id(id)
+                .orderId(orderId)
+                .trackingNumber("INV001")
+                .carrierCode("CJ")
+                .shippingStatus(ShippingStatus.SHIPPING)
+                .pollingActive(true)
+                .createdAt(LocalDateTime.of(2026, 4, 8, 10, 0))
+                .modifiedAt(LocalDateTime.of(2026, 4, 8, 10, 0))
+                .build());
+    }
+
+    private GetFulfillmentDeliveryStatusesResult createDeliveryStatusResult(
+            String ordNo, String crgStNm, String invoiceNo, String courierCode) {
+        return GetFulfillmentDeliveryStatusesResult.of(1,
+                List.of(createDeliveryStatusInfo(ordNo, crgStNm, invoiceNo, courierCode)));
+    }
+
+    private FulfillmentDeliveryStatusInfoResult createDeliveryStatusInfo(
+            String ordNo, String crgStNm, String invoiceNo, String courierCode) {
+        return FulfillmentDeliveryStatusInfoResult.of(
+                null, null, null, null, null,
+                null, crgStNm, null, null, null, null, null, null, null, null,
+                invoiceNo, ordNo, null, null, null, null, null, null, null,
+                courierCode, null, null, null, null, null, null, null, null,
+                null, null, null, null, null, null, null, null, null, null,
+                null, null, null
+        );
+    }
+}

--- a/fulfillment-service/fulfillment-domain/src/test/java/com/personal/marketnote/fulfillment/domain/shipping/ShippingStatusTest.java
+++ b/fulfillment-service/fulfillment-domain/src/test/java/com/personal/marketnote/fulfillment/domain/shipping/ShippingStatusTest.java
@@ -64,8 +64,8 @@ class ShippingStatusTest {
         }
 
         @ParameterizedTest
-        @EnumSource(value = ShippingStatus.class, names = {"DELIVERED", "CANCELLED", "RETURN_DELIVERED"})
-        @DisplayName("DELIVERED/CANCELLED/RETURN_DELIVERED 상태는 폴링 대상이 아니다")
+        @EnumSource(value = ShippingStatus.class, names = {"DELIVERED", "CANCELLED", "RETURN_DELIVERED", "DELIVERY_FAILED"})
+        @DisplayName("DELIVERED/CANCELLED/RETURN_DELIVERED/DELIVERY_FAILED 상태는 폴링 대상이 아니다")
         void nonPollingTargetStatuses(ShippingStatus status) {
             assertThat(status.isPollingTarget()).isFalse();
         }
@@ -76,8 +76,8 @@ class ShippingStatusTest {
     class TerminalTests {
 
         @ParameterizedTest
-        @EnumSource(value = ShippingStatus.class, names = {"DELIVERED", "CANCELLED", "RETURN_DELIVERED"})
-        @DisplayName("DELIVERED/CANCELLED/RETURN_DELIVERED 상태는 종료 상태이다")
+        @EnumSource(value = ShippingStatus.class, names = {"DELIVERED", "CANCELLED", "RETURN_DELIVERED", "DELIVERY_FAILED"})
+        @DisplayName("DELIVERED/CANCELLED/RETURN_DELIVERED/DELIVERY_FAILED 상태는 종료 상태이다")
         void terminalStatuses(ShippingStatus status) {
             assertThat(status.isTerminal()).isTrue();
         }
@@ -162,6 +162,43 @@ class ShippingStatusTest {
             for (ShippingStatus target : ShippingStatus.values()) {
                 assertThat(ShippingStatus.RETURN_DELIVERED.canTransitionTo(target)).isFalse();
             }
+        }
+
+        @Test
+        @DisplayName("SHIPPING에서 DELIVERY_FAILED로 전이할 수 있다")
+        void shippingToDeliveryFailed() {
+            assertThat(ShippingStatus.SHIPPING.canTransitionTo(ShippingStatus.DELIVERY_FAILED)).isTrue();
+        }
+
+        @Test
+        @DisplayName("PREPARING에서 DELIVERY_FAILED로 직접 전이할 수 없다")
+        void preparingToDeliveryFailed() {
+            assertThat(ShippingStatus.PREPARING.canTransitionTo(ShippingStatus.DELIVERY_FAILED)).isFalse();
+        }
+
+        @Test
+        @DisplayName("DELIVERY_FAILED에서는 어떤 상태로도 전이할 수 없다")
+        void deliveryFailedToAny() {
+            for (ShippingStatus target : ShippingStatus.values()) {
+                assertThat(ShippingStatus.DELIVERY_FAILED.canTransitionTo(target)).isFalse();
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("DELIVERY_FAILED 술어 메서드")
+    class DeliveryFailedPredicateTests {
+
+        @Test
+        @DisplayName("DELIVERY_FAILED 상태는 isDeliveryFailed()가 true를 반환한다")
+        void deliveryFailedIsDeliveryFailed() {
+            assertThat(ShippingStatus.DELIVERY_FAILED.isDeliveryFailed()).isTrue();
+        }
+
+        @Test
+        @DisplayName("SHIPPING 상태는 isDeliveryFailed()가 false를 반환한다")
+        void shippingIsNotDeliveryFailed() {
+            assertThat(ShippingStatus.SHIPPING.isDeliveryFailed()).isFalse();
         }
     }
 }

--- a/fulfillment-service/fulfillment-domain/src/test/java/com/personal/marketnote/fulfillment/domain/shipping/ShippingTrackerTest.java
+++ b/fulfillment-service/fulfillment-domain/src/test/java/com/personal/marketnote/fulfillment/domain/shipping/ShippingTrackerTest.java
@@ -258,6 +258,93 @@ class ShippingTrackerTest {
         }
     }
 
+    @Nested
+    @DisplayName("markDeliveryFailed - 배송불가 처리")
+    class MarkDeliveryFailedTests {
+
+        @Test
+        @DisplayName("SHIPPING 상태에서 배송불가 처리하면 DELIVERY_FAILED 상태가 되고 폴링이 비활성화된다")
+        void markDeliveryFailedFromShipping() {
+            ShippingTracker tracker = createShippingTracker();
+
+            tracker.markDeliveryFailed();
+
+            assertThat(tracker.isDeliveryFailed()).isTrue();
+            assertThat(tracker.isPollingActive()).isFalse();
+        }
+
+        @Test
+        @DisplayName("PREPARING 상태에서 배송불가 처리하면 예외가 발생한다")
+        void markDeliveryFailedFromPreparing() {
+            ShippingTracker tracker = createPreparingTracker();
+
+            assertThatThrownBy(() -> tracker.markDeliveryFailed())
+                    .isInstanceOf(InvalidShippingStatusTransitionException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("advanceToShipping - 송장번호 없이 배송중 전이")
+    class AdvanceToShippingTests {
+
+        @Test
+        @DisplayName("PREPARING 상태에서 advanceToShipping하면 SHIPPING 상태가 되고 송장번호는 null이다")
+        void advanceToShippingFromPreparing() {
+            ShippingTracker tracker = createPreparingTracker();
+
+            tracker.advanceToShipping();
+
+            assertThat(tracker.isShipping()).isTrue();
+            assertThat(tracker.getTrackingNumber()).isNull();
+            assertThat(tracker.getCarrierCode()).isNull();
+        }
+
+        @Test
+        @DisplayName("SHIPPING 상태에서 advanceToShipping하면 예외가 발생한다")
+        void advanceToShippingFromShipping() {
+            ShippingTracker tracker = createShippingTracker();
+
+            assertThatThrownBy(() -> tracker.advanceToShipping())
+                    .isInstanceOf(InvalidShippingStatusTransitionException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("updateTrackingInfo - 송장번호 갱신")
+    class UpdateTrackingInfoTests {
+
+        @Test
+        @DisplayName("SHIPPING 상태에서 송장번호를 갱신할 수 있다")
+        void updateTrackingInfoInShipping() {
+            ShippingTracker tracker = createPreparingTracker();
+            tracker.advanceToShipping();
+
+            tracker.updateTrackingInfo("9876543210", "HANJIN");
+
+            assertThat(tracker.getTrackingNumber()).isEqualTo("9876543210");
+            assertThat(tracker.getCarrierCode()).isEqualTo("HANJIN");
+        }
+
+        @Test
+        @DisplayName("PREPARING 상태에서 송장번호를 갱신하면 예외가 발생한다")
+        void updateTrackingInfoInPreparing() {
+            ShippingTracker tracker = createPreparingTracker();
+
+            assertThatThrownBy(() -> tracker.updateTrackingInfo("1234567890", "CJ"))
+                    .isInstanceOf(InvalidShippingStatusTransitionException.class);
+        }
+
+        @Test
+        @DisplayName("송장번호가 null이면 예외가 발생한다")
+        void updateTrackingInfoWithNullTrackingNumber() {
+            ShippingTracker tracker = createPreparingTracker();
+            tracker.advanceToShipping();
+
+            assertThatThrownBy(() -> tracker.updateTrackingInfo(null, "CJ"))
+                    .isInstanceOf(FulfillmentQueryParameterNoValueException.class);
+        }
+    }
+
     // --- 테스트 헬퍼 ---
 
     private ShippingTracker createPreparingTracker() {


### PR DESCRIPTION
## partially addresses #2143
## resolves #2567

## Test Case
- [x] ShippingStatusTest에 DELIVERY_FAILED 상태 테스트 추가
- [x] ShippingTrackerTest에 markDeliveryFailed/advanceToShipping/updateTrackingInfo 테스트 추가
- [x] FasstoCargoStatusMapperTest 신규
- [x] PollShippingStatusUseCaseTest 신규 (Mock 기반 유닛 테스트)