### PR TITLE
[#2164][#2123][#2100] feat: 주문 결제 완료 시 알림 발송 연동 기능 추가

### DIFF
--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/event/OrderPaymentCompletedNotificationConsumer.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/event/OrderPaymentCompletedNotificationConsumer.java
@@ -1,0 +1,72 @@
+package com.personal.marketnote.notification.adapter.in.event;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.common.kafka.KafkaTopicConstants;
+import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.EventPayloadValidator;
+import com.personal.marketnote.common.kafka.event.OrderPaymentCompletedEvent;
+import com.personal.marketnote.notification.port.in.command.SendNotificationCommand;
+import com.personal.marketnote.notification.port.in.usecase.notification.SendNotificationUseCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OrderPaymentCompletedNotificationConsumer {
+
+    private final SendNotificationUseCase sendNotificationUseCase;
+    private final ObjectMapper objectMapper;
+
+    @KafkaListener(
+            topics = KafkaTopicConstants.ORDER_PAYMENT_COMPLETED,
+            groupId = "notification-order"
+    )
+    public void handleOrderPaymentCompletedEvent(
+            ConsumerRecord<String, EventEnvelope<?>> record,
+            Acknowledgment acknowledgment
+    ) {
+        EventEnvelope<?> envelope = record.value();
+
+        if (EventPayloadValidator.hasInvalidEnvelope(envelope, record)) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        if (EventPayloadValidator.hasEventTypeMismatch(envelope, KafkaTopicConstants.ORDER_PAYMENT_COMPLETED)) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        OrderPaymentCompletedEvent payload = envelope.getPayloadAs(OrderPaymentCompletedEvent.class, objectMapper);
+
+        log.info("주문 결제 완료 이벤트 수신 (알림 발송). eventId={}, orderId={}, buyerId={}",
+                envelope.eventId(), payload.orderId(), payload.buyerId());
+
+        if (EventPayloadValidator.hasInvalidIds(envelope.eventId(),
+                EventPayloadValidator.id("orderId", payload.orderId()),
+                EventPayloadValidator.id("buyerId", payload.buyerId()))) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        SendNotificationCommand command = new SendNotificationCommand(
+                payload.buyerId(),
+                "ORDER_PAYMENT_COMPLETED",
+                Map.of("order_id", String.valueOf(payload.orderId())),
+                "PUSH_ONLY",
+                null
+        );
+        sendNotificationUseCase.sendNotification(command);
+
+        log.info("주문 결제 완료 알림 발송 완료. orderId={}, buyerId={}", payload.orderId(), payload.buyerId());
+
+        acknowledgment.acknowledge();
+    }
+}


### PR DESCRIPTION
## partially addresses #2164
## partially addresses #2123
## resolves #2100

## Task
- [x] `OrderPaymentCompletedNotificationConsumer` Kafka Consumer 구현
- [x] `commerce.order.payment-completed` 토픽 구독 (groupId: `notification-order`)
- [x] `EventPayloadValidator`로 envelope, eventType, orderId, buyerId 검증
- [x] `SendNotificationUseCase` 호출 (templateCode: `ORDER_PAYMENT_COMPLETED`, deliveryChannel: `PUSH_ONLY`)
