### PR TITLE
[#2164][#2124][#2665] feat: Redis Pub/Sub 기반 SSE 이벤트 브로드캐스트 구축 기능 추가

### DIFF
--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/web/sse/subscriber/SseEventRedisSubscriber.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/web/sse/subscriber/SseEventRedisSubscriber.java
@@ -1,0 +1,49 @@
+package com.personal.marketnote.notification.adapter.in.web.sse.subscriber;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.notification.adapter.in.web.sse.registry.SseConnectionRegistry;
+import com.personal.marketnote.notification.adapter.out.sse.SseEventMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.nio.charset.StandardCharsets;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class SseEventRedisSubscriber implements MessageListener {
+
+    private final SseConnectionRegistry sseConnectionRegistry;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void onMessage(Message message, byte[] pattern) {
+        String messageBody = new String(message.getBody(), StandardCharsets.UTF_8);
+
+        SseEventMessage sseEventMessage = deserialize(messageBody);
+        if (FormatValidator.hasNoValue(sseEventMessage)) {
+            return;
+        }
+
+        SseEmitter.SseEventBuilder event = SseEmitter.event()
+                .name(sseEventMessage.eventType())
+                .data(sseEventMessage.payload());
+
+        sseConnectionRegistry.sendToUser(sseEventMessage.userId(), event);
+    }
+
+    private SseEventMessage deserialize(String messageBody) {
+        try {
+            return objectMapper.readValue(messageBody, SseEventMessage.class);
+        } catch (JsonProcessingException exception) {
+            log.error("SSE 이벤트 메시지 역직렬화 실패: message={}", messageBody, exception);
+            return null;
+        }
+    }
+}

--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/out/sse/RedisSseEventPublishAdapter.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/out/sse/RedisSseEventPublishAdapter.java
@@ -1,0 +1,44 @@
+package com.personal.marketnote.notification.adapter.out.sse;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.notification.port.out.sse.PublishSseEventPort;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+import static com.personal.marketnote.notification.configuration.RedisPubSubConfig.SSE_NOTIFICATION_EVENTS_CHANNEL;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class RedisSseEventPublishAdapter implements PublishSseEventPort {
+
+    private final StringRedisTemplate stringRedisTemplate;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void publish(Long userId, String eventType, String payload) {
+        SseEventMessage message = new SseEventMessage(userId, eventType, payload);
+
+        String serialized = serialize(message);
+        if (FormatValidator.hasNoValue(serialized)) {
+            return;
+        }
+
+        stringRedisTemplate.convertAndSend(SSE_NOTIFICATION_EVENTS_CHANNEL, serialized);
+        log.debug("SSE 이벤트 Redis 발행: userId={}, eventType={}", userId, eventType);
+    }
+
+    private String serialize(SseEventMessage message) {
+        try {
+            return objectMapper.writeValueAsString(message);
+        } catch (JsonProcessingException exception) {
+            log.error("SSE 이벤트 메시지 직렬화 실패: userId={}, eventType={}",
+                    message.userId(), message.eventType(), exception);
+            return null;
+        }
+    }
+}

--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/out/sse/SseEventMessage.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/out/sse/SseEventMessage.java
@@ -1,0 +1,8 @@
+package com.personal.marketnote.notification.adapter.out.sse;
+
+public record SseEventMessage(
+        Long userId,
+        String eventType,
+        String payload
+) {
+}

--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/configuration/RedisPubSubConfig.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/configuration/RedisPubSubConfig.java
@@ -1,0 +1,31 @@
+package com.personal.marketnote.notification.configuration;
+
+import com.personal.marketnote.notification.adapter.in.web.sse.subscriber.SseEventRedisSubscriber;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+
+@Configuration
+public class RedisPubSubConfig {
+
+    public static final String SSE_NOTIFICATION_EVENTS_CHANNEL = "sse:notification-events";
+
+    @Bean
+    public ChannelTopic sseNotificationEventsTopic() {
+        return new ChannelTopic(SSE_NOTIFICATION_EVENTS_CHANNEL);
+    }
+
+    @Bean
+    public RedisMessageListenerContainer sseRedisMessageListenerContainer(
+            RedisConnectionFactory redisConnectionFactory,
+            SseEventRedisSubscriber sseEventRedisSubscriber,
+            ChannelTopic sseNotificationEventsTopic
+    ) {
+        RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+        container.setConnectionFactory(redisConnectionFactory);
+        container.addMessageListener(sseEventRedisSubscriber, sseNotificationEventsTopic);
+        return container;
+    }
+}

--- a/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/out/sse/PublishSseEventPort.java
+++ b/notification-service/notification-application/src/main/java/com/personal/marketnote/notification/port/out/sse/PublishSseEventPort.java
@@ -1,0 +1,6 @@
+package com.personal.marketnote.notification.port.out.sse;
+
+public interface PublishSseEventPort {
+
+    void publish(Long userId, String eventType, String payload);
+}


### PR DESCRIPTION
## partially addresses #2164
## partially addresses #2124
## resolves #2665

## Task
- [x] Redis Pub/Sub 설정 (RedisMessageListenerContainer)
- [x] SSE 이벤트 전용 Redis channel 정의 (sse:notification-events)
- [x] 이벤트 수신 시 로컬 SseConnectionRegistry 조회 후 SseEmitter.send() 전달 로직
- [x] 직렬화/역직렬화 처리 (SseEventMessage record)
- [x] PublishSseEventPort 인터페이스 (application 레이어)
- [x] RedisSseEventPublishAdapter 발행 어댑터 (adapters 레이어)
