### PR TITLE
[#2164][#2124][#2116] test: 알림 이력 조회 기능 자동화 테스트 추가

### DIFF
--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/web/notification/controller/NotificationController.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/web/notification/controller/NotificationController.java
@@ -1,0 +1,79 @@
+package com.personal.marketnote.notification.adapter.in.web.notification.controller;
+
+import com.personal.marketnote.common.adapter.in.api.format.BaseResponse;
+import com.personal.marketnote.common.utility.ElementExtractor;
+import com.personal.marketnote.notification.adapter.in.web.notification.controller.apidocs.GetNotificationHistoryApiDocs;
+import com.personal.marketnote.notification.adapter.in.web.notification.response.GetNotificationHistoryResponse;
+import com.personal.marketnote.notification.port.in.command.GetNotificationHistoryCommand;
+import com.personal.marketnote.notification.port.in.result.notification.GetNotificationHistoryResult;
+import com.personal.marketnote.notification.port.in.usecase.notification.GetNotificationHistoryUseCase;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.core.OAuth2AuthenticatedPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import static com.personal.marketnote.common.domain.exception.ExceptionCode.DEFAULT_SUCCESS_CODE;
+
+/**
+ * 알림 이력 컨트롤러
+ *
+ * @Author 성효빈
+ * @Date 2026-06-03
+ * @Description 사용자의 알림 이력 조회 API를 제공합니다.
+ */
+@RestController
+@RequestMapping("/api/v1/notifications")
+@Tag(name = "알림 이력 API", description = "사용자 알림 이력 관리 API")
+@RequiredArgsConstructor
+@Validated
+public class NotificationController {
+
+    private final GetNotificationHistoryUseCase getNotificationHistoryUseCase;
+
+    /**
+     * 알림 이력 조회
+     *
+     * @param principal 인증된 사용자
+     * @param cursor    이전 페이지 마지막 항목의 ID
+     * @param pageSize  페이지 크기 (기본 20)
+     * @return 알림 이력 목록 {@link GetNotificationHistoryResponse}
+     * @Author 성효빈
+     * @Date 2026-06-03
+     * @Description 인증된 사용자의 알림 발송 이력을 커서 기반 페이징으로 조회합니다.
+     */
+    @GetMapping
+    @GetNotificationHistoryApiDocs
+    public ResponseEntity<BaseResponse<GetNotificationHistoryResponse>> getNotificationHistory(
+            @AuthenticationPrincipal OAuth2AuthenticatedPrincipal principal,
+            @RequestParam(value = "cursor", required = false) Long cursor,
+            @RequestParam(value = "page-size", required = false, defaultValue = "20") @Min(1) @Max(100) int pageSize
+    ) {
+        GetNotificationHistoryCommand command = new GetNotificationHistoryCommand(
+                ElementExtractor.extractUserId(principal),
+                cursor,
+                pageSize
+        );
+
+        GetNotificationHistoryResult result = getNotificationHistoryUseCase.getNotificationHistory(command);
+        GetNotificationHistoryResponse response = GetNotificationHistoryResponse.from(result);
+
+        return new ResponseEntity<>(
+                BaseResponse.of(
+                        response,
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "알림 이력 조회 성공"
+                ),
+                HttpStatus.OK
+        );
+    }
+}

--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/web/notification/controller/apidocs/GetNotificationHistoryApiDocs.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/web/notification/controller/apidocs/GetNotificationHistoryApiDocs.java
@@ -1,0 +1,137 @@
+package com.personal.marketnote.notification.adapter.in.web.notification.controller.apidocs;
+
+import com.personal.marketnote.common.adapter.in.api.schema.StringResponseSchema;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Operation(
+        summary = "알림 이력 조회",
+        description = """
+                작성일자: 2026-06-03
+
+                작성자: 성효빈
+
+                ---
+
+                ## Description
+
+                - 인증된 사용자의 알림 발송 이력을 커서 기반 페이징으로 조회합니다.
+
+                - 최신순(id DESC)으로 정렬되며, 기본 페이지 크기는 20건입니다.
+
+                - 첫 페이지 요청 시 totalElements를 포함하여 반환합니다.
+
+                ---
+
+                ## Request Parameters
+
+                | **파라미터** | **타입** | **필수** | **기본값** | **설명** |
+                | --- | --- | --- | --- | --- |
+                | cursor | number | N | - | 이전 페이지 마지막 항목의 ID |
+                | page-size | number | N | 20 | 페이지 크기 (1~100) |
+
+                ---
+
+                ## Response
+
+                | **키** | **타입** | **설명** | **예시** |
+                | --- | --- | --- | --- |
+                | statusCode | number | 상태 코드 | 200 |
+                | code | string | 응답 코드 | "SUC01" |
+                | timestamp | string(datetime) | 응답 일시 | "2026-06-03T10:00:00.000" |
+                | content | object | 알림 이력 응답 | { notifications: { ... } } |
+                | message | string | 처리 결과 | "알림 이력 조회 성공" |
+
+                ### Response > content > notifications
+
+                | **키** | **타입** | **설명** |
+                | --- | --- | --- |
+                | totalElements | number | 전체 건수 (첫 페이지만) |
+                | hasNext | boolean | 다음 페이지 존재 여부 |
+                | nextCursor | number | 다음 페이지 커서 |
+                | items[] | array | 알림 항목 목록 |
+
+                ### Response > content > notifications > items[]
+
+                | **키** | **타입** | **설명** |
+                | --- | --- | --- |
+                | id | number | 알림 ID |
+                | notificationType | string | 알림 타입 |
+                | notificationTypeDescription | string | 알림 타입 설명 |
+                | title | string | 알림 제목 |
+                | body | string | 알림 본문 |
+                | deliveryChannel | string | 발송 채널 |
+                | isRead | boolean | 읽음 여부 |
+                | landingUrl | string | 딥링크 URL |
+                | sendStatus | string | 발송 상태 |
+                | scheduledAt | string(datetime) | 예약 발송 시각 |
+                | createdAt | string(datetime) | 생성 일시 |
+                """,
+        security = {@SecurityRequirement(name = "bearer")},
+        responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "조회 성공",
+                        content = @Content(
+                                schema = @Schema(implementation = StringResponseSchema.class),
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 200,
+                                          "code": "SUC01",
+                                          "timestamp": "2026-06-03T12:00:00.000",
+                                          "content": {
+                                            "notifications": {
+                                              "totalElements": 25,
+                                              "hasNext": true,
+                                              "nextCursor": 6,
+                                              "items": [
+                                                {
+                                                  "id": 25,
+                                                  "notificationType": "ORDER_PAYMENT_COMPLETED",
+                                                  "notificationTypeDescription": "주문 결제 완료",
+                                                  "title": "주문이 완료되었습니다",
+                                                  "body": "테스트 상품 외 1건이 결제되었습니다.",
+                                                  "deliveryChannel": "PUSH_AND_IN_APP",
+                                                  "isRead": false,
+                                                  "landingUrl": "/order/123",
+                                                  "sendStatus": "SENT",
+                                                  "scheduledAt": null,
+                                                  "createdAt": "2026-06-03T12:00:00"
+                                                }
+                                              ]
+                                            }
+                                          },
+                                          "message": "알림 이력 조회 성공"
+                                        }
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "401",
+                        description = "토큰 인증 실패",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 401,
+                                          "code": "UNAUTHORIZED",
+                                          "timestamp": "2026-06-03T12:00:00.000",
+                                          "content": null,
+                                          "message": "Invalid token"
+                                        }
+                                        """)
+                        )
+                )
+        }
+)
+public @interface GetNotificationHistoryApiDocs {
+}

--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/web/notification/response/GetNotificationHistoryResponse.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/web/notification/response/GetNotificationHistoryResponse.java
@@ -1,0 +1,25 @@
+package com.personal.marketnote.notification.adapter.in.web.notification.response;
+
+import com.personal.marketnote.common.adapter.in.response.CursorResponse;
+import com.personal.marketnote.notification.port.in.result.notification.GetNotificationHistoryResult;
+
+import java.util.List;
+
+public record GetNotificationHistoryResponse(
+        CursorResponse<NotificationItemResponse> notifications
+) {
+    public static GetNotificationHistoryResponse from(GetNotificationHistoryResult result) {
+        List<NotificationItemResponse> items = result.notifications().stream()
+                .map(NotificationItemResponse::from)
+                .toList();
+
+        CursorResponse<NotificationItemResponse> cursorResponse = new CursorResponse<>(
+                result.totalElements(),
+                result.hasNext(),
+                result.nextCursor(),
+                items
+        );
+
+        return new GetNotificationHistoryResponse(cursorResponse);
+    }
+}

--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/web/notification/response/NotificationItemResponse.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/web/notification/response/NotificationItemResponse.java
@@ -1,0 +1,37 @@
+package com.personal.marketnote.notification.adapter.in.web.notification.response;
+
+import com.personal.marketnote.notification.domain.notification.DeliveryChannel;
+import com.personal.marketnote.notification.domain.notification.SendStatus;
+import com.personal.marketnote.notification.port.in.result.notification.NotificationItemResult;
+
+import java.time.LocalDateTime;
+
+public record NotificationItemResponse(
+        Long id,
+        String notificationType,
+        String notificationTypeDescription,
+        String title,
+        String body,
+        DeliveryChannel deliveryChannel,
+        boolean isRead,
+        String landingUrl,
+        SendStatus sendStatus,
+        LocalDateTime scheduledAt,
+        LocalDateTime createdAt
+) {
+    public static NotificationItemResponse from(NotificationItemResult result) {
+        return new NotificationItemResponse(
+                result.id(),
+                result.notificationType(),
+                result.notificationTypeDescription(),
+                result.title(),
+                result.body(),
+                result.deliveryChannel(),
+                result.isRead(),
+                result.landingUrl(),
+                result.sendStatus(),
+                result.scheduledAt(),
+                result.createdAt()
+        );
+    }
+}

--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/out/mapper/NotificationJpaEntityToDomainMapper.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/out/mapper/NotificationJpaEntityToDomainMapper.java
@@ -1,0 +1,35 @@
+package com.personal.marketnote.notification.adapter.out.mapper;
+
+import com.personal.marketnote.notification.adapter.out.persistence.notification.entity.NotificationJpaEntity;
+import com.personal.marketnote.notification.domain.notification.Notification;
+import com.personal.marketnote.notification.domain.notification.NotificationSnapshotState;
+
+import java.util.Optional;
+
+public class NotificationJpaEntityToDomainMapper {
+
+    private NotificationJpaEntityToDomainMapper() {
+    }
+
+    public static Optional<Notification> mapToDomain(NotificationJpaEntity entity) {
+        return Optional.ofNullable(entity)
+                .map(e -> Notification.from(
+                        NotificationSnapshotState.builder()
+                                .id(e.getId())
+                                .userId(e.getUserId())
+                                .notificationType(e.getNotificationType())
+                                .title(e.getTitle())
+                                .body(e.getBody())
+                                .data(e.getData())
+                                .deliveryChannel(e.getDeliveryChannel())
+                                .isRead(e.isRead())
+                                .landingUrl(e.getLandingUrl())
+                                .sendStatus(e.getSendStatus())
+                                .scheduledAt(e.getScheduledAt())
+                                .status(e.getStatus())
+                                .createdAt(e.getCreatedAt())
+                                .modifiedAt(e.getModifiedAt())
+                                .build()
+                ));
+    }
+}

--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/out/persistence/notification/NotificationPersistenceAdapter.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/out/persistence/notification/NotificationPersistenceAdapter.java
@@ -1,0 +1,36 @@
+package com.personal.marketnote.notification.adapter.out.persistence.notification;
+
+import com.personal.marketnote.common.adapter.out.PersistenceAdapter;
+import com.personal.marketnote.common.domain.EntityStatus;
+import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.notification.adapter.out.mapper.NotificationJpaEntityToDomainMapper;
+import com.personal.marketnote.notification.adapter.out.persistence.notification.repository.NotificationJpaRepository;
+import com.personal.marketnote.notification.domain.notification.Notification;
+import com.personal.marketnote.notification.port.out.notification.FindNotificationPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+
+import java.util.List;
+
+@PersistenceAdapter
+@RequiredArgsConstructor
+public class NotificationPersistenceAdapter implements FindNotificationPort {
+
+    private final NotificationJpaRepository notificationJpaRepository;
+
+    @Override
+    public List<Notification> findByUserId(Long userId, Long cursor, int fetchSize) {
+        Long effectiveCursor = FormatValidator.hasValue(cursor) ? cursor : -1L;
+
+        return notificationJpaRepository.findByUserIdWithCursor(
+                        userId, EntityStatus.ACTIVE, effectiveCursor, PageRequest.of(0, fetchSize)
+                ).stream()
+                .flatMap(entity -> NotificationJpaEntityToDomainMapper.mapToDomain(entity).stream())
+                .toList();
+    }
+
+    @Override
+    public long countByUserId(Long userId) {
+        return notificationJpaRepository.countByUserIdAndStatus(userId, EntityStatus.ACTIVE);
+    }
+}

--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/out/persistence/notification/entity/NotificationJpaEntity.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/out/persistence/notification/entity/NotificationJpaEntity.java
@@ -1,0 +1,72 @@
+package com.personal.marketnote.notification.adapter.out.persistence.notification.entity;
+
+import com.personal.marketnote.common.adapter.out.persistence.audit.BaseGeneralEntity;
+import com.personal.marketnote.notification.domain.notification.DeliveryChannel;
+import com.personal.marketnote.notification.domain.notification.Notification;
+import com.personal.marketnote.notification.domain.notification.SendStatus;
+import com.personal.marketnote.notification.domain.template.NotificationType;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.DynamicInsert;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "notification", indexes = {
+        @Index(name = "idx_notification_user_id_status", columnList = "user_id, status")
+})
+@DynamicInsert
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+@Getter
+public class NotificationJpaEntity extends BaseGeneralEntity {
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "notification_type", nullable = false, length = 50)
+    @Enumerated(EnumType.STRING)
+    private NotificationType notificationType;
+
+    @Column(name = "title", nullable = false, length = 200)
+    private String title;
+
+    @Column(name = "body", nullable = false, length = 500)
+    private String body;
+
+    @Column(name = "data", columnDefinition = "TEXT")
+    private String data;
+
+    @Column(name = "delivery_channel", nullable = false, length = 30)
+    @Enumerated(EnumType.STRING)
+    private DeliveryChannel deliveryChannel;
+
+    @Column(name = "is_read", nullable = false)
+    private boolean isRead;
+
+    @Column(name = "landing_url", length = 500)
+    private String landingUrl;
+
+    @Column(name = "send_status", nullable = false, length = 20)
+    @Enumerated(EnumType.STRING)
+    private SendStatus sendStatus;
+
+    @Column(name = "scheduled_at")
+    private LocalDateTime scheduledAt;
+
+    public static NotificationJpaEntity from(Notification notification) {
+        return NotificationJpaEntity.builder()
+                .userId(notification.getUserId())
+                .notificationType(notification.getNotificationType())
+                .title(notification.getTitle())
+                .body(notification.getBody())
+                .data(notification.getData())
+                .deliveryChannel(notification.getDeliveryChannel())
+                .isRead(notification.isRead())
+                .landingUrl(notification.getLandingUrl())
+                .sendStatus(notification.getSendStatus())
+                .scheduledAt(notification.getScheduledAt())
+                .build();
+    }
+}

--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/out/persistence/notification/repository/NotificationJpaRepository.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/out/persistence/notification/repository/NotificationJpaRepository.java
@@ -1,0 +1,29 @@
+package com.personal.marketnote.notification.adapter.out.persistence.notification.repository;
+
+import com.personal.marketnote.common.domain.EntityStatus;
+import com.personal.marketnote.notification.adapter.out.persistence.notification.entity.NotificationJpaEntity;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface NotificationJpaRepository extends JpaRepository<NotificationJpaEntity, Long> {
+
+    @Query("""
+            SELECT n FROM NotificationJpaEntity n
+            WHERE n.userId = :userId
+              AND n.status = :status
+              AND (:cursor = -1L OR n.id < :cursor)
+            ORDER BY n.id DESC
+            """)
+    List<NotificationJpaEntity> findByUserIdWithCursor(
+            @Param("userId") Long userId,
+            @Param("status") EntityStatus status,
+            @Param("cursor") Long cursor,
+            Pageable pageable
+    );
+
+    long countByUserIdAndStatus(Long userId, EntityStatus status);
+}

--- a/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/in/command/GetNotificationHistoryCommand.java
+++ b/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/in/command/GetNotificationHistoryCommand.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.notification.port.in.command;
+
+public record GetNotificationHistoryCommand(
+        Long userId,
+        Long cursor,
+        int pageSize
+) {
+}

--- a/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/in/result/notification/GetNotificationHistoryResult.java
+++ b/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/in/result/notification/GetNotificationHistoryResult.java
@@ -1,0 +1,22 @@
+package com.personal.marketnote.notification.port.in.result.notification;
+
+import com.personal.marketnote.notification.domain.notification.Notification;
+
+import java.util.List;
+
+public record GetNotificationHistoryResult(
+        Long totalElements,
+        boolean hasNext,
+        Long nextCursor,
+        List<NotificationItemResult> notifications
+) {
+    public static GetNotificationHistoryResult from(Long totalElements,
+                                                     boolean hasNext,
+                                                     Long nextCursor,
+                                                     List<Notification> notifications) {
+        List<NotificationItemResult> items = notifications.stream()
+                .map(NotificationItemResult::from)
+                .toList();
+        return new GetNotificationHistoryResult(totalElements, hasNext, nextCursor, items);
+    }
+}

--- a/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/in/result/notification/NotificationItemResult.java
+++ b/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/in/result/notification/NotificationItemResult.java
@@ -1,0 +1,37 @@
+package com.personal.marketnote.notification.port.in.result.notification;
+
+import com.personal.marketnote.notification.domain.notification.DeliveryChannel;
+import com.personal.marketnote.notification.domain.notification.Notification;
+import com.personal.marketnote.notification.domain.notification.SendStatus;
+
+import java.time.LocalDateTime;
+
+public record NotificationItemResult(
+        Long id,
+        String notificationType,
+        String notificationTypeDescription,
+        String title,
+        String body,
+        DeliveryChannel deliveryChannel,
+        boolean isRead,
+        String landingUrl,
+        SendStatus sendStatus,
+        LocalDateTime scheduledAt,
+        LocalDateTime createdAt
+) {
+    public static NotificationItemResult from(Notification notification) {
+        return new NotificationItemResult(
+                notification.getId(),
+                notification.getNotificationType().name(),
+                notification.getNotificationType().getDescription(),
+                notification.getTitle(),
+                notification.getBody(),
+                notification.getDeliveryChannel(),
+                notification.isRead(),
+                notification.getLandingUrl(),
+                notification.getSendStatus(),
+                notification.getScheduledAt(),
+                notification.getCreatedAt()
+        );
+    }
+}

--- a/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/in/usecase/notification/GetNotificationHistoryUseCase.java
+++ b/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/in/usecase/notification/GetNotificationHistoryUseCase.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.notification.port.in.usecase.notification;
+
+import com.personal.marketnote.notification.port.in.command.GetNotificationHistoryCommand;
+import com.personal.marketnote.notification.port.in.result.notification.GetNotificationHistoryResult;
+
+public interface GetNotificationHistoryUseCase {
+
+    GetNotificationHistoryResult getNotificationHistory(GetNotificationHistoryCommand command);
+}

--- a/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/out/notification/FindNotificationPort.java
+++ b/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/out/notification/FindNotificationPort.java
@@ -1,0 +1,12 @@
+package com.personal.marketnote.notification.port.out.notification;
+
+import com.personal.marketnote.notification.domain.notification.Notification;
+
+import java.util.List;
+
+public interface FindNotificationPort {
+
+    List<Notification> findByUserId(Long userId, Long cursor, int fetchSize);
+
+    long countByUserId(Long userId);
+}

--- a/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/service/notification/GetNotificationHistoryService.java
+++ b/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/service/notification/GetNotificationHistoryService.java
@@ -1,0 +1,53 @@
+package com.personal.marketnote.notification.service.notification;
+
+import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.notification.domain.notification.Notification;
+import com.personal.marketnote.notification.port.in.command.GetNotificationHistoryCommand;
+import com.personal.marketnote.notification.port.in.result.notification.GetNotificationHistoryResult;
+import com.personal.marketnote.notification.port.in.usecase.notification.GetNotificationHistoryUseCase;
+import com.personal.marketnote.notification.port.out.notification.FindNotificationPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@UseCase
+@RequiredArgsConstructor
+@Transactional(isolation = READ_COMMITTED, readOnly = true)
+public class GetNotificationHistoryService implements GetNotificationHistoryUseCase {
+
+    private final FindNotificationPort findNotificationPort;
+
+    @Override
+    public GetNotificationHistoryResult getNotificationHistory(GetNotificationHistoryCommand command) {
+        int fetchSize = command.pageSize() + 1;
+        List<Notification> notifications = findNotificationPort.findByUserId(
+                command.userId(), command.cursor(), fetchSize
+        );
+
+        boolean hasNext = notifications.size() > command.pageSize();
+        List<Notification> pagedNotifications = hasNext
+                ? notifications.subList(0, command.pageSize())
+                : notifications;
+
+        Long nextCursor = pagedNotifications.isEmpty() ? null : pagedNotifications.getLast().getId();
+
+        Long totalElements = resolveTotalElements(command, hasNext, pagedNotifications.size());
+
+        return GetNotificationHistoryResult.from(totalElements, hasNext, nextCursor, pagedNotifications);
+    }
+
+    private Long resolveTotalElements(GetNotificationHistoryCommand command,
+                                      boolean hasNext, int currentSize) {
+        if (FormatValidator.hasValue(command.cursor())) {
+            return null;
+        }
+        if (!hasNext) {
+            return (long) currentSize;
+        }
+        return findNotificationPort.countByUserId(command.userId());
+    }
+}

--- a/notification-service/notification-application/src/test/java/com/personal/marketnote/notification/service/notification/GetNotificationHistoryUseCaseTest.java
+++ b/notification-service/notification-application/src/test/java/com/personal/marketnote/notification/service/notification/GetNotificationHistoryUseCaseTest.java
@@ -1,0 +1,196 @@
+package com.personal.marketnote.notification.service.notification;
+
+import com.personal.marketnote.common.domain.EntityStatus;
+import com.personal.marketnote.notification.domain.notification.*;
+import com.personal.marketnote.notification.domain.template.NotificationType;
+import com.personal.marketnote.notification.port.in.command.GetNotificationHistoryCommand;
+import com.personal.marketnote.notification.port.in.result.notification.GetNotificationHistoryResult;
+import com.personal.marketnote.notification.port.in.result.notification.NotificationItemResult;
+import com.personal.marketnote.notification.port.out.notification.FindNotificationPort;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class GetNotificationHistoryUseCaseTest {
+
+    @InjectMocks
+    private GetNotificationHistoryService getNotificationHistoryService;
+
+    @Mock
+    private FindNotificationPort findNotificationPort;
+
+    @Test
+    @DisplayName("첫 페이지 조회 시 totalElements를 포함하여 반환한다")
+    void shouldReturnTotalElementsOnFirstPage() {
+        // given
+        Long userId = 1L;
+        int pageSize = 2;
+        GetNotificationHistoryCommand command = new GetNotificationHistoryCommand(userId, null, pageSize);
+
+        List<Notification> notifications = createNotifications(3, userId);
+        when(findNotificationPort.findByUserId(userId, null, 3)).thenReturn(notifications);
+        when(findNotificationPort.countByUserId(userId)).thenReturn(10L);
+
+        // when
+        GetNotificationHistoryResult result = getNotificationHistoryService.getNotificationHistory(command);
+
+        // then
+        assertThat(result.totalElements()).isEqualTo(10L);
+        assertThat(result.hasNext()).isTrue();
+        assertThat(result.notifications()).hasSize(2);
+        assertThat(result.nextCursor()).isEqualTo(2L);
+
+        verify(findNotificationPort).findByUserId(userId, null, 3);
+        verify(findNotificationPort).countByUserId(userId);
+    }
+
+    @Test
+    @DisplayName("두 번째 페이지 조회 시 totalElements가 null이다")
+    void shouldReturnNullTotalElementsOnSubsequentPage() {
+        // given
+        Long userId = 1L;
+        Long cursor = 5L;
+        int pageSize = 2;
+        GetNotificationHistoryCommand command = new GetNotificationHistoryCommand(userId, cursor, pageSize);
+
+        List<Notification> notifications = createNotifications(3, userId);
+        when(findNotificationPort.findByUserId(userId, cursor, 3)).thenReturn(notifications);
+
+        // when
+        GetNotificationHistoryResult result = getNotificationHistoryService.getNotificationHistory(command);
+
+        // then
+        assertThat(result.totalElements()).isNull();
+        assertThat(result.hasNext()).isTrue();
+        assertThat(result.notifications()).hasSize(2);
+
+        verify(findNotificationPort).findByUserId(userId, cursor, 3);
+        verifyNoMoreInteractions(findNotificationPort);
+    }
+
+    @Test
+    @DisplayName("결과가 pageSize 이하이면 hasNext가 false이다")
+    void shouldReturnHasNextFalseWhenNoMoreResults() {
+        // given
+        Long userId = 1L;
+        int pageSize = 20;
+        GetNotificationHistoryCommand command = new GetNotificationHistoryCommand(userId, null, pageSize);
+
+        List<Notification> notifications = createNotifications(5, userId);
+        when(findNotificationPort.findByUserId(userId, null, 21)).thenReturn(notifications);
+
+        // when
+        GetNotificationHistoryResult result = getNotificationHistoryService.getNotificationHistory(command);
+
+        // then
+        assertThat(result.hasNext()).isFalse();
+        assertThat(result.totalElements()).isEqualTo(5L);
+        assertThat(result.notifications()).hasSize(5);
+
+        verify(findNotificationPort).findByUserId(userId, null, 21);
+        verifyNoMoreInteractions(findNotificationPort);
+    }
+
+    @Test
+    @DisplayName("결과가 비어있으면 빈 목록과 nextCursor null을 반환한다")
+    void shouldReturnEmptyResultWhenNoNotifications() {
+        // given
+        Long userId = 1L;
+        int pageSize = 20;
+        GetNotificationHistoryCommand command = new GetNotificationHistoryCommand(userId, null, pageSize);
+
+        when(findNotificationPort.findByUserId(userId, null, 21)).thenReturn(List.of());
+
+        // when
+        GetNotificationHistoryResult result = getNotificationHistoryService.getNotificationHistory(command);
+
+        // then
+        assertThat(result.notifications()).isEmpty();
+        assertThat(result.nextCursor()).isNull();
+        assertThat(result.hasNext()).isFalse();
+        assertThat(result.totalElements()).isEqualTo(0L);
+
+        verify(findNotificationPort).findByUserId(userId, null, 21);
+        verifyNoMoreInteractions(findNotificationPort);
+    }
+
+    @Test
+    @DisplayName("알림 항목의 상세 정보가 올바르게 매핑된다")
+    void shouldMapNotificationItemResultCorrectly() {
+        // given
+        Long userId = 1L;
+        int pageSize = 20;
+        GetNotificationHistoryCommand command = new GetNotificationHistoryCommand(userId, null, pageSize);
+
+        LocalDateTime now = LocalDateTime.of(2026, 4, 9, 12, 0);
+        Notification notification = Notification.from(
+                NotificationSnapshotState.builder()
+                        .id(100L)
+                        .userId(userId)
+                        .notificationType(NotificationType.ORDER_PAYMENT_COMPLETED)
+                        .title("주문이 완료되었습니다")
+                        .body("테스트 상품 외 1건이 결제되었습니다.")
+                        .deliveryChannel(DeliveryChannel.PUSH_AND_IN_APP)
+                        .isRead(false)
+                        .landingUrl("/order/123")
+                        .sendStatus(SendStatus.SENT)
+                        .status(EntityStatus.ACTIVE)
+                        .createdAt(now)
+                        .modifiedAt(now)
+                        .build()
+        );
+
+        when(findNotificationPort.findByUserId(userId, null, 21)).thenReturn(List.of(notification));
+
+        // when
+        GetNotificationHistoryResult result = getNotificationHistoryService.getNotificationHistory(command);
+
+        // then
+        assertThat(result.notifications()).hasSize(1);
+        NotificationItemResult item = result.notifications().getFirst();
+        assertThat(item.id()).isEqualTo(100L);
+        assertThat(item.notificationType()).isEqualTo("ORDER_PAYMENT_COMPLETED");
+        assertThat(item.notificationTypeDescription()).isEqualTo("주문 결제 완료");
+        assertThat(item.title()).isEqualTo("주문이 완료되었습니다");
+        assertThat(item.body()).isEqualTo("테스트 상품 외 1건이 결제되었습니다.");
+        assertThat(item.deliveryChannel()).isEqualTo(DeliveryChannel.PUSH_AND_IN_APP);
+        assertThat(item.isRead()).isFalse();
+        assertThat(item.landingUrl()).isEqualTo("/order/123");
+        assertThat(item.sendStatus()).isEqualTo(SendStatus.SENT);
+        assertThat(item.createdAt()).isEqualTo(now);
+    }
+
+    private List<Notification> createNotifications(int count, Long userId) {
+        LocalDateTime now = LocalDateTime.of(2026, 4, 9, 12, 0);
+        List<Notification> notifications = new ArrayList<>();
+        for (long i = count; i >= 1; i--) {
+            notifications.add(Notification.from(
+                    NotificationSnapshotState.builder()
+                            .id(i)
+                            .userId(userId)
+                            .notificationType(NotificationType.ORDER_PAYMENT_COMPLETED)
+                            .title("알림 " + i)
+                            .body("본문 " + i)
+                            .deliveryChannel(DeliveryChannel.PUSH_AND_IN_APP)
+                            .isRead(false)
+                            .sendStatus(SendStatus.SENT)
+                            .status(EntityStatus.ACTIVE)
+                            .createdAt(now.minusHours(i))
+                            .modifiedAt(now.minusHours(i))
+                            .build()
+            ));
+        }
+        return notifications;
+    }
+}

--- a/notification-service/notification-domain/src/main/java/com/personal/marketnote/notification/domain/notification/DeliveryChannel.java
+++ b/notification-service/notification-domain/src/main/java/com/personal/marketnote/notification/domain/notification/DeliveryChannel.java
@@ -1,0 +1,25 @@
+package com.personal.marketnote.notification.domain.notification;
+
+public enum DeliveryChannel {
+    PUSH_ONLY("푸시"),
+    IN_APP_ONLY("인앱"),
+    PUSH_AND_IN_APP("푸시+인앱");
+
+    private final String description;
+
+    DeliveryChannel(String description) {
+        this.description = description;
+    }
+
+    public boolean hasPush() {
+        return this == PUSH_ONLY || this == PUSH_AND_IN_APP;
+    }
+
+    public boolean hasInApp() {
+        return this == IN_APP_ONLY || this == PUSH_AND_IN_APP;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+}

--- a/notification-service/notification-domain/src/main/java/com/personal/marketnote/notification/domain/notification/InvalidNotificationException.java
+++ b/notification-service/notification-domain/src/main/java/com/personal/marketnote/notification/domain/notification/InvalidNotificationException.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.notification.domain.notification;
+
+public class InvalidNotificationException extends IllegalArgumentException {
+
+    public InvalidNotificationException(String message) {
+        super(message);
+    }
+}

--- a/notification-service/notification-domain/src/main/java/com/personal/marketnote/notification/domain/notification/Notification.java
+++ b/notification-service/notification-domain/src/main/java/com/personal/marketnote/notification/domain/notification/Notification.java
@@ -1,0 +1,95 @@
+package com.personal.marketnote.notification.domain.notification;
+
+import com.personal.marketnote.common.domain.BaseDomain;
+import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.notification.domain.template.NotificationType;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+@Getter
+public class Notification extends BaseDomain {
+    private Long id;
+    private Long userId;
+    private NotificationType notificationType;
+    private String title;
+    private String body;
+    private String data;
+    private DeliveryChannel deliveryChannel;
+    private boolean isRead;
+    private String landingUrl;
+    private SendStatus sendStatus;
+    private LocalDateTime scheduledAt;
+    private LocalDateTime createdAt;
+    private LocalDateTime modifiedAt;
+
+    public static Notification from(NotificationCreateState state) {
+        validate(state);
+
+        SendStatus initialStatus = FormatValidator.hasValue(state.getScheduledAt())
+                ? SendStatus.SCHEDULED
+                : SendStatus.PENDING;
+
+        Notification notification = Notification.builder()
+                .userId(state.getUserId())
+                .notificationType(state.getNotificationType())
+                .title(state.getTitle())
+                .body(state.getBody())
+                .data(state.getData())
+                .deliveryChannel(state.getDeliveryChannel())
+                .isRead(false)
+                .landingUrl(state.getLandingUrl())
+                .sendStatus(initialStatus)
+                .scheduledAt(state.getScheduledAt())
+                .build();
+        notification.activate();
+        return notification;
+    }
+
+    public static Notification from(NotificationSnapshotState state) {
+        Notification notification = Notification.builder()
+                .id(state.getId())
+                .userId(state.getUserId())
+                .notificationType(state.getNotificationType())
+                .title(state.getTitle())
+                .body(state.getBody())
+                .data(state.getData())
+                .deliveryChannel(state.getDeliveryChannel())
+                .isRead(state.isRead())
+                .landingUrl(state.getLandingUrl())
+                .sendStatus(state.getSendStatus())
+                .scheduledAt(state.getScheduledAt())
+                .createdAt(state.getCreatedAt())
+                .modifiedAt(state.getModifiedAt())
+                .build();
+        notification.status = state.getStatus();
+        return notification;
+    }
+
+    public void markAsRead() {
+        this.isRead = true;
+    }
+
+    public void markAsSent() {
+        this.sendStatus = SendStatus.SENT;
+    }
+
+    public void markAsFailed() {
+        this.sendStatus = SendStatus.FAILED;
+    }
+
+    private static void validate(NotificationCreateState state) {
+        if (FormatValidator.hasNoValue(state.getUserId())) {
+            throw new InvalidNotificationException("사용자 ID는 필수입니다.");
+        }
+        if (FormatValidator.hasNoValue(state.getNotificationType())) {
+            throw new InvalidNotificationException("알림 타입은 필수입니다.");
+        }
+        if (FormatValidator.hasNoValue(state.getDeliveryChannel())) {
+            throw new InvalidNotificationException("발송 채널은 필수입니다.");
+        }
+    }
+}

--- a/notification-service/notification-domain/src/main/java/com/personal/marketnote/notification/domain/notification/NotificationCreateState.java
+++ b/notification-service/notification-domain/src/main/java/com/personal/marketnote/notification/domain/notification/NotificationCreateState.java
@@ -1,0 +1,21 @@
+package com.personal.marketnote.notification.domain.notification;
+
+import com.personal.marketnote.notification.domain.template.NotificationType;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+@Getter
+public class NotificationCreateState {
+    private Long userId;
+    private NotificationType notificationType;
+    private String title;
+    private String body;
+    private String data;
+    private DeliveryChannel deliveryChannel;
+    private String landingUrl;
+    private LocalDateTime scheduledAt;
+}

--- a/notification-service/notification-domain/src/main/java/com/personal/marketnote/notification/domain/notification/NotificationSnapshotState.java
+++ b/notification-service/notification-domain/src/main/java/com/personal/marketnote/notification/domain/notification/NotificationSnapshotState.java
@@ -1,0 +1,28 @@
+package com.personal.marketnote.notification.domain.notification;
+
+import com.personal.marketnote.common.domain.EntityStatus;
+import com.personal.marketnote.notification.domain.template.NotificationType;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+@Getter
+public class NotificationSnapshotState {
+    private Long id;
+    private Long userId;
+    private NotificationType notificationType;
+    private String title;
+    private String body;
+    private String data;
+    private DeliveryChannel deliveryChannel;
+    private boolean isRead;
+    private String landingUrl;
+    private SendStatus sendStatus;
+    private LocalDateTime scheduledAt;
+    private EntityStatus status;
+    private LocalDateTime createdAt;
+    private LocalDateTime modifiedAt;
+}

--- a/notification-service/notification-domain/src/main/java/com/personal/marketnote/notification/domain/notification/SendStatus.java
+++ b/notification-service/notification-domain/src/main/java/com/personal/marketnote/notification/domain/notification/SendStatus.java
@@ -1,0 +1,39 @@
+package com.personal.marketnote.notification.domain.notification;
+
+public enum SendStatus {
+    PENDING("대기"),
+    SENT("발송 완료"),
+    FAILED("발송 실패"),
+    SKIPPED("건너뜀"),
+    SCHEDULED("예약");
+
+    private final String description;
+
+    SendStatus(String description) {
+        this.description = description;
+    }
+
+    public boolean isPending() {
+        return this == PENDING;
+    }
+
+    public boolean isSent() {
+        return this == SENT;
+    }
+
+    public boolean isFailed() {
+        return this == FAILED;
+    }
+
+    public boolean isSkipped() {
+        return this == SKIPPED;
+    }
+
+    public boolean isScheduled() {
+        return this == SCHEDULED;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+}

--- a/notification-service/notification-domain/src/test/java/com/personal/marketnote/notification/domain/notification/DeliveryChannelTest.java
+++ b/notification-service/notification-domain/src/test/java/com/personal/marketnote/notification/domain/notification/DeliveryChannelTest.java
@@ -1,0 +1,61 @@
+package com.personal.marketnote.notification.domain.notification;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DeliveryChannelTest {
+
+    @Nested
+    @DisplayName("PUSH_ONLY 채널")
+    class PushOnly {
+
+        @Test
+        @DisplayName("푸시를 포함한다")
+        void shouldHavePush() {
+            assertThat(DeliveryChannel.PUSH_ONLY.hasPush()).isTrue();
+        }
+
+        @Test
+        @DisplayName("인앱을 포함하지 않는다")
+        void shouldNotHaveInApp() {
+            assertThat(DeliveryChannel.PUSH_ONLY.hasInApp()).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("IN_APP_ONLY 채널")
+    class InAppOnly {
+
+        @Test
+        @DisplayName("푸시를 포함하지 않는다")
+        void shouldNotHavePush() {
+            assertThat(DeliveryChannel.IN_APP_ONLY.hasPush()).isFalse();
+        }
+
+        @Test
+        @DisplayName("인앱을 포함한다")
+        void shouldHaveInApp() {
+            assertThat(DeliveryChannel.IN_APP_ONLY.hasInApp()).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("PUSH_AND_IN_APP 채널")
+    class PushAndInApp {
+
+        @Test
+        @DisplayName("푸시를 포함한다")
+        void shouldHavePush() {
+            assertThat(DeliveryChannel.PUSH_AND_IN_APP.hasPush()).isTrue();
+        }
+
+        @Test
+        @DisplayName("인앱을 포함한다")
+        void shouldHaveInApp() {
+            assertThat(DeliveryChannel.PUSH_AND_IN_APP.hasInApp()).isTrue();
+        }
+    }
+}

--- a/notification-service/notification-domain/src/test/java/com/personal/marketnote/notification/domain/notification/NotificationTest.java
+++ b/notification-service/notification-domain/src/test/java/com/personal/marketnote/notification/domain/notification/NotificationTest.java
@@ -1,0 +1,247 @@
+package com.personal.marketnote.notification.domain.notification;
+
+import com.personal.marketnote.common.domain.EntityStatus;
+import com.personal.marketnote.notification.domain.template.NotificationType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class NotificationTest {
+
+    @Nested
+    @DisplayName("from(CreateState) 팩토리 메서드")
+    class FromCreateState {
+
+        @Test
+        @DisplayName("유효한 값으로 알림을 생성한다")
+        void shouldCreateNotificationWithValidValues() {
+            // given
+            NotificationCreateState state = NotificationCreateState.builder()
+                    .userId(1L)
+                    .notificationType(NotificationType.ORDER_PAYMENT_COMPLETED)
+                    .title("주문이 완료되었습니다")
+                    .body("테스트 상품 외 1건이 결제되었습니다.")
+                    .data("{\"orderId\":123}")
+                    .deliveryChannel(DeliveryChannel.PUSH_AND_IN_APP)
+                    .landingUrl("/order/123")
+                    .build();
+
+            // when
+            Notification notification = Notification.from(state);
+
+            // then
+            assertThat(notification.getUserId()).isEqualTo(1L);
+            assertThat(notification.getNotificationType()).isEqualTo(NotificationType.ORDER_PAYMENT_COMPLETED);
+            assertThat(notification.getTitle()).isEqualTo("주문이 완료되었습니다");
+            assertThat(notification.getBody()).isEqualTo("테스트 상품 외 1건이 결제되었습니다.");
+            assertThat(notification.getData()).isEqualTo("{\"orderId\":123}");
+            assertThat(notification.getDeliveryChannel()).isEqualTo(DeliveryChannel.PUSH_AND_IN_APP);
+            assertThat(notification.isRead()).isFalse();
+            assertThat(notification.getLandingUrl()).isEqualTo("/order/123");
+            assertThat(notification.getSendStatus()).isEqualTo(SendStatus.PENDING);
+            assertThat(notification.isActive()).isTrue();
+        }
+
+        @Test
+        @DisplayName("scheduledAt이 존재하면 sendStatus가 SCHEDULED로 설정된다")
+        void shouldSetScheduledStatusWhenScheduledAtExists() {
+            // given
+            LocalDateTime scheduledAt = LocalDateTime.of(2026, 4, 10, 9, 0);
+            NotificationCreateState state = NotificationCreateState.builder()
+                    .userId(1L)
+                    .notificationType(NotificationType.PURCHASE_CONFIRMATION_REQUEST)
+                    .title("구매 확정 요청")
+                    .body("구매 확정을 해주세요.")
+                    .deliveryChannel(DeliveryChannel.PUSH_AND_IN_APP)
+                    .scheduledAt(scheduledAt)
+                    .build();
+
+            // when
+            Notification notification = Notification.from(state);
+
+            // then
+            assertThat(notification.getSendStatus()).isEqualTo(SendStatus.SCHEDULED);
+            assertThat(notification.getScheduledAt()).isEqualTo(scheduledAt);
+        }
+
+        @Test
+        @DisplayName("userId가 null이면 예외가 발생한다")
+        void shouldThrowExceptionWhenUserIdIsNull() {
+            // given
+            NotificationCreateState state = NotificationCreateState.builder()
+                    .userId(null)
+                    .notificationType(NotificationType.ORDER_PAYMENT_COMPLETED)
+                    .title("제목")
+                    .body("본문")
+                    .deliveryChannel(DeliveryChannel.PUSH_ONLY)
+                    .build();
+
+            // when & then
+            assertThatThrownBy(() -> Notification.from(state))
+                    .isInstanceOf(InvalidNotificationException.class);
+        }
+
+        @Test
+        @DisplayName("notificationType이 null이면 예외가 발생한다")
+        void shouldThrowExceptionWhenNotificationTypeIsNull() {
+            // given
+            NotificationCreateState state = NotificationCreateState.builder()
+                    .userId(1L)
+                    .notificationType(null)
+                    .title("제목")
+                    .body("본문")
+                    .deliveryChannel(DeliveryChannel.PUSH_ONLY)
+                    .build();
+
+            // when & then
+            assertThatThrownBy(() -> Notification.from(state))
+                    .isInstanceOf(InvalidNotificationException.class);
+        }
+
+        @Test
+        @DisplayName("deliveryChannel이 null이면 예외가 발생한다")
+        void shouldThrowExceptionWhenDeliveryChannelIsNull() {
+            // given
+            NotificationCreateState state = NotificationCreateState.builder()
+                    .userId(1L)
+                    .notificationType(NotificationType.ORDER_PAYMENT_COMPLETED)
+                    .title("제목")
+                    .body("본문")
+                    .deliveryChannel(null)
+                    .build();
+
+            // when & then
+            assertThatThrownBy(() -> Notification.from(state))
+                    .isInstanceOf(InvalidNotificationException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("from(SnapshotState) 팩토리 메서드")
+    class FromSnapshotState {
+
+        @Test
+        @DisplayName("DB 스냅샷으로부터 알림을 복원한다")
+        void shouldRestoreNotificationFromSnapshot() {
+            // given
+            LocalDateTime now = LocalDateTime.of(2026, 4, 9, 12, 0);
+            NotificationSnapshotState state = NotificationSnapshotState.builder()
+                    .id(10L)
+                    .userId(1L)
+                    .notificationType(NotificationType.SHIPPING_STARTED)
+                    .title("배송이 시작되었습니다")
+                    .body("테스트 상품이 발송되었습니다.")
+                    .data("{\"orderId\":456}")
+                    .deliveryChannel(DeliveryChannel.PUSH_AND_IN_APP)
+                    .isRead(true)
+                    .landingUrl("/order/456")
+                    .sendStatus(SendStatus.SENT)
+                    .scheduledAt(null)
+                    .status(EntityStatus.ACTIVE)
+                    .createdAt(now)
+                    .modifiedAt(now)
+                    .build();
+
+            // when
+            Notification notification = Notification.from(state);
+
+            // then
+            assertThat(notification.getId()).isEqualTo(10L);
+            assertThat(notification.getUserId()).isEqualTo(1L);
+            assertThat(notification.getNotificationType()).isEqualTo(NotificationType.SHIPPING_STARTED);
+            assertThat(notification.isRead()).isTrue();
+            assertThat(notification.getSendStatus()).isEqualTo(SendStatus.SENT);
+            assertThat(notification.isActive()).isTrue();
+            assertThat(notification.getCreatedAt()).isEqualTo(now);
+        }
+
+        @Test
+        @DisplayName("비활성화 상태의 알림도 그대로 복원한다")
+        void shouldRestoreInactiveNotificationFromSnapshot() {
+            // given
+            LocalDateTime now = LocalDateTime.of(2026, 4, 9, 12, 0);
+            NotificationSnapshotState state = NotificationSnapshotState.builder()
+                    .id(20L)
+                    .userId(1L)
+                    .notificationType(NotificationType.NOTICE)
+                    .title("공지사항")
+                    .body("본문")
+                    .deliveryChannel(DeliveryChannel.IN_APP_ONLY)
+                    .isRead(false)
+                    .sendStatus(SendStatus.SENT)
+                    .status(EntityStatus.INACTIVE)
+                    .createdAt(now)
+                    .modifiedAt(now)
+                    .build();
+
+            // when
+            Notification notification = Notification.from(state);
+
+            // then
+            assertThat(notification.isInactive()).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("상태 전이 메서드")
+    class StatusTransition {
+
+        @Test
+        @DisplayName("읽음 처리를 한다")
+        void shouldMarkAsRead() {
+            // given
+            Notification notification = createDefaultNotification();
+            assertThat(notification.isRead()).isFalse();
+
+            // when
+            notification.markAsRead();
+
+            // then
+            assertThat(notification.isRead()).isTrue();
+        }
+
+        @Test
+        @DisplayName("발송 완료로 전환한다")
+        void shouldMarkAsSent() {
+            // given
+            Notification notification = createDefaultNotification();
+            assertThat(notification.getSendStatus()).isEqualTo(SendStatus.PENDING);
+
+            // when
+            notification.markAsSent();
+
+            // then
+            assertThat(notification.getSendStatus()).isEqualTo(SendStatus.SENT);
+        }
+
+        @Test
+        @DisplayName("발송 실패로 전환한다")
+        void shouldMarkAsFailed() {
+            // given
+            Notification notification = createDefaultNotification();
+
+            // when
+            notification.markAsFailed();
+
+            // then
+            assertThat(notification.getSendStatus()).isEqualTo(SendStatus.FAILED);
+        }
+    }
+
+    private Notification createDefaultNotification() {
+        NotificationCreateState state = NotificationCreateState.builder()
+                .userId(1L)
+                .notificationType(NotificationType.ORDER_PAYMENT_COMPLETED)
+                .title("주문이 완료되었습니다")
+                .body("테스트 상품 외 1건이 결제되었습니다.")
+                .deliveryChannel(DeliveryChannel.PUSH_AND_IN_APP)
+                .landingUrl("/order/123")
+                .build();
+        return Notification.from(state);
+    }
+}

--- a/notification-service/notification-domain/src/test/java/com/personal/marketnote/notification/domain/notification/SendStatusTest.java
+++ b/notification-service/notification-domain/src/test/java/com/personal/marketnote/notification/domain/notification/SendStatusTest.java
@@ -1,0 +1,71 @@
+package com.personal.marketnote.notification.domain.notification;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SendStatusTest {
+
+    @Nested
+    @DisplayName("PENDING 상태")
+    class Pending {
+
+        @Test
+        @DisplayName("isPending()이 true를 반환한다")
+        void shouldReturnTrueForIsPending() {
+            assertThat(SendStatus.PENDING.isPending()).isTrue();
+        }
+
+        @Test
+        @DisplayName("isSent()가 false를 반환한다")
+        void shouldReturnFalseForIsSent() {
+            assertThat(SendStatus.PENDING.isSent()).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("SENT 상태")
+    class Sent {
+
+        @Test
+        @DisplayName("isSent()가 true를 반환한다")
+        void shouldReturnTrueForIsSent() {
+            assertThat(SendStatus.SENT.isSent()).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("FAILED 상태")
+    class Failed {
+
+        @Test
+        @DisplayName("isFailed()가 true를 반환한다")
+        void shouldReturnTrueForIsFailed() {
+            assertThat(SendStatus.FAILED.isFailed()).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("SKIPPED 상태")
+    class Skipped {
+
+        @Test
+        @DisplayName("isSkipped()가 true를 반환한다")
+        void shouldReturnTrueForIsSkipped() {
+            assertThat(SendStatus.SKIPPED.isSkipped()).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("SCHEDULED 상태")
+    class Scheduled {
+
+        @Test
+        @DisplayName("isScheduled()가 true를 반환한다")
+        void shouldReturnTrueForIsScheduled() {
+            assertThat(SendStatus.SCHEDULED.isScheduled()).isTrue();
+        }
+    }
+}


### PR DESCRIPTION
## partially addresses #2164
## partially addresses #2124
## resolves #2116

## Test Case
- [x] PENDING 상태 / isPending()이 true를 반환한다
- [x] PENDING 상태 / isSent()가 false를 반환한다
- [x] SENT 상태 / isSent()가 true를 반환한다
- [x] FAILED 상태 / isFailed()가 true를 반환한다
- [x] SKIPPED 상태 / isSkipped()가 true를 반환한다
- [x] SCHEDULED 상태 / isScheduled()가 true를 반환한다
- [x] PUSH_ONLY 채널 / 푸시를 포함한다
- [x] PUSH_ONLY 채널 / 인앱을 포함하지 않는다
- [x] IN_APP_ONLY 채널 / 푸시를 포함하지 않는다
- [x] IN_APP_ONLY 채널 / 인앱을 포함한다
- [x] PUSH_AND_IN_APP 채널 / 푸시를 포함한다
- [x] PUSH_AND_IN_APP 채널 / 인앱을 포함한다
- [x] from(CreateState) 팩토리 메서드 / 유효한 값으로 알림을 생성한다
- [x] from(CreateState) 팩토리 메서드 / scheduledAt이 존재하면 sendStatus가 SCHEDULED로 설정된다
- [x] from(CreateState) 팩토리 메서드 / userId가 null이면 예외가 발생한다
- [x] from(CreateState) 팩토리 메서드 / notificationType이 null이면 예외가 발생한다
- [x] from(CreateState) 팩토리 메서드 / deliveryChannel이 null이면 예외가 발생한다
- [x] from(SnapshotState) 팩토리 메서드 / DB 스냅샷으로부터 알림을 복원한다
- [x] from(SnapshotState) 팩토리 메서드 / 비활성화 상태의 알림도 그대로 복원한다
- [x] 상태 전이 메서드 / 읽음 처리를 한다
- [x] 상태 전이 메서드 / 발송 완료로 전환한다
- [x] 상태 전이 메서드 / 발송 실패로 전환한다
- [x] 첫 페이지 조회 시 totalElements를 포함하여 반환한다
- [x] 두 번째 페이지 조회 시 totalElements가 null이다
- [x] 결과가 pageSize 이하이면 hasNext가 false이다
- [x] 결과가 비어있으면 빈 목록과 nextCursor null을 반환한다
- [x] 알림 항목의 상세 정보가 올바르게 매핑된다
