### PR TITLE
[#2164][#2664] feat: SSE 커넥션 인프라 구축 기능 추가

### DIFF
--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/configuration/NotificationSwaggerConfig.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/configuration/NotificationSwaggerConfig.java
@@ -32,6 +32,7 @@ public class NotificationSwaggerConfig {
 
     private static final List<String> TAGS_ORDER = List.of(
             "알림 API",
+            "SSE 알림 스트림 API",
             "서버 정보 API"
     );
 

--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/web/sse/controller/SseNotificationController.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/web/sse/controller/SseNotificationController.java
@@ -1,0 +1,40 @@
+package com.personal.marketnote.notification.adapter.in.web.sse.controller;
+
+import com.personal.marketnote.common.utility.ElementExtractor;
+import com.personal.marketnote.notification.adapter.in.web.sse.controller.apidocs.SubscribeSseStreamApiDocs;
+import com.personal.marketnote.notification.adapter.in.web.sse.registry.SseConnectionRegistry;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.core.OAuth2AuthenticatedPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@RestController
+@RequestMapping("/api/v1/notifications")
+@Tag(name = "SSE 알림 스트림 API", description = "실시간 알림 SSE 스트림 API")
+public class SseNotificationController {
+
+    private final SseConnectionRegistry sseConnectionRegistry;
+    private final long emitterTimeoutMs;
+
+    public SseNotificationController(
+            SseConnectionRegistry sseConnectionRegistry,
+            @Value("${sse.emitter.timeout-ms:1800000}") long emitterTimeoutMs
+    ) {
+        this.sseConnectionRegistry = sseConnectionRegistry;
+        this.emitterTimeoutMs = emitterTimeoutMs;
+    }
+
+    @GetMapping(value = "/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    @SubscribeSseStreamApiDocs
+    public SseEmitter subscribe(
+            @AuthenticationPrincipal OAuth2AuthenticatedPrincipal principal
+    ) {
+        Long userId = ElementExtractor.extractUserId(principal);
+        return sseConnectionRegistry.register(userId, emitterTimeoutMs);
+    }
+}

--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/web/sse/controller/apidocs/SubscribeSseStreamApiDocs.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/web/sse/controller/apidocs/SubscribeSseStreamApiDocs.java
@@ -1,0 +1,86 @@
+package com.personal.marketnote.notification.adapter.in.web.sse.controller.apidocs;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+@Operation(
+        summary = "SSE 알림 스트림 구독",
+        description = """
+                작성일자: 2026-09-03
+
+                작성자: 성효빈
+
+                ---
+
+                ## Description
+
+                - 인증된 사용자의 실시간 알림 SSE 스트림을 구독합니다.
+
+                - 연결 즉시 `event: connect / data: CONNECTED` 초기 이벤트가 전송됩니다.
+
+                - 30초 간격으로 heartbeat가 전송되어 커넥션이 유지됩니다.
+
+                - 동일 사용자가 재연결하면 이전 커넥션은 자동으로 종료됩니다.
+
+                ---
+
+                ## SSE Event Types
+
+                | **이벤트** | **설명** |
+                | --- | --- |
+                | connect | 초기 연결 확인 이벤트 |
+                | heartbeat | 커넥션 유지용 (comment, 클라이언트 핸들러에 전달되지 않음) |
+
+                ---
+
+                ## Response
+
+                `text/event-stream` 형식으로 스트리밍됩니다.
+
+                ```
+                event: connect
+                data: CONNECTED
+
+                : heartbeat
+                ```
+                """,
+        security = {@SecurityRequirement(name = "bearer")},
+        responses = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "SSE 스트림 연결 성공",
+                        content = @Content(
+                                mediaType = "text/event-stream",
+                                examples = @ExampleObject("""
+                                        event: connect
+                                        data: CONNECTED
+                                        """)
+                        )
+                ),
+                @ApiResponse(
+                        responseCode = "401",
+                        description = "토큰 인증 실패",
+                        content = @Content(
+                                examples = @ExampleObject("""
+                                        {
+                                          "statusCode": 401,
+                                          "code": "UNAUTHORIZED",
+                                          "timestamp": "2026-09-03T12:00:00.000",
+                                          "content": null,
+                                          "message": "Invalid token"
+                                        }
+                                        """)
+                        )
+                )
+        }
+)
+public @interface SubscribeSseStreamApiDocs {
+}

--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/web/sse/registry/SseConnectionLimitExceededException.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/web/sse/registry/SseConnectionLimitExceededException.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.notification.adapter.in.web.sse.registry;
+
+public class SseConnectionLimitExceededException extends RuntimeException {
+
+    public SseConnectionLimitExceededException(int maxConnections) {
+        super("ERR_SSE_01::SSE 최대 커넥션 수를 초과했습니다. maxConnections=" + maxConnections);
+    }
+}

--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/web/sse/registry/SseConnectionRegistry.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/web/sse/registry/SseConnectionRegistry.java
@@ -1,0 +1,103 @@
+package com.personal.marketnote.notification.adapter.in.web.sse.registry;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Component
+@Slf4j
+public class SseConnectionRegistry {
+
+    private final ConcurrentHashMap<Long, SseEmitter> connections = new ConcurrentHashMap<>();
+    private final int maxConnections;
+
+    public SseConnectionRegistry(
+            @Value("${sse.max-connections:5000}") int maxConnections
+    ) {
+        this.maxConnections = maxConnections;
+    }
+
+    public SseEmitter register(Long userId, long timeoutMs) {
+        if (!connections.containsKey(userId) && connections.size() >= maxConnections) {
+            log.warn("SSE 최대 커넥션 수 초과: maxConnections={}", maxConnections);
+            throw new SseConnectionLimitExceededException(maxConnections);
+        }
+
+        SseEmitter emitter = new SseEmitter(timeoutMs);
+
+        emitter.onCompletion(() -> {
+            connections.remove(userId, emitter);
+            log.debug("SSE 커넥션 완료: userId={}", userId);
+        });
+
+        emitter.onTimeout(() -> {
+            connections.remove(userId, emitter);
+            log.debug("SSE 커넥션 타임아웃: userId={}", userId);
+        });
+
+        emitter.onError(throwable -> {
+            connections.remove(userId, emitter);
+            log.debug("SSE 커넥션 에러: userId={}", userId, throwable);
+        });
+
+        SseEmitter previousEmitter = connections.put(userId, emitter);
+        if (previousEmitter != null) {
+            log.info("SSE 기존 커넥션 종료: userId={}", userId);
+            previousEmitter.complete();
+        }
+
+        log.info("SSE 커넥션 등록: userId={}, timeout={}ms", userId, timeoutMs);
+        sendConnectEvent(emitter, userId);
+
+        return emitter;
+    }
+
+    public void remove(Long userId) {
+        SseEmitter emitter = connections.remove(userId);
+        if (emitter != null) {
+            emitter.complete();
+            log.info("SSE 커넥션 제거: userId={}", userId);
+        }
+    }
+
+    public void sendToUser(Long userId, SseEmitter.SseEventBuilder event) {
+        SseEmitter emitter = connections.get(userId);
+        if (emitter == null) {
+            return;
+        }
+
+        try {
+            emitter.send(event);
+        } catch (IOException exception) {
+            connections.remove(userId, emitter);
+            emitter.completeWithError(exception);
+            log.warn("SSE 이벤트 전송 실패 (IO), 커넥션 제거: userId={}", userId);
+        } catch (IllegalStateException exception) {
+            connections.remove(userId, emitter);
+            log.warn("SSE 이벤트 전송 실패 (emitter 비활성), 커넥션 제거: userId={}", userId);
+        }
+    }
+
+    public Set<Long> getConnectedUserIds() {
+        return Set.copyOf(connections.keySet());
+    }
+
+    public int getConnectionCount() {
+        return connections.size();
+    }
+
+    private void sendConnectEvent(SseEmitter emitter, Long userId) {
+        try {
+            emitter.send(SseEmitter.event().name("connect").data("CONNECTED"));
+        } catch (IOException exception) {
+            connections.remove(userId, emitter);
+            emitter.completeWithError(exception);
+            log.warn("SSE 초기 연결 이벤트 전송 실패: userId={}", userId);
+        }
+    }
+}

--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/web/sse/scheduler/SseHeartbeatScheduler.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/web/sse/scheduler/SseHeartbeatScheduler.java
@@ -1,0 +1,35 @@
+package com.personal.marketnote.notification.adapter.in.web.sse.scheduler;
+
+import com.personal.marketnote.notification.adapter.in.web.sse.registry.SseConnectionRegistry;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.util.Set;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class SseHeartbeatScheduler {
+
+    private final SseConnectionRegistry sseConnectionRegistry;
+
+    @Scheduled(fixedDelayString = "${sse.heartbeat.interval-ms:30000}")
+    public void sendHeartbeat() {
+        Set<Long> connectedUserIds = sseConnectionRegistry.getConnectedUserIds();
+        if (connectedUserIds.isEmpty()) {
+            return;
+        }
+
+        log.debug("SSE heartbeat 전송 시작: 커넥션 수={}", connectedUserIds.size());
+
+        for (Long userId : connectedUserIds) {
+            SseEmitter.SseEventBuilder heartbeatEvent = SseEmitter.event().comment("heartbeat");
+            sseConnectionRegistry.sendToUser(userId, heartbeatEvent);
+        }
+
+        log.debug("SSE heartbeat 전송 완료: 커넥션 수={}", connectedUserIds.size());
+    }
+}

--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/configuration/SchedulingConfig.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/configuration/SchedulingConfig.java
@@ -1,0 +1,21 @@
+package com.personal.marketnote.notification.configuration;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+@Configuration
+@EnableScheduling
+public class SchedulingConfig {
+
+    @Bean
+    public ThreadPoolTaskScheduler taskScheduler() {
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        scheduler.setPoolSize(1);
+        scheduler.setThreadNamePrefix("notification-scheduler-");
+        scheduler.setWaitForTasksToCompleteOnShutdown(true);
+        scheduler.setAwaitTerminationSeconds(30);
+        return scheduler;
+    }
+}

--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/configuration/SseConfig.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/configuration/SseConfig.java
@@ -1,0 +1,18 @@
+package com.personal.marketnote.notification.configuration;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.AsyncSupportConfigurer;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class SseConfig implements WebMvcConfigurer {
+
+    @Value("${sse.emitter.timeout-ms:1800000}")
+    private long emitterTimeoutMs;
+
+    @Override
+    public void configureAsyncSupport(AsyncSupportConfigurer configurer) {
+        configurer.setDefaultTimeout(emitterTimeoutMs);
+    }
+}

--- a/notification-service/notification-adapters/src/main/resources/application.yml
+++ b/notification-service/notification-adapters/src/main/resources/application.yml
@@ -75,6 +75,13 @@ kafka:
   slack:
     webhook-url: ${KAFKA_SLACK_WEBHOOK_URL:}
 
+sse:
+  max-connections: ${SSE_MAX_CONNECTIONS:5000}
+  emitter:
+    timeout-ms: ${SSE_EMITTER_TIMEOUT_MS:1800000}
+  heartbeat:
+    interval-ms: ${SSE_HEARTBEAT_INTERVAL_MS:30000}
+
 management:
   endpoints:
     web:

--- a/notification-service/notification-adapters/src/test/resources/application-test.yml
+++ b/notification-service/notification-adapters/src/test/resources/application-test.yml
@@ -28,3 +28,4 @@ spring:
       - org.springframework.boot.autoconfigure.security.oauth2.resource.servlet.OAuth2ResourceServerAutoConfiguration
       - org.springframework.boot.autoconfigure.batch.BatchAutoConfiguration
       - org.springframework.boot.autoconfigure.kafka.KafkaAutoConfiguration
+      - org.springframework.boot.autoconfigure.task.TaskSchedulingAutoConfiguration


### PR DESCRIPTION
## partially addresses #2164
## resolves #2664

## Task
- [x] SseConnectionRegistry 구현 (ConcurrentHashMap 기반 userId→SseEmitter 매핑)
- [x] SseEmitter 생성/해제/타임아웃 관리 로직 구현
- [x] Heartbeat 스케줄러 구현 (30초 주기 ping으로 커넥션 유지)
- [x] SSE 스트림 엔드포인트 추가 (GET /api/v1/notifications/stream)
- [x] OAuth2 인증 기반 SSE 커넥션 인증 처리
- [x] 클라이언트 연결 해제 시 Registry 정리 로직
- [x] 글로벌 최대 커넥션 수 제한 (DoS 방어)
- [x] SseConnectionLimitExceededException 커스텀 예외
