### PR TITLE
[#2164][#2123][#2618] test: 광고성 알림 법적 준수 로직 자동화 테스트 추가

### DIFF
--- a/notification-service/notification-domain/src/main/java/com/personal/marketnote/notification/domain/notification/PromotionalNotificationPolicy.java
+++ b/notification-service/notification-domain/src/main/java/com/personal/marketnote/notification/domain/notification/PromotionalNotificationPolicy.java
@@ -1,0 +1,30 @@
+package com.personal.marketnote.notification.domain.notification;
+
+import com.personal.marketnote.notification.domain.template.NotificationCategory;
+
+public class PromotionalNotificationPolicy {
+
+    private static final String AD_LABEL_PREFIX = "(광고) ";
+    private static final String OPT_OUT_GUIDE_SUFFIX = "\n[수신거부:더보기>설정]";
+
+    private PromotionalNotificationPolicy() {
+    }
+
+    public static String applyAdLabel(String title) {
+        if (title.startsWith(AD_LABEL_PREFIX)) {
+            return title;
+        }
+        return AD_LABEL_PREFIX + title;
+    }
+
+    public static String applyOptOutGuide(String body) {
+        if (body.endsWith(OPT_OUT_GUIDE_SUFFIX)) {
+            return body;
+        }
+        return body + OPT_OUT_GUIDE_SUFFIX;
+    }
+
+    public static boolean shouldApplyPolicy(NotificationCategory category) {
+        return category.requiresAdLabel();
+    }
+}

--- a/notification-service/notification-domain/src/test/java/com/personal/marketnote/notification/domain/notification/PromotionalNotificationPolicyTest.java
+++ b/notification-service/notification-domain/src/test/java/com/personal/marketnote/notification/domain/notification/PromotionalNotificationPolicyTest.java
@@ -1,0 +1,96 @@
+package com.personal.marketnote.notification.domain.notification;
+
+import com.personal.marketnote.notification.domain.template.NotificationCategory;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PromotionalNotificationPolicyTest {
+
+    @Nested
+    @DisplayName("applyAdLabel 메서드")
+    class ApplyAdLabel {
+
+        @Test
+        @DisplayName("PROMOTIONAL 알림 제목 앞에 (광고) 접두사를 삽입한다")
+        void shouldPrependAdLabelToTitle() {
+            // given
+            String title = "이벤트 안내";
+
+            // when
+            String result = PromotionalNotificationPolicy.applyAdLabel(title);
+
+            // then
+            assertThat(result).isEqualTo("(광고) 이벤트 안내");
+        }
+
+        @Test
+        @DisplayName("이미 (광고) 접두사가 있으면 중복 삽입하지 않는다")
+        void shouldNotDuplicateAdLabel() {
+            // given
+            String title = "(광고) 이벤트 안내";
+
+            // when
+            String result = PromotionalNotificationPolicy.applyAdLabel(title);
+
+            // then
+            assertThat(result).isEqualTo("(광고) 이벤트 안내");
+        }
+    }
+
+    @Nested
+    @DisplayName("applyOptOutGuide 메서드")
+    class ApplyOptOutGuide {
+
+        @Test
+        @DisplayName("PROMOTIONAL 알림 본문 끝에 수신 거부 안내를 삽입한다")
+        void shouldAppendOptOutGuideToBody() {
+            // given
+            String body = "특별 할인 이벤트가 진행 중입니다.";
+
+            // when
+            String result = PromotionalNotificationPolicy.applyOptOutGuide(body);
+
+            // then
+            assertThat(result).isEqualTo("특별 할인 이벤트가 진행 중입니다.\n[수신거부:더보기>설정]");
+        }
+
+        @Test
+        @DisplayName("이미 수신 거부 안내가 있으면 중복 삽입하지 않는다")
+        void shouldNotDuplicateOptOutGuide() {
+            // given
+            String body = "특별 할인 이벤트가 진행 중입니다.\n[수신거부:더보기>설정]";
+
+            // when
+            String result = PromotionalNotificationPolicy.applyOptOutGuide(body);
+
+            // then
+            assertThat(result).isEqualTo("특별 할인 이벤트가 진행 중입니다.\n[수신거부:더보기>설정]");
+        }
+    }
+
+    @Nested
+    @DisplayName("shouldApplyPolicy 메서드")
+    class ShouldApplyPolicy {
+
+        @Test
+        @DisplayName("PROMOTIONAL 카테고리이면 정책을 적용한다")
+        void shouldApplyForPromotional() {
+            assertThat(PromotionalNotificationPolicy.shouldApplyPolicy(NotificationCategory.PROMOTIONAL)).isTrue();
+        }
+
+        @Test
+        @DisplayName("MANDATORY 카테고리이면 정책을 적용하지 않는다")
+        void shouldNotApplyForMandatory() {
+            assertThat(PromotionalNotificationPolicy.shouldApplyPolicy(NotificationCategory.MANDATORY)).isFalse();
+        }
+
+        @Test
+        @DisplayName("INFORMATIONAL 카테고리이면 정책을 적용하지 않는다")
+        void shouldNotApplyForInformational() {
+            assertThat(PromotionalNotificationPolicy.shouldApplyPolicy(NotificationCategory.INFORMATIONAL)).isFalse();
+        }
+    }
+}


### PR DESCRIPTION
## partially addresses #2164
## partially addresses #2123
## resolves #2618

## Test Case
- [x] applyAdLabel 메서드 / PROMOTIONAL 알림 제목 앞에 (광고) 접두사를 삽입한다
- [x] applyAdLabel 메서드 / 이미 (광고) 접두사가 있으면 중복 삽입하지 않는다
- [x] applyOptOutGuide 메서드 / PROMOTIONAL 알림 본문 끝에 수신 거부 안내를 삽입한다
- [x] applyOptOutGuide 메서드 / 이미 수신 거부 안내가 있으면 중복 삽입하지 않는다
- [x] shouldApplyPolicy 메서드 / PROMOTIONAL 카테고리이면 정책을 적용한다
- [x] shouldApplyPolicy 메서드 / MANDATORY 카테고리이면 정책을 적용하지 않는다
- [x] shouldApplyPolicy 메서드 / INFORMATIONAL 카테고리이면 정책을 적용하지 않는다
