### PR TITLE
[#2143][#2149] feat: 배송 상태 조회 내부 API 추가

### DIFF
--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/delivery/controller/InternalFulfillmentDeliveryController.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/delivery/controller/InternalFulfillmentDeliveryController.java
@@ -5,21 +5,25 @@ import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.fulfillment.adapter.in.web.delivery.controller.apidocs.CancelInternalFulfillmentDeliveryApiDocs;
 import com.personal.marketnote.fulfillment.adapter.in.web.delivery.controller.apidocs.GetFulfillmentWorkStatusApiDocs;
 import com.personal.marketnote.fulfillment.adapter.in.web.delivery.controller.apidocs.GetInternalReturnGodDetailApiDocs;
+import com.personal.marketnote.fulfillment.adapter.in.web.delivery.controller.apidocs.GetShippingStatusApiDocs;
 import com.personal.marketnote.fulfillment.adapter.in.web.delivery.controller.apidocs.RegisterInternalReturnDeliveryApiDocs;
 import com.personal.marketnote.fulfillment.adapter.in.web.delivery.request.CancelInternalFulfillmentDeliveryRequest;
 import com.personal.marketnote.fulfillment.adapter.in.web.delivery.request.RegisterInternalReturnDeliveryRequest;
 import com.personal.marketnote.fulfillment.adapter.in.web.delivery.response.CancelInternalFulfillmentDeliveryResponse;
 import com.personal.marketnote.fulfillment.adapter.in.web.delivery.response.GetFulfillmentWorkStatusResponse;
 import com.personal.marketnote.fulfillment.adapter.in.web.delivery.response.GetInternalReturnGodDetailResponse;
+import com.personal.marketnote.fulfillment.adapter.in.web.delivery.response.GetShippingStatusResponse;
 import com.personal.marketnote.fulfillment.adapter.in.web.delivery.response.RegisterInternalReturnDeliveryResponse;
 import com.personal.marketnote.fulfillment.port.in.command.*;
 import com.personal.marketnote.fulfillment.port.in.result.CancelInternalFulfillmentDeliveryResult;
 import com.personal.marketnote.fulfillment.port.in.result.GetFulfillmentWorkStatusResult;
 import com.personal.marketnote.fulfillment.port.in.result.GetInternalReturnGodDetailResult;
+import com.personal.marketnote.fulfillment.port.in.result.GetShippingStatusResult;
 import com.personal.marketnote.fulfillment.port.in.result.RegisterInternalReturnDeliveryResult;
 import com.personal.marketnote.fulfillment.port.in.usecase.CancelInternalFulfillmentDeliveryUseCase;
 import com.personal.marketnote.fulfillment.port.in.usecase.GetFulfillmentWorkStatusUseCase;
 import com.personal.marketnote.fulfillment.port.in.usecase.GetInternalReturnGodDetailUseCase;
+import com.personal.marketnote.fulfillment.port.in.usecase.GetShippingStatusUseCase;
 import com.personal.marketnote.fulfillment.port.in.usecase.RegisterInternalReturnDeliveryUseCase;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -47,6 +51,7 @@ public class InternalFulfillmentDeliveryController {
     private final CancelInternalFulfillmentDeliveryUseCase cancelInternalFulfillmentDeliveryUseCase;
     private final RegisterInternalReturnDeliveryUseCase registerInternalReturnDeliveryUseCase;
     private final GetInternalReturnGodDetailUseCase getInternalReturnGodDetailUseCase;
+    private final GetShippingStatusUseCase getShippingStatusUseCase;
 
     /**
      * 풀필먼트 작업 상태 조회 (서비스 간 통신용)
@@ -68,6 +73,31 @@ public class InternalFulfillmentDeliveryController {
                         HttpStatus.OK,
                         DEFAULT_SUCCESS_CODE,
                         "풀필먼트 작업 상태 조회 성공"
+                ),
+                HttpStatus.OK
+        );
+    }
+
+    /**
+     * 배송 상태 조회 (서비스 간 통신용)
+     *
+     * @param orderId 주문 ID
+     */
+    @GetMapping("/shipping-status")
+    @GetShippingStatusApiDocs
+    public ResponseEntity<BaseResponse<GetShippingStatusResponse>> getShippingStatus(
+            @RequestParam("order-id") Long orderId
+    ) {
+        GetShippingStatusResult result = getShippingStatusUseCase.getShippingStatus(
+                new GetShippingStatusCommand(orderId)
+        );
+
+        return new ResponseEntity<>(
+                BaseResponse.of(
+                        GetShippingStatusResponse.from(result),
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "배송 상태 조회 성공"
                 ),
                 HttpStatus.OK
         );

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/delivery/controller/apidocs/GetShippingStatusApiDocs.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/delivery/controller/apidocs/GetShippingStatusApiDocs.java
@@ -1,0 +1,32 @@
+package com.personal.marketnote.fulfillment.adapter.in.web.delivery.controller.apidocs;
+
+import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Operation(
+        summary = "배송 상태 조회",
+        description = "주문 ID로 ShippingTracker 기반 배송 상태를 조회합니다. 서비스 간 통신용 API입니다. 응답에 취소 가능 여부(cancellable), 송장번호, 택배사 코드, 마지막 폴링 시각이 포함됩니다.",
+        parameters = {
+                @Parameter(name = "order-id", description = "주문 ID", required = true)
+        },
+        responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "배송 상태 조회 성공",
+                        content = @Content(schema = @Schema(implementation = BaseResponse.class))
+                )
+        }
+)
+public @interface GetShippingStatusApiDocs {
+}

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/delivery/response/GetShippingStatusResponse.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/delivery/response/GetShippingStatusResponse.java
@@ -1,0 +1,25 @@
+package com.personal.marketnote.fulfillment.adapter.in.web.delivery.response;
+
+import com.personal.marketnote.fulfillment.port.in.result.GetShippingStatusResult;
+
+import java.time.LocalDateTime;
+
+public record GetShippingStatusResponse(
+        Long orderId,
+        String shippingStatus,
+        boolean cancellable,
+        String trackingNumber,
+        String carrierCode,
+        LocalDateTime lastPolledAt
+) {
+    public static GetShippingStatusResponse from(GetShippingStatusResult result) {
+        return new GetShippingStatusResponse(
+                result.orderId(),
+                result.shippingStatus(),
+                result.cancellable(),
+                result.trackingNumber(),
+                result.carrierCode(),
+                result.lastPolledAt()
+        );
+    }
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/GetShippingStatusCommand.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/GetShippingStatusCommand.java
@@ -1,0 +1,6 @@
+package com.personal.marketnote.fulfillment.port.in.command;
+
+public record GetShippingStatusCommand(
+        Long orderId
+) {
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/result/GetShippingStatusResult.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/result/GetShippingStatusResult.java
@@ -1,0 +1,13 @@
+package com.personal.marketnote.fulfillment.port.in.result;
+
+import java.time.LocalDateTime;
+
+public record GetShippingStatusResult(
+        Long orderId,
+        String shippingStatus,
+        boolean cancellable,
+        String trackingNumber,
+        String carrierCode,
+        LocalDateTime lastPolledAt
+) {
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/usecase/GetShippingStatusUseCase.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/usecase/GetShippingStatusUseCase.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.fulfillment.port.in.usecase;
+
+import com.personal.marketnote.fulfillment.port.in.command.GetShippingStatusCommand;
+import com.personal.marketnote.fulfillment.port.in.result.GetShippingStatusResult;
+
+public interface GetShippingStatusUseCase {
+    GetShippingStatusResult getShippingStatus(GetShippingStatusCommand command);
+}

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/shipping/GetShippingStatusService.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/shipping/GetShippingStatusService.java
@@ -1,0 +1,36 @@
+package com.personal.marketnote.fulfillment.service.shipping;
+
+import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.fulfillment.domain.exception.ShippingTrackerNotFoundException;
+import com.personal.marketnote.fulfillment.domain.shipping.ShippingTracker;
+import com.personal.marketnote.fulfillment.port.in.command.GetShippingStatusCommand;
+import com.personal.marketnote.fulfillment.port.in.result.GetShippingStatusResult;
+import com.personal.marketnote.fulfillment.port.in.usecase.GetShippingStatusUseCase;
+import com.personal.marketnote.fulfillment.port.out.shipping.FindShippingTrackerPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional(isolation = READ_COMMITTED, readOnly = true)
+public class GetShippingStatusService implements GetShippingStatusUseCase {
+
+    private final FindShippingTrackerPort findShippingTrackerPort;
+
+    @Override
+    public GetShippingStatusResult getShippingStatus(GetShippingStatusCommand command) {
+        ShippingTracker tracker = findShippingTrackerPort.findByOrderId(command.orderId())
+                .orElseThrow(() -> new ShippingTrackerNotFoundException(command.orderId()));
+
+        return new GetShippingStatusResult(
+                tracker.getOrderId(),
+                tracker.getShippingStatus().name(),
+                tracker.isPreparing(),
+                tracker.getTrackingNumber(),
+                tracker.getCarrierCode(),
+                tracker.getLastPolledAt()
+        );
+    }
+}


### PR DESCRIPTION
## partially addresses #2143
## resolves #2149

## Task
- [x] GetShippingStatusUseCase + Command + Result 정의
- [x] GetShippingStatusService 구현 (FindShippingTrackerPort.findByOrderId 사용)
- [x] PREPARING 상태일 때 cancellable=true (취소 가능 판단)
- [x] ShippingTracker 미존재 시 ShippingTrackerNotFoundException
- [x] GetShippingStatusResponse 응답 DTO + GetShippingStatusApiDocs 합성 어노테이션
- [x] InternalFulfillmentDeliveryController에 GET /api/v1/internal/fulfillment/deliveries/shipping-status 추가