### PR TITLE
[#2090][#2570] test: 디바이스 토큰 등록 기능 자동화 테스트 추가

### DIFF
--- a/notification-service/notification-application/src/test/java/com/personal/marketnote/notification/service/device/RegisterDeviceTokenUseCaseTest.java
+++ b/notification-service/notification-application/src/test/java/com/personal/marketnote/notification/service/device/RegisterDeviceTokenUseCaseTest.java
@@ -1,0 +1,164 @@
+package com.personal.marketnote.notification.service.device;
+
+import com.personal.marketnote.notification.domain.device.DeviceToken;
+import com.personal.marketnote.notification.domain.device.DeviceTokenCreateState;
+import com.personal.marketnote.notification.domain.device.DeviceTokenSnapshotState;
+import com.personal.marketnote.notification.domain.device.Platform;
+import com.personal.marketnote.notification.port.in.command.RegisterDeviceTokenCommand;
+import com.personal.marketnote.notification.port.in.result.device.RegisterDeviceTokenResult;
+import com.personal.marketnote.notification.port.out.device.DeleteDeviceTokenPort;
+import com.personal.marketnote.notification.port.out.device.FindDeviceTokenPort;
+import com.personal.marketnote.notification.port.out.device.SaveDeviceTokenPort;
+import com.personal.marketnote.notification.port.out.device.UpdateDeviceTokenPort;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class RegisterDeviceTokenUseCaseTest {
+
+    private static final LocalDateTime FIXED_NOW = LocalDateTime.of(2026, 4, 9, 10, 0);
+    private static final Clock FIXED_CLOCK = Clock.fixed(
+            FIXED_NOW.atZone(ZoneId.of("Asia/Seoul")).toInstant(), ZoneId.of("Asia/Seoul"));
+
+    @InjectMocks
+    private RegisterDeviceTokenService registerDeviceTokenService;
+
+    @Mock
+    private FindDeviceTokenPort findDeviceTokenPort;
+
+    @Mock
+    private SaveDeviceTokenPort saveDeviceTokenPort;
+
+    @Mock
+    private UpdateDeviceTokenPort updateDeviceTokenPort;
+
+    @Mock
+    private DeleteDeviceTokenPort deleteDeviceTokenPort;
+
+    @Mock
+    private Clock clock;
+
+    @Test
+    @DisplayName("신규 디바이스 토큰을 등록한다")
+    void shouldRegisterNewDeviceToken() {
+        // given
+        RegisterDeviceTokenCommand command = new RegisterDeviceTokenCommand(
+                100L,
+                "new-fcm-token",
+                "ANDROID",
+                "device-uuid-001"
+        );
+
+        when(findDeviceTokenPort.findActiveByDeviceId("device-uuid-001"))
+                .thenReturn(Optional.empty());
+        when(saveDeviceTokenPort.save(any(DeviceToken.class)))
+                .thenReturn(1L);
+        when(clock.instant()).thenReturn(FIXED_CLOCK.instant());
+        when(clock.getZone()).thenReturn(FIXED_CLOCK.getZone());
+
+        // when
+        RegisterDeviceTokenResult result = registerDeviceTokenService.registerDeviceToken(command);
+
+        // then
+        assertThat(result.id()).isEqualTo(1L);
+        assertThat(result.isNew()).isTrue();
+        verify(findDeviceTokenPort).findActiveByDeviceId("device-uuid-001");
+        verify(saveDeviceTokenPort).save(any(DeviceToken.class));
+        verify(updateDeviceTokenPort, never()).update(any());
+    }
+
+    @Test
+    @DisplayName("동일 사용자가 같은 deviceId로 재등록하면 기존 토큰을 갱신한다")
+    void shouldUpdateExistingDeviceTokenWhenSameOwner() {
+        // given
+        RegisterDeviceTokenCommand command = new RegisterDeviceTokenCommand(
+                100L,
+                "updated-fcm-token",
+                "IOS",
+                "device-uuid-001"
+        );
+
+        DeviceToken existing = DeviceToken.from(DeviceTokenCreateState.builder()
+                .userId(100L)
+                .token("old-fcm-token")
+                .platform(Platform.ANDROID)
+                .deviceId("device-uuid-001")
+                .lastUsedAt(FIXED_NOW.minusDays(1))
+                .build());
+
+        when(findDeviceTokenPort.findActiveByDeviceId("device-uuid-001"))
+                .thenReturn(Optional.of(existing));
+        when(updateDeviceTokenPort.update(any(DeviceToken.class)))
+                .thenReturn(10L);
+        when(clock.instant()).thenReturn(FIXED_CLOCK.instant());
+        when(clock.getZone()).thenReturn(FIXED_CLOCK.getZone());
+
+        // when
+        RegisterDeviceTokenResult result = registerDeviceTokenService.registerDeviceToken(command);
+
+        // then
+        assertThat(result.id()).isEqualTo(10L);
+        assertThat(result.isNew()).isFalse();
+        assertThat(existing.getUserId()).isEqualTo(100L);
+        assertThat(existing.getToken()).isEqualTo("updated-fcm-token");
+        assertThat(existing.getPlatform()).isEqualTo(Platform.IOS);
+        assertThat(existing.getLastUsedAt()).isEqualTo(FIXED_NOW);
+        verify(findDeviceTokenPort).findActiveByDeviceId("device-uuid-001");
+        verify(updateDeviceTokenPort).update(existing);
+        verify(saveDeviceTokenPort, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("다른 사용자가 같은 deviceId로 등록하면 기존 토큰을 삭제하고 신규 토큰을 등록한다")
+    void shouldDeleteExistingAndCreateNewWhenDifferentOwner() {
+        // given
+        RegisterDeviceTokenCommand command = new RegisterDeviceTokenCommand(
+                200L,
+                "new-user-fcm-token",
+                "IOS",
+                "device-uuid-001"
+        );
+
+        DeviceToken existing = DeviceToken.from(DeviceTokenSnapshotState.builder()
+                .id(10L)
+                .userId(100L)
+                .token("old-fcm-token")
+                .platform(Platform.ANDROID)
+                .deviceId("device-uuid-001")
+                .lastUsedAt(FIXED_NOW.minusDays(1))
+                .status(com.personal.marketnote.common.domain.EntityStatus.ACTIVE)
+                .createdAt(FIXED_NOW.minusDays(1))
+                .modifiedAt(FIXED_NOW.minusDays(1))
+                .build());
+
+        when(findDeviceTokenPort.findActiveByDeviceId("device-uuid-001"))
+                .thenReturn(Optional.of(existing));
+        when(saveDeviceTokenPort.save(any(DeviceToken.class)))
+                .thenReturn(11L);
+        when(clock.instant()).thenReturn(FIXED_CLOCK.instant());
+        when(clock.getZone()).thenReturn(FIXED_CLOCK.getZone());
+
+        // when
+        RegisterDeviceTokenResult result = registerDeviceTokenService.registerDeviceToken(command);
+
+        // then
+        assertThat(result.id()).isEqualTo(11L);
+        assertThat(result.isNew()).isTrue();
+        verify(deleteDeviceTokenPort).deleteById(10L);
+        verify(saveDeviceTokenPort).save(any(DeviceToken.class));
+        verify(updateDeviceTokenPort, never()).update(any());
+    }
+}

--- a/notification-service/notification-domain/src/test/java/com/personal/marketnote/notification/domain/device/DeviceTokenTest.java
+++ b/notification-service/notification-domain/src/test/java/com/personal/marketnote/notification/domain/device/DeviceTokenTest.java
@@ -1,0 +1,158 @@
+package com.personal.marketnote.notification.domain.device;
+
+import com.personal.marketnote.common.domain.EntityStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class DeviceTokenTest {
+
+    private static final LocalDateTime NOW = LocalDateTime.of(2026, 4, 9, 10, 0);
+
+    @Test
+    @DisplayName("CreateState로 디바이스 토큰을 생성한다")
+    void shouldCreateDeviceTokenFromCreateState() {
+        DeviceToken deviceToken = DeviceToken.from(DeviceTokenCreateState.builder()
+                .userId(100L)
+                .token("fcm-token-value")
+                .platform(Platform.ANDROID)
+                .deviceId("device-uuid-001")
+                .lastUsedAt(NOW)
+                .build());
+
+        assertThat(deviceToken.getUserId()).isEqualTo(100L);
+        assertThat(deviceToken.getToken()).isEqualTo("fcm-token-value");
+        assertThat(deviceToken.getPlatform()).isEqualTo(Platform.ANDROID);
+        assertThat(deviceToken.getDeviceId()).isEqualTo("device-uuid-001");
+        assertThat(deviceToken.getLastUsedAt()).isEqualTo(NOW);
+        assertThat(deviceToken.isActive()).isTrue();
+    }
+
+    @Test
+    @DisplayName("userId가 null이면 예외를 던진다")
+    void shouldThrowExceptionWhenUserIdIsNull() {
+        DeviceTokenCreateState state = DeviceTokenCreateState.builder()
+                .userId(null)
+                .token("fcm-token-value")
+                .platform(Platform.ANDROID)
+                .deviceId("device-uuid-001")
+                .lastUsedAt(NOW)
+                .build();
+
+        assertThatThrownBy(() -> DeviceToken.from(state))
+                .isInstanceOf(InvalidDeviceTokenException.class);
+    }
+
+    @Test
+    @DisplayName("token이 비어있으면 예외를 던진다")
+    void shouldThrowExceptionWhenTokenIsBlank() {
+        DeviceTokenCreateState state = DeviceTokenCreateState.builder()
+                .userId(100L)
+                .token(" ")
+                .platform(Platform.ANDROID)
+                .deviceId("device-uuid-001")
+                .lastUsedAt(NOW)
+                .build();
+
+        assertThatThrownBy(() -> DeviceToken.from(state))
+                .isInstanceOf(InvalidDeviceTokenException.class);
+    }
+
+    @Test
+    @DisplayName("deviceId가 비어있으면 예외를 던진다")
+    void shouldThrowExceptionWhenDeviceIdIsBlank() {
+        DeviceTokenCreateState state = DeviceTokenCreateState.builder()
+                .userId(100L)
+                .token("fcm-token-value")
+                .platform(Platform.ANDROID)
+                .deviceId("")
+                .lastUsedAt(NOW)
+                .build();
+
+        assertThatThrownBy(() -> DeviceToken.from(state))
+                .isInstanceOf(InvalidDeviceTokenException.class);
+    }
+
+    @Test
+    @DisplayName("platform이 null이면 예외를 던진다")
+    void shouldThrowExceptionWhenPlatformIsNull() {
+        DeviceTokenCreateState state = DeviceTokenCreateState.builder()
+                .userId(100L)
+                .token("fcm-token-value")
+                .platform(null)
+                .deviceId("device-uuid-001")
+                .lastUsedAt(NOW)
+                .build();
+
+        assertThatThrownBy(() -> DeviceToken.from(state))
+                .isInstanceOf(InvalidDeviceTokenException.class);
+    }
+
+    @Test
+    @DisplayName("SnapshotState로 디바이스 토큰을 복원한다")
+    void shouldRestoreDeviceTokenFromSnapshotState() {
+        DeviceToken deviceToken = DeviceToken.from(DeviceTokenSnapshotState.builder()
+                .id(1L)
+                .userId(100L)
+                .token("fcm-token-value")
+                .platform(Platform.IOS)
+                .deviceId("device-uuid-001")
+                .lastUsedAt(NOW)
+                .status(EntityStatus.ACTIVE)
+                .createdAt(NOW)
+                .modifiedAt(NOW)
+                .build());
+
+        assertThat(deviceToken.getId()).isEqualTo(1L);
+        assertThat(deviceToken.getUserId()).isEqualTo(100L);
+        assertThat(deviceToken.getPlatform()).isEqualTo(Platform.IOS);
+        assertThat(deviceToken.isActive()).isTrue();
+    }
+
+    @Test
+    @DisplayName("token을 갱신한다")
+    void shouldUpdateToken() {
+        DeviceToken deviceToken = activeDeviceToken();
+        LocalDateTime later = NOW.plusDays(1);
+
+        deviceToken.updateToken("new-token", Platform.IOS, later);
+
+        assertThat(deviceToken.getUserId()).isEqualTo(100L);
+        assertThat(deviceToken.getToken()).isEqualTo("new-token");
+        assertThat(deviceToken.getPlatform()).isEqualTo(Platform.IOS);
+        assertThat(deviceToken.getLastUsedAt()).isEqualTo(later);
+        assertThat(deviceToken.getDeviceId()).isEqualTo("device-uuid-001");
+    }
+
+    @Test
+    @DisplayName("token 갱신 시 새 token이 비어있으면 예외를 던진다")
+    void shouldThrowExceptionWhenUpdatingWithBlankToken() {
+        DeviceToken deviceToken = activeDeviceToken();
+
+        assertThatThrownBy(() -> deviceToken.updateToken("", Platform.IOS, NOW))
+                .isInstanceOf(InvalidDeviceTokenException.class);
+    }
+
+    @Test
+    @DisplayName("isOwnedBy는 소유자 userId와 일치할 때만 true를 반환한다")
+    void shouldReturnTrueWhenOwnedByUser() {
+        DeviceToken deviceToken = activeDeviceToken();
+
+        assertThat(deviceToken.isOwnedBy(100L)).isTrue();
+        assertThat(deviceToken.isOwnedBy(200L)).isFalse();
+    }
+
+    private DeviceToken activeDeviceToken() {
+        return DeviceToken.from(DeviceTokenCreateState.builder()
+                .userId(100L)
+                .token("fcm-token-value")
+                .platform(Platform.ANDROID)
+                .deviceId("device-uuid-001")
+                .lastUsedAt(NOW)
+                .build());
+    }
+}

--- a/notification-service/notification-domain/src/test/java/com/personal/marketnote/notification/domain/device/PlatformTest.java
+++ b/notification-service/notification-domain/src/test/java/com/personal/marketnote/notification/domain/device/PlatformTest.java
@@ -1,0 +1,55 @@
+package com.personal.marketnote.notification.domain.device;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class PlatformTest {
+
+    @Test
+    @DisplayName("ANDROID 문자열로 Platform을 생성한다")
+    void shouldCreateAndroidPlatform() {
+        Platform platform = Platform.from("ANDROID");
+
+        assertThat(platform).isEqualTo(Platform.ANDROID);
+    }
+
+    @Test
+    @DisplayName("IOS 문자열로 Platform을 생성한다")
+    void shouldCreateIosPlatform() {
+        Platform platform = Platform.from("IOS");
+
+        assertThat(platform).isEqualTo(Platform.IOS);
+    }
+
+    @Test
+    @DisplayName("소문자 android 문자열로 Platform을 생성한다")
+    void shouldCreatePlatformFromLowercase() {
+        Platform platform = Platform.from("android");
+
+        assertThat(platform).isEqualTo(Platform.ANDROID);
+    }
+
+    @Test
+    @DisplayName("알 수 없는 Platform 문자열이면 예외를 던진다")
+    void shouldThrowExceptionWhenUnknownPlatform() {
+        assertThatThrownBy(() -> Platform.from("WEB"))
+                .isInstanceOf(InvalidPlatformException.class);
+    }
+
+    @Test
+    @DisplayName("null 문자열이면 예외를 던진다")
+    void shouldThrowExceptionWhenNull() {
+        assertThatThrownBy(() -> Platform.from(null))
+                .isInstanceOf(InvalidPlatformException.class);
+    }
+
+    @Test
+    @DisplayName("빈 문자열이면 예외를 던진다")
+    void shouldThrowExceptionWhenEmpty() {
+        assertThatThrownBy(() -> Platform.from(""))
+                .isInstanceOf(InvalidPlatformException.class);
+    }
+}


### PR DESCRIPTION
## partially addresses #2090
## resolves #2570

## Task
- [x] Platform enum from() 단위 테스트 (6건)
- [x] DeviceToken 도메인 생성/검증/updateToken/isOwnedBy 단위 테스트 (9건)
- [x] RegisterDeviceTokenUseCase 신규/갱신/소유자 변경 분기 단위 테스트 (3건)