### PR TITLE
[#2164][#2123][#2646] fix: FcmPushNotificationClient @ConditionalOnBean 빈 등록 누락 위험 수정 및 Platform enum 술어 메서드 추가

### DIFF
--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/out/fcm/FcmPushNotificationClient.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/out/fcm/FcmPushNotificationClient.java
@@ -1,7 +1,6 @@
 package com.personal.marketnote.notification.adapter.out.fcm;
 
 import com.google.firebase.messaging.*;
-import com.personal.marketnote.common.adapter.out.ServiceAdapter;
 import com.personal.marketnote.notification.domain.device.Platform;
 import com.personal.marketnote.notification.domain.notification.FcmSendFailedException;
 import com.personal.marketnote.notification.port.out.command.SendPushNotificationCommand;
@@ -9,12 +8,9 @@ import com.personal.marketnote.notification.port.out.notification.SendPushNotifi
 import com.personal.marketnote.notification.port.out.result.SendPushNotificationResult;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 
 @Slf4j
-@ServiceAdapter
 @RequiredArgsConstructor
-@ConditionalOnBean(FirebaseMessaging.class)
 public class FcmPushNotificationClient implements SendPushNotificationPort {
 
     private final FirebaseMessaging firebaseMessaging;
@@ -50,7 +46,7 @@ public class FcmPushNotificationClient implements SendPushNotificationPort {
     }
 
     private void applyPlatformConfig(Message.Builder builder, Platform platform) {
-        if (platform == Platform.ANDROID) {
+        if (platform.isAndroid()) {
             builder.setAndroidConfig(AndroidConfig.builder()
                     .setNotification(AndroidNotification.builder()
                             .setChannelId("default")

--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/configuration/FirebaseConfig.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/configuration/FirebaseConfig.java
@@ -4,6 +4,8 @@ import com.google.auth.oauth2.GoogleCredentials;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
 import com.google.firebase.messaging.FirebaseMessaging;
+import com.personal.marketnote.notification.adapter.out.fcm.FcmPushNotificationClient;
+import com.personal.marketnote.notification.port.out.notification.SendPushNotificationPort;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
@@ -48,5 +50,10 @@ public class FirebaseConfig {
     @Bean
     public FirebaseMessaging firebaseMessaging(FirebaseApp firebaseApp) {
         return FirebaseMessaging.getInstance(firebaseApp);
+    }
+
+    @Bean
+    public SendPushNotificationPort sendPushNotificationPort(FirebaseMessaging firebaseMessaging) {
+        return new FcmPushNotificationClient(firebaseMessaging);
     }
 }

--- a/notification-service/notification-domain/src/main/java/com/personal/marketnote/notification/domain/device/Platform.java
+++ b/notification-service/notification-domain/src/main/java/com/personal/marketnote/notification/domain/device/Platform.java
@@ -6,6 +6,14 @@ public enum Platform {
     ANDROID,
     IOS;
 
+    public boolean isAndroid() {
+        return this == ANDROID;
+    }
+
+    public boolean isIos() {
+        return this == IOS;
+    }
+
     public static Platform from(String value) {
         if (FormatValidator.hasNoValue(value)) {
             throw new InvalidPlatformException("플랫폼 값이 비어있습니다.");


### PR DESCRIPTION
## partially addresses #2164
## partially addresses #2123
## resolves #2646

## Reason
- @ConditionalOnBean + @ServiceAdapter 조합은 컴포넌트 스캔 순서에 따라 FirebaseMessaging 빈이 아직 등록되지 않은 시점에 FcmPushNotificationClient가 누락될 수 있음
- Platform enum 직접 비교(== Platform.ANDROID)는 Tell, Don't Ask 원칙 위반

## Action
- [x] FcmPushNotificationClient에서 @ServiceAdapter, @ConditionalOnBean 제거
- [x] FirebaseConfig에 SendPushNotificationPort @Bean 메서드 추가 (명시적 빈 등록)
- [x] Platform enum에 isAndroid(), isIos() 술어 메서드 추가
- [x] FcmPushNotificationClient에서 platform == Platform.ANDROID를 platform.isAndroid()로 변경
