### PR TITLE
[#2164][#2123][#2098] feat: FCM 클라이언트 연동 기능 추가

### DIFF
--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/out/fcm/FcmPushNotificationClient.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/out/fcm/FcmPushNotificationClient.java
@@ -1,0 +1,89 @@
+package com.personal.marketnote.notification.adapter.out.fcm;
+
+import com.google.firebase.messaging.*;
+import com.personal.marketnote.common.adapter.out.ServiceAdapter;
+import com.personal.marketnote.notification.domain.device.Platform;
+import com.personal.marketnote.notification.domain.notification.FcmSendFailedException;
+import com.personal.marketnote.notification.port.out.command.SendPushNotificationCommand;
+import com.personal.marketnote.notification.port.out.notification.SendPushNotificationPort;
+import com.personal.marketnote.notification.port.out.result.SendPushNotificationResult;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+
+@Slf4j
+@ServiceAdapter
+@RequiredArgsConstructor
+@ConditionalOnBean(FirebaseMessaging.class)
+public class FcmPushNotificationClient implements SendPushNotificationPort {
+
+    private final FirebaseMessaging firebaseMessaging;
+
+    @Override
+    public SendPushNotificationResult send(SendPushNotificationCommand command) {
+        Message message = buildMessage(command);
+
+        try {
+            String messageId = firebaseMessaging.send(message);
+            log.info("FCM 발송 성공: messageId={}", messageId);
+            return SendPushNotificationResult.success(messageId);
+        } catch (FirebaseMessagingException fme) {
+            return handleFirebaseMessagingException(fme);
+        } catch (Exception e) {
+            log.error("FCM 발송 중 예상치 못한 오류: {}", e.getMessage());
+            throw new FcmSendFailedException("FCM 발송 중 예상치 못한 오류 발생");
+        }
+    }
+
+    private Message buildMessage(SendPushNotificationCommand command) {
+        Message.Builder builder = Message.builder()
+                .setToken(command.deviceToken())
+                .setNotification(Notification.builder()
+                        .setTitle(command.title())
+                        .setBody(command.body())
+                        .build())
+                .putData("url", command.url());
+
+        applyPlatformConfig(builder, command.platform());
+
+        return builder.build();
+    }
+
+    private void applyPlatformConfig(Message.Builder builder, Platform platform) {
+        if (platform == Platform.ANDROID) {
+            builder.setAndroidConfig(AndroidConfig.builder()
+                    .setNotification(AndroidNotification.builder()
+                            .setChannelId("default")
+                            .setSound("default")
+                            .build())
+                    .build());
+            return;
+        }
+
+        builder.setApnsConfig(ApnsConfig.builder()
+                .setAps(Aps.builder()
+                        .setSound("default")
+                        .setBadge(1)
+                        .setContentAvailable(true)
+                        .build())
+                .build());
+    }
+
+    private SendPushNotificationResult handleFirebaseMessagingException(FirebaseMessagingException fme) {
+        MessagingErrorCode errorCode = fme.getMessagingErrorCode();
+        String errorCodeName = errorCode != null ? errorCode.name() : "UNKNOWN";
+
+        if (isTokenInvalid(errorCode)) {
+            log.warn("FCM 토큰 무효: errorCode={}", errorCodeName);
+            return SendPushNotificationResult.tokenInvalid(errorCodeName);
+        }
+
+        log.error("FCM 발송 실패: errorCode={}", errorCodeName);
+        return SendPushNotificationResult.failure(errorCodeName);
+    }
+
+    private boolean isTokenInvalid(MessagingErrorCode errorCode) {
+        return errorCode == MessagingErrorCode.UNREGISTERED
+                || errorCode == MessagingErrorCode.INVALID_ARGUMENT;
+    }
+}

--- a/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/out/command/SendPushNotificationCommand.java
+++ b/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/out/command/SendPushNotificationCommand.java
@@ -1,0 +1,12 @@
+package com.personal.marketnote.notification.port.out.command;
+
+import com.personal.marketnote.notification.domain.device.Platform;
+
+public record SendPushNotificationCommand(
+        String deviceToken,
+        String title,
+        String body,
+        String url,
+        Platform platform
+) {
+}

--- a/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/out/notification/SendPushNotificationPort.java
+++ b/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/out/notification/SendPushNotificationPort.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.notification.port.out.notification;
+
+import com.personal.marketnote.notification.port.out.command.SendPushNotificationCommand;
+import com.personal.marketnote.notification.port.out.result.SendPushNotificationResult;
+
+public interface SendPushNotificationPort {
+
+    SendPushNotificationResult send(SendPushNotificationCommand command);
+}

--- a/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/out/result/SendPushNotificationResult.java
+++ b/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/out/result/SendPushNotificationResult.java
@@ -1,0 +1,20 @@
+package com.personal.marketnote.notification.port.out.result;
+
+public record SendPushNotificationResult(
+        boolean success,
+        String messageId,
+        String errorCode,
+        boolean tokenInvalid
+) {
+    public static SendPushNotificationResult success(String messageId) {
+        return new SendPushNotificationResult(true, messageId, null, false);
+    }
+
+    public static SendPushNotificationResult failure(String errorCode) {
+        return new SendPushNotificationResult(false, null, errorCode, false);
+    }
+
+    public static SendPushNotificationResult tokenInvalid(String errorCode) {
+        return new SendPushNotificationResult(false, null, errorCode, true);
+    }
+}

--- a/notification-service/notification-domain/src/main/java/com/personal/marketnote/notification/domain/notification/FcmSendFailedException.java
+++ b/notification-service/notification-domain/src/main/java/com/personal/marketnote/notification/domain/notification/FcmSendFailedException.java
@@ -1,0 +1,12 @@
+package com.personal.marketnote.notification.domain.notification;
+
+public class FcmSendFailedException extends RuntimeException {
+
+    public FcmSendFailedException(String message) {
+        super("ERR_FCM_01::" + message);
+    }
+
+    public FcmSendFailedException(String message, Throwable cause) {
+        super("ERR_FCM_01::" + message, cause);
+    }
+}


### PR DESCRIPTION
## partially addresses #2164
## partially addresses #2123
## resolves #2098

## Task
- [x] SendPushNotificationPort 정의
- [x] SendPushNotificationCommand record 정의
- [x] SendPushNotificationResult record 정의 (success/failure/tokenInvalid 팩토리 메서드)
- [x] FcmSendFailedException 도메인 예외 추가
- [x] FcmPushNotificationClient 구현 (@ServiceAdapter, @ConditionalOnBean)
- [x] notification + data 혼합 방식 FCM 메시지 빌드 (data.url 필드 포함)
- [x] Android/iOS 플랫폼별 설정 (AndroidConfig, ApnsConfig)
- [x] FCM 에러 코드별 처리 (UNREGISTERED/INVALID_ARGUMENT 시 tokenInvalid 플래그 반환)
