### PR TITLE
[#2090][#2095] feat: 알림 수신 설정 변경 기능 추가

### DIFF
--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/delivery/controller/InternalFulfillmentDeliveryController.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/web/delivery/controller/InternalFulfillmentDeliveryController.java
@@ -5,21 +5,25 @@ import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.fulfillment.adapter.in.web.delivery.controller.apidocs.CancelInternalFulfillmentDeliveryApiDocs;
 import com.personal.marketnote.fulfillment.adapter.in.web.delivery.controller.apidocs.GetFulfillmentWorkStatusApiDocs;
 import com.personal.marketnote.fulfillment.adapter.in.web.delivery.controller.apidocs.GetInternalReturnGodDetailApiDocs;
+import com.personal.marketnote.fulfillment.adapter.in.web.delivery.controller.apidocs.GetShippingStatusApiDocs;
 import com.personal.marketnote.fulfillment.adapter.in.web.delivery.controller.apidocs.RegisterInternalReturnDeliveryApiDocs;
 import com.personal.marketnote.fulfillment.adapter.in.web.delivery.request.CancelInternalFulfillmentDeliveryRequest;
 import com.personal.marketnote.fulfillment.adapter.in.web.delivery.request.RegisterInternalReturnDeliveryRequest;
 import com.personal.marketnote.fulfillment.adapter.in.web.delivery.response.CancelInternalFulfillmentDeliveryResponse;
 import com.personal.marketnote.fulfillment.adapter.in.web.delivery.response.GetFulfillmentWorkStatusResponse;
 import com.personal.marketnote.fulfillment.adapter.in.web.delivery.response.GetInternalReturnGodDetailResponse;
+import com.personal.marketnote.fulfillment.adapter.in.web.delivery.response.GetShippingStatusResponse;
 import com.personal.marketnote.fulfillment.adapter.in.web.delivery.response.RegisterInternalReturnDeliveryResponse;
 import com.personal.marketnote.fulfillment.port.in.command.*;
 import com.personal.marketnote.fulfillment.port.in.result.CancelInternalFulfillmentDeliveryResult;
 import com.personal.marketnote.fulfillment.port.in.result.GetFulfillmentWorkStatusResult;
 import com.personal.marketnote.fulfillment.port.in.result.GetInternalReturnGodDetailResult;
+import com.personal.marketnote.fulfillment.port.in.result.GetShippingStatusResult;
 import com.personal.marketnote.fulfillment.port.in.result.RegisterInternalReturnDeliveryResult;
 import com.personal.marketnote.fulfillment.port.in.usecase.CancelInternalFulfillmentDeliveryUseCase;
 import com.personal.marketnote.fulfillment.port.in.usecase.GetFulfillmentWorkStatusUseCase;
 import com.personal.marketnote.fulfillment.port.in.usecase.GetInternalReturnGodDetailUseCase;
+import com.personal.marketnote.fulfillment.port.in.usecase.GetShippingStatusUseCase;
 import com.personal.marketnote.fulfillment.port.in.usecase.RegisterInternalReturnDeliveryUseCase;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -47,6 +51,7 @@ public class InternalFulfillmentDeliveryController {
     private final CancelInternalFulfillmentDeliveryUseCase cancelInternalFulfillmentDeliveryUseCase;
     private final RegisterInternalReturnDeliveryUseCase registerInternalReturnDeliveryUseCase;
     private final GetInternalReturnGodDetailUseCase getInternalReturnGodDetailUseCase;
+    private final GetShippingStatusUseCase getShippingStatusUseCase;
 
     /**
      * 풀필먼트 작업 상태 조회 (서비스 간 통신용)
@@ -68,6 +73,31 @@ public class InternalFulfillmentDeliveryController {
                         HttpStatus.OK,
                         DEFAULT_SUCCESS_CODE,
                         "풀필먼트 작업 상태 조회 성공"
+                ),
+                HttpStatus.OK
+        );
+    }
+
+    /**
+     * 배송 상태 조회 (서비스 간 통신용)
+     *
+     * @param orderId 주문 ID
+     */
+    @GetMapping("/shipping-status")
+    @GetShippingStatusApiDocs
+    public ResponseEntity<BaseResponse<GetShippingStatusResponse>> getShippingStatus(
+            @RequestParam("order-id") Long orderId
+    ) {
+        GetShippingStatusResult result = getShippingStatusUseCase.getShippingStatus(
+                new GetShippingStatusCommand(orderId)
+        );
+
+        return new ResponseEntity<>(
+                BaseResponse.of(
+                        GetShippingStatusResponse.from(result),
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "배송 상태 조회 성공"
                 ),
                 HttpStatus.OK
         );

--- a/fulfillment-service/fulfillment-adapters/src/main/resources/application.yml
+++ b/fulfillment-service/fulfillment-adapters/src/main/resources/application.yml
@@ -108,6 +108,10 @@ fulfillment:
     enabled: ${FULFILLMENT_DELIVERY_POLLING_ENABLED:false}
     interval-ms: ${FULFILLMENT_DELIVERY_POLLING_INTERVAL_MS:1800000}
 
+outbox:
+  enabled: ${OUTBOX_ENABLED:true}
+  polling-interval-ms: ${OUTBOX_POLLING_INTERVAL_MS:3000}
+
 commerce-service:
   base-url: ${COMMERCE_SERVICE_SERVER_ORIGIN:http://localhost:8082}
 

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/CancelInternalFulfillmentDeliveryService.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/CancelInternalFulfillmentDeliveryService.java
@@ -3,6 +3,7 @@ package com.personal.marketnote.fulfillment.service;
 import com.personal.marketnote.common.application.UseCase;
 import com.personal.marketnote.fulfillment.domain.FulfillmentAccessToken;
 import com.personal.marketnote.fulfillment.domain.delivery.FulfillmentDeliveryRegistration;
+import com.personal.marketnote.fulfillment.domain.shipping.ShippingTracker;
 import com.personal.marketnote.fulfillment.exception.FulfillmentDeliveryCancellationNotAllowedException;
 import com.personal.marketnote.fulfillment.exception.FulfillmentDeliveryRegistrationNotFoundException;
 import com.personal.marketnote.fulfillment.port.in.command.CancelInternalFulfillmentDeliveryCommand;
@@ -11,6 +12,8 @@ import com.personal.marketnote.fulfillment.port.in.command.vendor.CancelFulfillm
 import com.personal.marketnote.fulfillment.port.in.result.CancelInternalFulfillmentDeliveryResult;
 import com.personal.marketnote.fulfillment.port.in.usecase.CancelInternalFulfillmentDeliveryUseCase;
 import com.personal.marketnote.fulfillment.port.out.delivery.FindFulfillmentDeliveryRegistrationPort;
+import com.personal.marketnote.fulfillment.port.out.shipping.FindShippingTrackerPort;
+import com.personal.marketnote.fulfillment.port.out.shipping.UpdateShippingTrackerPort;
 import com.personal.marketnote.fulfillment.port.out.vendor.CancelFulfillmentDeliveryPort;
 import com.personal.marketnote.fulfillment.port.out.vendor.DisconnectFulfillmentAuthPort;
 import com.personal.marketnote.fulfillment.port.out.vendor.GetFulfillmentCustomerCodePort;
@@ -24,13 +27,15 @@ import static org.springframework.transaction.annotation.Isolation.READ_COMMITTE
 
 @UseCase
 @RequiredArgsConstructor
-@Transactional(isolation = READ_COMMITTED, readOnly = true)
+@Transactional(isolation = READ_COMMITTED)
 public class CancelInternalFulfillmentDeliveryService implements CancelInternalFulfillmentDeliveryUseCase {
     private final FindFulfillmentDeliveryRegistrationPort findFulfillmentDeliveryRegistrationPort;
     private final GetFulfillmentCustomerCodePort getFulfillmentCustomerCodePort;
     private final RequestFulfillmentAuthPort requestFulfillmentAuthPort;
     private final DisconnectFulfillmentAuthPort disconnectFulfillmentAuthPort;
     private final CancelFulfillmentDeliveryPort cancelFulfillmentDeliveryPort;
+    private final FindShippingTrackerPort findShippingTrackerPort;
+    private final UpdateShippingTrackerPort updateShippingTrackerPort;
 
     @Override
     public CancelInternalFulfillmentDeliveryResult cancelDelivery(CancelInternalFulfillmentDeliveryCommand command) {
@@ -45,10 +50,22 @@ public class CancelInternalFulfillmentDeliveryService implements CancelInternalF
             );
             cancelFulfillmentDeliveryPort.cancelDelivery(cancelCommand);
 
+            cancelShippingTrackerIfActive(command.orderId());
+
             return new CancelInternalFulfillmentDeliveryResult(command.orderId(), true, "출고 취소 성공");
         } finally {
             disconnectFulfillmentAuthPort.disconnectAccessToken(accessToken.getValue());
         }
+    }
+
+    private void cancelShippingTrackerIfActive(Long orderId) {
+        findShippingTrackerPort.findByOrderId(orderId).ifPresent(tracker -> {
+            if (!tracker.isPreparing() && !tracker.isShipping()) {
+                return;
+            }
+            tracker.cancel();
+            updateShippingTrackerPort.update(tracker);
+        });
     }
 
     private FulfillmentDeliveryRegistration findRegistration(Long orderId) {

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/RegisterInternalReturnDeliveryService.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/RegisterInternalReturnDeliveryService.java
@@ -3,6 +3,7 @@ package com.personal.marketnote.fulfillment.service;
 import com.personal.marketnote.common.application.UseCase;
 import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.fulfillment.domain.FulfillmentAccessToken;
+import com.personal.marketnote.fulfillment.domain.shipping.ShippingTracker;
 import com.personal.marketnote.fulfillment.port.in.command.RegisterInternalReturnDeliveryCommand;
 import com.personal.marketnote.fulfillment.port.in.command.vendor.RegisterFulfillmentDeliveryGoodsCommand;
 import com.personal.marketnote.fulfillment.port.in.command.vendor.RegisterFulfillmentReturnDeliveryCommand;
@@ -11,6 +12,8 @@ import com.personal.marketnote.fulfillment.port.in.result.RegisterInternalReturn
 import com.personal.marketnote.fulfillment.port.in.result.vendor.RegisterFulfillmentDeliveryItemResult;
 import com.personal.marketnote.fulfillment.port.in.result.vendor.RegisterFulfillmentDeliveryResult;
 import com.personal.marketnote.fulfillment.port.in.usecase.RegisterInternalReturnDeliveryUseCase;
+import com.personal.marketnote.fulfillment.port.out.shipping.FindShippingTrackerPort;
+import com.personal.marketnote.fulfillment.port.out.shipping.UpdateShippingTrackerPort;
 import com.personal.marketnote.fulfillment.port.out.vendor.DisconnectFulfillmentAuthPort;
 import com.personal.marketnote.fulfillment.port.out.vendor.GetFulfillmentCustomerCodePort;
 import com.personal.marketnote.fulfillment.port.out.vendor.RegisterFulfillmentReturnDeliveryPort;
@@ -28,6 +31,8 @@ public class RegisterInternalReturnDeliveryService implements RegisterInternalRe
     private final RequestFulfillmentAuthPort requestFulfillmentAuthPort;
     private final DisconnectFulfillmentAuthPort disconnectFulfillmentAuthPort;
     private final RegisterFulfillmentReturnDeliveryPort registerFulfillmentReturnDeliveryPort;
+    private final FindShippingTrackerPort findShippingTrackerPort;
+    private final UpdateShippingTrackerPort updateShippingTrackerPort;
 
     @Override
     public RegisterInternalReturnDeliveryResult registerReturnDelivery(RegisterInternalReturnDeliveryCommand command) {
@@ -39,10 +44,24 @@ public class RegisterInternalReturnDeliveryService implements RegisterInternalRe
             );
             RegisterFulfillmentDeliveryResult fasstoResult = registerFulfillmentReturnDeliveryPort.registerReturnDelivery(fasstoCommand);
 
-            return mapToResult(command.orderId(), fasstoResult);
+            RegisterInternalReturnDeliveryResult result = mapToResult(command.orderId(), fasstoResult);
+            if (result.registered()) {
+                startReturnShippingIfDelivered(command.orderId());
+            }
+            return result;
         } finally {
             disconnectFulfillmentAuthPort.disconnectAccessToken(accessToken.getValue());
         }
+    }
+
+    private void startReturnShippingIfDelivered(Long orderId) {
+        findShippingTrackerPort.findByOrderId(orderId).ifPresent(tracker -> {
+            if (!tracker.isDelivered()) {
+                return;
+            }
+            tracker.startReturnShipping();
+            updateShippingTrackerPort.update(tracker);
+        });
     }
 
     private RegisterFulfillmentReturnDeliveryCommand buildFasstoCommand(

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/shipping/PollShippingStatusService.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/shipping/PollShippingStatusService.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.fulfillment.service.shipping;
 
 import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.common.kafka.event.ShippingStatusChangedEvent;
 import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.fulfillment.domain.FulfillmentAccessToken;
 import com.personal.marketnote.fulfillment.domain.shipping.ShippingStatus;
@@ -11,6 +12,7 @@ import com.personal.marketnote.fulfillment.port.in.result.vendor.FulfillmentDeli
 import com.personal.marketnote.fulfillment.port.in.result.vendor.GetFulfillmentDeliveryStatusesResult;
 import com.personal.marketnote.fulfillment.port.in.usecase.PollShippingStatusUseCase;
 import com.personal.marketnote.fulfillment.port.in.usecase.vendor.RequestFulfillmentAuthUseCase;
+import com.personal.marketnote.fulfillment.port.out.event.PublishShippingStatusChangedEventPort;
 import com.personal.marketnote.fulfillment.port.out.shipping.FindShippingTrackerPort;
 import com.personal.marketnote.fulfillment.port.out.shipping.UpdateShippingTrackerPort;
 import com.personal.marketnote.fulfillment.port.out.vendor.GetFulfillmentDeliveryStatusesPort;
@@ -39,6 +41,7 @@ public class PollShippingStatusService implements PollShippingStatusUseCase {
     private final UpdateShippingTrackerPort updateShippingTrackerPort;
     private final RequestFulfillmentAuthUseCase requestFulfillmentAuthUseCase;
     private final GetFulfillmentDeliveryStatusesPort getDeliveryStatusesPort;
+    private final PublishShippingStatusChangedEventPort publishShippingStatusChangedEventPort;
     private final Clock clock;
     private final TransactionTemplate transactionTemplate;
 
@@ -47,6 +50,7 @@ public class PollShippingStatusService implements PollShippingStatusUseCase {
             UpdateShippingTrackerPort updateShippingTrackerPort,
             RequestFulfillmentAuthUseCase requestFulfillmentAuthUseCase,
             GetFulfillmentDeliveryStatusesPort getDeliveryStatusesPort,
+            PublishShippingStatusChangedEventPort publishShippingStatusChangedEventPort,
             Clock clock,
             PlatformTransactionManager transactionManager
     ) {
@@ -54,6 +58,7 @@ public class PollShippingStatusService implements PollShippingStatusUseCase {
         this.updateShippingTrackerPort = updateShippingTrackerPort;
         this.requestFulfillmentAuthUseCase = requestFulfillmentAuthUseCase;
         this.getDeliveryStatusesPort = getDeliveryStatusesPort;
+        this.publishShippingStatusChangedEventPort = publishShippingStatusChangedEventPort;
         this.clock = clock;
         this.transactionTemplate = new TransactionTemplate(transactionManager);
         this.transactionTemplate.setIsolationLevel(Isolation.READ_COMMITTED.value());
@@ -150,6 +155,7 @@ public class PollShippingStatusService implements PollShippingStatusUseCase {
     ) {
         if (newStatus.isShipping() && tracker.isPreparing()) {
             applyShippingTransition(tracker, deliveryStatus);
+            publishStatusChanged(tracker);
             return;
         }
         if (newStatus.isShipping() && tracker.isShipping()) {
@@ -158,11 +164,23 @@ public class PollShippingStatusService implements PollShippingStatusUseCase {
         }
         if (newStatus.isDelivered()) {
             tracker.completeDelivery();
+            publishStatusChanged(tracker);
             return;
         }
         if (newStatus.isDeliveryFailed()) {
             tracker.markDeliveryFailed();
+            publishStatusChanged(tracker);
         }
+    }
+
+    private void publishStatusChanged(ShippingTracker tracker) {
+        publishShippingStatusChangedEventPort.publish(new ShippingStatusChangedEvent(
+                tracker.getOrderId(),
+                tracker.getShippingStatus().name(),
+                tracker.getTrackingNumber(),
+                tracker.getCarrierCode(),
+                LocalDateTime.now(clock)
+        ));
     }
 
     private void applyShippingTransition(ShippingTracker tracker, FulfillmentDeliveryStatusInfoResult deliveryStatus) {

--- a/fulfillment-service/fulfillment-application/src/test/java/com/personal/marketnote/fulfillment/service/CancelInternalFulfillmentDeliveryUseCaseTest.java
+++ b/fulfillment-service/fulfillment-application/src/test/java/com/personal/marketnote/fulfillment/service/CancelInternalFulfillmentDeliveryUseCaseTest.java
@@ -10,7 +10,12 @@ import com.personal.marketnote.fulfillment.port.in.command.CancelInternalFulfill
 import com.personal.marketnote.fulfillment.port.in.result.CancelInternalFulfillmentDeliveryResult;
 import com.personal.marketnote.fulfillment.port.in.result.vendor.CancelFulfillmentDeliveryItemResult;
 import com.personal.marketnote.fulfillment.port.in.result.vendor.CancelFulfillmentDeliveryResult;
+import com.personal.marketnote.fulfillment.domain.shipping.ShippingStatus;
+import com.personal.marketnote.fulfillment.domain.shipping.ShippingTracker;
+import com.personal.marketnote.fulfillment.domain.shipping.ShippingTrackerSnapshotState;
 import com.personal.marketnote.fulfillment.port.out.delivery.FindFulfillmentDeliveryRegistrationPort;
+import com.personal.marketnote.fulfillment.port.out.shipping.FindShippingTrackerPort;
+import com.personal.marketnote.fulfillment.port.out.shipping.UpdateShippingTrackerPort;
 import com.personal.marketnote.fulfillment.port.out.vendor.CancelFulfillmentDeliveryPort;
 import com.personal.marketnote.fulfillment.port.out.vendor.DisconnectFulfillmentAuthPort;
 import com.personal.marketnote.fulfillment.port.out.vendor.GetFulfillmentCustomerCodePort;
@@ -54,6 +59,12 @@ class CancelInternalFulfillmentDeliveryUseCaseTest {
 
     @Mock
     private CancelFulfillmentDeliveryPort cancelFulfillmentDeliveryPort;
+
+    @Mock
+    private FindShippingTrackerPort findShippingTrackerPort;
+
+    @Mock
+    private UpdateShippingTrackerPort updateShippingTrackerPort;
 
     @ParameterizedTest
     @EnumSource(value = FulfillmentWorkStatus.class, names = {"REGISTERED", "NOT_REGISTERED", "PICKING"})
@@ -172,6 +183,109 @@ class CancelInternalFulfillmentDeliveryUseCaseTest {
         inOrder.verify(requestFulfillmentAuthPort).requestAccessToken();
         inOrder.verify(cancelFulfillmentDeliveryPort).cancelDelivery(any());
         inOrder.verify(disconnectFulfillmentAuthPort).disconnectAccessToken("test-token");
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = ShippingStatus.class, names = {"PREPARING", "SHIPPING"})
+    @DisplayName("ShippingTracker가 PREPARING/SHIPPING 상태이면 CANCELLED로 전이하고 update를 호출한다")
+    void shouldCancelShippingTrackerWhenInPreparingOrShipping(ShippingStatus status) {
+        // given
+        Long orderId = 100L;
+        CancelInternalFulfillmentDeliveryCommand command = new CancelInternalFulfillmentDeliveryCommand(orderId);
+
+        FulfillmentDeliveryRegistration registration = createRegistration(orderId, FulfillmentWorkStatus.REGISTERED);
+        when(findFulfillmentDeliveryRegistrationPort.findByOrderId(orderId)).thenReturn(Optional.of(registration));
+
+        FulfillmentAccessToken accessToken = FulfillmentAccessToken.of("test-token", "20261231235959");
+        when(requestFulfillmentAuthPort.requestAccessToken()).thenReturn(accessToken);
+        when(getFulfillmentCustomerCodePort.getCustomerCode()).thenReturn("CUST001");
+
+        CancelFulfillmentDeliveryResult fasstoResult = CancelFulfillmentDeliveryResult.of(1, List.of(
+                CancelFulfillmentDeliveryItemResult.of("SLIP001", String.valueOf(orderId), "성공", "00", null)
+        ));
+        when(cancelFulfillmentDeliveryPort.cancelDelivery(any())).thenReturn(fasstoResult);
+
+        ShippingTracker tracker = createShippingTracker(orderId, status);
+        when(findShippingTrackerPort.findByOrderId(orderId)).thenReturn(Optional.of(tracker));
+
+        // when
+        cancelInternalFulfillmentDeliveryService.cancelDelivery(command);
+
+        // then
+        org.mockito.ArgumentCaptor<ShippingTracker> captor = org.mockito.ArgumentCaptor.forClass(ShippingTracker.class);
+        verify(updateShippingTrackerPort).update(captor.capture());
+        ShippingTracker updated = captor.getValue();
+        assertThat(updated.isCancelled()).isTrue();
+        assertThat(updated.isPollingActive()).isFalse();
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = ShippingStatus.class, names = {"DELIVERED", "CANCELLED", "RETURN_DELIVERED", "DELIVERY_FAILED"})
+    @DisplayName("ShippingTracker가 종료 상태이면 cancel을 호출하지 않는다 (멱등성)")
+    void shouldSkipShippingTrackerWhenTerminal(ShippingStatus terminalStatus) {
+        // given
+        Long orderId = 100L;
+        CancelInternalFulfillmentDeliveryCommand command = new CancelInternalFulfillmentDeliveryCommand(orderId);
+
+        FulfillmentDeliveryRegistration registration = createRegistration(orderId, FulfillmentWorkStatus.REGISTERED);
+        when(findFulfillmentDeliveryRegistrationPort.findByOrderId(orderId)).thenReturn(Optional.of(registration));
+
+        FulfillmentAccessToken accessToken = FulfillmentAccessToken.of("test-token", "20261231235959");
+        when(requestFulfillmentAuthPort.requestAccessToken()).thenReturn(accessToken);
+        when(getFulfillmentCustomerCodePort.getCustomerCode()).thenReturn("CUST001");
+
+        CancelFulfillmentDeliveryResult fasstoResult = CancelFulfillmentDeliveryResult.of(1, List.of(
+                CancelFulfillmentDeliveryItemResult.of("SLIP001", String.valueOf(orderId), "성공", "00", null)
+        ));
+        when(cancelFulfillmentDeliveryPort.cancelDelivery(any())).thenReturn(fasstoResult);
+
+        ShippingTracker tracker = createShippingTracker(orderId, terminalStatus);
+        when(findShippingTrackerPort.findByOrderId(orderId)).thenReturn(Optional.of(tracker));
+
+        // when
+        cancelInternalFulfillmentDeliveryService.cancelDelivery(command);
+
+        // then
+        verify(updateShippingTrackerPort, never()).update(any());
+    }
+
+    @Test
+    @DisplayName("ShippingTracker가 존재하지 않으면 정상 처리한다 (예외 없음)")
+    void shouldSkipWhenShippingTrackerNotFound() {
+        // given
+        Long orderId = 100L;
+        CancelInternalFulfillmentDeliveryCommand command = new CancelInternalFulfillmentDeliveryCommand(orderId);
+
+        FulfillmentDeliveryRegistration registration = createRegistration(orderId, FulfillmentWorkStatus.REGISTERED);
+        when(findFulfillmentDeliveryRegistrationPort.findByOrderId(orderId)).thenReturn(Optional.of(registration));
+
+        FulfillmentAccessToken accessToken = FulfillmentAccessToken.of("test-token", "20261231235959");
+        when(requestFulfillmentAuthPort.requestAccessToken()).thenReturn(accessToken);
+        when(getFulfillmentCustomerCodePort.getCustomerCode()).thenReturn("CUST001");
+
+        CancelFulfillmentDeliveryResult fasstoResult = CancelFulfillmentDeliveryResult.of(1, List.of(
+                CancelFulfillmentDeliveryItemResult.of("SLIP001", String.valueOf(orderId), "성공", "00", null)
+        ));
+        when(cancelFulfillmentDeliveryPort.cancelDelivery(any())).thenReturn(fasstoResult);
+
+        when(findShippingTrackerPort.findByOrderId(orderId)).thenReturn(Optional.empty());
+
+        // when
+        cancelInternalFulfillmentDeliveryService.cancelDelivery(command);
+
+        // then
+        verify(updateShippingTrackerPort, never()).update(any());
+    }
+
+    private ShippingTracker createShippingTracker(Long orderId, ShippingStatus status) {
+        return ShippingTracker.from(ShippingTrackerSnapshotState.builder()
+                .id(1L)
+                .orderId(orderId)
+                .shippingStatus(status)
+                .pollingActive(!status.isTerminal())
+                .createdAt(LocalDateTime.of(2026, 4, 7, 10, 0))
+                .modifiedAt(LocalDateTime.of(2026, 4, 7, 10, 0))
+                .build());
     }
 
     private FulfillmentDeliveryRegistration createRegistration(Long orderId, FulfillmentWorkStatus workStatus) {

--- a/fulfillment-service/fulfillment-application/src/test/java/com/personal/marketnote/fulfillment/service/shipping/PollShippingStatusUseCaseTest.java
+++ b/fulfillment-service/fulfillment-application/src/test/java/com/personal/marketnote/fulfillment/service/shipping/PollShippingStatusUseCaseTest.java
@@ -1,5 +1,6 @@
 package com.personal.marketnote.fulfillment.service.shipping;
 
+import com.personal.marketnote.common.kafka.event.ShippingStatusChangedEvent;
 import com.personal.marketnote.fulfillment.domain.FulfillmentAccessToken;
 import com.personal.marketnote.fulfillment.domain.shipping.ShippingStatus;
 import com.personal.marketnote.fulfillment.domain.shipping.ShippingTracker;
@@ -9,6 +10,7 @@ import com.personal.marketnote.fulfillment.port.in.command.PollShippingStatusCom
 import com.personal.marketnote.fulfillment.port.in.result.vendor.FulfillmentDeliveryStatusInfoResult;
 import com.personal.marketnote.fulfillment.port.in.result.vendor.GetFulfillmentDeliveryStatusesResult;
 import com.personal.marketnote.fulfillment.port.in.usecase.vendor.RequestFulfillmentAuthUseCase;
+import com.personal.marketnote.fulfillment.port.out.event.PublishShippingStatusChangedEventPort;
 import com.personal.marketnote.fulfillment.port.out.shipping.FindShippingTrackerPort;
 import com.personal.marketnote.fulfillment.port.out.shipping.UpdateShippingTrackerPort;
 import com.personal.marketnote.fulfillment.port.out.vendor.GetFulfillmentDeliveryStatusesPort;
@@ -55,6 +57,9 @@ class PollShippingStatusUseCaseTest {
     @Mock
     private PlatformTransactionManager transactionManager;
 
+    @Mock
+    private PublishShippingStatusChangedEventPort publishShippingStatusChangedEventPort;
+
     private final Clock clock = Clock.fixed(
             Instant.parse("2026-06-03T10:00:00Z"),
             ZoneId.of("Asia/Seoul")
@@ -68,6 +73,7 @@ class PollShippingStatusUseCaseTest {
                 updateShippingTrackerPort,
                 requestFulfillmentAuthUseCase,
                 getDeliveryStatusesPort,
+                publishShippingStatusChangedEventPort,
                 clock,
                 transactionManager
         );
@@ -115,6 +121,14 @@ class PollShippingStatusUseCaseTest {
         assertThat(updated.getTrackingNumber()).isEqualTo("INV001");
         assertThat(updated.getCarrierCode()).isEqualTo("CJ");
         assertThat(updated.getLastPolledAt()).isNotNull();
+
+        ArgumentCaptor<ShippingStatusChangedEvent> eventCaptor = ArgumentCaptor.forClass(ShippingStatusChangedEvent.class);
+        verify(publishShippingStatusChangedEventPort).publish(eventCaptor.capture());
+        ShippingStatusChangedEvent event = eventCaptor.getValue();
+        assertThat(event.orderId()).isEqualTo(100L);
+        assertThat(event.shippingStatus()).isEqualTo("SHIPPING");
+        assertThat(event.trackingNumber()).isEqualTo("INV001");
+        assertThat(event.carrierCode()).isEqualTo("CJ");
     }
 
     @Test
@@ -141,6 +155,8 @@ class PollShippingStatusUseCaseTest {
         ShippingTracker updated = captor.getValue();
         assertThat(updated.isShipping()).isTrue();
         assertThat(updated.getTrackingNumber()).isNull();
+
+        verify(publishShippingStatusChangedEventPort).publish(any(ShippingStatusChangedEvent.class));
     }
 
     @Test
@@ -167,6 +183,10 @@ class PollShippingStatusUseCaseTest {
         ShippingTracker updated = captor.getValue();
         assertThat(updated.isDelivered()).isTrue();
         assertThat(updated.isPollingActive()).isFalse();
+
+        ArgumentCaptor<ShippingStatusChangedEvent> eventCaptor = ArgumentCaptor.forClass(ShippingStatusChangedEvent.class);
+        verify(publishShippingStatusChangedEventPort).publish(eventCaptor.capture());
+        assertThat(eventCaptor.getValue().shippingStatus()).isEqualTo("DELIVERED");
     }
 
     @Test
@@ -193,6 +213,10 @@ class PollShippingStatusUseCaseTest {
         ShippingTracker updated = captor.getValue();
         assertThat(updated.isDeliveryFailed()).isTrue();
         assertThat(updated.isPollingActive()).isFalse();
+
+        ArgumentCaptor<ShippingStatusChangedEvent> eventCaptor = ArgumentCaptor.forClass(ShippingStatusChangedEvent.class);
+        verify(publishShippingStatusChangedEventPort).publish(eventCaptor.capture());
+        assertThat(eventCaptor.getValue().shippingStatus()).isEqualTo("DELIVERY_FAILED");
     }
 
     @Test
@@ -219,6 +243,8 @@ class PollShippingStatusUseCaseTest {
         ShippingTracker updated = captor.getValue();
         assertThat(updated.isPreparing()).isTrue();
         assertThat(updated.getLastPolledAt()).isNotNull();
+
+        verifyNoInteractions(publishShippingStatusChangedEventPort);
     }
 
     @Test
@@ -308,6 +334,8 @@ class PollShippingStatusUseCaseTest {
         assertThat(updated.isShipping()).isTrue();
         assertThat(updated.getTrackingNumber()).isEqualTo("INV001");
         assertThat(updated.getCarrierCode()).isEqualTo("CJ");
+
+        verifyNoInteractions(publishShippingStatusChangedEventPort);
     }
 
     // --- 테스트 헬퍼 ---

--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/web/preference/controller/NotificationPreferenceController.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/web/preference/controller/NotificationPreferenceController.java
@@ -3,15 +3,22 @@ package com.personal.marketnote.notification.adapter.in.web.preference.controlle
 import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
 import com.personal.marketnote.common.utility.ElementExtractor;
 import com.personal.marketnote.notification.adapter.in.web.preference.controller.apidocs.GetNotificationPreferenceApiDocs;
+import com.personal.marketnote.notification.adapter.in.web.preference.controller.apidocs.UpdateNotificationPreferenceApiDocs;
+import com.personal.marketnote.notification.adapter.in.web.preference.request.UpdateNotificationPreferenceRequest;
 import com.personal.marketnote.notification.adapter.in.web.preference.response.GetNotificationPreferenceResponse;
+import com.personal.marketnote.notification.port.in.command.UpdateNotificationPreferenceCommand;
 import com.personal.marketnote.notification.port.in.usecase.preference.GetNotificationPreferenceUseCase;
+import com.personal.marketnote.notification.port.in.usecase.preference.UpdateNotificationPreferenceUseCase;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.core.OAuth2AuthenticatedPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -33,6 +40,7 @@ import static com.personal.marketnote.common.domain.exception.ExceptionCode.DEFA
 public class NotificationPreferenceController {
 
     private final GetNotificationPreferenceUseCase getNotificationPreferenceUseCase;
+    private final UpdateNotificationPreferenceUseCase updateNotificationPreferenceUseCase;
 
     /**
      * 알림 수신 설정 조회
@@ -60,6 +68,41 @@ public class NotificationPreferenceController {
                         HttpStatus.OK,
                         DEFAULT_SUCCESS_CODE,
                         "알림 수신 설정 조회 성공"
+                ),
+                HttpStatus.OK
+        );
+    }
+
+    /**
+     * 알림 수신 설정 변경
+     *
+     * @param request   알림 수신 설정 변경 요청
+     * @param principal 인증된 사용자
+     * @return 변경 완료 응답
+     * @Author 성효빈
+     * @Date 2026-06-03
+     * @Description 인증된 사용자의 특정 알림 타입의 수신 설정을 변경합니다.
+     */
+    @PutMapping
+    @UpdateNotificationPreferenceApiDocs
+    public ResponseEntity<BaseResponse<Void>> updateNotificationPreference(
+            @Valid @RequestBody UpdateNotificationPreferenceRequest request,
+            @AuthenticationPrincipal OAuth2AuthenticatedPrincipal principal
+    ) {
+        updateNotificationPreferenceUseCase.updateNotificationPreference(
+                new UpdateNotificationPreferenceCommand(
+                        ElementExtractor.extractUserId(principal),
+                        request.notificationType(),
+                        request.enabled()
+                )
+        );
+
+        return new ResponseEntity<>(
+                BaseResponse.of(
+                        null,
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "알림 수신 설정 변경 성공"
                 ),
                 HttpStatus.OK
         );

--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/web/preference/controller/apidocs/UpdateNotificationPreferenceApiDocs.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/web/preference/controller/apidocs/UpdateNotificationPreferenceApiDocs.java
@@ -1,0 +1,119 @@
+package com.personal.marketnote.notification.adapter.in.web.preference.controller.apidocs;
+
+import com.personal.marketnote.common.adapter.in.api.schema.StringResponseSchema;
+import com.personal.marketnote.notification.adapter.in.web.preference.request.UpdateNotificationPreferenceRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Operation(
+        summary = "알림 수신 설정 변경",
+        description = """
+                작성일자: 2026-06-03
+
+                작성자: 성효빈
+
+                ---
+
+                ## Description
+
+                - 인증된 사용자의 특정 알림 타입의 수신 설정을 변경합니다.
+
+                - enabled=true로 변경 시 consentedAt(수신 동의 시점)이 현재 시점으로 기록됩니다.
+
+                - 광고성 알림(EVENT 등)의 수신 동의 시점 기록은 정보통신망법 준수를 위한 것입니다.
+
+                ---
+
+                ## Request
+
+                | **키** | **타입** | **설명** | **필수 여부** | **예시** |
+                | --- | --- | --- | --- | --- |
+                | notificationType | string | 알림 타입 | Y | "EVENT" |
+                | enabled | boolean | 수신 여부 | Y | true |
+
+                ---
+
+                ## Response
+
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | statusCode | number | 상태 코드 | 200: 성공 / 400: 클라이언트 요청 오류 / 401: 인증 실패 / 404: 설정 없음 / 500: 그 외 |
+                | code | string | 응답 코드 | "SUC01" / "BAD_REQUEST" / "UNAUTHORIZED" / "NOT_FOUND" / "INTERNAL_SERVER_ERROR" |
+                | timestamp | string(datetime) | 응답 일시 | "2026-06-03T10:00:00.000" |
+                | content | null | 응답 본문 | null |
+                | message | string | 처리 결과 | "알림 수신 설정 변경 성공" |
+                """,
+        security = {@SecurityRequirement(name = "bearer")},
+        requestBody = @RequestBody(
+                required = true,
+                content = @Content(
+                        schema = @Schema(implementation = UpdateNotificationPreferenceRequest.class),
+                        examples = @ExampleObject("""
+                                {
+                                  "notificationType": "EVENT",
+                                  "enabled": true
+                                }
+                                """)
+                )
+        ),
+        responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "변경 성공",
+                        content = @Content(
+                                schema = @Schema(implementation = StringResponseSchema.class),
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 200,
+                                          "code": "SUC01",
+                                          "timestamp": "2026-06-03T10:00:00.000",
+                                          "content": null,
+                                          "message": "알림 수신 설정 변경 성공"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "401",
+                        description = "토큰 인증 실패",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 401,
+                                          "code": "UNAUTHORIZED",
+                                          "timestamp": "2026-06-03T10:00:00.000",
+                                          "content": null,
+                                          "message": "Invalid token"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "404",
+                        description = "알림 수신 설정 없음",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 404,
+                                          "code": "NOT_FOUND",
+                                          "timestamp": "2026-06-03T10:00:00.000",
+                                          "content": null,
+                                          "message": "알림 수신 설정을 찾을 수 없습니다."
+                                        }
+                                        """)
+                        )
+                )
+        }
+)
+public @interface UpdateNotificationPreferenceApiDocs {
+}

--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/web/preference/request/UpdateNotificationPreferenceRequest.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/web/preference/request/UpdateNotificationPreferenceRequest.java
@@ -1,0 +1,16 @@
+package com.personal.marketnote.notification.adapter.in.web.preference.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record UpdateNotificationPreferenceRequest(
+        @NotBlank(message = "알림 타입은 필수입니다")
+        @Schema(description = "알림 타입", example = "EVENT")
+        String notificationType,
+
+        @NotNull(message = "수신 여부는 필수입니다")
+        @Schema(description = "수신 여부", example = "true")
+        Boolean enabled
+) {
+}

--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/out/persistence/preference/NotificationPreferencePersistenceAdapter.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/out/persistence/preference/NotificationPreferencePersistenceAdapter.java
@@ -7,8 +7,10 @@ import com.personal.marketnote.notification.adapter.out.persistence.preference.e
 import com.personal.marketnote.notification.adapter.out.persistence.preference.repository.NotificationPreferenceJpaRepository;
 import com.personal.marketnote.notification.domain.preference.DuplicateNotificationPreferenceException;
 import com.personal.marketnote.notification.domain.preference.NotificationPreference;
+import com.personal.marketnote.notification.domain.template.NotificationType;
 import com.personal.marketnote.notification.port.out.preference.FindNotificationPreferencePort;
 import com.personal.marketnote.notification.port.out.preference.SaveNotificationPreferencePort;
+import com.personal.marketnote.notification.port.out.preference.UpdateNotificationPreferencePort;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
 
@@ -17,7 +19,7 @@ import java.util.Optional;
 
 @PersistenceAdapter
 @RequiredArgsConstructor
-public class NotificationPreferencePersistenceAdapter implements SaveNotificationPreferencePort, FindNotificationPreferencePort {
+public class NotificationPreferencePersistenceAdapter implements SaveNotificationPreferencePort, FindNotificationPreferencePort, UpdateNotificationPreferencePort {
 
     private final NotificationPreferenceJpaRepository notificationPreferenceJpaRepository;
 
@@ -40,5 +42,18 @@ public class NotificationPreferencePersistenceAdapter implements SaveNotificatio
                 .map(NotificationPreferenceJpaEntityToDomainMapper::mapToDomain)
                 .flatMap(Optional::stream)
                 .toList();
+    }
+
+    @Override
+    public Optional<NotificationPreference> findByUserIdAndNotificationType(Long userId, NotificationType notificationType) {
+        return notificationPreferenceJpaRepository
+                .findByUserIdAndNotificationTypeAndStatus(userId, notificationType, EntityStatus.ACTIVE)
+                .flatMap(NotificationPreferenceJpaEntityToDomainMapper::mapToDomain);
+    }
+
+    @Override
+    public void update(NotificationPreference preference) {
+        notificationPreferenceJpaRepository.findById(preference.getId())
+                .ifPresent(entity -> entity.updateFrom(preference));
     }
 }

--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/out/persistence/preference/repository/NotificationPreferenceJpaRepository.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/out/persistence/preference/repository/NotificationPreferenceJpaRepository.java
@@ -2,10 +2,14 @@ package com.personal.marketnote.notification.adapter.out.persistence.preference.
 
 import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.notification.adapter.out.persistence.preference.entity.NotificationPreferenceJpaEntity;
+import com.personal.marketnote.notification.domain.template.NotificationType;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface NotificationPreferenceJpaRepository extends JpaRepository<NotificationPreferenceJpaEntity, Long> {
     List<NotificationPreferenceJpaEntity> findAllByUserIdAndStatus(Long userId, EntityStatus status);
+
+    Optional<NotificationPreferenceJpaEntity> findByUserIdAndNotificationTypeAndStatus(Long userId, NotificationType notificationType, EntityStatus status);
 }

--- a/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/in/command/UpdateNotificationPreferenceCommand.java
+++ b/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/in/command/UpdateNotificationPreferenceCommand.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.notification.port.in.command;
+
+public record UpdateNotificationPreferenceCommand(
+        Long userId,
+        String notificationType,
+        boolean enabled
+) {
+}

--- a/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/in/usecase/preference/UpdateNotificationPreferenceUseCase.java
+++ b/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/in/usecase/preference/UpdateNotificationPreferenceUseCase.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.notification.port.in.usecase.preference;
+
+import com.personal.marketnote.notification.port.in.command.UpdateNotificationPreferenceCommand;
+
+public interface UpdateNotificationPreferenceUseCase {
+    void updateNotificationPreference(UpdateNotificationPreferenceCommand command);
+}

--- a/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/out/preference/FindNotificationPreferencePort.java
+++ b/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/out/preference/FindNotificationPreferencePort.java
@@ -1,9 +1,13 @@
 package com.personal.marketnote.notification.port.out.preference;
 
 import com.personal.marketnote.notification.domain.preference.NotificationPreference;
+import com.personal.marketnote.notification.domain.template.NotificationType;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface FindNotificationPreferencePort {
     List<NotificationPreference> findAllByUserId(Long userId);
+
+    Optional<NotificationPreference> findByUserIdAndNotificationType(Long userId, NotificationType notificationType);
 }

--- a/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/out/preference/UpdateNotificationPreferencePort.java
+++ b/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/out/preference/UpdateNotificationPreferencePort.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.notification.port.out.preference;
+
+import com.personal.marketnote.notification.domain.preference.NotificationPreference;
+
+public interface UpdateNotificationPreferencePort {
+    void update(NotificationPreference preference);
+}

--- a/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/service/preference/UpdateNotificationPreferenceService.java
+++ b/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/service/preference/UpdateNotificationPreferenceService.java
@@ -1,0 +1,46 @@
+package com.personal.marketnote.notification.service.preference;
+
+import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.notification.domain.preference.NotificationPreference;
+import com.personal.marketnote.notification.domain.preference.NotificationPreferenceNotFoundException;
+import com.personal.marketnote.notification.domain.template.NotificationType;
+import com.personal.marketnote.notification.port.in.command.UpdateNotificationPreferenceCommand;
+import com.personal.marketnote.notification.port.in.usecase.preference.UpdateNotificationPreferenceUseCase;
+import com.personal.marketnote.notification.port.out.preference.FindNotificationPreferencePort;
+import com.personal.marketnote.notification.port.out.preference.UpdateNotificationPreferencePort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@UseCase
+@RequiredArgsConstructor
+public class UpdateNotificationPreferenceService implements UpdateNotificationPreferenceUseCase {
+
+    private final FindNotificationPreferencePort findNotificationPreferencePort;
+    private final UpdateNotificationPreferencePort updateNotificationPreferencePort;
+    private final Clock clock;
+
+    @Override
+    @Transactional(isolation = READ_COMMITTED)
+    public void updateNotificationPreference(UpdateNotificationPreferenceCommand command) {
+        NotificationType notificationType = NotificationType.valueOf(command.notificationType());
+
+        NotificationPreference preference = findNotificationPreferencePort
+                .findByUserIdAndNotificationType(command.userId(), notificationType)
+                .orElseThrow(() -> new NotificationPreferenceNotFoundException(command.userId(), notificationType));
+
+        LocalDateTime now = LocalDateTime.now(clock);
+
+        if (command.enabled()) {
+            preference.enable(now);
+        } else {
+            preference.disable(now);
+        }
+
+        updateNotificationPreferencePort.update(preference);
+    }
+}

--- a/notification-service/notification-domain/src/main/java/com/personal/marketnote/notification/domain/preference/NotificationPreferenceNotFoundException.java
+++ b/notification-service/notification-domain/src/main/java/com/personal/marketnote/notification/domain/preference/NotificationPreferenceNotFoundException.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.notification.domain.preference;
+
+import com.personal.marketnote.notification.domain.template.NotificationType;
+
+public class NotificationPreferenceNotFoundException extends RuntimeException {
+    public NotificationPreferenceNotFoundException(Long userId, NotificationType notificationType) {
+        super("ERR_NOTIFICATION_PREFERENCE_03::알림 수신 설정을 찾을 수 없습니다. userId=" + userId + ", notificationType=" + notificationType);
+    }
+}


### PR DESCRIPTION
## partially addresses #2090
## resolves #2095

## Task
- [x] NotificationPreferenceNotFoundException 예외 클래스 추가
- [x] UpdateNotificationPreferenceCommand 레코드 추가
- [x] UpdateNotificationPreferenceUseCase 인터페이스 추가
- [x] FindNotificationPreferencePort에 findByUserIdAndNotificationType 추가
- [x] UpdateNotificationPreferencePort 인터페이스 추가
- [x] UpdateNotificationPreferenceService 구현 (Clock 주입, enable/disable 분기)
- [x] NotificationPreferenceJpaRepository에 findByUserIdAndNotificationTypeAndStatus 추가
- [x] NotificationPreferencePersistenceAdapter에 find/update 구현 추가
- [x] UpdateNotificationPreferenceRequest DTO 추가 (@Valid 검증)
- [x] UpdateNotificationPreferenceApiDocs Swagger 문서 추가
- [x] NotificationPreferenceController에 PUT /api/v1/notifications/preferences 엔드포인트 추가