### PR TITLE
[#2164][#2123][#2101][#2124][#2128] feat: 배송 시작 시 알림 발송 연동 기능 추가 / 배송 시작 시 인앱 알림 생성 기능 추가

### DIFF
--- a/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/event/ShippingStatusChangedOrderStatusConsumerTest.java
+++ b/commerce-service/commerce-adapters/src/test/java/com/personal/marketnote/commerce/adapter/in/event/ShippingStatusChangedOrderStatusConsumerTest.java
@@ -43,7 +43,7 @@ class ShippingStatusChangedOrderStatusConsumerTest {
 
     private ConsumerRecord<String, EventEnvelope<?>> buildRecord(Long orderId, String shippingStatus) {
         ShippingStatusChangedEvent event = new ShippingStatusChangedEvent(
-                orderId, shippingStatus, "TRACK-001", "CJ", LocalDateTime.of(2026, 4, 9, 10, 0)
+                orderId, 1L, shippingStatus, "TRACK-001", "CJ", LocalDateTime.of(2026, 4, 9, 10, 0)
         );
         EventEnvelope<ShippingStatusChangedEvent> envelope = new EventEnvelope<>(
                 "test-event-id", "fulfillment.shipping.status-changed", "fulfillment-service",
@@ -255,7 +255,7 @@ class ShippingStatusChangedOrderStatusConsumerTest {
     void handleShippingStatusChangedEvent_eventTypeMismatch_skipsAndAcknowledges() {
         // given
         ShippingStatusChangedEvent event = new ShippingStatusChangedEvent(
-                1L, "SHIPPING", "TRACK-001", "CJ", LocalDateTime.of(2026, 4, 9, 10, 0)
+                1L, 1L, "SHIPPING", "TRACK-001", "CJ", LocalDateTime.of(2026, 4, 9, 10, 0)
         );
         EventEnvelope<ShippingStatusChangedEvent> envelope = new EventEnvelope<>(
                 "test-event-id", "wrong.event.type", "fulfillment-service",

--- a/common/src/main/java/com/personal/marketnote/common/kafka/event/ShippingStatusChangedEvent.java
+++ b/common/src/main/java/com/personal/marketnote/common/kafka/event/ShippingStatusChangedEvent.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 
 public record ShippingStatusChangedEvent(
         Long orderId,
+        Long buyerId,
         String shippingStatus,
         String trackingNumber,
         String carrierCode,

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/event/OrderPaymentCompletedOutboundConsumer.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/in/event/OrderPaymentCompletedOutboundConsumer.java
@@ -83,7 +83,7 @@ public class OrderPaymentCompletedOutboundConsumer {
             //  — orderId 기반 출고 이력 DB 저장 (UNIQUE 제약) → 중복 시 FulfillmentDeliveryAlreadyRegisteredException
             //  — Consumer에서 FulfillmentDeliveryAlreadyRegisteredException catch → warn + acknowledge
 
-            createShippingTracker(payload.orderId(), envelope.eventId());
+            createShippingTracker(payload.orderId(), payload.buyerId(), envelope.eventId());
 
             log.info("Fulfillment 출고 요청 이벤트 처리 완료. orderId={}, orderProducts={}건",
                     payload.orderId(), payload.orderProducts().size());
@@ -99,9 +99,9 @@ public class OrderPaymentCompletedOutboundConsumer {
         acknowledgment.acknowledge();
     }
 
-    private void createShippingTracker(Long orderId, String eventId) {
-        CreateShippingTrackerCommand command = new CreateShippingTrackerCommand(orderId);
+    private void createShippingTracker(Long orderId, Long buyerId, String eventId) {
+        CreateShippingTrackerCommand command = new CreateShippingTrackerCommand(orderId, buyerId);
         createShippingTrackerUseCase.createShippingTracker(command);
-        log.info("배송 추적 생성 완료. eventId={}, orderId={}", eventId, orderId);
+        log.info("배송 추적 생성 완료. eventId={}, orderId={}, buyerId={}", eventId, orderId, buyerId);
     }
 }

--- a/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/persistence/shipping/entity/ShippingTrackerJpaEntity.java
+++ b/fulfillment-service/fulfillment-adapters/src/main/java/com/personal/marketnote/fulfillment/adapter/out/persistence/shipping/entity/ShippingTrackerJpaEntity.java
@@ -27,6 +27,9 @@ public class ShippingTrackerJpaEntity {
     @Column(name = "order_id", nullable = false, unique = true)
     private Long orderId;
 
+    @Column(name = "buyer_id", nullable = false)
+    private Long buyerId;
+
     @Column(name = "tracking_number")
     private String trackingNumber;
 
@@ -55,6 +58,7 @@ public class ShippingTrackerJpaEntity {
         return ShippingTrackerJpaEntity.builder()
                 .id(shippingTracker.getId())
                 .orderId(shippingTracker.getOrderId())
+                .buyerId(shippingTracker.getBuyerId())
                 .trackingNumber(shippingTracker.getTrackingNumber())
                 .carrierCode(shippingTracker.getCarrierCode())
                 .shippingStatus(shippingTracker.getShippingStatus())
@@ -70,6 +74,7 @@ public class ShippingTrackerJpaEntity {
                 ShippingTrackerSnapshotState.builder()
                         .id(id)
                         .orderId(orderId)
+                        .buyerId(buyerId)
                         .trackingNumber(trackingNumber)
                         .carrierCode(carrierCode)
                         .shippingStatus(shippingStatus)

--- a/fulfillment-service/fulfillment-adapters/src/main/resources/db/migration/V20260410__add_buyer_id_to_shipping_tracker.sql
+++ b/fulfillment-service/fulfillment-adapters/src/main/resources/db/migration/V20260410__add_buyer_id_to_shipping_tracker.sql
@@ -1,0 +1,1 @@
+ALTER TABLE shipping_tracker ADD COLUMN buyer_id BIGINT NOT NULL;

--- a/fulfillment-service/fulfillment-adapters/src/test/java/com/personal/marketnote/fulfillment/adapter/out/event/ShippingStatusEventOutboxAdapterTest.java
+++ b/fulfillment-service/fulfillment-adapters/src/test/java/com/personal/marketnote/fulfillment/adapter/out/event/ShippingStatusEventOutboxAdapterTest.java
@@ -52,6 +52,7 @@ class ShippingStatusEventOutboxAdapterTest {
         // given
         ShippingStatusChangedEvent event = new ShippingStatusChangedEvent(
                 100L,
+                1L,
                 "SHIPPING",
                 "INV001",
                 "CJ",
@@ -83,6 +84,7 @@ class ShippingStatusEventOutboxAdapterTest {
         // given
         ShippingStatusChangedEvent event = new ShippingStatusChangedEvent(
                 200L,
+                2L,
                 "DELIVERED",
                 "INV002",
                 "HANJIN",
@@ -109,6 +111,7 @@ class ShippingStatusEventOutboxAdapterTest {
         // given
         ShippingStatusChangedEvent event = new ShippingStatusChangedEvent(
                 300L,
+                3L,
                 "DELIVERY_FAILED",
                 "INV003",
                 "CJ",

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/CreateShippingTrackerCommand.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/port/in/command/CreateShippingTrackerCommand.java
@@ -1,6 +1,7 @@
 package com.personal.marketnote.fulfillment.port.in.command;
 
 public record CreateShippingTrackerCommand(
-        Long orderId
+        Long orderId,
+        Long buyerId
 ) {
 }

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/shipping/CreateShippingTrackerService.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/shipping/CreateShippingTrackerService.java
@@ -22,6 +22,7 @@ public class CreateShippingTrackerService implements CreateShippingTrackerUseCas
         ShippingTracker shippingTracker = ShippingTracker.from(
                 ShippingTrackerCreateState.builder()
                         .orderId(command.orderId())
+                        .buyerId(command.buyerId())
                         .build()
         );
         saveShippingTrackerPort.save(shippingTracker);

--- a/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/shipping/PollShippingStatusService.java
+++ b/fulfillment-service/fulfillment-application/src/main/java/com/personal/marketnote/fulfillment/service/shipping/PollShippingStatusService.java
@@ -176,6 +176,7 @@ public class PollShippingStatusService implements PollShippingStatusUseCase {
     private void publishStatusChanged(ShippingTracker tracker) {
         publishShippingStatusChangedEventPort.publish(new ShippingStatusChangedEvent(
                 tracker.getOrderId(),
+                tracker.getBuyerId(),
                 tracker.getShippingStatus().name(),
                 tracker.getTrackingNumber(),
                 tracker.getCarrierCode(),

--- a/fulfillment-service/fulfillment-application/src/test/java/com/personal/marketnote/fulfillment/service/shipping/CreateShippingTrackerUseCaseTest.java
+++ b/fulfillment-service/fulfillment-application/src/test/java/com/personal/marketnote/fulfillment/service/shipping/CreateShippingTrackerUseCaseTest.java
@@ -30,7 +30,7 @@ class CreateShippingTrackerUseCaseTest {
     @DisplayName("orderId로 ShippingTracker를 생성하면 PREPARING 상태로 저장된다")
     void createShippingTrackerWithOrderId() {
         // given
-        CreateShippingTrackerCommand command = new CreateShippingTrackerCommand(100L);
+        CreateShippingTrackerCommand command = new CreateShippingTrackerCommand(100L, 1L);
 
         // when
         createShippingTrackerService.createShippingTracker(command);
@@ -41,6 +41,7 @@ class CreateShippingTrackerUseCaseTest {
 
         ShippingTracker savedTracker = captor.getValue();
         assertThat(savedTracker.getOrderId()).isEqualTo(100L);
+        assertThat(savedTracker.getBuyerId()).isEqualTo(1L);
         assertThat(savedTracker.isPreparing()).isTrue();
         assertThat(savedTracker.isPollingActive()).isTrue();
     }
@@ -49,7 +50,7 @@ class CreateShippingTrackerUseCaseTest {
     @DisplayName("orderId가 null이면 예외가 발생한다")
     void createShippingTrackerWithNullOrderId() {
         // given
-        CreateShippingTrackerCommand command = new CreateShippingTrackerCommand(null);
+        CreateShippingTrackerCommand command = new CreateShippingTrackerCommand(null, 1L);
 
         // when & then
         assertThatThrownBy(() -> createShippingTrackerService.createShippingTracker(command))

--- a/fulfillment-service/fulfillment-application/src/test/java/com/personal/marketnote/fulfillment/service/shipping/PollShippingStatusUseCaseTest.java
+++ b/fulfillment-service/fulfillment-application/src/test/java/com/personal/marketnote/fulfillment/service/shipping/PollShippingStatusUseCaseTest.java
@@ -126,6 +126,7 @@ class PollShippingStatusUseCaseTest {
         verify(publishShippingStatusChangedEventPort).publish(eventCaptor.capture());
         ShippingStatusChangedEvent event = eventCaptor.getValue();
         assertThat(event.orderId()).isEqualTo(100L);
+        assertThat(event.buyerId()).isEqualTo(1L);
         assertThat(event.shippingStatus()).isEqualTo("SHIPPING");
         assertThat(event.trackingNumber()).isEqualTo("INV001");
         assertThat(event.carrierCode()).isEqualTo("CJ");
@@ -309,6 +310,7 @@ class PollShippingStatusUseCaseTest {
         ShippingTracker tracker = ShippingTracker.from(ShippingTrackerSnapshotState.builder()
                 .id(1L)
                 .orderId(100L)
+                .buyerId(1L)
                 .shippingStatus(ShippingStatus.SHIPPING)
                 .pollingActive(true)
                 .createdAt(LocalDateTime.of(2026, 4, 8, 10, 0))
@@ -344,6 +346,7 @@ class PollShippingStatusUseCaseTest {
         return ShippingTracker.from(ShippingTrackerSnapshotState.builder()
                 .id(id)
                 .orderId(orderId)
+                .buyerId(1L)
                 .shippingStatus(ShippingStatus.PREPARING)
                 .pollingActive(true)
                 .createdAt(LocalDateTime.of(2026, 4, 8, 10, 0))
@@ -355,6 +358,7 @@ class PollShippingStatusUseCaseTest {
         return ShippingTracker.from(ShippingTrackerSnapshotState.builder()
                 .id(id)
                 .orderId(orderId)
+                .buyerId(1L)
                 .trackingNumber("INV001")
                 .carrierCode("CJ")
                 .shippingStatus(ShippingStatus.SHIPPING)

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/shipping/ShippingTracker.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/shipping/ShippingTracker.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
 public class ShippingTracker {
     private Long id;
     private Long orderId;
+    private Long buyerId;
     private String trackingNumber;
     private String carrierCode;
     private ShippingStatus shippingStatus;
@@ -26,8 +27,12 @@ public class ShippingTracker {
         if (FormatValidator.hasNoValue(state.getOrderId())) {
             throw new FulfillmentQueryParameterNoValueException("orderId");
         }
+        if (FormatValidator.hasNoValue(state.getBuyerId())) {
+            throw new FulfillmentQueryParameterNoValueException("buyerId");
+        }
         return ShippingTracker.builder()
                 .orderId(state.getOrderId())
+                .buyerId(state.getBuyerId())
                 .shippingStatus(ShippingStatus.PREPARING)
                 .pollingActive(true)
                 .build();
@@ -37,6 +42,7 @@ public class ShippingTracker {
         return ShippingTracker.builder()
                 .id(state.getId())
                 .orderId(state.getOrderId())
+                .buyerId(state.getBuyerId())
                 .trackingNumber(state.getTrackingNumber())
                 .carrierCode(state.getCarrierCode())
                 .shippingStatus(state.getShippingStatus())

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/shipping/ShippingTrackerCreateState.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/shipping/ShippingTrackerCreateState.java
@@ -7,4 +7,5 @@ import lombok.Getter;
 @Builder
 public class ShippingTrackerCreateState {
     private final Long orderId;
+    private final Long buyerId;
 }

--- a/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/shipping/ShippingTrackerSnapshotState.java
+++ b/fulfillment-service/fulfillment-domain/src/main/java/com/personal/marketnote/fulfillment/domain/shipping/ShippingTrackerSnapshotState.java
@@ -10,6 +10,7 @@ import java.time.LocalDateTime;
 public class ShippingTrackerSnapshotState {
     private final Long id;
     private final Long orderId;
+    private final Long buyerId;
     private final String trackingNumber;
     private final String carrierCode;
     private final ShippingStatus shippingStatus;

--- a/fulfillment-service/fulfillment-domain/src/test/java/com/personal/marketnote/fulfillment/domain/shipping/ShippingTrackerTest.java
+++ b/fulfillment-service/fulfillment-domain/src/test/java/com/personal/marketnote/fulfillment/domain/shipping/ShippingTrackerTest.java
@@ -23,6 +23,7 @@ class ShippingTrackerTest {
         void createWithOrderId() {
             ShippingTrackerCreateState state = ShippingTrackerCreateState.builder()
                     .orderId(100L)
+                    .buyerId(1L)
                     .build();
 
             ShippingTracker tracker = ShippingTracker.from(state);
@@ -39,6 +40,19 @@ class ShippingTrackerTest {
         void createWithNullOrderId() {
             ShippingTrackerCreateState state = ShippingTrackerCreateState.builder()
                     .orderId(null)
+                    .buyerId(1L)
+                    .build();
+
+            assertThatThrownBy(() -> ShippingTracker.from(state))
+                    .isInstanceOf(FulfillmentQueryParameterNoValueException.class);
+        }
+
+        @Test
+        @DisplayName("buyerId가 null이면 예외가 발생한다")
+        void createWithNullBuyerId() {
+            ShippingTrackerCreateState state = ShippingTrackerCreateState.builder()
+                    .orderId(100L)
+                    .buyerId(null)
                     .build();
 
             assertThatThrownBy(() -> ShippingTracker.from(state))
@@ -57,6 +71,7 @@ class ShippingTrackerTest {
             ShippingTrackerSnapshotState state = ShippingTrackerSnapshotState.builder()
                     .id(1L)
                     .orderId(100L)
+                    .buyerId(1L)
                     .trackingNumber("1234567890")
                     .carrierCode("CJ")
                     .shippingStatus(ShippingStatus.SHIPPING)
@@ -350,6 +365,7 @@ class ShippingTrackerTest {
     private ShippingTracker createPreparingTracker() {
         return ShippingTracker.from(ShippingTrackerCreateState.builder()
                 .orderId(100L)
+                .buyerId(1L)
                 .build());
     }
 

--- a/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/event/ShippingStartedNotificationConsumer.java
+++ b/notification-service/notification-adapters/src/main/java/com/personal/marketnote/notification/adapter/in/event/ShippingStartedNotificationConsumer.java
@@ -1,0 +1,88 @@
+package com.personal.marketnote.notification.adapter.in.event;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.personal.marketnote.common.kafka.KafkaTopicConstants;
+import com.personal.marketnote.common.kafka.event.EventEnvelope;
+import com.personal.marketnote.common.kafka.event.EventPayloadValidator;
+import com.personal.marketnote.common.kafka.event.ShippingStatusChangedEvent;
+import com.personal.marketnote.common.utility.FormatValidator;
+import com.personal.marketnote.notification.port.in.command.SendNotificationCommand;
+import com.personal.marketnote.notification.port.in.usecase.notification.SendNotificationUseCase;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ShippingStartedNotificationConsumer {
+
+    private static final String SHIPPING_STATUS = "SHIPPING";
+
+    private final SendNotificationUseCase sendNotificationUseCase;
+    private final ObjectMapper objectMapper;
+
+    @KafkaListener(
+            topics = KafkaTopicConstants.SHIPPING_STATUS_CHANGED,
+            groupId = "notification-shipping"
+    )
+    public void handleShippingStatusChangedEvent(
+            ConsumerRecord<String, EventEnvelope<?>> record,
+            Acknowledgment acknowledgment
+    ) {
+        EventEnvelope<?> envelope = record.value();
+
+        if (EventPayloadValidator.hasInvalidEnvelope(envelope, record)) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        if (EventPayloadValidator.hasEventTypeMismatch(envelope, KafkaTopicConstants.SHIPPING_STATUS_CHANGED)) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        ShippingStatusChangedEvent payload = envelope.getPayloadAs(ShippingStatusChangedEvent.class, objectMapper);
+
+        if (!SHIPPING_STATUS.equals(payload.shippingStatus())) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        log.info("배송 시작 이벤트 수신 (알림 발송). eventId={}, orderId={}, buyerId={}",
+                envelope.eventId(), payload.orderId(), payload.buyerId());
+
+        if (EventPayloadValidator.hasInvalidIds(envelope.eventId(),
+                EventPayloadValidator.id("orderId", payload.orderId()),
+                EventPayloadValidator.id("buyerId", payload.buyerId()))) {
+            acknowledgment.acknowledge();
+            return;
+        }
+
+        try {
+            SendNotificationCommand command = new SendNotificationCommand(
+                    payload.buyerId(),
+                    "SHIPPING_STARTED",
+                    Map.of(
+                            "order_id", String.valueOf(payload.orderId()),
+                            "tracking_number", FormatValidator.hasValue(payload.trackingNumber()) ? payload.trackingNumber() : ""
+                    ),
+                    "PUSH_AND_IN_APP",
+                    null
+            );
+            sendNotificationUseCase.sendNotification(command);
+
+            log.info("배송 시작 알림 발송 완료. orderId={}, buyerId={}", payload.orderId(), payload.buyerId());
+        } catch (Exception e) {
+            log.error("배송 시작 알림 발송 실패. eventId={}, orderId={}, buyerId={}, error={}",
+                    envelope.eventId(), payload.orderId(), payload.buyerId(), e.getMessage(), e);
+        }
+
+        acknowledgment.acknowledge();
+    }
+}


### PR DESCRIPTION
## partially addresses #2164
## partially addresses #2123
## resolves #2101
## partially addresses #2124
## resolves #2128

## Task
- [x] ShippingStatusChangedEvent에 buyerId 필드 추가
- [x] ShippingTracker 도메인에 buyerId 필드 추가 및 null 검증
- [x] ShippingTrackerCreateState, SnapshotState에 buyerId 추가
- [x] CreateShippingTrackerCommand에 buyerId 추가
- [x] CreateShippingTrackerService에서 buyerId 전달
- [x] PollShippingStatusService.publishStatusChanged()에서 buyerId 포함
- [x] ShippingTrackerJpaEntity에 buyer_id 컬럼 추가 (NOT NULL)
- [x] OrderPaymentCompletedOutboundConsumer에서 buyerId 전달
- [x] Flyway 마이그레이션 추가 (V20260410__add_buyer_id_to_shipping_tracker.sql)
- [x] ShippingStartedNotificationConsumer 신규 작성 (SHIPPING 상태 필터링, PUSH_AND_IN_APP)
- [x] 기존 테스트 buyerId 시그니처 변경 반영
