### PR TITLE
[#929][#2659] feat: 주문 취소 실패 시 이벤트 발행 기능 추가

### DIFF
--- a/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/event/OrderEventKafkaProducer.java
+++ b/commerce-service/commerce-adapters/src/main/java/com/personal/marketnote/commerce/adapter/out/event/OrderEventKafkaProducer.java
@@ -11,6 +11,7 @@ import com.personal.marketnote.common.outbox.OutboxEvent;
 import com.personal.marketnote.common.outbox.SaveOutboxEventPort;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
 
 import java.time.Clock;
 import java.util.List;
@@ -25,6 +26,7 @@ public class OrderEventKafkaProducer implements PublishOrderEventPort {
     private final SaveOutboxEventPort saveOutboxEventPort;
     private final ObjectMapper objectMapper;
     private final Clock clock;
+    private final KafkaTemplate<String, Object> kafkaTemplate;
 
     @Override
     public void publishOrderPaymentCompletedEvent(Long orderId, Long buyerId, Long totalAmount,
@@ -121,6 +123,24 @@ public class OrderEventKafkaProducer implements PublishOrderEventPort {
         );
 
         saveToOutbox(envelope, topic, orderId.toString());
+    }
+
+    @Override
+    public void publishOrderCancelFailedEvent(Long orderId, Long buyerId) {
+        OrderCancelFailedEvent payload = new OrderCancelFailedEvent(orderId, buyerId);
+        String topic = KafkaTopicConstants.ORDER_CANCEL_FAILED;
+        EventEnvelope<OrderCancelFailedEvent> envelope = EventEnvelope.of(
+                topic, SOURCE, payload, clock
+        );
+
+        try {
+            kafkaTemplate.send(topic, orderId.toString(), envelope).get();
+            log.info("주문 취소 실패 이벤트 발행. topic={}, orderId={}, buyerId={}",
+                    topic, orderId, buyerId);
+        } catch (Exception e) {
+            log.error("주문 취소 실패 이벤트 발행 실패. topic={}, orderId={}, error={}",
+                    topic, orderId, e.getMessage(), e);
+        }
     }
 
     private <T> void saveToOutbox(EventEnvelope<T> envelope, String topic, String partitionKey) {

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/event/PublishOrderEventPort.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/port/out/event/PublishOrderEventPort.java
@@ -22,4 +22,6 @@ public interface PublishOrderEventPort {
                                    Long returnAmount, Long paymentAmount, Long pointAmount,
                                    Long shippingFee, boolean isFullReturn,
                                    Long returnShippingFee, List<OrderProduct> returnProducts);
+
+    void publishOrderCancelFailedEvent(Long orderId, Long buyerId);
 }

--- a/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/CancelOrderService.java
+++ b/commerce-service/commerce-application/src/main/java/com/personal/marketnote/commerce/service/order/CancelOrderService.java
@@ -143,10 +143,12 @@ public class CancelOrderService implements CancelOrderUseCase {
             CancelFulfillmentReleaseResult result = cancelFulfillmentReleasePort.cancelRelease(order.getId());
             if (!result.cancelled()) {
                 log.warn("풀필먼트 출고 취소 거부 - orderId: {}, message: {}", order.getId(), result.message());
+                publishOrderEventPort.publishOrderCancelFailedEvent(order.getId(), order.getBuyerId());
                 throw new OrderCancellationNotAllowedException(order.getId());
             }
         } catch (FulfillmentServiceRequestFailedException e) {
             log.error("풀필먼트 서비스 통신 실패로 주문 취소 거부 - orderId: {}", order.getId(), e);
+            publishOrderEventPort.publishOrderCancelFailedEvent(order.getId(), order.getBuyerId());
             throw new OrderCancellationNotAllowedException(order.getId());
         }
     }


### PR DESCRIPTION
## partially addresses #929
## resolves #2659

## Task
- [x] `PublishOrderEventPort`에 `publishOrderCancelFailedEvent` 메서드 추가
- [x] Adapter에 직접 발행 구현 (KafkaTemplate, Outbox 미사용)
- [x] `CancelOrderService.cancelFulfillmentIfRequired()`에서 취소 거부 시 이벤트 발행 후 예외 throw
