### PR TITLE
[#2090][#2577] test: 알림 수신 설정 초기화 기능 자동화 테스트 추가

### DIFF
--- a/notification-service/notification-application/src/test/java/com/personal/marketnote/notification/service/preference/InitializeNotificationPreferenceUseCaseTest.java
+++ b/notification-service/notification-application/src/test/java/com/personal/marketnote/notification/service/preference/InitializeNotificationPreferenceUseCaseTest.java
@@ -1,0 +1,53 @@
+package com.personal.marketnote.notification.service.preference;
+
+import com.personal.marketnote.notification.domain.preference.NotificationPreference;
+import com.personal.marketnote.notification.domain.template.NotificationType;
+import com.personal.marketnote.notification.port.in.command.InitializeNotificationPreferenceCommand;
+import com.personal.marketnote.notification.port.out.preference.SaveNotificationPreferencePort;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class InitializeNotificationPreferenceUseCaseTest {
+
+    @InjectMocks
+    private InitializeNotificationPreferenceService initializeNotificationPreferenceService;
+
+    @Mock
+    private SaveNotificationPreferencePort saveNotificationPreferencePort;
+
+    @Test
+    @DisplayName("모든 알림 타입에 대해 수신 설정을 enabled=true로 초기화한다")
+    void shouldInitializeAllNotificationTypesAsEnabled() {
+        // given
+        InitializeNotificationPreferenceCommand command = new InitializeNotificationPreferenceCommand(100L);
+        ArgumentCaptor<List<NotificationPreference>> captor = ArgumentCaptor.forClass(List.class);
+
+        // when
+        initializeNotificationPreferenceService.initializeNotificationPreference(command);
+
+        // then
+        verify(saveNotificationPreferencePort).saveAll(captor.capture());
+        List<NotificationPreference> saved = captor.getValue();
+
+        assertThat(saved).hasSize(NotificationType.values().length);
+        assertThat(saved).allSatisfy(preference -> {
+            assertThat(preference.getUserId()).isEqualTo(100L);
+            assertThat(preference.isEnabled()).isTrue();
+            assertThat(preference.getConsentedAt()).isNull();
+        });
+        assertThat(saved)
+                .extracting(NotificationPreference::getNotificationType)
+                .containsExactlyInAnyOrder(NotificationType.values());
+    }
+}

--- a/notification-service/notification-domain/src/test/java/com/personal/marketnote/notification/domain/preference/NotificationPreferenceTest.java
+++ b/notification-service/notification-domain/src/test/java/com/personal/marketnote/notification/domain/preference/NotificationPreferenceTest.java
@@ -1,0 +1,97 @@
+package com.personal.marketnote.notification.domain.preference;
+
+import com.personal.marketnote.common.domain.EntityStatus;
+import com.personal.marketnote.notification.domain.template.NotificationType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class NotificationPreferenceTest {
+
+    private static final LocalDateTime NOW = LocalDateTime.of(2026, 4, 9, 10, 0);
+
+    @Test
+    @DisplayName("CreateState로 알림 수신 설정을 생성한다")
+    void shouldCreateFromCreateState() {
+        NotificationPreference preference = NotificationPreference.from(NotificationPreferenceCreateState.builder()
+                .userId(100L)
+                .notificationType(NotificationType.ORDER_PAYMENT_COMPLETED)
+                .enabled(true)
+                .build());
+
+        assertThat(preference.getUserId()).isEqualTo(100L);
+        assertThat(preference.getNotificationType()).isEqualTo(NotificationType.ORDER_PAYMENT_COMPLETED);
+        assertThat(preference.isEnabled()).isTrue();
+        assertThat(preference.getConsentedAt()).isNull();
+        assertThat(preference.isActive()).isTrue();
+    }
+
+    @Test
+    @DisplayName("userId가 null이면 예외를 던진다")
+    void shouldThrowExceptionWhenUserIdIsNull() {
+        NotificationPreferenceCreateState state = NotificationPreferenceCreateState.builder()
+                .userId(null)
+                .notificationType(NotificationType.ORDER_PAYMENT_COMPLETED)
+                .enabled(true)
+                .build();
+
+        assertThatThrownBy(() -> NotificationPreference.from(state))
+                .isInstanceOf(InvalidNotificationPreferenceException.class);
+    }
+
+    @Test
+    @DisplayName("notificationType이 null이면 예외를 던진다")
+    void shouldThrowExceptionWhenNotificationTypeIsNull() {
+        NotificationPreferenceCreateState state = NotificationPreferenceCreateState.builder()
+                .userId(100L)
+                .notificationType(null)
+                .enabled(true)
+                .build();
+
+        assertThatThrownBy(() -> NotificationPreference.from(state))
+                .isInstanceOf(InvalidNotificationPreferenceException.class);
+    }
+
+    @Test
+    @DisplayName("SnapshotState로 알림 수신 설정을 복원한다")
+    void shouldRestoreFromSnapshotState() {
+        NotificationPreference preference = NotificationPreference.from(NotificationPreferenceSnapshotState.builder()
+                .id(1L)
+                .userId(100L)
+                .notificationType(NotificationType.ORDER_PAYMENT_COMPLETED)
+                .enabled(false)
+                .consentedAt(NOW)
+                .status(EntityStatus.ACTIVE)
+                .createdAt(NOW)
+                .modifiedAt(NOW)
+                .build());
+
+        assertThat(preference.getId()).isEqualTo(1L);
+        assertThat(preference.isEnabled()).isFalse();
+        assertThat(preference.getConsentedAt()).isEqualTo(NOW);
+    }
+
+    @Test
+    @DisplayName("enable/disable 상태 전이로 활성화 여부를 변경한다")
+    void shouldToggleEnabled() {
+        NotificationPreference preference = NotificationPreference.from(NotificationPreferenceCreateState.builder()
+                .userId(100L)
+                .notificationType(NotificationType.EVENT)
+                .enabled(true)
+                .build());
+
+        preference.disable(NOW);
+
+        assertThat(preference.isEnabled()).isFalse();
+        assertThat(preference.getConsentedAt()).isNull();
+
+        preference.enable(NOW);
+
+        assertThat(preference.isEnabled()).isTrue();
+        assertThat(preference.getConsentedAt()).isEqualTo(NOW);
+    }
+}


### PR DESCRIPTION
## partially addresses #2090
## resolves #2577

## Test Case
- [x] NotificationPreference 도메인 생성/검증/enable-disable 상태 전이 단위 테스트 (5건)
- [x] InitializeNotificationPreferenceUseCase 전체 타입 초기화 단위 테스트 (1건)