### PR TITLE
[#2143][#2590] test: 배송 상태 변경 시 Kafka 이벤트 Outbox 발행 기능 자동화 테스트 추가

### DIFF
--- a/fulfillment-service/fulfillment-adapters/src/test/java/com/personal/marketnote/fulfillment/adapter/out/event/ShippingStatusEventOutboxAdapterTest.java
+++ b/fulfillment-service/fulfillment-adapters/src/test/java/com/personal/marketnote/fulfillment/adapter/out/event/ShippingStatusEventOutboxAdapterTest.java
@@ -1,0 +1,125 @@
+package com.personal.marketnote.fulfillment.adapter.out.event;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.common.kafka.KafkaTopicConstants;
+import com.personal.marketnote.common.kafka.event.ShippingStatusChangedEvent;
+import com.personal.marketnote.common.outbox.OutboxEvent;
+import com.personal.marketnote.common.outbox.SaveOutboxEventPort;
+import com.personal.marketnote.fulfillment.exception.ShippingStatusEventSerializationException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ShippingStatusEventOutboxAdapter 테스트")
+class ShippingStatusEventOutboxAdapterTest {
+
+    @InjectMocks
+    private ShippingStatusEventOutboxAdapter adapter;
+
+    @Mock
+    private SaveOutboxEventPort saveOutboxEventPort;
+
+    @Spy
+    private ObjectMapper objectMapper = new ObjectMapper().findAndRegisterModules();
+
+    @Spy
+    private Clock clock = Clock.fixed(
+            Instant.parse("2026-06-03T10:00:00Z"),
+            ZoneId.of("Asia/Seoul")
+    );
+
+    @Test
+    @DisplayName("ShippingStatusChangedEvent를 OutboxEvent로 저장한다")
+    void publishSavesOutboxEvent() {
+        // given
+        ShippingStatusChangedEvent event = new ShippingStatusChangedEvent(
+                100L,
+                "SHIPPING",
+                "INV001",
+                "CJ",
+                LocalDateTime.of(2026, 4, 9, 10, 0)
+        );
+
+        // when
+        adapter.publish(event);
+
+        // then
+        ArgumentCaptor<OutboxEvent> captor = ArgumentCaptor.forClass(OutboxEvent.class);
+        verify(saveOutboxEventPort).save(captor.capture());
+
+        OutboxEvent outboxEvent = captor.getValue();
+        assertThat(outboxEvent.getTopic()).isEqualTo(KafkaTopicConstants.SHIPPING_STATUS_CHANGED);
+        assertThat(outboxEvent.getPartitionKey()).isEqualTo("100");
+        assertThat(outboxEvent.getEventType()).isEqualTo("ShippingStatusChangedEvent");
+        assertThat(outboxEvent.getSource()).isEqualTo("fulfillment-service");
+        assertThat(outboxEvent.getEventId()).isNotBlank();
+        assertThat(outboxEvent.getPayload()).contains("\"orderId\":100");
+        assertThat(outboxEvent.getPayload()).contains("\"shippingStatus\":\"SHIPPING\"");
+        assertThat(outboxEvent.getPayload()).contains("\"trackingNumber\":\"INV001\"");
+        assertThat(outboxEvent.getPayload()).contains("\"carrierCode\":\"CJ\"");
+    }
+
+    @Test
+    @DisplayName("페이로드 JSON이 올바르게 직렬화된다")
+    void payloadIsValidJson() throws Exception {
+        // given
+        ShippingStatusChangedEvent event = new ShippingStatusChangedEvent(
+                200L,
+                "DELIVERED",
+                "INV002",
+                "HANJIN",
+                LocalDateTime.of(2026, 4, 9, 12, 0)
+        );
+
+        // when
+        adapter.publish(event);
+
+        // then
+        ArgumentCaptor<OutboxEvent> captor = ArgumentCaptor.forClass(OutboxEvent.class);
+        verify(saveOutboxEventPort).save(captor.capture());
+
+        JsonNode parsed = objectMapper.readTree(captor.getValue().getPayload());
+        assertThat(parsed.get("orderId").asLong()).isEqualTo(200L);
+        assertThat(parsed.get("shippingStatus").asText()).isEqualTo("DELIVERED");
+        assertThat(parsed.get("trackingNumber").asText()).isEqualTo("INV002");
+        assertThat(parsed.get("carrierCode").asText()).isEqualTo("HANJIN");
+    }
+
+    @Test
+    @DisplayName("직렬화 실패 시 ShippingStatusEventSerializationException을 던진다")
+    void throwsOnSerializationFailure() throws Exception {
+        // given
+        ShippingStatusChangedEvent event = new ShippingStatusChangedEvent(
+                300L,
+                "DELIVERY_FAILED",
+                "INV003",
+                "CJ",
+                LocalDateTime.of(2026, 4, 9, 14, 0)
+        );
+        when(objectMapper.writeValueAsString(event))
+                .thenThrow(new JsonProcessingException("test failure") {});
+
+        // when & then
+        assertThatThrownBy(() -> adapter.publish(event))
+                .isInstanceOf(ShippingStatusEventSerializationException.class)
+                .hasMessageContaining("orderId=300");
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/test/java/com/personal/marketnote/fulfillment/service/shipping/PollShippingStatusUseCaseTest.java
+++ b/fulfillment-service/fulfillment-application/src/test/java/com/personal/marketnote/fulfillment/service/shipping/PollShippingStatusUseCaseTest.java
@@ -1,5 +1,6 @@
 package com.personal.marketnote.fulfillment.service.shipping;
 
+import com.personal.marketnote.common.kafka.event.ShippingStatusChangedEvent;
 import com.personal.marketnote.fulfillment.domain.FulfillmentAccessToken;
 import com.personal.marketnote.fulfillment.domain.shipping.ShippingStatus;
 import com.personal.marketnote.fulfillment.domain.shipping.ShippingTracker;
@@ -9,6 +10,7 @@ import com.personal.marketnote.fulfillment.port.in.command.PollShippingStatusCom
 import com.personal.marketnote.fulfillment.port.in.result.vendor.FulfillmentDeliveryStatusInfoResult;
 import com.personal.marketnote.fulfillment.port.in.result.vendor.GetFulfillmentDeliveryStatusesResult;
 import com.personal.marketnote.fulfillment.port.in.usecase.vendor.RequestFulfillmentAuthUseCase;
+import com.personal.marketnote.fulfillment.port.out.event.PublishShippingStatusChangedEventPort;
 import com.personal.marketnote.fulfillment.port.out.shipping.FindShippingTrackerPort;
 import com.personal.marketnote.fulfillment.port.out.shipping.UpdateShippingTrackerPort;
 import com.personal.marketnote.fulfillment.port.out.vendor.GetFulfillmentDeliveryStatusesPort;
@@ -55,6 +57,9 @@ class PollShippingStatusUseCaseTest {
     @Mock
     private PlatformTransactionManager transactionManager;
 
+    @Mock
+    private PublishShippingStatusChangedEventPort publishShippingStatusChangedEventPort;
+
     private final Clock clock = Clock.fixed(
             Instant.parse("2026-06-03T10:00:00Z"),
             ZoneId.of("Asia/Seoul")
@@ -68,6 +73,7 @@ class PollShippingStatusUseCaseTest {
                 updateShippingTrackerPort,
                 requestFulfillmentAuthUseCase,
                 getDeliveryStatusesPort,
+                publishShippingStatusChangedEventPort,
                 clock,
                 transactionManager
         );
@@ -115,6 +121,14 @@ class PollShippingStatusUseCaseTest {
         assertThat(updated.getTrackingNumber()).isEqualTo("INV001");
         assertThat(updated.getCarrierCode()).isEqualTo("CJ");
         assertThat(updated.getLastPolledAt()).isNotNull();
+
+        ArgumentCaptor<ShippingStatusChangedEvent> eventCaptor = ArgumentCaptor.forClass(ShippingStatusChangedEvent.class);
+        verify(publishShippingStatusChangedEventPort).publish(eventCaptor.capture());
+        ShippingStatusChangedEvent event = eventCaptor.getValue();
+        assertThat(event.orderId()).isEqualTo(100L);
+        assertThat(event.shippingStatus()).isEqualTo("SHIPPING");
+        assertThat(event.trackingNumber()).isEqualTo("INV001");
+        assertThat(event.carrierCode()).isEqualTo("CJ");
     }
 
     @Test
@@ -141,6 +155,8 @@ class PollShippingStatusUseCaseTest {
         ShippingTracker updated = captor.getValue();
         assertThat(updated.isShipping()).isTrue();
         assertThat(updated.getTrackingNumber()).isNull();
+
+        verify(publishShippingStatusChangedEventPort).publish(any(ShippingStatusChangedEvent.class));
     }
 
     @Test
@@ -167,6 +183,10 @@ class PollShippingStatusUseCaseTest {
         ShippingTracker updated = captor.getValue();
         assertThat(updated.isDelivered()).isTrue();
         assertThat(updated.isPollingActive()).isFalse();
+
+        ArgumentCaptor<ShippingStatusChangedEvent> eventCaptor = ArgumentCaptor.forClass(ShippingStatusChangedEvent.class);
+        verify(publishShippingStatusChangedEventPort).publish(eventCaptor.capture());
+        assertThat(eventCaptor.getValue().shippingStatus()).isEqualTo("DELIVERED");
     }
 
     @Test
@@ -193,6 +213,10 @@ class PollShippingStatusUseCaseTest {
         ShippingTracker updated = captor.getValue();
         assertThat(updated.isDeliveryFailed()).isTrue();
         assertThat(updated.isPollingActive()).isFalse();
+
+        ArgumentCaptor<ShippingStatusChangedEvent> eventCaptor = ArgumentCaptor.forClass(ShippingStatusChangedEvent.class);
+        verify(publishShippingStatusChangedEventPort).publish(eventCaptor.capture());
+        assertThat(eventCaptor.getValue().shippingStatus()).isEqualTo("DELIVERY_FAILED");
     }
 
     @Test
@@ -219,6 +243,8 @@ class PollShippingStatusUseCaseTest {
         ShippingTracker updated = captor.getValue();
         assertThat(updated.isPreparing()).isTrue();
         assertThat(updated.getLastPolledAt()).isNotNull();
+
+        verifyNoInteractions(publishShippingStatusChangedEventPort);
     }
 
     @Test
@@ -308,6 +334,8 @@ class PollShippingStatusUseCaseTest {
         assertThat(updated.isShipping()).isTrue();
         assertThat(updated.getTrackingNumber()).isEqualTo("INV001");
         assertThat(updated.getCarrierCode()).isEqualTo("CJ");
+
+        verifyNoInteractions(publishShippingStatusChangedEventPort);
     }
 
     // --- 테스트 헬퍼 ---


### PR DESCRIPTION
## partially addresses #2143
## resolves #2590

## Test Case
- [x] PollShippingStatusUseCaseTest에 PREPARING→SHIPPING/SHIPPING→DELIVERED/SHIPPING→DELIVERY_FAILED 전이 시 publish 호출 검증
- [x] 동일 상태 유지/송장번호만 갱신 시 publish 미호출 검증
- [x] ShippingStatusEventOutboxAdapterTest 신규 (OutboxEvent 저장 검증, 페이로드 JSON 직렬화 검증, 직렬화 실패 시 예외 검증)