### PR TITLE
[#2164][#2124][#2125] feat: 인앱 알림 읽음 처리 기능 추가

### DIFF
--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/web/notification/controller/NotificationController.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/web/notification/controller/NotificationController.java
@@ -5,8 +5,10 @@ import com.personal.marketnote.common.utility.ElementExtractor;
 import com.personal.marketnote.notification.adapter.in.web.notification.controller.apidocs.GetNotificationHistoryApiDocs;
 import com.personal.marketnote.notification.adapter.in.web.notification.response.GetNotificationHistoryResponse;
 import com.personal.marketnote.notification.port.in.command.GetNotificationHistoryCommand;
+import com.personal.marketnote.notification.port.in.command.MarkNotificationAsReadCommand;
 import com.personal.marketnote.notification.port.in.result.notification.GetNotificationHistoryResult;
 import com.personal.marketnote.notification.port.in.usecase.notification.GetNotificationHistoryUseCase;
+import com.personal.marketnote.notification.port.in.usecase.notification.MarkNotificationAsReadUseCase;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
@@ -16,10 +18,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.core.OAuth2AuthenticatedPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
 
 import static com.personal.marketnote.common.domain.exception.ExceptionCode.DEFAULT_SUCCESS_CODE;
 
@@ -38,6 +38,7 @@ import static com.personal.marketnote.common.domain.exception.ExceptionCode.DEFA
 public class NotificationController {
 
     private final GetNotificationHistoryUseCase getNotificationHistoryUseCase;
+    private final MarkNotificationAsReadUseCase markNotificationAsReadUseCase;
 
     /**
      * 알림 이력 조회
@@ -72,6 +73,28 @@ public class NotificationController {
                         HttpStatus.OK,
                         DEFAULT_SUCCESS_CODE,
                         "알림 이력 조회 성공"
+                ),
+                HttpStatus.OK
+        );
+    }
+
+    @PatchMapping("/{id}/read")
+    public ResponseEntity<BaseResponse<Void>> markNotificationAsRead(
+            @AuthenticationPrincipal OAuth2AuthenticatedPrincipal principal,
+            @PathVariable("id") Long id
+    ) {
+        MarkNotificationAsReadCommand command = new MarkNotificationAsReadCommand(
+                id,
+                ElementExtractor.extractUserId(principal)
+        );
+        markNotificationAsReadUseCase.markAsRead(command);
+
+        return new ResponseEntity<>(
+                BaseResponse.of(
+                        null,
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "알림 읽음 처리 성공"
                 ),
                 HttpStatus.OK
         );

--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/out/persistence/notification/NotificationPersistenceAdapter.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/out/persistence/notification/NotificationPersistenceAdapter.java
@@ -14,12 +14,19 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 
 import java.util.List;
+import java.util.Optional;
 
 @PersistenceAdapter
 @RequiredArgsConstructor
 public class NotificationPersistenceAdapter implements FindNotificationPort, SaveNotificationPort, UpdateNotificationPort {
 
     private final NotificationJpaRepository notificationJpaRepository;
+
+    @Override
+    public Optional<Notification> findActiveById(Long id) {
+        return notificationJpaRepository.findByIdAndStatus(id, EntityStatus.ACTIVE)
+                .flatMap(NotificationJpaEntityToDomainMapper::mapToDomain);
+    }
 
     @Override
     public List<Notification> findByUserId(Long userId, Long cursor, int fetchSize) {

--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/out/persistence/notification/repository/NotificationJpaRepository.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/out/persistence/notification/repository/NotificationJpaRepository.java
@@ -8,8 +8,11 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface NotificationJpaRepository extends JpaRepository<NotificationJpaEntity, Long> {
+
+    Optional<NotificationJpaEntity> findByIdAndStatus(Long id, EntityStatus status);
 
     @Query("""
             SELECT n FROM NotificationJpaEntity n

--- a/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/in/command/MarkNotificationAsReadCommand.java
+++ b/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/in/command/MarkNotificationAsReadCommand.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.notification.port.in.command;
+
+public record MarkNotificationAsReadCommand(
+        Long notificationId,
+        Long userId
+) {
+}

--- a/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/in/usecase/notification/MarkNotificationAsReadUseCase.java
+++ b/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/in/usecase/notification/MarkNotificationAsReadUseCase.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.notification.port.in.usecase.notification;
+
+import com.personal.marketnote.notification.port.in.command.MarkNotificationAsReadCommand;
+
+public interface MarkNotificationAsReadUseCase {
+    void markAsRead(MarkNotificationAsReadCommand command);
+}

--- a/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/out/notification/FindNotificationPort.java
+++ b/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/out/notification/FindNotificationPort.java
@@ -3,8 +3,11 @@ package com.personal.marketnote.notification.port.out.notification;
 import com.personal.marketnote.notification.domain.notification.Notification;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface FindNotificationPort {
+
+    Optional<Notification> findActiveById(Long id);
 
     List<Notification> findByUserId(Long userId, Long cursor, int fetchSize);
 

--- a/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/service/notification/MarkNotificationAsReadService.java
+++ b/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/service/notification/MarkNotificationAsReadService.java
@@ -1,0 +1,39 @@
+package com.personal.marketnote.notification.service.notification;
+
+import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.notification.domain.notification.Notification;
+import com.personal.marketnote.notification.domain.notification.NotificationNotFoundException;
+import com.personal.marketnote.notification.port.in.command.MarkNotificationAsReadCommand;
+import com.personal.marketnote.notification.port.in.usecase.notification.MarkNotificationAsReadUseCase;
+import com.personal.marketnote.notification.port.out.notification.FindNotificationPort;
+import com.personal.marketnote.notification.port.out.notification.UpdateNotificationPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@UseCase
+@RequiredArgsConstructor
+public class MarkNotificationAsReadService implements MarkNotificationAsReadUseCase {
+
+    private final FindNotificationPort findNotificationPort;
+    private final UpdateNotificationPort updateNotificationPort;
+
+    @Override
+    @Transactional(isolation = READ_COMMITTED)
+    public void markAsRead(MarkNotificationAsReadCommand command) {
+        Notification notification = findNotificationPort.findActiveById(command.notificationId())
+                .orElseThrow(() -> new NotificationNotFoundException(command.notificationId()));
+
+        if (!notification.isOwnedBy(command.userId())) {
+            throw new NotificationNotFoundException(command.notificationId());
+        }
+
+        if (notification.isRead()) {
+            return;
+        }
+
+        notification.markAsRead();
+        updateNotificationPort.update(notification);
+    }
+}

--- a/notification-service/notification-domain/src/main/java/com/personal/marketnote/notification/domain/notification/Notification.java
+++ b/notification-service/notification-domain/src/main/java/com/personal/marketnote/notification/domain/notification/Notification.java
@@ -69,6 +69,10 @@ public class Notification extends BaseDomain {
         return notification;
     }
 
+    public boolean isOwnedBy(Long userId) {
+        return this.userId.equals(userId);
+    }
+
     public void markAsRead() {
         this.isRead = true;
     }


### PR DESCRIPTION
## partially addresses #2164
## partially addresses #2124
## resolves #2125

## Task
- [x] MarkNotificationAsReadUseCase 인터페이스 정의
- [x] MarkNotificationAsReadCommand record 생성 (notificationId, userId)
- [x] MarkNotificationAsReadService 구현 (IDOR 방지 + 멱등성)
- [x] Notification.isOwnedBy(userId) 소유권 검증 메서드 추가
- [x] FindNotificationPort에 findActiveById 메서드 추가
- [x] NotificationPersistenceAdapter에 findActiveById 구현
- [x] NotificationJpaRepository에 findByIdAndStatus 추가
- [x] PATCH /api/v1/notifications/{id}/read 엔드포인트 추가
