### PR TITLE
[#2090][#2096] feat: 알림 수신 설정 초기화 기능 추가

### DIFF
--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/out/mapper/NotificationPreferenceJpaEntityToDomainMapper.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/out/mapper/NotificationPreferenceJpaEntityToDomainMapper.java
@@ -1,0 +1,29 @@
+package com.personal.marketnote.notification.adapter.out.mapper;
+
+import com.personal.marketnote.notification.adapter.out.persistence.preference.entity.NotificationPreferenceJpaEntity;
+import com.personal.marketnote.notification.domain.preference.NotificationPreference;
+import com.personal.marketnote.notification.domain.preference.NotificationPreferenceSnapshotState;
+
+import java.util.Optional;
+
+public class NotificationPreferenceJpaEntityToDomainMapper {
+
+    private NotificationPreferenceJpaEntityToDomainMapper() {
+    }
+
+    public static Optional<NotificationPreference> mapToDomain(NotificationPreferenceJpaEntity entity) {
+        return Optional.ofNullable(entity)
+                .map(e -> NotificationPreference.from(
+                        NotificationPreferenceSnapshotState.builder()
+                                .id(e.getId())
+                                .userId(e.getUserId())
+                                .notificationType(e.getNotificationType())
+                                .enabled(e.isEnabled())
+                                .consentedAt(e.getConsentedAt())
+                                .status(e.getStatus())
+                                .createdAt(e.getCreatedAt())
+                                .modifiedAt(e.getModifiedAt())
+                                .build()
+                ));
+    }
+}

--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/out/persistence/preference/NotificationPreferencePersistenceAdapter.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/out/persistence/preference/NotificationPreferencePersistenceAdapter.java
@@ -1,0 +1,32 @@
+package com.personal.marketnote.notification.adapter.out.persistence.preference;
+
+import com.personal.marketnote.common.adapter.out.PersistenceAdapter;
+import com.personal.marketnote.notification.adapter.out.persistence.preference.entity.NotificationPreferenceJpaEntity;
+import com.personal.marketnote.notification.adapter.out.persistence.preference.repository.NotificationPreferenceJpaRepository;
+import com.personal.marketnote.notification.domain.preference.DuplicateNotificationPreferenceException;
+import com.personal.marketnote.notification.domain.preference.NotificationPreference;
+import com.personal.marketnote.notification.port.out.preference.SaveNotificationPreferencePort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+
+import java.util.List;
+
+@PersistenceAdapter
+@RequiredArgsConstructor
+public class NotificationPreferencePersistenceAdapter implements SaveNotificationPreferencePort {
+
+    private final NotificationPreferenceJpaRepository notificationPreferenceJpaRepository;
+
+    @Override
+    public void saveAll(List<NotificationPreference> preferences) {
+        try {
+            List<NotificationPreferenceJpaEntity> entities = preferences.stream()
+                    .map(NotificationPreferenceJpaEntity::from)
+                    .toList();
+            notificationPreferenceJpaRepository.saveAll(entities);
+        } catch (DataIntegrityViolationException dive) {
+            Long userId = preferences.isEmpty() ? null : preferences.get(0).getUserId();
+            throw new DuplicateNotificationPreferenceException(userId);
+        }
+    }
+}

--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/out/persistence/preference/entity/NotificationPreferenceJpaEntity.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/out/persistence/preference/entity/NotificationPreferenceJpaEntity.java
@@ -1,0 +1,54 @@
+package com.personal.marketnote.notification.adapter.out.persistence.preference.entity;
+
+import com.personal.marketnote.common.adapter.out.persistence.audit.BaseGeneralEntity;
+import com.personal.marketnote.notification.domain.preference.NotificationPreference;
+import com.personal.marketnote.notification.domain.template.NotificationType;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.DynamicInsert;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "notification_preference", uniqueConstraints = {
+        @UniqueConstraint(name = "uk_notification_preference_user_type", columnNames = {"user_id", "notification_type"})
+}, indexes = {
+        @Index(name = "idx_notification_preference_user_id", columnList = "user_id")
+})
+@DynamicInsert
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+@Getter
+public class NotificationPreferenceJpaEntity extends BaseGeneralEntity {
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "notification_type", nullable = false, length = 50)
+    @Enumerated(EnumType.STRING)
+    private NotificationType notificationType;
+
+    @Column(name = "enabled", nullable = false)
+    private boolean enabled;
+
+    @Column(name = "consented_at")
+    private LocalDateTime consentedAt;
+
+    public static NotificationPreferenceJpaEntity from(NotificationPreference preference) {
+        return NotificationPreferenceJpaEntity.builder()
+                .userId(preference.getUserId())
+                .notificationType(preference.getNotificationType())
+                .enabled(preference.isEnabled())
+                .consentedAt(preference.getConsentedAt())
+                .build();
+    }
+
+    public void updateFrom(NotificationPreference preference) {
+        if (preference.isInactive()) {
+            deactivate();
+        }
+        this.enabled = preference.isEnabled();
+        this.consentedAt = preference.getConsentedAt();
+    }
+}

