### PR TITLE
[#929][#2658] feat: 주문 취소 실패 이벤트 클래스 및 Kafka 토픽 추가

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/configuration/CommerceSwaggerConfig.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/in/configuration/CommerceSwaggerConfig.java
@@ -124,6 +124,8 @@ public class CommerceSwaggerConfig {
                                 
                                 - [리워드 서비스](https://rewards.marketnote.store/swagger-ui/index.html)
                                 
+                                - [알림 서비스](https://notifications.marketnote.store/swagger-ui/index.html)
+                                
                                 - [파일 서비스](https://files.marketnote.store/swagger-ui/index.html)
                                 """)
                         .version("1.0"))

--- a/common/src/main/java/com/personal/marketnote/common/kafka/KafkaTopicConstants.java
+++ b/common/src/main/java/com/personal/marketnote/common/kafka/KafkaTopicConstants.java
@@ -12,6 +12,7 @@ public final class KafkaTopicConstants {
     public static final String PAYMENT_CANCELLED = "commerce.payment.cancelled";
     public static final String SETTLEMENT_EXECUTED = "commerce.settlement.executed";
     public static final String ORDER_CANCELLED = "commerce.order.cancelled";
+    public static final String ORDER_CANCEL_FAILED = "commerce.order.cancel-failed";
     public static final String ORDER_PURCHASE_CONFIRMED = "commerce.order.purchase-confirmed";
     public static final String ORDER_RETURNED = "commerce.order.returned";
     public static final String RETURN_INSPECTION_COMPLETED = "commerce.return-inspection.completed";

--- a/common/src/main/java/com/personal/marketnote/common/kafka/event/OrderCancelFailedEvent.java
+++ b/common/src/main/java/com/personal/marketnote/common/kafka/event/OrderCancelFailedEvent.java
@@ -1,0 +1,7 @@
+package com.personal.marketnote.common.kafka.event;
+
+public record OrderCancelFailedEvent(
+        Long orderId,
+        Long buyerId
+) {
+}

--- a/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/in/configuration/CommunitySwaggerConfig.java
+++ b/community-service/community-adapters/src/main/java/com/personal/marketnote/community/adapter/in/configuration/CommunitySwaggerConfig.java
@@ -120,6 +120,8 @@ public class CommunitySwaggerConfig {
                                 
                                 - [리워드 서비스](https://rewards.marketnote.store/swagger-ui/index.html)
                                 
+                                - [알림 서비스](https://notifications.marketnote.store/swagger-ui/index.html)
+                                
                                 - [파일 서비스](https://files.marketnote.store/swagger-ui/index.html)
                                 """)
                         .version("1.0"))

--- a/file-service/file-adapters/src/main/java/com/personal/marketnote/file/adapter/in/configuration/FileSwaggerConfig.java
+++ b/file-service/file-adapters/src/main/java/com/personal/marketnote/file/adapter/in/configuration/FileSwaggerConfig.java
@@ -119,6 +119,8 @@ public class FileSwaggerConfig {
                                 
                                 - [리워드 서비스](https://rewards.marketnote.store/swagger-ui/index.html)
                                 
+                                - [알림 서비스](https://notifications.marketnote.store/swagger-ui/index.html)
+                                
                                 - [파일 서비스](https://files.marketnote.store/swagger-ui/index.html)
                                 """)
                         .version("1.0"))

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter.in.configuration/FulfillmentSwaggerConfig.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter.in.configuration/FulfillmentSwaggerConfig.java
@@ -125,6 +125,8 @@ public class FulfillmentSwaggerConfig {
                                 
                                 - [리워드 서비스](https://rewards.marketnote.store/swagger-ui/index.html)
                                 
+                                - [알림 서비스](https://notifications.marketnote.store/swagger-ui/index.html)
+                                
                                 - [파일 서비스](https://files.marketnote.store/swagger-ui/index.html)
                                 """)
                         .version("1.0"))

--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/configuration/NotificationSwaggerConfig.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/configuration/NotificationSwaggerConfig.java
@@ -114,9 +114,9 @@ public class NotificationSwaggerConfig {
                                 
                                 - [리워드 서비스](https://rewards.marketnote.store/swagger-ui/index.html)
                                 
-                                - [파일 서비스](https://files.marketnote.store/swagger-ui/index.html)
-                                
                                 - [알림 서비스](https://notifications.marketnote.store/swagger-ui/index.html)
+                                
+                                - [파일 서비스](https://files.marketnote.store/swagger-ui/index.html)
                                 
                                 - [모니터링 대시보드](https://monitoring.marketnote.store/d/spring_boot_21/spring-boot-3-x-statistics) (인증 필요)
                                 """)

--- a/notification-service/notification-adapters/src/main/resources/application.yml
+++ b/notification-service/notification-adapters/src/main/resources/application.yml
@@ -55,7 +55,7 @@ client:
     allowed-origins: ${ACCESS_CONTROL_ALLOWED_ORIGINS:http://localhost:3000}
 
 server:
-  origin: ${SERVER_ORIGIN:http://localhost:8088}
+  origin: ${SERVER_ORIGIN:http://localhost:8086}
   error:
     include-exception: false
     include-stacktrace: NEVER

--- a/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/configuration/ProductSwaggerConfig.java
+++ b/product-service/product-adapters/src/main/java/com/personal/marketnote/product/adapter/in/configuration/ProductSwaggerConfig.java
@@ -123,6 +123,8 @@ public class ProductSwaggerConfig {
                                 
                                 - [리워드 서비스](https://rewards.marketnote.store/swagger-ui/index.html)
                                 
+                                - [알림 서비스](https://notifications.marketnote.store/swagger-ui/index.html)
+                                
                                 - [파일 서비스](https://files.marketnote.store/swagger-ui/index.html)
                                 """)
                         .version("1.0"))

--- a/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/configuration/RewardSwaggerConfig.java
+++ b/reward-service/reward-adapters/src/main/java/com/personal/marketnote/reward/adapter/in/configuration/RewardSwaggerConfig.java
@@ -120,6 +120,8 @@ public class RewardSwaggerConfig {
                                 
                                 - [리워드 서비스](https://rewards.marketnote.store/swagger-ui/index.html)
                                 
+                                - [알림 서비스](https://notifications.marketnote.store/swagger-ui/index.html)
+                                
                                 - [파일 서비스](https://files.marketnote.store/swagger-ui/index.html)
                                 """)
                         .version("1.0"))

--- a/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/configuration/UserSwaggerConfig.java
+++ b/user-service/user-adapters/src/main/java/com/personal/marketnote/user/adapter/in/configuration/UserSwaggerConfig.java
@@ -129,6 +129,8 @@ public class UserSwaggerConfig {
                                 
                                 - [리워드 서비스](https://rewards.marketnote.store/swagger-ui/index.html)
                                 
+                                - [알림 서비스](https://notifications.marketnote.store/swagger-ui/index.html)
+                                
                                 - [파일 서비스](https://files.marketnote.store/swagger-ui/index.html)
                                 """)
                         .version("1.0"))


### PR DESCRIPTION
## partially addresses #929
## resolves #2658

## Task
- [x] `OrderCancelFailedEvent` 레코드 클래스 생성 (common 모듈)
- [x] `KafkaTopicConstants.ORDER_CANCEL_FAILED` 토픽 상수 추가
- [x] Kafka 브로커에 `commerce.order.cancel-failed` 토픽 생성
- [x] Kafka 브로커에 `commerce.order.cancel-failed.dlt` DLT 토픽 생성
- [x] 전체 서비스 Swagger에 알림 서비스 링크 추가
- [x] 알림 서비스 로컬 포트 수정 (8088→8086)
