### PR TITLE
[#2164][#2124][#2126] feat: 읽지 않은 알림 수 조회 기능 추가

### DIFF
--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/web/notification/controller/NotificationController.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/web/notification/controller/NotificationController.java
@@ -7,7 +7,9 @@ import com.personal.marketnote.notification.adapter.in.web.notification.response
 import com.personal.marketnote.notification.port.in.command.GetNotificationHistoryCommand;
 import com.personal.marketnote.notification.port.in.command.MarkNotificationAsReadCommand;
 import com.personal.marketnote.notification.port.in.result.notification.GetNotificationHistoryResult;
+import com.personal.marketnote.notification.port.in.result.notification.GetUnreadNotificationCountResult;
 import com.personal.marketnote.notification.port.in.usecase.notification.GetNotificationHistoryUseCase;
+import com.personal.marketnote.notification.port.in.usecase.notification.GetUnreadNotificationCountUseCase;
 import com.personal.marketnote.notification.port.in.usecase.notification.MarkNotificationAsReadUseCase;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.Max;
@@ -39,6 +41,7 @@ public class NotificationController {
 
     private final GetNotificationHistoryUseCase getNotificationHistoryUseCase;
     private final MarkNotificationAsReadUseCase markNotificationAsReadUseCase;
+    private final GetUnreadNotificationCountUseCase getUnreadNotificationCountUseCase;
 
     /**
      * 알림 이력 조회
@@ -95,6 +98,25 @@ public class NotificationController {
                         HttpStatus.OK,
                         DEFAULT_SUCCESS_CODE,
                         "알림 읽음 처리 성공"
+                ),
+                HttpStatus.OK
+        );
+    }
+
+    @GetMapping("/unread-count")
+    public ResponseEntity<BaseResponse<GetUnreadNotificationCountResult>> getUnreadNotificationCount(
+            @AuthenticationPrincipal OAuth2AuthenticatedPrincipal principal
+    ) {
+        GetUnreadNotificationCountResult result = getUnreadNotificationCountUseCase.getUnreadCount(
+                ElementExtractor.extractUserId(principal)
+        );
+
+        return new ResponseEntity<>(
+                BaseResponse.of(
+                        result,
+                        HttpStatus.OK,
+                        DEFAULT_SUCCESS_CODE,
+                        "미읽음 알림 수 조회 성공"
                 ),
                 HttpStatus.OK
         );

--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/out/persistence/notification/NotificationPersistenceAdapter.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/out/persistence/notification/NotificationPersistenceAdapter.java
@@ -45,6 +45,11 @@ public class NotificationPersistenceAdapter implements FindNotificationPort, Sav
     }
 
     @Override
+    public long countUnreadByUserId(Long userId) {
+        return notificationJpaRepository.countByUserIdAndStatusAndIsRead(userId, EntityStatus.ACTIVE, false);
+    }
+
+    @Override
     public Notification save(Notification notification) {
         NotificationJpaEntity entity = NotificationJpaEntity.from(notification);
         NotificationJpaEntity saved = notificationJpaRepository.save(entity);

--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/out/persistence/notification/repository/NotificationJpaRepository.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/out/persistence/notification/repository/NotificationJpaRepository.java
@@ -29,4 +29,6 @@ public interface NotificationJpaRepository extends JpaRepository<NotificationJpa
     );
 
     long countByUserIdAndStatus(Long userId, EntityStatus status);
+
+    long countByUserIdAndStatusAndIsRead(Long userId, EntityStatus status, boolean isRead);
 }

--- a/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/in/result/notification/GetUnreadNotificationCountResult.java
+++ b/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/in/result/notification/GetUnreadNotificationCountResult.java
@@ -1,0 +1,6 @@
+package com.personal.marketnote.notification.port.in.result.notification;
+
+public record GetUnreadNotificationCountResult(
+        long unreadCount
+) {
+}

--- a/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/in/usecase/notification/GetUnreadNotificationCountUseCase.java
+++ b/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/in/usecase/notification/GetUnreadNotificationCountUseCase.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.notification.port.in.usecase.notification;
+
+import com.personal.marketnote.notification.port.in.result.notification.GetUnreadNotificationCountResult;
+
+public interface GetUnreadNotificationCountUseCase {
+    GetUnreadNotificationCountResult getUnreadCount(Long userId);
+}

--- a/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/out/notification/FindNotificationPort.java
+++ b/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/out/notification/FindNotificationPort.java
@@ -12,4 +12,6 @@ public interface FindNotificationPort {
     List<Notification> findByUserId(Long userId, Long cursor, int fetchSize);
 
     long countByUserId(Long userId);
+
+    long countUnreadByUserId(Long userId);
 }

--- a/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/service/notification/GetUnreadNotificationCountService.java
+++ b/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/service/notification/GetUnreadNotificationCountService.java
@@ -1,0 +1,24 @@
+package com.personal.marketnote.notification.service.notification;
+
+import com.personal.marketnote.common.application.UseCase;
+import com.personal.marketnote.notification.port.in.result.notification.GetUnreadNotificationCountResult;
+import com.personal.marketnote.notification.port.in.usecase.notification.GetUnreadNotificationCountUseCase;
+import com.personal.marketnote.notification.port.out.notification.FindNotificationPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.transaction.annotation.Isolation.READ_COMMITTED;
+
+@UseCase
+@RequiredArgsConstructor
+public class GetUnreadNotificationCountService implements GetUnreadNotificationCountUseCase {
+
+    private final FindNotificationPort findNotificationPort;
+
+    @Override
+    @Transactional(isolation = READ_COMMITTED, readOnly = true)
+    public GetUnreadNotificationCountResult getUnreadCount(Long userId) {
+        long unreadCount = findNotificationPort.countUnreadByUserId(userId);
+        return new GetUnreadNotificationCountResult(unreadCount);
+    }
+}


### PR DESCRIPTION
## partially addresses #2164
## partially addresses #2124
## resolves #2126

## Task
- [x] GetUnreadNotificationCountUseCase 인터페이스 정의
- [x] GetUnreadNotificationCountResult record 생성 (unreadCount)
- [x] GetUnreadNotificationCountService 구현 (readOnly 트랜잭션)
- [x] FindNotificationPort에 countUnreadByUserId 메서드 추가
- [x] NotificationPersistenceAdapter에 countUnreadByUserId 구현
- [x] NotificationJpaRepository에 countByUserIdAndStatusAndIsRead 추가
- [x] GET /api/v1/notifications/unread-count 엔드포인트 추가
