### PR TITLE
[#2164][#2123][#2610] test: FCM 클라이언트 연동 기능 자동화 테스트 추가

### DIFF
--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/out/fcm/FcmPushNotificationClient.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/out/fcm/FcmPushNotificationClient.java
@@ -1,0 +1,89 @@
+package com.personal.marketnote.notification.adapter.out.fcm;
+
+import com.google.firebase.messaging.*;
+import com.personal.marketnote.common.adapter.out.ServiceAdapter;
+import com.personal.marketnote.notification.domain.device.Platform;
+import com.personal.marketnote.notification.domain.notification.FcmSendFailedException;
+import com.personal.marketnote.notification.port.out.command.SendPushNotificationCommand;
+import com.personal.marketnote.notification.port.out.notification.SendPushNotificationPort;
+import com.personal.marketnote.notification.port.out.result.SendPushNotificationResult;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+
+@Slf4j
+@ServiceAdapter
+@RequiredArgsConstructor
+@ConditionalOnBean(FirebaseMessaging.class)
+public class FcmPushNotificationClient implements SendPushNotificationPort {
+
+    private final FirebaseMessaging firebaseMessaging;
+
+    @Override
+    public SendPushNotificationResult send(SendPushNotificationCommand command) {
+        Message message = buildMessage(command);
+
+        try {
+            String messageId = firebaseMessaging.send(message);
+            log.info("FCM 발송 성공: messageId={}", messageId);
+            return SendPushNotificationResult.success(messageId);
+        } catch (FirebaseMessagingException fme) {
+            return handleFirebaseMessagingException(fme);
+        } catch (Exception e) {
+            log.error("FCM 발송 중 예상치 못한 오류: {}", e.getMessage());
+            throw new FcmSendFailedException("FCM 발송 중 예상치 못한 오류 발생");
+        }
+    }
+
+    private Message buildMessage(SendPushNotificationCommand command) {
+        Message.Builder builder = Message.builder()
+                .setToken(command.deviceToken())
+                .setNotification(Notification.builder()
+                        .setTitle(command.title())
+                        .setBody(command.body())
+                        .build())
+                .putData("url", command.url());
+
+        applyPlatformConfig(builder, command.platform());
+
+        return builder.build();
+    }
+
+    private void applyPlatformConfig(Message.Builder builder, Platform platform) {
+        if (platform == Platform.ANDROID) {
+            builder.setAndroidConfig(AndroidConfig.builder()
+                    .setNotification(AndroidNotification.builder()
+                            .setChannelId("default")
+                            .setSound("default")
+                            .build())
+                    .build());
+            return;
+        }
+
+        builder.setApnsConfig(ApnsConfig.builder()
+                .setAps(Aps.builder()
+                        .setSound("default")
+                        .setBadge(1)
+                        .setContentAvailable(true)
+                        .build())
+                .build());
+    }
+
+    private SendPushNotificationResult handleFirebaseMessagingException(FirebaseMessagingException fme) {
+        MessagingErrorCode errorCode = fme.getMessagingErrorCode();
+        String errorCodeName = errorCode != null ? errorCode.name() : "UNKNOWN";
+
+        if (isTokenInvalid(errorCode)) {
+            log.warn("FCM 토큰 무효: errorCode={}", errorCodeName);
+            return SendPushNotificationResult.tokenInvalid(errorCodeName);
+        }
+
+        log.error("FCM 발송 실패: errorCode={}", errorCodeName);
+        return SendPushNotificationResult.failure(errorCodeName);
+    }
+
+    private boolean isTokenInvalid(MessagingErrorCode errorCode) {
+        return errorCode == MessagingErrorCode.UNREGISTERED
+                || errorCode == MessagingErrorCode.INVALID_ARGUMENT;
+    }
+}

--- a/notification-service/notification-adapters/src/test/java/com/personal/marketnote/notification/adapter/out/fcm/FcmPushNotificationClientTest.java
+++ b/notification-service/notification-adapters/src/test/java/com/personal/marketnote/notification/adapter/out/fcm/FcmPushNotificationClientTest.java
@@ -1,0 +1,162 @@
+package com.personal.marketnote.notification.adapter.out.fcm;
+
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.MessagingErrorCode;
+import com.personal.marketnote.notification.domain.device.Platform;
+import com.personal.marketnote.notification.domain.notification.FcmSendFailedException;
+import com.personal.marketnote.notification.port.out.command.SendPushNotificationCommand;
+import com.personal.marketnote.notification.port.out.result.SendPushNotificationResult;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class FcmPushNotificationClientTest {
+
+    @InjectMocks
+    private FcmPushNotificationClient fcmPushNotificationClient;
+
+    @Mock
+    private FirebaseMessaging firebaseMessaging;
+
+    @Nested
+    @DisplayName("FCM 메시지 발송 성공")
+    class SendSuccess {
+
+        @Test
+        @DisplayName("Android 디바이스에 FCM 메시지를 발송하면 messageId를 반환한다")
+        void shouldReturnMessageIdForAndroidDevice() throws Exception {
+            // given
+            SendPushNotificationCommand command = new SendPushNotificationCommand(
+                    "fcm-token-android", "[배송 시작]", "요청하신 상품이 배송 시작되었습니다.",
+                    "/order/12345", Platform.ANDROID
+            );
+            when(firebaseMessaging.send(any(Message.class))).thenReturn("projects/test/messages/12345");
+
+            // when
+            SendPushNotificationResult result = fcmPushNotificationClient.send(command);
+
+            // then
+            assertThat(result.success()).isTrue();
+            assertThat(result.messageId()).isEqualTo("projects/test/messages/12345");
+            assertThat(result.errorCode()).isNull();
+            assertThat(result.tokenInvalid()).isFalse();
+        }
+
+        @Test
+        @DisplayName("iOS 디바이스에 FCM 메시지를 발송하면 messageId를 반환한다")
+        void shouldReturnMessageIdForIosDevice() throws Exception {
+            // given
+            SendPushNotificationCommand command = new SendPushNotificationCommand(
+                    "fcm-token-ios", "[주문 완료]", "주문이 완료되었습니다.",
+                    "/order/67890", Platform.IOS
+            );
+            when(firebaseMessaging.send(any(Message.class))).thenReturn("projects/test/messages/67890");
+
+            // when
+            SendPushNotificationResult result = fcmPushNotificationClient.send(command);
+
+            // then
+            assertThat(result.success()).isTrue();
+            assertThat(result.messageId()).isEqualTo("projects/test/messages/67890");
+        }
+    }
+
+    @Nested
+    @DisplayName("FCM 토큰 무효 처리")
+    class TokenInvalid {
+
+        @Test
+        @DisplayName("UNREGISTERED 에러 시 tokenInvalid가 true를 반환한다")
+        void shouldReturnTokenInvalidForUnregistered() throws Exception {
+            // given
+            SendPushNotificationCommand command = createDefaultCommand();
+            FirebaseMessagingException exception = createFirebaseMessagingException(MessagingErrorCode.UNREGISTERED);
+            when(firebaseMessaging.send(any(Message.class))).thenThrow(exception);
+
+            // when
+            SendPushNotificationResult result = fcmPushNotificationClient.send(command);
+
+            // then
+            assertThat(result.success()).isFalse();
+            assertThat(result.tokenInvalid()).isTrue();
+            assertThat(result.errorCode()).isEqualTo("UNREGISTERED");
+        }
+
+        @Test
+        @DisplayName("INVALID_ARGUMENT 에러 시 tokenInvalid가 true를 반환한다")
+        void shouldReturnTokenInvalidForInvalidArgument() throws Exception {
+            // given
+            SendPushNotificationCommand command = createDefaultCommand();
+            FirebaseMessagingException exception = createFirebaseMessagingException(MessagingErrorCode.INVALID_ARGUMENT);
+            when(firebaseMessaging.send(any(Message.class))).thenThrow(exception);
+
+            // when
+            SendPushNotificationResult result = fcmPushNotificationClient.send(command);
+
+            // then
+            assertThat(result.success()).isFalse();
+            assertThat(result.tokenInvalid()).isTrue();
+            assertThat(result.errorCode()).isEqualTo("INVALID_ARGUMENT");
+        }
+    }
+
+    @Nested
+    @DisplayName("FCM 발송 실패 처리")
+    class SendFailure {
+
+        @Test
+        @DisplayName("INTERNAL 에러 시 success가 false를 반환한다")
+        void shouldReturnFailureForInternalError() throws Exception {
+            // given
+            SendPushNotificationCommand command = createDefaultCommand();
+            FirebaseMessagingException exception = createFirebaseMessagingException(MessagingErrorCode.INTERNAL);
+            when(firebaseMessaging.send(any(Message.class))).thenThrow(exception);
+
+            // when
+            SendPushNotificationResult result = fcmPushNotificationClient.send(command);
+
+            // then
+            assertThat(result.success()).isFalse();
+            assertThat(result.tokenInvalid()).isFalse();
+            assertThat(result.errorCode()).isEqualTo("INTERNAL");
+        }
+
+        @Test
+        @DisplayName("예상치 못한 예외 발생 시 FcmSendFailedException이 발생한다")
+        void shouldThrowFcmSendFailedExceptionForUnexpectedError() throws Exception {
+            // given
+            SendPushNotificationCommand command = createDefaultCommand();
+            when(firebaseMessaging.send(any(Message.class))).thenThrow(new RuntimeException("네트워크 오류"));
+
+            // when & then
+            assertThatThrownBy(() -> fcmPushNotificationClient.send(command))
+                    .isInstanceOf(FcmSendFailedException.class);
+        }
+    }
+
+    private SendPushNotificationCommand createDefaultCommand() {
+        return new SendPushNotificationCommand(
+                "fcm-token-test", "[알림]", "테스트 알림입니다.",
+                "/test/123", Platform.ANDROID
+        );
+    }
+
+    private FirebaseMessagingException createFirebaseMessagingException(MessagingErrorCode errorCode) {
+        FirebaseMessagingException exception = mock(FirebaseMessagingException.class);
+        when(exception.getMessagingErrorCode()).thenReturn(errorCode);
+        return exception;
+    }
+}

--- a/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/out/command/SendPushNotificationCommand.java
+++ b/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/out/command/SendPushNotificationCommand.java
@@ -1,0 +1,12 @@
+package com.personal.marketnote.notification.port.out.command;
+
+import com.personal.marketnote.notification.domain.device.Platform;
+
+public record SendPushNotificationCommand(
+        String deviceToken,
+        String title,
+        String body,
+        String url,
+        Platform platform
+) {
+}

--- a/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/out/notification/SendPushNotificationPort.java
+++ b/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/out/notification/SendPushNotificationPort.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.notification.port.out.notification;
+
+import com.personal.marketnote.notification.port.out.command.SendPushNotificationCommand;
+import com.personal.marketnote.notification.port.out.result.SendPushNotificationResult;
+
+public interface SendPushNotificationPort {
+
+    SendPushNotificationResult send(SendPushNotificationCommand command);
+}

--- a/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/out/result/SendPushNotificationResult.java
+++ b/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/out/result/SendPushNotificationResult.java
@@ -1,0 +1,20 @@
+package com.personal.marketnote.notification.port.out.result;
+
+public record SendPushNotificationResult(
+        boolean success,
+        String messageId,
+        String errorCode,
+        boolean tokenInvalid
+) {
+    public static SendPushNotificationResult success(String messageId) {
+        return new SendPushNotificationResult(true, messageId, null, false);
+    }
+
+    public static SendPushNotificationResult failure(String errorCode) {
+        return new SendPushNotificationResult(false, null, errorCode, false);
+    }
+
+    public static SendPushNotificationResult tokenInvalid(String errorCode) {
+        return new SendPushNotificationResult(false, null, errorCode, true);
+    }
+}

--- a/notification-service/notification-domain/src/main/java/com/personal/marketnote/notification/domain/notification/FcmSendFailedException.java
+++ b/notification-service/notification-domain/src/main/java/com/personal/marketnote/notification/domain/notification/FcmSendFailedException.java
@@ -1,0 +1,12 @@
+package com.personal.marketnote.notification.domain.notification;
+
+public class FcmSendFailedException extends RuntimeException {
+
+    public FcmSendFailedException(String message) {
+        super("ERR_FCM_01::" + message);
+    }
+
+    public FcmSendFailedException(String message, Throwable cause) {
+        super("ERR_FCM_01::" + message, cause);
+    }
+}


### PR DESCRIPTION
## partially addresses #2164
## partially addresses #2123
## resolves #2610

## Test Case
- [x] FCM 메시지 발송 성공 / Android 디바이스에 FCM 메시지를 발송하면 messageId를 반환한다
- [x] FCM 메시지 발송 성공 / iOS 디바이스에 FCM 메시지를 발송하면 messageId를 반환한다
- [x] FCM 토큰 무효 처리 / UNREGISTERED 에러 시 tokenInvalid가 true를 반환한다
- [x] FCM 토큰 무효 처리 / INVALID_ARGUMENT 에러 시 tokenInvalid가 true를 반환한다
- [x] FCM 발송 실패 처리 / INTERNAL 에러 시 success가 false를 반환한다
- [x] FCM 발송 실패 처리 / 예상치 못한 예외 발생 시 FcmSendFailedException이 발생한다
