### PR TITLE
[#2164][#2123][#2524][#2124][#2502] feat: 주문 취소 실패 시 푸시 알림 발송 기능 추가 / 주문 취소 실패 시 인앱 알림 생성 기능 추가

### DIFF
--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/event/OrderCancelFailedNotificationConsumer.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/event/OrderCancelFailedNotificationConsumer.java
@@ -1,0 +1,72 @@
+package com.personal.marketnote.notification.adapter.in.event;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.common.kafka.KafkaTopicConstants;
+import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.EventPayloadValidator;
+import com.personal.marketnote.common.kafka.event.OrderCancelFailedEvent;
+import com.personal.marketnote.notification.port.in.command.SendNotificationCommand;
+import com.personal.marketnote.notification.port.in.usecase.notification.SendNotificationUseCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OrderCancelFailedNotificationConsumer {
+
+    private final SendNotificationUseCase sendNotificationUseCase;
+    private final ObjectMapper objectMapper;
+
+    @KafkaListener(
+            topics = KafkaTopicConstants.ORDER_CANCEL_FAILED,
+            groupId = "notification-order"
+    )
+    public void handleOrderCancelFailedEvent(
+            ConsumerRecord<String, EventEnvelope<?>> record,
+            Acknowledgment acknowledgment
+    ) {
+        EventEnvelope<?> envelope = record.value();
+
+        if (EventPayloadValidator.hasInvalidEnvelope(envelope, record)) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        if (EventPayloadValidator.hasEventTypeMismatch(envelope, KafkaTopicConstants.ORDER_CANCEL_FAILED)) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        OrderCancelFailedEvent payload = envelope.getPayloadAs(OrderCancelFailedEvent.class, objectMapper);
+
+        log.info("주문 취소 실패 이벤트 수신 (알림 발송). eventId={}, orderId={}, buyerId={}",
+                envelope.eventId(), payload.orderId(), payload.buyerId());
+
+        if (EventPayloadValidator.hasInvalidIds(envelope.eventId(),
+                EventPayloadValidator.id("orderId", payload.orderId()),
+                EventPayloadValidator.id("buyerId", payload.buyerId()))) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        SendNotificationCommand command = new SendNotificationCommand(
+                payload.buyerId(),
+                "ORDER_CANCEL_FAILED",
+                Map.of("order_id", String.valueOf(payload.orderId())),
+                "PUSH_AND_IN_APP",
+                null
+        );
+        sendNotificationUseCase.sendNotification(command);
+
+        log.info("주문 취소 실패 알림 발송 완료. orderId={}, buyerId={}", payload.orderId(), payload.buyerId());
+
+        acknowledgment.acknowledge();
+    }
+}


### PR DESCRIPTION
## partially addresses #2164
## partially addresses #2123
## partially addresses #2124
## resolves #2524
## resolves #2502

## Task
- [x] `OrderCancelFailedNotificationConsumer` Kafka Consumer 구현
- [x] `commerce.order.cancel-failed` 토픽 구독 (groupId: `notification-order`)
- [x] `EventPayloadValidator`로 envelope, eventType, orderId, buyerId 검증
- [x] `SendNotificationUseCase` 호출 (templateCode: `ORDER_CANCEL_FAILED`, deliveryChannel: `PUSH_AND_IN_APP`)
- [x] 하나의 Consumer에서 푸시(#2524) + 인앱(#2502) 동시 처리
