### PR TITLE
[#2164][#2123][#2647] test: Platform enum 술어 메서드 자동화 테스트 추가

### DIFF
--- a/notification-service/notification-domain/src/test/java/com/personal/marketnote/notification/domain/device/PlatformTest.java
+++ b/notification-service/notification-domain/src/test/java/com/personal/marketnote/notification/domain/device/PlatformTest.java
@@ -52,4 +52,28 @@ class PlatformTest {
         assertThatThrownBy(() -> Platform.from(""))
                 .isInstanceOf(InvalidPlatformException.class);
     }
+
+    @Test
+    @DisplayName("ANDROID는 isAndroid()가 true를 반환한다")
+    void shouldReturnTrueForAndroidIsAndroid() {
+        assertThat(Platform.ANDROID.isAndroid()).isTrue();
+    }
+
+    @Test
+    @DisplayName("IOS는 isAndroid()가 false를 반환한다")
+    void shouldReturnFalseForIosIsAndroid() {
+        assertThat(Platform.IOS.isAndroid()).isFalse();
+    }
+
+    @Test
+    @DisplayName("IOS는 isIos()가 true를 반환한다")
+    void shouldReturnTrueForIosIsIos() {
+        assertThat(Platform.IOS.isIos()).isTrue();
+    }
+
+    @Test
+    @DisplayName("ANDROID는 isIos()가 false를 반환한다")
+    void shouldReturnFalseForAndroidIsIos() {
+        assertThat(Platform.ANDROID.isIos()).isFalse();
+    }
 }


### PR DESCRIPTION
## partially addresses #2164
## partially addresses #2123
## partially addresses #2647

## Test Case
- [x] ANDROID는 isAndroid()가 true를 반환한다
- [x] IOS는 isAndroid()가 false를 반환한다
- [x] IOS는 isIos()가 true를 반환한다
- [x] ANDROID는 isIos()가 false를 반환한다