--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/out/persistence/preference/repository/NotificationPreferenceJpaRepository.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/out/persistence/preference/repository/NotificationPreferenceJpaRepository.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.notification.adapter.out.persistence.preference.repository;
+
+import com.personal.marketnote.notification.adapter.out.persistence.preference.entity.NotificationPreferenceJpaEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NotificationPreferenceJpaRepository extends JpaRepository<NotificationPreferenceJpaEntity, Long> {
+}

--- a/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/in/command/InitializeNotificationPreferenceCommand.java
+++ b/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/in/command/InitializeNotificationPreferenceCommand.java
@@ -1,0 +1,6 @@
+package com.personal.marketnote.notification.port.in.command;
+
+public record InitializeNotificationPreferenceCommand(
+        Long userId
+) {
+}

--- a/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/in/usecase/preference/InitializeNotificationPreferenceUseCase.java
+++ b/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/in/usecase/preference/InitializeNotificationPreferenceUseCase.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.notification.port.in.usecase.preference;
+
+import com.personal.marketnote.notification.port.in.command.InitializeNotificationPreferenceCommand;
+
+public interface InitializeNotificationPreferenceUseCase {
+    void initializeNotificationPreference(InitializeNotificationPreferenceCommand command);
+}

--- a/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/out/preference/SaveNotificationPreferencePort.java
+++ b/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/out/preference/SaveNotificationPreferencePort.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.notification.port.out.preference;
+
+import com.personal.marketnote.notification.domain.preference.NotificationPreference;
+
+import java.util.List;
+
+public interface SaveNotificationPreferencePort {
+    void saveAll(List<NotificationPreference> preferences);
+}

--- a/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/service/preference/InitializeNotificationPreferenceService.java
+++ b/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/service/preference/InitializeNotificationPreferenceService.java
@@ -1,0 +1,37 @@
+package com.personal.marketnote.notification.service.preference;
+
+import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.notification.domain.preference.NotificationPreference;
+import com.personal.marketnote.notification.domain.preference.NotificationPreferenceCreateState;
+import com.personal.marketnote.notification.domain.template.NotificationType;
+import com.personal.marketnote.notification.port.in.command.InitializeNotificationPreferenceCommand;
+import com.personal.marketnote.notification.port.in.usecase.preference.InitializeNotificationPreferenceUseCase;
+import com.personal.marketnote.notification.port.out.preference.SaveNotificationPreferencePort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@UseCase
+@RequiredArgsConstructor
+public class InitializeNotificationPreferenceService implements InitializeNotificationPreferenceUseCase {
+
+    private final SaveNotificationPreferencePort saveNotificationPreferencePort;
+
+    @Override
+    @Transactional(isolation = READ_COMMITTED)
+    public void initializeNotificationPreference(InitializeNotificationPreferenceCommand command) {
+        List<NotificationPreference> preferences = Arrays.stream(NotificationType.values())
+                .map(type -> NotificationPreference.from(NotificationPreferenceCreateState.builder()
+                        .userId(command.userId())
+                        .notificationType(type)
+                        .enabled(true)
+                        .build()))
+                .toList();
+
+        saveNotificationPreferencePort.saveAll(preferences);
+    }
+}

--- a/notification-service/notification-domain/src/main/java/com/personal/marketnote/notification/domain/preference/DuplicateNotificationPreferenceException.java
+++ b/notification-service/notification-domain/src/main/java/com/personal/marketnote/notification/domain/preference/DuplicateNotificationPreferenceException.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.notification.domain.preference;
+
+public class DuplicateNotificationPreferenceException extends RuntimeException {
+    public DuplicateNotificationPreferenceException(Long userId) {
+        super("ERR_NOTIFICATION_PREFERENCE_02::이미 초기화된 알림 수신 설정입니다. userId=" + userId);
+    }
+}

--- a/notification-service/notification-domain/src/main/java/com/personal/marketnote/notification/domain/preference/InvalidNotificationPreferenceException.java
+++ b/notification-service/notification-domain/src/main/java/com/personal/marketnote/notification/domain/preference/InvalidNotificationPreferenceException.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.notification.domain.preference;
+
+public class InvalidNotificationPreferenceException extends IllegalArgumentException {
+    public InvalidNotificationPreferenceException(String message) {
+        super("ERR_NOTIFICATION_PREFERENCE_01::" + message);
+    }
+}

