### PR TITLE
[#2164][#2123][#2099] feat: 단건 알림 발송 (NotificationCategory별 분기) 기능 추가

### DIFF
--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/out/persistence/device/DeviceTokenPersistenceAdapter.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/out/persistence/device/DeviceTokenPersistenceAdapter.java
@@ -15,6 +15,7 @@ import com.personal.marketnote.notification.port.out.device.UpdateDeviceTokenPor
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
 
+import java.util.List;
 import java.util.Optional;
 
 @PersistenceAdapter
@@ -23,6 +24,13 @@ public class DeviceTokenPersistenceAdapter
         implements FindDeviceTokenPort, SaveDeviceTokenPort, UpdateDeviceTokenPort, DeleteDeviceTokenPort {
 
     private final DeviceTokenJpaRepository deviceTokenJpaRepository;
+
+    @Override
+    public List<DeviceToken> findActiveByUserId(Long userId) {
+        return deviceTokenJpaRepository.findByUserIdAndStatus(userId, EntityStatus.ACTIVE).stream()
+                .flatMap(entity -> DeviceTokenJpaEntityToDomainMapper.mapToDomain(entity).stream())
+                .toList();
+    }
 
     @Override
     public Optional<DeviceToken> findActiveByDeviceId(String deviceId) {

--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/out/persistence/device/repository/DeviceTokenJpaRepository.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/out/persistence/device/repository/DeviceTokenJpaRepository.java
@@ -4,9 +4,12 @@ import com.personal.marketnote.common.domain.EntityStatus;
 import com.personal.marketnote.notification.adapter.out.persistence.device.entity.DeviceTokenJpaEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface DeviceTokenJpaRepository extends JpaRepository<DeviceTokenJpaEntity, Long> {
 
     Optional<DeviceTokenJpaEntity> findByDeviceIdAndStatus(String deviceId, EntityStatus status);
+
+    List<DeviceTokenJpaEntity> findByUserIdAndStatus(Long userId, EntityStatus status);
 }

--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/out/persistence/notification/NotificationPersistenceAdapter.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/out/persistence/notification/NotificationPersistenceAdapter.java
@@ -6,7 +6,10 @@ import com.personal.marketnote.common.utility.FormatValidator;
 import com.personal.marketnote.notification.adapter.out.mapper.NotificationJpaEntityToDomainMapper;
 import com.personal.marketnote.notification.adapter.out.persistence.notification.repository.NotificationJpaRepository;
 import com.personal.marketnote.notification.domain.notification.Notification;
+import com.personal.marketnote.notification.adapter.out.persistence.notification.entity.NotificationJpaEntity;
 import com.personal.marketnote.notification.port.out.notification.FindNotificationPort;
+import com.personal.marketnote.notification.port.out.notification.SaveNotificationPort;
+import com.personal.marketnote.notification.port.out.notification.UpdateNotificationPort;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 
@@ -14,7 +17,7 @@ import java.util.List;
 
 @PersistenceAdapter
 @RequiredArgsConstructor
-public class NotificationPersistenceAdapter implements FindNotificationPort {
+public class NotificationPersistenceAdapter implements FindNotificationPort, SaveNotificationPort, UpdateNotificationPort {
 
     private final NotificationJpaRepository notificationJpaRepository;
 
@@ -32,5 +35,19 @@ public class NotificationPersistenceAdapter implements FindNotificationPort {
     @Override
     public long countByUserId(Long userId) {
         return notificationJpaRepository.countByUserIdAndStatus(userId, EntityStatus.ACTIVE);
+    }
+
+    @Override
+    public Notification save(Notification notification) {
+        NotificationJpaEntity entity = NotificationJpaEntity.from(notification);
+        NotificationJpaEntity saved = notificationJpaRepository.save(entity);
+        return NotificationJpaEntityToDomainMapper.mapToDomain(saved).orElseThrow();
+    }
+
+    @Override
+    public void update(Notification notification) {
+        NotificationJpaEntity entity = notificationJpaRepository.findById(notification.getId())
+                .orElseThrow(() -> new com.personal.marketnote.notification.domain.notification.NotificationNotFoundException(notification.getId()));
+        entity.updateFrom(notification);
     }
 }

--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/out/persistence/notification/entity/NotificationJpaEntity.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/out/persistence/notification/entity/NotificationJpaEntity.java
@@ -55,6 +55,11 @@ public class NotificationJpaEntity extends BaseGeneralEntity {
     @Column(name = "scheduled_at")
     private LocalDateTime scheduledAt;
 
+    public void updateFrom(Notification notification) {
+        this.sendStatus = notification.getSendStatus();
+        this.isRead = notification.isRead();
+    }
+
     public static NotificationJpaEntity from(Notification notification) {
         return NotificationJpaEntity.builder()
                 .userId(notification.getUserId())

--- a/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/in/command/SendNotificationCommand.java
+++ b/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/in/command/SendNotificationCommand.java
@@ -1,0 +1,13 @@
+package com.personal.marketnote.notification.port.in.command;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+public record SendNotificationCommand(
+        Long userId,
+        String templateCode,
+        Map<String, String> variables,
+        String deliveryChannel,
+        LocalDateTime scheduledAt
+) {
+}

--- a/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/in/result/notification/SendNotificationResult.java
+++ b/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/in/result/notification/SendNotificationResult.java
@@ -1,0 +1,9 @@
+package com.personal.marketnote.notification.port.in.result.notification;
+
+public record SendNotificationResult(
+        Long notificationId,
+        String sendStatus,
+        int sentDeviceCount,
+        int failedDeviceCount
+) {
+}

--- a/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/in/usecase/notification/SendNotificationUseCase.java
+++ b/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/in/usecase/notification/SendNotificationUseCase.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.notification.port.in.usecase.notification;
+
+import com.personal.marketnote.notification.port.in.command.SendNotificationCommand;
+import com.personal.marketnote.notification.port.in.result.notification.SendNotificationResult;
+
+public interface SendNotificationUseCase {
+    SendNotificationResult sendNotification(SendNotificationCommand command);
+}

--- a/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/out/device/FindDeviceTokenPort.java
+++ b/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/out/device/FindDeviceTokenPort.java
@@ -2,8 +2,11 @@ package com.personal.marketnote.notification.port.out.device;
 
 import com.personal.marketnote.notification.domain.device.DeviceToken;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface FindDeviceTokenPort {
     Optional<DeviceToken> findActiveByDeviceId(String deviceId);
+
+    List<DeviceToken> findActiveByUserId(Long userId);
 }

--- a/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/out/notification/SaveNotificationPort.java
+++ b/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/out/notification/SaveNotificationPort.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.notification.port.out.notification;
+
+import com.personal.marketnote.notification.domain.notification.Notification;
+
+public interface SaveNotificationPort {
+    Notification save(Notification notification);
+}

--- a/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/out/notification/UpdateNotificationPort.java
+++ b/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/out/notification/UpdateNotificationPort.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.notification.port.out.notification;
+
+import com.personal.marketnote.notification.domain.notification.Notification;
+
+public interface UpdateNotificationPort {
+    void update(Notification notification);
+}

--- a/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/service/notification/SendNotificationService.java
+++ b/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/service/notification/SendNotificationService.java
@@ -1,0 +1,191 @@
+package com.personal.marketnote.notification.service.notification;
+
+import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.notification.domain.device.DeviceToken;
+import com.personal.marketnote.notification.domain.notification.*;
+import com.personal.marketnote.notification.domain.preference.NotificationPreference;
+import com.personal.marketnote.notification.domain.template.NotificationCategory;
+import com.personal.marketnote.notification.domain.template.NotificationTemplate;
+import com.personal.marketnote.notification.domain.template.NotificationTemplateNotFoundException;
+import com.personal.marketnote.notification.domain.template.TemplateRenderer;
+import com.personal.marketnote.notification.port.in.command.SendNotificationCommand;
+import com.personal.marketnote.notification.port.in.result.notification.SendNotificationResult;
+import com.personal.marketnote.notification.port.in.usecase.notification.SendNotificationUseCase;
+import com.personal.marketnote.notification.port.out.command.SendPushNotificationCommand;
+import com.personal.marketnote.notification.port.out.device.DeleteDeviceTokenPort;
+import com.personal.marketnote.notification.port.out.device.FindDeviceTokenPort;
+import com.personal.marketnote.notification.port.out.notification.SaveNotificationPort;
+import com.personal.marketnote.notification.port.out.notification.SendPushNotificationPort;
+import com.personal.marketnote.notification.port.out.notification.UpdateNotificationPort;
+import com.personal.marketnote.notification.port.out.preference.FindNotificationPreferencePort;
+import com.personal.marketnote.notification.port.out.result.SendPushNotificationResult;
+import com.personal.marketnote.notification.port.out.template.FindNotificationTemplatePort;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@Slf4j
+@UseCase
+@RequiredArgsConstructor
+public class SendNotificationService implements SendNotificationUseCase {
+
+    private final FindNotificationTemplatePort findNotificationTemplatePort;
+    private final FindNotificationPreferencePort findNotificationPreferencePort;
+    private final FindDeviceTokenPort findDeviceTokenPort;
+    private final SaveNotificationPort saveNotificationPort;
+    private final UpdateNotificationPort updateNotificationPort;
+    private final SendPushNotificationPort sendPushNotificationPort;
+    private final DeleteDeviceTokenPort deleteDeviceTokenPort;
+    private final Clock clock;
+
+    @Override
+    @Transactional(isolation = READ_COMMITTED)
+    public SendNotificationResult sendNotification(SendNotificationCommand command) {
+        NotificationTemplate template = findTemplate(command.templateCode());
+        NotificationCategory category = template.getNotificationCategory();
+
+        if (shouldSkipByConsent(category, command.userId(), template)) {
+            return saveSkippedNotification(command, template);
+        }
+
+        String title = TemplateRenderer.render(template.getTitle(), command.variables());
+        String body = TemplateRenderer.render(template.getBodyTemplate(), command.variables());
+        String landingUrl = TemplateRenderer.render(template.getUrlTemplate(), command.variables());
+
+        if (PromotionalNotificationPolicy.shouldApplyPolicy(category)) {
+            title = PromotionalNotificationPolicy.applyAdLabel(title);
+            body = PromotionalNotificationPolicy.applyOptOutGuide(body);
+        }
+
+        LocalDateTime now = LocalDateTime.now(clock);
+        LocalDateTime scheduledAt = NightTimeNotificationPolicy.resolveScheduledAt(
+                category, now, command.scheduledAt());
+
+        DeliveryChannel deliveryChannel = DeliveryChannel.valueOf(command.deliveryChannel());
+        Notification notification = createAndSaveNotification(
+                command, template, title, body, landingUrl, deliveryChannel, scheduledAt);
+
+        if (!notification.getSendStatus().isPending()) {
+            return toResult(notification, 0, 0);
+        }
+
+        if (!deliveryChannel.hasPush()) {
+            return toResult(notification, 0, 0);
+        }
+
+        return sendPushNotifications(notification, title, body, landingUrl, command.userId());
+    }
+
+    private NotificationTemplate findTemplate(String templateCode) {
+        return findNotificationTemplatePort.findActiveByTemplateCode(templateCode)
+                .orElseThrow(() -> new NotificationTemplateNotFoundException(templateCode));
+    }
+
+    private boolean shouldSkipByConsent(NotificationCategory category, Long userId,
+                                         NotificationTemplate template) {
+        if (!category.requiresConsent()) {
+            return false;
+        }
+        Optional<NotificationPreference> preference =
+                findNotificationPreferencePort.findByUserIdAndNotificationType(
+                        userId, template.getNotificationType());
+        return preference.isEmpty() || !preference.get().isEnabled();
+    }
+
+    private SendNotificationResult saveSkippedNotification(SendNotificationCommand command,
+                                                            NotificationTemplate template) {
+        DeliveryChannel deliveryChannel = DeliveryChannel.valueOf(command.deliveryChannel());
+        NotificationCreateState state = NotificationCreateState.builder()
+                .userId(command.userId())
+                .notificationType(template.getNotificationType())
+                .title(template.getTitle())
+                .body(template.getBodyTemplate())
+                .deliveryChannel(deliveryChannel)
+                .build();
+
+        Notification notification = Notification.from(state);
+        notification.markAsSkipped();
+        Notification saved = saveNotificationPort.save(notification);
+
+        return toResult(saved, 0, 0);
+    }
+
+    private Notification createAndSaveNotification(SendNotificationCommand command,
+                                                    NotificationTemplate template,
+                                                    String title, String body, String landingUrl,
+                                                    DeliveryChannel deliveryChannel,
+                                                    LocalDateTime scheduledAt) {
+        NotificationCreateState state = NotificationCreateState.builder()
+                .userId(command.userId())
+                .notificationType(template.getNotificationType())
+                .title(title)
+                .body(body)
+                .deliveryChannel(deliveryChannel)
+                .landingUrl(landingUrl)
+                .scheduledAt(scheduledAt)
+                .build();
+
+        Notification notification = Notification.from(state);
+        return saveNotificationPort.save(notification);
+    }
+
+    private SendNotificationResult sendPushNotifications(Notification notification,
+                                                          String title, String body, String landingUrl,
+                                                          Long userId) {
+        List<DeviceToken> deviceTokens = findDeviceTokenPort.findActiveByUserId(userId);
+
+        if (deviceTokens.isEmpty()) {
+            notification.markAsFailed();
+            updateNotificationPort.update(notification);
+            return toResult(notification, 0, 0);
+        }
+
+        int sentCount = 0;
+        int failedCount = 0;
+
+        for (DeviceToken deviceToken : deviceTokens) {
+            SendPushNotificationCommand pushCommand = new SendPushNotificationCommand(
+                    deviceToken.getToken(), title, body, landingUrl, deviceToken.getPlatform());
+            try {
+                SendPushNotificationResult pushResult = sendPushNotificationPort.send(pushCommand);
+                if (pushResult.success()) {
+                    sentCount++;
+                    continue;
+                }
+                failedCount++;
+                if (pushResult.tokenInvalid()) {
+                    deleteDeviceTokenPort.deleteById(deviceToken.getId());
+                }
+            } catch (FcmSendFailedException fsfe) {
+                log.error("FCM 발송 중 예외 발생: userId={}, deviceId={}", userId, deviceToken.getDeviceId());
+                failedCount++;
+            }
+        }
+
+        if (sentCount > 0) {
+            notification.markAsSent();
+        }
+        if (sentCount == 0) {
+            notification.markAsFailed();
+        }
+        updateNotificationPort.update(notification);
+
+        return toResult(notification, sentCount, failedCount);
+    }
+
+    private SendNotificationResult toResult(Notification notification, int sentCount, int failedCount) {
+        return new SendNotificationResult(
+                notification.getId(),
+                notification.getSendStatus().name(),
+                sentCount,
+                failedCount
+        );
+    }
+}

--- a/notification-service/notification-domain/src/main/java/com/personal/marketnote/notification/domain/notification/Notification.java
+++ b/notification-service/notification-domain/src/main/java/com/personal/marketnote/notification/domain/notification/Notification.java
@@ -81,6 +81,10 @@ public class Notification extends BaseDomain {
         this.sendStatus = SendStatus.FAILED;
     }
 
+    public void markAsSkipped() {
+        this.sendStatus = SendStatus.SKIPPED;
+    }
+
     private static void validate(NotificationCreateState state) {
         if (FormatValidator.hasNoValue(state.getUserId())) {
             throw new InvalidNotificationException("사용자 ID는 필수입니다.");

--- a/notification-service/notification-domain/src/main/java/com/personal/marketnote/notification/domain/notification/NotificationNotFoundException.java
+++ b/notification-service/notification-domain/src/main/java/com/personal/marketnote/notification/domain/notification/NotificationNotFoundException.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.notification.domain.notification;
+
+public class NotificationNotFoundException extends RuntimeException {
+    public NotificationNotFoundException(Long id) {
+        super("ERR_NOTIFICATION_01::알림을 찾을 수 없습니다. id=" + id);
+    }
+}


### PR DESCRIPTION
## partially addresses #2164
## partially addresses #2123
## resolves #2099

## Task
- [x] SendNotificationUseCase 인터페이스 정의
- [x] SendNotificationCommand record 생성 (userId, templateCode, variables, deliveryChannel, scheduledAt)
- [x] SendNotificationResult record 생성 (notificationId, sendStatus, sentDeviceCount, failedDeviceCount)
- [x] SaveNotificationPort, UpdateNotificationPort 인터페이스 정의
- [x] FindDeviceTokenPort에 findActiveByUserId 메서드 추가
- [x] SendNotificationService 구현 (NotificationCategory별 분기 처리)
- [x] MANDATORY/INFORMATIONAL: 수신 설정 무시하고 발송
- [x] PROMOTIONAL: 수신 동의 검사, 광고 라벨/수신거부 안내 적용, 야간 지연 발송
- [x] NotificationPersistenceAdapter에 save/update 구현
- [x] DeviceTokenPersistenceAdapter에 findActiveByUserId 구현
- [x] NotificationJpaEntity에 updateFrom 메서드 추가
- [x] Notification.markAsSkipped() 메서드 추가
- [x] NotificationNotFoundException 도메인 예외 추가
