### PR TITLE
[#475][#2143][#2602] test: 커머스 서비스 SHIPPING_STATUS_CHANGED Consumer 자동화 테스트 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@
   <br><br>
 
 ## 📅 프로젝트 기간
-<b>2025. 12. 24 ~ </b>
+<b>2025. 12. 24 ~ 2026. 06. 20</b>
+<br>
+<b>2026. 09. 01 ~ </b>
 <br><br>
 
 ## 👫 구성원
@@ -23,6 +25,7 @@
 - [풀필먼트 서비스](https://fulfillment.marketnote.store/swagger-ui/index.html)
 - [커뮤니티 서비스](https://community.marketnote.store/swagger-ui/index.html)
 - [리워드 서비스](https://rewards.marketnote.store/swagger-ui/index.html)
+- [알림 서비스](https://notifications.marketnote.store/swagger-ui/index.html)
 - [파일 서비스](https://files.marketnote.store/swagger-ui/index.html)
   <br><br>
 

--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/ShippingStatusChangedOrderStatusConsumer.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/event/ShippingStatusChangedOrderStatusConsumer.java
@@ -1,0 +1,108 @@
+package com.personal.marketnote.commerce.adapter.in.event;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.commerce.domain.order.OrderStatus;
+import com.personal.marketnote.commerce.exception.InvalidOrderStatusTransitionException;
+import com.personal.marketnote.commerce.exception.OrderStatusAlreadyChangedException;
+import com.personal.marketnote.commerce.port.in.command.order.ChangeOrderStatusCommand;
+import com.personal.marketnote.commerce.port.in.usecase.order.ChangeOrderStatusUseCase;
+import com.personal.marketnote.common.kafka.KafkaTopicConstants;
+import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.EventPayloadValidator;
+import com.personal.marketnote.common.kafka.event.ShippingStatusChangedEvent;
+import com.personal.marketnote.common.utility.FormatValidator;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ShippingStatusChangedOrderStatusConsumer {
+    private static final String SHIPPING_STATUS_SHIPPING = "SHIPPING";
+    private static final String SHIPPING_STATUS_DELIVERED = "DELIVERED";
+    private static final String SHIPPING_STATUS_RETURN_SHIPPING = "RETURN_SHIPPING";
+    private static final String SHIPPING_STATUS_RETURN_DELIVERED = "RETURN_DELIVERED";
+
+    private final ChangeOrderStatusUseCase changeOrderStatusUseCase;
+    private final ObjectMapper objectMapper;
+
+    @KafkaListener(
+            topics = KafkaTopicConstants.SHIPPING_STATUS_CHANGED,
+            groupId = "commerce-order-status"
+    )
+    public void handleShippingStatusChangedEvent(
+            ConsumerRecord<String, EventEnvelope<?>> record,
+            Acknowledgment acknowledgment
+    ) {
+        EventEnvelope<?> envelope = record.value();
+
+        if (EventPayloadValidator.hasInvalidEnvelope(envelope, record)) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        if (EventPayloadValidator.hasEventTypeMismatch(envelope, KafkaTopicConstants.SHIPPING_STATUS_CHANGED)) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        try {
+            ShippingStatusChangedEvent payload = envelope.getPayloadAs(ShippingStatusChangedEvent.class, objectMapper);
+
+            log.info("배송 상태 변경 이벤트 수신. eventId={}, orderId={}, shippingStatus={}",
+                    envelope.eventId(), payload.orderId(), payload.shippingStatus());
+
+            if (EventPayloadValidator.hasInvalidIds(envelope.eventId(),
+                    EventPayloadValidator.id("orderId", payload.orderId()))) {
+                acknowledgment.acknowledge();
+                return;
+            }
+
+            OrderStatus orderStatus = resolveOrderStatus(payload.shippingStatus());
+            if (FormatValidator.hasNoValue(orderStatus)) {
+                log.info("주문 상태 전이 불필요한 배송 상태. eventId={}, shippingStatus={}",
+                        envelope.eventId(), payload.shippingStatus());
+                acknowledgment.acknowledge();
+                return;
+            }
+
+            ChangeOrderStatusCommand command = ChangeOrderStatusCommand.builder()
+                    .id(payload.orderId())
+                    .orderStatus(orderStatus)
+                    .build();
+            changeOrderStatusUseCase.changeOrderStatus(command);
+
+            log.info("Kafka 이벤트로 주문 상태 {} 변경 완료. orderId={}",
+                    orderStatus, payload.orderId());
+        } catch (OrderStatusAlreadyChangedException e) {
+            log.warn("이미 주문 상태가 변경됨. eventId={}, key={}, message={}",
+                    envelope.eventId(), record.key(), e.getMessage());
+        } catch (InvalidOrderStatusTransitionException e) {
+            log.warn("전이 불가 상태에서 배송 상태 변경 이벤트 수신. eventId={}, key={}, message={}",
+                    envelope.eventId(), record.key(), e.getMessage());
+        } catch (Exception e) {
+            log.error("주문 상태 변경 실패. eventId={}, key={}, error={}",
+                    envelope.eventId(), record.key(), e.getMessage(), e);
+            throw e;
+        }
+
+        acknowledgment.acknowledge();
+    }
+
+    private OrderStatus resolveOrderStatus(String shippingStatus) {
+        if (FormatValidator.hasNoValue(shippingStatus)) {
+            return null;
+        }
+        return switch (shippingStatus) {
+            case SHIPPING_STATUS_SHIPPING -> OrderStatus.SHIPPING;
+            case SHIPPING_STATUS_DELIVERED -> OrderStatus.DELIVERED;
+            case SHIPPING_STATUS_RETURN_SHIPPING -> OrderStatus.RETURN_IN_PROGRESS;
+            case SHIPPING_STATUS_RETURN_DELIVERED -> OrderStatus.RETURNED;
+            default -> null;
+        };
+    }
+}

--- a/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/event/ShippingStatusChangedOrderStatusConsumerTest.java
+++ b/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/event/ShippingStatusChangedOrderStatusConsumerTest.java
@@ -1,0 +1,306 @@
+package com.personal.marketnote.commerce.adapter.in.event;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.commerce.exception.InvalidOrderStatusTransitionException;
+import com.personal.marketnote.commerce.exception.OrderStatusAlreadyChangedException;
+import com.personal.marketnote.commerce.port.in.command.order.ChangeOrderStatusCommand;
+import com.personal.marketnote.commerce.port.in.usecase.order.ChangeOrderStatusUseCase;
+import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.ShippingStatusChangedEvent;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.support.Acknowledgment;
+
+import java.time.LocalDateTime;
+
+import static com.personal.marketnote.commerce.domain.order.OrderStatus.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ShippingStatusChangedOrderStatusConsumer 테스트")
+class ShippingStatusChangedOrderStatusConsumerTest {
+    @InjectMocks
+    private ShippingStatusChangedOrderStatusConsumer consumer;
+
+    @Mock
+    private ChangeOrderStatusUseCase changeOrderStatusUseCase;
+
+    @Spy
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @Mock
+    private Acknowledgment acknowledgment;
+
+    private ConsumerRecord<String, EventEnvelope<?>> buildRecord(Long orderId, String shippingStatus) {
+        ShippingStatusChangedEvent event = new ShippingStatusChangedEvent(
+                orderId, shippingStatus, "TRACK-001", "CJ", LocalDateTime.of(2026, 4, 9, 10, 0)
+        );
+        EventEnvelope<ShippingStatusChangedEvent> envelope = new EventEnvelope<>(
+                "test-event-id", "fulfillment.shipping.status-changed", "fulfillment-service",
+                LocalDateTime.of(2026, 4, 9, 10, 0), event
+        );
+        return new ConsumerRecord<>("fulfillment.shipping.status-changed", 0, 0L, String.valueOf(orderId), envelope);
+    }
+
+    @Test
+    @DisplayName("배송 상태 SHIPPING 이벤트 수신 시 주문 상태를 SHIPPING으로 변경하고 acknowledge한다")
+    void handleShippingStatusChangedEvent_shipping_changesOrderStatusToShippingAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, "SHIPPING");
+
+        // when
+        consumer.handleShippingStatusChangedEvent(record, acknowledgment);
+
+        // then
+        ArgumentCaptor<ChangeOrderStatusCommand> captor = ArgumentCaptor.forClass(ChangeOrderStatusCommand.class);
+        verify(changeOrderStatusUseCase).changeOrderStatus(captor.capture());
+
+        ChangeOrderStatusCommand command = captor.getValue();
+        assertThat(command.id()).isEqualTo(1L);
+        assertThat(command.orderStatus()).isEqualTo(SHIPPING);
+
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("배송 상태 DELIVERED 이벤트 수신 시 주문 상태를 DELIVERED로 변경하고 acknowledge한다")
+    void handleShippingStatusChangedEvent_delivered_changesOrderStatusToDeliveredAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, "DELIVERED");
+
+        // when
+        consumer.handleShippingStatusChangedEvent(record, acknowledgment);
+
+        // then
+        ArgumentCaptor<ChangeOrderStatusCommand> captor = ArgumentCaptor.forClass(ChangeOrderStatusCommand.class);
+        verify(changeOrderStatusUseCase).changeOrderStatus(captor.capture());
+
+        ChangeOrderStatusCommand command = captor.getValue();
+        assertThat(command.id()).isEqualTo(1L);
+        assertThat(command.orderStatus()).isEqualTo(DELIVERED);
+
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("배송 상태 RETURN_SHIPPING 이벤트 수신 시 주문 상태를 RETURN_IN_PROGRESS로 변경하고 acknowledge한다")
+    void handleShippingStatusChangedEvent_returnShipping_changesOrderStatusToReturnInProgressAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, "RETURN_SHIPPING");
+
+        // when
+        consumer.handleShippingStatusChangedEvent(record, acknowledgment);
+
+        // then
+        ArgumentCaptor<ChangeOrderStatusCommand> captor = ArgumentCaptor.forClass(ChangeOrderStatusCommand.class);
+        verify(changeOrderStatusUseCase).changeOrderStatus(captor.capture());
+
+        ChangeOrderStatusCommand command = captor.getValue();
+        assertThat(command.id()).isEqualTo(1L);
+        assertThat(command.orderStatus()).isEqualTo(RETURN_IN_PROGRESS);
+
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("배송 상태 RETURN_DELIVERED 이벤트 수신 시 주문 상태를 RETURNED로 변경하고 acknowledge한다")
+    void handleShippingStatusChangedEvent_returnDelivered_changesOrderStatusToReturnedAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, "RETURN_DELIVERED");
+
+        // when
+        consumer.handleShippingStatusChangedEvent(record, acknowledgment);
+
+        // then
+        ArgumentCaptor<ChangeOrderStatusCommand> captor = ArgumentCaptor.forClass(ChangeOrderStatusCommand.class);
+        verify(changeOrderStatusUseCase).changeOrderStatus(captor.capture());
+
+        ChangeOrderStatusCommand command = captor.getValue();
+        assertThat(command.id()).isEqualTo(1L);
+        assertThat(command.orderStatus()).isEqualTo(RETURNED);
+
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("매핑되지 않는 배송 상태(PREPARING) 이벤트 수신 시 UseCase를 호출하지 않고 acknowledge한다")
+    void handleShippingStatusChangedEvent_preparing_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, "PREPARING");
+
+        // when
+        consumer.handleShippingStatusChangedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(changeOrderStatusUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("매핑되지 않는 배송 상태(CANCELLED) 이벤트 수신 시 UseCase를 호출하지 않고 acknowledge한다")
+    void handleShippingStatusChangedEvent_cancelled_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, "CANCELLED");
+
+        // when
+        consumer.handleShippingStatusChangedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(changeOrderStatusUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("이미 해당 상태인 주문에 대해 OrderStatusAlreadyChangedException 발생 시 멱등 처리하고 acknowledge한다")
+    void handleShippingStatusChangedEvent_alreadyChanged_acknowledgesGracefully() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, "SHIPPING");
+        doThrow(new OrderStatusAlreadyChangedException(SHIPPING))
+                .when(changeOrderStatusUseCase).changeOrderStatus(any(ChangeOrderStatusCommand.class));
+
+        // when
+        consumer.handleShippingStatusChangedEvent(record, acknowledgment);
+
+        // then
+        verify(changeOrderStatusUseCase).changeOrderStatus(any(ChangeOrderStatusCommand.class));
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("전이 불가 상태에서 InvalidOrderStatusTransitionException 발생 시 무시하고 acknowledge한다")
+    void handleShippingStatusChangedEvent_invalidTransition_acknowledgesGracefully() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, "DELIVERED");
+        doThrow(new InvalidOrderStatusTransitionException(CANCELLED, DELIVERED))
+                .when(changeOrderStatusUseCase).changeOrderStatus(any(ChangeOrderStatusCommand.class));
+
+        // when
+        consumer.handleShippingStatusChangedEvent(record, acknowledgment);
+
+        // then
+        verify(changeOrderStatusUseCase).changeOrderStatus(any(ChangeOrderStatusCommand.class));
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("orderId가 null이면 UseCase를 호출하지 않고 acknowledge한다")
+    void handleShippingStatusChangedEvent_nullOrderId_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(null, "SHIPPING");
+
+        // when
+        consumer.handleShippingStatusChangedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(changeOrderStatusUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("orderId가 0이면 UseCase를 호출하지 않고 acknowledge한다")
+    void handleShippingStatusChangedEvent_zeroOrderId_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(0L, "SHIPPING");
+
+        // when
+        consumer.handleShippingStatusChangedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(changeOrderStatusUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("orderId가 음수이면 UseCase를 호출하지 않고 acknowledge한다")
+    void handleShippingStatusChangedEvent_negativeOrderId_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(-1L, "SHIPPING");
+
+        // when
+        consumer.handleShippingStatusChangedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(changeOrderStatusUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("envelope이 null이면 UseCase를 호출하지 않고 acknowledge한다")
+    void handleShippingStatusChangedEvent_nullEnvelope_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = new ConsumerRecord<>(
+                "fulfillment.shipping.status-changed", 0, 0L, "1", null
+        );
+
+        // when
+        consumer.handleShippingStatusChangedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(changeOrderStatusUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("eventType이 불일치하면 UseCase를 호출하지 않고 acknowledge한다")
+    void handleShippingStatusChangedEvent_eventTypeMismatch_skipsAndAcknowledges() {
+        // given
+        ShippingStatusChangedEvent event = new ShippingStatusChangedEvent(
+                1L, "SHIPPING", "TRACK-001", "CJ", LocalDateTime.of(2026, 4, 9, 10, 0)
+        );
+        EventEnvelope<ShippingStatusChangedEvent> envelope = new EventEnvelope<>(
+                "test-event-id", "wrong.event.type", "fulfillment-service",
+                LocalDateTime.of(2026, 4, 9, 10, 0), event
+        );
+        ConsumerRecord<String, EventEnvelope<?>> record = new ConsumerRecord<>(
+                "fulfillment.shipping.status-changed", 0, 0L, "1", envelope
+        );
+
+        // when
+        consumer.handleShippingStatusChangedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(changeOrderStatusUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("shippingStatus가 null이면 UseCase를 호출하지 않고 acknowledge한다")
+    void handleShippingStatusChangedEvent_nullShippingStatus_skipsAndAcknowledges() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, null);
+
+        // when
+        consumer.handleShippingStatusChangedEvent(record, acknowledgment);
+
+        // then
+        verifyNoInteractions(changeOrderStatusUseCase);
+        verify(acknowledgment).acknowledge();
+    }
+
+    @Test
+    @DisplayName("예상치 못한 예외 발생 시 DefaultErrorHandler로 위임되어 예외가 전파된다")
+    void handleShippingStatusChangedEvent_unexpectedException_propagatesForRetry() {
+        // given
+        ConsumerRecord<String, EventEnvelope<?>> record = buildRecord(1L, "SHIPPING");
+        doThrow(new RuntimeException("DB 연결 오류"))
+                .when(changeOrderStatusUseCase).changeOrderStatus(any(ChangeOrderStatusCommand.class));
+
+        // when & then
+        assertThatThrownBy(() -> consumer.handleShippingStatusChangedEvent(record, acknowledgment))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("DB 연결 오류");
+
+        verify(changeOrderStatusUseCase).changeOrderStatus(any(ChangeOrderStatusCommand.class));
+        verify(acknowledgment, never()).acknowledge();
+    }
+}


### PR DESCRIPTION
## partially addresses #475
## partially addresses #2143
## resolves #2602

## Test Case
- [x] 배송 상태 SHIPPING 이벤트 수신 시 주문 상태를 SHIPPING으로 변경하고 acknowledge한다
- [x] 배송 상태 DELIVERED 이벤트 수신 시 주문 상태를 DELIVERED로 변경하고 acknowledge한다
- [x] 배송 상태 RETURN_SHIPPING 이벤트 수신 시 주문 상태를 RETURN_IN_PROGRESS로 변경하고 acknowledge한다
- [x] 배송 상태 RETURN_DELIVERED 이벤트 수신 시 주문 상태를 RETURNED로 변경하고 acknowledge한다
- [x] 매핑되지 않는 배송 상태(PREPARING) 이벤트 수신 시 UseCase를 호출하지 않고 acknowledge한다
- [x] 매핑되지 않는 배송 상태(CANCELLED) 이벤트 수신 시 UseCase를 호출하지 않고 acknowledge한다
- [x] 이미 해당 상태인 주문에 대해 OrderStatusAlreadyChangedException 발생 시 멱등 처리하고 acknowledge한다
- [x] 전이 불가 상태에서 InvalidOrderStatusTransitionException 발생 시 무시하고 acknowledge한다
- [x] orderId가 null이면 UseCase를 호출하지 않고 acknowledge한다
- [x] orderId가 0이면 UseCase를 호출하지 않고 acknowledge한다
- [x] orderId가 음수이면 UseCase를 호출하지 않고 acknowledge한다
- [x] envelope이 null이면 UseCase를 호출하지 않고 acknowledge한다
- [x] eventType이 불일치하면 UseCase를 호출하지 않고 acknowledge한다
- [x] shippingStatus가 null이면 UseCase를 호출하지 않고 acknowledge한다
- [x] 예상치 못한 예외 발생 시 DefaultErrorHandler로 위임되어 예외가 전파된다