--- a/notification-service/notification-domain/src/main/java/com/personal/marketnote/notification/domain/preference/NotificationPreference.java
+++ b/notification-service/notification-domain/src/main/java/com/personal/marketnote/notification/domain/preference/NotificationPreference.java
@@ -1,0 +1,66 @@
+package com.personal.marketnote.notification.domain.preference;
+
+import com.personal.marketnote.common.domain.BaseDomain;
+import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.notification.domain.template.NotificationType;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+@Getter
+public class NotificationPreference extends BaseDomain {
+    private Long id;
+    private Long userId;
+    private NotificationType notificationType;
+    private boolean enabled;
+    private LocalDateTime consentedAt;
+    private LocalDateTime createdAt;
+    private LocalDateTime modifiedAt;
+
+    public static NotificationPreference from(NotificationPreferenceCreateState state) {
+        validate(state.getUserId(), state.getNotificationType());
+
+        NotificationPreference preference = NotificationPreference.builder()
+                .userId(state.getUserId())
+                .notificationType(state.getNotificationType())
+                .enabled(state.isEnabled())
+                .build();
+        preference.activate();
+        return preference;
+    }
+
+    public static NotificationPreference from(NotificationPreferenceSnapshotState state) {
+        NotificationPreference preference = NotificationPreference.builder()
+                .id(state.getId())
+                .userId(state.getUserId())
+                .notificationType(state.getNotificationType())
+                .enabled(state.isEnabled())
+                .consentedAt(state.getConsentedAt())
+                .createdAt(state.getCreatedAt())
+                .modifiedAt(state.getModifiedAt())
+                .build();
+        preference.status = state.getStatus();
+        return preference;
+    }
+
+    public void enable(LocalDateTime now) {
+        this.enabled = true;
+        this.consentedAt = now;
+    }
+
+    public void disable(LocalDateTime now) {
+        this.enabled = false;
+    }
+
+    private static void validate(Long userId, NotificationType notificationType) {
+        if (FormatValidator.hasNoValue(userId)) {
+            throw new InvalidNotificationPreferenceException("사용자 ID는 필수입니다.");
+        }
+        if (FormatValidator.hasNoValue(notificationType)) {
+            throw new InvalidNotificationPreferenceException("알림 타입은 필수입니다.");
+        }
+    }
+}

--- a/notification-service/notification-domain/src/main/java/com/personal/marketnote/notification/domain/preference/NotificationPreferenceCreateState.java
+++ b/notification-service/notification-domain/src/main/java/com/personal/marketnote/notification/domain/preference/NotificationPreferenceCreateState.java
@@ -1,0 +1,14 @@
+package com.personal.marketnote.notification.domain.preference;
+
+import com.personal.marketnote.notification.domain.template.NotificationType;
+import lombok.*;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+@Getter
+public class NotificationPreferenceCreateState {
+    private Long userId;
+    private NotificationType notificationType;
+    private boolean enabled;
+}

--- a/notification-service/notification-domain/src/main/java/com/personal/marketnote/notification/domain/preference/NotificationPreferenceSnapshotState.java
+++ b/notification-service/notification-domain/src/main/java/com/personal/marketnote/notification/domain/preference/NotificationPreferenceSnapshotState.java
@@ -1,0 +1,22 @@
+package com.personal.marketnote.notification.domain.preference;
+
+import com.personal.marketnote.common.domain.EntityStatus;
+import com.personal.marketnote.notification.domain.template.NotificationType;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+@Getter
+public class NotificationPreferenceSnapshotState {
+    private Long id;
+    private Long userId;
+    private NotificationType notificationType;
+    private boolean enabled;
+    private LocalDateTime consentedAt;
+    private EntityStatus status;
+    private LocalDateTime createdAt;
+    private LocalDateTime modifiedAt;
+}


### PR DESCRIPTION
## partially addresses #2090
## resolves #2096

## Task
- [x] NotificationPreference 도메인 (CreateState/SnapshotState 팩토리, enable/disable 상태 전이)
- [x] NotificationPreference 예외 2건 (InvalidNotificationPreference/DuplicateNotificationPreference)
- [x] InitializeNotificationPreferenceUseCase/Service/Command
- [x] SaveNotificationPreferencePort (bulk saveAll)
- [x] NotificationPreferenceJpaEntity/Repository/PersistenceAdapter/Mapper (UNIQUE user_id+notification_type)
- [x] NotificationType 18개 전체에 대해 enabled=true 초기화, DataIntegrityViolationException 변환