### PR TITLE
[#2143][#2147] feat: 배송 상태 변경 시 Kafka 이벤트 Outbox 발행 기능 추가

### DIFF
--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/event/ShippingStatusEventOutboxAdapter.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/event/ShippingStatusEventOutboxAdapter.java
@@ -1,0 +1,49 @@
+package com.personal.marketnote.fulfillment.adapter.out.event;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.common.kafka.KafkaTopicConstants;
+import com.personal.marketnote.common.kafka.event.ShippingStatusChangedEvent;
+import com.personal.marketnote.common.outbox.OutboxEvent;
+import com.personal.marketnote.common.outbox.SaveOutboxEventPort;
+import com.personal.marketnote.fulfillment.exception.ShippingStatusEventSerializationException;
+import com.personal.marketnote.fulfillment.port.out.event.PublishShippingStatusChangedEventPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.Clock;
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class ShippingStatusEventOutboxAdapter implements PublishShippingStatusChangedEventPort {
+
+    private static final String EVENT_SOURCE = "fulfillment-service";
+
+    private final SaveOutboxEventPort saveOutboxEventPort;
+    private final ObjectMapper objectMapper;
+    private final Clock clock;
+
+    @Override
+    public void publish(ShippingStatusChangedEvent event) {
+        String payload = serialize(event);
+        OutboxEvent outboxEvent = OutboxEvent.of(
+                UUID.randomUUID().toString(),
+                KafkaTopicConstants.SHIPPING_STATUS_CHANGED,
+                String.valueOf(event.orderId()),
+                ShippingStatusChangedEvent.class.getSimpleName(),
+                EVENT_SOURCE,
+                payload,
+                clock
+        );
+        saveOutboxEventPort.save(outboxEvent);
+    }
+
+    private String serialize(ShippingStatusChangedEvent event) {
+        try {
+            return objectMapper.writeValueAsString(event);
+        } catch (JsonProcessingException e) {
+            throw new ShippingStatusEventSerializationException(event.orderId(), e);
+        }
+    }
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/resources/application.yml
+++ b/fulfillment-service/fulfillment-adapters/src/main/resources/application.yml
@@ -108,6 +108,10 @@ fulfillment:
     enabled: ${FULFILLMENT_DELIVERY_POLLING_ENABLED:false}
     interval-ms: ${FULFILLMENT_DELIVERY_POLLING_INTERVAL_MS:1800000}
 
+outbox:
+  enabled: ${OUTBOX_ENABLED:true}
+  polling-interval-ms: ${OUTBOX_POLLING_INTERVAL_MS:3000}
+
 commerce-service:
   base-url: ${COMMERCE_SERVICE_SERVER_ORIGIN:http://localhost:8082}
 

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/ShippingStatusEventSerializationException.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/exception/ShippingStatusEventSerializationException.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.fulfillment.exception;
+
+public class ShippingStatusEventSerializationException extends RuntimeException {
+
+    public ShippingStatusEventSerializationException(Long orderId, Throwable cause) {
+        super("배송 상태 변경 이벤트 직렬화 실패. orderId=" + orderId, cause);
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/event/PublishShippingStatusChangedEventPort.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/out/event/PublishShippingStatusChangedEventPort.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.fulfillment.port.out.event;
+
+import com.personal.marketnote.common.kafka.event.ShippingStatusChangedEvent;
+
+public interface PublishShippingStatusChangedEventPort {
+    void publish(ShippingStatusChangedEvent event);
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/shipping/PollShippingStatusService.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/shipping/PollShippingStatusService.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.fulfillment.service.shipping;
 
 import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.common.kafka.event.ShippingStatusChangedEvent;
 import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.fulfillment.domain.FulfillmentAccessToken;
 import com.personal.marketnote.fulfillment.domain.shipping.ShippingStatus;
@@ -11,6 +12,7 @@ import com.personal.marketnote.fulfillment.port.in.result.vendor.FulfillmentDeli
 import com.personal.marketnote.fulfillment.port.in.result.vendor.GetFulfillmentDeliveryStatusesResult;
 import com.personal.marketnote.fulfillment.port.in.usecase.PollShippingStatusUseCase;
 import com.personal.marketnote.fulfillment.port.in.usecase.vendor.RequestFulfillmentAuthUseCase;
+import com.personal.marketnote.fulfillment.port.out.event.PublishShippingStatusChangedEventPort;
 import com.personal.marketnote.fulfillment.port.out.shipping.FindShippingTrackerPort;
 import com.personal.marketnote.fulfillment.port.out.shipping.UpdateShippingTrackerPort;
 import com.personal.marketnote.fulfillment.port.out.vendor.GetFulfillmentDeliveryStatusesPort;
@@ -39,6 +41,7 @@ public class PollShippingStatusService implements PollShippingStatusUseCase {
     private final UpdateShippingTrackerPort updateShippingTrackerPort;
     private final RequestFulfillmentAuthUseCase requestFulfillmentAuthUseCase;
     private final GetFulfillmentDeliveryStatusesPort getDeliveryStatusesPort;
+    private final PublishShippingStatusChangedEventPort publishShippingStatusChangedEventPort;
     private final Clock clock;
     private final TransactionTemplate transactionTemplate;
 
@@ -47,6 +50,7 @@ public class PollShippingStatusService implements PollShippingStatusUseCase {
             UpdateShippingTrackerPort updateShippingTrackerPort,
             RequestFulfillmentAuthUseCase requestFulfillmentAuthUseCase,
             GetFulfillmentDeliveryStatusesPort getDeliveryStatusesPort,
+            PublishShippingStatusChangedEventPort publishShippingStatusChangedEventPort,
             Clock clock,
             PlatformTransactionManager transactionManager
     ) {
@@ -54,6 +58,7 @@ public class PollShippingStatusService implements PollShippingStatusUseCase {
         this.updateShippingTrackerPort = updateShippingTrackerPort;
         this.requestFulfillmentAuthUseCase = requestFulfillmentAuthUseCase;
         this.getDeliveryStatusesPort = getDeliveryStatusesPort;
+        this.publishShippingStatusChangedEventPort = publishShippingStatusChangedEventPort;
         this.clock = clock;
         this.transactionTemplate = new TransactionTemplate(transactionManager);
         this.transactionTemplate.setIsolationLevel(Isolation.READ_COMMITTED.value());
@@ -150,6 +155,7 @@ public class PollShippingStatusService implements PollShippingStatusUseCase {
     ) {
         if (newStatus.isShipping() && tracker.isPreparing()) {
             applyShippingTransition(tracker, deliveryStatus);
+            publishStatusChanged(tracker);
             return;
         }
         if (newStatus.isShipping() && tracker.isShipping()) {
@@ -158,11 +164,23 @@ public class PollShippingStatusService implements PollShippingStatusUseCase {
         }
         if (newStatus.isDelivered()) {
             tracker.completeDelivery();
+            publishStatusChanged(tracker);
             return;
         }
         if (newStatus.isDeliveryFailed()) {
             tracker.markDeliveryFailed();
+            publishStatusChanged(tracker);
         }
+    }
+
+    private void publishStatusChanged(ShippingTracker tracker) {
+        publishShippingStatusChangedEventPort.publish(new ShippingStatusChangedEvent(
+                tracker.getOrderId(),
+                tracker.getShippingStatus().name(),
+                tracker.getTrackingNumber(),
+                tracker.getCarrierCode(),
+                LocalDateTime.now(clock)
+        ));
     }
 
     private void applyShippingTransition(ShippingTracker tracker, FulfillmentDeliveryStatusInfoResult deliveryStatus) {

--- a/notification-service/notification-application/src/test/java/com/personal/marketnote/notification/service/preference/InitializeNotificationPreferenceUseCaseTest.java
+++ b/notification-service/notification-application/src/test/java/com/personal/marketnote/notification/service/preference/InitializeNotificationPreferenceUseCaseTest.java
@@ -1,0 +1,53 @@
+package com.personal.marketnote.notification.service.preference;
+
+import com.personal.marketnote.notification.domain.preference.NotificationPreference;
+import com.personal.marketnote.notification.domain.template.NotificationType;
+import com.personal.marketnote.notification.port.in.command.InitializeNotificationPreferenceCommand;
+import com.personal.marketnote.notification.port.out.preference.SaveNotificationPreferencePort;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class InitializeNotificationPreferenceUseCaseTest {
+
+    @InjectMocks
+    private InitializeNotificationPreferenceService initializeNotificationPreferenceService;
+
+    @Mock
+    private SaveNotificationPreferencePort saveNotificationPreferencePort;
+
+    @Test
+    @DisplayName("모든 알림 타입에 대해 수신 설정을 enabled=true로 초기화한다")
+    void shouldInitializeAllNotificationTypesAsEnabled() {
+        // given
+        InitializeNotificationPreferenceCommand command = new InitializeNotificationPreferenceCommand(100L);
+        ArgumentCaptor<List<NotificationPreference>> captor = ArgumentCaptor.forClass(List.class);
+
+        // when
+        initializeNotificationPreferenceService.initializeNotificationPreference(command);
+
+        // then
+        verify(saveNotificationPreferencePort).saveAll(captor.capture());
+        List<NotificationPreference> saved = captor.getValue();
+
+        assertThat(saved).hasSize(NotificationType.values().length);
+        assertThat(saved).allSatisfy(preference -> {
+            assertThat(preference.getUserId()).isEqualTo(100L);
+            assertThat(preference.isEnabled()).isTrue();
+            assertThat(preference.getConsentedAt()).isNull();
+        });
+        assertThat(saved)
+                .extracting(NotificationPreference::getNotificationType)
+                .containsExactlyInAnyOrder(NotificationType.values());
+    }
+}

--- a/notification-service/notification-domain/src/test/java/com/personal/marketnote/notification/domain/preference/NotificationPreferenceTest.java
+++ b/notification-service/notification-domain/src/test/java/com/personal/marketnote/notification/domain/preference/NotificationPreferenceTest.java
@@ -1,0 +1,97 @@
+package com.personal.marketnote.notification.domain.preference;
+
+import com.personal.marketnote.common.domain.EntityStatus;
+import com.personal.marketnote.notification.domain.template.NotificationType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class NotificationPreferenceTest {
+
+    private static final LocalDateTime NOW = LocalDateTime.of(2026, 4, 9, 10, 0);
+
+    @Test
+    @DisplayName("CreateState로 알림 수신 설정을 생성한다")
+    void shouldCreateFromCreateState() {
+        NotificationPreference preference = NotificationPreference.from(NotificationPreferenceCreateState.builder()
+                .userId(100L)
+                .notificationType(NotificationType.ORDER_PAYMENT_COMPLETED)
+                .enabled(true)
+                .build());
+
+        assertThat(preference.getUserId()).isEqualTo(100L);
+        assertThat(preference.getNotificationType()).isEqualTo(NotificationType.ORDER_PAYMENT_COMPLETED);
+        assertThat(preference.isEnabled()).isTrue();
+        assertThat(preference.getConsentedAt()).isNull();
+        assertThat(preference.isActive()).isTrue();
+    }
+
+    @Test
+    @DisplayName("userId가 null이면 예외를 던진다")
+    void shouldThrowExceptionWhenUserIdIsNull() {
+        NotificationPreferenceCreateState state = NotificationPreferenceCreateState.builder()
+                .userId(null)
+                .notificationType(NotificationType.ORDER_PAYMENT_COMPLETED)
+                .enabled(true)
+                .build();
+
+        assertThatThrownBy(() -> NotificationPreference.from(state))
+                .isInstanceOf(InvalidNotificationPreferenceException.class);
+    }
+
+    @Test
+    @DisplayName("notificationType이 null이면 예외를 던진다")
+    void shouldThrowExceptionWhenNotificationTypeIsNull() {
+        NotificationPreferenceCreateState state = NotificationPreferenceCreateState.builder()
+                .userId(100L)
+                .notificationType(null)
+                .enabled(true)
+                .build();
+
+        assertThatThrownBy(() -> NotificationPreference.from(state))
+                .isInstanceOf(InvalidNotificationPreferenceException.class);
+    }
+
+    @Test
+    @DisplayName("SnapshotState로 알림 수신 설정을 복원한다")
+    void shouldRestoreFromSnapshotState() {
+        NotificationPreference preference = NotificationPreference.from(NotificationPreferenceSnapshotState.builder()
+                .id(1L)
+                .userId(100L)
+                .notificationType(NotificationType.ORDER_PAYMENT_COMPLETED)
+                .enabled(false)
+                .consentedAt(NOW)
+                .status(EntityStatus.ACTIVE)
+                .createdAt(NOW)
+                .modifiedAt(NOW)
+                .build());
+
+        assertThat(preference.getId()).isEqualTo(1L);
+        assertThat(preference.isEnabled()).isFalse();
+        assertThat(preference.getConsentedAt()).isEqualTo(NOW);
+    }
+
+    @Test
+    @DisplayName("enable/disable 상태 전이로 활성화 여부를 변경한다")
+    void shouldToggleEnabled() {
+        NotificationPreference preference = NotificationPreference.from(NotificationPreferenceCreateState.builder()
+                .userId(100L)
+                .notificationType(NotificationType.EVENT)
+                .enabled(true)
+                .build());
+
+        preference.disable(NOW);
+
+        assertThat(preference.isEnabled()).isFalse();
+        assertThat(preference.getConsentedAt()).isNull();
+
+        preference.enable(NOW);
+
+        assertThat(preference.isEnabled()).isTrue();
+        assertThat(preference.getConsentedAt()).isEqualTo(NOW);
+    }
+}


### PR DESCRIPTION
## partially addresses #2143
## resolves #2147

## Task
- [x] PublishShippingStatusChangedEventPort 정의
- [x] ShippingStatusEventOutboxAdapter 구현 (SaveOutboxEventPort 사용, ObjectMapper 직렬화)
- [x] PollShippingStatusService에서 PREPARING→SHIPPING/SHIPPING→DELIVERED/SHIPPING→DELIVERY_FAILED 전이 시 이벤트 발행
- [x] partitionKey: orderId (주문별 순서 보장)
- [x] eventId: UUID, source: fulfillment-service
- [x] ShippingStatusEventSerializationException 신규 (직렬화 실패 시)
- [x] application.yml에 outbox.enabled=true 추가 (OutboxEventPublisher 활성화)