### PR TITLE
[#2164][#2124][#2669] test: 알림 생성 시 SSE 실시간 이벤트 발행 연동 기능 자동화 테스트 추가

### DIFF
--- a/notification-service/notification-application/src/test/java/com/personal/marketnote/notification/service/notification/MarkNotificationAsReadUseCaseTest.java
+++ b/notification-service/notification-application/src/test/java/com/personal/marketnote/notification/service/notification/MarkNotificationAsReadUseCaseTest.java
@@ -6,6 +6,7 @@ import com.personal.marketnote.notification.domain.template.NotificationType;
 import com.personal.marketnote.notification.port.in.command.MarkNotificationAsReadCommand;
 import com.personal.marketnote.notification.port.out.notification.FindNotificationPort;
 import com.personal.marketnote.notification.port.out.notification.UpdateNotificationPort;
+import com.personal.marketnote.notification.port.out.sse.PublishSseEventPort;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -30,6 +31,9 @@ class MarkNotificationAsReadUseCaseTest {
 
     @Mock
     private UpdateNotificationPort updateNotificationPort;
+
+    @Mock
+    private PublishSseEventPort publishSseEventPort;
 
     @Test
     @DisplayName("알림이 존재하고 본인 소유이면 읽음 처리한다")

--- a/notification-service/notification-application/src/test/java/com/personal/marketnote/notification/service/notification/SendNotificationUseCaseTest.java
+++ b/notification-service/notification-application/src/test/java/com/personal/marketnote/notification/service/notification/SendNotificationUseCaseTest.java
@@ -10,11 +10,13 @@ import com.personal.marketnote.notification.port.in.result.notification.SendNoti
 import com.personal.marketnote.notification.port.out.command.SendPushNotificationCommand;
 import com.personal.marketnote.notification.port.out.device.DeleteDeviceTokenPort;
 import com.personal.marketnote.notification.port.out.device.FindDeviceTokenPort;
+import com.personal.marketnote.notification.port.out.notification.FindNotificationPort;
 import com.personal.marketnote.notification.port.out.notification.SaveNotificationPort;
 import com.personal.marketnote.notification.port.out.notification.SendPushNotificationPort;
 import com.personal.marketnote.notification.port.out.notification.UpdateNotificationPort;
 import com.personal.marketnote.notification.port.out.preference.FindNotificationPreferencePort;
 import com.personal.marketnote.notification.port.out.result.SendPushNotificationResult;
+import com.personal.marketnote.notification.port.out.sse.PublishSseEventPort;
 import com.personal.marketnote.notification.port.out.template.FindNotificationTemplatePort;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -61,6 +63,12 @@ class SendNotificationUseCaseTest {
 
     @Mock
     private DeleteDeviceTokenPort deleteDeviceTokenPort;
+
+    @Mock
+    private FindNotificationPort findNotificationPort;
+
+    @Mock
+    private PublishSseEventPort publishSseEventPort;
 
     @Spy
     private Clock clock = Clock.fixed(


### PR DESCRIPTION
## partially addresses #2164
## partially addresses #2124
## resolves #2669

## Test Case
- [x] 알림 저장 후 Redis Pub/Sub publish 호출 검증
- [x] publish 이벤트의 userId, unreadCount 값 검증
- [x] 읽음 처리 시 unreadCount 갱신 이벤트 발행 검증
- [x] SSE 이벤트 타입(UNREAD_COUNT_CHANGED) 검증
