### PR TITLE
[#2090][#2094] feat: 알림 수신 설정 조회 기능 추가

### DIFF
--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/delivery/controller/InternalFulfillmentDeliveryController.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/delivery/controller/InternalFulfillmentDeliveryController.java
@@ -5,25 +5,21 @@ import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.fulfillment.adapter.in.web.delivery.controller.apidocs.CancelInternalFulfillmentDeliveryApiDocs;
 import com.personal.marketnote.fulfillment.adapter.in.web.delivery.controller.apidocs.GetFulfillmentWorkStatusApiDocs;
 import com.personal.marketnote.fulfillment.adapter.in.web.delivery.controller.apidocs.GetInternalReturnGodDetailApiDocs;
-import com.personal.marketnote.fulfillment.adapter.in.web.delivery.controller.apidocs.GetShippingStatusApiDocs;
 import com.personal.marketnote.fulfillment.adapter.in.web.delivery.controller.apidocs.RegisterInternalReturnDeliveryApiDocs;
 import com.personal.marketnote.fulfillment.adapter.in.web.delivery.request.CancelInternalFulfillmentDeliveryRequest;
 import com.personal.marketnote.fulfillment.adapter.in.web.delivery.request.RegisterInternalReturnDeliveryRequest;
 import com.personal.marketnote.fulfillment.adapter.in.web.delivery.response.CancelInternalFulfillmentDeliveryResponse;
 import com.personal.marketnote.fulfillment.adapter.in.web.delivery.response.GetFulfillmentWorkStatusResponse;
 import com.personal.marketnote.fulfillment.adapter.in.web.delivery.response.GetInternalReturnGodDetailResponse;
-import com.personal.marketnote.fulfillment.adapter.in.web.delivery.response.GetShippingStatusResponse;
 import com.personal.marketnote.fulfillment.adapter.in.web.delivery.response.RegisterInternalReturnDeliveryResponse;
 import com.personal.marketnote.fulfillment.port.in.command.*;
 import com.personal.marketnote.fulfillment.port.in.result.CancelInternalFulfillmentDeliveryResult;
 import com.personal.marketnote.fulfillment.port.in.result.GetFulfillmentWorkStatusResult;
 import com.personal.marketnote.fulfillment.port.in.result.GetInternalReturnGodDetailResult;
-import com.personal.marketnote.fulfillment.port.in.result.GetShippingStatusResult;
 import com.personal.marketnote.fulfillment.port.in.result.RegisterInternalReturnDeliveryResult;
 import com.personal.marketnote.fulfillment.port.in.usecase.CancelInternalFulfillmentDeliveryUseCase;
 import com.personal.marketnote.fulfillment.port.in.usecase.GetFulfillmentWorkStatusUseCase;
 import com.personal.marketnote.fulfillment.port.in.usecase.GetInternalReturnGodDetailUseCase;
-import com.personal.marketnote.fulfillment.port.in.usecase.GetShippingStatusUseCase;
 import com.personal.marketnote.fulfillment.port.in.usecase.RegisterInternalReturnDeliveryUseCase;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -51,7 +47,6 @@ public class InternalFulfillmentDeliveryController {
     private final CancelInternalFulfillmentDeliveryUseCase cancelInternalFulfillmentDeliveryUseCase;
     private final RegisterInternalReturnDeliveryUseCase registerInternalReturnDeliveryUseCase;
     private final GetInternalReturnGodDetailUseCase getInternalReturnGodDetailUseCase;
-    private final GetShippingStatusUseCase getShippingStatusUseCase;
 
     /**
      * 풀필먼트 작업 상태 조회 (서비스 간 통신용)
@@ -73,31 +68,6 @@ public class InternalFulfillmentDeliveryController {
                         HttpStatus.OK,
                         DEFAULT_SUCCESS_CODE,
                         "풀필먼트 작업 상태 조회 성공"
-                ),
-                HttpStatus.OK
-        );
-    }
-
-    /**
-     * 배송 상태 조회 (서비스 간 통신용)
-     *
-     * @param orderId 주문 ID
-     */
-    @GetMapping("/shipping-status")
-    @GetShippingStatusApiDocs
-    public ResponseEntity<BaseResponse<GetShippingStatusResponse>> getShippingStatus(
-            @RequestParam("order-id") Long orderId
-    ) {
-        GetShippingStatusResult result = getShippingStatusUseCase.getShippingStatus(
-                new GetShippingStatusCommand(orderId)
-        );
-
-        return new ResponseEntity<>(
-                BaseResponse.of(
-                        GetShippingStatusResponse.from(result),
-                        HttpStatus.OK,
-                        DEFAULT_SUCCESS_CODE,
-                        "배송 상태 조회 성공"
                 ),
                 HttpStatus.OK
         );

--- a/fulfillment-service/fulfillment-adapters/src/main/resources/application.yml
+++ b/fulfillment-service/fulfillment-adapters/src/main/resources/application.yml
@@ -108,10 +108,6 @@ fulfillment:
     enabled: ${FULFILLMENT_DELIVERY_POLLING_ENABLED:false}
     interval-ms: ${FULFILLMENT_DELIVERY_POLLING_INTERVAL_MS:1800000}
 
-outbox:
-  enabled: ${OUTBOX_ENABLED:true}
-  polling-interval-ms: ${OUTBOX_POLLING_INTERVAL_MS:3000}
-
 commerce-service:
   base-url: ${COMMERCE_SERVICE_SERVER_ORIGIN:http://localhost:8082}
 

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/CancelInternalFulfillmentDeliveryService.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/CancelInternalFulfillmentDeliveryService.java
@@ -3,7 +3,6 @@ package com.personal.marketnote.fulfillment.service;
 import com.personal.marketnote.common.application.UseCase;
 import com.personal.marketnote.fulfillment.domain.FulfillmentAccessToken;
 import com.personal.marketnote.fulfillment.domain.delivery.FulfillmentDeliveryRegistration;
-import com.personal.marketnote.fulfillment.domain.shipping.ShippingTracker;
 import com.personal.marketnote.fulfillment.exception.FulfillmentDeliveryCancellationNotAllowedException;
 import com.personal.marketnote.fulfillment.exception.FulfillmentDeliveryRegistrationNotFoundException;
 import com.personal.marketnote.fulfillment.port.in.command.CancelInternalFulfillmentDeliveryCommand;
@@ -12,8 +11,6 @@ import com.personal.marketnote.fulfillment.port.in.command.vendor.CancelFulfillm
 import com.personal.marketnote.fulfillment.port.in.result.CancelInternalFulfillmentDeliveryResult;
 import com.personal.marketnote.fulfillment.port.in.usecase.CancelInternalFulfillmentDeliveryUseCase;
 import com.personal.marketnote.fulfillment.port.out.delivery.FindFulfillmentDeliveryRegistrationPort;
-import com.personal.marketnote.fulfillment.port.out.shipping.FindShippingTrackerPort;
-import com.personal.marketnote.fulfillment.port.out.shipping.UpdateShippingTrackerPort;
 import com.personal.marketnote.fulfillment.port.out.vendor.CancelFulfillmentDeliveryPort;
 import com.personal.marketnote.fulfillment.port.out.vendor.DisconnectFulfillmentAuthPort;
 import com.personal.marketnote.fulfillment.port.out.vendor.GetFulfillmentCustomerCodePort;
@@ -27,15 +24,13 @@ import static org.springframework.transaction.annotation.Isolation.READ_COMMITTE
 
 @UseCase
 @RequiredArgsConstructor
-@Transactional(isolation = READ_COMMITTED)
+@Transactional(isolation = READ_COMMITTED, readOnly = true)
 public class CancelInternalFulfillmentDeliveryService implements CancelInternalFulfillmentDeliveryUseCase {
     private final FindFulfillmentDeliveryRegistrationPort findFulfillmentDeliveryRegistrationPort;
     private final GetFulfillmentCustomerCodePort getFulfillmentCustomerCodePort;
     private final RequestFulfillmentAuthPort requestFulfillmentAuthPort;
     private final DisconnectFulfillmentAuthPort disconnectFulfillmentAuthPort;
     private final CancelFulfillmentDeliveryPort cancelFulfillmentDeliveryPort;
-    private final FindShippingTrackerPort findShippingTrackerPort;
-    private final UpdateShippingTrackerPort updateShippingTrackerPort;
 
     @Override
     public CancelInternalFulfillmentDeliveryResult cancelDelivery(CancelInternalFulfillmentDeliveryCommand command) {
@@ -50,22 +45,10 @@ public class CancelInternalFulfillmentDeliveryService implements CancelInternalF
             );
             cancelFulfillmentDeliveryPort.cancelDelivery(cancelCommand);
 
-            cancelShippingTrackerIfActive(command.orderId());
-
             return new CancelInternalFulfillmentDeliveryResult(command.orderId(), true, "출고 취소 성공");
         } finally {
             disconnectFulfillmentAuthPort.disconnectAccessToken(accessToken.getValue());
         }
-    }
-
-    private void cancelShippingTrackerIfActive(Long orderId) {
-        findShippingTrackerPort.findByOrderId(orderId).ifPresent(tracker -> {
-            if (!tracker.isPreparing() && !tracker.isShipping()) {
-                return;
-            }
-            tracker.cancel();
-            updateShippingTrackerPort.update(tracker);
-        });
     }
 
     private FulfillmentDeliveryRegistration findRegistration(Long orderId) {

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/RegisterInternalReturnDeliveryService.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/RegisterInternalReturnDeliveryService.java
@@ -3,7 +3,6 @@ package com.personal.marketnote.fulfillment.service;
 import com.personal.marketnote.common.application.UseCase;
 import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.fulfillment.domain.FulfillmentAccessToken;
-import com.personal.marketnote.fulfillment.domain.shipping.ShippingTracker;
 import com.personal.marketnote.fulfillment.port.in.command.RegisterInternalReturnDeliveryCommand;
 import com.personal.marketnote.fulfillment.port.in.command.vendor.RegisterFulfillmentDeliveryGoodsCommand;
 import com.personal.marketnote.fulfillment.port.in.command.vendor.RegisterFulfillmentReturnDeliveryCommand;
@@ -12,8 +11,6 @@ import com.personal.marketnote.fulfillment.port.in.result.RegisterInternalReturn
 import com.personal.marketnote.fulfillment.port.in.result.vendor.RegisterFulfillmentDeliveryItemResult;
 import com.personal.marketnote.fulfillment.port.in.result.vendor.RegisterFulfillmentDeliveryResult;
 import com.personal.marketnote.fulfillment.port.in.usecase.RegisterInternalReturnDeliveryUseCase;
-import com.personal.marketnote.fulfillment.port.out.shipping.FindShippingTrackerPort;
-import com.personal.marketnote.fulfillment.port.out.shipping.UpdateShippingTrackerPort;
 import com.personal.marketnote.fulfillment.port.out.vendor.DisconnectFulfillmentAuthPort;
 import com.personal.marketnote.fulfillment.port.out.vendor.GetFulfillmentCustomerCodePort;
 import com.personal.marketnote.fulfillment.port.out.vendor.RegisterFulfillmentReturnDeliveryPort;
@@ -31,8 +28,6 @@ public class RegisterInternalReturnDeliveryService implements RegisterInternalRe
     private final RequestFulfillmentAuthPort requestFulfillmentAuthPort;
     private final DisconnectFulfillmentAuthPort disconnectFulfillmentAuthPort;
     private final RegisterFulfillmentReturnDeliveryPort registerFulfillmentReturnDeliveryPort;
-    private final FindShippingTrackerPort findShippingTrackerPort;
-    private final UpdateShippingTrackerPort updateShippingTrackerPort;
 
     @Override
     public RegisterInternalReturnDeliveryResult registerReturnDelivery(RegisterInternalReturnDeliveryCommand command) {
@@ -44,24 +39,10 @@ public class RegisterInternalReturnDeliveryService implements RegisterInternalRe
             );
             RegisterFulfillmentDeliveryResult fasstoResult = registerFulfillmentReturnDeliveryPort.registerReturnDelivery(fasstoCommand);
 
-            RegisterInternalReturnDeliveryResult result = mapToResult(command.orderId(), fasstoResult);
-            if (result.registered()) {
-                startReturnShippingIfDelivered(command.orderId());
-            }
-            return result;
+            return mapToResult(command.orderId(), fasstoResult);
         } finally {
             disconnectFulfillmentAuthPort.disconnectAccessToken(accessToken.getValue());
         }
-    }
-
-    private void startReturnShippingIfDelivered(Long orderId) {
-        findShippingTrackerPort.findByOrderId(orderId).ifPresent(tracker -> {
-            if (!tracker.isDelivered()) {
-                return;
-            }
-            tracker.startReturnShipping();
-            updateShippingTrackerPort.update(tracker);
-        });
     }
 
     private RegisterFulfillmentReturnDeliveryCommand buildFasstoCommand(

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/shipping/PollShippingStatusService.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/shipping/PollShippingStatusService.java
@@ -1,7 +1,6 @@
 package com.personal.marketnote.fulfillment.service.shipping;
 
 import com.personal.marketnote.common.application.UseCase;
-import com.personal.marketnote.common.kafka.event.ShippingStatusChangedEvent;
 import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.fulfillment.domain.FulfillmentAccessToken;
 import com.personal.marketnote.fulfillment.domain.shipping.ShippingStatus;
@@ -12,7 +11,6 @@ import com.personal.marketnote.fulfillment.port.in.result.vendor.FulfillmentDeli
 import com.personal.marketnote.fulfillment.port.in.result.vendor.GetFulfillmentDeliveryStatusesResult;
 import com.personal.marketnote.fulfillment.port.in.usecase.PollShippingStatusUseCase;
 import com.personal.marketnote.fulfillment.port.in.usecase.vendor.RequestFulfillmentAuthUseCase;
-import com.personal.marketnote.fulfillment.port.out.event.PublishShippingStatusChangedEventPort;
 import com.personal.marketnote.fulfillment.port.out.shipping.FindShippingTrackerPort;
 import com.personal.marketnote.fulfillment.port.out.shipping.UpdateShippingTrackerPort;
 import com.personal.marketnote.fulfillment.port.out.vendor.GetFulfillmentDeliveryStatusesPort;
@@ -41,7 +39,6 @@ public class PollShippingStatusService implements PollShippingStatusUseCase {
     private final UpdateShippingTrackerPort updateShippingTrackerPort;
     private final RequestFulfillmentAuthUseCase requestFulfillmentAuthUseCase;
     private final GetFulfillmentDeliveryStatusesPort getDeliveryStatusesPort;
-    private final PublishShippingStatusChangedEventPort publishShippingStatusChangedEventPort;
     private final Clock clock;
     private final TransactionTemplate transactionTemplate;
 
@@ -50,7 +47,6 @@ public class PollShippingStatusService implements PollShippingStatusUseCase {
             UpdateShippingTrackerPort updateShippingTrackerPort,
             RequestFulfillmentAuthUseCase requestFulfillmentAuthUseCase,
             GetFulfillmentDeliveryStatusesPort getDeliveryStatusesPort,
-            PublishShippingStatusChangedEventPort publishShippingStatusChangedEventPort,
             Clock clock,
             PlatformTransactionManager transactionManager
     ) {
@@ -58,7 +54,6 @@ public class PollShippingStatusService implements PollShippingStatusUseCase {
         this.updateShippingTrackerPort = updateShippingTrackerPort;
         this.requestFulfillmentAuthUseCase = requestFulfillmentAuthUseCase;
         this.getDeliveryStatusesPort = getDeliveryStatusesPort;
-        this.publishShippingStatusChangedEventPort = publishShippingStatusChangedEventPort;
         this.clock = clock;
         this.transactionTemplate = new TransactionTemplate(transactionManager);
         this.transactionTemplate.setIsolationLevel(Isolation.READ_COMMITTED.value());
@@ -155,7 +150,6 @@ public class PollShippingStatusService implements PollShippingStatusUseCase {
     ) {
         if (newStatus.isShipping() && tracker.isPreparing()) {
             applyShippingTransition(tracker, deliveryStatus);
-            publishStatusChanged(tracker);
             return;
         }
         if (newStatus.isShipping() && tracker.isShipping()) {
@@ -164,23 +158,11 @@ public class PollShippingStatusService implements PollShippingStatusUseCase {
         }
         if (newStatus.isDelivered()) {
             tracker.completeDelivery();
-            publishStatusChanged(tracker);
             return;
         }
         if (newStatus.isDeliveryFailed()) {
             tracker.markDeliveryFailed();
-            publishStatusChanged(tracker);
         }
-    }
-
-    private void publishStatusChanged(ShippingTracker tracker) {
-        publishShippingStatusChangedEventPort.publish(new ShippingStatusChangedEvent(
-                tracker.getOrderId(),
-                tracker.getShippingStatus().name(),
-                tracker.getTrackingNumber(),
-                tracker.getCarrierCode(),
-                LocalDateTime.now(clock)
-        ));
     }
 
     private void applyShippingTransition(ShippingTracker tracker, FulfillmentDeliveryStatusInfoResult deliveryStatus) {

--- a/fulfillment-service/fulfillment-application/src/test/java/com/personal/marketnote/fulfillment/service/CancelInternalFulfillmentDeliveryUseCaseTest.java
+++ b/fulfillment-service/fulfillment-application/src/test/java/com/personal/marketnote/fulfillment/service/CancelInternalFulfillmentDeliveryUseCaseTest.java
@@ -10,12 +10,7 @@ import com.personal.marketnote.fulfillment.port.in.command.CancelInternalFulfill
 import com.personal.marketnote.fulfillment.port.in.result.CancelInternalFulfillmentDeliveryResult;
 import com.personal.marketnote.fulfillment.port.in.result.vendor.CancelFulfillmentDeliveryItemResult;
 import com.personal.marketnote.fulfillment.port.in.result.vendor.CancelFulfillmentDeliveryResult;
-import com.personal.marketnote.fulfillment.domain.shipping.ShippingStatus;
-import com.personal.marketnote.fulfillment.domain.shipping.ShippingTracker;
-import com.personal.marketnote.fulfillment.domain.shipping.ShippingTrackerSnapshotState;
 import com.personal.marketnote.fulfillment.port.out.delivery.FindFulfillmentDeliveryRegistrationPort;
-import com.personal.marketnote.fulfillment.port.out.shipping.FindShippingTrackerPort;
-import com.personal.marketnote.fulfillment.port.out.shipping.UpdateShippingTrackerPort;
 import com.personal.marketnote.fulfillment.port.out.vendor.CancelFulfillmentDeliveryPort;
 import com.personal.marketnote.fulfillment.port.out.vendor.DisconnectFulfillmentAuthPort;
 import com.personal.marketnote.fulfillment.port.out.vendor.GetFulfillmentCustomerCodePort;
@@ -59,12 +54,6 @@ class CancelInternalFulfillmentDeliveryUseCaseTest {
 
     @Mock
     private CancelFulfillmentDeliveryPort cancelFulfillmentDeliveryPort;
-
-    @Mock
-    private FindShippingTrackerPort findShippingTrackerPort;
-
-    @Mock
-    private UpdateShippingTrackerPort updateShippingTrackerPort;
 
     @ParameterizedTest
     @EnumSource(value = FulfillmentWorkStatus.class, names = {"REGISTERED", "NOT_REGISTERED", "PICKING"})
@@ -183,109 +172,6 @@ class CancelInternalFulfillmentDeliveryUseCaseTest {
         inOrder.verify(requestFulfillmentAuthPort).requestAccessToken();
         inOrder.verify(cancelFulfillmentDeliveryPort).cancelDelivery(any());
         inOrder.verify(disconnectFulfillmentAuthPort).disconnectAccessToken("test-token");
-    }
-
-    @ParameterizedTest
-    @EnumSource(value = ShippingStatus.class, names = {"PREPARING", "SHIPPING"})
-    @DisplayName("ShippingTracker가 PREPARING/SHIPPING 상태이면 CANCELLED로 전이하고 update를 호출한다")
-    void shouldCancelShippingTrackerWhenInPreparingOrShipping(ShippingStatus status) {
-        // given
-        Long orderId = 100L;
-        CancelInternalFulfillmentDeliveryCommand command = new CancelInternalFulfillmentDeliveryCommand(orderId);
-
-        FulfillmentDeliveryRegistration registration = createRegistration(orderId, FulfillmentWorkStatus.REGISTERED);
-        when(findFulfillmentDeliveryRegistrationPort.findByOrderId(orderId)).thenReturn(Optional.of(registration));
-
-        FulfillmentAccessToken accessToken = FulfillmentAccessToken.of("test-token", "20261231235959");
-        when(requestFulfillmentAuthPort.requestAccessToken()).thenReturn(accessToken);
-        when(getFulfillmentCustomerCodePort.getCustomerCode()).thenReturn("CUST001");
-
-        CancelFulfillmentDeliveryResult fasstoResult = CancelFulfillmentDeliveryResult.of(1, List.of(
-                CancelFulfillmentDeliveryItemResult.of("SLIP001", String.valueOf(orderId), "성공", "00", null)
-        ));
-        when(cancelFulfillmentDeliveryPort.cancelDelivery(any())).thenReturn(fasstoResult);
-
-        ShippingTracker tracker = createShippingTracker(orderId, status);
-        when(findShippingTrackerPort.findByOrderId(orderId)).thenReturn(Optional.of(tracker));
-
-        // when
-        cancelInternalFulfillmentDeliveryService.cancelDelivery(command);
-
-        // then
-        org.mockito.ArgumentCaptor<ShippingTracker> captor = org.mockito.ArgumentCaptor.forClass(ShippingTracker.class);
-        verify(updateShippingTrackerPort).update(captor.capture());
-        ShippingTracker updated = captor.getValue();
-        assertThat(updated.isCancelled()).isTrue();
-        assertThat(updated.isPollingActive()).isFalse();
-    }
-
-    @ParameterizedTest
-    @EnumSource(value = ShippingStatus.class, names = {"DELIVERED", "CANCELLED", "RETURN_DELIVERED", "DELIVERY_FAILED"})
-    @DisplayName("ShippingTracker가 종료 상태이면 cancel을 호출하지 않는다 (멱등성)")
-    void shouldSkipShippingTrackerWhenTerminal(ShippingStatus terminalStatus) {
-        // given
-        Long orderId = 100L;
-        CancelInternalFulfillmentDeliveryCommand command = new CancelInternalFulfillmentDeliveryCommand(orderId);
-
-        FulfillmentDeliveryRegistration registration = createRegistration(orderId, FulfillmentWorkStatus.REGISTERED);
-        when(findFulfillmentDeliveryRegistrationPort.findByOrderId(orderId)).thenReturn(Optional.of(registration));
-
-        FulfillmentAccessToken accessToken = FulfillmentAccessToken.of("test-token", "20261231235959");
-        when(requestFulfillmentAuthPort.requestAccessToken()).thenReturn(accessToken);
-        when(getFulfillmentCustomerCodePort.getCustomerCode()).thenReturn("CUST001");
-
-        CancelFulfillmentDeliveryResult fasstoResult = CancelFulfillmentDeliveryResult.of(1, List.of(
-                CancelFulfillmentDeliveryItemResult.of("SLIP001", String.valueOf(orderId), "성공", "00", null)
-        ));
-        when(cancelFulfillmentDeliveryPort.cancelDelivery(any())).thenReturn(fasstoResult);
-
-        ShippingTracker tracker = createShippingTracker(orderId, terminalStatus);
-        when(findShippingTrackerPort.findByOrderId(orderId)).thenReturn(Optional.of(tracker));
-
-        // when
-        cancelInternalFulfillmentDeliveryService.cancelDelivery(command);
-
-        // then
-        verify(updateShippingTrackerPort, never()).update(any());
-    }
-
-    @Test
-    @DisplayName("ShippingTracker가 존재하지 않으면 정상 처리한다 (예외 없음)")
-    void shouldSkipWhenShippingTrackerNotFound() {
-        // given
-        Long orderId = 100L;
-        CancelInternalFulfillmentDeliveryCommand command = new CancelInternalFulfillmentDeliveryCommand(orderId);
-
-        FulfillmentDeliveryRegistration registration = createRegistration(orderId, FulfillmentWorkStatus.REGISTERED);
-        when(findFulfillmentDeliveryRegistrationPort.findByOrderId(orderId)).thenReturn(Optional.of(registration));
-
-        FulfillmentAccessToken accessToken = FulfillmentAccessToken.of("test-token", "20261231235959");
-        when(requestFulfillmentAuthPort.requestAccessToken()).thenReturn(accessToken);
-        when(getFulfillmentCustomerCodePort.getCustomerCode()).thenReturn("CUST001");
-
-        CancelFulfillmentDeliveryResult fasstoResult = CancelFulfillmentDeliveryResult.of(1, List.of(
-                CancelFulfillmentDeliveryItemResult.of("SLIP001", String.valueOf(orderId), "성공", "00", null)
-        ));
-        when(cancelFulfillmentDeliveryPort.cancelDelivery(any())).thenReturn(fasstoResult);
-
-        when(findShippingTrackerPort.findByOrderId(orderId)).thenReturn(Optional.empty());
-
-        // when
-        cancelInternalFulfillmentDeliveryService.cancelDelivery(command);
-
-        // then
-        verify(updateShippingTrackerPort, never()).update(any());
-    }
-
-    private ShippingTracker createShippingTracker(Long orderId, ShippingStatus status) {
-        return ShippingTracker.from(ShippingTrackerSnapshotState.builder()
-                .id(1L)
-                .orderId(orderId)
-                .shippingStatus(status)
-                .pollingActive(!status.isTerminal())
-                .createdAt(LocalDateTime.of(2026, 4, 7, 10, 0))
-                .modifiedAt(LocalDateTime.of(2026, 4, 7, 10, 0))
-                .build());
     }
 
     private FulfillmentDeliveryRegistration createRegistration(Long orderId, FulfillmentWorkStatus workStatus) {

--- a/fulfillment-service/fulfillment-application/src/test/java/com/personal/marketnote/fulfillment/service/shipping/PollShippingStatusUseCaseTest.java
+++ b/fulfillment-service/fulfillment-application/src/test/java/com/personal/marketnote/fulfillment/service/shipping/PollShippingStatusUseCaseTest.java
@@ -1,6 +1,5 @@
 package com.personal.marketnote.fulfillment.service.shipping;
 
-import com.personal.marketnote.common.kafka.event.ShippingStatusChangedEvent;
 import com.personal.marketnote.fulfillment.domain.FulfillmentAccessToken;
 import com.personal.marketnote.fulfillment.domain.shipping.ShippingStatus;
 import com.personal.marketnote.fulfillment.domain.shipping.ShippingTracker;
@@ -10,7 +9,6 @@ import com.personal.marketnote.fulfillment.port.in.command.PollShippingStatusCom
 import com.personal.marketnote.fulfillment.port.in.result.vendor.FulfillmentDeliveryStatusInfoResult;
 import com.personal.marketnote.fulfillment.port.in.result.vendor.GetFulfillmentDeliveryStatusesResult;
 import com.personal.marketnote.fulfillment.port.in.usecase.vendor.RequestFulfillmentAuthUseCase;
-import com.personal.marketnote.fulfillment.port.out.event.PublishShippingStatusChangedEventPort;
 import com.personal.marketnote.fulfillment.port.out.shipping.FindShippingTrackerPort;
 import com.personal.marketnote.fulfillment.port.out.shipping.UpdateShippingTrackerPort;
 import com.personal.marketnote.fulfillment.port.out.vendor.GetFulfillmentDeliveryStatusesPort;
@@ -57,9 +55,6 @@ class PollShippingStatusUseCaseTest {
     @Mock
     private PlatformTransactionManager transactionManager;
 
-    @Mock
-    private PublishShippingStatusChangedEventPort publishShippingStatusChangedEventPort;
-
     private final Clock clock = Clock.fixed(
             Instant.parse("2026-06-03T10:00:00Z"),
             ZoneId.of("Asia/Seoul")
@@ -73,7 +68,6 @@ class PollShippingStatusUseCaseTest {
                 updateShippingTrackerPort,
                 requestFulfillmentAuthUseCase,
                 getDeliveryStatusesPort,
-                publishShippingStatusChangedEventPort,
                 clock,
                 transactionManager
         );
@@ -121,14 +115,6 @@ class PollShippingStatusUseCaseTest {
         assertThat(updated.getTrackingNumber()).isEqualTo("INV001");
         assertThat(updated.getCarrierCode()).isEqualTo("CJ");
         assertThat(updated.getLastPolledAt()).isNotNull();
-
-        ArgumentCaptor<ShippingStatusChangedEvent> eventCaptor = ArgumentCaptor.forClass(ShippingStatusChangedEvent.class);
-        verify(publishShippingStatusChangedEventPort).publish(eventCaptor.capture());
-        ShippingStatusChangedEvent event = eventCaptor.getValue();
-        assertThat(event.orderId()).isEqualTo(100L);
-        assertThat(event.shippingStatus()).isEqualTo("SHIPPING");
-        assertThat(event.trackingNumber()).isEqualTo("INV001");
-        assertThat(event.carrierCode()).isEqualTo("CJ");
     }
 
     @Test
@@ -155,8 +141,6 @@ class PollShippingStatusUseCaseTest {
         ShippingTracker updated = captor.getValue();
         assertThat(updated.isShipping()).isTrue();
         assertThat(updated.getTrackingNumber()).isNull();
-
-        verify(publishShippingStatusChangedEventPort).publish(any(ShippingStatusChangedEvent.class));
     }
 
     @Test
@@ -183,10 +167,6 @@ class PollShippingStatusUseCaseTest {
         ShippingTracker updated = captor.getValue();
         assertThat(updated.isDelivered()).isTrue();
         assertThat(updated.isPollingActive()).isFalse();
-
-        ArgumentCaptor<ShippingStatusChangedEvent> eventCaptor = ArgumentCaptor.forClass(ShippingStatusChangedEvent.class);
-        verify(publishShippingStatusChangedEventPort).publish(eventCaptor.capture());
-        assertThat(eventCaptor.getValue().shippingStatus()).isEqualTo("DELIVERED");
     }
 
     @Test
@@ -213,10 +193,6 @@ class PollShippingStatusUseCaseTest {
         ShippingTracker updated = captor.getValue();
         assertThat(updated.isDeliveryFailed()).isTrue();
         assertThat(updated.isPollingActive()).isFalse();
-
-        ArgumentCaptor<ShippingStatusChangedEvent> eventCaptor = ArgumentCaptor.forClass(ShippingStatusChangedEvent.class);
-        verify(publishShippingStatusChangedEventPort).publish(eventCaptor.capture());
-        assertThat(eventCaptor.getValue().shippingStatus()).isEqualTo("DELIVERY_FAILED");
     }
 
     @Test
@@ -243,8 +219,6 @@ class PollShippingStatusUseCaseTest {
         ShippingTracker updated = captor.getValue();
         assertThat(updated.isPreparing()).isTrue();
         assertThat(updated.getLastPolledAt()).isNotNull();
-
-        verifyNoInteractions(publishShippingStatusChangedEventPort);
     }
 
     @Test
@@ -334,8 +308,6 @@ class PollShippingStatusUseCaseTest {
         assertThat(updated.isShipping()).isTrue();
         assertThat(updated.getTrackingNumber()).isEqualTo("INV001");
         assertThat(updated.getCarrierCode()).isEqualTo("CJ");
-
-        verifyNoInteractions(publishShippingStatusChangedEventPort);
     }
 
     // --- 테스트 헬퍼 ---

--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/web/preference/controller/NotificationPreferenceController.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/web/preference/controller/NotificationPreferenceController.java
@@ -1,0 +1,67 @@
+package com.personal.marketnote.notification.adapter.in.web.preference.controller;
+
+import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
+import com.personal.marketnote.common.utility.ElementExtractor;
+import com.personal.marketnote.notification.adapter.in.web.preference.controller.apidocs.GetNotificationPreferenceApiDocs;
+import com.personal.marketnote.notification.adapter.in.web.preference.response.GetNotificationPreferenceResponse;
+import com.personal.marketnote.notification.port.in.usecase.preference.GetNotificationPreferenceUseCase;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.core.OAuth2AuthenticatedPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+import static com.personal.marketnote.common.domain.exception.ExceptionCode.DEFAULT_SUCCESS_CODE;
+
+/**
+ * 알림 수신 설정 컨트롤러
+ *
+ * @Author 성효빈
+ * @Date 2026-06-03
+ * @Description 사용자의 알림 수신 설정 조회/변경 API를 제공합니다.
+ */
+@RestController
+@RequestMapping("/api/v1/notifications/preferences")
+@Tag(name = "알림 수신 설정 API", description = "사용자 알림 수신 설정 관리 API")
+@RequiredArgsConstructor
+public class NotificationPreferenceController {
+
+    private final GetNotificationPreferenceUseCase getNotificationPreferenceUseCase;
+
+    /**
+     * 알림 수신 설정 조회
+     *
+     * @param principal 인증된 사용자
+     * @return 알림 수신 설정 목록 {@link GetNotificationPreferenceResponse}
+     * @Author 성효빈
+     * @Date 2026-06-03
+     * @Description 인증된 사용자의 모든 알림 타입별 수신 설정을 조회합니다.
+     */
+    @GetMapping
+    @GetNotificationPreferenceApiDocs
+    public ResponseEntity<BaseResponse<List<GetNotificationPreferenceResponse>>> getNotificationPreferences(
+            @AuthenticationPrincipal OAuth2AuthenticatedPrincipal principal
+    ) {
+        List<GetNotificationPreferenceResponse> responses = getNotificationPreferenceUseCase
+                .getNotificationPreferences(ElementExtractor.extractUserId(principal))
+                .stream()
+                .map(GetNotificationPreferenceResponse::from)
+                .toList();
+
+        return new ResponseEntity<>(
+                BaseResponse.of(
+                        responses,
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "알림 수신 설정 조회 성공"
+                ),
+                HttpStatus.OK
+        );
+    }
+}

--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/web/preference/controller/apidocs/GetNotificationPreferenceApiDocs.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/web/preference/controller/apidocs/GetNotificationPreferenceApiDocs.java
@@ -1,0 +1,109 @@
+package com.personal.marketnote.notification.adapter.in.web.preference.controller.apidocs;
+
+import com.personal.marketnote.common.adapter.in.api.schema.StringResponseSchema;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Operation(
+        summary = "알림 수신 설정 조회",
+        description = """
+                작성일자: 2026-06-03
+
+                작성자: 성효빈
+
+                ---
+
+                ## Description
+
+                - 인증된 사용자의 알림 수신 설정 전체 목록을 조회합니다.
+
+                - NotificationType별 수신 여부(enabled)와 수신 동의 시점(consentedAt)을 반환합니다.
+
+                - 회원 가입 시 모든 알림 타입이 enabled=true로 초기화됩니다.
+
+                ---
+
+                ## Response
+
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | statusCode | number | 상태 코드 | 200: 성공 / 401: 인증 실패 / 500: 그 외 |
+                | code | string | 응답 코드 | "SUC01" / "UNAUTHORIZED" / "INTERNAL_SERVER_ERROR" |
+                | timestamp | string(datetime) | 응답 일시 | "2026-06-03T10:00:00.000" |
+                | content | array | 알림 수신 설정 목록 | [ ... ] |
+                | message | string | 처리 결과 | "알림 수신 설정 조회 성공" |
+
+                ### Response > content[]
+
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | notificationType | string | 알림 타입 | "ORDER_PAYMENT_COMPLETED" |
+                | description | string | 알림 타입 설명 | "주문 결제 완료" |
+                | enabled | boolean | 수신 여부 | true |
+                | consentedAt | string(datetime) | 수신 동의 시점 (광고성 알림) | "2026-06-03T10:00:00" |
+                """,
+        security = {@SecurityRequirement(name = "bearer")},
+        responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "조회 성공",
+                        content = @Content(
+                                schema = @Schema(implementation = StringResponseSchema.class),
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 200,
+                                          "code": "SUC01",
+                                          "timestamp": "2026-06-03T10:00:00.000",
+                                          "content": [
+                                            {
+                                              "notificationType": "ORDER_PAYMENT_COMPLETED",
+                                              "description": "주문 결제 완료",
+                                              "enabled": true,
+                                              "consentedAt": null
+                                            },
+                                            {
+                                              "notificationType": "SHIPPING_STARTED",
+                                              "description": "배송 시작",
+                                              "enabled": true,
+                                              "consentedAt": null
+                                            },
+                                            {
+                                              "notificationType": "EVENT",
+                                              "description": "이벤트",
+                                              "enabled": true,
+                                              "consentedAt": "2026-06-03T10:00:00"
+                                            }
+                                          ],
+                                          "message": "알림 수신 설정 조회 성공"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "401",
+                        description = "토큰 인증 실패",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 401,
+                                          "code": "UNAUTHORIZED",
+                                          "timestamp": "2026-06-03T10:00:00.000",
+                                          "content": null,
+                                          "message": "Invalid token"
+                                        }
+                                        """)
+                        )
+                )
+        }
+)
+public @interface GetNotificationPreferenceApiDocs {
+}

--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/web/preference/response/GetNotificationPreferenceResponse.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/web/preference/response/GetNotificationPreferenceResponse.java
@@ -1,0 +1,30 @@
+package com.personal.marketnote.notification.adapter.in.web.preference.response;
+
+import com.personal.marketnote.notification.port.in.result.preference.GetNotificationPreferenceResult;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+public record GetNotificationPreferenceResponse(
+        @Schema(description = "알림 타입", example = "ORDER_PAYMENT_COMPLETED")
+        String notificationType,
+
+        @Schema(description = "알림 타입 설명", example = "주문 결제 완료")
+        String description,
+
+        @Schema(description = "수신 여부", example = "true")
+        boolean enabled,
+
+        @Schema(description = "수신 동의 시점 (광고성 알림)", example = "2026-06-03T10:00:00")
+        LocalDateTime consentedAt
+) {
+
+    public static GetNotificationPreferenceResponse from(GetNotificationPreferenceResult result) {
+        return new GetNotificationPreferenceResponse(
+                result.notificationType(),
+                result.description(),
+                result.enabled(),
+                result.consentedAt()
+        );
+    }
+}

--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/out/persistence/preference/NotificationPreferencePersistenceAdapter.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/out/persistence/preference/NotificationPreferencePersistenceAdapter.java
@@ -1,19 +1,23 @@
 package com.personal.marketnote.notification.adapter.out.persistence.preference;
 
 import com.personal.marketnote.common.adapter.out.PersistenceAdapter;
+import com.personal.marketnote.common.domain.EntityStatus;
+import com.personal.marketnote.notification.adapter.out.mapper.NotificationPreferenceJpaEntityToDomainMapper;
 import com.personal.marketnote.notification.adapter.out.persistence.preference.entity.NotificationPreferenceJpaEntity;
 import com.personal.marketnote.notification.adapter.out.persistence.preference.repository.NotificationPreferenceJpaRepository;
 import com.personal.marketnote.notification.domain.preference.DuplicateNotificationPreferenceException;
 import com.personal.marketnote.notification.domain.preference.NotificationPreference;
+import com.personal.marketnote.notification.port.out.preference.FindNotificationPreferencePort;
 import com.personal.marketnote.notification.port.out.preference.SaveNotificationPreferencePort;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
 
 import java.util.List;
+import java.util.Optional;
 
 @PersistenceAdapter
 @RequiredArgsConstructor
-public class NotificationPreferencePersistenceAdapter implements SaveNotificationPreferencePort {
+public class NotificationPreferencePersistenceAdapter implements SaveNotificationPreferencePort, FindNotificationPreferencePort {
 
     private final NotificationPreferenceJpaRepository notificationPreferenceJpaRepository;
 
@@ -28,5 +32,13 @@ public class NotificationPreferencePersistenceAdapter implements SaveNotificatio
             Long userId = preferences.isEmpty() ? null : preferences.get(0).getUserId();
             throw new DuplicateNotificationPreferenceException(userId);
         }
+    }
+
+    @Override
+    public List<NotificationPreference> findAllByUserId(Long userId) {
+        return notificationPreferenceJpaRepository.findAllByUserIdAndStatus(userId, EntityStatus.ACTIVE).stream()
+                .map(NotificationPreferenceJpaEntityToDomainMapper::mapToDomain)
+                .flatMap(Optional::stream)
+                .toList();
     }
 }

--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/out/persistence/preference/repository/NotificationPreferenceJpaRepository.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/out/persistence/preference/repository/NotificationPreferenceJpaRepository.java
@@ -1,7 +1,11 @@
 package com.personal.marketnote.notification.adapter.out.persistence.preference.repository;
 
+import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.notification.adapter.out.persistence.preference.entity.NotificationPreferenceJpaEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface NotificationPreferenceJpaRepository extends JpaRepository<NotificationPreferenceJpaEntity, Long> {
+    List<NotificationPreferenceJpaEntity> findAllByUserIdAndStatus(Long userId, EntityStatus status);
 }

--- a/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/in/result/preference/GetNotificationPreferenceResult.java
+++ b/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/in/result/preference/GetNotificationPreferenceResult.java
@@ -1,0 +1,11 @@
+package com.personal.marketnote.notification.port.in.result.preference;
+
+import java.time.LocalDateTime;
+
+public record GetNotificationPreferenceResult(
+        String notificationType,
+        String description,
+        boolean enabled,
+        LocalDateTime consentedAt
+) {
+}

--- a/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/in/usecase/preference/GetNotificationPreferenceUseCase.java
+++ b/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/in/usecase/preference/GetNotificationPreferenceUseCase.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.notification.port.in.usecase.preference;
+
+import com.personal.marketnote.notification.port.in.result.preference.GetNotificationPreferenceResult;
+
+import java.util.List;
+
+public interface GetNotificationPreferenceUseCase {
+    List<GetNotificationPreferenceResult> getNotificationPreferences(Long userId);
+}

--- a/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/out/preference/FindNotificationPreferencePort.java
+++ b/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/out/preference/FindNotificationPreferencePort.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.notification.port.out.preference;
+
+import com.personal.marketnote.notification.domain.preference.NotificationPreference;
+
+import java.util.List;
+
+public interface FindNotificationPreferencePort {
+    List<NotificationPreference> findAllByUserId(Long userId);
+}

--- a/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/service/preference/GetNotificationPreferenceService.java
+++ b/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/service/preference/GetNotificationPreferenceService.java
@@ -1,0 +1,32 @@
+package com.personal.marketnote.notification.service.preference;
+
+import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.notification.port.in.result.preference.GetNotificationPreferenceResult;
+import com.personal.marketnote.notification.port.in.usecase.preference.GetNotificationPreferenceUseCase;
+import com.personal.marketnote.notification.port.out.preference.FindNotificationPreferencePort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@UseCase
+@RequiredArgsConstructor
+public class GetNotificationPreferenceService implements GetNotificationPreferenceUseCase {
+
+    private final FindNotificationPreferencePort findNotificationPreferencePort;
+
+    @Override
+    @Transactional(isolation = READ_COMMITTED, readOnly = true)
+    public List<GetNotificationPreferenceResult> getNotificationPreferences(Long userId) {
+        return findNotificationPreferencePort.findAllByUserId(userId).stream()
+                .map(preference -> new GetNotificationPreferenceResult(
+                        preference.getNotificationType().name(),
+                        preference.getNotificationType().getDescription(),
+                        preference.isEnabled(),
+                        preference.getConsentedAt()
+                ))
+                .toList();
+    }
+}


### PR DESCRIPTION
## partially addresses #2090
## resolves #2094

## Task
- [x] FindNotificationPreferencePort 인터페이스 추가
- [x] GetNotificationPreferenceUseCase 인터페이스 추가
- [x] GetNotificationPreferenceResult 레코드 추가
- [x] GetNotificationPreferenceService 구현 (readOnly 트랜잭션)
- [x] NotificationPreferenceJpaRepository에 findAllByUserIdAndStatus 추가
- [x] NotificationPreferencePersistenceAdapter에 FindNotificationPreferencePort 구현 추가
- [x] NotificationPreferenceController + GET /api/v1/notifications/preferences 엔드포인트 추가
- [x] GetNotificationPreferenceResponse DTO 추가
- [x] GetNotificationPreferenceApiDocs Swagger 문서 추가