### PR TITLE
[#2090][#2093] feat: 디바이스 토큰 삭제 기능 추가 (#2572)

### DIFF
--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/persistence/shipping/ShippingTrackerPersistenceAdapter.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/persistence/shipping/ShippingTrackerPersistenceAdapter.java
@@ -1,17 +1,28 @@
 package com.personal.marketnote.fulfillment.adapter.out.persistence.shipping;
 
 import com.personal.marketnote.common.adapter.out.PersistenceAdapter;
+import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.fulfillment.adapter.out.persistence.shipping.entity.ShippingTrackerJpaEntity;
 import com.personal.marketnote.fulfillment.adapter.out.persistence.shipping.repository.ShippingTrackerJpaRepository;
 import com.personal.marketnote.fulfillment.domain.shipping.ShippingTracker;
+import com.personal.marketnote.fulfillment.domain.exception.ShippingTrackerNotFoundException;
 import com.personal.marketnote.fulfillment.exception.ShippingTrackerAlreadyExistsException;
+import com.personal.marketnote.fulfillment.port.out.shipping.FindShippingTrackerPort;
 import com.personal.marketnote.fulfillment.port.out.shipping.SaveShippingTrackerPort;
+import com.personal.marketnote.fulfillment.port.out.shipping.UpdateShippingTrackerPort;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
 
+import java.util.List;
+import java.util.Optional;
+
 @PersistenceAdapter
 @RequiredArgsConstructor
-public class ShippingTrackerPersistenceAdapter implements SaveShippingTrackerPort {
+public class ShippingTrackerPersistenceAdapter implements
+        SaveShippingTrackerPort,
+        FindShippingTrackerPort,
+        UpdateShippingTrackerPort {
+
     private final ShippingTrackerJpaRepository repository;
 
     @Override
@@ -21,5 +32,26 @@ public class ShippingTrackerPersistenceAdapter implements SaveShippingTrackerPor
         } catch (DataIntegrityViolationException e) {
             throw new ShippingTrackerAlreadyExistsException(shippingTracker.getOrderId());
         }
+    }
+
+    @Override
+    public List<ShippingTracker> findAllPollingActive() {
+        return repository.findByPollingActiveTrue().stream()
+                .map(ShippingTrackerJpaEntity::toDomain)
+                .toList();
+    }
+
+    @Override
+    public Optional<ShippingTracker> findByOrderId(Long orderId) {
+        return repository.findByOrderId(orderId)
+                .map(ShippingTrackerJpaEntity::toDomain);
+    }
+
+    @Override
+    public void update(ShippingTracker shippingTracker) {
+        if (FormatValidator.hasNoValue(shippingTracker.getId())) {
+            throw new ShippingTrackerNotFoundException(shippingTracker.getOrderId());
+        }
+        repository.saveAndFlush(ShippingTrackerJpaEntity.from(shippingTracker));
     }
 }

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/persistence/shipping/repository/ShippingTrackerJpaRepository.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/persistence/shipping/repository/ShippingTrackerJpaRepository.java
@@ -3,8 +3,11 @@ package com.personal.marketnote.fulfillment.adapter.out.persistence.shipping.rep
 import com.personal.marketnote.fulfillment.adapter.out.persistence.shipping.entity.ShippingTrackerJpaEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ShippingTrackerJpaRepository extends JpaRepository<ShippingTrackerJpaEntity, Long> {
     Optional<ShippingTrackerJpaEntity> findByOrderId(Long orderId);
+
+    List<ShippingTrackerJpaEntity> findByPollingActiveTrue();
 }

--- a/fulfillment-service/fulfillment-adapters/src/main/resources/application.yml
+++ b/fulfillment-service/fulfillment-adapters/src/main/resources/application.yml
@@ -103,6 +103,11 @@ vendor:
       api-cd: ${FASSTO_API_CD:change-me}
       api-key: ${FASSTO_API_KEY:change-me}
 
