### PR TITLE
[#2164][#2124][#2097] feat: 알림 이력 조회 기능 추가

### DIFF
--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/web/notification/controller/NotificationController.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/web/notification/controller/NotificationController.java
@@ -1,0 +1,79 @@
+package com.personal.marketnote.notification.adapter.in.web.notification.controller;
+
+import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
+import com.personal.marketnote.common.utility.ElementExtractor;
+import com.personal.marketnote.notification.adapter.in.web.notification.controller.apidocs.GetNotificationHistoryApiDocs;
+import com.personal.marketnote.notification.adapter.in.web.notification.response.GetNotificationHistoryResponse;
+import com.personal.marketnote.notification.port.in.command.GetNotificationHistoryCommand;
+import com.personal.marketnote.notification.port.in.result.notification.GetNotificationHistoryResult;
+import com.personal.marketnote.notification.port.in.usecase.notification.GetNotificationHistoryUseCase;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.core.OAuth2AuthenticatedPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import static com.personal.marketnote.common.domain.exception.ExceptionCode.DEFAULT_SUCCESS_CODE;
+
+/**
+ * 알림 이력 컨트롤러
+ *
+ * @Author 성효빈
+ * @Date 2026-06-03
+ * @Description 사용자의 알림 이력 조회 API를 제공합니다.
+ */
+@RestController
+@RequestMapping("/api/v1/notifications")
+@Tag(name = "알림 이력 API", description = "사용자 알림 이력 관리 API")
+@RequiredArgsConstructor
+@Validated
+public class NotificationController {
+
+    private final GetNotificationHistoryUseCase getNotificationHistoryUseCase;
+
+    /**
+     * 알림 이력 조회
+     *
+     * @param principal 인증된 사용자
+     * @param cursor    이전 페이지 마지막 항목의 ID
+     * @param pageSize  페이지 크기 (기본 20)
+     * @return 알림 이력 목록 {@link GetNotificationHistoryResponse}
+     * @Author 성효빈
+     * @Date 2026-06-03
+     * @Description 인증된 사용자의 알림 발송 이력을 커서 기반 페이징으로 조회합니다.
+     */
+    @GetMapping
+    @GetNotificationHistoryApiDocs
+    public ResponseEntity<BaseResponse<GetNotificationHistoryResponse>> getNotificationHistory(
+            @AuthenticationPrincipal OAuth2AuthenticatedPrincipal principal,
+            @RequestParam(value = "cursor", required = false) Long cursor,
+            @RequestParam(value = "page-size", required = false, defaultValue = "20") @Min(1) @Max(100) int pageSize
+    ) {
+        GetNotificationHistoryCommand command = new GetNotificationHistoryCommand(
+                ElementExtractor.extractUserId(principal),
+                cursor,
+                pageSize
+        );
+
+        GetNotificationHistoryResult result = getNotificationHistoryUseCase.getNotificationHistory(command);
+        GetNotificationHistoryResponse response = GetNotificationHistoryResponse.from(result);
+
+        return new ResponseEntity<>(
+                BaseResponse.of(
+                        response,
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "알림 이력 조회 성공"
+                ),
+                HttpStatus.OK
+        );
+    }
+}

--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/web/notification/controller/apidocs/GetNotificationHistoryApiDocs.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/web/notification/controller/apidocs/GetNotificationHistoryApiDocs.java
@@ -1,0 +1,137 @@
+package com.personal.marketnote.notification.adapter.in.web.notification.controller.apidocs;
+
+import com.personal.marketnote.common.adapter.in.api.schema.StringResponseSchema;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Operation(
+        summary = "알림 이력 조회",
+        description = """
+                작성일자: 2026-06-03
+
+                작성자: 성효빈
+
+                ---
+
+                ## Description
+
+                - 인증된 사용자의 알림 발송 이력을 커서 기반 페이징으로 조회합니다.
+
+                - 최신순(id DESC)으로 정렬되며, 기본 페이지 크기는 20건입니다.
+
+                - 첫 페이지 요청 시 totalElements를 포함하여 반환합니다.
+
+                ---
+
+                ## Request Parameters
+
+                | **파라미터** | **타입** | **필수** | **기본값** | **설명** |
+                | --- | --- | --- | --- | --- |
+                | cursor | number | N | - | 이전 페이지 마지막 항목의 ID |
+                | page-size | number | N | 20 | 페이지 크기 (1~100) |
+
+                ---
+
+                ## Response
+
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | statusCode | number | 상태 코드 | 200 |
+                | code | string | 응답 코드 | "SUC01" |
+                | timestamp | string(datetime) | 응답 일시 | "2026-06-03T10:00:00.000" |
+                | content | object | 알림 이력 응답 | { notifications: { ... } } |
+                | message | string | 처리 결과 | "알림 이력 조회 성공" |
+
+                ### Response > content > notifications
+
+                | **키** | **타입** | **설명** |
+                | --- | --- | --- |
+                | totalElements | number | 전체 건수 (첫 페이지만) |
+                | hasNext | boolean | 다음 페이지 존재 여부 |
+                | nextCursor | number | 다음 페이지 커서 |
+                | items[] | array | 알림 항목 목록 |
+
+                ### Response > content > notifications > items[]
+
+                | **키** | **타입** | **설명** |
+                | --- | --- | --- |
+                | id | number | 알림 ID |
+                | notificationType | string | 알림 타입 |
+                | notificationTypeDescription | string | 알림 타입 설명 |
+                | title | string | 알림 제목 |
+                | body | string | 알림 본문 |
+                | deliveryChannel | string | 발송 채널 |
+                | isRead | boolean | 읽음 여부 |
+                | landingUrl | string | 딥링크 URL |
+                | sendStatus | string | 발송 상태 |
+                | scheduledAt | string(datetime) | 예약 발송 시각 |
+                | createdAt | string(datetime) | 생성 일시 |
+                """,
+        security = {@SecurityRequirement(name = "bearer")},
+        responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "조회 성공",
+                        content = @Content(
+                                schema = @Schema(implementation = StringResponseSchema.class),
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 200,
+                                          "code": "SUC01",
+                                          "timestamp": "2026-06-03T12:00:00.000",
+                                          "content": {
+                                            "notifications": {
+                                              "totalElements": 25,
+                                              "hasNext": true,
+                                              "nextCursor": 6,
+                                              "items": [
+                                                {
+                                                  "id": 25,
+                                                  "notificationType": "ORDER_PAYMENT_COMPLETED",
+                                                  "notificationTypeDescription": "주문 결제 완료",
+                                                  "title": "주문이 완료되었습니다",
+                                                  "body": "테스트 상품 외 1건이 결제되었습니다.",
+                                                  "deliveryChannel": "PUSH_AND_IN_APP",
+                                                  "isRead": false,
+                                                  "landingUrl": "/order/123",
+                                                  "sendStatus": "SENT",
+                                                  "scheduledAt": null,
+                                                  "createdAt": "2026-06-03T12:00:00"
+                                                }
+                                              ]
+                                            }
+                                          },
+                                          "message": "알림 이력 조회 성공"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "401",
+                        description = "토큰 인증 실패",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 401,
+                                          "code": "UNAUTHORIZED",
+                                          "timestamp": "2026-06-03T12:00:00.000",
+                                          "content": null,
+                                          "message": "Invalid token"
+                                        }
+                                        """)
+                        )
+                )
+        }
+)
+public @interface GetNotificationHistoryApiDocs {
+}

--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/web/notification/response/GetNotificationHistoryResponse.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/web/notification/response/GetNotificationHistoryResponse.java
@@ -1,0 +1,25 @@
+package com.personal.marketnote.notification.adapter.in.web.notification.response;
+
+import com.personal.marketnote.common.adapter.in.response.CursorResponse;
+import com.personal.marketnote.notification.port.in.result.notification.GetNotificationHistoryResult;
+
+import java.util.List;
+
+public record GetNotificationHistoryResponse(
+        CursorResponse<NotificationItemResponse> notifications
+) {
+    public static GetNotificationHistoryResponse from(GetNotificationHistoryResult result) {
+        List<NotificationItemResponse> items = result.notifications().stream()
+                .map(NotificationItemResponse::from)
+                .toList();
+
+        CursorResponse<NotificationItemResponse> cursorResponse = new CursorResponse<>(
+                result.totalElements(),
+                result.hasNext(),
+                result.nextCursor(),
+                items
+        );
+
+        return new GetNotificationHistoryResponse(cursorResponse);
+    }
+}

--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/web/notification/response/NotificationItemResponse.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/web/notification/response/NotificationItemResponse.java
@@ -1,0 +1,37 @@
+package com.personal.marketnote.notification.adapter.in.web.notification.response;
+
+import com.personal.marketnote.notification.domain.notification.DeliveryChannel;
+import com.personal.marketnote.notification.domain.notification.SendStatus;
+import com.personal.marketnote.notification.port.in.result.notification.NotificationItemResult;
+
+import java.time.LocalDateTime;
+
+public record NotificationItemResponse(
+        Long id,
+        String notificationType,
+        String notificationTypeDescription,
+        String title,
+        String body,
+        DeliveryChannel deliveryChannel,
+        boolean isRead,
+        String landingUrl,
+        SendStatus sendStatus,
+        LocalDateTime scheduledAt,
+        LocalDateTime createdAt
+) {
+    public static NotificationItemResponse from(NotificationItemResult result) {
+        return new NotificationItemResponse(
+                result.id(),
+                result.notificationType(),
+                result.notificationTypeDescription(),
+                result.title(),
+                result.body(),
+                result.deliveryChannel(),
+                result.isRead(),
+                result.landingUrl(),
+                result.sendStatus(),
+                result.scheduledAt(),
+                result.createdAt()
+        );
+    }
+}

--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/out/mapper/NotificationJpaEntityToDomainMapper.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/out/mapper/NotificationJpaEntityToDomainMapper.java
@@ -1,0 +1,35 @@
+package com.personal.marketnote.notification.adapter.out.mapper;
+
+import com.personal.marketnote.notification.adapter.out.persistence.notification.entity.NotificationJpaEntity;
+import com.personal.marketnote.notification.domain.notification.Notification;
+import com.personal.marketnote.notification.domain.notification.NotificationSnapshotState;
+
+import java.util.Optional;
+
+public class NotificationJpaEntityToDomainMapper {
+
+    private NotificationJpaEntityToDomainMapper() {
+    }
+
+    public static Optional<Notification> mapToDomain(NotificationJpaEntity entity) {
+        return Optional.ofNullable(entity)
+                .map(e -> Notification.from(
+                        NotificationSnapshotState.builder()
+                                .id(e.getId())
+                                .userId(e.getUserId())
+                                .notificationType(e.getNotificationType())
+                                .title(e.getTitle())
+                                .body(e.getBody())
+                                .data(e.getData())
+                                .deliveryChannel(e.getDeliveryChannel())
+                                .isRead(e.isRead())
+                                .landingUrl(e.getLandingUrl())
+                                .sendStatus(e.getSendStatus())
+                                .scheduledAt(e.getScheduledAt())
+                                .status(e.getStatus())
+                                .createdAt(e.getCreatedAt())
+                                .modifiedAt(e.getModifiedAt())
+                                .build()
+                ));
+    }
+}

--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/out/persistence/notification/NotificationPersistenceAdapter.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/out/persistence/notification/NotificationPersistenceAdapter.java
@@ -1,0 +1,36 @@
+package com.personal.marketnote.notification.adapter.out.persistence.notification;
+
+import com.personal.marketnote.common.adapter.out.PersistenceAdapter;
+import com.personal.marketnote.common.domain.EntityStatus;
+import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.notification.adapter.out.mapper.NotificationJpaEntityToDomainMapper;
+import com.personal.marketnote.notification.adapter.out.persistence.notification.repository.NotificationJpaRepository;
+import com.personal.marketnote.notification.domain.notification.Notification;
+import com.personal.marketnote.notification.port.out.notification.FindNotificationPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+
+import java.util.List;
+
+@PersistenceAdapter
+@RequiredArgsConstructor
+public class NotificationPersistenceAdapter implements FindNotificationPort {
+
+    private final NotificationJpaRepository notificationJpaRepository;
+
+    @Override
+    public List<Notification> findByUserId(Long userId, Long cursor, int fetchSize) {
+        Long effectiveCursor = FormatValidator.hasValue(cursor) ? cursor : -1L;
+
+        return notificationJpaRepository.findByUserIdWithCursor(
+                        userId, EntityStatus.ACTIVE, effectiveCursor, PageRequest.of(0, fetchSize)
+                ).stream()
+                .flatMap(entity -> NotificationJpaEntityToDomainMapper.mapToDomain(entity).stream())
+                .toList();
+    }
+
+    @Override
+    public long countByUserId(Long userId) {
+        return notificationJpaRepository.countByUserIdAndStatus(userId, EntityStatus.ACTIVE);
+    }
+}

--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/out/persistence/notification/entity/NotificationJpaEntity.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/out/persistence/notification/entity/NotificationJpaEntity.java
@@ -1,0 +1,72 @@
+package com.personal.marketnote.notification.adapter.out.persistence.notification.entity;
+
+import com.personal.marketnote.common.adapter.out.persistence.audit.BaseGeneralEntity;
+import com.personal.marketnote.notification.domain.notification.DeliveryChannel;
+import com.personal.marketnote.notification.domain.notification.Notification;
+import com.personal.marketnote.notification.domain.notification.SendStatus;
+import com.personal.marketnote.notification.domain.template.NotificationType;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.DynamicInsert;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "notification", indexes = {
+        @Index(name = "idx_notification_user_id_status", columnList = "user_id, status")
+})
+@DynamicInsert
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+@Getter
+public class NotificationJpaEntity extends BaseGeneralEntity {
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "notification_type", nullable = false, length = 50)
+    @Enumerated(EnumType.STRING)
+    private NotificationType notificationType;
+
+    @Column(name = "title", nullable = false, length = 200)
+    private String title;
+
+    @Column(name = "body", nullable = false, length = 500)
+    private String body;
+
+    @Column(name = "data", columnDefinition = "TEXT")
+    private String data;
+
+    @Column(name = "delivery_channel", nullable = false, length = 30)
+    @Enumerated(EnumType.STRING)
+    private DeliveryChannel deliveryChannel;
+
+    @Column(name = "is_read", nullable = false)
+    private boolean isRead;
+
+    @Column(name = "landing_url", length = 500)
+    private String landingUrl;
+
+    @Column(name = "send_status", nullable = false, length = 20)
+    @Enumerated(EnumType.STRING)
+    private SendStatus sendStatus;
+
+    @Column(name = "scheduled_at")
+    private LocalDateTime scheduledAt;
+
+    public static NotificationJpaEntity from(Notification notification) {
+        return NotificationJpaEntity.builder()
+                .userId(notification.getUserId())
+                .notificationType(notification.getNotificationType())
+                .title(notification.getTitle())
+                .body(notification.getBody())
+                .data(notification.getData())
+                .deliveryChannel(notification.getDeliveryChannel())
+                .isRead(notification.isRead())
+                .landingUrl(notification.getLandingUrl())
+                .sendStatus(notification.getSendStatus())
+                .scheduledAt(notification.getScheduledAt())
+                .build();
+    }
+}

--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/out/persistence/notification/repository/NotificationJpaRepository.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/out/persistence/notification/repository/NotificationJpaRepository.java
@@ -1,0 +1,29 @@
+package com.personal.marketnote.notification.adapter.out.persistence.notification.repository;
+
+import com.personal.marketnote.common.domain.EntityStatus;
+import com.personal.marketnote.notification.adapter.out.persistence.notification.entity.NotificationJpaEntity;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface NotificationJpaRepository extends JpaRepository<NotificationJpaEntity, Long> {
+
+    @Query("""
+            SELECT n FROM NotificationJpaEntity n
+            WHERE n.userId = :userId
+              AND n.status = :status
+              AND (:cursor = -1L OR n.id < :cursor)
+            ORDER BY n.id DESC
+            """)
+    List<NotificationJpaEntity> findByUserIdWithCursor(
+            @Param("userId") Long userId,
+            @Param("status") EntityStatus status,
+            @Param("cursor") Long cursor,
+            Pageable pageable
+    );
+
+    long countByUserIdAndStatus(Long userId, EntityStatus status);
+}

--- a/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/in/command/GetNotificationHistoryCommand.java
+++ b/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/in/command/GetNotificationHistoryCommand.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.notification.port.in.command;
+
+public record GetNotificationHistoryCommand(
+        Long userId,
+        Long cursor,
+        int pageSize
+) {
+}

--- a/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/in/result/notification/GetNotificationHistoryResult.java
+++ b/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/in/result/notification/GetNotificationHistoryResult.java
@@ -1,0 +1,22 @@
+package com.personal.marketnote.notification.port.in.result.notification;
+
+import com.personal.marketnote.notification.domain.notification.Notification;
+
+import java.util.List;
+
+public record GetNotificationHistoryResult(
+        Long totalElements,
+        boolean hasNext,
+        Long nextCursor,
+        List<NotificationItemResult> notifications
+) {
+    public static GetNotificationHistoryResult from(Long totalElements,
+                                                     boolean hasNext,
+                                                     Long nextCursor,
+                                                     List<Notification> notifications) {
+        List<NotificationItemResult> items = notifications.stream()
+                .map(NotificationItemResult::from)
+                .toList();
+        return new GetNotificationHistoryResult(totalElements, hasNext, nextCursor, items);
+    }
+}

--- a/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/in/result/notification/NotificationItemResult.java
+++ b/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/in/result/notification/NotificationItemResult.java
@@ -1,0 +1,37 @@
+package com.personal.marketnote.notification.port.in.result.notification;
+
+import com.personal.marketnote.notification.domain.notification.DeliveryChannel;
+import com.personal.marketnote.notification.domain.notification.Notification;
+import com.personal.marketnote.notification.domain.notification.SendStatus;
+
+import java.time.LocalDateTime;
+
+public record NotificationItemResult(
+        Long id,
+        String notificationType,
+        String notificationTypeDescription,
+        String title,
+        String body,
+        DeliveryChannel deliveryChannel,
+        boolean isRead,
+        String landingUrl,
+        SendStatus sendStatus,
+        LocalDateTime scheduledAt,
+        LocalDateTime createdAt
+) {
+    public static NotificationItemResult from(Notification notification) {
+        return new NotificationItemResult(
+                notification.getId(),
+                notification.getNotificationType().name(),
+                notification.getNotificationType().getDescription(),
+                notification.getTitle(),
+                notification.getBody(),
+                notification.getDeliveryChannel(),
+                notification.isRead(),
+                notification.getLandingUrl(),
+                notification.getSendStatus(),
+                notification.getScheduledAt(),
+                notification.getCreatedAt()
+        );
+    }
+}

--- a/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/in/usecase/notification/GetNotificationHistoryUseCase.java
+++ b/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/in/usecase/notification/GetNotificationHistoryUseCase.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.notification.port.in.usecase.notification;
+
+import com.personal.marketnote.notification.port.in.command.GetNotificationHistoryCommand;
+import com.personal.marketnote.notification.port.in.result.notification.GetNotificationHistoryResult;
+
+public interface GetNotificationHistoryUseCase {
+
+    GetNotificationHistoryResult getNotificationHistory(GetNotificationHistoryCommand command);
+}

--- a/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/out/notification/FindNotificationPort.java
+++ b/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/out/notification/FindNotificationPort.java
@@ -1,0 +1,12 @@
+package com.personal.marketnote.notification.port.out.notification;
+
+import com.personal.marketnote.notification.domain.notification.Notification;
+
+import java.util.List;
+
+public interface FindNotificationPort {
+
+    List<Notification> findByUserId(Long userId, Long cursor, int fetchSize);
+
+    long countByUserId(Long userId);
+}

--- a/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/service/notification/GetNotificationHistoryService.java
+++ b/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/service/notification/GetNotificationHistoryService.java
@@ -1,0 +1,53 @@
+package com.personal.marketnote.notification.service.notification;
+
+import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.notification.domain.notification.Notification;
+import com.personal.marketnote.notification.port.in.command.GetNotificationHistoryCommand;
+import com.personal.marketnote.notification.port.in.result.notification.GetNotificationHistoryResult;
+import com.personal.marketnote.notification.port.in.usecase.notification.GetNotificationHistoryUseCase;
+import com.personal.marketnote.notification.port.out.notification.FindNotificationPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional(isolation = READ_COMMITTED, readOnly = true)
+public class GetNotificationHistoryService implements GetNotificationHistoryUseCase {
+
+    private final FindNotificationPort findNotificationPort;
+
+    @Override
+    public GetNotificationHistoryResult getNotificationHistory(GetNotificationHistoryCommand command) {
+        int fetchSize = command.pageSize() + 1;
+        List<Notification> notifications = findNotificationPort.findByUserId(
+                command.userId(), command.cursor(), fetchSize
+        );
+
+        boolean hasNext = notifications.size() > command.pageSize();
+        List<Notification> pagedNotifications = hasNext
+                ? notifications.subList(0, command.pageSize())
+                : notifications;
+
+        Long nextCursor = pagedNotifications.isEmpty() ? null : pagedNotifications.getLast().getId();
+
+        Long totalElements = resolveTotalElements(command, hasNext, pagedNotifications.size());
+
+        return GetNotificationHistoryResult.from(totalElements, hasNext, nextCursor, pagedNotifications);
+    }
+
+    private Long resolveTotalElements(GetNotificationHistoryCommand command,
+                                      boolean hasNext, int currentSize) {
+        if (FormatValidator.hasValue(command.cursor())) {
+            return null;
+        }
+        if (!hasNext) {
+            return (long) currentSize;
+        }
+        return findNotificationPort.countByUserId(command.userId());
+    }
+}

--- a/notification-service/notification-domain/src/main/java/com/personal/marketnote/notification/domain/notification/DeliveryChannel.java
+++ b/notification-service/notification-domain/src/main/java/com/personal/marketnote/notification/domain/notification/DeliveryChannel.java
@@ -1,0 +1,25 @@
+package com.personal.marketnote.notification.domain.notification;
+
+public enum DeliveryChannel {
+    PUSH_ONLY("푸시"),
+    IN_APP_ONLY("인앱"),
+    PUSH_AND_IN_APP("푸시+인앱");
+
+    private final String description;
+
+    DeliveryChannel(String description) {
+        this.description = description;
+    }
+
+    public boolean hasPush() {
+        return this == PUSH_ONLY || this == PUSH_AND_IN_APP;
+    }
+
+    public boolean hasInApp() {
+        return this == IN_APP_ONLY || this == PUSH_AND_IN_APP;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+}

--- a/notification-service/notification-domain/src/main/java/com/personal/marketnote/notification/domain/notification/InvalidNotificationException.java
+++ b/notification-service/notification-domain/src/main/java/com/personal/marketnote/notification/domain/notification/InvalidNotificationException.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.notification.domain.notification;
+
+public class InvalidNotificationException extends IllegalArgumentException {
+
+    public InvalidNotificationException(String message) {
+        super(message);
+    }
+}

--- a/notification-service/notification-domain/src/main/java/com/personal/marketnote/notification/domain/notification/Notification.java
+++ b/notification-service/notification-domain/src/main/java/com/personal/marketnote/notification/domain/notification/Notification.java
@@ -1,0 +1,95 @@
+package com.personal.marketnote.notification.domain.notification;
+
+import com.personal.marketnote.common.domain.BaseDomain;
+import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.notification.domain.template.NotificationType;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+@Getter
+public class Notification extends BaseDomain {
+    private Long id;
+    private Long userId;
+    private NotificationType notificationType;
+    private String title;
+    private String body;
+    private String data;
+    private DeliveryChannel deliveryChannel;
+    private boolean isRead;
+    private String landingUrl;
+    private SendStatus sendStatus;
+    private LocalDateTime scheduledAt;
+    private LocalDateTime createdAt;
+    private LocalDateTime modifiedAt;
+
+    public static Notification from(NotificationCreateState state) {
+        validate(state);
+
+        SendStatus initialStatus = FormatValidator.hasValue(state.getScheduledAt())
+                ? SendStatus.SCHEDULED
+                : SendStatus.PENDING;
+
+        Notification notification = Notification.builder()
+                .userId(state.getUserId())
+                .notificationType(state.getNotificationType())
+                .title(state.getTitle())
+                .body(state.getBody())
+                .data(state.getData())
+                .deliveryChannel(state.getDeliveryChannel())
+                .isRead(false)
+                .landingUrl(state.getLandingUrl())
+                .sendStatus(initialStatus)
+                .scheduledAt(state.getScheduledAt())
+                .build();
+        notification.activate();
+        return notification;
+    }
+
+    public static Notification from(NotificationSnapshotState state) {
+        Notification notification = Notification.builder()
+                .id(state.getId())
+                .userId(state.getUserId())
+                .notificationType(state.getNotificationType())
+                .title(state.getTitle())
+                .body(state.getBody())
+                .data(state.getData())
+                .deliveryChannel(state.getDeliveryChannel())
+                .isRead(state.isRead())
+                .landingUrl(state.getLandingUrl())
+                .sendStatus(state.getSendStatus())
+                .scheduledAt(state.getScheduledAt())
+                .createdAt(state.getCreatedAt())
+                .modifiedAt(state.getModifiedAt())
+                .build();
+        notification.status = state.getStatus();
+        return notification;
+    }
+
+    public void markAsRead() {
+        this.isRead = true;
+    }
+
+    public void markAsSent() {
+        this.sendStatus = SendStatus.SENT;
+    }
+
+    public void markAsFailed() {
+        this.sendStatus = SendStatus.FAILED;
+    }
+
+    private static void validate(NotificationCreateState state) {
+        if (FormatValidator.hasNoValue(state.getUserId())) {
+            throw new InvalidNotificationException("사용자 ID는 필수입니다.");
+        }
+        if (FormatValidator.hasNoValue(state.getNotificationType())) {
+            throw new InvalidNotificationException("알림 타입은 필수입니다.");
+        }
+        if (FormatValidator.hasNoValue(state.getDeliveryChannel())) {
+            throw new InvalidNotificationException("발송 채널은 필수입니다.");
+        }
+    }
+}

--- a/notification-service/notification-domain/src/main/java/com/personal/marketnote/notification/domain/notification/NotificationCreateState.java
+++ b/notification-service/notification-domain/src/main/java/com/personal/marketnote/notification/domain/notification/NotificationCreateState.java
@@ -1,0 +1,21 @@
+package com.personal.marketnote.notification.domain.notification;
+
+import com.personal.marketnote.notification.domain.template.NotificationType;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+@Getter
+public class NotificationCreateState {
+    private Long userId;
+    private NotificationType notificationType;
+    private String title;
+    private String body;
+    private String data;
+    private DeliveryChannel deliveryChannel;
+    private String landingUrl;
+    private LocalDateTime scheduledAt;
+}

--- a/notification-service/notification-domain/src/main/java/com/personal/marketnote/notification/domain/notification/NotificationSnapshotState.java
+++ b/notification-service/notification-domain/src/main/java/com/personal/marketnote/notification/domain/notification/NotificationSnapshotState.java
@@ -1,0 +1,28 @@
+package com.personal.marketnote.notification.domain.notification;
+
+import com.personal.marketnote.common.domain.EntityStatus;
+import com.personal.marketnote.notification.domain.template.NotificationType;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+@Getter
+public class NotificationSnapshotState {
+    private Long id;
+    private Long userId;
+    private NotificationType notificationType;
+    private String title;
+    private String body;
+    private String data;
+    private DeliveryChannel deliveryChannel;
+    private boolean isRead;
+    private String landingUrl;
+    private SendStatus sendStatus;
+    private LocalDateTime scheduledAt;
+    private EntityStatus status;
+    private LocalDateTime createdAt;
+    private LocalDateTime modifiedAt;
+}

--- a/notification-service/notification-domain/src/main/java/com/personal/marketnote/notification/domain/notification/SendStatus.java
+++ b/notification-service/notification-domain/src/main/java/com/personal/marketnote/notification/domain/notification/SendStatus.java
@@ -1,0 +1,39 @@
+package com.personal.marketnote.notification.domain.notification;
+
+public enum SendStatus {
+    PENDING("대기"),
+    SENT("발송 완료"),
+    FAILED("발송 실패"),
+    SKIPPED("건너뜀"),
+    SCHEDULED("예약");
+
+    private final String description;
+
+    SendStatus(String description) {
+        this.description = description;
+    }
+
+    public boolean isPending() {
+        return this == PENDING;
+    }
+
+    public boolean isSent() {
+        return this == SENT;
+    }
+
+    public boolean isFailed() {
+        return this == FAILED;
+    }
+
+    public boolean isSkipped() {
+        return this == SKIPPED;
+    }
+
+    public boolean isScheduled() {
+        return this == SCHEDULED;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+}


### PR DESCRIPTION
## partially addresses #2164
## partially addresses #2124
## resolves #2097

## Task
- [x] SendStatus enum (PENDING/SENT/FAILED/SKIPPED/SCHEDULED) 추가
- [x] DeliveryChannel enum (PUSH_ONLY/IN_APP_ONLY/PUSH_AND_IN_APP) 추가
- [x] NotificationCreateState, NotificationSnapshotState 추가
- [x] Notification 도메인 모델 (from CreateState/SnapshotState) 추가
- [x] InvalidNotificationException 추가
- [x] GetNotificationHistoryUseCase + Command/Result 추가
- [x] FindNotificationPort 추가
- [x] GetNotificationHistoryService 추가
- [x] NotificationJpaEntity + Repository 추가
- [x] NotificationJpaEntityToDomainMapper 추가
- [x] NotificationPersistenceAdapter 추가
- [x] GET /api/v1/notifications API (CursorResponse, pageSize=20) 추가
- [x] GetNotificationHistoryApiDocs 추가
- [x] NotificationItemResponse, GetNotificationHistoryResponse 추가
