### PR TITLE
[#2164][#2123][#2119] feat: 광고성 알림 법적 준수 로직 추가

### DIFF
--- a/notification-service/notification-domain/src/main/java/com/personal/marketnote/notification/domain/notification/PromotionalNotificationPolicy.java
+++ b/notification-service/notification-domain/src/main/java/com/personal/marketnote/notification/domain/notification/PromotionalNotificationPolicy.java
@@ -1,0 +1,30 @@
+package com.personal.marketnote.notification.domain.notification;
+
+import com.personal.marketnote.notification.domain.template.NotificationCategory;
+
+public class PromotionalNotificationPolicy {
+
+    private static final String AD_LABEL_PREFIX = "(광고) ";
+    private static final String OPT_OUT_GUIDE_SUFFIX = "\n[수신거부:더보기>설정]";
+
+    private PromotionalNotificationPolicy() {
+    }
+
+    public static String applyAdLabel(String title) {
+        if (title.startsWith(AD_LABEL_PREFIX)) {
+            return title;
+        }
+        return AD_LABEL_PREFIX + title;
+    }
+
+    public static String applyOptOutGuide(String body) {
+        if (body.endsWith(OPT_OUT_GUIDE_SUFFIX)) {
+            return body;
+        }
+        return body + OPT_OUT_GUIDE_SUFFIX;
+    }
+
+    public static boolean shouldApplyPolicy(NotificationCategory category) {
+        return category.requiresAdLabel();
+    }
+}


### PR DESCRIPTION
## partially addresses #2164
## partially addresses #2123
## resolves #2119

## Task
- [x] PROMOTIONAL 알림 제목 앞 "(광고)" 접두사 자동 삽입 (중복 삽입 방지)
- [x] PROMOTIONAL 알림 본문 끝 수신 거부 경로 자동 삽입 ("[수신거부:더보기>설정]", 중복 삽입 방지)
- [x] PromotionalNotificationPolicy 도메인 유틸리티 클래스 추가
- [x] NotificationCategory.requiresAdLabel() 기반 정책 적용 여부 판단