+fulfillment:
+  delivery-polling:
+    enabled: ${FULFILLMENT_DELIVERY_POLLING_ENABLED:false}
+    interval-ms: ${FULFILLMENT_DELIVERY_POLLING_INTERVAL_MS:1800000}
+
 commerce-service:
   base-url: ${COMMERCE_SERVICE_SERVER_ORIGIN:http://localhost:8082}
 

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/shipping/ShippingStatus.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/shipping/ShippingStatus.java
@@ -15,7 +15,8 @@ public enum ShippingStatus {
     DELIVERED("배송 완료"),
     CANCELLED("추적 종료"),
     RETURN_SHIPPING("회수 배송중"),
-    RETURN_DELIVERED("회수 완료");
+    RETURN_DELIVERED("회수 완료"),
+    DELIVERY_FAILED("배송불가");
 
     private final String description;
 
@@ -24,16 +25,17 @@ public enum ShippingStatus {
     );
 
     private static final Set<ShippingStatus> TERMINAL_STATUSES = EnumSet.of(
-            DELIVERED, CANCELLED, RETURN_DELIVERED
+            DELIVERED, CANCELLED, RETURN_DELIVERED, DELIVERY_FAILED
     );
 
-    private static final Map<ShippingStatus, Set<ShippingStatus>> ALLOWED_TRANSITIONS = Map.of(
-            PREPARING, EnumSet.of(SHIPPING, CANCELLED),
-            SHIPPING, EnumSet.of(DELIVERED, CANCELLED),
-            DELIVERED, EnumSet.of(RETURN_SHIPPING),
-            RETURN_SHIPPING, EnumSet.of(RETURN_DELIVERED),
-            CANCELLED, EnumSet.noneOf(ShippingStatus.class),
-            RETURN_DELIVERED, EnumSet.noneOf(ShippingStatus.class)
+    private static final Map<ShippingStatus, Set<ShippingStatus>> ALLOWED_TRANSITIONS = Map.ofEntries(
+            Map.entry(PREPARING, EnumSet.of(SHIPPING, CANCELLED)),
+            Map.entry(SHIPPING, EnumSet.of(DELIVERED, CANCELLED, DELIVERY_FAILED)),
+            Map.entry(DELIVERED, EnumSet.of(RETURN_SHIPPING)),
+            Map.entry(RETURN_SHIPPING, EnumSet.of(RETURN_DELIVERED)),
+            Map.entry(CANCELLED, EnumSet.noneOf(ShippingStatus.class)),
+            Map.entry(RETURN_DELIVERED, EnumSet.noneOf(ShippingStatus.class)),
+            Map.entry(DELIVERY_FAILED, EnumSet.noneOf(ShippingStatus.class))
     );
 
     public boolean isPreparing() {
@@ -58,6 +60,10 @@ public enum ShippingStatus {
 
     public boolean isReturnDelivered() {
         return this == RETURN_DELIVERED;
+    }
+
+    public boolean isDeliveryFailed() {
+        return this == DELIVERY_FAILED;
     }
 
     public boolean isPollingTarget() {

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/shipping/ShippingTracker.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/shipping/ShippingTracker.java
@@ -84,6 +84,31 @@ public class ShippingTracker {
         this.pollingActive = false;
     }
 
+    public void markDeliveryFailed() {
+        validateTransition(ShippingStatus.DELIVERY_FAILED);
+        this.shippingStatus = ShippingStatus.DELIVERY_FAILED;
+        this.pollingActive = false;
+    }
+
+    public void advanceToShipping() {
+        validateTransition(ShippingStatus.SHIPPING);
+        this.shippingStatus = ShippingStatus.SHIPPING;
+    }
+
+    public void updateTrackingInfo(String trackingNumber, String carrierCode) {
+        if (!isShipping()) {
+            throw new InvalidShippingStatusTransitionException(this.shippingStatus, ShippingStatus.SHIPPING);
+        }
+        if (FormatValidator.hasNoValue(trackingNumber)) {
+            throw new FulfillmentQueryParameterNoValueException("trackingNumber", "updateTrackingInfo");
+        }
+        if (FormatValidator.hasNoValue(carrierCode)) {
+            throw new FulfillmentQueryParameterNoValueException("carrierCode", "updateTrackingInfo");
+        }
+        this.trackingNumber = trackingNumber;
+        this.carrierCode = carrierCode;
+    }
+
     public void updateLastPolledAt(LocalDateTime polledAt) {
         if (FormatValidator.hasNoValue(polledAt)) {
             throw new FulfillmentQueryParameterNoValueException("polledAt", "updateLastPolledAt");
@@ -113,6 +138,18 @@ public class ShippingTracker {
 
     public boolean isReturnDelivered() {
         return shippingStatus.isReturnDelivered();
+    }
+
+    public boolean isDeliveryFailed() {
+        return shippingStatus.isDeliveryFailed();
+    }
+
+    public boolean hasStatus(ShippingStatus status) {
+        return this.shippingStatus == status;
+    }
+
+    public boolean hasNoTrackingNumber() {
+        return FormatValidator.hasNoValue(trackingNumber);
     }
 
     private void validateTransition(ShippingStatus target) {

--- a/fulfillment-service/fulfillment-domain/src/test/java/com/personal/marketnote/fulfillment/domain/shipping/ShippingStatusTest.java
+++ b/fulfillment-service/fulfillment-domain/src/test/java/com/personal/marketnote/fulfillment/domain/shipping/ShippingStatusTest.java
@@ -64,8 +64,8 @@ class ShippingStatusTest {
         }
 
         @ParameterizedTest
-        @EnumSource(value = ShippingStatus.class, names = {"DELIVERED", "CANCELLED", "RETURN_DELIVERED"})
-        @DisplayName("DELIVERED/CANCELLED/RETURN_DELIVERED 상태는 폴링 대상이 아니다")
+        @EnumSource(value = ShippingStatus.class, names = {"DELIVERED", "CANCELLED", "RETURN_DELIVERED", "DELIVERY_FAILED"})
+        @DisplayName("DELIVERED/CANCELLED/RETURN_DELIVERED/DELIVERY_FAILED 상태는 폴링 대상이 아니다")
         void nonPollingTargetStatuses(ShippingStatus status) {
             assertThat(status.isPollingTarget()).isFalse();
         }
@@ -76,8 +76,8 @@ class ShippingStatusTest {
     class TerminalTests {
 
         @ParameterizedTest
-        @EnumSource(value = ShippingStatus.class, names = {"DELIVERED", "CANCELLED", "RETURN_DELIVERED"})
-        @DisplayName("DELIVERED/CANCELLED/RETURN_DELIVERED 상태는 종료 상태이다")
+        @EnumSource(value = ShippingStatus.class, names = {"DELIVERED", "CANCELLED", "RETURN_DELIVERED", "DELIVERY_FAILED"})
+        @DisplayName("DELIVERED/CANCELLED/RETURN_DELIVERED/DELIVERY_FAILED 상태는 종료 상태이다")
         void terminalStatuses(ShippingStatus status) {
             assertThat(status.isTerminal()).isTrue();
         }
@@ -162,6 +162,43 @@ class ShippingStatusTest {
             for (ShippingStatus target : ShippingStatus.values()) {
                 assertThat(ShippingStatus.RETURN_DELIVERED.canTransitionTo(target)).isFalse();
             }
+        }
+
+        @Test
+        @DisplayName("SHIPPING에서 DELIVERY_FAILED로 전이할 수 있다")
+        void shippingToDeliveryFailed() {
+            assertThat(ShippingStatus.SHIPPING.canTransitionTo(ShippingStatus.DELIVERY_FAILED)).isTrue();
+        }
+
+        @Test
+        @DisplayName("PREPARING에서 DELIVERY_FAILED로 직접 전이할 수 없다")
+        void preparingToDeliveryFailed() {
+            assertThat(ShippingStatus.PREPARING.canTransitionTo(ShippingStatus.DELIVERY_FAILED)).isFalse();
+        }
+
+        @Test
+        @DisplayName("DELIVERY_FAILED에서는 어떤 상태로도 전이할 수 없다")
+        void deliveryFailedToAny() {
+            for (ShippingStatus target : ShippingStatus.values()) {
+                assertThat(ShippingStatus.DELIVERY_FAILED.canTransitionTo(target)).isFalse();
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("DELIVERY_FAILED 술어 메서드")
+    class DeliveryFailedPredicateTests {
+
+        @Test
+        @DisplayName("DELIVERY_FAILED 상태는 isDeliveryFailed()가 true를 반환한다")
+        void deliveryFailedIsDeliveryFailed() {
+            assertThat(ShippingStatus.DELIVERY_FAILED.isDeliveryFailed()).isTrue();
+        }
+
+        @Test
+        @DisplayName("SHIPPING 상태는 isDeliveryFailed()가 false를 반환한다")
+        void shippingIsNotDeliveryFailed() {
+            assertThat(ShippingStatus.SHIPPING.isDeliveryFailed()).isFalse();
         }
     }
 }

--- a/fulfillment-service/fulfillment-domain/src/test/java/com/personal/marketnote/fulfillment/domain/shipping/ShippingTrackerTest.java
+++ b/fulfillment-service/fulfillment-domain/src/test/java/com/personal/marketnote/fulfillment/domain/shipping/ShippingTrackerTest.java
@@ -258,6 +258,93 @@ class ShippingTrackerTest {
         }
     }
 
+    @Nested
+    @DisplayName("markDeliveryFailed - 배송불가 처리")
+    class MarkDeliveryFailedTests {
+
+        @Test
+        @DisplayName("SHIPPING 상태에서 배송불가 처리하면 DELIVERY_FAILED 상태가 되고 폴링이 비활성화된다")
+        void markDeliveryFailedFromShipping() {
+            ShippingTracker tracker = createShippingTracker();
+
+            tracker.markDeliveryFailed();
+
+            assertThat(tracker.isDeliveryFailed()).isTrue();
+            assertThat(tracker.isPollingActive()).isFalse();
+        }
+
+        @Test
+        @DisplayName("PREPARING 상태에서 배송불가 처리하면 예외가 발생한다")
+        void markDeliveryFailedFromPreparing() {
+            ShippingTracker tracker = createPreparingTracker();
+
+            assertThatThrownBy(() -> tracker.markDeliveryFailed())
+                    .isInstanceOf(InvalidShippingStatusTransitionException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("advanceToShipping - 송장번호 없이 배송중 전이")
+    class AdvanceToShippingTests {
+
+        @Test
+        @DisplayName("PREPARING 상태에서 advanceToShipping하면 SHIPPING 상태가 되고 송장번호는 null이다")
+        void advanceToShippingFromPreparing() {
+            ShippingTracker tracker = createPreparingTracker();
+
+            tracker.advanceToShipping();
+
+            assertThat(tracker.isShipping()).isTrue();
+            assertThat(tracker.getTrackingNumber()).isNull();
+            assertThat(tracker.getCarrierCode()).isNull();
+        }
+
+        @Test
+        @DisplayName("SHIPPING 상태에서 advanceToShipping하면 예외가 발생한다")
+        void advanceToShippingFromShipping() {
+            ShippingTracker tracker = createShippingTracker();
+
+            assertThatThrownBy(() -> tracker.advanceToShipping())
+                    .isInstanceOf(InvalidShippingStatusTransitionException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("updateTrackingInfo - 송장번호 갱신")
+    class UpdateTrackingInfoTests {
+
+        @Test
+        @DisplayName("SHIPPING 상태에서 송장번호를 갱신할 수 있다")
+        void updateTrackingInfoInShipping() {
+            ShippingTracker tracker = createPreparingTracker();
+            tracker.advanceToShipping();
+
+            tracker.updateTrackingInfo("9876543210", "HANJIN");
+
+            assertThat(tracker.getTrackingNumber()).isEqualTo("9876543210");
+            assertThat(tracker.getCarrierCode()).isEqualTo("HANJIN");
+        }
+
+        @Test
+        @DisplayName("PREPARING 상태에서 송장번호를 갱신하면 예외가 발생한다")
+        void updateTrackingInfoInPreparing() {
+            ShippingTracker tracker = createPreparingTracker();
+
+            assertThatThrownBy(() -> tracker.updateTrackingInfo("1234567890", "CJ"))
+                    .isInstanceOf(InvalidShippingStatusTransitionException.class);
+        }
+
+        @Test
+        @DisplayName("송장번호가 null이면 예외가 발생한다")
+        void updateTrackingInfoWithNullTrackingNumber() {
+            ShippingTracker tracker = createPreparingTracker();
+            tracker.advanceToShipping();
+
+            assertThatThrownBy(() -> tracker.updateTrackingInfo(null, "CJ"))
+                    .isInstanceOf(FulfillmentQueryParameterNoValueException.class);
+        }
+    }
+
     // --- 테스트 헬퍼 ---
 
     private ShippingTracker createPreparingTracker() {

--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/web/device/controller/DeviceTokenController.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/web/device/controller/DeviceTokenController.java
@@ -2,11 +2,14 @@ package com.personal.marketnote.notification.adapter.in.web.device.controller;
 
 import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
 import com.personal.marketnote.common.utility.ElementExtractor;
+import com.personal.marketnote.notification.adapter.in.web.device.controller.apidocs.DeleteDeviceTokenApiDocs;
 import com.personal.marketnote.notification.adapter.in.web.device.controller.apidocs.RegisterDeviceTokenApiDocs;
 import com.personal.marketnote.notification.adapter.in.web.device.request.RegisterDeviceTokenRequest;
 import com.personal.marketnote.notification.adapter.in.web.device.response.RegisterDeviceTokenResponse;
+import com.personal.marketnote.notification.port.in.command.DeleteDeviceTokenCommand;
 import com.personal.marketnote.notification.port.in.command.RegisterDeviceTokenCommand;
 import com.personal.marketnote.notification.port.in.result.device.RegisterDeviceTokenResult;
+import com.personal.marketnote.notification.port.in.usecase.device.DeleteDeviceTokenUseCase;
 import com.personal.marketnote.notification.port.in.usecase.device.RegisterDeviceTokenUseCase;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -15,6 +18,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.core.OAuth2AuthenticatedPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -27,7 +32,7 @@ import static com.personal.marketnote.common.domain.exception.ExceptionCode.DEFA
  *
  * @Author 성효빈
  * @Date 2026-06-03
- * @Description 사용자 디바이스의 FCM 토큰 등록 API를 제공합니다.
+ * @Description 사용자 디바이스의 FCM 토큰 등록/삭제 API를 제공합니다.
  */
 @RestController
 @RequestMapping("/api/v1/device-tokens")
@@ -36,6 +41,7 @@ import static com.personal.marketnote.common.domain.exception.ExceptionCode.DEFA
 public class DeviceTokenController {
 
     private final RegisterDeviceTokenUseCase registerDeviceTokenUseCase;
+    private final DeleteDeviceTokenUseCase deleteDeviceTokenUseCase;
 
     /**
      * 디바이스 토큰 등록/갱신
@@ -70,6 +76,40 @@ public class DeviceTokenController {
                         "디바이스 토큰 등록 성공"
                 ),
                 HttpStatus.CREATED
+        );
+    }
+
+    /**
+     * 디바이스 토큰 삭제
+     *
+     * @param deviceId  삭제할 기기 고유 식별자
+     * @param principal 인증된 사용자
+     * @return 삭제 완료 응답
+     * @Author 성효빈
+     * @Date 2026-06-03
+     * @Description 로그인한 사용자의 특정 기기 FCM 디바이스 토큰을 삭제합니다. 본인 소유 기기만 삭제 가능합니다.
+     */
+    @DeleteMapping("/{deviceId}")
+    @DeleteDeviceTokenApiDocs
+    public ResponseEntity<BaseResponse<Void>> deleteDeviceToken(
+            @PathVariable String deviceId,
+            @AuthenticationPrincipal OAuth2AuthenticatedPrincipal principal
+    ) {
+        deleteDeviceTokenUseCase.deleteDeviceToken(
+                new DeleteDeviceTokenCommand(
+                        ElementExtractor.extractUserId(principal),
+                        deviceId
+                )
+        );
+
+        return new ResponseEntity<>(
+                BaseResponse.of(
+                        null,
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "디바이스 토큰 삭제 성공"
+                ),
+                HttpStatus.OK
         );
     }
 }

--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/web/device/controller/apidocs/DeleteDeviceTokenApiDocs.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/web/device/controller/apidocs/DeleteDeviceTokenApiDocs.java
@@ -1,0 +1,105 @@
+package com.personal.marketnote.notification.adapter.in.web.device.controller.apidocs;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Operation(
+        summary = "디바이스 토큰 삭제",
+        description = """
+                작성일자: 2026-06-03
+
+                작성자: 성효빈
+
+                ---
+
+                ## Description
+
+                - 로그인한 사용자의 특정 기기 FCM 디바이스 토큰을 삭제합니다.
+
+                - 로그아웃, 앱 삭제 시 호출합니다.
+
+                - 본인 소유 기기만 삭제할 수 있습니다. 다른 사용자의 기기 또는 존재하지 않는 기기일 경우 404를 반환합니다.
+
+                ---
+
+                ## Path Variable
+
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | deviceId | string | 기기 고유 식별자 | "550e8400-e29b-41d4-a716-446655440000" |
+
+                ---
+
+                ## Response
+
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | statusCode | number | 상태 코드 | 200: 성공 / 401: 인증 실패 / 404: 찾을 수 없음 / 500: 그 외 |
+                | code | string | 응답 코드 | "SUC01" / "UNAUTHORIZED" / "NOT_FOUND" / "INTERNAL_SERVER_ERROR" |
+                | timestamp | string(datetime) | 응답 일시 | "2026-06-03T10:00:00.000" |
+                | content | null | 응답 본문 | null |
+                | message | string | 처리 결과 | "디바이스 토큰 삭제 성공" |
+                """,
+        security = {@SecurityRequirement(name = "bearer")},
+        parameters = {
+                @Parameter(name = "deviceId", description = "기기 고유 식별자", required = true, example = "550e8400-e29b-41d4-a716-446655440000")
+        },
+        responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "삭제 성공",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 200,
+                                          "code": "SUC01",
+                                          "timestamp": "2026-06-03T10:00:00.000",
+                                          "content": null,
+                                          "message": "디바이스 토큰 삭제 성공"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "401",
+                        description = "토큰 인증 실패",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 401,
+                                          "code": "UNAUTHORIZED",
+                                          "timestamp": "2026-06-03T10:00:00.000",
+                                          "content": null,
+                                          "message": "Invalid token"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "404",
+                        description = "디바이스 토큰 찾을 수 없음",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 404,
+                                          "code": "NOT_FOUND",
+                                          "timestamp": "2026-06-03T10:00:00.000",
+                                          "content": null,
+                                          "message": "디바이스 토큰을 찾을 수 없습니다."
+                                        }
+                                        """)
+                        )
+                )
+        }
+)
+public @interface DeleteDeviceTokenApiDocs {
+}

--- a/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/in/command/DeleteDeviceTokenCommand.java
+++ b/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/in/command/DeleteDeviceTokenCommand.java
@@ -1,0 +1,22 @@
+package com.personal.marketnote.notification.port.in.command;
+
+public record DeleteDeviceTokenCommand(
+        Long userId,
+        String deviceId
+) {
+
+    @Override
+    public String toString() {
+        return "DeleteDeviceTokenCommand{"
+                + "userId=" + userId
+                + ", deviceId=" + maskDeviceId(deviceId)
+                + "}";
+    }
+
+    private static String maskDeviceId(String deviceId) {
+        if (deviceId == null || deviceId.length() < 8) {
+            return "***";
+        }
+        return deviceId.substring(0, 4) + "***" + deviceId.substring(deviceId.length() - 4);
+    }
+}

--- a/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/in/usecase/device/DeleteDeviceTokenUseCase.java
+++ b/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/in/usecase/device/DeleteDeviceTokenUseCase.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.notification.port.in.usecase.device;
+
+import com.personal.marketnote.notification.port.in.command.DeleteDeviceTokenCommand;
+
+public interface DeleteDeviceTokenUseCase {
+    void deleteDeviceToken(DeleteDeviceTokenCommand command);
+}

--- a/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/service/device/DeleteDeviceTokenService.java
+++ b/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/service/device/DeleteDeviceTokenService.java
@@ -1,0 +1,34 @@
+package com.personal.marketnote.notification.service.device;
+
+import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.notification.domain.device.DeviceToken;
+import com.personal.marketnote.notification.domain.device.DeviceTokenNotFoundException;
+import com.personal.marketnote.notification.port.in.command.DeleteDeviceTokenCommand;
+import com.personal.marketnote.notification.port.in.usecase.device.DeleteDeviceTokenUseCase;
+import com.personal.marketnote.notification.port.out.device.DeleteDeviceTokenPort;
+import com.personal.marketnote.notification.port.out.device.FindDeviceTokenPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@UseCase
+@RequiredArgsConstructor
+public class DeleteDeviceTokenService implements DeleteDeviceTokenUseCase {
+
+    private final FindDeviceTokenPort findDeviceTokenPort;
+    private final DeleteDeviceTokenPort deleteDeviceTokenPort;
+
+    @Override
+    @Transactional(isolation = READ_COMMITTED)
+    public void deleteDeviceToken(DeleteDeviceTokenCommand command) {
+        DeviceToken deviceToken = findDeviceTokenPort.findActiveByDeviceId(command.deviceId())
+                .orElseThrow(DeviceTokenNotFoundException::new);
+
+        if (!deviceToken.isOwnedBy(command.userId())) {
+            throw new DeviceTokenNotFoundException();
+        }
+
+        deleteDeviceTokenPort.deleteById(deviceToken.getId());
+    }
+}

--- a/notification-service/notification-domain/src/main/java/com/personal/marketnote/notification/domain/device/DeviceTokenNotFoundException.java
+++ b/notification-service/notification-domain/src/main/java/com/personal/marketnote/notification/domain/device/DeviceTokenNotFoundException.java
@@ -4,4 +4,8 @@ public class DeviceTokenNotFoundException extends RuntimeException {
     public DeviceTokenNotFoundException(Long id) {
         super("ERR_DEVICE_TOKEN_03::디바이스 토큰을 찾을 수 없습니다. id=" + id);
     }
+
+    public DeviceTokenNotFoundException() {
+        super("ERR_DEVICE_TOKEN_03::디바이스 토큰을 찾을 수 없습니다.");
+    }
 }


### PR DESCRIPTION
## partially addresses #2090
## resolves #2093

## Task
- [x] DeleteDeviceTokenUseCase + Command (userId, deviceId 마스킹 toString)
- [x] DeleteDeviceTokenService (소유자 검증 후 삭제, 존재/소유자 불일치 모두 NotFound 통일로 존재 은닉)
- [x] DeviceTokenNotFoundException 무인자 생성자 추가
- [x] DELETE /api/v1/device-tokens/{deviceId} 컨트롤러 및 ApiDocs